### PR TITLE
Add dedicated Skill tool use message renderer

### DIFF
--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { renderMessageContent } from './messageRenderers'
+
+/** Build a tool_use assistant message for the given tool name and input. */
+function makeToolUseMessage(name: string, input: Record<string, unknown>) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', id: 'test-id', name, input }],
+    },
+  }
+}
+
+/** Render a tool_use message and return the trimmed text content. */
+function renderToolUseText(name: string, input: Record<string, unknown>): string {
+  const parsed = makeToolUseMessage(name, input)
+  const result = renderMessageContent(parsed, 0 /* ROLE_ASSISTANT */)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+describe('skill renderer', () => {
+  it('renders Skill: /create-pr', () => {
+    expect(renderToolUseText('Skill', { skill: 'create-pr' })).toBe('Skill: /create-pr')
+  })
+
+  it('renders Skill: /review-pr', () => {
+    expect(renderToolUseText('Skill', { skill: 'review-pr' })).toBe('Skill: /review-pr')
+  })
+
+  it('renders Skill: /commit', () => {
+    expect(renderToolUseText('Skill', { skill: 'commit' })).toBe('Skill: /commit')
+  })
+})

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -24,6 +24,7 @@ import Rows2 from 'lucide-solid/icons/rows-2'
 import Search from 'lucide-solid/icons/search'
 import Terminal from 'lucide-solid/icons/terminal'
 import TicketsPlane from 'lucide-solid/icons/tickets-plane'
+import Toolbox from 'lucide-solid/icons/toolbox'
 import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
 import Vote from 'lucide-solid/icons/vote'
 import { createSignal, Show } from 'solid-js'
@@ -87,6 +88,7 @@ export function toolIcon(name: string, size: number): JSX.Element {
     case 'EnterPlanMode': return <TicketsPlane size={size} class={toolUseIcon} />
     case 'ExitPlanMode': return <PlaneTakeoff size={size} class={toolUseIcon} />
     case 'AskUserQuestion': return <Vote size={size} class={toolUseIcon} />
+    case 'Skill': return <Toolbox size={size} class={toolUseIcon} />
     default: return <ChevronsRight size={size} class={toolUseIcon} />
   }
 }


### PR DESCRIPTION
## Motivation

The chat UI renders various tool invocations (e.g., `EnterPlanMode`, `ExitPlanMode`, `TodoWrite`) with specialized, human-readable displays. The `Skill` tool, which the agent uses to invoke named skills such as `/create-pr`, `/review-pr`, and `/commit`, previously fell through to the generic tool renderer and was shown in a raw, unformatted style. This change gives `Skill` tool invocations the same first-class treatment as other specialized tools.

## Modifications

- Added `renderSkill()` in `frontend/src/components/chat/messageRenderers.tsx` to render `Skill` tool_use messages as `Skill: /<skill-name>` with a Toolbox icon, matching the visual style of other specialized tool renderers.
- Registered `skillRenderer` (a `MessageContentRenderer` wrapper around `renderSkill`) in both `SPECIALIZED_TOOL_RENDERERS` (for O(1) dispatch) and the `_fallbackRenderers` list (for linear scan fallback).
- Added the `Skill` case to `toolIcon()` in `frontend/src/components/chat/toolRenderers.tsx`, mapping it to the `Toolbox` icon for consistency when the generic renderer is used in other contexts.
- Imported the `Toolbox` icon from `lucide-solid` in both `messageRenderers.tsx` and `toolRenderers.tsx`.
- Added unit tests in `frontend/src/components/chat/messageRenderers.test.tsx` covering three representative skill invocations: `/create-pr`, `/review-pr`, and `/commit`.

## Result

When the agent invokes the `Skill` tool, the chat message now displays a clean, labeled header such as `Skill: /create-pr` with a Toolbox icon, instead of a raw fallback representation. This makes skill invocations immediately recognizable in the conversation history.

🤖 Generated with Claude Code
