### PR TITLE
Refactor standalone mode into solo and dev modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ The `task dev` command uses `mprocs` to run two processes concurrently:
 - **Backend** — Runs Hub + Worker together in dev mode (with `-dev-frontend` flag to proxy to the frontend dev server)
 - **Frontend** — Bun dev server for the SolidJS web application
 
+To run in solo mode (localhost-only, no login) instead of dev mode during development:
+```bash
+task dev-solo
+```
+
 ---
 
 ## Development
@@ -345,10 +350,14 @@ By default this builds for `linux/amd64` and `linux/arm64`. You can override the
 task docker-build-alpine PLATFORM=linux/amd64 TAG=leapmux:dev
 ```
 
-The image uses a multi-stage build (buf, Bun, Go) and runs with [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. The Hub listens on port 4327 and data is stored in the `/data` volume.
+The image uses a multi-stage build (buf, Bun, Go) and runs with [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. The `LEAPMUX_MODE` environment variable selects the subcommand (`hub`, `worker`, `dev`, etc.) and is required. Data is stored in the `/data` volume.
 
 ```bash
-docker run -p 4327:4327 -v leapmux-data:/data leapmux:latest
+# Run as a hub (central service only)
+docker run -p 4327:4327 -e LEAPMUX_MODE=hub -v leapmux-data:/data leapmux:latest
+
+# Run as hub + worker together (dev mode)
+docker run -p 4327:4327 -e LEAPMUX_MODE=dev -v leapmux-data:/data leapmux:latest
 ```
 
 Pre-built images are published to GHCR in two variants:
@@ -490,7 +499,8 @@ leapmux/
 │
 ├── buf.gen.yaml            # Protocol Buffer code generation targets
 ├── buf.yaml                # Protocol Buffer linting configuration
-├── mprocs.yaml             # Development process configuration
+├── mprocs.yaml             # Dev mode process configuration (task dev)
+├── mprocs-solo.yaml        # Solo mode process configuration (task dev-solo)
 ├── README.md               # This file
 ├── Taskfile.yaml           # Build orchestration (go-task.dev)
 └── versions.yaml           # Version string and tool/image versions

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ By default this builds for `linux/amd64` and `linux/arm64`. You can override the
 task docker-build-alpine PLATFORM=linux/amd64 TAG=leapmux:dev
 ```
 
