### PR TITLE
Refactor chat renderers, fix popover and auto-scroll bugs

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -44,6 +44,8 @@ interface ChatViewProps {
   scrollStateRef?: (fn: () => { distFromBottom: number, atBottom: boolean } | undefined) => void
   /** Ref to expose a function that forces an immediate scroll-to-bottom (e.g. when sending a message). */
   scrollToBottomRef?: (fn: () => void) => void
+  /** Monotonic counter that increments on every addMessage (including thread merges). */
+  messageVersion?: number
   /** Called when the user quotes selected text in a chat message. */
   onQuote?: (text: string) => void
   /** Called when the user clicks the reply button on an assistant message. */
@@ -180,8 +182,11 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   // Auto-scroll the message list to the bottom when new content arrives
   // and the user is already at (or near) the bottom.
+  // messageVersion covers thread merges (tool_use_result merged into an
+  // existing tool_use) which don't change messages.length.
   createEffect(() => {
     void props.messages.length
+    void props.messageVersion
     void props.streamingText
     void props.agentWorking
     if (untrack(atBottom) && messageListRef) {

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -159,7 +159,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   }
 
   /** Tools whose single-line results should be auto-expanded. */
-  const AUTO_EXPAND_TOOLS = new Set(['Bash', 'Grep', 'Read', 'Write', 'Glob'])
+  const AUTO_EXPAND_TOOLS = new Set(['Bash', 'Edit', 'Grep', 'Read', 'Write', 'Glob'])
 
   // Check if the tool result content is short enough to auto-expand (single line).
   const shouldAutoExpand = (): boolean => {
@@ -322,6 +322,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       childTotalTokens: typeof tur?.totalTokens === 'number' ? tur.totalTokens : undefined,
       childTotalToolUseCount: typeof tur?.totalToolUseCount === 'number' ? tur.totalToolUseCount : undefined,
       childControlResponse: childControlResponse(),
+      childOriginalFile: typeof tur?.originalFile === 'string' ? tur.originalFile : undefined,
     }
   }
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -158,43 +158,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     }
   }
 
-  /** Tools whose single-line results should be auto-expanded. */
-  const AUTO_EXPAND_TOOLS = new Set(['Bash', 'Edit', 'Grep', 'Read', 'Write', 'Glob'])
-
-  // Check if the tool result content is short enough to auto-expand (single line).
-  const shouldAutoExpand = (): boolean => {
-    const children = parsed().children
-    if (children.length !== 1)
-      return false
-    // Only auto-expand for specific tool types
-    const toolInfo = parentToolInfo()
-    if (!toolInfo || !AUTO_EXPAND_TOOLS.has(toolInfo.name))
-      return false
-    try {
-      const child = children[0] as Record<string, unknown>
-      if (child?.type !== 'user')
-        return false
-      const msg = child.message as Record<string, unknown>
-      if (!msg?.content || !Array.isArray(msg.content))
-        return false
-      const toolResult = (msg.content as Array<Record<string, unknown>>).find(c => c.type === 'tool_result')
-      if (!toolResult)
-        return false
-      const resultData = toolResult as Record<string, unknown>
-      const resultContent = Array.isArray(resultData.content)
-        ? (resultData.content as Array<Record<string, unknown>>)
-            .filter(c => c.type === 'text')
-            .map(c => c.text)
-            .join('')
-        : String(resultData.content || '')
-      // Auto-expand if the result is a single line (no newlines) and short
-      return !resultContent.includes('\n') && resultContent.length > 0
-    }
-    catch { return false }
-  }
-
-  // Effective expanded state: manual toggle overrides auto-expand default.
-  const threadExpanded = () => threadExpandedManual() ?? shouldAutoExpand()
+  const threadExpanded = () => threadExpandedManual() ?? false
   const setThreadExpanded = (updater: boolean | ((prev: boolean) => boolean)) => {
     const current = threadExpanded()
     const next = typeof updater === 'function' ? updater(current) : updater
@@ -323,6 +287,11 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       childTotalToolUseCount: typeof tur?.totalToolUseCount === 'number' ? tur.totalToolUseCount : undefined,
       childControlResponse: childControlResponse(),
       childOriginalFile: typeof tur?.originalFile === 'string' ? tur.originalFile : undefined,
+      childGrepNumFiles: typeof tur?.numFiles === 'number' ? tur.numFiles : undefined,
+      childGrepNumLines: typeof tur?.numLines === 'number' ? tur.numLines : undefined,
+      childGlobNumFiles: typeof tur?.numFiles === 'number' ? tur.numFiles : undefined,
+      childGlobDurationMs: typeof tur?.durationMs === 'number' ? tur.durationMs : undefined,
+      childGlobTruncated: typeof tur?.truncated === 'boolean' ? tur.truncated : undefined,
     }
   }
 

