### PR TITLE
Support CLI_ARGS in test tasks for running specific tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,18 @@ task test-integration   # Integration tests
 task test-e2e           # End-to-end tests (Playwright)
 ```
 
-Run a specific E2E test file:
+Run specific tests by passing arguments after `--`:
 ```bash
-cd frontend && bun run test:e2e tests/e2e/25-chat-message-rendering.spec.ts
+# Go tests: -run <regex> <packages>
+task test-backend -- -run TestMyFunction ./internal/hub/...
+task test-integration -- -run TestMyFunction ./internal/hub/...
+
+# Frontend unit tests: pass a file path to Vitest
+task test-frontend -- src/lib/validate.test.ts
+
+# E2E tests: pass a file path or --grep <pattern> to Playwright
+task test-e2e -- tests/e2e/25-chat-message-rendering.spec.ts
+task test-e2e -- --grep "should persist theme"
 ```
 
 ### Linting

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -140,25 +140,25 @@ tasks:
     desc: Run Go tests
     deps: [lint-backend]
     cmds:
-      - go test ./...
+      - go test {{.CLI_ARGS | default "./..."}}
 
   test-frontend:
     desc: Run frontend unit tests
     deps: [lint-frontend]
     cmds:
-      - cd frontend && bun run test
+      - cd frontend && bun run test {{.CLI_ARGS}}
 
   test-integration:
     desc: Run integration tests
     deps: [lint-backend]
     cmds:
-      - go test -tags integration ./...
+      - go test -tags integration {{.CLI_ARGS | default "./..."}}
 
   test-e2e:
     desc: Run end-to-end tests
     deps: [lint-frontend]
     cmds:
-      - cd frontend && bun run test:e2e
+      - cd frontend && bun run test:e2e {{.CLI_ARGS}}
 
   # --- Linting ---
 


### PR DESCRIPTION
## Motivation
Running a specific subset of tests required invoking the underlying test runners (Go's `go test`, Vitest, Playwright) directly, bypassing the project's Taskfile targets. This was inconvenient and inconsistent across the different test suites.

## Modifications
- Added `CLI_ARGS` variable support to all four test tasks: `test-backend`, `test-frontend`, `test-integration`, and `test-e2e`
- Go test tasks use `{{.CLI_ARGS | default "./..."}}` so they continue to run all tests when no arguments are provided
- Frontend and e2e tasks use `{{.CLI_ARGS}}` to pass arguments directly to Vitest and Playwright respectively
- Updated `README.md` with examples demonstrating how to use the `--` separator to pass arguments to the underlying test runners

## Result
You can now run specific tests directly through the Taskfile targets without invoking the test runners manually. For example:

```sh
# Run a specific Go test by name
task test-backend -- -run TestMyFeature

# Run a specific frontend test file
task test-frontend -- src/components/MyComponent.test.ts

# Run a specific Playwright test pattern
task test-e2e -- --grep "login flow"
```

When no arguments are provided, all test tasks behave exactly as before.

🤖 Generated with Claude Code
