### PR TITLE
Fix worker three-dot button placement and sidebar spacing

### DIFF
--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -80,7 +80,7 @@ export const collapsibleTrigger = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': 'var(--space-1)',
-  'padding': '0 var(--space-3) 0 var(--space-4)',
+  'padding': '0 var(--space-2) 0 var(--space-4)',
   'minHeight': headerHeight,
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -80,7 +80,7 @@ export const collapsibleTrigger = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': 'var(--space-1)',
-  'padding': '0 var(--space-4)',
+  'padding': '0 var(--space-3) 0 var(--space-4)',
   'minHeight': headerHeight,
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -101,6 +101,11 @@ export const collapsibleTriggerStatic = style({
   },
 })
 
+/** Right-sidebar triggers keep the original --space-4 right padding. */
+export const collapsibleTriggerRight = style({
+  paddingRight: 'var(--space-4)',
+})
+
 /** Hide the OAT accordion chevron on a section header (e.g. first right-sidebar section). */
 export const collapsibleTriggerNoChevron = style({
   '::after': {

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -80,7 +80,7 @@ export const collapsibleTrigger = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': 'var(--space-1)',
-  'padding': '0 var(--space-2) 0 var(--space-4)',
+  'padding': '0 var(--space-4)',
   'minHeight': headerHeight,
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -349,7 +349,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                   data-testid={section().testId}
                 >
                   <summary
-                    class={`${styles.collapsibleTrigger} ${isStatic() || !canCollapse() ? styles.collapsibleTriggerStatic : ''} ${index() === 0 && props.side === 'right' ? styles.collapsibleTriggerNoChevron : ''}`}
+                    class={`${styles.collapsibleTrigger} ${props.side === 'right' ? styles.collapsibleTriggerRight : ''} ${isStatic() || !canCollapse() ? styles.collapsibleTriggerStatic : ''} ${index() === 0 && props.side === 'right' ? styles.collapsibleTriggerNoChevron : ''}`}
                     data-testid={section().testId ? `${section().testId}-summary` : undefined}
                     onClick={(e) => {
                       // Prevent native <details> toggle -- we control state

--- a/frontend/src/components/workers/WorkerSectionContent.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.tsx
@@ -37,10 +37,12 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
               <span class={listStyles.itemTitle}>
                 {props.workerInfo(worker.id)?.name ?? '\u2014'}
               </span>
-              <WorkerContextMenu
-                workerInfo={props.workerInfo(worker.id)}
-                onDeregister={() => props.onDeregister(worker)}
-              />
+              <div class={listStyles.itemActions}>
+                <WorkerContextMenu
+                  workerInfo={props.workerInfo(worker.id)}
+                  onDeregister={() => props.onDeregister(worker)}
+                />
+              </div>
             </div>
           )}
         </For>

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -161,7 +161,7 @@ export const itemActions = style({
   flexShrink: 0,
   marginLeft: 'auto',
   position: 'sticky',
-  right: 'var(--space-3)',
+  right: 'var(--space-2)',
 })
 
 /** Give itemActions a background on hover so it covers scrolled text underneath. */

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -161,7 +161,7 @@ export const itemActions = style({
   flexShrink: 0,
   marginLeft: 'auto',
   position: 'sticky',
-  right: 'var(--space-2)',
+  right: 'var(--space-3)',
 })
 
 /** Give itemActions a background on hover so it covers scrolled text underneath. */

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -102,7 +102,7 @@ export const item = style({
   'display': 'flex',
   'alignItems': 'center',
   'padding': 'var(--space-1) var(--space-3)',
-  'paddingLeft': 'var(--space-2)',
+  'paddingLeft': 'var(--space-1)',
   'cursor': 'pointer',
   'gap': 'var(--space-1)',
   ':hover': {


### PR DESCRIPTION
## Motivation

The three-dot context menu button in the Workers sidebar section was misplaced, unlike the equivalent buttons in WorkspaceSectionContent and DirectoryTree which render correctly. The Workers section was missing the wrapper element that handles right-alignment, sticky positioning, and hover background for the action button.

Additionally, the collapsible trigger right padding needed differentiation between left-sidebar and right-sidebar triggers to keep action buttons visually consistent across sidebar sections.

## Modifications

- Wrap `WorkerContextMenu` in a `listStyles.itemActions` div, matching the pattern used by `WorkspaceSectionContent` and `DirectoryTree`
- Change the `itemActions` sticky right offset to align with item right padding for consistent three-dot button positioning
- Reduce `item` left padding from `--space-2` to `--space-1`
- Adjust the left-sidebar collapsible trigger right padding from `--space-4` to `--space-3`
- Add a new `collapsibleTriggerRight` style class to preserve the original `--space-4` right padding for right-sidebar triggers

## Result

The three-dot context menu button in the Workers section now appears in the correct position, consistent with other sidebar sections. Collapsible trigger padding is correctly differentiated between left-sidebar and right-sidebar contexts, and list item left padding is tightened.

🤖 Generated with Claude Code
