### PR TITLE
Add Unix socket worker connections, relax name validation, and add random name generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,15 @@ LeapMux is built as a single Go binary (`leapmux`) that can run in three modes:
 - Wraps Claude Code instances and provides system access
 - Manages PTY sessions for terminal access
 - Provides file system browsing capabilities
-- Communicates with Hub via standard gRPC
+- Communicates with Hub via standard gRPC (over TCP or Unix domain socket)
 - Auto-reconnects to Hub on disconnection
 
 ### Communication
 
 - **Frontend → Hub**: ConnectRPC (gRPC-compatible) for RPCs, WebSocket for event streaming
-- **Worker → Hub**: Standard gRPC with bidirectional streaming.
+- **Worker → Hub**: Standard gRPC with bidirectional streaming (over TCP or Unix domain socket).
   - Workers initiate outbound connections to the Hub, so they can run behind NATs, without requiring inbound port access.
+  - For local workers on the same machine, connect via Unix domain socket using `unix:<socket-path>` as the Hub URL.
 - **Message Format**: Protocol Buffers (defined in `/proto/leapmux/v1/`)
 
 ---

--- a/cmd/leapmux/worker.go
+++ b/cmd/leapmux/worker.go
@@ -18,7 +18,7 @@ import (
 
 func runWorker(args []string) error {
 	fs := flag.NewFlagSet("worker", flag.ExitOnError)
-	hubURL := fs.String("hub", "http://localhost:4327", "Hub server URL")
+	hubURL := fs.String("hub", "http://localhost:4327", "Hub server URL or unix:<socket-path>")
 	dataDir := fs.String("data-dir", defaultWorkerDataDir(), "data directory")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	_ = fs.Parse(args)

--- a/frontend/src/components/common/RegistrationPage.tsx
+++ b/frontend/src/components/common/RegistrationPage.tsx
@@ -3,11 +3,14 @@ import type { Org } from '~/generated/leapmux/v1/org_pb'
 import type { GetRegistrationResponse } from '~/generated/leapmux/v1/worker_pb'
 import { useNavigate } from '@solidjs/router'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
+import RefreshCw from 'lucide-solid/icons/refresh-cw'
+import { generateSlug } from 'random-word-slugs'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient, workerClient } from '~/api/clients'
 import { RegistrationStatus } from '~/generated/leapmux/v1/worker_pb'
 import { validateName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
+import { labelRow, refreshButton } from '~/styles/shared.css'
 import { NotFoundPage } from './NotFoundPage'
 import * as styles from './RegistrationPage.css'
 
@@ -28,6 +31,8 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
   const [error, setError] = createSignal<string | null>(null)
   const [approved, setApproved] = createSignal(false)
   const [approvedWorkerId, setApprovedWorkerId] = createSignal<string | null>(null)
+
+  const randomName = () => generateSlug(3, { format: 'kebab' })
 
   onMount(async () => {
     try {
@@ -182,7 +187,21 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
                         </select>
                       </label>
                       <label>
-                        Worker Name
+                        <div class={labelRow}>
+                          Worker Name
+                          <button
+                            type="button"
+                            class={refreshButton}
+                            onClick={() => {
+                              const slug = randomName()
+                              setName(slug)
+                              setNameError(validateName(slug))
+                            }}
+                            title="Generate random name"
+                          >
+                            <RefreshCw size={14} />
+                          </button>
+                        </div>
                         <input
                           type="text"
                           value={name()}

--- a/frontend/src/components/common/RegistrationPage.tsx
+++ b/frontend/src/components/common/RegistrationPage.tsx
@@ -8,7 +8,7 @@ import { generateSlug } from 'random-word-slugs'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient, workerClient } from '~/api/clients'
 import { RegistrationStatus } from '~/generated/leapmux/v1/worker_pb'
-import { validateName } from '~/lib/validate'
+import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
 import { labelRow, refreshButton } from '~/styles/shared.css'
 import { NotFoundPage } from './NotFoundPage'
@@ -48,9 +48,9 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
       }
       // Auto-prefill name from hostname
       if (regResp.hostname) {
-        const prefilled = regResp.hostname.toLowerCase()
-        setName(prefilled)
-        setNameError(validateName(prefilled))
+        const { value, error } = sanitizeName(regResp.hostname.toLowerCase())
+        setName(value)
+        setNameError(error)
       }
     }
     catch (e) {
@@ -67,16 +67,17 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
     }
   })
 
