### PR TITLE
Replace spacing tokens with Oat CSS variables

### DIFF
--- a/frontend/src/components/admin/AdminSettingsPage.css.ts
+++ b/frontend/src/components/admin/AdminSettingsPage.css.ts
@@ -1,12 +1,11 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { backLink, errorText, successText } from '~/styles/shared.css'
 
 export const section = style({
-  marginBottom: spacing.xl,
+  marginBottom: 'var(--space-6)',
   borderBottom: '1px solid var(--border)',
-  paddingBottom: spacing.xl,
+  paddingBottom: 'var(--space-6)',
   selectors: {
     '&:last-child': {
       borderBottom: 'none',
@@ -18,7 +17,7 @@ export const section = style({
 export const fieldLabel = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   fontSize: 'var(--text-7)',
   fontWeight: 400,
   color: 'var(--muted-foreground)',
@@ -29,8 +28,8 @@ export const toggleRow = style({
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: spacing.md,
-  padding: `${spacing.sm} 0`,
+  gap: 'var(--space-3)',
+  padding: 'var(--space-2) 0',
 })
 
 export const toggleLabel = style({
@@ -41,8 +40,8 @@ export const toggleLabel = style({
 export const searchRow = style({
   display: 'flex',
   flexDirection: 'row',
-  gap: spacing.md,
-  marginBottom: spacing.lg,
+  gap: 'var(--space-3)',
+  marginBottom: 'var(--space-4)',
 })
 
 export const passwordSetIndicator = style({
@@ -52,8 +51,8 @@ export const passwordSetIndicator = style({
 })
 
 export const subsection = style({
-  marginTop: spacing.lg,
-  padding: spacing.lg,
+  marginTop: 'var(--space-4)',
+  padding: 'var(--space-4)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
@@ -63,17 +62,17 @@ export const inlineResetRow = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
 })
 
 export const pageContainer = style({
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
 })
 
 export const mutedHint = style({
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-8)',
-  padding: `${spacing.sm} 0`,
+  padding: 'var(--space-2) 0',
 })
 
 export const autoTable = style({
@@ -85,7 +84,7 @@ export const flexWrap = style({
 })
 
 export const inlineInput = style({
-  'padding': `2px ${spacing.sm}`,
+  'padding': '2px var(--space-2)',
   'backgroundColor': 'var(--background)',
   'border': '1px solid var(--border)',
   'borderRadius': 'var(--radius-small)',

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { resizeHandleSelectors } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/resizeHandle'
 
 export const editorResizeHandle = style({
   height: '4px',

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { resizeHandleSelectors, spacing } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/tokens'
 
 export const editorResizeHandle = style({
   height: '4px',
@@ -43,7 +43,7 @@ export const messageListSpacer = style({
 export const messageListContent = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.md,
+  gap: 'var(--space-3)',
 })
 
 export const messageList = style({
@@ -51,24 +51,24 @@ export const messageList = style({
   overflowX: 'hidden',
   overflowY: 'auto',
   overflowAnchor: 'none',
-  padding: `${spacing.lg} ${spacing.lg} ${spacing.lg} ${spacing.xl}`,
+  padding: 'var(--space-4) var(--space-4) var(--space-4) var(--space-6)',
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.md,
+  gap: 'var(--space-3)',
 })
 
 export const loadingOlderIndicator = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: spacing.sm,
-  padding: spacing.md,
+  gap: 'var(--space-2)',
+  padding: 'var(--space-3)',
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-7)',
 })
 
 export const inputArea = style({
-  padding: `${spacing.xs} ${spacing.md} ${spacing.md}`,
+  padding: 'var(--space-1) var(--space-3) var(--space-3)',
   flexShrink: 0,
 })
 
@@ -76,7 +76,7 @@ export const footerBar = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
   backgroundColor: 'var(--background)',
   flexShrink: 0,
 })
@@ -92,8 +92,8 @@ export const sendButton = style({
   'display': 'flex',
   'alignItems': 'center',
   'justifyContent': 'center',
-  'gap': spacing.xs,
-  'padding': `${spacing.xs} ${spacing.sm}`,
+  'gap': 'var(--space-1)',
+  'padding': 'var(--space-1) var(--space-2)',
   'fontSize': 'var(--text-7)',
   'fontWeight': 400,
   'borderRadius': 'var(--radius-small)',
@@ -129,8 +129,8 @@ export const interruptButton = style({
   'boxSizing': 'border-box',
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.xs,
-  'padding': `${spacing.xs} ${spacing.sm}`,
+  'gap': 'var(--space-1)',
+  'padding': 'var(--space-1) var(--space-2)',
   'fontSize': 'var(--text-7)',
   'fontWeight': 400,
   'borderRadius': 'var(--radius-small)',
@@ -151,8 +151,8 @@ export const settingsTrigger = style({
   boxSizing: 'border-box',
   display: 'inline-flex',
   alignItems: 'center',
-  gap: spacing.xs,
-  padding: `2px ${spacing.xs}`,
+  gap: 'var(--space-1)',
+  padding: '2px var(--space-1)',
   marginBottom: '3px',
   fontSize: 'var(--text-8)',
   color: 'var(--faint-foreground)',
@@ -170,14 +170,14 @@ export const settingsMenu = style({
   backgroundColor: 'var(--background)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
-  padding: `${spacing.xs} ${spacing.lg} 0 ${spacing.lg}`,
+  padding: 'var(--space-1) var(--space-4) 0 var(--space-4)',
   zIndex: 300,
   minWidth: '180px',
   boxShadow: 'var(--shadow-large)',
 })
 
 export const settingsGroupLabel = style({
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
   fontSize: 'var(--text-8)',
   fontWeight: 600,
   color: 'var(--muted-foreground)',
@@ -190,8 +190,8 @@ export const settingsRadioItem = style({
   'boxSizing': 'border-box',
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.sm,
-  'padding': `3px ${spacing.sm}`,
+  'gap': 'var(--space-2)',
+  'padding': '3px var(--space-2)',
   'fontSize': 'var(--text-8)',
   'color': 'var(--foreground)',
   'cursor': 'pointer',
@@ -204,7 +204,7 @@ export const settingsRadioItem = style({
 export const footerBarRight = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
 })
 
 export const infoTrigger = style({
@@ -230,7 +230,7 @@ export const infoTrigger = style({
 export const infoRow = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
 })
 
 export const infoLabel = style({
@@ -267,13 +267,13 @@ export const infoCopyButton = style({
 export const infoRows = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
 })
 
 export const infoSeparator = style({
   height: '1px',
   backgroundColor: 'var(--border)',
-  margin: `${spacing.xs} 0`,
+  margin: 'var(--space-1) 0',
 })
 
 export const infoContextUsage = style({

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -1,9 +1,8 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const banner = style({
   position: 'relative',
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
   borderRadius: 'var(--radius-medium)',
   border: '1px solid var(--border)',
   borderLeft: '3px solid var(--warning)',
@@ -15,46 +14,46 @@ export const bannerTitle = style({
   fontSize: 'var(--text-7)',
   fontWeight: 600,
   color: 'var(--foreground)',
-  marginBottom: spacing.sm,
+  marginBottom: 'var(--space-2)',
 })
 
 export const bannerContent = style({
   fontSize: 'var(--text-7)',
   color: 'var(--foreground)',
   lineHeight: 1.6,
-  marginBottom: spacing.md,
+  marginBottom: 'var(--space-3)',
   maxHeight: '300px',
   overflowY: 'auto',
 })
 
 export const bannerActions = style({
   display: 'flex',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   justifyContent: 'flex-end',
 })
 
 export const questionGroup = style({
-  marginBottom: spacing.md,
+  marginBottom: 'var(--space-3)',
 })
 
 export const questionLabel = style({
   fontSize: 'var(--text-7)',
   fontWeight: 400,
   color: 'var(--foreground)',
-  marginBottom: spacing.xs,
+  marginBottom: 'var(--space-1)',
 })
 
 export const optionList = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
 })
 
 export const optionItem = style({
   display: 'flex',
   alignItems: 'flex-start',
-  gap: spacing.sm,
-  padding: spacing.xs,
+  gap: 'var(--space-2)',
+  padding: 'var(--space-1)',
   borderRadius: 'var(--radius-small)',
   cursor: 'pointer',
   fontSize: 'var(--text-7)',
@@ -140,12 +139,12 @@ export const paginationItemAnswered = style({
 export const questionPageHeader = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
-  marginBottom: spacing.xs,
+  marginBottom: 'var(--space-1)',
 })
 
 // Control request content in MarkdownEditor banner slot
 export const controlBanner = style({
-  padding: `${spacing.sm} ${spacing.md}`,
+  padding: 'var(--space-2) var(--space-3)',
   fontSize: 'var(--text-7)',
   backgroundColor: 'var(--lm-warning-subtle)',
   borderBottom: '1px solid var(--border)',
@@ -158,7 +157,7 @@ export const controlBannerTitle = style({
   fontSize: 'var(--text-7)',
   fontWeight: 600,
   color: 'var(--foreground)',
-  marginBottom: spacing.xs,
+  marginBottom: 'var(--space-1)',
 })
 
 // Multi-question footer layout: [Stop] [YOLO]  [Pagination]  [Submit]
@@ -166,8 +165,8 @@ export const controlFooter = style({
   display: 'grid',
   gridTemplateColumns: '1fr auto 1fr',
   alignItems: 'center',
-  gap: spacing.xs,
-  padding: `${spacing.xs} ${spacing.sm}`,
+  gap: 'var(--space-1)',
+  padding: 'var(--space-1) var(--space-2)',
   backgroundColor: 'var(--background)',
   flexShrink: 0,
   flex: 1,
@@ -177,14 +176,14 @@ export const controlFooter = style({
 export const controlFooterLeft = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   justifyContent: 'flex-start',
 })
 
 export const controlFooterRight = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   justifyContent: 'flex-end',
   gridColumn: 3,
 })

--- a/frontend/src/components/chat/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/MarkdownEditor.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { codeBlockCode, codeBlockPre } from '~/styles/codeBlock'
-import { iconSize, spacing } from '~/styles/tokens'
+import { iconSize } from '~/styles/tokens'
 
 export const headingPreviewItem = style({
   margin: 0,
@@ -36,8 +36,8 @@ export const container = style({
 export const toolbar = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
-  padding: `${spacing.xs} ${spacing.sm}`,
+  gap: 'var(--space-1)',
+  padding: 'var(--space-1) var(--space-2)',
   borderBottom: '1px solid var(--border)',
   backgroundColor: 'var(--card)',
   flexShrink: 0,
@@ -82,7 +82,7 @@ export const linkPopover = style({
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
-  padding: spacing.xs,
+  padding: 'var(--space-1)',
   boxShadow: 'var(--shadow-large)',
   // Opacity animation matching OAT dropdown pattern
   opacity: 0,
@@ -99,14 +99,14 @@ export const linkPopover = style({
 
 export const linkPopoverForm = style({
   display: 'flex',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   alignItems: 'center',
 })
 
 export const linkPopoverInput = style({
   'all': 'unset',
   'fontSize': 'var(--text-7)',
-  'padding': `${spacing.xs} ${spacing.sm}`,
+  'padding': 'var(--space-1) var(--space-2)',
   'border': '1px solid var(--border)',
   'borderRadius': 'var(--radius-small)',
   'backgroundColor': 'var(--background)',
@@ -133,7 +133,7 @@ export const codeLangPopoverContent = style({
 export const comboboxControl = style({
   display: 'flex',
   alignItems: 'center',
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
   borderTop: '1px solid var(--border)',
 })
 
@@ -150,15 +150,15 @@ export const comboboxInput = style({
 export const comboboxListbox = style({
   maxHeight: '200px',
   overflowY: 'auto',
-  padding: spacing.xs,
+  padding: 'var(--space-1)',
 })
 
 export const comboboxItem = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   fontSize: 'var(--text-7)',
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
   cursor: 'pointer',
   color: 'var(--foreground)',
   borderRadius: 'var(--radius-small)',
@@ -186,7 +186,7 @@ export const editorWrapper = style({
 
 // ProseMirror editor layout
 globalStyle(`${editorWrapper} .ProseMirror`, {
-  padding: `${spacing.sm} ${spacing.md}`,
+  padding: 'var(--space-2) var(--space-3)',
   outline: 'none',
   minHeight: '20px',
   whiteSpace: 'pre-wrap',

--- a/frontend/src/components/chat/MessageBubble.css.ts
+++ b/frontend/src/components/chat/MessageBubble.css.ts
@@ -1,10 +1,9 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const floatingToolbar = style({
   position: 'absolute',
-  top: spacing.xs,
-  right: spacing.xs,
+  top: 'var(--space-1)',
+  right: 'var(--space-1)',
   display: 'flex',
   gap: '2px',
   zIndex: 10,
@@ -13,7 +12,7 @@ export const floatingToolbar = style({
 export const metaFloatingToolbar = style({
   position: 'absolute',
   top: '50%',
-  right: spacing.xs,
+  right: 'var(--space-1)',
   transform: 'translateY(-50%)',
   display: 'flex',
   gap: '2px',
@@ -22,8 +21,8 @@ export const metaFloatingToolbar = style({
 
 export const threadChildren = style({
   marginLeft: '6px',
-  paddingLeft: spacing.md,
-  paddingRight: spacing.md,
+  paddingLeft: 'var(--space-3)',
+  paddingRight: 'var(--space-3)',
   borderLeft: '2px solid var(--border)',
 })
 
@@ -38,7 +37,7 @@ export const messageWithError = style({
 export const messageError = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   paddingTop: '2px',
   fontSize: 'var(--text-8)',
   color: 'var(--danger)',

--- a/frontend/src/components/chat/ThinkingIndicator.css.ts
+++ b/frontend/src/components/chat/ThinkingIndicator.css.ts
@@ -1,12 +1,11 @@
 import { style } from '@vanilla-extract/css'
 import { thinkingPulse } from '~/styles/animations.css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
   alignItems: 'center',
   gap: '6px',
-  padding: `${spacing.sm} 0`,
+  padding: 'var(--space-2) 0',
 })
 
 export const dot = style({

--- a/frontend/src/components/chat/codeViewStyles.css.ts
+++ b/frontend/src/components/chat/codeViewStyles.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 // Code view container (used by Read tool result with syntax highlighting)
 export const codeViewContainer = style({
@@ -10,12 +9,12 @@ export const codeViewContainer = style({
   overflow: 'auto',
   borderRadius: 'var(--radius-small)',
   border: '1px solid var(--border)',
-  marginTop: spacing.xs,
+  marginTop: 'var(--space-1)',
 })
 
 export const codeViewLine = style({
   display: 'flex',
-  padding: `0 ${spacing.sm}`,
+  padding: '0 var(--space-2)',
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
 })
@@ -27,7 +26,7 @@ export const codeViewLineNumber = style({
   textAlign: 'right',
   color: 'var(--faint-foreground)',
   whiteSpace: 'nowrap',
-  marginRight: spacing.sm,
+  marginRight: 'var(--space-2)',
 })
 
 export const codeViewContent = style({

--- a/frontend/src/components/chat/diffStyles.css.ts
+++ b/frontend/src/components/chat/diffStyles.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 // Diff container
 export const diffContainer = style({
@@ -10,7 +9,7 @@ export const diffContainer = style({
   overflow: 'auto',
   borderRadius: 'var(--radius-small)',
   border: '1px solid var(--border)',
-  marginTop: spacing.xs,
+  marginTop: 'var(--space-1)',
 })
 
 export const diffRemoved = style({
@@ -35,7 +34,7 @@ export const diffAddedInline = style({
 
 export const diffLine = style({
   display: 'flex',
-  padding: `0 ${spacing.sm}`,
+  padding: '0 var(--space-2)',
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
 })
@@ -59,8 +58,8 @@ export const diffLineNumberNew = style({
   textAlign: 'right',
   color: 'var(--faint-foreground)',
   whiteSpace: 'nowrap',
-  marginLeft: spacing.xs,
-  marginRight: spacing.xs,
+  marginLeft: 'var(--space-1)',
+  marginRight: 'var(--space-1)',
 })
 
 export const diffPrefix = style({
@@ -97,7 +96,7 @@ export const diffSplitContainer = style({
   overflow: 'auto',
   borderRadius: 'var(--radius-small)',
   border: '1px solid var(--border)',
-  marginTop: spacing.xs,
+  marginTop: 'var(--space-1)',
 })
 
 globalStyle(`${diffSplitContainer} span[style]`, {

--- a/frontend/src/components/chat/markdownContent.css.ts
+++ b/frontend/src/components/chat/markdownContent.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { codeBlockCode, codeBlockPre } from '~/styles/codeBlock'
-import { iconSize, spacing } from '~/styles/tokens'
+import { iconSize } from '~/styles/tokens'
 
 export const markdownContent = style({
   wordBreak: 'break-word',
@@ -29,7 +29,7 @@ globalStyle(`html[data-theme="dark"] ${markdownContent} pre.shiki span`, {
 
 // Task list checkboxes
 globalStyle(`${markdownContent} li > input[type="checkbox"]`, {
-  marginRight: spacing.xs,
+  marginRight: 'var(--space-1)',
   verticalAlign: 'middle',
   pointerEvents: 'none',
 })
@@ -39,8 +39,8 @@ globalStyle(`${markdownContent} pre .copy-code-button`, {
   all: 'unset',
   boxSizing: 'border-box',
   position: 'absolute',
-  top: spacing.xs,
-  right: spacing.xs,
+  top: 'var(--space-1)',
+  right: 'var(--space-1)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -1,10 +1,9 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 import { toolHeaderActions, toolHeaderTimestamp } from './toolStyles.css'
 
 export const messageBubble = style({
   position: 'relative',
-  padding: `${spacing.md} ${spacing.lg}`,
+  padding: 'var(--space-3) var(--space-4)',
   borderRadius: 'var(--radius-medium)',
   lineHeight: 1.6,
   maxWidth: '85%',
@@ -35,14 +34,14 @@ export const thinkingMessage = style([messageBubble, {
 export const thinkingHeader = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   color: 'var(--muted-foreground)',
   cursor: 'pointer',
   userSelect: 'none',
 })
 
 export const thinkingContent = style({
-  marginTop: spacing.sm,
+  marginTop: 'var(--space-2)',
 })
 
 export const systemMessage = style([messageBubble, {
@@ -61,7 +60,7 @@ export const metaMessage = style({
 export const resultDivider = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-7)',
   selectors: {
@@ -84,7 +83,7 @@ export const resultDivider = style({
 export const controlResponseMessage = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   color: 'var(--foreground)',
   fontSize: 'var(--text-7)',
   alignSelf: 'stretch',
@@ -117,8 +116,8 @@ export const messageRowCenter = style({
 
 // Extra vertical spacing for user, assistant, and notification message rows
 globalStyle(`${messageRow}:has(> .${assistantMessage}), ${messageRow}:has(> .${thinkingMessage}), ${messageRowEnd}, ${messageRowCenter}`, {
-  marginTop: spacing.xs,
-  marginBottom: spacing.xs,
+  marginTop: 'var(--space-1)',
+  marginBottom: 'var(--space-1)',
 })
 
 // Inside messageRow, stretch meta messages (tools, result dividers) to fill available space
@@ -141,7 +140,7 @@ globalStyle(`${messageRow}:has(.${resultDivider}) > .${toolHeaderActions}`, {
 // Inside messageRowEnd, place actions to the left of the bubble in a 2-column grid (mirrored via RTL)
 globalStyle(`${messageRowEnd} > .${toolHeaderActions}`, {
   order: -1,
-  paddingRight: spacing.xs,
+  paddingRight: 'var(--space-1)',
   display: 'grid',
   gridTemplateColumns: 'auto auto',
   direction: 'rtl',
@@ -160,12 +159,12 @@ globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions}, 
 
 // Add left padding to timestamps in assistant grid so they align with the icon button below
 globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
-  paddingLeft: spacing.xs,
+  paddingLeft: 'var(--space-1)',
 })
 
 // Add right padding to timestamps in user grid (mirrored) so they align with the icon button below
 globalStyle(`${messageRowEnd} > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
-  paddingRight: spacing.xs,
+  paddingRight: 'var(--space-1)',
 })
 
 // Inside messageRowCenter, position actions at the right edge absolutely

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 // Tool use/result messages - document-style, no bubble
 export const toolMessage = style({
@@ -12,7 +11,7 @@ export const toolMessage = style({
 export const toolUseHeader = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   color: 'var(--muted-foreground)',
 })
 
@@ -20,8 +19,8 @@ export const toolUseHeader = style({
 export const toolResultHeader = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
-  marginBottom: spacing.xs,
+  gap: 'var(--space-1)',
+  marginBottom: 'var(--space-1)',
   color: 'var(--muted-foreground)',
 })
 
@@ -101,7 +100,7 @@ globalStyle(`html[data-theme="dark"] ${toolResultContentAnsi} pre.shiki span`, {
 // Prompt label shown above WebFetch tool result
 export const toolResultPrompt = style({
   color: 'var(--muted-foreground)',
-  marginBottom: spacing.xs,
+  marginBottom: 'var(--space-1)',
 })
 
 // Tool sub-detail line (monospace, aligned with description: icon 16px + gap 4px = 20px indent)
@@ -194,7 +193,7 @@ export const controlResponseTag = style({
 // AskUserQuestion: question item container
 export const questionItem = style({
   paddingLeft: '20px',
-  marginTop: spacing.xs,
+  marginTop: 'var(--space-1)',
 })
 
 // AskUserQuestion: question header label (bold)

--- a/frontend/src/components/common/LoginPage.css.ts
+++ b/frontend/src/components/common/LoginPage.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { authCard, errorText } from '~/styles/shared.css'
 
@@ -12,15 +11,15 @@ export const container = style({
 })
 
 export const authFooter = style({
-  marginTop: spacing.lg,
+  marginTop: 'var(--space-4)',
   fontSize: 'var(--text-8)',
 })
 
 export const verificationMessage = style({
-  padding: `${spacing.lg} 0`,
+  padding: 'var(--space-4) 0',
 })
 
 export const inlineLink = style({
-  marginTop: spacing.sm,
+  marginTop: 'var(--space-2)',
   display: 'inline-block',
 })

--- a/frontend/src/components/common/NotFoundPage.css.ts
+++ b/frontend/src/components/common/NotFoundPage.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -11,7 +10,7 @@ export const container = style({
 
 export const message = style({
   color: 'var(--muted-foreground)',
-  marginBottom: spacing.xl,
+  marginBottom: 'var(--space-6)',
   lineHeight: 1.5,
 })
 

--- a/frontend/src/components/common/RegistrationPage.css.ts
+++ b/frontend/src/components/common/RegistrationPage.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { authCardXWide, errorText } from '~/styles/shared.css'
 
@@ -14,8 +13,8 @@ export const container = style({
 export const infoGrid = style({
   display: 'grid',
   gridTemplateColumns: 'auto 1fr',
-  gap: `${spacing.xs} ${spacing.md}`,
-  marginBottom: spacing.xl,
+  gap: 'var(--space-1) var(--space-3)',
+  marginBottom: 'var(--space-6)',
 })
 
 export const infoLabel = style({
@@ -48,8 +47,8 @@ export const linkSecondary = style({
 })
 
 export const warningBox = style({
-  padding: spacing.md,
-  marginBottom: spacing.lg,
+  padding: 'var(--space-3)',
+  marginBottom: 'var(--space-4)',
   backgroundColor: 'var(--lm-warning-subtle)',
   border: '1px solid var(--warning)',
   borderRadius: 'var(--radius-medium)',
@@ -61,8 +60,8 @@ export const warningBox = style({
 export const actionRow = style({
   display: 'flex',
   justifyContent: 'center',
-  gap: spacing.lg,
-  marginTop: spacing.lg,
+  gap: 'var(--space-4)',
+  marginTop: 'var(--space-4)',
 })
 
 export const fieldError = style({

--- a/frontend/src/components/common/SelectionQuotePopover.css.ts
+++ b/frontend/src/components/common/SelectionQuotePopover.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const popover = style({
   'position': 'absolute',
@@ -24,7 +23,7 @@ export const quoteButton = style({
   justifyContent: 'center',
   gap: '4px',
   height: '28px',
-  paddingInline: spacing.sm,
+  paddingInline: 'var(--space-2)',
   cursor: 'pointer',
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-8)',

--- a/frontend/src/components/filebrowser/FileBrowser.css.ts
+++ b/frontend/src/components/filebrowser/FileBrowser.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -11,8 +10,8 @@ export const container = style({
 export const pathBar = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
-  padding: `${spacing.sm} ${spacing.md}`,
+  gap: 'var(--space-1)',
+  padding: 'var(--space-2) var(--space-3)',
   borderBottom: '1px solid var(--border)',
   flexShrink: 0,
   minHeight: '32px',
@@ -21,7 +20,7 @@ export const pathBar = style({
 export const breadcrumbList = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   listStyle: 'none',
   margin: 0,
   padding: 0,
@@ -45,14 +44,14 @@ export const pathSeparator = style({
 export const fileList = style({
   flex: 1,
   overflow: 'auto',
-  padding: `${spacing.xs} 0`,
+  padding: 'var(--space-1) 0',
 })
 
 export const fileItem = style({
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.sm,
-  'padding': `${spacing.xs} ${spacing.md}`,
+  'gap': 'var(--space-2)',
+  'padding': 'var(--space-1) var(--space-3)',
   'cursor': 'pointer',
   'fontSize': 'var(--text-7)',
   'color': 'var(--foreground)',
@@ -92,7 +91,7 @@ export const loadingState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
 })
@@ -101,7 +100,7 @@ export const errorState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',
 })
@@ -110,7 +109,7 @@ export const emptyState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
 })

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -1,6 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { codeViewContainer } from '~/components/chat/codeViewStyles.css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -18,12 +17,12 @@ export const content = style({
 
 export const statusBar = style({
   position: 'absolute',
-  bottom: spacing.sm,
-  right: spacing.md,
+  bottom: 'var(--space-2)',
+  right: 'var(--space-3)',
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
-  padding: `${spacing.xs} ${spacing.sm}`,
+  gap: 'var(--space-2)',
+  padding: 'var(--space-1) var(--space-2)',
   borderRadius: 'var(--radius-small)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
@@ -58,7 +57,7 @@ export const errorState = style({
   height: '100%',
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
   textAlign: 'center',
 })
 
@@ -69,7 +68,7 @@ export const imageSizeError = style({
   height: '100%',
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-7)',
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
   textAlign: 'center',
 })
 
@@ -83,7 +82,7 @@ export const hexContainer = style({
   fontVariantLigatures: 'none',
   fontSize: 'var(--text-8)',
   lineHeight: 1.5,
-  paddingInline: spacing.sm,
+  paddingInline: 'var(--space-2)',
   whiteSpace: 'pre',
   width: 'max-content',
   marginInline: 'auto',
@@ -115,7 +114,7 @@ globalStyle(`${textViewContainer} ${codeViewContainer}`, {
   borderRadius: 0,
   marginTop: 0,
   overflow: 'visible',
-  paddingBlock: spacing.sm,
+  paddingBlock: 'var(--space-2)',
 })
 
 // Container for views that have a render/source toggle (markdown, SVG)
@@ -128,8 +127,8 @@ export const toggleViewContainer = style({
 // Floating segmented toggle button at top-right
 export const viewToggle = style({
   'position': 'absolute',
-  'top': spacing.sm,
-  'right': spacing.md,
+  'top': 'var(--space-2)',
+  'right': 'var(--space-3)',
   'zIndex': 10,
   'display': 'flex',
   'borderRadius': 'var(--radius-small)',
@@ -172,7 +171,7 @@ export const viewToggleActive = style({
 })
 
 export const markdownContainer = style({
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
   overflow: 'auto',
   height: '100%',
 })
@@ -196,7 +195,7 @@ export const splitDivider = style({
 })
 
 export const splitPaneMarkdown = style({
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
 })
 
 export const splitPaneSource = style({})
@@ -208,14 +207,14 @@ globalStyle(`${splitPane} ${codeViewContainer}`, {
   borderRadius: 0,
   marginTop: 0,
   overflow: 'visible',
-  paddingBlock: spacing.sm,
+  paddingBlock: 'var(--space-2)',
 })
 
 // Floating toolbar for image zoom controls (top-left)
 export const imageToolbar = style({
   'position': 'absolute',
-  'top': spacing.sm,
-  'left': spacing.md,
+  'top': 'var(--space-2)',
+  'left': 'var(--space-3)',
   'zIndex': 10,
   'display': 'flex',
   'alignItems': 'center',
@@ -272,7 +271,7 @@ export const imageToolbarTextButton = style({
   alignItems: 'center',
   justifyContent: 'center',
   height: '28px',
-  paddingInline: spacing.xs,
+  paddingInline: 'var(--space-1)',
   cursor: 'pointer',
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-8)',
@@ -305,7 +304,7 @@ export const imageZoomWrapper = style({
   minWidth: '100%',
   minHeight: '100%',
   width: 'max-content',
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
 })
 
 // Checkerboard transparency pattern + border for images

--- a/frontend/src/components/fileviewer/HexView.tsx
+++ b/frontend/src/components/fileviewer/HexView.tsx
@@ -3,7 +3,7 @@ import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount } f
 import * as styles from './FileViewer.css'
 
 const FALLBACK_ROW_HEIGHT = 20
-const BASE_VPAD = 4 // matches spacing.xs
+const BASE_VPAD = 4 // matches var(--space-1)
 const OVERSCAN = 20
 
 /** Format a single hex row: offset | hex bytes | ASCII */

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -22,7 +22,7 @@ const MIME_MAP: Record<string, string> = {
   avif: 'image/avif',
 }
 
-const WRAPPER_PADDING = 16 // matches spacing.lg used in imageZoomWrapper
+const WRAPPER_PADDING = 16 // matches var(--space-4) used in imageZoomWrapper
 
 function getMimeType(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase() ?? ''

--- a/frontend/src/components/org/OrgManagementPage.css.ts
+++ b/frontend/src/components/org/OrgManagementPage.css.ts
@@ -1,18 +1,17 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { backLink, emptyState, errorText, successText } from '~/styles/shared.css'
 
 export const container = style({
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   maxWidth: '800px',
 })
 
 export const infoRow = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.md,
-  marginBottom: spacing.md,
+  gap: 'var(--space-3)',
+  marginBottom: 'var(--space-3)',
 })
 
 export const infoLabel = style({
@@ -28,13 +27,13 @@ export const infoValue = style({
 export const inviteForm = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
-  marginBottom: spacing.lg,
+  gap: 'var(--space-2)',
+  marginBottom: 'var(--space-4)',
 })
 
 export const deleteSection = style({
-  marginBottom: spacing.xxl,
-  padding: spacing.xl,
+  marginBottom: 'var(--space-8)',
+  padding: 'var(--space-6)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--danger)',
   borderRadius: 'var(--radius-medium)',
@@ -42,5 +41,5 @@ export const deleteSection = style({
 
 export const deleteDescription = style({
   color: 'var(--muted-foreground)',
-  marginBottom: spacing.lg,
+  marginBottom: 'var(--space-4)',
 })

--- a/frontend/src/components/settings/PreferencesPage.css.ts
+++ b/frontend/src/components/settings/PreferencesPage.css.ts
@@ -1,18 +1,17 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { backLink, errorText, successText, warningText } from '~/styles/shared.css'
 
 export const container = style({
   maxWidth: '600px',
   margin: '0 auto',
-  padding: spacing.xxl,
+  padding: 'var(--space-8)',
 })
 
 export const section = style({
-  marginBottom: spacing.xl,
+  marginBottom: 'var(--space-6)',
   borderBottom: '1px solid var(--border)',
-  paddingBottom: spacing.xl,
+  paddingBottom: 'var(--space-6)',
   selectors: {
     '&:last-child': {
       borderBottom: 'none',
@@ -24,7 +23,7 @@ export const section = style({
 export const fieldLabel = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   fontSize: 'var(--text-7)',
   fontWeight: 400,
   color: 'var(--muted-foreground)',
@@ -33,11 +32,11 @@ export const fieldLabel = style({
 export const pillGroup = style({
   display: 'flex',
   flexDirection: 'row',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
 })
 
 export const pillOption = style({
-  'padding': `${spacing.sm} ${spacing.lg}`,
+  'padding': 'var(--space-2) var(--space-4)',
   'backgroundColor': 'var(--card)',
   'color': 'var(--muted-foreground)',
   'border': '1px solid var(--border)',
@@ -51,7 +50,7 @@ export const pillOption = style({
 })
 
 export const pillOptionActive = style({
-  padding: `${spacing.sm} ${spacing.lg}`,
+  padding: 'var(--space-2) var(--space-4)',
   backgroundColor: 'var(--primary)',
   color: '#ffffff',
   border: '1px solid var(--primary)',
@@ -73,7 +72,7 @@ export const fontListHeader = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  marginTop: spacing.md,
+  marginTop: 'var(--space-3)',
 })
 
 export const fontList = style({
@@ -88,8 +87,8 @@ export const fontList = style({
 export const fontListItem = style({
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.sm,
-  'padding': `${spacing.sm} ${spacing.md}`,
+  'gap': 'var(--space-2)',
+  'padding': 'var(--space-2) var(--space-3)',
   'backgroundColor': 'var(--card)',
   'cursor': 'grab',
   ':hover': {
@@ -158,27 +157,27 @@ export const fontEditError = style({
 export const fontListEmpty = style({
   fontSize: 'var(--text-7)',
   color: 'var(--faint-foreground)',
-  padding: `${spacing.sm} 0`,
+  padding: 'var(--space-2) 0',
   fontStyle: 'italic',
 })
 
 export const fontAddRow = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
 })
 
 export const sliderGroup = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.sm,
-  marginTop: spacing.md,
+  gap: 'var(--space-2)',
+  marginTop: 'var(--space-3)',
 })
 
 export const sliderRow = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.md,
+  gap: 'var(--space-3)',
 })
 
 export const sliderValue = style({
@@ -192,5 +191,5 @@ export const volumeOverrideRow = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: spacing.md,
+  gap: 'var(--space-3)',
 })

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { resizeHandleSelectors } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/resizeHandle'
 
 export const shell = style({
   height: '100%',

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { resizeHandleSelectors, spacing } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/tokens'
 
 export const shell = style({
   height: '100%',
@@ -70,7 +70,7 @@ export const placeholder = style({
   flex: 1,
   color: 'var(--faint-foreground)',
   textAlign: 'center',
-  padding: `0 ${spacing.xl}`,
+  padding: '0 var(--space-6)',
 })
 
 export const emptyTileActions = style({
@@ -78,7 +78,7 @@ export const emptyTileActions = style({
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: spacing.md,
+  gap: 'var(--space-3)',
   flex: 1,
 })
 
@@ -89,7 +89,7 @@ export const emptyTileHint = style({
   flex: 1,
   color: 'var(--faint-foreground)',
   textAlign: 'center',
-  padding: `0 ${spacing.xl}`,
+  padding: '0 var(--space-6)',
   cursor: 'default',
 })
 

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { headerHeight, iconSize, resizeHandleSelectors, spacing } from '~/styles/tokens'
+import { headerHeight, iconSize, resizeHandleSelectors } from '~/styles/tokens'
 
 /** Inner flex-column wrapper for the expanded sidebar. */
 export const sidebarInner = style({
@@ -59,15 +59,15 @@ export const sidebarContent = style({
 export const sidebarHeaderActions = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   marginRight: '-4px',
 })
 
 export const collapsibleTrigger = style({
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.xs,
-  'padding': `0 ${spacing.lg}`,
+  'gap': 'var(--space-1)',
+  'padding': '0 var(--space-4)',
   'minHeight': headerHeight,
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,
@@ -135,8 +135,8 @@ export const sidebarRail = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: spacing.xs,
-  padding: `${spacing.xs} 0 ${spacing.sm}`,
+  gap: 'var(--space-1)',
+  padding: 'var(--space-1) 0 var(--space-2)',
   width: '100%',
   height: '100%',
   backgroundColor: 'var(--card)',
@@ -176,7 +176,7 @@ export const marginTopAuto = style({
 export const bottomSection = style({
   marginTop: 'auto',
   flexShrink: 0,
-  padding: `0 ${spacing.lg}`,
+  padding: '0 var(--space-4)',
   minHeight: headerHeight,
   display: 'flex',
   alignItems: 'center',
@@ -189,7 +189,7 @@ export const sectionDragHandle = style({
   'left': 0,
   'top': 0,
   'bottom': 0,
-  'width': spacing.lg,
+  'width': 'var(--space-4)',
   'display': 'flex',
   'alignItems': 'center',
   'justifyContent': 'center',
@@ -240,7 +240,7 @@ export const emptyDropZone = style({
   fontStyle: 'italic',
   border: '2px dashed var(--border)',
   borderRadius: '4px',
-  margin: spacing.sm,
+  margin: 'var(--space-2)',
 })
 
 /** Active state when a section drag is in progress over an empty sidebar. */

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { headerHeight, iconSize, resizeHandleSelectors } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/resizeHandle'
+import { headerHeight, iconSize } from '~/styles/tokens'
 
 /** Inner flex-column wrapper for the expanded sidebar. */
 export const sidebarInner = style({

--- a/frontend/src/components/shell/TabBar.css.ts
+++ b/frontend/src/components/shell/TabBar.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { headerHeightPx, spacing } from '~/styles/tokens'
+import { headerHeightPx } from '~/styles/tokens'
 
 export const tooltipTrigger = style({
   display: 'inline-flex',
@@ -9,7 +9,7 @@ export const tabBar = style({
   display: 'flex',
   alignItems: 'stretch',
   gap: '1px',
-  padding: `0 ${spacing.sm}`,
+  padding: '0 var(--space-2)',
   backgroundColor: 'var(--background)',
   flexShrink: 0,
   minHeight: `${headerHeightPx - 1}px`,
@@ -19,7 +19,7 @@ export const tabList = style({
   position: 'relative',
   display: 'flex',
   alignItems: 'stretch',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   flex: 1,
   overflowX: 'auto',
   scrollbarWidth: 'none',
@@ -33,7 +33,7 @@ export const tab = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': '6px',
-  'padding': `${spacing.xs} ${spacing.xs} ${spacing.xs} ${spacing.sm}`,
+  'padding': 'var(--space-1) var(--space-1) var(--space-1) var(--space-2)',
   'fontSize': 'var(--text-7)',
   'color': 'var(--muted-foreground)',
   'cursor': 'pointer',
@@ -67,7 +67,7 @@ export const newTabWrapper = style({
   position: 'relative',
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
 })
 
 export const tabNotification = style({
@@ -105,7 +105,7 @@ export const tabDragOverlay = style({
   display: 'flex',
   alignItems: 'center',
   gap: '6px',
-  padding: `${spacing.xs} 6px`,
+  padding: 'var(--space-1) 6px',
   fontSize: 'var(--text-7)',
   color: 'var(--foreground)',
   backgroundColor: 'var(--card)',
@@ -126,7 +126,7 @@ export const tabListDropTarget = style({
 })
 
 export const shellDefault = style({
-  marginLeft: spacing.xs,
+  marginLeft: 'var(--space-1)',
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
 })
@@ -164,13 +164,13 @@ export const collapsedOverflow = style({
 
 // --- Compact (240-359px): icon-only tabs, hide close unless hovered ---
 globalStyle(`[data-tile-size="compact"] ${tabBar}`, {
-  padding: `0 ${spacing.xs}`,
+  padding: '0 var(--space-1)',
   gap: '0',
 })
 
 globalStyle(`[data-tile-size="compact"] ${tab}`, {
   gap: '4px',
-  padding: `${spacing.xs}`,
+  padding: 'var(--space-1)',
   maxWidth: 'unset',
 })
 
@@ -188,13 +188,13 @@ globalStyle(`[data-tile-size="compact"] ${tab}:hover ${tabClose}`, {
 
 // --- Minimal (140-239px): also icon-only tabs + collapse new-tab buttons ---
 globalStyle(`[data-tile-size="minimal"] ${tabBar}`, {
-  padding: `0 ${spacing.xs}`,
+  padding: '0 var(--space-1)',
   gap: '0',
 })
 
 globalStyle(`[data-tile-size="minimal"] ${tab}`, {
   gap: '4px',
-  padding: `${spacing.xs}`,
+  padding: 'var(--space-1)',
   maxWidth: 'unset',
 })
 
@@ -226,7 +226,7 @@ globalStyle(`[data-tile-size="micro"] ${tabBar}`, {
 
 globalStyle(`[data-tile-size="micro"] ${tab}`, {
   gap: '4px',
-  padding: `${spacing.xs} 2px`,
+  padding: 'var(--space-1) 2px',
   maxWidth: 'unset',
 })
 

--- a/frontend/src/components/shell/Tile.css.ts
+++ b/frontend/src/components/shell/Tile.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const tabBarRow = style({
   display: 'flex',
@@ -42,9 +41,9 @@ export const splitActions = style({
   display: 'flex',
   alignItems: 'center',
   gap: '2px',
-  marginLeft: spacing.xs,
-  paddingLeft: spacing.xs,
-  paddingRight: spacing.xs,
+  marginLeft: 'var(--space-1)',
+  paddingLeft: 'var(--space-1)',
+  paddingRight: 'var(--space-1)',
   borderLeft: '1px solid var(--border)',
 })
 

--- a/frontend/src/components/shell/TilingLayout.css.ts
+++ b/frontend/src/components/shell/TilingLayout.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { resizeHandleSelectors } from '~/styles/tokens'
+import { resizeHandleSelectors } from '~/styles/resizeHandle'
 
 export const tilingRoot = style({
   flex: 1,

--- a/frontend/src/components/shell/UserMenu.css.ts
+++ b/frontend/src/components/shell/UserMenu.css.ts
@@ -1,10 +1,9 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   position: 'relative',
   borderTop: '1px solid var(--border)',
-  padding: spacing.sm,
+  padding: 'var(--space-2)',
   flexShrink: 0,
 })
 
@@ -13,7 +12,7 @@ export const trigger = style({
   'display': 'flex',
   'alignItems': 'center',
   'width': '100%',
-  'padding': `${spacing.sm} ${spacing.md}`,
+  'padding': 'var(--space-2) var(--space-3)',
   'borderRadius': 'var(--radius-medium)',
   'color': 'var(--foreground)',
   'fontSize': 'var(--text-7)',
@@ -36,7 +35,7 @@ export const orgItem = style({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
-  padding: `${spacing.sm} ${spacing.md}`,
+  padding: 'var(--space-2) var(--space-3)',
   borderRadius: 'var(--radius-small)',
   color: 'var(--foreground)',
   fontSize: 'var(--text-7)',
@@ -55,7 +54,7 @@ export const orgItemActive = style({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
-  padding: `${spacing.sm} ${spacing.md}`,
+  padding: 'var(--space-2) var(--space-3)',
   borderRadius: 'var(--radius-small)',
   color: 'var(--primary)',
   fontSize: 'var(--text-7)',

--- a/frontend/src/components/terminal/TerminalView.css.ts
+++ b/frontend/src/components/terminal/TerminalView.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const terminalInner = style({
   flex: 1,
@@ -25,5 +24,5 @@ export const terminalWrapper = style({
 // Apply padding to the xterm element rather than the wrapper so that
 // FitAddon correctly accounts for it when calculating rows/cols.
 globalStyle(`${terminalWrapper} .xterm`, {
-  padding: spacing.xs,
+  padding: 'var(--space-1)',
 })

--- a/frontend/src/components/todo/TodoList.css.ts
+++ b/frontend/src/components/todo/TodoList.css.ts
@@ -1,17 +1,16 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const todoList = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '2px',
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
 })
 
 export const todoItem = style({
   display: 'flex',
   alignItems: 'flex-start',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   padding: '3px 0',
   fontSize: 'var(--text-7)',
   lineHeight: 1.4,

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export const container = style({
   display: 'flex',
@@ -11,14 +10,14 @@ export const container = style({
 export const tree = style({
   flex: 1,
   overflow: 'auto',
-  padding: `${spacing.xs} 0`,
+  padding: 'var(--space-1) 0',
 })
 
 export const node = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': '4px',
-  'padding': `2px ${spacing.sm}`,
+  'padding': '2px var(--space-2)',
   'cursor': 'pointer',
   'fontSize': 'var(--text-7)',
   'color': 'var(--foreground)',
@@ -69,7 +68,7 @@ export const loadingState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
 })
@@ -77,14 +76,14 @@ export const loadingState = style({
 export const loadingInline = style({
   fontSize: 'var(--text-7)',
   color: 'var(--faint-foreground)',
-  padding: `2px ${spacing.sm}`,
+  padding: '2px var(--space-2)',
 })
 
 export const errorState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',
 })
@@ -93,7 +92,7 @@ export const emptyState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
 })
@@ -101,7 +100,7 @@ export const emptyState = style({
 export const emptyInline = style({
   fontSize: 'var(--text-7)',
   color: 'var(--faint-foreground)',
-  padding: `2px ${spacing.sm}`,
+  padding: '2px var(--space-2)',
 })
 
 export const nodeActions = style({
@@ -123,7 +122,7 @@ export const nodeMenuTrigger = style({
 export const pathInput = style({
   display: 'flex',
   alignItems: 'center',
-  padding: `${spacing.xs} ${spacing.sm}`,
+  padding: 'var(--space-1) var(--space-2)',
   borderBottom: '1px solid var(--border)',
   flexShrink: 0,
 })
@@ -134,7 +133,7 @@ export const pathInputField = style({
   'fontSize': 'var(--text-7)',
   'color': 'var(--foreground)',
   'fontFamily': 'var(--font-mono)',
-  'padding': `${spacing.xs} ${spacing.sm}`,
+  'padding': 'var(--space-1) var(--space-2)',
   'borderRadius': 'var(--radius-small)',
   'backgroundColor': 'var(--background)',
   'border': '1px solid var(--border)',

--- a/frontend/src/components/workers/WorkerListPage.css.ts
+++ b/frontend/src/components/workers/WorkerListPage.css.ts
@@ -1,10 +1,9 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { backLink, emptyState, errorText } from '~/styles/shared.css'
 
 export const container = style({
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
 })
 
 export const workerCard = style({
@@ -14,9 +13,9 @@ export const workerCard = style({
 export const sectionHeader = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
-  marginTop: spacing.xl,
-  marginBottom: spacing.md,
+  gap: 'var(--space-2)',
+  marginTop: 'var(--space-6)',
+  marginBottom: 'var(--space-3)',
 })
 
 export const sectionName = style({
@@ -35,13 +34,13 @@ export const sectionCount = style({
 export const cardGrid = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
 })
 
 export const cardInfo = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
+  gap: 'var(--space-1)',
   minWidth: 0,
   flex: 1,
 })
@@ -70,13 +69,13 @@ export const cardMeta = style({
 export const cardRight = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   flexShrink: 0,
-  marginLeft: spacing.md,
+  marginLeft: 'var(--space-3)',
 })
 
 export const emptySection = style({
-  padding: spacing.lg,
+  padding: 'var(--space-4)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
   textAlign: 'center',

--- a/frontend/src/components/workers/WorkerSettingsDialog.css.ts
+++ b/frontend/src/components/workers/WorkerSettingsDialog.css.ts
@@ -1,21 +1,20 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { errorText } from '~/styles/shared.css'
 
 export const description = style({
   color: 'var(--muted-foreground)',
   lineHeight: 1.5,
-  marginBottom: spacing.md,
+  marginBottom: 'var(--space-3)',
 })
 
 export const warning = style({
-  padding: spacing.md,
+  padding: 'var(--space-3)',
   backgroundColor: 'var(--lm-danger-subtle)',
   border: '1px solid var(--danger)',
   borderRadius: 'var(--radius-medium)',
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',
   lineHeight: 1.5,
-  marginBottom: spacing.lg,
+  marginBottom: 'var(--space-4)',
 })

--- a/frontend/src/components/workspace/WorkspaceSharingDialog.css.ts
+++ b/frontend/src/components/workspace/WorkspaceSharingDialog.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { spacing } from '~/styles/tokens'
 
 export { errorText } from '~/styles/shared.css'
 
@@ -8,9 +7,9 @@ export const memberList = style({
   overflowY: 'auto',
   display: 'flex',
   flexDirection: 'column',
-  gap: spacing.xs,
-  marginBottom: spacing.lg,
-  padding: spacing.sm,
+  gap: 'var(--space-1)',
+  marginBottom: 'var(--space-4)',
+  padding: 'var(--space-2)',
   backgroundColor: 'var(--background)',
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-medium)',
@@ -19,8 +18,8 @@ export const memberList = style({
 export const memberItem = style({
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.sm,
-  'padding': `${spacing.xs} ${spacing.sm}`,
+  'gap': 'var(--space-2)',
+  'padding': 'var(--space-1) var(--space-2)',
   'borderRadius': 'var(--radius-small)',
   'color': 'var(--foreground)',
   'cursor': 'pointer',

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -1,17 +1,17 @@
 import { style } from '@vanilla-extract/css'
-import { iconSize, spacing } from '~/styles/tokens'
+import { iconSize } from '~/styles/tokens'
 
 export const list = style({
   display: 'flex',
   flexDirection: 'column',
-  padding: `${spacing.xs} 0`,
+  padding: 'var(--space-1) 0',
 })
 
 export const sectionHeader = style({
   'display': 'flex',
   'alignItems': 'center',
-  'gap': spacing.xs,
-  'padding': `${spacing.xs} ${spacing.md}`,
+  'gap': 'var(--space-1)',
+  'padding': 'var(--space-1) var(--space-3)',
   'cursor': 'pointer',
   'userSelect': 'none',
   ':hover': {
@@ -99,10 +99,10 @@ export const sectionItems = style({
 export const item = style({
   'display': 'flex',
   'alignItems': 'center',
-  'padding': `${spacing.xs} ${spacing.md}`,
-  'paddingLeft': spacing.lg,
+  'padding': 'var(--space-1) var(--space-3)',
+  'paddingLeft': 'var(--space-4)',
   'cursor': 'pointer',
-  'gap': spacing.xs,
+  'gap': 'var(--space-1)',
   'borderRight': '2px solid transparent',
   ':hover': {
     backgroundColor: 'var(--card)',
@@ -133,7 +133,7 @@ export const itemRenameInput = style({
   'backgroundColor': 'var(--background)',
   'border': '1px solid var(--ring)',
   'borderRadius': 'var(--radius-small)',
-  'padding': `0 ${spacing.xs}`,
+  'padding': '0 var(--space-1)',
   'outline': 'none',
   'minWidth': 0,
   ':focus': {
@@ -162,8 +162,8 @@ export const sharedBadge = style({
 })
 
 export const emptySection = style({
-  padding: `${spacing.sm} ${spacing.lg}`,
-  paddingLeft: spacing.lg,
+  padding: 'var(--space-2) var(--space-4)',
+  paddingLeft: 'var(--space-4)',
   fontSize: 'var(--text-7)',
   color: 'var(--faint-foreground)',
   fontStyle: 'italic',
@@ -178,8 +178,8 @@ export const sectionHeaderDropTarget = style({
 })
 
 export const dragOverlay = style({
-  padding: `${spacing.xs} ${spacing.md}`,
-  paddingLeft: spacing.lg,
+  padding: 'var(--space-1) var(--space-3)',
+  paddingLeft: 'var(--space-4)',
   fontSize: 'var(--text-7)',
   fontWeight: 400,
   color: 'var(--foreground)',

--- a/frontend/src/styles/resizeHandle.ts
+++ b/frontend/src/styles/resizeHandle.ts
@@ -1,0 +1,35 @@
+/**
+ * Generates `::before` selectors for a resize handle with consistent
+ * hover/active visual feedback.
+ *
+ * @param direction  - `'horizontal'` for col-resize, `'vertical'` for row-resize
+ * @param defaultBackground - default `::before` background (default: `'transparent'`)
+ * @param prefix - selector prefix (default: `'&'`); use e.g.
+ *   `'&[data-direction="horizontal"]'` for attribute-qualified selectors
+ */
+export function resizeHandleSelectors(
+  direction: 'horizontal' | 'vertical',
+  defaultBackground = 'transparent',
+  prefix = '&',
+): Record<string, Record<string, unknown>> {
+  const isH = direction === 'horizontal'
+  return {
+    [`${prefix}::before`]: {
+      content: '""',
+      position: 'absolute',
+      ...(isH
+        ? { top: 0, bottom: 0, left: '50%', width: '1px', transform: 'translateX(-50%)' }
+        : { left: 0, right: 0, top: '50%', height: '1px', transform: 'translateY(-50%)' }),
+      background: defaultBackground,
+      transition: 'background 0.15s',
+    },
+    [`${prefix}:hover::before`]: {
+      background: 'var(--border)',
+      ...(isH ? { width: '4px' } : { height: '4px' }),
+    },
+    [`${prefix}:active::before`]: {
+      background: 'var(--primary)',
+      ...(isH ? { width: '1px' } : { height: '1px' }),
+    },
+  }
+}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -1,6 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { spin } from '~/styles/animations.css'
-import { spacing } from '~/styles/tokens'
 
 export const errorText = style({
   color: 'var(--danger)',
@@ -21,13 +20,13 @@ export const emptyState = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: spacing.xl,
+  padding: 'var(--space-6)',
   color: 'var(--faint-foreground)',
 })
 
 export const backLink = style({
   'display': 'inline-block',
-  'marginBottom': spacing.lg,
+  'marginBottom': 'var(--space-4)',
   'color': 'var(--primary)',
   'textDecoration': 'none',
   ':hover': {
@@ -51,7 +50,7 @@ export const menuSectionHeader = style({
   fontWeight: 600,
   color: 'var(--muted-foreground)',
   textTransform: 'uppercase',
-  padding: `${spacing.xs} ${spacing.md}`,
+  padding: 'var(--space-1) var(--space-3)',
 })
 
 // Layout utilities
@@ -117,13 +116,13 @@ export const dialogHeader = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: 0,
-  padding: 0,
+  padding: 'var(--space-6) var(--space-6) 0',
 })
 
 export const dialogCloseButton = style({
   position: 'absolute',
-  top: spacing.md,
-  right: spacing.md,
+  top: 'var(--space-6)',
+  right: 'var(--space-6)',
 })
 
 globalStyle(`${dialogHeader} > h2`, {
@@ -203,7 +202,7 @@ globalStyle(`${dialogStandard} > form > section > .vstack > label:has(.${treeCon
 export const checkboxRow = style({
   display: 'flex',
   alignItems: 'center',
-  gap: spacing.sm,
+  gap: 'var(--space-2)',
   cursor: 'pointer',
 })
 

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -1,12 +1,3 @@
-export const spacing = {
-  xs: '4px',
-  sm: '8px',
-  md: '12px',
-  lg: '16px',
-  xl: '24px',
-  xxl: '32px',
-}
-
 export const iconSize = {
   xxs: 10,
   xs: 12,

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -18,39 +18,3 @@ export const headerHeight = `${headerHeightPx}px`
 export const breakpoints = {
   mobile: 768, // px — below this width, use mobile layout
 }
-
-/**
- * Generates `::before` selectors for a resize handle with consistent
- * hover/active visual feedback.
- *
- * @param direction  - `'horizontal'` for col-resize, `'vertical'` for row-resize
- * @param defaultBackground - default `::before` background (default: `'transparent'`)
- * @param prefix - selector prefix (default: `'&'`); use e.g.
- *   `'&[data-direction="horizontal"]'` for attribute-qualified selectors
- */
-export function resizeHandleSelectors(
-  direction: 'horizontal' | 'vertical',
-  defaultBackground = 'transparent',
-  prefix = '&',
-): Record<string, Record<string, unknown>> {
-  const isH = direction === 'horizontal'
-  return {
-    [`${prefix}::before`]: {
-      content: '""',
-      position: 'absolute',
-      ...(isH
-        ? { top: 0, bottom: 0, left: '50%', width: '1px', transform: 'translateX(-50%)' }
-        : { left: 0, right: 0, top: '50%', height: '1px', transform: 'translateY(-50%)' }),
-      background: defaultBackground,
-      transition: 'background 0.15s',
-    },
-    [`${prefix}:hover::before`]: {
-      background: 'var(--border)',
-      ...(isH ? { width: '4px' } : { height: '4px' }),
-    },
-    [`${prefix}:active::before`]: {
-      background: 'var(--primary)',
-      ...(isH ? { width: '1px' } : { height: '1px' }),
-    },
-  }
-}


### PR DESCRIPTION
## Motivation

The frontend styling layer maintained a custom `spacing` object in `tokens.ts` that mapped named sizes (xs, sm, md, lg, xl, xxl) to pixel values. This intermediate layer duplicated what the Oat CSS framework already provides via CSS custom properties (`--space-*` variables). Using the Oat variables directly reduces abstraction, keeps spacing consistent with the design system, and removes a layer of indirection that served no purpose once Oat was adopted.

Additionally, the `resizeHandleSelectors` helper function was co-located with token definitions in `tokens.ts`, mixing two unrelated concerns in a single module.

## Modifications

- Remove the `spacing` export from `frontend/src/styles/tokens.ts` entirely, replacing all usages with Oat CSS variables using the following mapping:
  - `spacing.xs` (4px) -> `var(--space-1)`
  - `spacing.sm` (8px) -> `var(--space-2)`
  - `spacing.md` (12px) -> `var(--space-3)`
  - `spacing.lg` (16px) -> `var(--space-4)`
  - `spacing.xl` (24px) -> `var(--space-6)`
  - `spacing.xxl` (32px) -> `var(--space-8)`
- Extract `resizeHandleSelectors` into its own module at `frontend/src/styles/resizeHandle.ts` and update all import sites across 33 component CSS files
- Fix dialog header padding in `frontend/src/styles/shared.css.ts`: the header previously had `padding: 0`, which caused the title to sit flush against the dialog border; changed to `padding: 'var(--space-6) var(--space-6) 0'` and aligned the close button `top`/`right` offsets to `var(--space-6)` accordingly

## Result

Spacing values across the frontend now come directly from Oat CSS variables rather than a custom intermediate token object, keeping the codebase aligned with the design system and reducing the amount of custom token plumbing to maintain. The `resizeHandle` module is independently importable without pulling in unrelated token definitions. Dialog headers now render with correct padding between the title text and the dialog border edges.

🤖 Generated with Claude Code
