### PR TITLE
Introduce ToolUseLayout and add summaries for Grep/Glob/Agent tools

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -318,6 +318,9 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
         ? tur.task as RenderContext['childTask']
         : undefined,
       childToolResultStatus: typeof tur?.status === 'string' ? tur.status as string : undefined,
+      childTotalDurationMs: typeof tur?.totalDurationMs === 'number' ? tur.totalDurationMs : undefined,
+      childTotalTokens: typeof tur?.totalTokens === 'number' ? tur.totalTokens : undefined,
+      childTotalToolUseCount: typeof tur?.totalToolUseCount === 'number' ? tur.totalToolUseCount : undefined,
       childControlResponse: childControlResponse(),
     }
   }

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -96,4 +96,28 @@ describe('agent/task renderer', () => {
     })
     expect(text).toContain('Fix bug - Complete (code)')
   })
+
+  it('formats title as "SubAgent: rest" when description starts with subagent name', () => {
+    const text = renderToolUseText('Agent', { description: 'Explore message classification', subagent_type: 'Explore' })
+    expect(text).toContain('Explore: message classification')
+  })
+
+  it('does not format title when description does not start with subagent name', () => {
+    const text = renderToolUseText('Agent', { description: 'Search codebase', subagent_type: 'Explore' })
+    expect(text).toContain('Search codebase')
+    expect(text).not.toContain('Explore:')
+  })
+
+  it('shows stats summary when stats are provided', () => {
+    const text = renderToolUseText('Agent', { description: 'Search' }, {
+      threadChildCount: 1,
+      childToolResultStatus: 'completed',
+      childTotalDurationMs: 30000,
+      childTotalTokens: 500,
+      childTotalToolUseCount: 3,
+    })
+    expect(text).toContain('30s')
+    expect(text).toContain('500 tokens')
+    expect(text).toContain('3 tool uses')
+  })
 })

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -41,13 +41,13 @@ import {
   todoWriteRenderer,
 } from './taskRenderers'
 import {
-  ControlResponseTag,
   ToolHeaderActions,
   toolResultRenderer,
+  ToolUseLayout,
   toolUseRenderer,
 } from './toolRenderers'
 import {
-  toolInputDetail,
+  toolInputText,
   toolMessage,
   toolUseHeader,
   toolUseIcon,
@@ -102,6 +102,12 @@ export interface RenderContext {
   }
   /** Status from child tool_use_result (for Agent/Task status display). */
   childToolResultStatus?: string
+  /** Total duration in ms from child tool_use_result (for Agent/Task stats). */
+  childTotalDurationMs?: number
+  /** Total tokens from child tool_use_result (for Agent/Task stats). */
+  childTotalTokens?: number
+  /** Total tool use count from child tool_use_result (for Agent/Task stats). */
+  childTotalToolUseCount?: number
   /** Control response (approval/rejection) threaded into this tool_use. */
   childControlResponse?: { action: string, comment: string }
 }
@@ -125,26 +131,12 @@ function renderSkill(toolUse: Record<string, unknown>, context?: RenderContext):
   const skillName = isObject(input) ? String((input as Record<string, unknown>).skill || '') : ''
 
   return (
-    <div class={toolMessage}>
-      <div class={toolUseHeader}>
-        <span class={inlineFlex} title="Skill">
-          <Icon icon={Toolbox} size="md" class={toolUseIcon} />
-        </span>
-        <span class={toolInputDetail}>{`Skill: /${skillName}`}</span>
-        <ControlResponseTag response={context?.childControlResponse} />
-        <Show when={context}>
-          <ToolHeaderActions
-            createdAt={context!.createdAt}
-            updatedAt={context!.updatedAt}
-            threadCount={context!.threadChildCount ?? 0}
-            threadExpanded={context!.threadExpanded ?? false}
-            onToggleThread={context!.onToggleThread ?? (() => {})}
-            onCopyJson={context!.onCopyJson ?? (() => {})}
-            jsonCopied={context!.jsonCopied ?? false}
-          />
-        </Show>
-      </div>
-    </div>
+    <ToolUseLayout
+      icon={Toolbox}
+      toolName="Skill"
+      title={`Skill: /${skillName}`}
+      context={context}
+    />
   )
 }
 
@@ -192,7 +184,7 @@ function ThinkingMessage(props: { text: string, context?: RenderContext }): JSX.
         <span class={inlineFlex} title="Thinking">
           <Icon icon={Brain} size="md" class={toolUseIcon} />
         </span>
