### PR TITLE
Add collapsible content and tool grouping to control request banners

### DIFF
--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -150,6 +150,8 @@ export const controlBanner = style({
   backgroundColor: 'var(--lm-warning-subtle)',
   borderBottom: '1px solid var(--border)',
   flexShrink: 0,
+  maxHeight: '200px',
+  overflowY: 'auto',
 })
 
 export const controlBannerTitle = style({
@@ -185,6 +187,20 @@ export const controlFooterRight = style({
   gap: spacing.xs,
   justifyContent: 'flex-end',
   gridColumn: 3,
+})
+
+export const collapsibleToggle = style({
+  'all': 'unset',
+  'display': 'inline',
+  'fontSize': 'var(--text-8)',
+  'color': 'var(--muted-foreground)',
+  'cursor': 'pointer',
+  'textDecoration': 'underline',
+  'textDecorationStyle': 'dotted',
+  'textUnderlineOffset': '2px',
+  ':hover': {
+    color: 'var(--foreground)',
+  },
 })
 
 // Apply markdown content styling inside the banner

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -8,6 +8,7 @@ import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
 import { buildAllowResponse, buildDenyResponse, getToolInput } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
+import { CollapsibleList } from './CollapsibleList'
 import { sendResponse } from './types'
 
 // ---------------------------------------------------------------------------
@@ -169,8 +170,11 @@ export const AskUserQuestionContent: Component<{ request: ControlRequest, askSta
                     const radioName = createUniqueId()
                     return (
                       <fieldset>
-                        <For each={q().options}>
-                          {opt => (
+                        <CollapsibleList
+                          items={q().options}
+                          maxVisible={4}
+                          moreLabel={n => `Show ${n} more option${n === 1 ? '' : 's'}\u2026`}
+                          renderItem={opt => (
                             <label class={styles.optionItem} data-testid={`question-option-${opt.label}`}>
                               <input
                                 type="radio"
@@ -190,13 +194,16 @@ export const AskUserQuestionContent: Component<{ request: ControlRequest, askSta
                               </span>
                             </label>
                           )}
-                        </For>
+                        />
                       </fieldset>
                     )
                   })()}
                 >
-                  <For each={q().options}>
-                    {opt => (
+                  <CollapsibleList
+                    items={q().options}
+                    maxVisible={4}
+                    moreLabel={n => `Show ${n} more option${n === 1 ? '' : 's'}\u2026`}
+                    renderItem={opt => (
                       <label
                         class={styles.optionItem}
                         data-testid={`question-option-${opt.label}`}
@@ -215,7 +222,7 @@ export const AskUserQuestionContent: Component<{ request: ControlRequest, askSta
                         </span>
                       </label>
                     )}
-                  </For>
+                  />
                 </Show>
               </div>
             </div>

--- a/frontend/src/components/chat/controls/CollapsibleList.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleList.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from 'solid-js'
+import { createSignal, For, Show } from 'solid-js'
+import * as styles from '../ControlRequestBanner.css'
+
+interface CollapsibleListProps<T> {
+  items: T[]
+  maxVisible: number
+  renderItem: (item: T) => JSX.Element
+  /** Label for the "show more" toggle. Receives the count of hidden items. Default: "Show N more..." */
+  moreLabel?: (hiddenCount: number) => string
+  /** Label for the "show less" toggle. Default: "Show less" */
+  lessLabel?: string
+}
+
+export function CollapsibleList<T>(props: CollapsibleListProps<T>): JSX.Element {
+  const [expanded, setExpanded] = createSignal(false)
+
+  const shouldCollapse = () => props.items.length > props.maxVisible
+  const visibleItems = () =>
+    shouldCollapse() && !expanded()
+      ? props.items.slice(0, props.maxVisible)
+      : props.items
+  const hiddenCount = () => props.items.length - props.maxVisible
+
+  return (
+    <>
+      <For each={visibleItems()}>
+        {item => props.renderItem(item)}
+      </For>
+      <Show when={shouldCollapse()}>
+        <button
+          class={styles.collapsibleToggle}
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          {expanded()
+            ? (props.lessLabel ?? 'Show less')
+            : (props.moreLabel?.(hiddenCount()) ?? `Show ${hiddenCount()} more\u2026`)}
+        </button>
+      </Show>
+    </>
+  )
+}

--- a/frontend/src/components/chat/controls/CollapsibleText.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleText.tsx
@@ -1,0 +1,41 @@
+import type { JSX } from 'solid-js'
+import { createSignal, Show } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
+import * as styles from '../ControlRequestBanner.css'
+
+interface CollapsibleTextProps {
+  text: string
+  /** Maximum number of lines to show before collapsing. */
+  maxLines: number
+  /** Tag to wrap the text in. Default: 'pre' */
+  tag?: 'pre' | 'div'
+  class?: string
+}
+
+export function CollapsibleText(props: CollapsibleTextProps): JSX.Element {
+  const [expanded, setExpanded] = createSignal(false)
+
+  const lines = () => props.text.split('\n')
+  const shouldCollapse = () => lines().length > props.maxLines
+  const visibleText = () =>
+    shouldCollapse() && !expanded()
+      ? lines().slice(0, props.maxLines).join('\n')
+      : props.text
+  const hiddenCount = () => lines().length - props.maxLines
+
+  return (
+    <>
+      <Dynamic component={props.tag ?? 'pre'} class={props.class}>{visibleText()}</Dynamic>
+      <Show when={shouldCollapse()}>
+        <button
+          class={styles.collapsibleToggle}
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          {expanded()
+            ? 'Show less'
+            : `Show ${hiddenCount()} more line${hiddenCount() === 1 ? '' : 's'}\u2026`}
+        </button>
+      </Show>
+    </>
+  )
+}

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -6,6 +6,7 @@ import { Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { buildAllowResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
+import { CollapsibleText } from './CollapsibleText'
 import { sendResponse } from './types'
 
 export const GenericToolContent: Component<{ request: ControlRequest }> = (props) => {
@@ -26,7 +27,7 @@ export const GenericToolContent: Component<{ request: ControlRequest }> = (props
         Permission Required:
         {toolName()}
       </div>
-      <pre class={styles.toolSummary}>{inputSummary()}</pre>
+      <CollapsibleText text={inputSummary()} maxLines={6} class={styles.toolSummary} />
     </>
   )
 }

--- a/frontend/tests/unit/components/CollapsibleList.test.tsx
+++ b/frontend/tests/unit/components/CollapsibleList.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { CollapsibleList } from '~/components/chat/controls/CollapsibleList'
+
+describe('collapsibleList', () => {
+  it('renders all items when count is within maxVisible', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c']}
+        maxVisible={5}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    expect(screen.getByTestId('item-a')).toBeTruthy()
+    expect(screen.getByTestId('item-b')).toBeTruthy()
+    expect(screen.getByTestId('item-c')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders all items when count equals maxVisible', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c']}
+        maxVisible={3}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    expect(screen.getByTestId('item-a')).toBeTruthy()
+    expect(screen.getByTestId('item-b')).toBeTruthy()
+    expect(screen.getByTestId('item-c')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('collapses items exceeding maxVisible and shows toggle', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c', 'd', 'e']}
+        maxVisible={2}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    expect(screen.getByTestId('item-a')).toBeTruthy()
+    expect(screen.getByTestId('item-b')).toBeTruthy()
+    expect(screen.queryByTestId('item-c')).toBeNull()
+    expect(screen.queryByTestId('item-d')).toBeNull()
+    expect(screen.queryByTestId('item-e')).toBeNull()
+
+    const toggle = screen.getByRole('button')
+    expect(toggle.textContent).toBe('Show 3 more\u2026')
+  })
+
+  it('expands all items when toggle is clicked', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c', 'd', 'e']}
+        maxVisible={2}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByTestId('item-a')).toBeTruthy()
+    expect(screen.getByTestId('item-b')).toBeTruthy()
+    expect(screen.getByTestId('item-c')).toBeTruthy()
+    expect(screen.getByTestId('item-d')).toBeTruthy()
+    expect(screen.getByTestId('item-e')).toBeTruthy()
+
+    expect(screen.getByRole('button').textContent).toBe('Show less')
+  })
+
+  it('collapses back when toggle is clicked twice', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c', 'd', 'e']}
+        maxVisible={2}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    const toggle = screen.getByRole('button')
+    fireEvent.click(toggle) // expand
+    fireEvent.click(toggle) // collapse
+
+    expect(screen.queryByTestId('item-c')).toBeNull()
+    expect(toggle.textContent).toBe('Show 3 more\u2026')
+  })
+
+  it('uses custom moreLabel and lessLabel', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c']}
+        maxVisible={1}
+        moreLabel={n => `${n} hidden items`}
+        lessLabel="Collapse"
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    const toggle = screen.getByRole('button')
+    expect(toggle.textContent).toBe('2 hidden items')
+
+    fireEvent.click(toggle)
+    expect(toggle.textContent).toBe('Collapse')
+  })
+
+  it('handles singular "more" label for 1 hidden item', () => {
+    render(() => (
+      <CollapsibleList
+        items={['a', 'b', 'c']}
+        maxVisible={2}
+        renderItem={item => <span data-testid={`item-${item}`}>{item}</span>}
+      />
+    ))
+
+    expect(screen.getByRole('button').textContent).toBe('Show 1 more\u2026')
+  })
+})

--- a/frontend/tests/unit/components/CollapsibleText.test.tsx
+++ b/frontend/tests/unit/components/CollapsibleText.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { CollapsibleText } from '~/components/chat/controls/CollapsibleText'
+
+/** Get the text content of the rendered <pre> element. */
+function getPreText(): string {
+  return document.querySelector('pre')?.textContent ?? ''
+}
+
+describe('collapsibleText', () => {
+  it('renders full text when lines are within maxLines', () => {
+    const text = 'line 1\nline 2\nline 3'
+    render(() => <CollapsibleText text={text} maxLines={5} />)
+
+    expect(getPreText()).toBe(text)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders full text when lines equal maxLines', () => {
+    const text = 'line 1\nline 2\nline 3'
+    render(() => <CollapsibleText text={text} maxLines={3} />)
+
+    expect(getPreText()).toBe(text)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('truncates text exceeding maxLines and shows toggle', () => {
+    render(() => <CollapsibleText text={'line 1\nline 2\nline 3\nline 4\nline 5'} maxLines={2} />)
+
+    expect(getPreText()).toBe('line 1\nline 2')
+
+    const toggle = screen.getByRole('button')
+    expect(toggle.textContent).toBe('Show 3 more lines\u2026')
+  })
+
+  it('expands to full text when toggle is clicked', () => {
+    const text = 'line 1\nline 2\nline 3\nline 4\nline 5'
+    render(() => <CollapsibleText text={text} maxLines={2} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(getPreText()).toBe(text)
+    expect(screen.getByRole('button').textContent).toBe('Show less')
+  })
+
+  it('collapses back when toggle is clicked twice', () => {
+    render(() => <CollapsibleText text={'line 1\nline 2\nline 3\nline 4\nline 5'} maxLines={2} />)
+
+    const toggle = screen.getByRole('button')
+    fireEvent.click(toggle) // expand
+    fireEvent.click(toggle) // collapse
+
+    expect(getPreText()).toBe('line 1\nline 2')
+    expect(toggle.textContent).toBe('Show 3 more lines\u2026')
+  })
+
+  it('renders as pre tag by default', () => {
+    render(() => <CollapsibleText text="hello" maxLines={5} />)
+    expect(document.querySelector('pre')).toBeTruthy()
+    expect(document.querySelector('pre')!.textContent).toBe('hello')
+  })
+
+  it('renders as div tag when specified', () => {
+    const { container } = render(() => <CollapsibleText text="hello" maxLines={5} tag="div" />)
+    // The render wrapper is a <div>, the CollapsibleText also renders a <div>.
+    // Find the inner div (child of the container).
+    const innerDiv = container.querySelector('div')
+    expect(innerDiv).toBeTruthy()
+    expect(innerDiv!.textContent).toBe('hello')
+  })
+
+  it('applies custom class', () => {
+    render(() => <CollapsibleText text="hello" maxLines={5} class="my-class" />)
+    expect(document.querySelector('pre.my-class')).toBeTruthy()
+  })
+
+  it('handles singular line label', () => {
+    render(() => <CollapsibleText text={'line 1\nline 2\nline 3'} maxLines={2} />)
+    expect(screen.getByRole('button').textContent).toBe('Show 1 more line\u2026')
+  })
+})

--- a/frontend/tests/unit/components/ExitPlanModeContent.test.tsx
+++ b/frontend/tests/unit/components/ExitPlanModeContent.test.tsx
@@ -1,0 +1,96 @@
+import type { ControlRequest } from '~/stores/control.store'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { ExitPlanModeContent } from '~/components/chat/controls/ExitPlanModeControl'
+
+function makeRequest(allowedPrompts?: Array<{ tool: string, prompt: string }>): ControlRequest {
+  return {
+    requestId: 'req-1',
+    agentId: 'agent-1',
+    payload: {
+      request: {
+        tool_name: 'ExitPlanMode',
+        input: allowedPrompts ? { allowedPrompts } : {},
+      },
+    },
+  }
+}
+
+describe('exitPlanModeContent', () => {
+  it('shows fallback message when no permissions are requested', () => {
+    render(() => <ExitPlanModeContent request={makeRequest()} />)
+
+    expect(screen.getByText('Plan Ready for Review')).toBeTruthy()
+    expect(screen.getByText('The agent has finished planning and is ready to proceed.')).toBeTruthy()
+  })
+
+  it('groups permissions by tool name', () => {
+    const prompts = [
+      { tool: 'Bash', prompt: 'run tests' },
+      { tool: 'Bash', prompt: 'run build' },
+      { tool: 'Bash', prompt: 'install deps' },
+    ]
+    render(() => <ExitPlanModeContent request={makeRequest(prompts)} />)
+
+    expect(screen.getByText('Requested permissions:')).toBeTruthy()
+    // All Bash prompts should be joined in a single list item
+    expect(screen.getByText(/run tests, run build, install deps/)).toBeTruthy()
+  })
+
+  it('renders separate groups for different tools', () => {
+    const prompts = [
+      { tool: 'Bash', prompt: 'run tests' },
+      { tool: 'Read', prompt: 'read config.json' },
+      { tool: 'Bash', prompt: 'run build' },
+    ]
+    render(() => <ExitPlanModeContent request={makeRequest(prompts)} />)
+
+    // Bash group should have both prompts joined
+    expect(screen.getByText(/run tests, run build/)).toBeTruthy()
+    // Read group should be separate
+    expect(screen.getByText(/read config.json/)).toBeTruthy()
+  })
+
+  it('does not show collapsible toggle with 3 or fewer groups', () => {
+    const prompts = [
+      { tool: 'Bash', prompt: 'run tests' },
+      { tool: 'Read', prompt: 'read file' },
+      { tool: 'Write', prompt: 'write file' },
+    ]
+    render(() => <ExitPlanModeContent request={makeRequest(prompts)} />)
+
+    // No toggle button should be present
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('shows collapsible toggle with more than 3 groups', () => {
+    const prompts = [
+      { tool: 'Bash', prompt: 'run tests' },
+      { tool: 'Read', prompt: 'read file' },
+      { tool: 'Write', prompt: 'write file' },
+      { tool: 'Grep', prompt: 'search code' },
+      { tool: 'Glob', prompt: 'find files' },
+    ]
+    render(() => <ExitPlanModeContent request={makeRequest(prompts)} />)
+
+    const toggle = screen.getByRole('button')
+    expect(toggle.textContent).toContain('Show 2 more')
+  })
+
+  it('expands all groups when toggle is clicked', () => {
+    const prompts = [
+      { tool: 'Bash', prompt: 'run tests' },
+      { tool: 'Read', prompt: 'read file' },
+      { tool: 'Write', prompt: 'write file' },
+      { tool: 'Grep', prompt: 'search code' },
+      { tool: 'Glob', prompt: 'find files' },
+    ]
+    render(() => <ExitPlanModeContent request={makeRequest(prompts)} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText(/search code/)).toBeTruthy()
+    expect(screen.getByText(/find files/)).toBeTruthy()
+    expect(screen.getByRole('button').textContent).toBe('Show less')
+  })
+})

--- a/frontend/tests/unit/components/GenericToolContent.test.tsx
+++ b/frontend/tests/unit/components/GenericToolContent.test.tsx
@@ -1,0 +1,50 @@
+import type { ControlRequest } from '~/stores/control.store'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { GenericToolContent } from '~/components/chat/controls/GenericToolControl'
+
+function makeRequest(input: Record<string, unknown>): ControlRequest {
+  return {
+    requestId: 'req-1',
+    agentId: 'agent-1',
+    payload: {
+      request: { tool_name: 'Bash', input },
+    },
+  }
+}
+
+describe('genericToolContent', () => {
+  it('renders tool name and short JSON without toggle', () => {
+    render(() => <GenericToolContent request={makeRequest({ command: 'ls' })} />)
+
+    expect(screen.getByText(/Permission Required:/)).toBeTruthy()
+    expect(screen.getByText(/Bash/)).toBeTruthy()
+    // Short JSON should be fully visible with no toggle
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('truncates long JSON and shows toggle', () => {
+    const longInput: Record<string, string> = {}
+    for (let i = 0; i < 20; i++) {
+      longInput[`key_${i}`] = `value_${i}`
+    }
+    render(() => <GenericToolContent request={makeRequest(longInput)} />)
+
+    const toggle = screen.getByRole('button')
+    expect(toggle.textContent).toContain('more line')
+  })
+
+  it('expands long JSON when toggle is clicked', () => {
+    const longInput: Record<string, string> = {}
+    for (let i = 0; i < 20; i++) {
+      longInput[`key_${i}`] = `value_${i}`
+    }
+    render(() => <GenericToolContent request={makeRequest(longInput)} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    // All keys should now be visible
+    expect(screen.getByText(/key_19/)).toBeTruthy()
+    expect(screen.getByRole('button').textContent).toBe('Show less')
+  })
+})


### PR DESCRIPTION
## Motivation
Control request banners in the chat UI could become unwieldy when displaying large amounts of content — long JSON tool inputs, many question options, or multiple permission prompts covering the same tool. There was no mechanism to progressively disclose this content, causing banners to grow tall and push other UI elements out of view.

## Modifications
- Added two new reusable SolidJS components under `frontend/src/components/chat/controls/`:
  - `CollapsibleList<T>` — renders a list with a configurable `maxVisible` threshold, showing a "Show N more..." / "Show less" toggle when the item count exceeds it. Accepts custom `moreLabel` and `lessLabel` functions for flexible copy.
  - `CollapsibleText` — collapses multi-line text to a configurable `maxLines` limit, showing a "Show N more lines..." toggle. Supports rendering as either `<pre>` or `<div>`.
- Applied `CollapsibleText` in `GenericToolControl` to cap long JSON input summaries at 6 lines.
- Applied `CollapsibleList` in `AskUserQuestionControl` to cap question option lists at 4 visible entries.
- Enhanced `ExitPlanModeControl` to group permission prompts by tool name before rendering, so multiple prompts for the same tool (e.g., several Bash commands) are consolidated into a single list item. The grouped list is then rendered via `CollapsibleList` with a cap of 3 visible tool groups.
- Added a `collapsibleToggle` CSS class with dotted underline and hover styling for the expand/collapse buttons.
- Added a `maxHeight: 200px` with `overflow-y: auto` to control banner content to prevent banners from consuming excessive vertical space.
- Added comprehensive unit test coverage in 4 new test files covering `CollapsibleList`, `CollapsibleText`, `ExitPlanModeContent`, and `GenericToolContent`.

## Result
Control request banners are now more compact and readable. Long tool inputs, large option lists, and permission summaries with many entries are truncated by default and can be expanded on demand. Permission prompts in the plan review banner are grouped by tool name, reducing repetition when the same tool appears multiple times in a plan.

For example, a plan that requested Bash permissions for 10 different commands previously rendered 10 separate list items. After this change, all Bash prompts are consolidated into a single grouped entry, with a "Show N more groups..." toggle if there are more than 3 tool groups.

```tsx
// CollapsibleList usage example
<CollapsibleList
  items={options}
  maxVisible={4}
  renderItem={opt => <li>{opt.label}</li>}
  moreLabel={n => `Show ${n} more option${n === 1 ? '' : 's'}...`}
/>

// CollapsibleText usage example
<CollapsibleText text={jsonInput} maxLines={6} tag="pre" />
```

🤖 Generated with Claude Code
