### PR TITLE
Enforce workspace archive restrictions and add ConfirmDialog

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,44 @@
+import type { Component, JSX } from 'solid-js'
+import { onMount, Show } from 'solid-js'
+import { dialogCompact } from '~/styles/shared.css'
+import { ConfirmButton } from './ConfirmButton'
+
+interface ConfirmDialogProps {
+  title: string
+  children: JSX.Element
+  confirmLabel?: string
+  cancelLabel?: string
+  danger?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
+  let dlgRef!: HTMLDialogElement
+
+  onMount(() => dlgRef.showModal())
+
+  return (
+    <dialog ref={dlgRef} class={dialogCompact} closedby="any" onClose={() => props.onCancel()}>
+      <header><h2>{props.title}</h2></header>
+      <section>{props.children}</section>
+      <footer>
+        <button type="button" class="outline" onClick={() => props.onCancel()}>
+          {props.cancelLabel ?? 'Cancel'}
+        </button>
+        <Show
+          when={props.danger}
+          fallback={(
+            <button type="button" onClick={() => props.onConfirm()}>
+              {props.confirmLabel ?? 'OK'}
+            </button>
+          )}
+        >
+          <ConfirmButton class="danger" onClick={() => props.onConfirm()}>
+            {props.confirmLabel ?? 'OK'}
+          </ConfirmButton>
+        </Show>
+      </footer>
+    </dialog>
+  )
+}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -11,6 +11,7 @@ import { agentCallTimeout, agentLoadingTimeoutMs, apiCallTimeout } from '~/api/t
 import { AgentEditorPanel } from '~/components/chat/AgentEditorPanel'
 import { ChatView } from '~/components/chat/ChatView'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
+import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { NotFoundPage } from '~/components/common/NotFoundPage'
 import { showToast } from '~/components/common/Toast'
 import { CrossTileDragProvider } from '~/components/shell/CrossTileDragContext'
@@ -19,6 +20,7 @@ import { NewAgentDialog } from '~/components/shell/NewAgentDialog'
 import { NewTerminalDialog } from '~/components/shell/NewTerminalDialog'
 import { ResumeSessionDialog } from '~/components/shell/ResumeSessionDialog'
 import { RightSidebar } from '~/components/shell/RightSidebar'
+import { isWorkspaceMutatable } from '~/components/shell/sectionUtils'
 import { TabBar } from '~/components/shell/TabBar'
 import { getTerminalInstance, TerminalView } from '~/components/terminal/TerminalView'
 import { NewWorkspaceDialog } from '~/components/workspace/NewWorkspaceDialog'
@@ -27,6 +29,7 @@ import { useOrg } from '~/context/OrgContext'
 import { usePreferences } from '~/context/PreferencesContext'
 import { useWorkspace } from '~/context/WorkspaceContext'
 import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
+import { SectionType } from '~/generated/leapmux/v1/section_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { useIsMobile } from '~/hooks/useIsMobile'
@@ -337,13 +340,26 @@ export const AppShell: ParentComponent = (props) => {
     }, 500)
   }
 
