### PR TITLE
Default to repo root when opening dialogs from a worktree

### DIFF
--- a/frontend/scripts/only-bun.mjs
+++ b/frontend/scripts/only-bun.mjs
@@ -8,11 +8,13 @@ import { fileURLToPath } from 'node:url'
 
 const ua = env.npm_config_user_agent || ''
 if (!ua.startsWith('bun/')) {
-  // Clean up package-lock.json that npm creates before preinstall runs.
+  // Clean up lockfiles that other package managers create before preinstall runs.
   const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)))
-  const lockFile = join(projectRoot, 'package-lock.json')
-  if (existsSync(lockFile)) {
-    rmSync(lockFile)
+  for (const name of ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock']) {
+    const lockFile = join(projectRoot, name)
+    if (existsSync(lockFile)) {
+      rmSync(lockFile)
+    }
   }
 
   console.error(

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -2,8 +2,8 @@ import type { Component } from 'solid-js'
 import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
-import { createSignal, For, onMount, Show } from 'solid-js'
-import { agentClient, workerClient } from '~/api/clients'
+import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
+import { agentClient, gitClient, workerClient } from '~/api/clients'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
@@ -62,6 +62,26 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
       }
     }
   })
+
+  // If the default working directory is a worktree, resolve to the original repo root.
+  {
+    let resolved = false
+    createEffect(on(() => workerId(), async (wid) => {
+      if (resolved || !wid || !props.defaultWorkingDir)
+        return
+      resolved = true
+      try {
+        const resp = await gitClient.getGitInfo({
+          workerId: wid,
+          path: props.defaultWorkingDir,
+          orgId: org.orgId(),
+        })
+        if (resp.isWorktreeRoot && resp.repoRoot)
+          setWorkingDir(resp.repoRoot)
+      }
+      catch {}
+    }))
+  }
 
   const handleRefresh = async () => {
     setRefreshing(true)

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -2,7 +2,7 @@ import type { Component } from 'solid-js'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
-import { terminalClient, workerClient } from '~/api/clients'
+import { gitClient, terminalClient, workerClient } from '~/api/clients'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
@@ -61,6 +61,26 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
       }
     }
   })
+
+  // If the default working directory is a worktree, resolve to the original repo root.
+  {
+    let resolved = false
+    createEffect(on(() => workerId(), async (wid) => {
+      if (resolved || !wid || !props.defaultWorkingDir)
+        return
+      resolved = true
+      try {
+        const resp = await gitClient.getGitInfo({
+          workerId: wid,
+          path: props.defaultWorkingDir,
+          orgId: org.orgId(),
+        })
+        if (resp.isWorktreeRoot && resp.repoRoot)
+          setWorkingDir(resp.repoRoot)
+      }
+      catch {}
+    }))
+  }
 
   // Fetch available shells when worker changes
   createEffect(on(() => workerId(), async (id) => {


### PR DESCRIPTION
## Motivation

When a user opens the "New Agent" or "New Terminal" dialog while the current tab is in a worktree, the default working directory was set to the worktree root (e.g., `/path/to/repo/.worktrees/my-branch`). This was counterintuitive because users typically want to start new sessions from the original repository root and then optionally select a worktree branch from there, rather than being anchored to an existing worktree directory.

## Modifications

- In `NewAgentDialog.tsx` and `NewTerminalDialog.tsx`: added a `createEffect` that runs once after the worker is selected. It calls `gitClient.getGitInfo` on the default working directory and, if the path is detected as a worktree root (`isWorktreeRoot === true`), replaces the initial working directory with the original `repoRoot`.

- In `only-bun.mjs`: extended the lockfile cleanup to also remove `pnpm-lock.yaml` and `yarn.lock` in addition to the previously handled `package-lock.json`.

## Result

When a user opens the "New Agent" or "New Terminal" dialog from a tab running inside a worktree, the working directory picker now defaults to the original repository root instead of the worktree subdirectory.

The `only-bun.mjs` guard now also cleans up stale `pnpm-lock.yaml` and `yarn.lock` files if someone accidentally runs a non-Bun package manager.

🤖 Generated with Claude Code