--- a/frontend/src/components/chat/diffStyles.css.ts
+++ b/frontend/src/components/chat/diffStyles.css.ts
@@ -2,6 +2,7 @@ import { globalStyle, style } from '@vanilla-extract/css'
 
 // Diff container
 export const diffContainer = style({
+  position: 'relative',
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none',
   fontSize: 'var(--text-8)',
@@ -87,6 +88,7 @@ globalStyle(`html[data-theme="dark"] ${diffContainer} span[style]`, {
 
 // Split diff container (two columns side by side)
 export const diffSplitContainer = style({
+  position: 'relative',
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
   fontFamily: 'var(--font-mono)',
@@ -107,6 +109,61 @@ globalStyle(`${diffSplitContainer} span[style]`, {
 globalStyle(`html[data-theme="dark"] ${diffSplitContainer} span[style]`, {
   color: 'var(--shiki-dark)',
   backgroundColor: 'var(--shiki-dark-bg, transparent)',
+})
+
+// Gap separator row between hunks (shows hidden line count + expand buttons)
+export const diffGapSeparator = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 'var(--space-4)',
+  padding: 'var(--space-1) var(--space-2)',
+  fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  backgroundColor: 'color-mix(in srgb, var(--info) 6%, transparent)',
+  userSelect: 'none',
+  borderTop: '1px dashed var(--border)',
+  borderBottom: '1px dashed var(--border)',
+})
+
+// Clickable expand button inside the gap separator
+export const diffGapExpandButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-0-5)',
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  selectors: {
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+// Clickable variant of gap separator (small gaps that expand all at once)
+export const diffGapSeparatorClickable = style({
+  cursor: 'pointer',
+  selectors: {
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+// Remove top border when gap separator is the first element in the container
+export const diffGapSeparatorFirst = style({
+  borderTop: 'none',
+})
+
+// Remove bottom border when gap separator is the last element in the container
+export const diffGapSeparatorLast = style({
+  borderBottom: 'none',
+})
+
+// Gap separator spanning full width in split view grid
+export const diffGapSeparatorSplit = style({
+  gridColumn: '1 / -1',
 })
 
 export const diffSplitColumn = style({

--- a/frontend/src/components/chat/diffStyles.css.ts
+++ b/frontend/src/components/chat/diffStyles.css.ts
@@ -75,15 +75,16 @@ export const diffContent = style({
   minWidth: 0,
 })
 
-// Shiki dual-theme support for diff token spans
+// Shiki dual-theme support for diff token spans.
+// Only color is set here; backgroundColor is intentionally omitted so that
+// word-diff inline classes (diffRemovedInline, diffAddedInline) are not
+// overridden by a higher-specificity global rule.
 globalStyle(`${diffContainer} span[style]`, {
   color: 'var(--shiki-light)',
-  backgroundColor: 'var(--shiki-light-bg, transparent)',
 })
 
 globalStyle(`html[data-theme="dark"] ${diffContainer} span[style]`, {
   color: 'var(--shiki-dark)',
-  backgroundColor: 'var(--shiki-dark-bg, transparent)',
 })
 
 // Split diff container (two columns side by side)
@@ -103,12 +104,10 @@ export const diffSplitContainer = style({
 
 globalStyle(`${diffSplitContainer} span[style]`, {
   color: 'var(--shiki-light)',
-  backgroundColor: 'var(--shiki-light-bg, transparent)',
 })
 
 globalStyle(`html[data-theme="dark"] ${diffSplitContainer} span[style]`, {
   color: 'var(--shiki-dark)',
-  backgroundColor: 'var(--shiki-dark-bg, transparent)',
 })
 
 // Gap separator row between hunks (shows hidden line count + expand buttons)

--- a/frontend/src/components/chat/diffUtils.test.tsx
+++ b/frontend/src/components/chat/diffUtils.test.tsx
@@ -1,7 +1,8 @@
+import type { StructuredPatchHunk } from './diffUtils'
 import { render } from '@solidjs/testing-library'
 import { diffWordsWithSpace } from 'diff'
 import { describe, expect, it } from 'vitest'
-import { DiffView, rawDiffToHunks } from './diffUtils'
+import { computeGapMap, DiffView, groupByHunk, rawDiffToHunks } from './diffUtils'
 
 /**
  * Reconstruct one side of a word-diff using the same filtering logic
@@ -169,5 +170,109 @@ describe('rawDiffToHunks', () => {
     expect(removedLine).toBe('-        return value;')
     const addedLine = hunks[0].lines.find(l => l.startsWith('+'))
     expect(addedLine).toBe('+    return newValue;')
+  })
+})
+
+describe('computeGapMap', () => {
+  const originalFileLines = [
+    'line 1', // line 1
+    'line 2', // line 2
+    'line 3', // line 3
+    'line 4', // line 4
+    'line 5', // line 5
+    'line 6', // line 6
+    'line 7', // line 7
+    'line 8', // line 8
+    'line 9', // line 9
+    'line 10', // line 10
+  ]
+
+  it('computes leading gap before first hunk', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 4, oldLines: 2, newStart: 4, newLines: 2, lines: [' line 4', '-line 5', '+line 5 modified'] },
+    ]
+    const { gaps, trailing } = computeGapMap(hunks, originalFileLines)
+    expect(gaps.size).toBe(1)
+    const leadingGap = gaps.get(0)!
+    expect(leadingGap.startLineNumber).toBe(1)
+    expect(leadingGap.lines).toEqual(['line 1', 'line 2', 'line 3'])
+    // Trailing gap: lines 6..10
+    expect(trailing).not.toBeNull()
+    expect(trailing!.startLineNumber).toBe(6)
+    expect(trailing!.lines).toEqual(['line 6', 'line 7', 'line 8', 'line 9', 'line 10'])
+  })
+
+  it('computes inter-hunk gap', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 1, oldLines: 2, newStart: 1, newLines: 2, lines: ['-line 1', '+line 1 mod', ' line 2'] },
+      { oldStart: 7, oldLines: 2, newStart: 7, newLines: 2, lines: [' line 7', '-line 8', '+line 8 mod'] },
+    ]
+    const { gaps, trailing } = computeGapMap(hunks, originalFileLines)
+    // No leading gap (hunk starts at line 1)
+    expect(gaps.has(0)).toBe(false)
+    // Inter-hunk gap: lines 3..6
+    const interGap = gaps.get(1)!
+    expect(interGap.startLineNumber).toBe(3)
+    expect(interGap.lines).toEqual(['line 3', 'line 4', 'line 5', 'line 6'])
+    // Trailing gap: lines 9..10
+    expect(trailing).not.toBeNull()
+    expect(trailing!.startLineNumber).toBe(9)
+    expect(trailing!.lines).toEqual(['line 9', 'line 10'])
+  })
+
+  it('returns no trailing gap when last hunk reaches end of file', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 9, oldLines: 2, newStart: 9, newLines: 2, lines: [' line 9', '-line 10', '+line 10 mod'] },
+    ]
+    const { trailing } = computeGapMap(hunks, originalFileLines)
+    expect(trailing).toBeNull()
+  })
+
+  it('returns empty gaps for empty hunks array', () => {
+    const { gaps, trailing } = computeGapMap([], originalFileLines)
+    expect(gaps.size).toBe(0)
+    expect(trailing).toBeNull()
+  })
+
+  it('handles single hunk spanning entire file', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 1, oldLines: 10, newStart: 1, newLines: 10, lines: originalFileLines.map(l => ` ${l}`) },
+    ]
+    const { gaps, trailing } = computeGapMap(hunks, originalFileLines)
+    expect(gaps.size).toBe(0)
+    expect(trailing).toBeNull()
+  })
+})
+
+describe('groupByHunk', () => {
+  it('groups entries by hunkIndex', () => {
+    const entries = [
+      { hunkIndex: 0, value: 'a' },
+      { hunkIndex: 0, value: 'b' },
+      { hunkIndex: 1, value: 'c' },
+      { hunkIndex: 1, value: 'd' },
+      { hunkIndex: 1, value: 'e' },
+      { hunkIndex: 2, value: 'f' },
+    ]
+    const groups = groupByHunk(entries)
+    expect(groups).toHaveLength(3)
+    expect(groups[0]).toEqual([{ hunkIndex: 0, value: 'a' }, { hunkIndex: 0, value: 'b' }])
+    expect(groups[1]).toEqual([{ hunkIndex: 1, value: 'c' }, { hunkIndex: 1, value: 'd' }, { hunkIndex: 1, value: 'e' }])
+    expect(groups[2]).toEqual([{ hunkIndex: 2, value: 'f' }])
+  })
+
+  it('returns empty array for empty input', () => {
+    const groups = groupByHunk([])
+    expect(groups).toEqual([])
+  })
+
+  it('handles single group', () => {
+    const entries = [
+      { hunkIndex: 0, value: 'a' },
+      { hunkIndex: 0, value: 'b' },
+    ]
+    const groups = groupByHunk(entries)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toHaveLength(2)
   })
 })

--- a/frontend/src/components/chat/diffUtils.tsx
+++ b/frontend/src/components/chat/diffUtils.tsx
@@ -2,22 +2,32 @@ import type { JSX } from 'solid-js'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { CachedToken } from '~/lib/tokenCache'
 import { diffLines, diffWordsWithSpace } from 'diff'
+import ArrowDownFromLine from 'lucide-solid/icons/arrow-down-from-line'
+import ArrowUpFromLine from 'lucide-solid/icons/arrow-up-from-line'
+import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { guessLanguage } from '~/lib/languageMap'
 import { tokenizeAsync } from '~/lib/shikiWorkerClient'
 import { getCachedTokens } from '~/lib/tokenCache'
+import { spinner } from '~/styles/animations.css'
 import {
   diffAdded,
   diffAddedInline,
   diffContainer,
   diffContent,
+  diffGapExpandButton,
+  diffGapSeparator,
+  diffGapSeparatorClickable,
+  diffGapSeparatorFirst,
+  diffGapSeparatorLast,
+  diffGapSeparatorSplit,
   diffLine,
   diffLineNumber,
   diffLineNumberNew,
   diffPrefix,
   diffRemoved,
   diffRemovedInline,
-  diffSplitColumn,
   diffSplitContainer,
 } from './diffStyles.css'
 
@@ -31,19 +41,23 @@ export interface StructuredPatchHunk {
 }
 
 /** A single diff line with optional JSX content for inline highlights. */
-interface DiffLineEntry {
+export interface DiffLineEntry {
   oldNum: number | null
   newNum: number | null
   prefix: string
   content: JSX.Element | string
   type: 'added' | 'removed' | 'context'
+  /** Index of the hunk this line belongs to (for gap separators). */
+  hunkIndex: number
 }
 
 /** A single split diff line with optional JSX content. */
-interface SplitLineEntry {
+export interface SplitLineEntry {
   content: JSX.Element | string
   type: 'removed' | 'added' | 'context' | 'empty'
   num: number | null
+  /** Index of the hunk this line belongs to (for gap separators). */
+  hunkIndex: number
 }
 
 /**
@@ -231,6 +245,281 @@ function extractSidesFromHunks(hunks: StructuredPatchHunk[]): { oldCode: string,
   return { oldCode: oldLines.join('\n'), newCode: newLines.join('\n') }
 }
 
+/** A gap between hunks (or before the first / after the last hunk). */
+export interface DiffGap {
+  /** Lines from the original file that fill this gap. */
+  lines: string[]
+  /** 1-based line number of the first line in the gap. */
+  startLineNumber: number
+}
+
+/**
+ * Compute a map of gaps between hunks using the original file content.
+ * Returns a Map keyed by hunk index (gap *before* that hunk) plus an optional trailing gap.
+ *
+ * Gap at key 0 = lines before the first hunk.
+ * Gap at key N = lines between hunk N-1 and hunk N.
+ * Trailing gap is returned separately.
+ */
+export function computeGapMap(
+  hunks: StructuredPatchHunk[],
+  originalFileLines: string[],
+): { gaps: Map<number, DiffGap>, trailing: DiffGap | null } {
+  const gaps = new Map<number, DiffGap>()
+  let trailing: DiffGap | null = null
+
+  if (hunks.length === 0)
+    return { gaps, trailing }
+
+  // Gap before the first hunk (lines 1..firstHunk.oldStart-1)
+  const firstHunk = hunks[0]
+  if (firstHunk.oldStart > 1) {
+    const endLine = firstHunk.oldStart - 1 // 1-based inclusive
+    gaps.set(0, {
+      lines: originalFileLines.slice(0, endLine),
+      startLineNumber: 1,
+    })
+  }
+
+  // Gaps between consecutive hunks
+  for (let i = 1; i < hunks.length; i++) {
+    const prev = hunks[i - 1]
+    const curr = hunks[i]
+    const gapStart = prev.oldStart + prev.oldLines // 1-based, first line after prev hunk
+    const gapEnd = curr.oldStart - 1 // 1-based inclusive
+    if (gapEnd >= gapStart) {
+      gaps.set(i, {
+        lines: originalFileLines.slice(gapStart - 1, gapEnd),
+        startLineNumber: gapStart,
+      })
+    }
+  }
+
+  // Trailing gap (lines after the last hunk)
+  const lastHunk = hunks[hunks.length - 1]
+  const trailingStart = lastHunk.oldStart + lastHunk.oldLines // 1-based
+  if (trailingStart <= originalFileLines.length) {
+    trailing = {
+      lines: originalFileLines.slice(trailingStart - 1),
+      startLineNumber: trailingStart,
+    }
+  }
+
+  return { gaps, trailing }
+}
+
+/**
+ * Group diff line entries by their `hunkIndex` field.
+ * Returns an array of groups in hunk-index order.
+ */
+export function groupByHunk<T extends { hunkIndex: number }>(entries: T[]): T[][] {
+  if (entries.length === 0)
+    return []
+
+  const groups: T[][] = []
+  let currentIndex = entries[0].hunkIndex
+  let currentGroup: T[] = []
+
+  for (const entry of entries) {
+    if (entry.hunkIndex !== currentIndex) {
+      groups.push(currentGroup)
+      currentGroup = []
+      currentIndex = entry.hunkIndex
+    }
+    currentGroup.push(entry)
+  }
+  groups.push(currentGroup)
+  return groups
+}
+
+/** Number of context lines to reveal per expand click. */
+const GAP_EXPAND_STEP = 10
+
+/** Render a single context line from a gap with optional syntax highlighting. */
+function GapContextLine(props: { lineNum: number, text: string, tokens?: CachedToken[] | null, splitView?: boolean }): JSX.Element {
+  const content = () => renderTokenizedLine(props.text, props.tokens ?? null)
+  return (
+    <Show
+      when={props.splitView}
+      fallback={(
+        <div class={diffLine}>
+          <span class={diffLineNumber}>{props.lineNum}</span>
+          <span class={diffLineNumberNew}>{props.lineNum}</span>
+          <span class={diffPrefix}>{' '}</span>
+          <span class={diffContent}>{content()}</span>
+        </div>
+      )}
+    >
+      <div class={diffLine}>
+        <span class={diffLineNumber}>{props.lineNum}</span>
+        <span class={diffPrefix}>{' '}</span>
+        <span class={diffContent}>{content()}</span>
+      </div>
+      <div class={diffLine}>
+        <span class={diffLineNumber}>{props.lineNum}</span>
+        <span class={diffPrefix}>{' '}</span>
+        <span class={diffContent}>{content()}</span>
+      </div>
+    </Show>
+  )
+}
+
+/** Render a gap separator that incrementally expands context lines (up to 10 at a time). */
+function DiffGapSeparator(props: {
+  gap: DiffGap
+  /** File path used for lazy syntax highlighting of revealed gap lines. */
+  filePath?: string
+  revealedTop: number
+  revealedBottom: number
+  onExpandUp: () => void
+  onExpandDown: () => void
+  onExpandAll: () => void
+  /** Whether this is rendered inside a split diff grid (needs gridColumn span). */
+  splitView?: boolean
+  /** True when this gap is the first element in the diff container. */
+  isFirst?: boolean
+  /** True when this gap is the last element in the diff container. */
+  isLast?: boolean
+}): JSX.Element {
+  const total = () => props.gap.lines.length
+  const hiddenCount = () => total() - props.revealedTop - props.revealedBottom
+  const topLines = () => props.gap.lines.slice(0, props.revealedTop)
+  const bottomLines = () => props.revealedBottom > 0 ? props.gap.lines.slice(total() - props.revealedBottom) : []
+
+  // Lazy tokenization: only tokenize revealed lines on demand
+  const [tokenMap, setTokenMap] = createSignal<Map<number, CachedToken[]>>(new Map())
+  const [tokenizing, setTokenizing] = createSignal(false)
+
+  createEffect(on(
+    () => [props.revealedTop, props.revealedBottom, props.filePath, props.gap] as const,
+    ([revTop, revBottom, fp, gap]) => {
+      if ((revTop === 0 && revBottom === 0) || !fp)
+        return
+      const lang = guessLanguage(fp)
+      if (!lang)
+        return
+
+      // Collect indices of revealed lines that haven't been tokenized yet
+      const currentMap = tokenMap()
+      const untokenizedIndices: number[] = []
+      for (let i = 0; i < revTop; i++) {
+        if (!currentMap.has(i))
+          untokenizedIndices.push(i)
+      }
+      const bottomStart = gap.lines.length - revBottom
+      for (let i = bottomStart; i < gap.lines.length; i++) {
+        if (!currentMap.has(i))
+          untokenizedIndices.push(i)
+      }
+
+      if (untokenizedIndices.length === 0)
+        return
+
+      // Join only the untokenized lines for a single tokenization call
+      const linesToTokenize = untokenizedIndices.map(i => gap.lines[i])
+      const code = linesToTokenize.join('\n')
+
+      let cancelled = false
+
+      // Check cache synchronously first
+      const cached = getCachedTokens(lang, code)
+      if (cached) {
+        setTokenMap((prev) => {
+          const next = new Map(prev)
+          for (let j = 0; j < untokenizedIndices.length; j++)
+            next.set(untokenizedIndices[j], cached[j])
+          return next
+        })
+        return
+      }
+
+      setTokenizing(true)
+      tokenizeAsync(lang, code).then((tokens) => {
+        if (cancelled)
+          return
+        setTokenMap((prev) => {
+          const next = new Map(prev)
+          for (let j = 0; j < untokenizedIndices.length; j++)
+            next.set(untokenizedIndices[j], tokens[j])
+          return next
+        })
+        setTokenizing(false)
+      })
+
+      onCleanup(() => {
+        cancelled = true
+      })
+    },
+  ))
+
+  /** Get tokens for a gap line by its index within the gap (0-based). */
+  const tokensForGapLine = (gapIdx: number) => tokenMap().get(gapIdx) ?? null
+  const separatorClass = () => {
+    let cls = diffGapSeparator
+    if (props.splitView)
+      cls += ` ${diffGapSeparatorSplit}`
+    if (props.isFirst && props.revealedTop === 0)
+      cls += ` ${diffGapSeparatorFirst}`
+    if (props.isLast && props.revealedBottom === 0)
+      cls += ` ${diffGapSeparatorLast}`
+    return cls
+  }
+  const hiddenLabel = () => `${hiddenCount()} line${hiddenCount() === 1 ? '' : 's'} hidden`
+
+  return (
+    <>
+      <For each={topLines()}>
+        {(line, idx) => (
+          <GapContextLine
+            lineNum={props.gap.startLineNumber + idx()}
+            text={line}
+            tokens={tokensForGapLine(idx())}
+            splitView={props.splitView}
+          />
+        )}
+      </For>
+      <Show when={hiddenCount() > 0}>
+        <Show
+          when={hiddenCount() > GAP_EXPAND_STEP}
+          fallback={(
+            <div class={`${separatorClass()} ${diffGapSeparatorClickable}`} onClick={() => props.onExpandAll()}>
+              {hiddenLabel()}
+            </div>
+          )}
+        >
+          <div class={separatorClass()}>
+            <span class={diffGapExpandButton} onClick={() => props.onExpandUp()}>
+              <ArrowUpFromLine size={12} />
+              Expand up
+            </span>
+            <span>
+              {hiddenLabel()}
+              <Show when={tokenizing()}>
+                {' '}
+                <Icon icon={LoaderCircle} size="xs" class={spinner} />
+              </Show>
+            </span>
+            <span class={diffGapExpandButton} onClick={() => props.onExpandDown()}>
+              <ArrowDownFromLine size={12} />
+              Expand down
+            </span>
+          </div>
+        </Show>
+      </Show>
+      <For each={bottomLines()}>
+        {(line, idx) => (
+          <GapContextLine
+            lineNum={props.gap.startLineNumber + total() - props.revealedBottom + idx()}
+            text={line}
+            tokens={tokensForGapLine(total() - props.revealedBottom + idx())}
+            splitView={props.splitView}
+          />
+        )}
+      </For>
+    </>
+  )
+}
+
 /** Line limit for diff syntax highlighting. */
 const HIGHLIGHT_LINE_LIMIT = 1000
 
@@ -244,7 +533,8 @@ function buildUnifiedLines(
   let oldTokenLine = 0
   let newTokenLine = 0
 
-  for (const hunk of hunks) {
+  for (let hi = 0; hi < hunks.length; hi++) {
+    const hunk = hunks[hi]
     let oldLine = hunk.oldStart
     let newLine = hunk.newStart
     const lines = hunk.lines
@@ -272,21 +562,21 @@ function buildUnifiedLines(
 
         const paired = Math.min(removedLines.length, addedLines.length)
         for (let j = 0; j < paired; j++)
-          result.push({ oldNum: oldLine++, newNum: null, prefix: '-', content: renderRemovedInline(removedLines[j], addedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed' })
+          result.push({ oldNum: oldLine++, newNum: null, prefix: '-', content: renderRemovedInline(removedLines[j], addedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', hunkIndex: hi })
         for (let j = paired; j < removedLines.length; j++)
-          result.push({ oldNum: oldLine++, newNum: null, prefix: '-', content: renderTokenizedLine(removedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed' })
+          result.push({ oldNum: oldLine++, newNum: null, prefix: '-', content: renderTokenizedLine(removedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', hunkIndex: hi })
         for (let j = 0; j < paired; j++)
-          result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderAddedInline(removedLines[j], addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added' })
+          result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderAddedInline(removedLines[j], addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', hunkIndex: hi })
         for (let j = paired; j < addedLines.length; j++)
-          result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderTokenizedLine(addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added' })
+          result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderTokenizedLine(addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', hunkIndex: hi })
       }
       else if (prefix === '+') {
-        result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderTokenizedLine(lines[i].slice(1), newTokens?.[newTokenLine] ?? null), type: 'added' })
+        result.push({ oldNum: null, newNum: newLine++, prefix: '+', content: renderTokenizedLine(lines[i].slice(1), newTokens?.[newTokenLine] ?? null), type: 'added', hunkIndex: hi })
         newTokenLine++
         i++
       }
       else {
-        result.push({ oldNum: oldLine++, newNum: newLine++, prefix: ' ', content: renderTokenizedLine(lines[i].slice(1), oldTokens?.[oldTokenLine] ?? null), type: 'context' })
+        result.push({ oldNum: oldLine++, newNum: newLine++, prefix: ' ', content: renderTokenizedLine(lines[i].slice(1), oldTokens?.[oldTokenLine] ?? null), type: 'context', hunkIndex: hi })
         oldTokenLine++
         newTokenLine++
         i++
@@ -307,7 +597,8 @@ function buildSplitLines(
   let oldTokenLine = 0
   let newTokenLine = 0
 
-  for (const hunk of hunks) {
+  for (let hi = 0; hi < hunks.length; hi++) {
+    const hunk = hunks[hi]
     let oldLine = hunk.oldStart
     let newLine = hunk.newStart
     const lines = hunk.lines
@@ -334,28 +625,28 @@ function buildSplitLines(
 
         const paired = Math.min(removedLines.length, addedLines.length)
         for (let j = 0; j < paired; j++) {
-          left.push({ content: renderRemovedInline(removedLines[j], addedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', num: oldLine++ })
-          right.push({ content: renderAddedInline(removedLines[j], addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', num: newLine++ })
+          left.push({ content: renderRemovedInline(removedLines[j], addedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', num: oldLine++, hunkIndex: hi })
+          right.push({ content: renderAddedInline(removedLines[j], addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', num: newLine++, hunkIndex: hi })
         }
         for (let j = paired; j < removedLines.length; j++) {
-          left.push({ content: renderTokenizedLine(removedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', num: oldLine++ })
-          right.push({ content: '', type: 'empty', num: null })
+          left.push({ content: renderTokenizedLine(removedLines[j], oldTokens?.[removedTokenIndices[j]] ?? null), type: 'removed', num: oldLine++, hunkIndex: hi })
+          right.push({ content: '', type: 'empty', num: null, hunkIndex: hi })
         }
         for (let j = paired; j < addedLines.length; j++) {
-          left.push({ content: '', type: 'empty', num: null })
-          right.push({ content: renderTokenizedLine(addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', num: newLine++ })
+          left.push({ content: '', type: 'empty', num: null, hunkIndex: hi })
+          right.push({ content: renderTokenizedLine(addedLines[j], newTokens?.[addedTokenIndices[j]] ?? null), type: 'added', num: newLine++, hunkIndex: hi })
         }
       }
       else if (prefix === '+') {
-        left.push({ content: '', type: 'empty', num: null })
-        right.push({ content: renderTokenizedLine(lines[i].slice(1), newTokens?.[newTokenLine] ?? null), type: 'added', num: newLine++ })
+        left.push({ content: '', type: 'empty', num: null, hunkIndex: hi })
+        right.push({ content: renderTokenizedLine(lines[i].slice(1), newTokens?.[newTokenLine] ?? null), type: 'added', num: newLine++, hunkIndex: hi })
         newTokenLine++
         i++
       }
       else {
         const text = lines[i].slice(1)
-        left.push({ content: renderTokenizedLine(text, oldTokens?.[oldTokenLine] ?? null), type: 'context', num: oldLine++ })
-        right.push({ content: renderTokenizedLine(text, newTokens?.[newTokenLine] ?? null), type: 'context', num: newLine++ })
+        left.push({ content: renderTokenizedLine(text, oldTokens?.[oldTokenLine] ?? null), type: 'context', num: oldLine++, hunkIndex: hi })
+        right.push({ content: renderTokenizedLine(text, newTokens?.[newTokenLine] ?? null), type: 'context', num: newLine++, hunkIndex: hi })
         oldTokenLine++
         newTokenLine++
         i++
@@ -432,63 +723,257 @@ function useDiffTokens(
   return { oldTokens, newTokens }
 }
 
-/** Render a unified diff view from hunks. */
-function UnifiedDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string }): JSX.Element {
-  const { oldTokens, newTokens } = useDiffTokens(() => props.hunks, () => props.filePath)
-  const lines = () => buildUnifiedLines(props.hunks, oldTokens(), newTokens())
+/** Render a unified diff line. */
+function UnifiedDiffLine(props: { line: DiffLineEntry }): JSX.Element {
   return (
-    <div class={diffContainer}>
-      <For each={lines()}>
-        {line => (
-          <div class={`${diffLine} ${line.type === 'added' ? diffAdded : line.type === 'removed' ? diffRemoved : ''}`}>
-            <span class={diffLineNumber}>{line.oldNum ?? ''}</span>
-            <span class={diffLineNumberNew}>{line.newNum ?? ''}</span>
-            <span class={diffPrefix}>{line.prefix}</span>
-            <span class={diffContent}>{line.content}</span>
-          </div>
-        )}
-      </For>
+    <div class={`${diffLine} ${props.line.type === 'added' ? diffAdded : props.line.type === 'removed' ? diffRemoved : ''}`}>
+      <span class={diffLineNumber}>{props.line.oldNum ?? ''}</span>
+      <span class={diffLineNumberNew}>{props.line.newNum ?? ''}</span>
+      <span class={diffPrefix}>{props.line.prefix}</span>
+      <span class={diffContent}>{props.line.content}</span>
     </div>
   )
 }
 
+/** Render a unified diff view from hunks. */
+function UnifiedDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string, originalFile?: string }): JSX.Element {
+  const { oldTokens, newTokens } = useDiffTokens(() => props.hunks, () => props.filePath)
+  const lines = () => buildUnifiedLines(props.hunks, oldTokens(), newTokens())
+
+  const originalFileLines = () => props.originalFile?.split('\n')
+  const gapData = () => {
+    const ofl = originalFileLines()
+    if (!ofl)
+      return null
+    return computeGapMap(props.hunks, ofl)
+  }
+
+  const [gapReveals, setGapReveals] = createSignal<Map<string, { top: number, bottom: number }>>(new Map())
+  const getReveal = (key: string) => gapReveals().get(key) ?? { top: 0, bottom: 0 }
+  const expandDown = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      const cur = next.get(key) ?? { top: 0, bottom: 0 }
+      const maxMore = total - cur.top - cur.bottom
+      next.set(key, { ...cur, top: cur.top + Math.min(GAP_EXPAND_STEP, maxMore) })
+      return next
+    })
+  }
+  const expandUp = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      const cur = next.get(key) ?? { top: 0, bottom: 0 }
+      const maxMore = total - cur.top - cur.bottom
+      next.set(key, { ...cur, bottom: cur.bottom + Math.min(GAP_EXPAND_STEP, maxMore) })
+      return next
+    })
+  }
+  const expandAll = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      next.set(key, { top: total, bottom: 0 })
+      return next
+    })
+  }
+
+  return (
+    <div class={diffContainer}>
+      <Show
+        when={gapData()}
+        fallback={(
+          <For each={lines()}>
+            {line => <UnifiedDiffLine line={line} />}
+          </For>
+        )}
+      >
+        {(gd) => {
+          const groups = () => groupByHunk(lines())
+          return (
+            <For each={groups()}>
+              {(group, groupIdx) => {
+                const hi = () => group[0]?.hunkIndex ?? groupIdx()
+                const gapBefore = () => gd().gaps.get(hi())
+                const isTrailing = () => groupIdx() === groups().length - 1 ? gd().trailing : null
+                return (
+                  <>
+                    <Show when={gapBefore()}>
+                      {gap => (
+                        <DiffGapSeparator
+                          gap={gap()}
+                          filePath={props.filePath}
+                          revealedTop={getReveal(`before-${hi()}`).top}
+                          revealedBottom={getReveal(`before-${hi()}`).bottom}
+                          onExpandDown={() => expandDown(`before-${hi()}`, gap().lines.length)}
+                          onExpandUp={() => expandUp(`before-${hi()}`, gap().lines.length)}
+                          onExpandAll={() => expandAll(`before-${hi()}`, gap().lines.length)}
+                          isFirst={groupIdx() === 0}
+                        />
+                      )}
+                    </Show>
+                    <For each={group}>
+                      {line => <UnifiedDiffLine line={line} />}
+                    </For>
+                    <Show when={isTrailing()}>
+                      {trailing => (
+                        <DiffGapSeparator
+                          gap={trailing()}
+                          filePath={props.filePath}
+                          revealedTop={getReveal('trailing').top}
+                          revealedBottom={getReveal('trailing').bottom}
+                          onExpandDown={() => expandDown('trailing', trailing().lines.length)}
+                          onExpandUp={() => expandUp('trailing', trailing().lines.length)}
+                          onExpandAll={() => expandAll('trailing', trailing().lines.length)}
+                          isLast
+                        />
+                      )}
+                    </Show>
+                  </>
+                )
+              }}
+            </For>
+          )
+        }}
+      </Show>
+    </div>
+  )
+}
+
+/** Render a single split diff row (left + right lines rendered in the grid). */
+function SplitDiffRow(props: { left: SplitLineEntry, right: SplitLineEntry }): JSX.Element {
+  return (
+    <>
+      <div class={`${diffLine} ${props.left.type === 'removed' ? diffRemoved : ''}`}>
+        <span class={diffLineNumber}>{props.left.num ?? ''}</span>
+        <span class={diffPrefix}>{props.left.type === 'removed' ? '-' : ' '}</span>
+        <span class={diffContent}>{props.left.content}</span>
+      </div>
+      <div class={`${diffLine} ${props.right.type === 'added' ? diffAdded : ''}`}>
+        <span class={diffLineNumber}>{props.right.num ?? ''}</span>
+        <span class={diffPrefix}>{props.right.type === 'added' ? '+' : ' '}</span>
+        <span class={diffContent}>{props.right.content}</span>
+      </div>
+    </>
+  )
+}
+
 /** Render a split diff view from hunks (removed on left, added on right). */
-function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string }): JSX.Element {
+function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string, originalFile?: string }): JSX.Element {
   const { oldTokens, newTokens } = useDiffTokens(() => props.hunks, () => props.filePath)
   const splitLines = () => buildSplitLines(props.hunks, oldTokens(), newTokens())
+
+  const originalFileLines = () => props.originalFile?.split('\n')
+  const gapData = () => {
+    const ofl = originalFileLines()
+    if (!ofl)
+      return null
+    return computeGapMap(props.hunks, ofl)
+  }
+
+  const [gapReveals, setGapReveals] = createSignal<Map<string, { top: number, bottom: number }>>(new Map())
+  const getReveal = (key: string) => gapReveals().get(key) ?? { top: 0, bottom: 0 }
+  const expandDown = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      const cur = next.get(key) ?? { top: 0, bottom: 0 }
+      const maxMore = total - cur.top - cur.bottom
+      next.set(key, { ...cur, top: cur.top + Math.min(GAP_EXPAND_STEP, maxMore) })
+      return next
+    })
+  }
+  const expandUp = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      const cur = next.get(key) ?? { top: 0, bottom: 0 }
+      const maxMore = total - cur.top - cur.bottom
+      next.set(key, { ...cur, bottom: cur.bottom + Math.min(GAP_EXPAND_STEP, maxMore) })
+      return next
+    })
+  }
+  const expandAll = (key: string, total: number) => {
+    setGapReveals((prev) => {
+      const next = new Map(prev)
+      next.set(key, { top: total, bottom: 0 })
+      return next
+    })
+  }
+
   return (
     <div class={diffSplitContainer}>
-      <div class={diffSplitColumn}>
-        <For each={splitLines().left}>
-          {line => (
-            <div class={`${diffLine} ${line.type === 'removed' ? diffRemoved : ''}`}>
-              <span class={diffLineNumber}>{line.num ?? ''}</span>
-              <span class={diffPrefix}>{line.type === 'removed' ? '-' : ' '}</span>
-              <span class={diffContent}>{line.content}</span>
-            </div>
-          )}
-        </For>
-      </div>
-      <div class={diffSplitColumn}>
-        <For each={splitLines().right}>
-          {line => (
-            <div class={`${diffLine} ${line.type === 'added' ? diffAdded : ''}`}>
-              <span class={diffLineNumber}>{line.num ?? ''}</span>
-              <span class={diffPrefix}>{line.type === 'added' ? '+' : ' '}</span>
-              <span class={diffContent}>{line.content}</span>
-            </div>
-          )}
-        </For>
-      </div>
+      <Show
+        when={gapData()}
+        fallback={(
+          <For each={splitLines().left}>
+            {(leftLine, i) => {
+              const rightLine = () => splitLines().right[i()]
+              return <SplitDiffRow left={leftLine} right={rightLine()} />
+            }}
+          </For>
+        )}
+      >
+        {(gd) => {
+          const leftGroups = () => groupByHunk(splitLines().left)
+          const rightGroups = () => groupByHunk(splitLines().right)
+          return (
+            <For each={leftGroups()}>
+              {(leftGroup, groupIdx) => {
+                const hi = () => leftGroup[0]?.hunkIndex ?? groupIdx()
+                const rightGroup = () => rightGroups()[groupIdx()] ?? []
+                const gapBefore = () => gd().gaps.get(hi())
+                const isTrailing = () => groupIdx() === leftGroups().length - 1 ? gd().trailing : null
+                return (
+                  <>
+                    <Show when={gapBefore()}>
+                      {gap => (
+                        <DiffGapSeparator
+                          gap={gap()}
+                          filePath={props.filePath}
+                          revealedTop={getReveal(`before-${hi()}`).top}
+                          revealedBottom={getReveal(`before-${hi()}`).bottom}
+                          onExpandDown={() => expandDown(`before-${hi()}`, gap().lines.length)}
+                          onExpandUp={() => expandUp(`before-${hi()}`, gap().lines.length)}
+                          onExpandAll={() => expandAll(`before-${hi()}`, gap().lines.length)}
+                          splitView
+                          isFirst={groupIdx() === 0}
+                        />
+                      )}
+                    </Show>
+                    <For each={leftGroup}>
+                      {(leftLine, i) => {
+                        const rightLine = () => rightGroup()[i()] ?? { content: '', type: 'empty' as const, num: null, hunkIndex: hi() }
+                        return <SplitDiffRow left={leftLine} right={rightLine()} />
+                      }}
+                    </For>
+                    <Show when={isTrailing()}>
+                      {trailing => (
+                        <DiffGapSeparator
+                          gap={trailing()}
+                          filePath={props.filePath}
+                          revealedTop={getReveal('trailing').top}
+                          revealedBottom={getReveal('trailing').bottom}
+                          onExpandDown={() => expandDown('trailing', trailing().lines.length)}
+                          onExpandUp={() => expandUp('trailing', trailing().lines.length)}
+                          onExpandAll={() => expandAll('trailing', trailing().lines.length)}
+                          splitView
+                          isLast
+                        />
+                      )}
+                    </Show>
+                  </>
+                )
+              }}
+            </For>
+          )
+        }}
+      </Show>
     </div>
   )
 }
 
 /** Renders a diff view (unified or split) from hunks with optional syntax highlighting. */
-export function DiffView(props: { hunks: StructuredPatchHunk[], view: DiffViewPreference, filePath?: string }): JSX.Element {
+export function DiffView(props: { hunks: StructuredPatchHunk[], view: DiffViewPreference, filePath?: string, originalFile?: string }): JSX.Element {
   return (
-    <Show when={props.view === 'unified'} fallback={<SplitDiffView hunks={props.hunks} filePath={props.filePath} />}>
-      <UnifiedDiffView hunks={props.hunks} filePath={props.filePath} />
+    <Show when={props.view === 'unified'} fallback={<SplitDiffView hunks={props.hunks} filePath={props.filePath} originalFile={props.originalFile} />}>
+      <UnifiedDiffView hunks={props.hunks} filePath={props.filePath} originalFile={props.originalFile} />
     </Show>
   )
 }

--- a/frontend/src/components/chat/globRenderer.test.tsx
+++ b/frontend/src/components/chat/globRenderer.test.tsx
@@ -1,0 +1,238 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock renderAnsi to avoid shiki initialization in tests.
+vi.mock('~/lib/renderAnsi', () => ({
+  // eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching control characters
+  containsAnsi: (text: string) => /\x1B\[[\d;]*m/.test(text),
+  renderAnsi: (text: string) => `<pre class="shiki"><code>${text}</code></pre>`,
+}))
+
+// Mock renderMarkdown to avoid shiki initialization in tests.
+vi.mock('~/lib/renderMarkdown', () => ({
+  renderMarkdown: (text: string) => text,
+}))
+
+const { formatGlobSummary } = await import('./rendererUtils')
+const { renderMessageContent } = await import('./messageRenderers')
+type RenderContext = import('./messageRenderers').RenderContext
+
+/** Construct a Glob tool_use assistant message. */
+function makeGlobToolUse(input: Record<string, unknown> = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'test-glob',
+        name: 'Glob',
+        input: { pattern: 'frontend/src/**/*.test.*', ...input },
+      }],
+    },
+  }
+}
+
+/** Construct a Glob tool_result user message with tool_use_result. */
+function makeGlobToolResult(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        tool_use_id: 'test-glob',
+        type: 'tool_result',
+        content: resultContent,
+      }],
+    },
+    tool_use_result: toolUseResult,
+  }
+}
+
+/** Render a Glob tool_use message and return its text content. */
+function renderToolUseText(context?: RenderContext): string {
+  const msg = makeGlobToolUse()
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a Glob tool_result message and return its container element. */
+function renderToolResultContainer(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): HTMLElement {
+  const msg = makeGlobToolResult(resultContent, toolUseResult)
+  const result = renderMessageContent(msg, 1 /* USER */, context)
+  const { container } = render(() => result)
+  return container
+}
+
+/** Render a Glob tool_result message and return its text content. */
+function renderToolResultText(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): string {
+  return renderToolResultContainer(resultContent, toolUseResult, context).textContent?.trim() ?? ''
+}
+
+describe('formatGlobSummary', () => {
+  it('returns null when numFiles is undefined and no fallback', () => {
+    expect(formatGlobSummary(undefined)).toBeNull()
+  })
+
+  it('returns fallback when numFiles is undefined', () => {
+    expect(formatGlobSummary(undefined, undefined, undefined, 'Custom fallback')).toBe('Custom fallback')
+  })
+
+  it('returns "No files found" when numFiles is 0', () => {
+    expect(formatGlobSummary(0)).toBe('No files found')
+  })
+
+  it('returns fallback when numFiles is 0 and fallback provided', () => {
+    expect(formatGlobSummary(0, undefined, undefined, 'No matching files')).toBe('No matching files')
+  })
+
+  it('returns "Found N files" for numFiles > 0', () => {
+    expect(formatGlobSummary(4)).toBe('Found 4 files')
+  })
+
+  it('returns "Found 1 file" for singular', () => {
+    expect(formatGlobSummary(1)).toBe('Found 1 file')
+  })
+
+  it('includes duration when durationMs is provided', () => {
+    expect(formatGlobSummary(4, 1011)).toBe('Found 4 files \u00B7 Took 1s')
+  })
+
+  it('includes "Result truncated" when truncated is true', () => {
+    expect(formatGlobSummary(100, undefined, true)).toBe('Found 100 files \u00B7 Result truncated')
+  })
+
+  it('includes both duration and truncated', () => {
+    expect(formatGlobSummary(50, 2500, true)).toBe('Found 50 files \u00B7 Took 3s \u00B7 Result truncated')
+  })
+
+  it('omits truncated when false', () => {
+    expect(formatGlobSummary(4, 1011, false)).toBe('Found 4 files \u00B7 Took 1s')
+  })
+
+  it('shows duration with "No files found"', () => {
+    expect(formatGlobSummary(0, 500)).toBe('No files found \u00B7 Took 1s')
+  })
+})
+
+describe('glob tool_use collapsed summary', () => {
+  it('shows pattern in header', () => {
+    const text = renderToolUseText()
+    expect(text).toContain('frontend/src/**/*.test.*')
+  })
+
+  it('shows "Found N files" summary', () => {
+    const text = renderToolUseText({
+      childGlobNumFiles: 4,
+    })
+    expect(text).toContain('Found 4 files')
+  })
+
+  it('shows "Found N files · Took Xs" with duration', () => {
+    const text = renderToolUseText({
+      childGlobNumFiles: 4,
+      childGlobDurationMs: 1011,
+    })
+    expect(text).toContain('Found 4 files')
+    expect(text).toContain('Took 1s')
+  })
+
+  it('shows "Result truncated" when truncated', () => {
+    const text = renderToolUseText({
+      childGlobNumFiles: 100,
+      childGlobTruncated: true,
+    })
+    expect(text).toContain('Found 100 files')
+    expect(text).toContain('Result truncated')
+  })
+
+  it('shows "No files found" when numFiles is 0', () => {
+    const text = renderToolUseText({
+      childGlobNumFiles: 0,
+      childResultContent: 'No files found',
+    })
+    expect(text).toContain('No files found')
+  })
+
+  it('shows nothing when no result data yet', () => {
+    const text = renderToolUseText()
+    expect(text).not.toContain('Found')
+    expect(text).not.toContain('No files')
+  })
+})
+
+describe('glob tool_result expanded view', () => {
+  it('shows file list with relativized paths', () => {
+    const container = renderToolResultContainer(
+      '/home/user/project/src/foo.ts\n/home/user/project/src/bar.ts',
+      {
+        tool_name: 'Glob',
+        filenames: ['/home/user/project/src/foo.ts', '/home/user/project/src/bar.ts'],
+        numFiles: 2,
+        durationMs: 500,
+        truncated: false,
+      },
+      { workingDir: '/home/user/project' },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(2)
+    expect(listItems[0].textContent).toBe('src/foo.ts')
+    expect(listItems[1].textContent).toBe('src/bar.ts')
+  })
+
+  it('shows "No files found" when filenames is empty', () => {
+    const text = renderToolResultText('No files found', {
+      tool_name: 'Glob',
+      filenames: [],
+      numFiles: 0,
+      truncated: false,
+    })
+    expect(text).toContain('No files found')
+  })
+
+  it('shows fallback content when filenames is empty with custom message', () => {
+    const text = renderToolResultText('No matching files in directory', {
+      tool_name: 'Glob',
+      filenames: [],
+      numFiles: 0,
+      truncated: false,
+    })
+    expect(text).toContain('No matching files in directory')
+  })
+
+  it('falls back to raw preformatted text when tool_use_result is missing', () => {
+    const text = renderToolResultText(
+      '/home/user/project/src/foo.ts\n/home/user/project/src/bar.ts',
+      undefined,
+      { parentToolName: 'Glob' },
+    )
+    expect(text).toContain('/home/user/project/src/foo.ts')
+    expect(text).toContain('/home/user/project/src/bar.ts')
+  })
+
+  it('renders single file correctly', () => {
+    const container = renderToolResultContainer(
+      'src/only-file.ts',
+      {
+        tool_name: 'Glob',
+        filenames: ['src/only-file.ts'],
+        numFiles: 1,
+        truncated: false,
+      },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(1)
+    expect(listItems[0].textContent).toContain('only-file.ts')
+  })
+})

--- a/frontend/src/components/chat/grepRenderer.test.tsx
+++ b/frontend/src/components/chat/grepRenderer.test.tsx
@@ -1,0 +1,284 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock renderAnsi to avoid shiki initialization in tests.
+vi.mock('~/lib/renderAnsi', () => ({
+  // eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching control characters
+  containsAnsi: (text: string) => /\x1B\[[\d;]*m/.test(text),
+  renderAnsi: (text: string) => `<pre class="shiki"><code>${text}</code></pre>`,
+}))
+
+// Mock renderMarkdown to avoid shiki initialization in tests.
+vi.mock('~/lib/renderMarkdown', () => ({
+  renderMarkdown: (text: string) => text,
+}))
+
+const { formatGrepSummary } = await import('./rendererUtils')
+const { renderMessageContent } = await import('./messageRenderers')
+type RenderContext = import('./messageRenderers').RenderContext
+
+/** Construct a Grep tool_use assistant message. */
+function makeGrepToolUse(input: Record<string, unknown> = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'test-grep',
+        name: 'Grep',
+        input: { pattern: 'ToolHeaderActions', ...input },
+      }],
+    },
+  }
+}
+
+/** Construct a Grep tool_result user message with tool_use_result. */
+function makeGrepToolResult(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        tool_use_id: 'test-grep',
+        type: 'tool_result',
+        content: resultContent,
+      }],
+    },
+    tool_use_result: toolUseResult,
+  }
+}
+
+/** Render a Grep tool_use message and return its text content. */
+function renderToolUseText(context?: RenderContext): string {
+  const msg = makeGrepToolUse({ path: '/home/user/project/src' })
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a Grep tool_result message and return its text content. */
+function renderToolResultText(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): string {
+  const msg = makeGrepToolResult(resultContent, toolUseResult)
+  const result = renderMessageContent(msg, 1 /* USER */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a Grep tool_result message and return its container element. */
+function renderToolResultContainer(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): HTMLElement {
+  const msg = makeGrepToolResult(resultContent, toolUseResult)
+  const result = renderMessageContent(msg, 1 /* USER */, context)
+  const { container } = render(() => result)
+  return container
+}
+
+describe('formatGrepSummary', () => {
+  it('returns null when no structured data and no fallback', () => {
+    expect(formatGrepSummary(undefined, undefined)).toBeNull()
+  })
+
+  it('returns fallback when no structured data', () => {
+    expect(formatGrepSummary(undefined, undefined, 'Custom fallback')).toBe('Custom fallback')
+  })
+
+  it('returns "No matches found" when both are 0', () => {
+    expect(formatGrepSummary(0, 0)).toBe('No matches found')
+  })
+
+  it('returns fallback when both are 0 and fallback provided', () => {
+    expect(formatGrepSummary(0, 0, 'No files found')).toBe('No files found')
+  })
+
+  it('returns "Found N files" for files only', () => {
+    expect(formatGrepSummary(5, 0)).toBe('Found 5 files')
+  })
+
+  it('returns "Found 1 file" for singular file', () => {
+    expect(formatGrepSummary(1, 0)).toBe('Found 1 file')
+  })
+
+  it('returns "Found N lines" for lines only', () => {
+    expect(formatGrepSummary(0, 7)).toBe('Found 7 lines')
+  })
+
+  it('returns "Found 1 line" for singular line', () => {
+    expect(formatGrepSummary(0, 1)).toBe('Found 1 line')
+  })
+
+  it('returns "Found N files and M lines" for both', () => {
+    expect(formatGrepSummary(3, 12)).toBe('Found 3 files and 12 lines')
+  })
+
+  it('returns "Found 1 file and 1 line" for singular both', () => {
+    expect(formatGrepSummary(1, 1)).toBe('Found 1 file and 1 line')
+  })
+})
+
+describe('grep tool_use collapsed summary', () => {
+  it('shows pattern in header', () => {
+    const text = renderToolUseText()
+    expect(text).toContain('"ToolHeaderActions"')
+  })
+
+  it('shows path and "Found N lines" summary', () => {
+    const text = renderToolUseText({
+      childGrepNumFiles: 0,
+      childGrepNumLines: 7,
+      childResultContent: 'some match content',
+    })
+    expect(text).toContain('src')
+    expect(text).toContain('Found 7 lines')
+  })
+
+  it('shows "No matches found" when no results', () => {
+    const text = renderToolUseText({
+      childGrepNumFiles: 0,
+      childGrepNumLines: 0,
+      childResultContent: 'No matches found',
+    })
+    expect(text).toContain('No matches found')
+  })
+
+  it('shows fallback from childResultContent when numFiles and numLines are 0', () => {
+    const text = renderToolUseText({
+      childGrepNumFiles: 0,
+      childGrepNumLines: 0,
+      childResultContent: 'No files found',
+    })
+    expect(text).toContain('No files found')
+  })
+
+  it('shows "Found N files" for files_with_matches mode', () => {
+    const text = renderToolUseText({
+      childGrepNumFiles: 3,
+      childGrepNumLines: 0,
+    })
+    expect(text).toContain('Found 3 files')
+  })
+
+  it('shows "Found N files and M lines" for both', () => {
+    const text = renderToolUseText({
+      childGrepNumFiles: 2,
+      childGrepNumLines: 10,
+    })
+    expect(text).toContain('Found 2 files and 10 lines')
+  })
+
+  it('shows only path when no result data yet', () => {
+    const text = renderToolUseText()
+    expect(text).toContain('src')
+    expect(text).not.toContain('Found')
+    expect(text).not.toContain('No matches')
+  })
+})
+
+describe('grep tool_result expanded view', () => {
+  it('shows "No matches found" when numFiles and numLines are 0', () => {
+    const text = renderToolResultText('No matches found', {
+      tool_name: 'Grep',
+      numFiles: 0,
+      filenames: [],
+      content: '',
+      numLines: 0,
+    })
+    expect(text).toContain('No matches found')
+  })
+
+  it('shows fallback content when numFiles and numLines are 0 with custom message', () => {
+    const text = renderToolResultText('No files found', {
+      tool_name: 'Grep',
+      numFiles: 0,
+      filenames: [],
+      content: '',
+      numLines: 0,
+    })
+    expect(text).toContain('No files found')
+  })
+
+  it('shows content when numLines > 0', () => {
+    const matchContent = 'src/foo.ts\n42:const x = 1;\n43:const y = 2;'
+    const text = renderToolResultText(matchContent, {
+      tool_name: 'Grep',
+      numFiles: 0,
+      filenames: [],
+      content: matchContent,
+      numLines: 3,
+    })
+    expect(text).toContain('const x = 1;')
+  })
+
+  it('shows file list when numFiles > 0', () => {
+    const container = renderToolResultContainer(
+      'src/foo.ts\nsrc/bar.ts',
+      {
+        tool_name: 'Grep',
+        numFiles: 2,
+        filenames: ['src/foo.ts', 'src/bar.ts'],
+        content: '',
+        numLines: 0,
+      },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(2)
+    expect(listItems[0].textContent).toContain('foo.ts')
+    expect(listItems[1].textContent).toContain('bar.ts')
+  })
+
+  it('shows both file list and content when both numFiles and numLines > 0', () => {
+    const matchContent = '42:const x = 1;'
+    const container = renderToolResultContainer(
+      'src/foo.ts\n42:const x = 1;',
+      {
+        tool_name: 'Grep',
+        numFiles: 1,
+        filenames: ['src/foo.ts'],
+        content: matchContent,
+        numLines: 1,
+      },
+    )
+    const text = container.textContent ?? ''
+    // Check for file list
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(1)
+    // Check for content
+    expect(text).toContain('const x = 1;')
+  })
+
+  it('falls back to raw preformatted text when tool_use_result is missing', () => {
+    const text = renderToolResultText('raw grep output line 1\nline 2', undefined, {
+      parentToolName: 'Grep',
+    })
+    expect(text).toContain('raw grep output line 1')
+    expect(text).toContain('line 2')
+  })
+
+  it('relativizes file paths in file list', () => {
+    const container = renderToolResultContainer(
+      '/home/user/project/src/foo.ts',
+      {
+        tool_name: 'Grep',
+        numFiles: 1,
+        filenames: ['/home/user/project/src/foo.ts'],
+        content: '',
+        numLines: 0,
+      },
+      {
+        workingDir: '/home/user/project',
+      },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(1)
+    expect(listItems[0].textContent).toBe('src/foo.ts')
+  })
+})

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -89,12 +89,13 @@ describe('agent/task renderer', () => {
     expect(text).not.toContain('Complete')
   })
 
-  it('renders description + status + subagent_type together', () => {
+  it('renders description + subagent_type in title, status in summary', () => {
     const text = renderToolUseText('Agent', { description: 'Fix bug', subagent_type: 'code' }, {
       threadChildCount: 2,
       childToolResultStatus: 'completed',
     })
-    expect(text).toContain('Fix bug - Complete (code)')
+    expect(text).toContain('Fix bug (code)')
+    expect(text).toContain('Complete')
   })
 
   it('formats title as "SubAgent: rest" when description starts with subagent name', () => {

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -110,6 +110,8 @@ export interface RenderContext {
   childTotalToolUseCount?: number
   /** Control response (approval/rejection) threaded into this tool_use. */
   childControlResponse?: { action: string, comment: string }
+  /** Original file content before edit (for expandable context lines in diffs). */
+  childOriginalFile?: string
 }
 
 export interface MessageContentRenderer {

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -155,6 +155,8 @@ globalStyle(`${messageRow}:has(.${resultDivider}) > .${toolHeaderActions}`, {
 globalStyle(`${messageRowEnd} > .${toolHeaderActions}`, {
   order: -1,
   paddingRight: 'var(--space-1)',
+  paddingTop: 'var(--space-1)',
+  paddingBottom: 'var(--space-1)',
   display: 'grid',
   gridTemplateColumns: 'auto auto',
   direction: 'rtl',
@@ -167,6 +169,8 @@ globalStyle(`${messageRowEnd} > .${toolHeaderActions} > *`, {
 
 // 2-column grid layout for assistant/thinking bubble actions so primary actions sit adjacent to the bubble
 globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions}`, {
+  paddingTop: 'var(--space-1)',
+  paddingBottom: 'var(--space-1)',
   display: 'grid',
   gridTemplateColumns: 'auto auto',
 })

--- a/frontend/src/components/chat/planModeRenderers.tsx
+++ b/frontend/src/components/chat/planModeRenderers.tsx
@@ -4,7 +4,6 @@ import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import Hand from 'lucide-solid/icons/hand'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import Stamp from 'lucide-solid/icons/stamp'
-import TicketsPlane from 'lucide-solid/icons/tickets-plane'
 import { Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { renderMarkdown } from '~/lib/renderMarkdown'
@@ -18,19 +17,6 @@ import {
   toolUseHeader,
   toolUseIcon,
 } from './toolStyles.css'
-
-/** Render EnterPlanMode tool_use as a simple "Entering Plan Mode" text line. */
-export function renderEnterPlanMode(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
-  void toolUse
-  return (
-    <ToolUseLayout
-      icon={TicketsPlane}
-      toolName="EnterPlanMode"
-      title="Entering Plan Mode"
-      context={context}
-    />
-  )
-}
 
 /** Render ExitPlanMode tool_use with the plan from input.plan as a markdown document. */
 export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
@@ -95,18 +81,6 @@ export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: R
       </>
     </ToolUseLayout>
   )
-}
-
-export const enterPlanModeRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
-    const content = getAssistantContent(parsed)
-    if (!content)
-      return null
-    const toolUse = content.find(c => isObject(c) && c.type === 'tool_use' && c.name === 'EnterPlanMode')
-    if (!toolUse)
-      return null
-    return renderEnterPlanMode(toolUse as Record<string, unknown>, context)
-  },
 }
 
 export const exitPlanModeRenderer: MessageContentRenderer = {

--- a/frontend/src/components/chat/planModeRenderers.tsx
+++ b/frontend/src/components/chat/planModeRenderers.tsx
@@ -13,7 +13,7 @@ import { markdownContent } from './markdownContent.css'
 import { getAssistantContent, isObject, relativizePath } from './messageUtils'
 import { ToolUseLayout } from './toolRenderers'
 import {
-  toolInputSubDetail,
+  toolInputSummary,
   toolInputText,
   toolUseHeader,
   toolUseIcon,
@@ -54,7 +54,7 @@ export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: R
   }
 
   const summary = context?.childFilePath
-    ? <div class={toolInputSubDetail}>{relativizePath(context.childFilePath, context?.workingDir, context?.homeDir)}</div>
+    ? <div class={toolInputSummary}>{relativizePath(context.childFilePath, context?.workingDir, context?.homeDir)}</div>
     : undefined
 
   return (

--- a/frontend/src/components/chat/rendererUtils.ts
+++ b/frontend/src/components/chat/rendererUtils.ts
@@ -38,6 +38,38 @@ export function formatNumber(n: number): string {
   return n.toLocaleString('en-US')
 }
 
+/** Format a Grep result summary for display (without trailing colon). */
+export function formatGrepSummary(numFiles?: number, numLines?: number, fallback?: string | null): string | null {
+  if (numFiles === undefined && numLines === undefined)
+    return fallback || null
+  const nf = numFiles ?? 0
+  const nl = numLines ?? 0
+  if (nf <= 0 && nl <= 0)
+    return fallback || 'No matches found'
+  const parts: string[] = []
+  if (nf > 0)
+    parts.push(`${nf} file${nf === 1 ? '' : 's'}`)
+  if (nl > 0)
+    parts.push(`${nl} line${nl === 1 ? '' : 's'}`)
+  return `Found ${parts.join(' and ')}`
+}
+
+/** Format a Glob result summary for display. Parts are joined with " · ". */
+export function formatGlobSummary(numFiles?: number, durationMs?: number, truncated?: boolean, fallback?: string | null): string | null {
+  if (numFiles === undefined)
+    return fallback || null
+  const parts: string[] = []
+  if (numFiles <= 0)
+    parts.push(fallback || 'No files found')
+  else
+    parts.push(`Found ${numFiles} file${numFiles === 1 ? '' : 's'}`)
+  if (durationMs !== undefined)
+    parts.push(`Took ${formatDuration(durationMs)}`)
+  if (truncated)
+    parts.push('Result truncated')
+  return parts.join(' \u00B7 ')
+}
+
 /** Helper: format tool input for compact display (fallback for unknown tools) */
 export function formatToolInput(input: unknown): string {
   if (input === null || input === undefined || JSON.stringify(input) === '{}') {

--- a/frontend/src/components/chat/taskRenderers.tsx
+++ b/frontend/src/components/chat/taskRenderers.tsx
@@ -18,8 +18,8 @@ import { firstNonEmptyLine, formatDuration, formatNumber, formatTaskStatus } fro
 import { ToolUseLayout } from './toolRenderers'
 import {
   answerText,
-  toolInputSubDetail,
-  toolInputSubDetailExpanded,
+  toolInputSummary,
+  toolInputSummaryExpanded,
   toolResultContentAnsi,
   toolResultContentPre,
 } from './toolStyles.css'
@@ -42,7 +42,7 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
   const inProgressTask = todos.find(t => t.status === 'in_progress')
 
   const summary = (
-    <div class={toolInputSubDetail}>
+    <div class={toolInputSummary}>
       {inProgressTask ? `${inProgressTask.activeForm} \u00B7 ` : ''}
       {`${completedCount}/${count} completed`}
     </div>
@@ -118,7 +118,7 @@ export function renderTaskOutput(toolUse: Record<string, unknown>, context?: Ren
   const firstLine = firstNonEmptyLine(output)
 
   const title = `${status}${description ? ` - ${description}` : ''}`
-  const summary = firstLine ? <div class={toolInputSubDetail}>{firstLine}</div> : undefined
+  const summary = firstLine ? <div class={toolInputSummary}>{firstLine}</div> : undefined
 
   return (
     <ToolUseLayout
@@ -129,7 +129,7 @@ export function renderTaskOutput(toolUse: Record<string, unknown>, context?: Ren
       context={context}
     >
       <>
-        <div class={toolInputSubDetailExpanded}>
+        <div class={toolInputSummaryExpanded}>
           <Show when={task?.task_id}>
             {`task_id: ${task!.task_id}`}
           </Show>
@@ -222,7 +222,7 @@ export function renderAgentOrTask(toolUse: Record<string, unknown>, context?: Re
   if (toolUses !== undefined)
     parts.push(`${toolUses} tool use${toolUses === 1 ? '' : 's'}`)
   const summary = parts.length > 0
-    ? <div class={toolInputSubDetail}>{parts.join(' \u00B7 ')}</div>
+    ? <div class={toolInputSummary}>{parts.join(' \u00B7 ')}</div>
     : undefined
 
   return (
@@ -256,7 +256,7 @@ export const taskNotificationRenderer: MessageContentRenderer = {
 
     const summaryText = typeof parsed.summary === 'string' ? parsed.summary : 'Task notification'
     const outputFile = typeof parsed.output_file === 'string' ? parsed.output_file : null
-    const summary = outputFile ? <div class={toolInputSubDetail}>{outputFile}</div> : undefined
+    const summary = outputFile ? <div class={toolInputSummary}>{outputFile}</div> : undefined
 
     return (
       <ToolUseLayout

--- a/frontend/src/components/chat/taskRenderers.tsx
+++ b/frontend/src/components/chat/taskRenderers.tsx
@@ -3,25 +3,18 @@
 import type { JSX } from 'solid-js'
 import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import type { TodoItem } from '~/stores/chat.store'
-import Bot from 'lucide-solid/icons/bot'
 import ListTodo from 'lucide-solid/icons/list-todo'
-import SquareTerminal from 'lucide-solid/icons/square-terminal'
 import Terminal from 'lucide-solid/icons/terminal'
 import Vote from 'lucide-solid/icons/vote'
 import { For, Show } from 'solid-js'
 import { TodoList } from '~/components/todo/TodoList'
-import { containsAnsi, renderAnsi } from '~/lib/renderAnsi'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { markdownContent } from './markdownContent.css'
 import { getAssistantContent, isObject } from './messageUtils'
-import { firstNonEmptyLine, formatDuration, formatNumber, formatTaskStatus } from './rendererUtils'
 import { ToolUseLayout } from './toolRenderers'
 import {
   answerText,
   toolInputSummary,
-  toolInputSummaryExpanded,
-  toolResultContentAnsi,
-  toolResultContentPre,
 } from './toolStyles.css'
 
 /** Render TodoWrite tool_use with a visual todo list. Returns null if input is invalid. */
@@ -38,22 +31,13 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
 
   const count = todos.length
   const label = `${count} task${count === 1 ? '' : 's'}`
-  const completedCount = todos.filter(t => t.status === 'completed').length
-  const inProgressTask = todos.find(t => t.status === 'in_progress')
-
-  const summary = (
-    <div class={toolInputSummary}>
-      {inProgressTask ? `${inProgressTask.activeForm} \u00B7 ` : ''}
-      {`${completedCount}/${count} completed`}
-    </div>
-  )
 
   return (
     <ToolUseLayout
       icon={ListTodo}
       toolName="TodoWrite"
       title={label}
-      summary={summary}
+      alwaysVisible={true}
       context={context}
     >
       <TodoList todos={todos} />
@@ -108,48 +92,6 @@ export function renderAskUserQuestion(toolUse: Record<string, unknown>, context?
   )
 }
 
-/** Render TaskOutput tool_use with task status, description, and output. */
-export function renderTaskOutput(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
-  void toolUse
-  const task = context?.childTask
-  const status = formatTaskStatus(task?.status)
-  const description = task?.description
-  const output = task?.output
-  const firstLine = firstNonEmptyLine(output)
-
-  const title = `${status}${description ? ` - ${description}` : ''}`
-  const summary = firstLine ? <div class={toolInputSummary}>{firstLine}</div> : undefined
-
-  return (
-    <ToolUseLayout
-      icon={SquareTerminal}
-      toolName="TaskOutput"
-      title={title}
-      summary={summary}
-      context={context}
-    >
-      <>
-        <div class={toolInputSummaryExpanded}>
-          <Show when={task?.task_id}>
-            {`task_id: ${task!.task_id}`}
-          </Show>
-          <Show when={task?.task_type}>
-            {`\ntask_type: ${task!.task_type}`}
-          </Show>
-          <Show when={task?.exitCode !== undefined}>
-            {`\nexitCode: ${task!.exitCode}`}
-          </Show>
-        </div>
-        <Show when={output}>
-          {containsAnsi(output!)
-            ? <div class={toolResultContentAnsi} innerHTML={renderAnsi(output!)} />
-            : <div class={toolResultContentPre}>{output}</div>}
-        </Show>
-      </>
-    </ToolUseLayout>
-  )
-}
-
 export const todoWriteRenderer: MessageContentRenderer = {
   render(parsed, _role, context) {
     const content = getAssistantContent(parsed)
@@ -171,80 +113,6 @@ export const askUserQuestionRenderer: MessageContentRenderer = {
     if (!toolUse)
       return null
     return renderAskUserQuestion(toolUse as Record<string, unknown>, context)
-  },
-}
-
-export const taskOutputRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
-    const content = getAssistantContent(parsed)
-    if (!content)
-      return null
-    const toolUse = content.find(c => isObject(c) && c.type === 'tool_use' && c.name === 'TaskOutput')
-    if (!toolUse)
-      return null
-    return renderTaskOutput(toolUse as Record<string, unknown>, context)
-  },
-}
-
-/** Render Agent or Task tool_use with description, status, and subagent type. */
-export function renderAgentOrTask(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
-  const input = isObject(toolUse.input) ? toolUse.input as Record<string, unknown> : {}
-  const toolName = String(toolUse.name || 'Agent')
-  const description = String(input.description || toolName)
-  const subagentType = input.subagent_type ? String(input.subagent_type) : null
-
-  // Format title: if description starts with subagent name, use "SubAgent: rest" format
-  let titleDesc = description
-  if (subagentType) {
-    const prefix = subagentType.toLowerCase()
-    const descLower = description.toLowerCase()
-    if (descLower.startsWith(`${prefix} `))
-      titleDesc = `${subagentType}: ${description.slice(subagentType.length + 1)}`
-  }
-
-  const status = context?.childToolResultStatus
-  const hasChildren = (context?.threadChildCount ?? 0) > 0
-  const displayStatus = status
-    ? formatTaskStatus(status)
-    : (hasChildren ? 'Running' : null)
-
-  const title = `${titleDesc}${displayStatus ? ` - ${displayStatus}` : ''}${subagentType ? ` (${subagentType})` : ''}`
-
-  // Stats summary from child tool_use_result
-  const duration = context?.childTotalDurationMs
-  const tokens = context?.childTotalTokens
-  const toolUses = context?.childTotalToolUseCount
-  const parts: string[] = []
-  if (duration !== undefined)
-    parts.push(formatDuration(duration))
-  if (tokens !== undefined)
-    parts.push(`${formatNumber(tokens)} tokens`)
-  if (toolUses !== undefined)
-    parts.push(`${toolUses} tool use${toolUses === 1 ? '' : 's'}`)
-  const summary = parts.length > 0
-    ? <div class={toolInputSummary}>{parts.join(' \u00B7 ')}</div>
-    : undefined
-
-  return (
-    <ToolUseLayout
-      icon={Bot}
-      toolName={toolName}
-      title={title}
-      summary={summary}
-      context={context}
-    />
-  )
-}
-
-export const agentOrTaskRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
-    const content = getAssistantContent(parsed)
-    if (!content)
-      return null
-    const toolUse = content.find(c => isObject(c) && c.type === 'tool_use' && (c.name === 'Agent' || c.name === 'Task'))
-    if (!toolUse)
-      return null
-    return renderAgentOrTask(toolUse as Record<string, unknown>, context)
   },
 }
 

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -103,24 +103,25 @@ export const toolResultPrompt = style({
   marginBottom: 'var(--space-1)',
 })
 
-// Tool sub-detail line (monospace, aligned with description: icon 16px + gap 4px = 20px indent)
-const toolInputSubDetailBase = {
+// Tool summary line (monospace, aligned with description: icon 16px + gap 4px = 20px indent)
+const toolInputSummaryBase = {
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none' as const,
   fontSize: 'var(--text-8)',
-  color: 'var(--faint-foreground)',
+  color: 'var(--muted-foreground)',
   paddingLeft: '20px',
 }
 
-export const toolInputSubDetail = style({
-  ...toolInputSubDetailBase,
+export const toolInputSummary = style({
+  ...toolInputSummaryBase,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 })
 
-export const toolInputSubDetailExpanded = style({
-  ...toolInputSubDetailBase,
+export const toolInputSummaryExpanded = style({
+  ...toolInputSummaryBase,
+  paddingLeft: 0,
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
 })

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { todoList } from '~/components/todo/TodoList.css'
 
 // Tool use/result messages - document-style, no bubble
 export const toolMessage = style({
@@ -8,31 +9,20 @@ export const toolMessage = style({
 })
 
 // Tool use header: "» ToolName(...)"
+// Uses flex-start so multi-line titles keep icon + actions on the first line.
 export const toolUseHeader = style({
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   gap: 'var(--space-1)',
   color: 'var(--muted-foreground)',
 })
 
-// Tool result header: "« ToolName"
-export const toolResultHeader = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: 'var(--space-1)',
-  marginBottom: 'var(--space-1)',
-  color: 'var(--muted-foreground)',
-})
-
-// Icon styling
+// Icon styling — also used on the wrapper <span> so it acts as a flex-start-aligned
+// line-height box, keeping the icon vertically centred on the first text line.
 export const toolUseIcon = style({
   color: 'var(--muted-foreground)',
-  flexShrink: 0,
-})
-
-export const toolResultIcon = style({
-  color: 'var(--success)',
-  flexShrink: 0,
+  height: '1lh',
+  alignItems: 'center',
 })
 
 // Tool result content area (markdown)
@@ -103,13 +93,12 @@ export const toolResultPrompt = style({
   marginBottom: 'var(--space-1)',
 })
 
-// Tool summary line (monospace, aligned with description: icon 16px + gap 4px = 20px indent)
+// Tool summary line (monospace)
 const toolInputSummaryBase = {
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none' as const,
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
-  paddingLeft: '20px',
 }
 
 export const toolInputSummary = style({
@@ -121,7 +110,6 @@ export const toolInputSummary = style({
 
 export const toolInputSummaryExpanded = style({
   ...toolInputSummaryBase,
-  paddingLeft: 0,
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
 })
@@ -132,6 +120,7 @@ export const toolInputText = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+  minWidth: 0,
 })
 
 // Tool input code text (commands, patterns — monospaced)
@@ -142,6 +131,7 @@ export const toolInputCode = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+  minWidth: 0,
 })
 
 // Diff stat: added lines count (green)
@@ -165,7 +155,9 @@ export const toolInputPath = style({
 export const toolHeaderActions = style({
   display: 'flex',
   alignItems: 'center',
+  height: '1lh',
   gap: '2px',
+  flexShrink: 0,
   opacity: 0,
   transition: 'opacity 0.15s',
 })
@@ -199,21 +191,17 @@ export const toolBodyContent = style({
   borderLeft: '2px solid var(--border)',
 })
 
-// AskUserQuestion: question item container
-export const questionItem = style({
+// TodoList inside tool body: remove horizontal padding (toolBodyContent already provides it)
+globalStyle(`${toolBodyContent} > .${todoList}`, {
+  paddingLeft: 0,
+  paddingRight: 0,
+})
+
+// File list in Grep/Glob tool results
+export const toolFileList = style({
   paddingLeft: '20px',
-  marginTop: 'var(--space-1)',
-})
-
-// AskUserQuestion: question header label (bold)
-export const questionHeader = style({
-  fontWeight: 600,
-  color: 'var(--foreground)',
-})
-
-// AskUserQuestion: question text
-export const questionText = style({
-  color: 'var(--muted-foreground)',
+  margin: '4px 0',
+  fontSize: 'var(--text-8)',
 })
 
 // AskUserQuestion: answer text

--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -12,5 +12,5 @@ export interface IconProps extends Omit<LucideProps, 'size'> {
 export function Icon(props: IconProps) {
   const [local, rest] = splitProps(props, ['icon', 'size'])
   const px = () => iconSize[local.size]
-  return <local.icon size={px()} {...rest} />
+  return <local.icon size={px()} style={{ 'flex-shrink': '0', 'min-width': `${px()}px`, 'min-height': `${px()}px` }} {...rest} />
 }

--- a/frontend/src/components/common/SelectionQuotePopover.css.ts
+++ b/frontend/src/components/common/SelectionQuotePopover.css.ts
@@ -1,8 +1,8 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 
 export const popover = style({
-  'position': 'absolute',
-  'zIndex': 20,
+  'position': 'fixed',
+  'zIndex': 200,
   'display': 'flex',
   'borderRadius': 'var(--radius-small)',
   'border': '1px solid var(--border)',

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -470,7 +470,7 @@ export const AppShell: ParentComponent = (props) => {
         when={isWorkspaceRoute() && !workspaceNotFound()}
         fallback={<Show when={!workspaceNotFound()}><div class={styles.fullWindow}>{props.children}</div></Show>}
       >
-        <div style={{ '--mono-font-family': preferences.monoFontFamily(), 'display': 'contents' }}>
+        <div style={{ '--mono-font-family': preferences.monoFontFamily(), '--ui-font-family': preferences.uiFontFamily(), 'display': 'contents' }}>
           <Show
             when={!isMobile()}
             fallback={(

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -209,6 +209,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                 >
                   <ChatView
                     messages={chatStore.getMessages(agentId)}
+                    messageVersion={chatStore.getMessageVersion(agentId)}
                     streamingText={chatStore.state.streamingText[agentId] ?? ''}
                     agentWorking={agentStore.state.agents.find(a => a.id === agentId)?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId)) && controlStore.getRequests(agentId).length === 0}
                     messageErrors={chatStore.state.messageErrors}

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -68,35 +68,34 @@ export function createChatStore() {
     },
 
     addMessage(agentId: string, message: AgentChatMessage) {
-      setState('messagesByAgent', agentId, (prev = []) => {
-        // Check if a message with this ID already exists (thread merge:
-        // parent gets updated with child content and bumped seq).
-        // Search from end — thread merges almost always affect recent messages.
-        const existingIdx = prev.findLastIndex(m => m.id === message.id)
-        if (existingIdx !== -1) {
-          // Update in-place to avoid advancing lastSeq past messages
-          // that haven't arrived yet (which would cause the seq-based
-          // dedup below to incorrectly drop them).
-          const updated = [...prev]
-          updated[existingIdx] = message
-          return updated
-        }
+      // Thread merge: check if a message with this ID already exists.
+      // Search from end — thread merges almost always affect recent messages.
+      const messages = state.messagesByAgent[agentId]
+      const existingIdx = messages?.findLastIndex(m => m.id === message.id) ?? -1
 
-        // Fast path: message is in order (most common case).
-        if (prev.length === 0 || message.seq > prev[prev.length - 1].seq) {
-          return [...prev, message]
-        }
+      if (existingIdx !== -1) {
+        // Shallow-merge via path setter: preserves the store proxy reference
+        // so <For> keeps the existing MessageBubble (local UI state survives).
+        setState('messagesByAgent', agentId, existingIdx, message)
+      }
+      else {
+        setState('messagesByAgent', agentId, (prev = []) => {
+          // Fast path: message is in order (most common case).
+          if (prev.length === 0 || message.seq > prev[prev.length - 1].seq) {
+            return [...prev, message]
+          }
 
-        // Dedup: skip if a message with this exact seq already exists.
-        if (prev.findLastIndex(m => m.seq === message.seq) !== -1)
-          return prev
+          // Dedup: skip if a message with this exact seq already exists.
+          if (prev.findLastIndex(m => m.seq === message.seq) !== -1)
+            return prev
 
-        // Out-of-order message (e.g. catch-up replay after a thread merge
-        // advanced lastSeq): insert in sorted position by seq.
-        const insertAfter = prev.findLastIndex(m => m.seq < message.seq)
-        const insertIdx = insertAfter + 1
-        return [...prev.slice(0, insertIdx), message, ...prev.slice(insertIdx)]
-      })
+          // Out-of-order message (e.g. catch-up replay after a thread merge
+          // advanced lastSeq): insert in sorted position by seq.
+          const insertAfter = prev.findLastIndex(m => m.seq < message.seq)
+          const insertIdx = insertAfter + 1
+          return [...prev.slice(0, insertIdx), message, ...prev.slice(insertIdx)]
+        })
+      }
 
       // Track delivery errors
       if (message.deliveryError) {

--- a/frontend/src/styles/global.css.ts
+++ b/frontend/src/styles/global.css.ts
@@ -71,7 +71,8 @@ globalStyle(':root', {
     '--warning': 'rgb(245 158 11)',
     '--warning-foreground': 'rgb(34 32 30)',
 
-    // Typography — wire user-configurable mono font into Oat's variable
+    // Typography — wire user-configurable fonts into Oat's variables
+    '--font-sans': `var(--ui-font-family, system-ui, sans-serif)`,
     '--font-mono': `var(--mono-font-family, "Hack NF", Hack, "SF Mono", Consolas, monospace)`,
 
     // Borders and interactive

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -100,6 +100,26 @@ describe('createChatStore', () => {
     })
   })
 
+  it('should update message in-place on thread merge (same ID)', () => {
+    createRoot((dispose) => {
+      const store = createChatStore()
+      store.addMessage('agent1', makeMessage('msg1', 1n))
+      store.addMessage('agent1', makeMessage('msg2', 2n))
+
+      // Thread merge: same ID as msg1, bumped seq
+      const merged = makeMessage('msg1', 3n)
+      store.addMessage('agent1', merged)
+
+      const msgs = store.getMessages('agent1')
+      expect(msgs).toHaveLength(2)
+      // The merged message should be at its original position with updated seq
+      expect(msgs[0].id).toBe('msg1')
+      expect(msgs[0].seq).toBe(3n)
+      expect(msgs[1].id).toBe('msg2')
+      dispose()
+    })
+  })
+
   it('should not set error for message without deliveryError', () => {
     createRoot((dispose) => {
       const store = createChatStore()

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -625,4 +625,63 @@ describe('createChatStore', () => {
       })
     })
   })
+
+  describe('messageVersion', () => {
+    it('should return 0 for unknown agent', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        expect(store.getMessageVersion('unknown')).toBe(0)
+        dispose()
+      })
+    })
+
+    it('should increment on addMessage with a new message', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        expect(store.getMessageVersion('a1')).toBe(0)
+
+        store.addMessage('a1', makeMessage('m1', 1n))
+        expect(store.getMessageVersion('a1')).toBe(1)
+
+        store.addMessage('a1', makeMessage('m2', 2n))
+        expect(store.getMessageVersion('a1')).toBe(2)
+        dispose()
+      })
+    })
+
+    it('should increment on thread merge (same ID, updated content)', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMessage('m1', 1n))
+        expect(store.getMessageVersion('a1')).toBe(1)
+
+        // Thread merge: same ID as m1, bumped seq
+        store.addMessage('a1', makeMessage('m1', 3n))
+        expect(store.getMessageVersion('a1')).toBe(2)
+        dispose()
+      })
+    })
+
+    it('should not increment on setMessages', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.setMessages('a1', [makeMessage('m1', 1n), makeMessage('m2', 2n)])
+        expect(store.getMessageVersion('a1')).toBe(0)
+        dispose()
+      })
+    })
+
+    it('should track versions independently per agent', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMessage('m1', 1n))
+        store.addMessage('a2', makeMessage('m2', 2n))
+        store.addMessage('a1', makeMessage('m3', 3n))
+
+        expect(store.getMessageVersion('a1')).toBe(2)
+        expect(store.getMessageVersion('a2')).toBe(1)
+        dispose()
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Motivation

Several independent improvements were needed across the chat rendering layer:

1. Thread merges (where a `tool_use_result` is merged into an existing `tool_use` message) did not trigger auto-scroll because they do not change `messages.length`, only the contents of an existing item. The scroll effect had no way to detect these updates.

2. The `SelectionQuotePopover` used `position: fixed` but with a low `zIndex`, which couldn't compete with sibling sidebar panels in paint order. It was also clipped when appearing near viewport edges, and did not dismiss when focus moved to another input (clearing the text selection).

3. Tool rendering was split across many ad-hoc patterns (per-tool JSX duplicated across `taskRenderers`, `planModeRenderers`, etc.) with no consistent header layout component. Grep and Glob tool results had no structured summary view and no test coverage.

4. Diff views showed separators between hunks but provided no way to view the hidden context lines between them.

## Modifications

- Added a `messageVersion` monotonic counter to the chat store. It is incremented on every `addMessage` call, including thread merges that only update an existing message in-place. `ChatView` reads this counter in its auto-scroll effect alongside `messages.length`, so thread merges now trigger scrolling.

- Fixed `SelectionQuotePopover` by raising `zIndex` to 200 so it renders above sidebars. A `requestAnimationFrame` pass clamps the popover to viewport bounds after render to prevent edge clipping. A document-level `selectionchange` listener dismisses the popover when the selection is cleared (e.g. by focusing another input).

- Introduced `ToolUseLayout` as a shared layout component for all tool-use message headers. It owns the icon, title, `ControlResponseTag`, and `ToolHeaderActions` in one place. All specialized renderers (`taskRenderers`, `planModeRenderers`, `toolRenderers`) now delegate to `ToolUseLayout` instead of duplicating the header structure.

- Added structured summary views for Grep and Glob tool results. The Grep summary shows matched file and line counts; the Glob summary shows file count, duration, and truncation status. Summaries are derived from `tool_use_result` metadata passed through `RenderContext`.

- Extracted formatting helpers `formatGrepSummary`, `formatGlobSummary`, `formatDuration`, `formatNumber`, and `firstNonEmptyLine` into `rendererUtils.ts`. Per-tool detail rendering (file paths, diff stats, patterns) was moved to `toolDetailRenderers.tsx`.

- Added expandable gap context lines to diff views. Users can now click to incrementally reveal hidden lines between hunks. Syntax highlighting for revealed lines is applied lazily via Shiki only when expanded, so the initial diff render is not affected.

- Added test files `globRenderer.test.tsx` and `grepRenderer.test.tsx` covering the Grep/Glob summary and structured result rendering. Extended `MessageBubble.test.tsx` and `chat.store.test.ts` with coverage for the new `messageVersion` counter and bubble action rendering.

## Result

- Thread merges (e.g. when a tool result arrives and is stitched into an existing tool-use bubble) now correctly trigger auto-scroll when the user is at the bottom of the chat.
- The "Quote selection" popover appears above sidebars, is clamped to viewport bounds, and dismisses reliably when focus moves elsewhere.
- Grep and Glob tool-use bubbles now show a one-line summary in the collapsed header without requiring thread expansion.
- Diff gaps between hunks can be expanded incrementally to reveal hidden context lines, with syntax highlighting applied lazily on demand.

🤖 Generated with Claude Code