-        <span class={toolInputDetail}>Thinking</span>
+        <span class={toolInputText}>Thinking</span>
         <span class={`${inlineFlex} ${thinkingChevron}${expanded() ? ` ${thinkingChevronExpanded}` : ''}`}>
           <Icon icon={ChevronRight} size="sm" class={toolUseIcon} />
         </span>
@@ -238,7 +230,7 @@ const taskStartedRenderer: MessageContentRenderer = {
           <span class={inlineFlex} title="Task Started">
             <Icon icon={Bot} size="md" class={toolUseIcon} />
           </span>
-          <span class={toolInputDetail}>Task started</span>
+          <span class={toolInputText}>Task started</span>
         </div>
       </div>
     )

--- a/frontend/src/components/chat/rendererUtils.ts
+++ b/frontend/src/components/chat/rendererUtils.ts
@@ -23,6 +23,21 @@ export function firstNonEmptyLine(text?: string): string | null {
   return null
 }
 
+/** Format a duration in milliseconds as a human-readable string (e.g. "5s", "2m 30s"). */
+export function formatDuration(ms: number): string {
+  const totalSec = Math.round(ms / 1000)
+  if (totalSec < 60)
+    return `${totalSec}s`
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  return sec > 0 ? `${min}m ${sec}s` : `${min}m`
+}
+
+/** Format a number with locale-aware separators (e.g. 1,234). */
+export function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
 /** Helper: format tool input for compact display (fallback for unknown tools) */
 export function formatToolInput(input: unknown): string {
   if (input === null || input === undefined || JSON.stringify(input) === '{}') {

--- a/frontend/src/components/chat/toolDetailRenderers.tsx
+++ b/frontend/src/components/chat/toolDetailRenderers.tsx
@@ -5,12 +5,10 @@ import { diffLines } from 'diff'
 import { relativizePath } from './messageUtils'
 import {
   toolInputCode,
-  toolInputDetail,
   toolInputPath,
   toolInputStatAdded,
   toolInputStatRemoved,
-  toolInputSubDetail,
-  toolInputSubDetailExpanded,
+  toolInputText,
 } from './toolStyles.css'
 
 /** Render per-tool compact display for a tool_use block. */
@@ -24,7 +22,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       if (!desc && !cmd)
         return null
       const descText = desc ? (desc.length > 100 ? `${desc.slice(0, 100)}…` : desc) : ''
-      return <span class={toolInputDetail}>{descText || 'Run command'}</span>
+      return <span class={toolInputText}>{descText || 'Run command'}</span>
     }
     case 'Read': {
       const { file_path: path, offset, limit } = input as ReadInput
@@ -40,7 +38,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       return (
         <>
           <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
-          <span class={toolInputDetail}>{rangeStr}</span>
+          <span class={toolInputText}>{rangeStr}</span>
         </>
       )
     }
@@ -53,7 +51,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       return (
         <>
           <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
-          <span class={toolInputDetail}>{lineStr}</span>
+          <span class={toolInputText}>{lineStr}</span>
         </>
       )
     }
