### PR TITLE
Fix auto-scroll losing track of "at bottom" state in chat

### DIFF
--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -40,6 +40,12 @@ export const messageListSpacer = style({
   flex: 1,
 })
 
+export const messageListContent = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.md,
+})
+
 export const messageList = style({
   flex: 1,
   overflowX: 'hidden',

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -393,6 +393,9 @@ export const AppShell: ParentComponent = (props) => {
   // Ref for retrieving the first visible message seq from ChatView (for viewport save on tab switch).
   let getScrollState: (() => { distFromBottom: number, atBottom: boolean } | undefined) | undefined
 
+  // Ref for forcing a scroll-to-bottom in ChatView (e.g. on send message / control response).
+  let forceScrollToBottom: (() => void) | undefined
+
   // Container height for the center panel (used for max editor height calculation)
   const [centerPanelHeight, setCenterPanelHeight] = createSignal(0)
 
@@ -707,6 +710,7 @@ export const AppShell: ParentComponent = (props) => {
 
   // Handle control responses (permission grant/deny) for agent prompts
   const handleControlResponse = async (agentId: string, content: Uint8Array) => {
+    forceScrollToBottom?.()
     try {
       const agent = agentStore.state.agents.find(a => a.id === agentId)
       const isActive = agent?.status === AgentStatus.ACTIVE
@@ -1245,6 +1249,7 @@ export const AppShell: ParentComponent = (props) => {
                     savedViewportScroll={chatStore.getSavedViewportScroll(agentId)}
                     onClearSavedViewportScroll={() => chatStore.clearSavedViewportScroll(agentId)}
                     scrollStateRef={(fn) => { getScrollState = fn }}
+                    scrollToBottomRef={(fn) => { forceScrollToBottom = fn }}
                   />
                 </Show>
               </div>
@@ -1304,6 +1309,7 @@ export const AppShell: ParentComponent = (props) => {
           const id = focusedAgentId()
           if (!id)
             return
+          forceScrollToBottom?.()
           try {
             const sendAgent = agentStore.state.agents.find(a => a.id === id)
             await agentClient.sendAgentMessage({ agentId: id, content }, agentCallTimeout(sendAgent?.status === AgentStatus.ACTIVE))

--- a/frontend/tests/e2e/41-chat-pagination.spec.ts
+++ b/frontend/tests/e2e/41-chat-pagination.spec.ts
@@ -98,7 +98,7 @@ test.describe('Chat Pagination & Scroll', () => {
       const els = document.querySelectorAll<HTMLElement>('[class*="messageList"]')
       for (const el of els) {
         if (getComputedStyle(el).overflowY === 'auto') {
-          return el.scrollHeight - el.scrollTop - el.clientHeight < 16
+          return el.scrollHeight - el.scrollTop - el.clientHeight < 32
         }
       }
       return true


### PR DESCRIPTION
## Motivation

The chat view's auto-scroll feature was losing track of whether the user was at the bottom of the conversation. This happened because certain content changes — such as expand/collapse DOM mutations and editor resizes — do not trigger scroll events. Without a scroll event, the auto-scroll logic never had a chance to re-evaluate whether it should keep the view pinned to the bottom, causing new messages to appear off-screen even when the user had not manually scrolled up.

Additionally, when sending a message or receiving a control response, the scroll-to-bottom behavior was not always triggered reliably because the parent component had no way to imperatively force a scroll.

## Modifications

- Wrapped message content in a dedicated content container element so that DOM mutations within messages (e.g., expand/collapse actions) can be observed independently of the scroll container.
- Added a `ResizeObserver` that watches both the scroll container and the content container. When the user is at the bottom and either resizes, the view automatically scrolls to keep the latest content visible.
- Increased the "at bottom" detection threshold from 16px to 32px to prevent edge cases where the scroll position was close to but not exactly at the bottom.
- Added a `scrollToBottomRef` prop on `ChatView` that parent components can call to force an immediate scroll to the bottom, bypassing any pending auto-scroll state.
- Updated `AppShell` to use `scrollToBottomRef` when the user sends a message or a control response is received.
- Updated the e2e test in `frontend/tests/e2e/41-chat-pagination.spec.ts` to match the new 32px threshold.

## Result

New messages are no longer hidden off-screen when content changes happen without triggering scroll events. Sending a message or receiving a control response now reliably scrolls the chat view to the bottom, regardless of any intermediate DOM or layout changes.

🤖 Generated with Claude Code
