### PR TITLE
Fix chat scroll loss, tool icons, and worker dialog context

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -151,7 +151,6 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
     props,
     askState,
     () => editorContentRef,
-    setHasContent,
     resetEditorHeight,
   )
 

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -14,7 +14,7 @@ import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { getResetsAt } from '~/lib/rateLimitUtils'
 import { safeGetString, safeRemoveItem, safeSetString } from '~/lib/safeStorage'
 import { registerEditorRef, unregisterEditorRef } from '~/stores/editorRef.store'
-import { interruptPulse, spinner } from '~/styles/animations.css'
+import { spinner } from '~/styles/animations.css'
 import { iconSize } from '~/styles/tokens'
 import { useAgentInfoCard } from './AgentInfoCard'
 import * as styles from './ChatView.css'
@@ -380,7 +380,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                     <div class={styles.footerBarRight}>
                       <Show when={ctrl.showInterrupt()}>
                         <button
-                          class={`${styles.interruptButton} ${interruptLoading.loading() ? '' : interruptPulse}`}
+                          class="small"
+                          data-variant="secondary"
                           onClick={() => {
                             interruptLoading.start()
                             props.onInterrupt?.()

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -213,6 +213,7 @@ export const infoTrigger = style({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: 'var(--space-1)',
   padding: '2px',
   fontSize: 'var(--text-8)',
   color: 'var(--faint-foreground)',

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -114,36 +114,20 @@ export const sendButtonDisabled = style({
   },
 })
 
+export const scrollToBottomButton = style({
+  position: 'absolute',
+  bottom: 'var(--space-3)',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 10,
+})
+
 export const emptyChat = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   flex: 1,
   color: 'var(--faint-foreground)',
-})
-
-export const interruptButton = style({
-  'border': 'none',
-  'background': 'none',
-  'font': 'inherit',
-  'boxSizing': 'border-box',
-  'display': 'flex',
-  'alignItems': 'center',
-  'gap': 'var(--space-1)',
-  'padding': 'var(--space-1) var(--space-2)',
-  'fontSize': 'var(--text-7)',
-  'fontWeight': 400,
-  'borderRadius': 'var(--radius-small)',
-  'color': 'var(--muted-foreground)',
-  'cursor': 'pointer',
-  'vars': {
-    '--color-shift-from': 'var(--card)',
-    '--color-shift-to': 'var(--card)',
-  },
-  ':hover': {
-    backgroundColor: 'var(--card)',
-    color: 'var(--foreground)',
-  },
 })
 
 export const settingsTrigger = style({

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -5,7 +5,6 @@ import ArrowDown from 'lucide-solid/icons/arrow-down'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createEffect, createSignal, For, on, onCleanup, onMount, Show, untrack } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
-import { IconButton } from '~/components/common/IconButton'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { renderMarkdown } from '~/lib/renderMarkdown'
@@ -355,11 +354,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
           </Show>
         </div>
         <Show when={!atBottom()}>
-          <IconButton
-            icon={ArrowDown}
-            iconSize="md"
-            onClick={scrollToBottom}
-          />
+          <button type="button" class={`outline icon small ${styles.scrollToBottomButton}`} onClick={scrollToBottom}>
+            <Icon icon={ArrowDown} size="lg" />
+          </button>
         </Show>
       </div>
     </div>

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -190,6 +190,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     void props.streamingText
     void props.agentWorking
     if (untrack(atBottom) && messageListRef) {
+      // Skip scroll when hidden (e.g. inactive tab with display:none).
+      // The ResizeObserver will scroll to bottom when the tab becomes visible.
+      if (messageListRef.clientHeight === 0)
+        return
       autoScrollPending = true
       requestAnimationFrame(() => {
         messageListRef!.scrollTop = messageListRef!.scrollHeight
@@ -207,6 +211,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     () => props.savedViewportScroll,
     (saved) => {
       if (!messageListRef)
+        return
+      // Don't consume saved state while hidden — wait until the tab is
+      // visible so the ResizeObserver can apply the correct scroll position.
+      if (messageListRef.clientHeight === 0)
         return
       if (!saved) {
         requestAnimationFrame(() => checkAtBottom())
@@ -248,11 +256,37 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // with undelivered notifications" errors when collapsing large elements.
   onMount(() => {
     let resizeRafId = 0
+    let prevClientHeight = messageListRef?.clientHeight ?? 0
     const handleResize = () => {
       cancelAnimationFrame(resizeRafId)
       resizeRafId = requestAnimationFrame(() => {
         if (!messageListRef || scrollAnimationId !== null || autoScrollPending)
           return
+        // Detect hidden → visible transition (e.g. tab switch).
+        const ch = messageListRef.clientHeight
+        const wasHidden = prevClientHeight === 0 && ch > 0
+        prevClientHeight = ch
+        if (wasHidden) {
+          // Restore saved viewport scroll if available; otherwise use atBottom.
+          const saved = props.savedViewportScroll
+          if (saved) {
+            if (saved.atBottom) {
+              messageListRef.scrollTop = messageListRef.scrollHeight
+              setAtBottom(true)
+            }
+            else {
+              const maxScroll = messageListRef.scrollHeight - messageListRef.clientHeight
+              messageListRef.scrollTop = saved.distFromBottom > maxScroll ? 0 : maxScroll - saved.distFromBottom
+              setAtBottom(false)
+            }
+            props.onClearSavedViewportScroll?.()
+            return
+          }
+          if (atBottom()) {
+            messageListRef.scrollTop = messageListRef.scrollHeight
+            return
+          }
+        }
         if (atBottom()) {
           messageListRef.scrollTop = messageListRef.scrollHeight
         }

--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -306,10 +306,11 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   onCleanup(() => {
     clearTimeout(draftSaveTimer.current)
     // Save draft for the current agent/control-request before cleanup.
-    // getDraftKey() may return undefined during unmount (reactive getters
-    // can return null when the parent <Show> disposes), so fall back to
-    // the last known valid key.
-    const cleanupKey = getDraftKey() ?? latestDraftKey
+    // Prefer the cached latestDraftKey over getDraftKey(): during disposal
+    // reactive getters (props.agentId) may already reflect the NEW agent
+    // (e.g. tab switch causes FocusedAgentEditorPanel to be recreated,
+    // and focusedAgentId() has already changed by cleanup time).
+    const cleanupKey = latestDraftKey ?? getDraftKey()
     if (editorInstance && cleanupKey) {
       try {
         saveDraftFromEditor(editorInstance, cleanupKey)

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -1,6 +1,7 @@
 import type { ControlResponseHandlingProps } from './controlResponseHandling'
 import type { AskQuestionState } from './controls/types'
-import { createSignal } from 'solid-js'
+import type { ControlRequest } from '~/stores/control.store'
+import { createRoot, createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { useControlResponseHandling } from './controlResponseHandling'
 
@@ -18,16 +19,18 @@ function setup(overrides?: Partial<ControlResponseHandlingProps>) {
     onSendMessage,
     ...overrides,
   }
-  const [, setHasContent] = createSignal(false)
   const resetEditorHeight = vi.fn()
   const result = useControlResponseHandling(
     props,
     createMinimalAskState(),
     () => undefined,
-    setHasContent,
     resetEditorHeight,
   )
   return { result, onSendMessage, resetEditorHeight }
+}
+
+function makeControlRequest(requestId: string, agentId: string): ControlRequest {
+  return { requestId, agentId, payload: { tool_name: 'Bash', tool_input: {} } }
 }
 
 describe('handleSend', () => {
@@ -42,6 +45,59 @@ describe('handleSend', () => {
     expect(result.handleSend('   ')).toBe(false)
     expect(onSendMessage).not.toHaveBeenCalled()
   })
+
+  it('does not reset hasContent when activeRequestId changes due to tab switch', () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const reqA = makeControlRequest('req-A', 'agent-A')
+          const [controlRequests, setControlRequests] = createSignal<ControlRequest[]>([reqA])
+          const [hasContent, setHasContent] = createSignal(false)
+
+          const props: ControlResponseHandlingProps = {
+            agentId: 'agent-A',
+            get controlRequests() { return controlRequests() },
+            onSendMessage: vi.fn(),
+          }
+
+          useControlResponseHandling(
+            props,
+            createMinimalAskState(),
+            () => undefined,
+            vi.fn(),
+          )
+
+          // Let the initial createEffect run (deferred in SolidJS 1.9+).
+          await Promise.resolve()
+
+          // Simulate user typing feedback — editor has content.
+          setHasContent(true)
+          expect(hasContent()).toBe(true)
+
+          // Simulate switching to tab B (no control requests).
+          setControlRequests([])
+          // Let the activeRequestId effect run.
+          await Promise.resolve()
+
+          // Simulate switching back to tab A (control request reappears).
+          setControlRequests([reqA])
+          // Let the activeRequestId effect run.
+          await Promise.resolve()
+
+          // hasContent must NOT have been reset to false by the effect.
+          // The MarkdownEditor's own content change listener is the
+          // authoritative source for hasContent.
+          expect(hasContent()).toBe(true)
+
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e)
+        }
+      })
+    }))
 
   it.each([
     ['single character', 'a'],

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -1,4 +1,4 @@
-import type { Accessor, Setter } from 'solid-js'
+import type { Accessor } from 'solid-js'
 import type { AskQuestionState, EditorContentRef } from './controls/types'
 import type { ControlRequest } from '~/stores/control.store'
 import type { PermissionMode } from '~/utils/controlResponse'
@@ -35,7 +35,6 @@ export function useControlResponseHandling(
   props: ControlResponseHandlingProps,
   askState: AskQuestionState,
   editorContentRefAccessor: () => EditorContentRef | undefined,
-  setHasContent: Setter<boolean>,
   resetEditorHeightFn: () => void,
 ): ControlResponseHandlingResult {
   // Track previous non-plan mode for Shift+Tab toggling.
@@ -84,6 +83,11 @@ export function useControlResponseHandling(
   const activeRequestId = createMemo(() => activeControlRequest()?.requestId)
 
   // Reset AskUserQuestion state when the active request changes.
+  // NOTE: Do NOT call setHasContent(false) here.  The MarkdownEditor's
+  // controlRequestId swap effect is the authoritative source for editor
+  // content state — it loads the correct draft and calls onContentChange.
+  // Resetting hasContent here races with the MarkdownEditor and causes the
+  // "Send Feedback" button to disappear after a tab switch (A → B → A).
   createEffect(on(
     activeRequestId,
     (requestId) => {
@@ -94,14 +98,12 @@ export function useControlResponseHandling(
           askState.setSelections(saved.selections ?? {})
           askState.setCustomTexts(saved.customTexts ?? {})
           askState.setCurrentPage(saved.currentPage ?? 0)
-          setHasContent(false)
           return
         }
       }
       askState.setSelections({})
       askState.setCustomTexts({})
       askState.setCurrentPage(0)
-      setHasContent(false)
     },
   ))
 

--- a/frontend/src/components/chat/diffUtils.tsx
+++ b/frontend/src/components/chat/diffUtils.tsx
@@ -492,7 +492,7 @@ function DiffGapSeparator(props: {
               <ArrowUpFromLine size={12} />
               Expand up
             </span>
-            <span>
+            <span class={diffGapExpandButton} onClick={() => props.onExpandAll()}>
               {hiddenLabel()}
               <Show when={tokenizing()}>
                 {' '}

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -93,7 +93,7 @@ export interface RenderContext {
     status?: string
     description?: string
     output?: string
-    exitCode?: number
+    exitCode?: number | null
   }
   /** Status from child tool_use_result (for Agent/Task status display). */
   childToolResultStatus?: string

--- a/frontend/src/components/chat/rendererUtils.test.ts
+++ b/frontend/src/components/chat/rendererUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { formatCompactNumber } from './rendererUtils'
+
+describe('formatCompactNumber', () => {
+  it('numbers below 1000 are returned as-is', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(1)).toBe('1')
+    expect(formatCompactNumber(999)).toBe('999')
+  })
+
+  it('thousands use k suffix with one decimal', () => {
+    expect(formatCompactNumber(1000)).toBe('1k')
+    expect(formatCompactNumber(1500)).toBe('1.5k')
+    expect(formatCompactNumber(67738)).toBe('67.7k')
+    expect(formatCompactNumber(99900)).toBe('99.9k')
+  })
+
+  it('hundreds of thousands round the decimal', () => {
+    expect(formatCompactNumber(100_000)).toBe('100k')
+    expect(formatCompactNumber(250_000)).toBe('250k')
+    expect(formatCompactNumber(999_999)).toBe('1000k')
+  })
+
+  it('millions use m suffix with one decimal', () => {
+    expect(formatCompactNumber(1_000_000)).toBe('1m')
+    expect(formatCompactNumber(1_500_000)).toBe('1.5m')
+    expect(formatCompactNumber(12_345_678)).toBe('12.3m')
+  })
+
+  it('hundreds of millions round the decimal', () => {
+    expect(formatCompactNumber(100_000_000)).toBe('100m')
+    expect(formatCompactNumber(500_000_000)).toBe('500m')
+  })
+
+  it('billions use g suffix with one decimal', () => {
+    expect(formatCompactNumber(1_000_000_000)).toBe('1g')
+    expect(formatCompactNumber(2_500_000_000)).toBe('2.5g')
+  })
+
+  it('drops trailing .0 decimals', () => {
+    expect(formatCompactNumber(2000)).toBe('2k')
+    expect(formatCompactNumber(3_000_000)).toBe('3m')
+    expect(formatCompactNumber(4_000_000_000)).toBe('4g')
+  })
+})

--- a/frontend/src/components/chat/rendererUtils.ts
+++ b/frontend/src/components/chat/rendererUtils.ts
@@ -38,6 +38,22 @@ export function formatNumber(n: number): string {
   return n.toLocaleString('en-US')
 }
 
+/** Format a number in compact form (e.g. 1.2k, 3.5m, 1.1g). */
+export function formatCompactNumber(n: number): string {
+  if (n < 1000)
+    return String(n)
+  if (n < 1_000_000) {
+    const v = n / 1000
+    return `${v >= 100 ? Math.round(v) : Number(v.toFixed(1))}k`
+  }
+  if (n < 1_000_000_000) {
+    const v = n / 1_000_000
+    return `${v >= 100 ? Math.round(v) : Number(v.toFixed(1))}m`
+  }
+  const v = n / 1_000_000_000
+  return `${v >= 100 ? Math.round(v) : Number(v.toFixed(1))}g`
+}
+
 /** Format a Grep result summary for display (without trailing colon). */
 export function formatGrepSummary(numFiles?: number, numLines?: number, fallback?: string | null): string | null {
   if (numFiles === undefined && numLines === undefined)

--- a/frontend/src/components/chat/taskOutputRenderer.test.tsx
+++ b/frontend/src/components/chat/taskOutputRenderer.test.tsx
@@ -145,4 +145,31 @@ describe('renderTaskOutput', () => {
     const text = renderText({})
     expect(text).toContain('Waiting for output')
   })
+
+  it('exitCode null (process still running): shows status instead of "Exit code null"', () => {
+    const text = renderText({
+      childTask: {
+        task_id: 'b0c676c',
+        task_type: 'local_bash',
+        status: 'running',
+        description: 'Run full E2E suite',
+        output: '',
+        exitCode: null,
+      },
+    })
+    expect(text).not.toContain('Exit code null')
+    expect(text).toContain('Running')
+    expect(text).toContain('Task ID b0c676c')
+  })
+
+  it('exitCode 0 still shows "Exit code 0"', () => {
+    const text = renderText({
+      childTask: {
+        task_id: 'abc',
+        status: 'completed',
+        exitCode: 0,
+      },
+    })
+    expect(text).toContain('Exit code 0')
+  })
 })

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -11,22 +11,23 @@ import Check from 'lucide-solid/icons/check'
 import ChevronsRight from 'lucide-solid/icons/chevrons-right'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import Copy from 'lucide-solid/icons/copy'
+import File from 'lucide-solid/icons/file'
 import FilePen from 'lucide-solid/icons/file-pen'
 import FilePlus from 'lucide-solid/icons/file-plus'
-import FileText from 'lucide-solid/icons/file-text'
 import FoldVertical from 'lucide-solid/icons/fold-vertical'
 import FolderSearch from 'lucide-solid/icons/folder-search'
 import Globe from 'lucide-solid/icons/globe'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import OctagonX from 'lucide-solid/icons/octagon-x'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
+import PocketKnife from 'lucide-solid/icons/pocket-knife'
 import Quote from 'lucide-solid/icons/quote'
 import Rows2 from 'lucide-solid/icons/rows-2'
 import Search from 'lucide-solid/icons/search'
 import SquareTerminal from 'lucide-solid/icons/square-terminal'
 import Terminal from 'lucide-solid/icons/terminal'
+import TextSearch from 'lucide-solid/icons/text-search'
 import TicketsPlane from 'lucide-solid/icons/tickets-plane'
-import Toolbox from 'lucide-solid/icons/toolbox'
 import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
 import Vote from 'lucide-solid/icons/vote'
 import { createSignal, For, Show } from 'solid-js'
@@ -39,7 +40,7 @@ import { DiffView, rawDiffToHunks } from './diffUtils'
 import { getAssistantContent, isObject, relativizePath } from './messageUtils'
 import { parseCatNContent, ReadResultView } from './ReadResultView'
 import { RelativeTime } from './RelativeTime'
-import { firstNonEmptyLine, formatDuration, formatGlobSummary, formatGrepSummary, formatNumber, formatTaskStatus, formatToolInput } from './rendererUtils'
+import { firstNonEmptyLine, formatCompactNumber, formatDuration, formatGlobSummary, formatGrepSummary, formatTaskStatus, formatToolInput } from './rendererUtils'
 import { renderToolDetail } from './toolDetailRenderers'
 import {
   controlResponseTag,
@@ -143,10 +144,10 @@ export function ToolUseLayout(props: {
 export function toolIconFor(name: string): LucideIcon {
   switch (name) {
     case 'Bash': return Terminal
-    case 'Read': return FileText
+    case 'Read': return File
     case 'Write': return FilePlus
     case 'Edit': return FilePen
-    case 'Grep': return Search
+    case 'Grep': return TextSearch
     case 'Glob': return FolderSearch
     case 'Task': return Bot
     case 'Agent': return Bot
@@ -157,8 +158,8 @@ export function toolIconFor(name: string): LucideIcon {
     case 'ExitPlanMode': return PlaneTakeoff
     case 'AskUserQuestion': return Vote
     case 'TaskOutput': return SquareTerminal
-    case 'Skill': return Toolbox
-    case 'ToolSearch': return Toolbox
+    case 'Skill': return PocketKnife
+    case 'ToolSearch': return Search
     case 'TaskStop': return OctagonX
     default: return ChevronsRight
   }
@@ -349,8 +350,10 @@ function deriveToolSummary(toolName: string, input: Record<string, unknown>, con
     case 'TaskOutput': {
       const task = context?.childTask
       const parts: string[] = []
-      if (task?.exitCode !== undefined)
+      if (task?.exitCode != null)
         parts.push(`Exit code ${task.exitCode}`)
+      else if (task?.status)
+        parts.push(formatTaskStatus(task.status))
       if (task?.task_id)
         parts.push(`Task ID ${task.task_id}`)
       return parts.length > 0
@@ -375,10 +378,10 @@ function deriveToolSummary(toolName: string, input: Record<string, unknown>, con
         parts.push(displayStatus)
       if (context?.childTotalDurationMs !== undefined)
         parts.push(formatDuration(context.childTotalDurationMs))
-      if (context?.childTotalTokens !== undefined)
-        parts.push(`${formatNumber(context.childTotalTokens)} tokens`)
       if (context?.childTotalToolUseCount !== undefined)
         parts.push(`${context.childTotalToolUseCount} tool use${context.childTotalToolUseCount === 1 ? '' : 's'}`)
+      if (context?.childTotalTokens !== undefined)
+        parts.push(`${formatCompactNumber(context.childTotalTokens)} tokens`)
       return parts.length > 0
         ? <div class={toolInputSummary}>{parts.join(' \u00B7 ')}</div>
         : undefined

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -155,7 +155,17 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
                   <option value="">No workers online</option>
                 </Show>
                 <For each={workers()}>
-                  {b => <option value={b.id}>{workerInfoStore.workerInfo(b.id)?.name ?? b.id}</option>}
+                  {(b) => {
+                    const info = () => workerInfoStore.workerInfo(b.id)
+                    const label = () => {
+                      const i = info()
+                      if (!i)
+                        return b.id
+                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
+                      return details ? `${i.name} (${details})` : i.name
+                    }
+                    return <option value={b.id}>{label()}</option>
+                  }}
                 </For>
               </select>
             </label>

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -177,7 +177,17 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
                   <option value="">No workers online</option>
                 </Show>
                 <For each={workers()}>
-                  {b => <option value={b.id}>{workerInfoStore.workerInfo(b.id)?.name ?? b.id}</option>}
+                  {(b) => {
+                    const info = () => workerInfoStore.workerInfo(b.id)
+                    const label = () => {
+                      const i = info()
+                      if (!i)
+                        return b.id
+                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
+                      return details ? `${i.name} (${details})` : i.name
+                    }
+                    return <option value={b.id}>{label()}</option>
+                  }}
                 </For>
               </select>
             </label>

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -150,7 +150,17 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
                   <option value="">No workers online</option>
                 </Show>
                 <For each={workers()}>
-                  {b => <option value={b.id}>{workerInfoStore.workerInfo(b.id)?.name ?? b.id}</option>}
+                  {(b) => {
+                    const info = () => workerInfoStore.workerInfo(b.id)
+                    const label = () => {
+                      const i = info()
+                      if (!i)
+                        return b.id
+                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
+                      return details ? `${i.name} (${details})` : i.name
+                    }
+                    return <option value={b.id}>{label()}</option>
+                  }}
                 </For>
               </select>
             </label>

--- a/frontend/src/styles/animations.css.ts
+++ b/frontend/src/styles/animations.css.ts
@@ -9,16 +9,6 @@ export const spinner = style({
   animation: `${spin} 1s linear infinite`,
 })
 
-export const colorShiftPulse = keyframes({
-  '0%, 60%': { backgroundColor: 'var(--color-shift-from)' },
-  '80%': { backgroundColor: 'var(--color-shift-to)' },
-  '100%': { backgroundColor: 'var(--color-shift-from)' },
-})
-
-export const interruptPulse = style({
-  animation: `${colorShiftPulse} 5s ease-in-out infinite`,
-})
-
 export const thinkingPulse = keyframes({
   '0%, 100%': { opacity: 0.15 },
   '50%': { opacity: 0.6 },

--- a/frontend/tests/unit/components/MessageBubble.test.tsx
+++ b/frontend/tests/unit/components/MessageBubble.test.tsx
@@ -581,7 +581,8 @@ describe('taskOutput rendering', () => {
 
     const bubble = screen.getByTestId('message-content')
     expect(bubble.textContent).toContain('Build')
-    expect(bubble.textContent).not.toContain('Complete')
+    // When exitCode is absent but status is set, the formatted status is shown.
+    expect(bubble.textContent).toContain('Complete')
   })
 
   it('hides metadata when collapsed', () => {
@@ -935,7 +936,7 @@ describe('agent stats summary', () => {
 
     const bubble = screen.getByTestId('message-content')
     expect(bubble.textContent).toContain('1m 5s')
-    expect(bubble.textContent).toContain('1,234 tokens')
+    expect(bubble.textContent).toContain('1.2k tokens')
     expect(bubble.textContent).toContain('5 tool uses')
   })
 


### PR DESCRIPTION
## Motivation

Several issues in the chat view were degrading the user experience:

- The "Send Feedback" button would disappear after switching tabs due to a race condition in `controlResponseHandling` calling `setHasContent(false)` during tab transitions.
- Chat scroll position was not restored when switching back to a tab, and scroll events fired even when tabs were invisible (`display:none`).
- Draft content could be lost on tab switch because `MarkdownEditor`'s cleanup used the reactive `getDraftKey()` which had already updated to the new agent by unmount time.
- Task output displayed "Exit code null" when a process was still running instead of showing a meaningful status.
- Worker selection dropdowns showed only worker names, making it hard to distinguish workers by version, OS, or architecture.

## Modifications

- Removed the `setHasContent(false)` call in `controlResponseHandling` that was causing the "Send Feedback" button to vanish on tab switches; `MarkdownEditor`'s content change listener is now the sole authority for button visibility.
- Added `ResizeObserver` and `clientHeight` checks in `ChatView` to detect hidden-to-visible tab transitions, restoring saved scroll positions and suppressing scroll logic when the view is not visible.
- Changed `MarkdownEditor` cleanup to read from the cached `latestDraftKey` instead of the reactive `getDraftKey()` to preserve draft content across tab switches.
- Fixed `exitCode` type to `number | null` and updated task output rendering to show a formatted running status when `exitCode` is `null`.
- Migrated the interrupt button to standard `small`/`secondary` button classes, replacing the custom `interruptPulse` animation.
- Converted the scroll-to-bottom button from `IconButton` to a floating Oat outline button centered at the bottom of the message list with a larger icon.
- Added `formatCompactNumber()` utility to display token counts in Agent/Task summaries as compact values (e.g., 1.2k, 3.5m).
- Updated tool icon selections: Read uses `File`, Grep uses `TextSearch`, Skill uses `PocketKnife`, ToolSearch uses `Search`.
- Enhanced worker selection dropdown labels to include version, OS, and architecture (e.g., "worker-name (1.2.3, linux, amd64)") across `NewAgentDialog`, `NewTerminalDialog`, and `NewWorkspaceDialog`.
- Removed unused `interruptPulse` and `colorShiftPulse` animations from `animations.css.ts`.

## Result

- The "Send Feedback" button no longer disappears after switching between agent tabs.
- Switching back to a chat tab restores the previous scroll position instead of jumping to the top or triggering spurious scroll events.
- Draft content is reliably preserved when switching tabs.
- Running tasks display a meaningful status label instead of "Exit code null".
- Token counts in Agent/Task summaries are shown in a compact, readable format.
- Worker dropdowns show enough detail to distinguish workers by version and platform at a glance.

🤖 Generated with Claude Code
