### PR TITLE
feat(toast): Improve UX with close button, shorter duration, and repositioning

### DIFF
--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -1,9 +1,28 @@
 export type ToastType = 'danger' | 'success'
 
 export function showToast(message: string, type: ToastType = 'danger') {
-  window.ot.toast(message, '', {
-    variant: type === 'success' ? 'success' : 'danger',
-    placement: 'top-right',
-    duration: 5000,
+  const variant = type === 'success' ? 'success' : 'danger'
+
+  const toast = document.createElement('output')
+  toast.setAttribute('data-variant', variant)
+  toast.style.display = 'flex'
+  toast.style.alignItems = 'start'
+  toast.style.gap = 'var(--space-3)'
+
+  const msgEl = document.createElement('div')
+  msgEl.className = 'toast-message'
+  msgEl.style.flex = '1'
+  msgEl.textContent = message
+  toast.appendChild(msgEl)
+
+  const closeBtn = document.createElement('button')
+  closeBtn.setAttribute('data-close', '')
+  closeBtn.textContent = '\u00d7'
+  closeBtn.onclick = () => toast.remove()
+  toast.appendChild(closeBtn)
+
+  window.ot.toastEl(toast, {
+    placement: 'bottom-right',
+    duration: 3000,
   })
 }


### PR DESCRIPTION
## Motivation
Toast notifications in the application were previously displayed for 5 seconds at the top-right corner without user control. This could be disruptive for users who needed to interact with UI elements in that area or who wanted to dismiss notifications immediately after reading them.

## Modifications
- **Added close button**: Toast notifications now include an accessible close button (×) that allows users to dismiss messages explicitly
- **Shortened duration**: Reduced auto-dismiss time from 5000ms to 3000ms for faster, less intrusive notifications
- **Repositioned toasts**: Moved toast placement from `top-right` to `bottom-right` to reduce visual interference with common UI elements
- **Improved semantics**: Refactored toast implementation to use semantic `<output>` HTML element with flex layout for better accessibility
- **API change**: Migrated from `window.ot.toast()` to `window.ot.toastEl()` for programmatic toast creation
- **Test compatibility**: Updated E2E test helpers to intercept both legacy `toast()` and new `toastEl()` methods for comprehensive toast recording

## Result
Users can now dismiss toast notifications immediately by clicking the close button, reducing the need to wait for auto-dismissal. The shorter duration and bottom-right placement make notifications less disruptive while maintaining visibility. The semantic HTML structure improves screen reader compatibility.

🤖 Generated with Claude Code
