### PR TITLE
Add Icon component and fix dialog/tree state regressions

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -15,6 +15,7 @@ import SendHorizontal from 'lucide-solid/icons/send-horizontal'
 import Square from 'lucide-solid/icons/square'
 import { createEffect, createMemo, createSignal, createUniqueId, For, on, onCleanup, onMount, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { clearDraft } from '~/lib/editor/draftPersistence'
 import { formatRateLimitSummary, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_POPOVER_LABELS } from '~/lib/rateLimitUtils'
@@ -414,8 +415,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
             title="Copy session ID"
             data-testid="session-id-copy"
           >
-            <Show when={sessionIdCopied()} fallback={<Copy size={iconSize.xs} />}>
-              <Check size={iconSize.xs} />
+            <Show when={sessionIdCopied()} fallback={<Icon icon={Copy} size="xs" />}>
+              <Icon icon={Check} size="xs" />
             </Show>
           </button>
         </div>
@@ -529,9 +530,9 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
 
   const effortIcon = () => {
     switch (currentEffort()) {
-      case 'low': return <ChevronsDown size={iconSize.xs} />
-      case 'high': return <ChevronsUp size={iconSize.xs} />
-      default: return <Dot size={iconSize.xs} />
+      case 'low': return <Icon icon={ChevronsDown} size="xs" />
+      case 'high': return <Icon icon={ChevronsUp} size="xs" />
+      default: return <Icon icon={Dot} size="xs" />
     }
   }
 
@@ -547,8 +548,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           {modelLabel(currentModel())}
           {effortIcon()}
           {modeLabel(currentMode())}
-          <Show when={props.settingsLoading} fallback={<ChevronDown size={iconSize.xs} />}>
-            <LoaderCircle size={iconSize.xs} class={spinner} data-testid="settings-loading-spinner" />
+          <Show when={props.settingsLoading} fallback={<Icon icon={ChevronDown} size="xs" />}>
+            <Icon icon={LoaderCircle} size="xs" class={spinner} />
           </Show>
         </button>
       )}
@@ -799,8 +800,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                           disabled={interruptLoading.loading()}
                           data-testid="interrupt-button"
                         >
-                          <Show when={interruptLoading.loading()} fallback={<Square size={iconSize.sm} />}>
-                            <LoaderCircle size={iconSize.sm} class={spinner} />
+                          <Show when={interruptLoading.loading()} fallback={<Icon icon={Square} size="sm" />}>
+                            <Icon icon={LoaderCircle} size="sm" class={spinner} />
                           </Show>
                           {interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'}
                         </button>
@@ -815,8 +816,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                         }}
                         data-testid="send-button"
                       >
-                        <Show when={sending()} fallback={<SendHorizontal size={iconSize.sm} />}>
-                          <LoaderCircle size={iconSize.sm} class={spinner} />
+                        <Show when={sending()} fallback={<Icon icon={SendHorizontal} size="sm" />}>
+                          <Icon icon={LoaderCircle} size="sm" class={spinner} />
                         </Show>
                         Send
                       </button>

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -4,12 +4,12 @@ import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import ArrowDown from 'lucide-solid/icons/arrow-down'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createEffect, createSignal, For, on, onCleanup, onMount, Show, untrack } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { spinner } from '~/styles/animations.css'
-import { iconSize } from '~/styles/tokens'
 import * as styles from './ChatView.css'
 import { markdownContent } from './markdownContent.css'
 import { MessageBubble } from './MessageBubble'
@@ -277,7 +277,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
           >
             <Show when={props.fetchingOlder}>
               <div class={styles.loadingOlderIndicator}>
-                <LoaderCircle size={iconSize.sm} class={spinner} />
+                <Icon icon={LoaderCircle} size="sm" class={spinner} />
                 Loading older messages...
               </div>
             </Show>
@@ -318,7 +318,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         <Show when={!atBottom()}>
           <IconButton
             icon={ArrowDown}
-            iconSize={iconSize.md}
+            iconSize="md"
             onClick={scrollToBottom}
           />
         </Show>

--- a/frontend/src/components/chat/EditorToolbar.tsx
+++ b/frontend/src/components/chat/EditorToolbar.tsx
@@ -30,6 +30,7 @@ import Strikethrough from 'lucide-solid/icons/strikethrough'
 import TextQuote from 'lucide-solid/icons/text-quote'
 import { createUniqueId, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { positionPopoverAbove } from '~/lib/popoverPosition'
 import * as styles from './MarkdownEditor.css'
@@ -288,7 +289,7 @@ export const EditorToolbar: Component<EditorToolbarProps> = (props) => {
             data-testid="toolbar-heading"
             {...triggerProps}
           >
-            <ChevronDown size={10} />
+            <Icon icon={ChevronDown} size="xxs" />
           </IconButton>
         )}
         popoverRef={(el) => { headingMenuRef = el }}
@@ -503,8 +504,8 @@ export const EditorToolbar: Component<EditorToolbarProps> = (props) => {
             fallback={(
               <>
                 {isMac
-                  ? <Command size={10} class={styles.iconNudge} />
-                  : <ChevronUp size={10} class={styles.iconNudge} />}
+                  ? <Icon icon={Command} size="xxs" class={styles.iconNudge} />
+                  : <Icon icon={ChevronUp} size="xxs" class={styles.iconNudge} />}
                 <span>Enter sends</span>
               </>
             )}

--- a/frontend/src/components/chat/RelativeTime.tsx
+++ b/frontend/src/components/chat/RelativeTime.tsx
@@ -13,7 +13,7 @@ import Clock10 from 'lucide-solid/icons/clock-10'
 import Clock11 from 'lucide-solid/icons/clock-11'
 import Clock12 from 'lucide-solid/icons/clock-12'
 import { createSignal, onCleanup, onMount, Show } from 'solid-js'
-import { iconSize } from '~/styles/tokens'
+import { Icon } from '~/components/common/Icon'
 
 const clockIcons: Component<{ size: number }>[] = [
   Clock12,
@@ -85,8 +85,8 @@ export function RelativeTime(props: RelativeTimeProps) {
   })
 
   const ClockIcon = () => {
-    const Icon = clockIcons[hour12()]
-    return <Icon size={iconSize.xs} />
+    const ClockFace = clockIcons[hour12()]
+    return <Icon icon={ClockFace} size="xs" />
   }
 
   return (

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -4,6 +4,7 @@ import type { ControlRequest } from '~/stores/control.store'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createUniqueId, For, Show } from 'solid-js'
 import { agentLoadingTimeoutMs, apiLoadingTimeoutMs } from '~/api/transport'
+import { Icon } from '~/components/common/Icon'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
 import { buildAllowResponse, buildDenyResponse, getToolInput } from '~/utils/controlResponse'
@@ -340,7 +341,7 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
           disabled={stopping()}
           data-testid="control-stop-btn"
         >
