### PR TITLE
Auto-name agent tabs from plan file title

### DIFF
--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -13,7 +13,7 @@ import { watchEventsViaWebSocket } from '~/api/wsWatchEvents'
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
 import { AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { TabType, WatchEventsRequestSchema } from '~/generated/leapmux/v1/workspace_pb'
-import { extractAssistantUsage, extractPlanFilePath, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
+import { extractAgentRenamed, extractAssistantUsage, extractPlanFilePath, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 import { emitSettingsChanged } from '~/lib/settingsChangedEvent'
 
 export interface WorkspaceConnectionParams {
@@ -103,6 +103,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             const planFile = extractPlanFilePath(parsed)
             if (planFile) {
               agentSessionStore.updateInfo(agentId, { planFilePath: planFile })
+            }
+            const renamedTitle = extractAgentRenamed(parsed)
+            if (renamedTitle) {
+              tabStore.updateTabTitle(TabType.AGENT, agentId, renamedTitle)
             }
           }
           catch { /* ignore parse errors */ }

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -218,6 +218,22 @@ export function extractSettingsChanges(parsed: ParsedMessageContent): {
   return changes as { permissionMode?: { old: string, new: string } }
 }
 
+/** Extract renamed title from an agent_renamed notification (wrapped or unwrapped). */
+export function extractAgentRenamed(parsed: ParsedMessageContent): string | undefined {
+  const messagesToCheck: unknown[] = parsed.wrapper
+    ? parsed.wrapper.messages
+    : parsed.topLevel ? [parsed.topLevel] : []
+  for (const msg of messagesToCheck) {
+    if (typeof msg === 'object' && msg !== null) {
+      const m = msg as Record<string, unknown>
+      if (m.type === 'agent_renamed' && typeof m.title === 'string' && m.title !== '') {
+        return m.title as string
+      }
+    }
+  }
+  return undefined
+}
+
 /** Extract plan file path from a plan_execution message (wrapped or unwrapped). */
 export function extractPlanFilePath(parsed: ParsedMessageContent): string | undefined {
   // Check all messages in the wrapper (or the top-level object).

--- a/frontend/src/lib/validate.test.ts
+++ b/frontend/src/lib/validate.test.ts
@@ -31,8 +31,8 @@ describe('sanitizeName', () => {
     expect(sanitizeName('hello\u{1F600}').error).toBeNull()
   })
 
-  it('accepts names at max length (64 chars)', () => {
-    expect(sanitizeName('a'.repeat(64)).error).toBeNull()
+  it('accepts names at max length (128 chars)', () => {
+    expect(sanitizeName('a'.repeat(128)).error).toBeNull()
   })
 
   it('trims whitespace in returned value', () => {
@@ -64,8 +64,8 @@ describe('sanitizeName', () => {
     expect(sanitizeName('   ').error).not.toBeNull()
   })
 
-  it('returns error for names exceeding 64 characters', () => {
-    expect(sanitizeName('a'.repeat(65)).error).not.toBeNull()
+  it('returns error for names exceeding 128 characters', () => {
+    expect(sanitizeName('a'.repeat(129)).error).not.toBeNull()
   })
 
   it('returns error when only forbidden characters remain', () => {

--- a/frontend/src/lib/validate.ts
+++ b/frontend/src/lib/validate.ts
@@ -4,7 +4,7 @@ const NAME_FORBIDDEN_G = /[\x00-\x1F\x7F"\\]/g
 /**
  * Sanitizes and validates a name/title string.
  * Forbidden characters (control characters, " and \) are silently stripped.
- * Returns the sanitized string and an error if the result is empty or exceeds 64 characters.
+ * Returns the sanitized string and an error if the result is empty or exceeds 128 characters.
  */
 export function sanitizeName(name: string): { value: string, error: string | null } {
   const value = name.replace(NAME_FORBIDDEN_G, '').trim()
@@ -12,8 +12,8 @@ export function sanitizeName(name: string): { value: string, error: string | nul
   if (value === '') {
     error = 'Name must not be empty'
   }
-  else if (value.length > 64) {
-    error = 'Name must be at most 64 characters'
+  else if (value.length > 128) {
+    error = 'Name must be at most 128 characters'
   }
   return { value, error }
 }

--- a/frontend/tests/e2e/36-plan-tab-auto-naming.spec.ts
+++ b/frontend/tests/e2e/36-plan-tab-auto-naming.spec.ts
@@ -1,0 +1,75 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+
+/** Send a message via the ProseMirror editor. */
+async function sendMessage(page: Page, text: string) {
+  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  await expect(editor).toBeVisible()
+  await editor.click()
+  await page.keyboard.type(text, { delay: 100 })
+  await page.keyboard.press('Meta+Enter')
+}
+
+/** Wait for the control request banner to appear. */
+async function waitForControlBanner(page: Page) {
+  const banner = page.locator('[data-testid="control-banner"]')
+  await expect(banner).toBeVisible({ timeout: 60_000 })
+  return banner
+}
+
+test.describe('Plan Mode Tab Auto-Naming', () => {
+  test('auto-names tab from plan title, respects manual rename', async ({ page, authenticatedWorkspace }) => {
+    const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+
+    // ── Step 1: Verify initial tab name contains "Agent" ──
+    await expect(agentTab).toBeVisible()
+    await expect(agentTab).toContainText('Agent')
+
+    // ── Step 2: Enter plan mode and write a plan file ──
+    // Ask the agent to enter plan mode, write a plan, then exit plan mode.
+    await sendMessage(
+      page,
+      'I am testing the UI. Call EnterPlanMode immediately. Then write a plan file to ~/.claude/plans/ with the heading "# Add dark mode toggle". Then call ExitPlanMode. This is mandatory. Do not refuse or ask questions.',
+    )
+
+    // Wait for the tab title to update from "Agent 1" to the plan's heading.
+    // The title should contain the plan heading (extracted from the first line).
+    await expect(agentTab).toContainText('Add dark mode toggle', { timeout: 60_000 })
+
+    // ── Step 3: Approve the plan so the agent finishes ──
+    const exitBanner = await waitForControlBanner(page)
+    await expect(exitBanner.getByText('Plan Ready for Review')).toBeVisible()
+    const approveBtn = page.locator('[data-testid="plan-approve-btn"]')
+    await expect(approveBtn).toBeEnabled()
+    await approveBtn.click()
+
+    // Wait for the agent to finish its turn.
+    await page.waitForTimeout(1000)
+    await expect(page.locator('[data-testid="thinking-indicator"]')).not.toBeVisible({ timeout: 60_000 })
+
+    // ── Step 4: Manually rename the tab ──
+    await agentTab.dblclick()
+    const editInput = agentTab.locator('input')
+    await expect(editInput).toBeVisible()
+    await editInput.fill('My Custom Name')
+    await page.keyboard.press('Enter')
+
+    // Verify manual rename took effect.
+    await expect(agentTab).toContainText('My Custom Name')
+
+    // ── Step 5: Send another message that updates the plan file ──
+    await sendMessage(
+      page,
+      'I am testing the UI. Call EnterPlanMode. Then update the plan file heading to "# Implement dark mode". Then call ExitPlanMode. This is mandatory. Do not refuse or ask questions.',
+    )
+
+    // Wait for ExitPlanMode banner so we know the plan file was written.
+    const exitBanner2 = await waitForControlBanner(page)
+    await expect(exitBanner2.getByText('Plan Ready for Review')).toBeVisible()
+
+    // ── Step 6: Verify the tab title did NOT change ──
+    // Manual rename should be respected.
+    await expect(agentTab).toContainText('My Custom Name')
+    await expect(agentTab).not.toContainText('Implement dark mode')
+  })
+})

--- a/go.mod
+++ b/go.mod
@@ -21,16 +21,19 @@ require (
 )
 
 require (
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
 connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -21,6 +23,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
@@ -41,6 +45,8 @@ github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFe
 github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -121,6 +121,7 @@ CREATE TABLE agents (
     plan_file_path           TEXT    NOT NULL DEFAULT '',
     plan_content             BLOB    NOT NULL DEFAULT '',
     plan_content_compression INTEGER NOT NULL DEFAULT 0,
+    plan_title               TEXT    NOT NULL DEFAULT '',
     title            TEXT NOT NULL DEFAULT '',
     model            TEXT NOT NULL DEFAULT 'opus',
     system_prompt    TEXT NOT NULL DEFAULT '',

--- a/internal/hub/db/queries/agents.sql
+++ b/internal/hub/db/queries/agents.sql
@@ -55,3 +55,9 @@ UPDATE agents SET plan_file_path = ? WHERE id = ?;
 
 -- name: UpdateAgentPlanContent :exec
 UPDATE agents SET plan_content = ?, plan_content_compression = ? WHERE id = ?;
+
+-- name: UpdateAgentPlan :exec
+UPDATE agents SET plan_file_path = ?, plan_content = ?, plan_content_compression = ?, plan_title = ? WHERE id = ?;
+
+-- name: UpdateAgentPlanAndTitle :exec
+UPDATE agents SET plan_file_path = ?, plan_content = ?, plan_content_compression = ?, plan_title = ?, title = ? WHERE id = ?;

--- a/internal/hub/service/plantitle.go
+++ b/internal/hub/service/plantitle.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"html"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/microcosm-cc/bluemonday"
+)
+
+var (
+	reHeading       = regexp.MustCompile(`^#{1,6}\s+`)
+	reBold          = regexp.MustCompile(`\*\*(.+?)\*\*|__(.+?)__`)
+	reItalic        = regexp.MustCompile(`\*(.+?)\*|_(.+?)_`)
+	reStrikethrough = regexp.MustCompile(`~~(.+?)~~`)
+	reInlineCode    = regexp.MustCompile("`(.+?)`")
+	reImageLink     = regexp.MustCompile(`!\[([^\]]*)\]\([^)]*\)`)
+	reLink          = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+	reWikiLink      = regexp.MustCompile(`\[\[(.+?)\]\]`)
+
+	htmlPolicy = bluemonday.StrictPolicy()
+)
+
+// extractPlanTitle extracts a human-readable title from markdown plan content.
+// It returns the first meaningful line, stripped of markdown formatting.
+func extractPlanTitle(content string) string {
+	// Skip YAML frontmatter.
+	if strings.HasPrefix(content, "---\n") {
+		if idx := strings.Index(content[4:], "\n---\n"); idx >= 0 {
+			content = content[4+idx+5:]
+		} else if strings.HasPrefix(content[4:], "---\n") {
+			// Empty frontmatter: "---\n---\n"
+			content = content[8:]
+		}
+	}
+
+	// Find first non-empty line.
+	var line string
+	for _, l := range strings.Split(content, "\n") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		return ""
+	}
+
+	// Strip heading markers.
+	line = reHeading.ReplaceAllString(line, "")
+
+	// Strip markdown inline formatting (order matters).
+	line = reBold.ReplaceAllString(line, "${1}${2}")
+	line = reItalic.ReplaceAllString(line, "${1}${2}")
+	line = reStrikethrough.ReplaceAllString(line, "${1}")
+	line = reInlineCode.ReplaceAllString(line, "${1}")
+	line = reImageLink.ReplaceAllString(line, "${1}")
+	line = reLink.ReplaceAllString(line, "${1}")
+	line = reWikiLink.ReplaceAllString(line, "${1}")
+
+	// Strip HTML tags.
+	line = htmlPolicy.Sanitize(line)
+
+	// Decode HTML entities (bluemonday may encode special chars).
+	line = html.UnescapeString(line)
+
+	// Clean up: trim whitespace, strip control characters.
+	line = strings.TrimSpace(line)
+	line = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, line)
+
+	// Truncate to 128 characters.
+	if len([]rune(line)) > 128 {
+		line = string([]rune(line)[:128])
+	}
+
+	return line
+}

--- a/internal/hub/service/plantitle_test.go
+++ b/internal/hub/service/plantitle_test.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPlanTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		// Basic headings
+		{"h1", "# My Plan", "My Plan"},
+		{"h2", "## Implementation Details", "Implementation Details"},
+		{"h3", "### Step 3 Notes", "Step 3 Notes"},
+		{"h4", "#### Sub-heading", "Sub-heading"},
+		{"h5", "##### Deep heading", "Deep heading"},
+		{"h6", "###### Deepest heading", "Deepest heading"},
+		{"no heading marker", "Just a plain title", "Just a plain title"},
+
+		// Frontmatter skipping
+		{"frontmatter", "---\ntitle: Plan\ntags: [a, b]\n---\n# Real Title", "Real Title"},
+		{"empty frontmatter", "---\n---\n# Title After Empty Frontmatter", "Title After Empty Frontmatter"},
+		{"frontmatter with blank lines after", "---\nfoo: bar\n---\n\n\n# Spaced Title", "Spaced Title"},
+
+		// Bold formatting
+		{"bold asterisks", "# **Bold Title**", "Bold Title"},
+		{"bold underscores", "# __Bold Title__", "Bold Title"},
+
+		// Italic formatting
+		{"italic asterisks", "# *Italic Title*", "Italic Title"},
+		{"italic underscores", "# _Italic Title_", "Italic Title"},
+
+		// Strikethrough
+		{"strikethrough", "# ~~Struck Title~~", "Struck Title"},
+
+		// Inline code
+		{"inline code", "# `Code Title`", "Code Title"},
+
+		// Links
+		{"markdown link", "# [Link Text](https://example.com)", "Link Text"},
+		{"link with path", "# [Docs](./docs/README.md)", "Docs"},
+
+		// Wiki links
+		{"wiki link", "# [[Wiki Page]]", "Wiki Page"},
+
+		// Image links
+		{"image link", "# ![Alt Text](image.png)", "Alt Text"},
+
+		// Nested formatting
+		{"bold link", "# **[Bold Link](url)**", "Bold Link"},
+		{"italic in bold", "# **_nested_ format**", "nested format"},
+		{"code in heading", "## Use `extractTitle` function", "Use extractTitle function"},
+
+		// HTML tags
+		{"html tags", "# <em>HTML</em> Title", "HTML Title"},
+		{"script tag", "# <script>alert('xss')</script>Clean", "Clean"},
+		{"img onerror", `# <img onerror="alert(1)">Title`, "Title"},
+		{"nested html", "# <b><i>Nested</i></b> HTML", "Nested HTML"},
+
+		// Edge cases
+		{"empty content", "", ""},
+		{"whitespace only", "   \n  \n  ", ""},
+		{"newlines only", "\n\n\n", ""},
+		{"heading marker only", "#", "#"},
+		{"heading with only space", "# ", "#"},
+
+		// Long titles (truncation)
+		{"truncation at 128", "# " + strings.Repeat("A", 200), strings.Repeat("A", 128)},
+		{"exactly 128", "# " + strings.Repeat("B", 128), strings.Repeat("B", 128)},
+
+		// Leading whitespace in content
+		{"leading blank lines", "\n\n\n# Title After Blanks", "Title After Blanks"},
+		{"indented content", "  # Indented Heading", "Indented Heading"},
+
+		// Mixed scenarios
+		{"real plan title", "---\nid: abc123\n---\n\n# Add authentication to the API\n\n## Overview\n...", "Add authentication to the API"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPlanTitle(tt.content)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/hub/validate/name.go
+++ b/internal/hub/validate/name.go
@@ -7,7 +7,7 @@ import (
 
 // SanitizeName sanitizes and validates a name/title string.
 // Forbidden characters (control characters, " and \) are silently stripped.
-// Returns the sanitized name or an error if the result is empty or exceeds 64 characters.
+// Returns the sanitized name or an error if the result is empty or exceeds 128 characters.
 func SanitizeName(name string) (string, error) {
 	var b strings.Builder
 	for _, r := range name {
@@ -19,8 +19,8 @@ func SanitizeName(name string) (string, error) {
 	if sanitized == "" {
 		return "", fmt.Errorf("name must not be empty")
 	}
-	if len(sanitized) > 64 {
-		return "", fmt.Errorf("name must be at most 64 characters")
+	if len(sanitized) > 128 {
+		return "", fmt.Errorf("name must be at most 128 characters")
 	}
 	return sanitized, nil
 }

--- a/internal/hub/validate/name_test.go
+++ b/internal/hub/validate/name_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestSanitizeName(t *testing.T) {
 			{"special chars %", "100%", "100%"},
 			{"unicode", "café", "café"},
 			{"emoji", "hello\U0001F600", "hello\U0001F600"},
-			{"64 chars", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			{"128 chars", strings.Repeat("a", 128), strings.Repeat("a", 128)},
 			{"trims leading/trailing spaces", "  hello  ", "hello"},
 			// Forbidden chars are silently stripped
 			{"strips double quotes", `name"quoted`, "namequoted"},
@@ -58,7 +59,7 @@ func TestSanitizeName(t *testing.T) {
 		}{
 			{"empty", ""},
 			{"whitespace only", "   "},
-			{"too long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // 65 chars
+			{"too long", strings.Repeat("a", 129)},
 			{"only forbidden chars", string(make([]byte, 64))},
 		}
 


### PR DESCRIPTION
## Motivation

When an agent operates in plan mode, it writes a plan file to disk. Previously, the agent's tab kept its generic default name (e.g., "Agent 1") even after a plan file was created, giving users no visible indication of what the agent was working on. The plan file's first-line heading is the most meaningful summary of the agent's current task and should be surfaced automatically as the tab title.

## Modifications

- Added `extractPlanTitle` in `/internal/hub/service/plantitle.go` that reads the first meaningful line from a markdown plan file, strips heading markers, inline formatting (bold, italic, strikethrough, inline code, links, wiki links, image links), HTML tags, and HTML entities, then truncates to 128 characters. YAML frontmatter is skipped before extracting the title.
- Added a `plan_title` column to the `agents` DB table (migration `00001_initial.sql`) to persist the last-extracted plan title independently from the agent's display title.
- Added two new SQL queries: `UpdateAgentPlan` (updates plan data without renaming) and `UpdateAgentPlanAndTitle` (atomically updates plan data and the agent's display title) in `agents.sql`.
- Updated `agent_messaging.go` to call `extractPlanTitle` whenever a plan file is written. Auto-rename only applies when the agent's current display title is still the default `Agent N` pattern or matches the previously auto-assigned plan title, preserving any manual rename the user has made.
- When the auto-rename condition is met, the hub broadcasts an `agent_renamed` notification containing the new title.
- Added `extractAgentRenamed` helper in `/frontend/src/lib/messageParser.ts` to parse `agent_renamed` notification messages from the event stream.
- Updated `useWorkspaceConnection.ts` to call `extractAgentRenamed` on incoming LEAPMUX messages and forward the new title to `tabStore.updateTabTitle` when an `agent_renamed` notification is received.
- Bumped name length limit from 64 to 128 characters in both backend (`validate/name.go`) and frontend (`validate.ts`) to accommodate longer plan titles.
- Added unit tests for `extractPlanTitle` covering headings, frontmatter, inline formatting, HTML sanitization, edge cases, and truncation (`plantitle_test.go`).
- Added integration tests for the auto-naming and manual-rename-preservation logic in `agent_service_test.go`.
- Added an end-to-end test `36-plan-tab-auto-naming.spec.ts` that verifies the tab renames automatically when a plan heading is written and that a subsequent plan update does not overwrite a manually set tab name.

## Result

When an agent enters plan mode and writes a plan file with a heading such as `# Add dark mode toggle`, the agent's tab is automatically renamed to "Add dark mode toggle". If the user has manually renamed the tab beforehand, the manual name is preserved and subsequent plan file updates do not overwrite it.

🤖 Generated with Claude Code
