### PR TITLE
Add configurable timeout settings for API and worktree operations

### DIFF
--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -1,6 +1,7 @@
-import type { Interceptor } from '@connectrpc/connect'
-import { Code, ConnectError } from '@connectrpc/connect'
+import type { CallOptions, Interceptor } from '@connectrpc/connect'
+import { Code, ConnectError, createClient } from '@connectrpc/connect'
 import { createConnectTransport } from '@connectrpc/connect-web'
+import { UserService } from '~/generated/leapmux/v1/user_pb'
 
 const TOKEN_KEY = 'leapmux_token'
 
@@ -47,3 +48,97 @@ export const transport = createConnectTransport({
   interceptors: [authInterceptor],
   defaultTimeoutMs: 30_000,
 })
+
+// ---------------------------------------------------------------------------
+// Dynamic timeout configuration
+// ---------------------------------------------------------------------------
+
+/** Multiplier applied to backend timeouts for frontend RPC deadlines. */
+const TIMEOUT_MULTIPLIER = 1.5
+
+export interface TimeoutConfig {
+  apiTimeoutSeconds: number
+  agentStartupTimeoutSeconds: number
+  worktreeCreateTimeoutSeconds: number
+  worktreeDeleteTimeoutSeconds: number
+}
+
+const timeoutConfig: TimeoutConfig = {
+  apiTimeoutSeconds: 10,
+  agentStartupTimeoutSeconds: 30,
+  worktreeCreateTimeoutSeconds: 60,
+  worktreeDeleteTimeoutSeconds: 60,
+}
+
+/** Load timeout configuration from the server. Call after authentication. */
+export async function loadTimeouts(): Promise<void> {
+  try {
+    const client = createClient(UserService, transport)
+    const resp = await client.getTimeouts({})
+    if (resp.apiTimeoutSeconds > 0)
+      timeoutConfig.apiTimeoutSeconds = resp.apiTimeoutSeconds
+    if (resp.agentStartupTimeoutSeconds > 0)
+      timeoutConfig.agentStartupTimeoutSeconds = resp.agentStartupTimeoutSeconds
+    if (resp.worktreeCreateTimeoutSeconds > 0)
+      timeoutConfig.worktreeCreateTimeoutSeconds = resp.worktreeCreateTimeoutSeconds
+    if (resp.worktreeDeleteTimeoutSeconds > 0)
+      timeoutConfig.worktreeDeleteTimeoutSeconds = resp.worktreeDeleteTimeoutSeconds
+  }
+  catch {
+    // Use defaults if the server doesn't support this endpoint yet.
+  }
+}
+
+/** Get the current timeout config (for admin settings display). */
+export function getTimeoutConfig(): Readonly<TimeoutConfig> {
+  return timeoutConfig
+}
+
+// ---------------------------------------------------------------------------
+// Per-call timeout helpers (return CallOptions with timeoutMs)
+// ---------------------------------------------------------------------------
+
+/** RPC timeout for agent operations (start/resume + message delivery). */
+export function agentCallTimeout(agentActive: boolean): CallOptions {
+  const backendSec = agentActive
+    ? timeoutConfig.apiTimeoutSeconds
+    : timeoutConfig.agentStartupTimeoutSeconds + timeoutConfig.apiTimeoutSeconds
+  return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * backendSec * 1000) }
+}
+
+/** RPC timeout for worktree creation. */
+export function worktreeCreateCallTimeout(): CallOptions {
+  return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeCreateTimeoutSeconds * 1000) }
+}
+
+/** RPC timeout for worktree deletion / status check. */
+export function worktreeDeleteCallTimeout(): CallOptions {
+  return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeDeleteTimeoutSeconds * 1000) }
+}
+
+// ---------------------------------------------------------------------------
+// Loading indicator timeout helpers (return milliseconds)
+// ---------------------------------------------------------------------------
+
+/** Loading timeout for agent operations. */
+export function agentLoadingTimeoutMs(agentActive: boolean): number {
+  const backendSec = agentActive
+    ? timeoutConfig.apiTimeoutSeconds
+    : timeoutConfig.agentStartupTimeoutSeconds + timeoutConfig.apiTimeoutSeconds
+  return Math.ceil(TIMEOUT_MULTIPLIER * backendSec * 1000)
+}
+
+/** Loading timeout for worktree creation. */
+export function worktreeCreateLoadingTimeoutMs(): number {
+  return Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeCreateTimeoutSeconds * 1000)
+}
+
+/** Loading timeout for worktree deletion. */
+export function worktreeDeleteLoadingTimeoutMs(): number {
+  return Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeDeleteTimeoutSeconds * 1000)
+}
+
+/** Loading timeout for general API calls. */
+export function apiLoadingTimeoutMs(): number {
+  return Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.apiTimeoutSeconds * 1000)
+}

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -60,14 +60,12 @@ export interface TimeoutConfig {
   apiTimeoutSeconds: number
   agentStartupTimeoutSeconds: number
   worktreeCreateTimeoutSeconds: number
-  worktreeDeleteTimeoutSeconds: number
 }
 
 const timeoutConfig: TimeoutConfig = {
   apiTimeoutSeconds: 10,
   agentStartupTimeoutSeconds: 30,
   worktreeCreateTimeoutSeconds: 60,
-  worktreeDeleteTimeoutSeconds: 60,
 }
 
 /** Load timeout configuration from the server. Call after authentication. */
