### PR TITLE
Fix race condition in bypass permissions after plan mode exit

### DIFF
--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -3,7 +3,9 @@ import type { ActionsProps } from './types'
 import type { ControlRequest } from '~/stores/control.store'
 
 import { Show } from 'solid-js'
+import { apiCallTimeout } from '~/api/transport'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { waitForSettingsChanged } from '~/lib/settingsChangedEvent'
 import { buildAllowResponse, getToolInput } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { CollapsibleList } from './CollapsibleList'
@@ -80,9 +82,25 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
     sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
   }
 
-  const handleBypassPermissions = () => {
-    // Approve the current request first, then switch to bypass mode.
+  const handleBypassPermissions = async () => {
+    // Approve the current request first.
     sendResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId))
+
+    // The backend auto-sets permission mode to 'default' when ExitPlanMode
+    // is approved. Wait for that settings_changed notification before
+    // sending set_permission_mode, to avoid the race where our
+    // bypassPermissions request gets overwritten by the auto-set.
+    try {
+      await waitForSettingsChanged(
+        changes => changes.permissionMode?.old === 'plan',
+        apiCallTimeout().timeoutMs ?? 15_000,
+      )
+    }
+    catch {
+      // On timeout, proceed anyway — degrade to old behavior rather than
+      // silently dropping the user's intent.
+    }
+
     props.onPermissionModeChange?.('bypassPermissions')
   }
 

--- a/frontend/src/lib/settingsChangedEvent.ts
+++ b/frontend/src/lib/settingsChangedEvent.ts
@@ -1,0 +1,69 @@
+export interface SettingsChange {
+  permissionMode?: { old: string, new: string }
+}
+
+type Predicate = (changes: SettingsChange) => boolean
+
+interface Listener {
+  predicate: Predicate
+  resolve: () => void
+}
+
+let listeners: Listener[] = []
+
+/**
+ * Called by useWorkspaceConnection when a settings_changed LEAPMUX
+ * message is received. Resolves any waiting promises whose predicate matches.
+ */
+export function emitSettingsChanged(changes: SettingsChange): void {
+  const matched: Listener[] = []
+  const remaining: Listener[] = []
+  for (const entry of listeners) {
+    if (entry.predicate(changes)) {
+      matched.push(entry)
+    }
+    else {
+      remaining.push(entry)
+    }
+  }
+  listeners = remaining
+  for (const entry of matched) {
+    entry.resolve()
+  }
+}
+
+/**
+ * Returns a promise that resolves when a settings_changed event matching the
+ * predicate arrives, or rejects on timeout.
+ */
+export function waitForSettingsChanged(
+  predicate: Predicate,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const entry: Listener = {
+      predicate,
+      resolve: () => {
+        clearTimeout(timer)
+        resolve()
+      },
+    }
+
+    listeners.push(entry)
+
+    timer = setTimeout(() => {
+      const idx = listeners.indexOf(entry)
+      if (idx !== -1) {
+        listeners.splice(idx, 1)
+      }
+      reject(new Error('Timed out waiting for settings_changed'))
+    }, timeoutMs)
+  })
+}
+
+/** Visible for testing: clear all pending listeners. */
+export function _resetListeners(): void {
+  listeners = []
+}

--- a/frontend/tests/unit/lib/settingsChangedEvent.test.ts
+++ b/frontend/tests/unit/lib/settingsChangedEvent.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetListeners, emitSettingsChanged, waitForSettingsChanged } from '~/lib/settingsChangedEvent'
+
+describe('settingsChangedEvent', () => {
+  beforeEach(() => {
+    _resetListeners()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves when a matching event is emitted', async () => {
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('does not resolve for non-matching events', async () => {
+    let resolved = false
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    ).then(() => { resolved = true })
+
+    emitSettingsChanged({ permissionMode: { old: 'default', new: 'bypassPermissions' } })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    // Clean up by timing out
+    vi.advanceTimersByTime(5000)
+    await promise.catch(() => {})
+  })
+
+  it('rejects on timeout', async () => {
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    vi.advanceTimersByTime(5000)
+    await expect(promise).rejects.toThrow('Timed out waiting for settings_changed')
+  })
+
+  it('clears timer when resolved before timeout', async () => {
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+    await promise
+    // Advancing timers should not cause any issues
+    vi.advanceTimersByTime(10000)
+  })
+
+  it('supports multiple concurrent waiters with different predicates', async () => {
+    const p1 = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    const p2 = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'default',
+      5000,
+    )
+
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+    await expect(p1).resolves.toBeUndefined()
+
+    // p2 should still be pending — resolve it with a matching event
+    emitSettingsChanged({ permissionMode: { old: 'default', new: 'bypassPermissions' } })
+    await expect(p2).resolves.toBeUndefined()
+  })
+
+  it('removes listener from list after match', async () => {
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+    await promise
+
+    // A second emit should not cause errors
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+  })
+
+  it('removes listener from list after timeout', async () => {
+    const promise = waitForSettingsChanged(
+      c => c.permissionMode?.old === 'plan',
+      5000,
+    )
+    vi.advanceTimersByTime(5000)
+    await promise.catch(() => {})
+
+    // Emitting after timeout should not cause errors
+    emitSettingsChanged({ permissionMode: { old: 'plan', new: 'default' } })
+  })
+})


### PR DESCRIPTION
## Motivation

When a user approves an ExitPlanMode request and clicks "& Bypass Permissions", the backend automatically resets the permission mode from `plan` to `default` upon approval. Previously, the client sent the `set_permission_mode` (bypassPermissions) request immediately after approval, before this backend auto-reset arrived. The backend's auto-reset would then arrive and overwrite the client's bypassPermissions setting, leaving the session in `default` mode instead of the intended `bypassPermissions` mode.

## Modifications

- Added `/frontend/src/lib/settingsChangedEvent.ts`, a new event coordination module that exports `waitForSettingsChanged(predicate, timeoutMs)` and `emitSettingsChanged(changes)`, allowing async operations to synchronize on backend settings notifications without polling.
- Modified `ExitPlanModeActions.handleBypassPermissions` in `/frontend/src/components/chat/controls/ExitPlanModeControl.tsx` to await `waitForSettingsChanged()` for the backend's `plan` -> `default` permission mode transition before sending the bypassPermissions request. On timeout, the function degrades gracefully to the old behavior rather than dropping the user's intent.
- Updated `/frontend/src/hooks/useWorkspaceConnection.ts` to call `emitSettingsChanged()` whenever a `settings_changed` LEAPMUX message is received, wiring the backend notification into the new coordination layer.
- Added comprehensive unit tests in `/frontend/tests/unit/lib/settingsChangedEvent.test.ts` and extended `/frontend/tests/unit/components/ExitPlanModeControl.test.tsx` to cover timeout fallback and the correct sequencing of the bypass permissions flow.

## Result

Clicking "& Bypass Permissions" on a plan approval banner now reliably activates bypass permissions mode. The client waits for the backend's automatic permission mode reset to arrive before sending its own mode change, eliminating the race that previously caused the bypassPermissions setting to be silently overwritten.

🤖 Generated with Claude Code
