### PR TITLE
Fix multiple UI bugs and make default effort level configurable

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -177,9 +177,16 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
     }
   }))
 
+  // Memoize the active request ID so that the effect below only fires when
+  // the value actually changes. Without this, reactive store updates
+  // (e.g. controlStore.clearAgent during WebSocket reconnect) re-trigger the
+  // deps function even when the result is the same `undefined`, causing
+  // hasContent to be reset and disabling the send button after page refresh.
+  const activeRequestId = createMemo(() => activeControlRequest()?.requestId)
+
   // Reset AskUserQuestion state when the active request changes.
   createEffect(on(
-    () => activeControlRequest()?.requestId,
+    activeRequestId,
     (requestId) => {
       if (requestId && props.agentId) {
         const key = `leapmux-ask-state-${props.agentId}-${requestId}`

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -233,23 +233,32 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   // Observe size changes on both the scroll container (editor/window resize)
   // and the content wrapper (silent DOM mutations like expand/collapse).
+  // Defer scroll adjustments to a rAF to avoid "ResizeObserver loop completed
+  // with undelivered notifications" errors when collapsing large elements.
   onMount(() => {
+    let resizeRafId = 0
     const handleResize = () => {
-      if (!messageListRef || scrollAnimationId !== null || autoScrollPending)
-        return
-      if (atBottom()) {
-        messageListRef.scrollTop = messageListRef.scrollHeight
-      }
-      else {
-        checkAtBottom()
-      }
+      cancelAnimationFrame(resizeRafId)
+      resizeRafId = requestAnimationFrame(() => {
+        if (!messageListRef || scrollAnimationId !== null || autoScrollPending)
+          return
+        if (atBottom()) {
+          messageListRef.scrollTop = messageListRef.scrollHeight
+        }
+        else {
+          checkAtBottom()
+        }
+      })
     }
     const observer = new ResizeObserver(handleResize)
     if (messageListRef)
       observer.observe(messageListRef)
     if (contentRef)
       observer.observe(contentRef)
-    onCleanup(() => observer.disconnect())
+    onCleanup(() => {
+      cancelAnimationFrame(resizeRafId)
+      observer.disconnect()
+    })
   })
 
   return (

--- a/frontend/src/components/chat/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/MarkdownEditor.css.ts
@@ -192,23 +192,29 @@ globalStyle(`${editorWrapper} .ProseMirror`, {
   wordWrap: 'break-word',
 })
 
-// Code blocks need relative positioning for the language label
+// Code blocks: move horizontal scroll from <pre> to <code> so the
+// language label can be absolutely positioned without scrolling away.
 globalStyle(`${editorWrapper} .ProseMirror pre`, {
   position: 'relative',
+  overflowX: 'visible',
 })
 
-// Code block language label -- uses sticky + float to stay at top-right during horizontal scroll
+globalStyle(`${editorWrapper} .ProseMirror pre code`, {
+  display: 'block',
+  overflowX: 'auto',
+})
+
+// Code block language label -- absolutely positioned at top-right of <pre>
 globalStyle(`${editorWrapper} .ProseMirror pre .code-lang-label`, {
-  position: 'sticky',
-  float: 'right',
+  position: 'absolute',
   right: '4px',
+  top: '4px',
   fontSize: 'var(--text-8)',
   color: 'var(--faint-foreground)',
   cursor: 'pointer',
   padding: '1px 4px',
   borderRadius: 'var(--radius-small)',
   userSelect: 'none',
-  marginBottom: '-1.5em',
   zIndex: 1,
 })
 

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -99,7 +99,7 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
           onClick={handleReject}
           data-testid="plan-reject-btn"
         >
-          Send Feedback
+          {props.hasEditorContent ? 'Send Feedback' : 'Reject'}
         </button>
         <Show when={!props.hasEditorContent}>
           <ButtonGroup>

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -48,34 +48,32 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
   }
 
   return (
-    <Show
-      when={!props.hasEditorContent}
-      fallback={(
-        <button
-          class="outline"
-          onClick={handleDeny}
-          data-testid="control-deny-btn"
-        >
-          Send Feedback
-        </button>
-      )}
-    >
-      <ButtonGroup>
-        <button
-          onClick={handleAllow}
-          data-testid="control-allow-btn"
-        >
-          Allow
-        </button>
-        <button
-          data-variant="secondary"
-          onClick={handleBypassPermissions}
-          data-testid="control-bypass-btn"
-          title="Allow this request and stop asking for permissions"
-        >
-          & Bypass Permissions
-        </button>
-      </ButtonGroup>
-    </Show>
+    <>
+      <button
+        class="outline"
+        onClick={handleDeny}
+        data-testid="control-deny-btn"
+      >
+        {props.hasEditorContent ? 'Send Feedback' : 'Reject'}
+      </button>
+      <Show when={!props.hasEditorContent}>
+        <ButtonGroup>
+          <button
+            onClick={handleAllow}
+            data-testid="control-allow-btn"
+          >
+            Allow
+          </button>
+          <button
+            data-variant="secondary"
+            onClick={handleBypassPermissions}
+            data-testid="control-bypass-btn"
+            title="Allow this request and stop asking for permissions"
+          >
+            & Bypass Permissions
+          </button>
+        </ButtonGroup>
+      </Show>
+    </>
   )
 }

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -192,7 +192,7 @@ function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderCo
                   : <Hand size={16} class={toolUseIcon} />}
               </span>
               <span class={toolInputDetail}>
-                {cr().action === 'approved' ? 'Approved' : 'Rejected'}
+                {cr().action === 'approved' ? 'Approved' : cr().comment ? 'Sent feedback' : 'Rejected'}
               </span>
             </div>
             <Show when={cr().action !== 'approved' && cr().comment}>

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -226,7 +226,7 @@ export const controlResponseRenderer: MessageContentRenderer = {
       return (
         <div class={controlResponseMessage}>
           <div>
-            <div>Rejected:</div>
+            <div>Sent feedback:</div>
             <div class={markdownContent} innerHTML={renderMarkdown(comment)} />
           </div>
         </div>

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -16,8 +16,18 @@ export const LoginPage: Component = () => {
   const [password, setPassword] = createSignal('')
   const [submitting, setSubmitting] = createSignal(false)
   const [signupEnabled, setSignupEnabled] = createSignal(false)
+  let usernameRef!: HTMLInputElement
+  let passwordRef!: HTMLInputElement
 
   onMount(async () => {
+    // Focus the first empty input field (username if both empty).
+    if (!usernameRef.value) {
+      usernameRef.focus()
+    }
+    else if (!passwordRef.value) {
+      passwordRef.focus()
+    }
+
     try {
       const resp = await authClient.getSystemInfo({})
       setSignupEnabled(resp.signupEnabled)
@@ -59,6 +69,7 @@ export const LoginPage: Component = () => {
           <label>
             Username
             <input
+              ref={usernameRef}
               type="text"
               value={username()}
               onInput={e => setUsername(e.currentTarget.value)}
@@ -68,6 +79,7 @@ export const LoginPage: Component = () => {
           <label>
             Password
             <input
+              ref={passwordRef}
               type="password"
               value={password()}
               onInput={e => setPassword(e.currentTarget.value)}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -367,7 +367,8 @@ export const AppShell: ParentComponent = (props) => {
       return { workerId: agent?.workerId ?? '', workingDir: agent?.workingDir ?? '', homeDir: agent?.homeDir ?? '' }
     }
     else if (tab.type === TabType.FILE) {
-      const dir = tab.filePath ? tab.filePath.substring(0, tab.filePath.lastIndexOf('/')) || '/' : ''
+      // Use the stored working directory from the originating tab, not the file's directory.
+      const dir = tab.workingDir || (tab.filePath ? tab.filePath.substring(0, tab.filePath.lastIndexOf('/')) || '/' : '')
       // Find homeDir from any agent on the same worker
       const homeDir = agentStore.state.agents.find(a => a.workerId === tab.workerId)?.homeDir ?? ''
       return { workerId: tab.workerId ?? '', workingDir: dir, homeDir }
@@ -855,6 +856,7 @@ export const AppShell: ParentComponent = (props) => {
       id: tabId,
       filePath: path,
       workerId: ctx.workerId,
+      workingDir: ctx.workingDir,
       title: fileName,
       tileId,
     })

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -332,6 +332,23 @@ describe('extractAssistantUsage', () => {
     const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
     expect(extractAssistantUsage(parseMessageContent(msg))).toBeNull()
   })
+
+  it('returns null for subagent messages with parent_tool_use_id', () => {
+    const content = {
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_abc123',
+      total_cost_usd: 0.03,
+      message: {
+        usage: {
+          input_tokens: 500,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 100,
+        },
+      },
+    }
+    const msg = makeMsg(MessageRole.ASSISTANT, wrap(content))
+    expect(extractAssistantUsage(parseMessageContent(msg))).toBeNull()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -367,6 +384,20 @@ describe('extractResultMetadata', () => {
     const content = { type: 'result', subtype: 'turn_end' }
     const msg = makeMsg(MessageRole.RESULT, wrap(content))
     expect(extractResultMetadata(parseMessageContent(msg))).toEqual({ subtype: 'turn_end' })
+  })
+
+  it('returns null for subagent results with parent_tool_use_id', () => {
+    const content = {
+      type: 'result',
+      subtype: 'turn_end',
+      parent_tool_use_id: 'toolu_abc123',
+      total_cost_usd: 0.05,
+      modelUsage: {
+        'claude-sonnet': { contextWindow: 200000 },
+      },
+    }
+    const msg = makeMsg(MessageRole.RESULT, wrap(content))
+    expect(extractResultMetadata(parseMessageContent(msg))).toBeNull()
   })
 })
 

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -141,6 +141,9 @@ export function extractAssistantUsage(parsed: ParsedMessageContent): {
   const inner = getInnerMessage(parsed)
   if (!inner)
     return null
+  // Skip subagent messages — their usage is already included in the parent's totals.
+  if (inner.parent_tool_use_id)
+    return null
   const usage = (inner.message as Record<string, unknown> | undefined)?.usage as
     Record<string, unknown> | undefined
   if (!usage)
@@ -167,6 +170,9 @@ export function extractResultMetadata(parsed: ParsedMessageContent): {
 } | null {
   const inner = getInnerMessage(parsed)
   if (!inner)
+    return null
+  // Skip subagent messages — their usage is already included in the parent's totals.
+  if (inner.parent_tool_use_id)
     return null
 
   const result: { subtype?: string, contextWindow?: number, totalCostUsd?: number } = {}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 import { spin } from '~/styles/animations.css'
 import { spacing } from '~/styles/tokens'
 
@@ -94,6 +94,36 @@ export const dialogStandard = style({
 
 export const dialogCompact = style({
   maxWidth: '400px',
+  height: '80vh',
+})
+
+// Make dialog forms use flex layout so the tree container can fill remaining space.
+globalStyle(`${dialogCompact} > form`, {
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  flex: 1,
+  minHeight: 0,
+})
+
+globalStyle(`${dialogCompact} > form > section`, {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
+})
+
+globalStyle(`${dialogCompact} > form > section > .vstack`, {
+  flex: 1,
+  minHeight: 0,
+})
+
+// The label wrapping the DirectoryTree needs to grow and use flex layout.
+globalStyle(`${dialogCompact} > form > section > .vstack > label:has(.${treeContainer})`, {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
 })
 
 // Dialog form utilities
@@ -128,7 +158,8 @@ export const spinning = style({
 })
 
 export const treeContainer = style({
-  height: '250px',
+  flex: 1,
+  minHeight: 0,
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
   overflow: 'hidden',

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -118,14 +118,6 @@ globalStyle(`${dialogCompact} > form > section > .vstack`, {
   minHeight: 0,
 })
 
-// The label wrapping the DirectoryTree needs to grow and use flex layout.
-globalStyle(`${dialogCompact} > form > section > .vstack > label:has(.${treeContainer})`, {
-  display: 'flex',
-  flexDirection: 'column',
-  flex: 1,
-  minHeight: 0,
-})
-
 // Dialog form utilities
 
 export const labelRow = style({
@@ -163,6 +155,14 @@ export const treeContainer = style({
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
   overflow: 'hidden',
+})
+
+// The label wrapping the DirectoryTree needs to grow and use flex layout.
+globalStyle(`${dialogCompact} > form > section > .vstack > label:has(.${treeContainer})`, {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
 })
 
 // Worktree options

--- a/frontend/src/utils/controlResponse.ts
+++ b/frontend/src/utils/controlResponse.ts
@@ -64,7 +64,7 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermiss
 
 /** Default model and effort level for new agents. */
 export const DEFAULT_MODEL = import.meta.env.LEAPMUX_DEFAULT_MODEL || 'opus'
-export const DEFAULT_EFFORT = 'high'
+export const DEFAULT_EFFORT = import.meta.env.LEAPMUX_DEFAULT_EFFORT || 'high'
 
 /** Display labels for permission modes, models, and effort levels. */
 export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {

--- a/frontend/tests/e2e/25-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/25-no-worker-settings.spec.ts
@@ -98,11 +98,11 @@ test.describe('Settings and /clear without Worker', () => {
       await waitForNotification('Model (Sonnet \u2192 Haiku)')
       await waitForSettingsIdle()
 
-      // Step 6: Change effort (High → Medium)
+      // Step 6: Change effort (Low → Medium, default overridden via LEAPMUX_DEFAULT_EFFORT in e2e)
       await openSettingsMenu()
       await page.locator('[data-testid="effort-medium"]').click()
 
-      await waitForNotification('Effort (High \u2192 Medium)')
+      await waitForNotification('Effort (Low \u2192 Medium)')
 
       // Step 7: Send /clear
       await editor.click()

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -65,7 +65,7 @@ export const test = base.extend<
       dataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet' },
+      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet', LEAPMUX_DEFAULT_EFFORT: 'low' },
     })
 
     // Drain stdout/stderr

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -203,7 +203,7 @@ export async function restartHub(serverInfo: SeparateServerInfo) {
     hubDataDir,
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet' },
+    env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet', LEAPMUX_DEFAULT_EFFORT: 'low' },
   })
 
   hubProc.stdout?.resume()
@@ -264,7 +264,7 @@ export const processTest = base.extend<
       hubDataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet' },
+      env: { ...process.env, LEAPMUX_DEFAULT_MODEL: 'sonnet', LEAPMUX_DEFAULT_EFFORT: 'low' },
     })
     hubProc.stdout?.resume()
     hubProc.stderr?.resume()

--- a/frontend/tests/unit/components/GenericToolControl.test.tsx
+++ b/frontend/tests/unit/components/GenericToolControl.test.tsx
@@ -23,7 +23,7 @@ function makeAskState(): AskQuestionState {
 }
 
 describe('genericToolActions', () => {
-  it('shows Allow and Bypass Permissions when no editor content', () => {
+  it('shows Reject, Allow, and Bypass Permissions when no editor content', () => {
     render(() => (
       <GenericToolActions
         request={makeRequest()}
@@ -35,12 +35,13 @@ describe('genericToolActions', () => {
       />
     ))
 
+    expect(screen.getByTestId('control-deny-btn')).toBeTruthy()
+    expect(screen.getByTestId('control-deny-btn').textContent).toBe('Reject')
     expect(screen.getByTestId('control-allow-btn')).toBeTruthy()
     expect(screen.getByTestId('control-bypass-btn')).toBeTruthy()
-    expect(screen.queryByTestId('control-deny-btn')).toBeNull()
   })
 
-  it('shows only Deny when editor has content', () => {
+  it('shows only Send Feedback when editor has content', () => {
     render(() => (
       <GenericToolActions
         request={makeRequest()}
@@ -53,6 +54,7 @@ describe('genericToolActions', () => {
     ))
 
     expect(screen.getByTestId('control-deny-btn')).toBeTruthy()
+    expect(screen.getByTestId('control-deny-btn').textContent).toBe('Send Feedback')
     expect(screen.queryByTestId('control-allow-btn')).toBeNull()
     expect(screen.queryByTestId('control-bypass-btn')).toBeNull()
   })

--- a/internal/hub/service/agent_plan_mode.go
+++ b/internal/hub/service/agent_plan_mode.go
@@ -285,6 +285,7 @@ func (s *AgentService) trackPlanFilePath(ctx context.Context, agentID string, co
 		// If the title changed and auto-rename applies, also update the
 		// agent's display title atomically.
 		shouldAutoRename := newPlanTitle != "" &&
+			newPlanTitle != agent.Title &&
 			(agent.Title == agent.PlanTitle ||
 				regexp.MustCompile(`^Agent \d+$`).MatchString(agent.Title))
 		if shouldAutoRename {

--- a/internal/hub/service/helpers.go
+++ b/internal/hub/service/helpers.go
@@ -19,10 +19,9 @@ import (
 // Configurable via LEAPMUX_DEFAULT_MODEL environment variable.
 var DefaultModel = getEnvOrDefault("LEAPMUX_DEFAULT_MODEL", "opus")
 
-const (
-	// DefaultEffort is the effort level used when none is specified.
-	DefaultEffort = "high"
-)
+// DefaultEffort is the effort level used when none is specified.
+// Configurable via LEAPMUX_DEFAULT_EFFORT environment variable.
+var DefaultEffort = getEnvOrDefault("LEAPMUX_DEFAULT_EFFORT", "high")
 
 func getEnvOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {


### PR DESCRIPTION
## Motivation

Several user-facing bugs have accumulated across the chat UI, editor panel,
and backend cost tracking that degrade the day-to-day experience. Additionally,
operators deploying Leapmux have no way to change the default effort level
without modifying source code, making it difficult to tune the default behavior
for different environments.

## Modifications

**Bug fixes:**

- `AgentEditorPanel`: Memoize the active request ID so reactive store updates
  during WebSocket reconnect no longer reset `hasContent`, which was disabling
  the Send button after a page refresh with a draft already in the editor.
- `ChatView`: Defer scroll adjustments triggered by `ResizeObserver` to
  `requestAnimationFrame` to eliminate "ResizeObserver loop completed with
  undelivered notifications" errors when large chat elements collapse.
- `MarkdownEditor`: Move the horizontal scroll container from `<pre>` to
  `<code>` so the language label stays pinned at the top-right of a code block
  instead of scrolling away with the content.
- `GenericToolControl` / `ExitPlanModeControl`: Change Reject/Send Feedback
  button labels dynamically — show "Reject" when the editor is empty and
  "Send Feedback" when there is content. Chat history displays "Sent feedback"
  for rejected requests that included a comment.
- `LoginPage`: Auto-focus the first empty input field on mount so users can
  start typing immediately without clicking.
- `AppShell`: Store and pass the originating tab's working directory when
  opening file tabs, instead of incorrectly deriving it from the file path.
- `shared.css.ts`: Use flexbox layout for dialog forms so `DirectoryTree` fills
  the remaining dialog space dynamically rather than being capped at a fixed
  250 px height.
- `agent_plan_mode.go`: Skip emitting an `agent_renamed` notification when the
  new plan title is identical to the current title, preventing spurious updates.
- `messageParser.ts`: Add `parent_tool_use_id` checks in
  `extractAssistantUsage()` and `extractResultMetadata()` to exclude subagent
  messages from context usage and cost totals, preventing double-counting.

**New feature:**

- Make the default effort level configurable via the `LEAPMUX_DEFAULT_EFFORT`
  environment variable (backend `helpers.go`) and expose it to the frontend
  through `controlResponse.ts`. The built-in default remains `high`.

**Tests:**

- Added unit tests in `messageParser.test.ts` verifying that subagent messages
  are correctly excluded from usage and metadata extraction.
- Updated e2e test fixtures to set `LEAPMUX_DEFAULT_EFFORT=low` and adjusted
  effort-change expectations accordingly.

## Result

- The Send button no longer becomes disabled unexpectedly after a page refresh
  when draft content is present.
- The "ResizeObserver loop" console error no longer appears when chat messages
  collapse or expand.
- Long lines in code blocks scroll horizontally as expected; the language label
  remains visible at the top-right corner at all times.
- The Reject/Send Feedback button label reflects whether the user has typed a
  comment, making the action clearer.
- The login page is immediately ready for keyboard input without requiring a
  mouse click.
- File tabs correctly inherit the working directory of the tab they were opened
  from.
- The directory picker dialog resizes naturally to fill available space.
- Context usage and cost totals shown in the session info popover no longer
  inflate when subagents are active.
- Operators can now set `LEAPMUX_DEFAULT_EFFORT=low` (or any valid effort level)
  in their deployment environment to change the effort default without code
  changes.

🤖 Generated with Claude Code
