### PR TITLE
Default to Cmd+Enter for sending messages and fix build task ordering

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,9 @@ tasks:
 
   build:
     desc: Build all (backend + frontend)
-    deps: [build-backend, build-frontend]
+    cmds:
+      - task: generate
+      - task: build-backend
 
   embed-frontend:
     desc: Embed frontend assets for go:embed
@@ -116,6 +118,12 @@ tasks:
 
   test:
     desc: Run all tests
+    cmds:
+      - task: generate
+      - task: _test
+
+  _test:
+    internal: true
     deps: [test-backend, test-frontend]
 
   test-backend:
@@ -146,6 +154,12 @@ tasks:
 
   lint:
     desc: Run all linters
+    cmds:
+      - task: generate
+      - task: _lint
+
+  _lint:
+    internal: true
     deps: [lint-proto, lint-backend, lint-frontend]
 
   lint-proto:
@@ -187,8 +201,9 @@ tasks:
 
   dev:
     desc: Start all services for development
-    deps: [build-backend, build-frontend]
     cmds:
+      - task: generate
+      - task: build-backend
       - mprocs
 
   # --- Docker ---

--- a/frontend/src/components/chat/EditorToolbar.tsx
+++ b/frontend/src/components/chat/EditorToolbar.tsx
@@ -34,7 +34,7 @@ import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { positionPopoverAbove } from '~/lib/popoverPosition'
 import * as styles from './MarkdownEditor.css'
 
-type EnterKeyMode = 'default' | 'alt'
+type EnterKeyMode = 'enter-sends' | 'cmd-enter-sends'
 
 const isMac = typeof navigator !== 'undefined'
   && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
@@ -239,7 +239,7 @@ export const EditorToolbar: Component<EditorToolbarProps> = (props) => {
   const modKeyLabel = isMac ? 'Cmd' : 'Ctrl'
 
   const enterModeTitle = () => {
-    if (props.enterMode() === 'default') {
+    if (props.enterMode() === 'enter-sends') {
       return `Enter to send, Shift+Enter for new line. Click to switch to ${modKeyLabel}+Enter mode.`
     }
     return `${modKeyLabel}+Enter to send, Enter for new line. Click to switch to Enter mode.`
@@ -499,7 +499,7 @@ export const EditorToolbar: Component<EditorToolbarProps> = (props) => {
           }}
         >
           <Show
-            when={props.enterMode() === 'default'}
+            when={props.enterMode() === 'enter-sends'}
             fallback={(
               <>
                 {isMac

--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -39,7 +39,7 @@ import { CodeLanguagePopover } from './CodeLanguagePopover'
 import { EditorToolbar } from './EditorToolbar'
 import * as styles from './MarkdownEditor.css'
 
-type EnterKeyMode = 'default' | 'alt'
+type EnterKeyMode = 'enter-sends' | 'cmd-enter-sends'
 
 interface MarkdownEditorProps {
   /** Agent ID for per-tab draft persistence. */
@@ -68,7 +68,7 @@ const ENTER_KEY_MODE_KEY = 'leapmux-enter-key-mode'
 
 function getEnterKeyMode(): EnterKeyMode {
   const stored = safeGetString(ENTER_KEY_MODE_KEY)
-  return stored === 'alt' ? 'alt' : 'default'
+  return stored === 'enter-sends' ? 'enter-sends' : 'cmd-enter-sends'
 }
 
 const DRAFT_KEY_PREFIX = 'leapmux-editor-draft-'
@@ -145,7 +145,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
 
   // Persist enter key mode
   const toggleEnterMode = () => {
-    const next = enterMode() === 'default' ? 'alt' : 'default'
+    const next = enterMode() === 'enter-sends' ? 'cmd-enter-sends' : 'enter-sends'
     setEnterMode(next)
     safeSetString(ENTER_KEY_MODE_KEY, next)
   }
@@ -204,7 +204,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   }
 
   // Enter key mode reference for ProseMirror plugin (closures capture signal)
-  let enterModeRef: EnterKeyMode = 'default'
+  let enterModeRef: EnterKeyMode = 'cmd-enter-sends'
   createEffect(() => {
     enterModeRef = enterMode()
   })

--- a/frontend/src/lib/editor/plugins.ts
+++ b/frontend/src/lib/editor/plugins.ts
@@ -9,7 +9,7 @@ import { $prose } from '@milkdown/utils'
 /** Shared refs accessed by plugins via getter functions (closures over mutable refs). */
 export interface PluginRefs {
   getDisabled: () => boolean
-  getEnterMode: () => 'default' | 'alt'
+  getEnterMode: () => 'enter-sends' | 'cmd-enter-sends'
   getPlaceholder: () => string
   onSend: () => void
 }
@@ -47,7 +47,7 @@ export function createSendOnEnterPlugin(refs: Pick<PluginRefs, 'getDisabled' | '
           if (refs.getDisabled())
             return false
 
-          if (refs.getEnterMode() === 'default') {
+          if (refs.getEnterMode() === 'enter-sends') {
             if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
               // Don't intercept Enter if the current line looks like a code fence
               // or horizontal rule so that input rules can fire
@@ -875,8 +875,8 @@ export function createListItemEnterPlugin(refs: Pick<PluginRefs, 'getEnterMode'>
           if (event.key !== 'Enter' || event.shiftKey || event.metaKey || event.ctrlKey)
             return false
 
-          // In default enter-mode, Enter sends the message — let sendPlugin handle it
-          if (refs.getEnterMode() === 'default')
+          // In enter-sends mode, Enter sends the message — let sendPlugin handle it
+          if (refs.getEnterMode() === 'enter-sends')
             return false
 
           const { state } = view


### PR DESCRIPTION
## Motivation

New users opening the chat editor for the first time had Enter-to-send as the default behavior, which caused accidental message sends when pressing Enter to add a new line. Cmd+Enter (or Ctrl+Enter on Windows/Linux) is a safer and more deliberate default that matches the convention used by most modern chat tools.

Additionally, the Taskfile build pipeline had a race condition where `test` and `lint` tasks could trigger compilation before the `generate` task (protobuf and sqlc code generation) had completed, leading to build failures when generated files were absent or stale.

## Modifications

- Changed the default `EnterKeyMode` for new users from `'enter-sends'` to `'cmd-enter-sends'` in `MarkdownEditor.tsx`. The absence of a stored preference now produces `'cmd-enter-sends'` rather than `'enter-sends'`.
- Renamed the `EnterKeyMode` type values from the earlier `'default' | 'alt'` convention to the self-documenting `'enter-sends' | 'cmd-enter-sends'` across `EditorToolbar.tsx`, `MarkdownEditor.tsx`, and `plugins.ts`.
- Refactored `Taskfile.yml` to ensure `generate` always runs before `test` and `lint` by introducing internal sequencing tasks (`_test`, `_lint`). The same pattern is applied to `build` and `dev`.

## Result

- New users now get Cmd+Enter-to-send as the out-of-the-box experience. Pressing Enter inside the editor inserts a new line by default.
- Running `task test` or `task lint` on a fresh checkout no longer fails due to missing generated protobuf or sqlc files.

🤖 Generated with Claude Code