@@ -81,8 +79,6 @@ export async function loadTimeouts(): Promise<void> {
       timeoutConfig.agentStartupTimeoutSeconds = resp.agentStartupTimeoutSeconds
     if (resp.worktreeCreateTimeoutSeconds > 0)
       timeoutConfig.worktreeCreateTimeoutSeconds = resp.worktreeCreateTimeoutSeconds
-    if (resp.worktreeDeleteTimeoutSeconds > 0)
-      timeoutConfig.worktreeDeleteTimeoutSeconds = resp.worktreeDeleteTimeoutSeconds
   }
   catch {
     // Use defaults if the server doesn't support this endpoint yet.
@@ -111,9 +107,9 @@ export function worktreeCreateCallTimeout(): CallOptions {
   return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeCreateTimeoutSeconds * 1000) }
 }
 
-/** RPC timeout for worktree deletion / status check. */
-export function worktreeDeleteCallTimeout(): CallOptions {
-  return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeDeleteTimeoutSeconds * 1000) }
+/** RPC timeout for general API calls. */
+export function apiCallTimeout(): CallOptions {
+  return { timeoutMs: Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.apiTimeoutSeconds * 1000) }
 }
 
 // ---------------------------------------------------------------------------
@@ -131,11 +127,6 @@ export function agentLoadingTimeoutMs(agentActive: boolean): number {
 /** Loading timeout for worktree creation. */
 export function worktreeCreateLoadingTimeoutMs(): number {
   return Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeCreateTimeoutSeconds * 1000)
-}
-
-/** Loading timeout for worktree deletion. */
-export function worktreeDeleteLoadingTimeoutMs(): number {
-  return Math.ceil(TIMEOUT_MULTIPLIER * timeoutConfig.worktreeDeleteTimeoutSeconds * 1000)
 }
 
 /** Loading timeout for general API calls. */

--- a/frontend/src/components/admin/AdminSettingsPage.tsx
+++ b/frontend/src/components/admin/AdminSettingsPage.tsx
@@ -23,7 +23,6 @@ export const AdminSettingsPage: Component = () => {
   const [apiTimeout, setApiTimeout] = createSignal(10)
   const [agentStartupTimeout, setAgentStartupTimeout] = createSignal(30)
   const [worktreeCreateTimeout, setWorktreeCreateTimeout] = createSignal(60)
-  const [worktreeDeleteTimeout, setWorktreeDeleteTimeout] = createSignal(60)
   const [settingsSaving, setSettingsSaving] = createSignal(false)
   const [settingsMessage, setSettingsMessage] = createSignal<{ type: 'success' | 'error', text: string } | null>(null)
 
@@ -94,8 +93,6 @@ export const AdminSettingsPage: Component = () => {
           setAgentStartupTimeout(s.agentStartupTimeoutSeconds)
         if (s.worktreeCreateTimeoutSeconds > 0)
           setWorktreeCreateTimeout(s.worktreeCreateTimeoutSeconds)
-        if (s.worktreeDeleteTimeoutSeconds > 0)
-          setWorktreeDeleteTimeout(s.worktreeDeleteTimeoutSeconds)
       }
     }
     catch (e) {
@@ -146,7 +143,6 @@ export const AdminSettingsPage: Component = () => {
           apiTimeoutSeconds: apiTimeout(),
           agentStartupTimeoutSeconds: agentStartupTimeout(),
           worktreeCreateTimeoutSeconds: worktreeCreateTimeout(),
-          worktreeDeleteTimeoutSeconds: worktreeDeleteTimeout(),
         },
       })
       setSettingsMessage({ type: 'success', text: 'Settings saved.' })
@@ -318,10 +314,6 @@ export const AdminSettingsPage: Component = () => {
               <label class={styles.fieldLabel}>
                 Worktree Create Timeout (seconds)
                 <input type="number" min="1" max="600" value={String(worktreeCreateTimeout())} onInput={e => setWorktreeCreateTimeout(Number.parseInt(e.currentTarget.value) || 60)} />
-              </label>
-              <label class={styles.fieldLabel}>
-                Worktree Delete Timeout (seconds)
-                <input type="number" min="1" max="600" value={String(worktreeDeleteTimeout())} onInput={e => setWorktreeDeleteTimeout(Number.parseInt(e.currentTarget.value) || 60)} />
               </label>
             </div>
           </div>

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -3,6 +3,7 @@ import type { ActionsProps, AskQuestionState, EditorContentRef, Question } from 
 import type { ControlRequest } from '~/stores/control.store'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createUniqueId, For, Show } from 'solid-js'
+import { agentLoadingTimeoutMs, apiLoadingTimeoutMs } from '~/api/transport'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
 import { buildAllowResponse, buildDenyResponse, getToolInput } from '~/utils/controlResponse'
@@ -284,8 +285,8 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
     restoreEditorForPage(newPage)
   }
 