-          <Show when={stopping()}><LoaderCircle size={14} class={spinner} /></Show>
+          <Show when={stopping()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
           {stopping() ? 'Stopping...' : 'Stop'}
         </button>
         <button
@@ -379,7 +380,7 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
           disabled={!allAnswered() || submitting()}
           data-testid="control-submit-btn"
         >
-          <Show when={submitting()}><LoaderCircle size={14} class={spinner} /></Show>
+          <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
           {submitting() ? 'Submitting...' : 'Submit'}
         </button>
       </div>

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -20,6 +20,7 @@ import TicketsPlane from 'lucide-solid/icons/tickets-plane'
 import Toolbox from 'lucide-solid/icons/toolbox'
 import Vote from 'lucide-solid/icons/vote'
 import { createSignal, For, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { TodoList } from '~/components/todo/TodoList'
 import { containsAnsi, renderAnsi } from '~/lib/renderAnsi'
 import { renderMarkdown } from '~/lib/renderMarkdown'
@@ -127,7 +128,7 @@ function renderEnterPlanMode(toolUse: Record<string, unknown>, context?: RenderC
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="EnterPlanMode">
-          <TicketsPlane size={16} class={toolUseIcon} />
+          <Icon icon={TicketsPlane} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>Entering Plan Mode</span>
         <ControlResponseTag response={context?.childControlResponse} />
@@ -156,7 +157,7 @@ function renderSkill(toolUse: Record<string, unknown>, context?: RenderContext):
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="Skill">
-          <Toolbox size={16} class={toolUseIcon} />
+          <Icon icon={Toolbox} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>{`Skill: /${skillName}`}</span>
         <ControlResponseTag response={context?.childControlResponse} />
@@ -201,7 +202,7 @@ function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderCo
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="ExitPlanMode">
-          <PlaneTakeoff size={16} class={toolUseIcon} />
+          <Icon icon={PlaneTakeoff} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>Leaving Plan Mode</span>
         <Show when={context}>
@@ -232,8 +233,8 @@ function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderCo
             <div class={toolUseHeader}>
               <span class={inlineFlex}>
                 {cr().action === 'approved'
-                  ? <Stamp size={16} class={toolUseIcon} />
-                  : <Hand size={16} class={toolUseIcon} />}
+                  ? <Icon icon={Stamp} size="md" class={toolUseIcon} />
+                  : <Icon icon={Hand} size="md" class={toolUseIcon} />}
               </span>
               <span class={toolInputDetail}>
                 {cr().action === 'approved' ? 'Approved' : cr().comment ? 'Sent feedback' : 'Rejected'}
@@ -268,7 +269,7 @@ function renderTodoWrite(toolUse: Record<string, unknown>, context?: RenderConte
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="TodoWrite">
-          <ListTodo size={16} class={toolUseIcon} />
+          <Icon icon={ListTodo} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>{label}</span>
         <ControlResponseTag response={context?.childControlResponse} />
@@ -312,7 +313,7 @@ function renderAskUserQuestion(toolUse: Record<string, unknown>, context?: Rende
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="AskUserQuestion">
-          <Vote size={16} class={toolUseIcon} />
+          <Icon icon={Vote} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>{statusText}</span>
         <ControlResponseTag response={context?.childControlResponse} />
@@ -384,7 +385,7 @@ function renderTaskOutput(toolUse: Record<string, unknown>, context?: RenderCont
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title="TaskOutput">
-          <SquareTerminal size={16} class={toolUseIcon} />
+          <Icon icon={SquareTerminal} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>
           {status}
@@ -523,7 +524,7 @@ const taskNotificationRenderer: MessageContentRenderer = {
       <div class={toolMessage}>
         <div class={toolUseHeader}>
           <span class={inlineFlex} title="Task Notification">
-            <Terminal size={16} class={toolUseIcon} />
+            <Icon icon={Terminal} size="md" class={toolUseIcon} />
           </span>
           <span class={toolInputDetail}>{summary}</span>
           <Show when={context}>
@@ -570,13 +571,13 @@ function ThinkingMessage(props: { text: string, context?: RenderContext }): JSX.
     <>
       <div class={thinkingHeader} onClick={() => setExpanded(prev => !prev)}>
         <span class={inlineFlex} title="Thinking">
-          <Brain size={16} class={toolUseIcon} />
+          <Icon icon={Brain} size="md" class={toolUseIcon} />
         </span>
         <span class={toolInputDetail}>Thinking</span>
         <span class={inlineFlex}>
           {expanded()
-            ? <ChevronDown size={14} class={toolUseIcon} />
-            : <ChevronRight size={14} class={toolUseIcon} />}
+            ? <Icon icon={ChevronDown} size="sm" class={toolUseIcon} />
+            : <Icon icon={ChevronRight} size="sm" class={toolUseIcon} />}
         </span>
       </div>
       <Show when={expanded()}>
@@ -618,7 +619,7 @@ const taskStartedRenderer: MessageContentRenderer = {
       <div class={toolMessage}>
         <div class={toolUseHeader}>
           <span class={inlineFlex} title="Task Started">
-            <Bot size={16} class={toolUseIcon} />
+            <Icon icon={Bot} size="md" class={toolUseIcon} />
           </span>
           <span class={toolInputDetail}>Task started</span>
         </div>

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -4,6 +4,7 @@ import type { JSXElement } from 'solid-js'
 import type { MessageContentRenderer } from './messageRenderers'
 import ArrowDownToLine from 'lucide-solid/icons/arrow-down-to-line'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
+import { Icon } from '~/components/common/Icon'
 import { formatRateLimitMessage } from '~/lib/rateLimitUtils'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { spinner } from '~/styles/animations.css'
@@ -369,7 +370,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   if (showCompaction && compacting && !compactLabel && !microcompactLabel) {
     elements.push(
       <div class={resultDivider}>
-        <LoaderCircle size={14} class={spinner} />
+        <Icon icon={LoaderCircle} size="sm" class={spinner} />
         {' Compacting context...'}
       </div>,
     )
@@ -379,7 +380,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   if (showCompaction && compactLabel) {
     elements.push(
       <div class={resultDivider}>
-        <ArrowDownToLine size={14} />
+        <Icon icon={ArrowDownToLine} size="sm" />
         {` ${compactLabel}`}
       </div>,
     )
@@ -389,7 +390,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   if (showCompaction && microcompactLabel) {
     elements.push(
       <div class={resultDivider}>
-        <ArrowDownToLine size={14} />
+        <Icon icon={ArrowDownToLine} size="sm" />
         {` ${microcompactLabel}`}
       </div>,
     )

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -2,6 +2,7 @@
 import type { JSX } from 'solid-js'
 import type { StructuredPatchHunk } from './diffUtils'
 import type { MessageContentRenderer, RenderContext } from './messageRenderers'
+import type { IconSizeName } from '~/components/common/Icon'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { diffLines } from 'diff'
@@ -29,6 +30,7 @@ import Toolbox from 'lucide-solid/icons/toolbox'
 import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
 import Vote from 'lucide-solid/icons/vote'
 import { createSignal, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import { containsAnsi, renderAnsi } from '~/lib/renderAnsi'
 import { renderMarkdown } from '~/lib/renderMarkdown'
@@ -74,24 +76,24 @@ export function ControlResponseTag(props: { response?: { action: string, comment
 }
 
 /** Map tool name to its icon component. */
-export function toolIcon(name: string, size: number): JSX.Element {
+export function toolIcon(name: string, size: IconSizeName): JSX.Element {
   switch (name) {
-    case 'Bash': return <Terminal size={size} class={toolUseIcon} />
-    case 'Read': return <FileText size={size} class={toolUseIcon} />
-    case 'Write': return <FilePlus size={size} class={toolUseIcon} />
-    case 'Edit': return <FilePen size={size} class={toolUseIcon} />
-    case 'Grep': return <Search size={size} class={toolUseIcon} />
-    case 'Glob': return <FolderSearch size={size} class={toolUseIcon} />
-    case 'Task': return <Bot size={size} class={toolUseIcon} />
-    case 'WebFetch': return <Globe size={size} class={toolUseIcon} />
-    case 'WebSearch': return <Globe size={size} class={toolUseIcon} />
-    case 'TodoWrite': return <ListTodo size={size} class={toolUseIcon} />
-    case 'EnterPlanMode': return <TicketsPlane size={size} class={toolUseIcon} />
-    case 'ExitPlanMode': return <PlaneTakeoff size={size} class={toolUseIcon} />
-    case 'AskUserQuestion': return <Vote size={size} class={toolUseIcon} />
-    case 'TaskOutput': return <SquareTerminal size={size} class={toolUseIcon} />
-    case 'Skill': return <Toolbox size={size} class={toolUseIcon} />
-    default: return <ChevronsRight size={size} class={toolUseIcon} />
+    case 'Bash': return <Icon icon={Terminal} size={size} class={toolUseIcon} />
+    case 'Read': return <Icon icon={FileText} size={size} class={toolUseIcon} />
+    case 'Write': return <Icon icon={FilePlus} size={size} class={toolUseIcon} />
+    case 'Edit': return <Icon icon={FilePen} size={size} class={toolUseIcon} />
+    case 'Grep': return <Icon icon={Search} size={size} class={toolUseIcon} />
+    case 'Glob': return <Icon icon={FolderSearch} size={size} class={toolUseIcon} />
+    case 'Task': return <Icon icon={Bot} size={size} class={toolUseIcon} />
+    case 'WebFetch': return <Icon icon={Globe} size={size} class={toolUseIcon} />
+    case 'WebSearch': return <Icon icon={Globe} size={size} class={toolUseIcon} />
+    case 'TodoWrite': return <Icon icon={ListTodo} size={size} class={toolUseIcon} />
+    case 'EnterPlanMode': return <Icon icon={TicketsPlane} size={size} class={toolUseIcon} />
+    case 'ExitPlanMode': return <Icon icon={PlaneTakeoff} size={size} class={toolUseIcon} />
+    case 'AskUserQuestion': return <Icon icon={Vote} size={size} class={toolUseIcon} />
+    case 'TaskOutput': return <Icon icon={SquareTerminal} size={size} class={toolUseIcon} />
+    case 'Skill': return <Icon icon={Toolbox} size={size} class={toolUseIcon} />
+    default: return <Icon icon={ChevronsRight} size={size} class={toolUseIcon} />
   }
 }
 
@@ -364,7 +366,7 @@ function ToolUseMessage(props: {
     <div class={toolMessage}>
       <div class={toolUseHeader}>
         <span class={inlineFlex} title={props.toolName}>
-          {toolIcon(props.toolName, 16)}
+          {toolIcon(props.toolName, 'md')}
         </span>
         <span>
           {props.detail ?? props.toolName}

--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -1,0 +1,17 @@
+import type { LucideIcon } from 'lucide-solid'
+import type { JSX } from 'solid-js'
+import { iconSize } from '~/styles/tokens'
+
+export type IconSizeName = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+export interface IconProps {
+  icon: LucideIcon
+  size: IconSizeName
+  class?: string
+  style?: JSX.CSSProperties
+}
+
+export function Icon(props: IconProps) {
+  const px = () => iconSize[props.size]
+  return <props.icon size={px()} class={props.class} style={props.style} />
+}

--- a/frontend/src/components/common/IconButton.tsx
+++ b/frontend/src/components/common/IconButton.tsx
@@ -1,8 +1,10 @@
 import type { LucideIcon } from 'lucide-solid'
 import type { Component, ComponentProps, JSX } from 'solid-js'
+import type { IconSizeName } from './Icon'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { Show, splitProps } from 'solid-js'
 import { spinner } from '~/styles/animations.css'
+import { Icon } from './Icon'
 import * as styles from './IconButton.css'
 
 // ---------------------------------------------------------------------------
@@ -26,8 +28,8 @@ type ButtonHtmlAttributes = Omit<
 export interface IconButtonProps extends ButtonHtmlAttributes {
   /** The lucide-solid icon component to render. */
   icon: LucideIcon
-  /** Icon size in pixels. Default: 14 */
-  iconSize?: number
+  /** Icon size token name. Default: 'sm' */
+  iconSize?: IconSizeName
   /** Container size token. Default: none (intrinsic sizing). */
   size?: IconButtonSize
   /** Button state. Default: Enabled */
@@ -66,10 +68,11 @@ export const IconButton: Component<IconButtonProps> = (props) => {
   ])
 
   const state = () => local.state ?? IconButtonState.Enabled
-  const iconPx = () => local.iconSize ?? 14
+  const iconSz = () => local.iconSize ?? 'sm'
   const isDisabled = () =>
     state() === IconButtonState.Disabled || state() === IconButtonState.Loading
   const isLoading = () => state() === IconButtonState.Loading
+
   const isActive = () => state() === IconButtonState.Active
 
   const classes = () => {
@@ -93,8 +96,8 @@ export const IconButton: Component<IconButtonProps> = (props) => {
       onClick={local.onClick}
       {...rest}
     >
-      <Show when={isLoading()} fallback={<local.icon size={iconPx()} />}>
-        <LoaderCircle size={iconPx()} class={spinner} />
+      <Show when={isLoading()} fallback={<Icon icon={local.icon} size={iconSz()} />}>
+        <Icon icon={LoaderCircle} size={iconSz()} class={spinner} />
       </Show>
       {local.children}
     </button>

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -4,6 +4,7 @@ import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, onMount, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
+import { Icon } from '~/components/common/Icon'
 import { useAuth } from '~/context/AuthContext'
 import { spinner } from '~/styles/animations.css'
 import * as styles from './LoginPage.css'
@@ -93,7 +94,7 @@ export const LoginPage: Component = () => {
             type="submit"
             disabled={submitting() || !username() || !password()}
           >
-            <Show when={submitting()}><LoaderCircle size={14} class={spinner} /></Show>
+            <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting() ? 'Signing in...' : 'Sign in'}
           </button>
         </form>

--- a/frontend/src/components/common/RegistrationPage.tsx
+++ b/frontend/src/components/common/RegistrationPage.tsx
@@ -7,6 +7,7 @@ import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { generateSlug } from 'random-word-slugs'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient, workerClient } from '~/api/clients'
+import { Icon } from '~/components/common/Icon'
 import { RegistrationStatus } from '~/generated/leapmux/v1/worker_pb'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
@@ -200,7 +201,7 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
                             }}
                             title="Generate random name"
                           >
-                            <RefreshCw size={14} />
+                            <Icon icon={RefreshCw} size="sm" />
                           </button>
                         </div>
                         <input
@@ -220,7 +221,7 @@ export const RegistrationPage: Component<RegistrationPageProps> = (props) => {
                         type="submit"
                         disabled={submitting() || !name() || !!nameError() || !selectedOrgId()}
                       >
-                        <Show when={submitting()}><LoaderCircle size={14} class={spinner} /></Show>
+                        <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
                         {submitting() ? 'Approving...' : 'Approve'}
                       </button>
                     </form>

--- a/frontend/src/components/common/SelectionQuotePopover.tsx
+++ b/frontend/src/components/common/SelectionQuotePopover.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'solid-js'
 import Copy from 'lucide-solid/icons/copy'
 import Quote from 'lucide-solid/icons/quote'
 import { createSignal, onCleanup, onMount, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { extractLineRange, extractSelectionMarkdown } from '~/lib/quoteUtils'
 import * as styles from './SelectionQuotePopover.css'
 
@@ -115,7 +116,7 @@ export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.El
             onClick={handleQuoteClick}
             data-testid="quote-selection-button"
           >
-            <Quote size={14} />
+            <Icon icon={Quote} size="sm" />
             Quote
           </button>
           <button
@@ -123,7 +124,7 @@ export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.El
             onClick={handleCopyClick}
             data-testid="copy-selection-button"
           >
-            <Copy size={14} />
+            <Icon icon={Copy} size="sm" />
             Copy
           </button>
         </div>

--- a/frontend/src/components/common/SignupPage.tsx
+++ b/frontend/src/components/common/SignupPage.tsx
@@ -4,6 +4,7 @@ import { A, useNavigate } from '@solidjs/router'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, onMount, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
+import { Icon } from '~/components/common/Icon'
 import { useAuth } from '~/context/AuthContext'
 import { sanitizeSlug } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
@@ -118,7 +119,7 @@ export const SignupPage: Component = () => {
                   <div class={styles.errorText}>{error()}</div>
                 </Show>
                 <button type="submit" disabled={submitting() || !username() || !password()}>
-                  <Show when={submitting()}><LoaderCircle size={14} class={spinner} /></Show>
+                  <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
                   {submitting() ? 'Signing up...' : 'Sign up'}
                 </button>
               </form>

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -3,6 +3,7 @@ import type { ZoomMode } from './ImageToolbar'
 import type { ViewMode } from './ViewToggle'
 import AtSign from 'lucide-solid/icons/at-sign'
 import { createEffect, createMemo, createSignal, Match, onCleanup, Show, Switch, untrack } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { isSvgExtension } from '~/lib/fileType'
 import * as styles from './FileViewer.css'
 import { ImageToolbar, ZOOM_MAX, ZOOM_MIN } from './ImageToolbar'
@@ -212,7 +213,7 @@ export function ImageFileView(props: {
                 title="Mention in the chat"
                 data-testid="file-mention-button"
               >
-                <AtSign size={14} />
+                <Icon icon={AtSign} size="sm" />
               </button>
             </div>
           </Show>

--- a/frontend/src/components/fileviewer/ImageToolbar.tsx
+++ b/frontend/src/components/fileviewer/ImageToolbar.tsx
@@ -2,7 +2,7 @@ import type { JSX } from 'solid-js'
 import Maximize2 from 'lucide-solid/icons/maximize-2'
 import ZoomIn from 'lucide-solid/icons/zoom-in'
 import ZoomOut from 'lucide-solid/icons/zoom-out'
-import { iconSize } from '~/styles/tokens'
+import { Icon } from '~/components/common/Icon'
 import * as styles from './FileViewer.css'
 
 export type ZoomMode = 'fit' | 'actual' | number
@@ -50,7 +50,7 @@ export function ImageToolbar(props: {
         onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
         title="Zoom out"
       >
-        <ZoomOut size={iconSize.sm} />
+        <Icon icon={ZoomOut} size="sm" />
       </button>
       <span class={styles.imageToolbarLabel}>{zoomLabel(props.zoom, props.fitScale)}</span>
       <button
@@ -58,14 +58,14 @@ export function ImageToolbar(props: {
         onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
         title="Zoom in"
       >
-        <ZoomIn size={iconSize.sm} />
+        <Icon icon={ZoomIn} size="sm" />
       </button>
       <button
         class={styles.imageToolbarButton}
         onClick={() => props.onZoomChange('fit')}
         title="Fit to view"
       >
-        <Maximize2 size={iconSize.sm} />
+        <Icon icon={Maximize2} size="sm" />
       </button>
       <button
         class={styles.imageToolbarTextButton}

--- a/frontend/src/components/fileviewer/TextFileView.tsx
+++ b/frontend/src/components/fileviewer/TextFileView.tsx
@@ -3,6 +3,7 @@ import type { ParsedCatLine } from '~/components/chat/ReadResultView'
 import AtSign from 'lucide-solid/icons/at-sign'
 import { createMemo, Show } from 'solid-js'
 import { ReadResultView } from '~/components/chat/ReadResultView'
+import { Icon } from '~/components/common/Icon'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import * as styles from './FileViewer.css'
 
@@ -37,7 +38,7 @@ export function TextFileView(props: {
             title="Mention in the chat"
             data-testid="file-mention-button"
           >
-            <AtSign size={14} />
+            <Icon icon={AtSign} size="sm" />
           </button>
         </div>
       </Show>

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -4,6 +4,7 @@ import Code from 'lucide-solid/icons/code'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import Eye from 'lucide-solid/icons/eye'
 import { Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import * as styles from './FileViewer.css'
 
 export type ViewMode = 'render' | 'source' | 'split'
@@ -22,7 +23,7 @@ export function ViewToggle(props: {
         onClick={() => props.onToggle('render')}
         title="Rendered view"
       >
-        <Eye size={14} />
+        <Icon icon={Eye} size="sm" />
       </button>
       <Show when={props.showSplit}>
         <button
@@ -31,7 +32,7 @@ export function ViewToggle(props: {
           onClick={() => props.onToggle('split')}
           title="Side-by-side view"
         >
-          <Columns2 size={14} />
+          <Icon icon={Columns2} size="sm" />
         </button>
       </Show>
       <button
@@ -40,7 +41,7 @@ export function ViewToggle(props: {
         onClick={() => props.onToggle('source')}
         title="Source view"
       >
-        <Code size={14} />
+        <Icon icon={Code} size="sm" />
       </button>
       <Show when={props.onMention}>
         <div style={{ 'border-left': '1px solid var(--border)' }} />
@@ -50,7 +51,7 @@ export function ViewToggle(props: {
           title="Mention in the chat"
           data-testid="file-mention-button"
         >
-          <AtSign size={14} />
+          <Icon icon={AtSign} size="sm" />
         </button>
       </Show>
     </div>

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -14,6 +14,7 @@ import { ChatView } from '~/components/chat/ChatView'
 import { relativizePath } from '~/components/chat/messageUtils'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
+import { Icon } from '~/components/common/Icon'
 import { NotFoundPage } from '~/components/common/NotFoundPage'
 import { showToast } from '~/components/common/Toast'
 import { FileViewer } from '~/components/fileviewer/FileViewer'
@@ -1194,7 +1195,7 @@ export const AppShell: ParentComponent = (props) => {
                     agentOps.handleOpenAgent()
                   }}
                 >
-                  <Bot size={14} />
+                  <Icon icon={Bot} size="sm" />
                   {' '}
                   Open a new agent tab...
                 </button>
@@ -1206,7 +1207,7 @@ export const AppShell: ParentComponent = (props) => {
                     termOps.handleOpenTerminal()
                   }}
                 >
-                  <Terminal size={14} />
+                  <Icon icon={Terminal} size="sm" />
                   {' '}
                   Open a new terminal tab...
                 </button>
@@ -1625,7 +1626,7 @@ export const AppShell: ParentComponent = (props) => {
                                         setShowNewWorkspace(true)
                                       }}
                                     >
-                                      <Plus size={14} />
+                                      <Icon icon={Plus} size="sm" />
                                       {' '}
                                       Create a new workspace...
                                     </button>

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -7,8 +7,8 @@ import PanelLeftOpen from 'lucide-solid/icons/panel-left-open'
 import PanelRightClose from 'lucide-solid/icons/panel-right-close'
 import PanelRightOpen from 'lucide-solid/icons/panel-right-open'
 import { createEffect, createMemo, createSignal, For, on, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
-import { iconSize } from '~/styles/tokens'
 import * as styles from './CollapsibleSidebar.css'
 import { useOptionalSectionDrag } from './SectionDragContext'
 import { SECTION_DRAG_PREFIX, SIDEBAR_ZONE_PREFIX } from './sectionDragUtils'
@@ -383,7 +383,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
     return (
       <div class={`${styles.sidebarRail} ${railVariant}`}>
         {/* Expand button */}
-        <IconButton icon={ExpandIcon} iconSize={iconSize.lg} size="lg" title={`Expand ${props.side} sidebar`} onClick={() => props.onExpand()} />
+        <IconButton icon={ExpandIcon} iconSize="lg" size="lg" title={`Expand ${props.side} sidebar`} onClick={() => props.onExpand()} />
 
         {/* Top-positioned section icons + badges */}
         <For each={topSections}>
@@ -391,7 +391,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
             <>
               <IconButton
                 icon={section.railIcon}
-                iconSize={iconSize.lg}
+                iconSize="lg"
                 size="lg"
                 title={section.railTitle ?? section.title}
                 onClick={() => {
@@ -412,7 +412,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
           {section => (
             <Show
               when={section.railElement}
-              fallback={<IconButton icon={section.railIcon} iconSize={iconSize.lg} size="lg" title={section.railTitle ?? section.title} />}
+              fallback={<IconButton icon={section.railIcon} iconSize="lg" size="lg" title={section.railTitle ?? section.title} />}
             >
               {section.railElement}
             </Show>
@@ -429,7 +429,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                   fallback={(
                     <IconButton
                       icon={section.railIcon}
-                      iconSize={iconSize.lg}
+                      iconSize="lg"
                       size="lg"
                       title={section.railTitle ?? section.title}
                       onClick={() => {
@@ -627,13 +627,13 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                         // Use the draggable's activators for the drag handle only
                         {...(draggable?.dragActivators ?? {})}
                       >
-                        <GripVertical size={12} />
+                        <Icon icon={GripVertical} size="xs" />
                       </div>
                     </Show>
                     <Show when={index() === 0 && props.onCollapse && props.side === 'left'}>
                       <IconButton
                         icon={CollapseIcon}
-                        iconSize={iconSize.lg}
+                        iconSize="lg"
                         size="md"
                         style={{ 'margin-left': '-6px' }}
                         title="Collapse sidebar"
@@ -651,7 +651,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                     <Show when={index() === 0 && props.onCollapse && props.side === 'right'}>
                       <IconButton
                         icon={CollapseIcon}
-                        iconSize={iconSize.lg}
+                        iconSize="lg"
                         size="md"
                         style={{ 'margin-right': '-6px' }}
                         title="Collapse sidebar"

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -15,7 +15,6 @@ import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSection
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
 import { useAuth } from '~/context/AuthContext'
 import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
-import { iconSize } from '~/styles/tokens'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
 import { useSectionDrag } from './SectionDragContext'
@@ -160,7 +159,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
             ? (
                 <IconButton
                   icon={Plus}
-                  iconSize={iconSize.sm}
+                  iconSize="sm"
                   size="md"
                   title={`New workspace in ${group.section.name}`}
                   data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
@@ -263,7 +262,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
       railTitle: 'User menu',
       railElement: (
         <UserMenu
-          trigger={<IconButton icon={CircleUser} iconSize={iconSize.lg} size="lg" title="User menu" data-testid="user-menu-trigger" />}
+          trigger={<IconButton icon={CircleUser} iconSize="lg" size="lg" title="User menu" data-testid="user-menu-trigger" />}
         />
       ),
       content: () => (

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -6,6 +6,7 @@ import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
 import { agentClient, gitClient, workerClient } from '~/api/clients'
 import { agentCallTimeout, agentLoadingTimeoutMs } from '~/api/transport'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
@@ -136,7 +137,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
                   disabled={refreshing()}
                   title="Refresh workers"
                 >
-                  <RefreshCw size={14} class={refreshing() ? spinning : ''} />
+                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
                 </button>
               </div>
               <select
@@ -190,7 +191,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
             type="submit"
             disabled={submitting.loading() || !workerId() || (createWorktree() && !!worktreeBranchError())}
           >
-            <Show when={submitting.loading()}><LoaderCircle size={14} class={spinner} /></Show>
+            <Show when={submitting.loading()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting.loading() ? 'Creating...' : 'Create'}
           </button>
         </footer>

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -5,6 +5,7 @@ import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
 import { gitClient, terminalClient, workerClient } from '~/api/clients'
 import { apiLoadingTimeoutMs } from '~/api/transport'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
@@ -158,7 +159,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
                   disabled={refreshing()}
                   title="Refresh workers"
                 >
-                  <RefreshCw size={14} class={refreshing() ? spinning : ''} />
+                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
                 </button>
               </div>
               <select
@@ -230,7 +231,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
             type="submit"
             disabled={submitting.loading() || !workerId() || !shell() || (createWorktree() && !!worktreeBranchError())}
           >
-            <Show when={submitting.loading()}><LoaderCircle size={14} class={spinner} /></Show>
+            <Show when={submitting.loading()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting.loading() ? 'Creating...' : 'Create'}
           </button>
         </footer>

--- a/frontend/src/components/shell/ResumeSessionDialog.tsx
+++ b/frontend/src/components/shell/ResumeSessionDialog.tsx
@@ -5,6 +5,7 @@ import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
 import { agentLoadingTimeoutMs } from '~/api/transport'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
@@ -96,7 +97,7 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
                   disabled={refreshing()}
                   title="Refresh workers"
                 >
-                  <RefreshCw size={14} class={refreshing() ? spinning : ''} />
+                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
                 </button>
               </div>
               <select
@@ -141,7 +142,7 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
             data-testid="resume-session-submit"
           >
             <Show when={submitting.loading()}>
-              <LoaderCircle size={14} class={spinner} />
+              <Icon icon={LoaderCircle} size="sm" class={spinner} />
             </Show>
             Resume
           </button>

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -13,7 +13,6 @@ import * as swlStyles from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
 import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
-import { iconSize } from '~/styles/tokens'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
 import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
@@ -167,7 +166,7 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
             ? (
                 <IconButton
                   icon={Plus}
-                  iconSize={iconSize.sm}
+                  iconSize="sm"
                   size="md"
                   title={`New workspace in ${section.name}`}
                   data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -14,11 +14,11 @@ import Terminal from 'lucide-solid/icons/terminal'
 import X from 'lucide-solid/icons/x'
 import { createSignal, ErrorBoundary, For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { sanitizeName } from '~/lib/validate'
 import { tabKey, TabType } from '~/stores/tab.store'
 import { menuSectionHeader, monoFont } from '~/styles/shared.css'
-import { iconSize } from '~/styles/tokens'
 import { TABBAR_ZONE_PREFIX, useCrossTileDrag } from './CrossTileDragContext'
 import * as styles from './TabBar.css'
 
@@ -193,7 +193,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       }}
     >
       <span class={styles.tabIcon}>
-        {tab.type === TabType.AGENT ? <Bot size={14} /> : tab.type === TabType.FILE ? <FileText size={14} /> : <Terminal size={14} />}
+        {tab.type === TabType.AGENT ? <Icon icon={Bot} size="sm" /> : tab.type === TabType.FILE ? <Icon icon={FileText} size="sm" /> : <Icon icon={Terminal} size="sm" />}
       </span>
       <Show
         when={editingTabKey() === tabKey(tab)}
@@ -277,7 +277,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       <Show when={props.isMobile}>
         <IconButton
           icon={Menu}
-          iconSize={iconSize.lg}
+          iconSize="lg"
           size="xl"
           aria-label="Toggle workspaces"
           onClick={() => props.onToggleLeftSidebar?.()}
@@ -322,7 +322,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           <TabBarTooltip text={newAgentLabel()}>
             <IconButton
               icon={Bot}
-              iconSize={iconSize.md}
+              iconSize="md"
               size="md"
               state={props.newAgentLoading ? IconButtonState.Loading : IconButtonState.Enabled}
               data-testid="new-agent-button"
@@ -332,7 +332,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           <TabBarTooltip text={newTerminalLabel()}>
             <IconButton
               icon={Terminal}
-              iconSize={iconSize.md}
+              iconSize="md"
               size="md"
               state={props.newTerminalLoading ? IconButtonState.Loading : IconButtonState.Enabled}
               data-testid="new-terminal-button"
@@ -344,7 +344,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
               <TabBarTooltip text="More options">
                 <IconButton
                   icon={ChevronDown}
-                  iconSize={iconSize.md}
+                  iconSize="md"
                   size="md"
                   state={props.newShellLoading ? IconButtonState.Loading : IconButtonState.Enabled}
                   data-testid="tab-more-menu"
@@ -363,7 +363,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
             trigger={triggerProps => (
               <IconButton
                 icon={Plus}
-                iconSize={iconSize.md}
+                iconSize="md"
                 size="md"
                 data-testid="collapsed-new-tab-button"
                 {...triggerProps}
@@ -380,7 +380,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
             trigger={triggerProps => (
               <IconButton
                 icon={Ellipsis}
-                iconSize={iconSize.md}
+                iconSize="md"
                 size="md"
                 data-testid="collapsed-overflow-button"
                 {...triggerProps}
@@ -398,14 +398,14 @@ export const TabBar: Component<TabBarProps> = (props) => {
                       role="menuitem"
                       onClick={() => actions().onSplitHorizontal()}
                     >
-                      <Columns2 size={14} />
+                      <Icon icon={Columns2} size="sm" />
                       {' Split vertical'}
                     </button>
                     <button
                       role="menuitem"
                       onClick={() => actions().onSplitVertical()}
                     >
-                      <Rows2 size={14} />
+                      <Icon icon={Rows2} size="sm" />
                       {' Split horizontal'}
                     </button>
                   </Show>
@@ -414,7 +414,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
                       role="menuitem"
                       onClick={() => actions().onClose()}
                     >
-                      <X size={14} />
+                      <Icon icon={X} size="sm" />
                       {' Close tile'}
                     </button>
                   </Show>
@@ -427,7 +427,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       <Show when={props.isMobile}>
         <IconButton
           icon={PanelRight}
-          iconSize={iconSize.lg}
+          iconSize="lg"
           size="xl"
           aria-label="Toggle files"
           onClick={() => props.onToggleRightSidebar?.()}

--- a/frontend/src/components/shell/WorktreeOptions.tsx
+++ b/frontend/src/components/shell/WorktreeOptions.tsx
@@ -4,6 +4,7 @@ import { generateSlug } from 'random-word-slugs'
 import { createEffect, createMemo, createSignal, on, Show } from 'solid-js'
 import { gitClient } from '~/api/clients'
 import { tildify } from '~/components/chat/messageUtils'
+import { Icon } from '~/components/common/Icon'
 import { useOrg } from '~/context/OrgContext'
 import { validateBranchName } from '~/lib/validate'
 import { checkboxRow, errorText, labelRow, pathPreview, refreshButton, warningText } from '~/styles/shared.css'
@@ -115,7 +116,7 @@ export const WorktreeOptions: Component<WorktreeOptionsProps> = (props) => {
               onClick={randomizeBranch}
               title="Generate random name"
             >
-              <RefreshCw size={14} />
+              <Icon icon={RefreshCw} size="sm" />
             </button>
           </div>
           <input

--- a/frontend/src/components/todo/TodoList.tsx
+++ b/frontend/src/components/todo/TodoList.tsx
@@ -4,6 +4,7 @@ import Check from 'lucide-solid/icons/check'
 import Circle from 'lucide-solid/icons/circle'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { For, Match, Switch } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { spinner } from '~/styles/animations.css'
 import * as styles from './TodoList.css'
 
@@ -20,13 +21,13 @@ export const TodoList: Component<TodoListProps> = (props) => {
             <div class={styles.todoIcon}>
               <Switch>
                 <Match when={todo.status === 'completed'}>
-                  <Check size={14} class={styles.checkIcon} />
+                  <Icon icon={Check} size="sm" class={styles.checkIcon} />
                 </Match>
                 <Match when={todo.status === 'in_progress'}>
-                  <LoaderCircle size={14} class={`${styles.spinnerIcon} ${spinner}`} />
+                  <Icon icon={LoaderCircle} size="sm" class={`${styles.spinnerIcon} ${spinner}`} />
                 </Match>
                 <Match when={todo.status === 'pending'}>
-                  <Circle size={14} class={styles.pendingIcon} />
+                  <Icon icon={Circle} size="sm" class={styles.pendingIcon} />
                 </Match>
               </Switch>
             </div>

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -430,22 +430,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   // Restore state from sessionStorage when rootPath changes
   createEffect(() => {
     const key = storageKey()
-
-    // Migrate old expand-only keys
-    const oldKey = `directoryTree:expanded:${props.rootPath ?? '~'}`
-    try {
-      const oldData = sessionStorage.getItem(oldKey)
-      if (oldData) {
-        sessionStorage.removeItem(oldKey)
-        const paths: string[] = JSON.parse(oldData)
-        const expanded: Record<string, boolean> = {}
-        for (const p of paths) expanded[p] = true
-        setState({ expandedPaths: expanded, childrenCache: {} })
-        return
-      }
-    }
-    catch { /* ignore */ }
-
     try {
       const stored = sessionStorage.getItem(key)
       if (stored) {

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -10,9 +10,11 @@ import Folder from 'lucide-solid/icons/folder'
 import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
 import TerminalIcon from 'lucide-solid/icons/terminal'
 import { createEffect, createSignal, For, Show, untrack } from 'solid-js'
+import { createStore, produce } from 'solid-js/store'
 import { fileClient } from '~/api/clients'
 import { relativizePath, tildify } from '~/components/chat/messageUtils'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import * as styles from './DirectoryTree.css'
 
@@ -34,6 +36,71 @@ interface TreeNodeData {
   isDir: boolean
   size: bigint
 }
+
+// -------------------------------------------------------------------------
+// Serialization helpers for sessionStorage (BigInt ↔ string)
+// -------------------------------------------------------------------------
+
+interface TreeNodeDataJSON {
+  path: string
+  displayName: string
+  isDir: boolean
+  size: string
+}
+
+interface DirectoryTreeStateJSON {
+  expandedPaths: Record<string, boolean>
+  childrenCache: Record<string, TreeNodeDataJSON[]>
+}
+
+function serializeState(
+  expandedPaths: Record<string, boolean>,
+  childrenCache: Record<string, TreeNodeData[]>,
+): string {
+  const json: DirectoryTreeStateJSON = {
+    expandedPaths,
+    childrenCache: {},
+  }
+  for (const [key, nodes] of Object.entries(childrenCache)) {
+    json.childrenCache[key] = nodes.map(n => ({
+      path: n.path,
+      displayName: n.displayName,
+      isDir: n.isDir,
+      size: n.size.toString(),
+    }))
+  }
+  return JSON.stringify(json)
+}
+
+function deserializeState(raw: string): { expandedPaths: Record<string, boolean>, childrenCache: Record<string, TreeNodeData[]> } | null {
+  try {
+    const json: DirectoryTreeStateJSON = JSON.parse(raw)
+    if (!json || typeof json !== 'object')
+      return null
+    const childrenCache: Record<string, TreeNodeData[]> = {}
+    if (json.childrenCache) {
+      for (const [key, nodes] of Object.entries(json.childrenCache)) {
+        childrenCache[key] = nodes.map(n => ({
+          path: n.path,
+          displayName: n.displayName,
+          isDir: n.isDir,
+          size: BigInt(n.size),
+        }))
+      }
+    }
+    return {
+      expandedPaths: json.expandedPaths ?? {},
+      childrenCache,
+    }
+  }
+  catch {
+    return null
+  }
+}
+
+// -------------------------------------------------------------------------
+// File listing
+// -------------------------------------------------------------------------
 
 function sortEntries(a: FileInfo, b: FileInfo): number {
   if (a.isDir !== b.isDir)
@@ -75,7 +142,7 @@ function renderTreeContextMenu(menuProps: {
       trigger={triggerProps => (
         <IconButton
           icon={MoreHorizontal}
-          iconSize={12}
+          iconSize="xs"
           size="sm"
           class={styles.nodeMenuTrigger}
           onClick={(e: MouseEvent) => {
@@ -102,7 +169,7 @@ function renderTreeContextMenu(menuProps: {
             closeMenu()
           }}
         >
-          <AtSign size={14} />
+          <Icon icon={AtSign} size="sm" />
           Mention in chat
         </button>
       </Show>
@@ -115,7 +182,7 @@ function renderTreeContextMenu(menuProps: {
             closeMenu()
           }}
         >
-          <TerminalIcon size={14} />
+          <Icon icon={TerminalIcon} size="sm" />
           Open a terminal tab here
         </button>
       </Show>
@@ -127,7 +194,7 @@ function renderTreeContextMenu(menuProps: {
           closeMenu()
         }}
       >
-        <Copy size={14} />
+        <Icon icon={Copy} size="sm" />
         Copy path
       </button>
       <button
@@ -141,7 +208,7 @@ function renderTreeContextMenu(menuProps: {
           closeMenu()
         }}
       >
-        <ClipboardCopy size={14} />
+        <Icon icon={ClipboardCopy} size="sm" />
         Copy relative path
       </button>
     </DropdownMenu>
@@ -163,14 +230,16 @@ const TreeNode: Component<{
   homeDir?: string
   isNodeExpanded: (path: string) => boolean
   setNodeExpanded: (path: string, expanded: boolean) => void
+  getChildren: (path: string) => TreeNodeData[] | undefined
+  setChildren: (path: string, data: TreeNodeData[]) => void
 }> = (props) => {
-  const [children, setChildren] = createSignal<TreeNodeData[]>([])
   const [loading, setLoading] = createSignal(false)
-  const [loaded, setLoaded] = createSignal(false)
   let wrapperRef!: HTMLDivElement
 
   const expanded = () => props.isNodeExpanded(props.node.path)
   const isSelected = () => props.selectedPath === props.node.path
+  const children = () => props.getChildren(props.node.path) ?? []
+  const loaded = () => props.getChildren(props.node.path) !== undefined
 
   const scrollIntoViewIfNeeded = () => {
     const container = props.scrollContainer
@@ -191,8 +260,7 @@ const TreeNode: Component<{
     setLoading(true)
     try {
       const result = await loadChildren(props.workerId, props.node.path, props.showFiles)
-      setChildren(result)
-      setLoaded(true)
+      props.setChildren(props.node.path, result)
     }
     catch {
       // ignore load errors
@@ -278,16 +346,16 @@ const TreeNode: Component<{
         >
           <Show
             when={expanded()}
-            fallback={<ChevronRight size={16} class={styles.chevron} />}
+            fallback={<Icon icon={ChevronRight} size="md" class={styles.chevron} />}
           >
-            <ChevronDown size={16} class={styles.chevron} />
+            <Icon icon={ChevronDown} size="md" class={styles.chevron} />
           </Show>
         </Show>
         <Show
           when={props.node.isDir}
-          fallback={<File size={14} class={styles.fileIcon} />}
+          fallback={<Icon icon={File} size="sm" class={styles.fileIcon} />}
         >
-          <Folder size={14} class={styles.folderIcon} />
+          <Icon icon={Folder} size="sm" class={styles.folderIcon} />
         </Show>
         <span class={styles.nodeName}>{props.node.displayName}</span>
         <div class={styles.nodeActions}>
@@ -324,6 +392,8 @@ const TreeNode: Component<{
               homeDir={props.homeDir}
               isNodeExpanded={props.isNodeExpanded}
               setNodeExpanded={props.setNodeExpanded}
+              getChildren={props.getChildren}
+              setChildren={props.setChildren}
             />
           )}
         </For>
@@ -338,7 +408,6 @@ const TreeNode: Component<{
 }
 
 export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
-  const [rootChildren, setRootChildren] = createSignal<TreeNodeData[]>([])
   const [loading, setLoading] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
   const [inputValue, setInputValue] = createSignal('')
@@ -346,48 +415,83 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   let treeRef!: HTMLDivElement
 
   // -------------------------------------------------------------------------
-  // Expand/collapse state persistence via sessionStorage
+  // Centralized tree state: expanded paths + children cache
   // -------------------------------------------------------------------------
-  const storageKey = () => `directoryTree:expanded:${props.rootPath ?? '~'}`
+  const [state, setState] = createStore<{
+    expandedPaths: Record<string, boolean>
+    childrenCache: Record<string, TreeNodeData[]>
+  }>({
+    expandedPaths: {},
+    childrenCache: {},
+  })
 
-  const [expandedPaths, setExpandedPaths] = createSignal<Set<string>>(new Set())
+  const storageKey = () => `directoryTree:state:${props.rootPath ?? '~'}`
 
-  // Load persisted state on mount / when rootPath changes
+  // Restore state from sessionStorage when rootPath changes
   createEffect(() => {
     const key = storageKey()
+
+    // Migrate old expand-only keys
+    const oldKey = `directoryTree:expanded:${props.rootPath ?? '~'}`
+    try {
+      const oldData = sessionStorage.getItem(oldKey)
+      if (oldData) {
+        sessionStorage.removeItem(oldKey)
+        const paths: string[] = JSON.parse(oldData)
+        const expanded: Record<string, boolean> = {}
+        for (const p of paths) expanded[p] = true
+        setState({ expandedPaths: expanded, childrenCache: {} })
+        return
+      }
+    }
+    catch { /* ignore */ }
+
     try {
       const stored = sessionStorage.getItem(key)
       if (stored) {
-        setExpandedPaths(new Set(JSON.parse(stored)))
-        return
+        const restored = deserializeState(stored)
+        if (restored) {
+          setState(restored)
+          return
+        }
       }
     }
     catch { /* ignore corrupt data */ }
     // Default: root is expanded
-    setExpandedPaths(new Set([props.rootPath ?? '~']))
+    setState({
+      expandedPaths: { [props.rootPath ?? '~']: true },
+      childrenCache: {},
+    })
   })
 
-  // Persist whenever expanded set changes
+  // Persist state whenever it changes
   createEffect(() => {
-    const paths = expandedPaths()
+    // Read both to subscribe
+    const expanded = state.expandedPaths
+    const cache = state.childrenCache
     try {
-      sessionStorage.setItem(storageKey(), JSON.stringify([...paths]))
+      sessionStorage.setItem(storageKey(), serializeState(expanded, cache))
     }
     catch { /* quota exceeded — ignore */ }
   })
 
-  const isNodeExpanded = (path: string) => expandedPaths().has(path)
+  const isNodeExpanded = (path: string) => !!state.expandedPaths[path]
   const setNodeExpanded = (path: string, expanded: boolean) => {
-    setExpandedPaths((prev) => {
-      const next = new Set(prev)
+    setState(produce((s) => {
       if (expanded) {
-        next.add(path)
+        s.expandedPaths[path] = true
       }
       else {
-        next.delete(path)
+        delete s.expandedPaths[path]
       }
-      return next
-    })
+    }))
+  }
+
+  const getChildren = (path: string): TreeNodeData[] | undefined => state.childrenCache[path]
+  const setChildrenInStore = (path: string, data: TreeNodeData[]) => {
+    setState(produce((s) => {
+      s.childrenCache[path] = data
+    }))
   }
 
   const rootPath = () => props.rootPath ?? '~'
@@ -396,6 +500,9 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     const rp = rootPath()
     return rp.split('/').pop() || rp
   }
+
+  // Root children derived from the centralized cache
+  const rootChildren = () => getChildren(rootPath())
 
   // Sync external selectedPath to input (tildified for display)
   createEffect(() => {
@@ -409,15 +516,19 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     if (!workerId)
       return
 
+    // If we already have cached children (from sessionStorage or previous
+    // load), skip fetching — this eliminates flicker on tab switches.
+    if (getChildren(root) !== undefined)
+      return
+
     const version = ++loadVersion
     setLoading(true)
     setError(null)
-    setRootChildren([])
     loadChildren(workerId, root, props.showFiles ?? false)
       .then((children) => {
         if (version !== loadVersion)
           return
-        setRootChildren(children)
+        setChildrenInStore(root, children)
         setLoading(false)
       })
       .catch((err) => {
@@ -480,11 +591,11 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
           >
             <Show
               when={rootExpanded()}
-              fallback={<ChevronRight size={16} class={styles.chevron} />}
+              fallback={<Icon icon={ChevronRight} size="md" class={styles.chevron} />}
             >
-              <ChevronDown size={16} class={styles.chevron} />
+              <Icon icon={ChevronDown} size="md" class={styles.chevron} />
             </Show>
-            <Folder size={14} class={styles.folderIcon} />
+            <Icon icon={Folder} size="sm" class={styles.folderIcon} />
             <span class={styles.nodeName}>{rootDisplayName()}</span>
             <div class={styles.nodeActions}>
               {renderTreeContextMenu({
@@ -499,8 +610,12 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
           </div>
           <Show when={rootExpanded()}>
             <Show
-              when={rootChildren().length > 0}
-              fallback={<div class={styles.emptyState}>Empty directory</div>}
+              when={rootChildren() !== undefined && rootChildren()!.length > 0}
+              fallback={(
+                <Show when={rootChildren() !== undefined}>
+                  <div class={styles.emptyState}>Empty directory</div>
+                </Show>
+              )}
             >
               <For each={rootChildren()}>
                 {node => (
@@ -519,6 +634,8 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                     homeDir={props.homeDir}
                     isNodeExpanded={isNodeExpanded}
                     setNodeExpanded={setNodeExpanded}
+                    getChildren={getChildren}
+                    setChildren={setChildrenInStore}
                   />
                 )}
               </For>

--- a/frontend/src/components/workers/WorkerContextMenu.tsx
+++ b/frontend/src/components/workers/WorkerContextMenu.tsx
@@ -3,7 +3,6 @@ import Ellipsis from 'lucide-solid/icons/ellipsis'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { IconButton } from '~/components/common/IconButton'
 import { dangerMenuItem } from '~/styles/shared.css'
-import { iconSize } from '~/styles/tokens'
 
 interface WorkerContextMenuProps {
   onRename: () => void
@@ -14,7 +13,7 @@ export const WorkerContextMenu: Component<WorkerContextMenuProps> = (props) => {
   return (
     <DropdownMenu
       trigger={triggerProps => (
-        <IconButton icon={Ellipsis} iconSize={iconSize.md} size="lg" data-testid="worker-menu-trigger" {...triggerProps} />
+        <IconButton icon={Ellipsis} iconSize="md" size="lg" data-testid="worker-menu-trigger" {...triggerProps} />
       )}
     >
       <button role="menuitem" onClick={() => props.onRename()}>

--- a/frontend/src/components/workers/WorkerSettingsDialog.tsx
+++ b/frontend/src/components/workers/WorkerSettingsDialog.tsx
@@ -4,6 +4,7 @@ import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { sanitizeName } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
 import * as styles from './WorkerSettingsDialog.css'
@@ -112,7 +113,7 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
             </Show>
             <footer>
               <button onClick={() => handleRename()} disabled={renameSaving()}>
-                <Show when={renameSaving()}><LoaderCircle size={14} class={spinner} /></Show>
+                <Show when={renameSaving()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
                 {renameSaving() ? 'Saving...' : 'Save'}
               </button>
             </footer>
@@ -140,7 +141,7 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
               Cancel
             </button>
             <button data-variant="danger" onClick={() => handleDeregister()} disabled={deregisterLoading()} data-testid="deregister-confirm">
-              <Show when={deregisterLoading()}><LoaderCircle size={14} class={spinner} /></Show>
+              <Show when={deregisterLoading()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
               {deregisterLoading() ? 'Deregistering...' : 'Deregister'}
             </button>
           </footer>

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -6,6 +6,7 @@ import { generateSlug } from 'random-word-slugs'
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { workerClient, workspaceClient } from '~/api/clients'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { useOrg } from '~/context/OrgContext'
@@ -111,7 +112,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
                   disabled={refreshing()}
                   title="Refresh workers"
                 >
-                  <RefreshCw size={14} class={refreshing() ? spinning : ''} />
+                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
                 </button>
               </div>
               <select
@@ -135,7 +136,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
                   onClick={() => setTitle(randomTitle())}
                   title="Generate random name"
                 >
-                  <RefreshCw size={14} />
+                  <Icon icon={RefreshCw} size="sm" />
                 </button>
               </div>
               <input
@@ -187,7 +188,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
             type="submit"
             disabled={submitting() || !workerId() || !!titleError() || (createWorktree() && !!worktreeBranchError())}
           >
-            <Show when={submitting()}><LoaderCircle size={14} class={spinner} /></Show>
+            <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting() ? 'Creating...' : 'Create'}
           </button>
         </footer>

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -4,6 +4,7 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
 import { For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
 import { dangerMenuItem } from '~/styles/shared.css'
@@ -54,7 +55,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
           trigger={triggerProps => (
             <button role="menuitem" class="sub-trigger" {...triggerProps}>
               Move to
-              <ChevronRight size={12} />
+              <Icon icon={ChevronRight} size="xs" />
             </button>
           )}
         >

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -5,9 +5,9 @@ import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import { createDroppable, createSortable, SortableProvider, transformStyle } from '@thisbeyond/solid-dnd'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createEffect, createMemo, For, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { ShareMode } from '~/generated/leapmux/v1/common_pb'
 import { spinner } from '~/styles/animations.css'
-import { iconSize } from '~/styles/tokens'
 import { WorkspaceContextMenu } from './WorkspaceContextMenu'
 import * as styles from './workspaceList.css'
 
@@ -152,7 +152,7 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
 
                   <Show
                     when={!isLoading()}
-                    fallback={<LoaderCircle size={iconSize.xs} class={spinner} style={{ 'flex-shrink': '0' }} />}
+                    fallback={<Icon icon={LoaderCircle} size="xs" class={spinner} style={{ 'flex-shrink': '0' }} />}
                   >
                     <Show when={!isRenaming() && !props.isVirtual}>
                       <WorkspaceContextMenu

--- a/frontend/src/components/workspace/WorkspaceSharingDialog.tsx
+++ b/frontend/src/components/workspace/WorkspaceSharingDialog.tsx
@@ -4,6 +4,7 @@ import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient, workspaceClient } from '~/api/clients'
 import { Dialog } from '~/components/common/Dialog'
+import { Icon } from '~/components/common/Icon'
 import { useOrg } from '~/context/OrgContext'
 import { ShareMode } from '~/generated/leapmux/v1/common_pb'
 import { spinner } from '~/styles/animations.css'
@@ -114,7 +115,7 @@ export const WorkspaceSharingDialog: Component<WorkspaceSharingDialogProps> = (p
             Cancel
           </button>
           <button onClick={() => handleSave()} disabled={saving()}>
-            <Show when={saving()}><LoaderCircle size={14} class={spinner} /></Show>
+            <Show when={saving()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {saving() ? 'Saving...' : 'Save'}
           </button>
         </footer>

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -88,12 +88,13 @@ export const authCardXWide = style({
 // Dialog sizes
 
 export const dialogStandard = style({
+  'position': 'relative',
   'minWidth': '360px',
-  'maxWidth': '480px',
+  'maxWidth': '640px',
   'display': 'flex',
   'flexDirection': 'column',
   '@media': {
-    '(max-width: 479px)': {
+    '(max-width: 639px)': {
       minWidth: 'unset',
       maxWidth: '100vw',
       width: '100vw',
@@ -112,12 +113,21 @@ export const dialogTall = style({
 
 export const dialogHeader = style({
   display: 'flex',
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: 0,
+  padding: 0,
 })
 
 export const dialogCloseButton = style({
-  flexShrink: 0,
+  position: 'absolute',
+  top: spacing.md,
+  right: spacing.md,
+})
+
+globalStyle(`${dialogHeader} > h2`, {
+  margin: 0,
 })
 
 // Make dialog forms use flex layout so the tree container can fill remaining space.

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -8,6 +8,7 @@ export const spacing = {
 }
 
 export const iconSize = {
+  xxs: 10,
   xs: 12,
   sm: 14,
   md: 16,


### PR DESCRIPTION
## Motivation

Several related issues surfaced after the dialog and directory tree refactors introduced in recent PRs:

- Icons were rendered inline throughout the codebase using raw Lucide components with ad-hoc `size` props, making it difficult to enforce consistent sizing via design tokens.
- The close button inside the common `Dialog` component was positioned incorrectly because its `position: absolute` had no positioned ancestor to anchor to.
- The `DirectoryTree` component lost its expanded/loaded state across tab switches because the tree state (expanded paths and children cache) was stored only in local signals rather than being persisted to `sessionStorage`.

## Modifications

- Added a new `Icon` component (`frontend/src/components/common/Icon.tsx`) that wraps any `LucideIcon` and maps a named size token (`xxs` | `xs` | `sm` | `md` | `lg` | `xl`) to a pixel value from `iconSize` in `tokens.ts`. A corresponding `xxs: 10` entry was added to the `iconSize` token map.
- Migrated all 30+ call sites across chat, shell, file viewer, todo, tree, and workspace components from raw Lucide icon usage to the new `Icon` component. `IconButton` was updated to delegate to `Icon` internally.
- Fixed dialog close button positioning by adding `position: 'relative'` to the `dialogStandard` shared style, giving the absolutely-positioned `dialogCloseButton` a proper containing block.
- Refactored `DirectoryTree` to centralize expanded paths and children cache into a single `createStore` state object, serialized to and restored from `sessionStorage` on every change. `BigInt` sizes are round-tripped through string conversion to work around JSON limitations.
- Root directory loading now skips the network fetch when children are already present in the cache, eliminating the visual flicker that occurred when switching back to a tree tab.

## Result

- Icon sizes across the UI are now governed by a single set of named design tokens. Adding or resizing an icon variant requires a single change in `tokens.ts`.
- The dialog close button (X) renders in the correct top-right corner position relative to the dialog panel instead of floating to an unintended position.
- The directory tree no longer collapses and re-fetches when switching between tabs. Expanded folders and their loaded children are preserved across the entire browser session, making navigation feel instant after the first load.

```tsx
// Before – raw Lucide usage with a magic number
<RefreshCw size={14} class={refreshing() ? spinning : ''} />

// After – typed token-based Icon component
<Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
```

🤖 Generated with Claude Code
