### PR TITLE
Fix rapid-fire notification thread consolidation with soft-clear grace period

### DIFF
--- a/internal/hub/service/agent_service.go
+++ b/internal/hub/service/agent_service.go
@@ -38,8 +38,9 @@ type contextUsageSnapshot struct {
 // Used by persistNotificationThreaded to append consecutive notifications
 // into a single DB row.
 type notifThreadRef struct {
-	msgID string
-	seq   int64
+	msgID     string
+	seq       int64
+	softClear time.Time // set by non-notif messages; zero = thread is live
 }
 
 // AgentService implements the AgentServiceHandler interface.
@@ -54,6 +55,7 @@ type AgentService struct {
 	planModeToolUse sync.Map // tool_use_id (string) -> targetMode (string): pending EnterPlanMode/ExitPlanMode tool uses
 	contextUsage    sync.Map // agentID -> *contextUsageSnapshot: latest token usage
 	lastNotifThread sync.Map // agentID -> *notifThreadRef: current notification thread
+	notifMu         sync.Map // agentID -> *sync.Mutex: serializes notification threading
 	lastAgentStatus sync.Map // agentID -> string: last status value ("" = null, non-empty = actual value)
 	gitStatus       sync.Map // agentID -> *leapmuxv1.AgentGitStatus: latest git status from worker
 	homeDir         sync.Map // agentID -> string: worker's home directory


### PR DESCRIPTION
## Motivation

When an agent undergoes rapid permission-mode transitions (e.g. plan mode ->
default -> bypass permissions), the hub emits a `settings_changed` notification
for each transition. Between these notification messages, the agent stream can
also deliver non-notification messages such as assistant turns or tool results.

Previously, when a non-notification message arrived, the active notification
thread reference was hard-deleted. This meant that the next `settings_changed`
notification would be written as a new standalone DB row rather than being
appended to the existing thread, fragmenting what should be a single logical
group of changes into multiple separate chat messages.

Additionally, there was a race condition between `persistNotificationThreaded`
and the code path that cleared the thread reference: both paths accessed
`lastNotifThread` without mutual exclusion, making concurrent notification
delivery from the gRPC handler and the worker stream unsafe.

## Modifications

- Added `notifMu sync.Map` to `AgentService` that holds a per-agent `*sync.Mutex`, serializing all `persistNotificationThreaded` and `softClearNotifThread` calls for the same agent.
- Changed the non-notification message handling from a hard-delete of the thread reference to a soft-clear: when a non-notification message arrives, `softClearNotifThread` stamps the current thread ref with the current timestamp instead of removing it.
- Added `notifThreadGracePeriod` (1 second constant): a soft-cleared thread ref remains eligible for merging within this window, so a notification arriving shortly after a non-notification message is still appended to the existing thread and consolidated rather than written as a new row.
- Extended `notifThreadRef` with a `softClear time.Time` field to carry the soft-clear timestamp; a zero value means the thread is live and unconditionally eligible.
- When a soft-cleared thread is successfully revived by an incoming notification, `softClear` is reset to the zero value to mark the thread live again.
- Added tests covering `notifMutex` identity (same agent returns same mutex, different agents return distinct mutexes), `softClearNotifThread` timestamp behavior, no-op behavior when no thread exists, and concurrent serialization correctness (100 goroutines incrementing a shared counter).

## Result

Rapid-fire `settings_changed` notifications emitted during quick permission-mode
transitions (such as plan -> default -> bypass permissions) that are interleaved
with non-notification messages are now reliably consolidated into a single
notification thread row instead of appearing as multiple separate messages.

Concurrent notification delivery from different code paths no longer races on
the thread reference, eliminating a potential data-race crash.

🤖 Generated with Claude Code
