### PR TITLE
Standardize chat footer button styles with Oat defaults

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -380,8 +380,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                     <div class={styles.footerBarRight}>
                       <Show when={ctrl.showInterrupt()}>
                         <button
-                          class="small"
-                          data-variant="secondary"
+                          class="outline"
                           onClick={() => {
                             interruptLoading.start()
                             props.onInterrupt?.()
@@ -397,7 +396,6 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                       </Show>
                       <button
                         type="button"
-                        class={`${styles.sendButton} ${!hasContent() || props.disabled || sending() ? styles.sendButtonDisabled : ''}`}
                         disabled={!hasContent() || props.disabled || sending()}
                         onClick={() => {
                           startSending()

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -76,7 +76,7 @@ export const footerBar = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  padding: 'var(--space-1) var(--space-2)',
+  padding: 'var(--space-1) var(--space-1) var(--space-1) var(--space-3)',
   backgroundColor: 'var(--background)',
   flexShrink: 0,
 })
@@ -84,34 +84,6 @@ export const footerBar = style({
 export const footerBarLeft = style({
   display: 'flex',
   alignItems: 'center',
-})
-
-export const sendButton = style({
-  'all': 'unset',
-  'boxSizing': 'border-box',
-  'display': 'flex',
-  'alignItems': 'center',
-  'justifyContent': 'center',
-  'gap': 'var(--space-1)',
-  'padding': 'var(--space-1) var(--space-2)',
-  'fontSize': 'var(--text-7)',
-  'fontWeight': 400,
-  'borderRadius': 'var(--radius-small)',
-  'backgroundColor': 'var(--primary)',
-  'color': '#fff',
-  'cursor': 'pointer',
-  ':hover': {
-    backgroundColor: 'var(--primary)',
-  },
-})
-
-export const sendButtonDisabled = style({
-  'backgroundColor': 'var(--card)',
-  'color': 'var(--faint-foreground)',
-  'cursor': 'default',
-  ':hover': {
-    backgroundColor: 'var(--card)',
-  },
 })
 
 export const scrollToBottomButton = style({

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -110,6 +110,7 @@ export const settingsTrigger = style({
   gap: 'var(--space-1)',
   padding: '2px var(--space-1)',
   marginBottom: '3px',
+  marginLeft: '-3px',
   fontSize: 'var(--text-8)',
   color: 'var(--faint-foreground)',
   cursor: 'pointer',

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -172,7 +172,7 @@ export const controlFooter = style({
   gridTemplateColumns: '1fr auto 1fr',
   alignItems: 'center',
   gap: 'var(--space-1)',
-  padding: 'var(--space-1) var(--space-2)',
+  padding: 'var(--space-1) var(--space-1) var(--space-1) var(--space-3)',
   backgroundColor: 'var(--background)',
   flexShrink: 0,
   flex: 1,


### PR DESCRIPTION
## Motivation
The chat footer buttons used custom CSS classes that duplicated styling already provided by the Oat design system. This made the UI harder to maintain and caused visual inconsistencies compared to other parts of the application.

## Modifications
- Replaced custom `sendButton` and `sendButtonDisabled` CSS classes with Oat design system button variants, removing ~30 lines of custom styles from `ChatView.css.ts`
- Changed the interrupt button variant from `small` + `secondary` to `outline` to align with Oat defaults
- Adjusted footer padding from symmetric `var(--space-2)` to asymmetric padding with `var(--space-3)` on the left for better visual balance
- Added a -3px left margin to the settings trigger button to correct its visual alignment within the footer

## Result
The chat footer now uses Oat design system defaults consistently, reducing custom CSS surface area and keeping button styles in sync with the rest of the application. No user-facing behavioral changes.

🤖 Generated with Claude Code
