### PR TITLE
Extract shared message parser and fix todo persistence on page refresh

### DIFF
--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -1,0 +1,444 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { describe, expect, it } from 'vitest'
+import { ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import {
+  extractAssistantUsage,
+  extractRateLimitInfo,
+  extractResultMetadata,
+  extractSettingsChanges,
+  extractTodos,
+  findLatestTodos,
+  getInnerMessage,
+  getInnerMessageType,
+  parseMessageContent,
+} from './messageParser'
+
+/** Build a mock AgentChatMessage with the given JSON content (uncompressed). */
+function makeMsg(
+  role: MessageRole,
+  content: unknown,
+  opts?: { seq?: bigint },
+): AgentChatMessage {
+  return {
+    id: 'msg-1',
+    role,
+    content: new TextEncoder().encode(JSON.stringify(content)),
+    contentCompression: ContentCompression.NONE,
+    seq: opts?.seq ?? 1n,
+    createdAt: '',
+    updatedAt: '',
+    deliveryError: '',
+  } as AgentChatMessage
+}
+
+/** Wrap an inner message in the thread wrapper envelope. */
+function wrap(...messages: unknown[]): { old_seqs: number[], messages: unknown[] } {
+  return { old_seqs: [], messages }
+}
+
+// ---------------------------------------------------------------------------
+// parseMessageContent
+// ---------------------------------------------------------------------------
+
+describe('parseMessageContent', () => {
+  it('parses wrapped content', () => {
+    const inner = { type: 'assistant', message: { content: [] } }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(inner))
+    const result = parseMessageContent(msg)
+
+    expect(result.isWrapped).toBe(true)
+    expect(result.parentObject).toEqual(inner)
+    expect(result.wrapper).not.toBeNull()
+    expect(result.children).toEqual([])
+    expect(result.rawText).toBeTruthy()
+  })
+
+  it('parses wrapped content with children', () => {
+    const parent = { type: 'assistant', message: { content: [] } }
+    const child = { type: 'user', message: { content: 'result' } }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(parent, child))
+    const result = parseMessageContent(msg)
+
+    expect(result.parentObject).toEqual(parent)
+    expect(result.children).toEqual([child])
+  })
+
+  it('handles empty wrapper messages array', () => {
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap())
+    const result = parseMessageContent(msg)
+
+    expect(result.isWrapped).toBe(true)
+    expect(result.parentObject).toBeUndefined()
+    expect(result.children).toEqual([])
+  })
+
+  it('parses unwrapped content', () => {
+    const content = { type: 'agent_session_info', info: {} }
+    const msg = makeMsg(MessageRole.LEAPMUX, content)
+    const result = parseMessageContent(msg)
+
+    expect(result.isWrapped).toBe(false)
+    expect(result.parentObject).toEqual(content)
+    expect(result.topLevel).toEqual(content)
+    expect(result.wrapper).toBeNull()
+  })
+
+  it('returns safe defaults for invalid JSON', () => {
+    const msg = {
+      id: 'msg-1',
+      role: MessageRole.ASSISTANT,
+      content: new TextEncoder().encode('not json'),
+      contentCompression: ContentCompression.NONE,
+      seq: 1n,
+      createdAt: '',
+      updatedAt: '',
+      deliveryError: '',
+    } as AgentChatMessage
+    const result = parseMessageContent(msg)
+
+    expect(result.rawText).toBe('not json')
+    expect(result.topLevel).toBeNull()
+    expect(result.parentObject).toBeUndefined()
+  })
+
+  it('returns safe defaults for empty content', () => {
+    const msg = {
+      id: 'msg-1',
+      role: MessageRole.ASSISTANT,
+      content: new Uint8Array(),
+      contentCompression: ContentCompression.NONE,
+      seq: 1n,
+      createdAt: '',
+      updatedAt: '',
+      deliveryError: '',
+    } as AgentChatMessage
+    const result = parseMessageContent(msg)
+
+    // Empty Uint8Array decodes to "" which fails JSON.parse → topLevel null
+    expect(result.rawText).toBe('')
+    expect(result.topLevel).toBeNull()
+    expect(result.parentObject).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getInnerMessage / getInnerMessageType
+// ---------------------------------------------------------------------------
+
+describe('getInnerMessage', () => {
+  it('returns parentObject for wrapped content', () => {
+    const inner = { type: 'assistant', message: {} }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(inner))
+    const parsed = parseMessageContent(msg)
+
+    expect(getInnerMessage(parsed)).toEqual(inner)
+  })
+
+  it('returns topLevel for unwrapped content', () => {
+    const content = { type: 'agent_session_info' }
+    const msg = makeMsg(MessageRole.LEAPMUX, content)
+    const parsed = parseMessageContent(msg)
+
+    expect(getInnerMessage(parsed)).toEqual(content)
+  })
+})
+
+describe('getInnerMessageType', () => {
+  it('returns type from wrapped content', () => {
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap({ type: 'assistant' }))
+    expect(getInnerMessageType(parseMessageContent(msg))).toBe('assistant')
+  })
+
+  it('returns type from unwrapped content', () => {
+    const msg = makeMsg(MessageRole.LEAPMUX, { type: 'rate_limit' })
+    expect(getInnerMessageType(parseMessageContent(msg))).toBe('rate_limit')
+  })
+
+  it('returns undefined when no type', () => {
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap({ message: {} }))
+    expect(getInnerMessageType(parseMessageContent(msg))).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractTodos
+// ---------------------------------------------------------------------------
+
+describe('extractTodos', () => {
+  const todoContent = {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
+              { content: 'Deploy', status: 'in_progress', activeForm: 'Deploying' },
+              { content: 'Review', status: 'pending', activeForm: 'Reviewing' },
+            ],
+          },
+        },
+      ],
+    },
+  }
+
+  it('extracts todos from a valid TodoWrite message', () => {
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(todoContent))
+    const parsed = parseMessageContent(msg)
+    const todos = extractTodos(msg, parsed)
+
+    expect(todos).toEqual([
+      { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
+      { content: 'Deploy', status: 'in_progress', activeForm: 'Deploying' },
+      { content: 'Review', status: 'pending', activeForm: 'Reviewing' },
+    ])
+  })
+
+  it('returns null for non-ASSISTANT role', () => {
+    const msg = makeMsg(MessageRole.USER, wrap(todoContent))
+    const parsed = parseMessageContent(msg)
+    expect(extractTodos(msg, parsed)).toBeNull()
+  })
+
+  it('returns null for non-TodoWrite tool_use', () => {
+    const content = {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }],
+      },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    const parsed = parseMessageContent(msg)
+    expect(extractTodos(msg, parsed)).toBeNull()
+  })
+
+  it('returns null for assistant message with only text', () => {
+    const content = {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello' }] },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    const parsed = parseMessageContent(msg)
+    expect(extractTodos(msg, parsed)).toBeNull()
+  })
+
+  it('defaults unknown status to pending', () => {
+    const content = {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          name: 'TodoWrite',
+          input: { todos: [{ content: 'Task', status: 'unknown_status', activeForm: 'Working' }] },
+        }],
+      },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    const parsed = parseMessageContent(msg)
+    const todos = extractTodos(msg, parsed)
+    expect(todos![0].status).toBe('pending')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// findLatestTodos
+// ---------------------------------------------------------------------------
+
+describe('findLatestTodos', () => {
+  const makeTodoMsg = (seq: bigint, tasks: Array<{ content: string, status: string, activeForm: string }>) =>
+    makeMsg(MessageRole.ASSISTANT, wrap({
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          name: 'TodoWrite',
+          input: { todos: tasks },
+        }],
+      },
+    }), { seq })
+
+  it('finds the latest TodoWrite scanning backward', () => {
+    const messages = [
+      makeMsg(MessageRole.USER, wrap({ type: 'user', message: { content: 'hello' } }), { seq: 1n }),
+      makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
+      makeMsg(MessageRole.ASSISTANT, wrap({ type: 'assistant', message: { content: [{ type: 'text', text: 'response' }] } }), { seq: 3n }),
+      makeTodoMsg(4n, [{ content: 'New task', status: 'in_progress', activeForm: 'New' }]),
+      makeMsg(MessageRole.USER, wrap({ type: 'user', message: { content: 'bye' } }), { seq: 5n }),
+    ]
+    const todos = findLatestTodos(messages)
+    expect(todos).toEqual([{ content: 'New task', status: 'in_progress', activeForm: 'New' }])
+  })
+
+  it('returns null when no TodoWrite exists', () => {
+    const messages = [
+      makeMsg(MessageRole.USER, wrap({ type: 'user', message: { content: 'hello' } }), { seq: 1n }),
+      makeMsg(MessageRole.ASSISTANT, wrap({ type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }), { seq: 2n }),
+    ]
+    expect(findLatestTodos(messages)).toBeNull()
+  })
+
+  it('returns null for empty array', () => {
+    expect(findLatestTodos([])).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractAssistantUsage
+// ---------------------------------------------------------------------------
+
+describe('extractAssistantUsage', () => {
+  it('extracts usage and cost', () => {
+    const content = {
+      type: 'assistant',
+      total_cost_usd: 0.05,
+      message: {
+        usage: {
+          input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 300,
+        },
+      },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    const result = extractAssistantUsage(parseMessageContent(msg))
+
+    expect(result).toEqual({
+      totalCostUsd: 0.05,
+      contextUsage: {
+        inputTokens: 1000,
+        cacheCreationInputTokens: 200,
+        cacheReadInputTokens: 300,
+      },
+    })
+  })
+
+  it('extracts only cost when no token info', () => {
+    const content = {
+      type: 'assistant',
+      total_cost_usd: 0.01,
+      message: { usage: {} },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    const result = extractAssistantUsage(parseMessageContent(msg))
+    expect(result).toEqual({ totalCostUsd: 0.01 })
+  })
+
+  it('returns null when no usage field', () => {
+    const content = { type: 'assistant', message: {} }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    expect(extractAssistantUsage(parseMessageContent(msg))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractResultMetadata
+// ---------------------------------------------------------------------------
+
+describe('extractResultMetadata', () => {
+  it('extracts subtype, contextWindow, and cost', () => {
+    const content = {
+      type: 'result',
+      subtype: 'turn_end',
+      total_cost_usd: 0.10,
+      modelUsage: {
+        'claude-sonnet': { contextWindow: 200000 },
+      },
+    }
+    const msg = makeMsg(MessageRole.RESULT, wrap(content))
+    const result = extractResultMetadata(parseMessageContent(msg))
+
+    expect(result).toEqual({
+      subtype: 'turn_end',
+      contextWindow: 200000,
+      totalCostUsd: 0.10,
+    })
+  })
+
+  it('returns null for empty inner message', () => {
+    const msg = makeMsg(MessageRole.RESULT, wrap({}))
+    expect(extractResultMetadata(parseMessageContent(msg))).toBeNull()
+  })
+
+  it('extracts only subtype when no modelUsage or cost', () => {
+    const content = { type: 'result', subtype: 'turn_end' }
+    const msg = makeMsg(MessageRole.RESULT, wrap(content))
+    expect(extractResultMetadata(parseMessageContent(msg))).toEqual({ subtype: 'turn_end' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractRateLimitInfo
+// ---------------------------------------------------------------------------
+
+describe('extractRateLimitInfo', () => {
+  it('extracts rate limit info', () => {
+    const content = {
+      type: 'rate_limit',
+      rate_limit_info: {
+        rateLimitType: 'five_hour',
+        status: 'allowed_warning',
+        utilization: 0.85,
+      },
+    }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const result = extractRateLimitInfo(parseMessageContent(msg))
+
+    expect(result).toEqual({
+      key: 'five_hour',
+      info: { rateLimitType: 'five_hour', status: 'allowed_warning', utilization: 0.85 },
+    })
+  })
+
+  it('defaults key to unknown when rateLimitType is missing', () => {
+    const content = {
+      type: 'rate_limit',
+      rate_limit_info: { status: 'exceeded' },
+    }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const result = extractRateLimitInfo(parseMessageContent(msg))
+    expect(result!.key).toBe('unknown')
+  })
+
+  it('returns null for non-rate_limit type', () => {
+    const content = { type: 'settings_changed', rate_limit_info: {} }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    expect(extractRateLimitInfo(parseMessageContent(msg))).toBeNull()
+  })
+
+  it('returns null when rate_limit_info is missing', () => {
+    const content = { type: 'rate_limit' }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    expect(extractRateLimitInfo(parseMessageContent(msg))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractSettingsChanges
+// ---------------------------------------------------------------------------
+
+describe('extractSettingsChanges', () => {
+  it('extracts settings changes', () => {
+    const content = {
+      type: 'settings_changed',
+      changes: { permissionMode: { old: 'default', new: 'plan' } },
+    }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const result = extractSettingsChanges(parseMessageContent(msg))
+
+    expect(result).toEqual({ permissionMode: { old: 'default', new: 'plan' } })
+  })
+
+  it('returns null for non-settings_changed type', () => {
+    const content = { type: 'rate_limit', changes: {} }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    expect(extractSettingsChanges(parseMessageContent(msg))).toBeNull()
+  })
+
+  it('returns null when changes is missing', () => {
+    const content = { type: 'settings_changed' }
+    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    expect(extractSettingsChanges(parseMessageContent(msg))).toBeNull()
+  })
+})

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -1,0 +1,219 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { ContextUsageInfo } from '~/stores/agentSession.store'
+import type { TodoItem } from '~/stores/chat.store'
+import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { decompressContentToString } from '~/lib/decompress'
+
+/**
+ * The result of parsing a compressed AgentChatMessage. Every field is
+ * derived from a single decompress-then-JSON.parse pass.
+ */
+export interface ParsedMessageContent {
+  /** The raw decompressed text (for "Copy Raw JSON"). */
+  rawText: string
+  /** The top-level parsed JSON object, or null on parse failure. */
+  topLevel: Record<string, unknown> | null
+  /** Whether topLevel is a thread-wrapper envelope ({messages: [...]}) */
+  isWrapped: boolean
+  /** The first (parent) inner message object, or undefined. */
+  parentObject: Record<string, unknown> | undefined
+  /** Thread children (messages after the first), empty array if none. */
+  children: unknown[]
+  /** The wrapper envelope if wrapped, null otherwise. */
+  wrapper: { old_seqs: number[], messages: unknown[] } | null
+}
+
+const EMPTY_PARSED: ParsedMessageContent = {
+  rawText: '',
+  topLevel: null,
+  isWrapped: false,
+  parentObject: undefined,
+  children: [],
+  wrapper: null,
+}
+
+/**
+ * Decompress and parse an AgentChatMessage's content in a single pass.
+ * Never throws -- returns safe defaults on any failure.
+ */
+export function parseMessageContent(message: AgentChatMessage): ParsedMessageContent {
+  const text = decompressContentToString(message.content, message.contentCompression)
+  if (text === null)
+    return EMPTY_PARSED
+
+  try {
+    const obj = JSON.parse(text)
+    if (obj?.messages && Array.isArray(obj.messages)) {
+      // Wrapped format: {"old_seqs": [...], "messages": [{...}, ...]}
+      // An empty messages array can occur when notification consolidation
+      // cancels out all changes (e.g. plan mode toggled back).
+      if (obj.messages.length === 0)
+        return { rawText: text, topLevel: obj, isWrapped: true, parentObject: undefined, children: [], wrapper: obj }
+
+      const first = obj.messages[0]
+      const parent = (typeof first === 'object' && first !== null && !Array.isArray(first))
+        ? first as Record<string, unknown>
+        : undefined
+      return {
+        rawText: text,
+        topLevel: obj,
+        isWrapped: true,
+        parentObject: parent,
+        children: obj.messages.length > 1 ? obj.messages.slice(1) : [],
+        wrapper: obj,
+      }
+    }
+    // Not wrapped — treat the parsed object as the parent directly.
+    const parent = (typeof obj === 'object' && obj !== null && !Array.isArray(obj))
+      ? obj as Record<string, unknown>
+      : undefined
+    return { rawText: text, topLevel: obj, isWrapped: false, parentObject: parent, children: [], wrapper: null }
+  }
+  catch {
+    return { rawText: text, topLevel: null, isWrapped: false, parentObject: undefined, children: [], wrapper: null }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inner message accessors
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the unwrapped inner message -- the first message if wrapped,
+ * or the top-level object if not. Replaces the
+ * `parsed?.messages?.[0] ?? parsed` pattern.
+ */
+export function getInnerMessage(parsed: ParsedMessageContent): Record<string, unknown> | null {
+  return parsed.parentObject ?? parsed.topLevel
+}
+
+/**
+ * Get the inner message type string (e.g. 'assistant', 'context_cleared', 'rate_limit').
+ */
+export function getInnerMessageType(parsed: ParsedMessageContent): string | undefined {
+  const inner = getInnerMessage(parsed)
+  return inner?.type as string | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Domain-specific extractors
+// ---------------------------------------------------------------------------
+
+/** Extract TodoWrite todos from a parsed assistant message. Returns null if not applicable. */
+export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageContent): TodoItem[] | null {
+  if (message.role !== MessageRole.ASSISTANT)
+    return null
+  const parent = parsed.parentObject
+  if (!parent || parent.type !== 'assistant')
+    return null
+  const msg = parent.message as Record<string, unknown> | undefined
+  const content = msg?.content
+  if (!Array.isArray(content))
+    return null
+  const toolUse = content.find(
+    (c: Record<string, unknown>) => typeof c === 'object' && c !== null && c.type === 'tool_use' && c.name === 'TodoWrite',
+  )
+  if (!toolUse?.input?.todos || !Array.isArray(toolUse.input.todos))
+    return null
+  return toolUse.input.todos.map((t: Record<string, unknown>) => ({
+    content: String(t.content || ''),
+    status: t.status === 'in_progress' ? 'in_progress' as const : t.status === 'completed' ? 'completed' as const : 'pending' as const,
+    activeForm: String(t.activeForm || ''),
+  }))
+}
+
+/** Scan messages backward for the latest TodoWrite, returning todos or null. */
+export function findLatestTodos(messages: AgentChatMessage[]): TodoItem[] | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const parsed = parseMessageContent(messages[i])
+    const todos = extractTodos(messages[i], parsed)
+    if (todos)
+      return todos
+  }
+  return null
+}
+
+/** Extract context usage from an assistant message's inner usage field. */
+export function extractAssistantUsage(parsed: ParsedMessageContent): {
+  totalCostUsd?: number
+  contextUsage?: ContextUsageInfo
+} | null {
+  const inner = getInnerMessage(parsed)
+  if (!inner)
+    return null
+  const usage = (inner.message as Record<string, unknown> | undefined)?.usage as
+    Record<string, unknown> | undefined
+  if (!usage)
+    return null
+
+  const result: { totalCostUsd?: number, contextUsage?: ContextUsageInfo } = {}
+  if (typeof inner.total_cost_usd === 'number')
+    result.totalCostUsd = inner.total_cost_usd as number
+  if (typeof usage.input_tokens === 'number') {
+    result.contextUsage = {
+      inputTokens: (usage.input_tokens as number) ?? 0,
+      cacheCreationInputTokens: (usage.cache_creation_input_tokens as number) ?? 0,
+      cacheReadInputTokens: (usage.cache_read_input_tokens as number) ?? 0,
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null
+}
+
+/** Extract result-message metadata: subtype, contextWindow, totalCostUsd. */
+export function extractResultMetadata(parsed: ParsedMessageContent): {
+  subtype?: string
+  contextWindow?: number
+  totalCostUsd?: number
+} | null {
+  const inner = getInnerMessage(parsed)
+  if (!inner)
+    return null
+
+  const result: { subtype?: string, contextWindow?: number, totalCostUsd?: number } = {}
+
+  if (inner.subtype)
+    result.subtype = inner.subtype as string
+
+  if (inner.modelUsage && typeof inner.modelUsage === 'object') {
+    for (const modelData of Object.values(inner.modelUsage as Record<string, unknown>)) {
+      const md = modelData as Record<string, unknown> | undefined
+      if (md && typeof md.contextWindow === 'number') {
+        result.contextWindow = md.contextWindow as number
+        break
+      }
+    }
+  }
+
+  if (typeof inner.total_cost_usd === 'number')
+    result.totalCostUsd = inner.total_cost_usd as number
+
+  return Object.keys(result).length > 0 ? result : null
+}
+
+/** Extract rate limit info from a LEAPMUX rate_limit inner message. */
+export function extractRateLimitInfo(parsed: ParsedMessageContent): {
+  key: string
+  info: Record<string, unknown>
+} | null {
+  const inner = getInnerMessage(parsed)
+  if (!inner || inner.type !== 'rate_limit')
+    return null
+  const rlInfo = inner.rate_limit_info as Record<string, unknown> | undefined
+  if (!rlInfo || typeof rlInfo !== 'object')
+    return null
+  const key = (rlInfo.rateLimitType as string) || 'unknown'
+  return { key, info: rlInfo }
+}
+
+/** Extract settings changes from a LEAPMUX settings_changed inner message. */
+export function extractSettingsChanges(parsed: ParsedMessageContent): {
+  permissionMode?: { old: string, new: string }
+} | null {
+  const inner = getInnerMessage(parsed)
+  if (!inner || inner.type !== 'settings_changed')
+    return null
+  const changes = inner.changes as Record<string, unknown> | undefined
+  if (!changes || typeof changes !== 'object')
+    return null
+  return changes as { permissionMode?: { old: string, new: string } }
+}

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -1,22 +1,9 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
-import { decompressContentToString } from '~/lib/decompress'
+import { getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 
 /** RESULT-role messages with these inner types are mid-turn notifications, not turn ends. */
 const NOTIFICATION_TYPES = new Set(['settings_changed', 'context_cleared'])
-
-/** Parse the inner message type from a chat message's compressed content. */
-function getInnerMessageType(msg: AgentChatMessage): string | undefined {
-  try {
-    const text = decompressContentToString(msg.content, msg.contentCompression)
-    if (!text)
-      return undefined
-    const parsed = JSON.parse(text)
-    const inner = parsed?.messages?.[0] ?? parsed
-    return inner?.type as string | undefined
-  }
-  catch { return undefined }
-}
 
 /**
  * Whether the agent is still working — the last meaningful (non-notification)
@@ -32,7 +19,7 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     if (msg.role !== MessageRole.RESULT)
       return true
     // RESULT message — check if it's just a mid-turn notification to skip
-    const innerType = getInnerMessageType(msg)
+    const innerType = getInnerMessageType(parseMessageContent(msg))
     if (innerType && NOTIFICATION_TYPES.has(innerType))
       continue
     return false // real turn-end RESULT


### PR DESCRIPTION
## Motivation

Message content parsing — decompressing, JSON-parsing, and extracting
domain-specific fields such as todos, usage stats, rate limits, and
settings changes — was duplicated across `MessageBubble`, `useWorkspaceConnection`,
and `chat.store`. This made the logic hard to test and easy to drift out of sync.

Additionally, todos written by the agent (via the `TodoWrite` tool) were lost on
page refresh because the chat store only extracted them from incoming live messages,
not from message history loaded on startup via `loadInitialMessages` or `loadOlderMessages`.

## Modifications

- Created `/frontend/src/lib/messageParser.ts` with a single decompression and
  JSON parsing entry point, `parseMessageContent()`, that handles wrapped thread
  envelopes, unwrapped single messages, and parse failures with safe defaults.
- Added domain-specific extractors to the same module: `extractTodos`,
  `findLatestTodos`, `extractAssistantUsage`, `extractResultMetadata`,
  `extractRateLimitInfo`, and `extractSettingsChanges`, plus helpers
  `getInnerMessage` and `getInnerMessageType`.
- Removed duplicated inline parsing logic from `MessageBubble.tsx`,
  `useWorkspaceConnection.ts`, and `chat.store.ts`; all consumers now import
  from `messageParser.ts`.
- Fixed todo persistence: `chat.store.ts` now calls `findLatestTodos()` inside
  `applyMessages()` (used by both `loadInitialMessages` and `setMessages`) and
  also inside `loadOlderMessages` when no todos have been found yet, so todos
  are restored correctly after a browser reload.
- Added a comprehensive unit test suite in `messageParser.test.ts` (444 lines)
  covering wrapped and unwrapped content, empty wrapper arrays, invalid JSON,
  all domain-specific extractors, edge cases such as unknown todo status, and
  backward-scanning behavior of `findLatestTodos`.
- Extended `chat.store.test.ts` with additional coverage for the todo persistence
  fix (120 lines of new tests).

## Result

- Todos tracked by the agent are no longer lost when the page is refreshed;
  they are restored from message history as soon as initial messages load.
- All message parsing now runs through a single, well-tested code path, reducing
  the risk of silent inconsistencies between UI components.
- New `messageParser` module is fully unit-tested and straightforward to extend
  when new message types are introduced.

🤖 Generated with Claude Code
