### PR TITLE
Fix overly aggressive notification thread consolidation

### DIFF
--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -1,0 +1,106 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock messageRenderers to break the circular dependency (messageRenderers
+// imports from notificationRenderers at module-init time).
+vi.mock('./messageRenderers', () => ({
+  isObject: (v: unknown): v is Record<string, unknown> =>
+    typeof v === 'object' && v !== null && !Array.isArray(v),
+}))
+
+const { renderNotificationThread } = await import('./notificationRenderers')
+
+/** Extract all text content from the rendered container, trimmed. */
+function renderText(messages: unknown[]): string {
+  const result = renderNotificationThread(messages)
+  if (result === null)
+    return ''
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Check if the rendered output contains a specific substring. */
+function renderedContains(messages: unknown[], text: string): boolean {
+  return renderText(messages).includes(text)
+}
+
+describe('renderNotificationThread: compaction vs context_cleared ordering', () => {
+  const contextClearedMsg = { type: 'context_cleared' }
+  const compactBoundaryMsg = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    compact_metadata: { trigger: 'auto', pre_tokens: 100000 },
+  }
+  const compactingStatusMsg = {
+    type: 'system',
+    subtype: 'status',
+    status: 'compacting',
+  }
+
+  it('compaction AFTER context_cleared: shows compaction, hides "Context cleared"', () => {
+    const messages = [contextClearedMsg, compactBoundaryMsg]
+    expect(renderedContains(messages, 'Context compacted')).toBe(true)
+    expect(renderedContains(messages, 'Context cleared')).toBe(false)
+  })
+
+  it('compaction BEFORE context_cleared: hides compaction, shows "Context cleared"', () => {
+    const messages = [compactBoundaryMsg, contextClearedMsg]
+    expect(renderedContains(messages, 'Context compacted')).toBe(false)
+    expect(renderedContains(messages, 'Context cleared')).toBe(true)
+  })
+
+  it('plan_execution renders together with compaction', () => {
+    const planExecMsg = {
+      type: 'plan_execution',
+      context_cleared: true,
+      plan_file_path: '/path/plan.md',
+    }
+    const messages = [planExecMsg, compactBoundaryMsg]
+    const text = renderText(messages)
+    expect(text).toContain('Executing plan with clean context')
+    expect(text).toContain('Context compacted')
+  })
+
+  it('compacting spinner AFTER context_cleared: shows spinner, hides "Context cleared"', () => {
+    const messages = [contextClearedMsg, compactingStatusMsg]
+    expect(renderedContains(messages, 'Compacting context...')).toBe(true)
+    expect(renderedContains(messages, 'Context cleared')).toBe(false)
+  })
+
+  it('context_cleared alone: shows "Context cleared"', () => {
+    const messages = [contextClearedMsg]
+    expect(renderedContains(messages, 'Context cleared')).toBe(true)
+  })
+
+  it('compaction alone: shows compaction', () => {
+    const messages = [compactBoundaryMsg]
+    expect(renderedContains(messages, 'Context compacted')).toBe(true)
+    expect(renderedContains(messages, 'Context cleared')).toBe(false)
+  })
+
+  it('settings_changed with contextCleared BEFORE compaction: shows compaction, hides "Context cleared"', () => {
+    const settingsMsg = {
+      type: 'settings_changed',
+      changes: { model: { old: 'A', new: 'B' } },
+      contextCleared: true,
+    }
+    const messages = [settingsMsg, compactBoundaryMsg]
+    const text = renderText(messages)
+    expect(text).toContain('Context compacted')
+    expect(text).not.toContain('Context cleared')
+    expect(text).toContain('Model')
+  })
+
+  it('compaction BEFORE settings_changed with contextCleared: hides compaction, shows "Context cleared"', () => {
+    const settingsMsg = {
+      type: 'settings_changed',
+      changes: { model: { old: 'A', new: 'B' } },
+      contextCleared: true,
+    }
+    const messages = [compactBoundaryMsg, settingsMsg]
+    const text = renderText(messages)
+    expect(text).not.toContain('Context compacted')
+    expect(text).toContain('Context cleared')
+    expect(text).toContain('Model')
+  })
+})


### PR DESCRIPTION
## Motivation

The notification threading system, which consolidates consecutive hub notifications (settings changes, interrupts, rate limits, context clears, etc.) into a single database row, had two bugs that caused incorrect behavior in the chat UI.

**Backend:** The `softClearNotifThread` grace period was refreshable — every non-notification message (e.g., an assistant turn) would bump the soft-clear timestamp, so notifications separated by many regular messages could still be merged into the same thread long after they should have been separated. Additionally, a successful merge into a soft-cleared thread would fully revive the thread by resetting `softClear` to zero, allowing further notifications to merge indefinitely.

**Frontend:** `renderNotificationThread` always suppressed compaction rendering when `context_cleared` was present in the same thread, but the correct behavior depends on ordering: compaction *after* `context_cleared` should be shown (and "Context cleared" hidden), while compaction *before* `context_cleared` should be hidden (and "Context cleared" shown). Only the most recent context-affecting event is relevant to the user.

## Modifications

- `internal/hub/service/agent_messaging.go` — `softClearNotifThread` now checks `threadRef.softClear.IsZero()` before setting the timestamp, so the grace period starts only on the first non-notification message and cannot be refreshed by subsequent ones. Also removed the `threadRef.softClear = time.Time{}` revive line from `persistNotificationThreaded`, so soft-cleared threads stay soft-cleared after a merge.
- `internal/hub/service/agent_threading_test.go` — Adds `TestSoftClearNotifThread_DoesNotRefreshTimestamp` (verifies timestamp is not updated on second call) and `TestSoftClearNotifThread_FreshOnNewThread` (verifies a new thread ref has zero softClear and can be set fresh).
- `frontend/src/components/chat/notificationRenderers.tsx` — Adds `lastContextEventIsCompaction` tracking in the message loop. Each `context_cleared` or `settings_changed` with `contextCleared` sets it to `false`; each compaction-related system message (`status`/`compact_boundary`/`microcompact_boundary`) sets it to `true`. After the loop, "Context cleared" is only shown when `!lastContextEventIsCompaction`, and `showCompaction` uses `!contextCleared || lastContextEventIsCompaction`.
- `frontend/src/components/chat/notificationRenderers.test.tsx` (new) — 8 tests covering: compaction after/before `context_cleared`, plan execution co-rendering with compaction, compacting spinner after `context_cleared`, standalone cases, and `settings_changed` with `contextCleared` interactions.

## Result

- Notifications that are genuinely separated by user/assistant activity are no longer collapsed into the same thread entry. Each logical group of rapid-fire notifications gets its own bubble, while truly interleaved rapid notifications (e.g., a permission-mode change followed immediately by another) are still consolidated within the 1-second grace window.
- When both compaction and context_cleared appear in the same notification thread, only the most recent one is displayed: compaction after context_cleared shows the compaction info; context_cleared after compaction shows "Context cleared."
- `plan_execution` with `context_cleared: true` continues to render alongside compaction without interference, since it uses a separate `planExecContextCleared` flag.

🤖 Generated with Claude Code
