### PR TITLE
Add root node, context menu, terminal action, and tree state persistence

### DIFF
--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -328,6 +328,10 @@ export const AppShell: ParentComponent = (props) => {
           tabId: t.id,
           position: t.position ?? '',
           tileId: t.tileId ?? '',
+          workingDir: t.workingDir ?? '',
+          shellStartDir: t.type === TabType.TERMINAL
+            ? (terminalStore.state.terminals.find(term => term.id === t.id)?.shellStartDir ?? '')
+            : '',
         }))
 
       workspaceClient.saveLayout({
@@ -492,6 +496,8 @@ export const AppShell: ParentComponent = (props) => {
           terminalStore.addTerminal({
             id: t.terminalId,
             workspaceId: activeId,
+            workingDir: t.workingDir || undefined,
+            shellStartDir: t.shellStartDir || undefined,
             screen: t.screen.length > 0 ? t.screen : undefined,
             cols: t.cols || undefined,
             rows: t.rows || undefined,
@@ -569,7 +575,7 @@ export const AppShell: ParentComponent = (props) => {
           let tileId = tabTileMap.get(key) ?? defaultTileId
           if (!validTileIds.has(tileId))
             tileId = defaultTileId
-          tabStore.addTab({ type: TabType.TERMINAL, id: t.id, tileId }, false)
+          tabStore.addTab({ type: TabType.TERMINAL, id: t.id, tileId, workerId: t.workerId, workingDir: t.workingDir }, false)
         }
       }
 
@@ -1342,6 +1348,9 @@ export const AppShell: ParentComponent = (props) => {
             const ctx = getMruAgentContext()
             insertIntoMruAgentEditor(tabStore, formatFileMention(relativizePath(path, ctx.workingDir, ctx.homeDir)), 'inline')
           }}
+      onOpenTerminal={isActiveWorkspaceArchived()
+        ? undefined
+        : dirPath => termOps.handleOpenTerminal(dirPath)}
       showTodos={showTodos()}
       activeTodos={activeTodos()}
     />
@@ -1372,6 +1381,9 @@ export const AppShell: ParentComponent = (props) => {
             const ctx = getMruAgentContext()
             insertIntoMruAgentEditor(tabStore, formatFileMention(relativizePath(path, ctx.workingDir, ctx.homeDir)), 'inline')
           }}
+      onOpenTerminal={isActiveWorkspaceArchived()
+        ? undefined
+        : dirPath => termOps.handleOpenTerminal(dirPath)}
       sectionStore={sectionStore}
       isCollapsed={opts?.isCollapsed() ?? false}
       onExpand={opts?.onExpand ?? (() => {})}

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -49,6 +49,7 @@ interface LeftSidebarProps {
   onFileSelect: (path: string) => void
   onFileOpen?: (path: string) => void
   onFileMention?: (path: string) => void
+  onOpenTerminal?: (dirPath: string) => void
   showTodos: boolean
   activeTodos: TodoItem[]
 }
@@ -221,6 +222,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
                 onSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
                 onMention={props.onFileMention}
+                onOpenTerminal={props.onOpenTerminal}
                 rootPath={props.workingDir || '~'}
                 homeDir={props.homeDir}
               />

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -30,6 +30,7 @@ interface RightSidebarProps {
   onFileSelect: (path: string) => void
   onFileOpen?: (path: string) => void
   onFileMention?: (path: string) => void
+  onOpenTerminal?: (dirPath: string) => void
   sectionStore: ReturnType<typeof createSectionStore>
   isCollapsed: boolean
   onExpand: () => void
@@ -120,6 +121,7 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
                 onSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
                 onMention={props.onFileMention}
+                onOpenTerminal={props.onOpenTerminal}
                 rootPath={props.workingDir || '~'}
                 homeDir={props.homeDir}
               />

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -54,7 +54,7 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
       })
   })
 
-  const handleOpenTerminal = async () => {
+  const handleOpenTerminal = async (shellStartDir?: string) => {
     if (!props.isActiveWorkspaceMutatable())
       return
     const ws = props.activeWorkspace()
@@ -76,10 +76,11 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
         workingDir: ctx.workingDir,
         shell: '',
         workerId: ctx.workerId,
+        shellStartDir: shellStartDir ?? '',
       })
 
       const tileId = props.layoutStore.focusedTileId()