-  const { loading: submitting, start: startSubmitting, stop: stopSubmitting } = createLoadingSignal()
-  const { loading: stopping, start: startStopping, stop: stopStopping } = createLoadingSignal()
+  const { loading: submitting, start: startSubmitting, stop: stopSubmitting } = createLoadingSignal(agentLoadingTimeoutMs(true))
+  const { loading: stopping, start: startStopping, stop: stopStopping } = createLoadingSignal(apiLoadingTimeoutMs())
 
   const handleSubmit = async () => {
     startSubmitting()

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -6,7 +6,7 @@ import Resizable from '@corvu/resizable'
 import { useLocation, useNavigate, useParams, useSearchParams } from '@solidjs/router'
 import { createEffect, createMemo, createSignal, on, onMount, Show } from 'solid-js'
 import { agentClient, gitClient, sectionClient, terminalClient, workspaceClient } from '~/api/clients'
-import { agentCallTimeout, agentLoadingTimeoutMs, worktreeDeleteCallTimeout } from '~/api/transport'
+import { agentCallTimeout, agentLoadingTimeoutMs, apiCallTimeout } from '~/api/transport'
 import { AgentEditorPanel } from '~/components/chat/AgentEditorPanel'
 import { ChatView } from '~/components/chat/ChatView'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
@@ -784,7 +784,7 @@ export const AppShell: ParentComponent = (props) => {
       // Auto-handle worktree cleanup if the pre-close check stored a choice.
       if (resp.worktreeCleanupPending && resp.worktreeId) {
         if (pendingWorktreeChoice === 'remove') {
-          gitClient.forceRemoveWorktree({ worktreeId: resp.worktreeId }, worktreeDeleteCallTimeout()).catch(() => {})
+          gitClient.forceRemoveWorktree({ worktreeId: resp.worktreeId }, apiCallTimeout()).catch(() => {})
         }
         else {
           // Default to keep (if somehow no choice was stored)
@@ -864,7 +864,7 @@ export const AppShell: ParentComponent = (props) => {
       // Auto-handle worktree cleanup if the pre-close check stored a choice.
       if (resp.worktreeCleanupPending && resp.worktreeId) {
         if (pendingWorktreeChoice === 'remove') {
-          gitClient.forceRemoveWorktree({ worktreeId: resp.worktreeId }, worktreeDeleteCallTimeout()).catch(() => {})
+          gitClient.forceRemoveWorktree({ worktreeId: resp.worktreeId }, apiCallTimeout()).catch(() => {})
         }
         else {
           gitClient.keepWorktree({ worktreeId: resp.worktreeId }).catch(() => {})
@@ -968,7 +968,7 @@ export const AppShell: ParentComponent = (props) => {
     // Pre-close check: does this tab have a dirty worktree?
     try {
       const tabType = tab.type === TabType.AGENT ? TabType.AGENT : TabType.TERMINAL
-      const status = await gitClient.checkWorktreeStatus({ tabType, tabId: tab.id }, worktreeDeleteCallTimeout())
+      const status = await gitClient.checkWorktreeStatus({ tabType, tabId: tab.id }, apiCallTimeout())
       if (status.hasWorktree && status.isLastTab && status.isDirty) {
         const choice = await askWorktreeConfirmation(status)
         if (choice === 'cancel') {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -3,7 +3,7 @@ import type { User } from '~/generated/leapmux/v1/auth_pb'
 import { create } from '@bufbuild/protobuf'
 import { createContext, createSignal, onMount, useContext } from 'solid-js'
 import { authClient } from '~/api/clients'
-import { clearToken, getToken, setOnAuthError, setToken } from '~/api/transport'
+import { clearToken, getToken, loadTimeouts, setOnAuthError, setToken } from '~/api/transport'
 import { LoginRequestSchema } from '~/generated/leapmux/v1/auth_pb'
 
 interface AuthState {
@@ -34,6 +34,8 @@ export const AuthProvider: ParentComponent = (props) => {
       try {
         const resp = await authClient.getCurrentUser({})
         setUser(resp.user ?? null)
+        // Load timeout configuration after successful auth validation.
+        loadTimeouts().catch(() => {})
       }
       catch {
         clearToken()
@@ -50,6 +52,7 @@ export const AuthProvider: ParentComponent = (props) => {
       const resp = await authClient.login(req)
       setToken(resp.token)
       setUser(resp.user ?? null)
+      loadTimeouts().catch(() => {})
     }
     catch (e) {
       const msg = e instanceof Error ? e.message : 'Login failed'

--- a/internal/hub/auth/timeout_test.go
+++ b/internal/hub/auth/timeout_test.go
@@ -42,7 +42,7 @@ func setupTimeoutTestServer(t *testing.T, timeout time.Duration) (leapmuxv1conne
 	capture := &timeoutCapture{inner: service.NewAuthService(q)}
 
 	mux := http.NewServeMux()
-	interceptors := connect.WithInterceptors(auth.NewTimeoutInterceptor(timeout))
+	interceptors := connect.WithInterceptors(auth.NewTimeoutInterceptor(func() time.Duration { return timeout }))
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(capture, interceptors)
 	mux.Handle(path, handler)
 

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -252,16 +252,20 @@ CREATE TABLE user_preferences (
 
 -- System settings (single-row)
 CREATE TABLE system_settings (
-    id                          INTEGER PRIMARY KEY CHECK (id = 1),
-    signup_enabled              INTEGER NOT NULL DEFAULT 0,
-    email_verification_required INTEGER NOT NULL DEFAULT 0,
-    smtp_host                   TEXT NOT NULL DEFAULT '',
-    smtp_port                   INTEGER NOT NULL DEFAULT 587,
-    smtp_username               TEXT NOT NULL DEFAULT '',
-    smtp_password               TEXT NOT NULL DEFAULT '',
-    smtp_from_address           TEXT NOT NULL DEFAULT '',
-    smtp_use_tls                INTEGER NOT NULL DEFAULT 1,
-    updated_at                  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    id                              INTEGER PRIMARY KEY CHECK (id = 1),
+    signup_enabled                  INTEGER NOT NULL DEFAULT 0,
+    email_verification_required     INTEGER NOT NULL DEFAULT 0,
+    smtp_host                       TEXT NOT NULL DEFAULT '',
+    smtp_port                       INTEGER NOT NULL DEFAULT 587,
+    smtp_username                   TEXT NOT NULL DEFAULT '',
+    smtp_password                   TEXT NOT NULL DEFAULT '',
+    smtp_from_address               TEXT NOT NULL DEFAULT '',
+    smtp_use_tls                    INTEGER NOT NULL DEFAULT 1,
+    api_timeout_seconds             INTEGER NOT NULL DEFAULT 10,
+    agent_startup_timeout_seconds   INTEGER NOT NULL DEFAULT 30,
+    worktree_create_timeout_seconds INTEGER NOT NULL DEFAULT 60,
+    worktree_delete_timeout_seconds INTEGER NOT NULL DEFAULT 60,
+    updated_at                      DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
 -- Pending control requests (survive hub restarts)

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -264,7 +264,6 @@ CREATE TABLE system_settings (
     api_timeout_seconds             INTEGER NOT NULL DEFAULT 10,
     agent_startup_timeout_seconds   INTEGER NOT NULL DEFAULT 30,
     worktree_create_timeout_seconds INTEGER NOT NULL DEFAULT 60,
-    worktree_delete_timeout_seconds INTEGER NOT NULL DEFAULT 60,
     updated_at                      DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 

--- a/internal/hub/db/queries/system_settings.sql
+++ b/internal/hub/db/queries/system_settings.sql
@@ -11,5 +11,9 @@ UPDATE system_settings SET
   smtp_password = ?,
   smtp_from_address = ?,
   smtp_use_tls = ?,
+  api_timeout_seconds = ?,
+  agent_startup_timeout_seconds = ?,
+  worktree_create_timeout_seconds = ?,
+  worktree_delete_timeout_seconds = ?,
   updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = 1;

--- a/internal/hub/db/queries/system_settings.sql
+++ b/internal/hub/db/queries/system_settings.sql
@@ -14,6 +14,5 @@ UPDATE system_settings SET
   api_timeout_seconds = ?,
   agent_startup_timeout_seconds = ?,
   worktree_create_timeout_seconds = ?,
-  worktree_delete_timeout_seconds = ?,
   updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = 1;

--- a/internal/hub/service/admin_service.go
+++ b/internal/hub/service/admin_service.go
@@ -13,18 +13,20 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/id"
+	"github.com/leapmux/leapmux/internal/hub/timeout"
 	"github.com/leapmux/leapmux/internal/logging"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
 
 // AdminService implements the leapmux.v1.AdminService ConnectRPC handler.
 type AdminService struct {
-	queries *db.Queries
+	queries    *db.Queries
+	timeoutCfg *timeout.Config
 }
 
 // NewAdminService creates a new AdminService.
-func NewAdminService(q *db.Queries) *AdminService {
-	return &AdminService{queries: q}
+func NewAdminService(q *db.Queries, tc *timeout.Config) *AdminService {
+	return &AdminService{queries: q, timeoutCfg: tc}
 }
 
 func requireAdmin(ctx context.Context) (*auth.UserInfo, error) {
@@ -84,15 +86,36 @@ func (s *AdminService) UpdateSettings(ctx context.Context, req *connect.Request[
 		smtpUseTls = 1
 	}
 
+	apiTimeout := int64(reqSettings.GetApiTimeoutSeconds())
+	if apiTimeout <= 0 {
+		apiTimeout = timeout.DefaultAPITimeout
+	}
+	agentStartupTimeout := int64(reqSettings.GetAgentStartupTimeoutSeconds())
+	if agentStartupTimeout <= 0 {
+		agentStartupTimeout = timeout.DefaultAgentStartupTimeout
+	}
+	worktreeCreateTimeout := int64(reqSettings.GetWorktreeCreateTimeoutSeconds())
+	if worktreeCreateTimeout <= 0 {
+		worktreeCreateTimeout = timeout.DefaultWorktreeCreateTimeout
+	}
+	worktreeDeleteTimeout := int64(reqSettings.GetWorktreeDeleteTimeoutSeconds())
+	if worktreeDeleteTimeout <= 0 {
+		worktreeDeleteTimeout = timeout.DefaultWorktreeDeleteTimeout
+	}
+
 	if err := s.queries.UpdateSystemSettings(ctx, db.UpdateSystemSettingsParams{
-		SignupEnabled:             signupEnabled,
-		EmailVerificationRequired: emailVerificationRequired,
-		SmtpHost:                  reqSettings.GetSmtp().GetHost(),
-		SmtpPort:                  int64(reqSettings.GetSmtp().GetPort()),
-		SmtpUsername:              reqSettings.GetSmtp().GetUsername(),
-		SmtpPassword:              smtpPassword,
-		SmtpFromAddress:           reqSettings.GetSmtp().GetFromAddress(),
-		SmtpUseTls:                smtpUseTls,
+		SignupEnabled:                signupEnabled,
+		EmailVerificationRequired:    emailVerificationRequired,
+		SmtpHost:                     reqSettings.GetSmtp().GetHost(),
+		SmtpPort:                     int64(reqSettings.GetSmtp().GetPort()),
+		SmtpUsername:                 reqSettings.GetSmtp().GetUsername(),
+		SmtpPassword:                 smtpPassword,
+		SmtpFromAddress:              reqSettings.GetSmtp().GetFromAddress(),
+		SmtpUseTls:                   smtpUseTls,
+		ApiTimeoutSeconds:            apiTimeout,
+		AgentStartupTimeoutSeconds:   agentStartupTimeout,
+		WorktreeCreateTimeoutSeconds: worktreeCreateTimeout,
+		WorktreeDeleteTimeoutSeconds: worktreeDeleteTimeout,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("update settings: %w", err))
 	}
@@ -102,6 +125,9 @@ func (s *AdminService) UpdateSettings(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get updated settings: %w", err))
 	}
+
+	// Refresh the in-memory timeout config.
+	s.timeoutCfg.Refresh(updated)
 
 	return connect.NewResponse(&leapmuxv1.UpdateSettingsResponse{
 		Settings: settingsToProto(&updated),
@@ -427,5 +453,9 @@ func settingsToProto(s *db.SystemSetting) *leapmuxv1.SystemSettings {
 			FromAddress: s.SmtpFromAddress,
 			UseTls:      s.SmtpUseTls == 1,
 		},
+		ApiTimeoutSeconds:            int32(s.ApiTimeoutSeconds),
+		AgentStartupTimeoutSeconds:   int32(s.AgentStartupTimeoutSeconds),
+		WorktreeCreateTimeoutSeconds: int32(s.WorktreeCreateTimeoutSeconds),
+		WorktreeDeleteTimeoutSeconds: int32(s.WorktreeDeleteTimeoutSeconds),
 	}
 }

--- a/internal/hub/service/admin_service.go
+++ b/internal/hub/service/admin_service.go
@@ -98,10 +98,6 @@ func (s *AdminService) UpdateSettings(ctx context.Context, req *connect.Request[
 	if worktreeCreateTimeout <= 0 {
 		worktreeCreateTimeout = timeout.DefaultWorktreeCreateTimeout
 	}
-	worktreeDeleteTimeout := int64(reqSettings.GetWorktreeDeleteTimeoutSeconds())
-	if worktreeDeleteTimeout <= 0 {
-		worktreeDeleteTimeout = timeout.DefaultWorktreeDeleteTimeout
-	}
 
 	if err := s.queries.UpdateSystemSettings(ctx, db.UpdateSystemSettingsParams{
 		SignupEnabled:                signupEnabled,
@@ -115,7 +111,6 @@ func (s *AdminService) UpdateSettings(ctx context.Context, req *connect.Request[
 		ApiTimeoutSeconds:            apiTimeout,
 		AgentStartupTimeoutSeconds:   agentStartupTimeout,
 		WorktreeCreateTimeoutSeconds: worktreeCreateTimeout,
-		WorktreeDeleteTimeoutSeconds: worktreeDeleteTimeout,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("update settings: %w", err))
 	}
@@ -456,6 +451,5 @@ func settingsToProto(s *db.SystemSetting) *leapmuxv1.SystemSettings {
 		ApiTimeoutSeconds:            int32(s.ApiTimeoutSeconds),
 		AgentStartupTimeoutSeconds:   int32(s.AgentStartupTimeoutSeconds),
 		WorktreeCreateTimeoutSeconds: int32(s.WorktreeCreateTimeoutSeconds),
-		WorktreeDeleteTimeoutSeconds: int32(s.WorktreeDeleteTimeoutSeconds),
 	}
 }

--- a/internal/hub/service/admin_service_test.go
+++ b/internal/hub/service/admin_service_test.go
@@ -19,6 +19,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/id"
 	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/timeout"
 )
 
 type adminTestEnv struct {
@@ -43,7 +44,10 @@ func setupAdminTestServer(t *testing.T) *adminTestEnv {
 	err = bootstrap.Run(context.Background(), q)
 	require.NoError(t, err)
 
-	adminSvc := service.NewAdminService(q)
+	tc, err := timeout.NewFromDB(q)
+	require.NoError(t, err)
+
+	adminSvc := service.NewAdminService(q, tc)
 
 	mux := http.NewServeMux()
 	opts := connect.WithInterceptors(auth.NewInterceptor(q))

--- a/internal/hub/service/file_service_test.go
+++ b/internal/hub/service/file_service_test.go
@@ -18,6 +18,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/id"
 	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/timeout"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
 )
 
@@ -43,7 +44,11 @@ func setupFileTest(t *testing.T) *fileTestEnv {
 
 	queries := gendb.New(sqlDB)
 	workerMgr := workermgr.New()
-	pendingReqs := workermgr.NewPendingRequests()
+
+	tc, tcErr := timeout.NewFromDB(queries)
+	require.NoError(t, tcErr)
+
+	pendingReqs := workermgr.NewPendingRequests(tc.APITimeout)
 
 	fileSvc := service.NewFileService(queries, workerMgr, pendingReqs)
 

--- a/internal/hub/service/user_service.go
+++ b/internal/hub/service/user_service.go
@@ -159,7 +159,6 @@ func (s *UserService) GetTimeouts(ctx context.Context, req *connect.Request[leap
 		ApiTimeoutSeconds:            int32(s.timeoutCfg.APITimeout().Seconds()),
 		AgentStartupTimeoutSeconds:   int32(s.timeoutCfg.AgentStartupTimeout().Seconds()),
 		WorktreeCreateTimeoutSeconds: int32(s.timeoutCfg.WorktreeCreateTimeout().Seconds()),
-		WorktreeDeleteTimeoutSeconds: int32(s.timeoutCfg.WorktreeDeleteTimeout().Seconds()),
 	}), nil
 }
 

--- a/internal/hub/service/user_service.go
+++ b/internal/hub/service/user_service.go
@@ -10,18 +10,20 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/timeout"
 	"github.com/leapmux/leapmux/internal/hub/validate"
 	"golang.org/x/crypto/bcrypt"
 )
 
 // UserService implements the leapmux.v1.UserService ConnectRPC handler.
 type UserService struct {
-	queries *db.Queries
+	queries    *db.Queries
+	timeoutCfg *timeout.Config
 }
 
 // NewUserService creates a new UserService.
-func NewUserService(q *db.Queries) *UserService {
-	return &UserService{queries: q}
+func NewUserService(q *db.Queries, tc *timeout.Config) *UserService {
+	return &UserService{queries: q, timeoutCfg: tc}
 }
 
 func (s *UserService) UpdateProfile(ctx context.Context, req *connect.Request[leapmuxv1.UpdateProfileRequest]) (*connect.Response[leapmuxv1.UpdateProfileResponse], error) {
@@ -145,6 +147,19 @@ func (s *UserService) GetPreferences(ctx context.Context, req *connect.Request[l
 			TurnEndSound:          leapmuxv1.TurnEndSound(prefs.TurnEndSound),
 			TurnEndSoundVolume:    uint32(prefs.TurnEndSoundVolume),
 		},
+	}), nil
+}
+
+func (s *UserService) GetTimeouts(ctx context.Context, req *connect.Request[leapmuxv1.GetTimeoutsRequest]) (*connect.Response[leapmuxv1.GetTimeoutsResponse], error) {
+	if _, err := auth.MustGetUser(ctx); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&leapmuxv1.GetTimeoutsResponse{
+		ApiTimeoutSeconds:            int32(s.timeoutCfg.APITimeout().Seconds()),
+		AgentStartupTimeoutSeconds:   int32(s.timeoutCfg.AgentStartupTimeout().Seconds()),
+		WorktreeCreateTimeoutSeconds: int32(s.timeoutCfg.WorktreeCreateTimeout().Seconds()),
+		WorktreeDeleteTimeoutSeconds: int32(s.timeoutCfg.WorktreeDeleteTimeout().Seconds()),
 	}), nil
 }
 

--- a/internal/hub/service/user_service_test.go
+++ b/internal/hub/service/user_service_test.go
@@ -18,6 +18,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/id"
 	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/timeout"
 )
 
 type userTestEnv struct {
@@ -39,7 +40,11 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	require.NoError(t, err)
 
 	queries := gendb.New(sqlDB)
-	userSvc := service.NewUserService(queries)
+
+	tc, tcErr := timeout.NewFromDB(queries)
+	require.NoError(t, tcErr)
+
+	userSvc := service.NewUserService(queries, tc)
 
 	mux := http.NewServeMux()
 	opts := connect.WithInterceptors(auth.NewInterceptor(queries))

--- a/internal/hub/service/worktree_helper.go
+++ b/internal/hub/service/worktree_helper.go
@@ -231,7 +231,7 @@ func (h *WorktreeHelper) CheckTabWorktreeStatus(ctx context.Context, tabType lea
 		return result
 	}
 
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), h.timeoutCfg.WorktreeDeleteTimeout())
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), h.timeoutCfg.APITimeout())
 	defer deleteCancel()
 
 	resp, err := h.pending.SendAndWait(deleteCtx, conn, &leapmuxv1.ConnectResponse{
@@ -307,7 +307,7 @@ func (h *WorktreeHelper) UnregisterTabAndCleanup(ctx context.Context, tabType le
 		return WorktreeCleanupResult{}
 	}
 
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), h.timeoutCfg.WorktreeDeleteTimeout())
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), h.timeoutCfg.APITimeout())
 	defer deleteCancel()
 
 	resp, err := h.pending.SendAndWait(deleteCtx, conn, &leapmuxv1.ConnectResponse{

--- a/internal/hub/timeout/config.go
+++ b/internal/hub/timeout/config.go
@@ -1,0 +1,77 @@
+package timeout
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/generated/db"
+)
+
+// Default timeout values (in seconds).
+const (
+	DefaultAPITimeout            = 10
+	DefaultAgentStartupTimeout   = 30
+	DefaultWorktreeCreateTimeout = 60
+	DefaultWorktreeDeleteTimeout = 60
+)
+
+// Config holds configurable timeout values loaded from the database.
+// All methods are safe for concurrent use.
+type Config struct {
+	apiTimeout            atomic.Int64
+	agentStartupTimeout   atomic.Int64
+	worktreeCreateTimeout atomic.Int64
+	worktreeDeleteTimeout atomic.Int64
+}
+
+// NewFromDB loads timeout configuration from the database.
+func NewFromDB(q *db.Queries) (*Config, error) {
+	s, err := q.GetSystemSettings(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Config{}
+	c.refresh(s)
+	return c, nil
+}
+
+// Refresh updates the timeout values from a system settings row.
+func (c *Config) Refresh(s db.SystemSetting) {
+	c.refresh(s)
+}
+
+func (c *Config) refresh(s db.SystemSetting) {
+	c.apiTimeout.Store(clampTimeout(s.ApiTimeoutSeconds, DefaultAPITimeout))
+	c.agentStartupTimeout.Store(clampTimeout(s.AgentStartupTimeoutSeconds, DefaultAgentStartupTimeout))
+	c.worktreeCreateTimeout.Store(clampTimeout(s.WorktreeCreateTimeoutSeconds, DefaultWorktreeCreateTimeout))
+	c.worktreeDeleteTimeout.Store(clampTimeout(s.WorktreeDeleteTimeoutSeconds, DefaultWorktreeDeleteTimeout))
+}
+
+// APITimeout returns the general API timeout.
+func (c *Config) APITimeout() time.Duration {
+	return time.Duration(c.apiTimeout.Load()) * time.Second
+}
+
+// AgentStartupTimeout returns the agent startup/resume timeout.
+func (c *Config) AgentStartupTimeout() time.Duration {
+	return time.Duration(c.agentStartupTimeout.Load()) * time.Second
+}
+
+// WorktreeCreateTimeout returns the worktree creation timeout.
+func (c *Config) WorktreeCreateTimeout() time.Duration {
+	return time.Duration(c.worktreeCreateTimeout.Load()) * time.Second
+}
+
+// WorktreeDeleteTimeout returns the worktree deletion timeout.
+func (c *Config) WorktreeDeleteTimeout() time.Duration {
+	return time.Duration(c.worktreeDeleteTimeout.Load()) * time.Second
+}
+
+func clampTimeout(val int64, defaultVal int64) int64 {
+	if val <= 0 {
+		return defaultVal
+	}
+	return val
+}

--- a/internal/hub/timeout/config.go
+++ b/internal/hub/timeout/config.go
@@ -13,7 +13,6 @@ const (
 	DefaultAPITimeout            = 10
 	DefaultAgentStartupTimeout   = 30
 	DefaultWorktreeCreateTimeout = 60
-	DefaultWorktreeDeleteTimeout = 60
 )
 
 // Config holds configurable timeout values loaded from the database.
@@ -22,7 +21,6 @@ type Config struct {
 	apiTimeout            atomic.Int64
 	agentStartupTimeout   atomic.Int64
 	worktreeCreateTimeout atomic.Int64
-	worktreeDeleteTimeout atomic.Int64
 }
 
 // NewFromDB loads timeout configuration from the database.
@@ -46,7 +44,6 @@ func (c *Config) refresh(s db.SystemSetting) {
 	c.apiTimeout.Store(clampTimeout(s.ApiTimeoutSeconds, DefaultAPITimeout))
 	c.agentStartupTimeout.Store(clampTimeout(s.AgentStartupTimeoutSeconds, DefaultAgentStartupTimeout))
 	c.worktreeCreateTimeout.Store(clampTimeout(s.WorktreeCreateTimeoutSeconds, DefaultWorktreeCreateTimeout))
-	c.worktreeDeleteTimeout.Store(clampTimeout(s.WorktreeDeleteTimeoutSeconds, DefaultWorktreeDeleteTimeout))
 }
 
 // APITimeout returns the general API timeout.
@@ -62,11 +59,6 @@ func (c *Config) AgentStartupTimeout() time.Duration {
 // WorktreeCreateTimeout returns the worktree creation timeout.
 func (c *Config) WorktreeCreateTimeout() time.Duration {
 	return time.Duration(c.worktreeCreateTimeout.Load()) * time.Second
-}
-
-// WorktreeDeleteTimeout returns the worktree deletion timeout.
-func (c *Config) WorktreeDeleteTimeout() time.Duration {
-	return time.Duration(c.worktreeDeleteTimeout.Load()) * time.Second
 }
 
 func clampTimeout(val int64, defaultVal int64) int64 {

--- a/internal/hub/workermgr/pending_test.go
+++ b/internal/hub/workermgr/pending_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPendingRequests_Complete(t *testing.T) {
-	p := NewPendingRequests()
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 
 	// We can't use a real stream, so test Complete directly.
 	ch := make(chan *leapmuxv1.ConnectRequest, 1)
@@ -43,20 +43,20 @@ func TestPendingRequests_Complete(t *testing.T) {
 }
 
 func TestPendingRequests_CompleteUnknown(t *testing.T) {
-	p := NewPendingRequests()
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 	if p.Complete("unknown", &leapmuxv1.ConnectRequest{}) {
 		t.Fatal("expected Complete to return false for unknown request")
 	}
 }
 
 func TestPendingRequests_SendAndWait_NilConn(t *testing.T) {
-	p := NewPendingRequests()
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 	_, err := p.SendAndWait(context.Background(), nil, &leapmuxv1.ConnectResponse{})
 	require.Error(t, err)
 }
 
 func TestPendingRequests_SendAndWait_ContextCancel(t *testing.T) {
-	p := NewPendingRequests()
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 
 	// Create a conn with nil stream — Send will fail.
 	conn := &Conn{WorkerID: "b1", OrgID: "o1"}
@@ -69,7 +69,7 @@ func TestPendingRequests_SendAndWait_ContextCancel(t *testing.T) {
 }
 
 func TestPendingRequests_OutOfOrder(t *testing.T) {
-	p := NewPendingRequests()
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 
 	// Use a channel to safely capture sent messages from concurrent goroutines.
 	sentMsgs := make(chan *leapmuxv1.ConnectResponse, 2)

--- a/proto/leapmux/v1/admin.proto
+++ b/proto/leapmux/v1/admin.proto
@@ -51,7 +51,6 @@ message SystemSettings {
   int32 api_timeout_seconds = 4;
   int32 agent_startup_timeout_seconds = 5;
   int32 worktree_create_timeout_seconds = 6;
-  int32 worktree_delete_timeout_seconds = 7;
 }
 
 message SmtpConfig {

--- a/proto/leapmux/v1/admin.proto
+++ b/proto/leapmux/v1/admin.proto
@@ -48,6 +48,10 @@ message SystemSettings {
   bool signup_enabled = 1;
   bool email_verification_required = 2;
   SmtpConfig smtp = 3;
+  int32 api_timeout_seconds = 4;
+  int32 agent_startup_timeout_seconds = 5;
+  int32 worktree_create_timeout_seconds = 6;
+  int32 worktree_delete_timeout_seconds = 7;
 }
 
 message SmtpConfig {

--- a/proto/leapmux/v1/user.proto
+++ b/proto/leapmux/v1/user.proto
@@ -76,7 +76,6 @@ message GetTimeoutsResponse {
   int32 api_timeout_seconds = 1;
   int32 agent_startup_timeout_seconds = 2;
   int32 worktree_create_timeout_seconds = 3;
-  int32 worktree_delete_timeout_seconds = 4;
 }
 
 message UserPreferences {

--- a/proto/leapmux/v1/user.proto
+++ b/proto/leapmux/v1/user.proto
@@ -12,6 +12,8 @@ service UserService {
   rpc GetPreferences(GetPreferencesRequest) returns (GetPreferencesResponse);
   // Update the current user's preferences.
   rpc UpdatePreferences(UpdatePreferencesRequest) returns (UpdatePreferencesResponse);
+  // Get the current timeout configuration.
+  rpc GetTimeouts(GetTimeoutsRequest) returns (GetTimeoutsResponse);
 }
 
 message UpdateProfileRequest {
@@ -66,6 +68,15 @@ message UpdatePreferencesRequest {
 
 message UpdatePreferencesResponse {
   UserPreferences preferences = 1;
+}
+
+message GetTimeoutsRequest {}
+
+message GetTimeoutsResponse {
+  int32 api_timeout_seconds = 1;
+  int32 agent_startup_timeout_seconds = 2;
+  int32 worktree_create_timeout_seconds = 3;
+  int32 worktree_delete_timeout_seconds = 4;
 }
 
 message UserPreferences {


### PR DESCRIPTION
## Motivation

Previously, all operation timeouts in the hub were hardcoded at their
call sites. This made it impossible to tune timeout behavior without
recompiling, which was particularly problematic in slow or high-latency
environments where agent startup or worktree creation operations would
time out prematurely.

Additionally, the `ForceRemoveWorktree` RPC was blocking on the worker's
response before returning to the client. Worktree deletion can be slow
and the caller gains nothing from waiting for it, so slow deletions were
causing unnecessary timeout errors on the client side.

## Modifications

### Backend

- Added `internal/hub/timeout/config.go`: a new `timeout.Config` struct
  backed by atomic values for thread-safe concurrent reads. It holds
  three independently configurable durations:
  - `APITimeout` (default: 10s)
  - `AgentStartupTimeout` (default: 30s)
  - `WorktreeCreateTimeout` (default: 60s)

- Added three new columns to the `system_settings` database table:
  `api_timeout_seconds`, `agent_startup_timeout_seconds`,
  `worktree_create_timeout_seconds`. Values are loaded on startup via
  `timeout.NewFromDB` and refreshed when settings are updated.

- Updated all service constructors to accept `*timeout.Config` instead
  of hardcoded durations: `AdminService`, `UserService`, `AgentService`,
  `GitService`, `WorktreeHelper`, `Notifier`, `WSWatchEventsHandler`, and
  `PendingRequests`.

- Changed `NewTimeoutInterceptor` to accept a `func() time.Duration`
  instead of a static `time.Duration`, so each request picks up the
  current configured value.

- Added a new `GetTimeouts` RPC to `UserService` (proto: `user.proto`)
  that allows authenticated users (including non-admins) to fetch the
  current timeout values. This is used by the frontend to configure its
  own RPC deadlines.

- `ForceRemoveWorktree` in `GitService` now deletes the DB
  record first (the authoritative state) and then sends the physical
  removal request to the worker in a fire-and-forget goroutine. The RPC
  returns immediately without waiting for the worker to finish.

### Frontend

- Added `loadTimeouts()` to `frontend/src/api/transport.ts`, called
  after authentication, to fetch configured timeout values from the
  backend `GetTimeouts` RPC. Falls back to built-in defaults if the
  endpoint is unavailable.

- Added per-category timeout helper functions in `transport.ts`:
  - `agentCallTimeout(agentActive)` / `agentLoadingTimeoutMs(agentActive)`
  - `worktreeCreateCallTimeout()` / `worktreeCreateLoadingTimeoutMs()`
  - `apiCallTimeout()` / `apiLoadingTimeoutMs()`

  Frontend RPC deadlines are set to 1.5× the configured backend timeout
  to give the backend room to enforce its own deadline first.

- Added a Timeouts subsection to the Admin Settings page
  (`AdminSettingsPage.tsx`) with numeric input fields for all three
  timeout categories. Saving the settings immediately refreshes the
  in-browser timeout config via `loadTimeouts()`.

- Refactored `AppShell`, `NewAgentDialog`, `NewTerminalDialog`, and
  `ResumeSessionDialog` to pass the appropriate timeout helpers to RPC
  calls and loading indicators.

## Result

Administrators can now tune timeout thresholds through the Admin
Settings UI without rebuilding or redeploying the server:

- **API Timeout** governs general short-lived RPC calls.
- **Agent Startup Timeout** governs how long starting or resuming an
  agent session is allowed to take.
- **Worktree Create Timeout** governs how long creating a new git
  worktree is allowed to take.

The `ForceRemoveWorktree` operation no longer blocks waiting for the
worker, so users no longer see timeout errors when forcibly discarding a
worktree on a slow or busy worker.

The frontend respects the same thresholds, so browser-side RPC timeouts
and loading indicator timeouts stay in sync with the configured backend
values.

🤖 Generated with Claude Code
