### PR TITLE
Render `agent_renamed` notification properly in chat

### DIFF
--- a/frontend/src/components/chat/messageClassification.ts
+++ b/frontend/src/components/chat/messageClassification.ts
@@ -32,7 +32,7 @@ function isNotificationThreadWrapper(wrapper: { messages: unknown[] } | null): w
   const first = wrapper.messages[0] as Record<string, unknown>
   const t = first.type as string | undefined
   const st = first.subtype as string | undefined
-  return t === 'settings_changed' || t === 'context_cleared' || t === 'interrupted' || t === 'rate_limit' || t === 'plan_execution'
+  return t === 'settings_changed' || t === 'context_cleared' || t === 'interrupted' || t === 'rate_limit' || t === 'plan_execution' || t === 'agent_renamed'
     || (t === 'system' && st !== 'init' && st !== 'task_notification')
 }
 
@@ -74,7 +74,7 @@ export function classifyMessage(
   }
 
   // 4b. Non-system notification types
-  if (type === 'interrupted' || type === 'context_cleared' || type === 'settings_changed' || type === 'rate_limit')
+  if (type === 'interrupted' || type === 'context_cleared' || type === 'settings_changed' || type === 'rate_limit' || type === 'agent_renamed')
     return { kind: 'notification' }
 
   // 5. Result divider

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -24,6 +24,7 @@ import { inlineFlex } from '~/styles/shared.css'
 import { markdownContent } from './markdownContent.css'
 import { thinkingContent, thinkingHeader } from './messageStyles.css'
 import {
+  agentRenamedRenderer,
   compactBoundaryRenderer,
   contextClearedRenderer,
   controlResponseRenderer,
@@ -623,6 +624,7 @@ const KIND_RENDERERS: Record<string, (parsed: unknown, role: MessageRole, contex
     return settingsChangedRenderer.render(parsed, role, context)
       ?? interruptedRenderer.render(parsed, role, context)
       ?? contextClearedRenderer.render(parsed, role, context)
+      ?? agentRenamedRenderer.render(parsed, role, context)
       ?? rateLimitRenderer.render(parsed, role, context)
       ?? compactBoundaryRenderer.render(parsed, role, context)
       ?? microcompactBoundaryRenderer.render(parsed, role, context)
@@ -683,6 +685,7 @@ function getFallbackRenderers(): MessageContentRenderer[] {
       settingsChangedRenderer,
       interruptedRenderer,
       contextClearedRenderer,
+      agentRenamedRenderer,
       rateLimitRenderer,
       compactBoundaryRenderer,
       microcompactBoundaryRenderer,

--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -104,3 +104,40 @@ describe('renderNotificationThread: compaction vs context_cleared ordering', () 
     expect(text).toContain('Model')
   })
 })
+
+describe('renderNotificationThread: agent_renamed', () => {
+  it('standalone agent_renamed shows "Renamed to <title>"', () => {
+    const messages = [{ type: 'agent_renamed', title: 'My Plan' }]
+    expect(renderText(messages)).toBe('Renamed to My Plan')
+  })
+
+  it('agent_renamed with empty title renders nothing', () => {
+    const messages = [{ type: 'agent_renamed', title: '' }]
+    expect(renderText(messages)).toBe('')
+  })
+
+  it('agent_renamed with missing title renders nothing', () => {
+    const messages = [{ type: 'agent_renamed' }]
+    expect(renderText(messages)).toBe('')
+  })
+
+  it('agent_renamed combined with settings_changed in thread', () => {
+    const messages = [
+      { type: 'settings_changed', changes: { model: { old: 'A', new: 'B' } } },
+      { type: 'agent_renamed', title: 'Debug Session' },
+    ]
+    const text = renderText(messages)
+    expect(text).toContain('Model')
+    expect(text).toContain('Renamed to Debug Session')
+  })
+
+  it('agent_renamed combined with interrupted in thread', () => {
+    const messages = [
+      { type: 'agent_renamed', title: 'Test Plan' },
+      { type: 'interrupted' },
+    ]
+    const text = renderText(messages)
+    expect(text).toContain('Renamed to Test Plan')
+    expect(text).toContain('Interrupted')
+  })
+})

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -78,6 +78,23 @@ export const contextClearedRenderer: MessageContentRenderer = {
   },
 }
 
+/** Handles agent renamed notifications: {"type":"agent_renamed","title":"..."} */
+export const agentRenamedRenderer: MessageContentRenderer = {
+  render(parsed, _role, _context) {
+    if (!isObject(parsed) || parsed.type !== 'agent_renamed')
+      return null
+    const title = typeof parsed.title === 'string' ? parsed.title : ''
+    if (!title)
+      return null
+    return (
+      <div class={controlResponseMessage}>
+        {'Renamed to '}
+        {title}
+      </div>
+    )
+  },
+}
+
 /** Handles rate limit notifications: {"type":"rate_limit","rate_limit_info":{...}} */
 export const rateLimitRenderer: MessageContentRenderer = {
   render(parsed, _role, _context) {
@@ -301,6 +318,11 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
     }
     else if (t === 'interrupted') {
       interrupted = true
+    }
+    else if (t === 'agent_renamed') {
+      const title = typeof m.title === 'string' ? m.title : ''
+      if (title)
+        settingsParts.push(`Renamed to ${title}`)
     }
     else if (t === 'system' && st === 'status') {
       compacting = m.status === 'compacting'


### PR DESCRIPTION
## Motivation
When an agent is renamed, the chat UI had no way to display this event to the user. The `agent_renamed` message type was not registered in the notification pipeline, so rename events were silently ignored or rendered incorrectly.

## Modifications
- Added a new `agentRenamedRenderer` in `frontend/src/components/chat/notificationRenderers.tsx` that displays "Renamed to {title}" when an agent is renamed, following the same pattern as existing renderers (`settingsChanged`, `interrupted`, `contextCleared`)
- Registered `agent_renamed` in `frontend/src/components/chat/messageClassification.ts` so it is recognized as a notification type
- Wired `agentRenamedRenderer` into the renderer chain in `frontend/src/components/chat/messageRenderers.tsx` and included `agent_renamed` in notification thread aggregation
- Added 5 test cases in `frontend/src/components/chat/notificationRenderers.test.tsx` covering standalone rename notifications, empty/missing title handling, and combinations with other notification types (`settings_changed`, `interrupted`)

## Result
When an agent is renamed, the chat thread now shows a "Renamed to {title}" notification inline, consistent with how other agent lifecycle events (settings changes, interruptions, context clears) are displayed.

🤖 Generated with Claude Code
