### PR TITLE
Improve settings menu aesthetics and UX in chat

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -511,33 +511,31 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
       class={styles.settingsMenu}
       data-testid="agent-settings-menu"
     >
-      {/* Permission Mode */}
+      {/* Effort */}
       <fieldset>
-        <legend class={styles.settingsGroupLabel}>Permission Mode</legend>
-        <For each={PERMISSION_MODES}>
-          {mode => (
+        <legend class={styles.settingsGroupLabel}>Effort</legend>
+        <For each={EFFORTS}>
+          {effort => (
             <label
               role="menuitemradio"
               class={styles.settingsRadioItem}
-              data-testid={`permission-mode-${mode.value}`}
+              data-testid={`effort-${effort.value}`}
             >
               <input
                 type="radio"
-                name={`${menuId}-mode`}
-                value={mode.value}
-                checked={currentMode() === mode.value}
+                name={`${menuId}-effort`}
+                value={effort.value}
+                checked={currentEffort() === effort.value}
                 onChange={() => {
-                  props.onPermissionModeChange?.(mode.value as PermissionMode)
+                  props.onEffortChange?.(effort.value)
                   settingsPopoverEl?.hidePopover()
                 }}
               />
-              {mode.label}
+              {effort.label}
             </label>
           )}
         </For>
       </fieldset>
-
-      <hr class={styles.settingsSeparator} />
 
       {/* Model */}
       <fieldset>
@@ -565,29 +563,27 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         </For>
       </fieldset>
 
-      <hr class={styles.settingsSeparator} />
-
-      {/* Effort */}
+      {/* Permission Mode */}
       <fieldset>
-        <legend class={styles.settingsGroupLabel}>Effort</legend>
-        <For each={EFFORTS}>
-          {effort => (
+        <legend class={styles.settingsGroupLabel}>Permission Mode</legend>
+        <For each={PERMISSION_MODES}>
+          {mode => (
             <label
               role="menuitemradio"
               class={styles.settingsRadioItem}
-              data-testid={`effort-${effort.value}`}
+              data-testid={`permission-mode-${mode.value}`}
             >
               <input
                 type="radio"
-                name={`${menuId}-effort`}
-                value={effort.value}
-                checked={currentEffort() === effort.value}
+                name={`${menuId}-mode`}
+                value={mode.value}
+                checked={currentMode() === mode.value}
                 onChange={() => {
-                  props.onEffortChange?.(effort.value)
+                  props.onPermissionModeChange?.(mode.value as PermissionMode)
                   settingsPopoverEl?.hidePopover()
                 }}
               />
-              {effort.label}
+              {mode.label}
             </label>
           )}
         </For>

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -201,7 +201,6 @@ export const settingsRadioItem = style({
   },
 })
 
-
 export const footerBarRight = style({
   display: 'flex',
   alignItems: 'center',

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -167,10 +167,10 @@ export const settingsTrigger = style({
 })
 
 export const settingsMenu = style({
-  backgroundColor: 'var(--card)',
+  backgroundColor: 'var(--background)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
-  padding: `${spacing.xs} 0`,
+  padding: `${spacing.xs} ${spacing.lg} 0 ${spacing.lg}`,
   zIndex: 300,
   minWidth: '180px',
   boxShadow: 'var(--shadow-large)',
@@ -201,11 +201,6 @@ export const settingsRadioItem = style({
   },
 })
 
-export const settingsSeparator = style({
-  height: '1px',
-  backgroundColor: 'var(--border)',
-  margin: `${spacing.xs} 0`,
-})
 
 export const footerBarRight = style({
   display: 'flex',

--- a/frontend/src/components/chat/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/MarkdownEditor.css.ts
@@ -122,7 +122,7 @@ export const linkPopoverInput = style({
 export const codeLangPopoverContent = style({
   display: 'flex',
   flexDirection: 'column',
-  backgroundColor: 'var(--card)',
+  backgroundColor: 'var(--background)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
   boxShadow: 'var(--shadow-large)',


### PR DESCRIPTION
## Motivation
The agent settings menu in the chat editor had a few visual inconsistencies
that made it feel out of place compared to other dropdowns in the
application. The fieldset order put Permission Mode at the top, far from
the trigger button at the bottom of the dropdown, even though it is the
setting users adjust most often. The `<hr>` separators added unnecessary
visual noise. Additionally, the menu background used `var(--card)` (a sand
color) instead of `var(--background)` (white), which made it look different
from every other OAT dropdown in the UI. The same background mismatch
existed in the code language selector popover inside `MarkdownEditor`.

## Modifications
- Reordered settings menu fieldsets from Permission Mode → Model → Effort
  to Effort → Model → Permission Mode, placing the most frequently used
  setting closest to the trigger button at the bottom of the dropdown.
- Removed `<hr/>` separator elements between fieldsets to reduce visual
  clutter.
- Changed settings menu background color from `var(--card)` to
  `var(--background)` to match other OAT dropdowns.
- Added 16px horizontal padding to the settings menu and removed explicit
  bottom padding, relying on fieldset natural bottom margin instead.
- Applied the same `var(--background)` fix to the `codeLangPopoverContent`
  style in `MarkdownEditor.css.ts`.
- Removed the now-unused `settingsSeparator` CSS class from `ChatView.css.ts`.

## Result
The agent settings menu now opens with Permission Mode at the bottom,
closest to the trigger button, so the most commonly changed option is
immediately accessible. The menu background is consistent with all other
dropdowns in the application, and the removal of separator lines gives the
menu a cleaner, less cluttered look. The code language selector popover in
the Markdown editor also matches this consistent white background style.

🤖 Generated with Claude Code
