### PR TITLE
Add thinking indicator and fix agent working state detection

### DIFF
--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -216,25 +216,10 @@ export const settingsRadioItem = style({
   },
 })
 
-export const settingsRadioItemDisabled = style({
-  'opacity': 0.4,
-  'cursor': 'default',
-  ':hover': {
-    backgroundColor: 'transparent',
-  },
-})
-
 export const settingsSeparator = style({
   height: '1px',
   backgroundColor: 'var(--border)',
   margin: `${spacing.xs} 0`,
-})
-
-export const disabledFootnote = style({
-  fontSize: 'var(--text-8)',
-  color: 'var(--muted-foreground)',
-  padding: `2px ${spacing.sm} ${spacing.xs}`,
-  fontStyle: 'italic',
 })
 
 export const footerBarRight = style({

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -12,10 +12,13 @@ import * as styles from './ChatView.css'
 import { markdownContent } from './markdownContent.css'
 import { MessageBubble } from './MessageBubble'
 import { assistantMessage } from './messageStyles.css'
+import { ThinkingIndicator } from './ThinkingIndicator'
 
 interface ChatViewProps {
   messages: AgentChatMessage[]
   streamingText: string
+  /** Whether the agent is actively working (for showing the thinking indicator). */
+  agentWorking?: boolean
   messageErrors?: Record<string, string>
   onRetryMessage?: (messageId: string) => void
   onDeleteMessage?: (messageId: string) => void
@@ -163,6 +166,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   createEffect(() => {
     void props.messages.length
     void props.streamingText
+    void props.agentWorking
     if (untrack(atBottom) && messageListRef) {
       autoScrollPending = true
       requestAnimationFrame(() => {
@@ -221,7 +225,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
       <div class={styles.messageListWrapper}>
         <div ref={messageListRef} class={styles.messageList} onScroll={handleScroll}>
           <Show
-            when={props.messages.length > 0 || props.streamingText}
+            when={props.messages.length > 0 || props.streamingText || props.agentWorking}
             fallback={<div class={styles.emptyChat}>Send a message to start</div>}
           >
             <Show when={props.fetchingOlder}>
@@ -250,6 +254,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                 {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
                 <div class={markdownContent} innerHTML={renderedStreamHtml()} />
               </div>
+            </Show>
+            <Show when={props.agentWorking && !props.streamingText}>
+              <ThinkingIndicator />
             </Show>
           </Show>
         </div>

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -234,7 +234,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   }
 
   // Whether the message is rendered by a renderer that has its own internal ToolHeaderActions.
-  const hasInternalActions = () => category().kind === 'tool_use' || category().kind === 'assistant_thinking'
+  const hasInternalActions = () => category().kind === 'tool_use'
 
   const copyJson = async () => {
     await navigator.clipboard.writeText(prettifyJson(rawJson()))

--- a/frontend/src/components/chat/ThinkingIndicator.css.ts
+++ b/frontend/src/components/chat/ThinkingIndicator.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+import { thinkingPulse } from '~/styles/animations.css'
+import { spacing } from '~/styles/tokens'
+
+export const container = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  padding: `${spacing.sm} ${spacing.lg}`,
+})
+
+export const dot = style({
+  width: '7px',
+  height: '7px',
+  borderRadius: '50%',
+  backgroundColor: 'var(--muted-foreground)',
+  opacity: 0.15,
+  animation: `${thinkingPulse} 1.2s ease-in-out infinite`,
+})

--- a/frontend/src/components/chat/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/ThinkingIndicator.tsx
@@ -1,0 +1,10 @@
+import type { Component } from 'solid-js'
+import * as styles from './ThinkingIndicator.css'
+
+export const ThinkingIndicator: Component = () => (
+  <div class={styles.container} data-testid="thinking-indicator">
+    <span class={styles.dot} />
+    <span class={styles.dot} style={{ 'animation-delay': '0.3s' }} />
+    <span class={styles.dot} style={{ 'animation-delay': '0.6s' }} />
+  </div>
+)

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -431,17 +431,6 @@ function ThinkingMessage(props: { text: string, context?: RenderContext }): JSX.
             ? <ChevronDown size={14} class={toolUseIcon} />
             : <ChevronRight size={14} class={toolUseIcon} />}
         </span>
-        <Show when={props.context}>
-          <ToolHeaderActions
-            createdAt={props.context!.createdAt}
-            updatedAt={props.context!.updatedAt}
-            threadCount={0}
-            threadExpanded={false}
-            onToggleThread={() => {}}
-            onCopyJson={props.context!.onCopyJson ?? (() => {})}
-            jsonCopied={props.context!.jsonCopied ?? false}
-          />
-        </Show>
       </div>
       <Show when={expanded()}>
         <div class={thinkingContent}>

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -42,8 +42,6 @@ export const thinkingHeader = style({
 })
 
 export const thinkingContent = style({
-  fontStyle: 'italic',
-  color: 'var(--muted-foreground)',
   marginTop: spacing.sm,
 })
 

--- a/frontend/src/styles/animations.css.ts
+++ b/frontend/src/styles/animations.css.ts
@@ -18,3 +18,8 @@ export const colorShiftPulse = keyframes({
 export const interruptPulse = style({
   animation: `${colorShiftPulse} 5s ease-in-out infinite`,
 })
+
+export const thinkingPulse = keyframes({
+  '0%, 100%': { opacity: 0.15 },
+  '50%': { opacity: 0.6 },
+})

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -1,0 +1,34 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { decompressContentToString } from '~/lib/decompress'
+
+/** RESULT-role messages with these inner types are mid-turn notifications, not turn ends. */
+const NOTIFICATION_TYPES = new Set(['settings_changed', 'context_cleared'])
+
+/** Parse the inner message type from a chat message's compressed content. */
+function getInnerMessageType(msg: AgentChatMessage): string | undefined {
+  try {
+    const text = decompressContentToString(msg.content, msg.contentCompression)
+    if (!text) return undefined
+    const parsed = JSON.parse(text)
+    const inner = parsed?.messages?.[0] ?? parsed
+    return inner?.type as string | undefined
+  }
+  catch { return undefined }
+}
+
+/**
+ * Whether the agent is still working — the last meaningful (non-notification)
+ * message is not a turn-end RESULT.
+ */
+export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const msg = msgs[i]
+    if (msg.role !== MessageRole.RESULT) return true
+    // RESULT message — check if it's just a mid-turn notification to skip
+    const innerType = getInnerMessageType(msg)
+    if (innerType && NOTIFICATION_TYPES.has(innerType)) continue
+    return false // real turn-end RESULT
+  }
+  return false // no messages or all notifications
+}

--- a/frontend/tests/e2e/04-terminal.spec.ts
+++ b/frontend/tests/e2e/04-terminal.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { waitForLayoutSave } from './helpers'
 
 /** Read terminal text content from the active xterm's buffer (WebGL renderer makes DOM rows empty). */
 async function getTerminalText(page: Page): Promise<string> {
@@ -96,9 +97,15 @@ test.describe('Terminal', () => {
   })
 
   test('should restore terminal screen content after page refresh', async ({ page, authenticatedWorkspace }) => {
+    // Start listening for the layout save before opening the terminal
+    const saved = waitForLayoutSave(page)
+
     // Open a terminal via the tab bar
     await openTerminalViaUI(page)
     await expect(page.locator('.xterm')).toBeVisible()
+
+    // Wait for the layout save to complete so the terminal tab is persisted
+    await saved
 
     // Type a marker and wait for it to appear
     await typeInTerminal(page, 'echo SCREENRESTORE')

--- a/frontend/tests/e2e/19-tab-ordering.spec.ts
+++ b/frontend/tests/e2e/19-tab-ordering.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { waitForLayoutSave } from './helpers'
 
 test.describe('Tab Ordering Persistence', () => {
   test('should persist tab order after drag-drop reorder and page refresh', async ({ page, authenticatedWorkspace }) => {
@@ -43,15 +44,12 @@ test.describe('Tab Ordering Persistence', () => {
     await page.mouse.move(agentBox!.x + agentBox!.width / 2, agentBox!.y + agentBox!.height / 2, { steps: 10 })
     await page.mouse.up()
 
-    // Wait for the reorder API call to persist
-    await page.waitForTimeout(1000)
-
     // Verify reorder: [terminal, agent]
     const reorderedOrder = await getTabTypes()
     expect(reorderedOrder).toEqual(['terminal', 'agent'])
 
-    // Wait a moment, then refresh the page
-    await page.waitForTimeout(1000)
+    // Wait for the layout save to complete (500ms debounce + network round-trip)
+    await waitForLayoutSave(page)
     await page.reload()
 
     // Wait for tabs to load

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -29,7 +29,17 @@ test.describe('Chat Message Rendering', () => {
   test('should render assistant message as markdown', async ({ page, authenticatedWorkspace }) => {
     await sendAndWaitForReply(page, 'What is 2+2? Reply with just the number.')
 
-    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    // Wait for turn to complete so the text bubble is present
+    await expect(page.locator('[data-testid="interrupt-button"]')).not.toBeVisible({ timeout: 30_000 })
+
+    // Find an assistant bubble whose message-content contains <p> tags
+    // (skip thinking bubbles and turn-end indicators which have no <p>)
+    const assistantBubble = page.locator(
+      '[data-testid="message-bubble"][data-role="assistant"]',
+    ).filter({
+      has: page.locator('[data-testid="message-content"] p'),
+    }).first()
+
     const content = assistantBubble.locator('[data-testid="message-content"]')
 
     // Content should be rendered as HTML elements (e.g. <p> tags), not raw text

--- a/frontend/tests/e2e/50-tiling-layout.spec.ts
+++ b/frontend/tests/e2e/50-tiling-layout.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { waitForLayoutSave } from './helpers'
 
 /** Open a new agent via the tab bar add menu. */
 async function openAgentViaUI(page: import('@playwright/test').Page) {
@@ -104,8 +105,8 @@ test.describe('Tiling Layout', () => {
     await page.locator('[data-testid="split-horizontal"]').first().click()
     await expect(page.locator('[data-testid="tile"]')).toHaveCount(2)
 
-    // Wait for debounced layout save
-    await page.waitForTimeout(1000)
+    // Wait for the layout save to complete (500ms debounce + network round-trip)
+    await waitForLayoutSave(page)
 
     // Reload
     await page.reload()

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -624,6 +624,25 @@ export async function loginViaToken(page: Page, token: string) {
 }
 
 /**
+ * Wait for the debounced layout save API call to complete.
+ * Returns a promise that resolves once the SaveLayout response arrives.
+ * Must be called **before** the action that triggers the save, then awaited
+ * after the action completes.
+ *
+ * Usage:
+ *   const saved = waitForLayoutSave(page)
+ *   await doSomethingThatTriggersLayoutSave()
+ *   await saved
+ *   await page.reload()
+ */
+export function waitForLayoutSave(page: Page) {
+  return page.waitForResponse(
+    resp => resp.url().includes('WorkspaceService/SaveLayout') && resp.ok(),
+    { timeout: 10_000 },
+  )
+}
+
+/**
  * Wait for a workspace page to be fully loaded.
  * Waits for either a tab or the "No tabs in this tile" empty state.
  */

--- a/frontend/tests/unit/utils/agentState.test.ts
+++ b/frontend/tests/unit/utils/agentState.test.ts
@@ -1,0 +1,113 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { describe, expect, it } from 'vitest'
+import { ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { isAgentWorking } from '~/utils/agentState'
+
+/** Encode a JSON object as message content bytes. */
+function encode(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(obj))
+}
+
+/** Build a wrapper envelope (the standard message format). */
+function wrap(messages: unknown[]): Uint8Array {
+  return encode({ old_seqs: [], messages })
+}
+
+/** Build a minimal AgentChatMessage. */
+function makeMsg(role: MessageRole, content?: Uint8Array): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage' as const,
+    id: 'msg-1',
+    role,
+    seq: 1n,
+    createdAt: '',
+    updatedAt: '',
+    deliveryError: '',
+    content: content ?? new Uint8Array(),
+    contentCompression: ContentCompression.NONE,
+  } as AgentChatMessage
+}
+
+describe('isAgentWorking', () => {
+  it('returns false for an empty messages array', () => {
+    expect(isAgentWorking([])).toBe(false)
+  })
+
+  it('returns true when last message is USER role', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.USER),
+    ])).toBe(true)
+  })
+
+  it('returns true when last message is ASSISTANT role', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+    ])).toBe(true)
+  })
+
+  it('returns false when last message is a turn-end RESULT', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.USER),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'result', subtype: 'turn_result' }])),
+    ])).toBe(false)
+  })
+
+  it('skips settings_changed RESULT and finds preceding ASSISTANT', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'settings_changed' }])),
+    ])).toBe(true)
+  })
+
+  it('skips context_cleared RESULT and finds preceding ASSISTANT', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'context_cleared' }])),
+    ])).toBe(true)
+  })
+
+  it('skips multiple trailing notification RESULTs and finds preceding non-RESULT', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.USER),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'settings_changed' }])),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'context_cleared' }])),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'settings_changed' }])),
+    ])).toBe(true)
+  })
+
+  it('skips notification RESULTs but finds turn-end RESULT underneath', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'result', subtype: 'turn_result' }])),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'settings_changed' }])),
+    ])).toBe(false)
+  })
+
+  it('returns false when all messages are notification RESULTs', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'settings_changed' }])),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'context_cleared' }])),
+    ])).toBe(false)
+  })
+
+  it('does not skip interrupted RESULT (it is a genuine turn end)', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.RESULT, wrap([{ type: 'interrupted' }])),
+    ])).toBe(false)
+  })
+
+  it('handles RESULT with unparseable content as a turn end', () => {
+    const badContent = new TextEncoder().encode('not valid json')
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.RESULT, badContent),
+    ])).toBe(false)
+  })
+
+  it('handles RESULT with empty content as a turn end', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.RESULT),
+    ])).toBe(false)
+  })
+})


### PR DESCRIPTION
- Add `ThinkingIndicator` component — three animated pulsing dots shown while the agent is working but not yet streaming
- Introduce `isAgentWorking()` utility that correctly determines agent turn state by scanning message history and skipping mid-turn notifications (`settings_changed`, `context_cleared`)
- Simplify `AgentEditorPanel` props: replace `turnActive`/`streamingText` with a single `agentWorking` boolean
- Fix workspace loading race condition: track both `activeWorkspaceId` and `orgId` in the loading effect so `listTabs`/`getLayout` are not called with empty `orgId` after page reload
- Fix `persistLayout` to skip saves while workspace is still loading
- Replace hardcoded `waitForTimeout` in E2E tests with `waitForLayoutSave()` helper that waits for the actual `SaveLayout` API response
- Fix E2E tests for chat rendering, scroll behavior, and layout persistence

🤖 Generated with Claude Code
