### PR TITLE
Add file viewer with image zoom, hex view, and path sanitization

### DIFF
--- a/cmd/leapmux/worker.go
+++ b/cmd/leapmux/worker.go
@@ -51,7 +51,8 @@ func runWorker(args []string) error {
 	if state == nil || state.AuthToken == "" {
 		// No saved credentials — need to register.
 		hostname, _ := os.Hostname()
-		result, err := hub.Register(ctx, cfg.HubURL, hostname, runtime.GOOS, runtime.GOARCH, version)
+		homeDir, _ := os.UserHomeDir()
+		result, err := hub.Register(ctx, cfg.HubURL, hostname, runtime.GOOS, runtime.GOARCH, version, homeDir)
 		if err != nil {
 			return fmt.Errorf("registration: %w", err)
 		}

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -73,20 +73,6 @@ export const imageSizeError = style({
   textAlign: 'center',
 })
 
-export const imageContainer = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: spacing.lg,
-  height: '100%',
-})
-
-export const image = style({
-  maxWidth: '100%',
-  maxHeight: '100%',
-  objectFit: 'contain',
-})
-
 export const hexScroll = style({
   height: '100%',
   overflow: 'auto',
@@ -223,4 +209,108 @@ globalStyle(`${splitPane} ${codeViewContainer}`, {
   marginTop: 0,
   overflow: 'visible',
   paddingBlock: spacing.sm,
+})
+
+// Floating toolbar for image zoom controls (top-left)
+export const imageToolbar = style({
+  'position': 'absolute',
+  'top': spacing.sm,
+  'left': spacing.md,
+  'zIndex': 10,
+  'display': 'flex',
+  'alignItems': 'center',
+  'borderRadius': 'var(--radius-small)',
+  'border': '1px solid var(--border)',
+  'backgroundColor': 'var(--card)',
+  'opacity': 0.8,
+  'transition': 'opacity 0.15s',
+  ':hover': {
+    opacity: 1,
+  },
+})
+
+export const imageToolbarButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  transition: 'color 0.1s, background-color 0.1s',
+  selectors: {
+    '&:first-child': {
+      borderRadius: 'var(--radius-small) 0 0 var(--radius-small)',
+    },
+    '&:last-child': {
+      borderRadius: '0 var(--radius-small) var(--radius-small) 0',
+    },
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+export const imageToolbarLabel = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '48px',
+  height: '28px',
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  userSelect: 'none',
+  whiteSpace: 'nowrap',
+})
+
+export const imageToolbarTextButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '28px',
+  paddingInline: spacing.xs,
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+  transition: 'color 0.1s, background-color 0.1s',
+  borderRadius: '0 var(--radius-small) var(--radius-small) 0',
+  selectors: {
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+// Outer wrapper for image render area (toolbar + scroll container)
+export const imageRenderContainer = style({
+  position: 'relative',
+  height: '100%',
+})
+
+// Scrollable wrapper for zoomed images
+export const imageScrollContainer = style({
+  overflow: 'auto',
+  height: '100%',
+})
+
+// Centering wrapper for image (fit and zoomed)
+export const imageZoomWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: '100%',
+  minHeight: '100%',
+  width: 'max-content',
+  padding: spacing.lg,
+})
+
+// Checkerboard transparency pattern + border for images
+export const imageCheckerboard = style({
+  backgroundImage: 'repeating-conic-gradient(rgba(128,128,128,0.15) 0% 25%, transparent 0% 50%)',
+  backgroundSize: '16px 16px',
+  border: '1px solid var(--border)',
 })

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -1,0 +1,226 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+import { codeViewContainer } from '~/components/chat/codeViewStyles.css'
+import { spacing } from '~/styles/tokens'
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  overflow: 'hidden',
+  position: 'relative',
+})
+
+export const content = style({
+  flex: 1,
+  overflow: 'auto',
+  minHeight: 0,
+})
+
+export const statusBar = style({
+  position: 'absolute',
+  bottom: spacing.sm,
+  right: spacing.md,
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.sm,
+  padding: `${spacing.xs} ${spacing.sm}`,
+  borderRadius: 'var(--radius-small)',
+  backgroundColor: 'var(--card)',
+  border: '1px solid var(--border)',
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  pointerEvents: 'none',
+  opacity: 0.9,
+})
+
+export const statusMeta = style({
+  whiteSpace: 'nowrap',
+})
+
+export const truncationWarning = style({
+  color: 'var(--warning)',
+  whiteSpace: 'nowrap',
+})
+
+export const loadingState = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-7)',
+})
+
+export const errorState = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  color: 'var(--danger)',
+  fontSize: 'var(--text-7)',
+  padding: spacing.lg,
+  textAlign: 'center',
+})
+
+export const imageSizeError = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-7)',
+  padding: spacing.lg,
+  textAlign: 'center',
+})
+
+export const imageContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: spacing.lg,
+  height: '100%',
+})
+
+export const image = style({
+  maxWidth: '100%',
+  maxHeight: '100%',
+  objectFit: 'contain',
+})
+
+export const hexScroll = style({
+  height: '100%',
+  overflow: 'auto',
+})
+
+export const hexContainer = style({
+  fontFamily: 'var(--font-mono)',
+  fontVariantLigatures: 'none',
+  fontSize: 'var(--text-8)',
+  lineHeight: 1.5,
+  paddingInline: spacing.sm,
+  whiteSpace: 'pre',
+  width: 'max-content',
+  marginInline: 'auto',
+})
+
+export const hexOffset = style({
+  color: 'var(--faint-foreground)',
+  userSelect: 'none',
+})
+
+export const hexSeparator = style({
+  color: 'var(--faint-foreground)',
+  userSelect: 'none',
+})
+
+export const hexAscii = style({
+  color: 'var(--muted-foreground)',
+})
+
+export const textViewContainer = style({
+  height: '100%',
+  overflow: 'auto',
+})
+
+// Remove border/margin from code view when used inside the file viewer
+// and move padding here so the scrollbar stays at the container edge.
+globalStyle(`${textViewContainer} ${codeViewContainer}`, {
+  border: 'none',
+  borderRadius: 0,
+  marginTop: 0,
+  overflow: 'visible',
+  paddingBlock: spacing.sm,
+})
+
+// Container for views that have a render/source toggle (markdown, SVG)
+export const toggleViewContainer = style({
+  position: 'relative',
+  height: '100%',
+  overflow: 'auto',
+})
+
+// Floating segmented toggle button at top-right
+export const viewToggle = style({
+  'position': 'absolute',
+  'top': spacing.sm,
+  'right': spacing.md,
+  'zIndex': 10,
+  'display': 'flex',
+  'borderRadius': 'var(--radius-small)',
+  'border': '1px solid var(--border)',
+  'backgroundColor': 'var(--card)',
+  'opacity': 0.8,
+  'transition': 'opacity 0.15s',
+  ':hover': {
+    opacity: 1,
+  },
+})
+
+export const viewToggleButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  transition: 'color 0.1s, background-color 0.1s',
+  selectors: {
+    '&:first-child': {
+      borderRadius: 'var(--radius-small) 0 0 var(--radius-small)',
+    },
+    '&:last-child': {
+      borderRadius: '0 var(--radius-small) var(--radius-small) 0',
+    },
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+export const viewToggleActive = style({
+  backgroundColor: 'var(--accent)',
+  color: 'var(--foreground)',
+})
+
+export const markdownContainer = style({
+  padding: spacing.lg,
+  overflow: 'auto',
+  height: '100%',
+})
+
+// Side-by-side split view
+export const splitContainer = style({
+  display: 'flex',
+  height: '100%',
+})
+
+export const splitPane = style({
+  flex: 1,
+  overflow: 'auto',
+  minWidth: 0,
+})
+
+export const splitDivider = style({
+  width: '1px',
+  backgroundColor: 'var(--border)',
+  flexShrink: 0,
+})
+
+export const splitPaneMarkdown = style({
+  padding: spacing.lg,
+})
+
+export const splitPaneSource = style({})
+
+// Remove border/margin from code view when used inside split pane
+// and move padding here so the scrollbar stays at the pane edge.
+globalStyle(`${splitPane} ${codeViewContainer}`, {
+  border: 'none',
+  borderRadius: 0,
+  marginTop: 0,
+  overflow: 'visible',
+  paddingBlock: spacing.sm,
+})

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -1,0 +1,145 @@
+import type { Component } from 'solid-js'
+import type { FileViewMode } from '~/lib/fileType'
+import { createEffect, createSignal, on, Show } from 'solid-js'
+import { fileClient } from '~/api/clients'
+import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
+import * as styles from './FileViewer.css'
+import { HexView } from './HexView'
+import { ImageFileView } from './ImageFileView'
+import { MarkdownFileView } from './MarkdownFileView'
+import { TextFileView } from './TextFileView'
+
+const MAX_FILE_SIZE = 256 * 1024 // 256 KiB
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024)
+    return `${bytes} B`
+  const kb = bytes / 1024
+  if (kb < 1024)
+    return `${kb.toFixed(1)} KiB`
+  const mb = kb / 1024
+  return `${mb.toFixed(1)} MiB`
+}
+
+export const FileViewer: Component<{
+  workerId: string
+  filePath: string
+  displayMode?: string
+  onDisplayModeChange?: (mode: string) => void
+}> = (props) => {
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal<string | null>(null)
+  const [content, setContent] = createSignal<Uint8Array | null>(null)
+  const [totalSize, setTotalSize] = createSignal(0)
+  const [viewMode, setViewMode] = createSignal<FileViewMode>('text')
+  const [imageTooLarge, setImageTooLarge] = createSignal(false)
+
+  createEffect(on(
+    () => [props.workerId, props.filePath] as const,
+    async ([workerId, filePath]) => {
+      setLoading(true)
+      setError(null)
+      setContent(null)
+      setImageTooLarge(false)
+
+      try {
+        // First stat the file to get its size
+        const statResp = await fileClient.statFile({ workerId, path: filePath })
+        const fileSize = Number(statResp.info?.size ?? 0n)
+        setTotalSize(fileSize)
+
+        // For images, check size before reading
+        if (isImageExtension(filePath)) {
+          if (fileSize > MAX_FILE_SIZE) {
+            setImageTooLarge(true)
+            setViewMode('image')
+            setLoading(false)
+            return
+          }
+        }
+
+        // Read the file content (up to 256 KiB)
+        const readResp = await fileClient.readFile({
+          workerId,
+          path: filePath,
+          limit: BigInt(MAX_FILE_SIZE),
+        })
+        const bytes = new Uint8Array(readResp.content)
+        setContent(bytes)
+        setTotalSize(Number(readResp.totalSize))
+        setViewMode(detectFileViewMode(filePath, bytes))
+      }
+      catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load file')
+      }
+      finally {
+        setLoading(false)
+      }
+    },
+  ))
+
+  const isTruncated = () => content() !== null && content()!.length < totalSize()
+
+  return (
+    <div class={styles.container}>
+      <div class={styles.content}>
+        <Show when={loading()}>
+          <div class={styles.loadingState}>Loading...</div>
+        </Show>
+        <Show when={error()}>
+          <div class={styles.errorState}>{error()}</div>
+        </Show>
+        <Show when={!loading() && !error()}>
+          <Show when={imageTooLarge()}>
+            <div class={styles.imageSizeError}>
+              {`Image too large to preview (${formatSize(totalSize())})`}
+            </div>
+          </Show>
+          <Show when={viewMode() === 'text' && content()}>
+            <TextFileView
+              content={content()!}
+              filePath={props.filePath}
+              totalSize={totalSize()}
+            />
+          </Show>
+          <Show when={viewMode() === 'markdown' && content()}>
+            <MarkdownFileView
+              content={content()!}
+              filePath={props.filePath}
+              totalSize={totalSize()}
+              displayMode={props.displayMode}
+              onDisplayModeChange={props.onDisplayModeChange}
+            />
+          </Show>
+          <Show when={viewMode() === 'image' && content() && !imageTooLarge()}>
+            <ImageFileView
+              content={content()!}
+              filePath={props.filePath}
+              totalSize={totalSize()}
+              displayMode={props.displayMode}
+              onDisplayModeChange={props.onDisplayModeChange}
+            />
+          </Show>
+          <Show when={viewMode() === 'binary' && content()}>
+            <HexView
+              content={content()!}
+              totalSize={totalSize()}
+            />
+          </Show>
+        </Show>
+      </div>
+      <Show when={!loading() && !error() && (totalSize() > 0 || isTruncated())}>
+        <div class={styles.statusBar}>
+          <Show when={isTruncated()}>
+            <span class={styles.truncationWarning}>
+              {`Truncated at ${formatSize(MAX_FILE_SIZE)}`}
+            </span>
+          </Show>
+          <Show when={totalSize() > 0}>
+            <span class={styles.statusMeta}>{formatSize(totalSize())}</span>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/HexView.tsx
+++ b/frontend/src/components/fileviewer/HexView.tsx
@@ -1,0 +1,122 @@
+import type { JSX } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount } from 'solid-js'
+import * as styles from './FileViewer.css'
+
+const FALLBACK_ROW_HEIGHT = 20
+const BASE_VPAD = 4 // matches spacing.xs
+const OVERSCAN = 20
+
+/** Format a single hex row: offset | hex bytes | ASCII */
+function formatRow(bytes: Uint8Array, offset: number): { offsetStr: string, hex: string, ascii: string } {
+  const offsetStr = offset.toString(16).padStart(8, '0')
+  const hexParts: string[] = []
+  const asciiParts: string[] = []
+
+  for (let i = 0; i < 16; i++) {
+    if (i === 8)
+      hexParts.push('')
+    if (i < bytes.length) {
+      hexParts.push(bytes[i].toString(16).padStart(2, '0'))
+      const b = bytes[i]
+      asciiParts.push(b >= 0x20 && b <= 0x7E ? String.fromCharCode(b) : '.')
+    }
+    else {
+      hexParts.push('  ')
+      asciiParts.push(' ')
+    }
+  }
+
+  return {
+    offsetStr,
+    hex: hexParts.join(' '),
+    ascii: asciiParts.join(''),
+  }
+}
+
+export function HexView(props: {
+  content: Uint8Array
+  totalSize: number
+}): JSX.Element {
+  let scrollRef!: HTMLDivElement
+  const [scrollTop, setScrollTop] = createSignal(0)
+  const [viewHeight, setViewHeight] = createSignal(400)
+  const [rowHeight, setRowHeight] = createSignal(FALLBACK_ROW_HEIGHT)
+
+  const totalRows = createMemo(() => Math.max(1, Math.ceil(props.content.length / 16)))
+
+  const startIdx = createMemo(() =>
+    Math.max(0, Math.floor(scrollTop() / rowHeight()) - OVERSCAN),
+  )
+
+  const endIdx = createMemo(() =>
+    Math.min(totalRows(), Math.ceil((scrollTop() + viewHeight()) / rowHeight()) + OVERSCAN),
+  )
+
+  const visibleRows = createMemo(() => {
+    const s = startIdx()
+    const e = endIdx()
+    const result: Array<{ offset: number, bytes: Uint8Array }> = []
+    for (let i = s; i < e; i++) {
+      const off = i * 16
+      result.push({
+        offset: off,
+        bytes: props.content.subarray(off, Math.min(off + 16, props.content.length)),
+      })
+    }
+    return result
+  })
+
+  // Reset scroll when content changes
+  createEffect(on(() => props.content, () => {
+    if (scrollRef)
+      scrollRef.scrollTop = 0
+    setScrollTop(0)
+  }))
+
+  onMount(() => {
+    const obs = new ResizeObserver(([entry]) => setViewHeight(entry.contentRect.height))
+    obs.observe(scrollRef)
+    onCleanup(() => obs.disconnect())
+
+    // Measure actual row height from a rendered row
+    requestAnimationFrame(() => {
+      const row = scrollRef.querySelector('[data-hex-row]') as HTMLElement
+      if (row)
+        setRowHeight(row.offsetHeight)
+    })
+  })
+
+  const topPad = () => `${BASE_VPAD + startIdx() * rowHeight()}px`
+  const bottomPad = () => `${BASE_VPAD + Math.max(0, totalRows() - endIdx()) * rowHeight()}px`
+
+  return (
+    <div
+      ref={scrollRef}
+      class={styles.hexScroll}
+      onScroll={() => setScrollTop(scrollRef.scrollTop)}
+    >
+      <div
+        class={styles.hexContainer}
+        style={{ 'padding-top': topPad(), 'padding-bottom': bottomPad() }}
+      >
+        <For each={visibleRows()}>
+          {(row) => {
+            const formatted = formatRow(row.bytes, row.offset)
+            return (
+              <div data-hex-row>
+                <span class={styles.hexOffset}>{formatted.offsetStr}</span>
+                <span class={styles.hexSeparator}>{'  '}</span>
+                <span>{formatted.hex}</span>
+                <span class={styles.hexSeparator}>{'  '}</span>
+                <span class={styles.hexAscii}>{`\u2502${formatted.ascii}\u2502`}</span>
+              </div>
+            )
+          }}
+        </For>
+      </div>
+    </div>
+  )
+}
+
+/** Export the row formatter for testing. */
+export { formatRow }

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -1,0 +1,87 @@
+import type { JSX } from 'solid-js'
+import type { ViewMode } from './ViewToggle'
+import { createMemo, createSignal, onCleanup, Show, untrack } from 'solid-js'
+import { isSvgExtension } from '~/lib/fileType'
+import * as styles from './FileViewer.css'
+import { TextFileView } from './TextFileView'
+import { ViewToggle } from './ViewToggle'
+
+const MIME_MAP: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  bmp: 'image/bmp',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+}
+
+function getMimeType(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() ?? ''
+  return MIME_MAP[ext] ?? 'application/octet-stream'
+}
+
+function ImageRender(props: {
+  content: Uint8Array
+  filePath: string
+}): JSX.Element {
+  const blobUrl = createMemo(() => {
+    const blob = new Blob([props.content], { type: getMimeType(props.filePath) })
+    return URL.createObjectURL(blob)
+  })
+
+  onCleanup(() => {
+    URL.revokeObjectURL(blobUrl())
+  })
+
+  return (
+    <div class={styles.imageContainer}>
+      <img
+        src={blobUrl()}
+        alt={props.filePath.split('/').pop() ?? 'Image'}
+        class={styles.image}
+      />
+    </div>
+  )
+}
+
+export function ImageFileView(props: {
+  content: Uint8Array
+  filePath: string
+  totalSize?: number
+  displayMode?: string
+  onDisplayModeChange?: (mode: string) => void
+}): JSX.Element {
+  const isSvg = () => isSvgExtension(props.filePath)
+  const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
+
+  const handleModeChange = (m: ViewMode) => {
+    setMode(m)
+    props.onDisplayModeChange?.(m)
+  }
+
+  return (
+    <Show
+      when={isSvg()}
+      fallback={<ImageRender content={props.content} filePath={props.filePath} />}
+    >
+      <div class={styles.toggleViewContainer}>
+        <ViewToggle mode={mode()} onToggle={handleModeChange} />
+        <Show
+          when={mode() === 'render'}
+          fallback={(
+            <TextFileView
+              content={props.content}
+              filePath={props.filePath}
+              totalSize={props.totalSize ?? props.content.length}
+            />
+          )}
+        >
+          <ImageRender content={props.content} filePath={props.filePath} />
+        </Show>
+      </div>
+    </Show>
+  )
+}

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -1,8 +1,10 @@
 import type { JSX } from 'solid-js'
