### PR TITLE
Replace empty state text with interactive action buttons

### DIFF
--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -73,6 +73,26 @@ export const placeholder = style({
   padding: `0 ${spacing.xl}`,
 })
 
+export const emptyTileActions = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: spacing.md,
+  flex: 1,
+})
+
+export const emptyTileHint = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+  color: 'var(--faint-foreground)',
+  textAlign: 'center',
+  padding: `0 ${spacing.xl}`,
+  cursor: 'default',
+})
+
 // --- Mobile layout styles ---
 
 export const mobileShell = style({

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -5,6 +5,9 @@ import type { Tab } from '~/stores/tab.store'
 import type { PermissionMode } from '~/utils/controlResponse'
 import Resizable from '@corvu/resizable'
 import { useLocation, useNavigate, useParams, useSearchParams } from '@solidjs/router'
+import Bot from 'lucide-solid/icons/bot'
+import Plus from 'lucide-solid/icons/plus'
+import Terminal from 'lucide-solid/icons/terminal'
 import { createEffect, createMemo, createSignal, on, onMount, Show } from 'solid-js'
 import { agentClient, gitClient, sectionClient, terminalClient, workspaceClient } from '~/api/clients'
 import { agentCallTimeout, agentLoadingTimeoutMs, apiCallTimeout } from '~/api/transport'
@@ -1278,9 +1281,41 @@ export const AppShell: ParentComponent = (props) => {
 
         {/* Fallback when no tabs exist */}
         <Show when={!tab() && activeWorkspace()}>
-          <div class={styles.placeholder}>
-            No tabs in this tile. Click + to open an agent or terminal.
-          </div>
+          <Show
+            when={!hasMultipleTiles() || layoutStore.focusedTileId() === tileId}
+            fallback={(
+              <div class={styles.emptyTileHint} data-testid="empty-tile-hint">
+                No tabs in this tile.
+              </div>
+            )}
+          >
+            <div class={styles.emptyTileActions} data-testid="empty-tile-actions">
+              <button
+                class="outline"
+                data-testid="empty-tile-open-agent"
+                onClick={() => {
+                  layoutStore.setFocusedTile(tileId)
+                  handleOpenAgent()
+                }}
+              >
+                <Bot size={14} />
+                {' '}
+                Open a new agent tab...
+              </button>
+              <button
+                class="outline"
+                data-testid="empty-tile-open-terminal"
+                onClick={() => {
+                  layoutStore.setFocusedTile(tileId)
+                  handleOpenTerminal()
+                }}
+              >
+                <Terminal size={14} />
+                {' '}
+                Open a new terminal tab...
+              </button>
+            </div>
+          </Show>
         </Show>
       </>
     )
@@ -1647,8 +1682,19 @@ export const AppShell: ParentComponent = (props) => {
                               when={activeWorkspace() && !workspaceLoading()}
                               fallback={(
                                 <Show when={!activeWorkspace() && !workspace.activeWorkspaceId()}>
-                                  <div class={styles.placeholder}>
-                                    No workspaces yet. Click + to create one.
+                                  <div class={styles.emptyTileActions} data-testid="no-workspace-empty-state">
+                                    <button
+                                      class="outline"
+                                      data-testid="create-workspace-button"
+                                      onClick={() => {
+                                        setNewWorkspaceTargetSectionId(sectionStore.getInProgressSection()?.id ?? null)
+                                        setShowNewWorkspace(true)
+                                      }}
+                                    >
+                                      <Plus size={14} />
+                                      {' '}
+                                      Create a new workspace...
+                                    </button>
                                   </div>
                                 </Show>
                               )}

--- a/frontend/tests/e2e/18-workspace-ux.spec.ts
+++ b/frontend/tests/e2e/18-workspace-ux.spec.ts
@@ -61,8 +61,8 @@ test.describe('Workspace UX Enhancements', () => {
       // Verify all tabs are actually closed
       await expect(page.locator('[data-testid="tab"]')).toHaveCount(0)
 
-      // Empty state message should be visible
-      await expect(page.getByText('No tabs in this tile')).toBeVisible()
+      // Empty state actions should be visible
+      await expect(page.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})

--- a/frontend/tests/e2e/19a-workspace-lifecycle.spec.ts
+++ b/frontend/tests/e2e/19a-workspace-lifecycle.spec.ts
@@ -53,7 +53,7 @@ test.describe('Workspace Lifecycle', () => {
     // Use data-testid selectors to avoid strict mode violations from
     // text matches in context menus or other UI elements.
     await expect(
-      page.getByText('No workspaces yet')
+      page.locator('[data-testid="create-workspace-button"]')
         .or(page.locator('[data-testid="section-header-workspaces_in_progress"]'))
         .or(page.locator('[data-testid="section-header-workspaces_archived"]')),
     ).toBeVisible()

--- a/frontend/tests/e2e/60-empty-state-buttons.spec.ts
+++ b/frontend/tests/e2e/60-empty-state-buttons.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from './fixtures'
+import { loginViaToken } from './helpers'
+
+/** Close all tabs in the workspace by clicking close buttons. */
+async function closeAllTabs(page: import('@playwright/test').Page) {
+  const tabs = page.locator('[data-testid="tab"]')
+  const count = await tabs.count()
+  for (let i = count - 1; i >= 0; i--) {
+    const closeBtn = tabs.nth(i).locator('[data-testid="tab-close"]')
+    if (await closeBtn.isVisible()) {
+      await closeBtn.click()
+      await page.waitForTimeout(500)
+    }
+  }
+  await expect(page.locator('[data-testid="tab"]')).toHaveCount(0)
+}
+
+test.describe('Empty State Buttons', () => {
+  test('empty tile shows agent and terminal buttons', async ({ page, authenticatedWorkspace }) => {
+    await closeAllTabs(page)
+
+    const actions = page.locator('[data-testid="empty-tile-actions"]')
+    await expect(actions).toBeVisible()
+    await expect(page.locator('[data-testid="empty-tile-open-agent"]')).toBeVisible()
+    await expect(page.locator('[data-testid="empty-tile-open-terminal"]')).toBeVisible()
+    await expect(page.locator('[data-testid="empty-tile-open-agent"]')).toHaveText(/Open a new agent tab/)
+    await expect(page.locator('[data-testid="empty-tile-open-terminal"]')).toHaveText(/Open a new terminal tab/)
+  })
+
+  test('clicking agent button opens agent or dialog', async ({ page, authenticatedWorkspace }) => {
+    await closeAllTabs(page)
+    await expect(page.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
+
+    await page.locator('[data-testid="empty-tile-open-agent"]').click()
+
+    // Should open either a new agent tab or the new agent dialog
+    await expect(
+      page.locator('[data-testid="tab"][data-tab-type="agent"]')
+        .or(page.getByRole('heading', { name: 'New Agent' })),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('clicking terminal button opens terminal or dialog', async ({ page, authenticatedWorkspace }) => {
+    await closeAllTabs(page)
+    await expect(page.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
+
+    await page.locator('[data-testid="empty-tile-open-terminal"]').click()
+
+    // Should open either a new terminal tab or the new terminal dialog
+    await expect(
+      page.locator('[data-testid="tab"][data-tab-type="terminal"]')
+        .or(page.getByRole('heading', { name: 'New Terminal' })),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('multi-tile: unfocused empty tile shows hint, focused shows buttons', async ({ page, authenticatedWorkspace }) => {
+    // Start with a tab, then split to create a second tile
+    await page.locator('[data-testid="new-agent-button"]').click()
+    await page.locator('[data-testid="tab"]').first().waitFor()
+    await page.locator('[data-testid="split-horizontal"]').first().click()
+    await expect(page.locator('[data-testid="tile"]')).toHaveCount(2)
+
+    // The second tile is empty — it should show either hint or actions depending on focus.
+    // Click on the first tile to ensure it's focused.
+    const tile1 = page.locator('[data-testid="tile"]').nth(0)
+    await tile1.click()
+    await page.waitForTimeout(300)
+
+    // The unfocused empty tile should show the hint text
+    const tile2 = page.locator('[data-testid="tile"]').nth(1)
+    await expect(tile2.locator('[data-testid="empty-tile-hint"]')).toBeVisible()
+
+    // Now click on the second tile to focus it
+    await tile2.click()
+    await page.waitForTimeout(300)
+
+    // Focused empty tile should show action buttons
+    await expect(tile2.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
+    await expect(tile2.locator('[data-testid="empty-tile-open-agent"]')).toBeVisible()
+    await expect(tile2.locator('[data-testid="empty-tile-open-terminal"]')).toBeVisible()
+  })
+
+  test('no-workspace state shows create workspace button', async ({ page, leapmuxServer }) => {
+    const { adminToken } = leapmuxServer
+
+    // Log in and navigate to org root — other tests may have created workspaces
+    // which triggers auto-redirect. Only assert if the empty state is reachable.
+    await loginViaToken(page, adminToken)
+    await page.goto('/o/admin')
+
+    // Wait for page to settle
+    const createBtn = page.locator('[data-testid="create-workspace-button"]')
+    const sectionHeader = page.locator('[data-testid="section-header-workspaces_in_progress"]')
+      .or(page.locator('[data-testid="section-header-workspaces_archived"]'))
+
+    await expect(createBtn.or(sectionHeader)).toBeVisible()
+
+    // Only test the button behavior if the empty state is visible
+    if (await createBtn.isVisible()) {
+      await expect(createBtn).toHaveText(/Create a new workspace/)
+      await createBtn.click()
+      await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+      await page.keyboard.press('Escape')
+    }
+  })
+})

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -622,11 +622,12 @@ export function waitForLayoutSave(page: Page) {
 
 /**
  * Wait for a workspace page to be fully loaded.
- * Waits for either a tab or the "No tabs in this tile" empty state.
+ * Waits for either a tab or the empty tile actions/hint.
  */
 export async function waitForWorkspaceReady(page: Page) {
   await page.locator('[data-testid="tab"]')
-    .or(page.getByText('No tabs in this tile'))
+    .or(page.locator('[data-testid="empty-tile-actions"]'))
+    .or(page.locator('[data-testid="empty-tile-hint"]'))
     .first()
     .waitFor({ timeout: 15_000 })
 }


### PR DESCRIPTION
## Motivation
The empty tile and workspace states in the shell previously displayed static text, requiring users to navigate elsewhere to open a new agent or terminal tab. This created unnecessary friction when a tile had no open tabs or when no workspaces existed yet.

## Modifications
- Replaced the static "No tabs" empty tile text with interactive "Open a new agent" and "Open a new terminal" buttons with icons, visible when a tile is focused and empty
- Added a subtle "No tabs in this tile" hint for unfocused empty tiles in multi-tile layouts, keeping the UI uncluttered
- Replaced the "No workspaces yet" static text with a "Create a new workspace..." button in the workspace empty state
- Added two new CSS classes (`emptyTileActions` and `emptyTileHint`) to style the action buttons and hint text differently based on tile focus and layout
- Added a new e2e test file (`60-empty-state-buttons.spec.ts`) with 5 test cases covering button visibility, click functionality, and focus-based behavior
- Updated existing e2e tests in `18-workspace-ux.spec.ts` and `19a-workspace-lifecycle.spec.ts` to account for the new interactive empty state

## Result
Users can now open a new agent or terminal tab directly from an empty tile by clicking the prominent action buttons, rather than navigating to a separate menu. When multiple tiles are present, unfocused empty tiles show a minimal hint to avoid visual noise, while the focused empty tile shows the full set of action buttons.

🤖 Generated with Claude Code
