### PR TITLE
Extract tildify() and use it in session-id-popover directory display

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -25,6 +25,7 @@ import * as styles from './ChatView.css'
 import { computePercentage, contextSize, ContextUsageGrid, DEFAULT_BUFFER_PCT } from './ContextUsageGrid'
 import { ControlRequestActions, ControlRequestContent, trySubmitAskUserQuestion } from './ControlRequestBanner'
 import { clearDraft, MarkdownEditor } from './MarkdownEditor'
+import { tildify } from './messageRenderers'
 
 export interface AgentEditorPanelProps {
   agentId: string
@@ -416,7 +417,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
       <Show when={props.agent?.workingDir}>
         <div class={styles.infoRow}>
           <span class={styles.infoLabel}>Directory</span>
-          <span class={styles.infoValue}>{props.agent!.workingDir}</span>
+          <span class={styles.infoValue}>{tildify(props.agent!.workingDir!, props.agent!.homeDir)}</span>
         </div>
       </Show>
       <Show when={props.agentSessionInfo?.contextUsage}>

--- a/frontend/tests/unit/components/relativizePath.test.ts
+++ b/frontend/tests/unit/components/relativizePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { relativizePath } from '~/components/chat/messageRenderers'
+import { relativizePath, tildify } from '~/components/chat/messageRenderers'
 
 describe('relativizePath', () => {
   // --- Existing behavior (no homeDir) ---
@@ -70,5 +70,31 @@ describe('relativizePath', () => {
   it('handles empty homeDir gracefully', () => {
     expect(relativizePath('/home/user/foo', '/home/user/bar/baz/qux', ''))
       .toBe('../../../foo')
+  })
+})
+
+describe('tildify', () => {
+  it('returns absPath when no homeDir', () => {
+    expect(tildify('/home/user/project')).toBe('/home/user/project')
+    expect(tildify('/home/user/project', undefined)).toBe('/home/user/project')
+    expect(tildify('/home/user/project', '')).toBe('/home/user/project')
+  })
+
+  it('returns ~ for exact home directory', () => {
+    expect(tildify('/home/user', '/home/user')).toBe('~')
+  })
+
+  it('returns ~/... for sub-path under home', () => {
+    expect(tildify('/home/user/project', '/home/user')).toBe('~/project')
+    expect(tildify('/home/user/a/b/c', '/home/user')).toBe('~/a/b/c')
+  })
+
+  it('returns absPath when path is not under home', () => {
+    expect(tildify('/opt/data/file.txt', '/home/user')).toBe('/opt/data/file.txt')
+  })
+
+  it('handles homeDir with trailing slash', () => {
+    expect(tildify('/home/user/project', '/home/user/')).toBe('~/project')
+    expect(tildify('/home/user', '/home/user/')).toBe('~')
   })
 })


### PR DESCRIPTION
## Motivation

The session-id-popover in the agent editor panel displayed the working
directory as a raw absolute path (e.g. `/home/alice/my-project`). Paths
under the user's home directory are much easier to read when the home
prefix is replaced with `~`. The tilde-replacement logic already existed
inline inside `relativizePath()`, but it was not reusable and was not
applied to the directory row in the popover.

## Modifications

- Extracted a new exported `tildify(absPath, homeDir?)` function from
  `messageRenderers.tsx` that replaces a home-directory prefix with `~`.
  The function handles edge cases: missing or empty `homeDir`, trailing
  slashes on `homeDir`, exact home-directory match returning `~`, and
  paths that are not under the home directory.
- Refactored `relativizePath()` to call `tildify()` internally instead
  of duplicating the tilde-conversion logic.
- Updated `AgentEditorPanel` to import and apply `tildify()` when
  rendering the "Directory" row in the session-id-popover, using
  `agent.homeDir` as the reference.
- Added a dedicated `describe('tildify', ...)` block in
  `/frontend/tests/unit/components/relativizePath.test.ts` covering all
  edge cases, and extended the existing `relativizePath` suite with
  tilde-aware test cases.

## Result

The "Directory" row in the session-info popover now shows
tilde-abbreviated paths for directories under the user's home directory:

- Before: `/home/alice/my-project`
- After: `~/my-project`

Paths outside the home directory, or sessions without a `homeDir`, are
displayed unchanged.

🤖 Generated with Claude Code