@@ -78,7 +76,7 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
         <>
           <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
           {hasStats && (
-            <span class={toolInputDetail}>
+            <span class={toolInputText}>
               {' '}
               <span class={toolInputStatAdded}>
                 {`+${added}`}
@@ -116,39 +114,12 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       if (!url)
         return null
       return url.startsWith('https://')
-        ? <span class={toolInputDetail}><a href={url} target="_blank" rel="noopener noreferrer nofollow">{url}</a></span>
-        : <span class={toolInputDetail}>{url}</span>
+        ? <span class={toolInputText}><a href={url} target="_blank" rel="noopener noreferrer nofollow">{url}</a></span>
+        : <span class={toolInputText}>{url}</span>
     }
     case 'WebSearch': {
       const { query } = input as WebSearchInput
-      return query ? <span class={toolInputDetail}>{query}</span> : null
-    }
-    default:
-      return null
-  }
-}
-
-/** Render an optional sub-detail line below the tool header (e.g. Bash command, Grep path). */
-export function renderToolSubDetail(toolName: string, input: Record<string, unknown>, context?: RenderContext): JSX.Element | null {
-  const expanded = context?.threadExpanded
-  const cls = expanded ? toolInputSubDetailExpanded : toolInputSubDetail
-  switch (toolName) {
-    case 'Bash': {
-      const { command: cmd } = input as BashInput
-      if (!cmd)
-        return null
-      if (expanded) {
-        return <div class={cls}>{cmd}</div>
-      }
-      const firstLine = cmd.split('\n')[0]
-      const truncated = firstLine.length > 120 ? `${firstLine.slice(0, 120)}…` : firstLine
-      return <div class={cls}>{truncated}</div>
-    }
-    case 'Grep': {
-      const { path } = input as GrepInput
-      if (!path)
-        return null
-      return <div class={cls}>{relativizePath(path, context?.workingDir, context?.homeDir)}</div>
+      return query ? <span class={toolInputText}>{query}</span> : null
     }
     default:
       return null

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -126,7 +126,7 @@ export const toolInputSubDetailExpanded = style({
 })
 
 // Tool input detail text (natural language: descriptions, URLs, queries)
-export const toolInputDetail = style({
+export const toolInputText = style({
   color: 'var(--foreground)',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
@@ -188,6 +188,14 @@ export const controlResponseTag = style({
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-7)',
   flexShrink: 0,
+})
+
+// Body content area for tool_use renderers (expand-gated body below header)
+export const toolBodyContent = style({
+  marginLeft: '6px',
+  paddingLeft: 'var(--space-3)',
+  paddingRight: 'var(--space-3)',
+  borderLeft: '2px solid var(--border)',
 })
 
 // AskUserQuestion: question item container

--- a/frontend/tests/unit/components/ToolUseLayout.test.tsx
+++ b/frontend/tests/unit/components/ToolUseLayout.test.tsx
@@ -1,0 +1,211 @@
+import type { RenderContext } from '~/components/chat/messageRenderers'
+import { render, screen } from '@solidjs/testing-library'
+import ListTodo from 'lucide-solid/icons/list-todo'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { ToolUseLayout } from '~/components/chat/toolRenderers'
+import { toolBodyContent, toolInputText } from '~/components/chat/toolStyles.css'
+import { PreferencesProvider } from '~/context/PreferencesContext'
+
+// jsdom does not provide ResizeObserver
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+})
+
+function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    threadChildCount: 0,
+    threadExpanded: false,
+    onToggleThread: vi.fn(),
+    onCopyJson: vi.fn(),
+    jsonCopied: false,
+    ...overrides,
+  }
+}
+
+describe('toolUseLayout', () => {
+  it('renders title and icon in header', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="3 tasks"
+          context={makeContext()}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('3 tasks')
+    // Icon should be present as an SVG element
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('shows summary inside bordered area', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          summary={<div data-testid="test-summary">Summary text</div>}
+          context={makeContext()}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('Summary text')
+    expect(screen.getByTestId('test-summary')).not.toBeNull()
+    // Summary should be inside the toolBodyContent wrapper (bordered area)
+    const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
+    expect(bodyWrapper).not.toBeNull()
+    expect(bodyWrapper!.textContent).toContain('Summary text')
+  })
+
+  it('hides children when collapsed (default)', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          context={makeContext({ threadExpanded: false })}
+        >
+          <div data-testid="body-content">Body content</div>
+        </ToolUseLayout>
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).not.toContain('Body content')
+    expect(screen.queryByTestId('body-content')).toBeNull()
+  })
+
+  it('shows children when expanded', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          context={makeContext({ threadExpanded: true })}
+        >
+          <div data-testid="body-content">Body content</div>
+        </ToolUseLayout>
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('Body content')
+    expect(screen.getByTestId('body-content')).not.toBeNull()
+  })
+
+  it('alwaysVisible bypasses expand gating', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          alwaysVisible={true}
+          context={makeContext({ threadExpanded: false })}
+        >
+          <div data-testid="body-content">Always visible body</div>
+        </ToolUseLayout>
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('Always visible body')
+    expect(screen.getByTestId('body-content')).not.toBeNull()
+  })
+
+  it('applies left border by default', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          summary={<div>Summary</div>}
+          context={makeContext()}
+        />
+      </PreferencesProvider>
+    ))
+
+    const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
+    expect(bodyWrapper).not.toBeNull()
+  })
+
+  it('bordered={false} omits left border', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          bordered={false}
+          context={makeContext({ threadExpanded: true })}
+        >
+          <div>Body</div>
+        </ToolUseLayout>
+      </PreferencesProvider>
+    ))
+
+    const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
+    expect(bodyWrapper).toBeNull()
+  })
+
+  it('shows ControlResponseTag when approved', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          context={makeContext({
+            childControlResponse: { action: 'approved', comment: '' },
+          })}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('Approved')
+  })
+
+  it('shows ControlResponseTag when rejected', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="Header"
+          context={makeContext({
+            childControlResponse: { action: 'rejected', comment: 'Needs changes' },
+          })}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(container.textContent).toContain('Rejected: Needs changes')
+  })
+
+  it('renders JSX title without toolInputText wrapper', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title={<span data-testid="custom-title">Custom JSX</span>}
+          context={makeContext()}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByTestId('custom-title')).not.toBeNull()
+    expect(container.textContent).toContain('Custom JSX')
+    // Should NOT wrap JSX title in toolInputText span
+    const toolInputTextSpan = container.querySelector(`.${toolInputText}`)
+    expect(toolInputTextSpan).toBeNull()
+  })
+})


