### PR TITLE
Remove Shiki theme background overrides from code blocks

### DIFF
--- a/frontend/src/components/chat/markdownContent.css.ts
+++ b/frontend/src/components/chat/markdownContent.css.ts
@@ -13,7 +13,6 @@ globalStyle(`${markdownContent} pre`, {
 // Shiki dual-theme support via CSS variables
 globalStyle(`${markdownContent} pre.shiki`, {
   color: 'var(--shiki-light)',
-  backgroundColor: 'var(--shiki-light-bg)',
 })
 
 globalStyle(`${markdownContent} pre.shiki span`, {
@@ -22,7 +21,6 @@ globalStyle(`${markdownContent} pre.shiki span`, {
 
 globalStyle(`html[data-theme="dark"] ${markdownContent} pre.shiki`, {
   color: 'var(--shiki-dark)',
-  backgroundColor: 'var(--shiki-dark-bg)',
 })
 
 globalStyle(`html[data-theme="dark"] ${markdownContent} pre.shiki span`, {


### PR DESCRIPTION
## Motivation
Code blocks rendered by Shiki were using their own opaque theme backgrounds (`--shiki-light-bg` / `--shiki-dark-bg` from the GitHub Light/Dark themes) instead of the global semi-transparent foreground tint defined in `global.css.ts`. This produced inconsistent backgrounds when code blocks appeared on non-white surfaces, since the Shiki backgrounds are hardcoded white/dark values rather than surface-relative colors.

## Modifications
- Removed `backgroundColor: 'var(--shiki-light-bg)'` from the light-mode `pre.shiki` rule in `frontend/src/components/chat/markdownContent.css.ts`
- Removed `backgroundColor: 'var(--shiki-dark-bg)'` from the dark-mode `pre.shiki` rule in `frontend/src/components/chat/markdownContent.css.ts`

## Result
Shiki-rendered code blocks now inherit the global `code, pre` background (`rgb(from var(--foreground) r g b / 0.075)`), a semi-transparent foreground tint that adapts to any surface color. Code blocks display a consistent muted background regardless of what surface they appear on.

🤖 Generated with Claude Code
