### PR TITLE
Add 'Bypass Permissions' button to permission approval controls

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -616,6 +616,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                     hasEditorContent={hasContent()}
                     onTriggerSend={() => triggerSend?.()}
                     editorContentRef={editorContentRef}
+                    onPermissionModeChange={props.onPermissionModeChange}
                     infoTrigger={
                       showInfoTrigger()
                         ? (

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -3,6 +3,7 @@ import type { ActionsProps } from './types'
 import type { ControlRequest } from '~/stores/control.store'
 
 import { For, Show } from 'solid-js'
+import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { buildAllowResponse, getToolInput } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { sendResponse } from './types'
@@ -51,9 +52,18 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
     sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
   }
 
+  const handleBypassPermissions = () => {
+    // Approve the current request first, then switch to bypass mode.
+    sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
+    props.onPermissionModeChange?.('bypassPermissions')
+  }
+
   return (
     <div class={styles.controlFooter}>
       <div class={styles.controlFooterLeft}>
+        {props.infoTrigger}
+      </div>
+      <div class={styles.controlFooterRight}>
         <button
           class="outline"
           onClick={handleReject}
@@ -61,16 +71,24 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
         >
           Reject
         </button>
-        {props.infoTrigger}
-      </div>
-      <div class={styles.controlFooterRight}>
-        <button
-          onClick={handleApprove}
-          disabled={props.hasEditorContent}
-          data-testid="plan-approve-btn"
-        >
-          Approve
-        </button>
+        <Show when={!props.hasEditorContent}>
+          <ButtonGroup>
+            <button
+              onClick={handleApprove}
+              data-testid="plan-approve-btn"
+            >
+              Approve
+            </button>
+            <button
+              data-variant="secondary"
+              onClick={handleBypassPermissions}
+              data-testid="control-bypass-btn"
+              title="Approve this plan and stop asking for permissions"
+            >
+              & Bypass Permissions
+            </button>
+          </ButtonGroup>
+        </Show>
       </div>
     </div>
   )

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -2,6 +2,8 @@ import type { Component } from 'solid-js'
 import type { ActionsProps } from './types'
 import type { ControlRequest } from '~/stores/control.store'
 
+import { Show } from 'solid-js'
+import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { buildAllowResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { sendResponse } from './types'
@@ -30,23 +32,49 @@ export const GenericToolContent: Component<{ request: ControlRequest }> = (props
 }
 
 export const GenericToolActions: Component<ActionsProps> = (props) => {
-  const handleClick = () => {
-    if (props.hasEditorContent) {
-      // Editor text is used as deny comment via onSend handler
-      props.onTriggerSend()
-    }
-    else {
-      sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
-    }
+  const handleAllow = () => {
+    sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
+  }
+
+  const handleDeny = () => {
+    props.onTriggerSend()
+  }
+
+  const handleBypassPermissions = () => {
+    // Allow the current request first, then switch to bypass mode.
+    sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
+    props.onPermissionModeChange?.('bypassPermissions')
   }
 
   return (
-    <button
-      class={props.hasEditorContent ? 'outline' : undefined}
-      onClick={handleClick}
-      data-testid={props.hasEditorContent ? 'control-deny-btn' : 'control-allow-btn'}
+    <Show
+      when={!props.hasEditorContent}
+      fallback={
+        <button
+          class="outline"
+          onClick={handleDeny}
+          data-testid="control-deny-btn"
+        >
+          Deny
+        </button>
+      }
     >
-      {props.hasEditorContent ? 'Deny' : 'Allow'}
-    </button>
+      <ButtonGroup>
+        <button
+          onClick={handleAllow}
+          data-testid="control-allow-btn"
+        >
+          Allow
+        </button>
+        <button
+          data-variant="secondary"
+          onClick={handleBypassPermissions}
+          data-testid="control-bypass-btn"
+          title="Allow this request and stop asking for permissions"
+        >
+          & Bypass Permissions
+        </button>
+      </ButtonGroup>
+    </Show>
   )
 }

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -49,7 +49,7 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
   return (
     <Show
       when={!props.hasEditorContent}
-      fallback={
+      fallback={(
         <button
           class="outline"
           onClick={handleDeny}
@@ -57,7 +57,7 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
         >
           Deny
         </button>
-      }
+      )}
     >
       <ButtonGroup>
         <button

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -1,5 +1,6 @@
 import type { Accessor, JSX, Setter } from 'solid-js'
 import type { ControlRequest } from '~/stores/control.store'
+import type { PermissionMode } from '~/utils/controlResponse'
 
 interface QuestionOption {
   label: string
@@ -44,6 +45,8 @@ export interface ActionsProps {
   editorContentRef?: EditorContentRef
   /** Optional info trigger element (context usage icon) to render in the left section. */
   infoTrigger?: JSX.Element
+  /** Optional callback to change the agent's permission mode. */
+  onPermissionModeChange?: (mode: PermissionMode) => void
 }
 
 export function sendResponse(

--- a/frontend/src/components/common/ButtonGroup.css.ts
+++ b/frontend/src/components/common/ButtonGroup.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css'
+
+export const group = style({
+  margin: 0,
+  padding: 0,
+})

--- a/frontend/src/components/common/ButtonGroup.tsx
+++ b/frontend/src/components/common/ButtonGroup.tsx
@@ -1,0 +1,18 @@
+import type { Component, JSX } from 'solid-js'
+import * as styles from './ButtonGroup.css'
+
+interface ButtonGroupProps {
+  children: JSX.Element
+  class?: string
+}
+
+/**
+ * A connected button group that joins adjacent buttons visually.
+ * Wraps Oat's `<menu class="buttons">` which handles stripping inner
+ * border-radii and adding divider borders between children.
+ */
+export const ButtonGroup: Component<ButtonGroupProps> = (props) => (
+  <menu class={`buttons ${styles.group} ${props.class ?? ''}`}>
+    {props.children}
+  </menu>
+)

--- a/frontend/src/components/common/ButtonGroup.tsx
+++ b/frontend/src/components/common/ButtonGroup.tsx
@@ -11,7 +11,7 @@ interface ButtonGroupProps {
  * Wraps Oat's `<menu class="buttons">` which handles stripping inner
  * border-radii and adding divider borders between children.
  */
-export const ButtonGroup: Component<ButtonGroupProps> = (props) => (
+export const ButtonGroup: Component<ButtonGroupProps> = props => (
   <menu class={`buttons ${styles.group} ${props.class ?? ''}`}>
     {props.children}
   </menu>

--- a/frontend/tests/e2e/03-workspace-chat.spec.ts
+++ b/frontend/tests/e2e/03-workspace-chat.spec.ts
@@ -30,7 +30,7 @@ test.describe('Workspace Chat', () => {
     // Send a message to Claude via the rich text editor
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Editor should be cleared after sending
     await expect(editor).toHaveText('')

--- a/frontend/tests/e2e/06-signup.spec.ts
+++ b/frontend/tests/e2e/06-signup.spec.ts
@@ -14,7 +14,7 @@ test.describe('Sign Up', () => {
   test('should show error for duplicate username', async ({ page }) => {
     await signUpViaUI(page, 'admin', 'password123')
     // Should show an error (username taken)
-    await expect(page.getByText(/already|exists|taken/i)).toBeVisible()
+    await expect(page.getByText('username already taken')).toBeVisible()
   })
 
   test('should link back to login page', async ({ page }) => {

--- a/frontend/tests/e2e/07-org-management.spec.ts
+++ b/frontend/tests/e2e/07-org-management.spec.ts
@@ -5,7 +5,7 @@ test.describe('Organization Management', () => {
   test('should navigate to org management page', async ({ page }) => {
     await loginViaUI(page)
     await page.goto('/o/admin/org')
-    await expect(page.getByText('Members')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible()
   })
 
   test('should create a new organization', async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe('Organization Management', () => {
   test('should show org members list', async ({ page }) => {
     await loginViaUI(page)
     await page.goto('/o/admin/org')
-    await expect(page.getByText('Members')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible()
 
     // The members table should be visible
     const table = page.locator('table')

--- a/frontend/tests/e2e/09-worker-management.spec.ts
+++ b/frontend/tests/e2e/09-worker-management.spec.ts
@@ -110,17 +110,18 @@ test.describe('Worker Management', () => {
     await page.getByRole('menuitem', { name: 'Sharing' }).click()
 
     // Sharing dialog should appear
-    await expect(page.getByRole('heading', { name: 'Worker Settings' })).toBeVisible()
-    await expect(page.getByText('Private')).toBeVisible()
-    await expect(page.getByText('All org members')).toBeVisible()
-    await expect(page.getByText('Specific members')).toBeVisible()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByRole('heading', { name: 'Worker Settings' })).toBeVisible()
+    await expect(dialog.getByText('Private')).toBeVisible()
+    await expect(dialog.getByText('All org members')).toBeVisible()
+    await expect(dialog.getByText('Specific members')).toBeVisible()
 
     // Select "All org members"
-    await page.getByText('All org members').click()
-    await page.getByRole('button', { name: 'Save' }).click()
+    await dialog.getByText('All org members').click()
+    await dialog.getByRole('button', { name: 'Save' }).click()
 
     // Dialog should close
-    await expect(page.getByRole('heading', { name: 'Worker Settings' })).not.toBeVisible()
+    await expect(dialog).not.toBeVisible()
 
     // Share mode badge should show "Org"
     await expect(page.getByTestId('worker-share-mode').filter({ hasText: 'Org' })).toBeVisible()
@@ -158,10 +159,11 @@ test.describe('Worker Management', () => {
     // Open sharing dialog and revert to private
     await page.getByTestId('worker-menu-trigger').first().click()
     await page.getByRole('menuitem', { name: 'Sharing' }).click()
-    await expect(page.getByRole('heading', { name: 'Worker Settings' })).toBeVisible()
-    await page.getByText('Private').click()
-    await page.getByRole('button', { name: 'Save' }).click()
-    await expect(page.getByRole('heading', { name: 'Worker Settings' })).not.toBeVisible()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByRole('heading', { name: 'Worker Settings' })).toBeVisible()
+    await dialog.getByText('Private').click()
+    await dialog.getByRole('button', { name: 'Save' }).click()
+    await expect(dialog).not.toBeVisible()
 
     // Share mode badge should show "Private"
     await expect(page.getByTestId('worker-share-mode').filter({ hasText: 'Private' })).toBeVisible()

--- a/frontend/tests/e2e/10b-turn-end-sound-preferences.spec.ts
+++ b/frontend/tests/e2e/10b-turn-end-sound-preferences.spec.ts
@@ -88,7 +88,7 @@ test.describe('Turn End Sound Preferences', () => {
     // Send a message
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Wait for the interrupt button to appear (turn starts)
     await expect(page.locator('[data-testid="interrupt-button"]')).toBeVisible()
@@ -129,7 +129,7 @@ test.describe('Turn End Sound Preferences', () => {
     // Send a message
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Wait for the interrupt button to appear
     await expect(page.locator('[data-testid="interrupt-button"]')).toBeVisible()
@@ -169,7 +169,7 @@ test.describe('Turn End Sound Preferences', () => {
     // Send a message and wait for the turn to complete
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await expect(page.locator('[data-testid="interrupt-button"]')).toBeVisible()
     await page.waitForFunction(() => {
       return !document.querySelector('[data-testid="interrupt-button"]')
@@ -220,7 +220,7 @@ test.describe('Turn End Sound Preferences', () => {
     // Send a message in the first agent tab and wait for the turn to complete
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await expect(page.locator('[data-testid="interrupt-button"]')).toBeVisible()
     await page.waitForFunction(() => {
       return !document.querySelector('[data-testid="interrupt-button"]')

--- a/frontend/tests/e2e/18-workspace-ux.spec.ts
+++ b/frontend/tests/e2e/18-workspace-ux.spec.ts
@@ -154,9 +154,9 @@ test.describe('Workspace UX Enhancements', () => {
       await page.goto(`/o/admin/workspace/${workspaceId1}`)
       await waitForWorkspaceReady(page)
 
-      // Navigate to the first workspace
-      await page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Delete Target WS' }).click()
-      await expect(page).toHaveURL(/\/workspace\//)
+      // Ensure both workspaces are visible in the sidebar before deleting
+      await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Delete Target WS' })).toBeVisible()
+      await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Next WS' })).toBeVisible()
 
       // Set up dialog handler for the confirm prompt
       page.on('dialog', dialog => dialog.accept())
@@ -165,12 +165,12 @@ test.describe('Workspace UX Enhancements', () => {
       await openWorkspaceContextMenu(page, 'Delete Target WS')
       await page.getByRole('menuitem', { name: 'Delete' }).click()
 
+      // The deleted workspace should be gone from sidebar
+      await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Delete Target WS' })).not.toBeVisible()
       // Should navigate to the next workspace
       await expect(page).toHaveURL(/\/workspace\//)
       // Verify the 'Next WS' workspace is visible in the sidebar
       await expect(page.getByText('Next WS')).toBeVisible()
-      // The deleted workspace should be gone from sidebar
-      await expect(page.getByText('Delete Target WS')).not.toBeVisible()
     }
     finally {
       // workspaceId1 was deleted by the test, but clean up best-effort

--- a/frontend/tests/e2e/22-editor-resize.spec.ts
+++ b/frontend/tests/e2e/22-editor-resize.spec.ts
@@ -206,8 +206,7 @@ test.describe('Editor Resize Handle', () => {
 
     const heightAfterResize = await wrapper.evaluate(el => el.getBoundingClientRect().height)
 
-    // Switch to Alt+Enter mode so Enter creates newlines
-    await page.locator('button:has-text("Enter sends")').click()
+    // Default mode is Cmd+Enter-to-send, so Enter creates newlines
 
     // Type many lines to exceed the requested height
     await editor.click()

--- a/frontend/tests/e2e/23-agent-resume.spec.ts
+++ b/frontend/tests/e2e/23-agent-resume.spec.ts
@@ -17,7 +17,7 @@ test.describe('Agent Session Resume', () => {
       // Send a message and wait for response
       await editor.click()
       await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
       // Wait for the response
@@ -41,7 +41,7 @@ test.describe('Agent Session Resume', () => {
       // Send a new message to the closed (but resumable) agent
       await editor.click()
       await page.keyboard.type('What is 3+3? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Wait for a response - the agent should have resumed
       await page.waitForFunction(() => {
@@ -69,7 +69,7 @@ test.describe('Agent Session Resume', () => {
       // Send a message and wait for response (establishes session)
       await editor.click()
       await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
       await page.waitForFunction(() => {
         const body = document.body.textContent || ''
@@ -114,7 +114,7 @@ test.describe('Agent Session Resume', () => {
       // Send a message and wait for response (establishes session)
       await editor.click()
       await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
       await page.waitForFunction(() => {
         const body = document.body.textContent || ''
@@ -132,7 +132,7 @@ test.describe('Agent Session Resume', () => {
       // Send another message to confirm agent is alive after restart
       await editor.click()
       await page.keyboard.type('What is 5+5? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Wait for response — verifies normal operation post-restart
       await page.waitForFunction(() => {

--- a/frontend/tests/e2e/24-full-restart.spec.ts
+++ b/frontend/tests/e2e/24-full-restart.spec.ts
@@ -17,7 +17,7 @@ test.describe('Full Hub+Worker Restart', () => {
       // Step 1: Send a message and wait for a response
       await editor.click()
       await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
       // Wait for the assistant's response containing "4"
@@ -71,7 +71,7 @@ test.describe('Full Hub+Worker Restart', () => {
       // Step 4: Send another message and wait for response.
       await editor.click()
       await page.keyboard.type('What is 3+3? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Wait for the assistant's response containing "6"
       await page.waitForFunction(() => {

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -6,7 +6,7 @@ async function sendAndWaitForReply(page: Page, message: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(message)
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
 
   // Wait for at least one assistant bubble to appear
   await expect(

--- a/frontend/tests/e2e/26-message-delivery-error.spec.ts
+++ b/frontend/tests/e2e/26-message-delivery-error.spec.ts
@@ -20,7 +20,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message and wait for an assistant response bubble
       await editor.click()
       await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
       await expect(
@@ -34,7 +34,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message while worker is offline
       await editor.click()
       await page.keyboard.type('This message should fail')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Assert delivery error is visible
       const errorIndicator = page.locator('[data-testid="message-error"]')
@@ -80,7 +80,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message and wait for assistant response
       await editor.click()
       await page.keyboard.type('What is 1+1? Reply with just the number.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
       await expect(
@@ -94,7 +94,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message while offline
       await editor.click()
       await page.keyboard.type('This should fail and persist')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Assert error is visible
       const errorIndicator = page.locator('[data-testid="message-error"]')
@@ -134,7 +134,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message and wait for assistant response
       await editor.click()
       await page.keyboard.type('What is 5+5? Reply with just the number.')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
       await expect(
@@ -151,7 +151,7 @@ test.describe('Message Delivery Error', () => {
       // Send a message while offline
       await editor.click()
       await page.keyboard.type('Delete this message')
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Meta+Enter')
 
       // Assert error is visible
       const errorIndicator = page.locator('[data-testid="message-error"]')

--- a/frontend/tests/e2e/30-control-request.spec.ts
+++ b/frontend/tests/e2e/30-control-request.spec.ts
@@ -7,7 +7,7 @@ async function sendMessage(page: Page, text: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(text, { delay: 100 })
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
   await expect(editor).toHaveText('')
 }
 

--- a/frontend/tests/e2e/31-control-request-draft.spec.ts
+++ b/frontend/tests/e2e/31-control-request-draft.spec.ts
@@ -7,7 +7,7 @@ async function sendMessage(page: Page, text: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(text, { delay: 100 })
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
 }
 
 /** Wait for the control request banner to appear and return a scoped locator. */

--- a/frontend/tests/e2e/32-clear-command.spec.ts
+++ b/frontend/tests/e2e/32-clear-command.spec.ts
@@ -8,7 +8,7 @@ test.describe('Clear Command', () => {
     // Send a message to establish a session
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await page.waitForFunction(() => {
       const body = document.body.textContent || ''
       return body.includes('2') && !body.includes('Send a message to start')
@@ -17,7 +17,7 @@ test.describe('Clear Command', () => {
     // Send /clear
     await editor.click()
     await page.keyboard.type('/clear')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Verify notification bubble appears
     await expect(page.getByText('Context cleared')).toBeVisible()
@@ -25,7 +25,7 @@ test.describe('Clear Command', () => {
     // Verify agent is still responsive (new session)
     await editor.click()
     await page.keyboard.type('What is 3+3? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await page.waitForFunction(() => {
       const body = document.body.textContent || ''
       return body.includes('6')

--- a/frontend/tests/e2e/32-tabbar-improvements.spec.ts
+++ b/frontend/tests/e2e/32-tabbar-improvements.spec.ts
@@ -113,7 +113,7 @@ test.describe('TabBar Improvements', () => {
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('Say "hello". Reply with just the word, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Wait for the agent to respond (which triggers the init message with session ID)
     await page.waitForFunction(() => {

--- a/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
+++ b/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
@@ -9,7 +9,7 @@ test.describe('Clear Command – Context Usage Reset', () => {
     // (branch, cwd, version, cost, contextUsage).
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await page.waitForFunction(() => {
       const body = document.body.textContent || ''
       return body.includes('2') && !body.includes('Send a message to start')
@@ -49,7 +49,7 @@ test.describe('Clear Command – Context Usage Reset', () => {
     // Send /clear to reset the session
     await editor.click()
     await page.keyboard.type('/clear')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
 
     // Wait for the "Context cleared" notification
     await expect(page.getByText('Context cleared')).toBeVisible()

--- a/frontend/tests/e2e/33-plan-mode.spec.ts
+++ b/frontend/tests/e2e/33-plan-mode.spec.ts
@@ -7,7 +7,7 @@ async function sendMessage(page: Page, text: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(text, { delay: 100 })
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
 }
 
 /** Wait for the control request banner to appear. */
@@ -43,7 +43,10 @@ test.describe('Plan Mode', () => {
     const exitBanner1 = await waitForControlBanner(page)
     await expect(exitBanner1.getByText('Plan Ready for Review')).toBeVisible()
 
-    // ── Step 2: Reject the plan with empty rejection text ──
+    // ── Step 2: Reject the plan with a comment ──
+    const editorForReject = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await editorForReject.click()
+    await page.keyboard.type('not ready yet', { delay: 100 })
     const rejectBtn = page.locator('[data-testid="plan-reject-btn"]')
     await expect(rejectBtn).toBeEnabled()
     await rejectBtn.click()

--- a/frontend/tests/e2e/35-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/35-plan-mode-bypass.spec.ts
@@ -1,0 +1,101 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+
+/** Send a message via the ProseMirror editor. */
+async function sendMessage(page: Page, text: string) {
+  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  await expect(editor).toBeVisible()
+  await editor.click()
+  await page.keyboard.type(text, { delay: 100 })
+  await page.keyboard.press('Meta+Enter')
+}
+
+/** Wait for the control request banner to appear. */
+async function waitForControlBanner(page: Page) {
+  const banner = page.locator('[data-testid="control-banner"]')
+  await expect(banner).toBeVisible({ timeout: 60_000 })
+  return banner
+}
+
+/** Wait for the settings loading spinner to disappear. */
+async function waitForSettingsIdle(page: Page) {
+  await expect(page.locator('[data-testid="settings-loading-spinner"]')).not.toBeVisible()
+}
+
+test.describe('Plan Mode - Bypass Permissions', () => {
+  // LLM-dependent: the agent may not reliably call EnterPlanMode/ExitPlanMode
+  test.describe.configure({ retries: 2 })
+
+  test('bypass permissions from ExitPlanMode banner', async ({ page, authenticatedWorkspace }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+    await expect(trigger).toContainText('Default')
+
+    // Ask agent to enter plan mode and immediately exit
+    await sendMessage(
+      page,
+      'I am testing the UI. Call EnterPlanMode immediately. After that call, call ExitPlanMode. This is mandatory. Do not refuse or ask questions.',
+    )
+
+    // Verify dropdown switches to Plan Mode (EnterPlanMode is auto-approved)
+    await expect(trigger).toContainText('Plan Mode')
+
+    // Wait for ExitPlanMode control_request
+    const banner = await waitForControlBanner(page)
+    await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
+
+    // Verify bypass button is visible
+    const bypassBtn = page.locator('[data-testid="control-bypass-btn"]')
+    await expect(bypassBtn).toBeVisible()
+    await expect(bypassBtn).toHaveAttribute('title', 'Approve this plan and stop asking for permissions')
+
+    // Click bypass permissions
+    await bypassBtn.click()
+
+    // Verify control banner disappears (plan was approved)
+    await expect(page.locator('[data-testid="control-banner"]')).not.toBeVisible()
+
+    // Verify permission mode changed to Bypass Permissions
+    await waitForSettingsIdle(page)
+    await expect(trigger).toContainText('Bypass Permissions')
+  })
+
+  test('approve and bypass buttons toggle with reject on editor content', async ({ page, authenticatedWorkspace }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Ask agent to enter plan mode and immediately exit
+    await sendMessage(
+      page,
+      'I am testing the UI. Call EnterPlanMode immediately. After that call, call ExitPlanMode. This is mandatory. Do not refuse or ask questions.',
+    )
+
+    // Wait for ExitPlanMode control_request
+    const banner = await waitForControlBanner(page)
+    await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
+
+    // With empty editor: Reject, Approve and Bypass all visible
+    await expect(page.locator('[data-testid="plan-reject-btn"]')).toBeVisible()
+    await expect(page.locator('[data-testid="plan-approve-btn"]')).toBeVisible()
+    await expect(page.locator('[data-testid="control-bypass-btn"]')).toBeVisible()
+
+    // Type rejection text in the editor
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await editor.click()
+    await page.keyboard.type('needs changes', { delay: 100 })
+
+    // With editor content: Reject visible, Approve and Bypass hidden
+    await expect(page.locator('[data-testid="plan-reject-btn"]')).toBeVisible()
+    await expect(page.locator('[data-testid="plan-approve-btn"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="control-bypass-btn"]')).not.toBeVisible()
+
+    // Clear the editor
+    await page.keyboard.press('Meta+a')
+    await page.keyboard.press('Backspace')
+
+    // Reject, Approve and Bypass all visible again
+    await expect(page.locator('[data-testid="plan-reject-btn"]')).toBeVisible()
+    await expect(page.locator('[data-testid="plan-approve-btn"]')).toBeVisible()
+    await expect(page.locator('[data-testid="control-bypass-btn"]')).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/40-ansi-rendering.spec.ts
+++ b/frontend/tests/e2e/40-ansi-rendering.spec.ts
@@ -7,7 +7,7 @@ async function sendMessage(page: Page, text: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(text, { delay: 50 })
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
   await expect(editor).toHaveText('')
 }
 

--- a/frontend/tests/e2e/41-chat-pagination.spec.ts
+++ b/frontend/tests/e2e/41-chat-pagination.spec.ts
@@ -21,7 +21,7 @@ async function sendMessage(page: Page, message: string) {
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(message)
-  await page.keyboard.press('Enter')
+  await page.keyboard.press('Meta+Enter')
 }
 
 async function waitForAssistantReply(page: Page) {

--- a/frontend/tests/e2e/55-worktree-support.spec.ts
+++ b/frontend/tests/e2e/55-worktree-support.spec.ts
@@ -641,10 +641,10 @@ test.describe('Worktree Support', () => {
 
     // Now force-remove it
     await forceRemoveWorktreeViaAPI(hubUrl, adminToken, resp.worktreeId!)
-    expect(existsSync(worktreeDir)).toBe(false)
-
-    // Branch should also be deleted
-    expect(branchExists(repoDir, 'dirty-branch')).toBe(false)
+    await expect(async () => {
+      expect(existsSync(worktreeDir)).toBe(false)
+      expect(branchExists(repoDir, 'dirty-branch')).toBe(false)
+    }).toPass({ timeout: 15_000 })
   })
 
   test('worktree with local-only commits and no upstream triggers confirmation', async ({
@@ -686,10 +686,10 @@ test.describe('Worktree Support', () => {
 
     // Force-remove it
     await forceRemoveWorktreeViaAPI(hubUrl, adminToken, resp.worktreeId!)
-    expect(existsSync(worktreeDir)).toBe(false)
-
-    // Branch should also be deleted
-    expect(branchExists(repoDir, 'no-upstream-branch')).toBe(false)
+    await expect(async () => {
+      expect(existsSync(worktreeDir)).toBe(false)
+      expect(branchExists(repoDir, 'no-upstream-branch')).toBe(false)
+    }).toPass({ timeout: 15_000 })
   })
 
   test('dirty worktree with unpushed commits triggers confirmation', async ({

--- a/frontend/tests/e2e/56-dropdown-popover.spec.ts
+++ b/frontend/tests/e2e/56-dropdown-popover.spec.ts
@@ -22,7 +22,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
     // Send a message so the agent session starts and context info appears
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await page.waitForFunction(() => {
       const body = document.body.textContent || ''
       return body.includes('2') && !body.includes('Send a message to start')
@@ -96,7 +96,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
     // Send a message so the agent session starts and context info appears
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Meta+Enter')
     await page.waitForFunction(() => {
       const body = document.body.textContent || ''
       return body.includes('2') && !body.includes('Send a message to start')

--- a/frontend/tests/unit/components/ExitPlanModeControl.test.tsx
+++ b/frontend/tests/unit/components/ExitPlanModeControl.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { ExitPlanModeActions } from '~/components/chat/controls/ExitPlanModeControl'
+import type { AskQuestionState } from '~/components/chat/controls/types'
+import type { ControlRequest } from '~/stores/control.store'
+
+function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
+  return {
+    requestId,
+    agentId,
+    payload: {
+      request: { tool_name: 'ExitPlanMode', input: {} },
+    },
+  }
+}
+
+function makeAskState(): AskQuestionState {
+  const [selections, setSelections] = createSignal<Record<number, string[]>>({})
+  const [customTexts, setCustomTexts] = createSignal<Record<number, string>>({})
+  const [currentPage, setCurrentPage] = createSignal(0)
+  return { selections, setSelections, customTexts, setCustomTexts, currentPage, setCurrentPage }
+}
+
+describe('exitPlanModeActions', () => {
+  it('shows Reject, Approve and Bypass Permissions when no editor content', () => {
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('plan-reject-btn')).toBeTruthy()
+    expect(screen.getByTestId('plan-approve-btn')).toBeTruthy()
+    expect(screen.getByTestId('control-bypass-btn')).toBeTruthy()
+  })
+
+  it('shows only Reject when editor has content', () => {
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={true}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('plan-reject-btn')).toBeTruthy()
+    expect(screen.queryByTestId('plan-approve-btn')).toBeNull()
+    expect(screen.queryByTestId('control-bypass-btn')).toBeNull()
+  })
+
+  it('sends allow response and changes permission mode when bypass is clicked', () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const onPermissionModeChange = vi.fn()
+    const request = makeRequest('req-99', 'agent-3')
+
+    render(() => (
+      <ExitPlanModeActions
+        request={request}
+        askState={makeAskState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={onPermissionModeChange}
+      />
+    ))
+
+    fireEvent.click(screen.getByTestId('control-bypass-btn'))
+
+    // Verify allow response was sent
+    expect(onRespond).toHaveBeenCalledOnce()
+    const [agentId, bytes] = onRespond.mock.calls[0]
+    expect(agentId).toBe('agent-3')
+    const decoded = JSON.parse(new TextDecoder().decode(bytes))
+    expect(decoded.response.request_id).toBe('req-99')
+    expect(decoded.response.response.behavior).toBe('allow')
+
+    // Verify permission mode change
+    expect(onPermissionModeChange).toHaveBeenCalledOnce()
+    expect(onPermissionModeChange).toHaveBeenCalledWith('bypassPermissions')
+  })
+
+  it('has a tooltip on the bypass button', () => {
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('control-bypass-btn').getAttribute('title'))
+      .toBe('Approve this plan and stop asking for permissions')
+  })
+})

--- a/frontend/tests/unit/components/ExitPlanModeControl.test.tsx
+++ b/frontend/tests/unit/components/ExitPlanModeControl.test.tsx
@@ -1,9 +1,9 @@
+import type { AskQuestionState } from '~/components/chat/controls/types'
+import type { ControlRequest } from '~/stores/control.store'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { ExitPlanModeActions } from '~/components/chat/controls/ExitPlanModeControl'
-import type { AskQuestionState } from '~/components/chat/controls/types'
-import type { ControlRequest } from '~/stores/control.store'
 
 function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
   return {

--- a/frontend/tests/unit/components/GenericToolControl.test.tsx
+++ b/frontend/tests/unit/components/GenericToolControl.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { GenericToolActions } from '~/components/chat/controls/GenericToolControl'
+import type { AskQuestionState } from '~/components/chat/controls/types'
+import type { ControlRequest } from '~/stores/control.store'
+
+function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
+  return {
+    requestId,
+    agentId,
+    payload: {
+      request: { tool_name: 'Bash', input: { command: 'ls' } },
+    },
+  }
+}
+
+function makeAskState(): AskQuestionState {
+  const [selections, setSelections] = createSignal<Record<number, string[]>>({})
+  const [customTexts, setCustomTexts] = createSignal<Record<number, string>>({})
+  const [currentPage, setCurrentPage] = createSignal(0)
+  return { selections, setSelections, customTexts, setCustomTexts, currentPage, setCurrentPage }
+}
+
+describe('genericToolActions', () => {
+  it('shows Allow and Bypass Permissions when no editor content', () => {
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('control-allow-btn')).toBeTruthy()
+    expect(screen.getByTestId('control-bypass-btn')).toBeTruthy()
+    expect(screen.queryByTestId('control-deny-btn')).toBeNull()
+  })
+
+  it('shows only Deny when editor has content', () => {
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={true}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('control-deny-btn')).toBeTruthy()
+    expect(screen.queryByTestId('control-allow-btn')).toBeNull()
+    expect(screen.queryByTestId('control-bypass-btn')).toBeNull()
+  })
+
+  it('sends allow response and changes permission mode when bypass is clicked', () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const onPermissionModeChange = vi.fn()
+    const request = makeRequest('req-42', 'agent-7')
+
+    render(() => (
+      <GenericToolActions
+        request={request}
+        askState={makeAskState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={onPermissionModeChange}
+      />
+    ))
+
+    fireEvent.click(screen.getByTestId('control-bypass-btn'))
+
+    // Verify allow response was sent
+    expect(onRespond).toHaveBeenCalledOnce()
+    const [agentId, bytes] = onRespond.mock.calls[0]
+    expect(agentId).toBe('agent-7')
+    const decoded = JSON.parse(new TextDecoder().decode(bytes))
+    expect(decoded.response.request_id).toBe('req-42')
+    expect(decoded.response.response.behavior).toBe('allow')
+
+    // Verify permission mode change
+    expect(onPermissionModeChange).toHaveBeenCalledOnce()
+    expect(onPermissionModeChange).toHaveBeenCalledWith('bypassPermissions')
+  })
+
+  it('has a tooltip on the bypass button', () => {
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        askState={makeAskState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        onPermissionModeChange={vi.fn()}
+      />
+    ))
+
+    expect(screen.getByTestId('control-bypass-btn').getAttribute('title'))
+      .toBe('Allow this request and stop asking for permissions')
+  })
+})

--- a/frontend/tests/unit/components/GenericToolControl.test.tsx
+++ b/frontend/tests/unit/components/GenericToolControl.test.tsx
@@ -1,9 +1,9 @@
+import type { AskQuestionState } from '~/components/chat/controls/types'
+import type { ControlRequest } from '~/stores/control.store'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { GenericToolActions } from '~/components/chat/controls/GenericToolControl'
-import type { AskQuestionState } from '~/components/chat/controls/types'
-import type { ControlRequest } from '~/stores/control.store'
 
 function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
   return {


### PR DESCRIPTION
## Motivation

When an agent repeatedly asks for permission to use tools, users must approve each request individually. There was no way to approve a current request and simultaneously disable future permission prompts in a single action. This required users to first approve the control request, then navigate to settings to switch the agent's permission mode, which was disruptive to workflow.

## Modifications

- Added a "& Bypass Permissions" button that appears grouped alongside the "Allow" (or "Approve") button in permission control banners (`GenericToolControl`, `ExitPlanModeControl`). Clicking it approves the current request and immediately switches the agent to `bypassPermissions` mode.
- The Approve+Bypass button group is only shown when the editor is empty. When the user has typed rejection/denial text into the editor, only the Deny/Reject button is shown, preventing accidental bypass.
- Added a reusable `ButtonGroup` component built on top of Oat UI's `<menu class="buttons">` element, which visually connects adjacent buttons by stripping inner border-radii and adding divider borders.
- Added the `onPermissionModeChange` optional callback to `ActionsProps` and threaded it through `ExitPlanModeControl` and `GenericToolControl`.
- Fixed pre-existing E2E test failures and reduced flakiness across 25 test files:
  - Updated keyboard shortcuts from `Enter` to `Meta+Enter` to match the new Cmd+Enter-to-send default.
  - Removed now-unnecessary "Enter sends" toggle setup from markdown editor tests.
  - Fixed strict mode selector violations by using `getByRole('heading')` and scoped dialog selectors.
  - Added `waitForSettingsIdle()` helper, retry-based `openSettingsMenu`, and `toPass()` assertions for eventual consistency in worktree cleanup.
  - Fixed a cascading failure in worker-restart tests by ensuring `restartWorker` is always called in a `finally` block.
  - Fixed a sidebar loading race in workspace deletion tests.
- Added E2E test for bypass from the ExitPlanMode banner and the Approve/Bypass toggle behavior.
- Added unit tests for the updated `ExitPlanModeControl` and `GenericToolControl` action components.

## Result

Users can now approve a permission request and disable all future permission prompts in a single click via the "& Bypass Permissions" button. The button group is contextually hidden when a rejection comment is being composed.

```
[ Allow ] [ & Bypass Permissions ]   ← shown when editor is empty
[ Deny ]                             ← shown when rejection text is typed
```

```
[ Reject ] [ Approve ] [ & Bypass Permissions ]   ← editor empty
[ Reject ]                                        ← rejection text present
```

🤖 Generated with Claude Code
