### PR TITLE
Refactor shell drag-and-drop and resize handle styling

### DIFF
--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
+import { resizeHandleSelectors, spacing } from '~/styles/tokens'
 
 export const editorResizeHandle = style({
   height: '4px',
@@ -9,27 +9,7 @@ export const editorResizeHandle = style({
   userSelect: 'none',
   margin: '-2px 0',
   zIndex: 5,
-  selectors: {
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      top: '50%',
-      height: '2px',
-      transform: 'translateY(-50%)',
-      background: 'transparent',
-      transition: 'background 0.15s',
-    },
-    '&:hover::before': {
-      background: 'var(--border)',
-      height: '4px',
-    },
-    '&:active::before': {
-      background: 'var(--primary)',
-      height: '1px',
-    },
-  },
+  selectors: resizeHandleSelectors('vertical'),
 })
 
 export const editorResizeHandleActive = style({

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -2,25 +2,32 @@ import { style } from '@vanilla-extract/css'
 import { spacing } from '~/styles/tokens'
 
 export const editorResizeHandle = style({
-  height: '8px',
+  height: '4px',
   flexShrink: 0,
   cursor: 'row-resize',
   position: 'relative',
   userSelect: 'none',
+  margin: '-2px 0',
+  zIndex: 5,
   selectors: {
     '&::before': {
       content: '""',
       position: 'absolute',
-      left: '0',
-      right: '0',
+      left: 0,
+      right: 0,
       top: '50%',
-      height: '1px',
+      height: '2px',
       transform: 'translateY(-50%)',
       background: 'transparent',
       transition: 'background 0.15s',
     },
     '&:hover::before': {
       background: 'var(--border)',
+      height: '4px',
+    },
+    '&:active::before': {
+      background: 'var(--primary)',
+      height: '1px',
     },
   },
 })
@@ -29,6 +36,7 @@ export const editorResizeHandleActive = style({
   selectors: {
     '&::before': {
       background: 'var(--primary) !important',
+      height: '1px !important',
     },
   },
 })

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
+import { resizeHandleSelectors, spacing } from '~/styles/tokens'
 
 export const shell = style({
   height: '100%',
@@ -27,27 +27,7 @@ export const resizeHandle = style({
   margin: '0 -2px',
   zIndex: 5,
   cursor: 'col-resize',
-  selectors: {
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      bottom: 0,
-      left: '50%',
-      width: '2px',
-      transform: 'translateX(-50%)',
-      background: 'transparent',
-      transition: 'background 0.15s',
-    },
-    '&:hover::before': {
-      background: 'var(--border)',
-      width: '4px',
-    },
-    '&:active::before': {
-      background: 'var(--primary)',
-      width: '1px',
-    },
-  },
+  selectors: resizeHandleSelectors('horizontal'),
 })
 
 export const center = style({

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -17,18 +17,36 @@ export const sidebar = style({
 })
 
 export const resizeHandle = style({
-  'all': 'unset',
-  'boxSizing': 'border-box',
-  'width': '4px',
-  'background': 'transparent',
-  'borderRadius': 0,
-  'position': 'relative',
-  'flexShrink': 0,
-  ':hover': {
-    background: 'var(--secondary)',
-  },
-  ':active': {
-    background: 'var(--secondary)',
+  all: 'unset',
+  boxSizing: 'border-box',
+  width: '4px',
+  background: 'transparent',
+  borderRadius: 0,
+  position: 'relative',
+  flexShrink: 0,
+  margin: '0 -2px',
+  zIndex: 5,
+  cursor: 'col-resize',
+  selectors: {
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: '50%',
+      width: '2px',
+      transform: 'translateX(-50%)',
+      background: 'transparent',
+      transition: 'background 0.15s',
+    },
+    '&:hover::before': {
+      background: 'var(--border)',
+      width: '4px',
+    },
+    '&:active::before': {
+      background: 'var(--primary)',
+      width: '1px',
+    },
   },
 })
 

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1394,6 +1394,12 @@ export const AppShell: ParentComponent = (props) => {
       initialOpenSections={opts?.initialOpenSections}
       initialSectionSizes={opts?.initialSectionSizes}
       onSectionStateChange={opts?.onLeftStateChange}
+      workerId={getCurrentTabContext().workerId}
+      workingDir={getCurrentTabContext().workingDir}
+      fileTreePath={fileTreePath()}
+      onFileSelect={setFileTreePath}
+      showTodos={showTodos()}
+      activeTodos={activeTodos()}
     />
   )
 
@@ -1421,6 +1427,16 @@ export const AppShell: ParentComponent = (props) => {
       initialOpenSections={opts?.initialOpenSections}
       initialSectionSizes={opts?.initialSectionSizes}
       onSectionStateChange={opts?.onRightStateChange}
+      workspaces={workspaceStore.state.workspaces}
+      activeWorkspaceId={workspace.activeWorkspaceId()}
+      loadSections={loadSections}
+      onSelectWorkspace={handleSelectWorkspace}
+      onNewWorkspace={(sectionId) => {
+        setNewWorkspaceTargetSectionId(sectionId)
+        setShowNewWorkspace(true)
+      }}
+      onRefreshWorkspaces={() => loadWorkspaces()}
+      onDeleteWorkspace={handleDeleteWorkspace}
     />
   )
 

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -111,25 +111,32 @@ globalStyle(`${collapsiblePane} ~ ${collapsiblePane} > ${collapsibleTrigger}`, {
 })
 
 export const paneResizeHandle = style({
-  height: '8px',
+  height: '4px',
   flexShrink: 0,
   cursor: 'row-resize',
   position: 'relative',
   userSelect: 'none',
+  margin: '-2px 0',
+  zIndex: 5,
   selectors: {
     '&::before': {
       content: '""',
       position: 'absolute',
-      left: '0',
-      right: '0',
+      left: 0,
+      right: 0,
       top: '50%',
-      height: '1px',
+      height: '2px',
       transform: 'translateY(-50%)',
       background: 'transparent',
       transition: 'background 0.15s',
     },
     '&:hover::before': {
       background: 'var(--border)',
+      height: '4px',
+    },
+    '&:active::before': {
+      background: 'var(--primary)',
+      height: '1px',
     },
   },
 })
@@ -138,6 +145,7 @@ export const paneResizeHandleActive = style({
   selectors: {
     '&::before': {
       background: 'var(--primary) !important',
+      height: '1px !important',
     },
   },
 })

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -71,6 +71,7 @@ export const collapsibleTrigger = style({
   'minHeight': headerHeight,
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,
+  'position': 'relative',
   ':hover': {
     backgroundColor: 'var(--card)',
   },
@@ -82,6 +83,13 @@ export const collapsibleTriggerStatic = style({
   ':hover': {
     backgroundColor: 'unset',
   },
+  '::after': {
+    display: 'none',
+  },
+})
+
+/** Hide the OAT accordion chevron on a section header (e.g. first right-sidebar section). */
+export const collapsibleTriggerNoChevron = style({
   '::after': {
     display: 'none',
   },
@@ -187,18 +195,21 @@ export const bottomSection = style({
   borderTop: '1px solid var(--border)',
 })
 
-/** Drag handle for section headers (visible on hover). */
+/** Drag handle for section headers (visible on hover, absolutely positioned). */
 export const sectionDragHandle = style({
+  'position': 'absolute',
+  'left': 0,
+  'top': 0,
+  'bottom': 0,
+  'width': spacing.lg,
   'display': 'flex',
   'alignItems': 'center',
   'justifyContent': 'center',
   'cursor': 'grab',
   'opacity': 0,
   'transition': 'opacity 0.15s',
-  'marginLeft': '-6px',
-  'marginRight': '-2px',
   'color': 'var(--muted-foreground)',
-  'flexShrink': 0,
+  'zIndex': 1,
   ':active': {
     cursor: 'grabbing',
   },
@@ -215,4 +226,38 @@ globalStyle(`${collapsibleTrigger}:hover ${sectionDragHandle}:hover`, {
 /** Visual state while a section is being dragged. */
 export const collapsiblePaneDragging = style({
   opacity: 0.5,
+})
+
+/** Horizontal line indicating where a dragged section will be inserted. */
+export const dropIndicatorLine = style({
+  height: '2px',
+  backgroundColor: 'var(--primary)',
+  flexShrink: 0,
+  borderRadius: '1px',
+  margin: '-1px 0',
+  position: 'relative',
+  zIndex: 10,
+  pointerEvents: 'none',
+})
+
+/** Placeholder shown when a sidebar has no sections. */
+export const emptyDropZone = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+  minHeight: '60px',
+  color: 'var(--faint-foreground)',
+  fontSize: 'var(--text-7)',
+  fontStyle: 'italic',
+  border: '2px dashed var(--border)',
+  borderRadius: '4px',
+  margin: spacing.sm,
+})
+
+/** Active state when a section drag is in progress over an empty sidebar. */
+export const emptyDropZoneActive = style({
+  borderColor: 'var(--primary)',
+  color: 'var(--muted-foreground)',
+  backgroundColor: 'color-mix(in srgb, var(--primary) 5%, transparent)',
 })

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { headerHeight, iconSize, spacing } from '~/styles/tokens'
+import { headerHeight, iconSize, resizeHandleSelectors, spacing } from '~/styles/tokens'
 
 /** Inner flex-column wrapper for the expanded sidebar. */
 export const sidebarInner = style({
@@ -118,27 +118,7 @@ export const paneResizeHandle = style({
   userSelect: 'none',
   margin: '-2px 0',
   zIndex: 5,
-  selectors: {
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      top: '50%',
-      height: '2px',
-      transform: 'translateY(-50%)',
-      background: 'transparent',
-      transition: 'background 0.15s',
-    },
-    '&:hover::before': {
-      background: 'var(--border)',
-      height: '4px',
-    },
-    '&:active::before': {
-      background: 'var(--primary)',
-      height: '1px',
-    },
-  },
+  selectors: resizeHandleSelectors('vertical'),
 })
 
 export const paneResizeHandleActive = style({

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -1,33 +1,27 @@
 import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
-import type { Section } from '~/generated/leapmux/v1/section_pb'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
+import type { TodoItem } from '~/stores/chat.store'
 import type { createSectionStore } from '~/stores/section.store'
 
-import Archive from 'lucide-solid/icons/archive'
 import CircleUser from 'lucide-solid/icons/circle-user'
-import Folder from 'lucide-solid/icons/folder'
-import FolderTree from 'lucide-solid/icons/folder-tree'
-import Layers from 'lucide-solid/icons/layers'
-import ListChecks from 'lucide-solid/icons/list-checks'
 import Plus from 'lucide-solid/icons/plus'
-import Users from 'lucide-solid/icons/users'
-import { createMemo, createSignal, onCleanup, Show } from 'solid-js'
-import { sectionClient, workspaceClient } from '~/api/clients'
+import { createMemo, onCleanup, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
-import { showToast } from '~/components/common/Toast'
-import { dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
+import { TodoList } from '~/components/todo/TodoList'
+import { DirectoryTree } from '~/components/tree/DirectoryTree'
+import { emptySection as emptySectionStyle, dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
 import { useAuth } from '~/context/AuthContext'
 import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
-import { mid } from '~/lib/lexorank'
-import { sanitizeName } from '~/lib/validate'
 import { iconSize } from '~/styles/tokens'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
 import { useSectionDrag } from './SectionDragContext'
+import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
 import { UserMenu } from './UserMenu'
+import { useWorkspaceOperations } from './useWorkspaceOperations'
 
 interface LeftSidebarProps {
   workspaces: Workspace[]
@@ -44,316 +38,56 @@ interface LeftSidebarProps {
   initialOpenSections?: Record<string, boolean>
   initialSectionSizes?: Record<string, number>
   onSectionStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
-}
-
-interface SectionGroup {
-  section: Section
-  workspaces: Workspace[]
+  // File/todo props for rendering FILES/TODOS sections moved to this sidebar
+  workerId: string
+  workingDir: string
+  fileTreePath: string
+  onFileSelect: (path: string) => void
+  showTodos: boolean
+  activeTodos: TodoItem[]
 }
 
 export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   const auth = useAuth()
+  // eslint-disable-next-line solid/reactivity -- stable store reference for component lifetime
   const store = props.sectionStore
   const { setExternalDragHandler, setExternalOverlayRenderer } = useSectionDrag()
 
-  const [renamingWorkspaceId, setRenamingWorkspaceId] = createSignal<string | null>(null)
-  const [renameValue, setRenameValue] = createSignal('')
-  const [sharingWorkspaceId, setSharingWorkspaceId] = createSignal<string | null>(null)
-
-  // Per-workspace loading state (ref-counted to handle concurrent operations).
-  const [loadingCounts, setLoadingCounts] = createSignal<Map<string, number>>(new Map())
-
-  const startWorkspaceLoading = (workspaceId: string): () => void => {
-    setLoadingCounts((prev) => {
-      const next = new Map(prev)
-      next.set(workspaceId, (next.get(workspaceId) ?? 0) + 1)
-      return next
-    })
-    let called = false
-    return () => {
-      if (!called) {
-        called = true
-        setLoadingCounts((prev) => {
-          const next = new Map(prev)
-          const count = (next.get(workspaceId) ?? 1) - 1
-          if (count <= 0)
-            next.delete(workspaceId)
-          else
-            next.set(workspaceId, count)
-          return next
-        })
-      }
-    }
-  }
-
-  const isWorkspaceLoading = (id: string): boolean => {
-    return (loadingCounts().get(id) ?? 0) > 0
-  }
+  /* eslint-disable solid/reactivity -- callbacks are stable references */
+  const wsOps = useWorkspaceOperations({
+    workspaces: () => props.workspaces,
+    activeWorkspaceId: () => props.activeWorkspaceId,
+    sectionStore: store,
+    loadSections: props.loadSections,
+    onSelectWorkspace: props.onSelectWorkspace,
+    onNewWorkspace: props.onNewWorkspace,
+    onRefreshWorkspaces: props.onRefreshWorkspaces,
+    onDeleteWorkspace: props.onDeleteWorkspace,
+  })
+  /* eslint-enable solid/reactivity */
 
   // ---------------------------------------------------------------------------
   // Workspace grouping
   // ---------------------------------------------------------------------------
-
-  const currentUserId = createMemo(() => auth.user()?.id ?? '')
-
-  const ownedWorkspaces = createMemo(() =>
-    props.workspaces.filter(w => w.createdBy === currentUserId()),
-  )
-  const sharedWorkspaces = createMemo(() =>
-    props.workspaces.filter(w => w.createdBy !== currentUserId()),
-  )
 
   /** Get sections for the left sidebar, sorted by position. */
   const leftSections = createMemo(() =>
     store.getSectionsForSidebar(Sidebar.LEFT),
   )
 
-  const sectionGroups = createMemo((): SectionGroup[] => {
-    const sections = leftSections()
-    const groups: SectionGroup[] = []
-
-    const getWorkspacesForSection = (sectionId: string): Workspace[] => {
-      const sectionItems = store.state.items
-        .filter(i => i.sectionId === sectionId)
-        .sort((a, b) => a.position.localeCompare(b.position))
-      return sectionItems
-        .map(i => ownedWorkspaces().find(w => w.id === i.workspaceId))
-        .filter((w): w is Workspace => w != null)
-    }
-
-    const assignedIds = new Set(store.state.items.map(i => i.workspaceId))
-    const unassigned = ownedWorkspaces().filter(w => !assignedIds.has(w.id))
-
-    for (const section of sections) {
-      if (isWorkspaceSection(section.sectionType)) {
-        const sectionWorkspaces = getWorkspacesForSection(section.id)
-        groups.push({
-          section,
-          workspaces: section.sectionType === SectionType.WORKSPACES_IN_PROGRESS
-            ? [...sectionWorkspaces, ...unassigned]
-            : section.sectionType === SectionType.WORKSPACES_SHARED
-              ? sharedWorkspaces()
-              : sectionWorkspaces,
-        })
-      }
-      else {
-        // Non-workspace sections (FILES, TODOS) on the left sidebar get empty groups
-        groups.push({ section, workspaces: [] })
-      }
-    }
-
-    return groups
-  })
-
-  // ---------------------------------------------------------------------------
-  // Workspace operations
-  // ---------------------------------------------------------------------------
-
-  const startRename = (workspace: Workspace) => {
-    setRenamingWorkspaceId(workspace.id)
-    setRenameValue(workspace.title || 'Untitled')
-  }
-
-  const cancelRename = () => {
-    setRenamingWorkspaceId(null)
-    setRenameValue('')
-  }
-
-  const commitRename = async () => {
-    const id = renamingWorkspaceId()
-    const title = renameValue().trim()
-    if (!id || !title) {
-      cancelRename()
-      return
-    }
-    const done = startWorkspaceLoading(id)
-    try {
-      await workspaceClient.renameWorkspace({ workspaceId: id, title })
-      props.onRefreshWorkspaces()
-    }
-    catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to rename workspace', 'danger')
-    }
-    finally {
-      done()
-    }
-    cancelRename()
-  }
-
-  const moveWorkspace = async (workspaceId: string, sectionId: string) => {
-    const sectionItems = store.getItemsForSection(sectionId)
-    const lastItem = sectionItems[sectionItems.length - 1]
-    const position = lastItem ? mid(lastItem.position, '') : mid('', '')
-    const done = startWorkspaceLoading(workspaceId)
-    try {
-      await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
-      store.moveWorkspace(workspaceId, sectionId, position)
-    }
-    catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to move workspace', 'danger')
-    }
-    finally {
-      done()
-    }
-  }
-
-  const archiveWorkspace = async (workspaceId: string) => {
-    const archivedSection = store.getArchivedSection()
-    if (!archivedSection)
-      return
-    await moveWorkspace(workspaceId, archivedSection.id)
-  }
-
-  const unarchiveWorkspace = async (workspaceId: string) => {
-    const inProgressSection = store.getInProgressSection()
-    if (!inProgressSection)
-      return
-    await moveWorkspace(workspaceId, inProgressSection.id)
-  }
-
-  const findFirstNonArchivedWorkspaceId = (): string | null => {
-    for (const group of sectionGroups()) {
-      if (group.section.sectionType === SectionType.WORKSPACES_ARCHIVED)
-        continue
-      if (group.workspaces.length > 0)
-        return group.workspaces[0].id
-    }
-    return null
-  }
-
-  const deleteWorkspace = async (workspaceId: string) => {
-    // eslint-disable-next-line no-alert
-    if (!confirm('Are you sure you want to delete this workspace? This cannot be undone.'))
-      return
-    const done = startWorkspaceLoading(workspaceId)
-    try {
-      await workspaceClient.deleteWorkspace({ workspaceId })
-      props.onRefreshWorkspaces()
-      await props.loadSections()
-
-      if (props.onDeleteWorkspace) {
-        const nextId = findFirstNonArchivedWorkspaceId()
-        props.onDeleteWorkspace(workspaceId, nextId)
-      }
-    }
-    catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to delete workspace', 'danger')
-    }
-    finally {
-      done()
-    }
-  }
-
-  const getSectionId = (workspaceId: string): string | undefined => {
-    return store.getSectionForWorkspace(workspaceId)
-  }
-
-  const isWorkspaceArchived = (workspaceId: string): boolean => {
-    const archivedSection = store.getArchivedSection()
-    if (!archivedSection)
-      return false
-    return getSectionId(workspaceId) === archivedSection.id
-  }
-
-  const canAddToSection = (section: Section): boolean => {
-    return section.sectionType !== SectionType.WORKSPACES_ARCHIVED
-      && section.sectionType !== SectionType.WORKSPACES_SHARED
-      && isWorkspaceSection(section.sectionType)
-  }
+  const sectionGroups = createMemo(() =>
+    wsOps.buildSectionGroups(leftSections()),
+  )
 
   // ---------------------------------------------------------------------------
   // DnD
   // ---------------------------------------------------------------------------
 
-  const computeDropPosition = (
-    wsId: string,
-    targetWsId: string,
-    targetSectionId: string,
-    direction: 'before' | 'after',
-  ): string => {
-    const items = store.getItemsForSection(targetSectionId)
-      .filter(i => i.workspaceId !== wsId)
-    const targetIdx = items.findIndex(i => i.workspaceId === targetWsId)
-    if (targetIdx < 0) {
-      const lastItem = items[items.length - 1]
-      return lastItem ? mid(lastItem.position, '') : mid('', '')
-    }
-    if (direction === 'after') {
-      const prevPos = items[targetIdx].position
-      const nextPos = targetIdx + 1 < items.length ? items[targetIdx + 1].position : ''
-      return mid(prevPos, nextPos)
-    }
-    const prevPos = targetIdx > 0 ? items[targetIdx - 1].position : ''
-    const nextPos = items[targetIdx].position
-    return mid(prevPos, nextPos)
-  }
-
-  const handleDragEnd = ({ draggable, droppable }: { draggable: any, droppable?: any }) => {
-    if (!draggable || !droppable || draggable.id === droppable.id)
-      return
-
-    const dragId = String(draggable.id)
-    const dropId = String(droppable.id)
-
-    if (!dragId.startsWith('ws-'))
-      return
-
-    const wsId = dragId.slice(3)
-    const fromSectionId = draggable.data?.sectionId as string
-
-    // Don't allow dragging from the Shared section
-    const fromSection = store.state.sections.find(s => s.id === fromSectionId)
-    if (fromSection?.sectionType === SectionType.WORKSPACES_SHARED)
-      return
-
-    let targetSectionId: string
-    let position: string
-
-    if (dropId.startsWith('ws-')) {
-      const targetWsId = dropId.slice(3)
-      targetSectionId = droppable.data?.sectionId as string
-      const targetSection = store.state.sections.find(s => s.id === targetSectionId)
-      if (targetSection?.sectionType === SectionType.WORKSPACES_SHARED)
-        return
-
-      if (fromSectionId === targetSectionId) {
-        const items = store.getItemsForSection(targetSectionId)
-        const dragIdx = items.findIndex(i => i.workspaceId === wsId)
-        const dropIdx = items.findIndex(i => i.workspaceId === targetWsId)
-        const direction = dragIdx >= 0 && dragIdx < dropIdx ? 'after' : 'before'
-        position = computeDropPosition(wsId, targetWsId, targetSectionId, direction)
-      }
-      else {
-        position = computeDropPosition(wsId, targetWsId, targetSectionId, 'before')
-      }
-    }
-    else if (dropId.startsWith('section-')) {
-      targetSectionId = dropId.slice(8)
-      const targetSection = store.state.sections.find(s => s.id === targetSectionId)
-      if (targetSection?.sectionType === SectionType.WORKSPACES_SHARED || fromSectionId === targetSectionId)
-        return
-      const items = store.getItemsForSection(targetSectionId)
-      const lastItem = items[items.length - 1]
-      position = lastItem ? mid(lastItem.position, '') : mid('', '')
-    }
-    else {
-      return
-    }
-
-    store.moveWorkspace(wsId, targetSectionId, position)
-    const done = startWorkspaceLoading(wsId)
-    sectionClient.moveWorkspace({ workspaceId: wsId, sectionId: targetSectionId, position })
-      .catch((err) => {
-        showToast(err instanceof Error ? err.message : 'Failed to reorder workspace', 'danger')
-        props.loadSections()
-      })
-      .finally(() => done())
-  }
-
   // Register workspace DnD handlers with the unified SectionDragProvider.
   // This allows workspace dragging to work through the shared DragDropProvider
   // instead of requiring a separate nested provider (which would shadow section DnD).
-  setExternalDragHandler(handleDragEnd)
+  setExternalDragHandler(wsOps.handleWorkspaceDragEnd)
+  // eslint-disable-next-line solid/reactivity -- overlay renderer is called from DragOverlay, not a tracked scope
   setExternalOverlayRenderer((draggable: any) => {
     if (!draggable)
       return <></>
@@ -372,39 +106,14 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   })
 
   // ---------------------------------------------------------------------------
-  // Section icon mapping
-  // ---------------------------------------------------------------------------
-
-  const getSectionIcon = (section: Section) => {
-    switch (section.sectionType) {
-      case SectionType.WORKSPACES_IN_PROGRESS:
-        return Layers
-      case SectionType.WORKSPACES_ARCHIVED:
-        return Archive
-      case SectionType.WORKSPACES_SHARED:
-        return Users
-      case SectionType.FILES:
-        return FolderTree
-      case SectionType.TODOS:
-        return ListChecks
-      default:
-        return Folder
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Reactive helpers for content factories.
   // ---------------------------------------------------------------------------
 
-  const getWorkspacesForGroup = (sectionId: string): Workspace[] => {
-    const group = sectionGroups().find(g => g.section.id === sectionId)
-    return group?.workspaces ?? []
-  }
+  const getWorkspacesForGroup = (sectionId: string): Workspace[] =>
+    wsOps.getWorkspacesForGroup(sectionId, sectionGroups())
 
-  const isGroupShared = (sectionId: string): boolean => {
-    const group = sectionGroups().find(g => g.section.id === sectionId)
-    return group?.section.sectionType === SectionType.WORKSPACES_SHARED
-  }
+  const isGroupShared = (sectionId: string): boolean =>
+    wsOps.isGroupShared(sectionId, sectionGroups())
 
   // ---------------------------------------------------------------------------
   // Build sidebar section definitions
@@ -428,8 +137,8 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
           defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
           collapsible: true,
           draggable: true,
-          visible: !isShared || sharedWorkspaces().length > 0,
-          headerActions: canAddToSection(group.section)
+          visible: !isShared || wsOps.sharedWorkspaces().length > 0,
+          headerActions: wsOps.canAddToSection(group.section)
             ? (
                 <IconButton
                   icon={Plus}
@@ -451,32 +160,30 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
               workspaces={getWorkspacesForGroup(sectionId)}
               sectionId={sectionId}
               activeWorkspaceId={props.activeWorkspaceId}
-              currentUserId={currentUserId()}
+              currentUserId={wsOps.currentUserId()}
               isVirtual={isGroupShared(sectionId)}
               sections={store.state.sections}
               onSelect={props.onSelectWorkspace}
-              onRename={startRename}
-              onMoveTo={moveWorkspace}
-              onShare={id => setSharingWorkspaceId(id)}
-              onArchive={archiveWorkspace}
-              onUnarchive={unarchiveWorkspace}
-              onDelete={deleteWorkspace}
-              getSectionId={getSectionId}
-              isArchived={isWorkspaceArchived}
-              renamingWorkspaceId={renamingWorkspaceId()}
-              renameValue={renameValue()}
-              onRenameInput={v => setRenameValue(sanitizeName(v).value)}
-              onRenameCommit={commitRename}
-              onRenameCancel={cancelRename}
-              isWorkspaceLoading={isWorkspaceLoading}
+              onRename={wsOps.startRename}
+              onMoveTo={wsOps.moveWorkspace}
+              onShare={id => wsOps.setSharingWorkspaceId(id)}
+              onArchive={wsOps.archiveWorkspace}
+              onUnarchive={wsOps.unarchiveWorkspace}
+              onDelete={wsOps.deleteWorkspace}
+              getSectionId={wsOps.getSectionId}
+              isArchived={wsOps.isWorkspaceArchived}
+              renamingWorkspaceId={wsOps.renamingWorkspaceId()}
+              renameValue={wsOps.renameValue()}
+              onRenameInput={wsOps.onRenameInput}
+              onRenameCommit={wsOps.commitRename}
+              onRenameCancel={wsOps.cancelRename}
+              isWorkspaceLoading={wsOps.isWorkspaceLoading}
             />
           ),
         })
       }
-      else {
-        // Non-workspace sections (FILES, TODOS) rendered on the left sidebar.
-        // These are placeholder sections; the actual content is rendered by
-        // the unified builder in AppShell when moved here.
+      else if (sectionType === SectionType.FILES) {
+        // FILES section moved to the left sidebar — render DirectoryTree
         sections.push({
           id: sectionId,
           title: group.section.name,
@@ -486,7 +193,40 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
           collapsible: true,
           draggable: true,
           testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          content: () => <></>,
+          content: () => (
+            <Show
+              when={props.workerId}
+              fallback={<div class={emptySectionStyle}>No tab selected</div>}
+            >
+              <DirectoryTree
+                workerId={props.workerId}
+                showFiles
+                selectedPath={props.fileTreePath}
+                onSelect={props.onFileSelect}
+                rootPath={props.workingDir || '~'}
+              />
+            </Show>
+          ),
+        })
+      }
+      else if (sectionType === SectionType.TODOS) {
+        // TODOS section moved to the left sidebar — render TodoList
+        sections.push({
+          id: sectionId,
+          title: group.section.name,
+          railIcon: getSectionIcon(group.section),
+          railTitle: group.section.name,
+          visible: props.showTodos,
+          draggable: true,
+          testId: `section-header-${sectionTypeTestId(sectionType)}`,
+          railBadge: () => (
+            <span class={csStyles.railBadgeText}>
+              {props.activeTodos.filter(t => t.status === 'completed').length}
+              /
+              {props.activeTodos.length}
+            </span>
+          ),
+          content: () => <TodoList todos={props.activeTodos} />,
         })
       }
     }
@@ -536,13 +276,13 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
         onStateChange={props.onSectionStateChange}
       />
 
-      <Show when={sharingWorkspaceId()}>
+      <Show when={wsOps.sharingWorkspaceId()}>
         {workspaceId => (
           <WorkspaceSharingDialog
             workspaceId={workspaceId()}
-            onClose={() => setSharingWorkspaceId(null)}
+            onClose={() => wsOps.setSharingWorkspaceId(null)}
             onSaved={() => {
-              setSharingWorkspaceId(null)
+              wsOps.setSharingWorkspaceId(null)
               props.onRefreshWorkspaces()
             }}
           />
@@ -550,25 +290,4 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
       </Show>
     </>
   )
-}
-
-/** Whether the section type is a workspace section (can contain workspaces). */
-function isWorkspaceSection(sectionType: SectionType): boolean {
-  return sectionType === SectionType.WORKSPACES_IN_PROGRESS
-    || sectionType === SectionType.WORKSPACES_CUSTOM
-    || sectionType === SectionType.WORKSPACES_ARCHIVED
-    || sectionType === SectionType.WORKSPACES_SHARED
-}
-
-/** Map section type to a test ID slug. */
-function sectionTypeTestId(sectionType: SectionType): string {
-  switch (sectionType) {
-    case SectionType.WORKSPACES_IN_PROGRESS: return 'workspaces_in_progress'
-    case SectionType.WORKSPACES_CUSTOM: return 'workspaces_custom'
-    case SectionType.WORKSPACES_ARCHIVED: return 'workspaces_archived'
-    case SectionType.WORKSPACES_SHARED: return 'workspaces_shared'
-    case SectionType.FILES: return 'files'
-    case SectionType.TODOS: return 'todos'
-    default: return String(sectionType)
-  }
 }

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -1,16 +1,23 @@
 import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { TodoItem } from '~/stores/chat.store'
 import type { createSectionStore } from '~/stores/section.store'
-import FolderTree from 'lucide-solid/icons/folder-tree'
-import ListChecks from 'lucide-solid/icons/list-checks'
+
+import Plus from 'lucide-solid/icons/plus'
 import { createMemo, Show } from 'solid-js'
+import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import * as swlStyles from '~/components/workspace/workspaceList.css'
+import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
+import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
 import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { iconSize } from '~/styles/tokens'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
+import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
+import { useWorkspaceOperations } from './useWorkspaceOperations'
 
 interface RightSidebarProps {
   workspaceId: string
@@ -27,102 +34,196 @@ interface RightSidebarProps {
   initialOpenSections?: Record<string, boolean>
   initialSectionSizes?: Record<string, number>
   onSectionStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
+  // Workspace props for rendering workspace sections moved to this sidebar
+  workspaces: Workspace[]
+  activeWorkspaceId: string | null
+  loadSections: () => Promise<void>
+  onSelectWorkspace: (id: string) => void
+  onNewWorkspace: (sectionId: string | null) => void
+  onRefreshWorkspaces: () => void
+  onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
 }
 
 export const RightSidebar: Component<RightSidebarProps> = (props) => {
+  // eslint-disable-next-line solid/reactivity -- stable store reference for component lifetime
   const store = props.sectionStore
+
+  /* eslint-disable solid/reactivity -- callbacks are stable references */
+  const wsOps = useWorkspaceOperations({
+    workspaces: () => props.workspaces,
+    activeWorkspaceId: () => props.activeWorkspaceId,
+    sectionStore: store,
+    loadSections: props.loadSections,
+    onSelectWorkspace: props.onSelectWorkspace,
+    onNewWorkspace: props.onNewWorkspace,
+    onRefreshWorkspaces: props.onRefreshWorkspaces,
+    onDeleteWorkspace: props.onDeleteWorkspace,
+  })
+  /* eslint-enable solid/reactivity */
 
   /** Get sections assigned to the right sidebar, sorted by position. */
   const rightSections = createMemo(() =>
     store.getSectionsForSidebar(Sidebar.RIGHT),
   )
 
+  const sectionGroups = createMemo(() =>
+    wsOps.buildSectionGroups(rightSections()),
+  )
+
+  const getWorkspacesForGroup = (sectionId: string): Workspace[] =>
+    wsOps.getWorkspacesForGroup(sectionId, sectionGroups())
+
+  const isGroupShared = (sectionId: string): boolean =>
+    wsOps.isGroupShared(sectionId, sectionGroups())
+
   // Build section definitions reactively from the store
   const sections = (): SidebarSectionDef[] => {
     const secs = rightSections()
     return secs.map((section): SidebarSectionDef => {
-      switch (section.sectionType) {
-        case SectionType.FILES:
-          return {
-            id: section.id,
-            title: section.name,
-            railIcon: FolderTree,
-            railTitle: section.name,
-            collapsible: secs.length > 1,
-            draggable: true,
-            testId: 'section-header-files',
-            content: () => (
-              <Show
-                when={props.workerId}
-                fallback={<div class={swlStyles.emptySection}>No tab selected</div>}
-              >
-                <DirectoryTree
-                  workerId={props.workerId}
-                  showFiles
-                  selectedPath={props.fileTreePath}
-                  onSelect={props.onFileSelect}
-                  rootPath={props.workingDir || '~'}
+      const sectionType = section.sectionType
+
+      if (sectionType === SectionType.FILES) {
+        return {
+          id: section.id,
+          title: section.name,
+          railIcon: getSectionIcon(section),
+          railTitle: section.name,
+          collapsible: secs.length > 1,
+          draggable: true,
+          testId: 'section-header-files',
+          content: () => (
+            <Show
+              when={props.workerId}
+              fallback={<div class={swlStyles.emptySection}>No tab selected</div>}
+            >
+              <DirectoryTree
+                workerId={props.workerId}
+                showFiles
+                selectedPath={props.fileTreePath}
+                onSelect={props.onFileSelect}
+                rootPath={props.workingDir || '~'}
+              />
+            </Show>
+          ),
+        }
+      }
+
+      if (sectionType === SectionType.TODOS) {
+        return {
+          id: section.id,
+          title: section.name,
+          railIcon: getSectionIcon(section),
+          railTitle: section.name,
+          visible: props.showTodos,
+          draggable: true,
+          testId: 'section-header-todos',
+          railBadge: () => (
+            <span class={csStyles.railBadgeText}>
+              {props.activeTodos.filter(t => t.status === 'completed').length}
+              /
+              {props.activeTodos.length}
+            </span>
+          ),
+          content: () => <TodoList todos={props.activeTodos} />,
+        }
+      }
+
+      if (isWorkspaceSection(sectionType)) {
+        // Workspace section moved to the right sidebar — render full workspace content
+        const isShared = sectionType === SectionType.WORKSPACES_SHARED
+        const sectionId = section.id
+        return {
+          id: sectionId,
+          title: section.name,
+          railIcon: getSectionIcon(section),
+          railTitle: section.name,
+          defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
+          collapsible: true,
+          draggable: true,
+          visible: !isShared || wsOps.sharedWorkspaces().length > 0,
+          headerActions: wsOps.canAddToSection(section)
+            ? (
+                <IconButton
+                  icon={Plus}
+                  iconSize={iconSize.sm}
+                  size="md"
+                  title={`New workspace in ${section.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    props.onNewWorkspace(sectionId)
+                  }}
                 />
-              </Show>
-            ),
-          }
-        case SectionType.TODOS:
-          return {
-            id: section.id,
-            title: section.name,
-            railIcon: ListChecks,
-            railTitle: section.name,
-            visible: props.showTodos,
-            draggable: true,
-            testId: 'section-header-todos',
-            railBadge: () => (
-              <span class={csStyles.railBadgeText}>
-                {props.activeTodos.filter(t => t.status === 'completed').length}
-                /
-                {props.activeTodos.length}
-              </span>
-            ),
-            content: () => <TodoList todos={props.activeTodos} />,
-          }
-        default:
-          // Workspace sections that got moved to the right sidebar
-          return {
-            id: section.id,
-            title: section.name,
-            railIcon: FolderTree,
-            railTitle: section.name,
-            collapsible: true,
-            draggable: true,
-            testId: `section-header-${sectionTypeTestId(section.sectionType)}`,
-            content: () => <></>,
-          }
+              )
+            : undefined,
+          testId: `section-header-${sectionTypeTestId(sectionType)}`,
+          content: () => (
+            <WorkspaceSectionContent
+              workspaces={getWorkspacesForGroup(sectionId)}
+              sectionId={sectionId}
+              activeWorkspaceId={props.activeWorkspaceId}
+              currentUserId={wsOps.currentUserId()}
+              isVirtual={isGroupShared(sectionId)}
+              sections={store.state.sections}
+              onSelect={props.onSelectWorkspace}
+              onRename={wsOps.startRename}
+              onMoveTo={wsOps.moveWorkspace}
+              onShare={id => wsOps.setSharingWorkspaceId(id)}
+              onArchive={wsOps.archiveWorkspace}
+              onUnarchive={wsOps.unarchiveWorkspace}
+              onDelete={wsOps.deleteWorkspace}
+              getSectionId={wsOps.getSectionId}
+              isArchived={wsOps.isWorkspaceArchived}
+              renamingWorkspaceId={wsOps.renamingWorkspaceId()}
+              renameValue={wsOps.renameValue()}
+              onRenameInput={wsOps.onRenameInput}
+              onRenameCommit={wsOps.commitRename}
+              onRenameCancel={wsOps.cancelRename}
+              isWorkspaceLoading={wsOps.isWorkspaceLoading}
+            />
+          ),
+        }
+      }
+
+      // Unknown section type — empty fallback
+      return {
+        id: section.id,
+        title: section.name,
+        railIcon: getSectionIcon(section),
+        railTitle: section.name,
+        collapsible: true,
+        draggable: true,
+        testId: `section-header-${sectionTypeTestId(sectionType)}`,
+        content: () => <></>,
       }
     })
   }
 
   return (
-    <CollapsibleSidebar
-      sections={sections()}
-      side="right"
-      isCollapsed={props.isCollapsed}
-      onExpand={props.onExpand}
-      onCollapse={props.onCollapse}
-      initialOpenSections={props.initialOpenSections}
-      initialSectionSizes={props.initialSectionSizes}
-      onStateChange={props.onSectionStateChange}
-    />
-  )
-}
+    <>
+      <CollapsibleSidebar
+        sections={sections()}
+        side="right"
+        isCollapsed={props.isCollapsed}
+        onExpand={props.onExpand}
+        onCollapse={props.onCollapse}
+        initialOpenSections={props.initialOpenSections}
+        initialSectionSizes={props.initialSectionSizes}
+        onStateChange={props.onSectionStateChange}
+      />
 
-/** Map section type to a test ID slug. */
-function sectionTypeTestId(sectionType: SectionType): string {
-  switch (sectionType) {
-    case SectionType.WORKSPACES_IN_PROGRESS: return 'workspaces_in_progress'
-    case SectionType.WORKSPACES_CUSTOM: return 'workspaces_custom'
-    case SectionType.WORKSPACES_ARCHIVED: return 'workspaces_archived'
-    case SectionType.WORKSPACES_SHARED: return 'workspaces_shared'
-    case SectionType.FILES: return 'files'
-    case SectionType.TODOS: return 'todos'
-    default: return String(sectionType)
-  }
+      <Show when={wsOps.sharingWorkspaceId()}>
+        {workspaceId => (
+          <WorkspaceSharingDialog
+            workspaceId={workspaceId()}
+            onClose={() => wsOps.setSharingWorkspaceId(null)}
+            onSaved={() => {
+              wsOps.setSharingWorkspaceId(null)
+              props.onRefreshWorkspaces()
+            }}
+          />
+        )}
+      </Show>
+    </>
+  )
 }

--- a/frontend/src/components/shell/SectionDragContext.tsx
+++ b/frontend/src/components/shell/SectionDragContext.tsx
@@ -4,18 +4,29 @@ import { closestCenter, DragDropProvider, DragDropSensors, DragOverlay } from '@
 import { createContext, createSignal, useContext } from 'solid-js'
 import { Sidebar } from '~/generated/leapmux/v1/section_pb'
 import { mid } from '~/lib/lexorank'
+import {
+  computeInsertPosition,
+  findClosestSectionDroppable,
+  isNearIndicator as isNearIndicatorFn,
+  SECTION_DRAG_PREFIX,
+  SIDEBAR_ZONE_PREFIX,
+} from './sectionDragUtils'
 
-/** Prefix for section draggable IDs. */
-export const SECTION_DRAG_PREFIX = 'sidebar-section:'
-
-/** Prefix for sidebar drop-zone droppable IDs. */
-export const SIDEBAR_ZONE_PREFIX = 'sidebar-zone:'
+export { SECTION_DRAG_PREFIX, SIDEBAR_ZONE_PREFIX }
 
 type ExternalDragHandler = (event: { draggable: any, droppable: any }) => void
 type ExternalOverlayRenderer = (draggable: any) => JSX.Element
 
+export interface DropIndicator {
+  /** The section ID being hovered, or `__zone_left__` / `__zone_right__` for sidebar zones. */
+  targetSectionId: string
+  position: 'before' | 'after'
+}
+
 interface SectionDragState {
   draggedSectionId: () => string | null
+  /** Current drop indicator position (null when not dragging a section). */
+  dropIndicator: () => DropIndicator | null
   /** Register an external drag end handler (e.g., workspace DnD). */
   setExternalDragHandler: (handler: ExternalDragHandler | null) => void
   /** Register an external drag overlay renderer. */
@@ -31,6 +42,11 @@ export function useSectionDrag(): SectionDragState {
   return ctx
 }
 
+/** Non-throwing version of useSectionDrag for components that may render outside the provider. */
+export function useOptionalSectionDrag(): SectionDragState | undefined {
+  return useContext(SectionDragCtx)
+}
+
 interface SectionDragProviderProps {
   /** All sections (both sidebars), sorted by position within each sidebar. */
   sections: () => Section[]
@@ -41,49 +57,112 @@ interface SectionDragProviderProps {
   children: JSX.Element
 }
 
-/**
- * Custom collision detector that filters droppables based on drag type.
- * Section drags only interact with section/sidebar-zone droppables.
- * Workspace drags only interact with workspace/section droppables.
- * This prevents cross-type collisions when both section and workspace DnD
- * share the same DragDropProvider.
- */
-function filteredCollisionDetector(draggable: any, droppables: any[], context: any) {
-  const dragId = String(draggable?.id ?? '')
-
-  if (dragId.startsWith(SECTION_DRAG_PREFIX)) {
-    // Section drag — prioritize section droppables over sidebar zones.
-    // Try section droppables first; only fall back to zones when no
-    // section droppable is close enough (e.g. dragging into an empty sidebar).
-    const sectionDroppables = droppables.filter((d: any) =>
-      String(d.id).startsWith(SECTION_DRAG_PREFIX),
-    )
-    const sectionResult = closestCenter(draggable, sectionDroppables, context)
-    if (sectionResult)
-      return sectionResult
-
-    const zoneDroppables = droppables.filter((d: any) =>
-      String(d.id).startsWith(SIDEBAR_ZONE_PREFIX),
-    )
-    return closestCenter(draggable, zoneDroppables, context)
-  }
-
-  if (dragId.startsWith('ws-')) {
-    // Workspace drag — only consider workspace and section droppables
-    const filtered = droppables.filter((d: any) => {
-      const id = String(d.id)
-      return id.startsWith('ws-') || id.startsWith('section-')
-    })
-    return closestCenter(draggable, filtered, context)
-  }
-
-  return closestCenter(draggable, droppables, context)
-}
-
 export function SectionDragProvider(props: SectionDragProviderProps) {
   const [draggedSectionId, setDraggedSectionId] = createSignal<string | null>(null)
+  const [dropIndicator, setDropIndicator] = createSignal<DropIndicator | null>(null)
   const [externalHandler, setExternalHandler] = createSignal<ExternalDragHandler | null>(null)
   const [externalRenderer, setExternalRenderer] = createSignal<ExternalOverlayRenderer | null>(null)
+
+  // Track the last pointer position during a drag. solid-dnd resets
+  // draggable.transformed before firing onDragEnd, so we cannot rely
+  // on the transform for position computation. We track the raw
+  // pointer ourselves to determine before/after in handleDragEnd
+  // and for proximity-based indicator visibility.
+  let lastPointerX: number | null = null
+  let lastPointerY: number | null = null
+
+  // The current droppable target (set by handleDragOver).
+  // Used by the pointermove handler for proximity-based indicator visibility.
+  let currentDropTarget: {
+    droppable: any
+    targetSectionId: string
+    /** Zone targets use X-bounds check only; section targets use full proximity. */
+    isZone: boolean
+  } | null = null
+
+  /**
+   * Custom collision detector that filters droppables based on drag type.
+   * For section drags, uses the tracked pointer position (when available)
+   * as the reference point instead of the element's transformed center.
+   * This avoids mis-hits when the element center is offset from the cursor
+   * during cross-sidebar drags.
+   */
+  function collisionDetector(draggable: any, droppables: any[], context: any) {
+    const dragId = String(draggable?.id ?? '')
+
+    if (dragId.startsWith(SECTION_DRAG_PREFIX)) {
+      // Prefer the actual cursor position. Fall back to element top-center
+      // when the pointer hasn't moved yet (drag just started).
+      const ref = lastPointerX !== null && lastPointerY !== null
+        ? { x: lastPointerX, y: lastPointerY }
+        : {
+            x: draggable.transformed.center.x,
+            y: draggable.transformed.center.y - (draggable.layout.height / 2),
+          }
+      return findClosestSectionDroppable(dragId, droppables, ref)
+    }
+
+    if (dragId.startsWith('ws-')) {
+      const filtered = droppables.filter((d: any) => {
+        const id = String(d.id)
+        return id.startsWith('ws-') || id.startsWith('section-')
+      })
+      return closestCenter(draggable, filtered, context)
+    }
+
+    return closestCenter(draggable, droppables, context)
+  }
+
+  /** Check if the cursor is within the proximity zone of the drop indicator line. */
+  function isNearIndicator(droppableLayout: any, position: 'before' | 'after'): boolean {
+    if (lastPointerY === null || lastPointerX === null)
+      return false
+    return isNearIndicatorFn(droppableLayout, position, lastPointerX, lastPointerY)
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    lastPointerX = e.clientX
+    lastPointerY = e.clientY
+
+    // Update drop indicator visibility based on proximity.
+    // handleDragOver fires only on collision target changes, so this
+    // handler provides continuous proximity feedback for both section
+    // and zone targets.
+    if (currentDropTarget) {
+      const { droppable, targetSectionId, isZone } = currentDropTarget
+      if (isZone) {
+        const near = lastPointerX >= droppable.layout.left && lastPointerX <= droppable.layout.right
+        if (near)
+          setDropIndicator({ targetSectionId, position: 'after' })
+        else
+          setDropIndicator(null)
+      }
+      else {
+        // Determine position by which proximity zone(s) the cursor is in,
+        // rather than using a fixed threshold. This avoids showing the
+        // 'after' indicator at the section bottom when the cursor is at
+        // the header — for expanded sections the zones don't overlap so
+        // each zone maps to exactly one position; for collapsed sections
+        // the zones overlap and we pick the closer indicator line.
+        const nearBefore = isNearIndicator(droppable.layout, 'before')
+        const nearAfter = isNearIndicator(droppable.layout, 'after')
+        if (nearBefore && nearAfter) {
+          const distBefore = Math.abs(lastPointerY! - droppable.layout.top)
+          const distAfter = Math.abs(lastPointerY! - droppable.layout.bottom)
+          setDropIndicator({ targetSectionId, position: distBefore <= distAfter ? 'before' : 'after' })
+        }
+        else if (nearBefore) {
+          setDropIndicator({ targetSectionId, position: 'before' })
+        }
+        else if (nearAfter) {
+          setDropIndicator({ targetSectionId, position: 'after' })
+        }
+        else {
+          setDropIndicator(null)
+        }
+      }
+    }
+  }
 
   const handleDragStart = ({ draggable }: any) => {
     if (!draggable)
@@ -92,10 +171,72 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
     if (id.startsWith(SECTION_DRAG_PREFIX)) {
       setDraggedSectionId(id.slice(SECTION_DRAG_PREFIX.length))
     }
+    setDropIndicator(null)
+    lastPointerX = null
+    lastPointerY = null
+    currentDropTarget = null
+    document.addEventListener('pointermove', onPointerMove)
+  }
+
+  const handleDragOver = ({ draggable, droppable }: any) => {
+    if (!draggable || !droppable) {
+      currentDropTarget = null
+      setDropIndicator(null)
+      return
+    }
+
+    const dragId = String(draggable.id)
+    const dropId = String(droppable.id)
+
+    if (!dragId.startsWith(SECTION_DRAG_PREFIX)) {
+      currentDropTarget = null
+      setDropIndicator(null)
+      return
+    }
+
+    const sectionId = dragId.slice(SECTION_DRAG_PREFIX.length)
+
+    if (dropId.startsWith(SECTION_DRAG_PREFIX)) {
+      const targetSectionId = dropId.slice(SECTION_DRAG_PREFIX.length)
+      if (targetSectionId === sectionId) {
+        currentDropTarget = null
+        setDropIndicator(null)
+        return
+      }
+
+      currentDropTarget = { droppable, targetSectionId, isZone: false }
+      // Don't set the indicator here — onPointerMove manages visibility
+      // and computes position from cursor Y on every pointer move.
+    }
+    else if (dropId.startsWith(SIDEBAR_ZONE_PREFIX)) {
+      const sideStr = dropId.slice(SIDEBAR_ZONE_PREFIX.length)
+      // Only show the zone indicator for cross-sidebar moves.
+      // Same-sidebar zone drops are no-ops, so showing an indicator is misleading.
+      const targetSidebar = sideStr === 'left' ? Sidebar.LEFT : Sidebar.RIGHT
+      const draggedSection = props.sections().find(s => s.id === sectionId)
+      if (draggedSection && draggedSection.sidebar === targetSidebar) {
+        currentDropTarget = null
+        setDropIndicator(null)
+      }
+      else {
+        currentDropTarget = { droppable, targetSectionId: `__zone_${sideStr}__`, isZone: true }
+        // Don't set the indicator here — onPointerMove manages visibility
+        // based on whether the cursor is within the sidebar's X bounds.
+      }
+    }
+    else {
+      currentDropTarget = null
+      setDropIndicator(null)
+    }
   }
 
   const handleDragEnd = ({ draggable, droppable }: any) => {
     const dragId = String(draggable?.id ?? '')
+    const lastIndicator = dropIndicator()
+
+    document.removeEventListener('pointermove', onPointerMove)
+    currentDropTarget = null
+    setDropIndicator(null)
 
     if (dragId.startsWith(SECTION_DRAG_PREFIX)) {
       // Section drag handling
@@ -127,7 +268,28 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
 
         targetSidebar = targetSection.sidebar
 
-        // Compute position: insert before the target section
+        // Use the indicator position shown to the user so the drop matches
+        // the visual. Falls back to cursor-based computation when the
+        // indicator target doesn't match (e.g., collision changed at the
+        // last moment), and to index-based comparison as a last resort.
+        let insertPos: 'before' | 'after'
+        if (lastIndicator && lastIndicator.targetSectionId === targetSectionId) {
+          insertPos = lastIndicator.position
+        }
+        else if (lastPointerY !== null) {
+          const distBefore = Math.abs(lastPointerY - droppable.layout.top)
+          const distAfter = Math.abs(lastPointerY - droppable.layout.bottom)
+          insertPos = distBefore <= distAfter ? 'before' : 'after'
+        }
+        else {
+          insertPos = computeInsertPosition(sectionId, targetSectionId, sections)
+        }
+
+        // Reject the drop if the cursor is not near any indicator line.
+        if (lastPointerY !== null && !isNearIndicator(droppable.layout, 'before') && !isNearIndicator(droppable.layout, 'after')) {
+          return
+        }
+
         const sidebarSections = sections
           .filter(s => s.sidebar === targetSidebar && s.id !== sectionId)
           .sort((a, b) => a.position.localeCompare(b.position))
@@ -136,32 +298,15 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
         if (targetIdx < 0)
           return
 
-        // If dragging within the same sidebar, check direction
-        if (draggedSection.sidebar === targetSidebar) {
-          const dragIdx = sections
-            .filter(s => s.sidebar === targetSidebar)
-            .sort((a, b) => a.position.localeCompare(b.position))
-            .findIndex(s => s.id === sectionId)
-          const dropIdx = sections
-            .filter(s => s.sidebar === targetSidebar)
-            .sort((a, b) => a.position.localeCompare(b.position))
-            .findIndex(s => s.id === targetSectionId)
-
-          if (dragIdx < dropIdx) {
-            // Dragging down: insert after target
-            const nextPos = targetIdx + 1 < sidebarSections.length
-              ? sidebarSections[targetIdx + 1].position
-              : ''
-            position = mid(sidebarSections[targetIdx].position, nextPos)
-          }
-          else {
-            // Dragging up: insert before target
-            const prevPos = targetIdx > 0 ? sidebarSections[targetIdx - 1].position : ''
-            position = mid(prevPos, sidebarSections[targetIdx].position)
-          }
+        if (insertPos === 'after') {
+          // Insert after target
+          const nextPos = targetIdx + 1 < sidebarSections.length
+            ? sidebarSections[targetIdx + 1].position
+            : ''
+          position = mid(sidebarSections[targetIdx].position, nextPos)
         }
         else {
-          // Cross-sidebar: insert before target
+          // Insert before target
           const prevPos = targetIdx > 0 ? sidebarSections[targetIdx - 1].position : ''
           position = mid(prevPos, sidebarSections[targetIdx].position)
         }
@@ -173,6 +318,10 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
 
         if (draggedSection.sidebar === targetSidebar)
           return // Same sidebar zone without a target — no-op
+
+        // Reject the drop if the cursor is not within the sidebar's X bounds.
+        if (lastPointerX !== null && (lastPointerX < droppable.layout.left || lastPointerX > droppable.layout.right))
+          return
 
         const sidebarSections = sections
           .filter(s => s.sidebar === targetSidebar && s.id !== sectionId)
@@ -202,6 +351,7 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
 
   const ctxValue: SectionDragState = {
     draggedSectionId,
+    dropIndicator,
     setExternalDragHandler: h => setExternalHandler(() => h),
     setExternalOverlayRenderer: r => setExternalRenderer(() => r),
   }
@@ -210,8 +360,9 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
     <SectionDragCtx.Provider value={ctxValue}>
       <DragDropProvider
         onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
-        collisionDetector={filteredCollisionDetector}
+        collisionDetector={collisionDetector}
       >
         <DragDropSensors />
         {props.children}

--- a/frontend/src/components/shell/TabBar.css.ts
+++ b/frontend/src/components/shell/TabBar.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { headerHeight, spacing } from '~/styles/tokens'
+import { headerHeightPx, spacing } from '~/styles/tokens'
 
 export const tooltipTrigger = style({
   display: 'inline-flex',
@@ -12,7 +12,7 @@ export const tabBar = style({
   padding: `0 ${spacing.sm}`,
   backgroundColor: 'var(--background)',
   flexShrink: 0,
-  minHeight: headerHeight,
+  minHeight: `${headerHeightPx - 1}px`,
 })
 
 export const tabList = style({

--- a/frontend/src/components/shell/Tile.css.ts
+++ b/frontend/src/components/shell/Tile.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { spacing } from '~/styles/tokens'
 
 export const tabBarRow = style({
   display: 'flex',
@@ -41,8 +42,9 @@ export const splitActions = style({
   display: 'flex',
   alignItems: 'center',
   gap: '2px',
-  marginLeft: '4px',
-  paddingLeft: '4px',
+  marginLeft: spacing.xs,
+  paddingLeft: spacing.xs,
+  paddingRight: spacing.xs,
   borderLeft: '1px solid var(--border)',
 })
 

--- a/frontend/src/components/shell/TilingLayout.css.ts
+++ b/frontend/src/components/shell/TilingLayout.css.ts
@@ -28,14 +28,17 @@ export const tileResizeHandle = style({
   borderRadius: 0,
   position: 'relative',
   flexShrink: 0,
+  zIndex: 5,
   selectors: {
     '&[data-direction="horizontal"]': {
-      width: '6px',
+      width: '4px',
       cursor: 'col-resize',
+      margin: '0 -2px',
     },
     '&[data-direction="vertical"]': {
-      height: '6px',
+      height: '4px',
       cursor: 'row-resize',
+      margin: '-2px 0',
     },
     '&::before': {
       content: '""',
@@ -57,11 +60,21 @@ export const tileResizeHandle = style({
       height: '1px',
       transform: 'translateY(-50%)',
     },
-    '&:hover::before': {
-      background: 'var(--primary)',
+    '&[data-direction="horizontal"]:hover::before': {
+      background: 'var(--border)',
+      width: '4px',
     },
-    '&:active::before': {
+    '&[data-direction="vertical"]:hover::before': {
+      background: 'var(--border)',
+      height: '4px',
+    },
+    '&[data-direction="horizontal"]:active::before': {
       background: 'var(--primary)',
+      width: '1px',
+    },
+    '&[data-direction="vertical"]:active::before': {
+      background: 'var(--primary)',
+      height: '1px',
     },
   },
 })

--- a/frontend/src/components/shell/TilingLayout.css.ts
+++ b/frontend/src/components/shell/TilingLayout.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { resizeHandleSelectors } from '~/styles/tokens'
 
 export const tilingRoot = style({
   flex: 1,
@@ -40,41 +41,7 @@ export const tileResizeHandle = style({
       cursor: 'row-resize',
       margin: '-2px 0',
     },
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      background: 'var(--border)',
-      transition: 'background 0.15s',
-    },
-    '&[data-direction="horizontal"]::before': {
-      top: 0,
-      bottom: 0,
-      left: '50%',
-      width: '1px',
-      transform: 'translateX(-50%)',
-    },
-    '&[data-direction="vertical"]::before': {
-      left: 0,
-      right: 0,
-      top: '50%',
-      height: '1px',
-      transform: 'translateY(-50%)',
-    },
-    '&[data-direction="horizontal"]:hover::before': {
-      background: 'var(--border)',
-      width: '4px',
-    },
-    '&[data-direction="vertical"]:hover::before': {
-      background: 'var(--border)',
-      height: '4px',
-    },
-    '&[data-direction="horizontal"]:active::before': {
-      background: 'var(--primary)',
-      width: '1px',
-    },
-    '&[data-direction="vertical"]:active::before': {
-      background: 'var(--primary)',
-      height: '1px',
-    },
+    ...resizeHandleSelectors('horizontal', 'var(--border)', '&[data-direction="horizontal"]'),
+    ...resizeHandleSelectors('vertical', 'var(--border)', '&[data-direction="vertical"]'),
   },
 })

--- a/frontend/src/components/shell/sectionDragUtils.ts
+++ b/frontend/src/components/shell/sectionDragUtils.ts
@@ -1,0 +1,177 @@
+import type { Section } from '~/generated/leapmux/v1/section_pb'
+import { headerHeightPx } from '~/styles/tokens'
+
+/** Prefix for section draggable IDs. */
+export const SECTION_DRAG_PREFIX = 'sidebar-section:'
+
+/** Prefix for sidebar drop-zone droppable IDs. */
+export const SIDEBAR_ZONE_PREFIX = 'sidebar-zone:'
+
+/** Horizontal tolerance so the indicator still activates over the resize handle. */
+export const X_TOLERANCE = 4
+
+/**
+ * Vertical buffer for the gap between section droppables (pane resize handle).
+ * When the cursor is in this gap, we still attribute it to the nearest section
+ * rather than letting the sidebar zone win the distance comparison.
+ */
+export const INTER_SECTION_GAP = 8
+
+/** Extra buffer above/below the header for proximity activation. */
+export const PROXIMITY_BUFFER = Math.round(headerHeightPx / 2)
+
+/** Droppable layout shape used by collision detection and proximity checks. */
+export interface DroppableLayout {
+  top: number
+  bottom: number
+  left: number
+  right: number
+  center: { x: number, y: number }
+}
+
+/** Minimal droppable shape used by collision detection. */
+export interface Droppable {
+  id: string | number
+  layout: DroppableLayout
+}
+
+/**
+ * Find the closest section/zone droppable for a section drag.
+ * Uses a reference point for containment and distance checks.
+ * If the ref is inside a section's bounding box, that section wins immediately.
+ * Falls back to distance comparison, preferring sections over zones.
+ */
+export function findClosestSectionDroppable(
+  dragId: string,
+  droppables: Droppable[],
+  ref: { x: number, y: number },
+): Droppable | null {
+  // Section whose edge is closest when the cursor is in the inter-section gap
+  // (e.g., pane resize handle). Preferred over zones to avoid the sidebar zone
+  // winning the distance comparison when its center is closer.
+  let gapSection: Droppable | null = null
+  let gapEdgeDist = Infinity
+
+  let bestSection: Droppable | null = null
+  let bestSectionDist = Infinity
+  let bestZone: Droppable | null = null
+  let bestZoneDist = Infinity
+
+  for (const d of droppables) {
+    const id = String(d.id)
+    if (id === dragId)
+      continue
+
+    if (id.startsWith(SECTION_DRAG_PREFIX)) {
+      const l = d.layout
+
+      // Exact containment: reference point inside the section's bounding box
+      if (
+        ref.x >= l.left && ref.x <= l.right
+        && ref.y >= l.top && ref.y <= l.bottom
+      ) {
+        return d
+      }
+
+      // Gap containment: cursor is just outside the section's Y bounds
+      // (within the resize handle gap) but within the section's X bounds.
+      // Track the section whose edge is closest.
+      if (ref.x >= l.left - X_TOLERANCE && ref.x <= l.right + X_TOLERANCE) {
+        const edgeDist = ref.y < l.top ? l.top - ref.y : ref.y - l.bottom
+        if (edgeDist <= INTER_SECTION_GAP && edgeDist < gapEdgeDist) {
+          gapSection = d
+          gapEdgeDist = edgeDist
+        }
+      }
+
+      const dc = l.center
+      const dist = Math.sqrt((ref.x - dc.x) ** 2 + (ref.y - dc.y) ** 2)
+      if (dist < bestSectionDist) {
+        bestSectionDist = dist
+        bestSection = d
+      }
+    }
+    else if (id.startsWith(SIDEBAR_ZONE_PREFIX)) {
+      const dc = d.layout.center
+      const dist = Math.sqrt((ref.x - dc.x) ** 2 + (ref.y - dc.y) ** 2)
+      if (dist < bestZoneDist) {
+        bestZoneDist = dist
+        bestZone = d
+      }
+    }
+  }
+
+  // Prefer gap containment: when the cursor is in the inter-section gap,
+  // always pick the nearest section rather than falling through to distance
+  // comparison where the sidebar zone's center might be closer.
+  if (gapSection)
+    return gapSection
+
+  if (bestSection && bestSectionDist <= bestZoneDist)
+    return bestSection
+  if (bestZone && bestZoneDist < bestSectionDist)
+    return bestZone
+  return bestSection ?? bestZone
+}
+
+/**
+ * Compute the insertion position (before/after) relative to a target section,
+ * given the dragged section and all sections. Used as a fallback when the
+ * indicator position is unavailable.
+ */
+export function computeInsertPosition(
+  sectionId: string,
+  targetSectionId: string,
+  sections: Section[],
+  draggable?: { transformed: { center: { y: number } }, layout: { height: number } },
+  droppable?: { layout: { top: number } },
+): 'before' | 'after' {
+  const draggedSection = sections.find(s => s.id === sectionId)
+  const targetSection = sections.find(s => s.id === targetSectionId)
+  if (!draggedSection || !targetSection)
+    return 'before'
+
+  if (draggedSection.sidebar === targetSection.sidebar) {
+    // Same sidebar: compare indices to determine direction
+    const sidebarSections = sections
+      .filter(s => s.sidebar === targetSection.sidebar)
+      .sort((a, b) => a.position.localeCompare(b.position))
+    const dragIdx = sidebarSections.findIndex(s => s.id === sectionId)
+    const dropIdx = sidebarSections.findIndex(s => s.id === targetSectionId)
+    return dragIdx < dropIdx ? 'after' : 'before'
+  }
+
+  // Cross-sidebar: compare the drag reference point (top of dragged element)
+  // against the target section's header midpoint to determine before/after.
+  if (draggable && droppable) {
+    const refY = draggable.transformed.center.y - (draggable.layout.height / 2)
+    const headerMidY = droppable.layout.top + headerHeightPx / 2
+    return refY < headerMidY ? 'before' : 'after'
+  }
+
+  return 'before'
+}
+
+/**
+ * Check if a pointer position is within the proximity zone of a drop indicator line.
+ * The indicator line renders at the section top ('before') or bottom ('after').
+ */
+export function isNearIndicator(
+  droppableLayout: DroppableLayout,
+  position: 'before' | 'after',
+  pointerX: number,
+  pointerY: number,
+): boolean {
+  let zoneTop: number
+  let zoneBottom: number
+  if (position === 'before') {
+    zoneTop = droppableLayout.top - PROXIMITY_BUFFER
+    zoneBottom = droppableLayout.top + headerHeightPx + PROXIMITY_BUFFER
+  }
+  else {
+    zoneBottom = droppableLayout.bottom + PROXIMITY_BUFFER
+    zoneTop = droppableLayout.bottom - headerHeightPx - PROXIMITY_BUFFER
+  }
+  return pointerX >= droppableLayout.left - X_TOLERANCE && pointerX <= droppableLayout.right + X_TOLERANCE
+    && pointerY >= zoneTop && pointerY <= zoneBottom
+}

--- a/frontend/src/components/shell/sectionDragUtils.ts
+++ b/frontend/src/components/shell/sectionDragUtils.ts
@@ -15,7 +15,7 @@ export const X_TOLERANCE = 4
  * When the cursor is in this gap, we still attribute it to the nearest section
  * rather than letting the sidebar zone win the distance comparison.
  */
-export const INTER_SECTION_GAP = 8
+export const INTER_SECTION_GAP = 2
 
 /** Extra buffer above/below the header for proximity activation. */
 export const PROXIMITY_BUFFER = Math.round(headerHeightPx / 2)

--- a/frontend/src/components/shell/sectionUtils.ts
+++ b/frontend/src/components/shell/sectionUtils.ts
@@ -1,0 +1,48 @@
+import type { LucideIcon } from 'lucide-solid'
+import type { Section } from '~/generated/leapmux/v1/section_pb'
+import Archive from 'lucide-solid/icons/archive'
+import Folder from 'lucide-solid/icons/folder'
+import FolderTree from 'lucide-solid/icons/folder-tree'
+import Layers from 'lucide-solid/icons/layers'
+import ListChecks from 'lucide-solid/icons/list-checks'
+import Users from 'lucide-solid/icons/users'
+import { SectionType } from '~/generated/leapmux/v1/section_pb'
+
+/** Whether the section type is a workspace section (can contain workspaces). */
+export function isWorkspaceSection(sectionType: SectionType): boolean {
+  return sectionType === SectionType.WORKSPACES_IN_PROGRESS
+    || sectionType === SectionType.WORKSPACES_CUSTOM
+    || sectionType === SectionType.WORKSPACES_ARCHIVED
+    || sectionType === SectionType.WORKSPACES_SHARED
+}
+
+/** Map section type to a test ID slug. */
+export function sectionTypeTestId(sectionType: SectionType): string {
+  switch (sectionType) {
+    case SectionType.WORKSPACES_IN_PROGRESS: return 'workspaces_in_progress'
+    case SectionType.WORKSPACES_CUSTOM: return 'workspaces_custom'
+    case SectionType.WORKSPACES_ARCHIVED: return 'workspaces_archived'
+    case SectionType.WORKSPACES_SHARED: return 'workspaces_shared'
+    case SectionType.FILES: return 'files'
+    case SectionType.TODOS: return 'todos'
+    default: return String(sectionType)
+  }
+}
+
+/** Map section to its icon. */
+export function getSectionIcon(section: Section): LucideIcon {
+  switch (section.sectionType) {
+    case SectionType.WORKSPACES_IN_PROGRESS:
+      return Layers
+    case SectionType.WORKSPACES_ARCHIVED:
+      return Archive
+    case SectionType.WORKSPACES_SHARED:
+      return Users
+    case SectionType.FILES:
+      return FolderTree
+    case SectionType.TODOS:
+      return ListChecks
+    default:
+      return Folder
+  }
+}

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -1,0 +1,380 @@
+import type { Section } from '~/generated/leapmux/v1/section_pb'
+import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
+import type { createSectionStore } from '~/stores/section.store'
+
+import { createMemo, createSignal } from 'solid-js'
+import { sectionClient, workspaceClient } from '~/api/clients'
+import { showToast } from '~/components/common/Toast'
+import { useAuth } from '~/context/AuthContext'
+import { SectionType } from '~/generated/leapmux/v1/section_pb'
+import { mid } from '~/lib/lexorank'
+import { sanitizeName } from '~/lib/validate'
+import { isWorkspaceSection } from './sectionUtils'
+
+export interface SectionGroup {
+  section: Section
+  workspaces: Workspace[]
+}
+
+export interface UseWorkspaceOperationsProps {
+  workspaces: () => Workspace[]
+  activeWorkspaceId: () => string | null
+  sectionStore: ReturnType<typeof createSectionStore>
+  loadSections: () => Promise<void>
+  onSelectWorkspace: (id: string) => void
+  onNewWorkspace: (sectionId: string | null) => void
+  onRefreshWorkspaces: () => void
+  onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
+}
+
+export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
+  const auth = useAuth()
+  const store = props.sectionStore
+
+  const [renamingWorkspaceId, setRenamingWorkspaceId] = createSignal<string | null>(null)
+  const [renameValue, setRenameValue] = createSignal('')
+  const [sharingWorkspaceId, setSharingWorkspaceId] = createSignal<string | null>(null)
+
+  // Per-workspace loading state (ref-counted to handle concurrent operations).
+  const [loadingCounts, setLoadingCounts] = createSignal<Map<string, number>>(new Map())
+
+  const startWorkspaceLoading = (workspaceId: string): () => void => {
+    setLoadingCounts((prev) => {
+      const next = new Map(prev)
+      next.set(workspaceId, (next.get(workspaceId) ?? 0) + 1)
+      return next
+    })
+    let called = false
+    return () => {
+      if (!called) {
+        called = true
+        setLoadingCounts((prev) => {
+          const next = new Map(prev)
+          const count = (next.get(workspaceId) ?? 1) - 1
+          if (count <= 0)
+            next.delete(workspaceId)
+          else
+            next.set(workspaceId, count)
+          return next
+        })
+      }
+    }
+  }
+
+  const isWorkspaceLoading = (id: string): boolean => {
+    return (loadingCounts().get(id) ?? 0) > 0
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace grouping
+  // ---------------------------------------------------------------------------
+
+  const currentUserId = createMemo(() => auth.user()?.id ?? '')
+
+  const ownedWorkspaces = createMemo(() =>
+    props.workspaces().filter(w => w.createdBy === currentUserId()),
+  )
+  const sharedWorkspaces = createMemo(() =>
+    props.workspaces().filter(w => w.createdBy !== currentUserId()),
+  )
+
+  /**
+   * Build section groups for a given set of sections.
+   * Each group pairs a section with the workspaces it contains.
+   */
+  const buildSectionGroups = (sections: Section[]): SectionGroup[] => {
+    const groups: SectionGroup[] = []
+
+    const getWorkspacesForSection = (sectionId: string): Workspace[] => {
+      const sectionItems = store.state.items
+        .filter(i => i.sectionId === sectionId)
+        .sort((a, b) => a.position.localeCompare(b.position))
+      return sectionItems
+        .map(i => ownedWorkspaces().find(w => w.id === i.workspaceId))
+        .filter((w): w is Workspace => w != null)
+    }
+
+    const assignedIds = new Set(store.state.items.map(i => i.workspaceId))
+    const unassigned = ownedWorkspaces().filter(w => !assignedIds.has(w.id))
+
+    for (const section of sections) {
+      if (isWorkspaceSection(section.sectionType)) {
+        const sectionWorkspaces = getWorkspacesForSection(section.id)
+        groups.push({
+          section,
+          workspaces: section.sectionType === SectionType.WORKSPACES_IN_PROGRESS
+            ? [...sectionWorkspaces, ...unassigned]
+            : section.sectionType === SectionType.WORKSPACES_SHARED
+              ? sharedWorkspaces()
+              : sectionWorkspaces,
+        })
+      }
+      else {
+        groups.push({ section, workspaces: [] })
+      }
+    }
+
+    return groups
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace operations
+  // ---------------------------------------------------------------------------
+
+  const startRename = (workspace: Workspace) => {
+    setRenamingWorkspaceId(workspace.id)
+    setRenameValue(workspace.title || 'Untitled')
+  }
+
+  const cancelRename = () => {
+    setRenamingWorkspaceId(null)
+    setRenameValue('')
+  }
+
+  const commitRename = async () => {
+    const id = renamingWorkspaceId()
+    const title = renameValue().trim()
+    if (!id || !title) {
+      cancelRename()
+      return
+    }
+    const done = startWorkspaceLoading(id)
+    try {
+      await workspaceClient.renameWorkspace({ workspaceId: id, title })
+      props.onRefreshWorkspaces()
+    }
+    catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to rename workspace', 'danger')
+    }
+    finally {
+      done()
+    }
+    cancelRename()
+  }
+
+  const moveWorkspace = async (workspaceId: string, sectionId: string) => {
+    const sectionItems = store.getItemsForSection(sectionId)
+    const lastItem = sectionItems[sectionItems.length - 1]
+    const position = lastItem ? mid(lastItem.position, '') : mid('', '')
+    const done = startWorkspaceLoading(workspaceId)
+    try {
+      await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
+      store.moveWorkspace(workspaceId, sectionId, position)
+    }
+    catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to move workspace', 'danger')
+    }
+    finally {
+      done()
+    }
+  }
+
+  const archiveWorkspace = async (workspaceId: string) => {
+    const archivedSection = store.getArchivedSection()
+    if (!archivedSection)
+      return
+    await moveWorkspace(workspaceId, archivedSection.id)
+  }
+
+  const unarchiveWorkspace = async (workspaceId: string) => {
+    const inProgressSection = store.getInProgressSection()
+    if (!inProgressSection)
+      return
+    await moveWorkspace(workspaceId, inProgressSection.id)
+  }
+
+  const findFirstNonArchivedWorkspaceId = (): string | null => {
+    const allSections = store.state.sections
+    for (const section of allSections) {
+      if (section.sectionType === SectionType.WORKSPACES_ARCHIVED)
+        continue
+      if (!isWorkspaceSection(section.sectionType))
+        continue
+      const items = store.getItemsForSection(section.id)
+      if (items.length > 0) {
+        const ws = props.workspaces().find(w => w.id === items[0].workspaceId)
+        if (ws)
+          return ws.id
+      }
+    }
+    return null
+  }
+
+  const deleteWorkspace = async (workspaceId: string) => {
+    // eslint-disable-next-line no-alert
+    if (!confirm('Are you sure you want to delete this workspace? This cannot be undone.'))
+      return
+    const done = startWorkspaceLoading(workspaceId)
+    try {
+      await workspaceClient.deleteWorkspace({ workspaceId })
+      props.onRefreshWorkspaces()
+      await props.loadSections()
+
+      if (props.onDeleteWorkspace) {
+        const nextId = findFirstNonArchivedWorkspaceId()
+        props.onDeleteWorkspace(workspaceId, nextId)
+      }
+    }
+    catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to delete workspace', 'danger')
+    }
+    finally {
+      done()
+    }
+  }
+
+  const getSectionId = (workspaceId: string): string | undefined => {
+    return store.getSectionForWorkspace(workspaceId)
+  }
+
+  const isWorkspaceArchived = (workspaceId: string): boolean => {
+    const archivedSection = store.getArchivedSection()
+    if (!archivedSection)
+      return false
+    return getSectionId(workspaceId) === archivedSection.id
+  }
+
+  const canAddToSection = (section: Section): boolean => {
+    return section.sectionType !== SectionType.WORKSPACES_ARCHIVED
+      && section.sectionType !== SectionType.WORKSPACES_SHARED
+      && isWorkspaceSection(section.sectionType)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace DnD helpers
+  // ---------------------------------------------------------------------------
+
+  const computeDropPosition = (
+    wsId: string,
+    targetWsId: string,
+    targetSectionId: string,
+    direction: 'before' | 'after',
+  ): string => {
+    const items = store.getItemsForSection(targetSectionId)
+      .filter(i => i.workspaceId !== wsId)
+    const targetIdx = items.findIndex(i => i.workspaceId === targetWsId)
+    if (targetIdx < 0) {
+      const lastItem = items[items.length - 1]
+      return lastItem ? mid(lastItem.position, '') : mid('', '')
+    }
+    if (direction === 'after') {
+      const prevPos = items[targetIdx].position
+      const nextPos = targetIdx + 1 < items.length ? items[targetIdx + 1].position : ''
+      return mid(prevPos, nextPos)
+    }
+    const prevPos = targetIdx > 0 ? items[targetIdx - 1].position : ''
+    const nextPos = items[targetIdx].position
+    return mid(prevPos, nextPos)
+  }
+
+  const handleWorkspaceDragEnd = ({ draggable, droppable }: { draggable: any, droppable?: any }) => {
+    if (!draggable || !droppable || draggable.id === droppable.id)
+      return
+
+    const dragId = String(draggable.id)
+    const dropId = String(droppable.id)
+
+    if (!dragId.startsWith('ws-'))
+      return
+
+    const wsId = dragId.slice(3)
+    const fromSectionId = draggable.data?.sectionId as string
+
+    // Don't allow dragging from the Shared section
+    const fromSection = store.state.sections.find(s => s.id === fromSectionId)
+    if (fromSection?.sectionType === SectionType.WORKSPACES_SHARED)
+      return
+
+    let targetSectionId: string
+    let position: string
+
+    if (dropId.startsWith('ws-')) {
+      const targetWsId = dropId.slice(3)
+      targetSectionId = droppable.data?.sectionId as string
+      const targetSection = store.state.sections.find(s => s.id === targetSectionId)
+      if (targetSection?.sectionType === SectionType.WORKSPACES_SHARED)
+        return
+
+      if (fromSectionId === targetSectionId) {
+        const items = store.getItemsForSection(targetSectionId)
+        const dragIdx = items.findIndex(i => i.workspaceId === wsId)
+        const dropIdx = items.findIndex(i => i.workspaceId === targetWsId)
+        const direction = dragIdx >= 0 && dragIdx < dropIdx ? 'after' : 'before'
+        position = computeDropPosition(wsId, targetWsId, targetSectionId, direction)
+      }
+      else {
+        position = computeDropPosition(wsId, targetWsId, targetSectionId, 'before')
+      }
+    }
+    else if (dropId.startsWith('section-')) {
+      targetSectionId = dropId.slice(8)
+      const targetSection = store.state.sections.find(s => s.id === targetSectionId)
+      if (targetSection?.sectionType === SectionType.WORKSPACES_SHARED || fromSectionId === targetSectionId)
+        return
+      const items = store.getItemsForSection(targetSectionId)
+      const lastItem = items[items.length - 1]
+      position = lastItem ? mid(lastItem.position, '') : mid('', '')
+    }
+    else {
+      return
+    }
+
+    store.moveWorkspace(wsId, targetSectionId, position)
+    const done = startWorkspaceLoading(wsId)
+    sectionClient.moveWorkspace({ workspaceId: wsId, sectionId: targetSectionId, position })
+      .catch((err) => {
+        showToast(err instanceof Error ? err.message : 'Failed to reorder workspace', 'danger')
+        props.loadSections()
+      })
+      .finally(() => done())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reactive helpers for content factories
+  // ---------------------------------------------------------------------------
+
+  const getWorkspacesForGroup = (sectionId: string, groups: SectionGroup[]): Workspace[] => {
+    const group = groups.find(g => g.section.id === sectionId)
+    return group?.workspaces ?? []
+  }
+
+  const isGroupShared = (sectionId: string, groups: SectionGroup[]): boolean => {
+    const group = groups.find(g => g.section.id === sectionId)
+    return group?.section.sectionType === SectionType.WORKSPACES_SHARED
+  }
+
+  return {
+    // Signals
+    renamingWorkspaceId,
+    renameValue,
+    sharingWorkspaceId,
+    setSharingWorkspaceId,
+    currentUserId,
+    sharedWorkspaces,
+
+    // Grouping
+    buildSectionGroups,
+    getWorkspacesForGroup,
+    isGroupShared,
+
+    // Operations
+    startRename,
+    cancelRename,
+    commitRename,
+    moveWorkspace,
+    archiveWorkspace,
+    unarchiveWorkspace,
+    deleteWorkspace,
+    canAddToSection,
+    getSectionId,
+    isWorkspaceArchived,
+    isWorkspaceLoading,
+    onRenameInput: (v: string) => setRenameValue(sanitizeName(v).value),
+
+    // DnD
+    computeDropPosition,
+    handleWorkspaceDragEnd,
+  }
+}
+
+export type WorkspaceOperations = ReturnType<typeof useWorkspaceOperations>

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -148,4 +148,3 @@ export const pathPreview = style({
   color: 'var(--muted-foreground)',
   wordBreak: 'break-all',
 })
-

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -148,3 +148,4 @@ export const pathPreview = style({
   color: 'var(--muted-foreground)',
   wordBreak: 'break-all',
 })
+

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -26,3 +26,39 @@ export const headerHeight = `${headerHeightPx}px`
 export const breakpoints = {
   mobile: 768, // px — below this width, use mobile layout
 }
+
+/**
+ * Generates `::before` selectors for a resize handle with consistent
+ * hover/active visual feedback.
+ *
+ * @param direction  - `'horizontal'` for col-resize, `'vertical'` for row-resize
+ * @param defaultBackground - default `::before` background (default: `'transparent'`)
+ * @param prefix - selector prefix (default: `'&'`); use e.g.
+ *   `'&[data-direction="horizontal"]'` for attribute-qualified selectors
+ */
+export function resizeHandleSelectors(
+  direction: 'horizontal' | 'vertical',
+  defaultBackground = 'transparent',
+  prefix = '&',
+): Record<string, Record<string, unknown>> {
+  const isH = direction === 'horizontal'
+  return {
+    [`${prefix}::before`]: {
+      content: '""',
+      position: 'absolute',
+      ...(isH
+        ? { top: 0, bottom: 0, left: '50%', width: '1px', transform: 'translateX(-50%)' }
+        : { left: 0, right: 0, top: '50%', height: '1px', transform: 'translateY(-50%)' }),
+      background: defaultBackground,
+      transition: 'background 0.15s',
+    },
+    [`${prefix}:hover::before`]: {
+      background: 'var(--border)',
+      ...(isH ? { width: '4px' } : { height: '4px' }),
+    },
+    [`${prefix}:active::before`]: {
+      background: 'var(--primary)',
+      ...(isH ? { width: '1px' } : { height: '1px' }),
+    },
+  }
+}

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -20,7 +20,8 @@ export const iconSize = {
   },
 }
 
-export const headerHeight = '36px'
+export const headerHeightPx = 36
+export const headerHeight = `${headerHeightPx}px`
 
 export const breakpoints = {
   mobile: 768, // px — below this width, use mobile layout

--- a/frontend/tests/e2e/20-section-reorder.spec.ts
+++ b/frontend/tests/e2e/20-section-reorder.spec.ts
@@ -13,12 +13,16 @@ function waitForMoveSection(page: import('@playwright/test').Page) {
 /**
  * Helper: get ordered section testids from a sidebar container.
  * Returns an array like ['section-header-files', 'section-header-todos'].
+ * If `side` is given, only returns sections within that sidebar.
  */
-async function getSectionOrder(page: import('@playwright/test').Page) {
+async function getSectionOrder(page: import('@playwright/test').Page, side?: 'left' | 'right') {
   // Each section has a data-testid on the <details> element (section-header-*).
   // The <summary> also has a data-testid ending with "-summary", so we
   // exclude those to avoid double-counting.
-  const sections = page.locator(`[data-testid^="section-header-"]`)
+  const root = side
+    ? page.locator(`[data-testid="sidebar-${side}"]`)
+    : page
+  const sections = root.locator(`[data-testid^="section-header-"]`)
   const count = await sections.count()
   const result: string[] = []
   for (let i = 0; i < count; i++) {
@@ -31,25 +35,124 @@ async function getSectionOrder(page: import('@playwright/test').Page) {
 
 /**
  * Helper: drag a section by its drag handle to another section's position.
- * Uses the drag handle within the section identified by sourceTestId and
- * drops on the summary of the section identified by targetTestId.
+ *
+ * Proximity-based drop activation requires the cursor to be near the
+ * indicator line: 'before' indicator is at the section top, 'after'
+ * indicator is at the section bottom.  This helper detects direction
+ * and sidebar to choose the correct drop target:
+ *  - Cross-sidebar: target the upper header area → 'before' positioning.
+ *  - Same sidebar, dragging down: target the section bottom → 'after'.
+ *  - Same sidebar, dragging up: target the header top → 'before'.
  */
 async function dragSection(
   page: import('@playwright/test').Page,
   sourceTestId: string,
   targetTestId: string,
 ) {
-  // Find the drag handle within the source section
   const sourceHandle = page.locator(`[data-testid="${sourceTestId}"] [data-testid^="section-drag-handle-"]`)
+  const targetSummary = page.locator(`[data-testid="${targetTestId}-summary"]`)
+  const targetSection = page.locator(`[data-testid="${targetTestId}"]`)
+
+  await expect(sourceHandle).toBeVisible()
+  await expect(targetSummary).toBeVisible()
+
+  const sourceBox = (await sourceHandle.boundingBox())!
+  const targetSummaryBox = (await targetSummary.boundingBox())!
+
+  // Detect same vs cross sidebar
+  const sourceInLeft = await page.locator(`[data-testid="sidebar-left"] [data-testid="${sourceTestId}"]`).count() > 0
+  const targetInLeft = await page.locator(`[data-testid="sidebar-left"] [data-testid="${targetTestId}"]`).count() > 0
+  const sameSidebar = sourceInLeft === targetInLeft
+
+  const targetX = targetSummaryBox.x + targetSummaryBox.width / 2
+  let targetY: number
+
+  if (!sameSidebar) {
+    // Cross-sidebar: target the upper header area for 'before' positioning
+    targetY = targetSummaryBox.y + 5
+  }
+  else if (sourceBox.y < targetSummaryBox.y) {
+    // Same sidebar, source above target → 'after' indicator at section bottom
+    const sectionBox = (await targetSection.boundingBox())!
+    targetY = sectionBox.y + sectionBox.height - 5
+  }
+  else {
+    // Same sidebar, source below target → 'before' indicator at section top
+    targetY = targetSummaryBox.y + 5
+  }
+
+  await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await page.waitForTimeout(100)
+  await page.mouse.down()
+  await page.waitForTimeout(100)
+  await page.mouse.move(targetX, targetY, { steps: 15 })
+  await page.waitForTimeout(100)
+  await page.mouse.up()
+}
+
+/**
+ * Helper: drag a section by its drag handle to below another section.
+ * Drops near the bottom of the target section to trigger 'after' insertion
+ * within the proximity zone.
+ */
+async function dragSectionBelow(
+  page: import('@playwright/test').Page,
+  sourceTestId: string,
+  targetTestId: string,
+) {
+  const sourceHandle = page.locator(`[data-testid="${sourceTestId}"] [data-testid^="section-drag-handle-"]`)
+  const targetSection = page.locator(`[data-testid="${targetTestId}"]`)
   const targetSummary = page.locator(`[data-testid="${targetTestId}-summary"]`)
 
   await expect(sourceHandle).toBeVisible()
   await expect(targetSummary).toBeVisible()
 
   const sourceBox = (await sourceHandle.boundingBox())!
-  const targetBox = (await targetSummary.boundingBox())!
+  const sectionBox = (await targetSection.boundingBox())!
+  const targetSummaryBox = (await targetSummary.boundingBox())!
 
-  // Drag from center of source handle to center of target summary
+  await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await page.waitForTimeout(100)
+  await page.mouse.down()
+  await page.waitForTimeout(100)
+  // Drop near the bottom of the target section (within the 'after' proximity zone)
+  await page.mouse.move(targetSummaryBox.x + targetSummaryBox.width / 2, sectionBox.y + sectionBox.height + 5, { steps: 15 })
+  await page.waitForTimeout(100)
+  await page.mouse.up()
+}
+
+/**
+ * Helper: ensure a section is in the specified sidebar. Moves it if needed.
+ * Returns true if a move was performed.
+ */
+async function ensureSectionInSidebar(
+  page: import('@playwright/test').Page,
+  sectionTestId: string,
+  targetSide: 'left' | 'right',
+): Promise<boolean> {
+  const sectionsInTarget = await getSectionOrder(page, targetSide)
+  if (sectionsInTarget.includes(sectionTestId))
+    return false // already there
+
+  // Find a drop target in the target sidebar
+  if (sectionsInTarget.length > 0) {
+    const saved = waitForMoveSection(page)
+    await dragSection(page, sectionTestId, sectionsInTarget[0])
+    await saved
+    await page.waitForTimeout(300)
+    return true
+  }
+
+  // Target sidebar is empty — drag to the empty drop zone
+  const sourceHandle = page.locator(`[data-testid="${sectionTestId}"] [data-testid^="section-drag-handle-"]`)
+  const emptyZone = page.locator(`[data-testid="empty-drop-zone-${targetSide}"]`)
+  await expect(sourceHandle).toBeVisible()
+  await expect(emptyZone).toBeVisible()
+
+  const sourceBox = (await sourceHandle.boundingBox())!
+  const targetBox = (await emptyZone.boundingBox())!
+
+  const saved = waitForMoveSection(page)
   await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
   await page.waitForTimeout(100)
   await page.mouse.down()
@@ -57,9 +160,23 @@ async function dragSection(
   await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 15 })
   await page.waitForTimeout(100)
   await page.mouse.up()
+  await saved
+  await page.waitForTimeout(300)
+  return true
 }
 
+// ============================================================================
+// Each test is self-contained: it reads the current state and sets up its own
+// preconditions via helper moves. Tests can be run individually with --grep
+// or in any order. Section moves persist within a worker, but no test assumes
+// state from a prior test.
+//
+// Default initial state: Left=[In Progress, Archived], Right=[Files]
+// ============================================================================
+
 test.describe('Section Reorder & Move', () => {
+  // ---------- Read-only tests (no section moves) ----------
+
   test('should show drag handles on section headers', async ({ page, authenticatedWorkspace }) => {
     // Left sidebar sections should have drag handles
     const inProgressHandle = page.locator('[data-testid="section-header-workspaces_in_progress"] [data-testid^="section-drag-handle-"]')
@@ -80,140 +197,291 @@ test.describe('Section Reorder & Move', () => {
     await expect(page.locator('[data-testid^="section-drag-handle-user-menu"]')).toHaveCount(0)
   })
 
-  test('should reorder sections within the right sidebar', async ({ page, authenticatedWorkspace }) => {
-    // The Todos section is only visible when there are active todos, so we
-    // first move Archived from the left sidebar to the right sidebar to get
-    // two visible sections for reordering.
-    await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
-    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+  test('should not shift section title when drag handle is present', async ({ page, authenticatedWorkspace }) => {
+    // The drag handle should be absolutely positioned and not affect the
+    // section title alignment.
+    const dragHandle = page.locator('[data-testid^="section-drag-handle-"]').first()
+    await expect(dragHandle).toBeVisible()
 
-    // Move Archived to the right sidebar
-    const moveResp = waitForMoveSection(page)
-    await dragSection(page, 'section-header-workspaces_archived', 'section-header-files')
-    await moveResp
+    // Verify the drag handle has position: absolute (does not affect flow)
+    const position = await dragHandle.evaluate(el => getComputedStyle(el).position)
+    expect(position).toBe('absolute')
 
-    // Wait for UI to stabilize after the cross-sidebar move
+    // Verify the Archived section title (index > 0, no sidebar collapse button)
+    // has the same x as the section icon — both should be at the left padding offset.
+    const archivedSummary = page.locator('[data-testid="section-header-workspaces_archived-summary"]')
+    const archivedIcon = archivedSummary.locator('svg').first()
+    const archivedTitle = archivedSummary.locator('span').first()
+    await expect(archivedIcon).toBeVisible()
+    await expect(archivedTitle).toBeVisible()
+
+    const iconBox = (await archivedIcon.boundingBox())!
+    const titleBox = (await archivedTitle.boundingBox())!
+
+    // The title should be to the right of the icon (icon + gap)
+    // and the icon should be within the left padding area.
+    expect(titleBox.x).toBeGreaterThan(iconBox.x)
+  })
+
+  test('should show drop indicator line during section drag', async ({ page, authenticatedWorkspace }) => {
+    // Ensure both sections are visible
+    const inProgressHandle = page.locator('[data-testid="section-header-workspaces_in_progress"] [data-testid^="section-drag-handle-"]')
+    const archivedSummary = page.locator('[data-testid="section-header-workspaces_archived-summary"]')
+    await expect(inProgressHandle).toBeVisible()
+    await expect(archivedSummary).toBeVisible()
+
+    const sourceBox = (await inProgressHandle.boundingBox())!
+    const targetBox = (await archivedSummary.boundingBox())!
+
+    // Start drag and hold the mouse over the target
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+    await page.waitForTimeout(100)
+    await page.mouse.down()
+    await page.waitForTimeout(100)
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 15 })
+    await page.waitForTimeout(200)
+
+    // A drop indicator should be visible
+    const dropIndicator = page.locator('[data-testid="drop-indicator"]')
+    await expect(dropIndicator.first()).toBeVisible()
+
+    // Cancel the drag by reloading — this avoids completing the drop
+    // (which would change section order and affect subsequent tests).
+    // solid-dnd has no keyboard cancel support, so reload is the
+    // cleanest way to abort a drag without side effects.
+    await page.reload()
+
+    // After reload, drop indicator should not exist
+    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
+    await expect(page.locator('[data-testid="drop-indicator"]')).toHaveCount(0)
+  })
+
+  // ---------- Destructive tests (modify section positions) ----------
+  // Each test establishes its own preconditions, so they can run independently.
+
+  test('should render workspace content after moving workspace section to right sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure IP is in the left sidebar and a drop target exists in the right
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+
+    // The workspace item should be visible in the left sidebar
+    const wsItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    await expect(wsItem).toBeVisible()
+
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+    await expect(leftSidebar.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)).toBeVisible()
+
+    // Find a section in the right sidebar to use as drop target
+    const rightSections = await getSectionOrder(page, 'right')
+    expect(rightSections.length).toBeGreaterThanOrEqual(1)
+
+    // Move the In Progress section to the right sidebar
+    const saved = waitForMoveSection(page)
+    await dragSection(page, 'section-header-workspaces_in_progress', rightSections[0])
+    await saved
     await page.waitForTimeout(500)
 
-    // Verify both sections are now in the right sidebar (Archived before Files)
-    const order = await getSectionOrder(page)
-    expect(order).toContain('section-header-workspaces_archived')
-    expect(order).toContain('section-header-files')
+    // The workspace item should still be visible (now in the right sidebar)
+    await expect(wsItem).toBeVisible()
 
-    // Reload to ensure clean state before testing reorder within right sidebar
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+    await expect(rightSidebar.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)).toBeVisible()
+
+    // Workspace should still be clickable
+    await wsItem.click()
+    await expect(page).toHaveURL(new RegExp(`/workspace/${authenticatedWorkspace.workspaceId}`))
+  })
+
+  test('should render file tree after moving Files section to left sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure Files is in the right sidebar and a drop target exists in the left
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+
+    // Find a section in the left sidebar to use as drop target
+    const leftSections = await getSectionOrder(page, 'left')
+    expect(leftSections.length).toBeGreaterThanOrEqual(1)
+
+    // Move Files section to the left sidebar
+    const saved = waitForMoveSection(page)
+    await dragSection(page, 'section-header-files', leftSections[0])
+    await saved
+    await page.waitForTimeout(500)
+
+    // Files section should now be in the left sidebar
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+    await expect(leftSidebar.locator('[data-testid="section-header-files"]')).toBeVisible()
+
+    // The Files section content should not be empty — it should contain
+    // a directory tree or "No tab selected" fallback
+    const filesSection = page.locator('[data-testid="section-header-files"]')
+    await expect(filesSection).toBeVisible()
+
+    // Verify the section still has content (not empty)
+    const sectionContent = filesSection.locator('div').first()
+    await expect(sectionContent).toBeVisible()
+  })
+
+  test('should reorder sections within the right sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure at least 2 sections are in the right sidebar
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'right')
+    await ensureSectionInSidebar(page, 'section-header-workspaces_archived', 'right')
+
+    // Reload to get clean state after setup moves
     await page.reload()
+    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
     await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
-    await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
 
-    // Now reorder: drag Files above Archived
+    const rightBefore = await getSectionOrder(page, 'right')
+    expect(rightBefore.length).toBeGreaterThanOrEqual(2)
+    const first = rightBefore[0]
+    const second = rightBefore[1]
+
+    // Drag second above first
     const reorderResp = waitForMoveSection(page)
-    await dragSection(page, 'section-header-files', 'section-header-workspaces_archived')
+    await dragSection(page, second, first)
     await reorderResp
 
-    // Reload and verify persistence — check the server got the right order
+    // Reload and verify persistence — the order should be reversed
     await page.reload()
-    await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
-    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+    await expect(page.locator(`[data-testid="${first}"]`)).toBeVisible()
+    await expect(page.locator(`[data-testid="${second}"]`)).toBeVisible()
 
-    const reloadOrder = await getSectionOrder(page)
-    const reloadFilesIdx = reloadOrder.indexOf('section-header-files')
-    const reloadArchivedIdx = reloadOrder.indexOf('section-header-workspaces_archived')
-    expect(reloadFilesIdx).toBeLessThan(reloadArchivedIdx)
+    const reloadOrder = await getSectionOrder(page, 'right')
+    const reloadFirstIdx = reloadOrder.indexOf(first)
+    const reloadSecondIdx = reloadOrder.indexOf(second)
+    expect(reloadSecondIdx).toBeLessThan(reloadFirstIdx)
   })
 
   test('should reorder sections within the left sidebar', async ({ page, authenticatedWorkspace }) => {
-    // Wait for left sidebar sections
+    // Ensure at least 2 sections are in the left sidebar
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'left')
+
+    // Reload to get clean state after setup moves
+    await page.reload()
     await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
+    await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
 
-    // Expand Archived section so it's visible
-    const archived = page.locator('[data-testid="section-header-workspaces_archived"]')
-    await expect(archived).toBeVisible()
+    const initialOrder = await getSectionOrder(page, 'left')
+    expect(initialOrder.length).toBeGreaterThanOrEqual(2)
+    const first = initialOrder[0]
+    const second = initialOrder[1]
 
-    // Get initial order of left sidebar sections
-    const initialOrder = await getSectionOrder(page)
-    const ipIdx = initialOrder.indexOf('section-header-workspaces_in_progress')
-    const arIdx = initialOrder.indexOf('section-header-workspaces_archived')
-    expect(ipIdx).toBeGreaterThanOrEqual(0)
-    expect(arIdx).toBeGreaterThanOrEqual(0)
-    expect(ipIdx).toBeLessThan(arIdx)
-
-    // Drag Archived above In Progress
+    // Drag second above first
     const saved = waitForMoveSection(page)
-    await dragSection(page, 'section-header-workspaces_archived', 'section-header-workspaces_in_progress')
+    await dragSection(page, second, first)
     await saved
 
-    // Verify new order: Archived before In Progress
-    const newOrder = await getSectionOrder(page)
-    const newIpIdx = newOrder.indexOf('section-header-workspaces_in_progress')
-    const newArIdx = newOrder.indexOf('section-header-workspaces_archived')
-    expect(newArIdx).toBeLessThan(newIpIdx)
+    // Verify new order: second is now before first
+    const newOrder = await getSectionOrder(page, 'left')
+    const newFirstIdx = newOrder.indexOf(first)
+    const newSecondIdx = newOrder.indexOf(second)
+    expect(newSecondIdx).toBeLessThan(newFirstIdx)
 
     // Reload and verify persistence
     await page.reload()
-    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
-    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+    await expect(page.locator(`[data-testid="${first}"]`)).toBeVisible()
+    await expect(page.locator(`[data-testid="${second}"]`)).toBeVisible()
 
-    const reloadOrder = await getSectionOrder(page)
-    const reloadIpIdx = reloadOrder.indexOf('section-header-workspaces_in_progress')
-    const reloadArIdx = reloadOrder.indexOf('section-header-workspaces_archived')
-    expect(reloadArIdx).toBeLessThan(reloadIpIdx)
+    const reloadOrder = await getSectionOrder(page, 'left')
+    const reloadFirstIdx = reloadOrder.indexOf(first)
+    const reloadSecondIdx = reloadOrder.indexOf(second)
+    expect(reloadSecondIdx).toBeLessThan(reloadFirstIdx)
   })
 
   test('should move section from left sidebar to right sidebar', async ({ page, authenticatedWorkspace }) => {
-    // Ensure Archived is visible in left sidebar
-    const archived = page.locator('[data-testid="section-header-workspaces_archived"]')
-    await expect(archived).toBeVisible()
+    // Ensure both sidebars have at least one section
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
 
-    // Get the drag handle for Archived section
-    const archiveHandle = page.locator('[data-testid="section-header-workspaces_archived"] [data-testid^="section-drag-handle-"]')
-    await expect(archiveHandle).toBeVisible()
+    // Find a section in the left sidebar
+    const leftSections = await getSectionOrder(page, 'left')
+    expect(leftSections.length).toBeGreaterThanOrEqual(1)
+    const source = leftSections[leftSections.length - 1] // take the last one
 
-    // Find a target in the right sidebar (e.g., Files section)
-    const filesSection = page.locator('[data-testid="section-header-files"]')
-    await expect(filesSection).toBeVisible()
+    // Find a section in the right sidebar as drop target
+    const rightSections = await getSectionOrder(page, 'right')
+    expect(rightSections.length).toBeGreaterThanOrEqual(1)
+    const target = rightSections[0]
 
-    // Drag Archived to the right sidebar (on top of the Files section)
+    // Drag from left to right
     const saved = waitForMoveSection(page)
-    await dragSection(page, 'section-header-workspaces_archived', 'section-header-files')
+    await dragSection(page, source, target)
     await saved
-
-    // The Archived section should now be in the right sidebar area.
-    // Verify it's no longer before Files in the left sidebar order.
-    // After the move, Archived should be near Files (same sidebar).
     await page.waitForTimeout(500)
 
-    // Reload and verify persistence
+    // Reload and verify the section moved to the right sidebar
+    await page.reload()
+    await expect(page.locator(`[data-testid="${source}"]`)).toBeVisible()
+
+    const rightAfter = await getSectionOrder(page, 'right')
+    expect(rightAfter).toContain(source)
+  })
+
+  test('should move section from right sidebar to left sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure both sidebars have at least one section
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+
+    // Find a section in the right sidebar
+    const rightSections = await getSectionOrder(page, 'right')
+    expect(rightSections.length).toBeGreaterThanOrEqual(1)
+    const source = rightSections[rightSections.length - 1]
+
+    // Find a section in the left sidebar as drop target
+    const leftSections = await getSectionOrder(page, 'left')
+    expect(leftSections.length).toBeGreaterThanOrEqual(1)
+    const target = leftSections[0]
+
+    // Drag from right to left
+    const saved = waitForMoveSection(page)
+    await dragSection(page, source, target)
+    await saved
+    await page.waitForTimeout(500)
+
+    // Reload and verify the section moved to the left sidebar
+    await page.reload()
+    await expect(page.locator(`[data-testid="${source}"]`)).toBeVisible()
+
+    const leftAfter = await getSectionOrder(page, 'left')
+    expect(leftAfter).toContain(source)
+  })
+
+  test('should insert section after target when dropped below its header', async ({ page, authenticatedWorkspace }) => {
+    // Ensure Archived is in the left sidebar (so this is a cross-sidebar drag)
+    await ensureSectionInSidebar(page, 'section-header-workspaces_archived', 'left')
+    // Ensure Files is in the right sidebar
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+
+    // Reload to get clean layout state after setup moves
     await page.reload()
     await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
     await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
 
-    // After reload, Archived and Files should be adjacent (both in right sidebar)
-    const allSections = await getSectionOrder(page)
-    expect(allSections).toContain('section-header-workspaces_archived')
-    expect(allSections).toContain('section-header-files')
-  })
-
-  test('should move section from right sidebar to left sidebar', async ({ page, authenticatedWorkspace }) => {
-    // Files section should be in the right sidebar
-    const filesSection = page.locator('[data-testid="section-header-files"]')
-    await expect(filesSection).toBeVisible()
-
-    // Drag Files to the left sidebar's In Progress section
+    // Drag Archived from left sidebar below the Files header in right sidebar.
+    // This should place Archived AFTER Files (not before).
     const saved = waitForMoveSection(page)
-    await dragSection(page, 'section-header-files', 'section-header-workspaces_in_progress')
+    await dragSectionBelow(page, 'section-header-workspaces_archived', 'section-header-files')
     await saved
-
     await page.waitForTimeout(500)
+
+    // Verify Archived is now in the right sidebar, AFTER Files
+    const rightOrder = await getSectionOrder(page, 'right')
+    expect(rightOrder).toContain('section-header-workspaces_archived')
+    expect(rightOrder).toContain('section-header-files')
+    const filesIdx = rightOrder.indexOf('section-header-files')
+    const archivedIdx = rightOrder.indexOf('section-header-workspaces_archived')
+    expect(archivedIdx).toBeGreaterThan(filesIdx)
 
     // Reload and verify persistence
     await page.reload()
     await expect(page.locator('[data-testid="section-header-files"]')).toBeVisible()
-    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
+    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
 
-    // After reload, Files should be adjacent to In Progress (both in left sidebar)
-    const allSections = await getSectionOrder(page)
-    expect(allSections).toContain('section-header-files')
-    expect(allSections).toContain('section-header-workspaces_in_progress')
+    const reloadOrder = await getSectionOrder(page, 'right')
+    const reloadFilesIdx = reloadOrder.indexOf('section-header-files')
+    const reloadArchivedIdx = reloadOrder.indexOf('section-header-workspaces_archived')
+    expect(reloadArchivedIdx).toBeGreaterThan(reloadFilesIdx)
   })
 
   test('should preserve workspace DnD after section reorder', async ({ page, authenticatedWorkspace }) => {
@@ -224,5 +492,190 @@ test.describe('Section Reorder & Move', () => {
     // Verify workspace can still be interacted with (click to select)
     await wsItem.click()
     await expect(page).toHaveURL(new RegExp(`/workspace/${authenticatedWorkspace.workspaceId}`))
+  })
+
+  test('should show empty drop zone when all sections are moved from a sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure both sidebars have at least one section
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+
+    // Move all sections out of the right sidebar to create an empty sidebar
+    let rightSections = await getSectionOrder(page, 'right')
+    const leftTarget = (await getSectionOrder(page, 'left'))[0]
+
+    // Move each right sidebar section to the left sidebar
+    for (const section of rightSections) {
+      const saved = waitForMoveSection(page)
+      await dragSection(page, section, leftTarget)
+      await saved
+      await page.waitForTimeout(300)
+    }
+
+    // The right sidebar should now show the empty drop zone
+    const emptyZone = page.locator('[data-testid="empty-drop-zone-right"]')
+    await expect(emptyZone).toBeVisible()
+    await expect(emptyZone).toContainText('No sections')
+
+    // Verify no section headers remain in the right sidebar
+    rightSections = await getSectionOrder(page, 'right')
+    expect(rightSections.length).toBe(0)
+  })
+
+  test('should allow dragging section back into empty sidebar', async ({ page, authenticatedWorkspace }) => {
+    // Ensure both sidebars have sections before emptying the right
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+
+    // Ensure right sidebar is empty by moving everything to the left
+    const rightSections = await getSectionOrder(page, 'right')
+    if (rightSections.length > 0) {
+      const leftTarget = (await getSectionOrder(page, 'left'))[0]
+      for (const section of rightSections) {
+        const saved = waitForMoveSection(page)
+        await dragSection(page, section, leftTarget)
+        await saved
+        await page.waitForTimeout(300)
+      }
+    }
+
+    // Verify right sidebar is empty
+    await expect(page.locator('[data-testid="empty-drop-zone-right"]')).toBeVisible()
+
+    // Pick a section from the left sidebar to drag back
+    const leftSections = await getSectionOrder(page, 'left')
+    expect(leftSections.length).toBeGreaterThanOrEqual(1)
+    const sectionToMove = leftSections[leftSections.length - 1]
+
+    // Drag onto the empty drop zone
+    const sourceHandle = page.locator(`[data-testid="${sectionToMove}"] [data-testid^="section-drag-handle-"]`)
+    const emptyZone = page.locator('[data-testid="empty-drop-zone-right"]')
+    await expect(sourceHandle).toBeVisible()
+    await expect(emptyZone).toBeVisible()
+
+    const sourceBox = (await sourceHandle.boundingBox())!
+    const targetBox = (await emptyZone.boundingBox())!
+
+    const moveBack = waitForMoveSection(page)
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+    await page.waitForTimeout(100)
+    await page.mouse.down()
+    await page.waitForTimeout(100)
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 15 })
+    await page.waitForTimeout(100)
+    await page.mouse.up()
+    await moveBack
+
+    // The section should now be in the right sidebar
+    await page.waitForTimeout(500)
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+    await expect(rightSidebar.locator(`[data-testid="${sectionToMove}"]`)).toBeVisible()
+
+    // The empty drop zone should be gone
+    await expect(page.locator('[data-testid="empty-drop-zone-right"]')).toHaveCount(0)
+  })
+
+  test('should not change order when dropping section at header of its immediate successor', async ({ page, authenticatedWorkspace }) => {
+    // Ensure at least 2 sections in the same sidebar
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'left')
+    await ensureSectionInSidebar(page, 'section-header-workspaces_archived', 'left')
+
+    // Reload to get clean state
+    await page.reload()
+    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
+    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+    const orderBefore = await getSectionOrder(page, 'left')
+    expect(orderBefore.length).toBeGreaterThanOrEqual(2)
+    const first = orderBefore[0]
+    const second = orderBefore[1]
+
+    // Drag the first section to the top of the second section's header.
+    // This targets the 'before' indicator of the second section, which
+    // means "insert before second" — a no-op since first is already there.
+    const sourceHandle = page.locator(`[data-testid="${first}"] [data-testid^="section-drag-handle-"]`)
+    const targetSummary = page.locator(`[data-testid="${second}-summary"]`)
+    await expect(sourceHandle).toBeVisible()
+    await expect(targetSummary).toBeVisible()
+
+    const sourceBox = (await sourceHandle.boundingBox())!
+    const targetBox = (await targetSummary.boundingBox())!
+
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+    await page.waitForTimeout(100)
+    await page.mouse.down()
+    await page.waitForTimeout(100)
+    // Target the top of the second section's header — near the 'before' indicator
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 5, { steps: 15 })
+    await page.waitForTimeout(100)
+    await page.mouse.up()
+
+    // Brief wait for any potential server call
+    await page.waitForTimeout(300)
+
+    // Order should remain unchanged
+    const orderAfter = await getSectionOrder(page, 'left')
+    expect(orderAfter.indexOf(first)).toBe(orderBefore.indexOf(first))
+    expect(orderAfter.indexOf(second)).toBe(orderBefore.indexOf(second))
+  })
+
+  test('should place resize handle after expanded section and before collapsed section', async ({ page, authenticatedWorkspace }) => {
+    // Ensure 3 sections are in the right sidebar: Files (expanded),
+    // Archived (collapsed by default), In Progress (expanded).
+    await ensureSectionInSidebar(page, 'section-header-files', 'right')
+    await ensureSectionInSidebar(page, 'section-header-workspaces_archived', 'right')
+    await ensureSectionInSidebar(page, 'section-header-workspaces_in_progress', 'right')
+
+    await page.reload()
+
+    const filesSection = page.locator('[data-testid="section-header-files"]')
+    const archivedSection = page.locator('[data-testid="section-header-workspaces_archived"]')
+    const inProgressSection = page.locator('[data-testid="section-header-workspaces_in_progress"]')
+    await expect(filesSection).toBeVisible()
+    await expect(archivedSection).toBeVisible()
+    await expect(inProgressSection).toBeVisible()
+
+    // Ensure Files and In Progress are expanded, Archived is collapsed
+    const archivedDetails = page.locator('[data-testid="section-header-workspaces_archived"]')
+    if (await archivedDetails.getAttribute('open') !== null) {
+      await page.locator('[data-testid="section-header-workspaces_archived-summary"]').click()
+      await page.waitForTimeout(200)
+    }
+    const filesDetails = page.locator('[data-testid="section-header-files"]')
+    if (await filesDetails.getAttribute('open') === null) {
+      await page.locator('[data-testid="section-header-files-summary"]').click()
+      await page.waitForTimeout(200)
+    }
+    const ipDetails = page.locator('[data-testid="section-header-workspaces_in_progress"]')
+    if (await ipDetails.getAttribute('open') === null) {
+      await page.locator('[data-testid="section-header-workspaces_in_progress-summary"]').click()
+      await page.waitForTimeout(200)
+    }
+
+    // Check section order: Files should be first, then Archived, then IP
+    const order = await getSectionOrder(page, 'right')
+    const filesIdx = order.indexOf('section-header-files')
+    const archivedIdx = order.indexOf('section-header-workspaces_archived')
+    const ipIdx = order.indexOf('section-header-workspaces_in_progress')
+
+    // Only test resize handle placement if the order matches the expected layout
+    // (Files, Archived, In Progress). This test focuses on handle placement
+    // between expanded and collapsed sections.
+    if (filesIdx < archivedIdx && archivedIdx < ipIdx) {
+      // There should be exactly one resize handle visible (between the two
+      // expanded sections: Files and In Progress, with Archived collapsed
+      // in between). The handle should render before Archived (right after
+      // Files' expanded content), not between Archived and In Progress.
+      const handles = page.locator('[data-testid="sidebar-right"] [data-testid="pane-resize-handle"]')
+      const handleCount = await handles.count()
+      expect(handleCount).toBe(1)
+
+      // The resize handle should be between Files bottom and Archived top
+      const filesBox = (await filesSection.boundingBox())!
+      const archivedBox = (await archivedSection.boundingBox())!
+      const handleBox = (await handles.first().boundingBox())!
+
+      expect(handleBox.y).toBeGreaterThanOrEqual(filesBox.y + filesBox.height - 1)
+      expect(handleBox.y + handleBox.height).toBeLessThanOrEqual(archivedBox.y + 1)
+    }
   })
 })

--- a/frontend/tests/e2e/20-section-reorder.spec.ts
+++ b/frontend/tests/e2e/20-section-reorder.spec.ts
@@ -669,13 +669,15 @@ test.describe('Section Reorder & Move', () => {
       const handleCount = await handles.count()
       expect(handleCount).toBe(1)
 
-      // The resize handle should be between Files bottom and Archived top
+      // The resize handle takes 0 layout space (negative margins) but its
+      // center should be at the boundary between Files and Archived.
       const filesBox = (await filesSection.boundingBox())!
       const archivedBox = (await archivedSection.boundingBox())!
       const handleBox = (await handles.first().boundingBox())!
+      const handleCenter = handleBox.y + handleBox.height / 2
 
-      expect(handleBox.y).toBeGreaterThanOrEqual(filesBox.y + filesBox.height - 1)
-      expect(handleBox.y + handleBox.height).toBeLessThanOrEqual(archivedBox.y + 1)
+      expect(handleCenter).toBeGreaterThanOrEqual(filesBox.y + filesBox.height - 1)
+      expect(handleCenter).toBeLessThanOrEqual(archivedBox.y + 1)
     }
   })
 })

--- a/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
+++ b/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
@@ -51,11 +51,14 @@ test.describe('Clear Command – Context Usage Reset', () => {
     await page.keyboard.type('/clear')
     await page.keyboard.press('Meta+Enter')
 
-    // Wait for the "Context cleared" notification
+    // Wait for the "Context cleared" notification — this confirms the
+    // backend processed the clear and context_cleared event was received.
     await expect(page.getByText('Context cleared')).toBeVisible()
 
-    // After /clear, the info trigger (and its HoverCard) should no longer
-    // be visible because context usage and cost have been cleared.
-    await expect(infoTrigger).not.toBeVisible()
+    // After /clear, context usage is cleared. The ContextUsageGrid replaces
+    // the 3x3 grid with an Info icon fallback when contextUsage is undefined.
+    // The info trigger itself remains visible (session is still active).
+    await expect(infoTrigger).toBeVisible()
+    await expect(contextGrid).not.toBeVisible({ timeout: 10_000 })
   })
 })

--- a/frontend/tests/unit/components/sectionDragUtils.test.ts
+++ b/frontend/tests/unit/components/sectionDragUtils.test.ts
@@ -1,0 +1,347 @@
+import type { Droppable, DroppableLayout } from '~/components/shell/sectionDragUtils'
+import { describe, expect, it } from 'vitest'
+import {
+  computeInsertPosition,
+  findClosestSectionDroppable,
+  isNearIndicator,
+  PROXIMITY_BUFFER,
+  SECTION_DRAG_PREFIX,
+  SIDEBAR_ZONE_PREFIX,
+  X_TOLERANCE,
+} from '~/components/shell/sectionDragUtils'
+import { Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { headerHeightPx } from '~/styles/tokens'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Create a section droppable with the given bounding box. */
+function section(id: string, top: number, bottom: number, left = 0, right = 200): Droppable {
+  return {
+    id: `${SECTION_DRAG_PREFIX}${id}`,
+    layout: {
+      top,
+      bottom,
+      left,
+      right,
+      center: { x: (left + right) / 2, y: (top + bottom) / 2 },
+    },
+  }
+}
+
+/** Create a sidebar zone droppable covering the full sidebar area. */
+function zone(side: 'left' | 'right', top = 0, bottom = 400, left = 0, right = 200): Droppable {
+  return {
+    id: `${SIDEBAR_ZONE_PREFIX}${side}`,
+    layout: {
+      top,
+      bottom,
+      left,
+      right,
+      center: { x: (left + right) / 2, y: (top + bottom) / 2 },
+    },
+  }
+}
+
+/** Create a minimal Section object for computeInsertPosition tests. */
+function makeSection(id: string, sidebar: Sidebar, position: string) {
+  return { id, sidebar, position } as any
+}
+
+// ---------------------------------------------------------------------------
+// findClosestSectionDroppable
+// ---------------------------------------------------------------------------
+
+describe('findClosestSectionDroppable', () => {
+  const dragId = `${SECTION_DRAG_PREFIX}dragged`
+
+  describe('exact containment', () => {
+    it('should return the section when ref is inside its bounding box', () => {
+      const s = section('target', 100, 300)
+      const result = findClosestSectionDroppable(dragId, [s], { x: 100, y: 200 })
+      expect(result).toBe(s)
+    })
+
+    it('should return the section when ref is exactly on the boundary', () => {
+      const s = section('target', 100, 300, 0, 200)
+      expect(findClosestSectionDroppable(dragId, [s], { x: 0, y: 100 })).toBe(s)
+      expect(findClosestSectionDroppable(dragId, [s], { x: 200, y: 300 })).toBe(s)
+    })
+
+    it('should pick the first section containing the ref when multiple overlap', () => {
+      const s1 = section('a', 100, 300)
+      const s2 = section('b', 200, 400)
+      // ref at (100, 250) is inside both; s1 should win (first in array)
+      const result = findClosestSectionDroppable(dragId, [s1, s2], { x: 100, y: 250 })
+      expect(result).toBe(s1)
+    })
+  })
+
+  describe('skip self', () => {
+    it('should skip the dragged section', () => {
+      const self = section('dragged', 100, 300)
+      const other = section('other', 400, 500)
+      const result = findClosestSectionDroppable(dragId, [self, other], { x: 100, y: 200 })
+      expect(result).toBe(other)
+    })
+  })
+
+  describe('gap containment', () => {
+    // Two sections with an 8px gap between them (resize handle).
+    const sA = section('a', 0, 200, 0, 200)
+    const sB = section('b', 208, 408, 0, 200)
+    const sideZone = zone('left', 0, 408)
+
+    it('should prefer the nearest section edge in the inter-section gap', () => {
+      // Cursor at y=202, which is 2px below A's bottom edge
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 100, y: 202 })
+      expect(String(result!.id)).toBe(`${SECTION_DRAG_PREFIX}a`)
+    })
+
+    it('should prefer the closer section when cursor is in the middle of the gap', () => {
+      // Cursor at y=204 (midpoint of gap: 200..208)
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 100, y: 204 })
+      // Both are 4px away; last one wins in tie → B
+      expect(String(result!.id)).toMatch(/^sidebar-section:/)
+    })
+
+    it('should prefer section B when cursor is closer to B top', () => {
+      // Cursor at y=206, 6px from A bottom, 2px from B top
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 100, y: 206 })
+      expect(String(result!.id)).toBe(`${SECTION_DRAG_PREFIX}b`)
+    })
+
+    it('should win over zone even when zone center is closer', () => {
+      // The zone center is at y=204, exactly where the gap is.
+      // Without gap containment, the zone would win the distance comparison.
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 100, y: 204 })
+      expect(String(result!.id)).not.toContain(SIDEBAR_ZONE_PREFIX)
+    })
+
+    it('should require cursor to be within X bounds (+ tolerance)', () => {
+      // Cursor is outside the section X bounds by more than X_TOLERANCE
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 200 + X_TOLERANCE + 1, y: 204 })
+      // Gap check fails, falls to distance comparison
+      expect(String(result!.id)).not.toBe(`${SECTION_DRAG_PREFIX}a`)
+    })
+
+    it('should allow cursor on the sidebar resize handle (within X tolerance)', () => {
+      // Cursor is just outside X bounds but within tolerance
+      const result = findClosestSectionDroppable(dragId, [sA, sB, sideZone], { x: 200 + X_TOLERANCE, y: 202 })
+      expect(String(result!.id)).toBe(`${SECTION_DRAG_PREFIX}a`)
+    })
+  })
+
+  describe('distance fallback', () => {
+    it('should prefer section over zone when equidistant', () => {
+      const s = section('s', 100, 200, 0, 200)
+      const z = zone('left', 0, 400)
+      // Place cursor outside section, equidistant from section center and zone center
+      const sCenterY = 150
+      const zCenterY = 200
+      const y = (sCenterY + zCenterY) / 2 // exactly between the two centers
+      const result = findClosestSectionDroppable(dragId, [s, z], { x: 100, y })
+      // Section should be preferred (bestSectionDist <= bestZoneDist)
+      expect(String(result!.id)).toBe(`${SECTION_DRAG_PREFIX}s`)
+    })
+
+    it('should pick zone when its center is strictly closer', () => {
+      // Section far away at top, zone centered in middle
+      const s = section('s', 0, 36, 0, 200)
+      const z = zone('left', 0, 400)
+      // Cursor near the zone center (200), far from section center (18)
+      const result = findClosestSectionDroppable(dragId, [s, z], { x: 100, y: 300 })
+      expect(String(result!.id)).toBe(`${SIDEBAR_ZONE_PREFIX}left`)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return null when no droppables', () => {
+      expect(findClosestSectionDroppable(dragId, [], { x: 0, y: 0 })).toBeNull()
+    })
+
+    it('should return null when only the dragged section is present', () => {
+      const self = section('dragged', 0, 100)
+      expect(findClosestSectionDroppable(dragId, [self], { x: 50, y: 50 })).toBeNull()
+    })
+
+    it('should return zone when no sections exist', () => {
+      const z = zone('right')
+      const result = findClosestSectionDroppable(dragId, [z], { x: 100, y: 200 })
+      expect(String(result!.id)).toBe(`${SIDEBAR_ZONE_PREFIX}right`)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isNearIndicator
+// ---------------------------------------------------------------------------
+
+describe('isNearIndicator', () => {
+  // A section from (10, 100) to (210, 300)
+  const layout: DroppableLayout = {
+    top: 100,
+    bottom: 300,
+    left: 10,
+    right: 210,
+    center: { x: 110, y: 200 },
+  }
+
+  describe('before position', () => {
+    // Zone: top - PROXIMITY_BUFFER to top + headerHeightPx + PROXIMITY_BUFFER
+    const zoneTop = layout.top - PROXIMITY_BUFFER
+    const zoneBottom = layout.top + headerHeightPx + PROXIMITY_BUFFER
+
+    it('should return true when cursor is at the section top', () => {
+      expect(isNearIndicator(layout, 'before', 100, layout.top)).toBe(true)
+    })
+
+    it('should return true when cursor is within the zone bounds', () => {
+      expect(isNearIndicator(layout, 'before', 100, zoneTop)).toBe(true)
+      expect(isNearIndicator(layout, 'before', 100, zoneBottom)).toBe(true)
+    })
+
+    it('should return false when cursor is above the zone', () => {
+      expect(isNearIndicator(layout, 'before', 100, zoneTop - 1)).toBe(false)
+    })
+
+    it('should return false when cursor is below the zone', () => {
+      expect(isNearIndicator(layout, 'before', 100, zoneBottom + 1)).toBe(false)
+    })
+
+    it('should return false when cursor X is outside section bounds', () => {
+      expect(isNearIndicator(layout, 'before', layout.right + X_TOLERANCE + 1, layout.top)).toBe(false)
+      expect(isNearIndicator(layout, 'before', layout.left - X_TOLERANCE - 1, layout.top)).toBe(false)
+    })
+
+    it('should return true when cursor X is within X_TOLERANCE of section edge', () => {
+      expect(isNearIndicator(layout, 'before', layout.right + X_TOLERANCE, layout.top)).toBe(true)
+      expect(isNearIndicator(layout, 'before', layout.left - X_TOLERANCE, layout.top)).toBe(true)
+    })
+  })
+
+  describe('after position', () => {
+    // Zone: bottom - headerHeightPx - PROXIMITY_BUFFER to bottom + PROXIMITY_BUFFER
+    const zoneTop = layout.bottom - headerHeightPx - PROXIMITY_BUFFER
+    const zoneBottom = layout.bottom + PROXIMITY_BUFFER
+
+    it('should return true when cursor is at the section bottom', () => {
+      expect(isNearIndicator(layout, 'after', 100, layout.bottom)).toBe(true)
+    })
+
+    it('should return true when cursor is within the zone bounds', () => {
+      expect(isNearIndicator(layout, 'after', 100, zoneTop)).toBe(true)
+      expect(isNearIndicator(layout, 'after', 100, zoneBottom)).toBe(true)
+    })
+
+    it('should return false when cursor is above the zone', () => {
+      expect(isNearIndicator(layout, 'after', 100, zoneTop - 1)).toBe(false)
+    })
+
+    it('should return false when cursor is below the zone', () => {
+      expect(isNearIndicator(layout, 'after', 100, zoneBottom + 1)).toBe(false)
+    })
+  })
+
+  describe('expanded vs collapsed sections', () => {
+    it('should have non-overlapping zones for a tall expanded section', () => {
+      // Expanded section: 300px tall (100..400)
+      const expanded: DroppableLayout = {
+        top: 100,
+        bottom: 400,
+        left: 0,
+        right: 200,
+        center: { x: 100, y: 250 },
+      }
+      const midY = (expanded.top + expanded.bottom) / 2
+      // At the midpoint, neither zone should match
+      expect(isNearIndicator(expanded, 'before', 100, midY)).toBe(false)
+      expect(isNearIndicator(expanded, 'after', 100, midY)).toBe(false)
+    })
+
+    it('should have overlapping zones for a collapsed section', () => {
+      // Collapsed section: 36px tall (100..136)
+      const collapsed: DroppableLayout = {
+        top: 100,
+        bottom: 136,
+        left: 0,
+        right: 200,
+        center: { x: 100, y: 118 },
+      }
+      const midY = (collapsed.top + collapsed.bottom) / 2
+      // At the midpoint of a collapsed section, both zones should match
+      expect(isNearIndicator(collapsed, 'before', 100, midY)).toBe(true)
+      expect(isNearIndicator(collapsed, 'after', 100, midY)).toBe(true)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeInsertPosition
+// ---------------------------------------------------------------------------
+
+describe('computeInsertPosition', () => {
+  describe('same sidebar', () => {
+    const sections = [
+      makeSection('a', Sidebar.LEFT, 'aaa'),
+      makeSection('b', Sidebar.LEFT, 'bbb'),
+      makeSection('c', Sidebar.LEFT, 'ccc'),
+    ]
+
+    it('should return "after" when dragged section is above the target', () => {
+      expect(computeInsertPosition('a', 'b', sections)).toBe('after')
+      expect(computeInsertPosition('a', 'c', sections)).toBe('after')
+      expect(computeInsertPosition('b', 'c', sections)).toBe('after')
+    })
+
+    it('should return "before" when dragged section is below the target', () => {
+      expect(computeInsertPosition('c', 'b', sections)).toBe('before')
+      expect(computeInsertPosition('c', 'a', sections)).toBe('before')
+      expect(computeInsertPosition('b', 'a', sections)).toBe('before')
+    })
+  })
+
+  describe('cross-sidebar with draggable/droppable', () => {
+    const sections = [
+      makeSection('a', Sidebar.LEFT, 'aaa'),
+      makeSection('b', Sidebar.RIGHT, 'bbb'),
+    ]
+
+    it('should return "before" when drag ref is above the header midpoint', () => {
+      const draggable = { transformed: { center: { y: 100 } }, layout: { height: 36 } }
+      const droppable = { layout: { top: 100 } }
+      // refY = 100 - 18 = 82, headerMidY = 100 + 18 = 118
+      expect(computeInsertPosition('a', 'b', sections, draggable, droppable)).toBe('before')
+    })
+
+    it('should return "after" when drag ref is below the header midpoint', () => {
+      const draggable = { transformed: { center: { y: 200 } }, layout: { height: 36 } }
+      const droppable = { layout: { top: 100 } }
+      // refY = 200 - 18 = 182, headerMidY = 100 + 18 = 118
+      expect(computeInsertPosition('a', 'b', sections, draggable, droppable)).toBe('after')
+    })
+  })
+
+  describe('missing sections', () => {
+    it('should return "before" when dragged section is not found', () => {
+      const sections = [makeSection('b', Sidebar.LEFT, 'bbb')]
+      expect(computeInsertPosition('nonexistent', 'b', sections)).toBe('before')
+    })
+
+    it('should return "before" when target section is not found', () => {
+      const sections = [makeSection('a', Sidebar.LEFT, 'aaa')]
+      expect(computeInsertPosition('a', 'nonexistent', sections)).toBe('before')
+    })
+  })
+
+  describe('cross-sidebar without draggable/droppable', () => {
+    it('should return "before" as default fallback', () => {
+      const sections = [
+        makeSection('a', Sidebar.LEFT, 'aaa'),
+        makeSection('b', Sidebar.RIGHT, 'bbb'),
+      ]
+      expect(computeInsertPosition('a', 'b', sections)).toBe('before')
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

The sidebar section drag-and-drop logic and workspace operations were duplicated
across `LeftSidebar.tsx` and `RightSidebar.tsx`, making the code difficult to
maintain and evolve. Resize handle styling was similarly scattered, with the same
`::before` pseudo-element pattern copy-pasted across multiple component files.
Additionally, the drag-and-drop UX had several rough edges: the drop indicator
did not show insertion position clearly, cursor proximity was not used to gate
indicator visibility, and dragging sections across sidebars did not behave
predictably.

## Modifications

- Extracted shared drag-and-drop collision logic into
  `sectionDragUtils.ts`, exposing
  `findClosestSectionDroppable()`, `computeInsertPosition()`, and
  `isNearIndicator()` as individually testable pure functions.
- Extracted section type helpers (`isWorkspaceSection`, `getSectionIcon`,
  `sectionTypeTestId`) into `sectionUtils.ts`.
- Extracted workspace CRUD and drag-and-drop operations from both sidebars into
  a new `useWorkspaceOperations.ts` SolidJS hook,
  reducing `LeftSidebar.tsx` and `RightSidebar.tsx` significantly.
- Introduced a `resizeHandleSelectors(direction, defaultBackground, prefix)`
  helper in `tokens.ts` that generates the consistent
  `::before` hover/active visual feedback pattern, replacing duplicated CSS
  across `AppShell.css.ts`, `CollapsibleSidebar.css.ts`, `Tile.css.ts`, and
  `ChatView.css.ts`.
- Changed resize handle geometry from 8px to 4px with negative margins,
  so handles occupy zero layout space while remaining easily grabbable.
- Added visual drop indicator lines showing
  before/after insertion position during section drag operations, with
  proximity-based activation that requires the cursor to be near the indicator
  before a drop is accepted.
- Fixed cross-sidebar section drag to use the actual cursor Y position against
  the target section's header midpoint to determine before/after placement.
- Fixed collapse button visibility on the right sidebar's first section.
- Added 343 lines of unit tests covering drag utility functions.
- Expanded e2e tests with cross-sidebar drag detection, proximity-based drop activation, and reusable helpers.

## Result

- Sidebar section drag-and-drop now shows a clear indicator line at the exact
  insertion point and only accepts the drop when the cursor is within the proximity zone.
- Dragging sections between sidebars works predictably.
- Resize handles no longer push adjacent panels apart; they overlay the panel
  boundary and expand visually on hover without affecting layout.
- All resize handles share a single consistent hover/active style defined once in
  `resizeHandleSelectors()`.

🤖 Generated with Claude Code
