### PR TITLE
Fix seq race condition in message persistence by moving to DB

### DIFF
--- a/internal/hub/db/queries/messages.sql
+++ b/internal/hub/db/queries/messages.sql
@@ -1,5 +1,16 @@
--- name: CreateMessage :exec
-INSERT INTO messages (id, agent_id, seq, role, content, content_compression, thread_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+-- name: CreateMessage :one
+INSERT INTO messages (id, agent_id, seq, role, content, content_compression, thread_id, created_at)
+VALUES (
+  sqlc.arg(id),
+  sqlc.arg(agent_id),
+  (SELECT COALESCE(MAX(m.seq), 0) + 1 FROM messages m WHERE m.agent_id = sqlc.arg(agent_id)),
+  sqlc.arg(role),
+  sqlc.arg(content),
+  sqlc.arg(content_compression),
+  sqlc.arg(thread_id),
+  sqlc.arg(created_at)
+)
+RETURNING seq;
 
 -- name: ListMessagesByAgentID :many
 SELECT * FROM messages
@@ -24,9 +35,6 @@ WHERE agent_id = ?
 ORDER BY seq DESC
 LIMIT ?;
 
--- name: GetMaxSeqByAgentID :one
-SELECT CAST(COALESCE(MAX(seq), 0) AS INTEGER) AS max_seq FROM messages WHERE agent_id = ?;
-
 -- name: GetMessageByAgentAndID :one
 SELECT * FROM messages WHERE id = ? AND agent_id = ?;
 
@@ -36,8 +44,14 @@ UPDATE messages SET delivery_error = ? WHERE id = ? AND agent_id = ?;
 -- name: GetMessageByAgentAndThreadID :one
 SELECT * FROM messages WHERE agent_id = ? AND thread_id = ? AND role = 2 LIMIT 1;
 
--- name: UpdateMessageThread :exec
-UPDATE messages SET content = ?, content_compression = ?, seq = ?, updated_at = ? WHERE id = ? AND agent_id = ?;
+-- name: UpdateMessageThread :one
+UPDATE messages
+SET content = sqlc.arg(content),
+    content_compression = sqlc.arg(content_compression),
+    seq = (SELECT COALESCE(MAX(m.seq), 0) + 1 FROM messages m WHERE m.agent_id = sqlc.arg(agent_id)),
+    updated_at = sqlc.arg(updated_at)
+WHERE messages.id = sqlc.arg(id) AND messages.agent_id = sqlc.arg(agent_id)
+RETURNING seq;
 
 -- name: GetLatestMessageByAgentID :one
 SELECT * FROM messages WHERE agent_id = ? ORDER BY seq DESC LIMIT 1;

--- a/internal/hub/db/store_test.go
+++ b/internal/hub/db/store_test.go
@@ -303,16 +303,18 @@ func TestMessages_CRUD(t *testing.T) {
 
 	// Create messages.
 	for i := int64(1); i <= 3; i++ {
-		err := q.CreateMessage(ctx, gendb.CreateMessageParams{
+		seq, err := q.CreateMessage(ctx, gendb.CreateMessageParams{
 			ID:                 makeID(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 			Content:            []byte(`{"text":"hello"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
 		})
 		if err != nil {
 			t.Fatalf("CreateMessage seq=%d: %v", i, err)
+		}
+		if seq != i {
+			t.Errorf("CreateMessage returned seq=%d, want %d", seq, i)
 		}
 	}
 
@@ -334,13 +336,6 @@ func TestMessages_CRUD(t *testing.T) {
 	})
 	if len(msgs2) != 2 {
 		t.Errorf("len from seq 1 = %d, want 2", len(msgs2))
-	}
-
-	// Max seq.
-	maxSeq, err := q.GetMaxSeqByAgentID(ctx, agentID)
-	require.NoError(t, err)
-	if maxSeq != 3 {
-		t.Errorf("maxSeq = %d, want 3", maxSeq)
 	}
 }
 

--- a/internal/hub/service/agent_control.go
+++ b/internal/hub/service/agent_control.go
@@ -132,7 +132,7 @@ func (s *AgentService) SendControlResponse(
 			merged = s.mergeIntoThread(ctx, agentID, toolUseID, displayJSON)
 		}
 		if !merged {
-			if err := s.persistAndBroadcast(ctx, agentID, leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, displayJSON); err != nil {
+			if err := s.persistAndBroadcast(ctx, agentID, leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, displayJSON, ""); err != nil {
 				slog.Warn("failed to persist control response notification", "agent_id", agentID, "error", err)
 			}
 		}

--- a/internal/hub/service/agent_service_test.go
+++ b/internal/hub/service/agent_service_test.go
@@ -257,10 +257,9 @@ func TestAgentService_ListAgentMessages(t *testing.T) {
 
 	// Insert messages directly.
 	for i := int64(1); i <= 5; i++ {
-		_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+		_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 			ID:                 id.Generate(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{"type":"assistant"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -790,10 +789,9 @@ func TestAgentService_RetryAgentMessage_Success(t *testing.T) {
 
 	// Create a message with delivery_error set.
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"Hello retry"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -826,10 +824,9 @@ func TestAgentService_RetryAgentMessage_Failure(t *testing.T) {
 
 	// Create a message with delivery_error set.
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"Hello retry fail"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -893,10 +890,9 @@ func TestAgentService_RetryAgentMessage_RejectsNonUserMessage(t *testing.T) {
 	agentID := env.createAgentInDB(t, workspaceID, "Agent")
 
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 		Content:            []byte(`{"type":"assistant"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -921,10 +917,9 @@ func TestAgentService_RetryAgentMessage_RejectsNoDeliveryError(t *testing.T) {
 	agentID := env.createAgentInDB(t, workspaceID, "Agent")
 
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"No error here"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -944,10 +939,9 @@ func TestAgentService_DeleteAgentMessage_Success(t *testing.T) {
 	agentID := env.createAgentInDB(t, workspaceID, "Agent")
 
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"Delete me"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -992,10 +986,9 @@ func TestAgentService_DeleteAgentMessage_RejectsNoDeliveryError(t *testing.T) {
 	agentID := env.createAgentInDB(t, workspaceID, "Agent")
 
 	msgID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"No error"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1120,10 +1113,9 @@ func TestAgentService_ListAgentMessages_BackwardPagination(t *testing.T) {
 
 	// Insert 10 messages (seq 1-10).
 	for i := int64(1); i <= 10; i++ {
-		_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+		_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 			ID:                 id.Generate(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{"type":"assistant"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1163,10 +1155,9 @@ func TestAgentService_ListAgentMessages_LatestN(t *testing.T) {
 
 	// Insert 10 messages (seq 1-10).
 	for i := int64(1); i <= 10; i++ {
-		_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+		_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 			ID:                 id.Generate(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{"type":"assistant"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1204,10 +1195,9 @@ func TestAgentService_ListAgentMessages_MaxLimit(t *testing.T) {
 
 	// Insert 60 messages.
 	for i := int64(1); i <= 60; i++ {
-		_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+		_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 			ID:                 id.Generate(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{"type":"assistant"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1271,10 +1261,9 @@ func TestAgentService_ListAgentMessages_IncludesDeliveryError(t *testing.T) {
 
 	// Message with delivery error.
 	msg1ID := id.Generate()
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 msg1ID,
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
 		Content:            []byte(`{"content":"Failed msg"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1286,10 +1275,9 @@ func TestAgentService_ListAgentMessages_IncludesDeliveryError(t *testing.T) {
 	})
 
 	// Message without delivery error.
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 id.Generate(),
 		AgentID:            agentID,
-		Seq:                2,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 		Content:            []byte(`{"type":"assistant"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1313,7 +1301,6 @@ func TestMessageToProto_UpdatedAt(t *testing.T) {
 		msg := &gendb.Message{
 			ID:                 "msg-1",
 			AgentID:            "agent-1",
-			Seq:                1,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -1329,7 +1316,6 @@ func TestMessageToProto_UpdatedAt(t *testing.T) {
 		msg := &gendb.Message{
 			ID:                 "msg-2",
 			AgentID:            "agent-1",
-			Seq:                2,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,

--- a/internal/hub/service/workspace_service_test.go
+++ b/internal/hub/service/workspace_service_test.go
@@ -497,10 +497,9 @@ func TestWorkspaceService_WatchEvents_WithHistory(t *testing.T) {
 
 	// Insert 3 messages.
 	for i := int64(1); i <= 3; i++ {
-		_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+		_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 			ID:                 id.Generate(),
 			AgentID:            agentID,
-			Seq:                i,
 			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 			Content:            []byte(`{"type":"assistant"}`),
 			ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
@@ -537,10 +536,9 @@ func TestWorkspaceService_WatchEvents_LiveOnly(t *testing.T) {
 	agentID := env.createAgentInDB(t, workspaceID, "Agent")
 
 	// Insert a message that should NOT be replayed with afterSeq=-1.
-	_ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
+	_, _ = env.queries.CreateMessage(context.Background(), gendb.CreateMessageParams{
 		ID:                 id.Generate(),
 		AgentID:            agentID,
-		Seq:                1,
 		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
 		Content:            []byte(`{"type":"assistant"}`),
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,


### PR DESCRIPTION
## Motivation

Message sequence numbers (`seq`) were previously generated at the application layer by first calling `GetMaxSeqByAgentID()` to fetch the current maximum, then inserting a new message with `MAX + 1`. This introduced a classic TOCTOU (time-of-check-time-of-use) race condition: two concurrent operations on the same agent could read the same maximum sequence number and then both attempt to insert with the same `seq`, leading to duplicate or incorrect sequence assignments.

## Modifications

- Move `seq` calculation into the `CREATE MESSAGE` and `UPDATE MESSAGE THREAD` SQL queries themselves, using `MAX(seq) + 1` computed atomically within the INSERT/UPDATE statement. This ensures sequence assignment is a single atomic operation at the database level.

- Remove the `GetMaxSeqByAgentID` query entirely, as it is no longer needed.

- Remove application-level retry loops from `persistAndBroadcast` and `createNotificationStandalone`. These loops existed to handle `seq` collisions; database-level atomicity eliminates the possibility of such collisions.

- Update `CreateMessage` and `UpdateMessageThread` to return the assigned sequence number (changing from `:exec` to `:one`), allowing callers to obtain the generated `seq` directly from the database response rather than tracking it separately.

- Simplify `SendAgentMessage`, `HandleAgentOutput`, `appendToNotificationThread`, and `mergeIntoThread` by removing manual `seq` tracking and retry logic.

## Result

Concurrent message creation and threading operations on the same agent no longer race on sequence number assignment. The application-layer retry loops and the `GetMaxSeqByAgentID` query are gone, reducing code complexity alongside the fix.

The overall change is a net reduction of 86 lines despite adding the database-side sequence logic.

🤖 Generated with Claude Code
