### PR TITLE
Add specialized TaskOutput tool_use renderer with ANSI support

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -314,6 +314,9 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
         : undefined,
       childResultContent: extractChildResultContent(),
       childResultIsError: extractChildResultIsError(),
+      childTask: (typeof tur?.task === 'object' && tur.task !== null && !Array.isArray(tur.task))
+        ? tur.task as RenderContext['childTask']
+        : undefined,
       childControlResponse: childControlResponse(),
     }
   }

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -13,12 +13,14 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import Hand from 'lucide-solid/icons/hand'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
+import SquareTerminal from 'lucide-solid/icons/square-terminal'
 import Stamp from 'lucide-solid/icons/stamp'
 import Terminal from 'lucide-solid/icons/terminal'
 import TicketsPlane from 'lucide-solid/icons/tickets-plane'
 import Vote from 'lucide-solid/icons/vote'
 import { createSignal, For, Show } from 'solid-js'
 import { TodoList } from '~/components/todo/TodoList'
+import { containsAnsi, renderAnsi } from '~/lib/renderAnsi'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { inlineFlex } from '~/styles/shared.css'
 import { markdownContent } from './markdownContent.css'
@@ -46,7 +48,10 @@ import {
   answerText,
   toolInputDetail,
   toolInputSubDetail,
+  toolInputSubDetailExpanded,
   toolMessage,
+  toolResultContentAnsi,
+  toolResultContentPre,
   toolUseHeader,
   toolUseIcon,
 } from './toolStyles.css'
@@ -88,6 +93,15 @@ export interface RenderContext {
   childResultContent?: string
   /** Whether the child tool_result has is_error=true (for fallback rejection detection). */
   childResultIsError?: boolean
+  /** Task data from child tool_result (for TaskOutput renderer). */
+  childTask?: {
+    task_id?: string
+    task_type?: string
+    status?: string
+    description?: string
+    output?: string
+    exitCode?: number
+  }
   /** Control response (approval/rejection) threaded into this tool_use. */
   childControlResponse?: { action: string, comment: string }
 }
@@ -304,6 +318,92 @@ function renderAskUserQuestion(toolUse: Record<string, unknown>, context?: Rende
   )
 }
 
