### PR TITLE
Include plan file path in plan execution synthetic message

### DIFF
--- a/internal/hub/service/helpers_test.go
+++ b/internal/hub/service/helpers_test.go
@@ -173,6 +173,17 @@ func TestValidateBranchName(t *testing.T) {
 	}
 }
 
+func TestBuildPlanExecMessage_WithFilePath(t *testing.T) {
+	msg := buildPlanExecMessage("/home/user/.claude/plans/plan.md", "step 1\nstep 2")
+	expected := "Execute the following plan:\n\n---\n\nstep 1\nstep 2\n\n---\n\nThe above plan has been written to /home/user/.claude/plans/plan.md — re-read it if needed."
+	assert.Equal(t, expected, msg)
+}
+
+func TestBuildPlanExecMessage_WithoutFilePath(t *testing.T) {
+	msg := buildPlanExecMessage("", "step 1\nstep 2")
+	assert.Equal(t, "Execute the following plan:\n\n---\n\nstep 1\nstep 2", msg)
+}
+
 func TestClampInt32(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Motivation
When an agent's context is cleared for plan execution, a synthetic message is sent containing the plan content. However, if the agent's context is later compressed, the plan content may be lost and the agent has no way to recover it.

## Modifications
- Extracted a new `buildPlanExecMessage(planFilePath, planContent string) string` helper in `internal/hub/service/agent_messaging.go` that constructs the synthetic user message sent to agents after context-clearing restarts
- When a plan file path is available, the message now appends a footer: "The above plan has been written to {path} — re-read it if needed."
- Refactored `clearAgentContextForPlanExecution()` to use the new helper instead of inline string concatenation
- Added tests for the new helper function in `internal/hub/service/helpers_test.go`

## Result
Agents that have their context compressed after a plan execution restart can now re-read the original plan from disk, preventing loss of task context during long-running executions.

🤖 Generated with Claude Code