-  const handleNameInput = (value: string) => {
+  const handleNameInput = (raw: string) => {
+    const { value, error } = sanitizeName(raw)
     setName(value)
-    setNameError(validateName(value))
+    setNameError(error)
   }
 
   const handleApprove = async (e: Event) => {
     e.preventDefault()
-    const err = validateName(name())
-    if (err) {
-      setNameError(err)
+    const { error } = sanitizeName(name())
+    if (error) {
+      setNameError(error)
       return
     }
     setSubmitting(true)
@@ -193,9 +194,9 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
                             type="button"
                             class={refreshButton}
                             onClick={() => {
-                              const slug = randomName()
-                              setName(slug)
-                              setNameError(validateName(slug))
+                              const { value, error } = sanitizeName(randomName())
+                              setName(value)
+                              setNameError(error)
                             }}
                             title="Generate random name"
                           >

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '~/context/AuthContext'
 import { useOrg } from '~/context/OrgContext'
 import { SectionType } from '~/generated/leapmux/v1/section_pb'
 import { mid } from '~/lib/lexorank'
+import { sanitizeName } from '~/lib/validate'
 import { createSectionStore } from '~/stores/section.store'
 import { iconSize } from '~/styles/tokens'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
@@ -476,7 +477,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
             isArchived={isWorkspaceArchived}
             renamingWorkspaceId={renamingWorkspaceId()}
             renameValue={renameValue()}
-            onRenameInput={setRenameValue}
+            onRenameInput={v => setRenameValue(sanitizeName(v).value)}
             onRenameCommit={commitRename}
             onRenameCancel={cancelRename}
             isWorkspaceLoading={isWorkspaceLoading}

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -14,6 +14,7 @@ import X from 'lucide-solid/icons/x'
 import { createSignal, ErrorBoundary, For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { sanitizeName } from '~/lib/validate'
 import { tabKey, TabType } from '~/stores/tab.store'
 import { menuSectionHeader, monoFont } from '~/styles/shared.css'
 import { iconSize } from '~/styles/tokens'
@@ -192,7 +193,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           class={styles.tabEditInput}
           type="text"
           value={editingValue()}
-          onInput={e => setEditingValue(e.currentTarget.value)}
+          onInput={e => setEditingValue(sanitizeName(e.currentTarget.value).value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               commitEdit(tab)

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -8,7 +8,7 @@ import { workerClient, workspaceClient } from '~/api/clients'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
-import { validateName } from '~/lib/validate'
+import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
 import { dialogCompact, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
@@ -32,7 +32,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
   const [createWorktree, setCreateWorktree] = createSignal(false)
   const [worktreeBranch, setWorktreeBranch] = createSignal('')
   const [worktreeBranchError, setWorktreeBranchError] = createSignal<string | null>(null)
-  const titleError = createMemo(() => validateName(title()))
+  const titleError = createMemo(() => sanitizeName(title()).error)
 
   const fetchWorkers = async () => {
     try {
@@ -143,7 +143,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
               <input
                 type="text"
                 value={title()}
-                onInput={e => setTitle(e.currentTarget.value)}
+                onInput={e => setTitle(sanitizeName(e.currentTarget.value).value)}
                 placeholder="New Workspace"
               />
               <Show when={titleError()}>

--- a/frontend/src/lib/validate.test.ts
+++ b/frontend/src/lib/validate.test.ts
@@ -1,67 +1,74 @@
 import { describe, expect, it } from 'vitest'
 
-import { isValidName, validateName } from './validate'
+import { sanitizeName } from './validate'
 
-describe('validateName', () => {
-  it('accepts valid simple names', () => {
-    expect(validateName('hello')).toBeNull()
-    expect(validateName('hello world')).toBeNull()
-    expect(validateName('my-name')).toBeNull()
-    expect(validateName('my_name')).toBeNull()
-    expect(validateName('my.name')).toBeNull()
-    expect(validateName('name123')).toBeNull()
-    expect(validateName('My Name-1.0_beta')).toBeNull()
+describe('sanitizeName', () => {
+  it('returns sanitized value for valid names', () => {
+    expect(sanitizeName('hello')).toEqual({ value: 'hello', error: null })
+    expect(sanitizeName('hello world')).toEqual({ value: 'hello world', error: null })
+    expect(sanitizeName('my-name')).toEqual({ value: 'my-name', error: null })
+    expect(sanitizeName('my_name')).toEqual({ value: 'my_name', error: null })
+    expect(sanitizeName('my.name')).toEqual({ value: 'my.name', error: null })
+    expect(sanitizeName('name123')).toEqual({ value: 'name123', error: null })
+    expect(sanitizeName('My Name-1.0_beta')).toEqual({ value: 'My Name-1.0_beta', error: null })
+  })
+
+  it('accepts names with special characters', () => {
+    expect(sanitizeName('name@here').error).toBeNull()
+    expect(sanitizeName('hello!').error).toBeNull()
+    expect(sanitizeName('path/name').error).toBeNull()
+    expect(sanitizeName('it\'s fine').error).toBeNull()
+    expect(sanitizeName('a + b = c').error).toBeNull()
+    expect(sanitizeName('project (draft)').error).toBeNull()
+    expect(sanitizeName('100%').error).toBeNull()
+  })
+
+  it('accepts unicode characters', () => {
+    expect(sanitizeName('café').error).toBeNull()
+  })
+
+  it('accepts emoji', () => {
+    expect(sanitizeName('hello\u{1F600}').error).toBeNull()
   })
 
   it('accepts names at max length (64 chars)', () => {
-    expect(validateName('a'.repeat(64))).toBeNull()
+    expect(sanitizeName('a'.repeat(64)).error).toBeNull()
   })
 
-  it('trims whitespace before validation', () => {
-    expect(validateName('  hello  ')).toBeNull()
+  it('trims whitespace in returned value', () => {
+    const result = sanitizeName('  hello  ')
+    expect(result.value).toBe('hello')
+    expect(result.error).toBeNull()
   })
 
-  it('rejects empty strings', () => {
-    expect(validateName('')).not.toBeNull()
+  it('strips forbidden characters and returns sanitized value', () => {
+    expect(sanitizeName('name"quoted')).toEqual({ value: 'namequoted', error: null })
+    expect(sanitizeName('back\\slash')).toEqual({ value: 'backslash', error: null })
+    expect(sanitizeName('hello\tworld')).toEqual({ value: 'helloworld', error: null })
+    expect(sanitizeName('hello\nworld')).toEqual({ value: 'helloworld', error: null })
+    expect(sanitizeName('hello\x00world')).toEqual({ value: 'helloworld', error: null })
+    expect(sanitizeName('hello\x7Fworld')).toEqual({ value: 'helloworld', error: null })
   })
 
-  it('rejects whitespace-only strings', () => {
-    expect(validateName('   ')).not.toBeNull()
+  it('preserves allowed special characters', () => {
+    expect(sanitizeName('name@here!')).toEqual({ value: 'name@here!', error: null })
+    expect(sanitizeName('100%')).toEqual({ value: '100%', error: null })
+    expect(sanitizeName('café')).toEqual({ value: 'café', error: null })
   })
 
-  it('rejects names exceeding 64 characters', () => {
-    expect(validateName('a'.repeat(65))).not.toBeNull()
+  it('returns error for empty strings', () => {
+    expect(sanitizeName('').error).not.toBeNull()
   })
 
-  it('rejects special characters', () => {
-    expect(validateName('name@here')).not.toBeNull()
-    expect(validateName('hello!')).not.toBeNull()
-    expect(validateName('path/name')).not.toBeNull()
-    expect(validateName('back\\slash')).not.toBeNull()
-    expect(validateName('name"quoted')).not.toBeNull()
+  it('returns error for whitespace-only strings', () => {
+    expect(sanitizeName('   ').error).not.toBeNull()
   })
 
-  it('rejects unicode characters', () => {
-    expect(validateName('caf\u00E9')).not.toBeNull()
+  it('returns error for names exceeding 64 characters', () => {
+    expect(sanitizeName('a'.repeat(65)).error).not.toBeNull()
   })
 
-  it('rejects emoji', () => {
-    expect(validateName('hello\u{1F600}')).not.toBeNull()
-  })
-
-  it('rejects tabs and newlines', () => {
-    expect(validateName('hello\tworld')).not.toBeNull()
-    expect(validateName('hello\nworld')).not.toBeNull()
-  })
-})
-
-describe('isValidName', () => {
-  it('returns true for valid names', () => {
-    expect(isValidName('hello')).toBe(true)
-  })
-
-  it('returns false for invalid names', () => {
-    expect(isValidName('')).toBe(false)
-    expect(isValidName('name@here')).toBe(false)
+  it('returns error when only forbidden characters remain', () => {
+    expect(sanitizeName('"\\\t\n').error).not.toBeNull()
   })
 })

--- a/frontend/src/lib/validate.ts
+++ b/frontend/src/lib/validate.ts
@@ -1,29 +1,21 @@
-const NAME_PATTERN = /^[\w .\-]+$/
+// eslint-disable-next-line no-control-regex
+const NAME_FORBIDDEN_G = /[\x00-\x1F\x7F"\\]/g
 
 /**
- * Validates a name/title string.
- * Rules: trimmed non-empty, max 64 chars, only [a-zA-Z0-9 _\-.].
- * Returns an error message string, or null if valid.
+ * Sanitizes and validates a name/title string.
+ * Forbidden characters (control characters, " and \) are silently stripped.
+ * Returns the sanitized string and an error if the result is empty or exceeds 64 characters.
  */
-export function validateName(name: string): string | null {
-  const trimmed = name.trim()
-  if (trimmed === '') {
-    return 'Name must not be empty'
+export function sanitizeName(name: string): { value: string, error: string | null } {
+  const value = name.replace(NAME_FORBIDDEN_G, '').trim()
+  let error: string | null = null
+  if (value === '') {
+    error = 'Name must not be empty'
   }
-  if (trimmed.length > 64) {
-    return 'Name must be at most 64 characters'
+  else if (value.length > 64) {
+    error = 'Name must be at most 64 characters'
   }
-  if (!NAME_PATTERN.test(trimmed)) {
-    return 'Name must contain only letters, numbers, spaces, hyphens, underscores, and dots'
-  }
-  return null
-}
-
-/**
- * Returns true if the name is valid.
- */
-export function isValidName(name: string): boolean {
-  return validateName(name) === null
+  return { value, error }
 }
 
 // Characters forbidden in git branch names: space ~ ^ : ? * [ ] \

--- a/internal/hub/service/agent_service.go
+++ b/internal/hub/service/agent_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/id"
 	"github.com/leapmux/leapmux/internal/hub/timeout"
+	"github.com/leapmux/leapmux/internal/hub/validate"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
@@ -492,9 +493,9 @@ func (s *AgentService) RenameAgent(
 	}
 
 	agentID := req.Msg.GetAgentId()
-	title := req.Msg.GetTitle()
-	if title == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("title is required"))
+	title, err := validate.SanitizeName(req.Msg.GetTitle())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid title: %w", err))
 	}
 
 	agent, err := s.queries.GetAgentByID(ctx, agentID)

--- a/internal/hub/service/user_service.go
+++ b/internal/hub/service/user_service.go
@@ -168,23 +168,29 @@ func (s *UserService) UpdatePreferences(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
-	// Validate font names.
-	for _, name := range req.Msg.GetUiFonts() {
-		if err := validate.ValidateName(name); err != nil {
+	// Sanitize and validate font names.
+	uiFonts := req.Msg.GetUiFonts()
+	for i, name := range uiFonts {
+		sanitized, err := validate.SanitizeName(name)
+		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid UI font name %q: %w", name, err))
 		}
+		uiFonts[i] = sanitized
 	}
-	for _, name := range req.Msg.GetMonoFonts() {
-		if err := validate.ValidateName(name); err != nil {
+	monoFonts := req.Msg.GetMonoFonts()
+	for i, name := range monoFonts {
+		sanitized, err := validate.SanitizeName(name)
+		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid mono font name %q: %w", name, err))
 		}
+		monoFonts[i] = sanitized
 	}
 
-	uiFontsJSON, err := json.Marshal(req.Msg.GetUiFonts())
+	uiFontsJSON, err := json.Marshal(uiFonts)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("marshal ui_fonts: %w", err))
 	}
-	monoFontsJSON, err := json.Marshal(req.Msg.GetMonoFonts())
+	monoFontsJSON, err := json.Marshal(monoFonts)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("marshal mono_fonts: %w", err))
 	}

--- a/internal/hub/service/user_service_test.go
+++ b/internal/hub/service/user_service_test.go
@@ -219,7 +219,7 @@ func TestUserService_UpdatePreferences_InvalidFontName(t *testing.T) {
 	env := setupUserTest(t)
 
 	_, err := env.client.UpdatePreferences(context.Background(), authedReq(&leapmuxv1.UpdatePreferencesRequest{
-		UiFonts: []string{`Font "With" Quotes`},
+		UiFonts: []string{"  "},
 	}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))

--- a/internal/hub/service/worker_mgmt_service.go
+++ b/internal/hub/service/worker_mgmt_service.go
@@ -44,8 +44,8 @@ func (s *WorkerManagementService) ApproveRegistration(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("registration_token is required"))
 	}
 
-	name := req.Msg.GetName()
-	if err := validate.ValidateName(name); err != nil {
+	name, err := validate.SanitizeName(req.Msg.GetName())
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -201,8 +201,8 @@ func (s *WorkerManagementService) RenameWorker(
 		return nil, err
 	}
 
-	name := req.Msg.GetName()
-	if err := validate.ValidateName(name); err != nil {
+	name, err := validate.SanitizeName(req.Msg.GetName())
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 

--- a/internal/hub/service/workspace_service.go
+++ b/internal/hub/service/workspace_service.go
@@ -116,11 +116,14 @@ func (s *WorkspaceService) CreateWorkspace(
 	}
 
 	workspaceID := id.Generate()
-	title := req.Msg.GetTitle()
-	if title == "" {
+	var title string
+	if req.Msg.GetTitle() == "" {
 		title = "New Workspace"
-	} else if err := validate.ValidateName(title); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid workspace title: %w", err))
+	} else {
+		var err error
+		if title, err = validate.SanitizeName(req.Msg.GetTitle()); err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid workspace title: %w", err))
+		}
 	}
 
 	if err := s.queries.CreateWorkspace(ctx, db.CreateWorkspaceParams{
@@ -431,8 +434,8 @@ func (s *WorkspaceService) RenameWorkspace(
 		return nil, err
 	}
 
-	title := req.Msg.GetTitle()
-	if err := validate.ValidateName(title); err != nil {
+	title, err := validate.SanitizeName(req.Msg.GetTitle())
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid workspace title: %w", err))
 	}
 

--- a/internal/hub/service/workspace_service_test.go
+++ b/internal/hub/service/workspace_service_test.go
@@ -383,7 +383,7 @@ func TestWorkspaceService_UpdateWorkspaceSharing_NotOwner(t *testing.T) {
 func TestWorkspaceService_CreateWorkspace_EmptyName(t *testing.T) {
 	env := setupWorkspaceTest(t)
 
-	// A whitespace-only title passes through to ValidateName which rejects it.
+	// A whitespace-only title passes through to SanitizeName which rejects it.
 	_, err := env.client.CreateWorkspace(context.Background(), authedReq(&leapmuxv1.CreateWorkspaceRequest{
 		WorkerId: env.workerID,
 		Title:    " ",

--- a/internal/hub/validate/name.go
+++ b/internal/hub/validate/name.go
@@ -2,24 +2,25 @@ package validate
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 )
 
-var namePattern = regexp.MustCompile(`^[a-zA-Z0-9 _\-.]+$`)
-
-// ValidateName validates a name/title string.
-// Rules: trimmed non-empty, max 64 chars, only [a-zA-Z0-9 _\-.].
-func ValidateName(name string) error {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return fmt.Errorf("name must not be empty")
+// SanitizeName sanitizes and validates a name/title string.
+// Forbidden characters (control characters, " and \) are silently stripped.
+// Returns the sanitized name or an error if the result is empty or exceeds 64 characters.
+func SanitizeName(name string) (string, error) {
+	var b strings.Builder
+	for _, r := range name {
+		if r >= 0x20 && r != 0x7F && r != '"' && r != '\\' {
+			b.WriteRune(r)
+		}
 	}
-	if len(trimmed) > 64 {
-		return fmt.Errorf("name must be at most 64 characters")
+	sanitized := strings.TrimSpace(b.String())
+	if sanitized == "" {
+		return "", fmt.Errorf("name must not be empty")
 	}
-	if !namePattern.MatchString(trimmed) {
-		return fmt.Errorf("name must contain only letters, numbers, spaces, hyphens, underscores, and dots")
+	if len(sanitized) > 64 {
+		return "", fmt.Errorf("name must be at most 64 characters")
 	}
-	return nil
+	return sanitized, nil
 }

--- a/internal/hub/validate/name_test.go
+++ b/internal/hub/validate/name_test.go
@@ -4,46 +4,69 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestValidateName(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
-	}{
-		{"valid simple", "hello", false},
-		{"valid with spaces", "hello world", false},
-		{"valid with hyphens", "my-name", false},
-		{"valid with underscores", "my_name", false},
-		{"valid with dots", "my.name", false},
-		{"valid with numbers", "name123", false},
-		{"valid mixed", "My Name-1.0_beta", false},
-		{"valid max length", string(make([]byte, 64)), true}, // 64 null bytes are invalid chars
-		{"valid 64 chars", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},
-		{"empty", "", true},
-		{"whitespace only", "   ", true},
-		{"too long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true}, // 65 chars
-		{"special chars @", "name@here", true},
-		{"special chars !", "hello!", true},
-		{"special chars /", "path/name", true},
-		{"special chars \\", "back\\slash", true},
-		{"special chars quotes", `name"quoted`, true},
-		{"unicode", "caf\u00e9", true},
-		{"emoji", "hello\U0001F600", true},
-		{"leading spaces trimmed", "  hello  ", false},
-		{"tabs", "hello\tworld", true},
-		{"newline", "hello\nworld", true},
-	}
+func TestSanitizeName(t *testing.T) {
+	t.Run("returns sanitized name", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{"simple", "hello", "hello"},
+			{"with spaces", "hello world", "hello world"},
+			{"with hyphens", "my-name", "my-name"},
+			{"with underscores", "my_name", "my_name"},
+			{"with dots", "my.name", "my.name"},
+			{"with numbers", "name123", "name123"},
+			{"mixed", "My Name-1.0_beta", "My Name-1.0_beta"},
+			{"special chars @", "name@here", "name@here"},
+			{"special chars !", "hello!", "hello!"},
+			{"special chars /", "path/name", "path/name"},
+			{"special chars '", "it's fine", "it's fine"},
+			{"special chars +", "a + b = c", "a + b = c"},
+			{"special chars parens", "project (draft)", "project (draft)"},
+			{"special chars %", "100%", "100%"},
+			{"unicode", "café", "café"},
+			{"emoji", "hello\U0001F600", "hello\U0001F600"},
+			{"64 chars", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			{"trims leading/trailing spaces", "  hello  ", "hello"},
+			// Forbidden chars are silently stripped
+			{"strips double quotes", `name"quoted`, "namequoted"},
+			{"strips backslashes", "back\\slash", "backslash"},
+			{"strips tabs", "hello\tworld", "helloworld"},
+			{"strips newlines", "hello\nworld", "helloworld"},
+			{"strips control chars", "hello\x00world", "helloworld"},
+			{"strips 0x1F", "hello\x1Fworld", "helloworld"},
+			{"strips 0x7F", "hello\x7Fworld", "helloworld"},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateName(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err, "ValidateName(%q) should return error", tt.input)
-			} else {
-				assert.NoError(t, err, "ValidateName(%q) should not return error", tt.input)
-			}
-		})
-	}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := SanitizeName(tt.input)
+				require.NoError(t, err, "SanitizeName(%q) should not return error", tt.input)
+				assert.Equal(t, tt.want, got, "SanitizeName(%q) sanitized result", tt.input)
+			})
+		}
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input string
+		}{
+			{"empty", ""},
+			{"whitespace only", "   "},
+			{"too long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // 65 chars
+			{"only forbidden chars", string(make([]byte, 64))},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := SanitizeName(tt.input)
+				assert.Error(t, err, "SanitizeName(%q) should return error", tt.input)
+			})
+		}
+	})
 }

--- a/internal/worker/config/config.go
+++ b/internal/worker/config/config.go
@@ -11,7 +11,7 @@ import (
 
 // Config holds the worker's runtime configuration.
 type Config struct {
-	HubURL  string `json:"hub_url"`  // Hub server URL (e.g. "http://localhost:4327")
+	HubURL  string `json:"hub_url"`  // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
 	DataDir string `json:"data_dir"` // Directory for persistent state
 }
 
@@ -26,7 +26,7 @@ type State struct {
 // Call flag.Parse() separately after defining all flags.
 func DefineFlags() *Config {
 	c := &Config{}
-	flag.StringVar(&c.HubURL, "hub", "http://localhost:4327", "Hub server URL")
+	flag.StringVar(&c.HubURL, "hub", "http://localhost:4327", "Hub server URL or unix:<socket-path>")
 	flag.StringVar(&c.DataDir, "data-dir", defaultDataDir(), "data directory")
 	return c
 }

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -11,7 +11,7 @@ import (
 
 // RunConfig holds configuration for running the worker as a library.
 type RunConfig struct {
-	HubURL     string       // Hub server URL (e.g. "http://localhost:4327")
+	HubURL     string       // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
 	DataDir    string       // Directory for persistent state
 	AuthToken  string       // Pre-provisioned auth token (skip registration)
 	HTTPClient *http.Client // Custom HTTP client (e.g. for Unix socket transport)


### PR DESCRIPTION
## Motivation

Three independent usability improvements are bundled in this PR:

1. **Unix domain socket support for workers**: Workers running on the same host as the Hub previously had to connect over TCP, which adds unnecessary network overhead and can be blocked by host firewalls. A `unix:<path>` URL scheme allows same-host workers to bypass TCP entirely.

2. **Overly strict name validation**: The previous allowlist-based name validator rejected valid Unicode characters, non-ASCII letters, and emoji that are perfectly reasonable for worker names and workspace titles. The restriction was causing friction without providing meaningful safety guarantees.

3. **Worker name entry friction**: When approving a new worker registration, the user had to type a name from scratch. Auto-populating the hostname and offering a random name generator reduces the cognitive load at registration time.

## Modifications

**Unix domain socket connections (`internal/worker/hub/`)**
- Workers now accept `unix:<socket-path>` as the Hub URL in addition to standard HTTP/HTTPS URLs.
- Added a `newUnixSocketClient()` helper that creates an h2c HTTP/2 client dialing over a Unix socket, shared between `client.go` and `registration.go`.
- During registration, Unix socket connections display the relative approval path (e.g. `/register/<token>`) instead of constructing a browser URL, since the socket address is not navigable from a browser.
- `cmd/leapmux/standalone.go` was simplified by removing its custom HTTP client setup and delegating socket detection to the hub client module.

**Denylist-based name sanitization (`internal/hub/validate/`, `frontend/src/lib/validate.ts`)**
- `ValidateName` (allowlist regex) has been removed and replaced with `SanitizeName(name string) (string, error)` on the backend. The new function strips only control characters (< 0x20, 0x7F), double quotes, and backslashes, then trims whitespace. All other printable characters — including Unicode and emoji — are allowed.
- The frontend `validateName()` and `isValidName()` functions have been replaced with `sanitizeName(name: string): { value: string, error: string | null }`, which applies the same denylist logic via a single regex replacement.
- All call sites across `agent_service.go`, `user_service.go`, `worker_mgmt_service.go`, `workspace_service.go`, and every affected frontend component have been updated to call the new unified function.
- Input handlers now sanitize in real-time on every keystroke, so forbidden characters are silently removed as the user types rather than surfaced as an error after submission.

**Random name generator on the worker registration page (`frontend/src/components/common/RegistrationPage.tsx`)**
- Added a refresh button (using the `RefreshCw` icon from lucide-solid) next to the Worker Name field that generates a random three-word kebab-case name via the `random-word-slugs` library (e.g. `swift-golden-river`).
- The worker hostname is now auto-populated into the name field on page load, pre-sanitized through `sanitizeName`.

**Breaking changes**
- Backend: `validate.ValidateName` has been removed. Callers must switch to `validate.SanitizeName`.
- Frontend: `validateName()` and `isValidName()` have been removed. Callers must switch to `sanitizeName()`.

## Result

- Workers running on the same machine as the Hub can now connect without opening a TCP port:
  ```
  leapmux worker --hub unix:/run/leapmux/hub.sock
  ```
- Names and titles that contain Unicode characters, accented letters, or emoji (e.g. `"My MacBook Pro"`, `"proyecto-alpha"`) are now accepted everywhere instead of being rejected with a validation error. Forbidden characters are stripped silently, so users never see a confusing error for a reasonable input.
- On the worker approval page, the hostname is pre-filled as the suggested name and a single click on the refresh button generates a random readable name, reducing the effort needed to register a new worker.