-  // Whether the current user owns the active workspace
-  const isWorkspaceOwner = createMemo(() => {
-    const ws = activeWorkspace()
-    if (!ws)
+  // Whether the active workspace is in an archived section
+  const isActiveWorkspaceArchived = createMemo(() => {
+    const wsId = workspace.activeWorkspaceId()
+    if (!wsId)
       return false
-    return ws.createdBy === auth.user()?.id
+    const sectionId = sectionStore.getSectionForWorkspace(wsId)
+    if (!sectionId)
+      return false
+    const section = sectionStore.state.sections.find(s => s.id === sectionId)
+    return section?.sectionType === SectionType.WORKSPACES_ARCHIVED
   })
+
+  // Whether the active workspace can be mutated (create agents/terminals, etc.)
+  const isActiveWorkspaceMutatable = createMemo(() =>
+    isWorkspaceMutatable(activeWorkspace(), auth.user()?.id ?? '', isActiveWorkspaceArchived()),
+  )
+
+  // Confirmation dialog states
+  const [confirmDeleteWs, setConfirmDeleteWs] = createSignal<{ workspaceId: string, resolve: (confirmed: boolean) => void } | null>(null)
+  const [confirmArchiveWs, setConfirmArchiveWs] = createSignal<{ workspaceId: string, resolve: (confirmed: boolean) => void } | null>(null)
 
   // Active tab derived state
   const activeTab = createMemo(() => tabStore.activeTab())
@@ -436,6 +452,8 @@ export const AppShell: ParentComponent = (props) => {
 
   // Open a new agent in the active workspace (for click handlers)
   const handleOpenAgent = async () => {
+    if (!isActiveWorkspaceMutatable())
+      return
     const ws = activeWorkspace()
     if (!ws)
       return
@@ -455,6 +473,8 @@ export const AppShell: ParentComponent = (props) => {
 
   // Open a terminal with a specific shell
   const handleOpenTerminalWithShell = async (shell: string) => {
+    if (!isActiveWorkspaceMutatable())
+      return
     const ws = activeWorkspace()
     if (!ws)
       return
@@ -492,6 +512,8 @@ export const AppShell: ParentComponent = (props) => {
 
   // Resume an agent from an existing session ID
   const handleResumeAgent = async (sessionId: string, workerId: string) => {
+    if (!isActiveWorkspaceMutatable())
+      return
     const ws = activeWorkspace()
     if (!ws)
       return
@@ -862,6 +884,27 @@ export const AppShell: ParentComponent = (props) => {
     }
   }
 
+  // Promise-based confirmation callbacks for workspace operations
+  const handleConfirmDeleteWorkspace = (workspaceId: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      setConfirmDeleteWs({ workspaceId, resolve })
+    })
+
+  const handleConfirmArchiveWorkspace = (workspaceId: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      setConfirmArchiveWs({ workspaceId, resolve })
+    })
+
+  // Post-archive cleanup: clear local agent/terminal/tab state if the archived workspace is active
+  const handlePostArchiveWorkspace = (workspaceId: string) => {
+    if (workspace.activeWorkspaceId() === workspaceId) {
+      for (const agent of agentStore.state.agents) controlStore.clearAgent(agent.id)
+      agentStore.clear()
+      terminalStore.setTerminals([])
+      tabStore.clear()
+    }
+  }
+
   // Terminal handlers
   const handleTerminalInput = async (terminalId: string, data: Uint8Array) => {
     try {
@@ -927,6 +970,8 @@ export const AppShell: ParentComponent = (props) => {
   }
 
   const handleOpenTerminal = async () => {
+    if (!isActiveWorkspaceMutatable())
+      return
     const ws = activeWorkspace()
     if (!ws)
       return
@@ -1129,7 +1174,7 @@ export const AppShell: ParentComponent = (props) => {
       tileId={tileId}
       tabs={tabStore.getTabsForTile(tileId)}
       activeTabKey={tabStore.getActiveTabKeyForTile(tileId)}
-      showAddButton={isWorkspaceRoute() && !!activeWorkspace() && isWorkspaceOwner()}
+      showAddButton={isActiveWorkspaceMutatable()}
       onSelect={(tab) => {
         layoutStore.setFocusedTile(tileId)
         handleTabSelect(tab)
@@ -1278,8 +1323,13 @@ export const AppShell: ParentComponent = (props) => {
 
         {/* Fallback when no tabs exist */}
         <Show when={!tab() && activeWorkspace()}>
-          <div class={styles.placeholder}>
-            No tabs in this tile. Click + to open an agent or terminal.
+          <div class={styles.placeholder} data-testid="tile-empty-state">
+            <Show
+              when={!isActiveWorkspaceArchived()}
+              fallback="This workspace is archived. Unarchive it to create new agents or terminals."
+            >
+              No tabs in this tile. Click + to open an agent or terminal.
+            </Show>
           </div>
         </Show>
       </>
@@ -1394,6 +1444,9 @@ export const AppShell: ParentComponent = (props) => {
       }}
       onRefreshWorkspaces={() => loadWorkspaces()}
       onDeleteWorkspace={handleDeleteWorkspace}
+      onConfirmDelete={handleConfirmDeleteWorkspace}
+      onConfirmArchive={handleConfirmArchiveWorkspace}
+      onPostArchiveWorkspace={handlePostArchiveWorkspace}
       isCollapsed={opts?.isCollapsed() ?? false}
       onExpand={opts?.onExpand ?? (() => {})}
       onCollapse={opts?.onCollapse}
@@ -1443,6 +1496,9 @@ export const AppShell: ParentComponent = (props) => {
       }}
       onRefreshWorkspaces={() => loadWorkspaces()}
       onDeleteWorkspace={handleDeleteWorkspace}
+      onConfirmDelete={handleConfirmDeleteWorkspace}
+      onConfirmArchive={handleConfirmArchiveWorkspace}
+      onPostArchiveWorkspace={handlePostArchiveWorkspace}
     />
   )
 
@@ -1490,7 +1546,7 @@ export const AppShell: ParentComponent = (props) => {
                 <div class={styles.mobileCenter}>
                   {tabBarElement()}
                   {renderTileContent(layoutStore.focusedTileId())}
-                  <Show when={focusedAgentId()}>
+                  <Show when={focusedAgentId() && !isActiveWorkspaceArchived()}>
                     <FocusedAgentEditorPanel containerHeight={0} />
                   </Show>
                 </div>
@@ -1668,7 +1724,7 @@ export const AppShell: ParentComponent = (props) => {
                                   }}
                                 />
                               </CrossTileDragProvider>
-                              <Show when={focusedAgentId()}>
+                              <Show when={focusedAgentId() && !isActiveWorkspaceArchived()}>
                                 <FocusedAgentEditorPanel containerHeight={centerPanelHeight()} />
                               </Show>
                             </Show>
@@ -1801,6 +1857,45 @@ export const AppShell: ParentComponent = (props) => {
             setNewWorkspaceTargetSectionId(null)
           }}
         />
+      </Show>
+
+      <Show when={confirmDeleteWs()}>
+        {state => (
+          <ConfirmDialog
+            title="Delete Workspace"
+            confirmLabel="Delete"
+            danger
+            onConfirm={() => {
+              state().resolve(true)
+              setConfirmDeleteWs(null)
+            }}
+            onCancel={() => {
+              state().resolve(false)
+              setConfirmDeleteWs(null)
+            }}
+          >
+            <p>Are you sure you want to delete this workspace? This cannot be undone.</p>
+          </ConfirmDialog>
+        )}
+      </Show>
+
+      <Show when={confirmArchiveWs()}>
+        {state => (
+          <ConfirmDialog
+            title="Archive Workspace"
+            confirmLabel="Archive"
+            onConfirm={() => {
+              state().resolve(true)
+              setConfirmArchiveWs(null)
+            }}
+            onCancel={() => {
+              state().resolve(false)
+              setConfirmArchiveWs(null)
+            }}
+          >
+            <p>Are you sure you want to archive this workspace? All active agents and terminals will be stopped.</p>
+          </ConfirmDialog>
+        )}
       </Show>
 
       <Show when={worktreeConfirm()}>

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -32,6 +32,9 @@ interface LeftSidebarProps {
   onNewWorkspace: (sectionId: string | null) => void
   onRefreshWorkspaces: () => void | Promise<void>
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
+  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
+  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
+  onPostArchiveWorkspace?: (workspaceId: string) => void
   isCollapsed: boolean
   onExpand: () => void
   onCollapse?: () => void
@@ -63,6 +66,9 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
     onNewWorkspace: props.onNewWorkspace,
     onRefreshWorkspaces: props.onRefreshWorkspaces,
     onDeleteWorkspace: props.onDeleteWorkspace,
+    onConfirmDelete: props.onConfirmDelete,
+    onConfirmArchive: props.onConfirmArchive,
+    onPostArchiveWorkspace: props.onPostArchiveWorkspace,
   })
   /* eslint-enable solid/reactivity */
 

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -42,6 +42,9 @@ interface RightSidebarProps {
   onNewWorkspace: (sectionId: string | null) => void
   onRefreshWorkspaces: () => void | Promise<void>
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
+  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
+  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
+  onPostArchiveWorkspace?: (workspaceId: string) => void
 }
 
 export const RightSidebar: Component<RightSidebarProps> = (props) => {
@@ -58,6 +61,9 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
     onNewWorkspace: props.onNewWorkspace,
     onRefreshWorkspaces: props.onRefreshWorkspaces,
     onDeleteWorkspace: props.onDeleteWorkspace,
+    onConfirmDelete: props.onConfirmDelete,
+    onConfirmArchive: props.onConfirmArchive,
+    onPostArchiveWorkspace: props.onPostArchiveWorkspace,
   })
   /* eslint-enable solid/reactivity */
 

--- a/frontend/src/components/shell/sectionUtils.ts
+++ b/frontend/src/components/shell/sectionUtils.ts
@@ -29,6 +29,26 @@ export function sectionTypeTestId(sectionType: SectionType): string {
   }
 }
 
+/** Whether the section type is a valid "Move to" target for workspaces. */
+export function isMoveTargetSection(sectionType: SectionType): boolean {
+  return isWorkspaceSection(sectionType)
+    && sectionType !== SectionType.WORKSPACES_ARCHIVED
+    && sectionType !== SectionType.WORKSPACES_SHARED
+}
+
+/** Whether a workspace can be mutated (create agents/terminals, rename, etc.). */
+export function isWorkspaceMutatable(
+  workspace: { createdBy: string } | undefined,
+  currentUserId: string,
+  isArchived: boolean,
+): boolean {
+  if (!workspace)
+    return false
+  if (workspace.createdBy !== currentUserId)
+    return false
+  return !isArchived
+}
+
 /** Map section to its icon. */
 export function getSectionIcon(section: Section): LucideIcon {
   switch (section.sectionType) {

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -4,7 +4,7 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
 import { For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
-import { SectionType } from '~/generated/leapmux/v1/section_pb'
+import { isMoveTargetSection } from '~/components/shell/sectionUtils'
 import { dangerMenuItem } from '~/styles/shared.css'
 import * as listStyles from './workspaceList.css'
 
@@ -49,7 +49,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
             </button>
           )}
         >
-          <For each={props.sections.filter(s => s.id !== props.currentSectionId && s.sectionType !== SectionType.WORKSPACES_ARCHIVED)}>
+          <For each={props.sections.filter(s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType))}>
             {section => (
               <button
                 role="menuitem"

--- a/frontend/tests/e2e/14-workspace-context-menu.spec.ts
+++ b/frontend/tests/e2e/14-workspace-context-menu.spec.ts
@@ -79,12 +79,16 @@ test.describe('Workspace Context Menu', () => {
     await page.goto('/o/admin')
     await expect(page.getByText(workspaceName!.trim())).toBeVisible()
 
-    // Set up dialog handler for the confirm prompt
-    page.on('dialog', dialog => dialog.accept())
-
     // Open context menu and click Delete
     await openWorkspaceContextMenu(page, workspaceName!.trim())
     await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+    // ConfirmDialog should appear
+    const dialog = page.locator('dialog')
+    await expect(dialog).toBeVisible()
+    // Click the danger confirm button (two-step: arm then confirm)
+    await dialog.getByRole('button', { name: 'Delete' }).click()
+    await dialog.getByRole('button', { name: 'Confirm?' }).click()
 
     // Workspace should be gone
     await expect(page.getByText(workspaceName!.trim())).not.toBeVisible()

--- a/frontend/tests/e2e/14a-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/14a-workspace-archive.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from './fixtures'
+import { openWorkspaceContextMenu } from './helpers'
+
+test.describe('Workspace Archive', () => {
+  test('should archive workspace via context menu with confirmation dialog', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Open context menu and click Move to > Archive
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Move to' }).click()
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+
+    // Confirmation dialog should appear
+    const dialog = page.locator('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('Archive Workspace')).toBeVisible()
+    await expect(dialog.getByText('All active agents and terminals will be stopped')).toBeVisible()
+
+    // Confirm the archive
+    await dialog.getByRole('button', { name: 'Archive' }).click()
+
+    // Workspace should now be in the archived section
+    const archivedSection = page.locator('[data-testid="section-header-workspaces_archived"]')
+    await expect(archivedSection).toBeVisible()
+
+    // Add button should be hidden and archived empty state shown
+    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('This workspace is archived')
+  })
+
+  test('should cancel archive via confirmation dialog', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Open context menu and click Move to > Archive
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Move to' }).click()
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+
+    // Confirmation dialog should appear
+    const dialog = page.locator('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Cancel the archive
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+    // Dialog should close and workspace should still be in its original section
+    await expect(dialog).not.toBeVisible()
+    await expect(workspaceItem).toBeVisible()
+  })
+
+  test('should unarchive workspace and restore normal behavior', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+
+    // Archive the workspace first: open context menu using the workspace item directly
+    await workspaceItem.hover()
+    await workspaceItem.locator('button').first().click()
+    await page.getByRole('menuitem', { name: 'Move to' }).click()
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+    // Wait for the archived state
+    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('This workspace is archived')
+
+    // Expand the Archived section (collapsed by default) to reveal the workspace
+    await page.locator('[data-testid="section-header-workspaces_archived"]').click()
+    await expect(workspaceItem).toBeVisible()
+
+    // Now unarchive it: open context menu using the workspace item directly
+    // (cannot use openWorkspaceContextMenu because hasText would include changed menu item text)
+    await workspaceItem.hover()
+    await workspaceItem.locator('button').first().click()
+    await page.getByRole('menuitem', { name: 'Unarchive' }).click()
+
+    // Archived empty state should be gone
+    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('Click + to open')
+  })
+
+  test('should only show In Progress and Custom sections in Move-to menu', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Open context menu and click Move to to open submenu
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Move to' }).click()
+
+    // Wait for the submenu to appear
+    const archiveButton = page.getByRole('menuitem', { name: 'Archive' })
+    await expect(archiveButton).toBeVisible()
+
+    // Shared, Files, To-dos should NOT appear as move targets
+    const menuItems = page.getByRole('menuitem')
+    const allLabels = await menuItems.allTextContents()
+    expect(allLabels).not.toContain('Shared')
+    expect(allLabels).not.toContain('Files')
+    expect(allLabels).not.toContain('To-dos')
+  })
+
+  test('should delete workspace using ConfirmDialog instead of native confirm', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Navigate away so we can see delete result
+    await page.goto('/o/admin')
+    await expect(page.getByText(workspaceName!.trim())).toBeVisible()
+
+    // Open context menu and click Delete
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+    // ConfirmDialog should appear (not native dialog)
+    const dialog = page.locator('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('Delete Workspace')).toBeVisible()
+
+    // Confirm the delete (need to click twice due to ConfirmButton danger mode)
+    await dialog.getByRole('button', { name: 'Delete' }).click() // arms
+    await dialog.getByRole('button', { name: 'Confirm?' }).click() // confirms
+
+    // Workspace should be gone
+    await expect(page.getByText(workspaceName!.trim())).not.toBeVisible()
+  })
+})

--- a/frontend/tests/unit/components/ConfirmDialog.test.tsx
+++ b/frontend/tests/unit/components/ConfirmDialog.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { ConfirmDialog } from '~/components/common/ConfirmDialog'
+
+// Mock HTMLDialogElement.showModal since jsdom doesn't support it
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn()
+  HTMLDialogElement.prototype.close = vi.fn()
+})
+
+describe('confirmDialog', () => {
+  it('renders with title and message', () => {
+    render(() => (
+      <ConfirmDialog
+        title="Delete Item"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      >
+        <p>Are you sure?</p>
+      </ConfirmDialog>
+    ))
+    expect(screen.getByText('Delete Item')).toBeDefined()
+    expect(screen.getByText('Are you sure?')).toBeDefined()
+  })
+
+  it('shows default button labels', () => {
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    expect(screen.getByText('Cancel')).toBeDefined()
+    expect(screen.getByText('OK')).toBeDefined()
+  })
+
+  it('shows custom button labels', () => {
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    expect(screen.getByText('Keep')).toBeDefined()
+    expect(screen.getByText('Delete')).toBeDefined()
+  })
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn()
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    fireEvent.click(screen.getByText('OK'))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn()
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('uses ConfirmButton in danger mode', () => {
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        confirmLabel="Delete"
+        danger
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    // In danger mode, the confirm button is a ConfirmButton (requires two clicks)
+    const deleteBtn = screen.getByText('Delete')
+    expect(deleteBtn).toBeDefined()
+    // First click arms it, doesn't trigger confirm
+    fireEvent.click(deleteBtn)
+    expect(screen.getByText('Confirm?')).toBeDefined()
+  })
+
+  it('calls showModal on mount', () => {
+    render(() => (
+      <ConfirmDialog
+        title="Test"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      >
+        <p>Message</p>
+      </ConfirmDialog>
+    ))
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/unit/components/sectionUtils.test.ts
+++ b/frontend/tests/unit/components/sectionUtils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { isMoveTargetSection, isWorkspaceMutatable } from '~/components/shell/sectionUtils'
+import { SectionType } from '~/generated/leapmux/v1/section_pb'
+
+describe('isMoveTargetSection', () => {
+  it('returns true for IN_PROGRESS', () => {
+    expect(isMoveTargetSection(SectionType.WORKSPACES_IN_PROGRESS)).toBe(true)
+  })
+
+  it('returns true for CUSTOM', () => {
+    expect(isMoveTargetSection(SectionType.WORKSPACES_CUSTOM)).toBe(true)
+  })
+
+  it('returns false for ARCHIVED', () => {
+    expect(isMoveTargetSection(SectionType.WORKSPACES_ARCHIVED)).toBe(false)
+  })
+
+  it('returns false for SHARED', () => {
+    expect(isMoveTargetSection(SectionType.WORKSPACES_SHARED)).toBe(false)
+  })
+
+  it('returns false for FILES', () => {
+    expect(isMoveTargetSection(SectionType.FILES)).toBe(false)
+  })
+
+  it('returns false for TODOS', () => {
+    expect(isMoveTargetSection(SectionType.TODOS)).toBe(false)
+  })
+})
+
+describe('isWorkspaceMutatable', () => {
+  const userId = 'user-1'
+
+  it('returns true for owner on non-archived workspace', () => {
+    expect(isWorkspaceMutatable({ createdBy: userId }, userId, false)).toBe(true)
+  })
+
+  it('returns false for non-owner', () => {
+    expect(isWorkspaceMutatable({ createdBy: 'other-user' }, userId, false)).toBe(false)
+  })
+
+  it('returns false for archived workspace', () => {
+    expect(isWorkspaceMutatable({ createdBy: userId }, userId, true)).toBe(false)
+  })
+
+  it('returns false when workspace is undefined', () => {
+    expect(isWorkspaceMutatable(undefined, userId, false)).toBe(false)
+  })
+
+  it('returns false for non-owner on archived workspace', () => {
+    expect(isWorkspaceMutatable({ createdBy: 'other-user' }, userId, true)).toBe(false)
+  })
+})

--- a/hub/server.go
+++ b/hub/server.go
@@ -167,7 +167,9 @@ func NewServer(sc ServerConfig) (*Server, error) {
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(userPath, userHandler)
 
-	sectionSvc := service.NewSectionService(queries)
+	sectionSvc := service.NewSectionService(queries, wMgr)
+	sectionSvc.SetAgentService(agentSvc)
+	sectionSvc.SetTerminalService(terminalSvc)
 	sectionPath, sectionHandler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(sectionPath, sectionHandler)
 

--- a/internal/hub/db/queries/workspace_section_items.sql
+++ b/internal/hub/db/queries/workspace_section_items.sql
@@ -26,3 +26,8 @@ WHERE section_id = ?;
 -- name: MoveWorkspaceSectionItemsToSection :exec
 UPDATE workspace_section_items SET section_id = ?
 WHERE section_id = ?;
+
+-- name: IsWorkspaceInArchivedSection :one
+SELECT COUNT(*) > 0 AS is_archived FROM workspace_section_items wsi
+JOIN workspace_sections ws ON wsi.section_id = ws.id
+WHERE wsi.user_id = ? AND wsi.workspace_id = ? AND ws.section_type = 3;

--- a/internal/hub/service/agent_service.go
+++ b/internal/hub/service/agent_service.go
@@ -107,7 +107,7 @@ func (s *AgentService) OpenAgent(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("working_dir is required"))
 	}
 
-	// Verify the user can see the workspace.
+	// Verify the user can see the workspace and it is not archived.
 	wsInternal, err := s.queries.GetWorkspaceByIDInternal(ctx, workspaceID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -115,7 +115,7 @@ func (s *AgentService) OpenAgent(
 		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	if _, err := s.getVisibleWorkspace(ctx, user, wsInternal.OrgID, workspaceID); err != nil {
+	if _, err := getVisibleNonArchivedWorkspace(ctx, s.queries, user, wsInternal.OrgID, workspaceID); err != nil {
 		return nil, err
 	}
 
@@ -550,7 +550,7 @@ func (s *AgentService) RenameAgent(
 		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	if _, err := s.getVisibleWorkspace(ctx, user, wsInternal.OrgID, agent.WorkspaceID); err != nil {
+	if _, err := getVisibleNonArchivedWorkspace(ctx, s.queries, user, wsInternal.OrgID, agent.WorkspaceID); err != nil {
 		return nil, err
 	}
 

--- a/internal/hub/service/terminal_service.go
+++ b/internal/hub/service/terminal_service.go
@@ -57,6 +57,15 @@ func (s *TerminalService) verifyWorkspaceOwnership(ctx context.Context, user *au
 	return getVisibleWorkspace(ctx, s.queries, user, orgID, workspaceID)
 }
 
+// verifyNonArchivedWorkspaceOwnership checks visibility and that the workspace is not archived.
+func (s *TerminalService) verifyNonArchivedWorkspaceOwnership(ctx context.Context, user *auth.UserInfo, orgID, workspaceID string) (*db.Workspace, error) {
+	if workspaceID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("workspace_id is required"))
+	}
+
+	return getVisibleNonArchivedWorkspace(ctx, s.queries, user, orgID, workspaceID)
+}
+
 // getTerminalConn looks up the worker for a tracked terminal and returns its connection.
 func (s *TerminalService) getTerminalConn(terminalID string) (*workermgr.Conn, error) {
 	s.mu.RLock()
@@ -84,7 +93,7 @@ func (s *TerminalService) OpenTerminal(
 		return nil, err
 	}
 
-	_, err = s.verifyWorkspaceOwnership(ctx, user, req.Msg.GetOrgId(), req.Msg.GetWorkspaceId())
+	_, err = s.verifyNonArchivedWorkspaceOwnership(ctx, user, req.Msg.GetOrgId(), req.Msg.GetWorkspaceId())
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +271,7 @@ func (s *TerminalService) SendInput(
 		return nil, err
 	}
 
-	_, err = s.verifyWorkspaceOwnership(ctx, user, req.Msg.GetOrgId(), req.Msg.GetWorkspaceId())
+	_, err = s.verifyNonArchivedWorkspaceOwnership(ctx, user, req.Msg.GetOrgId(), req.Msg.GetWorkspaceId())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

Archived workspaces were not truly read-only: users could still open new
agents or terminals in them, and archiving a workspace did not stop
running sessions. There was also no accessible confirmation step before
destructive operations (archive, delete) - the UI relied on the browser's
native `window.confirm()` dialog, which cannot be styled and does not
support async flows.

## Modifications

**Backend**

- Added `IsWorkspaceInArchivedSection` SQL query and a
  `getVisibleNonArchivedWorkspace` helper in `internal/hub/service/helpers.go`
  that combines visibility and archive checks into a single call.
- Updated `AgentService.OpenAgent`, `AgentService.RenameAgent`,
  `TerminalService.OpenTerminal`, and `TerminalService.SendInput` to use
  `getVisibleNonArchivedWorkspace`, returning `FailedPrecondition` when a
  workspace is archived.
- Added `SectionService.cleanupArchivedWorkspace` in
  `internal/hub/service/section_service.go`
  that sends stop signals to all active agents and closes all terminals
  whenever a workspace is moved to the archived section.
- Added `SetAgentService` / `SetTerminalService` setter methods on
  `SectionService` to break the circular initialization dependency between
  the three services.

**Frontend**

- Added a new `ConfirmDialog` component in
  `frontend/src/components/common/ConfirmDialog.tsx`
  that renders a native `<dialog>` modal. Supports a `danger` prop that
  uses red button styling for destructive actions.
- Added `isWorkspaceMutatable()` and `isMoveTargetSection()` to
  `frontend/src/components/shell/sectionUtils.ts`
  to gate agent/terminal creation on workspace ownership and archive
  status, and restrict "Move to" context-menu targets.
- Updated `useWorkspaceOperations` to accept optional async
  `onConfirmArchive` / `onConfirmDelete` callbacks, and added
  `onPostArchiveWorkspace` to clear agent, terminal, and tab state after
  archive.
- `AppShell` now wires up `ConfirmDialog` modals for archive and delete,
  replacing `window.confirm()`. Archived workspaces display a read-only
  empty state instead of the new-agent UI.

**Tests**

- 3 new backend tests: archive closes agents, non-archive preserves
  agents, and archived section detection.
- 7 new unit tests for `ConfirmDialog`.
- 11 new unit tests for `sectionUtils`.
- 5 new e2e tests: archive with confirmation, cancel archive, unarchive,
  "Move to" menu filtering, and delete with `ConfirmDialog`.
- Updated existing delete e2e test to use `ConfirmDialog` instead of the
  native browser dialog.

## Result

- Archiving a workspace now immediately stops all running agents and
  terminals for that workspace on the server.
- Attempting to open an agent or terminal in an archived workspace returns
  a `FailedPrecondition` error instead of silently succeeding.
- The "Move to" submenu no longer lists invalid sections as targets.
- Archive and delete operations show a styled modal confirmation dialog
  instead of the browser's native `window.confirm()` prompt.
- The archived workspace tile displays a clear "This workspace is
  archived" message and hides the new-agent/terminal controls.

🤖 Generated with Claude Code
