### PR TITLE
Fix toolbar overlap in file viewer and style scroll-to-bottom button

### DIFF
--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -115,11 +115,18 @@ export const sendButtonDisabled = style({
 })
 
 export const scrollToBottomButton = style({
-  position: 'absolute',
-  bottom: 'var(--space-3)',
-  left: '50%',
-  transform: 'translateX(-50%)',
-  zIndex: 10,
+  'position': 'absolute',
+  'bottom': 'var(--space-3)',
+  'left': '50%',
+  'transform': 'translateX(-50%)',
+  'zIndex': 10,
+  'width': '36px',
+  'height': '36px',
+  'backgroundColor': 'var(--background)',
+  'opacity': 0.8,
+  ':hover': {
+    opacity: 1,
+  },
 })
 
 export const emptyChat = style({

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -354,7 +354,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
           </Show>
         </div>
         <Show when={!atBottom()}>
-          <button type="button" class={`outline icon small ${styles.scrollToBottomButton}`} onClick={scrollToBottom}>
+          <button type="button" class={`outline icon ${styles.scrollToBottomButton}`} onClick={scrollToBottom}>
             <Icon icon={ArrowDown} size="lg" />
           </button>
         </Show>

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -2,6 +2,10 @@ import { globalStyle, style } from '@vanilla-extract/css'
 import { codeViewContainer } from '~/components/chat/codeViewStyles.css'
 import { diffContainer, diffSplitContainer } from '~/components/chat/diffStyles.css'
 
+// Floating toolbar clearance: toolbar height (28px) + top offset + bottom gap.
+const toolbarClearance = 'calc(28px + var(--space-2) * 2)'
+export const TOOLBAR_CLEARANCE_PX = 44
+
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -16,11 +20,19 @@ export const content = style({
   minHeight: 0,
 })
 
+// Marker class applied to `content` when an outer floating toolbar is visible.
+export const hasFloatingToolbar = style({})
+
 // Remove border/margin from diff views when used inside the file viewer.
 globalStyle(`${content} ${diffContainer}, ${content} ${diffSplitContainer}`, {
   border: 'none',
   borderRadius: 0,
   marginTop: 0,
+})
+
+// Add toolbar clearance to diff views when an outer toolbar is present.
+globalStyle(`${hasFloatingToolbar} ${diffContainer}, ${hasFloatingToolbar} ${diffSplitContainer}`, {
+  paddingTop: toolbarClearance,
 })
 
 export const statusBar = style({
@@ -125,6 +137,12 @@ globalStyle(`${textViewContainer} ${codeViewContainer}`, {
   paddingBlock: 'var(--space-2)',
 })
 
+// Add toolbar clearance to code view when an outer toolbar is present
+// (direct child only — excludes text views nested inside toggleViewContainer).
+globalStyle(`${hasFloatingToolbar} > ${textViewContainer} ${codeViewContainer}`, {
+  paddingTop: toolbarClearance,
+})
+
 // Container for views that have a render/source toggle (markdown, SVG)
 export const toggleViewContainer = style({
   position: 'relative',
@@ -179,7 +197,8 @@ export const viewToggleActive = style({
 })
 
 export const markdownContainer = style({
-  padding: 'var(--space-4)',
+  boxSizing: 'border-box',
+  padding: `${toolbarClearance} var(--space-4) var(--space-4)`,
   overflow: 'auto',
   height: '100%',
 })
@@ -216,6 +235,19 @@ globalStyle(`${splitPane} ${codeViewContainer}`, {
   marginTop: 0,
   overflow: 'visible',
   paddingBlock: 'var(--space-2)',
+})
+
+// Add toolbar clearance inside toggleViewContainer (ViewToggle always present).
+globalStyle(`${toggleViewContainer} ${splitPaneMarkdown}`, {
+  paddingTop: toolbarClearance,
+})
+
+globalStyle(`${toggleViewContainer} ${splitPane} ${codeViewContainer}`, {
+  paddingTop: toolbarClearance,
+})
+
+globalStyle(`${toggleViewContainer} > ${textViewContainer} ${codeViewContainer}`, {
+  paddingTop: toolbarClearance,
 })
 
 // Floating toolbar for image zoom controls (top-left)
@@ -312,7 +344,7 @@ export const imageZoomWrapper = style({
   minWidth: '100%',
   minHeight: '100%',
   width: 'max-content',
-  padding: 'var(--space-4)',
+  padding: `${toolbarClearance} var(--space-4) var(--space-4)`,
 })
 
 // Checkerboard transparency pattern + border for images

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -12,6 +12,7 @@ import { GitFileRef } from '~/generated/leapmux/v1/git_pb'
 import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
 import { DiffModeToolbar } from './DiffModeToolbar'
 import * as styles from './FileViewer.css'
+import { TOOLBAR_CLEARANCE_PX } from './FileViewer.css'
 import { HexView } from './HexView'
 import { ImageFileView } from './ImageFileView'
 import { MarkdownFileView } from './MarkdownFileView'
@@ -283,7 +284,7 @@ export const FileViewer: Component<{
           </button>
         </div>
       </Show>
-      <div class={styles.content} ref={contentRef}>
+      <div class={`${styles.content}${showToolbar() || showOuterMention() ? ` ${styles.hasFloatingToolbar}` : ''}`} ref={contentRef}>
         <Show when={loading() || diffLoading()}>
           <div class={styles.loadingState}>Loading...</div>
         </Show>
@@ -355,6 +356,7 @@ export const FileViewer: Component<{
               <HexView
                 content={content()!}
                 totalSize={totalSize()}
+                topOffset={showToolbar() || showOuterMention() ? TOOLBAR_CLEARANCE_PX : 0}
               />
             </Show>
           </Show>

--- a/frontend/src/components/fileviewer/HexView.tsx
+++ b/frontend/src/components/fileviewer/HexView.tsx
@@ -36,6 +36,7 @@ function formatRow(bytes: Uint8Array, offset: number): { offsetStr: string, hex:
 export function HexView(props: {
   content: Uint8Array
   totalSize: number
+  topOffset?: number
 }): JSX.Element {
   let scrollRef!: HTMLDivElement
   const [scrollTop, setScrollTop] = createSignal(0)
@@ -43,13 +44,14 @@ export function HexView(props: {
   const [rowHeight, setRowHeight] = createSignal(FALLBACK_ROW_HEIGHT)
 
   const totalRows = createMemo(() => Math.max(1, Math.ceil(props.content.length / 16)))
+  const topOffset = () => props.topOffset ?? 0
 
   const startIdx = createMemo(() =>
-    Math.max(0, Math.floor(scrollTop() / rowHeight()) - OVERSCAN),
+    Math.max(0, Math.floor(Math.max(0, scrollTop() - topOffset()) / rowHeight()) - OVERSCAN),
   )
 
   const endIdx = createMemo(() =>
-    Math.min(totalRows(), Math.ceil((scrollTop() + viewHeight()) / rowHeight()) + OVERSCAN),
+    Math.min(totalRows(), Math.ceil(Math.max(0, scrollTop() - topOffset() + viewHeight()) / rowHeight()) + OVERSCAN),
   )
 
   const visibleRows = createMemo(() => {
@@ -86,7 +88,7 @@ export function HexView(props: {
     })
   })
 
-  const topPad = () => `${BASE_VPAD + startIdx() * rowHeight()}px`
+  const topPad = () => `${topOffset() + BASE_VPAD + startIdx() * rowHeight()}px`
   const bottomPad = () => `${BASE_VPAD + Math.max(0, totalRows() - endIdx()) * rowHeight()}px`
 
   return (

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -20,7 +20,8 @@ const MIME_MAP: Record<string, string> = {
   avif: 'image/avif',
 }
 
-const WRAPPER_PADDING = 16 // matches var(--space-4) used in imageZoomWrapper
+const WRAPPER_PADDING_X = 16 // matches var(--space-4) used in imageZoomWrapper
+const WRAPPER_PADDING_TOP = 44 // matches toolbar clearance used in imageZoomWrapper
 
 function getMimeType(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase() ?? ''
@@ -62,8 +63,8 @@ function ImageRender(props: {
     const cs = containerSize()
     if (!ns?.w || !ns?.h || !cs.w || !cs.h)
       return null
-    const availW = cs.w - WRAPPER_PADDING * 2
-    const availH = cs.h - WRAPPER_PADDING * 2
+    const availW = cs.w - WRAPPER_PADDING_X * 2
+    const availH = cs.h - WRAPPER_PADDING_TOP - WRAPPER_PADDING_X
     if (availW <= 0 || availH <= 0)
       return null
     return Math.min(availW / ns.w, availH / ns.h)
@@ -110,8 +111,8 @@ function ImageRender(props: {
       // Compute new scroll position to keep the point under cursor stable
       const newImgW = ns.w * newScale
       const newImgH = ns.h * newScale
-      const contentW = Math.max(el.clientWidth, newImgW + WRAPPER_PADDING * 2)
-      const contentH = Math.max(el.clientHeight, newImgH + WRAPPER_PADDING * 2)
+      const contentW = Math.max(el.clientWidth, newImgW + WRAPPER_PADDING_X * 2)
+      const contentH = Math.max(el.clientHeight, newImgH + WRAPPER_PADDING_TOP + WRAPPER_PADDING_X)
       const imgOffsetX = (contentW - newImgW) / 2
       const imgOffsetY = (contentH - newImgH) / 2
       el.scrollLeft = imgOffsetX + fracX * newImgW - viewX + e.deltaX


### PR DESCRIPTION
## Motivation

The floating toolbar in the file viewer was overlapping content because no clearance was reserved for it. This affected all view types — diff, code, markdown, hex, and image — causing content to render underneath the toolbar. Additionally, the scroll-to-bottom button in `ChatView` lacked explicit dimensions and a visible background, making it difficult to see and interact with.

## Modifications

- Introduced a `TOOLBAR_CLEARANCE_PX` constant (44px) in `FileViewer.css.ts` exported for use across view components, representing the floating toolbar height plus spacing.
- Added a `hasFloatingToolbar` CSS class to the `FileViewer` content container that applies `padding-top` to nested views when a toolbar is visible.
- Updated `HexView` scroll offset calculations to account for top offset when a toolbar is present, fixing row rendering and scroll positioning in virtualized hex output.
- Updated `ImageFileView` padding constants to separate horizontal padding (16px) from vertical toolbar clearance (44px), correcting zoom-to-fit calculations.
- Restyled the scroll-to-bottom button in `ChatView` with explicit 36x36px dimensions and a semi-transparent background (0.8 opacity, increasing to 1 on hover), replacing the previous unsized `small` CSS class.

## Result

The floating toolbar in the file viewer no longer overlaps content in any view type (diff, code, markdown, hex, or image). Content is offset correctly so it begins below the toolbar. The scroll-to-bottom button in the chat panel is now consistently visible with a well-defined size and background.

🤖 Generated with Claude Code
