### PR TITLE
Add git-aware file browser with diff viewer and keep tabs mounted

### DIFF
--- a/frontend/src/components/chat/diffUtils.tsx
+++ b/frontend/src/components/chat/diffUtils.tsx
@@ -5,7 +5,7 @@ import { diffLines, diffWordsWithSpace } from 'diff'
 import ArrowDownFromLine from 'lucide-solid/icons/arrow-down-from-line'
 import ArrowUpFromLine from 'lucide-solid/icons/arrow-up-from-line'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
-import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, on, onCleanup, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { guessLanguage } from '~/lib/languageMap'
 import { tokenizeAsync } from '~/lib/shikiWorkerClient'
@@ -738,9 +738,16 @@ function UnifiedDiffLine(props: { line: DiffLineEntry }): JSX.Element {
 /** Render a unified diff view from hunks. */
 function UnifiedDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string, originalFile?: string }): JSX.Element {
   const { oldTokens, newTokens } = useDiffTokens(() => props.hunks, () => props.filePath)
-  const lines = () => buildUnifiedLines(props.hunks, oldTokens(), newTokens())
+  const lines = createMemo(() => buildUnifiedLines(props.hunks, oldTokens(), newTokens()))
 
-  const originalFileLines = () => props.originalFile?.split('\n')
+  const originalFileLines = () => {
+    if (!props.originalFile)
+      return undefined
+    const lines = props.originalFile.split('\n')
+    if (lines.length > 0 && lines[lines.length - 1] === '')
+      lines.pop()
+    return lines
+  }
   const gapData = () => {
     const ofl = originalFileLines()
     if (!ofl)
@@ -859,9 +866,16 @@ function SplitDiffRow(props: { left: SplitLineEntry, right: SplitLineEntry }): J
 /** Render a split diff view from hunks (removed on left, added on right). */
 function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string, originalFile?: string }): JSX.Element {
   const { oldTokens, newTokens } = useDiffTokens(() => props.hunks, () => props.filePath)
-  const splitLines = () => buildSplitLines(props.hunks, oldTokens(), newTokens())
+  const splitLines = createMemo(() => buildSplitLines(props.hunks, oldTokens(), newTokens()))
 
-  const originalFileLines = () => props.originalFile?.split('\n')
+  const originalFileLines = () => {
+    if (!props.originalFile)
+      return undefined
+    const lines = props.originalFile.split('\n')
+    if (lines.length > 0 && lines[lines.length - 1] === '')
+      lines.pop()
+    return lines
+  }
   const gapData = () => {
     const ofl = originalFileLines()
     if (!ofl)

--- a/frontend/src/components/chat/rendererUtils.ts
+++ b/frontend/src/components/chat/rendererUtils.ts
@@ -3,7 +3,7 @@
 /** Format task status for display. */
 export function formatTaskStatus(status?: string): string {
   if (!status)
-    return 'Pending'
+    return 'Waiting for output'
   if (status === 'completed')
     return 'Complete'
   if (status === 'failed')

--- a/frontend/src/components/chat/taskOutputRenderer.test.tsx
+++ b/frontend/src/components/chat/taskOutputRenderer.test.tsx
@@ -52,8 +52,8 @@ describe('formatTaskStatus', () => {
     expect(formatTaskStatus('running')).toBe('Running')
   })
 
-  it('undefined → "Pending"', () => {
-    expect(formatTaskStatus(undefined)).toBe('Pending')
+  it('undefined → "Waiting for output"', () => {
+    expect(formatTaskStatus(undefined)).toBe('Waiting for output')
   })
 })
 
@@ -87,13 +87,13 @@ describe('renderTaskOutput', () => {
     expect(text).not.toContain('Complete')
   })
 
-  it('missing status: shows "Pending"', () => {
+  it('missing status: shows "Waiting for output"', () => {
     const text = renderText({
       childTask: {
         description: 'Some task',
       },
     })
-    expect(text).toContain('Pending')
+    expect(text).toContain('Waiting for output')
   })
 
   it('missing description: shows status only, no dash separator', () => {
@@ -134,15 +134,15 @@ describe('renderTaskOutput', () => {
     expect(text).toContain('Task ID xyz')
   })
 
-  it('all childTask properties missing (undefined): graceful "Pending" fallback', () => {
+  it('all childTask properties missing (undefined): graceful "Waiting for output" fallback', () => {
     const text = renderText({
       childTask: {},
     })
-    expect(text).toContain('Pending')
+    expect(text).toContain('Waiting for output')
   })
 
-  it('no childTask at all (no thread child yet): shows "Pending"', () => {
+  it('no childTask at all (no thread child yet): shows "Waiting for output"', () => {
     const text = renderText({})
-    expect(text).toContain('Pending')
+    expect(text).toContain('Waiting for output')
   })
 })

--- a/frontend/src/components/fileviewer/DiffModeToolbar.css.ts
+++ b/frontend/src/components/fileviewer/DiffModeToolbar.css.ts
@@ -1,10 +1,18 @@
 import { style } from '@vanilla-extract/css'
 
+// Wrapper positioned absolutely to center the toolbar without affecting layout.
+export const toolbarWrapper = style({
+  position: 'absolute',
+  top: 'var(--space-2)',
+  left: 0,
+  right: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  zIndex: 10,
+  pointerEvents: 'none',
+})
+
 export const toolbar = style({
-  'position': 'absolute',
-  'top': 'var(--space-2)',
-  'right': 'var(--space-3)',
-  'zIndex': 10,
   'display': 'flex',
   'gap': '1px',
   'borderRadius': 'var(--radius-small)',
@@ -12,6 +20,7 @@ export const toolbar = style({
   'backgroundColor': 'var(--card)',
   'opacity': 0.8,
   'transition': 'opacity 0.15s',
+  'pointerEvents': 'auto',
   ':hover': {
     opacity: 1,
   },

--- a/frontend/src/components/fileviewer/DiffModeToolbar.css.ts
+++ b/frontend/src/components/fileviewer/DiffModeToolbar.css.ts
@@ -1,0 +1,56 @@
+import { style } from '@vanilla-extract/css'
+
+export const toolbar = style({
+  'position': 'absolute',
+  'top': 'var(--space-2)',
+  'right': 'var(--space-3)',
+  'zIndex': 10,
+  'display': 'flex',
+  'gap': '1px',
+  'borderRadius': 'var(--radius-small)',
+  'border': '1px solid var(--border)',
+  'backgroundColor': 'var(--card)',
+  'opacity': 0.8,
+  'transition': 'opacity 0.15s',
+  ':hover': {
+    opacity: 1,
+  },
+})
+
+export const toolbarButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '28px',
+  paddingInline: 'var(--space-2)',
+  cursor: 'pointer',
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+  transition: 'color 0.1s, background-color 0.1s',
+  whiteSpace: 'nowrap',
+  selectors: {
+    '&:first-child': {
+      borderRadius: 'var(--radius-small) 0 0 var(--radius-small)',
+    },
+    '&:last-child': {
+      borderRadius: '0 var(--radius-small) var(--radius-small) 0',
+    },
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+export const toolbarButtonActive = style({
+  backgroundColor: 'var(--accent)',
+  color: 'var(--foreground)',
+})
+
+export const separator = style({
+  width: '1px',
+  alignSelf: 'stretch',
+  backgroundColor: 'var(--border)',
+  flexShrink: 0,
+})

--- a/frontend/src/components/fileviewer/DiffModeToolbar.tsx
+++ b/frontend/src/components/fileviewer/DiffModeToolbar.tsx
@@ -1,0 +1,48 @@
+import type { Component } from 'solid-js'
+import type { FileDiffBase, FileViewMode } from '~/stores/tab.store'
+import { Show } from 'solid-js'
+import * as styles from './DiffModeToolbar.css'
+
+export interface DiffModeToolbarProps {
+  mode: FileViewMode
+  diffBase?: FileDiffBase
+  hasStagedAndUnstaged?: boolean
+  onModeChange: (mode: FileViewMode) => void
+  onDiffBaseChange?: (base: FileDiffBase) => void
+}
+
+export const DiffModeToolbar: Component<DiffModeToolbarProps> = (props) => {
+  const btn = (label: string, mode: FileViewMode, testId?: string) => (
+    <button
+      class={`${styles.toolbarButton}${props.mode === mode ? ` ${styles.toolbarButtonActive}` : ''}`}
+      onClick={() => props.onModeChange(mode)}
+      data-testid={testId}
+    >
+      {label}
+    </button>
+  )
+
+  return (
+    <div class={styles.toolbar} data-testid="diff-mode-toolbar">
+      {btn('HEAD', 'head', 'diff-mode-head')}
+      {btn('Working', 'working', 'diff-mode-working')}
+      {btn('Unified', 'unified-diff', 'diff-mode-unified')}
+      {btn('Split', 'split-diff', 'diff-mode-split')}
+      <Show when={props.hasStagedAndUnstaged}>
+        <div class={styles.separator} />
+        <button
+          class={`${styles.toolbarButton}${props.diffBase === 'head-vs-working' ? ` ${styles.toolbarButtonActive}` : ''}`}
+          onClick={() => props.onDiffBaseChange?.('head-vs-working')}
+        >
+          vs Working
+        </button>
+        <button
+          class={`${styles.toolbarButton}${props.diffBase === 'head-vs-staged' ? ` ${styles.toolbarButtonActive}` : ''}`}
+          onClick={() => props.onDiffBaseChange?.('head-vs-staged')}
+        >
+          vs Staged
+        </button>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/DiffModeToolbar.tsx
+++ b/frontend/src/components/fileviewer/DiffModeToolbar.tsx
@@ -23,26 +23,28 @@ export const DiffModeToolbar: Component<DiffModeToolbarProps> = (props) => {
   )
 
   return (
-    <div class={styles.toolbar} data-testid="diff-mode-toolbar">
-      {btn('HEAD', 'head', 'diff-mode-head')}
-      {btn('Working', 'working', 'diff-mode-working')}
-      {btn('Unified', 'unified-diff', 'diff-mode-unified')}
-      {btn('Split', 'split-diff', 'diff-mode-split')}
-      <Show when={props.hasStagedAndUnstaged}>
-        <div class={styles.separator} />
-        <button
-          class={`${styles.toolbarButton}${props.diffBase === 'head-vs-working' ? ` ${styles.toolbarButtonActive}` : ''}`}
-          onClick={() => props.onDiffBaseChange?.('head-vs-working')}
-        >
-          vs Working
-        </button>
-        <button
-          class={`${styles.toolbarButton}${props.diffBase === 'head-vs-staged' ? ` ${styles.toolbarButtonActive}` : ''}`}
-          onClick={() => props.onDiffBaseChange?.('head-vs-staged')}
-        >
-          vs Staged
-        </button>
-      </Show>
+    <div class={styles.toolbarWrapper}>
+      <div class={styles.toolbar} data-testid="diff-mode-toolbar">
+        {btn('HEAD', 'head', 'diff-mode-head')}
+        {btn('Working', 'working', 'diff-mode-working')}
+        {btn('Unified', 'unified-diff', 'diff-mode-unified')}
+        {btn('Split', 'split-diff', 'diff-mode-split')}
+        <Show when={props.hasStagedAndUnstaged}>
+          <div class={styles.separator} />
+          <button
+            class={`${styles.toolbarButton}${props.diffBase === 'head-vs-working' ? ` ${styles.toolbarButtonActive}` : ''}`}
+            onClick={() => props.onDiffBaseChange?.('head-vs-working')}
+          >
+            vs Working
+          </button>
+          <button
+            class={`${styles.toolbarButton}${props.diffBase === 'head-vs-staged' ? ` ${styles.toolbarButtonActive}` : ''}`}
+            onClick={() => props.onDiffBaseChange?.('head-vs-staged')}
+          >
+            vs Staged
+          </button>
+        </Show>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { codeViewContainer } from '~/components/chat/codeViewStyles.css'
+import { diffContainer, diffSplitContainer } from '~/components/chat/diffStyles.css'
 
 export const container = style({
   display: 'flex',
@@ -13,6 +14,13 @@ export const content = style({
   flex: 1,
   overflow: 'auto',
   minHeight: 0,
+})
+
+// Remove border/margin from diff views when used inside the file viewer.
+globalStyle(`${content} ${diffContainer}, ${content} ${diffSplitContainer}`, {
+  border: 'none',
+  borderRadius: 0,
+  marginTop: 0,
 })
 
 export const statusBar = style({

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -169,6 +169,14 @@ export const FileViewer: Component<{
 
   const showToolbar = () => props.fileViewMode !== undefined
 
+  // Show the outer (floating) mention button for all modes except when
+  // ViewToggle handles it (markdown and SVG image views have the mention
+  // button integrated into their toggle control which already floats).
+  const hasViewToggle = () =>
+    !isDiffMode() && !isRefMode()
+    && (viewMode() === 'markdown' || (viewMode() === 'image' && props.filePath.toLowerCase().endsWith('.svg')))
+  const showOuterMention = () => !!props.onMention && !hasViewToggle()
+
   const diffHunks = createMemo(() => {
     const old = diffOldContent()
     const nw = diffNewContent()
@@ -264,7 +272,7 @@ export const FileViewer: Component<{
           onDiffBaseChange={base => props.onFileDiffBaseChange?.(base)}
         />
       </Show>
-      <Show when={(isDiffMode() || isRefMode()) && props.onMention}>
+      <Show when={showOuterMention()}>
         <div class={styles.viewToggle}>
           <button
             class={styles.viewToggleButton}
@@ -291,7 +299,6 @@ export const FileViewer: Component<{
               filePath={props.filePath}
               totalSize={diffOldContent()!.length}
               onQuote={props.onQuote}
-              onMention={props.onMention}
             />
           </Show>
           <Show when={isRefMode() && !diffLoading() && diffOldContent() === null}>
@@ -321,7 +328,6 @@ export const FileViewer: Component<{
                 filePath={props.filePath}
                 totalSize={totalSize()}
                 onQuote={props.onQuote}
-                onMention={props.onMention}
               />
             </Show>
             <Show when={viewMode() === 'markdown' && content()}>

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -1,8 +1,14 @@
 import type { Component } from 'solid-js'
+import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { FileViewMode } from '~/lib/fileType'
+import type { FileDiffBase, FileViewMode as TabFileViewMode } from '~/stores/tab.store'
 import { createEffect, createSignal, on, Show } from 'solid-js'
-import { fileClient } from '~/api/clients'
+import { fileClient, gitClient } from '~/api/clients'
+import { apiCallTimeout } from '~/api/transport'
+import { DiffView, rawDiffToHunks } from '~/components/chat/diffUtils'
+import { GitFileRef } from '~/generated/leapmux/v1/git_pb'
 import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
+import { DiffModeToolbar } from './DiffModeToolbar'
 import * as styles from './FileViewer.css'
 import { HexView } from './HexView'
 import { ImageFileView } from './ImageFileView'
@@ -28,6 +34,12 @@ export const FileViewer: Component<{
   onDisplayModeChange?: (mode: string) => void
   onQuote?: (text: string, startLine?: number, endLine?: number) => void
   onMention?: () => void
+  /** Tab-level diff mode. */
+  fileViewMode?: TabFileViewMode
+  fileDiffBase?: FileDiffBase
+  hasStagedAndUnstaged?: boolean
+  onFileViewModeChange?: (mode: TabFileViewMode) => void
+  onFileDiffBaseChange?: (base: FileDiffBase) => void
 }> = (props) => {
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal<string | null>(null)
@@ -36,6 +48,15 @@ export const FileViewer: Component<{
   const [viewMode, setViewMode] = createSignal<FileViewMode>('text')
   const [imageTooLarge, setImageTooLarge] = createSignal(false)
 
+  // Diff mode state
+  const [diffOldContent, setDiffOldContent] = createSignal<string | null>(null)
+  const [diffNewContent, setDiffNewContent] = createSignal<string | null>(null)
+  const [diffLoading, setDiffLoading] = createSignal(false)
+
+  const isDiffMode = () => props.fileViewMode === 'unified-diff' || props.fileViewMode === 'split-diff'
+  const isRefMode = () => props.fileViewMode === 'head' || props.fileViewMode === 'staged'
+
+  // Load working copy content.
   createEffect(on(
     () => [props.workerId, props.filePath] as const,
     async ([workerId, filePath]) => {
@@ -45,12 +66,10 @@ export const FileViewer: Component<{
       setImageTooLarge(false)
 
       try {
-        // First stat the file to get its size
         const statResp = await fileClient.statFile({ workerId, path: filePath })
         const fileSize = Number(statResp.info?.size ?? 0n)
         setTotalSize(fileSize)
 
-        // For images, check size before reading
         if (isImageExtension(filePath)) {
           if (fileSize > MAX_FILE_SIZE) {
             setImageTooLarge(true)
@@ -60,7 +79,6 @@ export const FileViewer: Component<{
           }
         }
 
-        // Read the file content (up to 256 KiB)
         const readResp = await fileClient.readFile({
           workerId,
           path: filePath,
@@ -80,63 +98,171 @@ export const FileViewer: Component<{
     },
   ))
 
+  // Load diff content when in diff or ref mode.
+  createEffect(on(
+    () => [props.workerId, props.filePath, props.fileViewMode, props.fileDiffBase] as const,
+    async ([workerId, filePath, fvMode, diffBase]) => {
+      if (!fvMode || fvMode === 'working') {
+        setDiffOldContent(null)
+        setDiffNewContent(null)
+        return
+      }
+
+      setDiffLoading(true)
+      try {
+        if (fvMode === 'head' || fvMode === 'staged') {
+          const ref = fvMode === 'head' ? GitFileRef.HEAD : GitFileRef.STAGED
+          const resp = await gitClient.readGitFile({ workerId, path: filePath, ref }, apiCallTimeout())
+          if (resp.exists) {
+            setDiffOldContent(new TextDecoder().decode(resp.content))
+          }
+          else {
+            setDiffOldContent(null)
+          }
+        }
+        else if (fvMode === 'unified-diff' || fvMode === 'split-diff') {
+          // Fetch HEAD version.
+          const headResp = await gitClient.readGitFile({
+            workerId,
+            path: filePath,
+            ref: GitFileRef.HEAD,
+          }, apiCallTimeout())
+          const headContent = headResp.exists ? new TextDecoder().decode(headResp.content) : ''
+          setDiffOldContent(headContent)
+
+          // Fetch the "new" version.
+          if (diffBase === 'head-vs-staged') {
+            const stagedResp = await gitClient.readGitFile({
+              workerId,
+              path: filePath,
+              ref: GitFileRef.STAGED,
+            }, apiCallTimeout())
+            setDiffNewContent(stagedResp.exists ? new TextDecoder().decode(stagedResp.content) : '')
+          }
+          else {
+            // head-vs-working: use the working copy content already loaded.
+            const bytes = content()
+            setDiffNewContent(bytes ? new TextDecoder().decode(bytes) : '')
+          }
+        }
+      }
+      catch {
+        // If git read fails, clear diff content.
+        setDiffOldContent(null)
+        setDiffNewContent(null)
+      }
+      finally {
+        setDiffLoading(false)
+      }
+    },
+  ))
+
   const isTruncated = () => content() !== null && content()!.length < totalSize()
+
+  const showToolbar = () => props.fileViewMode !== undefined
+
+  const diffHunks = () => {
+    const old = diffOldContent()
+    const nw = diffNewContent()
+    if (old === null || nw === null)
+      return []
+    return rawDiffToHunks(old, nw)
+  }
+
+  const diffViewPref = (): DiffViewPreference =>
+    props.fileViewMode === 'split-diff' ? 'split' : 'unified'
 
   return (
     <div class={styles.container}>
+      <Show when={showToolbar()}>
+        <DiffModeToolbar
+          mode={props.fileViewMode!}
+          diffBase={props.fileDiffBase}
+          hasStagedAndUnstaged={props.hasStagedAndUnstaged}
+          onModeChange={mode => props.onFileViewModeChange?.(mode)}
+          onDiffBaseChange={base => props.onFileDiffBaseChange?.(base)}
+        />
+      </Show>
       <div class={styles.content}>
-        <Show when={loading()}>
+        <Show when={loading() || diffLoading()}>
           <div class={styles.loadingState}>Loading...</div>
         </Show>
         <Show when={error()}>
           <div class={styles.errorState}>{error()}</div>
         </Show>
         <Show when={!loading() && !error()}>
-          <Show when={imageTooLarge()}>
-            <div class={styles.imageSizeError}>
-              {`Image too large to preview (${formatSize(totalSize())})`}
-            </div>
-          </Show>
-          <Show when={viewMode() === 'text' && content()}>
+          {/* Ref mode: show HEAD or staged content as text */}
+          <Show when={isRefMode() && !diffLoading() && diffOldContent() !== null}>
             <TextFileView
-              content={content()!}
+              content={new TextEncoder().encode(diffOldContent()!)}
               filePath={props.filePath}
-              totalSize={totalSize()}
+              totalSize={diffOldContent()!.length}
               onQuote={props.onQuote}
               onMention={props.onMention}
             />
           </Show>
-          <Show when={viewMode() === 'markdown' && content()}>
-            <MarkdownFileView
-              content={content()!}
+          <Show when={isRefMode() && !diffLoading() && diffOldContent() === null}>
+            <div class={styles.errorState}>File does not exist at this ref</div>
+          </Show>
+
+          {/* Diff mode: show unified or split diff */}
+          <Show when={isDiffMode() && !diffLoading() && diffOldContent() !== null && diffNewContent() !== null}>
+            <DiffView
+              hunks={diffHunks()}
+              view={diffViewPref()}
               filePath={props.filePath}
-              totalSize={totalSize()}
-              displayMode={props.displayMode}
-              onDisplayModeChange={props.onDisplayModeChange}
-              onQuote={props.onQuote}
-              onMention={props.onMention}
+              originalFile={diffOldContent() ?? undefined}
             />
           </Show>
-          <Show when={viewMode() === 'image' && content() && !imageTooLarge()}>
-            <ImageFileView
-              content={content()!}
-              filePath={props.filePath}
-              totalSize={totalSize()}
-              displayMode={props.displayMode}
-              onDisplayModeChange={props.onDisplayModeChange}
-              onQuote={props.onQuote}
-              onMention={props.onMention}
-            />
-          </Show>
-          <Show when={viewMode() === 'binary' && content()}>
-            <HexView
-              content={content()!}
-              totalSize={totalSize()}
-            />
+
+          {/* Working mode or no mode: show normal file content */}
+          <Show when={!isDiffMode() && !isRefMode()}>
+            <Show when={imageTooLarge()}>
+              <div class={styles.imageSizeError}>
+                {`Image too large to preview (${formatSize(totalSize())})`}
+              </div>
+            </Show>
+            <Show when={viewMode() === 'text' && content()}>
+              <TextFileView
+                content={content()!}
+                filePath={props.filePath}
+                totalSize={totalSize()}
+                onQuote={props.onQuote}
+                onMention={props.onMention}
+              />
+            </Show>
+            <Show when={viewMode() === 'markdown' && content()}>
+              <MarkdownFileView
+                content={content()!}
+                filePath={props.filePath}
+                totalSize={totalSize()}
+                displayMode={props.displayMode}
+                onDisplayModeChange={props.onDisplayModeChange}
+                onQuote={props.onQuote}
+                onMention={props.onMention}
+              />
+            </Show>
+            <Show when={viewMode() === 'image' && content() && !imageTooLarge()}>
+              <ImageFileView
+                content={content()!}
+                filePath={props.filePath}
+                totalSize={totalSize()}
+                displayMode={props.displayMode}
+                onDisplayModeChange={props.onDisplayModeChange}
+                onQuote={props.onQuote}
+                onMention={props.onMention}
+              />
+            </Show>
+            <Show when={viewMode() === 'binary' && content()}>
+              <HexView
+                content={content()!}
+                totalSize={totalSize()}
+              />
+            </Show>
           </Show>
         </Show>
       </div>
-      <Show when={!loading() && !error() && (totalSize() > 0 || isTruncated())}>
+      <Show when={!loading() && !error() && !isDiffMode() && !isRefMode() && (totalSize() > 0 || isTruncated())}>
         <div class={styles.statusBar}>
           <Show when={isTruncated()}>
             <span class={styles.truncationWarning}>

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -2,10 +2,13 @@ import type { Component } from 'solid-js'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { FileViewMode } from '~/lib/fileType'
 import type { FileDiffBase, FileViewMode as TabFileViewMode } from '~/stores/tab.store'
-import { createEffect, createSignal, on, Show } from 'solid-js'
+import AtSign from 'lucide-solid/icons/at-sign'
+import { createEffect, createMemo, createSignal, on, onCleanup, Show } from 'solid-js'
 import { fileClient, gitClient } from '~/api/clients'
 import { apiCallTimeout } from '~/api/transport'
+import { diffAdded, diffRemoved } from '~/components/chat/diffStyles.css'
 import { DiffView, rawDiffToHunks } from '~/components/chat/diffUtils'
+import { Icon } from '~/components/common/Icon'
 import { GitFileRef } from '~/generated/leapmux/v1/git_pb'
 import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
 import { DiffModeToolbar } from './DiffModeToolbar'
@@ -140,9 +143,14 @@ export const FileViewer: Component<{
             setDiffNewContent(stagedResp.exists ? new TextDecoder().decode(stagedResp.content) : '')
           }
           else {
-            // head-vs-working: use the working copy content already loaded.
-            const bytes = content()
-            setDiffNewContent(bytes ? new TextDecoder().decode(bytes) : '')
+            // head-vs-working: read working copy from disk to avoid race
+            // with the content-loading effect that runs concurrently.
+            const workingResp = await fileClient.readFile({
+              workerId,
+              path: filePath,
+              limit: BigInt(MAX_FILE_SIZE),
+            })
+            setDiffNewContent(new TextDecoder().decode(workingResp.content))
           }
         }
       }
@@ -161,16 +169,89 @@ export const FileViewer: Component<{
 
   const showToolbar = () => props.fileViewMode !== undefined
 
-  const diffHunks = () => {
+  const diffHunks = createMemo(() => {
     const old = diffOldContent()
     const nw = diffNewContent()
     if (old === null || nw === null)
       return []
     return rawDiffToHunks(old, nw)
-  }
+  })
 
   const diffViewPref = (): DiffViewPreference =>
     props.fileViewMode === 'split-diff' ? 'split' : 'unified'
+
+  let contentRef: HTMLDivElement | undefined
+
+  // Include the view mode in the scroll key so each mode has independent scroll.
+  // eslint-disable-next-line solid/reactivity
+  const scrollStoragePrefix = `leapmux:fileScroll:${props.workerId}:${props.filePath}`
+  const scrollStorageKey = () => `${scrollStoragePrefix}:${props.fileViewMode ?? 'working'}`
+
+  // Save scroll position when the view mode changes or on unmount.
+  let lastSavedKey: string | undefined
+  const saveScrollPosition = () => {
+    const key = lastSavedKey ?? scrollStorageKey()
+    if (contentRef && contentRef.scrollTop > 0) {
+      sessionStorage.setItem(key, String(contentRef.scrollTop))
+    }
+    else {
+      sessionStorage.removeItem(key)
+    }
+  }
+  onCleanup(saveScrollPosition)
+
+  // Restore saved scroll position or scroll to first diff entry.
+  createEffect(on(
+    () => [loading(), diffLoading(), isDiffMode(), diffHunks().length, props.fileViewMode] as const,
+    ([fileLoading, dLoading, diffMode, hunkCount, _fvMode]) => {
+      if (fileLoading || dLoading || !contentRef)
+        return
+
+      // Save scroll for the previous mode before switching.
+      if (lastSavedKey && lastSavedKey !== scrollStorageKey())
+        saveScrollPosition()
+      lastSavedKey = scrollStorageKey()
+
+      const savedStr = sessionStorage.getItem(scrollStorageKey())
+      if (savedStr != null) {
+        const scrollTop = Number(savedStr)
+        sessionStorage.removeItem(scrollStorageKey())
+        requestAnimationFrame(() => {
+          if (contentRef)
+            contentRef.scrollTop = scrollTop
+        })
+        return
+      }
+
+      if (!diffMode || hunkCount === 0)
+        return
+
+      requestAnimationFrame(() => {
+        const container = contentRef!
+        const diffElements = container.querySelectorAll(`.${diffAdded}, .${diffRemoved}`)
+        if (diffElements.length === 0)
+          return
+
+        const firstEl = diffElements[0] as HTMLElement
+        const lastEl = diffElements[diffElements.length - 1] as HTMLElement
+        const containerRect = container.getBoundingClientRect()
+        const firstRect = firstEl.getBoundingClientRect()
+        const lastRect = lastEl.getBoundingClientRect()
+
+        // Calculate the midpoint of the diff area relative to scroll.
+        const diffTop = firstRect.top - containerRect.top + container.scrollTop
+        const diffBottom = lastRect.bottom - containerRect.top + container.scrollTop
+        const diffMid = (diffTop + diffBottom) / 2
+        const viewportHeight = container.clientHeight
+
+        // Center the midpoint, but ensure the first diff line stays visible.
+        let targetScroll = diffMid - viewportHeight / 2
+        targetScroll = Math.min(targetScroll, diffTop)
+        targetScroll = Math.max(0, targetScroll)
+        container.scrollTop = targetScroll
+      })
+    },
+  ))
 
   return (
     <div class={styles.container}>
@@ -183,7 +264,19 @@ export const FileViewer: Component<{
           onDiffBaseChange={base => props.onFileDiffBaseChange?.(base)}
         />
       </Show>
-      <div class={styles.content}>
+      <Show when={(isDiffMode() || isRefMode()) && props.onMention}>
+        <div class={styles.viewToggle}>
+          <button
+            class={styles.viewToggleButton}
+            onClick={() => props.onMention?.()}
+            title="Mention in the chat"
+            data-testid="file-mention-button"
+          >
+            <Icon icon={AtSign} size="sm" />
+          </button>
+        </div>
+      </Show>
+      <div class={styles.content} ref={contentRef}>
         <Show when={loading() || diffLoading()}>
           <div class={styles.loadingState}>Loading...</div>
         </Show>

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -1,9 +1,7 @@
 import type { JSX } from 'solid-js'
 import type { ZoomMode } from './ImageToolbar'
 import type { ViewMode } from './ViewToggle'
-import AtSign from 'lucide-solid/icons/at-sign'
-import { createEffect, createMemo, createSignal, Match, onCleanup, Show, Switch, untrack } from 'solid-js'
-import { Icon } from '~/components/common/Icon'
+import { createEffect, createMemo, createSignal, Match, onCleanup, Switch, untrack } from 'solid-js'
 import { isSvgExtension } from '~/lib/fileType'
 import * as styles from './FileViewer.css'
 import { ImageToolbar, ZOOM_MAX, ZOOM_MIN } from './ImageToolbar'
@@ -204,21 +202,7 @@ export function ImageFileView(props: {
   return (
     <Switch>
       <Match when={!isSvg()}>
-        <div style={{ position: 'relative', height: '100%' }}>
-          <Show when={props.onMention}>
-            <div class={styles.viewToggle}>
-              <button
-                class={styles.viewToggleButton}
-                onClick={() => props.onMention?.()}
-                title="Mention in the chat"
-                data-testid="file-mention-button"
-              >
-                <Icon icon={AtSign} size="sm" />
-              </button>
-            </div>
-          </Show>
-          {renderImage()}
-        </div>
+        {renderImage()}
       </Match>
       <Match when={isSvg()}>
         <div class={styles.toggleViewContainer}>

--- a/frontend/src/components/fileviewer/TextFileView.tsx
+++ b/frontend/src/components/fileviewer/TextFileView.tsx
@@ -1,9 +1,7 @@
 import type { JSX } from 'solid-js'
 import type { ParsedCatLine } from '~/components/chat/ReadResultView'
-import AtSign from 'lucide-solid/icons/at-sign'
-import { createMemo, Show } from 'solid-js'
+import { createMemo } from 'solid-js'
 import { ReadResultView } from '~/components/chat/ReadResultView'
-import { Icon } from '~/components/common/Icon'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import * as styles from './FileViewer.css'
 
@@ -12,7 +10,6 @@ export function TextFileView(props: {
   filePath: string
   totalSize: number
   onQuote?: (text: string, startLine?: number, endLine?: number) => void
-  onMention?: () => void
 }): JSX.Element {
   let containerRef: HTMLDivElement | undefined
   const text = createMemo(() => new TextDecoder().decode(props.content))
@@ -29,19 +26,7 @@ export function TextFileView(props: {
   })
 
   return (
-    <div ref={containerRef} class={styles.textViewContainer} style={{ position: 'relative' }}>
-      <Show when={props.onMention}>
-        <div class={styles.viewToggle}>
-          <button
-            class={styles.viewToggleButton}
-            onClick={() => props.onMention?.()}
-            title="Mention in the chat"
-            data-testid="file-mention-button"
-          >
-            <Icon icon={AtSign} size="sm" />
-          </button>
-        </div>
-      </Show>
+    <div ref={containerRef} class={styles.textViewContainer}>
       <SelectionQuotePopover
         containerRef={containerRef}
         onQuote={(text, startLine, endLine) => props.onQuote?.(text, startLine, endLine)}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1,7 +1,7 @@
 import type { ParentComponent } from 'solid-js'
 import type { SidebarElementsOpts } from './SidebarElements'
 import { useLocation, useNavigate, useParams, useSearchParams } from '@solidjs/router'
-import { createEffect, createMemo, createSignal, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, on, Show } from 'solid-js'
 import { agentLoadingTimeoutMs, apiCallTimeout } from '~/api/transport'
 import { NotFoundPage } from '~/components/common/NotFoundPage'
 import { isWorkspaceMutatable } from '~/components/shell/sectionUtils'
@@ -324,7 +324,6 @@ export const AppShell: ParentComponent = (props) => {
     termOps,
     activeTab,
     getCurrentTabContext,
-    persistLayout,
     focusEditor: () => focusEditorRef.current?.(),
     getScrollState: () => getScrollStateRef.current?.(),
     setFileTreePath,
@@ -469,16 +468,23 @@ export const AppShell: ParentComponent = (props) => {
     },
   })
 
-  // Refresh git status when the workspace/worker context changes.
-  createEffect(() => {
-    const ctx = getCurrentTabContext()
-    if (ctx.workerId && ctx.workingDir) {
-      gitFileStatusStore.refresh(ctx.workerId, ctx.workingDir)
-    }
-    else {
-      gitFileStatusStore.clear()
-    }
-  })
+  // Refresh git status only when workerId or workingDir actually changes
+  // (not on every tab switch within the same worker context).
+  createEffect(on(
+    () => {
+      const ctx = getCurrentTabContext()
+      return `${ctx.workerId}\0${ctx.workingDir}`
+    },
+    () => {
+      const ctx = getCurrentTabContext()
+      if (ctx.workerId && ctx.workingDir) {
+        gitFileStatusStore.refresh(ctx.workerId, ctx.workingDir)
+      }
+      else {
+        gitFileStatusStore.clear()
+      }
+    },
+  ))
 
   return (
     <>

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -18,6 +18,7 @@ import { createAgentStore } from '~/stores/agent.store'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
 import { createChatStore } from '~/stores/chat.store'
 import { createControlStore } from '~/stores/control.store'
+import { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
 import { createLayoutStore } from '~/stores/layout.store'
 import { createSectionStore } from '~/stores/section.store'
 import { createTabStore } from '~/stores/tab.store'
@@ -56,6 +57,7 @@ export const AppShell: ParentComponent = (props) => {
   const controlStore = createControlStore()
   const agentSessionStore = createAgentSessionStore()
   const layoutStore = createLayoutStore()
+  const gitFileStatusStore = createGitFileStatusStore()
   const [fileTreePath, setFileTreePath] = createSignal('')
   const [showNewWorkspace, setShowNewWorkspace] = createSignal(false)
   const [preselectedWorkerId, setPreselectedWorkerId] = createSignal<string | undefined>(undefined)
@@ -425,6 +427,7 @@ export const AppShell: ParentComponent = (props) => {
     focusEditorRef,
     getScrollStateRef,
     forceScrollToBottomRef,
+    gitFileStatusStore,
   })
 
   // Sidebar element factories
@@ -455,6 +458,26 @@ export const AppShell: ParentComponent = (props) => {
     get showTodos() { return showTodos() },
     get activeTodos() { return activeTodos() },
     termOps,
+    gitStatusStore: gitFileStatusStore,
+    get activeFilePath() {
+      const active = tabStore.activeTab()
+      return active?.type === TabType.FILE ? active.filePath : undefined
+    },
+    get hasActiveFileTab() {
+      const active = tabStore.activeTab()
+      return active?.type === TabType.FILE
+    },
+  })
+
+  // Refresh git status when the workspace/worker context changes.
+  createEffect(() => {
+    const ctx = getCurrentTabContext()
+    if (ctx.workerId && ctx.workingDir) {
+      gitFileStatusStore.refresh(ctx.workerId, ctx.workingDir)
+    }
+    else {
+      gitFileStatusStore.clear()
+    }
   })
 
   return (

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -375,9 +375,17 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                       />
                     </Show>
                     <span class={styles.sidebarTitle}>{section().title}</span>
-                    <div class={styles.sidebarHeaderActions}>
-                      {section().headerActions}
-                    </div>
+                    <Show when={sectionOpen() && section().headerActions}>
+                      <div
+                        class={styles.sidebarHeaderActions}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          e.preventDefault()
+                        }}
+                      >
+                        {section().headerActions}
+                      </div>
+                    </Show>
                     <Show when={index() === 0 && props.onCollapse && props.side === 'right'}>
                       <IconButton
                         icon={CollapseIcon}

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { TodoItem } from '~/stores/chat.store'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import type { createSectionStore } from '~/stores/section.store'
 
 import CircleUser from 'lucide-solid/icons/circle-user'
@@ -9,7 +10,7 @@ import Plus from 'lucide-solid/icons/plus'
 import { createMemo, onCleanup, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
-import { DirectoryTree } from '~/components/tree/DirectoryTree'
+import { FilesSection } from '~/components/tree/FilesSection'
 import { emptySection as emptySectionStyle, dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
@@ -46,9 +47,12 @@ interface LeftSidebarProps {
   homeDir: string
   fileTreePath: string
   onFileSelect: (path: string) => void
-  onFileOpen?: (path: string) => void
+  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
   onFileMention?: (path: string) => void
   onOpenTerminal?: (dirPath: string) => void
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
+  activeFilePath?: string
+  hasActiveFileTab?: boolean
   showTodos: boolean
   activeTodos: TodoItem[]
 }
@@ -199,7 +203,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
         })
       }
       else if (sectionType === SectionType.FILES) {
-        // FILES section moved to the left sidebar — render DirectoryTree
+        // FILES section moved to the left sidebar — render FilesSection
         sections.push({
           id: sectionId,
           title: group.section.name,
@@ -214,16 +218,18 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
               when={props.workerId}
               fallback={<div class={emptySectionStyle}>No tab selected</div>}
             >
-              <DirectoryTree
+              <FilesSection
                 workerId={props.workerId}
-                showFiles
-                selectedPath={props.fileTreePath}
-                onSelect={props.onFileSelect}
+                workingDir={props.workingDir}
+                homeDir={props.homeDir}
+                fileTreePath={props.fileTreePath}
+                onFileSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
                 onMention={props.onFileMention}
                 onOpenTerminal={props.onOpenTerminal}
-                rootPath={props.workingDir || '~'}
-                homeDir={props.homeDir}
+                gitStatusStore={props.gitStatusStore!}
+                activeFilePath={props.activeFilePath}
+                hasActiveFileTab={props.hasActiveFileTab ?? false}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { TodoItem } from '~/stores/chat.store'
 import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
@@ -7,10 +8,10 @@ import type { createSectionStore } from '~/stores/section.store'
 
 import CircleUser from 'lucide-solid/icons/circle-user'
 import Plus from 'lucide-solid/icons/plus'
-import { createMemo, onCleanup, Show } from 'solid-js'
+import { createMemo, createSignal, onCleanup, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
-import { FilesSection } from '~/components/tree/FilesSection'
+import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
 import { emptySection as emptySectionStyle, dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
@@ -65,6 +66,11 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
 
   // Captured from CollapsibleSidebar's expandSectionRef callback.
   let expandSection: ((sectionId: string) => void) | undefined
+
+  // Handle for the FilesSection imperative API (e.g., collapseAll).
+  // Declared as a signal so reactive reads (e.g., isFiltered in header
+  // actions) re-evaluate when the handle is assigned after FilesSection mounts.
+  const [filesSectionHandle, setFilesSectionHandle] = createSignal<FilesSectionHandle | undefined>()
 
   /* eslint-disable solid/reactivity -- callbacks are stable references */
   const wsOps = useWorkspaceOperations({
@@ -213,6 +219,23 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
           collapsible: true,
           draggable: true,
           testId: `section-header-${sectionTypeTestId(sectionType)}`,
+          headerActions: (
+            <FilesSectionHeaderActions
+              onCollapseAll={() => filesSectionHandle()?.collapseAll()}
+              onLocateFile={() => {
+                if (props.activeFilePath)
+                  props.onFileSelect(props.activeFilePath)
+              }}
+              onRefresh={() => {
+                if (props.workerId && props.workingDir)
+                  props.gitStatusStore?.refresh(props.workerId, props.workingDir)
+              }}
+              hasActiveFileTab={props.hasActiveFileTab ?? false}
+              isFiltered={() => filesSectionHandle()?.isFiltered() ?? false}
+              flatListMode={() => filesSectionHandle()?.flatListMode() ?? false}
+              onToggleFlatList={() => filesSectionHandle()?.toggleFlatListMode()}
+            />
+          ),
           content: () => (
             <Show
               when={props.workerId}
@@ -230,6 +253,7 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
                 gitStatusStore={props.gitStatusStore!}
                 activeFilePath={props.activeFilePath}
                 hasActiveFileTab={props.hasActiveFileTab ?? false}
+                ref={setFilesSectionHandle}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -1,15 +1,16 @@
 import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { TodoItem } from '~/stores/chat.store'
 import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import type { createSectionStore } from '~/stores/section.store'
 
 import Plus from 'lucide-solid/icons/plus'
-import { createMemo, Show } from 'solid-js'
+import { createMemo, createSignal, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
-import { FilesSection } from '~/components/tree/FilesSection'
+import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
 import * as swlStyles from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
@@ -60,6 +61,11 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
 
   // Captured from CollapsibleSidebar's expandSectionRef callback.
   let expandSection: ((sectionId: string) => void) | undefined
+
+  // Handle for the FilesSection imperative API (e.g., collapseAll).
+  // Declared as a signal so reactive reads (e.g., isFiltered in header
+  // actions) re-evaluate when the handle is assigned after FilesSection mounts.
+  const [filesSectionHandle, setFilesSectionHandle] = createSignal<FilesSectionHandle | undefined>()
 
   /* eslint-disable solid/reactivity -- callbacks are stable references */
   const wsOps = useWorkspaceOperations({
@@ -112,6 +118,23 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
           collapsible: secs.length > 1,
           draggable: true,
           testId: 'section-header-files',
+          headerActions: (
+            <FilesSectionHeaderActions
+              onCollapseAll={() => filesSectionHandle()?.collapseAll()}
+              onLocateFile={() => {
+                if (props.activeFilePath)
+                  props.onFileSelect(props.activeFilePath)
+              }}
+              onRefresh={() => {
+                if (props.workerId && props.workingDir)
+                  props.gitStatusStore.refresh(props.workerId, props.workingDir)
+              }}
+              hasActiveFileTab={props.hasActiveFileTab}
+              isFiltered={() => filesSectionHandle()?.isFiltered() ?? false}
+              flatListMode={() => filesSectionHandle()?.flatListMode() ?? false}
+              onToggleFlatList={() => filesSectionHandle()?.toggleFlatListMode()}
+            />
+          ),
           content: () => (
             <Show
               when={props.workerId}
@@ -129,6 +152,7 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
                 gitStatusStore={props.gitStatusStore}
                 activeFilePath={props.activeFilePath}
                 hasActiveFileTab={props.hasActiveFileTab}
+                ref={setFilesSectionHandle}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -2,13 +2,14 @@ import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { TodoItem } from '~/stores/chat.store'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import type { createSectionStore } from '~/stores/section.store'
 
 import Plus from 'lucide-solid/icons/plus'
 import { createMemo, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
-import { DirectoryTree } from '~/components/tree/DirectoryTree'
+import { FilesSection } from '~/components/tree/FilesSection'
 import * as swlStyles from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
@@ -27,9 +28,12 @@ interface RightSidebarProps {
   activeTodos: TodoItem[]
   fileTreePath: string
   onFileSelect: (path: string) => void
-  onFileOpen?: (path: string) => void
+  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
   onFileMention?: (path: string) => void
   onOpenTerminal?: (dirPath: string) => void
+  gitStatusStore: ReturnType<typeof createGitFileStatusStore>
+  activeFilePath?: string
+  hasActiveFileTab: boolean
   sectionStore: ReturnType<typeof createSectionStore>
   isCollapsed: boolean
   onExpand: () => void
@@ -113,16 +117,18 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
               when={props.workerId}
               fallback={<div class={swlStyles.emptySection}>No tab selected</div>}
             >
-              <DirectoryTree
+              <FilesSection
                 workerId={props.workerId}
-                showFiles
-                selectedPath={props.fileTreePath}
-                onSelect={props.onFileSelect}
+                workingDir={props.workingDir}
+                homeDir={props.homeDir}
+                fileTreePath={props.fileTreePath}
+                onFileSelect={props.onFileSelect}
                 onFileOpen={props.onFileOpen}
                 onMention={props.onFileMention}
                 onOpenTerminal={props.onOpenTerminal}
-                rootPath={props.workingDir || '~'}
-                homeDir={props.homeDir}
+                gitStatusStore={props.gitStatusStore}
+                activeFilePath={props.activeFilePath}
+                hasActiveFileTab={props.hasActiveFileTab}
               />
             </Show>
           ),

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -2,6 +2,7 @@ import type { Accessor, JSX } from 'solid-js'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { Todo } from '~/stores/chat.store'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import type { createSectionStore } from '~/stores/section.store'
 import type { createTabStore } from '~/stores/tab.store'
 import { relativizePath } from '~/components/chat/messageUtils'
@@ -27,8 +28,11 @@ export interface SidebarElementsOpts {
   getMruAgentContext: () => { workingDir: string, homeDir: string }
   fileTreePath: string
   onFileSelect: (path: string) => void
-  onFileOpen: (path: string) => void
+  onFileOpen: (path: string, openSource?: GitFilterTab) => void
   isActiveWorkspaceArchived: boolean
+  gitStatusStore: ReturnType<typeof createGitFileStatusStore>
+  activeFilePath?: string
+  hasActiveFileTab: boolean
   showTodos: boolean
   activeTodos: Todo[]
   termOps: ReturnType<typeof useTerminalOperations>
@@ -81,6 +85,9 @@ export function createLeftSidebarElement(opts: SidebarElementsOpts, display?: Si
         : dirPath => opts.termOps.handleOpenTerminal(dirPath)}
       showTodos={opts.showTodos}
       activeTodos={opts.activeTodos}
+      gitStatusStore={opts.gitStatusStore}
+      activeFilePath={opts.activeFilePath}
+      hasActiveFileTab={opts.hasActiveFileTab}
     />
   )
 }
@@ -123,6 +130,9 @@ export function createRightSidebarElement(opts: SidebarElementsOpts, display?: S
       onConfirmDelete={opts.onConfirmDelete}
       onConfirmArchive={opts.onConfirmArchive}
       onPostArchiveWorkspace={opts.onPostArchiveWorkspace}
+      gitStatusStore={opts.gitStatusStore}
+      activeFilePath={opts.activeFilePath}
+      hasActiveFileTab={opts.hasActiveFileTab}
     />
   )
 }

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -12,7 +12,7 @@ import type { createTabStore, Tab } from '~/stores/tab.store'
 import type { createTerminalStore } from '~/stores/terminal.store'
 import Bot from 'lucide-solid/icons/bot'
 import Terminal from 'lucide-solid/icons/terminal'
-import { createMemo, Show } from 'solid-js'
+import { createEffect, createMemo, For, onCleanup, Show } from 'solid-js'
 import { agentClient } from '~/api/clients'
 import { agentCallTimeout } from '~/api/transport'
 import { AgentEditorPanel } from '~/components/chat/AgentEditorPanel'
@@ -187,6 +187,17 @@ export function createTileRenderer(opts: TileRendererOpts) {
       const t = tab()
       return t?.type === TabType.FILE ? t : null
     }
+    const tileAgentTabs = () => tabStore.getTabsForTile(tileId).filter(t => t.type === TabType.AGENT)
+    const tileFileTabs = () => tabStore.getTabsForTile(tileId).filter(t => t.type === TabType.FILE)
+    const agentScrollStates = new Map<string, () => { distFromBottom: number, atBottom: boolean } | undefined>()
+    const agentScrollToBottoms = new Map<string, () => void>()
+    createEffect(() => {
+      const activeId = agentTab()?.id
+      if (activeId) {
+        getScrollStateRef.current = agentScrollStates.get(activeId)
+        forceScrollToBottomRef.current = agentScrollToBottoms.get(activeId)
+      }
+    })
     const tileTerminalIds = () => new Set(
       tabStore.getTabsForTile(tileId)
         .filter(t => t.type === TabType.TERMINAL)
@@ -200,12 +211,16 @@ export function createTileRenderer(opts: TileRendererOpts) {
 
     return (
       <>
-        <Show when={agentTab()} keyed>
+        <For each={tileAgentTabs()}>
           {(at) => {
             const agentId = at.id
             const agent = () => agentStore.state.agents.find(a => a.id === agentId)
+            onCleanup(() => {
+              agentScrollStates.delete(agentId)
+              agentScrollToBottoms.delete(agentId)
+            })
             return (
-              <div class={styles.centerContent}>
+              <div class={styles.centerContent} classList={{ [styles.layoutHidden]: agentTab()?.id !== at.id }}>
                 <Show
                   when={agent()}
                   fallback={<div class={styles.placeholder}>Agent not found.</div>}
@@ -226,8 +241,16 @@ export function createTileRenderer(opts: TileRendererOpts) {
                     onTrimOldMessages={() => chatStore.trimOldMessages(agentId, 150)}
                     savedViewportScroll={chatStore.getSavedViewportScroll(agentId)}
                     onClearSavedViewportScroll={() => chatStore.clearSavedViewportScroll(agentId)}
-                    scrollStateRef={(fn) => { getScrollStateRef.current = fn }}
-                    scrollToBottomRef={(fn) => { forceScrollToBottomRef.current = fn }}
+                    scrollStateRef={(fn) => {
+                      agentScrollStates.set(agentId, fn)
+                      if (agentTab()?.id === at.id)
+                        getScrollStateRef.current = fn
+                    }}
+                    scrollToBottomRef={(fn) => {
+                      agentScrollToBottoms.set(agentId, fn)
+                      if (agentTab()?.id === at.id)
+                        forceScrollToBottomRef.current = fn
+                    }}
                     onQuote={isActiveWorkspaceArchived()
                       ? undefined
                       : (text) => {
@@ -245,7 +268,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
               </div>
             )
           }}
-        </Show>
+        </For>
 
         <Show when={hasTerminals()}>
           <div
@@ -264,14 +287,14 @@ export function createTileRenderer(opts: TileRendererOpts) {
           </div>
         </Show>
 
-        <Show when={fileTab()} keyed>
+        <For each={tileFileTabs()}>
           {(ft) => {
             const fileRelPath = () => {
               const ctx = getMruAgentContext()
               return relativizePath(ft.filePath ?? '', ctx.workingDir, ctx.homeDir)
             }
             return (
-              <div class={styles.centerContent}>
+              <div class={styles.centerContent} classList={{ [styles.layoutHidden]: fileTab()?.id !== ft.id }}>
                 <FileViewer
                   workerId={ft.workerId ?? ''}
                   filePath={ft.filePath ?? ''}
@@ -307,7 +330,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
               </div>
             )
           }}
-        </Show>
+        </For>
 
         <Show when={!tab() && activeWorkspace()}>
           <Show

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -6,6 +6,7 @@ import type { createAgentStore } from '~/stores/agent.store'
 import type { createAgentSessionStore } from '~/stores/agentSession.store'
 import type { createChatStore } from '~/stores/chat.store'
 import type { createControlStore } from '~/stores/control.store'
+import type { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
 import type { createLayoutStore } from '~/stores/layout.store'
 import type { createTabStore, Tab } from '~/stores/tab.store'
 import type { createTerminalStore } from '~/stores/terminal.store'
@@ -22,6 +23,7 @@ import { showToast } from '~/components/common/Toast'
 import { FileViewer } from '~/components/fileviewer/FileViewer'
 import { TerminalView } from '~/components/terminal/TerminalView'
 import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
+import { GitFileStatusCode } from '~/generated/leapmux/v1/git_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { formatFileMention, formatFileQuote } from '~/lib/quoteUtils'
 import { appendText, insertIntoMruAgentEditor } from '~/stores/editorRef.store'
@@ -65,6 +67,7 @@ interface TileRendererOpts {
   focusEditorRef: { current: (() => void) | undefined }
   getScrollStateRef: { current: (() => { distFromBottom: number, atBottom: boolean } | undefined) | undefined }
   forceScrollToBottomRef: { current: (() => void) | undefined }
+  gitFileStatusStore?: ReturnType<typeof createGitFileStatusStore>
 }
 
 export function createTileRenderer(opts: TileRendererOpts) {
@@ -286,6 +289,20 @@ export function createTileRenderer(opts: TileRendererOpts) {
                     : () => {
                         insertIntoMruAgentEditor(tabStore, formatFileMention(fileRelPath()), 'inline')
                       }}
+                  fileViewMode={ft.fileViewMode}
+                  fileDiffBase={ft.fileDiffBase}
+                  hasStagedAndUnstaged={(() => {
+                    const store = opts.gitFileStatusStore
+                    if (!store)
+                      return false
+                    const entry = store.getFileStatus(ft.filePath ?? '')
+                    if (!entry)
+                      return false
+                    return entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+                      && entry.unstagedStatus !== GitFileStatusCode.UNSPECIFIED
+                  })()}
+                  onFileViewModeChange={mode => tabStore.setTabFileViewMode(ft.type, ft.id, mode)}
+                  onFileDiffBaseChange={base => tabStore.setTabFileDiffBase(ft.type, ft.id, base)}
                 />
               </div>
             )

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -23,7 +23,6 @@ interface UseTabOperationsOpts {
   termOps: ReturnType<typeof useTerminalOperations>
   activeTab: () => Tab | undefined
   getCurrentTabContext: () => { workerId: string, workingDir: string, homeDir: string }
-  persistLayout: () => void
   focusEditor: () => void
   getScrollState: () => { distFromBottom: number, atBottom: boolean } | undefined
   setFileTreePath: (path: string) => void
@@ -41,7 +40,6 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     termOps,
     activeTab,
     getCurrentTabContext,
-    persistLayout,
     focusEditor,
     getScrollState,
     setFileTreePath,
@@ -112,7 +110,6 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
   const handleTabClose = async (tab: Tab) => {
     if (tab.type === TabType.FILE) {
       tabStore.removeTabFromTile(tab.type, tab.id, tab.tileId ?? '')
-      persistLayout()
       return
     }
 
@@ -169,7 +166,7 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     }
 
     // Determine initial view mode based on open source.
-    let fileViewMode: Tab['fileViewMode']
+    let fileViewMode: Tab['fileViewMode'] = 'working'
     let fileDiffBase: Tab['fileDiffBase']
     if (openSource === 'staged') {
       fileViewMode = 'unified-diff'
@@ -196,7 +193,6 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       fileOpenSource: openSource,
     })
     tabStore.setActiveTabForTile(tileId, TabType.FILE, tabId)
-    persistLayout()
   }
 
   // Reset file tree selection when active tab changes

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -4,7 +4,7 @@ import type { CheckWorktreeStatusResponse } from '~/generated/leapmux/v1/git_pb'
 import type { createAgentStore } from '~/stores/agent.store'
 import type { createChatStore } from '~/stores/chat.store'
 import type { createLayoutStore } from '~/stores/layout.store'
-import type { createTabStore, Tab } from '~/stores/tab.store'
+import type { createTabStore, FileOpenSource, Tab } from '~/stores/tab.store'
 import type { createTerminalStore } from '~/stores/terminal.store'
 import { createEffect, createSignal } from 'solid-js'
 import { gitClient } from '~/api/clients'
@@ -152,7 +152,7 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
   }
 
   let fileTabCounter = 0
-  const handleFileOpen = (path: string) => {
+  const handleFileOpen = (path: string, openSource?: FileOpenSource) => {
     const ctx = getCurrentTabContext()
     if (!ctx.workerId)
       return
@@ -168,6 +168,18 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       return
     }
 
+    // Determine initial view mode based on open source.
+    let fileViewMode: Tab['fileViewMode']
+    let fileDiffBase: Tab['fileDiffBase']
+    if (openSource === 'staged') {
+      fileViewMode = 'unified-diff'
+      fileDiffBase = 'head-vs-staged'
+    }
+    else if (openSource === 'changed' || openSource === 'unstaged') {
+      fileViewMode = 'unified-diff'
+      fileDiffBase = 'head-vs-working'
+    }
+
     const fileName = path.split('/').pop() ?? path
     const tileId = layoutStore.focusedTileId()
     const tabId = `file-${++fileTabCounter}-${Date.now()}`
@@ -179,6 +191,9 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       workingDir: ctx.workingDir,
       title: fileName,
       tileId,
+      fileViewMode,
+      fileDiffBase,
+      fileOpenSource: openSource,
     })
     tabStore.setActiveTabForTile(tileId, TabType.FILE, tabId)
     persistLayout()

--- a/frontend/src/components/shell/useTabPersistence.ts
+++ b/frontend/src/components/shell/useTabPersistence.ts
@@ -97,6 +97,8 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
         tileId: t.tileId,
         title: t.title,
         displayMode: t.displayMode,
+        fileViewMode: t.fileViewMode,
+        fileDiffBase: t.fileDiffBase,
       }))
     if (localTabs.length > 0) {
       sessionStorage.setItem(`leapmux:localTabs:${wsId}`, JSON.stringify(localTabs))

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -5,7 +5,7 @@ import type { createLayoutStore } from '~/stores/layout.store'
 import type { createTabStore } from '~/stores/tab.store'
 import type { createTerminalStore } from '~/stores/terminal.store'
 
-import { createEffect, createSignal } from 'solid-js'
+import { createEffect, createSignal, on } from 'solid-js'
 import { gitClient, terminalClient } from '~/api/clients'
 import { showToast } from '~/components/common/Toast'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
@@ -32,17 +32,14 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
   const [availableShells, setAvailableShells] = createSignal<string[]>([])
   const [defaultShell, setDefaultShell] = createSignal('')
 
-  // Load available shells when active tab's worker changes
-  createEffect(() => {
+  /** Load available shells on demand (e.g. when the new-terminal dialog opens). */
+  const loadAvailableShells = () => {
     const ws = props.activeWorkspace()
     if (!ws)
       return
     const ctx = props.getCurrentTabContext()
-    if (!ctx.workerId) {
-      setAvailableShells([])
-      setDefaultShell('')
+    if (!ctx.workerId)
       return
-    }
     terminalClient.listAvailableShells({ orgId: props.org.orgId(), workspaceId: ws.id, workerId: ctx.workerId })
       .then((resp) => {
         setAvailableShells(resp.shells)
@@ -52,7 +49,16 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
         setAvailableShells([])
         setDefaultShell('')
       })
-  })
+  }
+
+  // Load available shells once per workerId change so the tabbar dropdown is populated.
+  createEffect(on(
+    () => props.getCurrentTabContext().workerId,
+    (workerId) => {
+      if (workerId)
+        loadAvailableShells()
+    },
+  ))
 
   const handleOpenTerminal = async (shellStartDir?: string) => {
     if (!props.isActiveWorkspaceMutatable())
@@ -198,6 +204,7 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
     // Signals
     availableShells,
     defaultShell,
+    loadAvailableShells,
 
     // Handlers
     handleOpenTerminal,

--- a/frontend/src/components/shell/useWorkspaceRestore.ts
+++ b/frontend/src/components/shell/useWorkspaceRestore.ts
@@ -1,6 +1,6 @@
 import type { createAgentStore } from '~/stores/agent.store'
 import type { createLayoutStore } from '~/stores/layout.store'
-import type { createTabStore } from '~/stores/tab.store'
+import type { createTabStore, Tab } from '~/stores/tab.store'
 import type { createTerminalStore } from '~/stores/terminal.store'
 import { createEffect, on } from 'solid-js'
 import { agentClient, terminalClient, workspaceClient } from '~/api/clients'
@@ -146,6 +146,8 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
             tileId?: string
             title?: string
             displayMode?: string
+            fileViewMode?: string
+            fileDiffBase?: string
           }>
           for (const lt of localTabs) {
             let tileId = lt.tileId ?? defaultTileId
@@ -160,6 +162,8 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
               tileId,
               title: lt.title,
               displayMode: lt.displayMode,
+              fileViewMode: lt.fileViewMode as Tab['fileViewMode'],
+              fileDiffBase: lt.fileDiffBase as Tab['fileDiffBase'],
             }, false)
           }
         }

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -73,6 +73,13 @@ export const fileIcon = style({
   color: 'var(--muted-foreground)',
 })
 
+// Git-status icon color overrides (applied to folder/file icons).
+export const iconStaged = style({ color: 'var(--success)' })
+export const iconUnstaged = style({ color: 'var(--warning)' })
+export const iconUntracked = style({ color: 'var(--success)' })
+export const iconConflict = style({ color: 'var(--danger)' })
+export const iconDirChanged = style({ color: 'var(--warning)', opacity: 0.85 })
+
 export const nodeName = style({
   whiteSpace: 'nowrap',
 })

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import type { FileInfo } from '~/generated/leapmux/v1/file_pb'
+import type { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
 import AtSign from 'lucide-solid/icons/at-sign'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import ClipboardCopy from 'lucide-solid/icons/clipboard-copy'
@@ -16,7 +17,13 @@ import { relativizePath, tildify } from '~/components/chat/messageUtils'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
+import { GitFileStatusCode } from '~/generated/leapmux/v1/git_pb'
 import * as styles from './DirectoryTree.css'
+import * as fsStyles from './FilesSection.css'
+
+export interface DirectoryTreeHandle {
+  collapseAll: () => void
+}
 
 export interface DirectoryTreeProps {
   workerId: string
@@ -28,6 +35,11 @@ export interface DirectoryTreeProps {
   onOpenTerminal?: (dirPath: string) => void
   rootPath?: string
   homeDir?: string
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
+  /** When set, only show nodes whose paths are in this set. */
+  visiblePaths?: Set<string>
+  /** Ref callback for imperative actions (collapse all, etc.). */
+  ref?: (handle: DirectoryTreeHandle) => void
 }
 
 interface TreeNodeData {
@@ -215,6 +227,68 @@ function renderTreeContextMenu(menuProps: {
   )
 }
 
+/** Render git status indicator for a tree node (file or directory). */
+function renderNodeGitStatus(
+  node: TreeNodeData,
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>,
+): JSX.Element {
+  if (!gitStatusStore)
+    return <></>
+  if (node.isDir) {
+    // Show a small dot if any descendant has changes.
+    const hasChanges = gitStatusStore.hasChanges(node.path)
+    return (
+      <Show when={hasChanges}>
+        <span class={fsStyles.dirChangeIndicator} />
+      </Show>
+    )
+  }
+  // File: show status indicator + diff stats.
+  const entry = gitStatusStore.getFileStatus(node.path)
+  if (!entry)
+    return <></>
+  return (
+    <span class={fsStyles.statusGroup}>
+      <span
+        class={`${fsStyles.statusIndicator} ${
+          entry.unstagedStatus === GitFileStatusCode.UNMERGED || entry.stagedStatus === GitFileStatusCode.UNMERGED
+            ? fsStyles.statusConflict
+            : entry.unstagedStatus === GitFileStatusCode.UNTRACKED
+              ? fsStyles.statusUntracked
+              : entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
+                ? fsStyles.statusStaged
+                : fsStyles.statusUnstaged
+        }`}
+        data-testid={
+          entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+          && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
+            ? 'git-status-staged'
+            : entry.unstagedStatus === GitFileStatusCode.UNTRACKED
+              ? 'git-status-untracked'
+              : 'git-status-unstaged'
+        }
+      />
+      <Show when={entry.linesAdded + entry.stagedLinesAdded > 0 || entry.linesDeleted + entry.stagedLinesDeleted > 0}>
+        <span class={fsStyles.diffStats} data-testid="git-diff-stats">
+          <Show when={entry.linesAdded + entry.stagedLinesAdded > 0}>
+            <span class={fsStyles.diffStatsAdded}>
+              +
+              {entry.linesAdded + entry.stagedLinesAdded}
+            </span>
+          </Show>
+          {(entry.linesAdded + entry.stagedLinesAdded > 0 && entry.linesDeleted + entry.stagedLinesDeleted > 0) ? ' ' : ''}
+          <Show when={entry.linesDeleted + entry.stagedLinesDeleted > 0}>
+            <span class={fsStyles.diffStatsDeleted}>
+              -
+              {entry.linesDeleted + entry.stagedLinesDeleted}
+            </span>
+          </Show>
+        </span>
+      </Show>
+    </span>
+  )
+}
+
 const TreeNode: Component<{
   node: TreeNodeData
   workerId: string
@@ -232,13 +306,21 @@ const TreeNode: Component<{
   setNodeExpanded: (path: string, expanded: boolean) => void
   getChildren: (path: string) => TreeNodeData[] | undefined
   setChildren: (path: string, data: TreeNodeData[]) => void
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
+  visiblePaths?: Set<string>
 }> = (props) => {
   const [loading, setLoading] = createSignal(false)
   let wrapperRef!: HTMLDivElement
 
   const expanded = () => props.isNodeExpanded(props.node.path)
   const isSelected = () => props.selectedPath === props.node.path
-  const children = () => props.getChildren(props.node.path) ?? []
+  const allChildren = () => props.getChildren(props.node.path) ?? []
+  const children = () => {
+    const visible = props.visiblePaths
+    if (!visible)
+      return allChildren()
+    return allChildren().filter(c => visible.has(c.path))
+  }
   const loaded = () => props.getChildren(props.node.path) !== undefined
 
   const scrollIntoViewIfNeeded = () => {
@@ -358,6 +440,7 @@ const TreeNode: Component<{
           </Show>
         </Show>
         <span class={styles.nodeName}>{props.node.displayName}</span>
+        {renderNodeGitStatus(props.node, props.gitStatusStore)}
         <div class={styles.nodeActions}>
           {renderTreeContextMenu({
             path: props.node.path,
@@ -396,6 +479,8 @@ const TreeNode: Component<{
                   setNodeExpanded={props.setNodeExpanded}
                   getChildren={props.getChildren}
                   setChildren={props.setChildren}
+                  gitStatusStore={props.gitStatusStore}
+                  visiblePaths={props.visiblePaths}
                 />
               )}
             </For>
@@ -427,6 +512,21 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   }>({
     expandedPaths: {},
     childrenCache: {},
+  })
+
+  // Expose imperative handle via ref callback.
+  createEffect(() => {
+    props.ref?.({
+      collapseAll: () => {
+        setState(produce((s) => {
+          const rp = props.rootPath ?? '~'
+          for (const key of Object.keys(s.expandedPaths)) {
+            if (key !== rp)
+              delete s.expandedPaths[key]
+          }
+        }))
+      },
+    })
   })
 
   const storageKey = () => `directoryTree:state:${props.rootPath ?? '~'}`
@@ -489,8 +589,16 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     return rp.split('/').pop() || rp
   }
 
-  // Root children derived from the centralized cache
-  const rootChildren = () => getChildren(rootPath())
+  // Root children derived from the centralized cache, optionally filtered.
+  const rootChildren = () => {
+    const all = getChildren(rootPath())
+    if (!all)
+      return undefined
+    const visible = props.visiblePaths
+    if (!visible)
+      return all
+    return all.filter(c => visible.has(c.path))
+  }
 
   // Sync external selectedPath to input (tildified for display)
   createEffect(() => {
@@ -623,6 +731,8 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                           setNodeExpanded={setNodeExpanded}
                           getChildren={getChildren}
                           setChildren={setChildrenInStore}
+                          gitStatusStore={props.gitStatusStore}
+                          visiblePaths={props.visiblePaths}
                         />
                       )}
                     </For>

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -10,7 +10,7 @@ import FolderClosed from 'lucide-solid/icons/folder-closed'
 import FolderOpen from 'lucide-solid/icons/folder-open'
 import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
 import TerminalIcon from 'lucide-solid/icons/terminal'
-import { createEffect, createSignal, For, Show, untrack } from 'solid-js'
+import { createEffect, createSignal, For, on, Show } from 'solid-js'
 import { createStore, produce } from 'solid-js/store'
 import { fileClient } from '~/api/clients'
 import { relativizePath, tildify } from '~/components/chat/messageUtils'
@@ -227,62 +227,58 @@ function renderTreeContextMenu(menuProps: {
   )
 }
 
-/** Render git status indicator for a tree node (file or directory). */
-function renderNodeGitStatus(
+/** Return a CSS class to color the file/folder icon based on git status. */
+function getGitIconClass(
+  node: TreeNodeData,
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>,
+): { class: string, testId: string | undefined } {
+  if (!gitStatusStore)
+    return { class: '', testId: undefined }
+  if (node.isDir) {
+    const hasChanges = gitStatusStore.hasChanges(node.path)
+    return hasChanges
+      ? { class: styles.iconDirChanged, testId: undefined }
+      : { class: '', testId: undefined }
+  }
+  const entry = gitStatusStore.getFileStatus(node.path)
+  if (!entry)
+    return { class: '', testId: undefined }
+  if (entry.unstagedStatus === GitFileStatusCode.UNMERGED || entry.stagedStatus === GitFileStatusCode.UNMERGED)
+    return { class: styles.iconConflict, testId: 'git-status-unstaged' }
+  if (entry.unstagedStatus === GitFileStatusCode.UNTRACKED)
+    return { class: styles.iconUntracked, testId: 'git-status-untracked' }
+  if (entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED)
+    return { class: styles.iconStaged, testId: 'git-status-staged' }
+  return { class: styles.iconUnstaged, testId: 'git-status-unstaged' }
+}
+
+/** Render diff stats for a tree node (file only). */
+function renderNodeDiffStats(
   node: TreeNodeData,
   gitStatusStore?: ReturnType<typeof createGitFileStatusStore>,
 ): JSX.Element {
-  if (!gitStatusStore)
+  if (!gitStatusStore || node.isDir)
     return <></>
-  if (node.isDir) {
-    // Show a small dot if any descendant has changes.
-    const hasChanges = gitStatusStore.hasChanges(node.path)
-    return (
-      <Show when={hasChanges}>
-        <span class={fsStyles.dirChangeIndicator} />
-      </Show>
-    )
-  }
-  // File: show status indicator + diff stats.
   const entry = gitStatusStore.getFileStatus(node.path)
   if (!entry)
     return <></>
+  const totalAdded = entry.linesAdded + entry.stagedLinesAdded
+  const totalDeleted = entry.linesDeleted + entry.stagedLinesDeleted
+  if (totalAdded === 0 && totalDeleted === 0)
+    return <></>
   return (
-    <span class={fsStyles.statusGroup}>
-      <span
-        class={`${fsStyles.statusIndicator} ${
-          entry.unstagedStatus === GitFileStatusCode.UNMERGED || entry.stagedStatus === GitFileStatusCode.UNMERGED
-            ? fsStyles.statusConflict
-            : entry.unstagedStatus === GitFileStatusCode.UNTRACKED
-              ? fsStyles.statusUntracked
-              : entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
-                ? fsStyles.statusStaged
-                : fsStyles.statusUnstaged
-        }`}
-        data-testid={
-          entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
-          && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
-            ? 'git-status-staged'
-            : entry.unstagedStatus === GitFileStatusCode.UNTRACKED
-              ? 'git-status-untracked'
-              : 'git-status-unstaged'
-        }
-      />
-      <Show when={entry.linesAdded + entry.stagedLinesAdded > 0 || entry.linesDeleted + entry.stagedLinesDeleted > 0}>
-        <span class={fsStyles.diffStats} data-testid="git-diff-stats">
-          <Show when={entry.linesAdded + entry.stagedLinesAdded > 0}>
-            <span class={fsStyles.diffStatsAdded}>
-              +
-              {entry.linesAdded + entry.stagedLinesAdded}
-            </span>
-          </Show>
-          {(entry.linesAdded + entry.stagedLinesAdded > 0 && entry.linesDeleted + entry.stagedLinesDeleted > 0) ? ' ' : ''}
-          <Show when={entry.linesDeleted + entry.stagedLinesDeleted > 0}>
-            <span class={fsStyles.diffStatsDeleted}>
-              -
-              {entry.linesDeleted + entry.stagedLinesDeleted}
-            </span>
-          </Show>
+    <span class={fsStyles.diffStats} data-testid="git-diff-stats">
+      <Show when={totalAdded > 0}>
+        <span class={fsStyles.diffStatsAdded}>
+          +
+          {totalAdded}
+        </span>
+      </Show>
+      {totalAdded > 0 && totalDeleted > 0 ? ' ' : ''}
+      <Show when={totalDeleted > 0}>
+        <span class={fsStyles.diffStatsDeleted}>
+          -
+          {totalDeleted}
         </span>
       </Show>
     </span>
@@ -358,28 +354,28 @@ const TreeNode: Component<{
       props.onFileOpen?.(props.node.path)
       return
     }
-    props.onSelect(props.node.path)
     await doLoad()
     const willExpand = !expanded()
+    // Set expanded state before onSelect so that the scroll-on-select
+    // effect sees the correct state and skips scrolling on collapse.
     props.setNodeExpanded(props.node.path, willExpand)
+    props.onSelect(props.node.path)
     if (willExpand) {
       scrollIntoViewIfNeeded()
     }
   }
 
-  // Auto-expand when selectedPath is a descendant of this node.
-  createEffect(() => {
-    const selected = props.selectedPath
-    if (!props.node.isDir)
-      return
-    if (!selected.startsWith(`${props.node.path}/`))
-      return
-    if (loading())
-      return
+  // Auto-expand when selectedPath changes to a descendant of this node.
+  createEffect(on(
+    () => props.selectedPath,
+    (selected) => {
+      if (!props.node.isDir)
+        return
+      if (!selected.startsWith(`${props.node.path}/`))
+        return
 
-    if (!loaded()) {
-      untrack(() => {
-        doLoad().then(() => { // eslint-disable-line solid/reactivity -- one-shot async load inside untrack
+      if (!loaded()) {
+        doLoad().then(() => { // eslint-disable-line solid/reactivity -- one-shot async load
           props.setNodeExpanded(props.node.path, true)
           // Scroll into view for the deepest auto-expanded node.
           // Only scroll if this is the closest ancestor (children will handle deeper).
@@ -390,16 +386,19 @@ const TreeNode: Component<{
             scrollIntoViewIfNeeded()
           }
         })
-      })
-    }
-    else if (!expanded()) {
-      props.setNodeExpanded(props.node.path, true)
-    }
-  })
+      }
+      else if (!expanded()) {
+        props.setNodeExpanded(props.node.path, true)
+      }
+    },
+  ))
 
   // Scroll into view when this node is selected via path input.
+  // Skip for directories that are collapsed — collapsing should not scroll.
   createEffect(() => {
     if (props.selectedPath === props.node.path && wrapperRef) {
+      if (props.node.isDir && !expanded())
+        return
       const container = props.scrollContainer
       if (!container)
         return
@@ -414,6 +413,7 @@ const TreeNode: Component<{
   })
 
   const indent = () => `${8 + props.depth * 16}px`
+  const gitIcon = () => getGitIconClass(props.node, props.gitStatusStore)
 
   return (
     <div ref={wrapperRef}>
@@ -430,17 +430,17 @@ const TreeNode: Component<{
         </Show>
         <Show
           when={props.node.isDir}
-          fallback={<Icon icon={File} size="sm" class={styles.fileIcon} />}
+          fallback={<Icon icon={File} size="sm" class={gitIcon().class || styles.fileIcon} data-testid={gitIcon().testId} />}
         >
           <Show
             when={expanded()}
-            fallback={<Icon icon={FolderClosed} size="sm" class={styles.folderIcon} />}
+            fallback={<Icon icon={FolderClosed} size="sm" class={gitIcon().class || styles.folderIcon} data-testid={gitIcon().testId} />}
           >
-            <Icon icon={FolderOpen} size="sm" class={styles.folderIcon} />
+            <Icon icon={FolderOpen} size="sm" class={gitIcon().class || styles.folderIcon} data-testid={gitIcon().testId} />
           </Show>
         </Show>
         <span class={styles.nodeName}>{props.node.displayName}</span>
-        {renderNodeGitStatus(props.node, props.gitStatusStore)}
+        {renderNodeDiffStats(props.node, props.gitStatusStore)}
         <div class={styles.nodeActions}>
           {renderTreeContextMenu({
             path: props.node.path,
@@ -583,7 +583,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   }
 
   const rootPath = () => props.rootPath ?? '~'
-  const rootExpanded = () => isNodeExpanded(rootPath())
   const rootDisplayName = () => {
     const rp = rootPath()
     return rp.split('/').pop() || rp
@@ -652,10 +651,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     }
   }
 
-  const toggleRoot = () => {
-    setNodeExpanded(rootPath(), !rootExpanded())
-  }
-
   return (
     <div class={styles.container}>
       <div class={styles.pathInput}>
@@ -683,16 +678,9 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
             <div
               class={styles.node}
               style={{ 'padding-left': '8px' }}
-              onClick={toggleRoot}
               data-testid="tree-root-node"
             >
-              <Icon icon={ChevronRight} size="md" class={`${styles.chevron}${rootExpanded() ? ` ${styles.chevronExpanded}` : ''}`} />
-              <Show
-                when={rootExpanded()}
-                fallback={<Icon icon={FolderClosed} size="sm" class={styles.folderIcon} />}
-              >
-                <Icon icon={FolderOpen} size="sm" class={styles.folderIcon} />
-              </Show>
+              <Icon icon={FolderOpen} size="sm" class={styles.folderIcon} />
               <span class={styles.nodeName}>{rootDisplayName()}</span>
               <div class={styles.nodeActions}>
                 {renderTreeContextMenu({
@@ -706,11 +694,11 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
               </div>
             </div>
             <Show when={rootChildren() !== undefined}>
-              <div class={`${styles.childrenWrapper}${rootExpanded() ? ` ${styles.childrenWrapperExpanded}` : ''}`}>
+              <div class={`${styles.childrenWrapper} ${styles.childrenWrapperExpanded}`}>
                 <div class={styles.childrenInner}>
                   <Show
                     when={rootChildren()!.length > 0}
-                    fallback={<div class={styles.emptyState}>Empty directory</div>}
+                    fallback={<div class={styles.emptyState}>{props.visiblePaths ? 'No changes' : 'Empty directory'}</div>}
                   >
                     <For each={rootChildren()}>
                       {node => (
@@ -723,7 +711,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                           onFileOpen={props.onFileOpen}
                           onMention={props.onMention}
                           onOpenTerminal={props.onOpenTerminal}
-                          depth={1}
+                          depth={0}
                           scrollContainer={treeRef}
                           rootPath={rootPath()}
                           homeDir={props.homeDir}

--- a/frontend/src/components/tree/FilesSection.css.ts
+++ b/frontend/src/components/tree/FilesSection.css.ts
@@ -15,7 +15,7 @@ export const tabBar = style({
   borderBottom: '1px solid var(--border)',
   flexShrink: 0,
   fontSize: 'var(--text-8)',
-  backgroundColor: 'var(--background)',
+  backgroundColor: 'inherit',
 })
 
 export const tabButton = style({
@@ -83,38 +83,13 @@ export const flatListItemSelected = style({
   },
 })
 
-export const statusIndicator = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  flexShrink: 0,
-  width: '8px',
-  height: '8px',
-  borderRadius: '50%',
-})
-
-export const statusStaged = style({
-  backgroundColor: 'var(--success)',
-})
-
-export const statusUnstaged = style({
-  backgroundColor: 'var(--warning)',
-})
-
-export const statusUntracked = style({
-  backgroundColor: 'var(--muted-foreground)',
-})
-
-export const statusConflict = style({
-  backgroundColor: 'var(--danger)',
-})
-
 export const diffStats = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
-  marginLeft: 'auto',
+  marginLeft: '4px',
+  paddingRight: 'var(--space-1)',
   flexShrink: 0,
   whiteSpace: 'nowrap',
-  paddingRight: 'var(--space-2)',
 })
 
 export const diffStatsAdded = style({
@@ -123,22 +98,4 @@ export const diffStatsAdded = style({
 
 export const diffStatsDeleted = style({
   color: 'var(--danger)',
-})
-
-export const statusGroup = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: '4px',
-  marginLeft: '4px',
-  flexShrink: 0,
-})
-
-// Dot indicator for directories with changed descendants.
-export const dirChangeIndicator = style({
-  width: '6px',
-  height: '6px',
-  borderRadius: '50%',
-  backgroundColor: 'var(--warning)',
-  opacity: 0.7,
-  flexShrink: 0,
 })

--- a/frontend/src/components/tree/FilesSection.css.ts
+++ b/frontend/src/components/tree/FilesSection.css.ts
@@ -1,0 +1,144 @@
+import { style } from '@vanilla-extract/css'
+
+export const wrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  overflow: 'hidden',
+})
+
+export const tabBar = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1px',
+  padding: '0 var(--space-2)',
+  borderBottom: '1px solid var(--border)',
+  flexShrink: 0,
+  fontSize: 'var(--text-8)',
+  backgroundColor: 'var(--background)',
+})
+
+export const tabButton = style({
+  all: 'unset',
+  boxSizing: 'border-box',
+  cursor: 'pointer',
+  padding: 'var(--space-1) var(--space-2)',
+  color: 'var(--muted-foreground)',
+  borderBottom: '2px solid transparent',
+  transition: 'color 0.1s, border-color 0.1s',
+  whiteSpace: 'nowrap',
+  selectors: {
+    '&:hover': {
+      color: 'var(--foreground)',
+    },
+  },
+})
+
+export const tabButtonActive = style({
+  color: 'var(--foreground)',
+  borderBottomColor: 'var(--primary)',
+})
+
+export const toolbar = style({
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 'auto',
+  gap: '2px',
+  flexShrink: 0,
+})
+
+export const treeContent = style({
+  flex: 1,
+  overflow: 'hidden',
+  minHeight: 0,
+})
+
+export const flatList = style({
+  flex: 1,
+  overflow: 'auto',
+  padding: 'var(--space-1) 0',
+})
+
+export const flatListItem = style({
+  'display': 'flex',
+  'alignItems': 'center',
+  'gap': '4px',
+  'padding': '2px var(--space-2) 2px var(--space-3)',
+  'cursor': 'pointer',
+  'fontSize': 'var(--text-7)',
+  'color': 'var(--foreground)',
+  'userSelect': 'none',
+  'whiteSpace': 'nowrap',
+  ':hover': {
+    backgroundColor: 'var(--card)',
+  },
+})
+
+export const flatListItemSelected = style({
+  backgroundColor: 'var(--secondary)',
+  selectors: {
+    '&:hover': {
+      backgroundColor: 'var(--muted)',
+    },
+  },
+})
+
+export const statusIndicator = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  flexShrink: 0,
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+})
+
+export const statusStaged = style({
+  backgroundColor: 'var(--success)',
+})
+
+export const statusUnstaged = style({
+  backgroundColor: 'var(--warning)',
+})
+
+export const statusUntracked = style({
+  backgroundColor: 'var(--muted-foreground)',
+})
+
+export const statusConflict = style({
+  backgroundColor: 'var(--danger)',
+})
+
+export const diffStats = style({
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  marginLeft: 'auto',
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+  paddingRight: 'var(--space-2)',
+})
+
+export const diffStatsAdded = style({
+  color: 'var(--success)',
+})
+
+export const diffStatsDeleted = style({
+  color: 'var(--danger)',
+})
+
+export const statusGroup = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  marginLeft: '4px',
+  flexShrink: 0,
+})
+
+// Dot indicator for directories with changed descendants.
+export const dirChangeIndicator = style({
+  width: '6px',
+  height: '6px',
+  borderRadius: '50%',
+  backgroundColor: 'var(--warning)',
+  opacity: 0.7,
+  flexShrink: 0,
+})

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -3,15 +3,25 @@ import type { DirectoryTreeHandle } from './DirectoryTree'
 import type { GitFileStatusEntry } from '~/generated/leapmux/v1/git_pb'
 import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import ChevronsDownUp from 'lucide-solid/icons/chevrons-down-up'
+import FileIcon from 'lucide-solid/icons/file'
 import FolderTree from 'lucide-solid/icons/folder-tree'
 import List from 'lucide-solid/icons/list'
 import LocateFixed from 'lucide-solid/icons/locate-fixed'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
-import { createSignal, For, Show } from 'solid-js'
+import { createEffect, createSignal, For, Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/git_pb'
 import { DirectoryTree } from './DirectoryTree'
+import * as dtStyles from './DirectoryTree.css'
 import * as styles from './FilesSection.css'
+
+export interface FilesSectionHandle {
+  collapseAll: () => void
+  isFiltered: () => boolean
+  flatListMode: () => boolean
+  toggleFlatListMode: () => void
+}
 
 export interface FilesSectionProps {
   workerId: string
@@ -27,6 +37,18 @@ export interface FilesSectionProps {
   activeFilePath?: string
   /** Whether the active tab is a file tab (for locate button enabled state). */
   hasActiveFileTab: boolean
+  /** Ref callback for imperative actions (collapse all). */
+  ref?: (handle: FilesSectionHandle) => void
+}
+
+export interface FilesSectionHeaderActionsProps {
+  onCollapseAll: () => void
+  onLocateFile: () => void
+  onRefresh: () => void
+  hasActiveFileTab: boolean
+  isFiltered?: () => boolean
+  flatListMode?: () => boolean
+  onToggleFlatList?: () => void
 }
 
 const FILTER_TABS: { key: GitFilterTab, label: string }[] = [
@@ -36,39 +58,29 @@ const FILTER_TABS: { key: GitFilterTab, label: string }[] = [
   { key: 'unstaged', label: 'Unstaged' },
 ]
 
-/** Status indicator dot for a file entry. */
-export const FileStatusIndicator: Component<{ entry: GitFileStatusEntry }> = (props) => {
-  const statusClass = () => {
+/** Colored file icon for a git file entry. */
+export const FileStatusIcon: Component<{ entry: GitFileStatusEntry }> = (props) => {
+  const iconClass = () => {
     const e = props.entry
-    if (e.unstagedStatus === GitFileStatusCode.UNMERGED || e.stagedStatus === GitFileStatusCode.UNMERGED) {
-      return styles.statusConflict
-    }
-    if (e.unstagedStatus === GitFileStatusCode.UNTRACKED) {
-      return styles.statusUntracked
-    }
-    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED && e.unstagedStatus !== GitFileStatusCode.UNSPECIFIED) {
-      // Both staged and unstaged changes — show unstaged color.
-      return styles.statusUnstaged
-    }
-    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED) {
-      return styles.statusStaged
-    }
-    return styles.statusUnstaged
+    if (e.unstagedStatus === GitFileStatusCode.UNMERGED || e.stagedStatus === GitFileStatusCode.UNMERGED)
+      return dtStyles.iconConflict
+    if (e.unstagedStatus === GitFileStatusCode.UNTRACKED)
+      return dtStyles.iconUntracked
+    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED && e.unstagedStatus === GitFileStatusCode.UNSPECIFIED)
+      return dtStyles.iconStaged
+    return dtStyles.iconUnstaged
   }
 
-  return (
-    <span
-      class={`${styles.statusIndicator} ${statusClass()}`}
-      data-testid={
-        props.entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
-        && props.entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
-          ? 'git-status-staged'
-          : props.entry.unstagedStatus === GitFileStatusCode.UNTRACKED
-            ? 'git-status-untracked'
-            : 'git-status-unstaged'
-      }
-    />
-  )
+  const testId = () => {
+    const e = props.entry
+    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED && e.unstagedStatus === GitFileStatusCode.UNSPECIFIED)
+      return 'git-status-staged'
+    if (e.unstagedStatus === GitFileStatusCode.UNTRACKED)
+      return 'git-status-untracked'
+    return 'git-status-unstaged'
+  }
+
+  return <Icon icon={FileIcon} size="sm" class={iconClass()} data-testid={testId()} />
 }
 
 /** Diff stats badge showing +N -M. */
@@ -97,6 +109,51 @@ export const DiffStatsBadge: Component<{ entry: GitFileStatusEntry }> = (props) 
   )
 }
 
+/** Toolbar buttons rendered in the section header. */
+export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps> = (props) => {
+  return (
+    <>
+      <Show when={props.isFiltered?.()}>
+        <IconButton
+          icon={props.flatListMode?.() ? FolderTree : List}
+          iconSize="xs"
+          size="sm"
+          title={props.flatListMode?.() ? 'Tree view' : 'Flat list'}
+          state={props.flatListMode?.() ? IconButtonState.Active : IconButtonState.Enabled}
+          onClick={() => props.onToggleFlatList?.()}
+          data-testid="files-flat-list-toggle"
+        />
+      </Show>
+      <Show when={props.hasActiveFileTab}>
+        <IconButton
+          icon={LocateFixed}
+          iconSize="xs"
+          size="sm"
+          title="Locate active file"
+          onClick={() => props.onLocateFile()}
+          data-testid="files-locate-file"
+        />
+      </Show>
+      <IconButton
+        icon={ChevronsDownUp}
+        iconSize="xs"
+        size="sm"
+        title="Collapse all"
+        onClick={() => props.onCollapseAll()}
+        data-testid="files-collapse-all"
+      />
+      <IconButton
+        icon={RefreshCw}
+        iconSize="xs"
+        size="sm"
+        title="Refresh git status"
+        onClick={() => props.onRefresh()}
+        data-testid="files-refresh-git"
+      />
+    </>
+  )
+}
+
 export const FilesSection: Component<FilesSectionProps> = (props) => {
   const [activeFilter, setActiveFilter] = createSignal<GitFilterTab>('all')
   const [flatListMode, setFlatListMode] = createSignal(false)
@@ -104,24 +161,17 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
 
   const isFiltered = () => activeFilter() !== 'all'
 
+  // Expose imperative handle via ref callback.
+  createEffect(() => {
+    props.ref?.({
+      collapseAll: () => treeHandle?.collapseAll(),
+      isFiltered,
+      flatListMode,
+      toggleFlatListMode: () => setFlatListMode(prev => !prev),
+    })
+  })
+
   const changedFiles = () => props.gitStatusStore.getChangedFiles(activeFilter())
-
-  const handleRefresh = () => {
-    if (props.workerId && props.workingDir) {
-      props.gitStatusStore.refresh(props.workerId, props.workingDir)
-    }
-  }
-
-  const handleCollapseAll = () => {
-    treeHandle?.collapseAll()
-  }
-
-  const handleLocateFile = () => {
-    if (props.activeFilePath) {
-      // Setting selectedPath triggers the auto-expand + scroll effects in DirectoryTree.
-      props.onFileSelect(props.activeFilePath)
-    }
-  }
 
   const handleFlatFileOpen = (entry: GitFileStatusEntry) => {
     const root = props.gitStatusStore.state.repoRoot || props.workingDir
@@ -175,43 +225,6 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
               </button>
             )}
           </For>
-          <div class={styles.toolbar}>
-            <Show when={isFiltered()}>
-              <IconButton
-                icon={flatListMode() ? FolderTree : List}
-                iconSize="xs"
-                size="sm"
-                title={flatListMode() ? 'Tree view' : 'Flat list'}
-                onClick={() => setFlatListMode(prev => !prev)}
-                data-testid="files-flat-list-toggle"
-              />
-            </Show>
-            <IconButton
-              icon={ChevronsDownUp}
-              iconSize="xs"
-              size="sm"
-              title="Collapse all"
-              onClick={handleCollapseAll}
-              data-testid="files-collapse-all"
-            />
-            <IconButton
-              icon={LocateFixed}
-              iconSize="xs"
-              size="sm"
-              title="Locate active file"
-              onClick={handleLocateFile}
-              state={props.hasActiveFileTab ? IconButtonState.Enabled : IconButtonState.Disabled}
-              data-testid="files-locate-file"
-            />
-            <IconButton
-              icon={RefreshCw}
-              iconSize="xs"
-              size="sm"
-              title="Refresh git status"
-              onClick={handleRefresh}
-              data-testid="files-refresh-git"
-            />
-          </div>
         </div>
       </Show>
 
@@ -243,7 +256,7 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
                 class={styles.flatListItem}
                 onClick={() => handleFlatFileOpen(entry)}
               >
-                <FileStatusIndicator entry={entry} />
+                <FileStatusIcon entry={entry} />
                 <span>{entry.path}</span>
                 <DiffStatsBadge entry={entry} />
               </div>

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -1,0 +1,261 @@
+import type { Component } from 'solid-js'
+import type { DirectoryTreeHandle } from './DirectoryTree'
+import type { GitFileStatusEntry } from '~/generated/leapmux/v1/git_pb'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
+import ChevronsDownUp from 'lucide-solid/icons/chevrons-down-up'
+import FolderTree from 'lucide-solid/icons/folder-tree'
+import List from 'lucide-solid/icons/list'
+import LocateFixed from 'lucide-solid/icons/locate-fixed'
+import RefreshCw from 'lucide-solid/icons/refresh-cw'
+import { createSignal, For, Show } from 'solid-js'
+import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { GitFileStatusCode } from '~/generated/leapmux/v1/git_pb'
+import { DirectoryTree } from './DirectoryTree'
+import * as styles from './FilesSection.css'
+
+export interface FilesSectionProps {
+  workerId: string
+  workingDir: string
+  homeDir: string
+  fileTreePath: string
+  onFileSelect: (path: string) => void
+  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
+  onMention?: (path: string) => void
+  onOpenTerminal?: (dirPath: string) => void
+  gitStatusStore: ReturnType<typeof createGitFileStatusStore>
+  /** Currently active file tab's path (for locate file). */
+  activeFilePath?: string
+  /** Whether the active tab is a file tab (for locate button enabled state). */
+  hasActiveFileTab: boolean
+}
+
+const FILTER_TABS: { key: GitFilterTab, label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'changed', label: 'Changed' },
+  { key: 'staged', label: 'Staged' },
+  { key: 'unstaged', label: 'Unstaged' },
+]
+
+/** Status indicator dot for a file entry. */
+export const FileStatusIndicator: Component<{ entry: GitFileStatusEntry }> = (props) => {
+  const statusClass = () => {
+    const e = props.entry
+    if (e.unstagedStatus === GitFileStatusCode.UNMERGED || e.stagedStatus === GitFileStatusCode.UNMERGED) {
+      return styles.statusConflict
+    }
+    if (e.unstagedStatus === GitFileStatusCode.UNTRACKED) {
+      return styles.statusUntracked
+    }
+    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED && e.unstagedStatus !== GitFileStatusCode.UNSPECIFIED) {
+      // Both staged and unstaged changes — show unstaged color.
+      return styles.statusUnstaged
+    }
+    if (e.stagedStatus !== GitFileStatusCode.UNSPECIFIED) {
+      return styles.statusStaged
+    }
+    return styles.statusUnstaged
+  }
+
+  return (
+    <span
+      class={`${styles.statusIndicator} ${statusClass()}`}
+      data-testid={
+        props.entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+        && props.entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED
+          ? 'git-status-staged'
+          : props.entry.unstagedStatus === GitFileStatusCode.UNTRACKED
+            ? 'git-status-untracked'
+            : 'git-status-unstaged'
+      }
+    />
+  )
+}
+
+/** Diff stats badge showing +N -M. */
+export const DiffStatsBadge: Component<{ entry: GitFileStatusEntry }> = (props) => {
+  const totalAdded = () => props.entry.linesAdded + props.entry.stagedLinesAdded
+  const totalDeleted = () => props.entry.linesDeleted + props.entry.stagedLinesDeleted
+
+  return (
+    <Show when={totalAdded() > 0 || totalDeleted() > 0}>
+      <span class={styles.diffStats} data-testid="git-diff-stats">
+        <Show when={totalAdded() > 0}>
+          <span class={styles.diffStatsAdded}>
+            +
+            {totalAdded()}
+          </span>
+        </Show>
+        {totalAdded() > 0 && totalDeleted() > 0 ? ' ' : ''}
+        <Show when={totalDeleted() > 0}>
+          <span class={styles.diffStatsDeleted}>
+            -
+            {totalDeleted()}
+          </span>
+        </Show>
+      </span>
+    </Show>
+  )
+}
+
+export const FilesSection: Component<FilesSectionProps> = (props) => {
+  const [activeFilter, setActiveFilter] = createSignal<GitFilterTab>('all')
+  const [flatListMode, setFlatListMode] = createSignal(false)
+  let treeHandle: DirectoryTreeHandle | undefined
+
+  const isFiltered = () => activeFilter() !== 'all'
+
+  const changedFiles = () => props.gitStatusStore.getChangedFiles(activeFilter())
+
+  const handleRefresh = () => {
+    if (props.workerId && props.workingDir) {
+      props.gitStatusStore.refresh(props.workerId, props.workingDir)
+    }
+  }
+
+  const handleCollapseAll = () => {
+    treeHandle?.collapseAll()
+  }
+
+  const handleLocateFile = () => {
+    if (props.activeFilePath) {
+      // Setting selectedPath triggers the auto-expand + scroll effects in DirectoryTree.
+      props.onFileSelect(props.activeFilePath)
+    }
+  }
+
+  const handleFlatFileOpen = (entry: GitFileStatusEntry) => {
+    const root = props.gitStatusStore.state.repoRoot || props.workingDir
+    const absPath = `${root}/${entry.path}`
+    props.onFileOpen?.(absPath, activeFilter())
+  }
+
+  /** Compute visible paths for filtered tree view. */
+  const visiblePaths = (): Set<string> | undefined => {
+    if (!isFiltered())
+      return undefined
+
+    const files = changedFiles()
+    const root = props.gitStatusStore.state.repoRoot || props.workingDir
+    const paths = new Set<string>()
+
+    // Always include root.
+    paths.add(root)
+
+    for (const f of files) {
+      const absPath = `${root}/${f.path}`
+      paths.add(absPath)
+      // Add all ancestor directories.
+      let dir = absPath
+      while (true) {
+        const lastSlash = dir.lastIndexOf('/')
+        if (lastSlash <= 0)
+          break
+        dir = dir.substring(0, lastSlash)
+        if (dir === root)
+          break
+        paths.add(dir)
+      }
+    }
+
+    return paths
+  }
+
+  return (
+    <div class={styles.wrapper}>
+      <Show when={props.gitStatusStore.state.isGitRepo}>
+        <div class={styles.tabBar} data-testid="files-filter-tab-bar">
+          <For each={FILTER_TABS}>
+            {tab => (
+              <button
+                class={`${styles.tabButton}${activeFilter() === tab.key ? ` ${styles.tabButtonActive}` : ''}`}
+                onClick={() => setActiveFilter(tab.key)}
+                data-testid={`files-filter-${tab.key}`}
+              >
+                {tab.label}
+              </button>
+            )}
+          </For>
+          <div class={styles.toolbar}>
+            <Show when={isFiltered()}>
+              <IconButton
+                icon={flatListMode() ? FolderTree : List}
+                iconSize="xs"
+                size="sm"
+                title={flatListMode() ? 'Tree view' : 'Flat list'}
+                onClick={() => setFlatListMode(prev => !prev)}
+                data-testid="files-flat-list-toggle"
+              />
+            </Show>
+            <IconButton
+              icon={ChevronsDownUp}
+              iconSize="xs"
+              size="sm"
+              title="Collapse all"
+              onClick={handleCollapseAll}
+              data-testid="files-collapse-all"
+            />
+            <IconButton
+              icon={LocateFixed}
+              iconSize="xs"
+              size="sm"
+              title="Locate active file"
+              onClick={handleLocateFile}
+              state={props.hasActiveFileTab ? IconButtonState.Enabled : IconButtonState.Disabled}
+              data-testid="files-locate-file"
+            />
+            <IconButton
+              icon={RefreshCw}
+              iconSize="xs"
+              size="sm"
+              title="Refresh git status"
+              onClick={handleRefresh}
+              data-testid="files-refresh-git"
+            />
+          </div>
+        </div>
+      </Show>
+
+      <Show
+        when={isFiltered() && flatListMode()}
+        fallback={(
+          <div class={styles.treeContent}>
+            <DirectoryTree
+              workerId={props.workerId}
+              showFiles
+              selectedPath={props.fileTreePath}
+              onSelect={props.onFileSelect}
+              onFileOpen={path => props.onFileOpen?.(path, activeFilter())}
+              onMention={props.onMention}
+              onOpenTerminal={props.onOpenTerminal}
+              rootPath={props.workingDir || '~'}
+              homeDir={props.homeDir}
+              gitStatusStore={props.gitStatusStore}
+              visiblePaths={visiblePaths()}
+              ref={(h) => { treeHandle = h }}
+            />
+          </div>
+        )}
+      >
+        <div class={styles.flatList} data-testid="files-flat-list">
+          <For each={changedFiles()}>
+            {entry => (
+              <div
+                class={styles.flatListItem}
+                onClick={() => handleFlatFileOpen(entry)}
+              >
+                <FileStatusIndicator entry={entry} />
+                <span>{entry.path}</span>
+                <DiffStatsBadge entry={entry} />
+              </div>
+            )}
+          </For>
+          <Show when={changedFiles().length === 0}>
+            <div style={{ 'padding': 'var(--space-4)', 'color': 'var(--faint-foreground)', 'font-size': 'var(--text-7)', 'text-align': 'center' }}>
+              No changes
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/stores/gitFileStatus.store.ts
+++ b/frontend/src/stores/gitFileStatus.store.ts
@@ -1,0 +1,101 @@
+import type { GitFileStatusEntry } from '~/generated/leapmux/v1/git_pb'
+import { createSignal } from 'solid-js'
+import { createStore, produce } from 'solid-js/store'
+import { gitClient } from '~/api/clients'
+import { apiCallTimeout } from '~/api/transport'
+import { GitFileStatusCode } from '~/generated/leapmux/v1/git_pb'
+
+export { GitFileStatusCode }
+export type { GitFileStatusEntry }
+
+export type GitFilterTab = 'all' | 'changed' | 'staged' | 'unstaged'
+
+interface GitFileStatusState {
+  isGitRepo: boolean
+  repoRoot: string
+  files: GitFileStatusEntry[]
+}
+
+export function createGitFileStatusStore() {
+  const [state, setState] = createStore<GitFileStatusState>({
+    isGitRepo: false,
+    repoRoot: '',
+    files: [],
+  })
+
+  const [loading, setLoading] = createSignal(false)
+  const [lastFetchedAt, setLastFetchedAt] = createSignal(0)
+
+  const refresh = async (workerId: string, path: string) => {
+    if (!workerId || !path)
+      return
+    setLoading(true)
+    try {
+      const resp = await gitClient.getGitFileStatus({ workerId, path }, apiCallTimeout())
+      setState(produce((s) => {
+        s.isGitRepo = true
+        s.repoRoot = resp.repoRoot
+        s.files = resp.files
+      }))
+      setLastFetchedAt(Date.now())
+    }
+    catch {
+      setState(produce((s) => {
+        s.isGitRepo = false
+        s.repoRoot = ''
+        s.files = []
+      }))
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+
+  const clear = () => {
+    setState({ isGitRepo: false, repoRoot: '', files: [] })
+  }
+
+  const getFileStatus = (absPath: string): GitFileStatusEntry | undefined => {
+    // Convert absolute path to relative path from repo root.
+    const root = state.repoRoot
+    if (!root)
+      return undefined
+    const relPath = absPath.startsWith(`${root}/`) ? absPath.slice(root.length + 1) : absPath
+    return state.files.find(f => f.path === relPath)
+  }
+
+  const getChangedFiles = (filter: GitFilterTab): GitFileStatusEntry[] => {
+    if (filter === 'all')
+      return state.files
+    return state.files.filter((f) => {
+      if (filter === 'staged') {
+        return f.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+      }
+      if (filter === 'unstaged') {
+        return f.unstagedStatus !== GitFileStatusCode.UNSPECIFIED
+      }
+      // 'changed' — any change (staged or unstaged)
+      return f.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+        || f.unstagedStatus !== GitFileStatusCode.UNSPECIFIED
+    })
+  }
+
+  const hasChanges = (dirPath: string): boolean => {
+    const root = state.repoRoot
+    if (!root)
+      return false
+    const relDir = dirPath.startsWith(`${root}/`) ? dirPath.slice(root.length + 1) : dirPath
+    return state.files.some(f => f.path.startsWith(`${relDir}/`) || f.path === relDir)
+  }
+
+  return {
+    state,
+    loading,
+    lastFetchedAt,
+    refresh,
+    clear,
+    getFileStatus,
+    getChangedFiles,
+    hasChanges,
+  }
+}

--- a/frontend/src/stores/tab.store.ts
+++ b/frontend/src/stores/tab.store.ts
@@ -4,6 +4,10 @@ import { after, first, mid } from '~/lib/lexorank'
 
 export { TabType }
 
+export type FileViewMode = 'working' | 'head' | 'staged' | 'unified-diff' | 'split-diff'
+export type FileDiffBase = 'head-vs-working' | 'head-vs-staged'
+export type FileOpenSource = 'all' | 'changed' | 'staged' | 'unstaged'
+
 export interface Tab {
   type: TabType
   id: string
@@ -15,6 +19,9 @@ export interface Tab {
   workingDir?: string
   filePath?: string
   displayMode?: string
+  fileViewMode?: FileViewMode
+  fileDiffBase?: FileDiffBase
+  fileOpenSource?: FileOpenSource
 }
 
 export function tabKey(tab: Tab): string {
@@ -204,6 +211,18 @@ export function createTabStore() {
     setTabDisplayMode(type: TabType, id: string, displayMode: string) {
       const key = tabKey({ type, id })
       setState('tabs', t => tabKey(t) === key, 'displayMode', displayMode)
+    },
+
+    /** Set the file view mode for a file tab. */
+    setTabFileViewMode(type: TabType, id: string, mode: FileViewMode) {
+      const key = tabKey({ type, id })
+      setState('tabs', t => tabKey(t) === key, 'fileViewMode', mode)
+    },
+
+    /** Set the file diff base for a file tab. */
+    setTabFileDiffBase(type: TabType, id: string, base: FileDiffBase) {
+      const key = tabKey({ type, id })
+      setState('tabs', t => tabKey(t) === key, 'fileDiffBase', base)
     },
 
     /** Move a tab to a different tile, cleaning up source tile state. */

--- a/frontend/tests/e2e/41-chat-pagination.spec.ts
+++ b/frontend/tests/e2e/41-chat-pagination.spec.ts
@@ -141,8 +141,9 @@ test.describe('Chat Pagination & Scroll', () => {
     await waitForAssistantReply(page)
     await waitForTurnComplete(page)
 
-    // Verify message is visible
-    const chatContainer = page.locator('[data-testid="chat-container"]')
+    // Verify message is visible (use .first() because all agent tabs stay
+    // mounted and the locator may resolve to multiple elements)
+    const chatContainer = page.locator('[data-testid="chat-container"]').first()
     await expect(chatContainer).toContainText('First Agent Reply', { timeout: 30_000 })
 
     // Create a second agent tab
@@ -153,7 +154,7 @@ test.describe('Chat Pagination & Scroll', () => {
     const agentTabs = page.locator('[data-testid="tab"][data-tab-type="agent"]')
     await agentTabs.first().click()
 
-    // Wait for messages to load (initial load happens on tab switch)
+    // Wait for messages to load (tab content stays mounted across switches)
     await expect(chatContainer).toContainText('First Agent Reply', { timeout: 15_000 })
   })
 

--- a/frontend/tests/e2e/61-quote-and-mention.spec.ts
+++ b/frontend/tests/e2e/61-quote-and-mention.spec.ts
@@ -341,8 +341,9 @@ test.describe('Quote and Mention', () => {
       const lineElements = page.locator('[data-line-num]')
       await expect(lineElements.first()).toBeVisible({ timeout: 10_000 })
 
-      // Triple-click on a line to select text within the file view
-      await lineElements.first().click({ clickCount: 3 })
+      // Triple-click on a line to select text within the file view.
+      // Use nth(2) to avoid the floating DiffModeToolbar at the top.
+      await lineElements.nth(2).click({ clickCount: 3 })
 
       // Wait for the quote popover to appear
       await page.waitForTimeout(500)

--- a/frontend/tests/e2e/62-directory-tree.spec.ts
+++ b/frontend/tests/e2e/62-directory-tree.spec.ts
@@ -4,7 +4,7 @@ import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
 import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
 
 test.describe('DirectoryTree', () => {
-  test('root directory is visible and collapsible', async ({ page, leapmuxServer }) => {
+  test('root directory is always visible and expanded', async ({ page, leapmuxServer }) => {
     const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Tree Root Test', adminOrgId, process.cwd())
     try {
@@ -16,19 +16,11 @@ test.describe('DirectoryTree', () => {
       const rootNode = page.locator('[data-testid="tree-root-node"]')
       await expect(rootNode).toBeVisible({ timeout: 15_000 })
 
-      // Children should be visible (root starts expanded)
+      // Children should be visible (root is always expanded)
       await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
 
-      // Click root to collapse
+      // Clicking root should NOT collapse it (root is uncollapsible)
       await rootNode.click()
-
-      // Children should be hidden
-      await expect(page.getByText('package.json')).not.toBeVisible()
-
-      // Click root to expand again
-      await rootNode.click()
-
-      // Children should reappear
       await expect(page.getByText('package.json')).toBeVisible()
     }
     finally {
@@ -162,6 +154,134 @@ test.describe('DirectoryTree', () => {
     }
   })
 
+  test('collapsing a directory does not scroll the tree', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Collapse Scroll Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for tree to load
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Expand "src" to add more items to the tree
+      const srcNode = page.locator('span:text-is("src")').first()
+      await expect(srcNode).toBeVisible({ timeout: 5_000 })
+      await srcNode.click()
+      await page.waitForTimeout(500)
+
+      // Select a file to change selectedPath away from "src".
+      // This is needed because clicking src again to collapse only triggers
+      // the scroll-on-select effect when selectedPath actually changes.
+      const fileNode = page.getByText('package.json')
+      await fileNode.click()
+      await page.waitForTimeout(200)
+
+      // Find the tree scroll container (first ancestor with overflow: auto)
+      // and constrain its height to force it to be scrollable.
+      const scrollContainerHandle = await page.evaluateHandle(() => {
+        const node = document.querySelector('[data-testid="tree-root-node"]')
+        if (!node)
+          return null
+        let el: Element | null = node.parentElement
+        while (el) {
+          const style = window.getComputedStyle(el)
+          if (style.overflow === 'auto' || style.overflowY === 'auto')
+            return el
+          el = el.parentElement
+        }
+        return null
+      })
+
+      const isNull = await scrollContainerHandle.evaluate(el => el === null)
+      expect(isNull).toBe(false)
+
+      // Force the container to a small fixed height so tree content overflows
+      await scrollContainerHandle.evaluate((el) => {
+        if (el)
+          (el as HTMLElement).style.maxHeight = '150px'
+      })
+      await page.waitForTimeout(100)
+
+      // Verify the container is now scrollable
+      const scrollable = await scrollContainerHandle.evaluate(
+        el => el ? el.scrollHeight > el.clientHeight : false,
+      )
+      expect(scrollable).toBe(true)
+
+      // Scroll down so "src" is partially visible near the bottom
+      await scrollContainerHandle.evaluate((el) => {
+        if (el)
+          (el as HTMLElement).scrollTop = Math.min(50, el.scrollHeight - el.clientHeight)
+      })
+      await page.waitForTimeout(100)
+
+      const scrollTopBefore = await scrollContainerHandle.evaluate(
+        el => el ? (el as HTMLElement).scrollTop : 0,
+      )
+      expect(scrollTopBefore).toBeGreaterThan(0)
+
+      // Collapse "src" — should NOT change scroll position.
+      // selectedPath changes from the file to src, which would trigger
+      // the scroll-on-select effect without the fix.
+      await srcNode.click()
+      // Wait for rAF (the scroll-on-select effect fires in requestAnimationFrame)
+      await page.waitForTimeout(300)
+
+      const scrollTopAfter = await scrollContainerHandle.evaluate(
+        el => el ? (el as HTMLElement).scrollTop : 0,
+      )
+      expect(scrollTopAfter).toBe(scrollTopBefore)
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('collapse all collapses every expanded directory', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    // process.cwd() is the frontend directory in the test runner
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Collapse All Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for tree to load — root is expanded by default
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Expand "src" directory (child of root = frontend/)
+      const srcNode = page.locator('span:text-is("src")').first()
+      await expect(srcNode).toBeVisible({ timeout: 5_000 })
+      await srcNode.click()
+      await page.waitForTimeout(500)
+
+      // "components" should now be visible (child of src)
+      const componentsNode = page.locator('span:text-is("components")').first()
+      await expect(componentsNode).toBeVisible({ timeout: 5_000 })
+
+      // Click collapse all button
+      await page.locator('[data-testid="files-collapse-all"]').click()
+      // Wait for collapse animation (150ms transition)
+      await page.waitForTimeout(300)
+
+      // Root should still be expanded — root-level items still visible
+      await expect(page.getByText('package.json')).toBeVisible()
+      // "src" is a root child, so it should still be visible
+      await expect(srcNode).toBeVisible()
+      // But "components" (child of src) should be hidden because src is collapsed
+      await expect(componentsNode).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
   test('expand state persists across tab switches', async ({ page, leapmuxServer }) => {
     const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'State Persist Test', adminOrgId, process.cwd())
@@ -170,14 +290,24 @@ test.describe('DirectoryTree', () => {
       await page.goto(`/o/admin/workspace/${workspaceId}`)
       await waitForWorkspaceReady(page)
 
-      // Wait for tree to load and ensure root is expanded (default)
+      // Wait for tree to load
       const rootNode = page.locator('[data-testid="tree-root-node"]')
       await expect(rootNode).toBeVisible({ timeout: 15_000 })
       await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
 
-      // Collapse the root
-      await rootNode.click()
-      await expect(page.getByText('package.json')).not.toBeVisible()
+      // Expand "src" directory
+      const srcNode = page.locator('span:text-is("src")').first()
+      await expect(srcNode).toBeVisible({ timeout: 5_000 })
+      await srcNode.click()
+      await page.waitForTimeout(500)
+
+      // "components" should now be visible (child of src)
+      const componentsNode = page.locator('span:text-is("components")').first()
+      await expect(componentsNode).toBeVisible({ timeout: 5_000 })
+
+      // Collapse "src"
+      await srcNode.click()
+      await expect(componentsNode).not.toBeVisible()
 
       // Switch to a terminal tab (if exists) or create one
       const terminalTab = page.locator('[data-testid="tab"][data-tab-type="terminal"]')
@@ -191,9 +321,9 @@ test.describe('DirectoryTree', () => {
       await agentTab.first().click()
       await page.waitForTimeout(500)
 
-      // Root should still be collapsed (state persisted via sessionStorage)
-      await expect(rootNode).toBeVisible()
-      await expect(page.getByText('package.json')).not.toBeVisible()
+      // "src" should still be collapsed (state persisted via sessionStorage)
+      await expect(srcNode).toBeVisible()
+      await expect(componentsNode).not.toBeVisible()
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})

--- a/frontend/tests/e2e/63-git-file-status.spec.ts
+++ b/frontend/tests/e2e/63-git-file-status.spec.ts
@@ -215,9 +215,9 @@ test.describe('Git File Status', () => {
     }
   })
 
-  test('locate file button disabled when no file tab active', async ({ page, leapmuxServer }) => {
+  test('locate file button hidden when no file tab active', async ({ page, leapmuxServer }) => {
     const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
-    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Locate Disabled Test', adminOrgId, process.cwd())
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Locate Hidden Test', adminOrgId, process.cwd())
     try {
       await loginViaToken(page, adminToken)
       await page.goto(`/o/admin/workspace/${workspaceId}`)
@@ -225,11 +225,9 @@ test.describe('Git File Status', () => {
 
       await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
 
-      // When an agent tab is active (default), locate button should be disabled.
+      // When an agent tab is active (default), locate button should not be visible.
       const locateButton = page.locator('[data-testid="files-locate-file"]')
-      await expect(locateButton).toBeVisible()
-      // IconButton renders with the standard HTML disabled attribute.
-      await expect(locateButton).toBeDisabled()
+      await expect(locateButton).not.toBeVisible()
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})

--- a/frontend/tests/e2e/63-git-file-status.spec.ts
+++ b/frontend/tests/e2e/63-git-file-status.spec.ts
@@ -1,0 +1,294 @@
+import { execSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { expect, test } from './fixtures'
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
+import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+
+/**
+ * Creates a temporary git repo with controlled file states for testing.
+ * Returns the repo directory path. The caller must clean up via `rmSync`.
+ */
+function createTempGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'leapmux-e2e-git-'))
+  execSync('git init', { cwd: dir })
+  execSync('git config user.email "test@test.com"', { cwd: dir })
+  execSync('git config user.name "Test"', { cwd: dir })
+
+  // Create initial committed files.
+  writeFileSync(join(dir, 'clean.txt'), 'clean content')
+  writeFileSync(join(dir, 'file_a.txt'), 'original content a')
+  writeFileSync(join(dir, 'file_b.txt'), 'original content b')
+  execSync('git add .', { cwd: dir })
+  execSync('git commit -m "initial"', { cwd: dir })
+
+  // file_a: staged modification
+  writeFileSync(join(dir, 'file_a.txt'), 'modified content a\nnew line\n')
+  execSync('git add file_a.txt', { cwd: dir })
+
+  // file_b: unstaged modification
+  writeFileSync(join(dir, 'file_b.txt'), 'modified content b\nline2\nline3\n')
+
+  return dir
+}
+
+test.describe('Git File Status', () => {
+  test('git filter tab bar is visible for git repo workspace', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Git TabBar Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree to load.
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Tab bar should be visible in a git repo.
+      const tabBar = page.locator('[data-testid="files-filter-tab-bar"]')
+      await expect(tabBar).toBeVisible({ timeout: 15_000 })
+
+      // All 4 filter tabs should be present.
+      await expect(page.locator('[data-testid="files-filter-all"]')).toBeVisible()
+      await expect(page.locator('[data-testid="files-filter-changed"]')).toBeVisible()
+      await expect(page.locator('[data-testid="files-filter-staged"]')).toBeVisible()
+      await expect(page.locator('[data-testid="files-filter-unstaged"]')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('tab bar hidden for non-git directory', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    // Use /tmp as a non-git directory.
+    const tempDir = mkdtempSync(join(tmpdir(), 'leapmux-e2e-nongit-'))
+    writeFileSync(join(tempDir, 'hello.txt'), 'test')
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Non-Git Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for the file tree to load.
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Tab bar should NOT be visible.
+      await expect(page.locator('[data-testid="files-filter-tab-bar"]')).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('filter tabs show correct files', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const tempDir = createTempGitRepo()
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Filter Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      // Wait for tree to load.
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+      await expect(page.locator('[data-testid="files-filter-tab-bar"]')).toBeVisible({ timeout: 15_000 })
+
+      // "All" tab (default) should show all files including clean.txt.
+      await expect(page.getByText('clean.txt')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByText('file_a.txt')).toBeVisible()
+      await expect(page.getByText('file_b.txt')).toBeVisible()
+
+      // Switch to "Changed" tab — should show only changed files.
+      await page.locator('[data-testid="files-filter-changed"]').click()
+      await expect(page.getByText('file_a.txt')).toBeVisible()
+      await expect(page.getByText('file_b.txt')).toBeVisible()
+      await expect(page.getByText('clean.txt')).not.toBeVisible()
+
+      // Switch to "Staged" tab — should show only file_a.
+      await page.locator('[data-testid="files-filter-staged"]').click()
+      await expect(page.getByText('file_a.txt')).toBeVisible()
+      await expect(page.getByText('file_b.txt')).not.toBeVisible()
+
+      // Switch to "Unstaged" tab — should show only file_b.
+      await page.locator('[data-testid="files-filter-unstaged"]').click()
+      await expect(page.getByText('file_b.txt')).toBeVisible()
+      await expect(page.getByText('file_a.txt')).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('git status indicators on files', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const tempDir = createTempGitRepo()
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Status Indicator Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Switch to Changed tab to see status indicators.
+      await page.locator('[data-testid="files-filter-changed"]').click()
+
+      // Status indicators should be visible.
+      await expect(page.locator('[data-testid="git-status-staged"]')).toBeVisible({ timeout: 10_000 })
+      await expect(page.locator('[data-testid="git-status-unstaged"]')).toBeVisible()
+
+      // Diff stats badges should be visible.
+      await expect(page.locator('[data-testid="git-diff-stats"]').first()).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('flat list toggle in changed mode', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const tempDir = createTempGitRepo()
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Flat List Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Switch to Changed tab.
+      await page.locator('[data-testid="files-filter-changed"]').click()
+      await expect(page.getByText('file_a.txt')).toBeVisible({ timeout: 10_000 })
+
+      // Click flat list toggle.
+      await page.locator('[data-testid="files-flat-list-toggle"]').click()
+
+      // Flat list should be visible.
+      await expect(page.locator('[data-testid="files-flat-list"]')).toBeVisible()
+      await expect(page.getByText('file_a.txt')).toBeVisible()
+      await expect(page.getByText('file_b.txt')).toBeVisible()
+
+      // Toggle back.
+      await page.locator('[data-testid="files-flat-list-toggle"]').click()
+
+      // Tree view should return (flat list hidden).
+      await expect(page.locator('[data-testid="files-flat-list"]')).not.toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('collapse all button resets tree expansion', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Collapse All Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      const rootNode = page.locator('[data-testid="tree-root-node"]')
+      await expect(rootNode).toBeVisible({ timeout: 15_000 })
+
+      // Verify children are visible (root is expanded by default).
+      await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 })
+
+      // Expand a subdirectory.
+      await page.getByText('src').click()
+
+      // Click collapse all.
+      await page.locator('[data-testid="files-collapse-all"]').click()
+
+      // Wait for collapse to take effect. Only root should be expanded.
+      // Subdirectory contents should not be visible.
+      await expect(page.getByText('package.json')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('locate file button disabled when no file tab active', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Locate Disabled Test', adminOrgId, process.cwd())
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // When an agent tab is active (default), locate button should be disabled.
+      const locateButton = page.locator('[data-testid="files-locate-file"]')
+      await expect(locateButton).toBeVisible()
+      // IconButton renders with the standard HTML disabled attribute.
+      await expect(locateButton).toBeDisabled()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+
+  test('diff mode toolbar appears for changed files', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const tempDir = createTempGitRepo()
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Diff Toolbar Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Switch to Changed tab and click a file.
+      await page.locator('[data-testid="files-filter-changed"]').click()
+      await expect(page.getByText('file_b.txt')).toBeVisible({ timeout: 10_000 })
+      await page.getByText('file_b.txt').click()
+
+      // Diff mode toolbar should appear.
+      await expect(page.locator('[data-testid="diff-mode-toolbar"]')).toBeVisible({ timeout: 10_000 })
+
+      // Toolbar should have HEAD, Working, Unified, Split buttons.
+      await expect(page.locator('[data-testid="diff-mode-head"]')).toBeVisible()
+      await expect(page.locator('[data-testid="diff-mode-working"]')).toBeVisible()
+      await expect(page.locator('[data-testid="diff-mode-unified"]')).toBeVisible()
+      await expect(page.locator('[data-testid="diff-mode-split"]')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('opening from staged tab starts in diff view', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId, adminOrgId } = leapmuxServer
+    const tempDir = createTempGitRepo()
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, workerId, 'Staged Diff Test', adminOrgId, tempDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      await expect(page.locator('[data-testid="tree-root-node"]')).toBeVisible({ timeout: 15_000 })
+
+      // Switch to Staged tab and click file_a.
+      await page.locator('[data-testid="files-filter-staged"]').click()
+      await expect(page.getByText('file_a.txt')).toBeVisible({ timeout: 10_000 })
+      await page.getByText('file_a.txt').click()
+
+      // File should open with diff toolbar showing unified as active.
+      await expect(page.locator('[data-testid="diff-mode-toolbar"]')).toBeVisible({ timeout: 10_000 })
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/internal/hub/service/git_service.go
+++ b/internal/hub/service/git_service.go
@@ -204,6 +204,115 @@ func (s *GitService) KeepWorktree(
 	return connect.NewResponse(&leapmuxv1.KeepWorktreeResponse{}), nil
 }
 
+func (s *GitService) GetGitFileStatus(
+	ctx context.Context,
+	req *connect.Request[leapmuxv1.GetGitFileStatusRequest],
+) (*connect.Response[leapmuxv1.GetGitFileStatusResponse], error) {
+	user, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workerID := req.Msg.GetWorkerId()
+	conn, workerHomeDir, err := s.getWorkerConn(ctx, user, workerID, req.Msg.GetOrgId())
+	if err != nil {
+		return nil, err
+	}
+
+	gitPath := validate.SanitizePath(req.Msg.GetPath(), workerHomeDir)
+	if gitPath == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid path"))
+	}
+
+	resp, err := s.pending.SendAndWait(ctx, conn, &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_GitFileStatus{
+			GitFileStatus: &leapmuxv1.GitFileStatusRequest{
+				Path: gitPath,
+			},
+		},
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	statusResp := resp.GetGitFileStatusResp()
+	if statusResp == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unexpected response type"))
+	}
+
+	if statusResp.GetError() != "" {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("%s", statusResp.GetError()))
+	}
+
+	// Map worker bidi stream response to the RPC response type.
+	rpcFiles := make([]*leapmuxv1.GitFileStatusEntry, len(statusResp.GetFiles()))
+	for i, f := range statusResp.GetFiles() {
+		rpcFiles[i] = &leapmuxv1.GitFileStatusEntry{
+			Path:               f.GetPath(),
+			StagedStatus:       f.GetStagedStatus(),
+			UnstagedStatus:     f.GetUnstagedStatus(),
+			LinesAdded:         f.GetLinesAdded(),
+			LinesDeleted:       f.GetLinesDeleted(),
+			StagedLinesAdded:   f.GetStagedLinesAdded(),
+			StagedLinesDeleted: f.GetStagedLinesDeleted(),
+			OldPath:            f.GetOldPath(),
+		}
+	}
+
+	return connect.NewResponse(&leapmuxv1.GetGitFileStatusResponse{
+		RepoRoot: statusResp.GetRepoRoot(),
+		Files:    rpcFiles,
+	}), nil
+}
+
+func (s *GitService) ReadGitFile(
+	ctx context.Context,
+	req *connect.Request[leapmuxv1.ReadGitFileRequest],
+) (*connect.Response[leapmuxv1.ReadGitFileResponse], error) {
+	user, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workerID := req.Msg.GetWorkerId()
+	conn, workerHomeDir, err := s.getWorkerConn(ctx, user, workerID, req.Msg.GetOrgId())
+	if err != nil {
+		return nil, err
+	}
+
+	filePath := validate.SanitizePath(req.Msg.GetPath(), workerHomeDir)
+	if filePath == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid path"))
+	}
+
+	resp, err := s.pending.SendAndWait(ctx, conn, &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_GitFileRead{
+			GitFileRead: &leapmuxv1.GitFileReadRequest{
+				Path: filePath,
+				Ref:  req.Msg.GetRef(),
+			},
+		},
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	readResp := resp.GetGitFileReadResp()
+	if readResp == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unexpected response type"))
+	}
+
+	if readResp.GetError() != "" {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("%s", readResp.GetError()))
+	}
+
+	return connect.NewResponse(&leapmuxv1.ReadGitFileResponse{
+		Path:    readResp.GetPath(),
+		Content: readResp.GetContent(),
+		Exists:  readResp.GetExists(),
+	}), nil
+}
+
 func (s *GitService) getWorkerConn(ctx context.Context, user *auth.UserInfo, workerID, requestedOrgID string) (*workermgr.Conn, string, error) {
 	if workerID == "" {
 		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("worker_id is required"))

--- a/internal/worker/gitutil/gitutil.go
+++ b/internal/worker/gitutil/gitutil.go
@@ -440,6 +440,294 @@ func DeleteBranch(repoRoot, branchName string) error {
 	return nil
 }
 
+// FileStatus holds per-file git status information.
+type FileStatus struct {
+	Path               string
+	StagedStatus       byte // One of '.', 'M', 'A', 'D', 'R', 'C', 'T', '?', 'U'
+	UnstagedStatus     byte
+	LinesAdded         int
+	LinesDeleted       int
+	StagedLinesAdded   int
+	StagedLinesDeleted int
+	OldPath            string
+}
+
+// GetPerFileStatus returns per-file git status for the given directory.
+// It runs three git commands:
+//   - git status --porcelain=v2 -z (all changed files with XY status codes)
+//   - git diff --numstat -z (unstaged diff stats)
+//   - git diff --numstat --staged -z (staged diff stats)
+//
+// Returns nil for non-git directories.
+func GetPerFileStatus(dir string) ([]FileStatus, error) {
+	// 1. Get file status via porcelain v2.
+	cmd := exec.Command("git", "-C", dir, "status", "--porcelain=v2", "-z")
+	statusOut, err := cmd.Output()
+	if err != nil {
+		return nil, nil // Not a git repo or git unavailable.
+	}
+
+	files := parseStatusV2NUL(statusOut)
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	// Build a map for easy lookup.
+	fileMap := make(map[string]*FileStatus, len(files))
+	for i := range files {
+		fileMap[files[i].Path] = &files[i]
+	}
+
+	// 2. Get unstaged diff stats.
+	cmd2 := exec.Command("git", "-C", dir, "diff", "--numstat", "-z")
+	if numstatOut, err := cmd2.Output(); err == nil {
+		parseNumstatNUL(numstatOut, fileMap, false)
+	}
+
+	// 3. Get staged diff stats.
+	cmd3 := exec.Command("git", "-C", dir, "diff", "--numstat", "--staged", "-z")
+	if numstatOut, err := cmd3.Output(); err == nil {
+		parseNumstatNUL(numstatOut, fileMap, true)
+	}
+
+	return files, nil
+}
+
+// parseStatusV2NUL parses NUL-delimited `git status --porcelain=v2 -z` output.
+func parseStatusV2NUL(data []byte) []FileStatus {
+	var files []FileStatus
+	parts := splitNUL(data)
+
+	i := 0
+	for i < len(parts) {
+		entry := parts[i]
+		if len(entry) == 0 {
+			i++
+			continue
+		}
+
+		switch entry[0] {
+		case '1':
+			// Ordinary changed entry: "1 XY sub mH mI mW hH hI path"
+			fs := parseOrdinaryEntry(entry)
+			if fs != nil {
+				files = append(files, *fs)
+			}
+			i++
+
+		case '2':
+			// Renamed/copied entry: "2 XY sub mH mI mW hH hI Xscore path\0origPath"
+			fs := parseRenameEntry(entry)
+			if fs != nil {
+				// Next NUL-separated element is the original path.
+				if i+1 < len(parts) {
+					fs.OldPath = parts[i+1]
+					i += 2
+				} else {
+					i++
+				}
+				files = append(files, *fs)
+			} else {
+				i++
+			}
+
+		case 'u':
+			// Unmerged entry: "u XY sub m1 m2 m3 hH h1 h2 h3 path"
+			fs := parseUnmergedEntry(entry)
+			if fs != nil {
+				files = append(files, *fs)
+			}
+			i++
+
+		case '?':
+			// Untracked: "? path"
+			if len(entry) > 2 {
+				files = append(files, FileStatus{
+					Path:           entry[2:],
+					StagedStatus:   '.',
+					UnstagedStatus: '?',
+				})
+			}
+			i++
+
+		default:
+			i++
+		}
+	}
+
+	return files
+}
+
+func parseOrdinaryEntry(entry string) *FileStatus {
+	// Format: "1 XY sub mH mI mW hH hI path"
+	// Fields are space-separated, with path being the last field.
+	if len(entry) < 4 {
+		return nil
+	}
+	x := entry[2]
+	y := entry[3]
+	// Find the path: it's after the 8th space.
+	path := nthField(entry, 8)
+	if path == "" {
+		return nil
+	}
+	return &FileStatus{
+		Path:           path,
+		StagedStatus:   x,
+		UnstagedStatus: y,
+	}
+}
+
+func parseRenameEntry(entry string) *FileStatus {
+	// Format: "2 XY sub mH mI mW hH hI Xscore path"
+	if len(entry) < 4 {
+		return nil
+	}
+	x := entry[2]
+	y := entry[3]
+	path := nthField(entry, 9)
+	if path == "" {
+		return nil
+	}
+	return &FileStatus{
+		Path:           path,
+		StagedStatus:   x,
+		UnstagedStatus: y,
+	}
+}
+
+func parseUnmergedEntry(entry string) *FileStatus {
+	// Format: "u XY sub m1 m2 m3 hH h1 h2 h3 path"
+	if len(entry) < 4 {
+		return nil
+	}
+	x := entry[2]
+	y := entry[3]
+	path := nthField(entry, 10)
+	if path == "" {
+		return nil
+	}
+	return &FileStatus{
+		Path:           path,
+		StagedStatus:   x,
+		UnstagedStatus: y,
+	}
+}
+
+// nthField returns the content after the nth space in s (0-indexed).
+// e.g. nthField("a b c d", 2) == "c d", nthField("a b c d", 3) == "d"
+func nthField(s string, n int) string {
+	count := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			count++
+			if count == n {
+				return s[i+1:]
+			}
+		}
+	}
+	return ""
+}
+
+// parseNumstatNUL parses NUL-delimited `git diff --numstat -z` output.
+// When staged is true, it populates StagedLinesAdded/StagedLinesDeleted;
+// otherwise LinesAdded/LinesDeleted.
+func parseNumstatNUL(data []byte, fileMap map[string]*FileStatus, staged bool) {
+	// --numstat -z output format: "added\tdeleted\tpath\0" for regular files,
+	// or "added\tdeleted\t\0oldpath\0newpath\0" for renames.
+	parts := splitNUL(data)
+	i := 0
+	for i < len(parts) {
+		line := parts[i]
+		if line == "" {
+			i++
+			continue
+		}
+
+		// Each numstat entry is "added\tdeleted\tpath" or "added\tdeleted\t" (for renames).
+		tabs := strings.SplitN(line, "\t", 3)
+		if len(tabs) < 3 {
+			i++
+			continue
+		}
+
+		added, _ := fmt.Sscanf(tabs[0], "%d", new(int))
+		deleted, _ := fmt.Sscanf(tabs[1], "%d", new(int))
+		var addedVal, deletedVal int
+		if added > 0 {
+			_, _ = fmt.Sscanf(tabs[0], "%d", &addedVal)
+		}
+		if deleted > 0 {
+			_, _ = fmt.Sscanf(tabs[1], "%d", &deletedVal)
+		}
+
+		filePath := tabs[2]
+		if filePath == "" {
+			// Rename: next two parts are oldpath and newpath.
+			if i+2 < len(parts) {
+				filePath = parts[i+2] // Use new path.
+				i += 3
+			} else {
+				i++
+				continue
+			}
+		} else {
+			i++
+		}
+
+		if fs, ok := fileMap[filePath]; ok {
+			if staged {
+				fs.StagedLinesAdded = addedVal
+				fs.StagedLinesDeleted = deletedVal
+			} else {
+				fs.LinesAdded = addedVal
+				fs.LinesDeleted = deletedVal
+			}
+		}
+	}
+}
+
+// splitNUL splits data by NUL bytes, discarding a trailing empty element.
+func splitNUL(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	parts := strings.Split(string(data), "\x00")
+	// Trim trailing empty element from the final NUL.
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return parts
+}
+
+// ReadFileAtRef reads a file from git at the given ref.
+// ref must be "HEAD" or "STAGED" (empty ref means HEAD).
+// Returns (content, exists, error).
+func ReadFileAtRef(dir, relPath, ref string) ([]byte, bool, error) {
+	var spec string
+	switch strings.ToUpper(ref) {
+	case "STAGED", "":
+		// Staged (index): ":<path>"
+		spec = ":" + relPath
+	case "HEAD":
+		spec = "HEAD:" + relPath
+	default:
+		return nil, false, fmt.Errorf("unsupported ref: %q", ref)
+	}
+
+	cmd := exec.Command("git", "-C", dir, "show", spec)
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// Exit code 128 typically means the file doesn't exist at that ref.
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return output, true, nil
+}
+
 // findGitRoot walks up from path toward / looking for .git.
 // Returns:
 //   - gitDir: the absolute path of the main repo's .git directory

--- a/internal/worker/gitutil/gitutil_test.go
+++ b/internal/worker/gitutil/gitutil_test.go
@@ -659,3 +659,174 @@ func TestGetGitStatus_Stash(t *testing.T) {
 	require.NotNil(t, status)
 	assert.True(t, status.Stashed)
 }
+
+// --- Tests for GetPerFileStatus ---
+
+func TestGetPerFileStatus_MixedChanges(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Create committed file, then modify it (unstaged).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("modified content\nline2\n"), 0o644))
+
+	// Stage a new file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "staged.txt"), []byte("staged"), 0o644))
+	run(t, dir, "git", "add", "staged.txt")
+
+	// Create an untracked file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("untracked"), 0o644))
+
+	files, err := GetPerFileStatus(dir)
+	require.NoError(t, err)
+	require.NotNil(t, files)
+
+	// Build a map for easy lookup.
+	fileMap := make(map[string]*FileStatus, len(files))
+	for i := range files {
+		fileMap[files[i].Path] = &files[i]
+	}
+
+	// README.md should be unstaged modified.
+	readme, ok := fileMap["README.md"]
+	require.True(t, ok, "README.md should be in status")
+	assert.Equal(t, byte('.'), readme.StagedStatus)
+	assert.Equal(t, byte('M'), readme.UnstagedStatus)
+	assert.Greater(t, readme.LinesAdded, 0, "Should have lines added")
+
+	// staged.txt should be staged added.
+	staged, ok := fileMap["staged.txt"]
+	require.True(t, ok, "staged.txt should be in status")
+	assert.Equal(t, byte('A'), staged.StagedStatus)
+	assert.Equal(t, byte('.'), staged.UnstagedStatus)
+
+	// untracked.txt should be untracked.
+	untracked, ok := fileMap["untracked.txt"]
+	require.True(t, ok, "untracked.txt should be in status")
+	assert.Equal(t, byte('.'), untracked.StagedStatus)
+	assert.Equal(t, byte('?'), untracked.UnstagedStatus)
+}
+
+func TestGetPerFileStatus_EmptyRepo(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Clean repo — no changes.
+	files, err := GetPerFileStatus(dir)
+	require.NoError(t, err)
+	assert.Nil(t, files, "clean repo should return nil")
+}
+
+func TestGetPerFileStatus_NotGitRepo(t *testing.T) {
+	dir := resolvedTempDir(t)
+
+	files, err := GetPerFileStatus(dir)
+	require.NoError(t, err)
+	assert.Nil(t, files, "non-git directory should return nil")
+}
+
+func TestGetPerFileStatus_DeletedFile(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Delete a tracked file.
+	require.NoError(t, os.Remove(filepath.Join(dir, "README.md")))
+
+	files, err := GetPerFileStatus(dir)
+	require.NoError(t, err)
+	require.NotNil(t, files)
+
+	found := false
+	for _, f := range files {
+		if f.Path == "README.md" {
+			assert.Equal(t, byte('D'), f.UnstagedStatus)
+			found = true
+		}
+	}
+	assert.True(t, found, "README.md should appear as deleted")
+}
+
+func TestGetPerFileStatus_StagedAndUnstaged(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Stage a modification.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("staged change"), 0o644))
+	run(t, dir, "git", "add", "README.md")
+
+	// Make another modification (unstaged).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("staged change + more"), 0o644))
+
+	files, err := GetPerFileStatus(dir)
+	require.NoError(t, err)
+	require.NotNil(t, files)
+
+	for _, f := range files {
+		if f.Path == "README.md" {
+			assert.Equal(t, byte('M'), f.StagedStatus, "Should be staged modified")
+			assert.Equal(t, byte('M'), f.UnstagedStatus, "Should be unstaged modified")
+			assert.Greater(t, f.StagedLinesAdded+f.StagedLinesDeleted, 0, "Should have staged diff stats")
+			assert.Greater(t, f.LinesAdded+f.LinesDeleted, 0, "Should have unstaged diff stats")
+		}
+	}
+}
+
+// --- Tests for ReadFileAtRef ---
+
+func TestReadFileAtRef_HEAD(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Modify the file in the working tree.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("modified"), 0o644))
+
+	// Read HEAD version — should return original content.
+	content, exists, err := ReadFileAtRef(dir, "README.md", "HEAD")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "hello", string(content))
+}
+
+func TestReadFileAtRef_Staged(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Stage a modification.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("staged content"), 0o644))
+	run(t, dir, "git", "add", "README.md")
+
+	// Read staged version.
+	content, exists, err := ReadFileAtRef(dir, "README.md", "STAGED")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "staged content", string(content))
+}
+
+func TestReadFileAtRef_NonexistentFile(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	content, exists, err := ReadFileAtRef(dir, "nonexistent.txt", "HEAD")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Nil(t, content)
+}
+
+func TestReadFileAtRef_NewStagedFile(t *testing.T) {
+	dir := resolvedTempDir(t)
+	initGitRepo(t, dir)
+
+	// Stage a new file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new file"), 0o644))
+	run(t, dir, "git", "add", "new.txt")
+
+	// HEAD should not have it.
+	_, exists, err := ReadFileAtRef(dir, "new.txt", "HEAD")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Staged should have it.
+	content, exists, err := ReadFileAtRef(dir, "new.txt", "STAGED")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "new file", string(content))
+}

--- a/internal/worker/hub/client.go
+++ b/internal/worker/hub/client.go
@@ -308,6 +308,12 @@ func (c *Client) handleMessage(ctx context.Context, msg *leapmuxv1.ConnectRespon
 	case *leapmuxv1.ConnectResponse_GitWorktreeRemove:
 		c.handleGitWorktreeRemove(msg.GetRequestId(), payload.GitWorktreeRemove)
 
+	case *leapmuxv1.ConnectResponse_GitFileStatus:
+		c.handleGitFileStatus(msg.GetRequestId(), payload.GitFileStatus)
+
+	case *leapmuxv1.ConnectResponse_GitFileRead:
+		c.handleGitFileRead(msg.GetRequestId(), payload.GitFileRead)
+
 	case *leapmuxv1.ConnectResponse_Deregister:
 		c.handleDeregister(msg.GetRequestId(), payload.Deregister)
 

--- a/internal/worker/hub/git_file_handlers.go
+++ b/internal/worker/hub/git_file_handlers.go
@@ -1,0 +1,173 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/gitutil"
+)
+
+func (c *Client) handleGitFileStatus(requestID string, req *leapmuxv1.GitFileStatusRequest) {
+	resp := &leapmuxv1.GitFileStatusResponse{}
+
+	info, err := gitutil.GetGitInfo(req.GetPath())
+	if err != nil {
+		resp.Error = err.Error()
+		c.sendGitFileStatusResponse(requestID, resp)
+		return
+	}
+
+	if !info.IsGitRepo {
+		resp.Error = "not a git repository"
+		c.sendGitFileStatusResponse(requestID, resp)
+		return
+	}
+
+	workDir := req.GetPath()
+	// Compute repo root without symlink resolution so it matches the paths the
+	// frontend file browser uses (e.g. /var/... vs /private/var/... on macOS).
+	resp.RepoRoot = findRepoRootUnresolved(workDir, info.RepoRoot)
+
+	files, err := gitutil.GetPerFileStatus(workDir)
+	if err != nil {
+		resp.Error = err.Error()
+		c.sendGitFileStatusResponse(requestID, resp)
+		return
+	}
+
+	for _, f := range files {
+		entry := &leapmuxv1.GitFileStatusEntry{
+			Path:               f.Path,
+			StagedStatus:       toGitFileStatusCode(f.StagedStatus),
+			UnstagedStatus:     toGitFileStatusCode(f.UnstagedStatus),
+			LinesAdded:         int32(f.LinesAdded),
+			LinesDeleted:       int32(f.LinesDeleted),
+			StagedLinesAdded:   int32(f.StagedLinesAdded),
+			StagedLinesDeleted: int32(f.StagedLinesDeleted),
+			OldPath:            f.OldPath,
+		}
+		resp.Files = append(resp.Files, entry)
+	}
+
+	c.sendGitFileStatusResponse(requestID, resp)
+}
+
+func (c *Client) sendGitFileStatusResponse(requestID string, resp *leapmuxv1.GitFileStatusResponse) {
+	_ = c.Send(&leapmuxv1.ConnectRequest{
+		RequestId: requestID,
+		Payload: &leapmuxv1.ConnectRequest_GitFileStatusResp{
+			GitFileStatusResp: resp,
+		},
+	})
+}
+
+func (c *Client) handleGitFileRead(requestID string, req *leapmuxv1.GitFileReadRequest) {
+	resp := &leapmuxv1.GitFileReadResponse{Path: req.GetPath()}
+
+	absPath := req.GetPath()
+	info, err := gitutil.GetGitInfo(filepath.Dir(absPath))
+	if err != nil {
+		resp.Error = err.Error()
+		c.sendGitFileReadResponse(requestID, resp)
+		return
+	}
+
+	if !info.IsGitRepo {
+		resp.Error = "not a git repository"
+		c.sendGitFileReadResponse(requestID, resp)
+		return
+	}
+
+	// Compute the relative path from the repo root.
+	// Use unresolved root to match the frontend's path conventions,
+	// but fall back to the resolved root for the Rel computation.
+	unresolvedRoot := findRepoRootUnresolved(filepath.Dir(absPath), info.RepoRoot)
+	relPath, err := filepath.Rel(unresolvedRoot, absPath)
+	if err != nil {
+		// Retry with resolved root (symlink differences).
+		relPath, err = filepath.Rel(info.RepoRoot, absPath)
+		if err != nil {
+			resp.Error = err.Error()
+			c.sendGitFileReadResponse(requestID, resp)
+			return
+		}
+	}
+
+	var refStr string
+	switch req.GetRef() {
+	case leapmuxv1.GitFileRef_GIT_FILE_REF_HEAD:
+		refStr = "HEAD"
+	case leapmuxv1.GitFileRef_GIT_FILE_REF_STAGED:
+		refStr = "STAGED"
+	default:
+		refStr = "HEAD"
+	}
+
+	// ReadFileAtRef needs the actual git repo root (resolved) to run git commands.
+	content, exists, err := gitutil.ReadFileAtRef(info.RepoRoot, relPath, refStr)
+	if err != nil {
+		resp.Error = err.Error()
+		c.sendGitFileReadResponse(requestID, resp)
+		return
+	}
+
+	resp.Content = content
+	resp.Exists = exists
+	c.sendGitFileReadResponse(requestID, resp)
+}
+
+func (c *Client) sendGitFileReadResponse(requestID string, resp *leapmuxv1.GitFileReadResponse) {
+	_ = c.Send(&leapmuxv1.ConnectRequest{
+		RequestId: requestID,
+		Payload: &leapmuxv1.ConnectRequest_GitFileReadResp{
+			GitFileReadResp: resp,
+		},
+	})
+}
+
+// findRepoRootUnresolved walks up from dir (without resolving symlinks) to find
+// the directory containing .git. This ensures the returned root uses the same
+// path the caller provided, avoiding symlink mismatches (e.g. /var vs /private/var).
+// Falls back to resolvedRoot if the walk fails.
+func findRepoRootUnresolved(dir, resolvedRoot string) string {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return resolvedRoot
+	}
+	d := absDir
+	for {
+		dotGit := filepath.Join(d, ".git")
+		if fi, err := os.Lstat(dotGit); err == nil && (fi.IsDir() || fi.Mode().IsRegular()) {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return resolvedRoot
+		}
+		d = parent
+	}
+}
+
+func toGitFileStatusCode(b byte) leapmuxv1.GitFileStatusCode {
+	switch b {
+	case 'M':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_MODIFIED
+	case 'A':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_ADDED
+	case 'D':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_DELETED
+	case 'R':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_RENAMED
+	case 'C':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_COPIED
+	case 'T':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_TYPE_CHANGED
+	case '?':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_UNTRACKED
+	case 'U':
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_UNMERGED
+	default:
+		return leapmuxv1.GitFileStatusCode_GIT_FILE_STATUS_CODE_UNSPECIFIED
+	}
+}

--- a/proto/leapmux/v1/git.proto
+++ b/proto/leapmux/v1/git.proto
@@ -15,6 +15,10 @@ service GitService {
   rpc ForceRemoveWorktree(ForceRemoveWorktreeRequest) returns (ForceRemoveWorktreeResponse);
   // Keep a dirty worktree on disk (stop tracking it).
   rpc KeepWorktree(KeepWorktreeRequest) returns (KeepWorktreeResponse);
+  // Get per-file git status (staged/unstaged changes, diff stats).
+  rpc GetGitFileStatus(GetGitFileStatusRequest) returns (GetGitFileStatusResponse);
+  // Read a file at a specific git ref (HEAD or staged).
+  rpc ReadGitFile(ReadGitFileRequest) returns (ReadGitFileResponse);
 }
 
 message GetGitInfoRequest {
@@ -59,3 +63,60 @@ message KeepWorktreeRequest {
 }
 
 message KeepWorktreeResponse {}
+
+// --- Per-file git status ---
+
+// GitFileStatusCode describes the status of a file in the index or working tree.
+enum GitFileStatusCode {
+  GIT_FILE_STATUS_CODE_UNSPECIFIED = 0;
+  GIT_FILE_STATUS_CODE_MODIFIED = 1;
+  GIT_FILE_STATUS_CODE_ADDED = 2;
+  GIT_FILE_STATUS_CODE_DELETED = 3;
+  GIT_FILE_STATUS_CODE_RENAMED = 4;
+  GIT_FILE_STATUS_CODE_COPIED = 5;
+  GIT_FILE_STATUS_CODE_TYPE_CHANGED = 6;
+  GIT_FILE_STATUS_CODE_UNTRACKED = 7;
+  GIT_FILE_STATUS_CODE_UNMERGED = 8;
+}
+
+message GitFileStatusEntry {
+  string path = 1;                              // Path relative to repo root
+  GitFileStatusCode staged_status = 2;          // Status in the index (staged)
+  GitFileStatusCode unstaged_status = 3;        // Status in the working tree (unstaged)
+  int32 lines_added = 4;                        // Unstaged lines added
+  int32 lines_deleted = 5;                      // Unstaged lines deleted
+  int32 staged_lines_added = 6;                 // Staged lines added
+  int32 staged_lines_deleted = 7;               // Staged lines deleted
+  string old_path = 8;                          // Previous path (for renames/copies)
+}
+
+message GetGitFileStatusRequest {
+  string worker_id = 1;
+  string path = 2;       // Working directory (worker resolves to repo root)
+  string org_id = 3;
+}
+
+message GetGitFileStatusResponse {
+  string repo_root = 1;
+  repeated GitFileStatusEntry files = 2;  // Paths are relative to repo root
+}
+
+// GitFileRef specifies which version of a file to read.
+enum GitFileRef {
+  GIT_FILE_REF_UNSPECIFIED = 0;
+  GIT_FILE_REF_HEAD = 1;
+  GIT_FILE_REF_STAGED = 2;
+}
+
+message ReadGitFileRequest {
+  string worker_id = 1;
+  string path = 2;       // Absolute path to the file
+  GitFileRef ref = 3;
+  string org_id = 4;
+}
+
+message ReadGitFileResponse {
+  string path = 1;
+  bytes content = 2;
+  bool exists = 3;
+}

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -3,6 +3,7 @@ package leapmux.v1;
 
 import "leapmux/v1/agent.proto";
 import "leapmux/v1/common.proto";
+import "leapmux/v1/git.proto";
 
 // WorkerConnectorService is called BY Worker instances on Hub via gRPC.
 // Handles registration and the main bidirectional communication stream.
@@ -177,6 +178,8 @@ message ConnectRequest {
     GitInfoResponse git_info_resp = 33;
     GitWorktreeCreateResponse git_worktree_create_resp = 34;
     GitWorktreeRemoveResponse git_worktree_remove_resp = 35;
+    GitFileStatusResponse git_file_status_resp = 36;
+    GitFileReadResponse git_file_read_resp = 37;
     AgentInputAck agent_input_ack = 13;
     AgentGitInfo agent_git_info = 14;
     DeregisterAck deregister_ack = 40;
@@ -205,6 +208,8 @@ message ConnectResponse {
     GitInfoRequest git_info = 33;
     GitWorktreeCreateRequest git_worktree_create = 34;
     GitWorktreeRemoveRequest git_worktree_remove = 35;
+    GitFileStatusRequest git_file_status = 36;
+    GitFileReadRequest git_file_read = 37;
     DeregisterNotification deregister = 40;
     TerminateWorkspacesNotification terminate_workspaces = 41;
     HubShuttingDownNotification hub_shutting_down = 50;
@@ -444,6 +449,30 @@ message GitWorktreeRemoveResponse {
   string worktree_path = 1;
   bool is_clean = 2;          // False if uncommitted changes or unpushed commits
   string error = 3;
+}
+
+// --- Git file messages (used in bidi stream) ---
+
+message GitFileStatusRequest {
+  string path = 1;  // Working directory path (worker resolves to repo root)
+}
+
+message GitFileStatusResponse {
+  string repo_root = 1;
+  repeated GitFileStatusEntry files = 2;  // Uses GitFileStatusEntry from git.proto
+  string error = 3;
+}
+
+message GitFileReadRequest {
+  string path = 1;       // Absolute path to the file
+  GitFileRef ref = 2;    // Uses GitFileRef from git.proto
+}
+
+message GitFileReadResponse {
+  string path = 1;
+  bytes content = 2;
+  bool exists = 3;
+  string error = 4;
 }
 
 // --- Notification messages (used in bidi stream) ---


### PR DESCRIPTION
## Motivation

Developers using the file browser had no way to quickly see which files
have been modified, staged, or are untracked in the current git
repository. When switching between file tabs, component state (including
scroll position) was lost because inactive tabs were unmounted. There
was also no way to compare working tree or staged versions of a file
against HEAD from within the file viewer.

## Modifications

**Backend - Git file status API**

- Added two new RPCs to `GitService`: `GetGitFileStatus` (returns
  per-file staged/unstaged status and diff line counts parsed from
  `git status --porcelain=v2`) and `ReadGitFile` (reads file content at
  a specific git ref: HEAD or staged index).
- Created `internal/worker/gitutil` package with `GetPerFileStatus()`
  and `ReadFileAtRef()` helpers, including symlink-aware path
  resolution.
- Defined new protobuf messages and enums: `GitFileStatusEntry`,
  `GetGitFileStatusRequest/Response`, `ReadGitFileRequest/Response`,
  `GitFileStatusCode`, `GitFileRef` in `proto/leapmux/v1/git.proto`.

**File viewer**

- `FileViewer` now supports five view modes: HEAD, Working, Unified
  diff, and Split diff, switchable via a new floating `DiffModeToolbar`
  component anchored at the top-center of the viewer.
- When a file has both staged and unstaged changes, the toolbar exposes
  a diff-base selector (`vs Working` / `vs Staged`) to choose which
  version to compare against HEAD.
- The mention button is moved from the scrollable child views
  (`TextFileView`, `ImageFileView`) to `FileViewer`'s outer
  non-scrollable container so it floats alongside the toolbar and stays
  accessible during scroll.
- Diff line and split calculations now use `createMemo` to avoid
  redundant re-calculations on every render.

**File browser - git status integration**

- New `FilesSection` component wraps `DirectoryTree` and adds filter
  tabs: All, Changed, Staged, and Unstaged. Filtered views show
  color-coded file status icons (staged, unstaged, untracked, conflict)
  and `+N -M` diff stats badges next to each file entry.
- Flat-list mode toggle lets users switch between tree view and a simple
  flat list when a filter is active.
- New `gitFileStatus.store` manages fetching, caching, and filtering
  git file state; exposes `getFileStatus()`, `getChangedFiles()`, and
  `hasChanges()`.
- `DirectoryTree` enhanced to accept a `visiblePaths` set for filtered
  display, render git status decorations on entries, and expose an
  imperative `collapseAll()` handle.
- The sidebar header gains collapse-all, locate-active-file, refresh,
  and flat-list-mode-toggle action buttons.
- Files opened from a filtered git view auto-initialize in the
  appropriate diff mode (e.g., opening from the Staged filter opens the
  file in unified-diff mode with the staged base).

**Tab management**

- Tab content is now kept mounted across tab switches. `TileRenderer`
  replaces `<Show>` with `<For>` over all agent and file tabs, hiding
  inactive ones with a CSS `layoutHidden` class. This preserves scroll
  position and component state (e.g., virtual terminal state) when
  switching between tabs.
- Added `fileViewMode` and `fileDiffBase` properties to the `Tab`
  interface with persistence.
- Per-agent scroll state is stored in a `Map` so each agent tab
  independently restores its position when re-activated.

## Result

- The file browser sidebar now shows a git-aware view of the repository.
  Filter tabs let you quickly jump to Changed, Staged, or Unstaged files
  with color-coded icons and diff stats without leaving the browser.
- Switching between file and agent tabs no longer resets scroll position
  or terminal state; previously visited content is exactly where you
  left it.
- Opening a file from a git filter automatically opens it in the most
  relevant diff mode, so you can immediately see what changed.
- The `FileViewer` diff toolbar floats at the top-center and lets you
  switch between HEAD, Working, Unified diff, and Split diff at any
  time. Files with both staged and unstaged changes expose a base
  selector to choose which change set to inspect.

🤖 Generated with Claude Code