+/** Format task status for display. */
+export function formatTaskStatus(status?: string): string {
+  if (!status)
+    return 'Pending'
+  if (status === 'completed')
+    return 'Complete'
+  if (status === 'failed')
+    return 'Failed'
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+/** Return the first non-empty trimmed line from text, or null. */
+export function firstNonEmptyLine(text?: string): string | null {
+  if (!text)
+    return null
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed)
+      return trimmed
+  }
+  return null
+}
+
+/** Render TaskOutput tool_use with task status, description, and output. */
+function renderTaskOutput(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
+  const task = context?.childTask
+  const status = formatTaskStatus(task?.status)
+  const description = task?.description
+  const output = task?.output
+  const firstLine = firstNonEmptyLine(output)
+  const expanded = context?.threadExpanded ?? false
+
+  return (
+    <div class={toolMessage}>
+      <div class={toolUseHeader}>
+        <span class={inlineFlex} title="TaskOutput">
+          <SquareTerminal size={16} class={toolUseIcon} />
+        </span>
+        <span class={toolInputDetail}>
+          {status}
+          {description ? ` - ${description}` : ''}
+        </span>
+        <ControlResponseTag response={context?.childControlResponse} />
+        <Show when={context}>
+          <ToolHeaderActions
+            createdAt={context!.createdAt}
+            updatedAt={context!.updatedAt}
+            threadCount={context!.threadChildCount ?? 0}
+            threadExpanded={context!.threadExpanded ?? false}
+            onToggleThread={context!.onToggleThread ?? (() => {})}
+            onCopyJson={context!.onCopyJson ?? (() => {})}
+            jsonCopied={context!.jsonCopied ?? false}
+          />
+        </Show>
+      </div>
+      <Show when={!expanded && firstLine}>
+        <div class={toolInputSubDetail}>{firstLine}</div>
+      </Show>
+      <Show when={expanded}>
+        <div class={toolInputSubDetailExpanded}>
+          <Show when={task?.task_id}>
+            {`task_id: ${task!.task_id}`}
+          </Show>
+          <Show when={task?.task_type}>
+            {`\ntask_type: ${task!.task_type}`}
+          </Show>
+          <Show when={task?.status}>
+            {`\nstatus: ${task!.status}`}
+          </Show>
+          <Show when={description}>
+            {`\ndescription: ${description}`}
+          </Show>
+          <Show when={task?.exitCode !== undefined}>
+            {`\nexitCode: ${task!.exitCode}`}
+          </Show>
+        </div>
+        <Show when={output}>
+          {containsAnsi(output!)
+            ? <div class={toolResultContentAnsi} innerHTML={renderAnsi(output!)} />
+            : <div class={toolResultContentPre}>{output}</div>}
+        </Show>
+      </Show>
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // MessageContentRenderer wrappers (used by getFallbackRenderers linear scan)
 // ---------------------------------------------------------------------------
@@ -353,6 +453,18 @@ const askUserQuestionRenderer: MessageContentRenderer = {
     if (!toolUse)
       return null
     return renderAskUserQuestion(toolUse as Record<string, unknown>, context)
+  },
+}
+
+const taskOutputRenderer: MessageContentRenderer = {
+  render(parsed, _role, context) {
+    const content = getAssistantContent(parsed)
+    if (!content)
+      return null
+    const toolUse = content.find(c => isObject(c) && c.type === 'tool_use' && c.name === 'TaskOutput')
+    if (!toolUse)
+      return null
+    return renderTaskOutput(toolUse as Record<string, unknown>, context)
   },
 }
 
@@ -528,6 +640,7 @@ const SPECIALIZED_TOOL_RENDERERS: Record<string, (toolUse: Record<string, unknow
   ExitPlanMode: renderExitPlanMode,
   TodoWrite: renderTodoWrite,
   AskUserQuestion: renderAskUserQuestion,
+  TaskOutput: renderTaskOutput,
 }
 
 /** Dispatch rendering for a tool_use category: try specialized renderer first, then generic. */
@@ -612,6 +725,7 @@ function getFallbackRenderers(): MessageContentRenderer[] {
       enterPlanModeRenderer,
       todoWriteRenderer,
       askUserQuestionRenderer,
+      taskOutputRenderer,
       toolUseRenderer,
       toolResultRenderer,
       userTextContentRenderer,

--- a/frontend/src/components/chat/taskOutputRenderer.test.tsx
+++ b/frontend/src/components/chat/taskOutputRenderer.test.tsx
@@ -1,0 +1,178 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock renderAnsi to avoid shiki initialization in tests.
+vi.mock('~/lib/renderAnsi', () => ({
+  // eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching control characters
+  containsAnsi: (text: string) => /\x1B\[[\d;]*m/.test(text),
+  renderAnsi: (text: string) => `<pre class="shiki"><code>${text}</code></pre>`,
+}))
+
+// Mock renderMarkdown to avoid shiki initialization in tests.
+vi.mock('~/lib/renderMarkdown', () => ({
+  renderMarkdown: (text: string) => text,
+}))
+
+const { formatTaskStatus, firstNonEmptyLine, renderMessageContent } = await import('./messageRenderers')
+type RenderContext = import('./messageRenderers').RenderContext
+
+/** Construct a TaskOutput tool_use assistant message object. */
+function makeTaskOutputMessage() {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'test',
+        name: 'TaskOutput',
+        input: { task_id: 'test123', block: true, timeout: 120000 },
+      }],
+    },
+  }
+}
+
+/** Render a TaskOutput message with the given context and return the text content. */
+function renderText(context?: RenderContext): string {
+  const msg = makeTaskOutputMessage()
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a TaskOutput message with the given context and return the container innerHTML. */
+function renderHtml(context?: RenderContext): string {
+  const msg = makeTaskOutputMessage()
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.innerHTML
+}
+
+describe('formatTaskStatus', () => {
+  it('"completed" → "Complete"', () => {
+    expect(formatTaskStatus('completed')).toBe('Complete')
+  })
+
+  it('"failed" → "Failed"', () => {
+    expect(formatTaskStatus('failed')).toBe('Failed')
+  })
+
+  it('"running" → "Running"', () => {
+    expect(formatTaskStatus('running')).toBe('Running')
+  })
+
+  it('undefined → "Pending"', () => {
+    expect(formatTaskStatus(undefined)).toBe('Pending')
+  })
+})
+
+describe('firstNonEmptyLine', () => {
+  it('multi-line text with leading blank lines → returns first non-empty trimmed line', () => {
+    expect(firstNonEmptyLine('\n\n  hello world  \nsecond line')).toBe('hello world')
+  })
+
+  it('empty string → returns null', () => {
+    expect(firstNonEmptyLine('')).toBeNull()
+  })
+
+  it('undefined → returns null', () => {
+    expect(firstNonEmptyLine(undefined)).toBeNull()
+  })
+})
+
+describe('renderTaskOutput', () => {
+  it('all properties present: shows status and description', () => {
+    const text = renderText({
+      childTask: {
+        task_id: 'abc',
+        task_type: 'shell',
+        status: 'completed',
+        description: 'Build project',
+        output: 'Build succeeded',
+        exitCode: 0,
+      },
+    })
+    expect(text).toContain('Complete')
+    expect(text).toContain('Build project')
+  })
+
+  it('missing status: shows "Pending"', () => {
+    const text = renderText({
+      childTask: {
+        description: 'Some task',
+      },
+    })
+    expect(text).toContain('Pending')
+  })
+
+  it('missing description: shows status only, no dash separator', () => {
+    const text = renderText({
+      childTask: {
+        status: 'running',
+      },
+    })
+    expect(text).toContain('Running')
+    expect(text).not.toContain(' - ')
+  })
+
+  it('collapsed with output: first line shown as subdetail', () => {
+    const text = renderText({
+      childTask: {
+        status: 'completed',
+        description: 'Test run',
+        output: 'All tests passed\n42 tests total',
+      },
+    })
+    expect(text).toContain('All tests passed')
+  })
+
+  it('expanded shows property labels', () => {
+    const text = renderText({
+      threadExpanded: true,
+      childTask: {
+        task_id: 'xyz',
+        task_type: 'shell',
+        status: 'completed',
+        description: 'Run tests',
+        output: 'ok',
+        exitCode: 0,
+      },
+    })
+    expect(text).toContain('task_id:')
+    expect(text).toContain('task_type:')
+    expect(text).toContain('exitCode:')
+  })
+
+  it('expanded with ANSI output: rendered HTML contains shiki class', () => {
+    const html = renderHtml({
+      threadExpanded: true,
+      childTask: {
+        status: 'completed',
+        output: '\x1B[32mgreen text\x1B[0m',
+      },
+    })
+    expect(html).toContain('shiki')
+  })
+
+  it('expanded with plain output: text content includes the output', () => {
+    const text = renderText({
+      threadExpanded: true,
+      childTask: {
+        status: 'completed',
+        output: 'plain output text',
+      },
+    })
+    expect(text).toContain('plain output text')
+  })
+
+  it('all childTask properties missing (undefined): graceful "Pending" fallback', () => {
+    const text = renderText({
+      childTask: {},
+    })
+    expect(text).toContain('Pending')
+  })
+
+  it('no childTask at all (no thread child yet): shows "Pending"', () => {
+    const text = renderText({})
+    expect(text).toContain('Pending')
+  })
+})

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -22,6 +22,7 @@ import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import Quote from 'lucide-solid/icons/quote'
 import Rows2 from 'lucide-solid/icons/rows-2'
 import Search from 'lucide-solid/icons/search'
+import SquareTerminal from 'lucide-solid/icons/square-terminal'
 import Terminal from 'lucide-solid/icons/terminal'
 import TicketsPlane from 'lucide-solid/icons/tickets-plane'
 import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
@@ -87,6 +88,7 @@ export function toolIcon(name: string, size: number): JSX.Element {
     case 'EnterPlanMode': return <TicketsPlane size={size} class={toolUseIcon} />
     case 'ExitPlanMode': return <PlaneTakeoff size={size} class={toolUseIcon} />
     case 'AskUserQuestion': return <Vote size={size} class={toolUseIcon} />
+    case 'TaskOutput': return <SquareTerminal size={size} class={toolUseIcon} />
     default: return <ChevronsRight size={size} class={toolUseIcon} />
   }
 }
