### PR TITLE
Introduce common Dialog component and consolidate dialog styles

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,7 +1,7 @@
 import type { Component, JSX } from 'solid-js'
-import { onMount, Show } from 'solid-js'
-import { dialogStandard } from '~/styles/shared.css'
+import { Show } from 'solid-js'
 import { ConfirmButton } from './ConfirmButton'
+import { Dialog } from './Dialog'
 
 interface ConfirmDialogProps {
   title: string
@@ -14,13 +14,8 @@ interface ConfirmDialogProps {
 }
 
 export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
-  let dlgRef!: HTMLDialogElement
-
-  onMount(() => dlgRef.showModal())
-
   return (
-    <dialog ref={dlgRef} class={dialogStandard} closedby="any" onClose={() => props.onCancel()}>
-      <header><h2>{props.title}</h2></header>
+    <Dialog title={props.title} onClose={() => props.onCancel()}>
       <section>{props.children}</section>
       <footer>
         <button type="button" class="outline" onClick={() => props.onCancel()}>
@@ -39,6 +34,6 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
           </ConfirmButton>
         </Show>
       </footer>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -1,0 +1,42 @@
+import type { Component, JSX } from 'solid-js'
+import X from 'lucide-solid/icons/x'
+import { onMount } from 'solid-js'
+import { dialogCloseButton, dialogHeader, dialogStandard, dialogTall } from '~/styles/shared.css'
+import { IconButton } from './IconButton'
+
+interface DialogProps {
+  'title': string
+  'tall'?: boolean
+  'class'?: string
+  'data-testid'?: string
+  'onClose': () => void
+  'children': JSX.Element
+}
+
+export const Dialog: Component<DialogProps> = (props) => {
+  let dialogRef!: HTMLDialogElement
+
+  onMount(() => dialogRef.showModal())
+
+  return (
+    <dialog
+      ref={dialogRef}
+      class={`${dialogStandard}${props.tall ? ` ${dialogTall}` : ''}${props.class ? ` ${props.class}` : ''}`}
+      data-testid={props['data-testid']}
+      closedby="any"
+      onClose={() => props.onClose()}
+    >
+      <header class={dialogHeader}>
+        <h2>{props.title}</h2>
+        <IconButton
+          icon={X}
+          size="sm"
+          class={dialogCloseButton}
+          onClick={() => props.onClose()}
+          aria-label="Close"
+        />
+      </header>
+      {props.children}
+    </dialog>
+  )
+}

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -5,12 +5,13 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
 import { agentClient, gitClient, workerClient } from '~/api/clients'
 import { agentCallTimeout, agentLoadingTimeoutMs } from '~/api/transport'
+import { Dialog } from '~/components/common/Dialog'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewAgentDialogProps {
   workspaceId: string
@@ -24,7 +25,6 @@ interface NewAgentDialogProps {
 }
 
 export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
   const org = useOrg()
   const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
   const [workerId, setWorkerId] = createSignal('')
@@ -54,7 +54,6 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
 
   // Fetch on mount only
   onMount(async () => {
-    dialogRef.showModal()
     await fetchWorkers()
     // Pre-select worker if specified and online
     if (props.defaultWorkerId) {
@@ -123,8 +122,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
-      <header><h2>New Agent</h2></header>
+    <Dialog title="New Agent" tall onClose={() => props.onClose()}>
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
@@ -197,6 +195,6 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
           </button>
         </footer>
       </form>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -4,12 +4,13 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
 import { gitClient, terminalClient, workerClient } from '~/api/clients'
 import { apiLoadingTimeoutMs } from '~/api/transport'
+import { Dialog } from '~/components/common/Dialog'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewTerminalDialogProps {
   workspaceId: string
@@ -20,7 +21,6 @@ interface NewTerminalDialogProps {
 }
 
 export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
   const org = useOrg()
   const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
   const [workerId, setWorkerId] = createSignal('')
@@ -53,7 +53,6 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
 
   // Fetch on mount only
   onMount(async () => {
-    dialogRef.showModal()
     await fetchWorkers()
     // Pre-select worker if specified and online
     if (props.defaultWorkerId) {
@@ -145,8 +144,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
-      <header><h2>New Terminal</h2></header>
+    <Dialog title="New Terminal" tall onClose={() => props.onClose()}>
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
@@ -237,6 +235,6 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
           </button>
         </footer>
       </form>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/shell/ResumeSessionDialog.tsx
+++ b/frontend/src/components/shell/ResumeSessionDialog.tsx
@@ -4,10 +4,11 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
 import { agentLoadingTimeoutMs } from '~/api/transport'
+import { Dialog } from '~/components/common/Dialog'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard, errorText, labelRow, refreshButton, spinning } from '~/styles/shared.css'
+import { errorText, labelRow, refreshButton, spinning } from '~/styles/shared.css'
 
 interface ResumeSessionDialogProps {
   defaultWorkerId?: string
@@ -18,7 +19,6 @@ interface ResumeSessionDialogProps {
 const SESSION_ID_PATTERN = /^[\w-]+$/
 
 export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
   const org = useOrg()
   const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
   const [workerId, setWorkerId] = createSignal('')
@@ -56,7 +56,6 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
   }
 
   onMount(async () => {
-    dialogRef.showModal()
     await fetchWorkers()
     // Pre-select worker if specified and online
     if (props.defaultWorkerId) {
@@ -83,8 +82,7 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogStandard} onClose={() => props.onClose()}>
-      <header><h2>Resume an existing session</h2></header>
+    <Dialog title="Resume an existing session" onClose={() => props.onClose()}>
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
@@ -149,6 +147,6 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
           </button>
         </footer>
       </form>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/workers/WorkerSettingsDialog.tsx
+++ b/frontend/src/components/workers/WorkerSettingsDialog.tsx
@@ -3,9 +3,9 @@ import type { Worker } from '~/generated/leapmux/v1/worker_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
+import { Dialog } from '~/components/common/Dialog'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard } from '~/styles/shared.css'
 import * as styles from './WorkerSettingsDialog.css'
 
 export type WorkerSettingsTab = 'general' | 'deregister'
@@ -19,8 +19,6 @@ interface WorkerSettingsDialogProps {
 }
 
 export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
-
   // General tab state
   // eslint-disable-next-line solid/reactivity -- intentionally capture initial value
   const [name, setName] = createSignal(props.worker.name)
@@ -34,7 +32,6 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
   let tabsRef!: HTMLElement
 
   onMount(() => {
-    dialogRef.showModal()
     // Activate the correct tab based on initialTab prop
     if (props.initialTab && props.initialTab !== 'general' && tabsRef) {
       const tabIndex = props.initialTab === 'deregister' ? 1 : 0
@@ -85,9 +82,7 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogStandard} data-testid="worker-settings-dialog" onClose={() => props.onClose()}>
-      <header><h2>Worker Settings</h2></header>
-
+    <Dialog title="Worker Settings" data-testid="worker-settings-dialog" onClose={() => props.onClose()}>
       <ot-tabs ref={tabsRef}>
         <nav role="tablist">
           <button role="tab">General</button>
@@ -151,6 +146,6 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
           </footer>
         </div>
       </ot-tabs>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -5,12 +5,13 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { generateSlug } from 'random-word-slugs'
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { workerClient, workspaceClient } from '~/api/clients'
+import { Dialog } from '~/components/common/Dialog'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard, dialogWithTree, errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
 
 interface NewWorkspaceDialogProps {
   onCreated: (workspace: Workspace) => void
@@ -19,7 +20,6 @@ interface NewWorkspaceDialogProps {
 }
 
 export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
   const org = useOrg()
   const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
   const [workerId, setWorkerId] = createSignal('')
@@ -52,7 +52,6 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
 
   // Fetch on mount only
   onMount(async () => {
-    dialogRef.showModal()
     await fetchWorkers()
     // Pre-select worker if specified and online
     if (props.preselectedWorkerId) {
@@ -98,8 +97,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
   }
 
   return (
-    <dialog ref={dialogRef} class={`${dialogStandard} ${dialogWithTree}`} onClose={() => props.onClose()}>
-      <header><h2>New Workspace</h2></header>
+    <Dialog title="New Workspace" tall onClose={() => props.onClose()}>
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
@@ -194,6 +192,6 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
           </button>
         </footer>
       </form>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/components/workspace/WorkspaceSharingDialog.tsx
+++ b/frontend/src/components/workspace/WorkspaceSharingDialog.tsx
@@ -3,10 +3,10 @@ import type { OrgMember } from '~/generated/leapmux/v1/org_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient, workspaceClient } from '~/api/clients'
+import { Dialog } from '~/components/common/Dialog'
 import { useOrg } from '~/context/OrgContext'
 import { ShareMode } from '~/generated/leapmux/v1/common_pb'
 import { spinner } from '~/styles/animations.css'
-import { dialogStandard } from '~/styles/shared.css'
 import * as styles from './WorkspaceSharingDialog.css'
 
 interface WorkspaceSharingDialogProps {
@@ -16,7 +16,6 @@ interface WorkspaceSharingDialogProps {
 }
 
 export const WorkspaceSharingDialog: Component<WorkspaceSharingDialogProps> = (props) => {
-  let dialogRef!: HTMLDialogElement
   const org = useOrg()
   const [shareMode, setShareMode] = createSignal<ShareMode>(ShareMode.PRIVATE)
   const [selectedUserIds, setSelectedUserIds] = createSignal<string[]>([])
@@ -26,7 +25,6 @@ export const WorkspaceSharingDialog: Component<WorkspaceSharingDialogProps> = (p
   const [error, setError] = createSignal<string | null>(null)
 
   onMount(async () => {
-    dialogRef.showModal()
     try {
       const [sharesResp, membersResp] = await Promise.all([
         workspaceClient.listWorkspaceShares({ workspaceId: props.workspaceId }),
@@ -70,8 +68,7 @@ export const WorkspaceSharingDialog: Component<WorkspaceSharingDialogProps> = (p
   }
 
   return (
-    <dialog ref={dialogRef} class={dialogStandard} onClose={() => props.onClose()}>
-      <header><h2>Workspace Sharing</h2></header>
+    <Dialog title="Workspace Sharing" onClose={() => props.onClose()}>
       <Show when={!loading()} fallback={<div>Loading...</div>}>
         <section>
           <div class="vstack gap-4">
@@ -122,6 +119,6 @@ export const WorkspaceSharingDialog: Component<WorkspaceSharingDialogProps> = (p
           </button>
         </footer>
       </Show>
-    </dialog>
+    </Dialog>
   )
 }

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -88,14 +88,36 @@ export const authCardXWide = style({
 // Dialog sizes
 
 export const dialogStandard = style({
-  minWidth: '360px',
-  maxWidth: '480px',
-  display: 'flex',
-  flexDirection: 'column',
+  'minWidth': '360px',
+  'maxWidth': '480px',
+  'display': 'flex',
+  'flexDirection': 'column',
+  '@media': {
+    '(max-width: 479px)': {
+      minWidth: 'unset',
+      maxWidth: '100vw',
+      width: '100vw',
+    },
+  },
 })
 
-export const dialogWithTree = style({
-  height: '80vh',
+export const dialogTall = style({
+  'height': '80vh',
+  '@media': {
+    '(max-width: 479px)': {
+      height: '100vh',
+    },
+  },
+})
+
+export const dialogHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+})
+
+export const dialogCloseButton = style({
+  flexShrink: 0,
 })
 
 // Make dialog forms use flex layout so the tree container can fill remaining space.

--- a/frontend/tests/e2e/53-responsive-mobile-sidebar.spec.ts
+++ b/frontend/tests/e2e/53-responsive-mobile-sidebar.spec.ts
@@ -52,8 +52,8 @@ test.describe('Responsive Mobile Sidebar', () => {
     const overlay = page.locator('[class*="mobileOverlay"]')
     await expect(overlay).toBeVisible()
 
-    // Click the overlay to close the sidebar
-    await overlay.click()
+    // Click the uncovered strip of the overlay (right edge, outside the 80%-wide sidebar)
+    await overlay.click({ position: { x: 350, y: 333 } })
 
     // Left sidebar should be off-screen again
     await expect(leftSidebar).not.toBeInViewport()
@@ -84,8 +84,8 @@ test.describe('Responsive Mobile Sidebar', () => {
     const overlay = page.locator('[class*="mobileOverlay"]')
     await expect(overlay).toBeVisible()
 
-    // Click the overlay to close the sidebar
-    await overlay.click()
+    // Click the uncovered strip of the overlay (left edge, outside the 80%-wide sidebar)
+    await overlay.click({ position: { x: 25, y: 333 } })
 
     // Right sidebar should be off-screen again
     await expect(rightSidebar).not.toBeInViewport()


### PR DESCRIPTION
## Motivation
Dialog components across the frontend were duplicating the same boilerplate: manual `showModal()` calls, header layout with a close button, and repeated sizing/responsive CSS. This made it hard to apply consistent behavior or style changes across all dialogs in one place.

## Modifications
- Add `frontend/src/components/common/Dialog.tsx` — a new reusable `Dialog` component that encapsulates the native `<dialog>` element, calls `showModal()` on mount, renders a standard header with a title and close `IconButton`, supports an optional `tall` prop and a `data-testid` passthrough, and handles close via `closedby="any"`.
- Migrate all existing dialog components to use the new `Dialog` wrapper, removing their individual `showModal` lifecycle calls and header markup:
  - `ConfirmDialog.tsx`
  - `NewAgentDialog.tsx`
  - `NewTerminalDialog.tsx`
  - `ResumeSessionDialog.tsx`
  - `WorkerSettingsDialog.tsx`
  - `NewWorkspaceDialog.tsx`
  - `WorkspaceSharingDialog.tsx`
- Update `frontend/src/styles/shared.css.ts`: add responsive media queries to `dialogStandard` (full viewport width below 480px), rename `dialogWithTree` to `dialogTall` with responsive full height, and add `dialogHeader`/`dialogCloseButton` styles for the new header layout.
- Fix flaky mobile sidebar e2e test (`53-responsive-mobile-sidebar.spec.ts`) by clicking the uncovered overlay strip instead of the center point (which is intercepted by the sidebar at higher z-index).

## Result
All dialogs now share a single, consistent implementation. Adding a close button, adjusting the header layout, or changing responsive breakpoints only requires editing one file. Dialogs automatically handle `showModal()`, close-on-backdrop-click (`closedby="any"`), and mobile-friendly sizing (full viewport width below 480 px, full height for tall dialogs).

```tsx
// Before: each dialog managed its own lifecycle and header markup

// After: wrap with Dialog and provide a title and onClose handler
<Dialog title="New Agent" tall onClose={() => props.onClose()}>
  <form onSubmit={handleSubmit}>
    ...
  </form>
</Dialog>
```

🤖 Generated with Claude Code
