### PR TITLE
Add Agent/Task tool renderer with status display

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -317,6 +317,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       childTask: (typeof tur?.task === 'object' && tur.task !== null && !Array.isArray(tur.task))
         ? tur.task as RenderContext['childTask']
         : undefined,
+      childToolResultStatus: typeof tur?.status === 'string' ? tur.status as string : undefined,
       childControlResponse: childControlResponse(),
     }
   }

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -1,3 +1,4 @@
+import type { RenderContext } from './messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
 import { renderMessageContent } from './messageRenderers'
@@ -13,9 +14,9 @@ function makeToolUseMessage(name: string, input: Record<string, unknown>) {
 }
 
 /** Render a tool_use message and return the trimmed text content. */
-function renderToolUseText(name: string, input: Record<string, unknown>): string {
+function renderToolUseText(name: string, input: Record<string, unknown>, context?: RenderContext): string {
   const parsed = makeToolUseMessage(name, input)
-  const result = renderMessageContent(parsed, 0 /* ROLE_ASSISTANT */)
+  const result = renderMessageContent(parsed, 2 /* ASSISTANT */, context)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -31,5 +32,68 @@ describe('skill renderer', () => {
 
   it('renders Skill: /commit', () => {
     expect(renderToolUseText('Skill', { skill: 'commit' })).toBe('Skill: /commit')
+  })
+})
+
+describe('agent/task renderer', () => {
+  it('renders Agent with description only', () => {
+    expect(renderToolUseText('Agent', { description: 'Search codebase' }))
+      .toBe('Search codebase')
+  })
+
+  it('renders Task with description only', () => {
+    expect(renderToolUseText('Task', { description: 'Run tests' }))
+      .toBe('Run tests')
+  })
+
+  it('renders Agent with description and subagent_type', () => {
+    expect(renderToolUseText('Agent', { description: 'Search', subagent_type: 'Explore' }))
+      .toBe('Search (Explore)')
+  })
+
+  it('falls back to tool name when description is missing', () => {
+    expect(renderToolUseText('Agent', {})).toBe('Agent')
+    expect(renderToolUseText('Task', {})).toBe('Task')
+  })
+
+  it('shows "Running" when thread children exist but no status', () => {
+    const text = renderToolUseText('Agent', { description: 'Analyze code' }, {
+      threadChildCount: 1,
+    })
+    expect(text).toContain('Analyze code')
+    expect(text).toContain('Running')
+  })
+
+  it('shows "Complete" when childToolResultStatus is "completed"', () => {
+    const text = renderToolUseText('Agent', { description: 'Analyze code' }, {
+      threadChildCount: 2,
+      childToolResultStatus: 'completed',
+    })
+    expect(text).toContain('Analyze code')
+    expect(text).toContain('Complete')
+  })
+
+  it('shows "Failed" when childToolResultStatus is "failed"', () => {
+    const text = renderToolUseText('Task', { description: 'Build project' }, {
+      threadChildCount: 2,
+      childToolResultStatus: 'failed',
+    })
+    expect(text).toContain('Build project')
+    expect(text).toContain('Failed')
+  })
+
+  it('shows no status when no thread children', () => {
+    const text = renderToolUseText('Agent', { description: 'Search' })
+    expect(text).toBe('Search')
+    expect(text).not.toContain('Running')
+    expect(text).not.toContain('Complete')
+  })
+
+  it('renders description + status + subagent_type together', () => {
+    const text = renderToolUseText('Agent', { description: 'Fix bug', subagent_type: 'code' }, {
+      threadChildCount: 2,
+      childToolResultStatus: 'completed',
+    })
+    expect(text).toContain('Fix bug - Complete (code)')
   })
 })

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -31,7 +31,9 @@ import {
 } from './notificationRenderers'
 import { enterPlanModeRenderer, exitPlanModeRenderer, renderEnterPlanMode, renderExitPlanMode } from './planModeRenderers'
 import {
+  agentOrTaskRenderer,
   askUserQuestionRenderer,
+  renderAgentOrTask,
   renderAskUserQuestion,
   renderTaskOutput,
   renderTodoWrite,
@@ -99,6 +101,8 @@ export interface RenderContext {
     output?: string
     exitCode?: number
   }
+  /** Status from child tool_use_result (for Agent/Task status display). */
+  childToolResultStatus?: string
   /** Control response (approval/rejection) threaded into this tool_use. */
   childControlResponse?: { action: string, comment: string }
 }
@@ -301,6 +305,8 @@ const SPECIALIZED_TOOL_RENDERERS: Record<string, (toolUse: Record<string, unknow
   AskUserQuestion: renderAskUserQuestion,
   TaskOutput: renderTaskOutput,
   Skill: renderSkill,
+  Agent: renderAgentOrTask,
+  Task: renderAgentOrTask,
 }
 
 /** Dispatch rendering for a tool_use category: try specialized renderer first, then generic. */
@@ -387,6 +393,7 @@ function getFallbackRenderers(): MessageContentRenderer[] {
       todoWriteRenderer,
       askUserQuestionRenderer,
       taskOutputRenderer,
+      agentOrTaskRenderer,
       toolUseRenderer,
       toolResultRenderer,
       userTextContentRenderer,

--- a/frontend/src/components/chat/toolDetailRenderers.tsx
+++ b/frontend/src/components/chat/toolDetailRenderers.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from './messageRenderers'
-import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
+import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { diffLines } from 'diff'
 import { relativizePath } from './messageUtils'
 import {
@@ -108,15 +108,6 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
         <span class={toolInputCode}>
           {displayPattern}
           {path ? ` ${relativizePath(path, cwd, homeDir)}` : ''}
-        </span>
-      )
-    }
-    case 'Task': {
-      const { description: desc, subagent_type: subagentType } = input as TaskInput
-      return (
-        <span class={toolInputDetail}>
-          {desc || 'Task'}
-          {subagentType ? ` (${subagentType})` : ''}
         </span>
       )
     }

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -79,6 +79,7 @@ export function toolIcon(name: string, size: IconSizeName): JSX.Element {
     case 'Grep': return <Icon icon={Search} size={size} class={toolUseIcon} />
     case 'Glob': return <Icon icon={FolderSearch} size={size} class={toolUseIcon} />
     case 'Task': return <Icon icon={Bot} size={size} class={toolUseIcon} />
+    case 'Agent': return <Icon icon={Bot} size={size} class={toolUseIcon} />
     case 'WebFetch': return <Icon icon={Globe} size={size} class={toolUseIcon} />
     case 'WebSearch': return <Icon icon={Globe} size={size} class={toolUseIcon} />
     case 'TodoWrite': return <Icon icon={ListTodo} size={size} class={toolUseIcon} />

--- a/frontend/src/types/toolMessages.ts
+++ b/frontend/src/types/toolMessages.ts
@@ -46,6 +46,12 @@ export interface TaskInput {
   subagent_type?: string
 }
 
+export interface AgentInput {
+  description?: string
+  prompt?: string
+  subagent_type?: string
+}
+
 export interface WebFetchInput {
   url?: string
   prompt?: string
@@ -90,6 +96,7 @@ export type KnownToolInput
     | { toolName: 'Grep', input: GrepInput }
     | { toolName: 'Glob', input: GlobInput }
     | { toolName: 'Task', input: TaskInput }
+    | { toolName: 'Agent', input: AgentInput }
     | { toolName: 'WebFetch', input: WebFetchInput }
     | { toolName: 'WebSearch', input: WebSearchInput }
     | { toolName: 'TodoWrite', input: TodoWriteInput }
@@ -107,6 +114,7 @@ const KNOWN_TOOLS = new Set<string>([
   'Grep',
   'Glob',
   'Task',
+  'Agent',
   'WebFetch',
   'WebSearch',
   'TaskOutput',


### PR DESCRIPTION
## Motivation

The chat message UI had no dedicated renderer for the `Agent` and `Task` tool calls emitted by the Claude Code SDK. These messages would fall through to the generic `toolUseRenderer`, which showed only a raw tool name and JSON-formatted input with no contextual information about agent progress or completion status.

Users could not easily tell at a glance whether a subagent was still running, had completed successfully, or had failed.

## Modifications

- Added `renderAgentOrTask` render function and `agentOrTaskRenderer` in `taskRenderers.tsx` that handles both `Agent` and `Task` tool_use messages. The renderer displays:
  - The agent's `description` input field (falls back to the tool name when absent)
  - A computed status label (`Running` when thread children exist but no result, or a formatted status from `childToolResultStatus` such as `Complete` / `Failed`)
  - An optional `subagent_type` suffix in parentheses
  - A `Bot` icon consistent with the existing `toolIcon()` mapping
- Registered `Agent` and `Task` in the `SPECIALIZED_TOOL_RENDERERS` dispatch map and added `agentOrTaskRenderer` to the fallback renderer list.
- Added `AgentInput` interface to `toolMessages.ts`, along with entries in the `KnownToolInput` union and `KNOWN_TOOLS` set.
- Wired `childToolResultStatus` from `tool_use_result.status` in `MessageBubble.tsx` render context so the renderer can reflect the terminal status once the result arrives.
- Removed now-redundant `Task` case from `toolDetailRenderers.tsx` (the specialized renderer supersedes the generic detail path).
- Added comprehensive unit tests covering description-only, description + subagent_type, missing description fallback, `Running` during execution, `Complete` / `Failed` terminal states, and the combined `description - status (subagent_type)` format.

## Result

Agent and Task tool calls now render with a `Bot` icon and a human-readable summary line. While the subagent is active, the header shows `<description> - Running`. Once the result is received, it transitions to `<description> - Complete` or `<description> - Failed`, optionally followed by the subagent type in parentheses.

🤖 Generated with Claude Code
