### PR TITLE
Use tilde path simplification in frontend path display

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -21,6 +21,8 @@ interface ChatViewProps {
   onDeleteMessage?: (messageId: string) => void
   /** Workspace working directory for relativizing file paths in tool messages. */
   workingDir?: string
+  /** Worker's home directory for tilde (~) path simplification. */
+  homeDir?: string
   /** Whether there are older messages available to fetch. */
   hasOlderMessages?: boolean
   /** Whether a fetch for older messages is in progress. */
@@ -238,6 +240,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                     onRetry={() => props.onRetryMessage?.(msg.id)}
                     onDelete={() => props.onDeleteMessage?.(msg.id)}
                     workingDir={props.workingDir}
+                    homeDir={props.homeDir}
                   />
                 </div>
               )}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -90,6 +90,7 @@ interface MessageBubbleProps {
   onRetry?: () => void
   onDelete?: () => void
   workingDir?: string
+  homeDir?: string
 }
 
 export const MessageBubble: Component<MessageBubbleProps> = (props) => {
@@ -309,6 +310,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       createdAt: props.message.createdAt,
       updatedAt: props.message.updatedAt,
       workingDir: props.workingDir,
+      homeDir: props.homeDir,
       threadChildCount: nonControlChildren().length,
       threadExpanded: threadExpanded(),
       onToggleThread: () => setThreadExpanded(prev => !prev),
@@ -383,6 +385,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
                         <ErrorBoundary fallback={<span class={chatStyles.systemMessage}>Failed to render message</span>}>
                           {renderMessageContent(child, childRole(), {
                             workingDir: props.workingDir,
+                            homeDir: props.homeDir,
                             parentToolName: toolInfo?.name,
                             parentToolInput: toolInfo?.input,
                           })}

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -104,6 +104,7 @@ export function formatToolInput(input: unknown): string {
 /** Render per-tool compact display for a tool_use block. */
 export function renderToolDetail(toolName: string, input: Record<string, unknown>, context?: RenderContext): JSX.Element | null {
   const cwd = context?.workingDir
+  const homeDir = context?.homeDir
 
   switch (toolName) {
     case 'Bash': {
@@ -126,7 +127,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
             : ''
       return (
         <>
-          <span class={toolInputPath}>{relativizePath(path, cwd)}</span>
+          <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
           <span class={toolInputDetail}>{rangeStr}</span>
         </>
       )
@@ -139,7 +140,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       const lineStr = lineCount > 0 ? ` (${lineCount} ${lineCount === 1 ? 'line' : 'lines'})` : ''
       return (
         <>
-          <span class={toolInputPath}>{relativizePath(path, cwd)}</span>
+          <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
           <span class={toolInputDetail}>{lineStr}</span>
         </>
       )
@@ -163,7 +164,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       const hasStats = added > 0 || removed > 0
       return (
         <>
-          <span class={toolInputPath}>{relativizePath(path, cwd)}</span>
+          <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
           {hasStats && (
             <span class={toolInputDetail}>
               {' '}
@@ -189,12 +190,12 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       const { pattern, path } = input as GlobInput
       // Relativize pattern if it's an absolute path without glob wildcards
       const displayPattern = pattern && pattern.startsWith('/') && !pattern.includes('*')
-        ? relativizePath(pattern, cwd)
+        ? relativizePath(pattern, cwd, homeDir)
         : (pattern || '')
       return (
         <span class={toolInputCode}>
           {displayPattern}
-          {path ? ` ${relativizePath(path, cwd)}` : ''}
+          {path ? ` ${relativizePath(path, cwd, homeDir)}` : ''}
         </span>
       )
     }
@@ -244,7 +245,7 @@ export function renderToolSubDetail(toolName: string, input: Record<string, unkn
       const { path } = input as GrepInput
       if (!path)
         return null
-      return <div class={cls}>{relativizePath(path, context?.workingDir)}</div>
+      return <div class={cls}>{relativizePath(path, context?.workingDir, context?.homeDir)}</div>
     }
     default:
       return null
@@ -484,7 +485,7 @@ function ToolResultMessage(props: {
         >
           <div class={toolUseHeader}>
             <Show when={props.filePath}>
-              <span class={toolInputPath}>{relativizePath(props.filePath, props.context?.workingDir)}</span>
+              <span class={toolInputPath}>{relativizePath(props.filePath, props.context?.workingDir, props.context?.homeDir)}</span>
             </Show>
             <div class={toolHeaderActions}>
               <IconButton

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1186,6 +1186,7 @@ export const AppShell: ParentComponent = (props) => {
                     onRetryMessage={messageId => handleRetryMessage(agentId, messageId)}
                     onDeleteMessage={messageId => handleDeleteMessage(agentId, messageId)}
                     workingDir={agentStore.state.agents.find(a => a.id === agentId)?.workingDir}
+                    homeDir={agentStore.state.agents.find(a => a.id === agentId)?.homeDir}
                     hasOlderMessages={chatStore.hasOlderMessages(agentId)}
                     fetchingOlder={chatStore.isFetchingOlder(agentId)}
                     onLoadOlderMessages={() => chatStore.loadOlderMessages(agentId)}

--- a/frontend/tests/unit/components/relativizePath.test.ts
+++ b/frontend/tests/unit/components/relativizePath.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { relativizePath } from '~/components/chat/messageRenderers'
+
+describe('relativizePath', () => {
+  // --- Existing behavior (no homeDir) ---
+
+  it('returns absPath when no workingDir', () => {
+    expect(relativizePath('/home/user/foo')).toBe('/home/user/foo')
+  })
+
+  it('strips common prefix for paths under workingDir', () => {
+    expect(relativizePath('/home/user/project/src/foo.ts', '/home/user/project'))
+      .toBe('src/foo.ts')
+  })
+
+  it('handles workingDir with trailing slash', () => {
+    expect(relativizePath('/home/user/project/src/foo.ts', '/home/user/project/'))
+      .toBe('src/foo.ts')
+  })
+
+  it('produces ../ relative paths', () => {
+    expect(relativizePath('/home/user/other/file.ts', '/home/user/project'))
+      .toBe('../other/file.ts')
+  })
+
+  it('returns absolute path when relative is longer', () => {
+    // A path that shares no common prefix results in a long ../ chain
+    expect(relativizePath('/a', '/very/deeply/nested/working/directory'))
+      .toBe('/a')
+  })
+
+  // --- New tilde behavior ---
+
+  it('uses ~/... when shorter than ../ form', () => {
+    expect(relativizePath('/home/user/foo', '/home/user/bar/baz/qux', '/home/user'))
+      .toBe('~/foo')
+  })
+
+  it('prefers direct relative over tilde when path is under workingDir', () => {
+    expect(relativizePath('/home/user/project/src/foo.ts', '/home/user/project', '/home/user'))
+      .toBe('src/foo.ts')
+  })
+
+  it('uses ~ for exact home directory', () => {
+    expect(relativizePath('/home/user', '/some/other/dir', '/home/user'))
+      .toBe('~')
+  })
+
+  it('falls back to absolute when path is not under home', () => {
+    expect(relativizePath('/opt/data/file.txt', '/home/user/project', '/home/user'))
+      .toBe('/opt/data/file.txt')
+  })
+
+  it('handles homeDir with trailing slash', () => {
+    expect(relativizePath('/home/user/foo', '/home/user/bar/baz/qux', '/home/user/'))
+      .toBe('~/foo')
+  })
+
+  it('prefers ../ when shorter than tilde', () => {
+    // ../foo (6 chars) vs ~/project/foo (14 chars) -- ../ wins
+    expect(relativizePath('/home/user/project/foo', '/home/user/project/bar', '/home/user'))
+      .toBe('../foo')
+  })
+
+  it('handles undefined homeDir gracefully', () => {
+    expect(relativizePath('/home/user/foo', '/home/user/bar/baz/qux', undefined))
+      .toBe('../../../foo')
+  })
+
+  it('handles empty homeDir gracefully', () => {
+    expect(relativizePath('/home/user/foo', '/home/user/bar/baz/qux', ''))
+      .toBe('../../../foo')
+  })
+})

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -364,6 +364,10 @@ func (s *WorkerConnectorService) processWorkerMessage(
 		if gs := sanitizeGitStatus(payload.AgentStarted.GetGitStatus()); gs != nil {
 			s.agentSvc.StoreGitStatus(agentID, gs)
 		}
+		// Store worker home directory for tilde path display.
+		if homeDir := payload.AgentStarted.GetHomeDir(); homeDir != "" {
+			s.agentSvc.StoreHomeDir(agentID, homeDir)
+		}
 	case *leapmuxv1.ConnectRequest_AgentStopped:
 		agentID := payload.AgentStopped.GetAgentId()
 		slog.Info("agent stopped on worker",

--- a/internal/worker/hub/agent_handlers.go
+++ b/internal/worker/hub/agent_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"os"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/agent"
@@ -16,6 +17,7 @@ func (c *Client) handleAgentStart(ctx context.Context, requestID string, req *le
 	workspaceID := req.GetWorkspaceId()
 	model := req.GetModel()
 	workingDir := req.GetWorkingDir()
+	homeDir, _ := os.UserHomeDir()
 
 	if model == "" {
 		model = "haiku"
@@ -127,6 +129,7 @@ func (c *Client) handleAgentStart(ctx context.Context, requestID string, req *le
 				PermissionMode:     confirmedMode,
 				Effort:             req.GetEffort(),
 				GitStatus:          gitStatusToProto(gitutil.GetGitStatus(resolvedDir)),
+				HomeDir:            homeDir,
 			},
 		},
 	})

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -109,6 +109,7 @@ message AgentInfo {
   string worker_id = 11;        // Worker this agent runs on
   string working_dir = 12;      // Working directory on the worker
   AgentGitStatus git_status = 13; // Git status for the agent's working directory
+  string home_dir = 14;         // Worker's home directory for tilde path display
 }
 
 // --- Agent Messaging ---

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -275,6 +275,7 @@ message AgentStarted {
   string permission_mode = 6;      // Confirmed permission mode after startup handshake
   string effort = 7;               // Effort level echoed back from startup
   AgentGitStatus git_status = 8;   // Git status for the resolved working directory
+  string home_dir = 9;             // Worker's home directory for tilde path display
 }
 
 // AgentGitInfo carries git status updates from worker to hub (e.g. at turn-end).


### PR DESCRIPTION
## Motivation

File paths displayed in the chat UI were always shown as absolute paths or naive relative paths. When a worker's home directory is known, paths under it can be displayed more concisely using the `~/` prefix, improving readability — especially for long paths rooted in the user's home directory.

## Modifications

**Frontend**

- Enhanced `relativizePath()` to accept an optional `homeDir` parameter. When provided, it computes three candidate representations (direct relative, `../`-relative, and `~/`-prefixed) and picks the shortest one.
- Threaded `homeDir` through the chat component hierarchy: `AppShell` -> `ChatView` -> `MessageBubble` -> `messageRenderers` and `toolRenderers`, so tool input/output path display benefits from the simplification.
- Added unit tests in `frontend/tests/unit/components/relativizePath.test.ts` covering trailing slashes, undefined/empty `homeDir`, path length comparisons, and precedence rules.

**Backend**

- Extended `proto/leapmux/v1/agent.proto` and `proto/leapmux/v1/worker.proto` with a new `home_dir` field on `AgentInfo` and `AgentStarted` messages.
- Updated `internal/worker/hub/agent_handlers.go` to populate `home_dir` from the worker's environment on agent startup.
- Added `GetHomeDir()` and `StoreHomeDir()` to `AgentService` (`internal/hub/service/agent_service.go`) for caching the home directory per agent.
- Updated `WorkerConnectorService` (`internal/hub/service/worker_connector_service.go`) to persist the home directory when an agent starts.

## Result

Paths displayed in the chat UI are now shown in the shortest human-readable form. For example, a path like `/Users/alice/projects/foo/bar.go` is displayed as `~/projects/foo/bar.go` rather than the full absolute path, making tool outputs noticeably easier to read.

🤖 Generated with Claude Code
