### PR TITLE
Refactor RefreshButton to render via IconButton internally

### DIFF
--- a/frontend/src/components/common/RefreshButton.tsx
+++ b/frontend/src/components/common/RefreshButton.tsx
@@ -1,40 +1,41 @@
 import type { Component } from 'solid-js'
+import type { IconButtonSize } from './IconButton'
 import type { IconSizeName } from '~/components/common/Icon'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
-import { createSignal } from 'solid-js'
-import { Icon } from '~/components/common/Icon'
-import { refreshButton } from '~/styles/shared.css'
+import { createSignal, splitProps } from 'solid-js'
+import { IconButton, IconButtonState } from './IconButton'
 import * as styles from './RefreshButton.css'
 
 interface RefreshButtonProps {
-  onClick: () => void
-  disabled?: boolean
-  title?: string
-  size?: IconSizeName
+  'onClick': () => void
+  'disabled'?: boolean
+  'title'?: string
+  /** Icon size token. Default: 'sm' */
+  'iconSize'?: IconSizeName
+  /** Container size token. Default: none (intrinsic sizing). */
+  'size'?: IconButtonSize
+  'data-testid'?: string
 }
 
 export const RefreshButton: Component<RefreshButtonProps> = (props) => {
+  const [local, rest] = splitProps(props, ['onClick', 'disabled', 'iconSize', 'size'])
   const [animating, setAnimating] = createSignal(false)
 
   const handleClick = () => {
     setAnimating(true)
-    props.onClick()
+    local.onClick()
   }
 
   return (
-    <button
-      type="button"
-      class={refreshButton}
+    <IconButton
+      icon={RefreshCw}
+      iconSize={local.iconSize ?? 'sm'}
+      size={local.size}
+      state={local.disabled ? IconButtonState.Disabled : IconButtonState.Enabled}
       onClick={handleClick}
-      disabled={props.disabled}
-      title={props.title}
-    >
-      <Icon
-        icon={RefreshCw}
-        size={props.size ?? 'sm'}
-        class={animating() ? styles.spinning : ''}
-        onAnimationEnd={() => setAnimating(false)}
-      />
-    </button>
+      class={animating() ? styles.spinning : ''}
+      onAnimationEnd={() => setAnimating(false)}
+      {...rest}
+    />
   )
 }

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -7,10 +7,10 @@ import FileIcon from 'lucide-solid/icons/file'
 import FolderTree from 'lucide-solid/icons/folder-tree'
 import List from 'lucide-solid/icons/list'
 import LocateFixed from 'lucide-solid/icons/locate-fixed'
-import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import { createEffect, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { RefreshButton } from '~/components/common/RefreshButton'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { DirectoryTree } from './DirectoryTree'
 import * as styles from './FilesSection.css'
@@ -112,8 +112,7 @@ export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps
         onClick={() => props.onCollapseAll()}
         data-testid="files-collapse-all"
       />
-      <IconButton
-        icon={RefreshCw}
+      <RefreshButton
         iconSize="xs"
         size="sm"
         title="Refresh"

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -184,25 +184,6 @@ export const labelRow = style({
   gap: '6px',
 })
 
-export const refreshButton = style({
-  'all': 'unset',
-  'display': 'inline-flex',
-  'alignItems': 'center',
-  'justifyContent': 'center',
-  'padding': '2px',
-  'cursor': 'pointer',
-  'borderRadius': 'var(--radius-small)',
-  'color': 'var(--muted-foreground)',
-  ':hover': {
-    color: 'var(--foreground)',
-    backgroundColor: 'var(--card)',
-  },
-  ':disabled': {
-    cursor: 'not-allowed',
-    opacity: 0.6,
-  },
-})
-
 export const treeContainer = style({
   flex: 1,
   minHeight: 0,


### PR DESCRIPTION
## Motivation
`RefreshButton` was implemented as a raw `<button>` element with its own hand-rolled CSS class (`refreshButton` in `shared.css.ts`), duplicating layout, hover, disabled, and border-radius styles already provided by `IconButton`. This caused style drift and extra maintenance burden whenever `IconButton` changed.

## Modifications
- Rewrote `RefreshButton` to render an `<IconButton>` internally instead of a plain `<button>`, inheriting all standard button styling from the design system.
- Updated the `RefreshButtonProps` API: the single `size` prop (previously icon size) now maps to `IconButtonSize` for the container, and a new separate `iconSize` prop (`IconSizeName`, default `'sm'`) controls the icon size. Consumers that passed `size` for icon sizing must migrate to `iconSize`.
- Added `data-testid` passthrough to `RefreshButton` so callers can identify it in tests.
- Removed the `refreshButton` CSS class from `/frontend/src/styles/shared.css.ts` (19 lines deleted) since `IconButton` now covers all required styles.
- Simplified `FilesSectionHeaderActions` in `FilesSection.tsx`: replaced the manual `<IconButton icon={RefreshCw} ...>` wrapper with `<RefreshButton iconSize="xs" size="sm" ...>`, removing the direct `RefreshCw` icon import from that file.

## Result
`RefreshButton` is now a thin wrapper around `IconButton`, ensuring visual and behavioral consistency with all other icon buttons in the UI. There is no user-visible change in appearance or behavior. Callers that previously passed a single `size` prop for icon sizing must update to use `iconSize` instead.

🤖 Generated with Claude Code
