### PR TITLE
Add UI rendering for ToolSearch and TaskStop tools

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -292,6 +292,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
       childGlobNumFiles: typeof tur?.numFiles === 'number' ? tur.numFiles : undefined,
       childGlobDurationMs: typeof tur?.durationMs === 'number' ? tur.durationMs : undefined,
       childGlobTruncated: typeof tur?.truncated === 'boolean' ? tur.truncated : undefined,
+      childToolSearchMatches: Array.isArray(tur?.matches) ? tur.matches as string[] : undefined,
     }
   }
 

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -117,6 +117,8 @@ export interface RenderContext {
   childGlobDurationMs?: number
   /** Glob result: whether results were truncated from child tool_use_result. */
   childGlobTruncated?: boolean
+  /** ToolSearch result: matched tool names from child tool_use_result. */
+  childToolSearchMatches?: string[]
 }
 
 export interface MessageContentRenderer {

--- a/frontend/src/components/chat/taskStopRenderer.test.tsx
+++ b/frontend/src/components/chat/taskStopRenderer.test.tsx
@@ -1,0 +1,93 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock renderAnsi to avoid shiki initialization in tests.
+vi.mock('~/lib/renderAnsi', () => ({
+  // eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching control characters
+  containsAnsi: (text: string) => /\x1B\[[\d;]*m/.test(text),
+  renderAnsi: (text: string) => `<pre class="shiki"><code>${text}</code></pre>`,
+}))
+
+// Mock renderMarkdown to avoid shiki initialization in tests.
+vi.mock('~/lib/renderMarkdown', () => ({
+  renderMarkdown: (text: string) => text,
+}))
+
+const { renderMessageContent } = await import('./messageRenderers')
+type RenderContext = import('./messageRenderers').RenderContext
+
+/** Construct a TaskStop tool_use assistant message. */
+function makeTaskStopMessage(input: Record<string, unknown> = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'test-taskstop',
+        name: 'TaskStop',
+        input: { task_id: 'bfbc3f6', ...input },
+      }],
+    },
+  }
+}
+
+/** Construct a TaskStop tool_result user message. */
+function makeTaskStopResult(resultContent: string) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        tool_use_id: 'test-taskstop',
+        type: 'tool_result',
+        content: resultContent,
+      }],
+    },
+    tool_use_result: { tool_name: 'TaskStop' },
+  }
+}
+
+/** Render a TaskStop tool_use message and return its text content. */
+function renderToolUseText(input?: Record<string, unknown>, context?: RenderContext): string {
+  const msg = makeTaskStopMessage(input)
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a TaskStop tool_result message and return its text content. */
+function renderToolResultText(resultContent: string, context?: RenderContext): string {
+  const msg = makeTaskStopResult(resultContent)
+  const result = renderMessageContent(msg, 1 /* USER */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+describe('taskStop tool_use rendering', () => {
+  it('shows "Stop task" with task_id in header', () => {
+    const text = renderToolUseText()
+    expect(text).toContain('Stop task bfbc3f6')
+  })
+
+  it('shows different task_id', () => {
+    const text = renderToolUseText({ task_id: 'abc123' })
+    expect(text).toContain('Stop task abc123')
+  })
+
+  it('shows "Stop task" when task_id is missing', () => {
+    const text = renderToolUseText({ task_id: undefined })
+    expect(text).toContain('Stop task')
+  })
+})
+
+describe('taskStop tool_result rendering', () => {
+  it('shows result message content', () => {
+    const text = renderToolResultText('{"message":"Successfully stopped task: bfbc3f6"}')
+    expect(text).toContain('Successfully stopped task')
+  })
+
+  it('shows error message when task not found', () => {
+    const text = renderToolResultText('{"message":"Task not found: xyz"}')
+    expect(text).toContain('Task not found')
+  })
+})

--- a/frontend/src/components/chat/toolDetailRenderers.tsx
+++ b/frontend/src/components/chat/toolDetailRenderers.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from './messageRenderers'
-import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
+import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskStopInput, ToolSearchInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { diffLines } from 'diff'
 import { DiffStatsBadge } from '~/components/tree/gitStatusUtils'
 import { relativizePath } from './messageUtils'
@@ -117,6 +117,18 @@ export function renderToolDetail(toolName: string, input: Record<string, unknown
       const status = formatTaskStatus(task?.status)
       const title = `${status}${description ? ` - ${description}` : ''}`
       return <span class={toolInputText}>{title}</span>
+    }
+    case 'ToolSearch': {
+      const { query } = input as ToolSearchInput
+      return query
+        ? <span class={toolInputCode}>{`"${query}"`}</span>
+        : null
+    }
+    case 'TaskStop': {
+      const { task_id: taskId } = input as TaskStopInput
+      return taskId
+        ? <span class={toolInputText}>{`Stop task ${taskId}`}</span>
+        : <span class={toolInputText}>Stop task</span>
     }
     case 'EnterPlanMode':
       return <span class={toolInputText}>Entering Plan Mode</span>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -18,6 +18,7 @@ import FoldVertical from 'lucide-solid/icons/fold-vertical'
 import FolderSearch from 'lucide-solid/icons/folder-search'
 import Globe from 'lucide-solid/icons/globe'
 import ListTodo from 'lucide-solid/icons/list-todo'
+import OctagonX from 'lucide-solid/icons/octagon-x'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import Quote from 'lucide-solid/icons/quote'
 import Rows2 from 'lucide-solid/icons/rows-2'
@@ -157,6 +158,8 @@ export function toolIconFor(name: string): LucideIcon {
     case 'AskUserQuestion': return Vote
     case 'TaskOutput': return SquareTerminal
     case 'Skill': return Toolbox
+    case 'ToolSearch': return Toolbox
+    case 'TaskStop': return OctagonX
     default: return ChevronsRight
   }
 }
@@ -354,6 +357,12 @@ function deriveToolSummary(toolName: string, input: Record<string, unknown>, con
         ? <div class={toolInputSummary}>{parts.join(' \u00B7 ')}</div>
         : undefined
     }
+    case 'ToolSearch': {
+      const matches = context?.childToolSearchMatches
+      if (!matches || matches.length === 0)
+        return undefined
+      return <div class={toolInputSummary}>{`Found ${matches.length} tool${matches.length === 1 ? '' : 's'}`}</div>
+    }
     case 'Agent':
     case 'Task': {
       const status = context?.childToolResultStatus
@@ -465,6 +474,26 @@ function FileListView(props: {
         )}
       </For>
     </ul>
+  )
+}
+
+/** ToolSearch result view showing matched tool names. */
+function ToolSearchResultView(props: {
+  matches: string[]
+}): JSX.Element {
+  return (
+    <div class={toolMessage}>
+      <Show
+        when={props.matches.length > 0}
+        fallback={<div class={toolResultContentPre}>No tools found</div>}
+      >
+        <ul class={toolFileList}>
+          <For each={props.matches}>
+            {name => <li class={toolInputPath}>{name}</li>}
+          </For>
+        </ul>
+      </Show>
+    </div>
   )
 }
 
@@ -669,6 +698,12 @@ export const toolResultRenderer: MessageContentRenderer = {
           context={context}
         />
       )
+    }
+
+    // ToolSearch: render matched tool names from tool_use_result.
+    if (toolName === 'ToolSearch' && toolUseResult) {
+      const matches = Array.isArray(toolUseResult.matches) ? toolUseResult.matches as string[] : []
+      return <ToolSearchResultView matches={matches} />
     }
 
     // Glob: render structured result view when tool_use_result has filenames.

