### PR TITLE
Add quote selection, reply button, and @mention support

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -13,12 +13,13 @@ import Dot from 'lucide-solid/icons/dot'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import SendHorizontal from 'lucide-solid/icons/send-horizontal'
 import Square from 'lucide-solid/icons/square'
-import { createEffect, createMemo, createSignal, createUniqueId, For, on, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, createUniqueId, For, on, onCleanup, onMount, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { clearDraft } from '~/lib/editor/draftPersistence'
 import { formatRateLimitSummary, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_POPOVER_LABELS } from '~/lib/rateLimitUtils'
 import { safeGetJson, safeGetString, safeRemoveItem, safeSetJson, safeSetString } from '~/lib/safeStorage'
+import { registerEditorRef, unregisterEditorRef } from '~/stores/editorRef.store'
 import { interruptPulse, spinner } from '~/styles/animations.css'
 import { iconSize } from '~/styles/tokens'
 import { buildAllowResponse, buildDenyResponse, DEFAULT_EFFORT, DEFAULT_MODEL, EFFORT_LABELS, getToolName, MODEL_LABELS, PERMISSION_MODE_LABELS } from '~/utils/controlResponse'
@@ -131,6 +132,34 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
 
   // Editor content ref for programmatic get/set of editor markdown.
   let editorContentRef: EditorContentRef | undefined
+  let editorFocusFn: (() => void) | undefined
+
+  // Track the agent ID for which the editor ref is registered.  props.agentId
+  // is a reactive getter that may return null/undefined at cleanup time (e.g.
+  // when the <Show> that controls this component unmounts because the focused
+  // agent changed), so we must track the registered ID non-reactively.
+  let registeredAgentId: string | null = null
+
+  // Register/unregister editor refs with the global registry.
+  onMount(() => {
+    onCleanup(() => {
+      if (registeredAgentId) {
+        unregisterEditorRef(registeredAgentId)
+        registeredAgentId = null
+      }
+    })
+  })
+  createEffect(on(() => props.agentId, (agentId, prevAgentId) => {
+    if (prevAgentId) {
+      unregisterEditorRef(prevAgentId)
+      if (registeredAgentId === prevAgentId)
+        registeredAgentId = null
+    }
+    if (editorContentRef && editorFocusFn) {
+      registerEditorRef(agentId, { get: editorContentRef.get, set: editorContentRef.set, focus: editorFocusFn })
+      registeredAgentId = agentId
+    }
+  }))
 
   // Track previous non-plan mode for Shift+Tab toggling.
   let previousNonPlanMode: PermissionMode = 'default'
@@ -628,9 +657,20 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           }}
           sendRef={(fn) => { triggerSend = fn }}
           focusRef={(fn) => {
+            editorFocusFn = fn
             props.focusRef?.(fn)
+            if (editorContentRef) {
+              registerEditorRef(props.agentId, { get: editorContentRef.get, set: editorContentRef.set, focus: fn })
+              registeredAgentId = props.agentId
+            }
           }}
