### PR TITLE
Fix flaky e2e tests and add worktree lifecycle logging

### DIFF
--- a/frontend/tests/e2e/23-agent-resume.spec.ts
+++ b/frontend/tests/e2e/23-agent-resume.spec.ts
@@ -1,8 +1,9 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Agent Session Resume', () => {
   test('should resume agent session after worker restart', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Resume Test', adminOrgId)
     try {
@@ -55,6 +56,7 @@ test.describe('Agent Session Resume', () => {
   })
 
   test('should deliver control request after worker restart', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Control Request Restart', adminOrgId)
     try {
@@ -100,6 +102,7 @@ test.describe('Agent Session Resume', () => {
   })
 
   test('should handle interrupt after worker restart', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Interrupt Restart', adminOrgId)
     try {

--- a/frontend/tests/e2e/24-full-restart.spec.ts
+++ b/frontend/tests/e2e/24-full-restart.spec.ts
@@ -1,12 +1,9 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, restartHub, restartWorker, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, restartHub, restartWorker, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Full Hub+Worker Restart', () => {
-  // Infrastructure-dependent: timing between agent processing and shutdown
-  // can vary under heavy load when parallel workers share system resources.
-  test.describe.configure({ retries: 1 })
-
   test('should preserve chat history after hub and worker restart', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Full Restart Test', adminOrgId)
     try {
@@ -123,6 +120,7 @@ test.describe('Full Hub+Worker Restart', () => {
   })
 
   test('should not show thinking indicator after full restart during active turn', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Restart Thinking Test', adminOrgId)
     try {

--- a/frontend/tests/e2e/24-terminal-disconnect.spec.ts
+++ b/frontend/tests/e2e/24-terminal-disconnect.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, stopWorker, processTest as test } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, stopWorker, processTest as test } from './process-control-fixtures'
 
 /** Read terminal text content from the active xterm's buffer. */
 async function getTerminalText(page: Page): Promise<string> {
@@ -22,6 +22,7 @@ async function getTerminalText(page: Page): Promise<string> {
 
 test.describe('Terminal Disconnection', () => {
   test('should mark terminal as disconnected when worker stops', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Terminal Disconnect Test', adminOrgId)
     try {

--- a/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
+++ b/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
@@ -1,12 +1,9 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Worker Restart Thinking Indicator', () => {
-  // Infrastructure-dependent: timing between agent processing and worker stop
-  // can vary under heavy load when 4 parallel workers share system resources.
-  test.describe.configure({ retries: 1 })
-
   test('should hide thinking indicator when worker goes offline during agent turn', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Thinking Indicator Test', adminOrgId)
     try {
@@ -47,6 +44,7 @@ test.describe('Worker Restart Thinking Indicator', () => {
   })
 
   test('should resume agent after worker restart and new message', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Agent Resume Test', adminOrgId)
     try {

--- a/frontend/tests/e2e/25-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/25-no-worker-settings.spec.ts
@@ -1,10 +1,9 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, waitForWorkspaceReady } from './helpers'
-import { expect, restartHub, restartWorker, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, restartHub, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Settings and /clear without Worker', () => {
   test('should handle /clear and settings changes without worker', async ({ separateHubWorker, page }) => {
-    // Previous test file may have stopped the worker without restarting
-    await restartWorker(separateHubWorker)
+    await ensureWorkerOnline(separateHubWorker)
 
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'No Worker Settings Test', adminOrgId)
@@ -92,11 +91,11 @@ test.describe('Settings and /clear without Worker', () => {
       await waitForNotification('Mode (Default \u2192 Plan Mode)')
       await waitForSettingsIdle()
 
-      // Step 5: Change model (Haiku → Sonnet)
+      // Step 5: Change model (Sonnet → Haiku)
       await openSettingsMenu()
-      await page.locator('[data-testid="model-sonnet"]').click()
+      await page.locator('[data-testid="model-haiku"]').click()
 
-      await waitForNotification('Model (Haiku \u2192 Sonnet)')
+      await waitForNotification('Model (Sonnet \u2192 Haiku)')
       await waitForSettingsIdle()
 
       // Step 6: Change effort (High → Medium)

--- a/frontend/tests/e2e/26-message-delivery-error.spec.ts
+++ b/frontend/tests/e2e/26-message-delivery-error.spec.ts
@@ -1,10 +1,9 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, loginViaToken, loginViaUI, waitForWorkspaceReady } from './helpers'
-import { expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
+import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Message Delivery Error', () => {
   test('should show delivery error when worker is offline and retry on reconnect', async ({ separateHubWorker, page }) => {
-    // Previous test file may have stopped the worker without restarting
-    await restartWorker(separateHubWorker)
+    await ensureWorkerOnline(separateHubWorker)
 
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Delivery Error Test', adminOrgId)
@@ -67,6 +66,7 @@ test.describe('Message Delivery Error', () => {
   })
 
   test('should persist delivery error across page refresh', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Persist Error Test', adminOrgId)
     try {
@@ -118,8 +118,7 @@ test.describe('Message Delivery Error', () => {
   })
 
   test('should delete failed message', async ({ separateHubWorker, page }) => {
-    // Previous test may have stopped the worker without restarting
-    await restartWorker(separateHubWorker)
+    await ensureWorkerOnline(separateHubWorker)
 
     const { hubUrl, adminToken, workerId, adminOrgId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Delete Error Test', adminOrgId)

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -28,9 +28,9 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Default: Haiku model (overridden via LEAPMUX_DEFAULT_MODEL in e2e), Default permission mode
+    // Default: Sonnet model (overridden via LEAPMUX_DEFAULT_MODEL in e2e), Default permission mode
     const text = await getTriggerText(page)
-    expect(text).toContain('Haiku')
+    expect(text).toContain('Sonnet')
     expect(text).toContain('Default')
   })
 
@@ -66,10 +66,10 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Change model to Sonnet (default is Haiku, dropdown auto-closes on select)
+    // Change model to Haiku (default is Sonnet, dropdown auto-closes on select)
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet"]').click()
-    await expect(trigger).toContainText('Sonnet')
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
   })
 
   test('switch effort', async ({ authenticatedWorkspace, page }) => {
@@ -114,10 +114,10 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Change model to Sonnet (default is Haiku, dropdown auto-closes on select)
+    // Change model to Haiku (default is Sonnet, dropdown auto-closes on select)
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet"]').click()
-    await expect(trigger).toContainText('Sonnet')
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
 
     // Wait for restart to complete
     await page.waitForTimeout(5000)
@@ -125,10 +125,10 @@ test.describe('Agent Settings', () => {
     // Refresh the page
     await page.reload()
 
-    // Verify Sonnet is still selected after refresh
+    // Verify Haiku is still selected after refresh
     const triggerAfter = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(triggerAfter).toBeVisible()
-    await expect(triggerAfter).toContainText('Sonnet')
+    await expect(triggerAfter).toContainText('Haiku')
   })
 
   test('focus returns to editor after mode change', async ({ authenticatedWorkspace, page }) => {
@@ -256,13 +256,13 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Change model to Sonnet (default is Haiku) — should produce a notification
+    // Change model to Haiku (default is Sonnet) — should produce a notification
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet"]').click()
-    await expect(trigger).toContainText('Sonnet')
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
 
     // Verify the notification bubble appears in chat
-    await expect(page.getByText('Model (Haiku \u2192 Sonnet)')).toBeVisible()
+    await expect(page.getByText('Model (Sonnet \u2192 Haiku)')).toBeVisible()
   })
 
   test('permission mode change notification appears in chat', async ({ authenticatedWorkspace, page }) => {
@@ -282,9 +282,9 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Change model to Sonnet (default is Haiku) — trigger should show spinner briefly
+    // Change model to Haiku (default is Sonnet) — trigger should show spinner briefly
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet"]').click()
+    await page.locator('[data-testid="model-haiku"]').click()
 
     // The trigger should show a loading spinner
     const loadingSpinner = page.locator('[data-testid="settings-loading-spinner"]')
@@ -292,6 +292,6 @@ test.describe('Agent Settings', () => {
 
     // Eventually the spinner disappears after statusChange arrives
     await expect(loadingSpinner).not.toBeVisible()
-    await expect(trigger).toContainText('Sonnet')
+    await expect(trigger).toContainText('Haiku')
   })
 })

--- a/frontend/tests/e2e/31-control-request-draft.spec.ts
+++ b/frontend/tests/e2e/31-control-request-draft.spec.ts
@@ -18,9 +18,6 @@ async function waitForControlBanner(page: Page) {
 }
 
 test.describe('Control Request Draft Persistence', () => {
-  // LLM-dependent: the first test relies on the agent calling ExitPlanMode
-  test.describe.configure({ retries: 2 })
-
   test('ExitPlanMode draft survives page reload', async ({ page, authenticatedWorkspace }) => {
     // Trigger EnterPlanMode then ExitPlanMode (ExitPlanMode produces a control banner).
     await sendMessage(

--- a/frontend/tests/e2e/35-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/35-plan-mode-bypass.spec.ts
@@ -23,9 +23,6 @@ async function waitForSettingsIdle(page: Page) {
 }
 
 test.describe('Plan Mode - Bypass Permissions', () => {
-  // LLM-dependent: the agent may not reliably call EnterPlanMode/ExitPlanMode
-  test.describe.configure({ retries: 2 })
-
   test('bypass permissions from ExitPlanMode banner', async ({ page, authenticatedWorkspace }) => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()

--- a/frontend/tests/e2e/40-ansi-rendering.spec.ts
+++ b/frontend/tests/e2e/40-ansi-rendering.spec.ts
@@ -28,9 +28,6 @@ async function allowToolExecutionIfNeeded(page: Page) {
 }
 
 test.describe('ANSI Escape Sequence Rendering', () => {
-  // LLM-dependent: the agent may not reliably call the Bash tool as instructed
-  test.describe.configure({ retries: 2 })
-
   test('should render ANSI colored output from Bash tool as styled HTML', async ({ page, authenticatedWorkspace }) => {
     // Ask Claude to run `ls --color=always /` which produces ANSI colored output.
     // Directories and symlinks get colored by ls, and --color=always forces

--- a/frontend/tests/e2e/55-worktree-support.spec.ts
+++ b/frontend/tests/e2e/55-worktree-support.spec.ts
@@ -870,13 +870,12 @@ test.describe('Worktree Support', () => {
     await expect(page.getByRole('heading', { name: 'Dirty Worktree' })).not.toBeVisible()
     await expect(agentTab).not.toBeVisible({ timeout: 5000 })
 
-    // Worktree should be removed from disk
+    // Worktree directory and branch are deleted in the background by
+    // the worker after ForceRemoveWorktree returns, so poll for completion.
     await expect(async () => {
       expect(existsSync(worktreeDir)).toBe(false)
-    }).toPass({ timeout: 5000 })
-
-    // Branch should also be deleted
-    expect(branchExists(repoDir, 'dialog-branch')).toBe(false)
+      expect(branchExists(repoDir, 'dialog-branch')).toBe(false)
+    }).toPass({ timeout: 10_000 })
   })
 
   test('dirty worktree confirmation dialog: keep closes tab but preserves worktree', async ({

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -65,7 +65,7 @@ export const test = base.extend<
       dataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'haiku' },
+      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet' },
     })
 
     // Drain stdout/stderr


### PR DESCRIPTION
## Motivation

Several e2e test suites were configured with `test.describe.configure({ retries: N })`, which masked real intermittent failures by silently retrying rather than surfacing the underlying race conditions. Additionally, some tests unconditionally restarted the worker process even when it was already running, introducing unnecessary latency and further contributing to flakiness. Worktree lifecycle operations on both the hub and worker sides also lacked structured logging, making it difficult to trace worktree creation, reuse, and cleanup in production or during test investigations.

## Modifications

- Removed `test.describe.configure({ retries: N })` from 6 test suites (`24-full-restart`, `24-worker-restart-thinking-indicator`, `31-control-request-draft`, `33-plan-mode`, `35-plan-mode-bypass`, `40-ansi-rendering`) that were hiding genuine failures.
- Added `ensureWorkerOnline()` helper to `process-control-fixtures.ts` that performs a single HTTP check against `ListWorkers` before deciding whether a restart is needed. Tests that previously called `restartWorker()` unconditionally are updated to call this lighter-weight alternative.
- Updated `workspace` fixture in `process-control-fixtures.ts` to call `ensureWorkerOnline()` before creating a workspace, guarding all dependent tests.
- Changed the default test model from Haiku to Sonnet by updating `LEAPMUX_DEFAULT_MODEL` in fixtures and correcting the related assertions across affected spec files.
- Improved Plan Mode test resilience in `33-plan-mode.spec.ts` to tolerate variable LLM behavior (checking if the ExitPlanMode banner already appeared after a rejection).
- Combined worktree and branch deletion polling into a single wait loop in `55-worktree-support.spec.ts`.
- Added `slog.Info` and `slog.Warn` structured log statements throughout `internal/hub/service/worktree_helper.go` covering worktree creation requests, reuse decisions, DB record saves, tab registration, tab count checks, and cleanup attempts.
- Added `slog.Info` and `slog.Warn` structured log statements in `internal/hub/service/git_service.go` for `CheckWorktreeStatus` and `ForceRemoveWorktree` RPC handlers.
- Added `slog.Info` and `slog.Warn` structured log statements in `internal/worker/hub/git_handlers.go` for `handleGitWorktreeCreate` and `handleGitWorktreeRemove`, covering creation, removal, cleanliness checks, and branch deletion.

## Result

- E2e test suites no longer silently retry on failure; genuine intermittent failures will now surface and be addressed at the root cause.
- Tests that do not require a worker restart complete faster because `ensureWorkerOnline()` short-circuits when the worker is already online.
- Worktree lifecycle events (creation, reuse, registration, cleanup) are now visible in structured logs on both the hub and worker, making it straightforward to diagnose worktree-related issues in any environment.

🤖 Generated with Claude Code
