### PR TITLE
Add e2e tests to CI and ignore timestamp build artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,21 @@ jobs:
 
       - name: Test
         run: task test
+
+      - name: Install Playwright browsers
+        if: github.event_name == 'push'
+        run: cd frontend && bunx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        if: github.event_name == 'push'
+        run: task test-e2e
+
+      - name: Upload Playwright report
+        if: github.event_name == 'push' && failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/
 .output/
 frontend/dist/
 frontend/public/leapmux-service-worker-*
+frontend/app.config.timestamp_*
 
 # IDE
 .idea/


### PR DESCRIPTION
## Motivation
End-to-end tests existed in the project but were not being executed in CI, meaning regressions caught only by e2e tests could slip into the main branch undetected. Additionally, Vite's build tool generates `frontend/app.config.timestamp_*` files locally that were not excluded from version control, creating noise in the working tree.

## Modifications
- Added Playwright browser installation (Chromium) and `task test-e2e` execution to the CI workflow, running only on push events to the `main` branch (not on pull requests, to keep PR checks fast)
- Added an artifact upload step that captures the Playwright HTML report and test results on failure, with a 7-day retention period, to aid in debugging broken e2e tests on CI
- Added `frontend/app.config.timestamp_*` to `.gitignore` to prevent Vite-generated timestamp files from appearing as untracked changes

## Result
E2e tests now run automatically on every push to `main`, giving the team confidence that full-stack user flows remain working after merges. When an e2e test fails on CI, the Playwright report is available as a downloadable artifact for up to 7 days, making it straightforward to diagnose the failure without needing to reproduce it locally. Developers no longer see spurious untracked `app.config.timestamp_*` files in their working tree.

🤖 Generated with Claude Code