-The image uses a multi-stage build (buf, Bun, Go) and runs with [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. The `LEAPMUX_MODE` environment variable selects the subcommand (`hub`, `worker`, `dev`, etc.) and is required. Data is stored in the `/data` volume.
+The image uses a multi-stage build (buf, Bun, Go) and runs with [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. The `LEAPMUX_MODE` environment variable selects the subcommand (`hub`, `worker`, `dev`, etc.) and is required. Data and configuration are stored under `/data/<mode>/` (e.g. `/data/hub/`) in the `/data` volume.
 
 ```bash
 # Run as a hub (central service only)

--- a/README.md
+++ b/README.md
@@ -40,34 +40,69 @@ LeapMux is an **AI coding agent multiplexer** that enables developers to run mul
 
 ## Architecture
 
-LeapMux uses a three-tier architecture. The Hub handles authentication and routing, while the Frontend communicates directly with Workers through end-to-end encrypted channels relayed by the Hub:
+LeapMux is built as a single Go binary (`leapmux`) that runs in two deployment modes:
+
+### Solo Mode (default)
+
+Run `leapmux` with no subcommand for a zero-config, single-user setup. Hub and Worker run in the same process, bound to localhost only. No login is required — the UI opens directly into the workspace.
+
+```
+                 LeapMux (127.0.0.1:4327)
+┌──────────────────────────────────────────────────────┐
+│                                                      │
+│  ┌─────────────┐  in-process   ┌──────────────────┐  │
+│  │     Hub     │◄─────────────►│     Worker       │  │
+│  │  (no auth)  │               │  ┌────────────┐  │  │
+│  │  + SQLite   │               │  │Claude Code │  │  │
+│  │             │               │  │ (multiple) │  │  │
+│  └─────────────┘               │  └────────────┘  │  │
+│         ▲                      │  + SQLite        │  │
+│         │                      └──────────────────┘  │
+│         │ ConnectRPC + WebSocket (E2EE)              │
+└─────────┼────────────────────────────────────────────┘
+          │
+          ▼
+   ┌──────────────┐
+   │   Frontend   │
+   │  (Browser)   │
+   └──────────────┘
+```
+
+### Distributed Mode
+
+For multi-user and remote setups, run `leapmux hub` and `leapmux worker` separately. The Hub handles authentication and relays end-to-end encrypted traffic between the Frontend and Workers. Workers can be on different machines, behind NATs — they initiate outbound connections to the Hub.
 
 ```
 ┌─────────────────┐  ConnectRPC  ┌─────────────────┐                 ┌───────────────────┐
 │                 │  WebSocket   │                 │   gRPC (bidi)   │  Worker 1         │
-│    Frontend     │◄────────────►│       Hub       │◄───────────────►│  ┌─────────────┐  │
+│    Frontend     │◄────────────►│      Hub        │◄───────────────►│  ┌─────────────┐  │
 │    (Browser)    │    (E2EE)    │    (Relay)      │                 │  │ Claude Code │  │
 │                 │              │                 │                 │  │ (multiple)  │  │
 │    SolidJS      │              │   Go Service    │                 │  └─────────────┘  │
-│    Web App      │              │   + Database    │                 │  + Database       │
+│    Web App      │              │   + SQLite      │                 │  + SQLite         │
 │                 │              │                 │                 └───────────────────┘
 └─────────────────┘              └─────────────────┘                           ⋮
-                                         │                          ┌───────────────────┐
-                                         ▼                          │  Worker N         │
-                                 ┌───────────────┐                  │  ┌─────────────┐  │
-                                 │    SQLite     │                  │  │ Claude Code │  │
-                                 │               │                  │  │ (multiple)  │  │
-                                 └───────────────┘                  │  └─────────────┘  │
-                                                                    │  + Database       │
-                                                                    └───────────────────┘
+                                                                     ┌───────────────────┐
+                                                                     │  Worker N         │
+                                                                     │  ┌─────────────┐  │
+                                                                     │  │ Claude Code │  │
+                                                                     │  │ (multiple)  │  │
+                                                                     │  └─────────────┘  │
+                                                                     │  + SQLite         │
+                                                                     └───────────────────┘
 ```
 
-LeapMux is built as a single Go binary (`leapmux`) that can run in multiple modes:
-- **`leapmux`** (no subcommand) — Solo mode: Hub + Worker on loopback (`127.0.0.1:4327`), no login required, single-user
-- **`leapmux hub`** — Runs only the Hub (central service)
-- **`leapmux worker`** — Runs only a Worker (connects to a remote Hub)
-- **`leapmux dev`** — Dev mode: Hub + Worker on all interfaces, login required, all multi-user features enabled
-- **`leapmux version`** — Prints the version and exits
+### Modes
+
+LeapMux is a single binary with these subcommands:
+
+| Command | Mode | Description |
+|---------|------|-------------|
+| `leapmux` | Solo | Hub + Worker on `127.0.0.1:4327`, no login, single-user |
+| `leapmux hub` | Hub | Central service only (authentication, relay, database) |
+| `leapmux worker` | Worker | Connects to a remote Hub |
+| `leapmux dev` | Dev | Hub + Worker on `:4327` (all interfaces), login required, all features |
+| `leapmux version` | — | Prints version and exits |
 
 ### Components
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ LeapMux uses a three-tier architecture. The Hub handles authentication and routi
                                                                     └───────────────────┘
 ```
 
-LeapMux is built as a single Go binary (`leapmux`) that can run in three modes:
+LeapMux is built as a single Go binary (`leapmux`) that can run in multiple modes:
+- **`leapmux`** (no subcommand) — Solo mode: Hub + Worker on loopback (`127.0.0.1:4327`), no login required, single-user
 - **`leapmux hub`** — Runs only the Hub (central service)
 - **`leapmux worker`** — Runs only a Worker (connects to a remote Hub)
-- **`leapmux`** (no subcommand) — Runs Hub + Worker together (standalone mode)
+- **`leapmux dev`** — Dev mode: Hub + Worker on all interfaces, login required, all multi-user features enabled
 - **`leapmux version`** — Prints the version and exits
 
 ### Components
@@ -176,7 +177,7 @@ http://localhost:4327
 ```
 
 The `task dev` command uses `mprocs` to run two processes concurrently:
-- **Backend** — Runs Hub + Worker together in standalone mode (with `-dev-frontend` flag to proxy to the frontend dev server)
+- **Backend** — Runs Hub + Worker together in dev mode (with `-dev-frontend` flag to proxy to the frontend dev server)
 - **Frontend** — Bun dev server for the SolidJS web application
 
 ---
@@ -382,8 +383,8 @@ leapmux/
 │
 ├── cmd/leapmux/            # Unified binary entry point
 │   ├── hub.go              # Hub mode
-│   ├── main.go             # Subcommand routing (hub, worker, standalone)
-│   ├── standalone.go       # Standalone mode (hub + worker, default)
+│   ├── main.go             # Subcommand routing (hub, worker, solo, dev)
+│   ├── solo.go             # Solo/dev mode (hub + worker, default)
 │   └── worker.go           # Worker mode
 │
 ├── docker/                 # Dockerfile and s6-overlay service definitions

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,6 +266,12 @@ tasks:
       - task: build-backend
       - mprocs
 
+  dev-solo:
+    desc: Start solo mode for development
+    cmds:
+      - task: generate
+      - mprocs --config mprocs-solo.yaml
+
   # --- Docker ---
 
   docker-build:

--- a/cmd/leapmux/main.go
+++ b/cmd/leapmux/main.go
@@ -14,8 +14,13 @@ func main() {
 	logging.Setup()
 
 	if len(os.Args) < 2 {
-		// No subcommand: run standalone mode (default).
-		if err := runStandalone(os.Args[1:]); err != nil {
+		// No subcommand: run solo mode (default).
+		if os.Getenv("LEAPMUX_DOCKER") == "1" {
+			fmt.Fprintf(os.Stderr, "error: LEAPMUX_MODE env var is required in Docker\n")
+			fmt.Fprintf(os.Stderr, "usage: leapmux [hub|worker|dev|version] [flags]\n")
+			os.Exit(1)
+		}
+		if err := runSolo(os.Args[1:], true); err != nil {
 			slog.Error("fatal", "error", err)
 			os.Exit(1)
 		}
@@ -33,19 +38,29 @@ func main() {
 			slog.Error("fatal", "error", err)
 			os.Exit(1)
 		}
+	case "dev":
+		if err := runSolo(os.Args[2:], false); err != nil {
+			slog.Error("fatal", "error", err)
+			os.Exit(1)
+		}
 	case "version":
 		fmt.Println(version)
 	default:
-		// If the first arg starts with '-', treat as standalone flags.
+		// If the first arg starts with '-', treat as solo flags.
 		if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
-			if err := runStandalone(os.Args[1:]); err != nil {
+			if os.Getenv("LEAPMUX_DOCKER") == "1" {
+				fmt.Fprintf(os.Stderr, "error: LEAPMUX_MODE env var is required in Docker\n")
+				fmt.Fprintf(os.Stderr, "usage: leapmux [hub|worker|dev|version] [flags]\n")
+				os.Exit(1)
+			}
+			if err := runSolo(os.Args[1:], true); err != nil {
 				slog.Error("fatal", "error", err)
 				os.Exit(1)
 			}
 			return
 		}
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-		fmt.Fprintf(os.Stderr, "usage: leapmux [hub|worker|version] [flags]\n")
+		fmt.Fprintf(os.Stderr, "usage: leapmux [hub|worker|dev|version] [flags]\n")
 		os.Exit(1)
 	}
 }

--- a/cmd/leapmux/solo.go
+++ b/cmd/leapmux/solo.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,14 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/confmap"
-	"github.com/knadh/koanf/providers/file"
-	"github.com/knadh/koanf/v2"
 	"github.com/leapmux/leapmux/hub"
-	internalconfig "github.com/leapmux/leapmux/internal/config"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
-	hubdb "github.com/leapmux/leapmux/internal/hub/db"
 	"github.com/leapmux/leapmux/internal/logging"
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	"github.com/leapmux/leapmux/worker"
@@ -50,120 +43,40 @@ func runSolo(args []string, soloMode bool) error {
 	defaultConfigDir := "~/.config/leapmux/" + modeName
 	defaultConfigFile := defaultConfigDir + "/" + modeName + ".yaml"
 
-	// Pre-scan for -config flag.
-	configPath := internalconfig.ExtractConfigFlag(args, defaultConfigFile)
-
-	// Define CLI flags.
-	fs := flag.NewFlagSet("leapmux", flag.ContinueOnError)
-	fs.String("config", defaultConfigFile, "path to config file")
-	fs.String("addr", defaultAddr, "TCP listen address")
-	fs.String("data-dir", ".", "data directory")
-	fs.String("dev-frontend", "", "Vite dev server URL (dev mode)")
-	fs.Int("db-max-conns", hubdb.DefaultMaxConns, "maximum number of open database connections")
-	fs.String("log-level", "info", "log level (debug, info, warn, error)")
-	showVersion := fs.Bool("version", false, "print version and exit")
-
-	if err := fs.Parse(args); err != nil {
+	hubCfg, showVersion, err := hubconfig.LoadWithOptions(args, hubconfig.LoadOptions{
+		DefaultAddr:       defaultAddr,
+		DefaultConfigDir:  defaultConfigDir,
+		DefaultConfigFile: defaultConfigFile,
+		FlagSetName:       "leapmux",
+		CLIFlags:          []string{"addr", "data-dir", "dev-frontend", "db-max-conns", "log-level"},
+		SoloMode:          soloMode,
+	})
+	if err != nil {
 		return err
 	}
 
-	if *showVersion {
+	if showVersion {
 		fmt.Println(version)
 		return nil
 	}
 
-	// Flag name -> koanf key mapping.
-	fieldMap := map[string]string{
-		"addr":         "addr",
-		"data-dir":     "data_dir",
-		"dev-frontend": "dev_frontend",
-		"db-max-conns": "db_max_conns",
-		"log-level":    "log_level",
-	}
-
-	defaults := map[string]interface{}{
-		"addr":                            defaultAddr,
-		"data_dir":                        ".",
-		"dev_frontend":                    "",
-		"db_max_conns":                    hubdb.DefaultMaxConns,
-		"log_level":                       "info",
-		"signup_enabled":                  false,
-		"email_verification_required":     false,
-		"smtp_host":                       "",
-		"smtp_port":                       587,
-		"smtp_username":                   "",
-		"smtp_password":                   "",
-		"smtp_from_address":               "",
-		"smtp_use_tls":                    true,
-		"api_timeout_seconds":             10,
-		"agent_startup_timeout_seconds":   30,
-		"worktree_create_timeout_seconds": 60,
-	}
-
-	k := koanf.New(".")
-	fp := internalconfig.NewFlagProvider(fs, fieldMap)
-
-	if err := internalconfig.Load(k, defaults, configPath, "LEAPMUX_HUB_", fp); err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
-
-	addr := k.String("addr")
-	devFrontend := k.String("dev_frontend")
-	dbMaxConns := k.Int("db_max_conns")
-	logLevel := k.String("log_level")
-
-	// Resolve relative data_dir against config file directory.
-	dataDir := internalconfig.ResolveDataDir(k.String("data_dir"), configPath, defaultConfigDir)
-
-	level, err := logging.ParseLevel(logLevel)
+	level, err := logging.ParseLevel(hubCfg.LogLevel)
 	if err != nil {
 		return fmt.Errorf("invalid log level: %w", err)
 	}
 	logging.SetLevel(level)
 
-	logging.PrintBanner(modeName, version, addr)
-	logging.PrintAccessURL(addr)
+	logging.PrintBanner(modeName, version, hubCfg.Addr)
+	logging.PrintAccessURL(hubCfg.Addr)
+
+	// Split the data dir into hub and worker subdirectories.
+	dataDir := hubCfg.DataDir
+	hubCfg.DataDir = filepath.Join(dataDir, "hub")
+	workerDataDir := filepath.Join(dataDir, "worker")
 
 	// Ensure top-level data directory exists.
 	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return fmt.Errorf("create data dir: %w", err)
-	}
-
-	hubDataDir := filepath.Join(dataDir, "hub")
-	workerDataDir := filepath.Join(dataDir, "worker")
-
-	// Load hub config file if it exists at {data-dir}/hub/hub.yaml.
-	hubConfigPath := filepath.Join(hubDataDir, "hub.yaml")
-	hubK := koanf.New(".")
-	hubDefaults := map[string]interface{}{
-		"max_message_size":       0,
-		"max_incomplete_chunked": 0,
-	}
-	_ = hubK.Load(confmap.Provider(hubDefaults, "."), nil)
-	if _, statErr := os.Stat(hubConfigPath); statErr == nil {
-		_ = hubK.Load(file.Provider(hubConfigPath), yaml.Parser())
-	}
-
-	hubCfg := &hubconfig.Config{
-		Addr:                         addr,
-		DataDir:                      hubDataDir,
-		DevFrontend:                  devFrontend,
-		DBMaxConns:                   dbMaxConns,
-		MaxMessageSize:               hubK.Int("max_message_size"),
-		MaxIncompleteChunked:         hubK.Int("max_incomplete_chunked"),
-		LogLevel:                     logLevel,
-		SignupEnabled:                k.Bool("signup_enabled"),
-		EmailVerificationRequired:    k.Bool("email_verification_required"),
-		SmtpHost:                     k.String("smtp_host"),
-		SmtpPort:                     k.Int("smtp_port"),
-		SmtpUsername:                 k.String("smtp_username"),
-		SmtpPassword:                 k.String("smtp_password"),
-		SmtpFromAddress:              k.String("smtp_from_address"),
-		SmtpUseTLS:                   k.Bool("smtp_use_tls"),
-		APITimeoutSeconds:            k.Int("api_timeout_seconds"),
-		AgentStartupTimeoutSeconds:   k.Int("agent_startup_timeout_seconds"),
-		WorktreeCreateTimeoutSeconds: k.Int("worktree_create_timeout_seconds"),
-		SoloMode:                     soloMode,
 	}
 
 	// Start the Hub server.
@@ -237,14 +150,14 @@ func runSolo(args []string, soloMode bool) error {
 			PublicKey:           publicKey,
 			WorkerID:            state.WorkerID,
 			Version:             version,
-			DBMaxConns:          dbMaxConns,
+			DBMaxConns:          hubCfg.DBMaxConns,
 			AgentStartupTimeout: hubCfg.AgentStartupTimeout(),
 		}); err != nil {
 			slog.Error("worker error", "error", err)
 		}
 	}()
 
-	slog.Info("leapmux "+modeName+" listening", "addr", addr)
+	slog.Info("leapmux "+modeName+" listening", "addr", hubCfg.Addr)
 
 	// Wait for Hub error or context cancellation.
 	select {

--- a/cmd/leapmux/solo.go
+++ b/cmd/leapmux/solo.go
@@ -47,10 +47,17 @@ func runSolo(args []string, soloMode bool) error {
 		defaultAddr = ":4327"
 	}
 
+	defaultConfigDir := "~/.config/leapmux/" + modeName
+	defaultConfigFile := defaultConfigDir + "/" + modeName + ".yaml"
+
+	// Pre-scan for -config flag.
+	configPath := internalconfig.ExtractConfigFlag(args, defaultConfigFile)
+
 	// Define CLI flags.
 	fs := flag.NewFlagSet("leapmux", flag.ContinueOnError)
+	fs.String("config", defaultConfigFile, "path to config file")
 	fs.String("addr", defaultAddr, "TCP listen address")
-	fs.String("data-dir", defaultSoloDataDir(), "data directory")
+	fs.String("data-dir", ".", "data directory")
 	fs.String("dev-frontend", "", "Vite dev server URL (dev mode)")
 	fs.Int("db-max-conns", hubdb.DefaultMaxConns, "maximum number of open database connections")
 	fs.String("log-level", "info", "log level (debug, info, warn, error)")
@@ -76,7 +83,7 @@ func runSolo(args []string, soloMode bool) error {
 
 	defaults := map[string]interface{}{
 		"addr":                            defaultAddr,
-		"data_dir":                        defaultSoloDataDir(),
+		"data_dir":                        ".",
 		"dev_frontend":                    "",
 		"db_max_conns":                    hubdb.DefaultMaxConns,
 		"log_level":                       "info",
@@ -96,18 +103,17 @@ func runSolo(args []string, soloMode bool) error {
 	k := koanf.New(".")
 	fp := internalconfig.NewFlagProvider(fs, fieldMap)
 
-	if err := internalconfig.Load(k, defaults, "", "LEAPMUX_HUB_", fp); err != nil {
+	if err := internalconfig.Load(k, defaults, configPath, "LEAPMUX_HUB_", fp); err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
 	addr := k.String("addr")
-	dataDir := k.String("data_dir")
 	devFrontend := k.String("dev_frontend")
 	dbMaxConns := k.Int("db_max_conns")
 	logLevel := k.String("log_level")
 
-	// Expand ~ in data dir.
-	dataDir = internalconfig.ExpandHome(dataDir)
+	// Resolve relative data_dir against config file directory.
+	dataDir := internalconfig.ResolveDataDir(k.String("data_dir"), configPath, defaultConfigDir)
 
 	level, err := logging.ParseLevel(logLevel)
 	if err != nil {
@@ -314,12 +320,4 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 	}
 
 	return state, nil
-}
-
-func defaultSoloDataDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".config", "leapmux")
-	}
-	return filepath.Join(home, ".config", "leapmux")
 }

--- a/cmd/leapmux/solo.go
+++ b/cmd/leapmux/solo.go
@@ -28,19 +28,29 @@ import (
 	"github.com/leapmux/leapmux/worker"
 )
 
-// standaloneState persists the auto-registered worker credentials.
-type standaloneState struct {
+// soloState persists the auto-registered worker credentials.
+type soloState struct {
 	WorkerID   string `json:"worker_id"`
 	AuthToken  string `json:"auth_token"`
 	PublicKey  string `json:"public_key,omitempty"`
 	PrivateKey string `json:"private_key,omitempty"`
 }
 
-func runStandalone(args []string) error {
+func runSolo(args []string, soloMode bool) error {
+	modeName := "solo"
+	if !soloMode {
+		modeName = "dev"
+	}
+
+	defaultAddr := "127.0.0.1:4327"
+	if !soloMode {
+		defaultAddr = ":4327"
+	}
+
 	// Define CLI flags.
 	fs := flag.NewFlagSet("leapmux", flag.ContinueOnError)
-	fs.String("addr", ":4327", "TCP listen address")
-	fs.String("data-dir", defaultStandaloneDataDir(), "data directory")
+	fs.String("addr", defaultAddr, "TCP listen address")
+	fs.String("data-dir", defaultSoloDataDir(), "data directory")
 	fs.String("dev-frontend", "", "Vite dev server URL (dev mode)")
 	fs.Int("db-max-conns", hubdb.DefaultMaxConns, "maximum number of open database connections")
 	fs.String("log-level", "info", "log level (debug, info, warn, error)")
@@ -65,8 +75,8 @@ func runStandalone(args []string) error {
 	}
 
 	defaults := map[string]interface{}{
-		"addr":                            ":4327",
-		"data_dir":                        defaultStandaloneDataDir(),
+		"addr":                            defaultAddr,
+		"data_dir":                        defaultSoloDataDir(),
 		"dev_frontend":                    "",
 		"db_max_conns":                    hubdb.DefaultMaxConns,
 		"log_level":                       "info",
@@ -105,7 +115,7 @@ func runStandalone(args []string) error {
 	}
 	logging.SetLevel(level)
 
-	logging.PrintBanner("standalone", version, addr)
+	logging.PrintBanner(modeName, version, addr)
 	logging.PrintAccessURL(addr)
 
 	// Ensure top-level data directory exists.
@@ -147,6 +157,7 @@ func runStandalone(args []string) error {
 		APITimeoutSeconds:            k.Int("api_timeout_seconds"),
 		AgentStartupTimeoutSeconds:   k.Int("agent_startup_timeout_seconds"),
 		WorktreeCreateTimeoutSeconds: k.Int("worktree_create_timeout_seconds"),
+		SoloMode:                     soloMode,
 	}
 
 	// Start the Hub server.
@@ -203,7 +214,7 @@ func runStandalone(args []string) error {
 	privateKey, _ := base64.StdEncoding.DecodeString(state.PrivateKey)
 	publicKey, _ := base64.StdEncoding.DecodeString(state.PublicKey)
 
-	slog.Info("standalone worker registered",
+	slog.Info(modeName+" worker registered",
 		"worker_id", state.WorkerID,
 		"socket", socketPath,
 	)
@@ -227,7 +238,7 @@ func runStandalone(args []string) error {
 		}
 	}()
 
-	slog.Info("leapmux standalone listening", "addr", addr)
+	slog.Info("leapmux "+modeName+" listening", "addr", addr)
 
 	// Wait for Hub error or context cancellation.
 	select {
@@ -258,7 +269,7 @@ func waitForSocket(ctx context.Context, path string) error {
 
 // loadOrCreateWorkerState loads saved credentials or creates a new worker
 // record directly in the Hub's database (avoiding the registration flow).
-func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath, workerDataDir string) (*standaloneState, error) {
+func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath, workerDataDir string) (*soloState, error) {
 	if err := os.MkdirAll(workerDataDir, 0o750); err != nil {
 		return nil, fmt.Errorf("create worker data dir: %w", err)
 	}
@@ -266,7 +277,7 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 	// Try loading existing state.
 	data, err := os.ReadFile(statePath)
 	if err == nil {
-		var s standaloneState
+		var s soloState
 		if json.Unmarshal(data, &s) == nil && s.WorkerID != "" && s.AuthToken != "" {
 			// Verify the worker still exists in the DB.
 			if dbErr := server.GetWorkerByID(ctx, s.WorkerID); dbErr == nil {
@@ -289,7 +300,7 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 		return nil, err
 	}
 
-	state := &standaloneState{
+	state := &soloState{
 		WorkerID:  creds.WorkerID,
 		AuthToken: creds.AuthToken,
 	}
@@ -305,7 +316,7 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 	return state, nil
 }
 
-func defaultStandaloneDataDir() string {
+func defaultSoloDataDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".config", "leapmux")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -141,4 +141,6 @@ RUN mkdir -p /data
 EXPOSE 4327
 VOLUME /data
 
+ENV LEAPMUX_DOCKER=1
+
 ENTRYPOINT ["/init"]

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/leapmux/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/leapmux/run
@@ -1,3 +1,5 @@
-#!/command/execlineb -P
-importas MODE LEAPMUX_MODE
-/usr/local/bin/leapmux ${MODE} -data-dir /data
+#!/bin/sh
+config="/data/${LEAPMUX_MODE}/${LEAPMUX_MODE}.yaml"
+mkdir -p "$(dirname "$config")"
+[ -f "$config" ] || touch "$config"
+exec /usr/local/bin/leapmux ${LEAPMUX_MODE} -config "$config"

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/leapmux/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/leapmux/run
@@ -1,2 +1,3 @@
 #!/command/execlineb -P
-/usr/local/bin/leapmux -addr :4327 -data-dir /data
+importas MODE LEAPMUX_MODE
+/usr/local/bin/leapmux ${MODE} -data-dir /data

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -130,6 +130,7 @@ import {
 } from '~/generated/leapmux/v1/workspace_pb'
 import { ChannelManager } from '~/lib/channel'
 import { createLogger } from '~/lib/logger'
+import { isSoloMode } from '~/lib/systemInfo'
 
 const log = createLogger('workerRpc')
 
@@ -167,12 +168,19 @@ class BrowserChannelTransport implements ChannelTransport {
   }
 
   createWebSocket(): WebSocket {
-    const token = getToken()
-    if (!token) {
-      throw new Error('not authenticated')
-    }
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsUrl = `${wsProtocol}//${window.location.host}/ws/channel?token=${encodeURIComponent(token)}`
+    let wsUrl: string
+    if (isSoloMode()) {
+      // Solo mode: no session token needed; backend auto-authenticates.
+      wsUrl = `${wsProtocol}//${window.location.host}/ws/channel`
+    }
+    else {
+      const token = getToken()
+      if (!token) {
+        throw new Error('not authenticated')
+      }
+      wsUrl = `${wsProtocol}//${window.location.host}/ws/channel?token=${encodeURIComponent(token)}`
+    }
     const ws = new WebSocket(wsUrl, ['channel-relay'])
     ws.binaryType = 'arraybuffer'
     return ws

--- a/frontend/src/components/common/AuthGuard.tsx
+++ b/frontend/src/components/common/AuthGuard.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from '@solidjs/router'
 import { createEffect, createMemo, Show } from 'solid-js'
 import { NotFoundPage } from '~/components/common/NotFoundPage'
 import { useAuth } from '~/context/AuthContext'
+import { isSoloMode } from '~/lib/systemInfo'
 import { centeredFull } from '~/styles/shared.css'
 
 interface AuthGuardProps {
@@ -18,7 +19,7 @@ export const AuthGuard: ParentComponent<AuthGuardProps> = (props) => {
     if (auth.loading())
       return
 
-    if (!auth.isAuthenticated()) {
+    if (!auth.isAuthenticated() && !isSoloMode()) {
       const returnTo = location.pathname + location.search
       navigate(`/login?redirect=${encodeURIComponent(returnTo)}`, { replace: true })
     }

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -6,6 +6,7 @@ import { createSignal, onMount, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { Icon } from '~/components/common/Icon'
 import { useAuth } from '~/context/AuthContext'
+import { isSoloMode } from '~/lib/systemInfo'
 import { spinner } from '~/styles/animations.css'
 import * as styles from './LoginPage.css'
 
@@ -21,6 +22,11 @@ export const LoginPage: Component = () => {
   let passwordRef!: HTMLInputElement
 
   onMount(async () => {
+    if (isSoloMode()) {
+      navigate('/o/admin', { replace: true })
+      return
+    }
+
     // Focus the first empty input field (username if both empty).
     if (!usernameRef.value) {
       usernameRef.focus()

--- a/frontend/src/components/common/RefreshButton.css.ts
+++ b/frontend/src/components/common/RefreshButton.css.ts
@@ -1,0 +1,10 @@
+import { keyframes, style } from '@vanilla-extract/css'
+
+const spinOnce = keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' },
+})
+
+export const spinning = style({
+  animation: `${spinOnce} 0.4s ease-in-out`,
+})

--- a/frontend/src/components/common/RefreshButton.tsx
+++ b/frontend/src/components/common/RefreshButton.tsx
@@ -1,0 +1,40 @@
+import type { Component } from 'solid-js'
+import type { IconSizeName } from '~/components/common/Icon'
+import RefreshCw from 'lucide-solid/icons/refresh-cw'
+import { createSignal } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
+import { refreshButton } from '~/styles/shared.css'
+import * as styles from './RefreshButton.css'
+
+interface RefreshButtonProps {
+  onClick: () => void
+  disabled?: boolean
+  title?: string
+  size?: IconSizeName
+}
+
+export const RefreshButton: Component<RefreshButtonProps> = (props) => {
+  const [animating, setAnimating] = createSignal(false)
+
+  const handleClick = () => {
+    setAnimating(true)
+    props.onClick()
+  }
+
+  return (
+    <button
+      type="button"
+      class={refreshButton}
+      onClick={handleClick}
+      disabled={props.disabled}
+      title={props.title}
+    >
+      <Icon
+        icon={RefreshCw}
+        size={props.size ?? 'sm'}
+        class={animating() ? styles.spinning : ''}
+        onAnimationEnd={() => setAnimating(false)}
+      />
+    </button>
+  )
+}

--- a/frontend/src/components/org/OrgManagementPage.tsx
+++ b/frontend/src/components/org/OrgManagementPage.tsx
@@ -1,13 +1,14 @@
 import type { Component } from 'solid-js'
 import type { OrgMember } from '~/generated/leapmux/v1/org_pb'
 
-import { A, useParams } from '@solidjs/router'
-import { createEffect, createSignal, For, Show } from 'solid-js'
+import { A, useNavigate, useParams } from '@solidjs/router'
+import { createEffect, createSignal, For, onMount, Show } from 'solid-js'
 import { orgClient } from '~/api/clients'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { useAuth } from '~/context/AuthContext'
 import { useOrg } from '~/context/OrgContext'
 import { OrgMemberRole } from '~/generated/leapmux/v1/org_pb'
+import { isSoloMode } from '~/lib/systemInfo'
 import { sanitizeSlug } from '~/lib/validate'
 import * as styles from './OrgManagementPage.css'
 
@@ -15,6 +16,13 @@ export const OrgManagementPage: Component = () => {
   const auth = useAuth()
   const org = useOrg()
   const params = useParams<{ orgSlug: string }>()
+  const navigate = useNavigate()
+
+  onMount(() => {
+    if (isSoloMode()) {
+      navigate(`/o/${params.orgSlug}`, { replace: true })
+    }
+  })
 
   // Org name editing
   const [editName, setEditName] = createSignal('')

--- a/frontend/src/components/settings/PreferencesDialog.tsx
+++ b/frontend/src/components/settings/PreferencesDialog.tsx
@@ -1,5 +1,7 @@
 import type { Component } from 'solid-js'
+import { Show } from 'solid-js'
 import { Dialog } from '~/components/common/Dialog'
+import { isSoloMode } from '~/lib/systemInfo'
 import { AccountAppearanceSettings, BrowserAppearanceSettings } from './AppearanceSettings'
 import { FontSettings } from './FontSettings'
 import { PasswordSettings } from './PasswordSettings'
@@ -13,25 +15,35 @@ export const PreferencesDialog: Component<PreferencesDialogProps> = (props) => {
   return (
     <Dialog title="Preferences" tall onClose={props.onClose}>
       <section>
-        <ot-tabs>
-          <nav role="tablist">
-            <button role="tab">This Browser</button>
-            <button role="tab">Account Defaults</button>
-          </nav>
+        <Show
+          when={!isSoloMode()}
+          fallback={(
+            <>
+              <AccountAppearanceSettings />
+              <FontSettings />
+            </>
+          )}
+        >
+          <ot-tabs>
+            <nav role="tablist">
+              <button role="tab">This Browser</button>
+              <button role="tab">Account Defaults</button>
+            </nav>
 
-          {/* ===== THIS BROWSER TAB ===== */}
-          <div role="tabpanel">
-            <BrowserAppearanceSettings />
-          </div>
+            {/* ===== THIS BROWSER TAB ===== */}
+            <div role="tabpanel">
+              <BrowserAppearanceSettings />
+            </div>
 
-          {/* ===== ACCOUNT DEFAULTS TAB ===== */}
-          <div role="tabpanel">
-            <AccountAppearanceSettings />
-            <FontSettings />
-            <ProfileSettings />
-            <PasswordSettings />
-          </div>
-        </ot-tabs>
+            {/* ===== ACCOUNT DEFAULTS TAB ===== */}
+            <div role="tabpanel">
+              <AccountAppearanceSettings />
+              <FontSettings />
+              <ProfileSettings />
+              <PasswordSettings />
+            </div>
+          </ot-tabs>
+        </Show>
       </section>
     </Dialog>
   )

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -1,0 +1,33 @@
+import type { Component } from 'solid-js'
+import type { WorkerDialogState } from '~/hooks/createWorkerDialogState'
+import { Show } from 'solid-js'
+import { RefreshButton } from '~/components/common/RefreshButton'
+import { DirectoryTree } from '~/components/tree/DirectoryTree'
+import { labelRow, treeContainer } from '~/styles/shared.css'
+
+interface DirectorySelectorProps {
+  state: WorkerDialogState
+}
+
+export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
+  return (
+    <label>
+      <div class={labelRow}>
+        Working Directory
+        <RefreshButton onClick={() => props.state.refreshTree()} title="Refresh directory tree" />
+      </div>
+      <Show when={props.state.workerId()}>
+        <div class={treeContainer}>
+          <DirectoryTree
+            workerId={props.state.workerId()}
+            selectedPath={props.state.workingDir()}
+            onSelect={props.state.setWorkingDir}
+            rootPath="~"
+            homeDir={props.state.workerInfoStore.getHomeDir(props.state.workerId())}
+            ref={props.state.treeRef}
+          />
+        </div>
+      </Show>
+    </label>
+  )
+}

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -13,6 +13,7 @@ import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry
 
 import CircleUser from 'lucide-solid/icons/circle-user'
 import Plus from 'lucide-solid/icons/plus'
+import Settings from 'lucide-solid/icons/settings'
 import { createMemo, createSignal, onCleanup, Show } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
@@ -23,6 +24,7 @@ import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSection
 import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
 import { useAuth } from '~/context/AuthContext'
 import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { isSoloMode } from '~/lib/systemInfo'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
 import { useSectionDrag } from './SectionDragContext'
@@ -336,24 +338,25 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
     }
 
     // User Menu section (rail-only in collapsed, rendered at bottom in expanded)
+    const solo = isSoloMode()
     sections.push({
       id: 'user-menu',
-      title: 'User',
+      title: solo ? 'Preferences' : 'User',
       railOnly: true,
       railPosition: 'bottom',
       collapsible: false,
-      railIcon: CircleUser,
-      railTitle: 'User menu',
+      railIcon: solo ? Settings : CircleUser,
+      railTitle: solo ? 'Preferences' : 'User menu',
       railElement: (
         <UserMenu
-          trigger={<IconButton icon={CircleUser} iconSize="lg" size="lg" title="User menu" data-testid="user-menu-trigger" />}
+          trigger={<IconButton icon={solo ? Settings : CircleUser} iconSize="lg" size="lg" title={solo ? 'Preferences' : 'User menu'} data-testid="user-menu-trigger" />}
         />
       ),
       content: () => (
         <UserMenu
           trigger={(
             <span class={csStyles.sidebarTitle} style={{ cursor: 'pointer' }} data-testid="user-menu-trigger">
-              {auth.user()?.username ?? '...'}
+              {solo ? 'Preferences' : (auth.user()?.username ?? '...')}
             </span>
           )}
         />

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -1,21 +1,19 @@
 import type { Component } from 'solid-js'
 import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
-import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
-import { workerClient } from '~/api/clients'
+import { Show } from 'solid-js'
 import { agentLoadingTimeoutMs } from '~/api/transport'
 import * as workerRpc from '~/api/workerRpc'
 import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
 import { isAgentCreateDisabled } from '~/components/shell/dialogValidation'
+import { DirectorySelector } from '~/components/shell/DirectorySelector'
+import { WorkerSelector } from '~/components/shell/WorkerSelector'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
-import { DirectoryTree } from '~/components/tree/DirectoryTree'
-import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
-import { createWorkerInfoStore } from '~/stores/workerInfo.store'
+import { createWorkerDialogState } from '~/hooks/createWorkerDialogState'
 import { spinner } from '~/styles/animations.css'
-import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText } from '~/styles/shared.css'
 
 interface NewAgentDialogProps {
   workspaceId: string
@@ -29,93 +27,30 @@ interface NewAgentDialogProps {
 }
 
 export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
-  const org = useOrg()
-  const workerInfoStore = createWorkerInfoStore()
-  const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
-  const [workerId, setWorkerId] = createSignal('')
-  const [workingDir, setWorkingDir] = createSignal(props.defaultWorkingDir ?? '')
-  const submitting = createLoadingSignal(agentLoadingTimeoutMs(false))
-  const [error, setError] = createSignal<string | null>(null)
-  const [refreshing, setRefreshing] = createSignal(false)
-  const [createWorktree, setCreateWorktree] = createSignal(false)
-  const [worktreeBranch, setWorktreeBranch] = createSignal('')
-  const [worktreeBranchError, setWorktreeBranchError] = createSignal<string | null>(null)
-
-  const fetchWorkers = async () => {
-    try {
-      const resp = await workerClient.listWorkers({ orgId: org.orgId() })
-      const online = resp.workers.filter(b => b.online)
-      setWorkers(online)
-      if (online.length > 0 && !workerId()) {
-        setWorkerId(online[0].id)
-      }
-      // Fetch system info for homeDir via E2EE.
-      for (const w of online) {
-        workerInfoStore.fetchWorkerInfo(w.id)
-      }
-      return online.length > 0
-    }
-    catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load workers')
-      return false
-    }
-  }
-
-  // Fetch on mount only
-  onMount(async () => {
-    await fetchWorkers()
-    // Pre-select worker if specified and online
-    if (props.defaultWorkerId) {
-      const match = workers().find(b => b.id === props.defaultWorkerId)
-      if (match) {
-        setWorkerId(match.id)
-      }
-    }
+  const state = createWorkerDialogState({
+    preselectedWorkerId: props.defaultWorkerId,
+    defaultWorkingDir: props.defaultWorkingDir,
+    resolveWorktree: true,
   })
-
-  // If the default working directory is a worktree, resolve to the original repo root.
-  {
-    let resolved = false
-    createEffect(on(() => workerId(), async (wid) => {
-      if (resolved || !wid || !props.defaultWorkingDir)
-        return
-      resolved = true
-      try {
-        const resp = await workerRpc.getGitInfo(wid, {
-          workerId: wid,
-          path: props.defaultWorkingDir,
-          orgId: org.orgId(),
-        })
-        if (resp.isWorktreeRoot && resp.repoRoot)
-          setWorkingDir(resp.repoRoot)
-      }
-      catch {}
-    }))
-  }
-
-  const handleRefresh = async () => {
-    setRefreshing(true)
-    await fetchWorkers()
-    setRefreshing(false)
-  }
+  const submitting = createLoadingSignal(agentLoadingTimeoutMs(false))
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
-    if (!workerId() || !workingDir().trim())
+    if (!state.workerId() || !state.workingDir().trim())
       return
 
     submitting.start()
-    setError(null)
+    state.setError(null)
     try {
-      const resp = await workerRpc.openAgent(workerId(), {
+      const resp = await workerRpc.openAgent(state.workerId(), {
         workspaceId: props.workspaceId,
         model: props.defaultModel ?? '',
         title: props.defaultTitle ?? '',
         systemPrompt: '',
-        workerId: workerId(),
-        workingDir: workingDir(),
-        createWorktree: createWorktree(),
-        worktreeBranch: worktreeBranch(),
+        workerId: state.workerId(),
+        workingDir: state.workingDir(),
+        createWorktree: state.createWorktree(),
+        worktreeBranch: state.worktreeBranch(),
         ...(props.sessionId ? { agentSessionId: props.sessionId } : {}),
       })
       if (resp.agent) {
@@ -123,7 +58,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
       }
     }
     catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create agent')
+      state.setError(err instanceof Error ? err.message : 'Failed to create agent')
     }
     finally {
       submitting.stop()
@@ -135,69 +70,18 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
-            <label>
-              <div class={labelRow}>
-                Worker
-                <button
-                  type="button"
-                  class={refreshButton}
-                  onClick={handleRefresh}
-                  disabled={refreshing()}
-                  title="Refresh workers"
-                >
-                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
-                </button>
-              </div>
-              <select
-                value={workerId()}
-                onChange={e => setWorkerId(e.currentTarget.value)}
-              >
-                <Show when={workers().length === 0}>
-                  <option value="">No workers online</option>
-                </Show>
-                <For each={workers()}>
-                  {(b) => {
-                    const info = () => workerInfoStore.workerInfo(b.id)
-                    const label = () => {
-                      const i = info()
-                      if (!i)
-                        return b.id
-                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
-                      return details ? `${i.name} (${details})` : i.name
-                    }
-                    return <option value={b.id}>{label()}</option>
-                  }}
-                </For>
-              </select>
-            </label>
-            <label>
-              Working Directory
-              <Show when={workerId()}>
-                <div class={treeContainer}>
-                  <DirectoryTree
-                    workerId={workerId()}
-                    selectedPath={workingDir()}
-                    onSelect={setWorkingDir}
-                    rootPath="~"
-                    homeDir={workerInfoStore.getHomeDir(workerId())}
-                  />
-                </div>
-              </Show>
-            </label>
-            <Show when={workerId()}>
+            <WorkerSelector state={state} />
+            <DirectorySelector state={state} />
+            <Show when={state.workerId()}>
               <WorktreeOptions
-                workerId={workerId()}
-                selectedPath={workingDir()}
-                homeDir={workerInfoStore.getHomeDir(workerId())}
-                onWorktreeChange={(create, branch, branchError) => {
-                  setCreateWorktree(create)
-                  setWorktreeBranch(branch)
-                  setWorktreeBranchError(branchError)
-                }}
+                workerId={state.workerId()}
+                selectedPath={state.workingDir()}
+                homeDir={state.workerInfoStore.getHomeDir(state.workerId())}
+                onWorktreeChange={state.handleWorktreeChange}
               />
             </Show>
-            <Show when={error()}>
-              <div class={errorText}>{error()}</div>
+            <Show when={state.error()}>
+              <div class={errorText}>{state.error()}</div>
             </Show>
           </div>
         </section>
@@ -207,7 +91,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
           </button>
           <button
             type="submit"
-            disabled={isAgentCreateDisabled({ submitting: submitting.loading(), workerId: workerId(), workingDir: workingDir(), createWorktree: createWorktree(), worktreeBranchError: worktreeBranchError() })}
+            disabled={isAgentCreateDisabled({ submitting: submitting.loading(), workerId: state.workerId(), workingDir: state.workingDir(), createWorktree: state.createWorktree(), worktreeBranchError: state.worktreeBranchError() })}
           >
             <Show when={submitting.loading()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting.loading() ? 'Creating...' : 'Create'}

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -1,20 +1,18 @@
 import type { Component } from 'solid-js'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
-import { createEffect, createSignal, For, on, onMount, Show } from 'solid-js'
-import { workerClient } from '~/api/clients'
+import { createEffect, createSignal, For, on, Show } from 'solid-js'
 import { apiLoadingTimeoutMs } from '~/api/transport'
 import * as workerRpc from '~/api/workerRpc'
 import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
 import { isTerminalCreateDisabled } from '~/components/shell/dialogValidation'
+import { DirectorySelector } from '~/components/shell/DirectorySelector'
+import { WorkerSelector } from '~/components/shell/WorkerSelector'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
-import { DirectoryTree } from '~/components/tree/DirectoryTree'
-import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
-import { createWorkerInfoStore } from '~/stores/workerInfo.store'
+import { createWorkerDialogState } from '~/hooks/createWorkerDialogState'
 import { spinner } from '~/styles/animations.css'
-import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText } from '~/styles/shared.css'
 
 interface NewTerminalDialogProps {
   workspaceId: string
@@ -25,75 +23,18 @@ interface NewTerminalDialogProps {
 }
 
 export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
-  const org = useOrg()
-  const workerInfoStore = createWorkerInfoStore()
-  const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
-  const [workerId, setWorkerId] = createSignal('')
-  const [workingDir, setWorkingDir] = createSignal(props.defaultWorkingDir ?? '')
+  const state = createWorkerDialogState({
+    preselectedWorkerId: props.defaultWorkerId,
+    defaultWorkingDir: props.defaultWorkingDir,
+    resolveWorktree: true,
+  })
   const [shells, setShells] = createSignal<string[]>([])
   const [shell, setShell] = createSignal('')
   const [shellsLoading, setShellsLoading] = createSignal(false)
   const submitting = createLoadingSignal(apiLoadingTimeoutMs())
-  const [error, setError] = createSignal<string | null>(null)
-  const [refreshing, setRefreshing] = createSignal(false)
-  const [createWorktree, setCreateWorktree] = createSignal(false)
-  const [worktreeBranch, setWorktreeBranch] = createSignal('')
-  const [worktreeBranchError, setWorktreeBranchError] = createSignal<string | null>(null)
-
-  const fetchWorkers = async () => {
-    try {
-      const resp = await workerClient.listWorkers({ orgId: org.orgId() })
-      const online = resp.workers.filter(b => b.online)
-      setWorkers(online)
-      if (online.length > 0 && !workerId()) {
-        setWorkerId(online[0].id)
-      }
-      // Fetch system info for homeDir via E2EE.
-      for (const w of online) {
-        workerInfoStore.fetchWorkerInfo(w.id)
-      }
-      return online.length > 0
-    }
-    catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load workers')
-      return false
-    }
-  }
-
-  // Fetch on mount only
-  onMount(async () => {
-    await fetchWorkers()
-    // Pre-select worker if specified and online
-    if (props.defaultWorkerId) {
-      const match = workers().find(b => b.id === props.defaultWorkerId)
-      if (match) {
-        setWorkerId(match.id)
-      }
-    }
-  })
-
-  // If the default working directory is a worktree, resolve to the original repo root.
-  {
-    let resolved = false
-    createEffect(on(() => workerId(), async (wid) => {
-      if (resolved || !wid || !props.defaultWorkingDir)
-        return
-      resolved = true
-      try {
-        const resp = await workerRpc.getGitInfo(wid, {
-          workerId: wid,
-          path: props.defaultWorkingDir,
-          orgId: org.orgId(),
-        })
-        if (resp.isWorktreeRoot && resp.repoRoot)
-          setWorkingDir(resp.repoRoot)
-      }
-      catch {}
-    }))
-  }
 
   // Fetch available shells when worker changes
-  createEffect(on(() => workerId(), async (id) => {
+  createEffect(on(() => state.workerId(), async (id) => {
     if (!id)
       return
 
@@ -102,7 +43,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
     setShell('')
     try {
       const resp = await workerRpc.listAvailableShells(id, {
-        orgId: org.orgId(),
+        orgId: state.org.orgId(),
         workspaceId: props.workspaceId,
         workerId: id,
       })
@@ -110,42 +51,36 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
       setShell(resp.defaultShell || (resp.shells.length > 0 ? resp.shells[0] : ''))
     }
     catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load shells')
+      state.setError(e instanceof Error ? e.message : 'Failed to load shells')
     }
     finally {
       setShellsLoading(false)
     }
   }))
 
-  const handleRefresh = async () => {
-    setRefreshing(true)
-    await fetchWorkers()
-    setRefreshing(false)
-  }
-
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
-    if (!workerId() || !workingDir().trim() || !shell())
+    if (!state.workerId() || !state.workingDir().trim() || !shell())
       return
 
     submitting.start()
-    setError(null)
+    state.setError(null)
     try {
-      const resp = await workerRpc.openTerminal(workerId(), {
-        orgId: org.orgId(),
+      const resp = await workerRpc.openTerminal(state.workerId(), {
+        orgId: state.org.orgId(),
         workspaceId: props.workspaceId,
         cols: 80,
         rows: 24,
-        workingDir: workingDir(),
+        workingDir: state.workingDir(),
         shell: shell(),
-        workerId: workerId(),
-        createWorktree: createWorktree(),
-        worktreeBranch: worktreeBranch(),
+        workerId: state.workerId(),
+        createWorktree: state.createWorktree(),
+        worktreeBranch: state.worktreeBranch(),
       })
-      props.onCreated(resp.terminalId, workerId(), workingDir())
+      props.onCreated(resp.terminalId, state.workerId(), state.workingDir())
     }
     catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create terminal')
+      state.setError(err instanceof Error ? err.message : 'Failed to create terminal')
     }
     finally {
       submitting.stop()
@@ -157,65 +92,14 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
-            <label>
-              <div class={labelRow}>
-                Worker
-                <button
-                  type="button"
-                  class={refreshButton}
-                  onClick={handleRefresh}
-                  disabled={refreshing()}
-                  title="Refresh workers"
-                >
-                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
-                </button>
-              </div>
-              <select
-                value={workerId()}
-                onChange={e => setWorkerId(e.currentTarget.value)}
-              >
-                <Show when={workers().length === 0}>
-                  <option value="">No workers online</option>
-                </Show>
-                <For each={workers()}>
-                  {(b) => {
-                    const info = () => workerInfoStore.workerInfo(b.id)
-                    const label = () => {
-                      const i = info()
-                      if (!i)
-                        return b.id
-                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
-                      return details ? `${i.name} (${details})` : i.name
-                    }
-                    return <option value={b.id}>{label()}</option>
-                  }}
-                </For>
-              </select>
-            </label>
-            <label>
-              Working Directory
-              <Show when={workerId()}>
-                <div class={treeContainer}>
-                  <DirectoryTree
-                    workerId={workerId()}
-                    selectedPath={workingDir()}
-                    onSelect={setWorkingDir}
-                    rootPath="~"
-                    homeDir={workerInfoStore.getHomeDir(workerId())}
-                  />
-                </div>
-              </Show>
-            </label>
-            <Show when={workerId()}>
+            <WorkerSelector state={state} />
+            <DirectorySelector state={state} />
+            <Show when={state.workerId()}>
               <WorktreeOptions
-                workerId={workerId()}
-                selectedPath={workingDir()}
-                homeDir={workerInfoStore.getHomeDir(workerId())}
-                onWorktreeChange={(create, branch, branchError) => {
-                  setCreateWorktree(create)
-                  setWorktreeBranch(branch)
-                  setWorktreeBranchError(branchError)
-                }}
+                workerId={state.workerId()}
+                selectedPath={state.workingDir()}
+                homeDir={state.workerInfoStore.getHomeDir(state.workerId())}
+                onWorktreeChange={state.handleWorktreeChange}
               />
             </Show>
             <label>
@@ -236,8 +120,8 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
                 </For>
               </select>
             </label>
-            <Show when={error()}>
-              <div class={errorText}>{error()}</div>
+            <Show when={state.error()}>
+              <div class={errorText}>{state.error()}</div>
             </Show>
           </div>
         </section>
@@ -247,7 +131,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
           </button>
           <button
             type="submit"
-            disabled={isTerminalCreateDisabled({ submitting: submitting.loading(), workerId: workerId(), workingDir: workingDir(), shell: shell(), createWorktree: createWorktree(), worktreeBranchError: worktreeBranchError() })}
+            disabled={isTerminalCreateDisabled({ submitting: submitting.loading(), workerId: state.workerId(), workingDir: state.workingDir(), shell: shell(), createWorktree: state.createWorktree(), worktreeBranchError: state.worktreeBranchError() })}
           >
             <Show when={submitting.loading()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting.loading() ? 'Creating...' : 'Create'}

--- a/frontend/src/components/shell/ResumeSessionDialog.tsx
+++ b/frontend/src/components/shell/ResumeSessionDialog.tsx
@@ -1,16 +1,16 @@
 import type { Component } from 'solid-js'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
 import { agentLoadingTimeoutMs } from '~/api/transport'
 import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
+import { RefreshButton } from '~/components/common/RefreshButton'
 import { useOrg } from '~/context/OrgContext'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { createWorkerInfoStore } from '~/stores/workerInfo.store'
 import { spinner } from '~/styles/animations.css'
-import { errorText, labelRow, refreshButton, spinning } from '~/styles/shared.css'
+import { errorText, labelRow } from '~/styles/shared.css'
 
 interface ResumeSessionDialogProps {
   defaultWorkerId?: string
@@ -96,15 +96,7 @@ export const ResumeSessionDialog: Component<ResumeSessionDialogProps> = (props) 
             <label>
               <div class={labelRow}>
                 Worker
-                <button
-                  type="button"
-                  class={refreshButton}
-                  onClick={handleRefresh}
-                  disabled={refreshing()}
-                  title="Refresh workers"
-                >
-                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
-                </button>
+                <RefreshButton onClick={handleRefresh} disabled={refreshing()} title="Refresh workers" />
               </div>
               <select
                 value={workerId()}

--- a/frontend/src/components/shell/UserMenu.tsx
+++ b/frontend/src/components/shell/UserMenu.tsx
@@ -6,6 +6,7 @@ import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { PreferencesDialog } from '~/components/settings/PreferencesDialog'
 import { useAuth } from '~/context/AuthContext'
 import { useOrg } from '~/context/OrgContext'
+import { isSoloMode } from '~/lib/systemInfo'
 import { dangerMenuItem, menuSectionHeader } from '~/styles/shared.css'
 import * as styles from './UserMenu.css'
 
@@ -32,33 +33,35 @@ export const UserMenu: Component<UserMenuProps> = (props) => {
       <button role="menuitem" onClick={() => setShowPreferencesDialog(true)}>
         Preferences
       </button>
-      <hr />
-      <li class={menuSectionHeader}>Switch organization</li>
-      <div class={styles.orgList}>
-        <For each={org.orgs()}>
-          {o => (
-            <button
-              role="menuitem"
-              class={o.name === org.slug() ? styles.orgItemActive : styles.orgItem}
-              onClick={() => navigate(`/o/${o.name}`)}
-            >
-              {o.name}
-              <Show when={o.isPersonal}>
-                <span class={styles.personalTag}>(personal)</span>
-              </Show>
-            </button>
-          )}
-        </For>
-      </div>
-      <hr />
-      <Show when={auth.user()?.isAdmin}>
-        <button role="menuitem" onClick={() => setShowAdminDialog(true)}>
-          Administration
+      <Show when={!isSoloMode()}>
+        <hr />
+        <li class={menuSectionHeader}>Switch organization</li>
+        <div class={styles.orgList}>
+          <For each={org.orgs()}>
+            {o => (
+              <button
+                role="menuitem"
+                class={o.name === org.slug() ? styles.orgItemActive : styles.orgItem}
+                onClick={() => navigate(`/o/${o.name}`)}
+              >
+                {o.name}
+                <Show when={o.isPersonal}>
+                  <span class={styles.personalTag}>(personal)</span>
+                </Show>
+              </button>
+            )}
+          </For>
+        </div>
+        <hr />
+        <Show when={auth.user()?.isAdmin}>
+          <button role="menuitem" onClick={() => setShowAdminDialog(true)}>
+            Administration
+          </button>
+        </Show>
+        <button role="menuitem" class={dangerMenuItem} onClick={() => handleLogout()}>
+          Log out
         </button>
       </Show>
-      <button role="menuitem" class={dangerMenuItem} onClick={() => handleLogout()}>
-        Log out
-      </button>
     </>
   )
 
@@ -71,7 +74,7 @@ export const UserMenu: Component<UserMenuProps> = (props) => {
             <DropdownMenu
               trigger={triggerProps => (
                 <button class={styles.trigger} data-testid="user-menu-trigger" {...triggerProps}>
-                  {auth.user()?.username ?? '...'}
+                  {isSoloMode() ? 'Preferences' : (auth.user()?.username ?? '...')}
                 </button>
               )}
             >

--- a/frontend/src/components/shell/WorkerSelector.tsx
+++ b/frontend/src/components/shell/WorkerSelector.tsx
@@ -1,0 +1,41 @@
+import type { Component } from 'solid-js'
+import type { WorkerDialogState } from '~/hooks/createWorkerDialogState'
+import { For, Show } from 'solid-js'
+import { RefreshButton } from '~/components/common/RefreshButton'
+import { labelRow } from '~/styles/shared.css'
+
+interface WorkerSelectorProps {
+  state: WorkerDialogState
+}
+
+export const WorkerSelector: Component<WorkerSelectorProps> = (props) => {
+  return (
+    <label>
+      <div class={labelRow}>
+        Worker
+        <RefreshButton onClick={props.state.handleRefresh} disabled={props.state.refreshing()} title="Refresh workers" />
+      </div>
+      <select
+        value={props.state.workerId()}
+        onChange={e => props.state.setWorkerId(e.currentTarget.value)}
+      >
+        <Show when={props.state.workers().length === 0}>
+          <option value="">No workers online</option>
+        </Show>
+        <For each={props.state.workers()}>
+          {(b) => {
+            const info = () => props.state.workerInfoStore.workerInfo(b.id)
+            const label = () => {
+              const i = info()
+              if (!i)
+                return b.id
+              const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
+              return details ? `${i.name} (${details})` : i.name
+            }
+            return <option value={b.id}>{label()}</option>
+          }}
+        </For>
+      </select>
+    </label>
+  )
+}

--- a/frontend/src/components/shell/WorktreeOptions.tsx
+++ b/frontend/src/components/shell/WorktreeOptions.tsx
@@ -1,13 +1,12 @@
 import type { Component } from 'solid-js'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { generateSlug } from 'random-word-slugs'
 import { createEffect, createMemo, createSignal, on, Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { tildify } from '~/components/chat/messageUtils'
-import { Icon } from '~/components/common/Icon'
+import { RefreshButton } from '~/components/common/RefreshButton'
 import { useOrg } from '~/context/OrgContext'
 import { validateBranchName } from '~/lib/validate'
-import { checkboxRow, errorText, labelRow, pathPreview, refreshButton, warningText } from '~/styles/shared.css'
+import { checkboxRow, errorText, labelRow, pathPreview, warningText } from '~/styles/shared.css'
 
 interface WorktreeOptionsProps {
   workerId: string
@@ -129,14 +128,7 @@ export const WorktreeOptions: Component<WorktreeOptionsProps> = (props) => {
         <label>
           <div class={labelRow}>
             Branch Name
-            <button
-              type="button"
-              class={refreshButton}
-              onClick={randomizeBranch}
-              title="Generate random name"
-            >
-              <Icon icon={RefreshCw} size="sm" />
-            </button>
+            <RefreshButton onClick={randomizeBranch} title="Generate random name" />
           </div>
           <input
             type="text"

--- a/frontend/src/components/workers/WorkerContextMenu.tsx
+++ b/frontend/src/components/workers/WorkerContextMenu.tsx
@@ -6,6 +6,7 @@ import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { IconButton } from '~/components/common/IconButton'
 import { showInfoToast } from '~/components/common/Toast'
 import * as listStyles from '~/components/workspace/workspaceList.css'
+import { isSoloMode } from '~/lib/systemInfo'
 import { dangerMenuItem } from '~/styles/shared.css'
 
 interface WorkerContextMenuProps {
@@ -58,10 +59,12 @@ export const WorkerContextMenu: Component<WorkerContextMenuProps> = (props) => {
           </button>
         )}
       </Show>
-      <hr />
-      <button role="menuitem" class={dangerMenuItem} onClick={() => props.onDeregister()}>
-        Deregister...
-      </button>
+      <Show when={!isSoloMode()}>
+        <hr />
+        <button role="menuitem" class={dangerMenuItem} onClick={() => props.onDeregister()}>
+          Deregister...
+        </button>
+      </Show>
     </DropdownMenu>
   )
 }

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -1,22 +1,22 @@
 import type { Component } from 'solid-js'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { generateSlug } from 'random-word-slugs'
-import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
-import { workerClient, workspaceClient } from '~/api/clients'
+import { createMemo, createSignal, Show } from 'solid-js'
+import { workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
+import { RefreshButton } from '~/components/common/RefreshButton'
 import { isWorkspaceCreateDisabled } from '~/components/shell/dialogValidation'
+import { DirectorySelector } from '~/components/shell/DirectorySelector'
+import { WorkerSelector } from '~/components/shell/WorkerSelector'
 import { WorktreeOptions } from '~/components/shell/WorktreeOptions'
-import { DirectoryTree } from '~/components/tree/DirectoryTree'
-import { useOrg } from '~/context/OrgContext'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { createWorkerDialogState } from '~/hooks/createWorkerDialogState'
 import { sanitizeName } from '~/lib/validate'
-import { createWorkerInfoStore } from '~/stores/workerInfo.store'
 import { spinner } from '~/styles/animations.css'
-import { errorText, labelRow, refreshButton, spinning, treeContainer } from '~/styles/shared.css'
+import { errorText, labelRow } from '~/styles/shared.css'
 
 interface NewWorkspaceDialogProps {
   onCreated: (workspace: Workspace, workerId: string) => void
@@ -25,86 +25,42 @@ interface NewWorkspaceDialogProps {
 }
 
 export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) => {
-  const org = useOrg()
-  const workerInfoStore = createWorkerInfoStore()
-  const [workers, setWorkers] = createSignal<import('~/generated/leapmux/v1/worker_pb').Worker[]>([])
-  const [workerId, setWorkerId] = createSignal('')
+  // eslint-disable-next-line solid/reactivity -- one-time initial value
+  const state = createWorkerDialogState({ preselectedWorkerId: props.preselectedWorkerId })
   const randomTitle = () => generateSlug(3, { format: 'title' })
   const [title, setTitle] = createSignal(randomTitle())
-  const [workingDir, setWorkingDir] = createSignal('')
   const [submitting, setSubmitting] = createSignal(false)
-  const [error, setError] = createSignal<string | null>(null)
-  const [refreshing, setRefreshing] = createSignal(false)
-  const [createWorktree, setCreateWorktree] = createSignal(false)
-  const [worktreeBranch, setWorktreeBranch] = createSignal('')
-  const [worktreeBranchError, setWorktreeBranchError] = createSignal<string | null>(null)
   const titleError = createMemo(() => sanitizeName(title()).error)
-
-  const fetchWorkers = async () => {
-    try {
-      const resp = await workerClient.listWorkers({ orgId: org.orgId() })
-      const online = resp.workers.filter(b => b.online)
-      setWorkers(online)
-      if (online.length > 0 && !workerId()) {
-        setWorkerId(online[0].id)
-      }
-      // Fetch system info for homeDir via E2EE.
-      for (const w of online) {
-        workerInfoStore.fetchWorkerInfo(w.id)
-      }
-      return online.length > 0
-    }
-    catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load workers')
-      return false
-    }
-  }
-
-  // Fetch on mount only
-  onMount(async () => {
-    await fetchWorkers()
-    // Pre-select worker if specified and online
-    if (props.preselectedWorkerId) {
-      const match = workers().find(b => b.id === props.preselectedWorkerId)
-      if (match) {
-        setWorkerId(match.id)
-      }
-    }
-  })
-
-  const handleRefresh = async () => {
-    setRefreshing(true)
-    await fetchWorkers()
-    setRefreshing(false)
-  }
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
-    if (!workerId() || !workingDir().trim())
+    if (!state.workerId() || !state.workingDir().trim())
       return
 
     setSubmitting(true)
-    setError(null)
+    state.setError(null)
+    let createdWorkspaceId: string | undefined
     try {
       // 1. Create workspace on hub.
       const wsResp = await workspaceClient.createWorkspace({
-        orgId: org.orgId(),
+        orgId: state.org.orgId(),
         title: title().trim(),
       })
       if (!wsResp.workspace)
         throw new Error('No workspace in response')
+      createdWorkspaceId = wsResp.workspace.id
 
       // 2. Open the first agent on the selected worker.
-      const wid = workerId()
+      const wid = state.workerId()
       const agentResp = await workerRpc.openAgent(wid, {
         workspaceId: wsResp.workspace.id,
         model: '',
         title: 'Agent 1',
         systemPrompt: '',
         workerId: wid,
-        workingDir: workingDir(),
-        createWorktree: createWorktree(),
-        worktreeBranch: worktreeBranch(),
+        workingDir: state.workingDir(),
+        createWorktree: state.createWorktree(),
+        worktreeBranch: state.worktreeBranch(),
       })
 
       // 3. Register the agent tab on the hub.
@@ -118,7 +74,11 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
       props.onCreated(wsResp.workspace, wid)
     }
     catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create workspace')
+      // Roll back the workspace if it was created but a subsequent step failed.
+      if (createdWorkspaceId) {
+        workspaceClient.deleteWorkspace({ workspaceId: createdWorkspaceId }).catch(() => {})
+      }
+      state.setError(err instanceof Error ? err.message : 'Failed to create workspace')
     }
     finally {
       setSubmitting(false)
@@ -130,52 +90,11 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
       <form onSubmit={handleSubmit}>
         <section>
           <div class="vstack gap-4">
-            <label>
-              <div class={labelRow}>
-                Worker
-                <button
-                  type="button"
-                  class={refreshButton}
-                  onClick={handleRefresh}
-                  disabled={refreshing()}
-                  title="Refresh workers"
-                >
-                  <Icon icon={RefreshCw} size="sm" class={refreshing() ? spinning : ''} />
-                </button>
-              </div>
-              <select
-                value={workerId()}
-                onChange={e => setWorkerId(e.currentTarget.value)}
-              >
-                <Show when={workers().length === 0}>
-                  <option value="">No workers online</option>
-                </Show>
-                <For each={workers()}>
-                  {(b) => {
-                    const info = () => workerInfoStore.workerInfo(b.id)
-                    const label = () => {
-                      const i = info()
-                      if (!i)
-                        return b.id
-                      const details = [i.version, i.os, i.arch].filter(Boolean).join(', ')
-                      return details ? `${i.name} (${details})` : i.name
-                    }
-                    return <option value={b.id}>{label()}</option>
-                  }}
-                </For>
-              </select>
-            </label>
+            <WorkerSelector state={state} />
             <label>
               <div class={labelRow}>
                 Title
-                <button
-                  type="button"
-                  class={refreshButton}
-                  onClick={() => setTitle(randomTitle())}
-                  title="Generate random name"
-                >
-                  <Icon icon={RefreshCw} size="sm" />
-                </button>
+                <RefreshButton onClick={() => setTitle(randomTitle())} title="Generate random name" />
               </div>
               <input
                 type="text"
@@ -187,34 +106,17 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
                 <div class={errorText}>{titleError()}</div>
               </Show>
             </label>
-            <label>
-              Working Directory
-              <Show when={workerId()}>
-                <div class={treeContainer}>
-                  <DirectoryTree
-                    workerId={workerId()}
-                    selectedPath={workingDir()}
-                    onSelect={setWorkingDir}
-                    rootPath="~"
-                    homeDir={workerInfoStore.getHomeDir(workerId())}
-                  />
-                </div>
-              </Show>
-            </label>
-            <Show when={workerId()}>
+            <DirectorySelector state={state} />
+            <Show when={state.workerId()}>
               <WorktreeOptions
-                workerId={workerId()}
-                selectedPath={workingDir()}
-                homeDir={workerInfoStore.getHomeDir(workerId())}
-                onWorktreeChange={(create, branch, branchError) => {
-                  setCreateWorktree(create)
-                  setWorktreeBranch(branch)
-                  setWorktreeBranchError(branchError)
-                }}
+                workerId={state.workerId()}
+                selectedPath={state.workingDir()}
+                homeDir={state.workerInfoStore.getHomeDir(state.workerId())}
+                onWorktreeChange={state.handleWorktreeChange}
               />
             </Show>
-            <Show when={error()}>
-              <div class={errorText}>{error()}</div>
+            <Show when={state.error()}>
+              <div class={errorText}>{state.error()}</div>
             </Show>
           </div>
         </section>
@@ -224,7 +126,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
           </button>
           <button
             type="submit"
-            disabled={isWorkspaceCreateDisabled({ submitting: submitting(), workerId: workerId(), workingDir: workingDir(), titleError: titleError(), createWorktree: createWorktree(), worktreeBranchError: worktreeBranchError() })}
+            disabled={isWorkspaceCreateDisabled({ submitting: submitting(), workerId: state.workerId(), workingDir: state.workingDir(), titleError: titleError(), createWorktree: state.createWorktree(), worktreeBranchError: state.worktreeBranchError() })}
           >
             <Show when={submitting()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
             {submitting() ? 'Creating...' : 'Create'}

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -7,6 +7,7 @@ import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
+import { isSoloMode } from '~/lib/systemInfo'
 import { dangerMenuItem } from '~/styles/shared.css'
 import * as listStyles from './workspaceList.css'
 
@@ -72,7 +73,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
         </DropdownMenu>
       </Show>
 
-      <Show when={props.isOwner}>
+      <Show when={props.isOwner && !isSoloMode()}>
         <button role="menuitem" onClick={() => props.onShare()}>
           Share...
         </button>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,6 +5,7 @@ import { createContext, createSignal, onMount, useContext } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { clearToken, getToken, loadTimeouts, setOnAuthError, setToken } from '~/api/transport'
 import { LoginRequestSchema } from '~/generated/leapmux/v1/auth_pb'
+import { isSoloMode, loadSystemInfo } from '~/lib/systemInfo'
 
 interface AuthState {
   user: () => User | null
@@ -25,16 +26,32 @@ export const AuthProvider: ParentComponent = (props) => {
 
   // Register auth error callback for auto-logout on 401.
   setOnAuthError(() => {
-    setUser(null)
+    if (!isSoloMode()) {
+      setUser(null)
+    }
   })
 
   onMount(async () => {
+    await loadSystemInfo()
+
+    if (isSoloMode()) {
+      try {
+        const resp = await authClient.getCurrentUser({})
+        setUser(resp.user ?? null)
+        loadTimeouts().catch(() => {})
+      }
+      catch {
+        // Solo mode should always work; ignore errors.
+      }
+      setLoading(false)
+      return
+    }
+
     const token = getToken()
     if (token) {
       try {
         const resp = await authClient.getCurrentUser({})
         setUser(resp.user ?? null)
-        // Load timeout configuration after successful auth validation.
         loadTimeouts().catch(() => {})
       }
       catch {
@@ -65,6 +82,8 @@ export const AuthProvider: ParentComponent = (props) => {
   }
 
   const logout = async () => {
+    if (isSoloMode())
+      return
     try {
       await authClient.logout({})
     }

--- a/frontend/src/hooks/createWorkerDialogState.ts
+++ b/frontend/src/hooks/createWorkerDialogState.ts
@@ -1,0 +1,116 @@
+import type { DirectoryTreeHandle } from '~/components/tree/DirectoryTree'
+import type { Worker } from '~/generated/leapmux/v1/worker_pb'
+import { createEffect, createSignal, on, onMount } from 'solid-js'
+import { workerClient } from '~/api/clients'
+import * as workerRpc from '~/api/workerRpc'
+import { useOrg } from '~/context/OrgContext'
+import { createWorkerInfoStore } from '~/stores/workerInfo.store'
+
+interface WorkerDialogStateOptions {
+  preselectedWorkerId?: string
+  defaultWorkingDir?: string
+  /** When true, resolves worktree roots to the original repo root on mount. */
+  resolveWorktree?: boolean
+}
+
+export function createWorkerDialogState(options: WorkerDialogStateOptions = {}) {
+  const org = useOrg()
+  const workerInfoStore = createWorkerInfoStore()
+  const [workers, setWorkers] = createSignal<Worker[]>([])
+  const [workerId, setWorkerId] = createSignal('')
+  const [workingDir, setWorkingDir] = createSignal(options.defaultWorkingDir ?? '')
+  const [error, setError] = createSignal<string | null>(null)
+  const [refreshing, setRefreshing] = createSignal(false)
+  const [createWorktree, setCreateWorktree] = createSignal(false)
+  const [worktreeBranch, setWorktreeBranch] = createSignal('')
+  const [worktreeBranchError, setWorktreeBranchError] = createSignal<string | null>(null)
+  let treeHandle: DirectoryTreeHandle | undefined
+
+  const fetchWorkers = async () => {
+    try {
+      const resp = await workerClient.listWorkers({ orgId: org.orgId() })
+      const online = resp.workers.filter(b => b.online)
+      setWorkers(online)
+      if (online.length > 0 && !workerId()) {
+        setWorkerId(online[0].id)
+      }
+      // Fetch system info for homeDir via E2EE.
+      for (const w of online) {
+        workerInfoStore.fetchWorkerInfo(w.id)
+      }
+      return online.length > 0
+    }
+    catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load workers')
+      return false
+    }
+  }
+
+  // Fetch on mount only
+  onMount(async () => {
+    await fetchWorkers()
+    // Pre-select worker if specified and online
+    if (options.preselectedWorkerId) {
+      const match = workers().find(b => b.id === options.preselectedWorkerId)
+      if (match) {
+        setWorkerId(match.id)
+      }
+    }
+    // Refresh the directory tree to show latest contents.
+    treeHandle?.refresh()
+  })
+
+  // If the default working directory is a worktree, resolve to the original repo root.
+  if (options.resolveWorktree) {
+    let resolved = false
+    createEffect(on(() => workerId(), async (wid) => {
+      if (resolved || !wid || !options.defaultWorkingDir)
+        return
+      resolved = true
+      try {
+        const resp = await workerRpc.getGitInfo(wid, {
+          workerId: wid,
+          path: options.defaultWorkingDir,
+          orgId: org.orgId(),
+        })
+        if (resp.isWorktreeRoot && resp.repoRoot)
+          setWorkingDir(resp.repoRoot)
+      }
+      catch {}
+    }))
+  }
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    await fetchWorkers()
+    setRefreshing(false)
+  }
+
+  const handleWorktreeChange = (create: boolean, branch: string, branchError: string | null) => {
+    setCreateWorktree(create)
+    setWorktreeBranch(branch)
+    setWorktreeBranchError(branchError)
+  }
+
+  return {
+    org,
+    workerInfoStore,
+    workers,
+    workerId,
+    setWorkerId,
+    workingDir,
+    setWorkingDir,
+    error,
+    setError,
+    refreshing,
+    handleRefresh,
+    createWorktree,
+    worktreeBranch,
+    worktreeBranchError,
+    handleWorktreeChange,
+    treeRef: (h: DirectoryTreeHandle) => { treeHandle = h },
+    refreshTree: () => treeHandle?.refresh(),
+  }
+}
+
+export type WorkerDialogState = ReturnType<typeof createWorkerDialogState>

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -1,0 +1,21 @@
+import { authClient } from '~/api/clients'
+
+let soloMode = false
+let loaded = false
+
+export async function loadSystemInfo(): Promise<void> {
+  if (loaded)
+    return
+  try {
+    const resp = await authClient.getSystemInfo({})
+    soloMode = resp.soloMode
+    loaded = true
+  }
+  catch {
+    // Ignore — defaults to false (non-solo)
+  }
+}
+
+export function isSoloMode(): boolean {
+  return soloMode
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,17 +1,21 @@
 import { useNavigate } from '@solidjs/router'
-import { onMount } from 'solid-js'
+import { createEffect } from 'solid-js'
 import { useAuth } from '~/context/AuthContext'
+import { isSoloMode } from '~/lib/systemInfo'
 
 export default function IndexRoute() {
   const auth = useAuth()
   const navigate = useNavigate()
 
-  onMount(() => {
+  createEffect(() => {
+    if (auth.loading())
+      return
+
     const user = auth.user()
     if (user) {
       navigate(`/o/${user.username}`, { replace: true })
     }
-    else {
+    else if (!isSoloMode()) {
       navigate('/login', { replace: true })
     }
   })

--- a/frontend/src/routes/register/[token].tsx
+++ b/frontend/src/routes/register/[token].tsx
@@ -1,12 +1,18 @@
-import { useParams } from '@solidjs/router'
+import { useNavigate, useParams } from '@solidjs/router'
 import { onMount } from 'solid-js'
 import { AuthGuard } from '~/components/common/AuthGuard'
 import { RegistrationPage } from '~/components/common/RegistrationPage'
+import { isSoloMode } from '~/lib/systemInfo'
 
 export default function RegisterRoute() {
   const params = useParams<{ token: string }>()
+  const navigate = useNavigate()
+
   onMount(() => {
     document.title = 'Register Worker - LeapMux'
+    if (isSoloMode()) {
+      navigate('/o/admin', { replace: true })
+    }
   })
   return (
     <AuthGuard>

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -1,9 +1,16 @@
+import { useNavigate } from '@solidjs/router'
 import { onMount } from 'solid-js'
 import { SignupPage } from '~/components/common/SignupPage'
+import { isSoloMode } from '~/lib/systemInfo'
 
 export default function SignupRoute() {
+  const navigate = useNavigate()
+
   onMount(() => {
     document.title = 'Sign Up - LeapMux'
+    if (isSoloMode()) {
+      navigate('/o/admin', { replace: true })
+    }
   })
   return <SignupPage />
 }

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -1,5 +1,4 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { spin } from '~/styles/animations.css'
 
 export const errorText = style({
   color: 'var(--danger)',
@@ -202,10 +201,6 @@ export const refreshButton = style({
     cursor: 'not-allowed',
     opacity: 0.6,
   },
-})
-
-export const spinning = style({
-  animation: `${spin} 1s linear infinite`,
 })
 
 export const treeContainer = style({

--- a/frontend/tests/e2e/02-registration.spec.ts
+++ b/frontend/tests/e2e/02-registration.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 import { loginViaUI } from './helpers/ui'
 
 test.describe('Worker Registration', () => {
-  // In standalone mode, the worker is auto-registered with name "Local".
+  // In dev mode, the worker is auto-registered with name "Local".
   // These tests verify the worker appears online in the UI.
 
   test('should show worker online in new workspace dialog after approval', async ({ page }) => {
@@ -18,7 +18,7 @@ test.describe('Worker Registration', () => {
     await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
 
     // The initial fetch on mount should find the worker (already online).
-    // Verify the worker name appears in the dropdown (standalone uses "Local")
+    // Verify the worker name appears in the dropdown (dev mode uses "Local")
     await expect(page.locator('select').first()).toContainText('Local')
   })
 

--- a/frontend/tests/e2e/09-worker-management.spec.ts
+++ b/frontend/tests/e2e/09-worker-management.spec.ts
@@ -11,7 +11,7 @@ test.describe('Worker Management', () => {
     if (!isOpen)
       await workersSection.locator('> summary').click()
 
-    // Should contain the worker named "Local" (standalone sets LEAPMUX_WORKER_NAME=Local)
+    // Should contain the worker named "Local" (dev mode sets LEAPMUX_WORKER_NAME=Local)
     await expect(workersSection.getByText('Local')).toBeVisible()
   })
 

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -44,17 +44,18 @@ export const test = base.extend<
     leapmuxServer: ServerInfo
   }
 >({
-  // Worker-scoped fixture: spawns a fresh standalone instance per test file
+  // Worker-scoped fixture: spawns a fresh dev-mode instance per test file
   // eslint-disable-next-line no-empty-pattern
   leapmuxServer: [async ({}, use) => {
     const globalState = getGlobalState()
-    const dataDir = mkdtempSync(join(tmpdir(), 'leapmux-e2e-standalone-'))
+    const dataDir = mkdtempSync(join(tmpdir(), 'leapmux-e2e-dev-'))
     const port = await findFreePort()
     const hubUrl = `http://localhost:${port}`
 
-    console.log(`[e2e] Starting standalone instance on port ${port}...`)
+    console.log(`[e2e] Starting dev instance on port ${port}...`)
 
     const proc = spawn(globalState.binaryPath, [
+      'dev',
       '-addr',
       `:${port}`,
       '-data-dir',
@@ -69,7 +70,7 @@ export const test = base.extend<
     proc.stderr?.resume()
 
     await waitForServer(hubUrl)
-    console.log(`[e2e] Standalone instance ready on port ${port}`)
+    console.log(`[e2e] Dev instance ready on port ${port}`)
 
     // Login as admin (bootstrap creates admin/admin)
     const adminToken = await loginViaAPI(hubUrl, 'admin', 'admin')
@@ -89,10 +90,10 @@ export const test = base.extend<
     }
     catch { /* already dead */ }
     rmSync(dataDir, { recursive: true, force: true })
-    console.log(`[e2e] Standalone instance on port ${port} stopped`)
+    console.log(`[e2e] Dev instance on port ${port} stopped`)
   }, { scope: 'worker' }],
 
-  // Override page to set baseURL dynamically from the standalone instance
+  // Override page to set baseURL dynamically from the dev instance
   page: async ({ leapmuxServer, browser }, use) => {
     const context = await browser.newContext({
       baseURL: leapmuxServer.hubUrl,

--- a/hub/server.go
+++ b/hub/server.go
@@ -238,7 +238,8 @@ func (s *Server) GetWorkerByID(ctx context.Context, workerID string) error {
 
 // GetAdminUser returns the admin user's ID and org ID.
 func (s *Server) GetAdminUser(ctx context.Context) (userID, orgID string, err error) {
-	user, err := s.queries.GetUserByUsername(ctx, "admin")
+	username := bootstrap.Username(s.cfg.SoloMode)
+	user, err := s.queries.GetUserByUsername(ctx, username)
 	if err != nil {
 		return "", "", fmt.Errorf("get admin user: %w", err)
 	}

--- a/hub/server.go
+++ b/hub/server.go
@@ -1,5 +1,5 @@
 // Package hub provides a reusable Hub server that can be embedded
-// in other binaries (e.g. the standalone all-in-one binary).
+// in other binaries (e.g. the solo/dev all-in-one binary).
 package hub
 
 import (
@@ -82,7 +82,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 
 	queries := gendb.New(sqlDB)
 
-	if err := bootstrap.Run(context.Background(), queries); err != nil {
+	if err := bootstrap.Run(context.Background(), queries, cfg.SoloMode); err != nil {
 		_ = sqlDB.Close()
 		return nil, fmt.Errorf("bootstrap: %w", err)
 	}
@@ -104,7 +104,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		auth.NewShutdownInterceptor(shutdownCh),
 		metrics.NewInterceptor(),
 		auth.NewTimeoutInterceptor(cfg.APITimeout),
-		auth.NewInterceptor(queries),
+		auth.NewInterceptor(queries, cfg.SoloMode),
 	)
 
 	mux := http.NewServeMux()
@@ -113,7 +113,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(authSvc, connectOpts)
 	mux.Handle(authPath, authHandler)
 
-	connectorSvc := service.NewWorkerConnectorService(queries, wMgr)
+	connectorSvc := service.NewWorkerConnectorService(queries, wMgr, cfg.SoloMode)
 	connectorSvc.SetShutdownCh(shutdownCh)
 	connectorSvc.SetChannelMgr(cMgr)
 	connectorSvc.SetPendingRequests(pendingReqs)
@@ -121,7 +121,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	mux.Handle(connectorPath, connectorHandler)
 
 	notifierSvc := notifier.New(queries, wMgr, pendingReqs, cfg)
-	mgmtSvc := service.NewWorkerManagementService(queries, wMgr, notifierSvc)
+	mgmtSvc := service.NewWorkerManagementService(queries, wMgr, notifierSvc, cfg.SoloMode)
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(mgmtSvc, connectOpts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
@@ -133,7 +133,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	channelRelay := service.NewChannelRelayHandler(queries, wMgr, cMgr)
 	mux.Handle("/ws/channel", channelRelay)
 
-	orgSvc := service.NewOrgService(queries, nil)
+	orgSvc := service.NewOrgService(queries, nil, cfg.SoloMode)
 	orgPath, orgHandler := leapmuxv1connect.NewOrgServiceHandler(orgSvc, connectOpts)
 	mux.Handle(orgPath, orgHandler)
 
@@ -145,11 +145,11 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	sectionPath, sectionHandler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, connectOpts)
 	mux.Handle(sectionPath, sectionHandler)
 
-	adminSvc := service.NewAdminService(queries)
+	adminSvc := service.NewAdminService(queries, cfg.SoloMode)
 	adminPath, adminHandler := leapmuxv1connect.NewAdminServiceHandler(adminSvc, connectOpts)
 	mux.Handle(adminPath, adminHandler)
 
-	workspaceSvc := service.NewWorkspaceService(sqlDB, queries)
+	workspaceSvc := service.NewWorkspaceService(sqlDB, queries, cfg.SoloMode)
 	workspacePath, workspaceHandler := leapmuxv1connect.NewWorkspaceServiceHandler(workspaceSvc, connectOpts)
 	mux.Handle(workspacePath, workspaceHandler)
 
@@ -191,7 +191,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 }
 
 // Queries returns the Hub's store queries for direct database access
-// (e.g. for standalone auto-registration).
+// (e.g. for solo/dev auto-registration).
 func (s *Server) Queries() *gendb.Queries {
 	return s.queries
 }
@@ -208,7 +208,7 @@ type WorkerCredentials struct {
 }
 
 // RegisterWorker creates a worker record directly in the database,
-// bypassing the normal registration flow. This is used by the standalone
+// bypassing the normal registration flow. This is used by the solo/dev
 // binary to auto-register a local worker.
 func (s *Server) RegisterWorker(ctx context.Context, orgID, registeredBy string) (*WorkerCredentials, error) {
 	workerID := id.Generate()

--- a/hub/server.go
+++ b/hub/server.go
@@ -130,7 +130,19 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	mux.Handle(channelPath, channelHandler)
 
 	// WebSocket endpoint for encrypted channel relay (Frontend ↔ Worker).
-	channelRelay := service.NewChannelRelayHandler(queries, wMgr, cMgr)
+	var soloUser *auth.UserInfo
+	if cfg.SoloMode {
+		username := bootstrap.Username(cfg.SoloMode)
+		if u, lookupErr := queries.GetUserByUsername(context.Background(), username); lookupErr == nil {
+			soloUser = &auth.UserInfo{
+				ID:       u.ID,
+				OrgID:    u.OrgID,
+				Username: u.Username,
+				IsAdmin:  u.IsAdmin == 1,
+			}
+		}
+	}
+	channelRelay := service.NewChannelRelayHandler(queries, wMgr, cMgr, soloUser)
 	mux.Handle("/ws/channel", channelRelay)
 
 	orgSvc := service.NewOrgService(queries, nil, cfg.SoloMode)

--- a/internal/hub/auth/interceptor.go
+++ b/internal/hub/auth/interceptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/generated/db"
 )
 
@@ -35,7 +36,7 @@ type authInterceptor struct {
 func NewInterceptor(q *db.Queries, soloMode bool) connect.Interceptor {
 	a := &authInterceptor{queries: q, soloMode: soloMode}
 	if soloMode {
-		user, err := q.GetUserByUsername(context.Background(), "admin")
+		user, err := q.GetUserByUsername(context.Background(), bootstrap.Username(soloMode))
 		if err == nil {
 			a.soloUser = &UserInfo{
 				ID:       user.ID,

--- a/internal/hub/auth/interceptor.go
+++ b/internal/hub/auth/interceptor.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
 	"github.com/leapmux/leapmux/internal/hub/generated/db"
@@ -22,19 +23,45 @@ var publicProcedures = map[string]bool{
 // authInterceptor implements connect.Interceptor to validate Bearer tokens
 // on both unary and streaming RPCs.
 type authInterceptor struct {
-	queries *db.Queries
+	queries  *db.Queries
+	soloMode bool
+	soloUser *UserInfo
 }
 
 // NewInterceptor creates a ConnectRPC interceptor that validates Bearer tokens
 // and attaches user info to the context. Public procedures (login, worker
-// registration) are exempt from auth checks.
-func NewInterceptor(q *db.Queries) connect.Interceptor {
-	return &authInterceptor{queries: q}
+// registration) are exempt from auth checks. In solo mode, all requests are
+// automatically authenticated as the admin user.
+func NewInterceptor(q *db.Queries, soloMode bool) connect.Interceptor {
+	a := &authInterceptor{queries: q, soloMode: soloMode}
+	if soloMode {
+		user, err := q.GetUserByUsername(context.Background(), "admin")
+		if err == nil {
+			a.soloUser = &UserInfo{
+				ID:       user.ID,
+				OrgID:    user.OrgID,
+				Username: user.Username,
+				IsAdmin:  user.IsAdmin == 1,
+			}
+		}
+	}
+	return a
 }
 
 func (a *authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		if publicProcedures[req.Spec().Procedure] {
+			if a.soloMode && a.soloUser != nil {
+				ctx = WithUser(ctx, a.soloUser)
+			}
+			return next(ctx, req)
+		}
+
+		if a.soloMode {
+			if a.soloUser == nil {
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("solo mode admin user not found"))
+			}
+			ctx = WithUser(ctx, a.soloUser)
 			return next(ctx, req)
 		}
 
@@ -60,6 +87,17 @@ func (a *authInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) 
 func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		if publicProcedures[conn.Spec().Procedure] {
+			if a.soloMode && a.soloUser != nil {
+				ctx = WithUser(ctx, a.soloUser)
+			}
+			return next(ctx, conn)
+		}
+
+		if a.soloMode {
+			if a.soloUser == nil {
+				return connect.NewError(connect.CodeInternal, fmt.Errorf("solo mode admin user not found"))
+			}
+			ctx = WithUser(ctx, a.soloUser)
 			return next(ctx, conn)
 		}
 

--- a/internal/hub/auth/interceptor_test.go
+++ b/internal/hub/auth/interceptor_test.go
@@ -92,6 +92,31 @@ func TestInterceptor_PrivateProcedure_ValidToken(t *testing.T) {
 	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
 }
 
+func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
+	q := setupDB(t)
+
+	// Bootstrap in solo mode creates a user named "solo".
+	err := bootstrap.Run(context.Background(), q, true)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	interceptors := connect.WithInterceptors(auth.NewInterceptor(q, true))
+	authSvc := service.NewAuthService(q, &config.Config{SoloMode: true})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+
+	// In solo mode, private endpoints should work without any token.
+	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
+	require.NoError(t, err)
+	assert.Equal(t, "solo", resp.Msg.GetUser().GetUsername())
+	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
+}
+
 func TestInterceptor_PrivateProcedure_InvalidToken(t *testing.T) {
 	client := setupInterceptorTestServer(t)
 

--- a/internal/hub/auth/interceptor_test.go
+++ b/internal/hub/auth/interceptor_test.go
@@ -27,11 +27,11 @@ func setupInterceptorTestServer(t *testing.T) leapmuxv1connect.AuthServiceClient
 	q := setupDB(t)
 
 	// Bootstrap creates an admin user (admin/admin).
-	err := bootstrap.Run(context.Background(), q)
+	err := bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptors := connect.WithInterceptors(auth.NewInterceptor(q))
+	interceptors := connect.WithInterceptors(auth.NewInterceptor(q, false))
 	authSvc := service.NewAuthService(q, &config.Config{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)

--- a/internal/hub/auth/shutdown_test.go
+++ b/internal/hub/auth/shutdown_test.go
@@ -22,7 +22,7 @@ func setupShutdownTestServer(t *testing.T, shutdownCh chan struct{}) leapmuxv1co
 	t.Helper()
 
 	q := setupDB(t)
-	err := bootstrap.Run(context.Background(), q)
+	err := bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()

--- a/internal/hub/auth/timeout_test.go
+++ b/internal/hub/auth/timeout_test.go
@@ -37,7 +37,7 @@ func setupTimeoutTestServer(t *testing.T, timeout time.Duration) (leapmuxv1conne
 	t.Helper()
 
 	q := setupDB(t)
-	err := bootstrap.Run(context.Background(), q)
+	err := bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	capture := &timeoutCapture{inner: service.NewAuthService(q, &config.Config{})}

--- a/internal/hub/bootstrap/bootstrap.go
+++ b/internal/hub/bootstrap/bootstrap.go
@@ -13,9 +13,16 @@ import (
 )
 
 const (
-	defaultUsername = "admin"
 	defaultPassword = "admin"
 )
+
+// Username returns the default admin username for the given mode.
+func Username(soloMode bool) string {
+	if soloMode {
+		return "solo"
+	}
+	return "admin"
+}
 
 // Run creates the personal org and admin user if no organizations
 // exist yet. This is a no-op if the database already has data.
@@ -29,10 +36,12 @@ func Run(ctx context.Context, q *db.Queries, soloMode bool) error {
 		return nil
 	}
 
+	username := Username(soloMode)
+
 	orgID := id.Generate()
 	if err := q.CreateOrg(ctx, db.CreateOrgParams{
 		ID:         orgID,
-		Name:       defaultUsername,
+		Name:       username,
 		IsPersonal: 1,
 	}); err != nil {
 		return fmt.Errorf("create personal org: %w", err)
@@ -47,13 +56,18 @@ func Run(ctx context.Context, q *db.Queries, soloMode bool) error {
 		passwordHash = string(hash)
 	}
 
+	displayName := "Admin"
+	if soloMode {
+		displayName = "Solo"
+	}
+
 	userID := id.Generate()
 	if err := q.CreateUser(ctx, db.CreateUserParams{
 		ID:           userID,
 		OrgID:        orgID,
-		Username:     defaultUsername,
+		Username:     username,
 		PasswordHash: passwordHash,
-		DisplayName:  "Admin",
+		DisplayName:  displayName,
 		Email:        "",
 		IsAdmin:      1,
 	}); err != nil {
@@ -77,7 +91,7 @@ func Run(ctx context.Context, q *db.Queries, soloMode bool) error {
 	slog.Info("bootstrap: created personal org and admin user",
 		"org_id", orgID,
 		"user_id", userID,
-		"username", defaultUsername,
+		"username", username,
 	)
 
 	return nil

--- a/internal/hub/bootstrap/bootstrap.go
+++ b/internal/hub/bootstrap/bootstrap.go
@@ -19,7 +19,7 @@ const (
 
 // Run creates the personal org and admin user if no organizations
 // exist yet. This is a no-op if the database already has data.
-func Run(ctx context.Context, q *db.Queries) error {
+func Run(ctx context.Context, q *db.Queries, soloMode bool) error {
 	count, err := q.CountOrgs(ctx)
 	if err != nil {
 		return fmt.Errorf("count orgs: %w", err)
@@ -38,9 +38,13 @@ func Run(ctx context.Context, q *db.Queries) error {
 		return fmt.Errorf("create personal org: %w", err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(defaultPassword), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Errorf("hash password: %w", err)
+	var passwordHash string
+	if !soloMode {
+		hash, err := bcrypt.GenerateFromPassword([]byte(defaultPassword), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("hash password: %w", err)
+		}
+		passwordHash = string(hash)
 	}
 
 	userID := id.Generate()
@@ -48,7 +52,7 @@ func Run(ctx context.Context, q *db.Queries) error {
 		ID:           userID,
 		OrgID:        orgID,
 		Username:     defaultUsername,
-		PasswordHash: string(hash),
+		PasswordHash: passwordHash,
 		DisplayName:  "Admin",
 		Email:        "",
 		IsAdmin:      1,

--- a/internal/hub/bootstrap/bootstrap_test.go
+++ b/internal/hub/bootstrap/bootstrap_test.go
@@ -29,7 +29,7 @@ func TestRun_CreatesOrgAndAdmin(t *testing.T) {
 	q := setupDB(t)
 	ctx := context.Background()
 
-	err := bootstrap.Run(ctx, q)
+	err := bootstrap.Run(ctx, q, false)
 	require.NoError(t, err)
 
 	// Verify org was created.
@@ -53,11 +53,11 @@ func TestRun_Idempotent(t *testing.T) {
 	q := setupDB(t)
 	ctx := context.Background()
 
-	err := bootstrap.Run(ctx, q)
+	err := bootstrap.Run(ctx, q, false)
 	require.NoError(t, err)
 
 	// Second run should be a no-op (org already exists).
-	err = bootstrap.Run(ctx, q)
+	err = bootstrap.Run(ctx, q, false)
 	require.NoError(t, err)
 
 	// Should still have exactly one org.

--- a/internal/hub/bootstrap/bootstrap_test.go
+++ b/internal/hub/bootstrap/bootstrap_test.go
@@ -49,6 +49,29 @@ func TestRun_CreatesOrgAndAdmin(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRun_SoloMode(t *testing.T) {
+	q := setupDB(t)
+	ctx := context.Background()
+
+	err := bootstrap.Run(ctx, q, true)
+	require.NoError(t, err)
+
+	// Verify org was created with "solo" name.
+	org, err := q.GetOrgByName(ctx, "solo")
+	require.NoError(t, err)
+	assert.Equal(t, "solo", org.Name)
+
+	// Verify user was created with "solo" username.
+	user, err := q.GetUserByUsername(ctx, "solo")
+	require.NoError(t, err)
+	assert.Equal(t, "solo", user.Username)
+	assert.Equal(t, org.ID, user.OrgID)
+	assert.Equal(t, int64(1), user.IsAdmin)
+
+	// Verify password hash is empty in solo mode.
+	assert.Empty(t, user.PasswordHash)
+}
+
 func TestRun_Idempotent(t *testing.T) {
 	q := setupDB(t)
 	ctx := context.Background()

--- a/internal/hub/config/config.go
+++ b/internal/hub/config/config.go
@@ -76,33 +76,121 @@ func (c *Config) WorktreeCreateTimeout() time.Duration {
 	return time.Duration(v) * time.Second
 }
 
+// LoadOptions parameterizes differences between hub and solo/dev mode config loading.
+type LoadOptions struct {
+	DefaultAddr       string   // default listen address (hub: ":4327", solo: "127.0.0.1:4327")
+	DefaultConfigDir  string   // for data_dir resolution (e.g. "~/.config/leapmux/solo")
+	DefaultConfigFile string   // default config file path
+	FlagSetName       string   // flag.NewFlagSet name ("hub" vs "leapmux")
+	CLIFlags          []string // if non-nil, only register these flags (solo exposes a subset)
+	SoloMode          bool     // set on resulting Config
+}
+
 // Load parses hub configuration from defaults, config file, env vars, and CLI flags.
 // Returns the config, whether -version was requested, and any error.
 func Load(args []string) (*Config, bool, error) {
-	// Pre-scan for -config flag.
-	configPath := internalconfig.ExtractConfigFlag(args, defaultConfigFile)
+	return LoadWithOptions(args, LoadOptions{})
+}
 
-	// Define CLI flags.
-	fs := flag.NewFlagSet("hub", flag.ContinueOnError)
-	fs.String("config", defaultConfigFile, "path to config file")
-	fs.String("addr", defaultAddr, "listen address")
-	fs.String("data-dir", ".", "data directory")
-	fs.String("dev-frontend", "", "Vite dev server URL for reverse proxy (dev mode only)")
-	fs.Int("db-max-conns", hubdb.DefaultMaxConns, "maximum number of open database connections")
-	fs.Int("max-message-size", 0, "maximum reassembled channel message size in bytes (default 16 MiB)")
-	fs.Int("max-incomplete-chunked", 0, "maximum in-flight chunked sequences per channel (default 4)")
-	fs.String("log-level", defaultLogLevel, "log level (debug, info, warn, error)")
-	fs.Bool("signup-enabled", false, "enable user sign-up")
-	fs.Bool("email-verification-required", false, "require email verification on sign-up")
-	fs.String("smtp-host", "", "SMTP server host")
-	fs.Int("smtp-port", 587, "SMTP server port")
-	fs.String("smtp-username", "", "SMTP username")
-	fs.String("smtp-password", "", "SMTP password")
-	fs.String("smtp-from-address", "", "SMTP from address")
-	fs.Bool("smtp-use-tls", true, "use TLS for SMTP")
-	fs.Int("api-timeout-seconds", DefaultAPITimeoutSeconds, "general API timeout in seconds")
-	fs.Int("agent-startup-timeout-seconds", DefaultAgentStartupTimeoutSeconds, "agent startup timeout in seconds")
-	fs.Int("worktree-create-timeout-seconds", DefaultWorktreeCreateTimeoutSeconds, "worktree creation timeout in seconds")
+// LoadWithOptions parses hub configuration with customizable options.
+// Zero-value LoadOptions fields fall back to hub defaults.
+func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
+	addr := opts.DefaultAddr
+	if addr == "" {
+		addr = defaultAddr
+	}
+	configDir := opts.DefaultConfigDir
+	if configDir == "" {
+		configDir = defaultConfigDir
+	}
+	configFile := opts.DefaultConfigFile
+	if configFile == "" {
+		configFile = defaultConfigFile
+	}
+	fsName := opts.FlagSetName
+	if fsName == "" {
+		fsName = "hub"
+	}
+
+	// Pre-scan for -config flag.
+	configPath := internalconfig.ExtractConfigFlag(args, configFile)
+
+	// All available flags with their definitions.
+	type flagDef struct {
+		name     string
+		koanfKey string
+		usage    string
+		// Exactly one of these is set.
+		strDefault  *string
+		intDefault  *int
+		boolDefault *bool
+	}
+
+	strVal := func(s string) *string { return &s }
+	intVal := func(i int) *int { return &i }
+	boolVal := func(b bool) *bool { return &b }
+
+	allFlags := []flagDef{
+		{"addr", "addr", "listen address", strVal(addr), nil, nil},
+		{"data-dir", "data_dir", "data directory", strVal("."), nil, nil},
+		{"dev-frontend", "dev_frontend", "Vite dev server URL for reverse proxy (dev mode only)", strVal(""), nil, nil},
+		{"db-max-conns", "db_max_conns", "maximum number of open database connections", nil, intVal(hubdb.DefaultMaxConns), nil},
+		{"max-message-size", "max_message_size", "maximum reassembled channel message size in bytes (default 16 MiB)", nil, intVal(0), nil},
+		{"max-incomplete-chunked", "max_incomplete_chunked", "maximum in-flight chunked sequences per channel (default 4)", nil, intVal(0), nil},
+		{"log-level", "log_level", "log level (debug, info, warn, error)", strVal(defaultLogLevel), nil, nil},
+		{"signup-enabled", "signup_enabled", "enable user sign-up", nil, nil, boolVal(false)},
+		{"email-verification-required", "email_verification_required", "require email verification on sign-up", nil, nil, boolVal(false)},
+		{"smtp-host", "smtp_host", "SMTP server host", strVal(""), nil, nil},
+		{"smtp-port", "smtp_port", "SMTP server port", nil, intVal(587), nil},
+		{"smtp-username", "smtp_username", "SMTP username", strVal(""), nil, nil},
+		{"smtp-password", "smtp_password", "SMTP password", strVal(""), nil, nil},
+		{"smtp-from-address", "smtp_from_address", "SMTP from address", strVal(""), nil, nil},
+		{"smtp-use-tls", "smtp_use_tls", "use TLS for SMTP", nil, nil, boolVal(true)},
+		{"api-timeout-seconds", "api_timeout_seconds", "general API timeout in seconds", nil, intVal(DefaultAPITimeoutSeconds), nil},
+		{"agent-startup-timeout-seconds", "agent_startup_timeout_seconds", "agent startup timeout in seconds", nil, intVal(DefaultAgentStartupTimeoutSeconds), nil},
+		{"worktree-create-timeout-seconds", "worktree_create_timeout_seconds", "worktree creation timeout in seconds", nil, intVal(DefaultWorktreeCreateTimeoutSeconds), nil},
+	}
+
+	// Build the set of allowed CLI flags.
+	var allowedFlags map[string]bool
+	if opts.CLIFlags != nil {
+		allowedFlags = make(map[string]bool, len(opts.CLIFlags))
+		for _, f := range opts.CLIFlags {
+			allowedFlags[f] = true
+		}
+	}
+
+	// Define CLI flags and build fieldMap/defaults from the canonical list.
+	fs := flag.NewFlagSet(fsName, flag.ContinueOnError)
+	fs.String("config", configFile, "path to config file")
+	fieldMap := make(map[string]string, len(allFlags))
+	defaults := make(map[string]interface{}, len(allFlags))
+
+	for _, fd := range allFlags {
+		// Always add to defaults.
+		switch {
+		case fd.strDefault != nil:
+			defaults[fd.koanfKey] = *fd.strDefault
+		case fd.intDefault != nil:
+			defaults[fd.koanfKey] = *fd.intDefault
+		case fd.boolDefault != nil:
+			defaults[fd.koanfKey] = *fd.boolDefault
+		}
+
+		// Register CLI flag only if allowed.
+		if allowedFlags != nil && !allowedFlags[fd.name] {
+			continue
+		}
+		fieldMap[fd.name] = fd.koanfKey
+		switch {
+		case fd.strDefault != nil:
+			fs.String(fd.name, *fd.strDefault, fd.usage)
+		case fd.intDefault != nil:
+			fs.Int(fd.name, *fd.intDefault, fd.usage)
+		case fd.boolDefault != nil:
+			fs.Bool(fd.name, *fd.boolDefault, fd.usage)
+		}
+	}
 	showVersion := fs.Bool("version", false, "print version and exit")
 
 	if err := fs.Parse(args); err != nil {
@@ -111,49 +199,6 @@ func Load(args []string) (*Config, bool, error) {
 
 	if *showVersion {
 		return nil, true, nil
-	}
-
-	// Flag name -> koanf key mapping.
-	fieldMap := map[string]string{
-		"addr":                            "addr",
-		"data-dir":                        "data_dir",
-		"dev-frontend":                    "dev_frontend",
-		"db-max-conns":                    "db_max_conns",
-		"max-message-size":                "max_message_size",
-		"max-incomplete-chunked":          "max_incomplete_chunked",
-		"log-level":                       "log_level",
-		"signup-enabled":                  "signup_enabled",
-		"email-verification-required":     "email_verification_required",
-		"smtp-host":                       "smtp_host",
-		"smtp-port":                       "smtp_port",
-		"smtp-username":                   "smtp_username",
-		"smtp-password":                   "smtp_password",
-		"smtp-from-address":               "smtp_from_address",
-		"smtp-use-tls":                    "smtp_use_tls",
-		"api-timeout-seconds":             "api_timeout_seconds",
-		"agent-startup-timeout-seconds":   "agent_startup_timeout_seconds",
-		"worktree-create-timeout-seconds": "worktree_create_timeout_seconds",
-	}
-
-	defaults := map[string]interface{}{
-		"addr":                            defaultAddr,
-		"data_dir":                        ".",
-		"dev_frontend":                    "",
-		"db_max_conns":                    hubdb.DefaultMaxConns,
-		"max_message_size":                0,
-		"max_incomplete_chunked":          0,
-		"log_level":                       defaultLogLevel,
-		"signup_enabled":                  false,
-		"email_verification_required":     false,
-		"smtp_host":                       "",
-		"smtp_port":                       587,
-		"smtp_username":                   "",
-		"smtp_password":                   "",
-		"smtp_from_address":               "",
-		"smtp_use_tls":                    true,
-		"api_timeout_seconds":             DefaultAPITimeoutSeconds,
-		"agent_startup_timeout_seconds":   DefaultAgentStartupTimeoutSeconds,
-		"worktree_create_timeout_seconds": DefaultWorktreeCreateTimeoutSeconds,
 	}
 
 	k := koanf.New(".")
@@ -169,7 +214,8 @@ func Load(args []string) (*Config, bool, error) {
 	}
 
 	// Resolve relative data_dir against config file directory.
-	cfg.DataDir = internalconfig.ResolveDataDir(cfg.DataDir, configPath, defaultConfigDir)
+	cfg.DataDir = internalconfig.ResolveDataDir(cfg.DataDir, configPath, configDir)
+	cfg.SoloMode = opts.SoloMode
 
 	return &cfg, false, nil
 }

--- a/internal/hub/config/config.go
+++ b/internal/hub/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	APITimeoutSeconds            int    `koanf:"api_timeout_seconds"`
 	AgentStartupTimeoutSeconds   int    `koanf:"agent_startup_timeout_seconds"`
 	WorktreeCreateTimeoutSeconds int    `koanf:"worktree_create_timeout_seconds"`
+	SoloMode                     bool
 }
 
 // APITimeout returns the general API timeout as a duration.
@@ -175,10 +176,6 @@ func Load(args []string) (*Config, bool, error) {
 
 // Validate checks the configuration values and ensures required directories exist.
 func (c *Config) Validate() error {
-	if c.Addr == "" {
-		return fmt.Errorf("addr is required")
-	}
-
 	// Ensure data dir exists.
 	if err := os.MkdirAll(c.DataDir, 0o750); err != nil {
 		return fmt.Errorf("create data dir: %w", err)

--- a/internal/hub/config/config_test.go
+++ b/internal/hub/config/config_test.go
@@ -123,6 +123,90 @@ log_level: "debug"
 	})
 }
 
+func TestLoadWithOptions(t *testing.T) {
+	t.Run("custom DefaultAddr applied", func(t *testing.T) {
+		cfg, _, err := LoadWithOptions(nil, LoadOptions{
+			DefaultAddr: "127.0.0.1:4327",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:4327", cfg.Addr)
+	})
+
+	t.Run("SoloMode set on output", func(t *testing.T) {
+		cfg, _, err := LoadWithOptions(nil, LoadOptions{
+			SoloMode: true,
+		})
+		require.NoError(t, err)
+		assert.True(t, cfg.SoloMode)
+	})
+
+	t.Run("SoloMode false by default", func(t *testing.T) {
+		cfg, _, err := LoadWithOptions(nil, LoadOptions{})
+		require.NoError(t, err)
+		assert.False(t, cfg.SoloMode)
+	})
+
+	t.Run("CLIFlags restriction rejects unlisted flags", func(t *testing.T) {
+		_, _, err := LoadWithOptions([]string{"-signup-enabled"}, LoadOptions{
+			CLIFlags: []string{"addr", "data-dir", "log-level"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("CLIFlags restriction allows listed flags", func(t *testing.T) {
+		cfg, _, err := LoadWithOptions([]string{"-addr", ":9999"}, LoadOptions{
+			CLIFlags: []string{"addr", "data-dir", "log-level"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ":9999", cfg.Addr)
+	})
+
+	t.Run("config file values for all fields work with CLIFlags restriction", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "solo.yaml")
+		yamlContent := `max_message_size: 1024
+max_incomplete_chunked: 8
+signup_enabled: true
+`
+		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o644))
+
+		cfg, _, err := LoadWithOptions([]string{"-config", configPath}, LoadOptions{
+			CLIFlags: []string{"addr", "data-dir", "log-level"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1024, cfg.MaxMessageSize)
+		assert.Equal(t, 8, cfg.MaxIncompleteChunked)
+		assert.True(t, cfg.SignupEnabled)
+	})
+
+	t.Run("custom DefaultConfigDir used for data dir resolution", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		cfg, _, err := LoadWithOptions(nil, LoadOptions{
+			DefaultConfigDir: "~/.config/leapmux/solo",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".config/leapmux/solo"), cfg.DataDir)
+	})
+
+	t.Run("custom FlagSetName", func(t *testing.T) {
+		// Verify it doesn't error (flag set name is internal).
+		_, _, err := LoadWithOptions(nil, LoadOptions{
+			FlagSetName: "leapmux",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("version flag works with options", func(t *testing.T) {
+		_, showVersion, err := LoadWithOptions([]string{"-version"}, LoadOptions{
+			CLIFlags: []string{"addr"},
+		})
+		require.NoError(t, err)
+		assert.True(t, showVersion)
+	})
+}
+
 func TestValidate(t *testing.T) {
 	t.Run("empty addr returns error", func(t *testing.T) {
 		cfg := &Config{Addr: ""}

--- a/internal/hub/service/admin_service.go
+++ b/internal/hub/service/admin_service.go
@@ -19,12 +19,13 @@ import (
 
 // AdminService implements the leapmux.v1.AdminService ConnectRPC handler.
 type AdminService struct {
-	queries *db.Queries
+	queries  *db.Queries
+	soloMode bool
 }
 
 // NewAdminService creates a new AdminService.
-func NewAdminService(q *db.Queries) *AdminService {
-	return &AdminService{queries: q}
+func NewAdminService(q *db.Queries, soloMode bool) *AdminService {
+	return &AdminService{queries: q, soloMode: soloMode}
 }
 
 func requireAdmin(ctx context.Context) (*auth.UserInfo, error) {
@@ -129,6 +130,9 @@ func (s *AdminService) GetUser(ctx context.Context, req *connect.Request[leapmux
 }
 
 func (s *AdminService) CreateUser(ctx context.Context, req *connect.Request[leapmuxv1.CreateUserRequest]) (*connect.Response[leapmuxv1.CreateUserResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("user management is not available in solo mode"))
+	}
 	if _, err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
@@ -200,6 +204,9 @@ func (s *AdminService) CreateUser(ctx context.Context, req *connect.Request[leap
 }
 
 func (s *AdminService) UpdateUser(ctx context.Context, req *connect.Request[leapmuxv1.UpdateUserRequest]) (*connect.Response[leapmuxv1.UpdateUserResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("user management is not available in solo mode"))
+	}
 	caller, err := requireAdmin(ctx)
 	if err != nil {
 		return nil, err
@@ -261,6 +268,9 @@ func (s *AdminService) UpdateUser(ctx context.Context, req *connect.Request[leap
 }
 
 func (s *AdminService) DeleteUser(ctx context.Context, req *connect.Request[leapmuxv1.DeleteUserRequest]) (*connect.Response[leapmuxv1.DeleteUserResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("user management is not available in solo mode"))
+	}
 	caller, err := requireAdmin(ctx)
 	if err != nil {
 		return nil, err
@@ -288,6 +298,9 @@ func (s *AdminService) DeleteUser(ctx context.Context, req *connect.Request[leap
 }
 
 func (s *AdminService) ResetUserPassword(ctx context.Context, req *connect.Request[leapmuxv1.ResetUserPasswordRequest]) (*connect.Response[leapmuxv1.ResetUserPasswordResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("user management is not available in solo mode"))
+	}
 	if _, err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}

--- a/internal/hub/service/admin_service_test.go
+++ b/internal/hub/service/admin_service_test.go
@@ -40,13 +40,13 @@ func setupAdminTestServer(t *testing.T) *adminTestEnv {
 
 	q := gendb.New(sqlDB)
 
-	err = bootstrap.Run(context.Background(), q)
+	err = bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
-	adminSvc := service.NewAdminService(q)
+	adminSvc := service.NewAdminService(q, false)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 	path, handler := leapmuxv1connect.NewAdminServiceHandler(adminSvc, opts)
 	mux.Handle(path, handler)
 

--- a/internal/hub/service/auth_service.go
+++ b/internal/hub/service/auth_service.go
@@ -75,6 +75,9 @@ func (s *AuthService) GetCurrentUser(ctx context.Context, req *connect.Request[l
 }
 
 func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1.SignUpRequest]) (*connect.Response[leapmuxv1.SignUpResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sign-up is not available in solo mode"))
+	}
 	if !s.cfg.SignupEnabled {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sign-up is disabled"))
 	}
@@ -238,6 +241,7 @@ func (s *AuthService) VerifyEmail(ctx context.Context, req *connect.Request[leap
 func (s *AuthService) GetSystemInfo(ctx context.Context, req *connect.Request[leapmuxv1.GetSystemInfoRequest]) (*connect.Response[leapmuxv1.GetSystemInfoResponse], error) {
 	return connect.NewResponse(&leapmuxv1.GetSystemInfoResponse{
 		SignupEnabled: s.cfg.SignupEnabled,
+		SoloMode:      s.cfg.SoloMode,
 	}), nil
 }
 

--- a/internal/hub/service/auth_service_test.go
+++ b/internal/hub/service/auth_service_test.go
@@ -32,11 +32,11 @@ func setupAuthTestServer(t *testing.T, cfg *config.Config) (leapmuxv1connect.Aut
 
 	q := gendb.New(sqlDB)
 
-	err = bootstrap.Run(context.Background(), q)
+	err = bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 	authSvc := service.NewAuthService(q, cfg)
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(path, handler)
@@ -181,7 +181,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 
 	// Set up a UserService client using the same queries and auth interceptor.
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 	userSvc := service.NewUserService(q, testConfig())
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)

--- a/internal/hub/service/channel_service_test.go
+++ b/internal/hub/service/channel_service_test.go
@@ -47,7 +47,7 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 
 	q := gendb.New(sqlDB)
 
-	err = bootstrap.Run(context.Background(), q)
+	err = bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	cfg := testConfig()
@@ -56,17 +56,17 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(service.NewAuthService(q, cfg), opts)
 	mux.Handle(authPath, authHandler)
 
 	connPath, connHandler := leapmuxv1connect.NewWorkerConnectorServiceHandler(
-		service.NewWorkerConnectorService(q, wMgr), opts)
+		service.NewWorkerConnectorService(q, wMgr, false), opts)
 	mux.Handle(connPath, connHandler)
 
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(
-		service.NewWorkerManagementService(q, wMgr, nil), opts)
+		service.NewWorkerManagementService(q, wMgr, nil, false), opts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
 	channelSvc := service.NewChannelService(q, wMgr, cMgr, pendingReqs)

--- a/internal/hub/service/org_service.go
+++ b/internal/hub/service/org_service.go
@@ -20,17 +20,21 @@ import (
 type OrgService struct {
 	queries  *db.Queries
 	notifier *notifier.Notifier
+	soloMode bool
 }
 
 // NewOrgService creates a new OrgService.
-func NewOrgService(q *db.Queries, n *notifier.Notifier) *OrgService {
-	return &OrgService{queries: q, notifier: n}
+func NewOrgService(q *db.Queries, n *notifier.Notifier, soloMode bool) *OrgService {
+	return &OrgService{queries: q, notifier: n, soloMode: soloMode}
 }
 
 func (s *OrgService) CreateOrg(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.CreateOrgRequest],
 ) (*connect.Response[leapmuxv1.CreateOrgResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("organization management is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -162,6 +166,9 @@ func (s *OrgService) DeleteOrg(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.DeleteOrgRequest],
 ) (*connect.Response[leapmuxv1.DeleteOrgResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("organization management is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -283,6 +290,9 @@ func (s *OrgService) InviteOrgMember(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.InviteOrgMemberRequest],
 ) (*connect.Response[leapmuxv1.InviteOrgMemberResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("organization management is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -362,6 +372,9 @@ func (s *OrgService) RemoveOrgMember(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.RemoveOrgMemberRequest],
 ) (*connect.Response[leapmuxv1.RemoveOrgMemberResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("organization management is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -438,6 +451,9 @@ func (s *OrgService) UpdateOrgMember(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.UpdateOrgMemberRequest],
 ) (*connect.Response[leapmuxv1.UpdateOrgMemberResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("organization management is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/hub/service/org_service_test.go
+++ b/internal/hub/service/org_service_test.go
@@ -43,7 +43,7 @@ func setupOrgTestServer(t *testing.T) *orgTestEnv {
 
 	q := gendb.New(sqlDB)
 
-	err = bootstrap.Run(context.Background(), q)
+	err = bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	bgMgr := workermgr.New()
@@ -53,9 +53,9 @@ func setupOrgTestServer(t *testing.T) *orgTestEnv {
 	notifierSvc := notifier.New(q, bgMgr, pendingReqs, cfg)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 
-	orgSvc := service.NewOrgService(q, notifierSvc)
+	orgSvc := service.NewOrgService(q, notifierSvc, false)
 	orgPath, orgHandler := leapmuxv1connect.NewOrgServiceHandler(orgSvc, opts)
 	mux.Handle(orgPath, orgHandler)
 

--- a/internal/hub/service/section_service_test.go
+++ b/internal/hub/service/section_service_test.go
@@ -42,7 +42,7 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	sectionSvc := service.NewSectionService(queries)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(queries))
+	opts := connect.WithInterceptors(auth.NewInterceptor(queries, false))
 	path, handler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(path, handler)
 

--- a/internal/hub/service/user_service.go
+++ b/internal/hub/service/user_service.go
@@ -27,6 +27,9 @@ func NewUserService(q *db.Queries, cfg *config.Config) *UserService {
 }
 
 func (s *UserService) UpdateProfile(ctx context.Context, req *connect.Request[leapmuxv1.UpdateProfileRequest]) (*connect.Response[leapmuxv1.UpdateProfileResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("profile changes are not available in solo mode"))
+	}
 	userInfo, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -84,6 +87,9 @@ func (s *UserService) UpdateProfile(ctx context.Context, req *connect.Request[le
 }
 
 func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[leapmuxv1.ChangePasswordRequest]) (*connect.Response[leapmuxv1.ChangePasswordResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("password changes are not available in solo mode"))
+	}
 	userInfo, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/hub/service/user_service_test.go
+++ b/internal/hub/service/user_service_test.go
@@ -43,7 +43,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	userSvc := service.NewUserService(queries, testConfig())
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(queries))
+	opts := connect.WithInterceptors(auth.NewInterceptor(queries, false))
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
 

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -27,11 +27,12 @@ type WorkerConnectorService struct {
 	pending    *workermgr.PendingRequests
 	notifier   *notifier.Notifier
 	shutdownCh <-chan struct{}
+	soloMode   bool
 }
 
 // NewWorkerConnectorService creates a new WorkerConnectorService.
-func NewWorkerConnectorService(q *db.Queries, mgr *workermgr.Manager) *WorkerConnectorService {
-	return &WorkerConnectorService{queries: q, workerMgr: mgr}
+func NewWorkerConnectorService(q *db.Queries, mgr *workermgr.Manager, soloMode bool) *WorkerConnectorService {
+	return &WorkerConnectorService{queries: q, workerMgr: mgr, soloMode: soloMode}
 }
 
 // SetChannelMgr sets the channel manager for routing encrypted channel traffic.
@@ -59,6 +60,9 @@ func (s *WorkerConnectorService) RequestRegistration(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.RequestRegistrationRequest],
 ) (*connect.Response[leapmuxv1.RequestRegistrationResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker registration is not available in solo mode"))
+	}
 	// Expire old pending registrations first.
 	if err := s.queries.ExpireRegistrations(ctx); err != nil {
 		slog.Debug("failed to expire registrations", "error", err)

--- a/internal/hub/service/worker_mgmt_service.go
+++ b/internal/hub/service/worker_mgmt_service.go
@@ -23,17 +23,21 @@ type WorkerManagementService struct {
 	queries   *db.Queries
 	workerMgr *workermgr.Manager
 	notifier  *notifier.Notifier
+	soloMode  bool
 }
 
 // NewWorkerManagementService creates a new WorkerManagementService.
-func NewWorkerManagementService(q *db.Queries, mgr *workermgr.Manager, n *notifier.Notifier) *WorkerManagementService {
-	return &WorkerManagementService{queries: q, workerMgr: mgr, notifier: n}
+func NewWorkerManagementService(q *db.Queries, mgr *workermgr.Manager, n *notifier.Notifier, soloMode bool) *WorkerManagementService {
+	return &WorkerManagementService{queries: q, workerMgr: mgr, notifier: n, soloMode: soloMode}
 }
 
 func (s *WorkerManagementService) ApproveRegistration(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.ApproveRegistrationRequest],
 ) (*connect.Response[leapmuxv1.ApproveRegistrationResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker registration approval is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -193,6 +197,9 @@ func (s *WorkerManagementService) DeregisterWorker(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.DeregisterWorkerRequest],
 ) (*connect.Response[leapmuxv1.DeregisterWorkerResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker deregistration is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/hub/service/worker_service_test.go
+++ b/internal/hub/service/worker_service_test.go
@@ -42,7 +42,7 @@ func setupWorkerTestServer(t *testing.T) *workerTestEnv {
 
 	q := gendb.New(sqlDB)
 
-	err = bootstrap.Run(context.Background(), q)
+	err = bootstrap.Run(context.Background(), q, false)
 	require.NoError(t, err)
 
 	bgMgr := workermgr.New()
@@ -52,17 +52,17 @@ func setupWorkerTestServer(t *testing.T) *workerTestEnv {
 	notifierSvc := notifier.New(q, bgMgr, pendingReqs, cfg)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(q))
+	opts := connect.WithInterceptors(auth.NewInterceptor(q, false))
 
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(service.NewAuthService(q, cfg), opts)
 	mux.Handle(authPath, authHandler)
 
 	connPath, connHandler := leapmuxv1connect.NewWorkerConnectorServiceHandler(
-		service.NewWorkerConnectorService(q, bgMgr), opts)
+		service.NewWorkerConnectorService(q, bgMgr, false), opts)
 	mux.Handle(connPath, connHandler)
 
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(
-		service.NewWorkerManagementService(q, bgMgr, notifierSvc), opts)
+		service.NewWorkerManagementService(q, bgMgr, notifierSvc, false), opts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
 	server := httptest.NewServer(mux)

--- a/internal/hub/service/workspace_service.go
+++ b/internal/hub/service/workspace_service.go
@@ -24,13 +24,14 @@ type layoutJSON struct {
 
 // WorkspaceService implements the WorkspaceServiceHandler interface.
 type WorkspaceService struct {
-	db      *sql.DB
-	queries *db.Queries
+	db       *sql.DB
+	queries  *db.Queries
+	soloMode bool
 }
 
 // NewWorkspaceService creates a new WorkspaceService.
-func NewWorkspaceService(sqlDB *sql.DB, q *db.Queries) *WorkspaceService {
-	return &WorkspaceService{db: sqlDB, queries: q}
+func NewWorkspaceService(sqlDB *sql.DB, q *db.Queries, soloMode bool) *WorkspaceService {
+	return &WorkspaceService{db: sqlDB, queries: q, soloMode: soloMode}
 }
 
 // workspaceToProto converts a hub DB workspace row to the proto Workspace message.
@@ -209,6 +210,9 @@ func (s *WorkspaceService) UpdateWorkspaceSharing(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.UpdateWorkspaceSharingRequest],
 ) (*connect.Response[leapmuxv1.UpdateWorkspaceSharingResponse], error) {
+	if s.soloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("workspace sharing is not available in solo mode"))
+	}
 	user, err := auth.MustGetUser(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/hub/service/workspace_service_test.go
+++ b/internal/hub/service/workspace_service_test.go
@@ -45,10 +45,10 @@ func setupWorkspaceTest(t *testing.T) *workspaceTestEnv {
 	require.NoError(t, err)
 
 	queries := gendb.New(sqlDB)
-	workspaceSvc := service.NewWorkspaceService(sqlDB, queries)
+	workspaceSvc := service.NewWorkspaceService(sqlDB, queries, false)
 
 	mux := http.NewServeMux()
-	opts := connect.WithInterceptors(auth.NewInterceptor(queries))
+	opts := connect.WithInterceptors(auth.NewInterceptor(queries, false))
 	path, handler := leapmuxv1connect.NewWorkspaceServiceHandler(workspaceSvc, opts)
 	mux.Handle(path, handler)
 

--- a/internal/hub/service/ws_channel_relay.go
+++ b/internal/hub/service/ws_channel_relay.go
@@ -27,6 +27,7 @@ type ChannelRelayHandler struct {
 	queries    *db.Queries
 	workerMgr  *workermgr.Manager
 	channelMgr *channelmgr.Manager
+	soloUser   *auth.UserInfo
 }
 
 // NewChannelRelayHandler creates a new WebSocket relay handler.
@@ -34,28 +35,37 @@ func NewChannelRelayHandler(
 	q *db.Queries,
 	wMgr *workermgr.Manager,
 	cMgr *channelmgr.Manager,
+	soloUser *auth.UserInfo,
 ) *ChannelRelayHandler {
 	return &ChannelRelayHandler{
 		queries:    q,
 		workerMgr:  wMgr,
 		channelMgr: cMgr,
+		soloUser:   soloUser,
 	}
 }
 
 // ServeHTTP upgrades the connection to a multiplexed WebSocket and relays
 // channel messages for all channels belonging to the authenticated user.
 func (h *ChannelRelayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		http.Error(w, "missing token parameter", http.StatusBadRequest)
-		return
-	}
+	var user *auth.UserInfo
 
-	// Authenticate user.
-	user, err := auth.ValidateToken(r.Context(), h.queries, token)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+	if h.soloUser != nil {
+		// Solo mode: auto-authenticate as the solo user.
+		user = h.soloUser
+	} else {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			http.Error(w, "missing token parameter", http.StatusBadRequest)
+			return
+		}
+
+		var err error
+		user, err = auth.ValidateToken(r.Context(), h.queries, token)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 
 	// Upgrade to WebSocket.

--- a/internal/logging/banner.go
+++ b/internal/logging/banner.go
@@ -50,13 +50,22 @@ var workerArt = [6]string{
 	`                                     `,
 }
 
-var standaloneArt = [6]string{
-	`  ____  _                  _       _                  `,
-	` / ___|| |_ __ _ _ __   __| | __ _| | ___  _ __   ___ `,
-	` \___ \| __/ _` + "`" + ` | '_ \ / _` + "`" + ` |/ _` + "`" + ` | |/ _ \| '_ \ / _ \`,
-	`  ___) | || (_| | | | | (_| | (_| | | (_) | | | |  __/`,
-	` |____/ \__\__,_|_| |_|\__,_|\__,_|_|\___/|_| |_|\___|`,
-	`                                                       `,
+var soloArt = [6]string{
+	`  ____        _       `,
+	` / ___|  ___ | | ___  `,
+	` \___ \ / _ \| |/ _ \ `,
+	`  ___) | (_) | | (_) |`,
+	` |____/ \___/|_|\___/ `,
+	`                      `,
+}
+
+var devArt = [6]string{
+	`  ____             `,
+	` |  _ \  _____   __`,
+	` | | | |/ _ \ \ / /`,
+	` | |_| |  __/\ V / `,
+	` |____/ \___| \_/  `,
+	`                   `,
 }
 
 // PrintBanner prints the LeapMux ASCII art logo with mode-specific
@@ -74,8 +83,11 @@ func PrintBanner(mode, ver, addr string) {
 	case "worker":
 		modeArt = &workerArt
 		modeColor = yellow
-	default: // standalone
-		modeArt = &standaloneArt
+	case "dev":
+		modeArt = &devArt
+		modeColor = yellow
+	default: // solo
+		modeArt = &soloArt
 		modeColor = magenta
 	}
 

--- a/internal/logging/banner.go
+++ b/internal/logging/banner.go
@@ -28,7 +28,7 @@ var logoLines = [6]string{
 	` | |   / _ \/ _` + "`" + ` | '_ \ | |\/| | | | \ \/ /`,
 	` | |__|  __/ (_| | |_) || |  | | |_| |>  < `,
 	` |_____\___|\__,_| .__/ |_|  |_|\__,_/_/\_\`,
-	`                  |_|                       `,
+	`                 |_|                        `,
 }
 
 // Mode-specific ASCII art (right-side, same height as logo).

--- a/mprocs-solo.yaml
+++ b/mprocs-solo.yaml
@@ -1,0 +1,5 @@
+procs:
+  backend:
+    shell: "go run ./cmd/leapmux -dev-frontend http://localhost:4328"
+  frontend:
+    shell: "cd frontend && bun run dev"

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,5 +1,5 @@
 procs:
   backend:
-    shell: "go run ./cmd/leapmux dev -log-level debug -dev-frontend http://localhost:4328"
+    shell: "go run ./cmd/leapmux dev -dev-frontend http://localhost:4328"
   frontend:
     shell: "cd frontend && bun run dev"

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,5 +1,5 @@
 procs:
   backend:
-    shell: "go run ./cmd/leapmux -log-level debug -dev-frontend http://localhost:4328"
+    shell: "go run ./cmd/leapmux dev -log-level debug -dev-frontend http://localhost:4328"
   frontend:
     shell: "cd frontend && bun run dev"

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -75,4 +75,5 @@ message GetSystemInfoRequest {}
 
 message GetSystemInfoResponse {
   bool signup_enabled = 1;
+  bool solo_mode = 2;
 }

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -1,5 +1,5 @@
 // Package worker provides an exported entry point for running the
-// LeapMux worker as a library (e.g. from the standalone binary).
+// LeapMux worker as a library (e.g. from the solo/dev binary).
 package worker
 
 import (


### PR DESCRIPTION
## Motivation

The previous "standalone" mode combined two distinct use cases into one: a secure single-user local setup and a network-accessible development environment. This conflation made it difficult to enforce appropriate security boundaries for each scenario and added confusion about which flags and behaviors applied in which context.

A cleaner split is needed where "solo" mode is the default for personal, localhost-only use and "dev" mode is explicitly opt-in for development work that requires network accessibility.

## Modifications

**Mode split and CLI restructuring**
- Renamed "standalone" to "solo" mode (`leapmux` or no subcommand); this is the default, localhost-only mode
- Introduced "dev" mode (`leapmux dev`) for network-accessible development; CLI flags are gated per mode

**Configuration and data isolation**
- Solo and dev modes now use separate config files: `~/.config/leapmux/solo/solo.yaml` and `~/.config/leapmux/dev/dev.yaml`, with mode-specific data subdirectories
- Introduced `config.LoadWithOptions()` to allow modes to customize defaults without duplicating config loading logic
- (Breaking) `bootstrap.Run()` signature changed to accept a `soloMode` parameter; the bootstrap user is now named `"solo"` instead of `"admin"` in solo mode

**Authentication**
- Auth interceptor now auto-authenticates all requests as the `"solo"` user in solo mode, bypassing token validation entirely
- WebSocket `ChannelRelayHandler` accepts an optional solo user for automatic channel authentication
- Fixed a bug where solo mode WebSocket channel auth failed because the user was looked up as `"admin"` instead of `"solo"`

**Multi-user operation guards**
- AdminService, OrgService, WorkerConnectorService, WorkerManagementService, UserService, and WorkspaceService reject multi-user operations when running in solo mode

**Docker**
- Docker image sets `LEAPMUX_DOCKER=1` and requires an explicit `LEAPMUX_MODE` environment variable
- (Breaking) Docker entrypoint now requires `LEAPMUX_MODE` to be set; per-mode config directories are used inside the container

**Frontend**
- Added `systemInfo.ts` with `isSoloMode()` for mode detection; auth flow, routing, and UI elements (user menu, org switcher, admin panel, worker deregistration, preferences layout) are conditioned on solo mode
- New `createWorkerDialogState` hook centralizes worker selection, working directory management, and worktree state shared across NewAgent, NewTerminal, and NewWorkspace dialogs, reducing approximately 60 lines of duplication per dialog
- New `WorkerSelector` and `DirectorySelector` components extracted from dialog implementations
- New `RefreshButton` component with 360-degree rotation animation on click, replacing inline implementations across 5 files
- Fixed `NewWorkspaceDialog` to roll back workspace creation if the subsequent agent open fails
- E2E tests updated for the terminology change from "standalone" to "dev" mode

**Documentation**
- README restructured with architecture diagrams for solo, dev, and distributed modes

## Result

- Running `leapmux` (no subcommand) starts solo mode: a secure, localhost-only single-user experience with no authentication prompts and no multi-user operations exposed
- Running `leapmux dev` starts dev mode: a network-accessible hub suitable for local development workflows
- Solo and dev mode configurations and data are fully isolated from each other and from previous standalone configurations
- WebSocket channel relay no longer fails for solo mode users due to incorrect username lookup
- The frontend suppresses irrelevant multi-user UI (org switcher, admin panel, user menu) when running in solo mode
- Docker deployments must now set `LEAPMUX_MODE` explicitly, making the intended operating mode unambiguous

🤖 Generated with Claude Code