+import type { ZoomMode } from './ImageToolbar'
 import type { ViewMode } from './ViewToggle'
-import { createMemo, createSignal, onCleanup, Show, untrack } from 'solid-js'
+import { createEffect, createMemo, createSignal, Match, onCleanup, Switch, untrack } from 'solid-js'
 import { isSvgExtension } from '~/lib/fileType'
 import * as styles from './FileViewer.css'
+import { ImageToolbar } from './ImageToolbar'
 import { TextFileView } from './TextFileView'
 import { ViewToggle } from './ViewToggle'
 
@@ -18,6 +20,8 @@ const MIME_MAP: Record<string, string> = {
   avif: 'image/avif',
 }
 
+const WRAPPER_PADDING = 16 // matches spacing.lg used in imageZoomWrapper
+
 function getMimeType(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase() ?? ''
   return MIME_MAP[ext] ?? 'application/octet-stream'
@@ -26,7 +30,13 @@ function getMimeType(path: string): string {
 function ImageRender(props: {
   content: Uint8Array
   filePath: string
+  zoom: ZoomMode
+  onZoomChange: (mode: ZoomMode) => void
 }): JSX.Element {
+  let containerRef!: HTMLDivElement
+  const [naturalSize, setNaturalSize] = createSignal<{ w: number, h: number } | null>(null)
+  const [containerSize, setContainerSize] = createSignal({ w: 0, h: 0 })
+
   const blobUrl = createMemo(() => {
     const blob = new Blob([props.content], { type: getMimeType(props.filePath) })
     return URL.createObjectURL(blob)
@@ -36,13 +46,72 @@ function ImageRender(props: {
     URL.revokeObjectURL(blobUrl())
   })
 
+  createEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry)
+        setContainerSize({ w: entry.contentRect.width, h: entry.contentRect.height })
+    })
+    observer.observe(containerRef)
+    onCleanup(() => observer.disconnect())
+  })
+
+  const fitScale = createMemo(() => {
+    const ns = naturalSize()
+    const cs = containerSize()
+    if (!ns?.w || !ns?.h || !cs.w || !cs.h)
+      return null
+    const availW = cs.w - WRAPPER_PADDING * 2
+    const availH = cs.h - WRAPPER_PADDING * 2
+    if (availW <= 0 || availH <= 0)
+      return null
+    return Math.min(availW / ns.w, availH / ns.h)
+  })
+
+  const displaySize = createMemo(() => {
+    const ns = naturalSize()
+    if (!ns)
+      return null
+    const z = props.zoom
+    if (z === 'fit') {
+      const fs = fitScale()
+      if (fs == null)
+        return null
+      return { w: ns.w * fs, h: ns.h * fs }
+    }
+    const s = z === 'actual' ? 1 : z
+    return { w: ns.w * s, h: ns.h * s }
+  })
+
+  const alt = () => props.filePath.split('/').pop() ?? 'Image'
+
+  const handleLoad: JSX.EventHandler<HTMLImageElement, Event> = (e) => {
+    const img = e.currentTarget
+    setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight })
+  }
+
   return (
-    <div class={styles.imageContainer}>
-      <img
-        src={blobUrl()}
-        alt={props.filePath.split('/').pop() ?? 'Image'}
-        class={styles.image}
-      />
+    <div ref={containerRef} class={styles.imageRenderContainer}>
+      <ImageToolbar zoom={props.zoom} fitScale={fitScale()} onZoomChange={props.onZoomChange} />
+      <div class={styles.imageScrollContainer}>
+        <div class={styles.imageZoomWrapper}>
+          <img
+            src={blobUrl()}
+            alt={alt()}
+            class={styles.imageCheckerboard}
+            style={displaySize()
+              ? {
+                  width: `${displaySize()!.w}px`,
+                  height: `${displaySize()!.h}px`,
+                }
+              : {
+                  'max-width': '100%',
+                  'max-height': '100%',
+                  'object-fit': 'contain',
+                }}
+            onLoad={handleLoad}
+          />
+        </div>
+      </div>
     </div>
   )
 }