-          contentRef={(get, set) => { editorContentRef = { get, set } }}
+          contentRef={(get, set) => {
+            editorContentRef = { get, set }
+            if (editorFocusFn) {
+              registerEditorRef(props.agentId, { get, set, focus: editorFocusFn })
+              registeredAgentId = props.agentId
+            }
+          }}
           placeholder={isAskUserQuestion() ? 'Type a custom answer...' : activeControlRequest() ? 'Type a rejection reason...' : undefined}
           allowEmptySend={!!activeControlRequest() && !isAskUserQuestion()}
           banner={

--- a/frontend/src/components/chat/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/MarkdownEditor.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { codeBlockCode, codeBlockPre } from '~/styles/codeBlock'
 import { iconSize, spacing } from '~/styles/tokens'
 
 export const headingPreviewItem = style({
@@ -192,17 +193,9 @@ globalStyle(`${editorWrapper} .ProseMirror`, {
   wordWrap: 'break-word',
 })
 
-// Code blocks: move horizontal scroll from <pre> to <code> so the
-// language label can be absolutely positioned without scrolling away.
-globalStyle(`${editorWrapper} .ProseMirror pre`, {
-  position: 'relative',
-  overflowX: 'visible',
-})
-
-globalStyle(`${editorWrapper} .ProseMirror pre code`, {
-  display: 'block',
-  overflowX: 'auto',
-})
+// Code blocks: move scroll to <code> so the language label stays fixed.
+globalStyle(`${editorWrapper} .ProseMirror pre`, codeBlockPre('visible'))
+globalStyle(`${editorWrapper} .ProseMirror pre code`, codeBlockCode)
 
 // Code block language label -- absolutely positioned at top-right of <pre>
 globalStyle(`${editorWrapper} .ProseMirror pre .code-lang-label`, {

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -328,7 +328,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       return null
     return content
       .filter(c => c.type === 'text' || c.type === 'thinking')
-      .map(c => String(c.text || ''))
+      .map(c => String(c.type === 'thinking' ? (c as Record<string, unknown>).thinking || '' : c.text || ''))
       .join('\n')
       .trim() || null
   }

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -332,8 +332,28 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       .trim() || null
   }
 
+  // Extract user text for the quote button.
+  const extractUserText = (): string | null => {
+    const cat = category()
+    if (cat.kind !== 'user_text' && cat.kind !== 'user_content')
+      return null
+    const obj = parsed().parentObject
+    if (!obj)
+      return null
+    if (cat.kind === 'user_text') {
+      const msg = obj.message as Record<string, unknown> | undefined
+      if (typeof msg?.content === 'string')
+        return msg.content.trim() || null
+    }
+    if (cat.kind === 'user_content' && typeof obj.content === 'string')
+      return (obj.content as string).trim() || null
+    return null
+  }
+
+  const extractQuotableText = () => extractAssistantText() ?? extractUserText()
+
   const handleReply = () => {
-    const text = extractAssistantText()
+    const text = extractQuotableText()
     if (text && props.onReply) {
       props.onReply(formatChatQuote(text))
     }
@@ -376,7 +396,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
               onToggleThread={() => setThreadExpanded(prev => !prev)}
               onCopyJson={copyJson}
               jsonCopied={jsonCopied()}
-              onReply={extractAssistantText() ? handleReply : undefined}
+              onReply={extractQuotableText() ? handleReply : undefined}
             />
           </Show>
         </div>

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -103,6 +103,7 @@ interface MessageBubbleProps {
 export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   const prefs = usePreferences()
   const [jsonCopied, setJsonCopied] = createSignal(false)
+  const [markdownCopied, setMarkdownCopied] = createSignal(false)
   const [threadExpandedManual, setThreadExpandedManual] = createSignal<boolean | null>(null)
   let contentRef: HTMLDivElement | undefined
 
@@ -359,6 +360,15 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     }
   }
 
+  const copyMarkdown = async () => {
+    const text = extractQuotableText()
+    if (!text)
+      return
+    await navigator.clipboard.writeText(text)
+    setMarkdownCopied(true)
+    setTimeout(() => setMarkdownCopied(false), 2000)
+  }
+
   const rowClass = () => messageRowClass(category().kind, props.message.role)
   const bubbleClass = () => messageBubbleClass(category().kind, props.message.role)
 
@@ -397,6 +407,8 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
               onCopyJson={copyJson}
               jsonCopied={jsonCopied()}
               onReply={extractQuotableText() ? handleReply : undefined}
+              onCopyMarkdown={extractQuotableText() ? copyMarkdown : undefined}
+              markdownCopied={markdownCopied()}
             />
           </Show>
         </div>

--- a/frontend/src/components/chat/ReadResultView.tsx
+++ b/frontend/src/components/chat/ReadResultView.tsx
@@ -109,7 +109,7 @@ export function ReadResultView(props: {
             return t?.[index()] ?? null
           }
           return (
-            <div class={codeViewLine}>
+            <div class={codeViewLine} data-line-num={line.num}>
               <span
                 class={codeViewLineNumber}
                 style={{ width: lineNumWidth() }}

--- a/frontend/src/components/chat/markdownContent.css.ts
+++ b/frontend/src/components/chat/markdownContent.css.ts
@@ -1,14 +1,14 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { codeBlockCode, codeBlockPre } from '~/styles/codeBlock'
 import { iconSize, spacing } from '~/styles/tokens'
 
 export const markdownContent = style({
   wordBreak: 'break-word',
 })
 
-// Code blocks need relative positioning for the copy button
-globalStyle(`${markdownContent} pre`, {
-  position: 'relative',
-})
+// Code blocks: move scroll to <code> so the copy button stays fixed.
+globalStyle(`${markdownContent} pre`, codeBlockPre('hidden'))
+globalStyle(`${markdownContent} pre code`, codeBlockCode)
 
 // Shiki dual-theme support via CSS variables
 globalStyle(`${markdownContent} pre.shiki`, {

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { spacing } from '~/styles/tokens'
-import { toolHeaderActions, toolHeaderHiddenGroup } from './toolStyles.css'
+import { toolHeaderActions, toolHeaderTimestamp } from './toolStyles.css'
 
 export const messageBubble = style({
   position: 'relative',
@@ -136,14 +136,35 @@ globalStyle(`${messageRow}:has(.${resultDivider}) > .${toolHeaderActions}`, {
   position: 'absolute',
   right: 0,
   marginLeft: 0,
-  paddingLeft: 0,
 })
 
-// Inside messageRowEnd, place actions to the left of the bubble
+// Inside messageRowEnd, place actions to the left of the bubble in a 2-column grid (mirrored via RTL)
 globalStyle(`${messageRowEnd} > .${toolHeaderActions}`, {
   order: -1,
-  marginLeft: 0,
-  paddingLeft: 0,
+  paddingRight: spacing.xs,
+  display: 'grid',
+  gridTemplateColumns: 'auto auto',
+  direction: 'rtl',
+})
+
+// Reset direction on children so text inside buttons renders LTR
+globalStyle(`${messageRowEnd} > .${toolHeaderActions} > *`, {
+  direction: 'ltr',
+})
+
+// 2-column grid layout for assistant/thinking bubble actions so primary actions sit adjacent to the bubble
+globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions}`, {
+  display: 'grid',
+  gridTemplateColumns: 'auto auto',
+})
+
+// Add left padding to timestamps in assistant grid so they align with the icon button below
+globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
+  paddingLeft: spacing.xs,
+})
+
+// Add right padding to timestamps in user grid (mirrored) so they align with the icon button below
+globalStyle(`${messageRowEnd} > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
   paddingRight: spacing.xs,
 })
 
@@ -152,11 +173,10 @@ globalStyle(`${messageRowCenter} > .${toolHeaderActions}`, {
   position: 'absolute',
   right: 0,
   marginLeft: 0,
-  paddingLeft: 0,
 })
 
-// When hovering a message row, reveal the hidden button group
-globalStyle(`${messageRow}:hover .${toolHeaderHiddenGroup}, ${messageRowEnd}:hover .${toolHeaderHiddenGroup}, ${messageRowCenter}:hover .${toolHeaderHiddenGroup}`, {
+// When hovering a message row, reveal the actions
+globalStyle(`${messageRow}:hover .${toolHeaderActions}, ${messageRowEnd}:hover .${toolHeaderActions}, ${messageRowCenter}:hover .${toolHeaderActions}`, {
   opacity: 1,
 })
 

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { spacing } from '~/styles/tokens'
-import { toolHeaderActions, toolHeaderButtonHidden } from './toolStyles.css'
+import { toolHeaderActions, toolHeaderHiddenGroup } from './toolStyles.css'
 
 export const messageBubble = style({
   position: 'relative',
@@ -155,8 +155,8 @@ globalStyle(`${messageRowCenter} > .${toolHeaderActions}`, {
   paddingLeft: 0,
 })
 
-// When hovering a message row, reveal hidden toolbar buttons
-globalStyle(`${messageRow}:hover .${toolHeaderButtonHidden}, ${messageRowEnd}:hover .${toolHeaderButtonHidden}, ${messageRowCenter}:hover .${toolHeaderButtonHidden}`, {
+// When hovering a message row, reveal the hidden button group
+globalStyle(`${messageRow}:hover .${toolHeaderHiddenGroup}, ${messageRowEnd}:hover .${toolHeaderHiddenGroup}, ${messageRowCenter}:hover .${toolHeaderHiddenGroup}`, {
   opacity: 1,
 })
 

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -5,6 +5,7 @@ import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { diffLines } from 'diff'
+import ArrowUpLeft from 'lucide-solid/icons/arrow-up-left'
 import Bot from 'lucide-solid/icons/bot'
 import Braces from 'lucide-solid/icons/braces'
 import Check from 'lucide-solid/icons/check'
@@ -252,7 +253,7 @@ export function renderToolSubDetail(toolName: string, input: Record<string, unkn
   }
 }
 
-/** Actions area in tool header: Raw JSON copy + diff toggle + thread expander, all with tooltips. */
+/** Actions area in tool header: Reply + Raw JSON copy + diff toggle + thread expander, all with tooltips. */
 export function ToolHeaderActions(props: {
   /** ISO timestamp for relative time display. */
   createdAt?: string
@@ -269,6 +270,8 @@ export function ToolHeaderActions(props: {
   diffView?: DiffViewPreference
   /** Toggle diff view between unified and split. */
   onToggleDiffView?: () => void
+  /** Reply callback — when provided, shows a reply button. */
+  onReply?: () => void
 }): JSX.Element {
   const timestamp = () => props.updatedAt || props.createdAt
   return (
@@ -277,6 +280,16 @@ export function ToolHeaderActions(props: {
         <RelativeTime
           timestamp={timestamp()!}
           class={`${toolHeaderButtonHidden} ${toolHeaderTimestamp}`}
+        />
+      </Show>
+      <Show when={props.onReply}>
+        <IconButton
+          icon={ArrowUpLeft}
+          size="sm"
+          class={toolHeaderButtonHidden}
+          data-testid="message-reply"
+          onClick={() => props.onReply?.()}
+          title="Reply"
         />
       </Show>
       <Show when={props.onCopyJson}>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -5,7 +5,6 @@ import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { diffLines } from 'diff'
-import ArrowUpLeft from 'lucide-solid/icons/arrow-up-left'
 import Bot from 'lucide-solid/icons/bot'
 import Braces from 'lucide-solid/icons/braces'
 import Check from 'lucide-solid/icons/check'
@@ -19,6 +18,7 @@ import FolderSearch from 'lucide-solid/icons/folder-search'
 import Globe from 'lucide-solid/icons/globe'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
+import Quote from 'lucide-solid/icons/quote'
 import Rows2 from 'lucide-solid/icons/rows-2'
 import Search from 'lucide-solid/icons/search'
 import Terminal from 'lucide-solid/icons/terminal'
@@ -37,7 +37,7 @@ import { RelativeTime } from './RelativeTime'
 import {
   controlResponseTag,
   toolHeaderActions,
-  toolHeaderButtonHidden,
+  toolHeaderHiddenGroup,
   toolHeaderTimestamp,
   toolInputCode,
   toolInputDetail,
@@ -276,30 +276,30 @@ export function ToolHeaderActions(props: {
   const timestamp = () => props.updatedAt || props.createdAt
   return (
     <div class={toolHeaderActions} data-testid="message-toolbar">
-      <Show when={timestamp()}>
-        <RelativeTime
-          timestamp={timestamp()!}
-          class={`${toolHeaderButtonHidden} ${toolHeaderTimestamp}`}
-        />
-      </Show>
+      <div class={toolHeaderHiddenGroup}>
+        <Show when={timestamp()}>
+          <RelativeTime
+            timestamp={timestamp()!}
+            class={toolHeaderTimestamp}
+          />
+        </Show>
+        <Show when={props.onCopyJson}>
+          <IconButton
+            icon={props.jsonCopied ? Check : Braces}
+            size="sm"
+            data-testid="message-copy-json"
+            onClick={() => props.onCopyJson?.()}
+            title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
+          />
+        </Show>
+      </div>
       <Show when={props.onReply}>
         <IconButton
-          icon={ArrowUpLeft}
+          icon={Quote}
           size="sm"
-          class={toolHeaderButtonHidden}
-          data-testid="message-reply"
+          data-testid="message-quote"
           onClick={() => props.onReply?.()}
-          title="Reply"
-        />
-      </Show>
-      <Show when={props.onCopyJson}>
-        <IconButton
-          icon={props.jsonCopied ? Check : Braces}
-          size="sm"
-          class={toolHeaderButtonHidden}
-          data-testid="message-copy-json"
-          onClick={() => props.onCopyJson?.()}
-          title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
+          title="Quote"
         />
       </Show>
       <Show when={props.hasDiff && props.onToggleDiffView}>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -10,6 +10,7 @@ import Braces from 'lucide-solid/icons/braces'
 import Check from 'lucide-solid/icons/check'
 import ChevronsRight from 'lucide-solid/icons/chevrons-right'
 import Columns2 from 'lucide-solid/icons/columns-2'
+import Copy from 'lucide-solid/icons/copy'
 import FilePen from 'lucide-solid/icons/file-pen'
 import FilePlus from 'lucide-solid/icons/file-plus'
 import FileText from 'lucide-solid/icons/file-text'
@@ -37,7 +38,7 @@ import { RelativeTime } from './RelativeTime'
 import {
   controlResponseTag,
   toolHeaderActions,
-  toolHeaderHiddenGroup,
+
   toolHeaderTimestamp,
   toolInputCode,
   toolInputDetail,
@@ -272,27 +273,13 @@ export function ToolHeaderActions(props: {
   onToggleDiffView?: () => void
   /** Reply callback — when provided, shows a reply button. */
   onReply?: () => void
+  /** Copy markdown callback — when provided, shows a copy markdown button. */
+  onCopyMarkdown?: () => void
+  markdownCopied?: boolean
 }): JSX.Element {
   const timestamp = () => props.updatedAt || props.createdAt
   return (
     <div class={toolHeaderActions} data-testid="message-toolbar">
-      <div class={toolHeaderHiddenGroup}>
-        <Show when={timestamp()}>
-          <RelativeTime
-            timestamp={timestamp()!}
-            class={toolHeaderTimestamp}
-          />
-        </Show>
-        <Show when={props.onCopyJson}>
-          <IconButton
-            icon={props.jsonCopied ? Check : Braces}
-            size="sm"
-            data-testid="message-copy-json"
-            onClick={() => props.onCopyJson?.()}
-            title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
-          />
-        </Show>
-      </div>
       <Show when={props.onReply}>
         <IconButton
           icon={Quote}
@@ -300,6 +287,30 @@ export function ToolHeaderActions(props: {
           data-testid="message-quote"
           onClick={() => props.onReply?.()}
           title="Quote"
+        />
+      </Show>
+      <Show when={timestamp()}>
+        <RelativeTime
+          timestamp={timestamp()!}
+          class={toolHeaderTimestamp}
+        />
+      </Show>
+      <Show when={props.onCopyMarkdown}>
+        <IconButton
+          icon={props.markdownCopied ? Check : Copy}
+          size="sm"
+          data-testid="message-copy-markdown"
+          onClick={() => props.onCopyMarkdown?.()}
+          title={props.markdownCopied ? 'Copied' : 'Copy Markdown'}
+        />
+      </Show>
+      <Show when={props.onCopyJson}>
+        <IconButton
+          icon={props.jsonCopied ? Check : Braces}
+          size="sm"
+          data-testid="message-copy-json"
+          onClick={() => props.onCopyJson?.()}
+          title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
         />
       </Show>
       <Show when={props.hasDiff && props.onToggleDiffView}>

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -166,16 +166,6 @@ export const toolHeaderActions = style({
   display: 'flex',
   alignItems: 'center',
   gap: '2px',
-  marginLeft: 'auto',
-  paddingLeft: spacing.md,
-})
-
-// Group wrapper for buttons hidden by default and revealed on hover.
-// Animates as a single unit so all hidden buttons fade in/out together.
-export const toolHeaderHiddenGroup = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '2px',
   opacity: 0,
   transition: 'opacity 0.15s',
 })
@@ -189,9 +179,9 @@ export const toolHeaderTimestamp = style({
   lineHeight: 1,
 })
 
-// When hovering the actions area, reveal the hidden group
-globalStyle(`${toolHeaderActions}:hover .${toolHeaderHiddenGroup}`, {
-  opacity: 1,
+// Inside tool-use headers, right-align the actions area
+globalStyle(`${toolUseHeader} .${toolHeaderActions}`, {
+  marginLeft: 'auto',
 })
 
 // Inline control response tag in tool header (approved/rejected indicator)

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -170,9 +170,14 @@ export const toolHeaderActions = style({
   paddingLeft: spacing.md,
 })
 
-// Hidden variant: invisible by default, visible on hover (for advanced-user actions like Copy Raw JSON)
-export const toolHeaderButtonHidden = style({
+// Group wrapper for buttons hidden by default and revealed on hover.
+// Animates as a single unit so all hidden buttons fade in/out together.
+export const toolHeaderHiddenGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2px',
   opacity: 0,
+  transition: 'opacity 0.15s',
 })
 
 // Timestamp text in tool header actions (muted, small)
@@ -184,8 +189,8 @@ export const toolHeaderTimestamp = style({
   lineHeight: 1,
 })
 
-// When hovering the actions area, reveal hidden buttons
-globalStyle(`${toolHeaderActions}:hover .${toolHeaderButtonHidden}`, {
+// When hovering the actions area, reveal the hidden group
+globalStyle(`${toolHeaderActions}:hover .${toolHeaderHiddenGroup}`, {
   opacity: 1,
 })
 

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import { onMount, Show } from 'solid-js'
-import { dialogCompact } from '~/styles/shared.css'
+import { dialogStandard } from '~/styles/shared.css'
 import { ConfirmButton } from './ConfirmButton'
 
 interface ConfirmDialogProps {
@@ -19,7 +19,7 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
   onMount(() => dlgRef.showModal())
 
   return (
-    <dialog ref={dlgRef} class={dialogCompact} closedby="any" onClose={() => props.onCancel()}>
+    <dialog ref={dlgRef} class={dialogStandard} closedby="any" onClose={() => props.onCancel()}>
       <header><h2>{props.title}</h2></header>
       <section>{props.children}</section>
       <footer>

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -254,6 +254,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
             ref={popoverRefCallback /* eslint-disable-line solid/reactivity -- ref callback, not a signal */}
             class={props.class}
             data-testid={props['data-testid']}
+            onClick={e => e.stopPropagation()}
           >
             {props.children}
           </menu>
@@ -265,6 +266,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
           ref={popoverRefCallback /* eslint-disable-line solid/reactivity -- ref callback, not a signal */}
           class={props.class}
           data-testid={props['data-testid']}
+          onClick={e => e.stopPropagation()}
         >
           {props.children}
         </div>

--- a/frontend/src/components/common/SelectionQuotePopover.css.ts
+++ b/frontend/src/components/common/SelectionQuotePopover.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 import { spacing } from '~/styles/tokens'
 
 export const popover = style({
@@ -35,4 +35,9 @@ export const quoteButton = style({
       color: 'var(--foreground)',
     },
   },
+})
+
+// Separator between adjacent buttons
+globalStyle(`${quoteButton} + .${quoteButton}`, {
+  borderLeft: '1px solid var(--border)',
 })

--- a/frontend/src/components/common/SelectionQuotePopover.css.ts
+++ b/frontend/src/components/common/SelectionQuotePopover.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css'
+import { spacing } from '~/styles/tokens'
+
+export const popover = style({
+  'position': 'absolute',
+  'zIndex': 20,
+  'display': 'flex',
+  'borderRadius': 'var(--radius-small)',
+  'border': '1px solid var(--border)',
+  'backgroundColor': 'var(--card)',
+  'boxShadow': '0 2px 8px rgba(0, 0, 0, 0.15)',
+  'opacity': 0.9,
+  'transition': 'opacity 0.1s',
+  ':hover': {
+    opacity: 1,
+  },
+})
+
+export const quoteButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '4px',
+  height: '28px',
+  paddingInline: spacing.sm,
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+  transition: 'color 0.1s',
+  borderRadius: 'var(--radius-small)',
+  selectors: {
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})

--- a/frontend/src/components/common/SelectionQuotePopover.tsx
+++ b/frontend/src/components/common/SelectionQuotePopover.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'solid-js'
+import Copy from 'lucide-solid/icons/copy'
 import Quote from 'lucide-solid/icons/quote'
 import { createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { extractLineRange, extractSelectionMarkdown } from '~/lib/quoteUtils'
@@ -60,6 +61,20 @@ export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.El
     })
   }
 
+  const handleCopyClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed)
+      return
+
+    const lineRange = extractLineRange(selection)
+    const text = lineRange ? selection.toString() : extractSelectionMarkdown(selection)
+    void navigator.clipboard.writeText(text)
+    selection.removeAllRanges()
+    hidePopover()
+  }
+
   const handleQuoteClick = (e: MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -102,6 +117,14 @@ export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.El
           >
             <Quote size={14} />
             Quote
+          </button>
+          <button
+            class={styles.quoteButton}
+            onClick={handleCopyClick}
+            data-testid="copy-selection-button"
+          >
+            <Copy size={14} />
+            Copy
           </button>
         </div>
       </Show>

--- a/frontend/src/components/common/SelectionQuotePopover.tsx
+++ b/frontend/src/components/common/SelectionQuotePopover.tsx
@@ -1,0 +1,106 @@
+import type { JSX } from 'solid-js'
+import Quote from 'lucide-solid/icons/quote'
+import { createSignal, onCleanup, onMount, Show } from 'solid-js'
+import { extractLineRange } from '~/lib/quoteUtils'
+import * as styles from './SelectionQuotePopover.css'
+
+interface SelectionQuotePopoverProps {
+  containerRef: HTMLElement | undefined
+  onQuote: (selectedText: string, startLine?: number, endLine?: number) => void
+  children: JSX.Element
+}
+
+export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.Element {
+  let wrapperRef!: HTMLDivElement
+  let popoverRef: HTMLDivElement | undefined
+  const [visible, setVisible] = createSignal(false)
+  const [position, setPosition] = createSignal({ top: 0, left: 0 })
+
+  const hidePopover = () => setVisible(false)
+
+  const handleMouseDown = (e: MouseEvent) => {
+    // Don't hide the popover when clicking the popover itself (Quote button)
+    if (popoverRef?.contains(e.target as Node))
+      return
+    hidePopover()
+  }
+
+  const handleMouseUp = () => {
+    // Small delay to let the browser finalize the selection
+    requestAnimationFrame(() => {
+      const selection = window.getSelection()
+      if (!selection || selection.isCollapsed || !selection.toString().trim())
+        return
+
+      const container = props.containerRef ?? wrapperRef
+      if (!container)
+        return
+
+      // Check that the selection is within our container
+      if (!container.contains(selection.anchorNode) || !container.contains(selection.focusNode))
+        return
+
+      // Position the popover above the end of the selection
+      const range = selection.getRangeAt(0)
+      const rects = range.getClientRects()
+      if (rects.length === 0)
+        return
+
+      const lastRect = rects[rects.length - 1]
+      const containerRect = wrapperRef.getBoundingClientRect()
+
+      setPosition({
+        top: lastRect.top - containerRect.top - 34,
+        left: lastRect.right - containerRect.left,
+      })
+      setVisible(true)
+    })
+  }
+
+  const handleQuoteClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed)
+      return
+
+    const text = selection.toString()
+    const lineRange = extractLineRange(selection)
+    props.onQuote(text, lineRange?.startLine, lineRange?.endLine)
+    selection.removeAllRanges()
+    hidePopover()
+  }
+
+  onMount(() => {
+    const el = wrapperRef
+    el.addEventListener('mousedown', handleMouseDown)
+    el.addEventListener('mouseup', handleMouseUp)
+    onCleanup(() => {
+      el.removeEventListener('mousedown', handleMouseDown)
+      el.removeEventListener('mouseup', handleMouseUp)
+    })
+  })
+
+  return (
+    <div ref={wrapperRef} style={{ position: 'relative' }}>
+      {props.children}
+      <Show when={visible()}>
+        <div
+          ref={popoverRef}
+          class={styles.popover}
+          style={{ top: `${position().top}px`, left: `${position().left}px` }}
+          data-testid="quote-selection-popover"
+        >
+          <button
+            class={styles.quoteButton}
+            onClick={handleQuoteClick}
+            data-testid="quote-selection-button"
+          >
+            <Quote size={14} />
+            Quote
+          </button>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -26,6 +26,8 @@ export const FileViewer: Component<{
   filePath: string
   displayMode?: string
   onDisplayModeChange?: (mode: string) => void
+  onQuote?: (text: string, startLine?: number, endLine?: number) => void
+  onMention?: () => void
 }> = (props) => {
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal<string | null>(null)
@@ -100,6 +102,8 @@ export const FileViewer: Component<{
               content={content()!}
               filePath={props.filePath}
               totalSize={totalSize()}
+              onQuote={props.onQuote}
+              onMention={props.onMention}
             />
           </Show>
           <Show when={viewMode() === 'markdown' && content()}>
@@ -109,6 +113,8 @@ export const FileViewer: Component<{
               totalSize={totalSize()}
               displayMode={props.displayMode}
               onDisplayModeChange={props.onDisplayModeChange}
+              onQuote={props.onQuote}
+              onMention={props.onMention}
             />
           </Show>
           <Show when={viewMode() === 'image' && content() && !imageTooLarge()}>
@@ -118,6 +124,8 @@ export const FileViewer: Component<{
               totalSize={totalSize()}
               displayMode={props.displayMode}
               onDisplayModeChange={props.onDisplayModeChange}
+              onQuote={props.onQuote}
+              onMention={props.onMention}
             />
           </Show>
           <Show when={viewMode() === 'binary' && content()}>

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -1,7 +1,8 @@
 import type { JSX } from 'solid-js'
 import type { ZoomMode } from './ImageToolbar'
 import type { ViewMode } from './ViewToggle'
-import { createEffect, createMemo, createSignal, Match, onCleanup, Switch, untrack } from 'solid-js'
+import AtSign from 'lucide-solid/icons/at-sign'
+import { createEffect, createMemo, createSignal, Match, onCleanup, Show, Switch, untrack } from 'solid-js'
 import { isSvgExtension } from '~/lib/fileType'
 import * as styles from './FileViewer.css'
 import { ImageToolbar, ZOOM_MAX, ZOOM_MIN } from './ImageToolbar'
@@ -178,6 +179,8 @@ export function ImageFileView(props: {
   totalSize?: number
   displayMode?: string
   onDisplayModeChange?: (mode: string) => void
+  onQuote?: (text: string, startLine?: number, endLine?: number) => void
+  onMention?: () => void
 }): JSX.Element {
   const isSvg = () => isSvgExtension(props.filePath)
   const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
@@ -200,11 +203,25 @@ export function ImageFileView(props: {
   return (
     <Switch>
       <Match when={!isSvg()}>
-        {renderImage()}
+        <div style={{ position: 'relative', height: '100%' }}>
+          <Show when={props.onMention}>
+            <div class={styles.viewToggle}>
+              <button
+                class={styles.viewToggleButton}
+                onClick={() => props.onMention?.()}
+                title="Mention in the chat"
+                data-testid="file-mention-button"
+              >
+                <AtSign size={14} />
+              </button>
+            </div>
+          </Show>
+          {renderImage()}
+        </div>
       </Match>
       <Match when={isSvg()}>
         <div class={styles.toggleViewContainer}>
-          <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit />
+          <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit onMention={props.onMention} />
           <Switch>
             <Match when={mode() === 'render'}>
               {renderImage()}
@@ -220,6 +237,7 @@ export function ImageFileView(props: {
                     content={props.content}
                     filePath={props.filePath}
                     totalSize={props.totalSize ?? props.content.length}
+                    onQuote={props.onQuote}
                   />
                 </div>
               </div>
@@ -229,6 +247,7 @@ export function ImageFileView(props: {
                 content={props.content}
                 filePath={props.filePath}
                 totalSize={props.totalSize ?? props.content.length}
+                onQuote={props.onQuote}
               />
             </Match>
           </Switch>

--- a/frontend/src/components/fileviewer/TextFileView.tsx
+++ b/frontend/src/components/fileviewer/TextFileView.tsx
@@ -1,14 +1,19 @@
 import type { JSX } from 'solid-js'
 import type { ParsedCatLine } from '~/components/chat/ReadResultView'
-import { createMemo } from 'solid-js'
+import AtSign from 'lucide-solid/icons/at-sign'
+import { createMemo, Show } from 'solid-js'
 import { ReadResultView } from '~/components/chat/ReadResultView'
+import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import * as styles from './FileViewer.css'
 
 export function TextFileView(props: {
   content: Uint8Array
   filePath: string
   totalSize: number
+  onQuote?: (text: string, startLine?: number, endLine?: number) => void
+  onMention?: () => void
 }): JSX.Element {
+  let containerRef: HTMLDivElement | undefined
   const text = createMemo(() => new TextDecoder().decode(props.content))
 
   const lines = createMemo((): ParsedCatLine[] => {
@@ -23,8 +28,25 @@ export function TextFileView(props: {
   })
 
   return (
-    <div class={styles.textViewContainer}>
-      <ReadResultView lines={lines()} filePath={props.filePath} />
+    <div ref={containerRef} class={styles.textViewContainer} style={{ position: 'relative' }}>
+      <Show when={props.onMention}>
+        <div class={styles.viewToggle}>
+          <button
+            class={styles.viewToggleButton}
+            onClick={() => props.onMention?.()}
+            title="Mention in the chat"
+            data-testid="file-mention-button"
+          >
+            <AtSign size={14} />
+          </button>
+        </div>
+      </Show>
+      <SelectionQuotePopover
+        containerRef={containerRef}
+        onQuote={(text, startLine, endLine) => props.onQuote?.(text, startLine, endLine)}
+      >
+        <ReadResultView lines={lines()} filePath={props.filePath} />
+      </SelectionQuotePopover>
     </div>
   )
 }

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'solid-js'
+import AtSign from 'lucide-solid/icons/at-sign'
 import Code from 'lucide-solid/icons/code'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import Eye from 'lucide-solid/icons/eye'
@@ -11,6 +12,7 @@ export function ViewToggle(props: {
   mode: ViewMode
   onToggle: (mode: ViewMode) => void
   showSplit?: boolean
+  onMention?: () => void
 }): JSX.Element {
   return (
     <div class={styles.viewToggle}>
@@ -40,6 +42,17 @@ export function ViewToggle(props: {
       >
         <Code size={14} />
       </button>
+      <Show when={props.onMention}>
+        <div style={{ 'border-left': '1px solid var(--border)' }} />
+        <button
+          class={styles.viewToggleButton}
+          onClick={() => props.onMention?.()}
+          title="Mention in the chat"
+          data-testid="file-mention-button"
+        >
+          <AtSign size={14} />
+        </button>
+      </Show>
     </div>
   )
 }

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -49,7 +49,7 @@ import { createSectionStore } from '~/stores/section.store'
 import { createTabStore, tabKey } from '~/stores/tab.store'
 import { createTerminalStore } from '~/stores/terminal.store'
 import { createWorkspaceStore } from '~/stores/workspace.store'
-import { dialogCompact } from '~/styles/shared.css'
+import { dialogStandard } from '~/styles/shared.css'
 import { isAgentWorking } from '~/utils/agentState'
 import * as styles from './AppShell.css'
 import { SectionDragProvider } from './SectionDragContext'
@@ -1813,7 +1813,7 @@ export const AppShell: ParentComponent = (props) => {
             setWorktreeConfirm(null)
           }
           return (
-            <dialog ref={dlgRef} class={dialogCompact} onClose={handleCancel}>
+            <dialog ref={dlgRef} class={dialogStandard} onClose={handleCancel}>
               <header><h2>Dirty Worktree</h2></header>
               <section>
                 <p>The worktree has uncommitted changes or unpushed commits:</p>

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -72,6 +72,8 @@ export interface CollapsibleSidebarProps {
   initialSectionSizes?: Record<string, number>
   /** Called whenever open sections or section sizes change. */
   onStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
+  /** Ref callback that exposes the expand-section function to the parent. */
+  expandSectionRef?: (expand: (sectionId: string) => void) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +103,13 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
   const notifyStateChange = () => {
     props.onStateChange?.(openSections(), sectionSizes())
   }
+
+  // Expose expand-section function to the parent via ref callback.
+  // eslint-disable-next-line solid/reactivity -- ref callback is called once during setup
+  props.expandSectionRef?.((sectionId: string) => {
+    setOpenSections(prev => ({ ...prev, [sectionId]: true }))
+    notifyStateChange()
+  })
 
   /** Quick lookup for the latest section definition by ID. */
   const sectionById = createMemo(() => {

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -59,6 +59,9 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   const store = props.sectionStore
   const { setExternalDragHandler, setExternalOverlayRenderer } = useSectionDrag()
 
+  // Captured from CollapsibleSidebar's expandSectionRef callback.
+  let expandSection: ((sectionId: string) => void) | undefined
+
   /* eslint-disable solid/reactivity -- callbacks are stable references */
   const wsOps = useWorkspaceOperations({
     workspaces: () => props.workspaces,
@@ -71,7 +74,12 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
     onDeleteWorkspace: props.onDeleteWorkspace,
     onConfirmDelete: props.onConfirmDelete,
     onConfirmArchive: props.onConfirmArchive,
-    onPostArchiveWorkspace: props.onPostArchiveWorkspace,
+    onPostArchiveWorkspace: (workspaceId) => {
+      const archivedSection = store.getArchivedSection()
+      if (archivedSection && expandSection)
+        expandSection(archivedSection.id)
+      props.onPostArchiveWorkspace?.(workspaceId)
+    },
   })
   /* eslint-enable solid/reactivity */
 
@@ -179,7 +187,6 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
               onArchive={wsOps.archiveWorkspace}
               onUnarchive={wsOps.unarchiveWorkspace}
               onDelete={wsOps.deleteWorkspace}
-              getSectionId={wsOps.getSectionId}
               isArchived={wsOps.isWorkspaceArchived}
               renamingWorkspaceId={wsOps.renamingWorkspaceId()}
               renameValue={wsOps.renameValue()}
@@ -286,6 +293,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
         initialOpenSections={props.initialOpenSections}
         initialSectionSizes={props.initialSectionSizes}
         onStateChange={props.onSectionStateChange}
+        expandSectionRef={fn => expandSection = fn}
       />
 
       <Show when={wsOps.sharingWorkspaceId()}>

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -48,6 +48,7 @@ interface LeftSidebarProps {
   fileTreePath: string
   onFileSelect: (path: string) => void
   onFileOpen?: (path: string) => void
+  onFileMention?: (path: string) => void
   showTodos: boolean
   activeTodos: TodoItem[]
 }
@@ -212,6 +213,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
                 selectedPath={props.fileTreePath}
                 onSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
+                onMention={props.onFileMention}
                 rootPath={props.workingDir || '~'}
                 homeDir={props.homeDir}
               />

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -10,7 +10,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewAgentDialogProps {
   workspaceId: string
@@ -123,7 +123,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Agent</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -10,7 +10,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewAgentDialogProps {
   workspaceId: string
@@ -123,7 +123,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogCompact} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Agent</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -9,7 +9,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewTerminalDialogProps {
   workspaceId: string
@@ -145,7 +145,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogCompact} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Terminal</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -9,7 +9,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewTerminalDialogProps {
   workspaceId: string
@@ -145,7 +145,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Terminal</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/shell/ResumeSessionDialog.tsx
+++ b/frontend/src/components/shell/ResumeSessionDialog.tsx
@@ -7,7 +7,7 @@ import { agentLoadingTimeoutMs } from '~/api/transport'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, errorText, labelRow, refreshButton, spinning } from '~/styles/shared.css'
+import { dialogStandard, errorText, labelRow, refreshButton, spinning } from '~/styles/shared.css'
 
 interface ResumeSessionDialogProps {
   defaultWorkerId?: string
@@ -83,7 +83,7 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogCompact} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={dialogStandard} onClose={() => props.onClose()}>
       <header><h2>Resume an existing session</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -29,6 +29,7 @@ interface RightSidebarProps {
   fileTreePath: string
   onFileSelect: (path: string) => void
   onFileOpen?: (path: string) => void
+  onFileMention?: (path: string) => void
   sectionStore: ReturnType<typeof createSectionStore>
   isCollapsed: boolean
   onExpand: () => void
@@ -110,6 +111,7 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
                 selectedPath={props.fileTreePath}
                 onSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
+                onMention={props.onFileMention}
                 rootPath={props.workingDir || '~'}
                 homeDir={props.homeDir}
               />

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -54,6 +54,9 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
   // eslint-disable-next-line solid/reactivity -- stable store reference for component lifetime
   const store = props.sectionStore
 
+  // Captured from CollapsibleSidebar's expandSectionRef callback.
+  let expandSection: ((sectionId: string) => void) | undefined
+
   /* eslint-disable solid/reactivity -- callbacks are stable references */
   const wsOps = useWorkspaceOperations({
     workspaces: () => props.workspaces,
@@ -66,7 +69,12 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
     onDeleteWorkspace: props.onDeleteWorkspace,
     onConfirmDelete: props.onConfirmDelete,
     onConfirmArchive: props.onConfirmArchive,
-    onPostArchiveWorkspace: props.onPostArchiveWorkspace,
+    onPostArchiveWorkspace: (workspaceId) => {
+      const archivedSection = store.getArchivedSection()
+      if (archivedSection && expandSection)
+        expandSection(archivedSection.id)
+      props.onPostArchiveWorkspace?.(workspaceId)
+    },
   })
   /* eslint-enable solid/reactivity */
 
@@ -184,7 +192,6 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
               onArchive={wsOps.archiveWorkspace}
               onUnarchive={wsOps.unarchiveWorkspace}
               onDelete={wsOps.deleteWorkspace}
-              getSectionId={wsOps.getSectionId}
               isArchived={wsOps.isWorkspaceArchived}
               renamingWorkspaceId={wsOps.renamingWorkspaceId()}
               renameValue={wsOps.renameValue()}
@@ -222,6 +229,7 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
         initialOpenSections={props.initialOpenSections}
         initialSectionSizes={props.initialSectionSizes}
         onStateChange={props.onSectionStateChange}
+        expandSectionRef={fn => expandSection = fn}
       />
 
       <Show when={wsOps.sharingWorkspaceId()}>

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -79,6 +79,7 @@ interface TabBarProps {
   onToggleLeftSidebar?: () => void
   onToggleRightSidebar?: () => void
   tileActions?: TileActions
+  readOnly?: boolean
 }
 
 export const TabBar: Component<TabBarProps> = (props) => {
@@ -179,7 +180,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       onAuxClick={(e: MouseEvent) => {
         if (e.button === 1) {
           e.preventDefault()
-          if (props.closingTabKeys?.has(tabKey(tab)))
+          if ((props.readOnly && tab.type !== TabType.FILE) || props.closingTabKeys?.has(tabKey(tab)))
             return
           props.onClose(tab)
         }
@@ -187,7 +188,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       onDblClick={(e: MouseEvent) => {
         e.preventDefault()
         e.stopPropagation()
-        if (tab.type !== TabType.FILE)
+        if (tab.type !== TabType.FILE && !props.readOnly)
           startEditing(tab)
       }}
     >
@@ -225,19 +226,21 @@ export const TabBar: Component<TabBarProps> = (props) => {
       <Show when={tab.hasNotification}>
         <span class={styles.tabNotification} data-testid="tab-notification" />
       </Show>
-      <IconButton
-        icon={X}
-        class={styles.tabClose}
-        state={props.closingTabKeys?.has(tabKey(tab)) ? IconButtonState.Loading : IconButtonState.Enabled}
-        data-testid="tab-close"
-        onPointerDown={e => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation()
-          if (props.closingTabKeys?.has(tabKey(tab)))
-            return
-          props.onClose(tab)
-        }}
-      />
+      <Show when={!props.readOnly || tab.type === TabType.FILE}>
+        <IconButton
+          icon={X}
+          class={styles.tabClose}
+          state={props.closingTabKeys?.has(tabKey(tab)) ? IconButtonState.Loading : IconButtonState.Enabled}
+          data-testid="tab-close"
+          onPointerDown={e => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation()
+            if (props.closingTabKeys?.has(tabKey(tab)))
+              return
+            props.onClose(tab)
+          }}
+        />
+      </Show>
     </div>
   )
 

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -383,7 +383,6 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     unarchiveWorkspace,
     deleteWorkspace,
     canAddToSection,
-    getSectionId,
     isWorkspaceArchived,
     isWorkspaceLoading,
     onRenameInput: (v: string) => setRenameValue(sanitizeName(v).value),

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { iconSize, spacing } from '~/styles/tokens'
+import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -114,20 +114,6 @@ export const nodeActions = style({
   selectors: {
     [`${node}:hover &`]: { opacity: 1 },
   },
-})
-
-export const nodeActionButton = style({
-  'all': 'unset',
-  'display': 'flex',
-  'alignItems': 'center',
-  'justifyContent': 'center',
-  'width': iconSize.container.sm,
-  'height': iconSize.container.sm,
-  'borderRadius': '3px',
-  'flexShrink': 0,
-  'color': 'var(--faint-foreground)',
-  'cursor': 'pointer',
-  ':hover': { color: 'var(--foreground)' },
 })
 
 export const pathInput = style({

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
+import { iconSize, spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -102,6 +102,32 @@ export const emptyInline = style({
   fontSize: 'var(--text-7)',
   color: 'var(--faint-foreground)',
   padding: `2px ${spacing.sm}`,
+})
+
+export const nodeActions = style({
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 'auto',
+  flexShrink: 0,
+  opacity: 0,
+  transition: 'opacity 0.15s',
+  selectors: {
+    [`${node}:hover &`]: { opacity: 1 },
+  },
+})
+
+export const nodeActionButton = style({
+  'all': 'unset',
+  'display': 'flex',
+  'alignItems': 'center',
+  'justifyContent': 'center',
+  'width': iconSize.container.sm,
+  'height': iconSize.container.sm,
+  'borderRadius': '3px',
+  'flexShrink': 0,
+  'color': 'var(--faint-foreground)',
+  'cursor': 'pointer',
+  ':hover': { color: 'var(--foreground)' },
 })
 
 export const pathInput = style({

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -8,6 +8,7 @@ import Folder from 'lucide-solid/icons/folder'
 import { createEffect, createSignal, For, Show, untrack } from 'solid-js'
 import { fileClient } from '~/api/clients'
 import { tildify } from '~/components/chat/messageUtils'
+import { IconButton } from '~/components/common/IconButton'
 import * as styles from './DirectoryTree.css'
 
 export interface DirectoryTreeProps {
@@ -190,17 +191,17 @@ const TreeNode: Component<{
         <span class={styles.nodeName}>{props.node.displayName}</span>
         <Show when={props.onMention}>
           <div class={styles.nodeActions}>
-            <button
-              class={styles.nodeActionButton}
+            <IconButton
+              icon={AtSign}
+              iconSize={12}
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation()
                 props.onMention?.(props.node.path)
               }}
               title="Mention in the chat"
               data-testid="tree-mention-button"
-            >
-              <AtSign size={12} />
-            </button>
+            />
           </div>
         </Show>
       </div>

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { FileInfo } from '~/generated/leapmux/v1/file_pb'
+import AtSign from 'lucide-solid/icons/at-sign'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import File from 'lucide-solid/icons/file'
@@ -15,6 +16,7 @@ export interface DirectoryTreeProps {
   selectedPath: string
   onSelect: (path: string) => void
   onFileOpen?: (path: string) => void
+  onMention?: (path: string) => void
   rootPath?: string
   homeDir?: string
 }
@@ -56,6 +58,7 @@ const TreeNode: Component<{
   selectedPath: string
   onSelect: (path: string) => void
   onFileOpen?: (path: string) => void
+  onMention?: (path: string) => void
   depth: number
   scrollContainer?: HTMLDivElement
 }> = (props) => {
@@ -185,6 +188,21 @@ const TreeNode: Component<{
           <Folder size={14} class={styles.folderIcon} />
         </Show>
         <span class={styles.nodeName}>{props.node.displayName}</span>
+        <Show when={props.onMention}>
+          <div class={styles.nodeActions}>
+            <button
+              class={styles.nodeActionButton}
+              onClick={(e) => {
+                e.stopPropagation()
+                props.onMention?.(props.node.path)
+              }}
+              title="Mention in the chat"
+              data-testid="tree-mention-button"
+            >
+              <AtSign size={12} />
+            </button>
+          </div>
+        </Show>
       </div>
       <Show when={loading()}>
         <div class={styles.loadingInline} style={{ 'padding-left': `${8 + (props.depth + 1) * 16}px` }}>
@@ -201,6 +219,7 @@ const TreeNode: Component<{
               selectedPath={props.selectedPath}
               onSelect={props.onSelect}
               onFileOpen={props.onFileOpen}
+              onMention={props.onMention}
               depth={props.depth + 1}
               scrollContainer={props.scrollContainer}
             />
@@ -307,6 +326,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                   selectedPath={props.selectedPath}
                   onSelect={props.onSelect}
                   onFileOpen={props.onFileOpen}
+                  onMention={props.onMention}
                   depth={0}
                   scrollContainer={treeRef}
                 />

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -10,7 +10,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewWorkspaceDialogProps {
   onCreated: (workspace: Workspace) => void
@@ -98,7 +98,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Workspace</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -10,7 +10,7 @@ import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
-import { dialogCompact, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { dialogCompact, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewWorkspaceDialogProps {
   onCreated: (workspace: Workspace) => void
@@ -98,7 +98,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogCompact} onClose={() => props.onClose()}>
+    <dialog ref={dialogRef} class={`${dialogCompact} ${dialogWithTree}`} onClose={() => props.onClose()}>
       <header><h2>New Workspace</h2></header>
       <form onSubmit={handleSubmit}>
         <section>

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -4,6 +4,7 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
 import { For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { IconButton } from '~/components/common/IconButton'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
 import { dangerMenuItem } from '~/styles/shared.css'
 import * as listStyles from './workspaceList.css'
@@ -25,13 +26,21 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
   return (
     <DropdownMenu
       trigger={triggerProps => (
-        <button
+        <IconButton
+          icon={MoreHorizontal}
+          size="sm"
           class={listStyles.itemMenuTrigger}
-          onClick={(e: MouseEvent) => e.stopPropagation()}
-          {...triggerProps}
-        >
-          <MoreHorizontal size={14} />
-        </button>
+          onClick={(e: MouseEvent) => {
+            e.stopPropagation()
+            triggerProps.onClick()
+          }}
+          ref={triggerProps.ref}
+          onPointerDown={(e: PointerEvent) => {
+            e.stopPropagation()
+            triggerProps.onPointerDown(e)
+          }}
+          aria-expanded={triggerProps['aria-expanded']}
+        />
       )}
     >
       <Show when={props.isOwner}>
@@ -40,7 +49,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
         </button>
       </Show>
 
-      <Show when={!props.isArchived}>
+      <Show when={!props.isArchived && props.sections.some(s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType))}>
         <DropdownMenu
           trigger={triggerProps => (
             <button role="menuitem" class="sub-trigger" {...triggerProps}>
@@ -59,25 +68,24 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
               </button>
             )}
           </For>
-          <hr />
-          <button
-            role="menuitem"
-            onClick={() => props.onArchive()}
-          >
-            Archive
-          </button>
         </DropdownMenu>
+      </Show>
+
+      <Show when={props.isOwner}>
+        <button role="menuitem" onClick={() => props.onShare()}>
+          Share...
+        </button>
+      </Show>
+
+      <Show when={!props.isArchived}>
+        <button role="menuitem" onClick={() => props.onArchive()}>
+          Archive
+        </button>
       </Show>
 
       <Show when={props.isArchived}>
         <button role="menuitem" onClick={() => props.onUnarchive()}>
           Unarchive
-        </button>
-      </Show>
-
-      <Show when={props.isOwner}>
-        <button role="menuitem" onClick={() => props.onShare()}>
-          Share
         </button>
       </Show>
 

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -142,26 +142,13 @@ export const itemRenameInput = style({
 })
 
 export const itemMenuTrigger = style({
-  'all': 'unset',
-  'display': 'flex',
-  'alignItems': 'center',
-  'justifyContent': 'center',
-  'width': iconSize.container.sm,
-  'height': iconSize.container.sm,
-  'borderRadius': '3px',
-  'flexShrink': 0,
-  'color': 'var(--faint-foreground)',
-  'cursor': 'pointer',
-  'opacity': 0,
-  'transition': 'opacity 0.15s',
-  ':hover': {
-    color: 'var(--foreground)',
-  },
-  'selectors': {
+  opacity: 0,
+  transition: 'opacity 0.15s',
+  selectors: {
     [`${item}:hover &`]: {
       opacity: 1,
     },
-    '&[data-expanded]': {
+    '&[aria-expanded="true"]': {
       opacity: 1,
     },
   },

--- a/frontend/src/lib/quoteUtils.test.ts
+++ b/frontend/src/lib/quoteUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { formatChatQuote, formatFileMention, formatFileQuote } from './quoteUtils'
+
+describe('formatFileQuote', () => {
+  it('formats single-line selection with :lineNum', () => {
+    expect(formatFileQuote('src/main.ts', 10, 10, 'const x = 1')).toBe(
+      'At src/main.ts:10\n\n> ```\n> const x = 1\n> ```',
+    )
+  })
+
+  it('formats multi-line selection with :startLine-endLine', () => {
+    expect(formatFileQuote('src/main.ts', 10, 12, 'line1\nline2\nline3')).toBe(
+      'At src/main.ts:10-12\n\n> ```\n> line1\n> line2\n> line3\n> ```',
+    )
+  })
+
+  it('preserves empty lines in selected text', () => {
+    expect(formatFileQuote('test.ts', 1, 3, 'a\n\nb')).toBe(
+      'At test.ts:1-3\n\n> ```\n> a\n> \n> b\n> ```',
+    )
+  })
+})
+
+describe('formatChatQuote', () => {
+  it('wraps single-line text as blockquote', () => {
+    expect(formatChatQuote('hello')).toBe('> hello')
+  })
+
+  it('wraps multi-line text as blockquote', () => {
+    expect(formatChatQuote('hello\nworld')).toBe('> hello\n> world')
+  })
+
+  it('handles empty lines', () => {
+    expect(formatChatQuote('a\n\nb')).toBe('> a\n> \n> b')
+  })
+})
+
+describe('formatFileMention', () => {
+  it('prefixes path with @', () => {
+    expect(formatFileMention('src/main.ts')).toBe('@src/main.ts')
+  })
+
+  it('works with simple filename', () => {
+    expect(formatFileMention('package.json')).toBe('@package.json')
+  })
+})

--- a/frontend/src/lib/quoteUtils.test.ts
+++ b/frontend/src/lib/quoteUtils.test.ts
@@ -1,37 +1,44 @@
 import { describe, expect, it } from 'vitest'
-import { formatChatQuote, formatFileMention, formatFileQuote } from './quoteUtils'
+import { formatChatQuote, formatFileMention, formatFileQuote, nodeToMarkdown } from './quoteUtils'
+
+/** Helper: parse an HTML string into a DocumentFragment for nodeToMarkdown tests. */
+function html(str: string): DocumentFragment {
+  const template = document.createElement('template')
+  template.innerHTML = str
+  return template.content
+}
 
 describe('formatFileQuote', () => {
-  it('formats single-line selection with :lineNum', () => {
+  it('formats single-line selection with @mention and (Line N)', () => {
     expect(formatFileQuote('src/main.ts', 10, 10, 'const x = 1')).toBe(
-      'At src/main.ts:10\n\n> ```\n> const x = 1\n> ```',
+      'From @src/main.ts (Line 10):\n\n> ```\n> const x = 1\n> ```',
     )
   })
 
-  it('formats multi-line selection with :startLine-endLine', () => {
+  it('formats multi-line selection with @mention and (Line N-M)', () => {
     expect(formatFileQuote('src/main.ts', 10, 12, 'line1\nline2\nline3')).toBe(
-      'At src/main.ts:10-12\n\n> ```\n> line1\n> line2\n> line3\n> ```',
+      'From @src/main.ts (Line 10-12):\n\n> ```\n> line1\n> line2\n> line3\n> ```',
     )
   })
 
   it('preserves empty lines in selected text', () => {
     expect(formatFileQuote('test.ts', 1, 3, 'a\n\nb')).toBe(
-      'At test.ts:1-3\n\n> ```\n> a\n> \n> b\n> ```',
+      'From @test.ts (Line 1-3):\n\n> ```\n> a\n> \n> b\n> ```',
     )
   })
 })
 
 describe('formatChatQuote', () => {
   it('wraps single-line text as blockquote', () => {
-    expect(formatChatQuote('hello')).toBe('> hello')
+    expect(formatChatQuote('hello')).toBe('> hello\n\n')
   })
 
   it('wraps multi-line text as blockquote', () => {
-    expect(formatChatQuote('hello\nworld')).toBe('> hello\n> world')
+    expect(formatChatQuote('hello\nworld')).toBe('> hello\n> world\n\n')
   })
 
   it('handles empty lines', () => {
-    expect(formatChatQuote('a\n\nb')).toBe('> a\n> \n> b')
+    expect(formatChatQuote('a\n\nb')).toBe('> a\n> \n> b\n\n')
   })
 })
 
@@ -42,5 +49,151 @@ describe('formatFileMention', () => {
 
   it('works with simple filename', () => {
     expect(formatFileMention('package.json')).toBe('@package.json')
+  })
+})
+
+describe('nodeToMarkdown', () => {
+  it('returns plain text from a text node', () => {
+    expect(nodeToMarkdown(html('hello world'))).toBe('hello world')
+  })
+
+  it('converts <strong> to **bold**', () => {
+    expect(nodeToMarkdown(html('<strong>bold</strong>'))).toBe('**bold**')
+  })
+
+  it('converts <b> to **bold**', () => {
+    expect(nodeToMarkdown(html('<b>bold</b>'))).toBe('**bold**')
+  })
+
+  it('converts <em> to *italic*', () => {
+    expect(nodeToMarkdown(html('<em>italic</em>'))).toBe('*italic*')
+  })
+
+  it('converts <i> to *italic*', () => {
+    expect(nodeToMarkdown(html('<i>italic</i>'))).toBe('*italic*')
+  })
+
+  it('converts inline <code> to backticks', () => {
+    expect(nodeToMarkdown(html('<code>foo()</code>'))).toBe('`foo()`')
+  })
+
+  it('converts <del> / <s> to ~~strikethrough~~', () => {
+    expect(nodeToMarkdown(html('<del>removed</del>'))).toBe('~~removed~~')
+    expect(nodeToMarkdown(html('<s>removed</s>'))).toBe('~~removed~~')
+  })
+
+  it('converts <a> to [text](href)', () => {
+    expect(nodeToMarkdown(html('<a href="https://example.com">link</a>')))
+      .toBe('[link](https://example.com)')
+  })
+
+  it('handles <a> without href', () => {
+    expect(nodeToMarkdown(html('<a>text</a>'))).toBe('text')
+  })
+
+  it('converts <br> to newline', () => {
+    expect(nodeToMarkdown(html('a<br>b'))).toBe('a\nb')
+  })
+
+  it('converts <p> to paragraph with trailing double newline', () => {
+    expect(nodeToMarkdown(html('<p>first</p><p>second</p>')))
+      .toBe('first\n\nsecond\n\n')
+  })
+
+  it('converts headings to # prefixed lines', () => {
+    expect(nodeToMarkdown(html('<h1>Title</h1>'))).toBe('# Title\n\n')
+    expect(nodeToMarkdown(html('<h2>Sub</h2>'))).toBe('## Sub\n\n')
+    expect(nodeToMarkdown(html('<h3>H3</h3>'))).toBe('### H3\n\n')
+  })
+
+  it('converts <hr> to ---', () => {
+    expect(nodeToMarkdown(html('<hr>'))).toBe('\n---\n')
+  })
+
+  it('converts unordered list', () => {
+    expect(nodeToMarkdown(html('<ul><li>a</li><li>b</li></ul>')))
+      .toBe('- a\n- b\n\n')
+  })
+
+  it('converts ordered list', () => {
+    expect(nodeToMarkdown(html('<ol><li>first</li><li>second</li></ol>')))
+      .toBe('1. first\n2. second\n\n')
+  })
+
+  it('converts <pre><code> to fenced code block', () => {
+    expect(nodeToMarkdown(html('<pre><code>x = 1</code></pre>')))
+      .toBe('\n```\nx = 1\n```\n')
+  })
+
+  it('extracts language from code class in <pre>', () => {
+    expect(nodeToMarkdown(html('<pre><code class="language-ts">const x = 1</code></pre>')))
+      .toBe('\n```ts\nconst x = 1\n```\n')
+  })
+
+  it('converts <blockquote> to > prefixed lines', () => {
+    expect(nodeToMarkdown(html('<blockquote><p>quoted text</p></blockquote>')))
+      .toBe('> quoted text\n')
+  })
+
+  it('converts nested blockquote content', () => {
+    expect(nodeToMarkdown(html('<blockquote><p>line 1</p><p>line 2</p></blockquote>')))
+      .toBe('> line 1\n> \n> line 2\n')
+  })
+
+  it('handles nested inline formatting', () => {
+    expect(nodeToMarkdown(html('<p>This is <strong>bold and <em>italic</em></strong> text</p>')))
+      .toBe('This is **bold and *italic*** text\n\n')
+  })
+
+  it('converts <div> with trailing newline', () => {
+    expect(nodeToMarkdown(html('<div>line</div>'))).toBe('line\n')
+  })
+
+  it('passes through unknown tags by rendering children', () => {
+    expect(nodeToMarkdown(html('<span>inner</span>'))).toBe('inner')
+  })
+
+  it('converts blockquote containing a list', () => {
+    expect(nodeToMarkdown(html('<blockquote><ul><li>a</li><li>b</li></ul></blockquote>')))
+      .toBe('> - a\n> - b\n')
+  })
+
+  it('converts blockquote containing a code block', () => {
+    expect(nodeToMarkdown(html('<blockquote><pre><code>x = 1</code></pre></blockquote>')))
+      .toBe('> \n> ```\n> x = 1\n> ```\n')
+  })
+
+  it('converts nested blockquotes', () => {
+    expect(nodeToMarkdown(html('<blockquote><blockquote><p>deep</p></blockquote></blockquote>')))
+      .toBe('> > deep\n')
+  })
+
+  it('converts paragraph with inline code and bold mixed', () => {
+    expect(nodeToMarkdown(html('<p>Use <code>foo()</code> with <strong>caution</strong></p>')))
+      .toBe('Use `foo()` with **caution**\n\n')
+  })
+
+  it('converts list items with inline formatting', () => {
+    expect(nodeToMarkdown(html('<ul><li><strong>bold</strong> item</li><li><em>italic</em> item</li></ul>')))
+      .toBe('- **bold** item\n- *italic* item\n\n')
+  })
+
+  it('converts ordered list with code and links', () => {
+    expect(nodeToMarkdown(html('<ol><li>Run <code>npm install</code></li><li>See <a href="https://example.com">docs</a></li></ol>')))
+      .toBe('1. Run `npm install`\n2. See [docs](https://example.com)\n\n')
+  })
+
+  it('converts mixed paragraphs, code block, and list', () => {
+    expect(nodeToMarkdown(html(
+      '<p>Intro text</p>'
+      + '<pre><code class="language-js">const x = 1</code></pre>'
+      + '<ul><li>note 1</li><li>note 2</li></ul>',
+    ))).toBe('Intro text\n\n\n```js\nconst x = 1\n```\n- note 1\n- note 2\n\n')
+  })
+
+  it('converts blockquote with paragraphs and a nested list', () => {
+    expect(nodeToMarkdown(html(
+      '<blockquote><p>Quote intro</p><ul><li>point A</li><li>point B</li></ul></blockquote>',
+    ))).toBe('> Quote intro\n> \n> - point A\n> - point B\n')
   })
 })

--- a/frontend/src/lib/quoteUtils.ts
+++ b/frontend/src/lib/quoteUtils.ts
@@ -1,0 +1,51 @@
+/**
+ * Format a file quote with path, line range, and selected text in a fenced code block blockquote.
+ */
+export function formatFileQuote(filePath: string, startLine: number, endLine: number, selectedText: string): string {
+  const lineRef = startLine === endLine ? `:${startLine}` : `:${startLine}-${endLine}`
+  const quotedLines = selectedText.split('\n').map(line => `> ${line}`)
+  return `At ${filePath}${lineRef}\n\n> \`\`\`\n${quotedLines.join('\n')}\n> \`\`\``
+}
+
+/**
+ * Format chat text as a blockquote (each line prefixed with "> ").
+ */
+export function formatChatQuote(text: string): string {
+  return text.split('\n').map(line => `> ${line}`).join('\n')
+}
+
+/**
+ * Format a file path as an @mention.
+ */
+export function formatFileMention(relativePath: string): string {
+  return `@${relativePath}`
+}
+
+/**
+ * Extract line range from a DOM selection by walking up to find data-line-num attributes.
+ */
+export function extractLineRange(selection: Selection): { startLine: number, endLine: number } | null {
+  const anchorLine = findLineNum(selection.anchorNode)
+  const focusLine = findLineNum(selection.focusNode)
+  if (anchorLine == null || focusLine == null)
+    return null
+  const startLine = Math.min(anchorLine, focusLine)
+  const endLine = Math.max(anchorLine, focusLine)
+  return { startLine, endLine }
+}
+
+function findLineNum(node: Node | null): number | null {
+  let current: Node | null = node
+  while (current) {
+    if (current instanceof HTMLElement) {
+      const attr = current.getAttribute('data-line-num')
+      if (attr != null) {
+        const num = Number.parseInt(attr, 10)
+        if (!Number.isNaN(num))
+          return num
+      }
+    }
+    current = current.parentElement
+  }
+  return null
+}

--- a/frontend/src/lib/quoteUtils.ts
+++ b/frontend/src/lib/quoteUtils.ts
@@ -2,16 +2,16 @@
  * Format a file quote with path, line range, and selected text in a fenced code block blockquote.
  */
 export function formatFileQuote(filePath: string, startLine: number, endLine: number, selectedText: string): string {
-  const lineRef = startLine === endLine ? `:${startLine}` : `:${startLine}-${endLine}`
+  const lineRef = startLine === endLine ? `Line ${startLine}` : `Line ${startLine}-${endLine}`
   const quotedLines = selectedText.split('\n').map(line => `> ${line}`)
-  return `At ${filePath}${lineRef}\n\n> \`\`\`\n${quotedLines.join('\n')}\n> \`\`\``
+  return `From @${filePath} (${lineRef}):\n\n> \`\`\`\n${quotedLines.join('\n')}\n> \`\`\``
 }
 
 /**
  * Format chat text as a blockquote (each line prefixed with "> ").
  */
 export function formatChatQuote(text: string): string {
-  return text.split('\n').map(line => `> ${line}`).join('\n')
+  return `${text.split('\n').map(line => `> ${line}`).join('\n')}\n\n`
 }
 
 /**
@@ -19,6 +19,93 @@ export function formatChatQuote(text: string): string {
  */
 export function formatFileMention(relativePath: string): string {
   return `@${relativePath}`
+}
+
+/**
+ * Extract markdown-like text from a DOM selection, preserving inline formatting.
+ * Falls back to plain selection.toString() if no range is available.
+ */
+export function extractSelectionMarkdown(selection: Selection): string {
+  if (selection.rangeCount === 0)
+    return selection.toString()
+  const range = selection.getRangeAt(0)
+  const fragment = range.cloneContents()
+  return nodeToMarkdown(fragment).trim()
+}
+
+/** Convert a DOM node tree to a markdown string, preserving inline formatting. */
+export function nodeToMarkdown(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE)
+    return node.textContent ?? ''
+
+  if (!(node instanceof HTMLElement) && !(node instanceof DocumentFragment))
+    return node.textContent ?? ''
+
+  const tag = node instanceof HTMLElement ? node.tagName.toLowerCase() : ''
+  const childMd = () => Array.from(node.childNodes).map(nodeToMarkdown).join('')
+
+  switch (tag) {
+    case 'strong':
+    case 'b':
+      return `**${childMd()}**`
+    case 'em':
+    case 'i':
+      return `*${childMd()}*`
+    case 'code': {
+      // Inline code (not inside <pre>)
+      const text = node.textContent ?? ''
+      return `\`${text}\``
+    }
+    case 'pre': {
+      // Code block — extract language hint from <code> child class
+      const codeChild = node.querySelector('code')
+      const text = codeChild?.textContent ?? node.textContent ?? ''
+      let lang = ''
+      if (codeChild) {
+        const cls = Array.from(codeChild.classList).find(c => c.startsWith('language-'))
+        if (cls)
+          lang = cls.slice('language-'.length)
+      }
+      return `\n\`\`\`${lang}\n${text}\n\`\`\`\n`
+    }
+    case 'a': {
+      const href = (node as HTMLAnchorElement).getAttribute('href') ?? ''
+      return href ? `[${childMd()}](${href})` : childMd()
+    }
+    case 'br':
+      return '\n'
+    case 'p':
+      return `${childMd()}\n\n`
+    case 'blockquote': {
+      const inner = childMd().replace(/\n+$/, '')
+      return `${inner.split('\n').map(line => `> ${line}`).join('\n')}\n`
+    }
+    case 'ul':
+    case 'ol':
+      return `${childMd()}\n`
+    case 'li': {
+      const parent = node instanceof HTMLElement ? node.parentElement : null
+      if (parent?.tagName.toLowerCase() === 'ol') {
+        const idx = Array.from(parent.children).indexOf(node as HTMLElement) + 1
+        return `${idx}. ${childMd().trim()}\n`
+      }
+      return `- ${childMd().trim()}\n`
+    }
+    case 'h1': return `# ${childMd()}\n\n`
+    case 'h2': return `## ${childMd()}\n\n`
+    case 'h3': return `### ${childMd()}\n\n`
+    case 'h4': return `#### ${childMd()}\n\n`
+    case 'h5': return `##### ${childMd()}\n\n`
+    case 'h6': return `###### ${childMd()}\n\n`
+    case 'hr': return '\n---\n'
+    case 'del':
+    case 's':
+      return `~~${childMd()}~~`
+    case 'div':
+      return `${childMd()}\n`
+    default:
+      return childMd()
+  }
 }
 
 /**

--- a/frontend/src/stores/editorRef.store.test.ts
+++ b/frontend/src/stores/editorRef.store.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { computeSeparator } from './editorRef.store'
+
+describe('computeSeparator', () => {
+  it('returns empty string when current is empty (block)', () => {
+    expect(computeSeparator('', 'block')).toBe('')
+  })
+
+  it('returns empty string when current is empty (inline)', () => {
+    expect(computeSeparator('', 'inline')).toBe('')
+  })
+
+  it('returns \\n\\n for block mode with existing content', () => {
+    expect(computeSeparator('hello', 'block')).toBe('\n\n')
+  })
+
+  it('returns space for inline mode with existing content', () => {
+    expect(computeSeparator('hello', 'inline')).toBe(' ')
+  })
+
+  it('returns empty string for inline mode when current ends with newline', () => {
+    expect(computeSeparator('hello\n', 'inline')).toBe('')
+  })
+
+  it('returns \\n\\n for block mode even when current ends with newline', () => {
+    expect(computeSeparator('hello\n', 'block')).toBe('\n\n')
+  })
+})

--- a/frontend/src/stores/editorRef.store.ts
+++ b/frontend/src/stores/editorRef.store.ts
@@ -1,0 +1,92 @@
+import type { Tab } from '~/stores/tab.store'
+import { TabType } from '~/stores/tab.store'
+
+export interface EditorRef {
+  get: () => string
+  set: (value: string) => void
+  focus: () => void
+}
+
+const registry = new Map<string, EditorRef>()
+/** Pending text to insert when an editor ref is registered. */
+const pendingInserts = new Map<string, string>()
+
+export function registerEditorRef(agentId: string, ref: EditorRef): void {
+  registry.set(agentId, ref)
+  // Flush any pending insert that was queued before the component mounted.
+  // Milkdown's ProseMirror view may silently reject replaceAll if it isn't
+  // fully initialized, so we retry a few times with increasing delays.
+  const pending = pendingInserts.get(agentId)
+  if (pending != null) {
+    pendingInserts.delete(agentId)
+    const tryFlush = (attempt: number) => {
+      ref.set(pending)
+      // Verify the text was actually inserted (ref.set may silently fail).
+      if (ref.get().length === 0 && attempt < 10) {
+        setTimeout(() => tryFlush(attempt + 1), 50)
+      }
+      else {
+        ref.focus()
+      }
+    }
+    // Start with a small delay to let the editor settle after mount.
+    setTimeout(() => tryFlush(0), 50)
+  }
+}
+
+export function unregisterEditorRef(agentId: string): void {
+  registry.delete(agentId)
+}
+
+export function getEditorRef(agentId: string): EditorRef | undefined {
+  return registry.get(agentId)
+}
+
+/** Append text to an editor's existing content as a new paragraph. */
+export function appendText(agentId: string, text: string): void {
+  const ref = registry.get(agentId)
+  if (!ref)
+    return
+  const current = ref.get()
+  const combined = current ? `${current}\n\n${text}` : text
+  ref.set(combined)
+}
+
+/**
+ * Find the MRU agent tab and insert text into its editor.
+ * Activates the agent tab and focuses the editor.
+ */
+export function insertIntoMruAgentEditor(
+  tabStore: {
+    state: { tabs: Tab[], mruOrder: string[] }
+    setActiveTab: (type: TabType, id: string) => void
+    setActiveTabForTile: (tileId: string, type: TabType, id: string) => void
+  },
+  text: string,
+): void {
+  const agentPrefix = `${TabType.AGENT}:`
+  const mruKey = tabStore.state.mruOrder.find(k => k.startsWith(agentPrefix))
+  if (!mruKey)
+    return
+  const agentId = mruKey.slice(agentPrefix.length)
+
+  // Try to insert directly if the ref is available (same-tab scenario).
+  const ref = registry.get(agentId)
+  if (ref) {
+    const current = ref.get()
+    ref.set(current ? `${current}\n\n${text}` : text)
+    ref.focus()
+  }
+  else {
+    // Editor is not mounted yet — queue text for when it registers.
+    const existing = pendingInserts.get(agentId)
+    pendingInserts.set(agentId, existing ? `${existing}\n\n${text}` : text)
+  }
+
+  // Activate the agent tab (global + per-tile).
+  tabStore.setActiveTab(TabType.AGENT, agentId)
+  const tab = tabStore.state.tabs.find(t => t.type === TabType.AGENT && t.id === agentId)
+  if (tab?.tileId) {
+    tabStore.setActiveTabForTile(tab.tileId, TabType.AGENT, agentId)
+  }
+}

--- a/frontend/src/styles/codeBlock.ts
+++ b/frontend/src/styles/codeBlock.ts
@@ -1,0 +1,30 @@
+import type { StyleRule } from '@vanilla-extract/css'
+
+/**
+ * Shared code block styles: move horizontal scroll from `<pre>` (set by Oat)
+ * to `<code>` so that absolutely-positioned overlays (copy button, language
+ * label) stay fixed. Padding is also moved to `<code>` so the scrollbar
+ * sits at the `<pre>` border edge.
+ *
+ * Usage in a `.css.ts` file:
+ * ```ts
+ * globalStyle(`${parent} pre`, codeBlockPre('hidden'))
+ * globalStyle(`${parent} pre code`, codeBlockCode)
+ * ```
+ */
+
+/** Styles for `<pre>`: reset padding, set position, and configure overflow. */
+export function codeBlockPre(overflowX: 'hidden' | 'visible'): StyleRule {
+  return {
+    position: 'relative',
+    overflowX,
+    padding: 0,
+  }
+}
+
+/** Styles for `<pre> code`: block display, horizontal scroll, and padding. */
+export const codeBlockCode: StyleRule = {
+  display: 'block',
+  overflowX: 'auto',
+  padding: 'var(--space-4)',
+}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -94,6 +94,11 @@ export const dialogStandard = style({
 
 export const dialogCompact = style({
   maxWidth: '400px',
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const dialogWithTree = style({
   height: '80vh',
 })
 

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -90,10 +90,6 @@ export const authCardXWide = style({
 export const dialogStandard = style({
   minWidth: '360px',
   maxWidth: '480px',
-})
-
-export const dialogCompact = style({
-  maxWidth: '400px',
   display: 'flex',
   flexDirection: 'column',
 })
@@ -103,7 +99,7 @@ export const dialogWithTree = style({
 })
 
 // Make dialog forms use flex layout so the tree container can fill remaining space.
-globalStyle(`${dialogCompact} > form`, {
+globalStyle(`${dialogStandard} > form`, {
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
@@ -111,14 +107,14 @@ globalStyle(`${dialogCompact} > form`, {
   minHeight: 0,
 })
 
-globalStyle(`${dialogCompact} > form > section`, {
+globalStyle(`${dialogStandard} > form > section`, {
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
   minHeight: 0,
 })
 
-globalStyle(`${dialogCompact} > form > section > .vstack`, {
+globalStyle(`${dialogStandard} > form > section > .vstack`, {
   flex: 1,
   minHeight: 0,
 })
@@ -163,7 +159,7 @@ export const treeContainer = style({
 })
 
 // The label wrapping the DirectoryTree needs to grow and use flex layout.
-globalStyle(`${dialogCompact} > form > section > .vstack > label:has(.${treeContainer})`, {
+globalStyle(`${dialogStandard} > form > section > .vstack > label:has(.${treeContainer})`, {
   display: 'flex',
   flexDirection: 'column',
   flex: 1,

--- a/frontend/tests/e2e/13-workspace-sections.spec.ts
+++ b/frontend/tests/e2e/13-workspace-sections.spec.ts
@@ -36,10 +36,7 @@ test.describe('Workspace Sections', () => {
     const workspaceName = await wsItem.textContent()
     await openWorkspaceContextMenu(page, workspaceName!.trim())
 
-    // Click "Move to" submenu trigger to open the sub-menu (uses popovertarget)
-    await page.getByRole('menuitem', { name: 'Move to' }).click()
-
-    // Click "Archive"
+    // Click "Archive" (top-level menu item)
     await page.getByRole('menuitem', { name: 'Archive' }).click()
 
     // Confirm the archive in the ConfirmDialog
@@ -47,11 +44,8 @@ test.describe('Workspace Sections', () => {
     await expect(dialog).toBeVisible()
     await dialog.getByRole('button', { name: 'Archive' }).click()
 
-    // Archived section header should appear
+    // Archived section header should appear and be auto-expanded
     await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
-
-    // Archived section is collapsed by default — expand it to see the workspace
-    await page.locator('[data-testid="section-header-workspaces_archived"]').click()
     await expect(wsItem).toBeVisible()
   })
 

--- a/frontend/tests/e2e/14a-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/14a-workspace-archive.spec.ts
@@ -1,14 +1,20 @@
+import process from 'node:process'
 import { expect, test } from './fixtures'
-import { openWorkspaceContextMenu } from './helpers'
+import {
+  createWorkspaceViaAPI,
+  deleteWorkspaceViaAPI,
+  loginViaToken,
+  openWorkspaceContextMenu,
+  waitForWorkspaceReady,
+} from './helpers'
 
 test.describe('Workspace Archive', () => {
   test('should archive workspace via context menu with confirmation dialog', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
     const workspaceName = await workspaceItem.textContent()
 
-    // Open context menu and click Move to > Archive
+    // Open context menu and click Archive (top-level menu item)
     await openWorkspaceContextMenu(page, workspaceName!.trim())
-    await page.getByRole('menuitem', { name: 'Move to' }).click()
     await page.getByRole('menuitem', { name: 'Archive' }).click()
 
     // Confirmation dialog should appear
@@ -20,21 +26,20 @@ test.describe('Workspace Archive', () => {
     // Confirm the archive
     await dialog.getByRole('button', { name: 'Archive' }).click()
 
-    // Workspace should now be in the archived section
+    // Workspace should now be in the archived section (auto-expanded)
     const archivedSection = page.locator('[data-testid="section-header-workspaces_archived"]')
     await expect(archivedSection).toBeVisible()
 
-    // Add button should be hidden and archived empty state shown
-    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('This workspace is archived')
+    // Workspace item should be visible inside the archived section (auto-expanded)
+    await expect(workspaceItem).toBeVisible()
   })
 
   test('should cancel archive via confirmation dialog', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
     const workspaceName = await workspaceItem.textContent()
 
-    // Open context menu and click Move to > Archive
+    // Open context menu and click Archive (top-level menu item)
     await openWorkspaceContextMenu(page, workspaceName!.trim())
-    await page.getByRole('menuitem', { name: 'Move to' }).click()
     await page.getByRole('menuitem', { name: 'Archive' }).click()
 
     // Confirmation dialog should appear
@@ -55,45 +60,213 @@ test.describe('Workspace Archive', () => {
     // Archive the workspace first: open context menu using the workspace item directly
     await workspaceItem.hover()
     await workspaceItem.locator('button').first().click()
-    await page.getByRole('menuitem', { name: 'Move to' }).click()
     await page.getByRole('menuitem', { name: 'Archive' }).click()
     await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
-    // Wait for the archived state
-    await expect(page.locator('[data-testid="tile-empty-state"]')).toContainText('This workspace is archived')
-
-    // Expand the Archived section (collapsed by default) to reveal the workspace
-    await page.locator('[data-testid="section-header-workspaces_archived"]').click()
+    // Wait for the archived section to appear (auto-expanded)
+    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
     await expect(workspaceItem).toBeVisible()
 
     // Now unarchive it: open context menu using the workspace item directly
-    // (cannot use openWorkspaceContextMenu because hasText would include changed menu item text)
     await workspaceItem.hover()
     await workspaceItem.locator('button').first().click()
     await page.getByRole('menuitem', { name: 'Unarchive' }).click()
 
-    // Archived empty state should be gone, replaced by interactive action buttons
-    await expect(page.locator('[data-testid="empty-tile-actions"]')).toBeVisible()
+    // Workspace is active again — add-tab buttons should be visible
+    await expect(page.locator('[data-testid="new-agent-button"]')).toBeVisible()
   })
 
-  test('should only show In Progress and Custom sections in Move-to menu', async ({ page, authenticatedWorkspace }) => {
+  test('should not show Move-to when workspace is in the only target section', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
     const workspaceName = await workspaceItem.textContent()
 
-    // Open context menu and click Move to to open submenu
+    // Open context menu — with only one workspace section (In Progress),
+    // "Move to" should not appear since there are no other target sections
     await openWorkspaceContextMenu(page, workspaceName!.trim())
-    await page.getByRole('menuitem', { name: 'Move to' }).click()
 
-    // Wait for the submenu to appear
-    const archiveButton = page.getByRole('menuitem', { name: 'Archive' })
-    await expect(archiveButton).toBeVisible()
+    // "Move to" should not be visible (no other non-archived, non-shared sections to move to)
+    await expect(page.getByRole('menuitem', { name: 'Move to' })).not.toBeVisible()
 
-    // Shared, Files, To-dos should NOT appear as move targets
+    // Other menu items should be present
+    await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Archive' })).toBeVisible()
+  })
+
+  test('should only show valid workspace sections in Move-to menu', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Open context menu
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+
+    // Shared, Files, To-dos should NOT appear as menu items for move targets
     const menuItems = page.getByRole('menuitem')
     const allLabels = await menuItems.allTextContents()
     expect(allLabels).not.toContain('Shared')
     expect(allLabels).not.toContain('Files')
     expect(allLabels).not.toContain('To-dos')
+  })
+
+  test('should auto-expand archived section after archiving', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Archive the workspace
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+    // The archived section should be visible and expanded (auto-expand)
+    const archivedSection = page.locator('[data-testid="section-header-workspaces_archived"]')
+    await expect(archivedSection).toBeVisible()
+
+    // The workspace item should be visible inside the archived section without
+    // manually expanding it — proving the section was auto-expanded
+    await expect(workspaceItem).toBeVisible()
+  })
+
+  test('should keep tabs visible after archiving active workspace', async ({ page, authenticatedWorkspace }) => {
+    // The fixture auto-creates a workspace with an agent tab.
+    // Verify at least one agent tab is visible before archiving.
+    const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+    await expect(agentTab).toBeVisible()
+
+    const workspaceItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
+    const workspaceName = await workspaceItem.textContent()
+
+    // Archive the workspace
+    await openWorkspaceContextMenu(page, workspaceName!.trim())
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+    // Tabs should still be visible (read-only) after archiving
+    await expect(agentTab).toBeVisible()
+
+    // Close button should be hidden (readOnly mode)
+    await expect(agentTab.locator('[data-testid="tab-close"]')).not.toBeVisible()
+
+    // The add-tab buttons should be hidden (workspace is archived)
+    await expect(page.locator('[data-testid="new-agent-button"]')).not.toBeVisible()
+
+    // Editor panel should be hidden for archived workspaces
+    await expect(page.locator('[data-testid="agent-editor-panel"]')).not.toBeVisible()
+  })
+
+  test('should allow closing file tabs in archived workspace', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'File Tab Close', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree and open a file tab
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+      await page.getByText('package.json').click()
+      const fileTab = page.locator('[data-testid="tab"][data-tab-type="file"]')
+      await expect(fileTab).toBeVisible({ timeout: 10_000 })
+
+      // Archive the workspace
+      await openWorkspaceContextMenu(page, 'File Tab Close')
+      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+      // Wait for archived section to appear
+      await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+      // Agent tab close button should be hidden (readOnly mode)
+      const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+      await expect(agentTab.locator('[data-testid="tab-close"]')).not.toBeVisible()
+
+      // File tab should still be visible with a close button
+      await expect(fileTab).toBeVisible()
+      const closeButton = fileTab.locator('[data-testid="tab-close"]')
+      await expect(closeButton).toBeVisible()
+
+      // Click the close button to close the file tab
+      await closeButton.click()
+
+      // File tab should be gone
+      await expect(fileTab).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('should hide tree mention button in archived workspace', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'No Mention', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree to load
+      const packageJsonNode = page.getByText('package.json')
+      await expect(packageJsonNode).toBeVisible({ timeout: 15_000 })
+
+      // Verify mention button IS visible before archive
+      await packageJsonNode.hover()
+      const treeRow = packageJsonNode.locator('..')
+      const mentionButton = treeRow.locator('[data-testid="tree-mention-button"]')
+      await expect(mentionButton).toBeVisible()
+
+      // Move mouse away to close the hover
+      await page.mouse.move(0, 0)
+
+      // Archive the workspace
+      await openWorkspaceContextMenu(page, 'No Mention')
+      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+      // Wait for archived section
+      await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+      // Hover over tree node — mention button should NOT be visible
+      await packageJsonNode.hover()
+      await expect(mentionButton).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('should hide file mention button in archived workspace', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'No File Mention', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree and open a file tab
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+      await page.getByText('package.json').click()
+      const fileTab = page.locator('[data-testid="tab"][data-tab-type="file"]')
+      await expect(fileTab).toBeVisible({ timeout: 10_000 })
+
+      // Verify file mention button IS visible before archive
+      const fileMentionButton = page.locator('[data-testid="file-mention-button"]')
+      await expect(fileMentionButton).toBeVisible({ timeout: 5_000 })
+
+      // Archive the workspace
+      await openWorkspaceContextMenu(page, 'No File Mention')
+      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+
+      // Wait for archived section
+      await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+      // Click the file tab to view it again (it may have switched to agent tab)
+      await fileTab.click()
+
+      // File mention button should NOT be visible
+      await expect(fileMentionButton).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
   })
 
   test('should delete workspace using ConfirmDialog instead of native confirm', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -52,23 +52,26 @@ test.describe('Chat Message Rendering', () => {
 
     const bubble = page.locator('[data-testid="message-bubble"]').first()
     const row = bubble.locator('..') // parent messageRow div
-    // Check the copy-JSON button (which has opacity:0 by default via toolHeaderButtonHidden).
+    // The hidden button group (timestamp + copy JSON) has opacity:0 by default
+    // and is revealed on hover via toolHeaderHiddenGroup.
     // Playwright's toBeVisible() does not consider opacity:0 as hidden, so we check CSS directly.
-    const copyButton = row.locator('[data-testid="message-copy-json"]')
+    const toolbar = row.locator('[data-testid="message-toolbar"]')
+    // The first child div inside the toolbar is the hidden group wrapper
+    const hiddenGroup = toolbar.locator('> div').first()
 
     // Move mouse away first to ensure no hover state
     await page.mouse.move(0, 0)
 
-    // Hidden toolbar button should have opacity 0 initially
-    await expect(copyButton).toHaveCSS('opacity', '0')
+    // Hidden group should have opacity 0 initially
+    await expect(hiddenGroup).toHaveCSS('opacity', '0')
 
-    // Hover over the bubble — row hover rule reveals hidden buttons
+    // Hover over the bubble — row hover rule reveals the hidden group
     await bubble.hover()
-    await expect(copyButton).toHaveCSS('opacity', '1')
+    await expect(hiddenGroup).toHaveCSS('opacity', '1')
 
     // Move mouse away
     await page.mouse.move(0, 0)
-    await expect(copyButton).toHaveCSS('opacity', '0')
+    await expect(hiddenGroup).toHaveCSS('opacity', '0')
   })
 
   test('should copy Raw JSON to clipboard on button click', async ({ page, context, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -52,26 +52,23 @@ test.describe('Chat Message Rendering', () => {
 
     const bubble = page.locator('[data-testid="message-bubble"]').first()
     const row = bubble.locator('..') // parent messageRow div
-    // The hidden button group (timestamp + copy JSON) has opacity:0 by default
-    // and is revealed on hover via toolHeaderHiddenGroup.
+    // The toolbar has opacity:0 by default and is revealed on hover via toolHeaderActions.
     // Playwright's toBeVisible() does not consider opacity:0 as hidden, so we check CSS directly.
     const toolbar = row.locator('[data-testid="message-toolbar"]')
-    // The first child div inside the toolbar is the hidden group wrapper
-    const hiddenGroup = toolbar.locator('> div').first()
 
     // Move mouse away first to ensure no hover state
     await page.mouse.move(0, 0)
 
-    // Hidden group should have opacity 0 initially
-    await expect(hiddenGroup).toHaveCSS('opacity', '0')
+    // Toolbar should have opacity 0 initially
+    await expect(toolbar).toHaveCSS('opacity', '0')
 
-    // Hover over the bubble — row hover rule reveals the hidden group
+    // Hover over the bubble — row hover rule reveals the toolbar
     await bubble.hover()
-    await expect(hiddenGroup).toHaveCSS('opacity', '1')
+    await expect(toolbar).toHaveCSS('opacity', '1')
 
     // Move mouse away
     await page.mouse.move(0, 0)
-    await expect(hiddenGroup).toHaveCSS('opacity', '0')
+    await expect(toolbar).toHaveCSS('opacity', '0')
   })
 
   test('should copy Raw JSON to clipboard on button click', async ({ page, context, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/30-control-request.spec.ts
+++ b/frontend/tests/e2e/30-control-request.spec.ts
@@ -32,12 +32,20 @@ async function clickOption(page: Page, label: string) {
   await option.click()
 }
 
+// AskUserQuestion requires `description` for every option. Include it in all
+// test payloads so the tool call passes validation regardless of whether the
+// LLM copies the JSON literally or rewrites it.
+
+const COLOR_Q_3 = '{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red","description":"Red color"},{"label":"Blue","description":"Blue color"},{"label":"Green","description":"Green color"}]}'
+const COLOR_Q_2 = '{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red","description":"Red color"},{"label":"Blue","description":"Blue color"}]}'
+const SIZE_Q = '{"question":"Pick a size","header":"Size","multiSelect":false,"options":[{"label":"Small","description":"Small size"},{"label":"Large","description":"Large size"}]}'
+
 test.describe('Control Request - AskUserQuestion', () => {
   test('single question - select an option and submit', async ({ page, authenticatedWorkspace }) => {
     // Send a message that triggers AskUserQuestion
     await sendMessage(
       page,
-      'Use AskUserQuestion and tell me what I answered: {"questions":[{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red"},{"label":"Blue"},{"label":"Green"}]}]}',
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_3}]}`,
     )
 
     // Wait for the control banner
@@ -72,7 +80,7 @@ test.describe('Control Request - AskUserQuestion', () => {
     // Send a message with 2 questions
     await sendMessage(
       page,
-      'Use AskUserQuestion and tell me what I answered: {"questions":[{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red"},{"label":"Blue"}]},{"question":"Pick a size","header":"Size","multiSelect":false,"options":[{"label":"Small"},{"label":"Large"}]}]}',
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_2},${SIZE_Q}]}`,
     )
 
     const banner = await waitForControlBanner(page)
@@ -112,7 +120,7 @@ test.describe('Control Request - AskUserQuestion', () => {
   test('multi-question - option click auto-advances to next page', async ({ page, authenticatedWorkspace }) => {
     await sendMessage(
       page,
-      'Use AskUserQuestion and tell me what I answered: {"questions":[{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red"},{"label":"Blue"}]},{"question":"Pick a size","header":"Size","multiSelect":false,"options":[{"label":"Small"},{"label":"Large"}]}]}',
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_2},${SIZE_Q}]}`,
     )
 
     const banner = await waitForControlBanner(page)
@@ -145,7 +153,7 @@ test.describe('Control Request - AskUserQuestion', () => {
   test('YOLO button fills unanswered questions', async ({ page, authenticatedWorkspace }) => {
     await sendMessage(
       page,
-      'Use AskUserQuestion and tell me what I answered: {"questions":[{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red"},{"label":"Blue"}]},{"question":"Pick a size","header":"Size","multiSelect":false,"options":[{"label":"Small"},{"label":"Large"}]}]}',
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_2},${SIZE_Q}]}`,
     )
 
     await waitForControlBanner(page)
@@ -170,7 +178,7 @@ test.describe('Control Request - AskUserQuestion', () => {
   test('Stop button rejects the request', async ({ page, authenticatedWorkspace }) => {
     await sendMessage(
       page,
-      'Use AskUserQuestion and tell me what I answered: {"questions":[{"question":"Pick a color","header":"Color","multiSelect":false,"options":[{"label":"Red"},{"label":"Blue"}]}]}',
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_2}]}`,
     )
 
     await waitForControlBanner(page)

--- a/frontend/tests/e2e/55-worktree-support.spec.ts
+++ b/frontend/tests/e2e/55-worktree-support.spec.ts
@@ -53,6 +53,22 @@ async function waitForOrgPageReady(page: Page) {
 }
 
 /**
+ * Open the "New Workspace" dialog by clicking whichever button is available.
+ * The left sidebar may be collapsed (rail mode), hiding `sidebar-new-workspace`.
+ * Fall back to the empty-state `create-workspace-button` in the main area.
+ */
+async function openNewWorkspaceDialog(page: Page) {
+  const sidebarBtn = page.locator('[data-testid="sidebar-new-workspace"]')
+  const createBtn = page.locator('[data-testid="create-workspace-button"]')
+  await expect(sidebarBtn.or(createBtn)).toBeVisible()
+  if (await sidebarBtn.isVisible())
+    await sidebarBtn.click()
+  else
+    await createBtn.click()
+  await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+}
+
+/**
  * Create a workspace with a worktree enabled via the ConnectRPC API.
  * Returns the workspace ID.
  */
@@ -280,8 +296,7 @@ test.describe('Worktree Support', () => {
     await waitForOrgPageReady(page)
 
     // Open new workspace dialog via sidebar button
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -315,8 +330,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -346,8 +360,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -440,8 +453,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -950,8 +962,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -981,8 +992,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -1058,8 +1068,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 
@@ -1115,8 +1124,7 @@ test.describe('Worktree Support', () => {
     await page.goto('/o/admin')
     await waitForOrgPageReady(page)
 
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     await waitForWorker(page)
 

--- a/frontend/tests/e2e/61-quote-and-mention.spec.ts
+++ b/frontend/tests/e2e/61-quote-and-mention.spec.ts
@@ -1,0 +1,206 @@
+import process from 'node:process'
+import { expect, test } from './fixtures'
+import {
+  createWorkspaceViaAPI,
+  deleteWorkspaceViaAPI,
+  loginViaToken,
+  sendMessage,
+  waitForAgentIdle,
+  waitForWorkspaceReady,
+} from './helpers'
+
+test.describe('Quote and Mention', () => {
+  test('reply button on assistant message inserts quoted text into editor', async ({ page, authenticatedWorkspace }) => {
+    // Wait for the editor to be ready
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+
+    // Send a message and wait for the assistant to reply
+    await sendMessage(page, 'Say exactly: Hello world')
+    await waitForAgentIdle(page)
+
+    // Find an assistant bubble row
+    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    await expect(assistantBubble).toBeVisible()
+
+    // Hover the row to reveal the reply button (it's hidden by default via opacity: 0)
+    const messageRow = assistantBubble.locator('..')
+    await messageRow.hover()
+
+    // The reply button should become visible
+    const replyButton = messageRow.locator('[data-testid="message-reply"]')
+    await expect(replyButton).toBeVisible()
+
+    // Click the reply button
+    await replyButton.click()
+
+    // Verify the editor now contains a blockquote (Milkdown renders > text as <blockquote>)
+    await expect(editor.locator('blockquote')).toBeVisible()
+  })
+
+  test('text selection in chat message shows quote popover', async ({ page, authenticatedWorkspace }) => {
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+
+    // Send a message and wait for the assistant to reply
+    await sendMessage(page, 'Say exactly: The quick brown fox jumps over the lazy dog')
+    await waitForAgentIdle(page)
+
+    // Find the assistant message content
+    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    await expect(assistantBubble).toBeVisible()
+
+    const messageContent = assistantBubble.locator('[data-testid="message-content"]')
+
+    // Triple-click to select a paragraph of text
+    await messageContent.click({ clickCount: 3 })
+
+    // Wait a bit for the popover to appear (mouseup triggers it)
+    await page.waitForTimeout(500)
+
+    // The quote popover should appear
+    const quoteButton = page.locator('[data-testid="quote-selection-button"]')
+    await expect(quoteButton).toBeVisible({ timeout: 5_000 })
+
+    // Click the quote button
+    await quoteButton.click()
+
+    // Verify the editor now contains a blockquote (Milkdown renders > text as <blockquote>)
+    await expect(editor.locator('blockquote')).toBeVisible()
+  })
+
+  test('AtSign mention button in DirectoryTree hover', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Tree Mention Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Ensure an agent tab exists and the editor is ready
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await expect(editor).toBeVisible()
+
+      // Wait for the file tree to load — package.json should be visible
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Find the tree node row containing package.json and hover it
+      const packageJsonNode = page.getByText('package.json')
+      await packageJsonNode.hover()
+
+      // Click the mention button that appears within the same tree node row
+      const treeRow = packageJsonNode.locator('..')
+      const mentionButton = treeRow.locator('[data-testid="tree-mention-button"]')
+      await expect(mentionButton).toBeVisible()
+      await mentionButton.click()
+
+      // Verify the editor contains @package.json (the path is relative to cwd)
+      await expect(editor).toContainText('@package.json')
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('AtSign mention button in file view toolbar', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'File Mention Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Ensure an agent tab exists and click it to populate MRU
+      const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]')
+      await expect(agentTab).toBeVisible()
+      await agentTab.click()
+
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await expect(editor).toBeVisible()
+
+      // Wait for the file tree to load
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Click on package.json to open it as a file tab
+      await page.getByText('package.json').click()
+
+      // Wait for the file tab to appear and become active
+      const fileTab = page.locator('[data-testid="tab"][data-tab-type="file"]')
+      await expect(fileTab).toBeVisible({ timeout: 10_000 })
+
+      // Wait for file content to load
+      await page.waitForTimeout(1000)
+
+      // Find the mention button in the floating toolbar
+      const mentionButton = page.locator('[data-testid="file-mention-button"]')
+      await expect(mentionButton).toBeVisible({ timeout: 5_000 })
+
+      // Click the mention button
+      await mentionButton.click()
+
+      // Wait for the agent tab to become active (tab switch + component mount)
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"][aria-selected="true"]'))
+        .toBeVisible({ timeout: 5_000 })
+
+      // Verify the editor contains @package.json
+      await expect(editor).toContainText('@package.json')
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('text selection quote in file view inserts with file path and line numbers', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'File Quote Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Ensure an agent tab exists and click it to populate MRU
+      const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]')
+      await expect(agentTab).toBeVisible()
+      await agentTab.click()
+
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await expect(editor).toBeVisible()
+
+      // Wait for the file tree to load
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Click on package.json to open it as a file tab
+      await page.getByText('package.json').click()
+
+      // Wait for the file tab and content to load
+      const fileTab = page.locator('[data-testid="tab"][data-tab-type="file"]')
+      await expect(fileTab).toBeVisible({ timeout: 10_000 })
+
+      // Wait for line-numbered content to appear (data-line-num attributes)
+      const lineElements = page.locator('[data-line-num]')
+      await expect(lineElements.first()).toBeVisible({ timeout: 10_000 })
+
+      // Triple-click on a line to select text within the file view
+      await lineElements.first().click({ clickCount: 3 })
+
+      // Wait for the quote popover to appear
+      await page.waitForTimeout(500)
+
+      const quoteButton = page.locator('[data-testid="quote-selection-button"]')
+      await expect(quoteButton).toBeVisible({ timeout: 5_000 })
+
+      // Click the quote button
+      await quoteButton.click()
+
+      // Wait for the agent tab to become active (tab switch + component mount)
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"][aria-selected="true"]'))
+        .toBeVisible({ timeout: 5_000 })
+
+      // Verify the editor contains the expected format with "At" and the path
+      await expect(editor).toContainText('At')
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+})

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -680,6 +680,43 @@ export async function deleteWorkspaceViaAPI(
 }
 
 /**
+ * List all workspaces in an org via the Connect API.
+ */
+export async function listWorkspacesViaAPI(
+  hubUrl: string,
+  token: string,
+  orgId: string,
+): Promise<{ id: string }[]> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.WorkspaceService/ListWorkspaces`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ orgId }),
+  })
+  if (!res.ok) {
+    throw new Error(`listWorkspacesViaAPI failed: ${res.status}`)
+  }
+  const data = await res.json() as { workspaces: { id: string }[] }
+  return data.workspaces ?? []
+}
+
+/**
+ * Delete all workspaces in an org via the Connect API (best effort).
+ */
+export async function deleteAllWorkspacesViaAPI(
+  hubUrl: string,
+  token: string,
+  orgId: string,
+): Promise<void> {
+  const workspaces = await listWorkspacesViaAPI(hubUrl, token, orgId)
+  for (const ws of workspaces) {
+    await deleteWorkspaceViaAPI(hubUrl, token, ws.id).catch(() => {})
+  }
+}
+
+/**
  * Inject auth token into localStorage before navigation.
  * Uses addInitScript so the token is set before any page scripts run.
  * Must be called **before** any page.goto() calls.

--- a/frontend/tests/unit/components/MessageBubble.test.tsx
+++ b/frontend/tests/unit/components/MessageBubble.test.tsx
@@ -209,6 +209,59 @@ describe('askUserQuestion thread rendering', () => {
 // rawJson (Copy Raw JSON feature)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Thinking message toolbar buttons (Quote / Copy Markdown)
+// ---------------------------------------------------------------------------
+
+describe('thinking message toolbar buttons', () => {
+  it('shows Quote and Copy Markdown buttons for thinking messages', () => {
+    const innerMsg = {
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: 'Let me think about this...' }] },
+    }
+    const msg = makeMsg({
+      role: MessageRole.ASSISTANT,
+      content: wrapContent([innerMsg]),
+    })
+
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} onReply={() => {}} />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.queryByTestId('message-quote')).not.toBeNull()
+    expect(screen.queryByTestId('message-copy-markdown')).not.toBeNull()
+  })
+
+  it('copies thinking content to clipboard via Copy Markdown', async () => {
+    const thinkingText = 'Let me think step by step about this problem.'
+    const innerMsg = {
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: thinkingText }] },
+    }
+    const msg = makeMsg({
+      role: MessageRole.ASSISTANT,
+      content: wrapContent([innerMsg]),
+    })
+
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} onReply={() => {}} />
+      </PreferencesProvider>
+    ))
+
+    const copyBtn = screen.getByTestId('message-copy-markdown')
+    fireEvent.click(copyBtn)
+    await waitFor(() => expect(clipboardContent).not.toBeNull())
+    expect(clipboardContent).toBe(thinkingText)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// rawJson (Copy Raw JSON feature)
+// ---------------------------------------------------------------------------
+
 describe('messageBubble rawJson', () => {
   it('includes metadata fields', async () => {
     const innerMsg = {

--- a/frontend/tests/unit/components/TabBar.test.tsx
+++ b/frontend/tests/unit/components/TabBar.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { TabBar } from '~/components/shell/TabBar'
+import { TabType } from '~/stores/tab.store'
+
+// Mock solid-dnd to avoid DragDropProvider context requirement
+vi.mock('@thisbeyond/solid-dnd', () => ({
+  createSortable: () => ({}),
+  createDroppable: () => () => {},
+  SortableProvider: (props: any) => props.children,
+  transformStyle: () => undefined,
+}))
+
+// Mock CrossTileDragContext
+vi.mock('~/components/shell/CrossTileDragContext', () => ({
+  TABBAR_ZONE_PREFIX: 'tabbar:',
+  useCrossTileDrag: () => {
+    throw new Error('not in provider')
+  },
+}))
+
+// Mock DropdownMenu to render children directly (jsdom lacks popover API)
+vi.mock('~/components/common/DropdownMenu', () => ({
+  DropdownMenu(props: any) {
+    const trigger = typeof props.trigger === 'function'
+      ? props.trigger({
+          'aria-expanded': false,
+          'ref': () => {},
+          'onPointerDown': () => {},
+          'onClick': () => {},
+        })
+      : props.trigger
+    return (
+      <>
+        {trigger}
+        {props.children}
+      </>
+    )
+  },
+}))
+
+// Mock TabBar.css to provide minimal class names
+vi.mock('~/components/shell/TabBar.css', () => ({
+  tabBar: 'tabBar',
+  tabList: 'tabList',
+  tabListDropTarget: 'tabListDropTarget',
+  tab: 'tab',
+  tabDragging: 'tabDragging',
+  tabIcon: 'tabIcon',
+  tabText: 'tabText',
+  tabEditInput: 'tabEditInput',
+  tabNotification: 'tabNotification',
+  tabClose: 'tabClose',
+  tooltipTrigger: 'tooltipTrigger',
+  newTabWrapper: 'newTabWrapper',
+  collapsedNewTab: 'collapsedNewTab',
+  collapsedOverflow: 'collapsedOverflow',
+  shellDefault: 'shellDefault',
+}))
+
+function noop() {}
+
+const defaultProps = {
+  tileId: 'tile-1',
+  tabs: [] as any[],
+  activeTabKey: null,
+  showAddButton: true,
+  onSelect: noop,
+  onClose: noop,
+  onRename: noop as any,
+  onNewAgent: noop,
+  onNewTerminal: noop,
+}
+
+function makeTab(type: TabType, id: string, title?: string) {
+  return { type, id, title, position: '0|' }
+}
+
+describe('tabBar readOnly prop', () => {
+  it('shows close button for all tab types when readOnly is false', () => {
+    const tabs = [
+      makeTab(TabType.AGENT, 'a1', 'Agent 1'),
+      makeTab(TabType.TERMINAL, 't1', 'Terminal 1'),
+      makeTab(TabType.FILE, 'f1', 'File 1'),
+    ]
+    render(() => (
+      <TabBar
+        {...defaultProps}
+        tabs={tabs}
+        readOnly={false}
+      />
+    ))
+    const closeButtons = screen.getAllByTestId('tab-close')
+    expect(closeButtons).toHaveLength(3)
+  })
+
+  it('hides close button for agent and terminal tabs when readOnly is true', () => {
+    const tabs = [
+      makeTab(TabType.AGENT, 'a1', 'Agent 1'),
+      makeTab(TabType.TERMINAL, 't1', 'Terminal 1'),
+    ]
+    render(() => (
+      <TabBar
+        {...defaultProps}
+        tabs={tabs}
+        readOnly={true}
+      />
+    ))
+    const closeButtons = screen.queryAllByTestId('tab-close')
+    expect(closeButtons).toHaveLength(0)
+  })
+
+  it('shows close button for file tabs when readOnly is true', () => {
+    const tabs = [
+      makeTab(TabType.FILE, 'f1', 'readme.md'),
+    ]
+    render(() => (
+      <TabBar
+        {...defaultProps}
+        tabs={tabs}
+        readOnly={true}
+      />
+    ))
+    const closeButtons = screen.getAllByTestId('tab-close')
+    expect(closeButtons).toHaveLength(1)
+  })
+
+  it('shows close button for file tab but not agent/terminal when readOnly is true', () => {
+    const tabs = [
+      makeTab(TabType.AGENT, 'a1', 'Agent 1'),
+      makeTab(TabType.TERMINAL, 't1', 'Terminal 1'),
+      makeTab(TabType.FILE, 'f1', 'readme.md'),
+    ]
+    render(() => (
+      <TabBar
+        {...defaultProps}
+        tabs={tabs}
+        readOnly={true}
+      />
+    ))
+    // Only the file tab should have a close button
+    const closeButtons = screen.getAllByTestId('tab-close')
+    expect(closeButtons).toHaveLength(1)
+  })
+
+  it('hides add-tab buttons when readOnly is true', () => {
+    render(() => (
+      <TabBar
+        {...defaultProps}
+        tabs={[makeTab(TabType.AGENT, 'a1', 'Agent')]}
+        readOnly={true}
+        showAddButton={false}
+      />
+    ))
+    expect(screen.queryByTestId('new-agent-button')).toBeNull()
+    expect(screen.queryByTestId('new-terminal-button')).toBeNull()
+  })
+})

--- a/frontend/tests/unit/components/ViewToggle.test.tsx
+++ b/frontend/tests/unit/components/ViewToggle.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { ViewToggle } from '~/components/fileviewer/ViewToggle'
+
+// Mock FileViewer.css to provide minimal class names
+vi.mock('~/components/fileviewer/FileViewer.css', () => ({
+  viewToggle: 'viewToggle',
+  viewToggleButton: 'viewToggleButton',
+  viewToggleActive: 'viewToggleActive',
+}))
+
+function noop() {}
+
+describe('viewToggle', () => {
+  it('shows mention button when onMention is provided', () => {
+    render(() => (
+      <ViewToggle
+        mode="render"
+        onToggle={noop}
+        onMention={() => {}}
+      />
+    ))
+    expect(screen.getByTestId('file-mention-button')).toBeTruthy()
+  })
+
+  it('hides mention button when onMention is undefined', () => {
+    render(() => (
+      <ViewToggle
+        mode="render"
+        onToggle={noop}
+      />
+    ))
+    expect(screen.queryByTestId('file-mention-button')).toBeNull()
+  })
+
+  it('calls onMention when mention button is clicked', () => {
+    const onMention = vi.fn()
+    render(() => (
+      <ViewToggle
+        mode="render"
+        onToggle={noop}
+        onMention={onMention}
+      />
+    ))
+    screen.getByTestId('file-mention-button').click()
+    expect(onMention).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/tests/unit/components/WorkspaceContextMenu.test.tsx
+++ b/frontend/tests/unit/components/WorkspaceContextMenu.test.tsx
@@ -1,0 +1,181 @@
+import { create } from '@bufbuild/protobuf'
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { WorkspaceContextMenu } from '~/components/workspace/WorkspaceContextMenu'
+import { SectionSchema, SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
+
+// Mock DropdownMenu to render children directly (jsdom lacks popover API).
+vi.mock('~/components/common/DropdownMenu', () => ({
+  DropdownMenu(props: any) {
+    // Render trigger (if function, call with dummy props) and children
+    const trigger = typeof props.trigger === 'function'
+      ? props.trigger({
+          'aria-expanded': true,
+          'ref': () => {},
+          'onPointerDown': () => {},
+          'onClick': () => {},
+        })
+      : props.trigger
+    return (
+      <>
+        {trigger}
+        {props.children}
+      </>
+    )
+  },
+}))
+
+function makeSection(
+  id: string,
+  name: string,
+  sectionType: SectionType,
+) {
+  return create(SectionSchema, {
+    id,
+    name,
+    position: '',
+    sectionType,
+    sidebar: Sidebar.LEFT,
+  })
+}
+
+function noop() {}
+
+const defaultProps = {
+  isOwner: true,
+  isArchived: false,
+  sections: [] as ReturnType<typeof makeSection>[],
+  currentSectionId: 'sec-ip',
+  onRename: noop,
+  onMoveTo: noop as (sectionId: string) => void,
+  onShare: noop,
+  onArchive: noop,
+  onUnarchive: noop,
+  onDelete: noop,
+}
+
+describe('workspaceContextMenu', () => {
+  it('hides Move-to when isArchived is true', () => {
+    const sections = [
+      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
+      makeSection('sec-custom', 'My Section', SectionType.WORKSPACES_CUSTOM),
+    ]
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        isArchived={true}
+        sections={sections}
+      />
+    ))
+    expect(screen.queryByText('Move to')).toBeNull()
+    // Unarchive should be visible instead of Archive
+    expect(screen.getByText('Unarchive')).toBeTruthy()
+    expect(screen.queryByText('Archive')).toBeNull()
+  })
+
+  it('hides Move-to when no other target sections exist', () => {
+    // Only one workspace section — the current one
+    const sections = [
+      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
+      makeSection('sec-archived', 'Archived', SectionType.WORKSPACES_ARCHIVED),
+      makeSection('sec-files', 'Files', SectionType.FILES),
+    ]
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        sections={sections}
+        currentSectionId="sec-ip"
+      />
+    ))
+    // Move to should not be visible because the only target sections
+    // are the current section, archived (excluded), and files (excluded)
+    expect(screen.queryByText('Move to')).toBeNull()
+  })
+
+  it('shows Move-to when other target sections exist', () => {
+    const sections = [
+      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
+      makeSection('sec-custom', 'My Section', SectionType.WORKSPACES_CUSTOM),
+    ]
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        sections={sections}
+        currentSectionId="sec-ip"
+      />
+    ))
+    expect(screen.getByText('Move to')).toBeTruthy()
+    // The submenu should list the custom section but not the current section
+    expect(screen.getByText('My Section')).toBeTruthy()
+    expect(screen.queryByText('In Progress')).toBeNull()
+  })
+
+  it('excludes current section from Move-to list', () => {
+    const sections = [
+      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
+      makeSection('sec-custom1', 'Alpha', SectionType.WORKSPACES_CUSTOM),
+      makeSection('sec-custom2', 'Beta', SectionType.WORKSPACES_CUSTOM),
+    ]
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        sections={sections}
+        currentSectionId="sec-custom1"
+      />
+    ))
+    // Alpha (current section) should not appear; others should
+    expect(screen.queryByText('Alpha')).toBeNull()
+    expect(screen.getByText('In Progress')).toBeTruthy()
+    expect(screen.getByText('Beta')).toBeTruthy()
+  })
+
+  it('shows "Share..." label', () => {
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
+      />
+    ))
+    expect(screen.getByText('Share...')).toBeTruthy()
+  })
+
+  it('shows Archive for non-archived workspaces', () => {
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        isArchived={false}
+        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
+      />
+    ))
+    expect(screen.getByText('Archive')).toBeTruthy()
+    expect(screen.queryByText('Unarchive')).toBeNull()
+  })
+
+  it('shows Unarchive for archived workspaces', () => {
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        isArchived={true}
+        sections={[makeSection('sec-archived', 'Archived', SectionType.WORKSPACES_ARCHIVED)]}
+        currentSectionId="sec-archived"
+      />
+    ))
+    expect(screen.getByText('Unarchive')).toBeTruthy()
+    expect(screen.queryByText('Archive')).toBeNull()
+  })
+
+  it('hides owner-only items when not owner', () => {
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        isOwner={false}
+        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
+      />
+    ))
+    expect(screen.queryByText('Rename')).toBeNull()
+    expect(screen.queryByText('Share...')).toBeNull()
+    expect(screen.queryByText('Delete')).toBeNull()
+    // Archive should still be visible (not owner-only)
+    expect(screen.getByText('Archive')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Motivation

Working with agent chat and file content requires friction-free ways to reference
existing text. Users had no way to quote a selection from a message or file into
the editor, no way to @mention a file directly from the file viewer or sidebar,
and no Copy Markdown action on messages. Additionally, the message toolbar was
cramped (buttons hidden on hover), code block copy buttons scrolled away with
content, and archive UX required extra steps to locate the newly archived
workspace.

## Modifications

**Quote and reply**
- Added `SelectionQuotePopover` that appears above any text selection with "Quote"
  and "Copy" actions; wired into `ChatView`, `TextFileView`, and `MarkdownFileView`
- Added a reply button on `MessageBubble` that inserts a formatted blockquote into
  the composer; thinking messages now also show Quote and Copy Markdown buttons
- Added `formatChatQuote`, `formatFileQuote`, `formatFileMention`, and
  `extractSelectionMarkdown` / `nodeToMarkdown` utilities for consistent quote
  formatting across contexts

**@mention from file viewer and sidebars**
- Added `onMention` / `onQuote` callback props through `DirectoryTree`,
  `TextFileView`, `ImageFileView`, and `ViewToggle`
- Paths are relativized against the MRU agent tab's working directory so mentions
  stay portable

**Editor reference registry**
- Introduced `editorRef.store` (`registerEditorRef`, `unregisterEditorRef`,
  `appendText`, `insertIntoMruAgentEditor`) so any component can insert text into
  the most-recently-used agent editor without prop-drilling

**Toolbar and code block polish**
- Redesigned message action toolbar to a 2x2 grid; Quote and Copy Markdown are now
  always visible instead of hidden on hover
- Added `Copy Markdown` button to message bubbles
- Fixed code block copy button staying pinned during horizontal scroll by extracting
  shared styling into `codeBlock.ts` and giving `<pre>` `position: relative` with
  `<code>` handling `overflowX: auto`
- Scrollbar aligned to the content border

**Archive and workspace UX**
- Auto-expands the Archived section in the workspace sidebar immediately after
  archiving via new `expandSectionRef` callback
- Archived workspaces are now read-only: tab renaming disabled, only file tabs can
  be closed, and quote/reply callbacks are suppressed
- Workspace context menu reordered and uses `IconButton`; drag state tracked to
  suppress spurious clicks after drag operations

**Style consolidation**
- (Refactor) Merged `dialogCompact` into `dialogStandard`, widening compact dialogs
  from 400 px to 480 px and eliminating duplicated CSS

**Draft persistence**
- `MarkdownEditor` now saves drafts even when props become `null` during component
  unmount by tracking `latestDraftKey` independently of reactive getters

**Tests**
- New E2E suite `61-quote-and-mention.spec.ts` covering reply-with-quote, text
  selection copy, and @mention flows
- 3 new unit test suites: `TabBar`, `ViewToggle`, `WorkspaceContextMenu`
- Expanded `MessageBubble` unit tests for button visibility on thinking messages
- API helper functions added: `createWorkspaceViaAPI`, `deleteWorkspaceViaAPI`,
  `loginViaToken`, `waitForWorkspaceReady`, `sendMessage`, `waitForAgentIdle`

## Result

Users can now select text in any chat message or file view and immediately quote it
into the composer with a single click. Clicking the reply button on a message, or
the "Quote" action in the selection popover, produces a properly formatted blockquote
followed by the cursor ready to type. Files and directories can be @mentioned
directly from the file viewer and sidebars without leaving the current view.

Code block copy buttons no longer scroll out of view when a wide code block is
scrolled horizontally. Archiving a workspace immediately reveals it in the expanded
Archived section without requiring a manual scroll. Archived workspaces are
protected from accidental edits.

🤖 Generated with Claude Code