--- a/frontend/src/components/chat/toolSearchRenderer.test.tsx
+++ b/frontend/src/components/chat/toolSearchRenderer.test.tsx
@@ -1,0 +1,156 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock renderAnsi to avoid shiki initialization in tests.
+vi.mock('~/lib/renderAnsi', () => ({
+  // eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching control characters
+  containsAnsi: (text: string) => /\x1B\[[\d;]*m/.test(text),
+  renderAnsi: (text: string) => `<pre class="shiki"><code>${text}</code></pre>`,
+}))
+
+// Mock renderMarkdown to avoid shiki initialization in tests.
+vi.mock('~/lib/renderMarkdown', () => ({
+  renderMarkdown: (text: string) => text,
+}))
+
+const { renderMessageContent } = await import('./messageRenderers')
+type RenderContext = import('./messageRenderers').RenderContext
+
+/** Construct a ToolSearch tool_use assistant message. */
+function makeToolSearchMessage(input: Record<string, unknown> = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'test-toolsearch',
+        name: 'ToolSearch',
+        input: { query: 'select:Read,Glob,Grep', ...input },
+      }],
+    },
+  }
+}
+
+/** Construct a ToolSearch tool_result user message. */
+function makeToolSearchResult(
+  toolRefs: string[],
+  toolUseResult?: Record<string, unknown>,
+) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        tool_use_id: 'test-toolsearch',
+        type: 'tool_result',
+        content: toolRefs.map(name => ({ type: 'tool_reference', tool_name: name })),
+      }],
+    },
+    tool_use_result: toolUseResult,
+  }
+}
+
+/** Render a ToolSearch tool_use message and return its text content. */
+function renderToolUseText(input?: Record<string, unknown>, context?: RenderContext): string {
+  const msg = makeToolSearchMessage(input)
+  const result = renderMessageContent(msg, 2 /* ASSISTANT */, context)
+  const { container } = render(() => result)
+  return container.textContent?.trim() ?? ''
+}
+
+/** Render a ToolSearch tool_result message and return its container element. */
+function renderToolResultContainer(
+  toolRefs: string[],
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): HTMLElement {
+  const msg = makeToolSearchResult(toolRefs, toolUseResult)
+  const result = renderMessageContent(msg, 1 /* USER */, context)
+  const { container } = render(() => result)
+  return container
+}
+
+describe('toolSearch tool_use rendering', () => {
+  it('shows query string in header', () => {
+    const text = renderToolUseText()
+    expect(text).toContain('"select:Read,Glob,Grep"')
+  })
+
+  it('shows custom query string', () => {
+    const text = renderToolUseText({ query: 'slack message' })
+    expect(text).toContain('"slack message"')
+  })
+
+  it('renders without error when query is missing', () => {
+    const text = renderToolUseText({ query: undefined })
+    expect(text).toContain('ToolSearch')
+  })
+
+  it('shows query with max_results', () => {
+    const text = renderToolUseText({ query: 'notebook', max_results: 3 })
+    expect(text).toContain('"notebook"')
+  })
+
+  it('shows "Found N tools" summary when matches available', () => {
+    const text = renderToolUseText(undefined, {
+      childToolSearchMatches: ['Read', 'Glob', 'Grep'],
+    })
+    expect(text).toContain('Found 3 tools')
+  })
+
+  it('shows "Found 1 tool" for singular match', () => {
+    const text = renderToolUseText(undefined, {
+      childToolSearchMatches: ['Edit'],
+    })
+    expect(text).toContain('Found 1 tool')
+  })
+})
+
+describe('toolSearch tool_result rendering', () => {
+  it('shows matched tool names as list items', () => {
+    const container = renderToolResultContainer(
+      ['Read', 'Glob', 'Grep', 'Bash'],
+      {
+        tool_name: 'ToolSearch',
+        matches: ['Read', 'Glob', 'Grep', 'Bash'],
+        query: 'select:Read,Glob,Grep,Bash',
+        total_deferred_tools: 19,
+      },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(4)
+    expect(listItems[0].textContent).toBe('Read')
+    expect(listItems[1].textContent).toBe('Glob')
+    expect(listItems[2].textContent).toBe('Grep')
+    expect(listItems[3].textContent).toBe('Bash')
+  })
+
+  it('shows single matched tool', () => {
+    const container = renderToolResultContainer(
+      ['Edit'],
+      {
+        tool_name: 'ToolSearch',
+        matches: ['Edit'],
+        query: 'select:Edit',
+        total_deferred_tools: 19,
+      },
+    )
+    const listItems = container.querySelectorAll('li')
+    expect(listItems.length).toBe(1)
+    expect(listItems[0].textContent).toBe('Edit')
+  })
+
+  it('shows "No tools found" when matches is empty', () => {
+    const container = renderToolResultContainer(
+      [],
+      {
+        tool_name: 'ToolSearch',
+        matches: [],
+        query: 'nonexistent',
+        total_deferred_tools: 19,
+      },
+    )
+    const text = container.textContent ?? ''
+    expect(text).toContain('No tools found')
+  })
+})

--- a/frontend/src/types/toolMessages.ts
+++ b/frontend/src/types/toolMessages.ts
@@ -75,6 +75,15 @@ export interface TaskOutputInput {
   timeout?: number
 }
 
+export interface ToolSearchInput {
+  query?: string
+  max_results?: number
+}
+
+export interface TaskStopInput {
+  task_id?: string
+}
+
 export interface AskUserQuestionInput {
   questions?: Array<{
     question?: string
@@ -101,6 +110,8 @@ export type KnownToolInput
     | { toolName: 'WebSearch', input: WebSearchInput }
     | { toolName: 'TodoWrite', input: TodoWriteInput }
     | { toolName: 'TaskOutput', input: TaskOutputInput }
+    | { toolName: 'ToolSearch', input: ToolSearchInput }
+    | { toolName: 'TaskStop', input: TaskStopInput }
     | { toolName: 'AskUserQuestion', input: AskUserQuestionInput }
 
 /** All known tool names. */
@@ -119,6 +130,8 @@ const KNOWN_TOOLS = new Set<string>([
   'WebSearch',
   'TaskOutput',
   'TodoWrite',
+  'ToolSearch',
+  'TaskStop',
   'AskUserQuestion',
 ])
 


### PR DESCRIPTION
## Motivation
The chat interface lacked rendering support for two tool types — `ToolSearch` and `TaskStop` — that are used to search available tools and stop background tasks. Without dedicated renderers, these tool invocations and their results appeared as unformatted raw data in the message stream, making it difficult for users to understand what the agent was doing.

## Modifications
- Added `ToolSearchInput` and `TaskStopInput` interfaces to `toolMessages.ts`, and registered both as members of the `KnownToolInput` discriminated union and the `KNOWN_TOOLS` set.
- Implemented `ToolSearch` rendering in `toolRenderers.tsx`: displays matched tool names as a list with a "No tools found" fallback and a summary count shown alongside other child tool outputs.
- Implemented `TaskStop` rendering showing the target task ID in the header and surfacing success or error result messages.
- Extended `RenderContext` to track `childToolSearchMatches` so `ToolSearch` match counts appear consistently in summary views.
- Wired both new renderers into the message rendering pipeline via `toolDetailRenderers.tsx` and `messageRenderers.tsx`.
- Integrated the `OctagonX` icon for `TaskStop` tool visualization.
- Added 249 lines of test coverage across `toolSearchRenderer.test.tsx` and `taskStopRenderer.test.tsx`, verifying `tool_use` invocations and `tool_result` rendering for both tools.

## Result
Users now see properly formatted output in the chat when the agent invokes `ToolSearch` or `TaskStop`. A `ToolSearch` result displays a labeled list of matching tool names (or a "No tools found" message), along with a match count summary. A `TaskStop` result displays the targeted task ID and the outcome message, giving users clear visibility into background task management.

🤖 Generated with Claude Code
