### PR TITLE
Fix mobile layout crash and add responsive sidebar e2e tests

### DIFF
--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -147,6 +147,11 @@ export const mobileOverlay = style({
   zIndex: 99,
 })
 
+export const mobileTabBar = style({
+  position: 'relative',
+  zIndex: 100,
+})
+
 // --- End mobile layout styles ---
 
 export const dragPreviewTooltip = style({

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -106,8 +106,14 @@ export const AppShell: ParentComponent = (props) => {
   const isMobile = useIsMobile()
   const [leftSidebarOpen, setLeftSidebarOpen] = createSignal(false)
   const [rightSidebarOpen, setRightSidebarOpen] = createSignal(false)
-  const toggleLeftSidebar = () => setLeftSidebarOpen(prev => !prev)
-  const toggleRightSidebar = () => setRightSidebarOpen(prev => !prev)
+  const toggleLeftSidebar = () => {
+    setLeftSidebarOpen(prev => !prev)
+    setRightSidebarOpen(false)
+  }
+  const toggleRightSidebar = () => {
+    setRightSidebarOpen(prev => !prev)
+    setLeftSidebarOpen(false)
+  }
   const closeAllSidebars = () => {
     setLeftSidebarOpen(false)
     setRightSidebarOpen(false)
@@ -1407,37 +1413,45 @@ export const AppShell: ParentComponent = (props) => {
             when={!isMobile()}
             fallback={(
               /* ---- Mobile layout ---- */
-              <div class={styles.mobileShell}>
-                {/* Overlay backdrop */}
-                <Show when={leftSidebarOpen() || rightSidebarOpen()}>
-                  <div class={styles.mobileOverlay} onClick={closeAllSidebars} />
-                </Show>
-
-                {/* Left sidebar overlay */}
-                <div
-                  class={styles.mobileSidebar}
-                  classList={{ [styles.mobileSidebarOpen]: leftSidebarOpen() }}
-                >
-                  {leftSidebarElement()}
-                </div>
-
-                {/* Right sidebar overlay */}
-                <div
-                  class={`${styles.mobileSidebar} ${styles.mobileSidebarRight}`}
-                  classList={{ [styles.mobileSidebarOpen]: rightSidebarOpen() }}
-                >
-                  {rightSidebarElement()}
-                </div>
-
-                {/* Center content - single tile on mobile */}
-                <div class={styles.mobileCenter}>
-                  {tabBarElement()}
-                  {renderTileContent(layoutStore.focusedTileId())}
-                  <Show when={focusedAgentId() && !isActiveWorkspaceArchived()}>
-                    <FocusedAgentEditorPanel containerHeight={0} />
+              <SectionDragProvider
+                sections={() => sectionStore.state.sections}
+                onMoveSection={handleMoveSection}
+                onMoveSectionServer={handleMoveSectionServer}
+              >
+                <div class={styles.mobileShell}>
+                  {/* Overlay backdrop */}
+                  <Show when={leftSidebarOpen() || rightSidebarOpen()}>
+                    <div class={styles.mobileOverlay} onClick={closeAllSidebars} />
                   </Show>
+
+                  {/* Left sidebar overlay */}
+                  <div
+                    class={styles.mobileSidebar}
+                    classList={{ [styles.mobileSidebarOpen]: leftSidebarOpen() }}
+                  >
+                    {leftSidebarElement()}
+                  </div>
+
+                  {/* Right sidebar overlay */}
+                  <div
+                    class={`${styles.mobileSidebar} ${styles.mobileSidebarRight}`}
+                    classList={{ [styles.mobileSidebarOpen]: rightSidebarOpen() }}
+                  >
+                    {rightSidebarElement()}
+                  </div>
+
+                  {/* Center content - single tile on mobile */}
+                  <div class={styles.mobileCenter}>
+                    <div class={styles.mobileTabBar}>
+                      {tabBarElement()}
+                    </div>
+                    {renderTileContent(layoutStore.focusedTileId())}
+                    <Show when={focusedAgentId() && !isActiveWorkspaceArchived()}>
+                      <FocusedAgentEditorPanel containerHeight={0} />
+                    </Show>
+                  </div>
                 </div>
-              </div>
+              </SectionDragProvider>
             )}
           >
             {/* ---- Desktop layout ---- */}

--- a/frontend/tests/e2e/53-responsive-mobile-sidebar.spec.ts
+++ b/frontend/tests/e2e/53-responsive-mobile-sidebar.spec.ts
@@ -1,0 +1,142 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { waitForWorkspaceReady } from './helpers'
+
+/** Switch to a smartphone-sized viewport, reload, and wait for the mobile layout. */
+async function switchToMobile(page: Page) {
+  await page.setViewportSize({ width: 375, height: 667 })
+  await page.reload()
+  await waitForWorkspaceReady(page)
+  // Wait for mobile toggle buttons to appear (indicates mobile layout is active)
+  await expect(page.getByRole('button', { name: 'Toggle workspaces' })).toBeVisible()
+}
+
+test.describe('Responsive Mobile Sidebar', () => {
+  test('should hide desktop sidebars and show toggle buttons on mobile', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    // Desktop sidebar sections should not be visible (they're off-screen)
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+    await expect(leftSidebar).not.toBeInViewport()
+
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+    await expect(rightSidebar).not.toBeInViewport()
+
+    // Mobile toggle buttons should be visible in the tab bar
+    await expect(page.getByRole('button', { name: 'Toggle workspaces' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Toggle files' })).toBeVisible()
+
+    // Desktop resize handles should not exist
+    await expect(page.locator('[data-testid="resize-handle"]')).toHaveCount(0)
+  })
+
+  test('should open and close left sidebar', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    const leftToggle = page.getByRole('button', { name: 'Toggle workspaces' })
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+
+    // Initially the left sidebar should be off-screen
+    await expect(leftSidebar).not.toBeInViewport()
+
+    // Click the toggle to open the left sidebar
+    await leftToggle.click()
+
+    // Left sidebar should now be visible (in viewport)
+    await expect(leftSidebar).toBeInViewport()
+
+    // The "In Progress" section header should be visible
+    await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
+
+    // Overlay should be present
+    const overlay = page.locator('[class*="mobileOverlay"]')
+    await expect(overlay).toBeVisible()
+
+    // Click the overlay to close the sidebar
+    await overlay.click()
+
+    // Left sidebar should be off-screen again
+    await expect(leftSidebar).not.toBeInViewport()
+
+    // Overlay should be gone
+    await expect(overlay).not.toBeVisible()
+  })
+
+  test('should open and close right sidebar', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    const rightToggle = page.getByRole('button', { name: 'Toggle files' })
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+
+    // Initially the right sidebar should be off-screen
+    await expect(rightSidebar).not.toBeInViewport()
+
+    // Click the toggle to open the right sidebar
+    await rightToggle.click()
+
+    // Right sidebar should now be visible
+    await expect(rightSidebar).toBeInViewport()
+
+    // The "Files" section header should be visible
+    await expect(page.locator('[data-testid="section-header-files-summary"]')).toBeVisible()
+
+    // Overlay should be present
+    const overlay = page.locator('[class*="mobileOverlay"]')
+    await expect(overlay).toBeVisible()
+
+    // Click the overlay to close the sidebar
+    await overlay.click()
+
+    // Right sidebar should be off-screen again
+    await expect(rightSidebar).not.toBeInViewport()
+  })
+
+  test('should close left sidebar when toggle is clicked again', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    const leftToggle = page.getByRole('button', { name: 'Toggle workspaces' })
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+
+    // Open
+    await leftToggle.click()
+    await expect(leftSidebar).toBeInViewport()
+
+    // Close via the toggle button (not the overlay)
+    await leftToggle.click()
+    await expect(leftSidebar).not.toBeInViewport()
+  })
+
+  test('should close right sidebar when toggle is clicked again', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    const rightToggle = page.getByRole('button', { name: 'Toggle files' })
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+
+    // Open
+    await rightToggle.click()
+    await expect(rightSidebar).toBeInViewport()
+
+    // Close via the toggle button (not the overlay)
+    await rightToggle.click()
+    await expect(rightSidebar).not.toBeInViewport()
+  })
+
+  test('should close open sidebar when the other sidebar is opened', async ({ page, authenticatedWorkspace }) => {
+    await switchToMobile(page)
+
+    const leftToggle = page.getByRole('button', { name: 'Toggle workspaces' })
+    const rightToggle = page.getByRole('button', { name: 'Toggle files' })
+    const leftSidebar = page.locator('[data-testid="sidebar-left"]')
+    const rightSidebar = page.locator('[data-testid="sidebar-right"]')
+
+    // Open left sidebar
+    await leftToggle.click()
+    await expect(leftSidebar).toBeInViewport()
+    await expect(rightSidebar).not.toBeInViewport()
+
+    // Open right sidebar — left should close
+    await rightToggle.click()
+    await expect(rightSidebar).toBeInViewport()
+    await expect(leftSidebar).not.toBeInViewport()
+  })
+})


### PR DESCRIPTION
## Motivation
The mobile layout was crashing due to a missing `SectionDragProvider` wrapper in the mobile shell fallback path. Additionally, both sidebars could be open simultaneously, causing UI conflicts, and the tab bar lacked the correct stacking context to appear above the overlay on mobile.

## Modifications
- Wrap the mobile shell in `SectionDragProvider` to fix the crash caused by missing drag-and-drop context on mobile
- Make sidebar toggle functions mutually exclusive so opening one sidebar automatically closes the other
- Add `mobileTabBar` CSS class with `z-index: 100` to keep the tab bar above the overlay on mobile
- Wrap the tab bar in a dedicated container on mobile to establish a proper stacking context
- Add 6 e2e tests in `frontend/tests/e2e/53-responsive-mobile-sidebar.spec.ts` covering sidebar open/close behavior, overlay interactions, and mutual exclusivity

## Result
- The mobile layout no longer crashes when drag-and-drop context is needed
- Opening the left sidebar automatically closes the right sidebar (and vice versa), eliminating conflicting UI states
- The tab bar now renders above the overlay on mobile as expected

🤖 Generated with Claude Code