### PR DESCRIPTION
## Motivation

Tool header and body rendering logic was duplicated across `taskRenderers`, `planModeRenderers`, and `messageRenderers`. Each renderer independently assembled the same icon wrapper, title span, `ControlResponseTag`, `ToolHeaderActions` block, and bordered body area, making the code hard to maintain and inconsistent to extend.

Additionally, the Grep, Glob, and Agent/Task tools showed no summary information after their tool-use headers — users had to expand the thread to learn basic facts like how many files were found, how many tokens an agent consumed, or which path was searched.

## Modifications

- Introduced `ToolUseLayout` component in `toolRenderers.tsx` that centralises the header/body boilerplate: icon, string or JSX title (strings auto-wrap in `toolInputText`; JSX renders as-is), `ControlResponseTag`, conditional `ToolHeaderActions`, and a bordered body area that gates children behind expand state.
- Refactored `ToolUseMessage`, `renderTodoWrite`, `renderAskUserQuestion`, `renderTaskOutput`, `renderAgentOrTask`, `renderEnterPlanMode`, `renderExitPlanMode`, and `renderSkill` to all delegate to `ToolUseLayout`, removing roughly 30-50 lines of duplicated header boilerplate per renderer.
- Added `deriveToolSummary()` in `toolRenderers.tsx` that produces a one-line summary element for Bash (first line of command, truncated at 120 chars), Grep (target path + first non-empty result line), and Glob (file count or "No files found"). This replaces the now-deleted `renderToolSubDetail` function in `toolDetailRenderers.tsx`.
- Added Agent/Task stats summary: duration, token count, and tool use count are read from three new `RenderContext` properties (`childTotalDurationMs`, `childTotalTokens`, `childTotalToolUseCount`) and displayed as a dot-separated line (e.g. `12s · 4,321 tokens · 8 tool uses`).
- Reformatted Agent/Task titles: when the description begins with the subagent type name (e.g. `"Explore message classification"`), the title is rewritten as `"Explore: message classification"`.
- Added `formatDuration()` and `formatNumber()` utility functions to `rendererUtils.ts`.
- Renamed CSS class `toolInputDetail` to `toolInputText` for semantic clarity.
- Replaced `toolIcon()` (which returned rendered JSX) with `toolIconFor()` (returns a raw Lucide component), enabling `ToolUseLayout` to render icons uniformly.
- Added `ToolUseLayout.test.tsx` with 12 tests covering header/icon rendering, summary placement inside the bordered area, expand/collapse gating, `alwaysVisible` bypass, `bordered={false}` behavior, `ControlResponseTag` variants, and JSX title pass-through.
- Extended `MessageBubble.test.tsx` with tests for TodoWrite collapse/expand, task count display, progress tracking, TaskOutput status display, and Grep/Glob/Agent tool result summaries.

## Result

Tool renderers share a single `ToolUseLayout` component, reducing duplication and making future renderer additions straightforward. Users now see at-a-glance summaries on Grep, Glob, and Agent/Task tool-use messages without needing to expand the thread:

- A Grep block shows the searched path and the first line of results.
- A Glob block shows how many files were matched.
- An Agent/Task block shows total elapsed time, tokens consumed, and number of tool invocations.
- Summaries are always visible inside the bordered body area even when the thread is collapsed.

🤖 Generated with Claude Code
