### PR TITLE
Fix message drop race in addMessage seq-based dedup

### DIFF
--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -120,18 +120,31 @@ export function createChatStore() {
       setState('messagesByAgent', agentId, (prev = []) => {
         // Check if a message with this ID already exists (thread merge:
         // parent gets updated with child content and bumped seq).
-        const existingIdx = prev.findIndex(m => m.id === message.id)
+        // Search from end — thread merges almost always affect recent messages.
+        const existingIdx = prev.findLastIndex(m => m.id === message.id)
         if (existingIdx !== -1) {
-          // Remove old and append at end (seq was bumped).
-          return [...prev.slice(0, existingIdx), ...prev.slice(existingIdx + 1), message]
+          // Update in-place to avoid advancing lastSeq past messages
+          // that haven't arrived yet (which would cause the seq-based
+          // dedup below to incorrectly drop them).
+          const updated = [...prev]
+          updated[existingIdx] = message
+          return updated
         }
 
-        // Dedup: skip if we already have this or a later seq
-        if (prev.length > 0 && message.seq <= prev[prev.length - 1].seq) {
+        // Fast path: message is in order (most common case).
+        if (prev.length === 0 || message.seq > prev[prev.length - 1].seq) {
+          return [...prev, message]
+        }
+
+        // Dedup: skip if a message with this exact seq already exists.
+        if (prev.findLastIndex(m => m.seq === message.seq) !== -1)
           return prev
-        }
 
-        return [...prev, message]
+        // Out-of-order message (e.g. catch-up replay after a thread merge
+        // advanced lastSeq): insert in sorted position by seq.
+        const insertAfter = prev.findLastIndex(m => m.seq < message.seq)
+        const insertIdx = insertAfter + 1
+        return [...prev.slice(0, insertIdx), message, ...prev.slice(insertIdx)]
       })
 
       // Track delivery errors

--- a/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
+++ b/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, restartWorker, stopWorker, waitForWorkerOffline, processTest as test } from './process-control-fixtures'
+import { expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Worker Restart Thinking Indicator', () => {
   test('should hide thinking indicator when worker goes offline during agent turn', async ({ separateHubWorker, page }) => {


### PR DESCRIPTION
## Motivation

When switching to an agent tab that had received messages during inactivity, the catch-up replay could silently drop messages. The most visible symptom was that the `ExitPlanMode` message containing the plan text would be missing after a tab switch — the approve/reject control banner appeared, but the chat message with the plan was absent. Refreshing the page restored the correct state.

The root cause was in the seq-based deduplication logic inside `addMessage` in `frontend/src/stores/chat.store.ts`. When a thread-merged message arrived (same message ID with a bumped seq), the old code removed it from its original position and appended it at the end of the array. This moved it to the tail, advancing the effective `lastSeq` (derived from `prev[prev.length - 1].seq`) past messages that had not yet been delivered. The subsequent dedup check `message.seq <= lastSeq` then incorrectly filtered out those later messages.

## Modifications

- Thread-merged messages (same ID, updated seq) are now updated **in-place**, preserving their array position instead of being moved to the end. This prevents `lastSeq` from jumping ahead of undelivered messages.
- The overly broad `message.seq <= lastSeq` dedup condition is replaced with an exact seq equality check, so only truly duplicate sequence numbers are skipped.
- Out-of-order messages, which were previously dropped silently, are now inserted at the correct sorted position by seq.
- All linear scans over the message array now use `findLastIndex` instead of `findIndex` for better amortized performance on recently added messages.

## Result

Switching to an agent tab that received an `ExitPlanMode` control request during inactivity now correctly displays the plan message alongside the approve/reject banner. Refreshing the page is no longer required to see the plan text.

🤖 Generated with Claude Code
