### PR TITLE
Fix tab rename input to allow typing spaces

### DIFF
--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -195,6 +195,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           value={editingValue()}
           onInput={e => setEditingValue(sanitizeName(e.currentTarget.value).value)}
           onKeyDown={(e) => {
+            e.stopPropagation()
             if (e.key === 'Enter') {
               commitEdit(tab)
             }

--- a/frontend/tests/e2e/32-tabbar-improvements.spec.ts
+++ b/frontend/tests/e2e/32-tabbar-improvements.spec.ts
@@ -164,6 +164,31 @@ test.describe('TabBar Improvements', () => {
     await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(initialCount)
   })
 
+  test('should rename a tab via double-click and allow spaces in the name', async ({ page, authenticatedWorkspace }) => {
+    // Double-click the tab to start renaming
+    const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+    await agentTab.dblclick()
+
+    // The rename input should appear and be focused
+    const editInput = agentTab.locator('input')
+    await expect(editInput).toBeVisible()
+    await expect(editInput).toBeFocused()
+
+    // Clear and type a new name that includes a space
+    await editInput.fill('')
+    await editInput.pressSequentially('My Agent')
+
+    // Verify the input value contains the space
+    await expect(editInput).toHaveValue('My Agent')
+
+    // Confirm by pressing Enter
+    await editInput.press('Enter')
+
+    // The input should disappear and the tab should show the new name
+    await expect(editInput).not.toBeVisible()
+    await expect(agentTab.locator('[class*="tabText"]')).toHaveText('My Agent')
+  })
+
   test('should create a new agent by double-clicking empty tab bar area', async ({ page, authenticatedWorkspace }) => {
     // Count initial agent tabs
     const initialCount = await page.locator('[data-testid="tab"][data-tab-type="agent"]').count()


### PR DESCRIPTION
## Motivation
When renaming a tab in the tab bar, users were unable to type spaces in the rename input. This was caused by keyboard events propagating up the component tree, where space key presses were being intercepted and handled by parent components before reaching the input field.

## Modifications
- Added `e.stopPropagation()` to the `onKeyDown` handler of the tab rename input in `frontend/src/components/shell/TabBar.tsx` to prevent keyboard events from bubbling up
- Added an E2E test in `frontend/tests/e2e/32-tabbar-improvements.spec.ts` that verifies tab renaming via double-click and confirms that tab names containing spaces are correctly accepted and displayed

## Result
Users can now type spaces when renaming a tab. For example, renaming a tab to "My Project" or "SSH Session 1" works as expected without spaces being swallowed by keyboard shortcut handlers.

🤖 Generated with Claude Code
