### PR TITLE
Enable source map generation and serving for frontend bundles

### DIFF
--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   ssr: false,
   server: { static: true },
   vite: {
+    build: { sourcemap: true },
     plugins: [
       vanillaExtractPlugin({ identifiers: 'debug' }),
       {

--- a/internal/hub/frontend/embed.go
+++ b/internal/hub/frontend/embed.go
@@ -14,6 +14,8 @@ import (
 func init() {
 	// Ensure .webmanifest files are served with the correct MIME type.
 	_ = mime.AddExtensionType(".webmanifest", "application/manifest+json")
+	// Ensure .map (source map) files are served with the correct MIME type.
+	_ = mime.AddExtensionType(".map", "application/json")
 }
 
 // Handler returns an http.Handler that serves the embedded frontend assets.


### PR DESCRIPTION
## Motivation
Without source maps, debugging JavaScript errors in production is difficult because stack traces and DevTools point to minified, bundled code rather than the original source files. This change enables source maps so that developers and users can get meaningful stack traces and use browser DevTools to inspect the original TypeScript/JavaScript source.

## Modifications
- Add `build: { sourcemap: true }` to the Vite configuration in `frontend/app.config.ts` to generate `.map` files alongside production bundles
- Register the `.map` file extension with the `application/json` MIME type in the Go frontend handler (`internal/hub/frontend/embed.go`) so source map files are served with the correct `Content-Type` header

## Result
Browser DevTools now display original TypeScript/JavaScript source code when debugging the frontend in production, rather than minified bundle output. Stack traces in error reports will reference readable source locations instead of mangled identifiers.

🤖 Generated with Claude Code
