### PR TITLE
Merge test-integration into test-backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ task test
 Run specific test suites:
 ```bash
 task test-backend       # Backend tests
-task test-frontend      # Frontend unit tests (Vitest)
+task test-frontend      # Frontend tests (Vitest)
 task test-e2e           # End-to-end tests (Playwright)
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ task test
 
 Run specific test suites:
 ```bash
-task test-backend       # Go tests including integration (hub + worker)
+task test-backend       # Backend tests
 task test-frontend      # Frontend unit tests (Vitest)
 task test-e2e           # End-to-end tests (Playwright)
 ```

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ task test-e2e           # End-to-end tests (Playwright)
 
 Run specific tests by passing arguments after `--`:
 ```bash
-# Go tests: -run <regex> <packages>
+# Backend tests: -run <regex> <packages>
 task test-backend -- -run TestMyFunction ./internal/hub/...
 
 # Frontend unit tests: pass a file path to Vitest

--- a/README.md
+++ b/README.md
@@ -192,16 +192,15 @@ The `leapmux` binary is output to the project root.
 
 ### Testing
 
-Run all tests:
+Run all tests (except E2E):
 ```bash
 task test
 ```
 
 Run specific test suites:
 ```bash
-task test-backend       # Go unit tests (hub + worker)
+task test-backend       # Go tests including integration (hub + worker)
 task test-frontend      # Frontend unit tests (Vitest)
-task test-integration   # Integration tests
 task test-e2e           # End-to-end tests (Playwright)
 ```
 
@@ -209,7 +208,6 @@ Run specific tests by passing arguments after `--`:
 ```bash
 # Go tests: -run <regex> <packages>
 task test-backend -- -run TestMyFunction ./internal/hub/...
-task test-integration -- -run TestMyFunction ./internal/hub/...
 
 # Frontend unit tests: pass a file path to Vitest
 task test-frontend -- src/lib/validate.test.ts
@@ -475,7 +473,6 @@ Ensure all linters and tests pass before submitting:
 ```bash
 task lint
 task test
-task test-integration
 task test-e2e
 ```
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -137,10 +137,10 @@ tasks:
     deps: [test-backend, test-frontend]
 
   test-backend:
-    desc: Run Go tests
+    desc: Run Go tests (unit + integration)
     deps: [lint-backend]
     cmds:
-      - go test {{.CLI_ARGS | default "./..."}}
+      - go test -tags integration {{.CLI_ARGS | default "./..."}}
 
   test-frontend:
     desc: Run frontend unit tests
@@ -148,11 +148,6 @@ tasks:
     cmds:
       - cd frontend && bun run test {{.CLI_ARGS}}
 
-  test-integration:
-    desc: Run integration tests
-    deps: [lint-backend]
-    cmds:
-      - go test -tags integration {{.CLI_ARGS | default "./..."}}
 
   test-e2e:
     desc: Run end-to-end tests


### PR DESCRIPTION
## Motivation
Running backend tests required two separate commands: `task test-backend` for unit tests and `task test-integration` for integration tests. This split added unnecessary friction to the testing workflow and made it easy to accidentally skip integration tests.

## Modifications
- Removed the standalone `test-integration` task from `Taskfile.yaml`
- Updated `test-backend` to run both unit and integration tests using the `-tags integration` flag
- (Deprecated) `task test-integration` no longer exists; use `task test-backend` instead
- Renamed "Go tests" to "Backend tests" in `README.md` and updated the description to reflect "(unit + integration)"
- Removed references to `test-integration` from the README task table

## Result
Running `task test-backend` now executes both unit and integration tests in a single command. The `test-integration` task has been removed entirely.

**Breaking change**: Any scripts or workflows invoking `task test-integration` must be updated to use `task test-backend` instead.

🤖 Generated with Claude Code
