### PR TITLE
fix(hub): Return empty slice for no-op settings_changed consolidation

### DIFF
--- a/internal/hub/service/agent_threading.go
+++ b/internal/hub/service/agent_threading.go
@@ -362,12 +362,8 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 
 	if len(result) == 0 {
 		// Everything consolidated away (e.g. settings toggled back and forth).
-		// Return a no-op settings_changed that renders as invisible on the frontend.
-		data, _ := json.Marshal(map[string]interface{}{
-			"type":    "settings_changed",
-			"changes": map[string]interface{}{},
-		})
-		return []json.RawMessage{data}
+		// Return an empty slice; the frontend treats empty wrappers as hidden.
+		return []json.RawMessage{}
 	}
 
 	return result

--- a/internal/hub/service/agent_threading_test.go
+++ b/internal/hub/service/agent_threading_test.go
@@ -290,15 +290,8 @@ func TestConsolidateNotificationThread_SettingsChangedNoOp(t *testing.T) {
 	})
 
 	result := consolidateNotificationThread([]json.RawMessage{msg1, msg2})
-	// No effective changes → no-op settings_changed fallback.
-	require.Len(t, result, 1)
-	var entry struct {
-		Type    string                 `json:"type"`
-		Changes map[string]interface{} `json:"changes"`
-	}
-	require.NoError(t, json.Unmarshal(result[0], &entry))
-	assert.Equal(t, "settings_changed", entry.Type)
-	assert.Empty(t, entry.Changes, "expected empty changes for no-op consolidation")
+	// No effective changes → empty slice (frontend treats as hidden).
+	require.Empty(t, result, "expected empty slice for no-op consolidation")
 }
 
 func TestConsolidateNotificationThread_ContextClearedDedup(t *testing.T) {


### PR DESCRIPTION
## Motivation

When all `settings_changed` messages in a notification thread cancel each other out (e.g., mode toggled default→plan→default), `consolidateNotificationThread` returned a sentinel `{type: "settings_changed", changes: {}}` message instead of an empty slice. This sentinel was persisted in the DB and rendered as an empty, content-less notification on the frontend.

## Modifications

- `internal/hub/service/agent_threading.go`: In the no-op path of `consolidateNotificationThread`, return `[]json.RawMessage{}` instead of constructing and returning a sentinel `settings_changed` message with empty `changes`.
- `internal/hub/service/agent_threading_test.go`: Update `TestConsolidateNotificationThread_SettingsChangedNoOp` to assert `require.Empty(t, result)` instead of checking for a single sentinel entry.

## Result

`consolidateNotificationThread` now returns an empty slice when all `settings_changed` entries cancel out. The frontend already classifies empty wrappers as `hidden`, so no content-less notifications will be persisted or displayed.

🤖 Generated with Claude Code