@@ -56,32 +125,59 @@ export function ImageFileView(props: {
 }): JSX.Element {
   const isSvg = () => isSvgExtension(props.filePath)
   const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
+  const [zoom, setZoom] = createSignal<ZoomMode>('fit')
 
   const handleModeChange = (m: ViewMode) => {
     setMode(m)
     props.onDisplayModeChange?.(m)
   }
 
+  const renderImage = () => (
+    <ImageRender
+      content={props.content}
+      filePath={props.filePath}
+      zoom={zoom()}
+      onZoomChange={setZoom}
+    />
+  )
+
   return (
-    <Show
-      when={isSvg()}
-      fallback={<ImageRender content={props.content} filePath={props.filePath} />}
-    >
-      <div class={styles.toggleViewContainer}>
-        <ViewToggle mode={mode()} onToggle={handleModeChange} />
-        <Show
-          when={mode() === 'render'}
-          fallback={(
-            <TextFileView
-              content={props.content}
-              filePath={props.filePath}
-              totalSize={props.totalSize ?? props.content.length}
-            />
-          )}
-        >
-          <ImageRender content={props.content} filePath={props.filePath} />
-        </Show>
-      </div>
-    </Show>
+    <Switch>
+      <Match when={!isSvg()}>
+        {renderImage()}
+      </Match>
+      <Match when={isSvg()}>
+        <div class={styles.toggleViewContainer}>
+          <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit />
+          <Switch>
+            <Match when={mode() === 'render'}>
+              {renderImage()}
+            </Match>
+            <Match when={mode() === 'split'}>
+              <div class={styles.splitContainer}>
+                <div class={styles.splitPane}>
+                  {renderImage()}
+                </div>
+                <div class={styles.splitDivider} />
+                <div class={styles.splitPane}>
+                  <TextFileView
+                    content={props.content}
+                    filePath={props.filePath}
+                    totalSize={props.totalSize ?? props.content.length}
+                  />
+                </div>
+              </div>
+            </Match>
+            <Match when={mode() === 'source'}>
+              <TextFileView
+                content={props.content}
+                filePath={props.filePath}
+                totalSize={props.totalSize ?? props.content.length}
+              />
+            </Match>
+          </Switch>
+        </div>
+      </Match>
+    </Switch>
   )
 }

