### PR TITLE
Add context-aware tooltips to new agent/terminal buttons

### DIFF
--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1098,6 +1098,7 @@ export const AppShell: ParentComponent = (props) => {
           })
         }
       }}
+      hasActiveTabContext={!!getCurrentTabContext().workerId}
       isEditingRef={(fn) => { isTabEditing = fn }}
       onNewAgent={handleOpenAgent}
       onNewTerminal={handleOpenTerminal}

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -70,6 +70,7 @@ interface TabBarProps {
   newAgentLoading?: boolean
   newTerminalLoading?: boolean
   newShellLoading?: boolean
+  hasActiveTabContext?: boolean
   closingTabKeys?: Set<string>
   isEditingRef?: (fn: () => boolean) => void
   isMobile?: boolean
@@ -79,6 +80,9 @@ interface TabBarProps {
 }
 
 export const TabBar: Component<TabBarProps> = (props) => {
+  const newAgentLabel = () => props.hasActiveTabContext ? 'New agent at the current working directory' : 'New agent...'
+  const newTerminalLabel = () => props.hasActiveTabContext ? 'New terminal at the current working directory' : 'New terminal...'
+
   const [editingTabKey, setEditingTabKey] = createSignal<string | null>(null)
   const [editingValue, setEditingValue] = createSignal('')
 
@@ -306,7 +310,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       <Show when={props.showAddButton}>
         {/* Full / Compact: individual new-tab buttons */}
         <div class={styles.newTabWrapper}>
-          <TabBarTooltip text="New agent">
+          <TabBarTooltip text={newAgentLabel()}>
             <IconButton
               icon={Bot}
               iconSize={iconSize.md}
@@ -316,7 +320,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
               onClick={() => props.onNewAgent()}
             />
           </TabBarTooltip>
-          <TabBarTooltip text="New terminal">
+          <TabBarTooltip text={newTerminalLabel()}>
             <IconButton
               icon={Terminal}
               iconSize={iconSize.md}
@@ -357,15 +361,6 @@ export const TabBar: Component<TabBarProps> = (props) => {
               />
             )}
           >
-            <button role="menuitem" onClick={() => props.onNewAgent()}>
-              <Bot size={14} />
-              {' New agent'}
-            </button>
-            <button role="menuitem" onClick={() => props.onNewTerminal()}>
-              <Terminal size={14} />
-              {' New terminal'}
-            </button>
-            <hr />
             {renderMoreMenuItems()}
           </DropdownMenu>
         </div>
@@ -383,15 +378,6 @@ export const TabBar: Component<TabBarProps> = (props) => {
               />
             )}
           >
-            <button role="menuitem" onClick={() => props.onNewAgent()}>
-              <Bot size={14} />
-              {' New agent'}
-            </button>
-            <button role="menuitem" onClick={() => props.onNewTerminal()}>
-              <Terminal size={14} />
-              {' New terminal'}
-            </button>
-            <hr />
             {renderMoreMenuItems()}
             <Show when={props.tileActions}>
               {actions => (

--- a/frontend/tests/e2e/52-responsive-tile-tabbar.spec.ts
+++ b/frontend/tests/e2e/52-responsive-tile-tabbar.spec.ts
@@ -144,6 +144,26 @@ test.describe('Responsive Tile TabBar', () => {
     }
   })
 
+  test('new tab button tooltips reflect active tab context', async ({ page, authenticatedWorkspace }) => {
+    const agentBtn = page.locator('[data-testid="new-agent-button"]')
+    const terminalBtn = page.locator('[data-testid="new-terminal-button"]')
+
+    // Workspace starts with an active tab — tooltips should indicate the working directory
+    await openAgentViaUI(page)
+    await expect(agentBtn.locator('..')).toHaveAttribute('title', 'New agent at the current working directory')
+    await expect(terminalBtn.locator('..')).toHaveAttribute('title', 'New terminal at the current working directory')
+
+    // Close all tabs to remove active tab context
+    while (await page.locator('[data-testid="tab-close"]').count() > 0) {
+      await page.locator('[data-testid="tab-close"]').first().click()
+      await page.waitForTimeout(300)
+    }
+
+    // Now tooltips should show the "..." variant
+    await expect(agentBtn.locator('..')).toHaveAttribute('title', 'New agent...')
+    await expect(terminalBtn.locator('..')).toHaveAttribute('title', 'New terminal...')
+  })
+
   test('short height: tab bar height reduced when tile is short', async ({ page, authenticatedWorkspace }) => {
     await openAgentViaUI(page)
 


### PR DESCRIPTION
## Motivation
The "New agent" and "New terminal" buttons in the tab bar lacked tooltips, making it unclear to users what context would be used when creating a new agent or terminal. Additionally, collapsed dropdown menus in minimal/micro responsive modes contained duplicate entries for these actions.

## Modifications
- Added a `hasActiveTabContext` prop to the `TabBar` component that controls tooltip text for the "New agent" and "New terminal" buttons
- When an active tab is present, tooltips read "New agent/terminal at the current working directory"; when idle, they read "New agent/terminal..."
- Removed duplicate "New agent" and "New terminal" entries from collapsed dropdown menus in minimal/micro responsive modes, since `renderMoreMenuItems` already provides them
- Added an e2e test (`52-responsive-tile-tabbar.spec.ts`) verifying tooltip text updates correctly based on active tab context

## Result
Users can now see context-aware tooltips on the "New agent" and "New terminal" buttons that communicate whether the new session will open in the current working directory or start fresh. Collapsed responsive menus no longer show duplicate entries for these actions.

🤖 Generated with Claude Code
