### PR TITLE
Add worker name and plan file to popover, restructure plan_execution notification

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -353,6 +353,12 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
 
   const infoHoverCardContent = () => (
     <>
+      <Show when={props.agent?.workerName}>
+        <div class={styles.infoRow} data-testid="info-row-worker">
+          <span class={styles.infoLabel}>Worker</span>
+          <span class={styles.infoValue}>{props.agent!.workerName}</span>
+        </div>
+      </Show>
       <Show when={props.agent?.agentSessionId}>
         <div class={styles.infoRow}>
           <span class={styles.infoLabel}>Session ID</span>
@@ -415,9 +421,17 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         })()}
       </Show>
       <Show when={props.agent?.workingDir}>
-        <div class={styles.infoRow}>
+        <div class={styles.infoRow} data-testid="info-row-directory">
           <span class={styles.infoLabel}>Directory</span>
           <span class={styles.infoValue}>{tildify(props.agent!.workingDir!, props.agent!.homeDir)}</span>
+        </div>
+      </Show>
+      <Show when={props.agentSessionInfo?.planFilePath}>
+        <div class={styles.infoRow} data-testid="info-row-plan-file">
+          <span class={styles.infoLabel}>Plan File</span>
+          <span class={styles.infoValue}>
+            {tildify(props.agentSessionInfo!.planFilePath!, props.agent?.homeDir)}
+          </span>
         </div>
       </Show>
       <Show when={props.agentSessionInfo?.contextUsage}>

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -29,7 +29,6 @@ import {
   controlResponseRenderer,
   interruptedRenderer,
   microcompactBoundaryRenderer,
-  planExecutionRenderer,
   rateLimitRenderer,
   resultRenderer,
   settingsChangedRenderer,
@@ -624,7 +623,6 @@ const KIND_RENDERERS: Record<string, (parsed: unknown, role: MessageRole, contex
     return settingsChangedRenderer.render(parsed, role, context)
       ?? interruptedRenderer.render(parsed, role, context)
       ?? contextClearedRenderer.render(parsed, role, context)
-      ?? planExecutionRenderer.render(parsed, role, context)
       ?? rateLimitRenderer.render(parsed, role, context)
       ?? compactBoundaryRenderer.render(parsed, role, context)
       ?? microcompactBoundaryRenderer.render(parsed, role, context)
@@ -685,7 +683,6 @@ function getFallbackRenderers(): MessageContentRenderer[] {
       settingsChangedRenderer,
       interruptedRenderer,
       contextClearedRenderer,
-      planExecutionRenderer,
       rateLimitRenderer,
       compactBoundaryRenderer,
       microcompactBoundaryRenderer,

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -13,7 +13,7 @@ import { watchEventsViaWebSocket } from '~/api/wsWatchEvents'
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
 import { AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { TabType, WatchEventsRequestSchema } from '~/generated/leapmux/v1/workspace_pb'
-import { extractAssistantUsage, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
+import { extractAssistantUsage, extractPlanFilePath, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 import { emitSettingsChanged } from '~/lib/settingsChangedEvent'
 
 export interface WorkspaceConnectionParams {
@@ -99,6 +99,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             const sc = extractSettingsChanges(parsed)
             if (sc) {
               emitSettingsChanged(sc)
+            }
+            const planFile = extractPlanFilePath(parsed)
+            if (planFile) {
+              agentSessionStore.updateInfo(agentId, { planFilePath: planFile })
             }
           }
           catch { /* ignore parse errors */ }

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -217,3 +217,20 @@ export function extractSettingsChanges(parsed: ParsedMessageContent): {
     return null
   return changes as { permissionMode?: { old: string, new: string } }
 }
+
+/** Extract plan file path from a plan_execution message (wrapped or unwrapped). */
+export function extractPlanFilePath(parsed: ParsedMessageContent): string | undefined {
+  // Check all messages in the wrapper (or the top-level object).
+  const messagesToCheck: unknown[] = parsed.wrapper
+    ? parsed.wrapper.messages
+    : parsed.topLevel ? [parsed.topLevel] : []
+  for (const msg of messagesToCheck) {
+    if (typeof msg === 'object' && msg !== null) {
+      const m = msg as Record<string, unknown>
+      if (m.type === 'plan_execution' && typeof m.plan_file_path === 'string' && m.plan_file_path !== '') {
+        return m.plan_file_path as string
+      }
+    }
+  }
+  return undefined
+}

--- a/frontend/src/stores/agentSession.store.ts
+++ b/frontend/src/stores/agentSession.store.ts
@@ -23,6 +23,7 @@ export interface AgentSessionInfo {
   totalCostUsd?: number
   contextUsage?: ContextUsageInfo
   rateLimits?: Record<string, RateLimitInfo> // keyed by rateLimitType
+  planFilePath?: string
 }
 
 const STORAGE_KEY_PREFIX = 'leapmux-agent-session-'

--- a/frontend/tests/e2e/33-plan-mode.spec.ts
+++ b/frontend/tests/e2e/33-plan-mode.spec.ts
@@ -78,5 +78,13 @@ test.describe('Plan Mode', () => {
 
     // Verify dropdown switches to Accept Edits (plan approval sets acceptEdits mode)
     await expect(trigger).toContainText('Accept Edits')
+
+    // ── Step 5: Verify Plan File is shown in the popover ──
+    const infoTrigger = page.locator('[data-testid="session-id-trigger"]')
+    await expect(infoTrigger).toBeVisible({ timeout: 30_000 })
+    await infoTrigger.click()
+    const popover = page.locator('[data-testid="session-id-popover"]')
+    await expect(popover).toBeVisible()
+    await expect(popover.locator('[data-testid="info-row-plan-file"]')).toBeVisible()
   })
 })

--- a/frontend/tests/e2e/56-dropdown-popover.spec.ts
+++ b/frontend/tests/e2e/56-dropdown-popover.spec.ts
@@ -38,6 +38,10 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
     const popover = page.locator('[data-testid="session-id-popover"]')
     await expect(popover).toBeVisible()
 
+    // Verify worker name and directory are shown in the popover
+    await expect(popover.locator('[data-testid="info-row-worker"]')).toBeVisible()
+    await expect(popover.locator('[data-testid="info-row-directory"]')).toBeVisible()
+
     // Now click the editor text input area — this should light-dismiss the
     // popover and leave focus in the editor.
     // The popover may be positioned above the trigger (data-flipped), so

--- a/frontend/tests/unit/stores/agentSession.store.test.ts
+++ b/frontend/tests/unit/stores/agentSession.store.test.ts
@@ -155,4 +155,26 @@ describe('createAgentSessionStore', () => {
       dispose()
     })
   })
+
+  it('should store and retrieve planFilePath', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('agent-1', { planFilePath: '/home/user/.claude/plans/plan.md' })
+      const info = store.getInfo('agent-1')
+      expect(info.planFilePath).toBe('/home/user/.claude/plans/plan.md')
+      dispose()
+    })
+  })
+
+  it('should update planFilePath without affecting other fields', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('agent-1', { totalCostUsd: 2.0 })
+      store.updateInfo('agent-1', { planFilePath: '/path/plan.md' })
+      const info = store.getInfo('agent-1')
+      expect(info.totalCostUsd).toBe(2.0)
+      expect(info.planFilePath).toBe('/path/plan.md')
+      dispose()
+    })
+  })
 })

