### PR TITLE
Hide allowed rate limit notifications and extract summary formatter

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -16,7 +16,7 @@ import Square from 'lucide-solid/icons/square'
 import { createEffect, createMemo, createSignal, createUniqueId, For, on, onCleanup, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
-import { formatCountdown, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_TYPE_LABELS } from '~/lib/rateLimitUtils'
+import { formatRateLimitSummary, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_POPOVER_LABELS } from '~/lib/rateLimitUtils'
 import { safeGetJson, safeGetString, safeRemoveItem, safeSetJson, safeSetString } from '~/lib/safeStorage'
 import { interruptPulse, spinner } from '~/styles/animations.css'
 import { iconSize } from '~/styles/tokens'
@@ -449,27 +449,12 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
       <Show when={props.agentSessionInfo?.rateLimits && Object.keys(props.agentSessionInfo!.rateLimits!).length > 0}>
         <For each={Object.values(props.agentSessionInfo!.rateLimits!)}>
           {(info) => {
-            const resetsAt = getResetsAt(info)
-            const typeLabel = RATE_LIMIT_TYPE_LABELS[info.rateLimitType ?? ''] ?? info.rateLimitType ?? 'Rate Limit'
-            const pct = info.utilization != null ? `${Math.round(info.utilization * 100)}%` : null
+            const typeLabel = RATE_LIMIT_POPOVER_LABELS[info.rateLimitType ?? ''] ?? info.rateLimitType ?? 'Rate Limit'
             return (
-              <>
-                <div class={styles.infoRow}>
-                  <span class={styles.infoLabel}>{typeLabel}</span>
-                  <span class={styles.infoValue}>
-                    {pct ? `${pct} used` : (info.status === 'allowed' || info.status === 'allowed_warning' ? 'Allowed' : 'Reached')}
-                    {info.isUsingOverage ? ' (overage)' : ''}
-                  </span>
-                </div>
-                <Show when={resetsAt}>
-                  <div class={styles.infoRow}>
-                    <span class={styles.infoLabel}>Resets In</span>
-                    <span class={styles.infoValue} title={new Date(resetsAt! * 1000).toLocaleString()}>
-                      {formatCountdown(resetsAt!) ?? 'now'}
-                    </span>
-                  </div>
-                </Show>
-              </>
+              <div class={styles.infoRow}>
+                <span class={styles.infoLabel}>{typeLabel}</span>
+                <span class={styles.infoValue}>{formatRateLimitSummary(info)}</span>
+              </div>
             )
           }}
         </For>

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -86,6 +86,9 @@ export const rateLimitRenderer: MessageContentRenderer = {
     const info = parsed.rate_limit_info
     if (!isObject(info))
       return <div class={controlResponseMessage}>Rate limit update</div>
+    // Hide "allowed" status from chat — the popover still shows it.
+    if ((info as Record<string, unknown>).status === 'allowed')
+      return null
     return <div class={controlResponseMessage}>{formatRateLimitMessage(info as Record<string, unknown>)}</div>
   },
 }
@@ -307,9 +310,10 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   if (interrupted)
     settingsParts.push('Interrupted')
 
-  // Add rate limit messages (one per rateLimitType).
+  // Add rate limit messages (one per rateLimitType), skipping "allowed" status.
   for (const info of Object.values(rateLimitByType)) {
-    settingsParts.push(formatRateLimitMessage(info))
+    if (info.status !== 'allowed')
+      settingsParts.push(formatRateLimitMessage(info))
   }
 
   const settingsLine = settingsParts.length > 0 ? settingsParts.join(', ') : null


### PR DESCRIPTION
## Motivation
Rate limit events with "allowed" status were appearing in chat notification threads, creating visual noise for users. These events don't require user attention since the operation was permitted to proceed. Additionally, the rate limit summary formatting logic was duplicated across components, making it harder to maintain consistent display.

## Modifications
- Filter out rate limit events with "allowed" status from chat notification rendering in `notificationRenderers.tsx`, so they no longer appear as inline messages in the conversation thread
- Add `formatRateLimitSummary()` utility function in `frontend/src/lib/rateLimitUtils.ts` that generates concise single-line summaries (e.g., "Allowed, resets in 4:59") for popover card display
- Add `RATE_LIMIT_POPOVER_LABELS` constant with popover-specific label mappings ("5-Hour Rate Limit", "7-Day Rate Limit")
- Simplify `AgentEditorPanel.tsx` rate limit rendering by replacing 16 lines of inline formatting logic with a single call to `formatRateLimitSummary()`
- Add 6 new unit test cases covering allowed, warning, and exceeded states, utilization display, overage handling, and edge cases

## Result
Rate limit events that were permitted ("allowed" status) no longer appear as notification messages in the chat thread, reducing clutter while keeping the popover display intact for users who want to inspect rate limit details. The consolidated formatting logic ensures consistent display across components.

🤖 Generated with Claude Code