@@ -499,7 +501,7 @@ function ToolResultMessage(props: {
           when={hasDiff()}
           fallback={
             props.isPreText
-              ? (props.toolName === 'Bash' && containsAnsi(props.resultContent))
+              ? ((props.toolName === 'Bash' || props.toolName === 'TaskOutput') && containsAnsi(props.resultContent))
                   /* eslint-disable-next-line solid/no-innerhtml -- HTML from renderAnsi, not user input */
                   ? <div class={toolResultContentAnsi} innerHTML={renderAnsi(props.resultContent)} />
                   : renderReadOrPre(props.toolName, props.resultContent, props.context)

--- a/frontend/src/types/toolMessages.ts
+++ b/frontend/src/types/toolMessages.ts
@@ -63,6 +63,12 @@ export interface TodoWriteInput {
   }>
 }
 
+export interface TaskOutputInput {
+  task_id?: string
+  block?: boolean
+  timeout?: number
+}
+
 export interface AskUserQuestionInput {
   questions?: Array<{
     question?: string
@@ -87,6 +93,7 @@ export type KnownToolInput
     | { toolName: 'WebFetch', input: WebFetchInput }
     | { toolName: 'WebSearch', input: WebSearchInput }
     | { toolName: 'TodoWrite', input: TodoWriteInput }
+    | { toolName: 'TaskOutput', input: TaskOutputInput }
     | { toolName: 'AskUserQuestion', input: AskUserQuestionInput }
 
 /** All known tool names. */
@@ -102,6 +109,7 @@ const KNOWN_TOOLS = new Set<string>([
   'Task',
   'WebFetch',
   'WebSearch',
+  'TaskOutput',
   'TodoWrite',
   'AskUserQuestion',
 ])


### PR DESCRIPTION
## Motivation

The `TaskOutput` tool is used by sub-agents to report task execution results (status, description, terminal output) back to the orchestrating agent. Previously, `TaskOutput` tool_use messages fell through to the generic tool renderer, which displayed the raw input parameters (`task_id`, `block`, `timeout`) rather than the actual task result data stored in the accompanying tool_result. This made it difficult to understand what a task did and how it completed when reading the chat history.

## Modifications

- Added `renderTaskOutput()` in `messageRenderers.tsx` — a dedicated renderer for `TaskOutput` tool_use messages that displays a `SquareTerminal` icon, the formatted task status, and the task description in the header row.
- Added `formatTaskStatus()` helper that normalizes raw status strings for display (e.g. `"completed"` becomes `"Complete"`, `"failed"` becomes `"Failed"`, unknown statuses are title-cased).
- Added `firstNonEmptyLine()` helper that extracts the first non-blank trimmed line from multiline output text, used as a collapsed preview.
- Implemented collapsible detail view: when collapsed, the first non-empty output line is shown as a subdued subdetail; when expanded, all task metadata fields (`task_id`, `task_type`, `status`, `description`, `exitCode`) and the full output are shown.
- Added ANSI escape sequence rendering for `TaskOutput` output, using the same `renderAnsi` path as `Bash` tool output, so colored terminal output is rendered faithfully.
- Added `childTask` property to the `RenderContext` interface to carry task metadata from the tool_result into the tool_use renderer, populated in `MessageBubble.tsx` from `tool_use_result.task`.
- Added `TaskOutputInput` interface in `/frontend/src/types/toolMessages.ts` (`task_id`, `block`, `timeout`) and registered `TaskOutput` in the `KnownToolInput` discriminated union and `KNOWN_TOOLS` set.
- Registered `TaskOutput` in the `SPECIALIZED_TOOL_RENDERERS` dispatch map so it is resolved in O(1) rather than through the fallback linear scan.
- Added `taskOutputRenderer.test.tsx` (178 lines) covering `formatTaskStatus`, `firstNonEmptyLine`, and `renderTaskOutput` — including collapsed/expanded states, missing fields, and ANSI output rendering.

## Result

`TaskOutput` tool_use messages in the chat now display a recognizable square-terminal icon with the human-readable task status and description in the header. When collapsed, the first line of the task's terminal output is shown as a preview. When expanded, all task metadata and the full output are visible, with ANSI color codes rendered as styled text rather than raw escape sequences.

🤖 Generated with Claude Code
