### PR TITLE
Improve editor UX with smart formatting and fix auto-continue race condition

### DIFF
--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -10,14 +10,18 @@ import {
   commonmark,
   createCodeBlockCommand,
   createCodeBlockInputRule as milkdownCreateCodeBlockInputRule,
+  emphasisStarInputRule as milkdownEmphasisStarInputRule,
+  emphasisUnderscoreInputRule as milkdownEmphasisUnderscoreInputRule,
+  inlineCodeInputRule as milkdownInlineCodeInputRule,
   insertHrInputRule as milkdownInsertHrInputRule,
+  strongInputRule as milkdownStrongInputRule,
   toggleInlineCodeCommand,
 } from '@milkdown/preset-commonmark'
-import { gfm } from '@milkdown/preset-gfm'
+import { gfm, strikethroughInputRule as milkdownStrikethroughInputRule } from '@milkdown/preset-gfm'
 import { TextSelection } from '@milkdown/prose/state'
 import { callCommand, replaceAll } from '@milkdown/utils'
 import { createEffect, createSignal, on, onCleanup, onMount } from 'solid-js'
-import { createBulletListAfterHardBreakInputRule, createCodeBlockInputRule, createHrInputRule, createLinkInputRule, createOrderedListAfterHardBreakInputRule } from '~/lib/editor/inputRules'
+import { createBulletListAfterHardBreakInputRule, createCodeBlockInputRule, createEmphasisStarInputRule, createEmphasisUnderscoreInputRule, createHrInputRule, createInlineCodeInputRule, createLinkInputRule, createOrderedListAfterHardBreakInputRule, createStrikethroughInputRule, createStrongInputRule } from '~/lib/editor/inputRules'
 import {
   createBlockquoteBackspacePlugin,
   createCodeBlockBackspacePlugin,
@@ -29,6 +33,7 @@ import {
   createListItemEnterPlugin,
   createMarkdownPastePlugin,
   createPlaceholderPlugin,
+  createSelectionWrapPlugin,
   createSendOnEnterPlugin,
   createSuppressTextSubstitutionPlugin,
   createTabKeyPlugin,
@@ -307,11 +312,17 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       const codeSpanEscapePlugin = createCodeSpanEscapePlugin()
       const markdownPastePlugin = createMarkdownPastePlugin()
       const linkBoundaryPlugin = createLinkBoundaryPlugin()
+      const selectionWrapPlugin = createSelectionWrapPlugin()
       const linkInputRule = createLinkInputRule()
       const codeBlockInputRule = createCodeBlockInputRule()
       const hrInputRule = createHrInputRule()
       const bulletListAfterHardBreakRule = createBulletListAfterHardBreakInputRule()
       const orderedListAfterHardBreakRule = createOrderedListAfterHardBreakInputRule()
+      const strongInputRule = createStrongInputRule()
+      const emphasisStarInputRule = createEmphasisStarInputRule()
+      const emphasisUnderscoreInputRule = createEmphasisUnderscoreInputRule()
+      const inlineCodeInputRule = createInlineCodeInputRule()
+      const strikethroughInputRule = createStrikethroughInputRule()
 
       const shikiParser = createShikiParser(shikiHighlighter, {
         themes: { light: 'github-light', dark: 'github-dark' },
@@ -353,8 +364,16 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
             }
           })
         })
-        .use(commonmark.filter(p => p !== milkdownInsertHrInputRule && p !== milkdownCreateCodeBlockInputRule))
-        .use(gfm)
+        .use(selectionWrapPlugin)
+        .use(commonmark.filter(p =>
+          p !== milkdownInsertHrInputRule
+          && p !== milkdownCreateCodeBlockInputRule
+          && p !== milkdownStrongInputRule
+          && p !== milkdownEmphasisStarInputRule
+          && p !== milkdownEmphasisUnderscoreInputRule
+          && p !== milkdownInlineCodeInputRule,
+        ))
+        .use(gfm.filter(p => p !== milkdownStrikethroughInputRule))
         .use(history)
         .use(markdownPastePlugin)
         .use(clipboard)
