### PR TITLE
Make worktree removal async and fix e2e test flakiness

### DIFF
--- a/frontend/tests/e2e/02-registration.spec.ts
+++ b/frontend/tests/e2e/02-registration.spec.ts
@@ -18,7 +18,8 @@ test.describe('Worker Registration', () => {
     await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
 
     // The initial fetch on mount should find the worker (already online).
-    await expect(page.getByRole('button', { name: 'Create' })).toBeEnabled()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByRole('button', { name: 'Create', exact: true })).toBeEnabled()
 
     // Verify the worker name appears in the dropdown (standalone uses "Local")
     await expect(page.locator('select').first()).toContainText('Local')

--- a/frontend/tests/e2e/13-workspace-sections.spec.ts
+++ b/frontend/tests/e2e/13-workspace-sections.spec.ts
@@ -42,6 +42,11 @@ test.describe('Workspace Sections', () => {
     // Click "Archive"
     await page.getByRole('menuitem', { name: 'Archive' }).click()
 
+    // Confirm the archive in the ConfirmDialog
+    const dialog = page.locator('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Archive' }).click()
+
     // Archived section header should appear
     await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
 

--- a/frontend/tests/e2e/14a-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/14a-workspace-archive.spec.ts
@@ -72,8 +72,8 @@ test.describe('Workspace Archive', () => {
     await workspaceItem.locator('button').first().click()
     await page.getByRole('menuitem', { name: 'Unarchive' }).click()
 
-    // Archived empty state should be gone
-    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('Click + to open')
+    // Archived empty state should be gone, replaced by interactive action buttons
+    await expect(page.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
   })
 
   test('should only show In Progress and Custom sections in Move-to menu', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/18-workspace-ux.spec.ts
+++ b/frontend/tests/e2e/18-workspace-ux.spec.ts
@@ -158,12 +158,15 @@ test.describe('Workspace UX Enhancements', () => {
       await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Delete Target WS' })).toBeVisible()
       await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Next WS' })).toBeVisible()
 
-      // Set up dialog handler for the confirm prompt
-      page.on('dialog', dialog => dialog.accept())
-
       // Delete the active workspace
       await openWorkspaceContextMenu(page, 'Delete Target WS')
       await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+      // Confirm the delete via ConfirmDialog (danger mode: arm then confirm)
+      const dialog = page.locator('dialog')
+      await expect(dialog).toBeVisible()
+      await dialog.getByRole('button', { name: 'Delete' }).click()
+      await dialog.getByRole('button', { name: 'Confirm?' }).click()
 
       // The deleted workspace should be gone from sidebar
       await expect(page.locator('[data-testid^="workspace-item-"]').filter({ hasText: 'Delete Target WS' })).not.toBeVisible()

--- a/internal/worker/hub/client_test.go
+++ b/internal/worker/hub/client_test.go
@@ -225,7 +225,9 @@ func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 	client.connectWithReconnect(ctx, "token", mockConnect, bo, 1*time.Hour)
 
 	// Verify that later gaps don't exceed MaxInterval + tolerance.
-	tolerance := 5 * time.Millisecond
+	// Use a generous tolerance because OS scheduling jitter on short intervals
+	// can easily add several milliseconds.
+	tolerance := 50 * time.Millisecond
 	for i := 1; i < len(timestamps); i++ {
 		gap := timestamps[i].Sub(timestamps[i-1])
 		assert.LessOrEqual(t, gap, bo.MaxInterval+tolerance, "gap[%d]=%v exceeds MaxInterval=%v", i, gap, bo.MaxInterval)


### PR DESCRIPTION
## Motivation

Worktree removal involves disk I/O (deleting the worktree directory and
optionally deleting the associated branch) which can take a noticeable
amount of time. When the Hub dispatches a `SendAndWait` request to the
Worker, the Worker performed the entire removal synchronously before
responding, causing the Hub's 10-second API timeout to expire on slow
git operations.

In addition, several e2e tests were failing due to:
- Synchronous assertions against worktree deletion that is now async
- Playwright strict-mode violations where `getByRole('button', { name: 'Create' })`
  matched both the sidebar "Create a new workspace..." button and the
  dialog "Create" button
- Tests not updated for the `ConfirmDialog` component (archive/delete
  operations) and the interactive empty-state buttons
- A flaky backoff timing test with insufficient tolerance for OS jitter

## Modifications

**Backend (`internal/worker/hub/git_handlers.go`)**

- `handleGitWorktreeRemove` now sends the success response to the Hub
  immediately after confirming the worktree is clean (or that force-removal
  was requested) and the git repo is valid, then performs the actual
  `gitutil.RemoveWorktree` and optional branch deletion in a background
  goroutine. All other code paths (check-only, dirty+not-forced, git-info
  error) remain unchanged.

**Backend test (`internal/worker/hub/client_test.go`)**

- Increased backoff tolerance in `TestConnectWithReconnect_BackoffCapsAtMax`
  from 5ms to 50ms to account for OS scheduling jitter on sub-millisecond
  intervals.

**E2e test helpers (`frontend/tests/e2e/helpers.ts`)**

- `createWorkspaceViaUI`: Scoped `createBtn` and `refreshBtn` locators to
  the dialog element with `exact: true` to avoid strict-mode violations
  with the sidebar "Create a new workspace..." button.
- `getWorkerId`: Now polls with retry logic (30s timeout, 500ms interval)
  until the worker is both registered in the DB and has an active
  bidi-stream connection (online), preventing fixture setup races.

**E2e test suites**

- `55-worktree-support.spec.ts`: Added `waitForPathDeleted` polling helper
  that waits for the worktree directory and branch ref to be deleted
  asynchronously. Refactored `waitForWorker` to scope button locators to
  the dialog. Fixed `createBtn` references that were broken by the
  refactor.
- `02-registration.spec.ts`: Scoped Create button assertion to the dialog
  to avoid strict-mode violation.
- `13-workspace-sections.spec.ts`: Added `ConfirmDialog` handling after
  clicking "Archive" from the context menu.
- `14a-workspace-archive.spec.ts`: Replaced stale `'Click + to open'`
  assertion with `empty-tile-actions` testid check matching the new
  interactive empty-state buttons.
- `18-workspace-ux.spec.ts`: Replaced native `page.on('dialog')` handler
  with `ConfirmDialog` two-click interaction (Delete → Confirm?) for
  workspace deletion.

## Result

- Worktree removal no longer causes Hub request timeouts. The Worker
  responds immediately once safety checks pass and performs the disk
  work in the background.
- E2e tests that cover worktree lifecycle correctly wait for async
  deletion to complete before asserting on-disk state.
- E2e tests for workspace archive, delete, and registration no longer
  fail due to strict-mode violations, missing ConfirmDialog handling,
  or stale UI assertions.

🤖 Generated with Claude Code
