### PR TITLE
Fix stale thinking indicator shown after hub restart

### DIFF
--- a/internal/hub/db/queries/agents.sql
+++ b/internal/hub/db/queries/agents.sql
@@ -28,6 +28,10 @@ WHERE workspace_id = ? AND status = 1;
 UPDATE agents SET status = 2, closed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE worker_id = ? AND status = 1;
 
+-- name: CloseAllActiveAgents :exec
+UPDATE agents SET status = 2, closed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE status = 1;
+
 -- name: RenameAgent :execresult
 UPDATE agents SET title = ? WHERE id = ?;
 


### PR DESCRIPTION
## Motivation

When the hub shuts down while an agent is mid-turn, `cleanupWorker()` skips
database writes to avoid touching a closing database. This leaves the agent
record with a stale `ACTIVE` status. On the next startup, the frontend reads
that stale status and displays the thinking indicator indefinitely for an
agent that is no longer running — with no way to dismiss it.

## Modifications

- Added a `CloseAllActiveAgents` SQL query in `internal/hub/db/queries/agents.sql`
  that sets all ACTIVE agents to INACTIVE (`status = 2`) and records a
  `closed_at` timestamp.
- Called `CloseAllActiveAgents` during hub startup in `hub/server.go`
  (`NewServer()`) immediately after bootstrapping. No agent process can
  survive a hub restart, so marking all ACTIVE agents as INACTIVE is always
  correct. The `agent_session_id` is preserved so agents remain resumable.
- Added an e2e test case `should not show thinking indicator after full
  restart during active turn` in `frontend/tests/e2e/24-full-restart.spec.ts`
  that stops the worker and hub while an agent is processing, restarts both,
  and asserts the thinking indicator is not visible after reload. The test
  suite is configured with one retry to accommodate timing variation under
  heavy parallel load.

## Result

After a hub restart, agents that were mid-turn at shutdown are now marked
INACTIVE in the database before any client can connect. The frontend
correctly reflects this: you no longer see a thinking indicator that spins
forever after restarting the hub while an agent was active.

🤖 Generated with Claude Code