-      props.terminalStore.addTerminal({ id: resp.terminalId, workspaceId: ws.id, workerId: ctx.workerId, workingDir: ctx.workingDir })
+      props.terminalStore.addTerminal({ id: resp.terminalId, workspaceId: ws.id, workerId: ctx.workerId, workingDir: ctx.workingDir, shellStartDir: shellStartDir ?? ctx.workingDir })
       props.tabStore.addTab({ type: TabType.TERMINAL, id: resp.terminalId, title, tileId, workerId: ctx.workerId, workingDir: ctx.workingDir })
       props.tabStore.setActiveTabForTile(tileId, TabType.TERMINAL, resp.terminalId)
       props.persistLayout?.()

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -109,10 +109,14 @@ export const nodeActions = style({
   alignItems: 'center',
   marginLeft: 'auto',
   flexShrink: 0,
+})
+
+export const nodeMenuTrigger = style({
   opacity: 0,
   transition: 'opacity 0.15s',
   selectors: {
     [`${node}:hover &`]: { opacity: 1 },
+    '&[aria-expanded="true"]': { opacity: 1 },
   },
 })
 

--- a/frontend/src/stores/terminal.store.ts
+++ b/frontend/src/stores/terminal.store.ts
@@ -5,6 +5,7 @@ export interface TerminalInfo {
   workspaceId: string
   workerId?: string
   workingDir?: string
+  shellStartDir?: string
   screen?: Uint8Array
   cols?: number
   rows?: number

--- a/frontend/tests/e2e/14a-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/14a-workspace-archive.spec.ts
@@ -206,13 +206,18 @@ test.describe('Workspace Archive', () => {
       const packageJsonNode = page.getByText('package.json')
       await expect(packageJsonNode).toBeVisible({ timeout: 15_000 })
 
-      // Verify mention button IS visible before archive
+      // Verify mention button IS visible before archive (via context menu)
       await packageJsonNode.hover()
       const treeRow = packageJsonNode.locator('..')
-      const mentionButton = treeRow.locator('[data-testid="tree-mention-button"]')
+      const contextButton = treeRow.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+      const mentionButton = page.locator('[data-testid="tree-mention-button"]:visible')
       await expect(mentionButton).toBeVisible()
+      // Close menu by pressing Escape
+      await page.keyboard.press('Escape')
 
-      // Move mouse away to close the hover
+      // Move mouse away
       await page.mouse.move(0, 0)
 
       // Archive the workspace
@@ -223,8 +228,9 @@ test.describe('Workspace Archive', () => {
       // Wait for archived section
       await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
 
-      // Hover over tree node — mention button should NOT be visible
+      // Hover over tree node — open context menu, mention button should NOT be there
       await packageJsonNode.hover()
+      await contextButton.click()
       await expect(mentionButton).not.toBeVisible()
     }
     finally {

--- a/frontend/tests/e2e/61-quote-and-mention.spec.ts
+++ b/frontend/tests/e2e/61-quote-and-mention.spec.ts
@@ -134,7 +134,7 @@ test.describe('Quote and Mention', () => {
     await expect(editor.locator('blockquote')).toBeVisible()
   })
 
-  test('AtSign mention button in DirectoryTree hover', async ({ page, leapmuxServer }) => {
+  test('AtSign mention button in DirectoryTree context menu', async ({ page, leapmuxServer }) => {
     const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Tree Mention Test', adminOrgId, process.cwd())
     try {
@@ -153,9 +153,14 @@ test.describe('Quote and Mention', () => {
       const packageJsonNode = page.getByText('package.json')
       await packageJsonNode.hover()
 
-      // Click the mention button that appears within the same tree node row
+      // Click the context menu button (three dots) that appears on hover
       const treeRow = packageJsonNode.locator('..')
-      const mentionButton = treeRow.locator('[data-testid="tree-mention-button"]')
+      const contextButton = treeRow.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+
+      // Click "Mention in chat" from the visible dropdown
+      const mentionButton = page.locator('[data-testid="tree-mention-button"]:visible')
       await expect(mentionButton).toBeVisible()
       await mentionButton.click()
 
@@ -278,20 +283,29 @@ test.describe('Quote and Mention', () => {
       // Wait for the file tree to load — package.json should be visible
       await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
 
-      // First mention: hover and click package.json
+      // First mention: hover, open context menu, and click mention for package.json
       const packageJsonNode = page.getByText('package.json')
       await packageJsonNode.hover()
       const treeRow1 = packageJsonNode.locator('..')
-      const mentionButton1 = treeRow1.locator('[data-testid="tree-mention-button"]')
+      const contextButton1 = treeRow1.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton1).toBeVisible()
+      await contextButton1.click()
+      const mentionButton1 = page.locator('[data-testid="tree-mention-button"]:visible')
       await expect(mentionButton1).toBeVisible()
       await mentionButton1.click()
       await expect(editor).toContainText('@package.json')
 
-      // Second mention: hover and click tsconfig.json (or another file)
+      // Wait for the first context menu to fully close before interacting with the next node
+      await expect(page.locator('[data-testid="tree-mention-button"]:visible')).toHaveCount(0)
+
+      // Second mention: hover, open context menu, and click mention for tsconfig.json
       const tsconfigNode = page.getByText('tsconfig.json')
       await tsconfigNode.hover()
       const treeRow2 = tsconfigNode.locator('..')
-      const mentionButton2 = treeRow2.locator('[data-testid="tree-mention-button"]')
+      const contextButton2 = treeRow2.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton2).toBeVisible()
+      await contextButton2.click()
+      const mentionButton2 = page.locator('[data-testid="tree-mention-button"]:visible')
       await expect(mentionButton2).toBeVisible()
       await mentionButton2.click()
 

--- a/frontend/tests/e2e/62-directory-tree.spec.ts
+++ b/frontend/tests/e2e/62-directory-tree.spec.ts
@@ -1,0 +1,206 @@
+import process from 'node:process'
+import { expect, test } from './fixtures'
+import {
+  createWorkspaceViaAPI,
+  deleteWorkspaceViaAPI,
+  loginViaToken,
+  waitForWorkspaceReady,
+} from './helpers'
+
+test.describe('DirectoryTree', () => {
+  test('root directory is visible and collapsible', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Tree Root Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // The root node should be visible
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+
+      // Children should be visible (root starts expanded)
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Click root to collapse
+      await rootNode.click()
+
+      // Children should be hidden
+      await expect(page.getByText('package.json')).not.toBeVisible()
+
+      // Click root to expand again
+      await rootNode.click()
+
+      // Children should reappear
+      await expect(page.getByText('package.json')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('directory context menu shows 4 items including terminal', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Dir Menu Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for root node to appear
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+
+      // Hover the root node and open context menu
+      await rootNode.hover()
+      const contextButton = rootNode.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+
+      // All 4 menu items should be visible for a directory (use :visible to scope to the open popover)
+      await expect(page.locator('[data-testid="tree-mention-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-open-terminal-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-copy-path-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-copy-relative-path-button"]:visible')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('file context menu shows 3 items without terminal', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'File Menu Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree to load
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Hover on package.json file and open context menu
+      const fileNode = page.getByText('package.json')
+      await fileNode.hover()
+      const treeRow = fileNode.locator('..')
+      const contextButton = treeRow.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+
+      // 3 items: mention, copy path, copy relative path — but NOT terminal
+      await expect(page.locator('[data-testid="tree-mention-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-copy-path-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-copy-relative-path-button"]:visible')).toBeVisible()
+      await expect(page.locator('[data-testid="tree-open-terminal-button"]:visible')).toHaveCount(0)
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('open terminal tab from directory context menu', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Open Terminal Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for root node
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+
+      // Hover and open context menu on the root directory
+      await rootNode.hover()
+      const contextButton = rootNode.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+
+      // Click "Open a terminal tab here"
+      const terminalButton = page.locator('[data-testid="tree-open-terminal-button"]:visible')
+      await expect(terminalButton).toBeVisible()
+      await terminalButton.click()
+
+      // A terminal tab should appear
+      const terminalTab = page.locator('[data-testid="tab"][data-tab-type="terminal"]')
+      await expect(terminalTab).toBeVisible({ timeout: 10_000 })
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('copy path copies absolute path to clipboard', async ({ page, context, leapmuxServer }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Copy Path Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for file tree
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Open context menu on package.json
+      const fileNode = page.getByText('package.json')
+      await fileNode.hover()
+      const treeRow = fileNode.locator('..')
+      const contextButton = treeRow.locator('[data-testid="tree-context-button"]')
+      await expect(contextButton).toBeVisible()
+      await contextButton.click()
+
+      // Click "Copy path" from the visible dropdown
+      const copyPathButton = page.locator('[data-testid="tree-copy-path-button"]:visible')
+      await expect(copyPathButton).toBeVisible()
+      await copyPathButton.click()
+
+      // Clipboard should contain the absolute path (ends with /package.json)
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+      expect(clipboardText).toContain('package.json')
+      expect(clipboardText).toMatch(/^\//)
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('expand state persists across tab switches', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'State Persist Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for tree to load and ensure root is expanded (default)
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Collapse the root
+      await rootNode.click()
+      await expect(page.getByText('package.json')).not.toBeVisible()
+
+      // Switch to a terminal tab (if exists) or create one
+      const terminalTab = page.locator('[data-testid="tab"][data-tab-type="terminal"]')
+      const hasTerminal = await terminalTab.count() > 0
+      if (hasTerminal) {
+        await terminalTab.first().click()
+      }
+
+      // Switch back to agent tab
+      const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]')
+      await agentTab.first().click()
+      await page.waitForTimeout(500)
+
+      // Root should still be collapsed (state persisted via sessionStorage)
+      await expect(rootNode).toBeVisible()
+      await expect(page.getByText('package.json')).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+})

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -187,11 +187,13 @@ CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(sect
 
 -- Workspace tabs (unified ordering for agents + terminals)
 CREATE TABLE workspace_tabs (
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    tab_type     INTEGER NOT NULL,
-    tab_id       TEXT NOT NULL,
-    position     TEXT NOT NULL,
-    tile_id      TEXT NOT NULL DEFAULT '',
+    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    tab_type        INTEGER NOT NULL,
+    tab_id          TEXT NOT NULL,
+    position        TEXT NOT NULL,
+    tile_id         TEXT NOT NULL DEFAULT '',
+    working_dir     TEXT NOT NULL DEFAULT '',
+    shell_start_dir TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (workspace_id, tab_type, tab_id)
 );
 CREATE INDEX idx_workspace_tabs_workspace ON workspace_tabs(workspace_id);

--- a/internal/hub/db/queries/workspace_tabs.sql
+++ b/internal/hub/db/queries/workspace_tabs.sql
@@ -1,9 +1,11 @@
 -- name: UpsertWorkspaceTab :exec
-INSERT INTO workspace_tabs (workspace_id, tab_type, tab_id, position, tile_id)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_tabs (workspace_id, tab_type, tab_id, position, tile_id, working_dir, shell_start_dir)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (workspace_id, tab_type, tab_id) DO UPDATE SET
   position = excluded.position,
-  tile_id = excluded.tile_id;
+  tile_id = excluded.tile_id,
+  working_dir = excluded.working_dir,
+  shell_start_dir = excluded.shell_start_dir;
 
 -- name: ListWorkspaceTabsByWorkspace :many
 SELECT * FROM workspace_tabs

--- a/internal/hub/service/workspace_agent_ops.go
+++ b/internal/hub/service/workspace_agent_ops.go
@@ -81,11 +81,13 @@ func (s *WorkspaceService) SaveLayout(
 		}
 		for _, tab := range tabs {
 			if err := s.queries.UpsertWorkspaceTab(ctx, db.UpsertWorkspaceTabParams{
-				WorkspaceID: workspaceID,
-				TabType:     tab.GetTabType(),
-				TabID:       tab.GetTabId(),
-				Position:    tab.GetPosition(),
-				TileID:      tab.GetTileId(),
+				WorkspaceID:   workspaceID,
+				TabType:       tab.GetTabType(),
+				TabID:         tab.GetTabId(),
+				Position:      tab.GetPosition(),
+				TileID:        tab.GetTileId(),
+				WorkingDir:    tab.GetWorkingDir(),
+				ShellStartDir: tab.GetShellStartDir(),
 			}); err != nil {
 				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("save workspace tab: %w", err))
 			}

--- a/internal/hub/service/workspace_service.go
+++ b/internal/hub/service/workspace_service.go
@@ -209,11 +209,13 @@ func (s *WorkspaceService) CreateWorkspace(
 	// Create initial tab entry for the agent.
 	if agentID != "" {
 		if err := s.queries.UpsertWorkspaceTab(ctx, db.UpsertWorkspaceTabParams{
-			WorkspaceID: workspaceID,
-			TabType:     leapmuxv1.TabType_TAB_TYPE_AGENT,
-			TabID:       agentID,
-			Position:    lexorank.First(),
-			TileID:      "",
+			WorkspaceID:   workspaceID,
+			TabType:       leapmuxv1.TabType_TAB_TYPE_AGENT,
+			TabID:         agentID,
+			Position:      lexorank.First(),
+			TileID:        "",
+			WorkingDir:    workingDir,
+			ShellStartDir: "",
 		}); err != nil {
 			slog.Warn("failed to create initial workspace tab", "workspace_id", workspaceID, "agent_id", agentID, "error", err)
 		}
@@ -562,10 +564,12 @@ func (s *WorkspaceService) ListTabs(
 	protoTabs := make([]*leapmuxv1.WorkspaceTab, len(tabs))
 	for i, tab := range tabs {
 		protoTabs[i] = &leapmuxv1.WorkspaceTab{
-			TabType:  tab.TabType,
-			TabId:    tab.TabID,
-			Position: tab.Position,
-			TileId:   tab.TileID,
+			TabType:       tab.TabType,
+			TabId:         tab.TabID,
+			Position:      tab.Position,
+			TileId:        tab.TileID,
+			WorkingDir:    tab.WorkingDir,
+			ShellStartDir: tab.ShellStartDir,
 		}
 	}
 

--- a/proto/leapmux/v1/terminal.proto
+++ b/proto/leapmux/v1/terminal.proto
@@ -29,6 +29,7 @@ message OpenTerminalRequest {
   string worker_id = 6;         // Target worker (required)
   bool create_worktree = 7;     // If true, create a git worktree before starting
   string worktree_branch = 8;   // Branch name for the worktree
+  string shell_start_dir = 10;  // Where the shell starts (defaults to working_dir if empty)
 }
 
 message OpenTerminalResponse {
@@ -81,6 +82,8 @@ message TerminalInfo {
   uint32 rows = 3;
   bytes screen = 4;
   bool exited = 5;
+  string working_dir = 6;       // Tab's working directory context
+  string shell_start_dir = 7;   // Where the shell started
 }
 
 message TerminalData {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -135,6 +135,8 @@ message WorkspaceTab {
   string tab_id = 2;
   string position = 3;
   string tile_id = 4;
+  string working_dir = 5;        // Tab's working directory context
+  string shell_start_dir = 6;    // Where the shell started (terminal tabs only)
 }
 
 message ListTabsRequest {


### PR DESCRIPTION
## Motivation

The directory tree sidebar lacked several key usability features. There was no visible root node, making it unclear what the top-level directory was. The only action available on tree nodes was an inline mention button, with no way to open a terminal at a specific directory or copy paths. Additionally, the tree's expanded/collapsed state was lost every time the user switched tabs, forcing repeated navigation.

On the backend, there was no way to track or persist the starting directory of a shell session separately from the workspace's working directory context, which made it impossible to restore terminals to the correct directory on reconnect.

## Modifications

**Frontend (`DirectoryTree`):**
- Added a root directory row as an explicit expandable/collapsible node at the top of the tree (`data-testid="tree-root-node"`), defaulting to expanded
- Replaced the inline mention button on each tree node with a three-dot dropdown context menu (`data-testid="tree-context-button"`) containing:
  - "Mention in chat" (directories and files)
  - "Open a terminal tab here" (directories only)
  - "Copy path" (absolute path to clipboard)
  - "Copy relative path" (relative to root, or `.` for the root itself)
- Added `onOpenTerminal` prop to `DirectoryTreeProps` and wired it through `AppShell`, `LeftSidebar`, `RightSidebar`, and `useTerminalOperations`
- Implemented sessionStorage-based persistence for the tree's expand/collapse state, keyed by root path, so state survives tab switches within a session

**Backend (terminal service and persistence):**
- Added `shell_start_dir` field to `OpenTerminalRequest` proto: where the shell actually starts, independent of the tab's `working_dir` context
- Added `working_dir` and `shell_start_dir` fields to `TerminalInfo` proto so the frontend can restore terminal directory state
- Added `working_dir` and `shell_start_dir` columns to the `workspace_tabs` database table for layout persistence
- Terminal service validates `shell_start_dir` with path sanitization and falls back to `working_dir` when not provided
- `ListTerminals` response now includes enriched `working_dir` and `shell_start_dir` from stored routing metadata

**Tests:**
- Added 6 new e2e tests covering root node, context menus, terminal action, path copying, and state persistence
- Added 4 new backend unit tests for `shell_start_dir` validation, defaults, directory enrichment, and layout persistence
- Updated existing e2e tests to use the new context menu flow

## Result

Users can now see and collapse the root directory in the file tree. Hovering any directory or file reveals a context menu via a three-dot button. From a directory node, selecting "Open a terminal tab here" opens a new terminal tab with the shell starting in that directory. Users can also copy the absolute or relative path of any node to the clipboard. The expanded/collapsed state of the tree is preserved when switching between workspace tabs.

🤖 Generated with Claude Code