--- a/frontend/src/components/fileviewer/ImageToolbar.tsx
+++ b/frontend/src/components/fileviewer/ImageToolbar.tsx
@@ -1,0 +1,79 @@
+import type { JSX } from 'solid-js'
+import Maximize2 from 'lucide-solid/icons/maximize-2'
+import ZoomIn from 'lucide-solid/icons/zoom-in'
+import ZoomOut from 'lucide-solid/icons/zoom-out'
+import { iconSize } from '~/styles/tokens'
+import * as styles from './FileViewer.css'
+
+export type ZoomMode = 'fit' | 'actual' | number
+
+export const ZOOM_STEP = 0.25
+export const ZOOM_MIN = 0.25
+export const ZOOM_MAX = 5
+
+export function zoomLabel(mode: ZoomMode, fitScale?: number | null): string {
+  if (mode === 'fit') {
+    if (fitScale != null)
+      return `${Number.parseFloat((fitScale * 100).toFixed(1))}%`
+    return 'Fit'
+  }
+  if (mode === 'actual')
+    return '100%'
+  return `${Math.round(mode * 100)}%`
+}
+
+export function zoomIn(current: ZoomMode, fitScale?: number | null): ZoomMode {
+  const scale = current === 'fit'
+    ? (fitScale ?? 1)
+    : current === 'actual' ? 1 : current
+  const next = Math.round((scale + ZOOM_STEP) * 100) / 100
+  return Math.min(next, ZOOM_MAX)
+}
+
+export function zoomOut(current: ZoomMode, fitScale?: number | null): ZoomMode {
+  const scale = current === 'fit'
+    ? (fitScale ?? 1)
+    : current === 'actual' ? 1 : current
+  const next = Math.round((scale - ZOOM_STEP) * 100) / 100
+  return Math.max(next, ZOOM_MIN)
+}
+
+export function ImageToolbar(props: {
+  zoom: ZoomMode
+  fitScale?: number | null
+  onZoomChange: (mode: ZoomMode) => void
+}): JSX.Element {
+  return (
+    <div class={styles.imageToolbar}>
+      <button
+        class={styles.imageToolbarButton}
+        onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
+        title="Zoom out"
+      >
+        <ZoomOut size={iconSize.sm} />
+      </button>
+      <span class={styles.imageToolbarLabel}>{zoomLabel(props.zoom, props.fitScale)}</span>
+      <button
+        class={styles.imageToolbarButton}
+        onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
+        title="Zoom in"
+      >
+        <ZoomIn size={iconSize.sm} />
+      </button>
+      <button
+        class={styles.imageToolbarButton}
+        onClick={() => props.onZoomChange('fit')}
+        title="Fit to view"
+      >
+        <Maximize2 size={iconSize.sm} />
+      </button>
+      <button
+        class={styles.imageToolbarTextButton}
+        onClick={() => props.onZoomChange('actual')}
+        title="Actual size (100%)"
+      >
+        100%
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/MarkdownFileView.tsx
+++ b/frontend/src/components/fileviewer/MarkdownFileView.tsx
@@ -1,0 +1,94 @@
+import type { JSX } from 'solid-js'
+import type { ViewMode } from './ViewToggle'
+import type { ParsedCatLine } from '~/components/chat/ReadResultView'
+import { createMemo, createSignal, Show, untrack } from 'solid-js'
+import { markdownContent } from '~/components/chat/markdownContent.css'
+import { ReadResultView } from '~/components/chat/ReadResultView'
+import { renderMarkdown } from '~/lib/renderMarkdown'
+import * as styles from './FileViewer.css'
+import { TextFileView } from './TextFileView'
+import { ViewToggle } from './ViewToggle'
+
+export function MarkdownFileView(props: {
+  content: Uint8Array
+  filePath: string
+  totalSize: number
+  displayMode?: string
+  onDisplayModeChange?: (mode: string) => void
+}): JSX.Element {
+  const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
+
+  const handleModeChange = (m: ViewMode) => {
+    setMode(m)
+    props.onDisplayModeChange?.(m)
+  }
+
+  const text = createMemo(() => new TextDecoder().decode(props.content))
+  const html = createMemo(() => renderMarkdown(text()))
+
+  const lines = createMemo((): ParsedCatLine[] => {
+    const raw = text()
+    if (!raw)
+      return []
+    const split = raw.split('\n')
+    if (split.length > 0 && split[split.length - 1] === '')
+      split.pop()
+    return split.map((line, i) => ({ num: i + 1, text: line }))
+  })
+
+  // Proportional scroll sync for side-by-side view
+  let leftRef!: HTMLDivElement
+  let rightRef!: HTMLDivElement
+  let ignoreScroll = false
+
+  const syncScroll = (source: HTMLDivElement, target: HTMLDivElement) => {
+    if (ignoreScroll)
+      return
+    ignoreScroll = true
+    const max = source.scrollHeight - source.clientHeight
+    const ratio = max > 0 ? source.scrollTop / max : 0
+    target.scrollTop = ratio * (target.scrollHeight - target.clientHeight)
+    requestAnimationFrame(() => {
+      ignoreScroll = false
+    })
+  }
+
+  return (
+    <div class={styles.toggleViewContainer}>
+      <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit />
+      <Show when={mode() === 'render'}>
+        <div class={styles.markdownContainer}>
+          {/* eslint-disable-next-line solid/no-innerhtml -- intentional: rendered markdown */}
+          <div class={markdownContent} innerHTML={html()} />
+        </div>
+      </Show>
+      <Show when={mode() === 'split'}>
+        <div class={styles.splitContainer}>
+          <div
+            class={styles.splitPane}
+            ref={leftRef}
+            onScroll={() => syncScroll(leftRef, rightRef)}
+          >
+            {/* eslint-disable-next-line solid/no-innerhtml -- intentional: rendered markdown */}
+            <div class={`${styles.splitPaneMarkdown} ${markdownContent}`} innerHTML={html()} />
+          </div>
+          <div class={styles.splitDivider} />
+          <div
+            class={`${styles.splitPane} ${styles.splitPaneSource}`}
+            ref={rightRef}
+            onScroll={() => syncScroll(rightRef, leftRef)}
+          >
+            <ReadResultView lines={lines()} filePath={props.filePath} />
+          </div>
+        </div>
+      </Show>
+      <Show when={mode() === 'source'}>
+        <TextFileView
+          content={props.content}
+          filePath={props.filePath}
+          totalSize={props.totalSize}
+        />
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/TextFileView.tsx
+++ b/frontend/src/components/fileviewer/TextFileView.tsx
@@ -1,0 +1,30 @@
+import type { JSX } from 'solid-js'
+import type { ParsedCatLine } from '~/components/chat/ReadResultView'
+import { createMemo } from 'solid-js'
+import { ReadResultView } from '~/components/chat/ReadResultView'
+import * as styles from './FileViewer.css'
+
+export function TextFileView(props: {
+  content: Uint8Array
+  filePath: string
+  totalSize: number
+}): JSX.Element {
+  const text = createMemo(() => new TextDecoder().decode(props.content))
+
+  const lines = createMemo((): ParsedCatLine[] => {
+    const raw = text()
+    if (!raw)
+      return []
+    const split = raw.split('\n')
+    // Remove trailing empty line from split
+    if (split.length > 0 && split[split.length - 1] === '')
+      split.pop()
+    return split.map((line, i) => ({ num: i + 1, text: line }))
+  })
+
+  return (
+    <div class={styles.textViewContainer}>
+      <ReadResultView lines={lines()} filePath={props.filePath} />
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -1,0 +1,45 @@
+import type { JSX } from 'solid-js'
+import Code from 'lucide-solid/icons/code'
+import Columns2 from 'lucide-solid/icons/columns-2'
+import Eye from 'lucide-solid/icons/eye'
+import { Show } from 'solid-js'
+import * as styles from './FileViewer.css'
+
+export type ViewMode = 'render' | 'source' | 'split'
+
+export function ViewToggle(props: {
+  mode: ViewMode
+  onToggle: (mode: ViewMode) => void
+  showSplit?: boolean
+}): JSX.Element {
+  return (
+    <div class={styles.viewToggle}>
+      <button
+        class={styles.viewToggleButton}
+        classList={{ [styles.viewToggleActive]: props.mode === 'render' }}
+        onClick={() => props.onToggle('render')}
+        title="Rendered view"
+      >
+        <Eye size={14} />
+      </button>
+      <Show when={props.showSplit}>
+        <button
+          class={styles.viewToggleButton}
+          classList={{ [styles.viewToggleActive]: props.mode === 'split' }}
+          onClick={() => props.onToggle('split')}
+          title="Side-by-side view"
+        >
+          <Columns2 size={14} />
+        </button>
+      </Show>
+      <button
+        class={styles.viewToggleButton}
+        classList={{ [styles.viewToggleActive]: props.mode === 'source' }}
+        onClick={() => props.onToggle('source')}
+        title="Source view"
+      >
+        <Code size={14} />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -44,8 +44,10 @@ interface LeftSidebarProps {
   // File/todo props for rendering FILES/TODOS sections moved to this sidebar
   workerId: string
   workingDir: string
+  homeDir: string
   fileTreePath: string
   onFileSelect: (path: string) => void
+  onFileOpen?: (path: string) => void
   showTodos: boolean
   activeTodos: TodoItem[]
 }
@@ -209,7 +211,9 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
                 showFiles
                 selectedPath={props.fileTreePath}
                 onSelect={props.onFileSelect}
+                onFileOpen={props.onFileOpen}
                 rootPath={props.workingDir || '~'}
+                homeDir={props.homeDir}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -162,6 +162,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
                     selectedPath={workingDir()}
                     onSelect={setWorkingDir}
                     rootPath="~"
+                    homeDir={workers().find(w => w.id === workerId())?.homeDir}
                   />
                 </div>
               </Show>
@@ -170,6 +171,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
               <WorktreeOptions
                 workerId={workerId()}
                 selectedPath={workingDir()}
+                homeDir={workers().find(w => w.id === workerId())?.homeDir}
                 onWorktreeChange={(create, branch, branchError) => {
                   setCreateWorktree(create)
                   setWorktreeBranch(branch)

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -184,6 +184,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
                     selectedPath={workingDir()}
                     onSelect={setWorkingDir}
                     rootPath="~"
+                    homeDir={workers().find(w => w.id === workerId())?.homeDir}
                   />
                 </div>
               </Show>
@@ -192,6 +193,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
               <WorktreeOptions
                 workerId={workerId()}
                 selectedPath={workingDir()}
+                homeDir={workers().find(w => w.id === workerId())?.homeDir}
                 onWorktreeChange={(create, branch, branchError) => {
                   setCreateWorktree(create)
                   setWorktreeBranch(branch)

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -23,10 +23,12 @@ interface RightSidebarProps {
   workspaceId: string
   workerId: string
   workingDir: string
+  homeDir: string
   showTodos: boolean
   activeTodos: TodoItem[]
   fileTreePath: string
   onFileSelect: (path: string) => void
+  onFileOpen?: (path: string) => void
   sectionStore: ReturnType<typeof createSectionStore>
   isCollapsed: boolean
   onExpand: () => void
@@ -107,7 +109,9 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
                 showFiles
                 selectedPath={props.fileTreePath}
                 onSelect={props.onFileSelect}
+                onFileOpen={props.onFileOpen}
                 rootPath={props.workingDir || '~'}
+                homeDir={props.homeDir}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -5,6 +5,7 @@ import Bot from 'lucide-solid/icons/bot'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import Ellipsis from 'lucide-solid/icons/ellipsis'
+import FileText from 'lucide-solid/icons/file-text'
 import Menu from 'lucide-solid/icons/menu'
 import PanelRight from 'lucide-solid/icons/panel-right'
 import Plus from 'lucide-solid/icons/plus'
@@ -39,6 +40,7 @@ function tabTypeLabel(type: TabType): string {
   switch (type) {
     case TabType.AGENT: return 'agent'
     case TabType.TERMINAL: return 'terminal'
+    case TabType.FILE: return 'file'
     default: return 'unknown'
   }
 }
@@ -111,6 +113,8 @@ export const TabBar: Component<TabBarProps> = (props) => {
   const tabLabel = (tab: Tab): string => {
     if (tab.title)
       return tab.title
+    if (tab.type === TabType.FILE)
+      return tab.filePath?.split('/').pop() ?? 'File'
     return tab.type === TabType.AGENT ? 'Agent' : 'Terminal'
   }
 
@@ -183,11 +187,12 @@ export const TabBar: Component<TabBarProps> = (props) => {
       onDblClick={(e: MouseEvent) => {
         e.preventDefault()
         e.stopPropagation()
-        startEditing(tab)
+        if (tab.type !== TabType.FILE)
+          startEditing(tab)
       }}
     >
       <span class={styles.tabIcon}>
-        {tab.type === TabType.AGENT ? <Bot size={14} /> : <Terminal size={14} />}
+        {tab.type === TabType.AGENT ? <Bot size={14} /> : tab.type === TabType.FILE ? <FileText size={14} /> : <Terminal size={14} />}
       </span>
       <Show
         when={editingTabKey() === tabKey(tab)}

--- a/frontend/src/components/shell/WorktreeOptions.tsx
+++ b/frontend/src/components/shell/WorktreeOptions.tsx
@@ -3,6 +3,7 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { generateSlug } from 'random-word-slugs'
 import { createEffect, createMemo, createSignal, on, Show } from 'solid-js'
 import { gitClient } from '~/api/clients'
+import { tildify } from '~/components/chat/messageUtils'
 import { useOrg } from '~/context/OrgContext'
 import { validateBranchName } from '~/lib/validate'
 import { checkboxRow, errorText, labelRow, pathPreview, refreshButton, warningText } from '~/styles/shared.css'
@@ -10,6 +11,7 @@ import { checkboxRow, errorText, labelRow, pathPreview, refreshButton, warningTe
 interface WorktreeOptionsProps {
   workerId: string
   selectedPath: string
+  homeDir?: string
   onWorktreeChange: (create: boolean, branch: string, branchError: string | null) => void
 }
 
@@ -130,7 +132,7 @@ export const WorktreeOptions: Component<WorktreeOptionsProps> = (props) => {
           <div class={pathPreview}>
             Worktree path:
             {' '}
-            <code>{worktreePath()}</code>
+            <code title={worktreePath()}>{tildify(worktreePath(), props.homeDir)}</code>
           </div>
         </Show>
       </Show>

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -159,6 +159,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
                     selectedPath={workingDir()}
                     onSelect={setWorkingDir}
                     rootPath="~"
+                    homeDir={workers().find(w => w.id === workerId())?.homeDir}
                   />
                 </div>
               </Show>
@@ -167,6 +168,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
               <WorktreeOptions
                 workerId={workerId()}
                 selectedPath={workingDir()}
+                homeDir={workers().find(w => w.id === workerId())?.homeDir}
                 onWorktreeChange={(create, branch, branchError) => {
                   setCreateWorktree(create)
                   setWorktreeBranch(branch)

--- a/frontend/src/lib/fileType.ts
+++ b/frontend/src/lib/fileType.ts
@@ -1,0 +1,61 @@
+const IMAGE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+  'ico',
+  'avif',
+])
+
+const MARKDOWN_EXTENSIONS = new Set([
+  'md',
+  'markdown',
+  'mdx',
+])
+
+/** Check if a file path has an image extension. */
+export function isImageExtension(path: string): boolean {
+  const ext = path.split('.').pop()?.toLowerCase() ?? ''
+  return IMAGE_EXTENSIONS.has(ext)
+}
+
+/** Check if a file path has a markdown extension. */
+export function isMarkdownExtension(path: string): boolean {
+  const ext = path.split('.').pop()?.toLowerCase() ?? ''
+  return MARKDOWN_EXTENSIONS.has(ext)
+}
+
+/** Check if a file path has an SVG extension. */
+export function isSvgExtension(path: string): boolean {
+  return (path.split('.').pop()?.toLowerCase() ?? '') === 'svg'
+}
+
+/** Check if content appears to be binary (contains null bytes or high ratio of non-printable chars). */
+export function isBinaryContent(bytes: Uint8Array): boolean {
+  const checkLen = Math.min(bytes.length, 512)
+  let nonPrintable = 0
+  for (let i = 0; i < checkLen; i++) {
+    const b = bytes[i]
+    if (b === 0)
+      return true
+    if (b < 7 || (b > 14 && b < 32 && b !== 27))
+      nonPrintable++
+  }
+  return checkLen > 0 && nonPrintable / checkLen > 0.3
+}
+
+export type FileViewMode = 'text' | 'image' | 'binary' | 'markdown'
+
+/** Detect the appropriate view mode for a file. */
+export function detectFileViewMode(path: string, content: Uint8Array): FileViewMode {
+  if (isImageExtension(path))
+    return 'image'
+  if (isMarkdownExtension(path))
+    return 'markdown'
+  if (isBinaryContent(content))
+    return 'binary'
+  return 'text'
+}

--- a/frontend/tests/e2e/20-markdown-editor.spec.ts
+++ b/frontend/tests/e2e/20-markdown-editor.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures'
-import { openAgentViaUI, PLAN_MODE_PROMPT } from './helpers'
+import { enterAndExitPlanMode, openAgentViaUI } from './helpers'
 
 test.describe('Markdown Editor Toolbar', () => {
   test('should show active state on bold button when text is bold', async ({ page, authenticatedWorkspace }) => {
@@ -1642,17 +1642,8 @@ test.describe('ArrowDown Code Block Scroll', () => {
 
 test.describe('Send Feedback Button Labels', () => {
   test('ExitPlanMode banner shows Send Feedback instead of Reject', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
-    await expect(editor).toBeVisible()
-    await editor.click()
-
-    // Ask agent to enter plan mode and exit with a dummy plan
-    await page.keyboard.type(PLAN_MODE_PROMPT, { delay: 50 })
-    await page.keyboard.press('Meta+Enter')
-
-    // Wait for ExitPlanMode control_request
-    const banner = page.locator('[data-testid="control-banner"]')
-    await expect(banner).toBeVisible({ timeout: 60_000 })
+    // Enter plan mode, write a dummy plan, and exit
+    const banner = await enterAndExitPlanMode(page)
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
     // Verify the reject button says "Send Feedback"

--- a/frontend/tests/e2e/31-control-request-draft.spec.ts
+++ b/frontend/tests/e2e/31-control-request-draft.spec.ts
@@ -1,30 +1,10 @@
-import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { PLAN_MODE_PROMPT } from './helpers'
-
-/** Send a message via the ProseMirror editor. */
-async function sendMessage(page: Page, text: string) {
-  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
-  await expect(editor).toBeVisible()
-  await editor.click()
-  await page.keyboard.type(text, { delay: 100 })
-  await page.keyboard.press('Meta+Enter')
-}
-
-/** Wait for the control request banner to appear and return a scoped locator. */
-async function waitForControlBanner(page: Page) {
-  const banner = page.locator('[data-testid="control-banner"]')
-  await expect(banner).toBeVisible({ timeout: 60_000 })
-  return banner
-}
+import { enterAndExitPlanMode, sendMessage, waitForControlBanner } from './helpers'
 
 test.describe('Control Request Draft Persistence', () => {
   test('ExitPlanMode draft survives page reload', async ({ page, authenticatedWorkspace }) => {
-    // Trigger EnterPlanMode then ExitPlanMode (ExitPlanMode produces a control banner).
-    await sendMessage(page, PLAN_MODE_PROMPT)
-
-    // Wait for ExitPlanMode control banner.
-    const banner = await waitForControlBanner(page)
+    // Enter plan mode, write a dummy plan, and exit.
+    const banner = await enterAndExitPlanMode(page)
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
     // Type a rejection reason in the editor.

--- a/frontend/tests/unit/components/hexView.test.ts
+++ b/frontend/tests/unit/components/hexView.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { formatRow } from '~/components/fileviewer/HexView'
+
+describe('formatRow', () => {
+  it('formats a full 16-byte row', () => {
+    const bytes = new Uint8Array([
+      0x48,
+      0x65,
+      0x6C,
+      0x6C,
+      0x6F,
+      0x20,
+      0x57,
+      0x6F,
+      0x72,
+      0x6C,
+      0x64,
+      0x21,
+      0x0A,
+      0x00,
+      0x00,
+      0x00,
+    ])
+    const result = formatRow(bytes, 0)
+    expect(result.offsetStr).toBe('00000000')
+    expect(result.hex).toBe('48 65 6c 6c 6f 20 57 6f  72 6c 64 21 0a 00 00 00')
+    expect(result.ascii).toBe('Hello World!....')
+  })
+
+  it('formats a partial row with padding', () => {
+    const bytes = new Uint8Array([0x48, 0x69])
+    const result = formatRow(bytes, 0x10)
+    expect(result.offsetStr).toBe('00000010')
+    expect(result.hex).toBe('48 69                                           ')
+    expect(result.ascii).toBe('Hi              ')
+  })
+
+  it('replaces non-printable chars with dots in ASCII', () => {
+    const bytes = new Uint8Array([0x01, 0x7F, 0x41, 0x1B])
+    const result = formatRow(bytes, 0)
+    // 0x01 -> '.', 0x7F -> '.', 0x41 -> 'A', 0x1B -> '.' (ESC is < 0x20)
+    expect(result.ascii.substring(0, 4)).toBe('..A.')
+  })
+
+  it('formats offset correctly for large addresses', () => {
+    const bytes = new Uint8Array([0x41])
+    const result = formatRow(bytes, 0x1FFFFF0)
+    expect(result.offsetStr).toBe('01fffff0')
+  })
+
+  it('handles empty bytes', () => {
+    const bytes = new Uint8Array(0)
+    const result = formatRow(bytes, 0)
+    expect(result.offsetStr).toBe('00000000')
+    expect(result.ascii).toBe('                ')
+  })
+
+  it('handles exactly 8 bytes (first group full, second group empty)', () => {
+    const bytes = new Uint8Array([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48])
+    const result = formatRow(bytes, 0)
+    expect(result.hex).toBe('41 42 43 44 45 46 47 48                         ')
+    expect(result.ascii).toBe('ABCDEFGH        ')
+  })
+})

--- a/frontend/tests/unit/components/imageToolbar.test.ts
+++ b/frontend/tests/unit/components/imageToolbar.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ZOOM_MAX,
+  ZOOM_MIN,
+  ZOOM_STEP,
+  zoomIn,
+  zoomLabel,
+  zoomOut,
+} from '~/components/fileviewer/ImageToolbar'
+
+describe('zoomLabel', () => {
+  it('returns "Fit" for fit mode without fitScale', () => {
+    expect(zoomLabel('fit')).toBe('Fit')
+    expect(zoomLabel('fit', null)).toBe('Fit')
+    expect(zoomLabel('fit', undefined)).toBe('Fit')
+  })
+
+  it('returns just the percentage for fit mode with fitScale', () => {
+    expect(zoomLabel('fit', 0.123)).toBe('12.3%')
+    expect(zoomLabel('fit', 0.5)).toBe('50%')
+    expect(zoomLabel('fit', 1)).toBe('100%')
+    expect(zoomLabel('fit', 0.456)).toBe('45.6%')
+    expect(zoomLabel('fit', 2.5)).toBe('250%')
+  })
+
+  it('returns "100%" for actual mode', () => {
+    expect(zoomLabel('actual')).toBe('100%')
+  })
+
+  it('returns percentage for numeric scale', () => {
+    expect(zoomLabel(0.5)).toBe('50%')
+    expect(zoomLabel(1)).toBe('100%')
+    expect(zoomLabel(1.5)).toBe('150%')
+    expect(zoomLabel(2)).toBe('200%')
+    expect(zoomLabel(0.25)).toBe('25%')
+  })
+
+  it('rounds to nearest integer percentage', () => {
+    expect(zoomLabel(0.333)).toBe('33%')
+    expect(zoomLabel(1.666)).toBe('167%')
+  })
+
+  it('ignores fitScale for non-fit modes', () => {
+    expect(zoomLabel('actual', 0.5)).toBe('100%')
+    expect(zoomLabel(1.5, 0.5)).toBe('150%')
+  })
+})
+
+describe('zoomIn', () => {
+  it('increases numeric scale by ZOOM_STEP', () => {
+    expect(zoomIn(1)).toBe(1 + ZOOM_STEP)
+    expect(zoomIn(0.5)).toBe(0.5 + ZOOM_STEP)
+    expect(zoomIn(2)).toBe(2 + ZOOM_STEP)
+  })
+
+  it('treats fit as scale 1 when no fitScale provided', () => {
+    expect(zoomIn('fit')).toBe(1 + ZOOM_STEP)
+  })
+
+  it('uses fitScale as base when provided for fit mode', () => {
+    expect(zoomIn('fit', 0.5)).toBe(0.5 + ZOOM_STEP)
+    expect(zoomIn('fit', 2)).toBe(2 + ZOOM_STEP)
+  })
+
+  it('ignores fitScale for non-fit modes', () => {
+    expect(zoomIn('actual', 0.5)).toBe(1 + ZOOM_STEP)
+    expect(zoomIn(1.5, 0.5)).toBe(1.5 + ZOOM_STEP)
+  })
+
+  it('treats actual as scale 1 and increases', () => {
+    expect(zoomIn('actual')).toBe(1 + ZOOM_STEP)
+  })
+
+  it('clamps at ZOOM_MAX', () => {
+    expect(zoomIn(ZOOM_MAX)).toBe(ZOOM_MAX)
+    expect(zoomIn(ZOOM_MAX - 0.1)).toBe(ZOOM_MAX)
+  })
+})
+
+describe('zoomOut', () => {
+  it('decreases numeric scale by ZOOM_STEP', () => {
+    expect(zoomOut(1)).toBe(1 - ZOOM_STEP)
+    expect(zoomOut(1.5)).toBe(1.5 - ZOOM_STEP)
+    expect(zoomOut(2)).toBe(2 - ZOOM_STEP)
+  })
+
+  it('treats fit as scale 1 when no fitScale provided', () => {
+    expect(zoomOut('fit')).toBe(1 - ZOOM_STEP)
+  })
+
+  it('uses fitScale as base when provided for fit mode', () => {
+    expect(zoomOut('fit', 0.5)).toBe(ZOOM_MIN)
+    expect(zoomOut('fit', 2)).toBe(2 - ZOOM_STEP)
+  })
+
+  it('ignores fitScale for non-fit modes', () => {
+    expect(zoomOut('actual', 0.5)).toBe(1 - ZOOM_STEP)
+    expect(zoomOut(1.5, 0.5)).toBe(1.5 - ZOOM_STEP)
+  })
+
+  it('treats actual as scale 1 and decreases', () => {
+    expect(zoomOut('actual')).toBe(1 - ZOOM_STEP)
+  })
+
+  it('clamps at ZOOM_MIN', () => {
+    expect(zoomOut(ZOOM_MIN)).toBe(ZOOM_MIN)
+    expect(zoomOut(ZOOM_MIN + 0.1)).toBe(ZOOM_MIN)
+  })
+})

--- a/frontend/tests/unit/lib/fileType.test.ts
+++ b/frontend/tests/unit/lib/fileType.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { detectFileViewMode, isBinaryContent, isImageExtension, isMarkdownExtension, isSvgExtension } from '~/lib/fileType'
+
+describe('isImageExtension', () => {
+  const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'avif']
+  for (const ext of imageExts) {
+    it(`returns true for .${ext}`, () => {
+      expect(isImageExtension(`test.${ext}`)).toBe(true)
+    })
+    it(`returns true for .${ext.toUpperCase()} (case-insensitive)`, () => {
+      expect(isImageExtension(`test.${ext.toUpperCase()}`)).toBe(true)
+    })
+  }
+
+  it('returns false for text files', () => {
+    expect(isImageExtension('test.txt')).toBe(false)
+    expect(isImageExtension('test.ts')).toBe(false)
+    expect(isImageExtension('test.json')).toBe(false)
+  })
+
+  it('returns false for files without extension', () => {
+    expect(isImageExtension('Makefile')).toBe(false)
+  })
+
+  it('handles paths with directories', () => {
+    expect(isImageExtension('/home/user/images/photo.png')).toBe(true)
+    expect(isImageExtension('/home/user/code/main.go')).toBe(false)
+  })
+})
+
+describe('isMarkdownExtension', () => {
+  it('returns true for .md', () => {
+    expect(isMarkdownExtension('README.md')).toBe(true)
+  })
+
+  it('returns true for .markdown', () => {
+    expect(isMarkdownExtension('doc.markdown')).toBe(true)
+  })
+
+  it('returns true for .mdx', () => {
+    expect(isMarkdownExtension('page.mdx')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isMarkdownExtension('README.MD')).toBe(true)
+  })
+
+  it('returns false for non-markdown files', () => {
+    expect(isMarkdownExtension('test.txt')).toBe(false)
+    expect(isMarkdownExtension('test.ts')).toBe(false)
+  })
+})
+
+describe('isSvgExtension', () => {
+  it('returns true for .svg', () => {
+    expect(isSvgExtension('icon.svg')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isSvgExtension('icon.SVG')).toBe(true)
+  })
+
+  it('returns false for non-svg files', () => {
+    expect(isSvgExtension('icon.png')).toBe(false)
+  })
+})
+
+describe('isBinaryContent', () => {
+  it('returns true for content with null bytes', () => {
+    const bytes = new Uint8Array([0x48, 0x65, 0x6C, 0x00, 0x6F])
+    expect(isBinaryContent(bytes)).toBe(true)
+  })
+
+  it('returns false for printable ASCII text', () => {
+    const text = new TextEncoder().encode('Hello, World!\n')
+    expect(isBinaryContent(text)).toBe(false)
+  })
+
+  it('returns false for UTF-8 text', () => {
+    const text = new TextEncoder().encode('Hello 你好 こんにちは')
+    expect(isBinaryContent(text)).toBe(false)
+  })
+
+  it('returns true for high ratio of non-printable bytes', () => {
+    const bytes = new Uint8Array(100)
+    for (let i = 0; i < 100; i++) bytes[i] = i < 50 ? 0x01 : 0x41
+    expect(isBinaryContent(bytes)).toBe(true)
+  })
+
+  it('returns false for empty content', () => {
+    expect(isBinaryContent(new Uint8Array(0))).toBe(false)
+  })
+
+  it('only checks first 512 bytes', () => {
+    const bytes = new Uint8Array(1024)
+    bytes.fill(0x41) // Fill with 'A'
+    bytes[600] = 0x00 // Null byte after 512-byte check window
+    expect(isBinaryContent(bytes)).toBe(false)
+  })
+})
+
+describe('detectFileViewMode', () => {
+  it('returns "image" for image extensions', () => {
+    expect(detectFileViewMode('photo.png', new Uint8Array([0x89, 0x50, 0x4E, 0x47]))).toBe('image')
+  })
+
+  it('returns "markdown" for markdown extensions', () => {
+    const text = new TextEncoder().encode('# Hello World')
+    expect(detectFileViewMode('README.md', text)).toBe('markdown')
+  })
+
+  it('returns "text" for text content', () => {
+    const text = new TextEncoder().encode('function hello() {}')
+    expect(detectFileViewMode('main.ts', text)).toBe('text')
+  })
+
+  it('returns "binary" for binary content with non-image extension', () => {
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03])
+    expect(detectFileViewMode('data.bin', bytes)).toBe('binary')
+  })
+
+  it('prioritizes image extension over binary content', () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x00])
+    expect(detectFileViewMode('image.png', bytes)).toBe('image')
+  })
+
+  it('prioritizes markdown extension over binary check', () => {
+    const text = new TextEncoder().encode('# Title\n\nSome content')
+    expect(detectFileViewMode('doc.md', text)).toBe('markdown')
+  })
+})

--- a/frontend/tests/unit/stores/tab.store.test.ts
+++ b/frontend/tests/unit/stores/tab.store.test.ts
@@ -440,6 +440,43 @@ describe('createTabStore', () => {
     })
   })
 
+  it('should set display mode on a file tab', () => {
+    createRoot((dispose) => {
+      const store = createTabStore()
+      store.addTab({ type: TabType.FILE, id: 'f1', filePath: '/home/user/readme.md' })
+      store.setTabDisplayMode(TabType.FILE, 'f1', 'source')
+      expect(store.state.tabs[0].displayMode).toBe('source')
+      dispose()
+    })
+  })
+
+  it('should update display mode on an existing tab', () => {
+    createRoot((dispose) => {
+      const store = createTabStore()
+      store.addTab({ type: TabType.FILE, id: 'f1', filePath: '/home/user/readme.md' })
+      store.setTabDisplayMode(TabType.FILE, 'f1', 'render')
+      expect(store.state.tabs[0].displayMode).toBe('render')
+      store.setTabDisplayMode(TabType.FILE, 'f1', 'split')
+      expect(store.state.tabs[0].displayMode).toBe('split')
+      dispose()
+    })
+  })
+
+  it('should preserve display mode across other tab operations', () => {
+    createRoot((dispose) => {
+      const store = createTabStore()
+      store.addTab({ type: TabType.FILE, id: 'f1', filePath: '/home/user/readme.md' })
+      store.setTabDisplayMode(TabType.FILE, 'f1', 'split')
+      // Add another tab — f1 display mode should persist
+      store.addTab({ type: TabType.AGENT, id: 'a1' })
+      expect(store.state.tabs[0].displayMode).toBe('split')
+      // Update title — display mode should persist
+      store.updateTabTitle(TabType.FILE, 'f1', 'renamed')
+      expect(store.state.tabs[0].displayMode).toBe('split')
+      dispose()
+    })
+  })
+
   it('moveTabToTile with only one tab in source tile should set active to null', () => {
     createRoot((dispose) => {
       const store = createTabStore()

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -56,6 +56,7 @@ CREATE TABLE workers (
     status        INTEGER NOT NULL DEFAULT 1,
     created_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_seen_at  DATETIME,
+    home_dir      TEXT NOT NULL DEFAULT '',
     UNIQUE(org_id, name)
 );
 CREATE INDEX idx_workers_org_id ON workers(org_id);
@@ -81,6 +82,7 @@ CREATE TABLE worker_registrations (
     os          TEXT NOT NULL DEFAULT '',
     arch        TEXT NOT NULL DEFAULT '',
     version     TEXT NOT NULL DEFAULT '',
+    home_dir    TEXT NOT NULL DEFAULT '',
     status      INTEGER NOT NULL DEFAULT 1,
     worker_id   TEXT REFERENCES workers(id) ON DELETE SET NULL,
     approved_by TEXT REFERENCES users(id),

--- a/internal/hub/db/queries/registrations.sql
+++ b/internal/hub/db/queries/registrations.sql
@@ -1,6 +1,6 @@
 -- name: CreateRegistration :exec
-INSERT INTO worker_registrations (id, hostname, os, arch, version, expires_at)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT INTO worker_registrations (id, hostname, os, arch, version, home_dir, expires_at)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetRegistrationByID :one
 SELECT * FROM worker_registrations WHERE id = ?;

--- a/internal/hub/db/queries/workers.sql
+++ b/internal/hub/db/queries/workers.sql
@@ -1,6 +1,6 @@
 -- name: CreateWorker :exec
-INSERT INTO workers (id, org_id, name, hostname, os, arch, auth_token, registered_by)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO workers (id, org_id, name, hostname, os, arch, auth_token, registered_by, home_dir)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetWorkerByID :one
 SELECT * FROM workers WHERE id = ? AND org_id = ?;
@@ -63,3 +63,6 @@ WHERE w.org_id = ? AND w.created_by = ? AND w.is_deleted = 0;
 
 -- name: UpdateWorkerLastSeen :exec
 UPDATE workers SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?;
+
+-- name: UpdateWorkerHomeDir :exec
+UPDATE workers SET home_dir = ? WHERE id = ? AND home_dir != ?;

--- a/internal/hub/service/worker_mgmt_service.go
+++ b/internal/hub/service/worker_mgmt_service.go
@@ -81,6 +81,7 @@ func (s *WorkerManagementService) ApproveRegistration(
 		Arch:         reg.Arch,
 		AuthToken:    authToken,
 		RegisteredBy: user.ID,
+		HomeDir:      reg.HomeDir,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create worker: %w", err))
 	}
@@ -303,5 +304,6 @@ func (s *WorkerManagementService) workerToProto(b *db.Worker) *leapmuxv1.Worker 
 		CreatedAt:    timefmt.Format(b.CreatedAt),
 		LastSeenAt:   lastSeen,
 		RegisteredBy: b.RegisteredBy,
+		HomeDir:      b.HomeDir,
 	}
 }

--- a/internal/hub/service/workspace_service.go
+++ b/internal/hub/service/workspace_service.go
@@ -96,9 +96,9 @@ func (s *WorkspaceService) CreateWorkspace(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker is being deregistered"))
 	}
 
-	workingDir := req.Msg.GetWorkingDir()
+	workingDir := validate.SanitizePath(req.Msg.GetWorkingDir(), worker.HomeDir)
 	if workingDir == "" {
-		workingDir = "."
+		workingDir = validate.SanitizePath("~", worker.HomeDir)
 	}
 
 	// Create worktree if requested (before workspace DB insert so failures are clean).
@@ -194,7 +194,7 @@ func (s *WorkspaceService) CreateWorkspace(
 						slog.Warn("failed to set initial agent permission mode", "agent_id", agentID, "error", err)
 					}
 				}
-				if homeDir := resp.GetAgentStarted().GetHomeDir(); homeDir != "" {
+				if homeDir := validate.SanitizePath(resp.GetAgentStarted().GetHomeDir(), ""); homeDir != "" {
 					if err := s.queries.UpdateAgentHomeDir(ctx, db.UpdateAgentHomeDirParams{
 						HomeDir: homeDir,
 						ID:      agentID,

--- a/internal/hub/validate/path.go
+++ b/internal/hub/validate/path.go
@@ -1,0 +1,69 @@
+package validate
+
+import (
+	"path"
+	"strings"
+)
+
+// SanitizePath sanitizes a filesystem path.
+// It strips control characters, trims whitespace, rejects path traversal,
+// and normalizes the result. Empty input returns "".
+//
+// When homeDir is non-empty, tilde paths (~, ~/...) are expanded using it.
+// When homeDir is empty, tilde paths are rejected.
+//
+// Accepted forms:
+//   - Absolute paths: /home/user, /Users/john
+//   - Tilde paths (when homeDir is provided): ~, ~/projects
+//
+// Rejected forms:
+//   - Relative paths: home/user, ./foo
+//   - Path traversal: /home/../etc/passwd
+//   - Tilde paths (when homeDir is empty)
+//   - Empty or whitespace-only strings
+func SanitizePath(value, homeDir string) string {
+	// Strip control characters (< 0x20 and 0x7F).
+	var b strings.Builder
+	for _, r := range value {
+		if r < 0x20 || r == 0x7F {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	s := strings.TrimSpace(b.String())
+	if s == "" {
+		return ""
+	}
+
+	// Expand or reject tilde paths.
+	if s == "~" || strings.HasPrefix(s, "~/") {
+		if homeDir == "" {
+			return ""
+		}
+		if s == "~" {
+			s = homeDir
+		} else {
+			rest := strings.TrimLeft(s[2:], "/")
+			if rest == "" {
+				s = homeDir
+			} else {
+				s = homeDir + "/" + rest
+			}
+		}
+	}
+
+	// Must be absolute.
+	if !strings.HasPrefix(s, "/") {
+		return ""
+	}
+
+	// Reject path traversal before normalizing (Clean resolves ".." components).
+	for _, comp := range strings.Split(s, "/") {
+		if comp == ".." {
+			return ""
+		}
+	}
+
+	// Normalize.
+	return path.Clean(s)
+}

--- a/internal/hub/validate/path_test.go
+++ b/internal/hub/validate/path_test.go
@@ -1,0 +1,66 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		homeDir string
+		want    string
+	}{
+		// Absolute paths (homeDir irrelevant).
+		{"absolute path", "/home/user", "", "/home/user"},
+		{"absolute macOS", "/Users/john", "", "/Users/john"},
+		{"root path", "/", "", "/"},
+
+		// Tilde expansion with homeDir.
+		{"tilde alone", "~", "/home/user", "/home/user"},
+		{"tilde with slash", "~/", "/home/user", "/home/user"},
+		{"tilde subdir", "~/projects", "/home/user", "/home/user/projects"},
+		{"tilde nested", "~/projects/myapp", "/home/user", "/home/user/projects/myapp"},
+		{"tilde trailing slash", "~/projects/", "/home/user", "/home/user/projects"},
+		{"tilde double slashes", "~//projects", "/home/user", "/home/user/projects"},
+		{"tilde dot component", "~/./projects", "/home/user", "/home/user/projects"},
+
+		// Tilde rejected without homeDir.
+		{"tilde no homeDir", "~", "", ""},
+		{"tilde subdir no homeDir", "~/projects", "", ""},
+
+		// Empty and whitespace.
+		{"empty string", "", "", ""},
+		{"whitespace only", "   ", "", ""},
+
+		// Relative paths (rejected).
+		{"relative path", "home/user", "", ""},
+		{"dot-relative", "./foo", "", ""},
+		{"bare name", "foo", "", ""},
+
+		// Path traversal (rejected).
+		{"traversal mid", "/home/../etc/passwd", "", ""},
+		{"traversal end", "/home/user/..", "", ""},
+		{"traversal only", "/..", "", ""},
+		{"tilde traversal", "~/../etc/passwd", "/home/user", ""},
+
+		// Control character stripping.
+		{"control chars stripped", "/home/\x01user", "", "/home/user"},
+		{"control chars empty", "\x01\x02\x03", "", ""},
+		{"DEL stripped", "/home/\x7Fuser", "", "/home/user"},
+		{"tilde control chars", "~/\x01projects", "/home/user", "/home/user/projects"},
+
+		// Normalization.
+		{"trailing slash", "/home/user/", "", "/home/user"},
+		{"double slashes", "/home//user", "", "/home/user"},
+		{"dot components", "/home/./user", "", "/home/user"},
+		{"whitespace trimmed", "  /home/user  ", "", "/home/user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SanitizePath(tt.input, tt.homeDir))
+		})
+	}
+}

--- a/internal/worker/hub/client.go
+++ b/internal/worker/hub/client.go
@@ -230,9 +230,10 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 
 	// Send an initial heartbeat to trigger the Hub's bidi stream handler.
 	// ConnectRPC with gRPC protocol only sends HTTP/2 headers on the first Send().
+	homeDir, _ := os.UserHomeDir()
 	if err := stream.Send(&leapmuxv1.ConnectRequest{
 		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
-			Heartbeat: &leapmuxv1.Heartbeat{},
+			Heartbeat: &leapmuxv1.Heartbeat{HomeDir: homeDir},
 		},
 	}); err != nil {
 		return fmt.Errorf("initial heartbeat: %w", err)

--- a/internal/worker/hub/file_handlers.go
+++ b/internal/worker/hub/file_handlers.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (c *Client) handleFileBrowse(requestID string, req *leapmuxv1.FileBrowseRequest) {
-	path, entries, err := filebrowser.ListDirectory(req.GetPath())
+	path, entries, err := filebrowser.ListDirectory(req.GetPath(), int(req.GetMaxDepth()))
 	resp := &leapmuxv1.FileBrowseResponse{Path: path}
 
 	if err != nil {

--- a/internal/worker/hub/registration.go
+++ b/internal/worker/hub/registration.go
@@ -29,7 +29,7 @@ type RegistrationResult struct {
 // 3. Poll until the registration is approved or expires.
 //
 // If hubURL starts with "unix:", it creates a Unix domain socket transport automatically.
-func Register(ctx context.Context, hubURL, hostname, os, arch, version string) (*RegistrationResult, error) {
+func Register(ctx context.Context, hubURL, hostname, os, arch, version, homeDir string) (*RegistrationResult, error) {
 	var httpClient *http.Client
 	connectURL := hubURL
 	if strings.HasPrefix(hubURL, "unix:") {
@@ -44,13 +44,13 @@ func Register(ctx context.Context, hubURL, hostname, os, arch, version string) (
 		connectURL,
 		connect.WithGRPC(),
 	)
-	return registerWithClient(ctx, client, hubURL, hostname, os, arch, version, newDefaultBackoff())
+	return registerWithClient(ctx, client, hubURL, hostname, os, arch, version, homeDir, newDefaultBackoff())
 }
 
 func registerWithClient(
 	ctx context.Context,
 	client leapmuxv1connect.WorkerConnectorServiceClient,
-	hubURL, hostname, os, arch, version string,
+	hubURL, hostname, os, arch, version, homeDir string,
 	bo backoff.BackOff,
 ) (*RegistrationResult, error) {
 	// Step 1: Request registration with retry.
@@ -63,6 +63,7 @@ func registerWithClient(
 				Os:       os,
 				Arch:     arch,
 				Version:  version,
+				HomeDir:  homeDir,
 			},
 		))
 		if err == nil {

--- a/internal/worker/hub/registration_test.go
+++ b/internal/worker/hub/registration_test.go
@@ -64,7 +64,7 @@ func TestRegisterWithClient_RetriesUntilHubAvailable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "test-host", "linux", "amd64", "0.0.1", newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "test-host", "linux", "amd64", "0.0.1", "/home/test", newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(failCount+1), attempts.Load(), "RequestRegistration call count")
@@ -91,7 +91,7 @@ func TestRegisterWithClient_StopsOnContextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	_, err := registerWithClient(ctx, mock, "http://localhost:0", "test-host", "linux", "amd64", "0.0.1", newFastBackoff())
+	_, err := registerWithClient(ctx, mock, "http://localhost:0", "test-host", "linux", "amd64", "0.0.1", "/home/test", newFastBackoff())
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.GreaterOrEqual(t, attempts.Load(), int32(1), "expected at least 1 attempt")
 }
@@ -128,7 +128,7 @@ func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", bo)
+	_, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", "/home/test", bo)
 	require.NoError(t, err, "registerWithClient failed")
 
 	// Verify gaps between retries are increasing.
@@ -169,7 +169,7 @@ func TestRegisterWithClient_LongPollPendingThenApproved(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", "/home/test", newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(3), pollCount.Load(), "PollRegistration call count")
@@ -205,7 +205,7 @@ func TestRegisterWithClient_PollErrorRetries(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "h", "linux", "amd64", "0.0.1", "/home/test", newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(2), pollCount.Load(), "PollRegistration call count")

--- a/proto/leapmux/v1/file.proto
+++ b/proto/leapmux/v1/file.proto
@@ -17,6 +17,7 @@ message ListDirectoryRequest {
   string worker_id = 1;
   string path = 2;
   string org_id = 3;
+  int32 max_depth = 4; // When > 0, merge single-child directories server-side up to this depth
 }
 
 message ListDirectoryResponse {

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -39,6 +39,7 @@ message RequestRegistrationRequest {
   string os = 2;
   string arch = 3;
   string version = 4;
+  string home_dir = 5;
 }
 
 message RequestRegistrationResponse {
@@ -153,6 +154,7 @@ message Worker {
   string created_at = 8;
   string last_seen_at = 9;
   string registered_by = 10;
+  string home_dir = 11;          // Worker's home directory for tilde path display
 }
 
 // --- Bidirectional stream envelope messages ---
@@ -360,6 +362,7 @@ message ShellListResponse {
 
 message FileBrowseRequest {
   string path = 1;
+  int32 max_depth = 2; // When > 0, merge single-child directories server-side up to this depth
 }
 
 message FileBrowseResponse {
@@ -471,4 +474,5 @@ message HubShuttingDownNotification {
 
 message Heartbeat {
   int64 timestamp_ms = 1;
+  string home_dir = 2;           // Worker's home directory (sent with first heartbeat)
 }

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -36,6 +36,7 @@ enum TabType {
   TAB_TYPE_UNSPECIFIED = 0;
   TAB_TYPE_AGENT = 1;
   TAB_TYPE_TERMINAL = 2;
+  TAB_TYPE_FILE = 3; // Ephemeral file viewer tab (not persisted to backend)
 }
 
 // --- Workspace CRUD ---


### PR DESCRIPTION
## Motivation

Users had no way to view files directly in the UI — clicking a file in the
directory tree opened nothing. Additionally, all file, git, and terminal
service operations accepted raw path strings without sanitization, creating
exposure to path traversal attacks and control character injection. There was
also no support for tilde paths (`~`, `~/projects`), which are natural to use
but were silently invalid.

## Modifications

**File Viewer (frontend)**

- Added a new `FileViewer` component suite that automatically detects the
  appropriate view mode from file extension and content:
  - `TextFileView` — syntax-highlighted text with line numbers
  - `MarkdownFileView` — rendered markdown with a source/render toggle
  - `ImageFileView` — interactive image viewer with zoom toolbar (zoom in/out,
    fit-to-view, 100%) and trackpad pinch-to-zoom (ctrl+scroll) that preserves
    the point under the cursor
  - `HexView` — virtualized hex dump with offset, bytes, and ASCII columns for
    binary files
- SVG files gain a render/source/split view toggle so the rendered graphic and
    its source can be inspected side by side
- Added `detectFileViewMode()`, `isImageExtension()`, `isMarkdownExtension()`,
  `isSvgExtension()`, and `isBinaryContent()` utilities in `fileType.ts`
- Extended the tab store with `filePath` and `displayMode` fields and a new
  `setTabDisplayMode()` method so display preferences persist per file tab
- Added `TAB_TYPE_FILE` to the `TabType` proto enum for ephemeral file viewer
  tabs that are not persisted to the backend
- Integrated `FileViewer` into `AppShell`; clicking a file in the directory
  tree opens it in a new FILE tab with deduplication

**Directory Tree**

- Added `onFileOpen` callback to `DirectoryTree` so file clicks propagate to
  the shell
- Refactored directory collapsing to use the new server-side `maxDepth: 5`
  parameter, eliminating client-side recursive merging

**Path Sanitization and Home Directory (backend)**

- Introduced `validate.SanitizePath(value, homeDir string)` to centrally
  validate and normalize filesystem paths: strips control characters, trims
  whitespace, expands tilde paths when `homeDir` is provided, rejects relative
  paths and path traversal (`..` components), and normalizes the result
- Added `home_dir` field to the `Worker` and `WorkerRegistration` database
  tables, proto messages, and registration/heartbeat APIs so the worker's home
  directory is available server-side
- Applied `SanitizePath` to all incoming paths in `FileService`, `GitService`,
  and `TerminalService`
- Added `maxDepth` parameter to `FileBrowseRequest` proto and implemented
  recursive single-child directory merging server-side in `ListDirectory()`
- Propagated `homeDir` through the UI (`NewAgentDialog`, `NewTerminalDialog`,
  sidebar components) and added a `tildify()` utility to display paths relative
  to the home directory

**E2E Tests**

- Extracted shared helpers `sendMessage()`, `waitForControlBanner()`, and
  `waitForAgentIdle()` into `helpers.ts` to reduce duplication across test files
- Split plan mode test workflows into two sequential prompts to improve LLM
  reliability and eliminate race conditions
- Added unit tests for `HexView`, `ImageToolbar`, `fileType` utilities, and tab
  store changes

**Breaking changes / notable behavior changes**

- Paths containing `..` components, control characters, or relative segments
  are now rejected by all file, git, and terminal operations
- Tilde paths are now accepted in file and terminal operations when the worker
  has a registered home directory

## Result

- Clicking a file in the directory tree now opens it in a dedicated tab with
  the appropriate viewer selected automatically
- Images can be zoomed interactively with the toolbar or by pinching on a
  trackpad; the zoom point stays under the cursor
- SVG files can be inspected in a side-by-side render/source split view
- Binary files are displayed as a hex dump instead of garbled text
- Path traversal attacks (e.g., `../../etc/passwd`) and control character
  injection are now blocked at the service layer for all file, git, and terminal
  operations
- Tilde paths such as `~/projects/myapp` now work in file browsing and terminal
  sessions
- The directory tree now collapses long single-child chains server-side,
  reducing the number of round-trip RPC calls needed to render a deep tree

🤖 Generated with Claude Code
