### PR TITLE
Fix thinking indicator visibility when worker goes offline

### DIFF
--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1185,7 +1185,7 @@ export const AppShell: ParentComponent = (props) => {
                   <ChatView
                     messages={chatStore.getMessages(agentId)}
                     streamingText={chatStore.state.streamingText[agentId] ?? ''}
-                    agentWorking={isAgentWorking(chatStore.getMessages(agentId)) && controlStore.getRequests(agentId).length === 0}
+                    agentWorking={agentStore.state.agents.find(a => a.id === agentId)?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId)) && controlStore.getRequests(agentId).length === 0}
                     messageErrors={chatStore.state.messageErrors}
                     onRetryMessage={messageId => handleRetryMessage(agentId, messageId)}
                     onDeleteMessage={messageId => handleDeleteMessage(agentId, messageId)}
@@ -1274,7 +1274,7 @@ export const AppShell: ParentComponent = (props) => {
         onInterrupt={handleInterrupt}
         settingsLoading={settingsLoading.loading()}
         agentContextInfo={agentContextStore.getInfo(agentId())}
-        agentWorking={isAgentWorking(chatStore.getMessages(agentId()))}
+        agentWorking={agentStore.state.agents.find(a => a.id === agentId())?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId()))}
         containerHeight={props.containerHeight}
       />
     )

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -60,8 +60,6 @@ function extractTodos(message: AgentChatMessage): TodoItem[] | null {
 interface ChatStoreState {
   messagesByAgent: Record<string, AgentChatMessage[]>
   streamingText: Record<string, string>
-  /** Whether each agent is currently processing a turn (user sent a message, agent hasn't finished). */
-  turnActive: Record<string, boolean>
   messageErrors: Record<string, string>
   /** Latest TodoWrite todos per agent, updated incrementally as messages arrive. */
   todosByAgent: Record<string, TodoItem[]>
@@ -80,7 +78,6 @@ export function createChatStore() {
   const [state, setState] = createStore<ChatStoreState>({
     messagesByAgent: {},
     streamingText: {},
-    turnActive: {},
     messageErrors: {},
     todosByAgent: {},
     loading: false,
@@ -176,14 +173,6 @@ export function createChatStore() {
 
     clearStreamingText(agentId: string) {
       setState('streamingText', agentId, '')
-    },
-
-    setTurnActive(agentId: string, active: boolean) {
-      setState('turnActive', agentId, active)
-    },
-
-    isTurnActive(agentId: string): boolean {
-      return state.turnActive[agentId] ?? false
     },
 
     getTodos(agentId: string): TodoItem[] {

--- a/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
+++ b/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
@@ -1,0 +1,103 @@
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
+import { expect, restartWorker, stopWorker, waitForWorkerOffline, processTest as test } from './process-control-fixtures'
+
+test.describe('Worker Restart Thinking Indicator', () => {
+  test('should hide thinking indicator when worker goes offline during agent turn', async ({ separateHubWorker, page }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Thinking Indicator Test', adminOrgId)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for agent tab and editor
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await expect(editor).toBeVisible()
+
+      // Send a message to start an agent turn
+      await editor.click()
+      await page.keyboard.type('Write a very long essay about the history of computing. Make it extremely detailed.')
+      await page.keyboard.press('Enter')
+      await expect(editor).toHaveText('')
+
+      // Wait for thinking indicator or streaming to appear (agent is processing)
+      const thinkingIndicator = page.locator('[data-testid="thinking-indicator"]')
+      const streamingText = page.locator('[data-testid="message-bubble"][data-role="assistant"]')
+      await expect(thinkingIndicator.or(streamingText)).toBeVisible({ timeout: 30_000 })
+
+      // Stop the worker while agent is working
+      await stopWorker()
+      await waitForWorkerOffline(hubUrl, adminToken)
+
+      // Thinking indicator should disappear (agent status becomes INACTIVE)
+      await expect(thinkingIndicator).not.toBeVisible({ timeout: 30_000 })
+
+      // Interrupt button should also disappear
+      const interruptButton = page.locator('[data-testid="interrupt-button"]')
+      await expect(interruptButton).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('should resume agent after worker restart and new message', async ({ separateHubWorker, page }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Agent Resume Test', adminOrgId)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await expect(editor).toBeVisible()
+
+      // Send a message and wait for a response
+      await editor.click()
+      await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
+      await page.keyboard.press('Enter')
+
+      // Wait for the assistant's response
+      await page.waitForFunction(() => {
+        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+        for (const b of bubbles) {
+          if (b.textContent?.includes('4'))
+            return true
+        }
+        return false
+      }, { timeout: 60_000 })
+
+      // Stop the worker
+      await stopWorker()
+      await waitForWorkerOffline(hubUrl, adminToken)
+
+      // Thinking indicator should not be visible
+      const thinkingIndicator = page.locator('[data-testid="thinking-indicator"]')
+      await expect(thinkingIndicator).not.toBeVisible()
+
+      // Restart the worker
+      await restartWorker(separateHubWorker)
+
+      // Thinking indicator should still be hidden (agent not auto-restarted)
+      await expect(thinkingIndicator).not.toBeVisible()
+
+      // Send a new message — agent should restart and respond
+      await editor.click()
+      await page.keyboard.type('What is 3+3? Reply with just the number, nothing else.')
+      await page.keyboard.press('Enter')
+
+      // Wait for the assistant's response containing "6"
+      await page.waitForFunction(() => {
+        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+        for (const b of bubbles) {
+          if (b.textContent?.includes('6'))
+            return true
+        }
+        return false
+      }, { timeout: 60_000 })
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+})

--- a/internal/hub/agentmgr/watcher_test.go
+++ b/internal/hub/agentmgr/watcher_test.go
@@ -46,7 +46,7 @@ func TestManager_Unwatch(t *testing.T) {
 		Event: &leapmuxv1.AgentEvent_StatusChange{
 			StatusChange: &leapmuxv1.AgentStatusChange{
 				AgentId: "a1",
-				Status:  leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED,
+				Status:  leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE,
 			},
 		},
 	})
@@ -115,7 +115,7 @@ func TestManager_BroadcastMany(t *testing.T) {
 				Event: &leapmuxv1.AgentEvent_StatusChange{
 					StatusChange: &leapmuxv1.AgentStatusChange{
 						AgentId: "a2",
-						Status:  leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED,
+						Status:  leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE,
 					},
 				},
 			},
@@ -136,7 +136,7 @@ func TestManager_BroadcastMany(t *testing.T) {
 	case got := <-w2.C():
 		require.NotNil(t, got.GetStatusChange())
 		assert.Equal(t, "a2", got.GetStatusChange().GetAgentId())
-		assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED, got.GetStatusChange().GetStatus())
+		assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE, got.GetStatusChange().GetStatus())
 	default:
 		require.Fail(t, "expected event on w2 channel")
 	}

--- a/internal/hub/notifier/notifier.go
+++ b/internal/hub/notifier/notifier.go
@@ -301,7 +301,7 @@ func (n *Notifier) terminateWorkspacesOnWorker(ctx context.Context, workerID str
 				Event: &leapmuxv1.AgentEvent_StatusChange{
 					StatusChange: &leapmuxv1.AgentStatusChange{
 						AgentId:        agentID,
-						Status:         leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED,
+						Status:         leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE,
 						AgentSessionId: sessionID,
 						WorkerOnline:   false,
 					},
@@ -343,7 +343,7 @@ func (n *Notifier) closeWorkspace(ctx context.Context, workspaceID string) {
 				Event: &leapmuxv1.AgentEvent_StatusChange{
 					StatusChange: &leapmuxv1.AgentStatusChange{
 						AgentId:        agentID,
-						Status:         leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED,
+						Status:         leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE,
 						AgentSessionId: sessionID,
 						WorkerOnline:   false, // Workspace closed due to worker going away
 					},

--- a/internal/hub/service/agent_service_test.go
+++ b/internal/hub/service/agent_service_test.go
@@ -204,7 +204,7 @@ func TestAgentService_CloseAgent(t *testing.T) {
 	for _, a := range listResp.Msg.GetAgents() {
 		if a.GetId() == agentID {
 			found = true
-			assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED, a.GetStatus())
+			assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE, a.GetStatus())
 		}
 	}
 	assert.True(t, found, "closed agent not found in list")

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -493,7 +493,7 @@ func (s *WorkerConnectorService) cleanupWorker(workerID string) {
 		}
 		if aErr == nil {
 			sc := AgentStatusChange(&a, false)
-			sc.Status = leapmuxv1.AgentStatus_AGENT_STATUS_CLOSED
+			sc.Status = leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE
 			sc.GitStatus = s.agentSvc.GetGitStatus(agentID)
 			events = append(events, agentmgr.AgentBroadcast{
 				AgentID: agentID,

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -31,7 +31,7 @@ service AgentService {
 enum AgentStatus {
   AGENT_STATUS_UNSPECIFIED = 0;
   AGENT_STATUS_ACTIVE = 1;
-  AGENT_STATUS_CLOSED = 2;
+  AGENT_STATUS_INACTIVE = 2;
 }
 
 // MessageRole identifies who produced a chat message.


### PR DESCRIPTION
## Motivation

When a worker process disconnects while an agent was mid-turn, the thinking indicator and interrupt button remained visible indefinitely in the frontend. The root cause was that `agentWorking` was computed solely from message history (`isAgentWorking(messages)`), which had no knowledge of the agent's real-time connection state. Even after the worker went offline and the agent transitioned to `INACTIVE`, the UI continued showing the indicator because the last message in history still looked like an in-progress turn.

Additionally, `AGENT_STATUS_CLOSED` was a misleading name for the state where an agent's worker has gone offline — the agent is not permanently closed, just inactive because its worker is unreachable. The rename to `AGENT_STATUS_INACTIVE` better reflects the lifecycle: the worker may come back online and the agent can be resumed.

## Modifications

- **Proto rename**: `AGENT_STATUS_CLOSED` is renamed to `AGENT_STATUS_INACTIVE` in `proto/leapmux/v1/agent.proto`. The integer wire value remains `2`, so there is no wire compatibility break. All backend and generated frontend code is updated accordingly.

- **Fixed `agentWorking` condition**: In `AppShell.tsx`, the `agentWorking` prop passed to `ChatView` and `AgentEditorPanel` now requires `agent.status === AgentStatus.ACTIVE` in addition to the existing message-history check. When the worker goes offline and the agent transitions to `INACTIVE`, the indicator hides immediately.

- **Stale streaming text cleanup**: In `useWorkspaceConnection.ts`, when the `workerOnline` signal goes false, the frontend now calls `chatStore.clearStreamingText(a.id)` for every agent. This prevents orphaned streaming text from persisting after a worker disconnection.

- **Removed unused `isTurnActive` state**: `setTurnActive` and `isTurnActive` were set in four places in `chat.store.ts` but never read. These methods and all their call sites have been deleted.

- **E2E test coverage**: `frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts` adds two new tests:
  - Verifies the thinking indicator and interrupt button disappear when the worker stops during an agent turn.
  - Verifies the agent correctly resumes after a worker restart and a new message is sent.

## Result

- You no longer see a stuck thinking indicator or interrupt button after a worker process disconnects mid-turn. The UI correctly reflects the `INACTIVE` agent status as soon as the status change event is received.
- Stale streaming text no longer lingers in the chat view after a worker goes offline.
- The `AGENT_STATUS_CLOSED` enum value is now named `AGENT_STATUS_INACTIVE` throughout the codebase. Any code outside this repository that references the old name by string will need to be updated, but on-wire protobuf consumers are unaffected since the numeric value is unchanged.

🤖 Generated with Claude Code