--- a/internal/hub/service/agent_control.go
+++ b/internal/hub/service/agent_control.go
@@ -502,8 +502,9 @@ func (s *AgentService) planExecTimeout(agentID, toolUseID string, config *PlanEx
 			slog.Warn("plan exec timeout: no plan content found, continuing with retained context",
 				"agent_id", agentID)
 			s.broadcastNotification(ctx, agentID, map[string]interface{}{
-				"type":    "plan_execution",
-				"message": "Executing plan with retained context",
+				"type":            "plan_execution",
+				"context_cleared": false,
+				"plan_file_path":  agent.PlanFilePath,
 			})
 			return
 		}

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -420,10 +420,11 @@ func (s *WorkerConnectorService) processWorkerMessage(
 					}
 
 					// Broadcast plan execution notification.
-					if opts.Notification != "" {
+					if opts.PlanExec {
 						s.agentSvc.broadcastNotification(bgCtx, agentID, map[string]interface{}{
-							"type":    "plan_execution",
-							"message": opts.Notification,
+							"type":            "plan_execution",
+							"context_cleared": opts.ClearSession,
+							"plan_file_path":  opts.PlanFilePath,
 						})
 					}
 

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -107,9 +107,10 @@ message AgentInfo {
   string permission_mode = 9;
   string effort = 10;
   string worker_id = 11;        // Worker this agent runs on
-  string working_dir = 12;      // Working directory on the worker
-  AgentGitStatus git_status = 13; // Git status for the agent's working directory
-  string home_dir = 14;         // Worker's home directory for tilde path display
+  string worker_name = 12;      // Human-readable worker name
+  string working_dir = 13;      // Working directory on the worker
+  AgentGitStatus git_status = 14; // Git status for the agent's working directory
+  string home_dir = 15;         // Worker's home directory for tilde path display
 }
 
 // --- Agent Messaging ---


### PR DESCRIPTION
## Motivation

The agent session info popover lacked visibility into which worker is handling an agent and which plan file is being executed. Additionally, the `plan_execution` notification was sent as an unstructured plain string, making it difficult for the frontend to extract semantic information such as whether context was cleared and which plan file path was involved.

## Modifications

**Backend (Go + Proto):**
- Added `worker_name` field to `AgentInfo` in `proto/leapmux/v1/agent.proto`; subsequent fields were renumbered (acceptable since the project is unreleased)
- Changed `RestartOptions` from a single `Notification string` field to `PlanExec bool` and `PlanFilePath string` fields in `internal/hub/service/agent_service.go`
- Updated `plan_execution` broadcasts in `agent_messaging.go`, `worker_connector_service.go`, and `agent_control.go` to emit structured JSON: `{"type":"plan_execution","context_cleared":bool,"plan_file_path":string}` instead of a plain string
- Added `plan_execution` consolidation logic in `agent_threading.go`: keeps the latest notification, and when a `plan_execution` carries `context_cleared:true`, it subsumes redundant standalone `context_cleared` entries
- `OpenAgent` now fetches worker name in a single call; `ListAgents` batch-fetches worker names
- Added tests covering consolidation behavior and `agentToProto` worker name population (`agent_threading_test.go`)

**Frontend (TypeScript/SolidJS):**
- Added Worker and Plan File rows (with `data-testid="info-row-worker"` and `data-testid="info-row-plan-file"`) to the session info popover in `AgentEditorPanel.tsx`
- Updated `notificationRenderers.tsx` to read the structured `context_cleared` boolean from `plan_execution` and render "Executing plan with clean context" or "Executing plan retaining context"; suppresses the redundant standalone "Context cleared" notification when `plan_execution` already carries that semantic
- Removed dead `planExecutionRenderer` from `messageRenderers.tsx` (plan_execution always arrives wrapped in a `notification_thread`)
- Added `extractPlanFilePath` function in `messageParser.ts` that scans wrapped and unwrapped messages for a `plan_execution` entry with a non-empty `plan_file_path`
- Stored `planFilePath` in `agentSessionStore` via `useWorkspaceConnection.ts`
- Added 5 unit tests for `extractPlanFilePath` and 2 unit tests for `planFilePath` store behavior
- Extended e2e tests in `33-plan-mode.spec.ts` to assert `info-row-plan-file` is visible after plan approval, and in `56-dropdown-popover.spec.ts` to assert worker and directory rows are visible

## Result

The agent session info popover now displays the worker name and the active plan file path alongside the existing directory entry. Plan execution notifications carry structured data, enabling the UI to render context-sensitive messages ("Executing plan with clean context" vs. "Executing plan retaining context") without duplicating the "Context cleared" notification when it is already implied by the plan execution event.

🤖 Generated with Claude Code