@@ -379,6 +398,11 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         .use(bulletListAfterHardBreakRule)
         .use(orderedListAfterHardBreakRule)
         .use(codeBlockInputRule)
+        .use(strongInputRule)
+        .use(emphasisStarInputRule)
+        .use(emphasisUnderscoreInputRule)
+        .use(inlineCodeInputRule)
+        .use(strikethroughInputRule)
         .create()
     }
 

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -99,7 +99,7 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
           onClick={handleReject}
           data-testid="plan-reject-btn"
         >
-          Reject
+          Send Feedback
         </button>
         <Show when={!props.hasEditorContent}>
           <ButtonGroup>

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -56,7 +56,7 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
           onClick={handleDeny}
           data-testid="control-deny-btn"
         >
-          Deny
+          Send Feedback
         </button>
       )}
     >

--- a/internal/hub/service/agent_auto_continue.go
+++ b/internal/hub/service/agent_auto_continue.go
@@ -101,6 +101,12 @@ func (s *AgentService) scheduleAutoContinue(agentID string) {
 			return
 		case <-time.After(interval):
 		}
+		// Re-check cancellation after the timer fires: when both channels
+		// are ready simultaneously, Go's select picks one at random, so
+		// the timer branch may win even though the context was cancelled.
+		if ctx.Err() != nil {
+			return
+		}
 		s.sendAutoContinueMessage(ctx, agentID)
 	}()
 }


### PR DESCRIPTION
## Motivation

The markdown editor lacked smart formatting behaviors that users expect from modern text editors: typing special characters over selections should wrap or toggle formatting, formatting syntax should not activate inside code spans, and pasting code into code blocks should not double-wrap content with delimiters.

Separately, the auto-continue goroutine in the hub service had a race condition where Go's non-deterministic `select` statement could choose the timer branch even after the context was already cancelled, causing auto-continue messages to be sent after they should have been suppressed.

## Modifications

**Editor UX improvements (`frontend/`):**

- Renamed "Reject" and "Deny" buttons in control banners to "Send Feedback" for clearer user intent (`ExitPlanModeControl.tsx`, `GenericToolControl.tsx`)
- Added `createSelectionWrapPlugin()` that wraps selected text with brackets (`()`, `[]`, `{}`) or toggles markdown marks (bold, italic, inline code, strikethrough) when the user types the corresponding special character; bracket wrapping works inside code blocks, but mark toggling is suppressed there
- Replaced Milkdown's built-in input rules with code-aware variants (`createStrongInputRule()`, `createEmphasisStarInputRule()`, `createEmphasisUnderscoreInputRule()`, `createInlineCodeInputRule()`, `createStrikethroughInputRule()`) that do not activate inside inline code spans
- Enhanced the markdown paste plugin to strip fenced code block delimiters, inline backticks, and surrounding `<br />` tags when pasting into an existing code block or inline code span
- Added 383 lines of e2e tests covering button labels, paste behavior in code contexts, formatting suppression inside inline code, and selection wrapping

**Backend race condition fix (`internal/hub/service/agent_auto_continue.go`):**

- Added an explicit `ctx.Err()` check after the timer fires in `scheduleAutoContinue` to handle the case where both the context cancellation and timer channels become ready simultaneously and Go's `select` picks the timer branch

## Result

- Typing `(`, `[`, or `{` with text selected wraps the selection in the corresponding bracket pair
- Typing `*`, `_`, `` ` ``, or `~` with text selected toggles the corresponding markdown mark on the selection
- Markdown formatting syntax (e.g., `**bold**`) no longer activates when typed inside an inline code span
- Pasting a fenced code block or inline code snippet into an existing code block inserts the raw content without the surrounding delimiters
- Control banners now show "Send Feedback" instead of "Reject"/"Deny", making the action's purpose clearer
- Auto-continue messages are no longer sent after their scheduling context has been cancelled

🤖 Generated with Claude Code
