### PR TITLE
Upgrade E2EE to hybrid post-quantum Noise_NK and add runtime encryption mode discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LeapMux is an **AI coding agent multiplexer** that enables developers to run mul
 - **Git-Aware File Browser**: Browse files on remote backends with real-time git status, change/staged/unstaged filters, and inline diffs
 - **Rich File Viewer**: Syntax-highlighted source, image preview with zoom/pan, hex view for binaries, and side-by-side or unified diffs
 - **Git Worktree Management**: Agents and terminals auto-create isolated git worktrees per task, with dirty-worktree protection
-- **End-to-End Encryption**: All Frontend-Worker traffic is encrypted via hybrid post-quantum Noise_NK (X25519 + ML-KEM-768 + SLH-DSA) over multiplexed WebSocket channels
+- **End-to-End Encryption**: All Frontend-Worker traffic is encrypted via hybrid post-quantum Noise_NK (X25519 + ML-KEM-1024 + SLH-DSA) over multiplexed WebSocket channels
 - **Multi-Organization Support**: Create teams with role-based access control (Owner/Admin/Member)
 - **Workspace Sharing**: Collaborate by sharing workspaces with specific users or organization members
 - **Backend Management**: Register and manage multiple development backends with approval workflow
@@ -130,7 +130,7 @@ LeapMux is a single binary with these subcommands:
 ### Communication
 
 - **Frontend → Hub**: ConnectRPC (gRPC-compatible) for authentication, workspace management, and worker registration
-- **Frontend → Worker (via Hub relay)**: End-to-end encrypted channels using hybrid post-quantum Noise_NK (X25519 + ML-KEM-768 for key exchange, SLH-DSA for static key authentication, ChaChaPoly + BLAKE2b for transport), multiplexed over a single WebSocket connection through the Hub
+- **Frontend → Worker (via Hub relay)**: End-to-end encrypted channels using hybrid post-quantum Noise_NK (X25519 + ML-KEM-1024 for key exchange, SLH-DSA for static key authentication, ChaChaPoly + BLAKE2b for transport), multiplexed over a single WebSocket connection through the Hub
 - **Worker → Hub**: Standard gRPC with bidirectional streaming (over TCP or Unix domain socket).
   - Workers initiate outbound connections to the Hub, so they can run behind NATs, without requiring inbound port access.
   - For local workers on the same machine, connect via Unix domain socket using `unix:<socket-path>` as the Hub URL.
@@ -377,7 +377,7 @@ Tool and base image versions are centralized in the `versions.yaml` file at the 
 
 - **[Bun](https://bun.sh/)** - Runtime and package manager
 - **[ConnectRPC](https://connectrpc.com/)** - RPC client for browser
-- **[Noble](https://paulmillr.com/noble/)** - Cryptographic primitives for E2EE (X25519, ML-KEM-768, SLH-DSA, ChaCha20-Poly1305, BLAKE2b)
+- **[Noble](https://paulmillr.com/noble/)** - Cryptographic primitives for E2EE (X25519, ML-KEM-1024, SLH-DSA, ChaCha20-Poly1305, BLAKE2b)
 - **[Corvu](https://corvu.dev/)** - Resizable panel components
 - **[Lucide](https://lucide.dev/)** - Icon library
 - **[Milkdown](https://milkdown.dev/)** - Markdown editor

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LeapMux is an **AI coding agent multiplexer** that enables developers to run mul
 - **Git-Aware File Browser**: Browse files on remote backends with real-time git status, change/staged/unstaged filters, and inline diffs
 - **Rich File Viewer**: Syntax-highlighted source, image preview with zoom/pan, hex view for binaries, and side-by-side or unified diffs
 - **Git Worktree Management**: Agents and terminals auto-create isolated git worktrees per task, with dirty-worktree protection
-- **End-to-End Encryption**: All Frontend-Worker traffic is encrypted via Noise_NK over multiplexed WebSocket channels
+- **End-to-End Encryption**: All Frontend-Worker traffic is encrypted via hybrid post-quantum Noise_NK (X25519 + ML-KEM-768 + SLH-DSA) over multiplexed WebSocket channels
 - **Multi-Organization Support**: Create teams with role-based access control (Owner/Admin/Member)
 - **Workspace Sharing**: Collaborate by sharing workspaces with specific users or organization members
 - **Backend Management**: Register and manage multiple development backends with approval workflow
@@ -109,7 +109,7 @@ LeapMux is a single binary with these subcommands:
 **Frontend (SolidJS)**
 - Web application providing the user interface
 - Communicates with Hub via ConnectRPC (for auth and workspace management)
-- Establishes end-to-end encrypted channels to Workers (Noise_NK handshake, multiplexed WebSocket relay)
+- Establishes end-to-end encrypted channels to Workers (hybrid post-quantum Noise_NK handshake, multiplexed WebSocket relay)
 - Key pinning with TOFU (Trust On First Use) model for Worker identity verification
 - Manages UI state for workspaces, agents, terminals, and file browsing
 
@@ -130,7 +130,7 @@ LeapMux is a single binary with these subcommands:
 ### Communication
 
 - **Frontend → Hub**: ConnectRPC (gRPC-compatible) for authentication, workspace management, and worker registration
-- **Frontend → Worker (via Hub relay)**: End-to-end encrypted channels using Noise_NK_25519_ChaChaPoly_BLAKE2b, multiplexed over a single WebSocket connection through the Hub
+- **Frontend → Worker (via Hub relay)**: End-to-end encrypted channels using hybrid post-quantum Noise_NK (X25519 + ML-KEM-768 for key exchange, SLH-DSA for static key authentication, ChaChaPoly + BLAKE2b for transport), multiplexed over a single WebSocket connection through the Hub
 - **Worker → Hub**: Standard gRPC with bidirectional streaming (over TCP or Unix domain socket).
   - Workers initiate outbound connections to the Hub, so they can run behind NATs, without requiring inbound port access.
   - For local workers on the same machine, connect via Unix domain socket using `unix:<socket-path>` as the Hub URL.
@@ -377,7 +377,7 @@ Tool and base image versions are centralized in the `versions.yaml` file at the 
 
 - **[Bun](https://bun.sh/)** - Runtime and package manager
 - **[ConnectRPC](https://connectrpc.com/)** - RPC client for browser
-- **[Noble](https://paulmillr.com/noble/)** - Cryptographic primitives for E2EE (X25519, ChaCha20-Poly1305, BLAKE2b)
+- **[Noble](https://paulmillr.com/noble/)** - Cryptographic primitives for E2EE (X25519, ML-KEM-768, SLH-DSA, ChaCha20-Poly1305, BLAKE2b)
 - **[Corvu](https://corvu.dev/)** - Resizable panel components
 - **[Lucide](https://lucide.dev/)** - Icon library
 - **[Milkdown](https://milkdown.dev/)** - Markdown editor

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run `leapmux` with no subcommand for a zero-config, single-user setup. Hub and W
 │  └─────────────┘               │  └────────────┘  │  │
 │         ▲                      │  + SQLite        │  │
 │         │                      └──────────────────┘  │
-│         │ ConnectRPC + WebSocket (E2EE)              │
+│         │ ConnectRPC + WebSocket                      │
 └─────────┼────────────────────────────────────────────┘
           │
           ▼

--- a/cmd/leapmux/solo.go
+++ b/cmd/leapmux/solo.go
@@ -23,10 +23,14 @@ import (
 
 // soloState persists the auto-registered worker credentials.
 type soloState struct {
-	WorkerID   string `json:"worker_id"`
-	AuthToken  string `json:"auth_token"`
-	PublicKey  string `json:"public_key,omitempty"`
-	PrivateKey string `json:"private_key,omitempty"`
+	WorkerID         string `json:"worker_id"`
+	AuthToken        string `json:"auth_token"`
+	PublicKey        string `json:"public_key,omitempty"`
+	PrivateKey       string `json:"private_key,omitempty"`
+	MlkemPublicKey   string `json:"mlkem_public_key,omitempty"`
+	MlkemPrivateKey  string `json:"mlkem_private_key,omitempty"`
+	SlhdsaPublicKey  string `json:"slhdsa_public_key,omitempty"`
+	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"`
 }
 
 func runSolo(args []string, soloMode bool) error {
@@ -114,24 +118,40 @@ func runSolo(args []string, soloMode bool) error {
 		return fmt.Errorf("auto-register worker: %w", err)
 	}
 
-	// Ensure the worker has an X25519 keypair for E2EE channels.
-	if state.PublicKey == "" || state.PrivateKey == "" {
-		kp, kpErr := noiseutil.GenerateKeypair()
+	// Ensure the worker has a composite keypair for E2EE channels.
+	if state.PublicKey == "" || state.PrivateKey == "" || state.MlkemPublicKey == "" || state.MlkemPrivateKey == "" || state.SlhdsaPublicKey == "" || state.SlhdsaPrivateKey == "" {
+		ck, kpErr := noiseutil.GenerateCompositeKeypair()
 		if kpErr != nil {
 			stop()
 			wg.Wait()
-			return fmt.Errorf("generate keypair: %w", kpErr)
+			return fmt.Errorf("generate composite keypair: %w", kpErr)
 		}
-		state.PublicKey = base64.StdEncoding.EncodeToString(kp.Public)
-		state.PrivateKey = base64.StdEncoding.EncodeToString(kp.Private)
+		slhdsaPub, _ := ck.SlhdsaPublicKeyBytes()
+		slhdsaPriv, _ := ck.SlhdsaPrivateKey.MarshalBinary()
+		state.PublicKey = base64.StdEncoding.EncodeToString(ck.X25519Public)
+		state.PrivateKey = base64.StdEncoding.EncodeToString(ck.X25519Private)
+		state.MlkemPublicKey = base64.StdEncoding.EncodeToString(ck.MlkemPublicKeyBytes())
+		state.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
+		state.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
+		state.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
 		stateData, _ := json.MarshalIndent(state, "", "  ")
 		if writeErr := os.WriteFile(statePath, stateData, 0o600); writeErr != nil {
 			slog.Warn("failed to save keypair", "error", writeErr)
 		}
 	}
 
-	privateKey, _ := base64.StdEncoding.DecodeString(state.PrivateKey)
-	publicKey, _ := base64.StdEncoding.DecodeString(state.PublicKey)
+	compositeKey, ckErr := noiseutil.RestoreCompositeKeypair(
+		mustDecode64(state.PublicKey),
+		mustDecode64(state.PrivateKey),
+		mustDecode64(state.MlkemPrivateKey),
+		mustDecode64(state.SlhdsaPublicKey),
+		mustDecode64(state.SlhdsaPrivateKey),
+	)
+	if ckErr != nil {
+		stop()
+		wg.Wait()
+		return fmt.Errorf("restore composite keypair: %w", ckErr)
+	}
 
 	slog.Info(modeName+" worker registered",
 		"worker_id", state.WorkerID,
@@ -146,8 +166,7 @@ func runSolo(args []string, soloMode bool) error {
 			HubURL:              "unix:" + socketPath,
 			DataDir:             workerDataDir,
 			AuthToken:           state.AuthToken,
-			PrivateKey:          privateKey,
-			PublicKey:           publicKey,
+			CompositeKey:        compositeKey,
 			WorkerID:            state.WorkerID,
 			Version:             version,
 			DBMaxConns:          hubCfg.DBMaxConns,
@@ -233,4 +252,9 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 	}
 
 	return state, nil
+}
+
+func mustDecode64(s string) []byte {
+	b, _ := base64.StdEncoding.DecodeString(s)
+	return b
 }

--- a/cmd/leapmux/solo.go
+++ b/cmd/leapmux/solo.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/logging"
@@ -162,6 +163,10 @@ func runSolo(args []string, soloMode bool) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		encMode := leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
+		if soloMode {
+			encMode = leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED
+		}
 		if err := worker.Run(ctx, worker.RunConfig{
 			HubURL:              "unix:" + socketPath,
 			DataDir:             workerDataDir,
@@ -171,6 +176,7 @@ func runSolo(args []string, soloMode bool) error {
 			Version:             version,
 			DBMaxConns:          hubCfg.DBMaxConns,
 			AgentStartupTimeout: hubCfg.AgentStartupTimeout(),
+			EncryptionMode:      encMode,
 		}); err != nil {
 			slog.Error("worker error", "error", err)
 		}

--- a/cmd/leapmux/worker.go
+++ b/cmd/leapmux/worker.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	"github.com/leapmux/leapmux/internal/logging"
-	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	"github.com/leapmux/leapmux/internal/worker/config"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
@@ -53,11 +52,11 @@ func runWorker(args []string) error {
 		state = &config.State{}
 	}
 
-	// Ensure the worker has an X25519 keypair for E2EE channels.
-	// Generated before registration so the public key can be sent to the Hub.
-	generated, err := state.EnsureKeypair()
+	// Ensure the worker has a composite keypair for E2EE channels.
+	// Generated before registration so the public keys can be sent to the Hub.
+	generated, err := state.EnsureCompositeKeypair()
 	if err != nil {
-		return fmt.Errorf("ensure keypair: %w", err)
+		return fmt.Errorf("ensure composite keypair: %w", err)
 	}
 	if generated {
 		if err := cfg.SaveState(state); err != nil {
@@ -67,11 +66,12 @@ func runWorker(args []string) error {
 
 	if state.AuthToken == "" {
 		// No saved credentials — need to register.
-		publicKey, pkErr := state.PublicKeyBytes()
-		if pkErr != nil {
-			return fmt.Errorf("decode public key for registration: %w", pkErr)
+		compositeKey, ckErr := state.CompositeKeypair()
+		if ckErr != nil {
+			return fmt.Errorf("restore composite keypair for registration: %w", ckErr)
 		}
-		result, regErr := hub.Register(ctx, cfg.HubURL, version, publicKey)
+		slhdsaPub, _ := compositeKey.SlhdsaPublicKeyBytes()
+		result, regErr := hub.Register(ctx, cfg.HubURL, version, compositeKey.X25519Public, compositeKey.MlkemPublicKeyBytes(), slhdsaPub)
 		if regErr != nil {
 			return fmt.Errorf("registration: %w", regErr)
 		}
@@ -87,19 +87,15 @@ func runWorker(args []string) error {
 		slog.Info("credentials saved", "path", cfg.StatePath())
 	}
 
-	privateKey, err := state.PrivateKeyBytes()
+	compositeKey, err := state.CompositeKeypair()
 	if err != nil {
-		return fmt.Errorf("decode private key: %w", err)
-	}
-	publicKey, err := state.PublicKeyBytes()
-	if err != nil {
-		return fmt.Errorf("decode public key: %w", err)
+		return fmt.Errorf("restore composite keypair: %w", err)
 	}
 
 	slog.Info("starting worker",
 		"worker_id", state.WorkerID,
 		"hub", cfg.HubURL,
-		"key_fingerprint", noiseutil.KeyFingerprint(publicKey),
+		"key_fingerprint", compositeKey.Fingerprint(),
 	)
 
 	// Open the Worker-local database for persistent state.
@@ -123,7 +119,7 @@ func runWorker(args []string) error {
 	homeDir, _ := os.UserHomeDir()
 
 	// Set up E2EE channel manager with service handlers.
-	channelMgr := channel.NewManager(privateKey, publicKey, client.Send)
+	channelMgr := channel.NewManager(compositeKey, client.Send)
 	if cfg.MaxMessageSize > 0 {
 		channelMgr.SetMaxMessageSize(cfg.MaxMessageSize)
 	}
@@ -156,7 +152,10 @@ func runWorker(args []string) error {
 	})
 
 	client.SetChannelMgr(channelMgr)
-	client.PublicKey = publicKey
+	client.PublicKey = compositeKey.X25519Public
+	client.MlkemPublicKey = compositeKey.MlkemPublicKeyBytes()
+	slhdsaPub, _ := compositeKey.SlhdsaPublicKeyBytes()
+	client.SlhdsaPublicKey = slhdsaPub
 
 	client.OnDeregister = func() {
 		slog.Info("worker deregistered by hub, clearing state and shutting down")

--- a/cmd/leapmux/worker.go
+++ b/cmd/leapmux/worker.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/logging"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	"github.com/leapmux/leapmux/internal/worker/config"
@@ -96,6 +97,7 @@ func runWorker(args []string) error {
 		"worker_id", state.WorkerID,
 		"hub", cfg.HubURL,
 		"key_fingerprint", compositeKey.Fingerprint(),
+		"encryption_mode", cfg.EncryptionMode,
 	)
 
 	// Open the Worker-local database for persistent state.
@@ -119,7 +121,8 @@ func runWorker(args []string) error {
 	homeDir, _ := os.UserHomeDir()
 
 	// Set up E2EE channel manager with service handlers.
-	channelMgr := channel.NewManager(compositeKey, client.Send)
+	encMode := cfg.EncryptionModeProto()
+	channelMgr := channel.NewManager(compositeKey, encMode, client.Send)
 	if cfg.MaxMessageSize > 0 {
 		channelMgr.SetMaxMessageSize(cfg.MaxMessageSize)
 	}
@@ -152,10 +155,14 @@ func runWorker(args []string) error {
 	})
 
 	client.SetChannelMgr(channelMgr)
+	client.EncryptionMode = encMode
 	client.PublicKey = compositeKey.X25519Public
-	client.MlkemPublicKey = compositeKey.MlkemPublicKeyBytes()
-	slhdsaPub, _ := compositeKey.SlhdsaPublicKeyBytes()
-	client.SlhdsaPublicKey = slhdsaPub
+	if encMode != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC &&
+		encMode != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED {
+		client.MlkemPublicKey = compositeKey.MlkemPublicKeyBytes()
+		slhdsaPub, _ := compositeKey.SlhdsaPublicKeyBytes()
+		client.SlhdsaPublicKey = slhdsaPub
+	}
 
 	client.OnDeregister = func() {
 		slog.Info("worker deregistered by hub, clearing state and shutting down")

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -22,6 +22,7 @@
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.5.4",
         "@shikijs/rehype": "^4.0.2",
         "@solidjs/router": "^0.15.4",
         "@solidjs/start": "^1.3.2",
@@ -304,6 +305,8 @@
     "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@noble/post-quantum": ["@noble/post-quantum@0.5.4", "", { "dependencies": { "@noble/curves": "~2.0.0", "@noble/hashes": "~2.0.0" } }, "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
+    "@noble/post-quantum": "^0.5.4",
     "@shikijs/rehype": "^4.0.2",
     "@solidjs/router": "^0.15.4",
     "@solidjs/start": "^1.3.2",

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -20,7 +20,7 @@ import type {
   SendControlResponseResponse,
   UpdateAgentSettingsResponse,
 } from '~/generated/leapmux/v1/agent_pb'
-import type { InnerStreamMessage } from '~/generated/leapmux/v1/channel_pb'
+import type { EncryptionMode, InnerStreamMessage } from '~/generated/leapmux/v1/channel_pb'
 import type {
   ListDirectoryResponse,
   ReadFileResponse,
@@ -160,6 +160,11 @@ class BrowserChannelTransport implements ChannelTransport {
       mlkemPublicKey: resp.mlkemPublicKey,
       slhdsaPublicKey: resp.slhdsaPublicKey,
     }
+  }
+
+  async getWorkerEncryptionMode(workerId: string): Promise<EncryptionMode> {
+    const resp = await channelRpcClient.getWorkerEncryptionMode({ workerId })
+    return resp.encryptionMode
   }
 
   async openChannel(workerId: string, handshakePayload: Uint8Array): Promise<{ channelId: string, handshakePayload: Uint8Array }> {

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -51,7 +51,7 @@ import type {
   MoveTabWorkspaceResponse,
   WatchEventsResponse,
 } from '~/generated/leapmux/v1/workspace_pb'
-import type { ChannelTransport, KeyPinDecision } from '~/lib/channel'
+import type { ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '~/lib/channel'
 import { create, fromBinary, toBinary, toJsonString } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { getToken, transport } from '~/api/transport'
@@ -153,9 +153,13 @@ export function setGetUserId(fn: () => string): void {
 }
 
 class BrowserChannelTransport implements ChannelTransport {
-  async getWorkerPublicKey(workerId: string): Promise<Uint8Array> {
+  async getWorkerPublicKey(workerId: string): Promise<WorkerKeyBundle> {
     const resp = await channelRpcClient.getWorkerPublicKey({ workerId })
-    return resp.publicKey
+    return {
+      x25519PublicKey: resp.publicKey,
+      mlkemPublicKey: resp.mlkemPublicKey,
+      slhdsaPublicKey: resp.slhdsaPublicKey,
+    }
   }
 
   async openChannel(workerId: string, handshakePayload: Uint8Array): Promise<{ channelId: string, handshakePayload: Uint8Array }> {

--- a/frontend/src/components/shell/CollapsibleSidebar.test.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.test.tsx
@@ -237,6 +237,6 @@ describe('collapsibleSidebar', () => {
     // Sidebar inner container should be hidden (content stays mounted)
     expect(screen.getByTestId('sidebar-left').style.display).toBe('none')
     // Expand button should be visible
-    expect(screen.getByTitle('Expand left sidebar')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Expand left sidebar' })).toBeTruthy()
   })
 })

--- a/frontend/src/lib/channel.test.ts
+++ b/frontend/src/lib/channel.test.ts
@@ -1,4 +1,4 @@
-import type { ChannelTransport, KeyPinDecision } from './channel'
+import type { ChannelTransport, KeyPinDecision, WorkerKeyBundle } from './channel'
 import type { Session } from './noise'
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
 import { chacha20poly1305 } from '@noble/ciphers/chacha.js'
@@ -175,10 +175,14 @@ const sessions = new Map<string, { initiator: Session, responder: Session }>()
 
 function createMockTransport(mockWs: MockWebSocket): ChannelTransport {
   return {
-    async getWorkerPublicKey(_workerId: string): Promise<Uint8Array> {
-      // Return a dummy 32-byte key. The real handshake is bypassed
+    async getWorkerPublicKey(_workerId: string): Promise<WorkerKeyBundle> {
+      // Return dummy keys. The real handshake is bypassed
       // since we mock initiatorHandshake1/2.
-      return new Uint8Array(32)
+      return {
+        x25519PublicKey: new Uint8Array(32),
+        mlkemPublicKey: new Uint8Array(1568),
+        slhdsaPublicKey: new Uint8Array(64),
+      }
     },
     async openChannel(_workerId: string, _handshakePayload: Uint8Array) {
       const channelId = `ch-${Math.random().toString(36).slice(2, 8)}`
@@ -186,7 +190,7 @@ function createMockTransport(mockWs: MockWebSocket): ChannelTransport {
       sessions.set(channelId, pair)
       // Return the handshake payload that initiatorHandshake2 expects.
       // Since we mock the handshake functions, the actual bytes don't matter.
-      return { channelId, handshakePayload: new Uint8Array(48) }
+      return { channelId, handshakePayload: new Uint8Array(49904) }
     },
     async closeChannel(_channelId: string) {},
     createWebSocket(): WebSocket {
@@ -203,14 +207,14 @@ function createMockTransport(mockWs: MockWebSocket): ChannelTransport {
 
 // ---- Mock handshake functions (injected via ChannelManager DI) ----
 
-function mockHandshake1(_publicKey: Uint8Array) {
+function mockHandshake1(_remoteX25519Pub: Uint8Array, _remoteMlkemPub: Uint8Array) {
   return {
     handshakeState: {} as any,
-    message1: new Uint8Array(48),
+    message1: new Uint8Array(1616),
   }
 }
 
-function mockHandshake2(_state: any, _message2: Uint8Array) {
+function mockHandshake2(_state: any, _message2: Uint8Array, _remoteSlhdsaPub: Uint8Array) {
   const entries = [...sessions.entries()]
   const lastEntry = entries.at(-1)
   if (!lastEntry)

--- a/frontend/src/lib/channel.test.ts
+++ b/frontend/src/lib/channel.test.ts
@@ -5,6 +5,7 @@ import { chacha20poly1305 } from '@noble/ciphers/chacha.js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ChannelMessageSchema,
+  EncryptionMode,
   InnerMessageSchema,
   InnerRpcRequestSchema,
   InnerRpcResponseSchema,
@@ -183,6 +184,9 @@ function createMockTransport(mockWs: MockWebSocket): ChannelTransport {
         mlkemPublicKey: new Uint8Array(1568),
         slhdsaPublicKey: new Uint8Array(64),
       }
+    },
+    async getWorkerEncryptionMode(_workerId: string): Promise<EncryptionMode> {
+      return EncryptionMode.POST_QUANTUM
     },
     async openChannel(_workerId: string, _handshakePayload: Uint8Array) {
       const channelId = `ch-${Math.random().toString(36).slice(2, 8)}`
@@ -986,6 +990,194 @@ describe('channelManager', () => {
       // Close the channel — should not crash and should clean up.
       await mgr.closeChannel(channelId)
       expect(mgr.isOpen(channelId)).toBe(false)
+    })
+  })
+
+  describe('encryption modes', () => {
+    it('should open a channel with disabled encryption (passthrough)', async () => {
+      // Create a transport that returns DISABLED mode.
+      const disabledWs = new MockWebSocket()
+      const disabledTransport: ChannelTransport = {
+        async getWorkerPublicKey(_workerId: string): Promise<WorkerKeyBundle> {
+          return {
+            x25519PublicKey: new Uint8Array(32),
+            mlkemPublicKey: new Uint8Array(0),
+            slhdsaPublicKey: new Uint8Array(0),
+          }
+        },
+        async getWorkerEncryptionMode(_workerId: string): Promise<EncryptionMode> {
+          return EncryptionMode.DISABLED
+        },
+        async openChannel(_workerId: string, handshakePayload: Uint8Array) {
+          // Disabled mode sends empty handshake.
+          expect(handshakePayload.length).toBe(0)
+          const channelId = `ch-disabled-${Math.random().toString(36).slice(2, 8)}`
+          return { channelId, handshakePayload: new Uint8Array(0) }
+        },
+        async closeChannel(_channelId: string) {},
+        createWebSocket(): WebSocket {
+          return disabledWs as any
+        },
+        async confirmKeyPin(): Promise<KeyPinDecision> {
+          return 'accept'
+        },
+        getUserId(): string {
+          return 'test-user-id'
+        },
+      }
+
+      const disabledMgr = new ChannelManager(disabledTransport)
+
+      const openPromise = disabledMgr.openChannel('w-disabled')
+      await flushMicrotasks()
+      disabledWs.readyState = MockWebSocket.OPEN
+      disabledWs.simulateOpen()
+      await flushMicrotasks()
+
+      // Simulate claim accept — passthrough means plaintext is sent as-is.
+      const lastSent = disabledWs.sent.at(-1)
+      const sentMsg = decodeWireMessage(lastSent)
+      const chId = sentMsg.channelId
+
+      // In disabled mode, ciphertext IS the plaintext (passthrough).
+      const claimPlaintext = sentMsg.ciphertext
+      const claimEnvelope = fromBinary(InnerMessageSchema, claimPlaintext)
+      expect(claimEnvelope.kind.case).toBe('userIdClaim')
+
+      // Send back a successful claim response — also in plaintext.
+      const claimResp = create(UserIdClaimResponseSchema, { success: true })
+      const respEnv = create(InnerMessageSchema, {
+        kind: { case: 'userIdClaimResponse', value: claimResp },
+      })
+      const respPlaintext = toBinary(InnerMessageSchema, respEnv)
+      disabledWs.simulateMessage(encodeWireMessage(chId, respPlaintext))
+
+      const channelId = await openPromise
+      expect(disabledMgr.isOpen(channelId)).toBe(true)
+
+      // Send a call and verify it works with passthrough.
+      const callPromise = disabledMgr.call(channelId, 'TestMethod', new Uint8Array([1, 2, 3]))
+
+      const reqSentMsg = decodeWireMessage(disabledWs.sent.at(-1))
+      const reqPlaintext = reqSentMsg.ciphertext // passthrough: ciphertext = plaintext
+      const reqEnvelope = fromBinary(InnerMessageSchema, reqPlaintext)
+      expect(reqEnvelope.kind.case).toBe('request')
+
+      // Respond in plaintext.
+      const rpcResp = create(InnerRpcResponseSchema, {
+        payload: new Uint8Array([4, 5, 6]),
+        isError: false,
+      })
+      const rpcRespEnv = create(InnerMessageSchema, {
+        kind: { case: 'response', value: rpcResp },
+      })
+      const rpcRespPt = toBinary(InnerMessageSchema, rpcRespEnv)
+      disabledWs.simulateMessage(encodeWireMessage(channelId, rpcRespPt, { id: 1 }))
+
+      const resp = await callPromise
+      expect(resp.payload).toEqual(new Uint8Array([4, 5, 6]))
+
+      disabledMgr.closeAll()
+    })
+
+    it('should open a channel with classic encryption (X25519 only)', async () => {
+      // Create a transport that returns CLASSIC mode.
+      const classicWs = new MockWebSocket()
+      const classicSessions = new Map<string, { initiator: Session, responder: Session }>()
+
+      const classicTransport: ChannelTransport = {
+        async getWorkerPublicKey(_workerId: string): Promise<WorkerKeyBundle> {
+          return {
+            x25519PublicKey: new Uint8Array(32),
+            mlkemPublicKey: new Uint8Array(0),
+            slhdsaPublicKey: new Uint8Array(0),
+          }
+        },
+        async getWorkerEncryptionMode(_workerId: string): Promise<EncryptionMode> {
+          return EncryptionMode.CLASSIC
+        },
+        async openChannel(_workerId: string, _handshakePayload: Uint8Array) {
+          const channelId = `ch-classic-${Math.random().toString(36).slice(2, 8)}`
+          const pair = createTestSession()
+          classicSessions.set(channelId, pair)
+          return { channelId, handshakePayload: new Uint8Array(48) }
+        },
+        async closeChannel(_channelId: string) {},
+        createWebSocket(): WebSocket {
+          return classicWs as any
+        },
+        async confirmKeyPin(): Promise<KeyPinDecision> {
+          return 'accept'
+        },
+        getUserId(): string {
+          return 'test-user-id'
+        },
+      }
+
+      // Mock classic handshake functions.
+      function mockClassicHS1(_remoteX25519Pub: Uint8Array) {
+        return {
+          handshakeState: {} as any,
+          message1: new Uint8Array(48),
+        }
+      }
+
+      function mockClassicHS2(_state: any, _message2: Uint8Array) {
+        const entries = [...classicSessions.entries()]
+        const lastEntry = entries.at(-1)
+        if (!lastEntry)
+          throw new Error('No session registered')
+        return lastEntry[1].initiator
+      }
+
+      const classicMgr = new ChannelManager(classicTransport, {
+        classicHandshake1: mockClassicHS1,
+        classicHandshake2: mockClassicHS2,
+      })
+
+      const openPromise = classicMgr.openChannel('w-classic')
+      await flushMicrotasks()
+      classicWs.readyState = MockWebSocket.OPEN
+      classicWs.simulateOpen()
+      await flushMicrotasks()
+
+      // Simulate claim accept (encrypted with test session).
+      const lastSent = classicWs.sent.at(-1)
+      const sentMsg = decodeWireMessage(lastSent)
+      const chId = sentMsg.channelId
+      const pair = classicSessions.get(chId)!
+
+      pair.responder.receive.decrypt(sentMsg.ciphertext)
+
+      const claimResp = create(UserIdClaimResponseSchema, { success: true })
+      const claimEnv = create(InnerMessageSchema, {
+        kind: { case: 'userIdClaimResponse', value: claimResp },
+      })
+      const claimPt = toBinary(InnerMessageSchema, claimEnv)
+      const claimCt = pair.responder.send.encrypt(claimPt)
+      classicWs.simulateMessage(encodeWireMessage(chId, claimCt))
+
+      const channelId = await openPromise
+      expect(classicMgr.isOpen(channelId)).toBe(true)
+
+      // Verify a call works through the encrypted channel.
+      const callPromise = classicMgr.call(channelId, 'TestMethod', new Uint8Array([1, 2]))
+
+      const resp = create(InnerRpcResponseSchema, {
+        payload: new Uint8Array([3, 4]),
+        isError: false,
+      })
+      const respEnv = create(InnerMessageSchema, {
+        kind: { case: 'response', value: resp },
+      })
+      const respPt = toBinary(InnerMessageSchema, respEnv)
+      const respCt = pair.responder.send.encrypt(respPt)
+      classicWs.simulateMessage(encodeWireMessage(channelId, respCt, { id: 1 }))
+
+      const result = await callPromise
+      expect(result.payload).toEqual(new Uint8Array([3, 4]))
+
+      classicMgr.closeAll()
     })
   })
 

--- a/frontend/src/lib/channel.ts
+++ b/frontend/src/lib/channel.ts
@@ -21,12 +21,13 @@ import { create, fromBinary, toBinary, toJsonString } from '@bufbuild/protobuf'
 import {
   ChannelMessageFlags,
   ChannelMessageSchema,
+  EncryptionMode,
   InnerMessageSchema,
   InnerRpcRequestSchema,
   UserIdClaimSchema,
 } from '~/generated/leapmux/v1/channel_pb'
 import { createLogger } from './logger'
-import { concatBytes } from './noise'
+import { initiatorHandshake1 as classicHandshake1, initiatorHandshake2 as classicHandshake2, concatBytes } from './noise'
 import { initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
 import { safeGetJson, safeRemoveItem, safeSetJson } from './safeStorage'
 
@@ -65,6 +66,7 @@ export interface WorkerKeyBundle {
 /** Transport interface for platform-specific RPC and WebSocket creation. */
 export interface ChannelTransport {
   getWorkerPublicKey: (workerId: string) => Promise<WorkerKeyBundle>
+  getWorkerEncryptionMode: (workerId: string) => Promise<EncryptionMode>
   openChannel: (workerId: string, handshakePayload: Uint8Array) => Promise<{ channelId: string, handshakePayload: Uint8Array }>
   closeChannel: (channelId: string) => Promise<void>
   createWebSocket: () => WebSocket
@@ -124,9 +126,38 @@ const DEFAULT_RPC_TIMEOUT_MS = 10_000
 export interface ChannelManagerOpts {
   handshake1?: typeof initiatorHandshake1
   handshake2?: typeof initiatorHandshake2
+  classicHandshake1?: typeof classicHandshake1
+  classicHandshake2?: typeof classicHandshake2
   maxMessageSize?: number
   /** Timeout for individual RPC calls in milliseconds. Defaults to 30s. */
   rpcTimeout?: number
+}
+
+/** A no-op cipher that passes data through without encryption (disabled mode). */
+class PassthroughCipher {
+  encrypt(plaintext: Uint8Array): Uint8Array {
+    const out = new Uint8Array(plaintext.length)
+    out.set(plaintext)
+    return out
+  }
+
+  decrypt(ciphertext: Uint8Array): Uint8Array {
+    const out = new Uint8Array(ciphertext.length)
+    out.set(ciphertext)
+    return out
+  }
+
+  needsRekey(): boolean {
+    return false
+  }
+}
+
+/** Create a passthrough session that passes data through without encryption. */
+function createPassthroughSession(): Session {
+  return {
+    send: new PassthroughCipher() as any,
+    receive: new PassthroughCipher() as any,
+  }
 }
 
 /** ChannelManager manages encrypted E2EE channels to Workers. */
@@ -137,6 +168,8 @@ export class ChannelManager {
   private wsPromise: Promise<void> | null = null
   private handshake1: typeof initiatorHandshake1
   private handshake2: typeof initiatorHandshake2
+  private classicHS1: typeof classicHandshake1
+  private classicHS2: typeof classicHandshake2
   private maxMessageSize: number
   private rpcTimeout: number
   /** Workers whose keys were rejected by the user during this session. */
@@ -150,6 +183,8 @@ export class ChannelManager {
     this.transport = transport
     this.handshake1 = opts?.handshake1 ?? initiatorHandshake1
     this.handshake2 = opts?.handshake2 ?? initiatorHandshake2
+    this.classicHS1 = opts?.classicHandshake1 ?? classicHandshake1
+    this.classicHS2 = opts?.classicHandshake2 ?? classicHandshake2
     this.maxMessageSize = opts?.maxMessageSize ?? DEFAULT_MAX_MESSAGE_SIZE
     this.rpcTimeout = opts?.rpcTimeout ?? DEFAULT_RPC_TIMEOUT_MS
   }
@@ -193,46 +228,68 @@ export class ChannelManager {
    * and connects the shared WebSocket relay.
    */
   async openChannel(workerId: string): Promise<string> {
-    // 1. Get Worker's key bundle (X25519 + ML-KEM + SLH-DSA).
-    const keyBundle = await this.transport.getWorkerPublicKey(workerId)
+    // 1. Get Worker's encryption mode from live connection, then fetch keys.
+    const mode = await this.transport.getWorkerEncryptionMode(workerId)
+    const keyBundle = mode !== EncryptionMode.DISABLED
+      ? await this.transport.getWorkerPublicKey(workerId)
+      : { x25519PublicKey: new Uint8Array(0), mlkemPublicKey: new Uint8Array(0), slhdsaPublicKey: new Uint8Array(0) }
 
-    // 2. Key pinning (TOFU model) — pin composite key.
-    const compositeKeyBytes = concatBytes(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey, keyBundle.slhdsaPublicKey)
-    const publicKeyHex = bytesToHex(compositeKeyBytes)
-    const pinKey = `leapmux:key-pin:${workerId}`
-    const pinned = safeGetJson<{ publicKeyHex: string, firstSeen: number }>(pinKey)
+    // 2. Key pinning (TOFU model) — pin composite key (skip for disabled mode).
+    let pinKey = ''
+    let pinned: { publicKeyHex: string, firstSeen: number } | null = null
+    let publicKeyHex = ''
 
-    if (pinned && pinned.publicKeyHex !== publicKeyHex) {
-      // Auto-reject if the user already rejected this worker in this session.
-      if (this.rejectedWorkers.has(workerId)) {
-        throw new ChannelError('client', 'Worker public key rejected by user')
+    if (mode !== EncryptionMode.DISABLED) {
+      const compositeKeyBytes = concatBytes(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey, keyBundle.slhdsaPublicKey)
+      publicKeyHex = bytesToHex(compositeKeyBytes)
+      pinKey = `leapmux:key-pin:${workerId}`
+      pinned = safeGetJson<{ publicKeyHex: string, firstSeen: number }>(pinKey) ?? null
+
+      if (pinned && pinned.publicKeyHex !== publicKeyHex) {
+        // Auto-reject if the user already rejected this worker in this session.
+        if (this.rejectedWorkers.has(workerId)) {
+          throw new ChannelError('client', 'Worker public key rejected by user')
+        }
+
+        // Key mismatch — ask user.
+        const { keyFingerprintHex } = await import('./fingerprint')
+        const decision = await this.transport.confirmKeyPin(
+          workerId,
+          keyFingerprintHex(pinned.publicKeyHex),
+          keyFingerprintHex(publicKeyHex),
+        )
+        if (decision === 'reject') {
+          this.rejectedWorkers.add(workerId)
+          throw new ChannelError('client', 'Worker public key rejected by user')
+        }
+        // User accepted the new key.
+        safeSetJson(pinKey, { publicKeyHex, firstSeen: Date.now() })
       }
-
-      // Key mismatch — ask user.
-      const { keyFingerprintHex } = await import('./fingerprint')
-      const decision = await this.transport.confirmKeyPin(
-        workerId,
-        keyFingerprintHex(pinned.publicKeyHex),
-        keyFingerprintHex(publicKeyHex),
-      )
-      if (decision === 'reject') {
-        this.rejectedWorkers.add(workerId)
-        throw new ChannelError('client', 'Worker public key rejected by user')
-      }
-      // User accepted the new key.
-      safeSetJson(pinKey, { publicKeyHex, firstSeen: Date.now() })
     }
 
-    // 3. Perform hybrid Noise_NK handshake (message 1).
-    const { handshakeState, message1 } = this.handshake1(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey)
+    // 3. Perform handshake based on encryption mode.
+    let session: Session
+    let result: { channelId: string, handshakePayload: Uint8Array }
 
-    // 4. Send handshake via Hub and get response.
-    const result = await this.transport.openChannel(workerId, message1)
+    if (mode === EncryptionMode.DISABLED) {
+      // No encryption — open channel with empty handshake, use passthrough session.
+      result = await this.transport.openChannel(workerId, new Uint8Array(0))
+      session = createPassthroughSession()
+    }
+    else if (mode === EncryptionMode.CLASSIC) {
+      // Classical Noise_NK (X25519 only).
+      const hs = this.classicHS1(keyBundle.x25519PublicKey)
+      result = await this.transport.openChannel(workerId, hs.message1)
+      session = this.classicHS2(hs.handshakeState, result.handshakePayload)
+    }
+    else {
+      // Post-quantum hybrid Noise_NK (X25519 + ML-KEM + SLH-DSA).
+      const hs = this.handshake1(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey)
+      result = await this.transport.openChannel(workerId, hs.message1)
+      session = this.handshake2(hs.handshakeState, result.handshakePayload, keyBundle.slhdsaPublicKey)
+    }
 
-    // 5. Complete hybrid handshake (message 2) — verifies SLH-DSA signature.
-    const session = this.handshake2(handshakeState, result.handshakePayload, keyBundle.slhdsaPublicKey)
-
-    // 6. Ensure shared WebSocket is connected.
+    // 4. Ensure shared WebSocket is connected.
     await this.ensureWebSocket()
 
     const channel: ActiveChannel = {
@@ -249,12 +306,12 @@ export class ChannelManager {
 
     this.channels.set(result.channelId, channel)
 
-    // 7. Pin key on first use (TOFU).
-    if (!pinned) {
+    // 5. Pin key on first use (TOFU) — skip for disabled mode.
+    if (mode !== EncryptionMode.DISABLED && !pinned) {
       safeSetJson(pinKey, { publicKeyHex, firstSeen: Date.now() })
     }
 
-    // 8. Send UserIdClaim as first encrypted message.
+    // 6. Send UserIdClaim as first encrypted message.
     try {
       await this.sendUserIdClaim(channel)
     }

--- a/frontend/src/lib/channel.ts
+++ b/frontend/src/lib/channel.ts
@@ -26,7 +26,8 @@ import {
   UserIdClaimSchema,
 } from '~/generated/leapmux/v1/channel_pb'
 import { createLogger } from './logger'
-import { initiatorHandshake1, initiatorHandshake2 } from './noise'
+import { concatBytes } from './noise'
+import { initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
 import { safeGetJson, safeRemoveItem, safeSetJson } from './safeStorage'
 
 const log = createLogger('channel')
@@ -54,9 +55,16 @@ export class ChannelError extends Error {
   }
 }
 
+/** Worker key bundle returned by transport. */
+export interface WorkerKeyBundle {
+  x25519PublicKey: Uint8Array
+  mlkemPublicKey: Uint8Array
+  slhdsaPublicKey: Uint8Array
+}
+
 /** Transport interface for platform-specific RPC and WebSocket creation. */
 export interface ChannelTransport {
-  getWorkerPublicKey: (workerId: string) => Promise<Uint8Array>
+  getWorkerPublicKey: (workerId: string) => Promise<WorkerKeyBundle>
   openChannel: (workerId: string, handshakePayload: Uint8Array) => Promise<{ channelId: string, handshakePayload: Uint8Array }>
   closeChannel: (channelId: string) => Promise<void>
   createWebSocket: () => WebSocket
@@ -185,11 +193,12 @@ export class ChannelManager {
    * and connects the shared WebSocket relay.
    */
   async openChannel(workerId: string): Promise<string> {
-    // 1. Get Worker's public key.
-    const publicKey = await this.transport.getWorkerPublicKey(workerId)
+    // 1. Get Worker's key bundle (X25519 + ML-KEM + SLH-DSA).
+    const keyBundle = await this.transport.getWorkerPublicKey(workerId)
 
-    // 2. Key pinning (TOFU model).
-    const publicKeyHex = bytesToHex(publicKey)
+    // 2. Key pinning (TOFU model) — pin composite key.
+    const compositeKeyBytes = concatBytes(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey, keyBundle.slhdsaPublicKey)
+    const publicKeyHex = bytesToHex(compositeKeyBytes)
     const pinKey = `leapmux:key-pin:${workerId}`
     const pinned = safeGetJson<{ publicKeyHex: string, firstSeen: number }>(pinKey)
 
@@ -214,14 +223,14 @@ export class ChannelManager {
       safeSetJson(pinKey, { publicKeyHex, firstSeen: Date.now() })
     }
 
-    // 3. Perform Noise_NK handshake (message 1).
-    const { handshakeState, message1 } = this.handshake1(publicKey)
+    // 3. Perform hybrid Noise_NK handshake (message 1).
+    const { handshakeState, message1 } = this.handshake1(keyBundle.x25519PublicKey, keyBundle.mlkemPublicKey)
 
     // 4. Send handshake via Hub and get response.
     const result = await this.transport.openChannel(workerId, message1)
 
-    // 5. Complete handshake (message 2).
-    const session = this.handshake2(handshakeState, result.handshakePayload)
+    // 5. Complete hybrid handshake (message 2) — verifies SLH-DSA signature.
+    const session = this.handshake2(handshakeState, result.handshakePayload, keyBundle.slhdsaPublicKey)
 
     // 6. Ensure shared WebSocket is connected.
     await this.ensureWebSocket()

--- a/frontend/src/lib/noise-hybrid.test.ts
+++ b/frontend/src/lib/noise-hybrid.test.ts
@@ -1,0 +1,254 @@
+import { chacha20poly1305 } from '@noble/ciphers/chacha.js'
+import { x25519 } from '@noble/curves/ed25519.js'
+import { blake2b } from '@noble/hashes/blake2.js'
+/**
+ * Tests for hybrid post-quantum Noise_NK handshake.
+ *
+ * Simulates the responder (Worker) side in TypeScript to test the
+ * initiator implementation in noise-hybrid.ts.
+ */
+import { ml_kem1024 } from '@noble/post-quantum/ml-kem.js'
+import { slh_dsa_shake_256f } from '@noble/post-quantum/slh-dsa.js'
+
+import { describe, expect, it } from 'vitest'
+import { concatBytes, hkdf } from './noise'
+import { initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
+
+const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
+const DH_LEN = 32
+const AEAD_TAG_SIZE = 16
+
+function encrypt(key: Uint8Array, nonce: number, ad: Uint8Array, plaintext: Uint8Array): Uint8Array {
+  const nonceBytes = new Uint8Array(12)
+  new DataView(nonceBytes.buffer).setUint32(4, nonce, true)
+  return chacha20poly1305(key, nonceBytes, ad).encrypt(plaintext)
+}
+
+function decrypt(key: Uint8Array, nonce: number, ad: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+  const nonceBytes = new Uint8Array(12)
+  new DataView(nonceBytes.buffer).setUint32(4, nonce, true)
+  return chacha20poly1305(key, nonceBytes, ad).decrypt(ciphertext)
+}
+
+interface SimpleCipherState {
+  k: Uint8Array
+  n: number
+}
+
+/**
+ * Minimal hybrid responder handshake for testing.
+ */
+function responderHandshake(
+  x25519Priv: Uint8Array,
+  x25519Pub: Uint8Array,
+  mlkemPriv: Uint8Array,
+  slhdsaPriv: Uint8Array,
+  message1: Uint8Array,
+): {
+  message2: Uint8Array
+  send: SimpleCipherState
+  receive: SimpleCipherState
+} {
+  const noiseMsg1Len = DH_LEN + AEAD_TAG_SIZE // 48
+  const mlkemCT = message1.slice(noiseMsg1Len)
+
+  // Init symmetric state.
+  const nameBytes = new TextEncoder().encode(PROTOCOL_NAME)
+  let h = new Uint8Array(64)
+  h.set(nameBytes)
+  let ck = new Uint8Array(h)
+  let hasK = false
+  let k = new Uint8Array(32)
+  let n = 0
+
+  function mixHash(data: Uint8Array) {
+    h = blake2b(concatBytes(h, data))
+  }
+  function mixKey(ikm: Uint8Array) {
+    const [newCk, tempK] = hkdf(ck, ikm)
+    ck = new Uint8Array(newCk)
+    k = new Uint8Array(tempK.slice(0, 32))
+    n = 0
+    hasK = true
+  }
+  function decryptAndHash(ct: Uint8Array): Uint8Array {
+    if (!hasK) {
+      mixHash(ct)
+      return ct
+    }
+    const pt = decrypt(k, n, h, ct)
+    mixHash(ct)
+    n++
+    return pt
+  }
+  function encryptAndHash(pt: Uint8Array): Uint8Array {
+    if (!hasK) {
+      mixHash(pt)
+      return pt
+    }
+    const ct = encrypt(k, n, h, pt)
+    mixHash(ct)
+    n++
+    return ct
+  }
+
+  // Mix empty prologue.
+  mixHash(new Uint8Array(0))
+
+  // Pre-message: <- s
+  mixHash(x25519Pub)
+
+  // Read message 1: -> e, es
+  const re = message1.slice(0, DH_LEN)
+  mixHash(re)
+
+  const dhES = x25519.getSharedSecret(x25519Priv, re)
+  mixKey(dhES)
+
+  decryptAndHash(message1.slice(DH_LEN, noiseMsg1Len))
+
+  // Write message 2: <- e, ee
+  const ePriv = x25519.utils.randomSecretKey()
+  const ePub = x25519.getPublicKey(ePriv)
+  mixHash(ePub)
+
+  const dhEE = x25519.getSharedSecret(ePriv, re)
+  mixKey(dhEE)
+
+  const encPayload = encryptAndHash(new Uint8Array(0))
+  const noiseMsg2 = concatBytes(ePub, encPayload)
+
+  // ML-KEM decapsulation.
+  const mlkemSS = ml_kem1024.decapsulate(mlkemCT, mlkemPriv)
+
+  // Compute transcript: BLAKE2b(h || mlkem_ct || mlkem_ss)
+  const transcript = blake2b(concatBytes(h, mlkemCT, mlkemSS))
+
+  // Sign transcript with SLH-DSA.
+  const sig = slh_dsa_shake_256f.sign(transcript, slhdsaPriv)
+
+  // Hybrid split: mix ML-KEM SS into ck before deriving keys.
+  const [ck2] = hkdf(ck, mlkemSS)
+  ck = ck2
+  const [tempK1, tempK2] = hkdf(ck, new Uint8Array(0))
+
+  return {
+    message2: concatBytes(noiseMsg2, sig),
+    send: { k: tempK1.slice(0, 32), n: 0 },
+    receive: { k: tempK2.slice(0, 32), n: 0 },
+  }
+}
+
+function simpleCipherEncrypt(state: SimpleCipherState, plaintext: Uint8Array): Uint8Array {
+  const ct = encrypt(state.k, state.n, new Uint8Array(0), plaintext)
+  state.n++
+  return ct
+}
+
+function simpleCipherDecrypt(state: SimpleCipherState, ciphertext: Uint8Array): Uint8Array {
+  const pt = decrypt(state.k, state.n, new Uint8Array(0), ciphertext)
+  state.n++
+  return pt
+}
+
+describe('hybrid Noise_NK handshake', { timeout: 120_000 }, () => {
+  // Generate worker key bundle once — these are slow operations.
+  const x25519Priv = x25519.utils.randomSecretKey()
+  const x25519Pub = x25519.getPublicKey(x25519Priv)
+  const mlkemKeys = ml_kem1024.keygen()
+  const slhdsaKeys = slh_dsa_shake_256f.keygen()
+
+  it('should complete a full hybrid handshake and exchange messages', () => {
+    // Initiator creates message 1.
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    expect(message1.length).toBe(48 + 1568) // noiseMsg1 + mlkemCT
+
+    // Responder processes and creates message 2.
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+    expect(responder.message2.length).toBe(48 + 49856) // noiseMsg2 + slhdsaSig
+
+    // Initiator completes handshake.
+    const session = initiatorHandshake2(handshakeState, responder.message2, slhdsaKeys.publicKey)
+
+    // Test initiator → responder.
+    const msg1 = new TextEncoder().encode('hello from initiator')
+    const ct1 = session.send.encrypt(msg1)
+    const pt1 = simpleCipherDecrypt(responder.receive, ct1)
+    expect(new TextDecoder().decode(pt1)).toBe('hello from initiator')
+
+    // Test responder → initiator.
+    const msg2 = new TextEncoder().encode('hello from responder')
+    const ct2 = simpleCipherEncrypt(responder.send, msg2)
+    const pt2 = session.receive.decrypt(ct2)
+    expect(new TextDecoder().decode(pt2)).toBe('hello from responder')
+  })
+
+  it('should handle multiple messages in sequence', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+    const session = initiatorHandshake2(handshakeState, responder.message2, slhdsaKeys.publicKey)
+
+    for (let i = 0; i < 50; i++) {
+      const fwd = new TextEncoder().encode(`forward-${i}`)
+      const fwdCt = session.send.encrypt(fwd)
+      const fwdPt = simpleCipherDecrypt(responder.receive, fwdCt)
+      expect(new TextDecoder().decode(fwdPt)).toBe(`forward-${i}`)
+
+      const bwd = new TextEncoder().encode(`backward-${i}`)
+      const bwdCt = simpleCipherEncrypt(responder.send, bwd)
+      const bwdPt = session.receive.decrypt(bwdCt)
+      expect(new TextDecoder().decode(bwdPt)).toBe(`backward-${i}`)
+    }
+  })
+
+  it('should fail with wrong SLH-DSA key', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+
+    // Use a different SLH-DSA public key for verification.
+    const wrongKeys = slh_dsa_shake_256f.keygen()
+    expect(() => initiatorHandshake2(handshakeState, responder.message2, wrongKeys.publicKey))
+      .toThrow('SLH-DSA')
+  })
+
+  it('should fail with short message2', () => {
+    const { handshakeState } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    expect(() => initiatorHandshake2(handshakeState, new Uint8Array(16), slhdsaKeys.publicKey))
+      .toThrow('too short')
+  })
+
+  it('should encrypt empty messages', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+    const session = initiatorHandshake2(handshakeState, responder.message2, slhdsaKeys.publicKey)
+
+    const ct = session.send.encrypt(new Uint8Array(0))
+    expect(ct.length).toBeGreaterThan(0) // Auth tag
+    const pt = simpleCipherDecrypt(responder.receive, ct)
+    expect(pt.length).toBe(0)
+  })
+})

--- a/frontend/src/lib/noise-hybrid.test.ts
+++ b/frontend/src/lib/noise-hybrid.test.ts
@@ -12,7 +12,7 @@ import { slh_dsa_shake_256f } from '@noble/post-quantum/slh-dsa.js'
 
 import { describe, expect, it } from 'vitest'
 import { concatBytes, hkdf } from './noise'
-import { initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
+import { clearHandshakeState, initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
 const DH_LEN = 32
@@ -106,6 +106,9 @@ function responderHandshake(
   mixKey(dhES)
 
   decryptAndHash(message1.slice(DH_LEN, noiseMsg1Len))
+
+  // Bind ML-KEM ciphertext into the handshake hash (matches initiator's mixHash).
+  mixHash(mlkemCT)
 
   // Write message 2: <- e, ee
   const ePriv = x25519.utils.randomSecretKey()
@@ -232,7 +235,104 @@ describe('hybrid Noise_NK handshake', { timeout: 120_000 }, () => {
   it('should fail with short message2', () => {
     const { handshakeState } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
     expect(() => initiatorHandshake2(handshakeState, new Uint8Array(16), slhdsaKeys.publicKey))
-      .toThrow('too short')
+      .toThrow('wrong size')
+  })
+
+  it('should fail with oversized message2', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+    // Append an extra byte to the valid message2.
+    const oversized = new Uint8Array(responder.message2.length + 1)
+    oversized.set(responder.message2)
+    expect(() => initiatorHandshake2(handshakeState, oversized, slhdsaKeys.publicKey))
+      .toThrow('wrong size')
+  })
+
+  it('should zero handshake state after completing handshake', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+
+    // Verify sensitive material exists before handshake2.
+    expect(handshakeState.mlkemSS.length).toBeGreaterThan(0)
+    expect(handshakeState.mlkemCT.length).toBeGreaterThan(0)
+    expect(handshakeState.e.privateKey.length).toBeGreaterThan(0)
+
+    initiatorHandshake2(handshakeState, responder.message2, slhdsaKeys.publicKey)
+
+    // After handshake2, all sensitive fields should be zeroed.
+    expect(handshakeState.mlkemSS.every(b => b === 0)).toBe(true)
+    expect(handshakeState.mlkemCT.every(b => b === 0)).toBe(true)
+    expect(handshakeState.e.privateKey.every(b => b === 0)).toBe(true)
+    expect(handshakeState.ss.h.every(b => b === 0)).toBe(true)
+    expect(handshakeState.ss.ck.every(b => b === 0)).toBe(true)
+    expect(handshakeState.ss.k.every(b => b === 0)).toBe(true)
+  })
+
+  it('should zero handshake state on SLH-DSA verification failure', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      message1,
+    )
+
+    const wrongKeys = slh_dsa_shake_256f.keygen()
+    expect(() => initiatorHandshake2(handshakeState, responder.message2, wrongKeys.publicKey))
+      .toThrow('SLH-DSA')
+
+    // Even on failure, sensitive material should be zeroed.
+    expect(handshakeState.mlkemSS.every(b => b === 0)).toBe(true)
+    expect(handshakeState.e.privateKey.every(b => b === 0)).toBe(true)
+  })
+
+  it('should zero handshake state via clearHandshakeState', () => {
+    const { handshakeState } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+
+    // Verify non-zero before clearing.
+    expect(handshakeState.mlkemSS.some(b => b !== 0)).toBe(true)
+
+    clearHandshakeState(handshakeState)
+
+    expect(handshakeState.mlkemSS.every(b => b === 0)).toBe(true)
+    expect(handshakeState.mlkemCT.every(b => b === 0)).toBe(true)
+    expect(handshakeState.e.privateKey.every(b => b === 0)).toBe(true)
+  })
+
+  it('should fail when ML-KEM ciphertext is tampered (handshake hash divergence)', () => {
+    const { handshakeState, message1 } = initiatorHandshake1(x25519Pub, mlkemKeys.publicKey)
+
+    // Tamper with the ML-KEM ciphertext portion (after the 48-byte Noise message).
+    const tampered = new Uint8Array(message1)
+    tampered[48] ^= 0xFF
+
+    // Responder processes tampered message — ML-KEM implicit rejection means
+    // decapsulation succeeds with a random shared secret.
+    const responder = responderHandshake(
+      x25519Priv,
+      x25519Pub,
+      mlkemKeys.secretKey,
+      slhdsaKeys.secretKey,
+      tampered,
+    )
+
+    // Initiator should fail because handshake hashes diverged
+    // (mixHash(mlkemCT) differs between initiator and responder).
+    expect(() => initiatorHandshake2(handshakeState, responder.message2, slhdsaKeys.publicKey))
+      .toThrow()
   })
 
   it('should encrypt empty messages', () => {

--- a/frontend/src/lib/noise-hybrid.ts
+++ b/frontend/src/lib/noise-hybrid.ts
@@ -60,6 +60,7 @@ export function initiatorHandshake1(
   // es: DH(e, rs)
   const dhES = x25519.getSharedSecret(ePriv, remoteX25519Pub)
   ss.mixKey(dhES)
+  dhES.fill(0)
 
   // Encrypt empty payload.
   const encPayload = ss.encryptAndHash(new Uint8Array(0))
@@ -67,6 +68,9 @@ export function initiatorHandshake1(
 
   // ML-KEM-1024 encapsulation.
   const { cipherText: mlkemCT, sharedSecret: mlkemSS } = ml_kem1024.encapsulate(remoteMlkemPub)
+
+  // Bind ML-KEM ciphertext into the handshake hash (matches responder's mixHash).
+  ss.mixHash(mlkemCT)
 
   return {
     handshakeState: {
@@ -78,6 +82,17 @@ export function initiatorHandshake1(
     },
     message1: concatBytes(noiseMsg1, mlkemCT),
   }
+}
+
+/**
+ * Zero all sensitive fields in a HybridHandshakeState.
+ * Only secrets are zeroed — public keys (rs, e.publicKey) are not sensitive.
+ */
+export function clearHandshakeState(state: HybridHandshakeState): void {
+  state.ss.clear()
+  state.e.privateKey.fill(0)
+  state.mlkemSS.fill(0)
+  state.mlkemCT.fill(0)
 }
 
 /**
@@ -97,8 +112,8 @@ export function initiatorHandshake2(
   const { ss, e, mlkemSS, mlkemCT } = state
 
   const expectedLen = NOISE_MSG_LEN + SLHDSA_SIG_SIZE
-  if (message2.length < expectedLen) {
-    throw new Error(`noise-hybrid: message2 too short (${message2.length} < ${expectedLen})`)
+  if (message2.length !== expectedLen) {
+    throw new Error(`noise-hybrid: message2 wrong size (${message2.length} !== ${expectedLen})`)
   }
 
   const noiseMsg2 = message2.slice(0, NOISE_MSG_LEN)
@@ -111,6 +126,7 @@ export function initiatorHandshake2(
   // ee: DH(e, re)
   const dhEE = x25519.getSharedSecret(e.privateKey, re)
   ss.mixKey(dhEE)
+  dhEE.fill(0)
 
   // Decrypt payload (should be empty).
   const encPayload = noiseMsg2.slice(DH_LEN)
@@ -122,11 +138,15 @@ export function initiatorHandshake2(
   // Verify SLH-DSA signature.
   const valid = slh_dsa_shake_256f.verify(slhdsaSig, transcript, remoteSlhdsaPub)
   if (!valid) {
+    clearHandshakeState(state)
     throw new Error('noise-hybrid: SLH-DSA signature verification failed')
   }
 
   // Hybrid split: mix ML-KEM shared secret into chaining key before deriving cipher keys.
   const [c1, c2] = ss.hybridSplit(mlkemSS)
+
+  // Zero sensitive handshake material.
+  clearHandshakeState(state)
 
   // Initiator convention: send=c2, receive=c1
   return { send: c2, receive: c1 }

--- a/frontend/src/lib/noise-hybrid.ts
+++ b/frontend/src/lib/noise-hybrid.ts
@@ -1,0 +1,133 @@
+import type { Session } from './noise'
+import { x25519 } from '@noble/curves/ed25519.js'
+import { blake2b } from '@noble/hashes/blake2.js'
+/**
+ * Hybrid post-quantum Noise_NK handshake — initiator (Frontend) side.
+ *
+ * Extends the classical Noise_NK_25519_ChaChaPoly_BLAKE2b with:
+ *   - ML-KEM-1024 (FIPS 203) key encapsulation
+ *   - SLH-DSA-SHAKE-256f (FIPS 205) transcript authentication
+ *
+ * Message 1: noise_msg1 (48 bytes) || mlkem_ciphertext (1568 bytes) = 1616 bytes
+ * Message 2: noise_msg2 (48 bytes) || slhdsa_signature (49856 bytes) = 49904 bytes
+ */
+import { ml_kem1024 } from '@noble/post-quantum/ml-kem.js'
+
+import { slh_dsa_shake_256f } from '@noble/post-quantum/slh-dsa.js'
+import { concatBytes, SymmetricState } from './noise'
+
+const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
+const DH_LEN = 32
+const AEAD_TAG_SIZE = 16
+const NOISE_MSG_LEN = DH_LEN + AEAD_TAG_SIZE // 48 bytes
+const SLHDSA_SIG_SIZE = 49856
+
+export interface HybridHandshakeState {
+  ss: SymmetricState
+  e: { privateKey: Uint8Array, publicKey: Uint8Array }
+  rs: Uint8Array
+  mlkemSS: Uint8Array
+  mlkemCT: Uint8Array
+}
+
+/**
+ * initiatorHandshake1 creates the first hybrid handshake message.
+ *
+ * @param remoteX25519Pub - Worker's X25519 static public key (32 bytes)
+ * @param remoteMlkemPub - Worker's ML-KEM-1024 encapsulation key (1568 bytes)
+ * @returns Handshake state and message1 (1616 bytes)
+ */
+export function initiatorHandshake1(
+  remoteX25519Pub: Uint8Array,
+  remoteMlkemPub: Uint8Array,
+): {
+  handshakeState: HybridHandshakeState
+  message1: Uint8Array
+} {
+  const ss = new SymmetricState(PROTOCOL_NAME)
+
+  // Mix empty prologue.
+  ss.mixHash(new Uint8Array(0))
+
+  // Pre-message pattern: <- s
+  ss.mixHash(remoteX25519Pub)
+
+  // -> e, es
+  const ePriv = x25519.utils.randomSecretKey()
+  const ePub = x25519.getPublicKey(ePriv)
+  ss.mixHash(ePub)
+
+  // es: DH(e, rs)
+  const dhES = x25519.getSharedSecret(ePriv, remoteX25519Pub)
+  ss.mixKey(dhES)
+
+  // Encrypt empty payload.
+  const encPayload = ss.encryptAndHash(new Uint8Array(0))
+  const noiseMsg1 = concatBytes(ePub, encPayload)
+
+  // ML-KEM-1024 encapsulation.
+  const { cipherText: mlkemCT, sharedSecret: mlkemSS } = ml_kem1024.encapsulate(remoteMlkemPub)
+
+  return {
+    handshakeState: {
+      ss,
+      e: { privateKey: ePriv, publicKey: ePub },
+      rs: remoteX25519Pub,
+      mlkemSS,
+      mlkemCT,
+    },
+    message1: concatBytes(noiseMsg1, mlkemCT),
+  }
+}
+
+/**
+ * initiatorHandshake2 completes the hybrid handshake by processing
+ * the responder's message2 and verifying the SLH-DSA transcript signature.
+ *
+ * @param state - Handshake state from initiatorHandshake1
+ * @param message2 - Responder's message (49904 bytes)
+ * @param remoteSlhdsaPub - Worker's SLH-DSA-SHAKE-256f public key (64 bytes)
+ * @returns Established encrypted Session
+ */
+export function initiatorHandshake2(
+  state: HybridHandshakeState,
+  message2: Uint8Array,
+  remoteSlhdsaPub: Uint8Array,
+): Session {
+  const { ss, e, mlkemSS, mlkemCT } = state
+
+  const expectedLen = NOISE_MSG_LEN + SLHDSA_SIG_SIZE
+  if (message2.length < expectedLen) {
+    throw new Error(`noise-hybrid: message2 too short (${message2.length} < ${expectedLen})`)
+  }
+
+  const noiseMsg2 = message2.slice(0, NOISE_MSG_LEN)
+  const slhdsaSig = message2.slice(NOISE_MSG_LEN)
+
+  // <- e, ee
+  const re = noiseMsg2.slice(0, DH_LEN)
+  ss.mixHash(re)
+
+  // ee: DH(e, re)
+  const dhEE = x25519.getSharedSecret(e.privateKey, re)
+  ss.mixKey(dhEE)
+
+  // Decrypt payload (should be empty).
+  const encPayload = noiseMsg2.slice(DH_LEN)
+  ss.decryptAndHash(encPayload)
+
+  // Compute transcript: BLAKE2b(handshake_hash || mlkem_ct || mlkem_ss)
+  const transcript = blake2b(concatBytes(ss.h, mlkemCT, mlkemSS))
+
+  // Verify SLH-DSA signature.
+  const valid = slh_dsa_shake_256f.verify(slhdsaSig, transcript, remoteSlhdsaPub)
+  if (!valid) {
+    throw new Error('noise-hybrid: SLH-DSA signature verification failed')
+  }
+
+  // Hybrid split: mix ML-KEM shared secret into chaining key before deriving cipher keys.
+  const [c1, c2] = ss.hybridSplit(mlkemSS)
+
+  // Initiator convention: send=c2, receive=c1
+  return { send: c2, receive: c1 }
+}

--- a/frontend/src/lib/noise.ts
+++ b/frontend/src/lib/noise.ts
@@ -36,7 +36,7 @@ function generateKeypair(): { privateKey: Uint8Array, publicKey: Uint8Array } {
   return { privateKey, publicKey }
 }
 
-function hkdf(
+export function hkdf(
   chainingKey: Uint8Array,
   inputKeyMaterial: Uint8Array,
 ): [Uint8Array, Uint8Array] {
@@ -60,7 +60,7 @@ function decrypt(key: Uint8Array, nonce: number, ad: Uint8Array, ciphertext: Uin
   return cipher.decrypt(ciphertext)
 }
 
-function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
   let totalLen = 0
   for (const a of arrays) totalLen += a.length
   const result = new Uint8Array(totalLen)
@@ -75,7 +75,7 @@ function concatBytes(...arrays: Uint8Array[]): Uint8Array {
 // ---- Noise Protocol State Machines ----
 
 /** SymmetricState manages the handshake hash (h) and chaining key (ck). */
-class SymmetricState {
+export class SymmetricState {
   h: Uint8Array // handshake hash (64 bytes for BLAKE2b)
   ck: Uint8Array // chaining key (64 bytes for BLAKE2b)
   hasK: boolean
@@ -138,6 +138,17 @@ class SymmetricState {
       new CipherState(tempK1.slice(0, 32)), // truncate to 32 for ChaChaPoly
       new CipherState(tempK2.slice(0, 32)),
     ]
+  }
+
+  /**
+   * hybridSplit mixes extra key material (e.g. ML-KEM shared secret)
+   * into the chaining key before deriving cipher keys.
+   */
+  hybridSplit(extraKeyMaterial: Uint8Array): [CipherState, CipherState] {
+    // Mix extra key material into chaining key.
+    const [ck2] = hkdf(this.ck, extraKeyMaterial)
+    this.ck = ck2
+    return this.split()
   }
 }
 

--- a/frontend/src/lib/noise.ts
+++ b/frontend/src/lib/noise.ts
@@ -150,6 +150,15 @@ export class SymmetricState {
     this.ck = ck2
     return this.split()
   }
+
+  /** Zero all sensitive fields in the symmetric state. */
+  clear(): void {
+    this.h.fill(0)
+    this.ck.fill(0)
+    this.k.fill(0)
+    this.hasK = false
+    this.n = 0
+  }
 }
 
 /** CipherState for post-handshake encryption/decryption. */
@@ -231,6 +240,7 @@ export function initiatorHandshake1(remoteStaticPubKey: Uint8Array): {
   // es: DH(e, rs)
   const dhResult = dh(e.privateKey, remoteStaticPubKey)
   ss.mixKey(dhResult)
+  dhResult.fill(0)
 
   // Encrypt empty payload (no payload in handshake message 1).
   const encPayload = ss.encryptAndHash(new Uint8Array(0))
@@ -241,6 +251,15 @@ export function initiatorHandshake1(remoteStaticPubKey: Uint8Array): {
     handshakeState: { ss, e, rs: remoteStaticPubKey },
     message1,
   }
+}
+
+/**
+ * Zero all sensitive fields in a classical HandshakeState.
+ * Only secrets are zeroed — public keys (rs, e.publicKey) are not sensitive.
+ */
+export function clearClassicalHandshakeState(state: HandshakeState): void {
+  state.ss.clear()
+  state.e.privateKey.fill(0)
 }
 
 /**
@@ -263,6 +282,7 @@ export function initiatorHandshake2(state: HandshakeState, message2: Uint8Array)
   // ee: DH(e, re)
   const dhResult = dh(e.privateKey, re)
   ss.mixKey(dhResult)
+  dhResult.fill(0)
 
   // Decrypt payload (should be empty).
   const payload = message2.slice(32)
@@ -273,5 +293,9 @@ export function initiatorHandshake2(state: HandshakeState, message2: Uint8Array)
   //   Responder: send=cs1, receive=cs2
   //   Initiator: send=cs2, receive=cs1
   const [c1, c2] = ss.split()
+
+  // Zero sensitive handshake material.
+  clearClassicalHandshakeState(state)
+
   return { send: c2, receive: c1 }
 }

--- a/frontend/tests/e2e/helpers/e2e-channel.ts
+++ b/frontend/tests/e2e/helpers/e2e-channel.ts
@@ -5,7 +5,7 @@
  * allowing the shared ChannelManager to work in Node.js/Bun test environments.
  */
 
-import type { ChannelTransport, KeyPinDecision } from '../../../src/lib/channel'
+import type { ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '../../../src/lib/channel'
 import { Buffer } from 'node:buffer'
 import { ChannelManager } from '../../../src/lib/channel'
 
@@ -30,7 +30,7 @@ class FetchChannelTransport implements ChannelTransport {
     this.userId = userId
   }
 
-  async getWorkerPublicKey(workerId: string): Promise<Uint8Array> {
+  async getWorkerPublicKey(workerId: string): Promise<WorkerKeyBundle> {
     const resp = await fetch(`${this.hubUrl}/leapmux.v1.ChannelService/GetWorkerPublicKey`, {
       method: 'POST',
       headers: {
@@ -43,8 +43,12 @@ class FetchChannelTransport implements ChannelTransport {
       const body = await resp.text().catch(() => '')
       throw new Error(`GetWorkerPublicKey failed: ${resp.status} ${body}`)
     }
-    const data = await resp.json() as { publicKey: string }
-    return base64ToBytes(data.publicKey)
+    const data = await resp.json() as { publicKey: string, mlkemPublicKey: string, slhdsaPublicKey: string }
+    return {
+      x25519PublicKey: base64ToBytes(data.publicKey),
+      mlkemPublicKey: base64ToBytes(data.mlkemPublicKey),
+      slhdsaPublicKey: base64ToBytes(data.slhdsaPublicKey),
+    }
   }
 
   async openChannel(workerId: string, handshakePayload: Uint8Array): Promise<{ channelId: string, handshakePayload: Uint8Array }> {

--- a/frontend/tests/unit/components/MessageBubble.test.tsx
+++ b/frontend/tests/unit/components/MessageBubble.test.tsx
@@ -498,7 +498,7 @@ describe('todoWrite collapse/expand', () => {
     ))
 
     // Expand button should not exist since alwaysVisible hides it
-    expect(screen.queryByTitle('Expand 1 tool result')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Expand 1 tool result' })).toBeNull()
   })
 
   it('body has left border (always visible)', () => {
@@ -630,7 +630,7 @@ describe('taskOutput rendering', () => {
     ))
 
     // Click the expand button
-    const expandBtn = screen.getByTitle('Expand 1 tool result')
+    const expandBtn = screen.getByRole('button', { name: 'Expand 1 tool result' })
     fireEvent.click(expandBtn)
 
     const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
@@ -659,7 +659,7 @@ describe('taskOutput rendering', () => {
     ))
 
     // Click the expand button
-    const expandBtn = screen.getByTitle('Expand 1 tool result')
+    const expandBtn = screen.getByRole('button', { name: 'Expand 1 tool result' })
     fireEvent.click(expandBtn)
 
     const bubble = screen.getByTestId('message-content')
@@ -1061,7 +1061,7 @@ describe('edit/write alwaysVisible', () => {
     const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
     expect(bodyWrapper).not.toBeNull()
     // Expand button should not exist since alwaysVisible hides it
-    expect(screen.queryByTitle('Expand 1 tool result')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Expand 1 tool result' })).toBeNull()
   })
 
   it('write body is visible without expanding and shows additions diff', () => {
@@ -1081,7 +1081,7 @@ describe('edit/write alwaysVisible', () => {
     const bodyWrapper = container.querySelector(`.${toolBodyContent}`)
     expect(bodyWrapper).not.toBeNull()
     // Expand button should not exist since alwaysVisible hides it
-    expect(screen.queryByTitle('Expand 1 tool result')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Expand 1 tool result' })).toBeNull()
     // Should show the file content as an additions diff
     const bubble = screen.getByTestId('message-content')
     expect(bubble.textContent).toContain('hello')

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty v1.1.24
-	github.com/flynn/noise v1.1.0
 	github.com/klauspost/compress v1.18.4
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/confmap v1.0.0
@@ -33,6 +32,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=

--- a/hub/server.go
+++ b/hub/server.go
@@ -227,11 +227,13 @@ func (s *Server) RegisterWorker(ctx context.Context, orgID, registeredBy string)
 	authToken := id.Generate()
 
 	if err := s.queries.CreateWorker(ctx, gendb.CreateWorkerParams{
-		ID:           workerID,
-		OrgID:        orgID,
-		AuthToken:    authToken,
-		RegisteredBy: registeredBy,
-		PublicKey:    []byte{},
+		ID:              workerID,
+		OrgID:           orgID,
+		AuthToken:       authToken,
+		RegisteredBy:    registeredBy,
+		PublicKey:       []byte{},
+		MlkemPublicKey:  []byte{},
+		SlhdsaPublicKey: []byte{},
 	}); err != nil {
 		return nil, fmt.Errorf("create worker: %w", err)
 	}

--- a/internal/hub/db/migrations/00001_initial.sql
+++ b/internal/hub/db/migrations/00001_initial.sql
@@ -52,7 +52,9 @@ CREATE TABLE workers (
     status        INTEGER NOT NULL DEFAULT 1,
     created_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_seen_at  DATETIME,
-    public_key    BLOB NOT NULL DEFAULT ''
+    public_key    BLOB NOT NULL DEFAULT '',
+    mlkem_public_key  BLOB NOT NULL DEFAULT '',
+    slhdsa_public_key BLOB NOT NULL DEFAULT ''
 );
 CREATE INDEX idx_workers_org_id ON workers(org_id);
 
@@ -75,6 +77,8 @@ CREATE TABLE worker_registrations (
     id          TEXT PRIMARY KEY,
     version     TEXT NOT NULL DEFAULT '',
     public_key  BLOB NOT NULL DEFAULT '',
+    mlkem_public_key  BLOB NOT NULL DEFAULT '',
+    slhdsa_public_key BLOB NOT NULL DEFAULT '',
     status      INTEGER NOT NULL DEFAULT 1,
     worker_id   TEXT REFERENCES workers(id) ON DELETE SET NULL,
     approved_by TEXT REFERENCES users(id),

--- a/internal/hub/db/queries/registrations.sql
+++ b/internal/hub/db/queries/registrations.sql
@@ -1,6 +1,6 @@
 -- name: CreateRegistration :exec
-INSERT INTO worker_registrations (id, version, public_key, expires_at)
-VALUES (?, ?, ?, ?);
+INSERT INTO worker_registrations (id, version, public_key, mlkem_public_key, slhdsa_public_key, expires_at)
+VALUES (?, ?, ?, ?, ?, ?);
 
 -- name: GetRegistrationByID :one
 SELECT * FROM worker_registrations WHERE id = ?;

--- a/internal/hub/db/queries/workers.sql
+++ b/internal/hub/db/queries/workers.sql
@@ -1,6 +1,6 @@
 -- name: CreateWorker :exec
-INSERT INTO workers (id, org_id, auth_token, registered_by, public_key)
-VALUES (?, ?, ?, ?, ?);
+INSERT INTO workers (id, org_id, auth_token, registered_by, public_key, mlkem_public_key, slhdsa_public_key)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetWorkerByID :one
 SELECT * FROM workers WHERE id = ? AND org_id = ?;
@@ -48,7 +48,7 @@ SELECT id FROM workers WHERE org_id = ? AND registered_by = ? AND status = 1;
 UPDATE workers SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?;
 
 -- name: UpdateWorkerPublicKey :exec
-UPDATE workers SET public_key = ? WHERE id = ?;
+UPDATE workers SET public_key = ?, mlkem_public_key = ?, slhdsa_public_key = ? WHERE id = ?;
 
 -- name: GetWorkerPublicKey :one
-SELECT public_key FROM workers WHERE id = ?;
+SELECT public_key, mlkem_public_key, slhdsa_public_key FROM workers WHERE id = ?;

--- a/internal/hub/db/store_test.go
+++ b/internal/hub/db/store_test.go
@@ -120,11 +120,13 @@ func TestWorkers_CRUD(t *testing.T) {
 	workerID := makeID()
 	token := makeID()
 	err := q.CreateWorker(ctx, gendb.CreateWorkerParams{
-		ID:           workerID,
-		OrgID:        orgID,
-		AuthToken:    token,
-		RegisteredBy: userID,
-		PublicKey:    []byte{},
+		ID:              workerID,
+		OrgID:           orgID,
+		AuthToken:       token,
+		RegisteredBy:    userID,
+		PublicKey:       []byte{},
+		MlkemPublicKey:  []byte{},
+		SlhdsaPublicKey: []byte{},
 	})
 	require.NoError(t, err)
 
@@ -179,16 +181,18 @@ func TestRegistrations(t *testing.T) {
 	_ = q.CreateWorker(ctx, gendb.CreateWorkerParams{
 		ID: workerID, OrgID: orgID,
 		AuthToken: makeID(), RegisteredBy: userID,
-		PublicKey: []byte{},
+		PublicKey: []byte{}, MlkemPublicKey: []byte{}, SlhdsaPublicKey: []byte{},
 	})
 
 	regID := makeID()
 	expires := time.Now().Add(10 * time.Minute).UTC()
 	err := q.CreateRegistration(ctx, gendb.CreateRegistrationParams{
-		ID:        regID,
-		Version:   "0.1.0",
-		PublicKey: []byte("test-public-key"),
-		ExpiresAt: expires,
+		ID:              regID,
+		Version:         "0.1.0",
+		PublicKey:       []byte("test-public-key"),
+		MlkemPublicKey:  []byte("test-mlkem-key"),
+		SlhdsaPublicKey: []byte("test-slhdsa-key"),
+		ExpiresAt:       expires,
 	})
 	require.NoError(t, err)
 
@@ -221,7 +225,7 @@ func TestRegistrations_Expire(t *testing.T) {
 	expires := time.Now().Add(-1 * time.Minute).UTC()
 	_ = q.CreateRegistration(ctx, gendb.CreateRegistrationParams{
 		ID: regID, Version: "v",
-		PublicKey: []byte("test-key"),
+		PublicKey: []byte("test-key"), MlkemPublicKey: []byte{}, SlhdsaPublicKey: []byte{},
 		ExpiresAt: expires,
 	})
 

--- a/internal/hub/service/channel_service.go
+++ b/internal/hub/service/channel_service.go
@@ -57,7 +57,7 @@ func (s *ChannelService) GetWorkerPublicKey(
 		return nil, err
 	}
 
-	pubKey, err := s.queries.GetWorkerPublicKey(ctx, workerID)
+	keys, err := s.queries.GetWorkerPublicKey(ctx, workerID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("worker not found"))
@@ -65,12 +65,14 @@ func (s *ChannelService) GetWorkerPublicKey(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	if len(pubKey) == 0 {
+	if len(keys.PublicKey) == 0 {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker has no public key"))
 	}
 
 	return connect.NewResponse(&leapmuxv1.GetWorkerPublicKeyResponse{
-		PublicKey: pubKey,
+		PublicKey:       keys.PublicKey,
+		MlkemPublicKey:  keys.MlkemPublicKey,
+		SlhdsaPublicKey: keys.SlhdsaPublicKey,
 	}), nil
 }
 

--- a/internal/hub/service/channel_service.go
+++ b/internal/hub/service/channel_service.go
@@ -76,6 +76,41 @@ func (s *ChannelService) GetWorkerPublicKey(
 	}), nil
 }
 
+func (s *ChannelService) GetWorkerEncryptionMode(
+	ctx context.Context,
+	req *connect.Request[leapmuxv1.GetWorkerEncryptionModeRequest],
+) (*connect.Response[leapmuxv1.GetWorkerEncryptionModeResponse], error) {
+	user, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workerID := req.Msg.GetWorkerId()
+	if workerID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("worker_id is required"))
+	}
+
+	// Verify user has access to this worker.
+	if _, err := s.verifyWorkerAccess(ctx, user, workerID); err != nil {
+		return nil, err
+	}
+
+	// Read encryption mode from the live connection (not DB).
+	conn := s.workerMgr.Get(workerID)
+	if conn == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("worker is offline"))
+	}
+
+	encMode := conn.EncryptionMode
+	if encMode == leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
+		encMode = leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
+	}
+
+	return connect.NewResponse(&leapmuxv1.GetWorkerEncryptionModeResponse{
+		EncryptionMode: encMode,
+	}), nil
+}
+
 func (s *ChannelService) OpenChannel(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.OpenChannelRequest],
@@ -90,9 +125,7 @@ func (s *ChannelService) OpenChannel(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("worker_id is required"))
 	}
 
-	if len(req.Msg.GetHandshakePayload()) == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("handshake_payload is required"))
-	}
+	// handshake_payload may be empty for disabled encryption mode (solo/loopback).
 
 	// Verify user has access to this worker and get the worker's org.
 	worker, err := s.verifyWorkerAccess(ctx, user, workerID)

--- a/internal/hub/service/channel_service_test.go
+++ b/internal/hub/service/channel_service_test.go
@@ -117,8 +117,10 @@ func (e *channelTestEnv) createWorkerWithKey(t *testing.T, token string, publicK
 	// Set the public key.
 	if len(publicKey) > 0 {
 		err = e.queries.UpdateWorkerPublicKey(ctx, gendb.UpdateWorkerPublicKeyParams{
-			PublicKey: publicKey,
-			ID:        workerID,
+			PublicKey:       publicKey,
+			MlkemPublicKey:  []byte{},
+			SlhdsaPublicKey: []byte{},
+			ID:              workerID,
 		})
 		require.NoError(t, err)
 	}
@@ -203,15 +205,6 @@ func TestOpenChannel_EmptyFields(t *testing.T) {
 		&leapmuxv1.OpenChannelRequest{
 			WorkerId:         "",
 			HandshakePayload: []byte("data"),
-		}, token))
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-
-	// Empty handshake_payload.
-	_, err = env.channelClient.OpenChannel(ctx, authedReq(
-		&leapmuxv1.OpenChannelRequest{
-			WorkerId:         "some-id",
-			HandshakePayload: nil,
 		}, token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
@@ -337,6 +330,222 @@ func TestGetWorkerPublicKey_Unauthenticated(t *testing.T) {
 		&leapmuxv1.GetWorkerPublicKeyRequest{WorkerId: "any"}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// --- GetWorkerEncryptionMode tests ---
+
+func TestGetWorkerEncryptionMode_WorkerOffline(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	_, err := env.channelClient.GetWorkerEncryptionMode(ctx, authedReq(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: workerID}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+func TestGetWorkerEncryptionMode_EmptyWorkerID(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	_, err := env.channelClient.GetWorkerEncryptionMode(ctx, authedReq(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: ""}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestGetWorkerEncryptionMode_Unauthenticated(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+
+	_, err := env.channelClient.GetWorkerEncryptionMode(ctx, connect.NewRequest(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: "any"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestGetWorkerEncryptionMode_PostQuantum(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	// Simulate worker online with POST_QUANTUM mode.
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM,
+	}
+	env.workerMgr.Register(conn)
+
+	resp, err := env.channelClient.GetWorkerEncryptionMode(ctx, authedReq(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: workerID}, token))
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, resp.Msg.GetEncryptionMode())
+}
+
+func TestGetWorkerEncryptionMode_Classic(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC,
+	}
+	env.workerMgr.Register(conn)
+
+	resp, err := env.channelClient.GetWorkerEncryptionMode(ctx, authedReq(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: workerID}, token))
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC, resp.Msg.GetEncryptionMode())
+}
+
+func TestGetWorkerEncryptionMode_UnspecifiedDefaultsToPostQuantum(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	// Register with UNSPECIFIED — should be normalized to POST_QUANTUM.
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED,
+	}
+	env.workerMgr.Register(conn)
+
+	resp, err := env.channelClient.GetWorkerEncryptionMode(ctx, authedReq(
+		&leapmuxv1.GetWorkerEncryptionModeRequest{WorkerId: workerID}, token))
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, resp.Msg.GetEncryptionMode())
+}
+
+// --- Handshake scenario tests with different encryption modes ---
+
+func TestOpenChannel_PostQuantumHandshake(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM,
+		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+			sentCh <- msg
+			return nil
+		},
+	}
+	env.workerMgr.Register(conn)
+
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	_, err := env.channelClient.OpenChannel(shortCtx, authedReq(
+		&leapmuxv1.OpenChannelRequest{
+			WorkerId:         workerID,
+			HandshakePayload: []byte("pq-handshake-msg1"),
+		}, token))
+	// Times out because mock worker doesn't respond.
+	require.Error(t, err)
+
+	select {
+	case sentMsg := <-sentCh:
+		assert.NotNil(t, sentMsg.GetChannelOpen())
+		assert.Equal(t, []byte("pq-handshake-msg1"), sentMsg.GetChannelOpen().GetHandshakePayload())
+	default:
+		t.Fatal("expected a message to be sent to worker")
+	}
+}
+
+func TestOpenChannel_ClassicHandshake(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC,
+		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+			sentCh <- msg
+			return nil
+		},
+	}
+	env.workerMgr.Register(conn)
+
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	_, err := env.channelClient.OpenChannel(shortCtx, authedReq(
+		&leapmuxv1.OpenChannelRequest{
+			WorkerId:         workerID,
+			HandshakePayload: []byte("classic-handshake-msg1"),
+		}, token))
+	require.Error(t, err)
+
+	select {
+	case sentMsg := <-sentCh:
+		assert.NotNil(t, sentMsg.GetChannelOpen())
+		assert.Equal(t, []byte("classic-handshake-msg1"), sentMsg.GetChannelOpen().GetHandshakePayload())
+	default:
+		t.Fatal("expected a message to be sent to worker")
+	}
+}
+
+func TestOpenChannel_DisabledHandshake(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
+	conn := &workermgr.Conn{
+		WorkerID:       workerID,
+		OrgID:          "test-org",
+		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED,
+		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+			sentCh <- msg
+			return nil
+		},
+	}
+	env.workerMgr.Register(conn)
+
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	// Disabled mode sends empty handshake payload.
+	_, err := env.channelClient.OpenChannel(shortCtx, authedReq(
+		&leapmuxv1.OpenChannelRequest{
+			WorkerId:         workerID,
+			HandshakePayload: []byte{},
+		}, token))
+	require.Error(t, err)
+
+	select {
+	case sentMsg := <-sentCh:
+		assert.NotNil(t, sentMsg.GetChannelOpen())
+		assert.Empty(t, sentMsg.GetChannelOpen().GetHandshakePayload())
+	default:
+		t.Fatal("expected a message to be sent to worker")
+	}
 }
 
 func (e *channelTestEnv) createSecondUser(t *testing.T) (userID, token string) {

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -279,7 +279,9 @@ func (s *WorkerConnectorService) Connect(
 			idleTimer.Reset(workerIdleTimeout)
 
 			msg := result.msg
-			s.processWorkerMessage(ctx, conn, worker.ID, msg)
+			if err := s.processWorkerMessage(ctx, conn, worker.ID, msg); err != nil {
+				return connect.NewError(connect.CodeInvalidArgument, err)
+			}
 
 		case <-idleTimer.C:
 			// A message may have arrived at the same instant the timer
@@ -291,7 +293,9 @@ func (s *WorkerConnectorService) Connect(
 					return nil
 				}
 				idleTimer.Reset(workerIdleTimeout)
-				s.processWorkerMessage(ctx, conn, worker.ID, result.msg)
+				if err := s.processWorkerMessage(ctx, conn, worker.ID, result.msg); err != nil {
+					return connect.NewError(connect.CodeInvalidArgument, err)
+				}
 				continue
 			default:
 			}
@@ -306,17 +310,28 @@ func (s *WorkerConnectorService) Connect(
 }
 
 // processWorkerMessage handles a single message from the worker stream.
+// Returns a non-nil error to terminate the connection (e.g. invalid config).
 func (s *WorkerConnectorService) processWorkerMessage(
 	ctx context.Context,
 	conn *workermgr.Conn,
 	workerID string,
 	msg *leapmuxv1.ConnectRequest,
-) {
+) error {
 	// Update last seen periodically on heartbeats.
 	if hb := msg.GetHeartbeat(); hb != nil {
 		if err := s.queries.UpdateWorkerLastSeen(ctx, workerID); err != nil {
 			slog.Warn("failed to update worker last seen on heartbeat", "worker_id", workerID, "error", err)
 		}
+		// Cache encryption mode on the live connection (not persisted to DB).
+		encMode := hb.GetEncryptionMode()
+		if encMode == leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
+			encMode = leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
+		}
+		// Reject disabled encryption in non-solo mode.
+		if encMode == leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED && !s.soloMode {
+			return fmt.Errorf("disabled encryption mode is only allowed in solo mode")
+		}
+		conn.EncryptionMode = encMode
 		// Persist worker's public keys if provided (sent with the initial heartbeat).
 		if pk := hb.GetPublicKey(); len(pk) > 0 {
 			if err := s.queries.UpdateWorkerPublicKey(ctx, db.UpdateWorkerPublicKeyParams{
@@ -337,20 +352,20 @@ func (s *WorkerConnectorService) processWorkerMessage(
 		}); err != nil {
 			slog.Debug("failed to send heartbeat response", "worker_id", workerID, "error", err)
 		}
-		return
+		return nil
 	}
 
 	// Try to complete pending request-response pairs (file operations).
 	if s.pending != nil && msg.GetRequestId() != "" {
 		if s.pending.Complete(msg.GetRequestId(), msg) {
-			return
+			return nil
 		}
 	}
 
 	// Handle workspace tab sync from worker.
 	if tabSync := msg.GetWorkspaceTabsSync(); tabSync != nil {
 		s.handleWorkspaceTabsSync(ctx, workerID, tabSync)
-		return
+		return nil
 	}
 
 	// Route channel messages from worker to frontend.
@@ -369,7 +384,7 @@ func (s *WorkerConnectorService) processWorkerMessage(
 					"correlation_id", chMsg.GetCorrelationId(),
 					"error", err,
 				)
-				return
+				return nil
 			}
 
 			slog.Debug("relaying channel message from worker",
@@ -385,13 +400,14 @@ func (s *WorkerConnectorService) processWorkerMessage(
 				)
 			}
 		}
-		return
+		return nil
 	}
 
 	slog.Debug("unhandled worker message",
 		"worker_id", workerID,
 		"request_id", msg.GetRequestId(),
 	)
+	return nil
 }
 
 // handleWorkspaceTabsSync reconciles the hub's workspace_tabs for the connecting worker.

--- a/internal/hub/service/worker_connector_service.go
+++ b/internal/hub/service/worker_connector_service.go
@@ -80,12 +80,22 @@ func (s *WorkerConnectorService) RequestRegistration(
 	if publicKey == nil {
 		publicKey = []byte{}
 	}
+	mlkemPublicKey := req.Msg.GetMlkemPublicKey()
+	if mlkemPublicKey == nil {
+		mlkemPublicKey = []byte{}
+	}
+	slhdsaPublicKey := req.Msg.GetSlhdsaPublicKey()
+	if slhdsaPublicKey == nil {
+		slhdsaPublicKey = []byte{}
+	}
 
 	if err := s.queries.CreateRegistration(ctx, db.CreateRegistrationParams{
-		ID:        regID,
-		Version:   version,
-		PublicKey: publicKey,
-		ExpiresAt: expiresAt,
+		ID:              regID,
+		Version:         version,
+		PublicKey:       publicKey,
+		MlkemPublicKey:  mlkemPublicKey,
+		SlhdsaPublicKey: slhdsaPublicKey,
+		ExpiresAt:       expiresAt,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create registration: %w", err))
 	}
@@ -307,11 +317,13 @@ func (s *WorkerConnectorService) processWorkerMessage(
 		if err := s.queries.UpdateWorkerLastSeen(ctx, workerID); err != nil {
 			slog.Warn("failed to update worker last seen on heartbeat", "worker_id", workerID, "error", err)
 		}
-		// Persist worker's public key if provided (sent with the initial heartbeat).
+		// Persist worker's public keys if provided (sent with the initial heartbeat).
 		if pk := hb.GetPublicKey(); len(pk) > 0 {
 			if err := s.queries.UpdateWorkerPublicKey(ctx, db.UpdateWorkerPublicKeyParams{
-				PublicKey: pk,
-				ID:        workerID,
+				PublicKey:       pk,
+				MlkemPublicKey:  hb.GetMlkemPublicKey(),
+				SlhdsaPublicKey: hb.GetSlhdsaPublicKey(),
+				ID:              workerID,
 			}); err != nil {
 				slog.Warn("failed to update worker public key", "worker_id", workerID, "error", err)
 			}

--- a/internal/hub/service/worker_connector_service_test.go
+++ b/internal/hub/service/worker_connector_service_test.go
@@ -11,6 +11,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	hubdb "github.com/leapmux/leapmux/internal/hub/db"
 	db "github.com/leapmux/leapmux/internal/hub/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/workermgr"
 )
 
 // setupSyncTest creates a WorkerConnectorService with an in-memory hub DB
@@ -213,4 +214,89 @@ func TestHandleWorkspaceTabsSync_EmptyHubState(t *testing.T) {
 	tabs, err := q.ListWorkspaceTabsByWorker(ctx, "w1")
 	require.NoError(t, err)
 	assert.Empty(t, tabs, "hub should not gain tabs from worker-only entries")
+}
+
+// --- Encryption mode validation tests ---
+
+func setupEncryptionModeTest(t *testing.T, soloMode bool) (*WorkerConnectorService, *workermgr.Conn) {
+	t.Helper()
+	svc, _ := setupSyncTest(t, []string{"w1"}, nil)
+	svc.soloMode = soloMode
+	conn := &workermgr.Conn{WorkerID: "w1", OrgID: "org-1"}
+	return svc, conn
+}
+
+func TestProcessWorkerMessage_DisabledModeRejectedInNonSolo(t *testing.T) {
+	svc, conn := setupEncryptionModeTest(t, false)
+	ctx := context.Background()
+
+	err := svc.processWorkerMessage(ctx, conn, "w1", &leapmuxv1.ConnectRequest{
+		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
+			Heartbeat: &leapmuxv1.Heartbeat{
+				EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "solo mode")
+}
+
+func TestProcessWorkerMessage_DisabledModeAllowedInSolo(t *testing.T) {
+	svc, conn := setupEncryptionModeTest(t, true)
+	ctx := context.Background()
+
+	err := svc.processWorkerMessage(ctx, conn, "w1", &leapmuxv1.ConnectRequest{
+		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
+			Heartbeat: &leapmuxv1.Heartbeat{
+				EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED, conn.EncryptionMode)
+}
+
+func TestProcessWorkerMessage_ClassicModeAccepted(t *testing.T) {
+	svc, conn := setupEncryptionModeTest(t, false)
+	ctx := context.Background()
+
+	err := svc.processWorkerMessage(ctx, conn, "w1", &leapmuxv1.ConnectRequest{
+		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
+			Heartbeat: &leapmuxv1.Heartbeat{
+				EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC, conn.EncryptionMode)
+}
+
+func TestProcessWorkerMessage_PostQuantumModeAccepted(t *testing.T) {
+	svc, conn := setupEncryptionModeTest(t, false)
+	ctx := context.Background()
+
+	err := svc.processWorkerMessage(ctx, conn, "w1", &leapmuxv1.ConnectRequest{
+		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
+			Heartbeat: &leapmuxv1.Heartbeat{
+				EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, conn.EncryptionMode)
+}
+
+func TestProcessWorkerMessage_UnspecifiedDefaultsToPostQuantum(t *testing.T) {
+	svc, conn := setupEncryptionModeTest(t, false)
+	ctx := context.Background()
+
+	err := svc.processWorkerMessage(ctx, conn, "w1", &leapmuxv1.ConnectRequest{
+		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
+			Heartbeat: &leapmuxv1.Heartbeat{
+				EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, conn.EncryptionMode)
 }

--- a/internal/hub/service/worker_mgmt_service.go
+++ b/internal/hub/service/worker_mgmt_service.go
@@ -71,18 +71,28 @@ func (s *WorkerManagementService) ApproveRegistration(
 	workerID := id.Generate()
 	authToken := id.Generate()
 
-	// Copy public key from registration to worker (may be empty if worker didn't send one).
+	// Copy public keys from registration to worker (may be empty if worker didn't send them).
 	publicKey := reg.PublicKey
 	if publicKey == nil {
 		publicKey = []byte{}
 	}
+	mlkemPK := reg.MlkemPublicKey
+	if mlkemPK == nil {
+		mlkemPK = []byte{}
+	}
+	slhdsaPK := reg.SlhdsaPublicKey
+	if slhdsaPK == nil {
+		slhdsaPK = []byte{}
+	}
 
 	if err := s.queries.CreateWorker(ctx, db.CreateWorkerParams{
-		ID:           workerID,
-		OrgID:        orgID,
-		AuthToken:    authToken,
-		RegisteredBy: user.ID,
-		PublicKey:    publicKey,
+		ID:              workerID,
+		OrgID:           orgID,
+		AuthToken:       authToken,
+		RegisteredBy:    user.ID,
+		PublicKey:       publicKey,
+		MlkemPublicKey:  mlkemPK,
+		SlhdsaPublicKey: slhdsaPK,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create worker: %w", err))
 	}
@@ -257,7 +267,7 @@ func (s *WorkerManagementService) GetRegistration(
 
 	var fingerprint string
 	if len(reg.PublicKey) > 0 {
-		fingerprint = noiseutil.KeyFingerprint(reg.PublicKey)
+		fingerprint = noiseutil.CompositeKeyFingerprint(reg.PublicKey, reg.MlkemPublicKey, reg.SlhdsaPublicKey)
 	}
 
 	return connect.NewResponse(&leapmuxv1.GetRegistrationResponse{

--- a/internal/hub/service/workspace_service_test.go
+++ b/internal/hub/service/workspace_service_test.go
@@ -78,11 +78,13 @@ func setupWorkspaceTest(t *testing.T) *workspaceTestEnv {
 	})
 
 	_ = queries.CreateWorker(context.Background(), gendb.CreateWorkerParams{
-		ID:           "w1",
-		OrgID:        orgID,
-		AuthToken:    "tok",
-		RegisteredBy: userID,
-		PublicKey:    []byte("key"),
+		ID:              "w1",
+		OrgID:           orgID,
+		AuthToken:       "tok",
+		RegisteredBy:    userID,
+		PublicKey:       []byte("key"),
+		MlkemPublicKey:  []byte{},
+		SlhdsaPublicKey: []byte{},
 	})
 
 	token, _, err := auth.Login(context.Background(), queries, "testuser", "pass")

--- a/internal/hub/workermgr/manager.go
+++ b/internal/hub/workermgr/manager.go
@@ -14,11 +14,12 @@ import (
 
 // Conn represents a connected worker's bidirectional stream.
 type Conn struct {
-	WorkerID string
-	OrgID    string
-	Stream   *connect.BidiStream[leapmuxv1.ConnectRequest, leapmuxv1.ConnectResponse]
-	SendFn   func(*leapmuxv1.ConnectResponse) error // Optional: overrides Stream.Send for testing.
-	mu       sync.Mutex
+	WorkerID       string
+	OrgID          string
+	EncryptionMode leapmuxv1.EncryptionMode // Set from the initial heartbeat.
+	Stream         *connect.BidiStream[leapmuxv1.ConnectRequest, leapmuxv1.ConnectResponse]
+	SendFn         func(*leapmuxv1.ConnectResponse) error // Optional: overrides Stream.Send for testing.
+	mu             sync.Mutex
 }
 
 // Send sends a message to the worker via the bidi stream.

--- a/internal/noise/fingerprint.go
+++ b/internal/noise/fingerprint.go
@@ -81,6 +81,16 @@ var wordlist = [256]string{
 	"zany", "zeal", "zero", "zest", "zinc", "zone", "zoom",
 }
 
+// CompositeKeyFingerprint generates a 4-word fingerprint from the concatenation
+// of x25519, ML-KEM, and SLH-DSA public key bytes: BLAKE2b(x25519 || mlkem || slhdsa).
+func CompositeKeyFingerprint(x25519Pub, mlkemPub, slhdsaPub []byte) string {
+	composite := make([]byte, 0, len(x25519Pub)+len(mlkemPub)+len(slhdsaPub))
+	composite = append(composite, x25519Pub...)
+	composite = append(composite, mlkemPub...)
+	composite = append(composite, slhdsaPub...)
+	return KeyFingerprint(composite)
+}
+
 // KeyFingerprint generates a human-friendly 4-word fingerprint from a
 // public key. The fingerprint is derived by hashing the key with BLAKE2b
 // and mapping the first 4 bytes to the wordlist.
@@ -93,13 +103,14 @@ func KeyFingerprint(publicKey []byte) string {
 	return strings.Join(words, "-")
 }
 
-// KeyFingerprintHex generates a fingerprint from a hex-encoded public key.
+// KeyFingerprintHex generates a fingerprint from a hex-encoded public key
+// (or concatenated composite key bytes).
 func KeyFingerprintHex(publicKeyHex string) (string, error) {
-	if len(publicKeyHex) != 64 {
-		return "", fmt.Errorf("invalid public key hex length: %d (expected 64)", len(publicKeyHex))
+	if len(publicKeyHex)%2 != 0 || len(publicKeyHex) == 0 {
+		return "", fmt.Errorf("invalid public key hex length: %d", len(publicKeyHex))
 	}
-	key := make([]byte, 32)
-	for i := 0; i < 32; i++ {
+	key := make([]byte, len(publicKeyHex)/2)
+	for i := range key {
 		b, err := hexByte(publicKeyHex[i*2], publicKeyHex[i*2+1])
 		if err != nil {
 			return "", err

--- a/internal/noise/interop_test.go
+++ b/internal/noise/interop_test.go
@@ -9,38 +9,43 @@ import (
 )
 
 // TestPrintInteropVector generates a test vector that can be used to verify
-// the TypeScript Noise_NK implementation against the Go implementation.
+// the TypeScript hybrid Noise_NK implementation against the Go implementation.
 //
 // To use: run `go test -run TestPrintInteropVector -v` and copy the output
 // into a TypeScript test that verifies the same values.
 func TestPrintInteropVector(t *testing.T) {
-	workerKey, err := GenerateKeypair()
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	fmt.Printf("staticPublicKey: %s\n", hex.EncodeToString(workerKey.Public))
-	fmt.Printf("staticPrivateKey: %s\n", hex.EncodeToString(workerKey.Private))
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
 
-	// Go initiator creates message1
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	fmt.Printf("x25519PublicKey: %s\n", hex.EncodeToString(workerKey.X25519Public))
+	fmt.Printf("x25519PrivateKey: %s\n", hex.EncodeToString(workerKey.X25519Private))
+	fmt.Printf("mlkemPublicKey (len=%d): %s\n", len(workerKey.MlkemPublicKeyBytes()), hex.EncodeToString(workerKey.MlkemPublicKeyBytes()))
+	fmt.Printf("slhdsaPublicKey (len=%d): %s\n", len(slhdsaPubBytes), hex.EncodeToString(slhdsaPubBytes))
+
+	// Go initiator creates message1.
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 	fmt.Printf("message1 (len=%d): %s\n", len(msg1), hex.EncodeToString(msg1))
 
-	// Go responder processes message1
+	// Go responder processes message1.
 	msg2, workerSession, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 	fmt.Printf("message2 (len=%d): %s\n", len(msg2), hex.EncodeToString(msg2))
 
-	// Go initiator completes handshake
-	initiatorSession, err := InitiatorHandshake2(hs, msg2)
+	// Go initiator completes handshake.
+	initiatorSession, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 
-	// Encrypt a test message initiator -> responder
+	// Encrypt a test message initiator -> responder.
 	testMsg := []byte("hello")
 	ct, err := initiatorSession.Encrypt(testMsg)
 	require.NoError(t, err)
 	fmt.Printf("encrypted 'hello' (initiator->responder): %s\n", hex.EncodeToString(ct))
 
-	// Verify responder can decrypt
+	// Verify responder can decrypt.
 	pt, err := workerSession.Decrypt(ct)
 	require.NoError(t, err)
 	require.Equal(t, testMsg, pt)

--- a/internal/noise/noise.go
+++ b/internal/noise/noise.go
@@ -367,12 +367,18 @@ func ResponderHandshake(compositeKey *CompositeKeypair, message1 []byte) (respon
 		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
 	}
 	ss.mixKey(dhES)
+	zeroBytes(dhES)
 
 	// Decrypt payload from message 1.
 	_, err = ss.decryptAndHash(noiseMsg1[dhLen:])
 	if err != nil {
 		return nil, nil, fmt.Errorf("noise: decrypt message1 payload: %w", err)
 	}
+
+	// Bind ML-KEM ciphertext into the handshake hash so that tampering with
+	// the ciphertext causes the message2 AEAD to fail, independent of the
+	// SLH-DSA transcript signature.
+	ss.mixHash(mlkemCT)
 
 	// Write message 2: <- e, ee
 	// Generate responder ephemeral.
@@ -389,6 +395,7 @@ func ResponderHandshake(compositeKey *CompositeKeypair, message1 []byte) (respon
 		return nil, nil, fmt.Errorf("noise: ee DH failed: %w", err)
 	}
 	ss.mixKey(dhEE)
+	zeroBytes(dhEE)
 
 	// Encrypt empty payload.
 	encPayload, err := ss.encryptAndHash(nil)
@@ -410,11 +417,14 @@ func ResponderHandshake(compositeKey *CompositeKeypair, message1 []byte) (respon
 	// Sign transcript with SLH-DSA.
 	sig, err := compositeKey.SlhdsaPrivateKey.Sign(rand.Reader, transcript, nil)
 	if err != nil {
+		zeroBytes(mlkemSS)
 		return nil, nil, fmt.Errorf("noise: SLH-DSA sign: %w", err)
 	}
 
 	// Hybrid split: combine classical ck with ML-KEM shared secret.
 	send, recv := ss.hybridSplit(mlkemSS)
+	zeroBytes(mlkemSS)
+	ss.clear()
 
 	return append(noiseMsg2, sig...), &Session{Send: send, Receive: recv}, nil
 }
@@ -453,6 +463,7 @@ func InitiatorHandshake1(remoteX25519Pub, remoteMlkemPub []byte) (*HandshakeStat
 		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
 	}
 	ss.mixKey(dhES)
+	zeroBytes(dhES)
 
 	// Encrypt empty payload.
 	encPayload, err := ss.encryptAndHash(nil)
@@ -468,6 +479,9 @@ func InitiatorHandshake1(remoteX25519Pub, remoteMlkemPub []byte) (*HandshakeStat
 		return nil, nil, fmt.Errorf("noise: parse ML-KEM encapsulation key: %w", err)
 	}
 	mlkemSS, mlkemCT := mlkemEK.Encapsulate()
+
+	// Bind ML-KEM ciphertext into the handshake hash (matches responder's mixHash).
+	ss.mixHash(mlkemCT)
 
 	message1 := append(noiseMsg1, mlkemCT...)
 
@@ -510,6 +524,7 @@ func InitiatorHandshake2(hs *HandshakeState, message2 []byte, remoteSlhdsaPub []
 		return nil, fmt.Errorf("noise: ee DH failed: %w", err)
 	}
 	ss.mixKey(dhEE)
+	zeroBytes(dhEE)
 
 	// Decrypt payload.
 	_, err = ss.decryptAndHash(noiseMsg2[dhLen:])
@@ -532,6 +547,9 @@ func InitiatorHandshake2(hs *HandshakeState, message2 []byte, remoteSlhdsaPub []
 	// Hybrid split: combine classical ck with ML-KEM shared secret.
 	// Initiator convention: send=cs2, receive=cs1.
 	cs1, cs2 := ss.hybridSplit(hs.mlkemSS)
+	ss.clear()
+	hs.Clear()
+
 	return &Session{Send: cs2, Receive: cs1}, nil
 }
 
@@ -565,6 +583,7 @@ func ClassicalResponderHandshake(x25519Pub, x25519Priv []byte, message1 []byte) 
 		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
 	}
 	ss.mixKey(dhES)
+	zeroBytes(dhES)
 
 	if _, err = ss.decryptAndHash(message1[dhLen:]); err != nil {
 		return nil, nil, fmt.Errorf("noise: decrypt message1 payload: %w", err)
@@ -582,6 +601,7 @@ func ClassicalResponderHandshake(x25519Pub, x25519Priv []byte, message1 []byte) 
 		return nil, nil, fmt.Errorf("noise: ee DH failed: %w", err)
 	}
 	ss.mixKey(dhEE)
+	zeroBytes(dhEE)
 
 	encPayload, err := ss.encryptAndHash(nil)
 	if err != nil {
@@ -589,6 +609,7 @@ func ClassicalResponderHandshake(x25519Pub, x25519Priv []byte, message1 []byte) 
 	}
 
 	send, recv := ss.split()
+	ss.clear()
 	return append(ePub, encPayload...), &Session{Send: send, Receive: recv}, nil
 }
 
@@ -616,6 +637,7 @@ func ClassicalInitiatorHandshake1(remoteX25519Pub []byte) (*HandshakeState, []by
 		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
 	}
 	ss.mixKey(dhES)
+	zeroBytes(dhES)
 
 	encPayload, err := ss.encryptAndHash(nil)
 	if err != nil {
@@ -650,13 +672,47 @@ func ClassicalInitiatorHandshake2(hs *HandshakeState, message2 []byte) (*Session
 		return nil, fmt.Errorf("noise: ee DH failed: %w", err)
 	}
 	ss.mixKey(dhEE)
+	zeroBytes(dhEE)
 
 	if _, err = ss.decryptAndHash(message2[dhLen:]); err != nil {
 		return nil, fmt.Errorf("noise: decrypt message2 payload: %w", err)
 	}
 
 	cs1, cs2 := ss.split()
+	ss.clear()
+	hs.Clear()
 	return &Session{Send: cs2, Receive: cs1}, nil
+}
+
+// ---- Key material zeroing ----
+
+// zeroBytes overwrites a byte slice with zeros to limit key material lifetime in memory.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// clear zeroes the symmetric state's sensitive fields after split/hybridSplit.
+func (ss *symmetricState) clear() {
+	zeroBytes(ss.ck[:])
+	zeroBytes(ss.k[:])
+	zeroBytes(ss.h[:])
+	ss.hasK = false
+	ss.n = 0
+}
+
+// Clear zeroes all sensitive fields in the HandshakeState.
+// Only secrets are zeroed — public keys (rs) are not sensitive.
+// Called automatically by InitiatorHandshake2 after completing the handshake.
+func (hs *HandshakeState) Clear() {
+	if hs.ss != nil {
+		hs.ss.clear()
+		hs.ss = nil
+	}
+	hs.ePriv = nil
+	zeroBytes(hs.mlkemSS)
+	zeroBytes(hs.mlkemCT)
 }
 
 // ---- Crypto primitives ----

--- a/internal/noise/noise.go
+++ b/internal/noise/noise.go
@@ -1,16 +1,23 @@
-// Package noise implements Noise_NK handshake and session management
-// for end-to-end encrypted channels between Frontend and Worker.
+// Package noise implements a hybrid post-quantum Noise_NK handshake and session
+// management for end-to-end encrypted channels between Frontend and Worker.
+//
+// The protocol combines classical X25519 + ChaCha20-Poly1305 + BLAKE2b with
+// post-quantum ML-KEM-1024 (FIPS 203) and SLH-DSA-SHAKE-256f (FIPS 205).
+// Security is maintained even if either the classical or PQ algorithm is broken.
 package noise
 
 import (
+	"crypto/ecdh"
+	"crypto/hmac"
+	"crypto/mlkem"
 	"crypto/rand"
 	"fmt"
+	"hash"
 
-	"github.com/flynn/noise"
+	"github.com/cloudflare/circl/sign/slhdsa"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/chacha20poly1305"
 )
-
-// CipherSuite is Noise_NK_25519_ChaChaPoly_BLAKE2b.
-var CipherSuite = noise.NewCipherSuite(noise.DH25519, noise.CipherChaChaPoly, noise.HashBLAKE2b)
 
 const (
 	// SoftNonceLimit triggers re-handshake when exceeded.
@@ -19,118 +26,558 @@ const (
 	HardNonceLimit = uint64(1<<32 - 1) // 2^32-1
 	// MaxPlaintextSize is the Noise spec transport message limit minus auth tag.
 	MaxPlaintextSize = 65535 - 16
+
+	protocolName = "Noise_NK_25519_ChaChaPoly_BLAKE2b"
+	hashLen      = 64 // BLAKE2b output length
+	dhLen        = 32 // X25519 key length
+	keyLen       = 32 // ChaCha20-Poly1305 key length
+
+	// MlkemPublicKeySize is the size of an ML-KEM-1024 encapsulation key.
+	MlkemPublicKeySize = 1568
+	// MlkemCiphertextSize is the size of an ML-KEM-1024 ciphertext.
+	MlkemCiphertextSize = 1568
+	// SlhdsaPublicKeySize is the size of an SLH-DSA-SHAKE-256f public key.
+	SlhdsaPublicKeySize = 64
+	// SlhdsaSignatureSize is the size of an SLH-DSA-SHAKE-256f signature.
+	SlhdsaSignatureSize = 49856
 )
 
-// Keypair is an alias for the underlying Noise DHKey type (X25519).
-type Keypair = noise.DHKey
+// ---- Composite Keypair ----
 
-// GenerateKeypair generates a new X25519 static key pair for use as
-// a Noise responder (Worker) identity.
-func GenerateKeypair() (noise.DHKey, error) {
-	return CipherSuite.GenerateKeypair(rand.Reader)
+// CompositeKeypair holds X25519, ML-KEM-1024, and SLH-DSA-SHAKE-256f key material.
+type CompositeKeypair struct {
+	// X25519
+	X25519Public  []byte
+	X25519Private []byte
+
+	// ML-KEM-1024
+	MlkemDecapsulationKey *mlkem.DecapsulationKey1024
+
+	// SLH-DSA-SHAKE-256f
+	SlhdsaPublicKey  slhdsa.PublicKey
+	SlhdsaPrivateKey slhdsa.PrivateKey
 }
 
-// Session wraps a pair of Noise CipherState objects for bidirectional
-// encrypted communication after a completed handshake.
-type Session struct {
-	Send    *noise.CipherState
-	Receive *noise.CipherState
+// MlkemPublicKeyBytes returns the ML-KEM-1024 encapsulation key bytes.
+func (ck *CompositeKeypair) MlkemPublicKeyBytes() []byte {
+	return ck.MlkemDecapsulationKey.EncapsulationKey().Bytes()
 }
 
-// Encrypt encrypts plaintext using the send cipher. Enforces the Noise
-// spec plaintext size limit and nonce hard limit.
-func (s *Session) Encrypt(plaintext []byte) ([]byte, error) {
+// SlhdsaPublicKeyBytes returns the SLH-DSA public key bytes.
+func (ck *CompositeKeypair) SlhdsaPublicKeyBytes() ([]byte, error) {
+	return ck.SlhdsaPublicKey.MarshalBinary()
+}
+
+// Fingerprint returns a 4-word composite fingerprint of all public keys.
+func (ck *CompositeKeypair) Fingerprint() string {
+	slhdsaPub, _ := ck.SlhdsaPublicKeyBytes()
+	return CompositeKeyFingerprint(ck.X25519Public, ck.MlkemPublicKeyBytes(), slhdsaPub)
+}
+
+// GenerateCompositeKeypair generates X25519 + ML-KEM-1024 + SLH-DSA-SHAKE-256f key material.
+func GenerateCompositeKeypair() (*CompositeKeypair, error) {
+	// X25519
+	x25519Priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate X25519 key: %w", err)
+	}
+
+	// ML-KEM-1024
+	mlkemDK, err := mlkem.GenerateKey1024()
+	if err != nil {
+		return nil, fmt.Errorf("generate ML-KEM-1024 key: %w", err)
+	}
+
+	// SLH-DSA-SHAKE-256f
+	slhdsaPub, slhdsaPriv, err := slhdsa.GenerateKey(rand.Reader, slhdsa.SHAKE_256f)
+	if err != nil {
+		return nil, fmt.Errorf("generate SLH-DSA key: %w", err)
+	}
+
+	return &CompositeKeypair{
+		X25519Public:          x25519Priv.PublicKey().Bytes(),
+		X25519Private:         x25519Priv.Bytes(),
+		MlkemDecapsulationKey: mlkemDK,
+		SlhdsaPublicKey:       slhdsaPub,
+		SlhdsaPrivateKey:      slhdsaPriv,
+	}, nil
+}
+
+// RestoreCompositeKeypair reconstructs a CompositeKeypair from serialized key bytes.
+func RestoreCompositeKeypair(x25519Pub, x25519Priv, mlkemPrivBytes, slhdsaPubBytes, slhdsaPrivBytes []byte) (*CompositeKeypair, error) {
+	mlkemDK, err := mlkem.NewDecapsulationKey1024(mlkemPrivBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse ML-KEM decapsulation key: %w", err)
+	}
+
+	slhdsaPub := slhdsa.PublicKey{ID: slhdsa.SHAKE_256f}
+	if err := slhdsaPub.UnmarshalBinary(slhdsaPubBytes); err != nil {
+		return nil, fmt.Errorf("parse SLH-DSA public key: %w", err)
+	}
+
+	slhdsaPriv := slhdsa.PrivateKey{ID: slhdsa.SHAKE_256f}
+	if err := slhdsaPriv.UnmarshalBinary(slhdsaPrivBytes); err != nil {
+		return nil, fmt.Errorf("parse SLH-DSA private key: %w", err)
+	}
+
+	return &CompositeKeypair{
+		X25519Public:          x25519Pub,
+		X25519Private:         x25519Priv,
+		MlkemDecapsulationKey: mlkemDK,
+		SlhdsaPublicKey:       slhdsaPub,
+		SlhdsaPrivateKey:      slhdsaPriv,
+	}, nil
+}
+
+// ---- Symmetric State (Noise protocol core) ----
+
+type symmetricState struct {
+	h    [hashLen]byte // handshake hash
+	ck   [hashLen]byte // chaining key
+	hasK bool
+	k    [keyLen]byte // cipher key
+	n    uint32       // nonce counter
+}
+
+func newSymmetricState() *symmetricState {
+	ss := &symmetricState{}
+	// Protocol name fits in 64 bytes, so we pad it.
+	nameBytes := []byte(protocolName)
+	copy(ss.h[:], nameBytes)
+	ss.ck = ss.h
+	return ss
+}
+
+func (ss *symmetricState) mixHash(data []byte) {
+	h, _ := blake2b.New512(nil)
+	h.Write(ss.h[:])
+	h.Write(data)
+	copy(ss.h[:], h.Sum(nil))
+}
+
+func (ss *symmetricState) mixKey(ikm []byte) {
+	ck, tempK := noiseHKDF(ss.ck[:], ikm)
+	ss.ck = ck
+	copy(ss.k[:], tempK[:keyLen])
+	ss.n = 0
+	ss.hasK = true
+}
+
+func (ss *symmetricState) encryptAndHash(plaintext []byte) ([]byte, error) {
+	if !ss.hasK {
+		ss.mixHash(plaintext)
+		out := make([]byte, len(plaintext))
+		copy(out, plaintext)
+		return out, nil
+	}
+	ct, err := aeadEncrypt(ss.k[:], ss.n, ss.h[:], plaintext)
+	if err != nil {
+		return nil, err
+	}
+	ss.mixHash(ct)
+	ss.n++
+	return ct, nil
+}
+
+func (ss *symmetricState) decryptAndHash(ciphertext []byte) ([]byte, error) {
+	if !ss.hasK {
+		ss.mixHash(ciphertext)
+		out := make([]byte, len(ciphertext))
+		copy(out, ciphertext)
+		return out, nil
+	}
+	pt, err := aeadDecrypt(ss.k[:], ss.n, ss.h[:], ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	ss.mixHash(ciphertext)
+	ss.n++
+	return pt, nil
+}
+
+func (ss *symmetricState) split() (*CipherState, *CipherState) {
+	tempK1, tempK2 := noiseHKDF(ss.ck[:], nil)
+	var k1, k2 [keyLen]byte
+	copy(k1[:], tempK1[:keyLen])
+	copy(k2[:], tempK2[:keyLen])
+	return &CipherState{k: k1}, &CipherState{k: k2}
+}
+
+// hybridSplit mixes extra key material (ML-KEM shared secret) into the chaining
+// key before deriving the final cipher keys. This binds both classical and PQ
+// secrets into the session keys.
+func (ss *symmetricState) hybridSplit(extraKeyMaterial []byte) (*CipherState, *CipherState) {
+	// Mix ML-KEM shared secret into chaining key.
+	ck2, _ := noiseHKDF(ss.ck[:], extraKeyMaterial)
+	// Derive cipher keys from the combined chaining key.
+	tempK1, tempK2 := noiseHKDF(ck2[:], nil)
+	var k1, k2 [keyLen]byte
+	copy(k1[:], tempK1[:keyLen])
+	copy(k2[:], tempK2[:keyLen])
+	return &CipherState{k: k1}, &CipherState{k: k2}
+}
+
+// ---- CipherState (post-handshake) ----
+
+// CipherState manages a key and nonce for post-handshake encryption/decryption.
+type CipherState struct {
+	k [keyLen]byte
+	n uint64
+}
+
+// Encrypt encrypts plaintext using the cipher key.
+func (cs *CipherState) Encrypt(plaintext []byte) ([]byte, error) {
 	if len(plaintext) > MaxPlaintextSize {
 		return nil, fmt.Errorf("noise: plaintext too large (%d > %d)", len(plaintext), MaxPlaintextSize)
 	}
-	if s.Send.Nonce() > HardNonceLimit {
+	if cs.n > HardNonceLimit {
 		return nil, fmt.Errorf("noise: send nonce exceeded hard limit")
 	}
-	return s.Send.Encrypt(nil, nil, plaintext)
+	ct, err := aeadEncrypt(cs.k[:], uint32(cs.n), nil, plaintext)
+	if err != nil {
+		return nil, err
+	}
+	cs.n++
+	return ct, nil
 }
 
-// Decrypt decrypts ciphertext using the receive cipher. Enforces the
-// nonce hard limit.
-func (s *Session) Decrypt(ciphertext []byte) ([]byte, error) {
-	if s.Receive.Nonce() > HardNonceLimit {
+// Decrypt decrypts ciphertext using the cipher key.
+func (cs *CipherState) Decrypt(ciphertext []byte) ([]byte, error) {
+	if cs.n > HardNonceLimit {
 		return nil, fmt.Errorf("noise: receive nonce exceeded hard limit")
 	}
-	return s.Receive.Decrypt(nil, nil, ciphertext)
+	pt, err := aeadDecrypt(cs.k[:], uint32(cs.n), nil, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	cs.n++
+	return pt, nil
+}
+
+// Nonce returns the current nonce value.
+func (cs *CipherState) Nonce() uint64 {
+	return cs.n
+}
+
+// NeedsRekey returns true if the nonce has exceeded the soft limit.
+func (cs *CipherState) NeedsRekey() bool {
+	return cs.n > SoftNonceLimit
+}
+
+// ---- Session ----
+
+// Session wraps send/receive CipherState objects for bidirectional
+// encrypted communication after a completed handshake.
+type Session struct {
+	Send    *CipherState
+	Receive *CipherState
+}
+
+// Encrypt encrypts plaintext using the send cipher.
+func (s *Session) Encrypt(plaintext []byte) ([]byte, error) {
+	return s.Send.Encrypt(plaintext)
+}
+
+// Decrypt decrypts ciphertext using the receive cipher.
+func (s *Session) Decrypt(ciphertext []byte) ([]byte, error) {
+	return s.Receive.Decrypt(ciphertext)
 }
 
 // NeedsRekey returns true if the send nonce has exceeded the soft limit.
 func (s *Session) NeedsRekey() bool {
-	return s.Send.Nonce() > SoftNonceLimit
+	return s.Send.NeedsRekey()
 }
 
-// ResponderHandshake performs the responder (Worker) side of Noise_NK.
-// It takes the Worker's static key pair, the initiator's first handshake
-// message, and returns the response message and established session.
-func ResponderHandshake(staticKey Keypair, message1 []byte) (response []byte, session *Session, err error) {
-	hs, err := noise.NewHandshakeState(noise.Config{
-		CipherSuite:   CipherSuite,
-		Pattern:       noise.HandshakeNK,
-		Initiator:     false,
-		StaticKeypair: staticKey,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("create handshake state: %w", err)
-	}
+// ---- Handshake State (for two-step initiator) ----
 
-	// Process message 1 from initiator
-	_, _, _, err = hs.ReadMessage(nil, message1)
-	if err != nil {
-		return nil, nil, fmt.Errorf("read handshake message 1: %w", err)
-	}
-
-	// Write message 2 (response)
-	response, send, receive, err := hs.WriteMessage(nil, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("write handshake message 2: %w", err)
-	}
-
-	if send == nil || receive == nil {
-		return nil, nil, fmt.Errorf("handshake not complete after 2 messages")
-	}
-
-	return response, &Session{Send: send, Receive: receive}, nil
+// HandshakeState holds intermediate state between handshake messages.
+type HandshakeState struct {
+	ss      *symmetricState
+	ePriv   *ecdh.PrivateKey
+	rs      []byte // remote static public key (X25519)
+	mlkemSS []byte // ML-KEM shared secret
+	mlkemCT []byte // ML-KEM ciphertext (needed for transcript)
 }
 
-// InitiatorHandshake1 creates the initiator (Frontend) side of Noise_NK
-// and produces the first handshake message. Call InitiatorHandshake2 with
-// the responder's reply to complete the handshake.
-//
-// Returns the handshake state (needed for step 2) and the first message.
-func InitiatorHandshake1(remoteStaticPubKey []byte) (hs *noise.HandshakeState, message1 []byte, err error) {
-	hs, err = noise.NewHandshakeState(noise.Config{
-		CipherSuite: CipherSuite,
-		Pattern:     noise.HandshakeNK,
-		Initiator:   true,
-		PeerStatic:  remoteStaticPubKey,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("create handshake state: %w", err)
+// ---- Responder Handshake (Worker) ----
+
+// ResponderHandshake performs the responder (Worker) side of the hybrid Noise_NK handshake.
+// It takes the Worker's composite keypair and the initiator's first handshake message
+// (which contains noise_msg1 || mlkem_ciphertext), and returns the response message
+// (noise_msg2 || slhdsa_signature) and established session.
+func ResponderHandshake(compositeKey *CompositeKeypair, message1 []byte) (response []byte, session *Session, err error) {
+	// message1 = noise_msg1 (32 + 16 = 48 bytes) || mlkem_ciphertext (1568 bytes)
+	noiseMsg1Len := dhLen + chacha20poly1305.Overhead // 32 + 16 = 48
+	expectedLen := noiseMsg1Len + MlkemCiphertextSize
+	if len(message1) != expectedLen {
+		return nil, nil, fmt.Errorf("noise: message1 wrong size: got %d, want %d", len(message1), expectedLen)
 	}
 
-	message1, _, _, err = hs.WriteMessage(nil, nil)
+	noiseMsg1 := message1[:noiseMsg1Len]
+	mlkemCT := message1[noiseMsg1Len:]
+
+	// Initialize symmetric state.
+	ss := newSymmetricState()
+
+	// Mix empty prologue.
+	ss.mixHash(nil)
+
+	// Pre-message: <- s (mix responder's static public key).
+	ss.mixHash(compositeKey.X25519Public)
+
+	// Read message 1: -> e, es
+	// Read initiator's ephemeral public key.
+	re := noiseMsg1[:dhLen]
+	ss.mixHash(re)
+
+	// es: DH(s, re) — responder's static private with initiator's ephemeral.
+	reKey, err := ecdh.X25519().NewPublicKey(re)
 	if err != nil {
-		return nil, nil, fmt.Errorf("write handshake message 1: %w", err)
+		return nil, nil, fmt.Errorf("noise: invalid initiator ephemeral key: %w", err)
+	}
+	sPriv, err := ecdh.X25519().NewPrivateKey(compositeKey.X25519Private)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: invalid responder static private key: %w", err)
+	}
+	dhES, err := sPriv.ECDH(reKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
+	}
+	ss.mixKey(dhES)
+
+	// Decrypt payload from message 1.
+	_, err = ss.decryptAndHash(noiseMsg1[dhLen:])
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: decrypt message1 payload: %w", err)
 	}
 
-	return hs, message1, nil
+	// Write message 2: <- e, ee
+	// Generate responder ephemeral.
+	ePriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: generate responder ephemeral: %w", err)
+	}
+	ePub := ePriv.PublicKey().Bytes()
+	ss.mixHash(ePub)
+
+	// ee: DH(e, re).
+	dhEE, err := ePriv.ECDH(reKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: ee DH failed: %w", err)
+	}
+	ss.mixKey(dhEE)
+
+	// Encrypt empty payload.
+	encPayload, err := ss.encryptAndHash(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: encrypt message2 payload: %w", err)
+	}
+
+	noiseMsg2 := append(ePub, encPayload...)
+
+	// ML-KEM decapsulation.
+	mlkemSS, err := compositeKey.MlkemDecapsulationKey.Decapsulate(mlkemCT)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: ML-KEM decapsulate: %w", err)
+	}
+
+	// Compute transcript for SLH-DSA signing.
+	transcript := computeTranscript(ss.h[:], mlkemCT, mlkemSS)
+
+	// Sign transcript with SLH-DSA.
+	sig, err := compositeKey.SlhdsaPrivateKey.Sign(rand.Reader, transcript, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: SLH-DSA sign: %w", err)
+	}
+
+	// Hybrid split: combine classical ck with ML-KEM shared secret.
+	send, recv := ss.hybridSplit(mlkemSS)
+
+	return append(noiseMsg2, sig...), &Session{Send: send, Receive: recv}, nil
 }
 
-// InitiatorHandshake2 completes the initiator side by processing the
-// responder's handshake response message.
-func InitiatorHandshake2(hs *noise.HandshakeState, message2 []byte) (*Session, error) {
-	_, receive, send, err := hs.ReadMessage(nil, message2)
+// ---- Initiator Handshake (Frontend, Go side for testing) ----
+
+// InitiatorHandshake1 creates the first handshake message for the hybrid Noise_NK initiator.
+// Returns the handshake state (needed for step 2) and the first message
+// (noise_msg1 || mlkem_ciphertext).
+func InitiatorHandshake1(remoteX25519Pub, remoteMlkemPub []byte) (*HandshakeState, []byte, error) {
+	// Initialize symmetric state.
+	ss := newSymmetricState()
+
+	// Mix empty prologue.
+	ss.mixHash(nil)
+
+	// Pre-message: <- s (mix responder's static public key).
+	ss.mixHash(remoteX25519Pub)
+
+	// -> e, es
+	// Generate ephemeral keypair.
+	ePriv, err := ecdh.X25519().GenerateKey(rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("read handshake message 2: %w", err)
+		return nil, nil, fmt.Errorf("noise: generate initiator ephemeral: %w", err)
+	}
+	ePub := ePriv.PublicKey().Bytes()
+	ss.mixHash(ePub)
+
+	// es: DH(e, rs).
+	rsKey, err := ecdh.X25519().NewPublicKey(remoteX25519Pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: invalid remote static public key: %w", err)
+	}
+	dhES, err := ePriv.ECDH(rsKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
+	}
+	ss.mixKey(dhES)
+
+	// Encrypt empty payload.
+	encPayload, err := ss.encryptAndHash(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: encrypt message1 payload: %w", err)
 	}
 
-	if send == nil || receive == nil {
-		return nil, fmt.Errorf("handshake not complete after 2 messages")
-	}
+	noiseMsg1 := append(ePub, encPayload...)
 
-	return &Session{Send: send, Receive: receive}, nil
+	// ML-KEM encapsulation.
+	mlkemEK, err := mlkem.NewEncapsulationKey1024(remoteMlkemPub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: parse ML-KEM encapsulation key: %w", err)
+	}
+	mlkemSS, mlkemCT := mlkemEK.Encapsulate()
+
+	message1 := append(noiseMsg1, mlkemCT...)
+
+	return &HandshakeState{
+		ss:      ss,
+		ePriv:   ePriv,
+		rs:      remoteX25519Pub,
+		mlkemSS: mlkemSS,
+		mlkemCT: mlkemCT,
+	}, message1, nil
 }
+
+// InitiatorHandshake2 completes the initiator side by processing the responder's
+// handshake response message (noise_msg2 || slhdsa_signature).
+// It verifies the SLH-DSA signature and combines keys via HKDF.
+func InitiatorHandshake2(hs *HandshakeState, message2 []byte, remoteSlhdsaPub []byte) (*Session, error) {
+	noiseMsg2Len := dhLen + chacha20poly1305.Overhead // 32 + 16 = 48
+	expectedLen := noiseMsg2Len + SlhdsaSignatureSize
+	if len(message2) != expectedLen {
+		return nil, fmt.Errorf("noise: message2 wrong size: got %d, want %d", len(message2), expectedLen)
+	}
+
+	noiseMsg2 := message2[:noiseMsg2Len]
+	slhdsaSig := message2[noiseMsg2Len:]
+
+	ss := hs.ss
+
+	// <- e, ee
+	// Read responder's ephemeral public key.
+	re := noiseMsg2[:dhLen]
+	ss.mixHash(re)
+
+	// ee: DH(e, re).
+	reKey, err := ecdh.X25519().NewPublicKey(re)
+	if err != nil {
+		return nil, fmt.Errorf("noise: invalid responder ephemeral key: %w", err)
+	}
+	dhEE, err := hs.ePriv.ECDH(reKey)
+	if err != nil {
+		return nil, fmt.Errorf("noise: ee DH failed: %w", err)
+	}
+	ss.mixKey(dhEE)
+
+	// Decrypt payload.
+	_, err = ss.decryptAndHash(noiseMsg2[dhLen:])
+	if err != nil {
+		return nil, fmt.Errorf("noise: decrypt message2 payload: %w", err)
+	}
+
+	// Verify SLH-DSA signature over transcript.
+	transcript := computeTranscript(ss.h[:], hs.mlkemCT, hs.mlkemSS)
+
+	slhdsaPubKey := slhdsa.PublicKey{ID: slhdsa.SHAKE_256f}
+	if err := slhdsaPubKey.UnmarshalBinary(remoteSlhdsaPub); err != nil {
+		return nil, fmt.Errorf("noise: parse SLH-DSA public key: %w", err)
+	}
+
+	if !slhdsa.Verify(&slhdsaPubKey, slhdsa.NewMessage(transcript), slhdsaSig, nil) {
+		return nil, fmt.Errorf("noise: SLH-DSA signature verification failed")
+	}
+
+	// Hybrid split: combine classical ck with ML-KEM shared secret.
+	// Initiator convention: send=cs2, receive=cs1.
+	cs1, cs2 := ss.hybridSplit(hs.mlkemSS)
+	return &Session{Send: cs2, Receive: cs1}, nil
+}
+
+// ---- Crypto primitives ----
+
+func blake2bHash() hash.Hash {
+	h, _ := blake2b.New512(nil)
+	return h
+}
+
+// noiseHKDF implements the Noise HKDF using HMAC-BLAKE2b.
+func noiseHKDF(chainingKey, inputKeyMaterial []byte) (out1 [hashLen]byte, out2 [hashLen]byte) {
+	// Extract
+	mac := hmac.New(blake2bHash, chainingKey)
+	if inputKeyMaterial != nil {
+		mac.Write(inputKeyMaterial)
+	}
+	tempKey := mac.Sum(nil)
+
+	// Expand 1
+	mac = hmac.New(blake2bHash, tempKey)
+	mac.Write([]byte{1})
+	o1 := mac.Sum(nil)
+	copy(out1[:], o1)
+
+	// Expand 2
+	mac = hmac.New(blake2bHash, tempKey)
+	mac.Write(o1)
+	mac.Write([]byte{2})
+	copy(out2[:], mac.Sum(nil))
+
+	return
+}
+
+// aeadEncrypt encrypts with ChaCha20-Poly1305.
+func aeadEncrypt(key []byte, nonce uint32, ad, plaintext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	nonceBytes := make([]byte, chacha20poly1305.NonceSize)
+	nonceBytes[4] = byte(nonce)
+	nonceBytes[5] = byte(nonce >> 8)
+	nonceBytes[6] = byte(nonce >> 16)
+	nonceBytes[7] = byte(nonce >> 24)
+	return aead.Seal(nil, nonceBytes, plaintext, ad), nil
+}
+
+// aeadDecrypt decrypts with ChaCha20-Poly1305.
+func aeadDecrypt(key []byte, nonce uint32, ad, ciphertext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	nonceBytes := make([]byte, chacha20poly1305.NonceSize)
+	nonceBytes[4] = byte(nonce)
+	nonceBytes[5] = byte(nonce >> 8)
+	nonceBytes[6] = byte(nonce >> 16)
+	nonceBytes[7] = byte(nonce >> 24)
+	return aead.Open(nil, nonceBytes, ciphertext, ad)
+}
+
+// computeTranscript computes BLAKE2b(handshake_hash || mlkem_ct || mlkem_ss).
+func computeTranscript(handshakeHash, mlkemCT, mlkemSS []byte) []byte {
+	h, _ := blake2b.New512(nil)
+	h.Write(handshakeHash)
+	h.Write(mlkemCT)
+	h.Write(mlkemSS)
+	return h.Sum(nil)
+}
+
+

--- a/internal/noise/noise.go
+++ b/internal/noise/noise.go
@@ -221,12 +221,18 @@ func (ss *symmetricState) hybridSplit(extraKeyMaterial []byte) (*CipherState, *C
 
 // CipherState manages a key and nonce for post-handshake encryption/decryption.
 type CipherState struct {
-	k [keyLen]byte
-	n uint64
+	k           [keyLen]byte
+	n           uint64
+	passthrough bool // when true, data passes through without encryption
 }
 
 // Encrypt encrypts plaintext using the cipher key.
 func (cs *CipherState) Encrypt(plaintext []byte) ([]byte, error) {
+	if cs.passthrough {
+		out := make([]byte, len(plaintext))
+		copy(out, plaintext)
+		return out, nil
+	}
 	if len(plaintext) > MaxPlaintextSize {
 		return nil, fmt.Errorf("noise: plaintext too large (%d > %d)", len(plaintext), MaxPlaintextSize)
 	}
@@ -243,6 +249,11 @@ func (cs *CipherState) Encrypt(plaintext []byte) ([]byte, error) {
 
 // Decrypt decrypts ciphertext using the cipher key.
 func (cs *CipherState) Decrypt(ciphertext []byte) ([]byte, error) {
+	if cs.passthrough {
+		out := make([]byte, len(ciphertext))
+		copy(out, ciphertext)
+		return out, nil
+	}
 	if cs.n > HardNonceLimit {
 		return nil, fmt.Errorf("noise: receive nonce exceeded hard limit")
 	}
@@ -261,6 +272,9 @@ func (cs *CipherState) Nonce() uint64 {
 
 // NeedsRekey returns true if the nonce has exceeded the soft limit.
 func (cs *CipherState) NeedsRekey() bool {
+	if cs.passthrough {
+		return false
+	}
 	return cs.n > SoftNonceLimit
 }
 
@@ -286,6 +300,15 @@ func (s *Session) Decrypt(ciphertext []byte) ([]byte, error) {
 // NeedsRekey returns true if the send nonce has exceeded the soft limit.
 func (s *Session) NeedsRekey() bool {
 	return s.Send.NeedsRekey()
+}
+
+// NewPassthroughSession creates a Session that passes data through without encryption.
+// Used when encryption is disabled (solo mode only).
+func NewPassthroughSession() *Session {
+	return &Session{
+		Send:    &CipherState{passthrough: true},
+		Receive: &CipherState{passthrough: true},
+	}
 }
 
 // ---- Handshake State (for two-step initiator) ----
@@ -512,6 +535,130 @@ func InitiatorHandshake2(hs *HandshakeState, message2 []byte, remoteSlhdsaPub []
 	return &Session{Send: cs2, Receive: cs1}, nil
 }
 
+// ---- Classical Responder Handshake (Worker, X25519 only) ----
+
+// ClassicalResponderHandshake performs the responder side of the classical Noise_NK handshake.
+// message1 = noise_msg1 (48 bytes), response = noise_msg2 (48 bytes).
+func ClassicalResponderHandshake(x25519Pub, x25519Priv []byte, message1 []byte) (response []byte, session *Session, err error) {
+	noiseMsg1Len := dhLen + chacha20poly1305.Overhead // 48
+	if len(message1) != noiseMsg1Len {
+		return nil, nil, fmt.Errorf("noise: classical message1 wrong size: got %d, want %d", len(message1), noiseMsg1Len)
+	}
+
+	ss := newSymmetricState()
+	ss.mixHash(nil)
+	ss.mixHash(x25519Pub)
+
+	re := message1[:dhLen]
+	ss.mixHash(re)
+
+	reKey, err := ecdh.X25519().NewPublicKey(re)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: invalid initiator ephemeral key: %w", err)
+	}
+	sPriv, err := ecdh.X25519().NewPrivateKey(x25519Priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: invalid responder static private key: %w", err)
+	}
+	dhES, err := sPriv.ECDH(reKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
+	}
+	ss.mixKey(dhES)
+
+	if _, err = ss.decryptAndHash(message1[dhLen:]); err != nil {
+		return nil, nil, fmt.Errorf("noise: decrypt message1 payload: %w", err)
+	}
+
+	ePriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: generate responder ephemeral: %w", err)
+	}
+	ePub := ePriv.PublicKey().Bytes()
+	ss.mixHash(ePub)
+
+	dhEE, err := ePriv.ECDH(reKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: ee DH failed: %w", err)
+	}
+	ss.mixKey(dhEE)
+
+	encPayload, err := ss.encryptAndHash(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: encrypt message2 payload: %w", err)
+	}
+
+	send, recv := ss.split()
+	return append(ePub, encPayload...), &Session{Send: send, Receive: recv}, nil
+}
+
+// ---- Classical Initiator Handshake (Frontend, Go side for testing) ----
+
+// ClassicalInitiatorHandshake1 creates the first message for the classical Noise_NK initiator.
+func ClassicalInitiatorHandshake1(remoteX25519Pub []byte) (*HandshakeState, []byte, error) {
+	ss := newSymmetricState()
+	ss.mixHash(nil)
+	ss.mixHash(remoteX25519Pub)
+
+	ePriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: generate initiator ephemeral: %w", err)
+	}
+	ePub := ePriv.PublicKey().Bytes()
+	ss.mixHash(ePub)
+
+	rsKey, err := ecdh.X25519().NewPublicKey(remoteX25519Pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: invalid remote static public key: %w", err)
+	}
+	dhES, err := ePriv.ECDH(rsKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: es DH failed: %w", err)
+	}
+	ss.mixKey(dhES)
+
+	encPayload, err := ss.encryptAndHash(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise: encrypt message1 payload: %w", err)
+	}
+
+	return &HandshakeState{
+		ss:    ss,
+		ePriv: ePriv,
+		rs:    remoteX25519Pub,
+	}, append(ePub, encPayload...), nil
+}
+
+// ClassicalInitiatorHandshake2 completes the classical Noise_NK initiator handshake.
+func ClassicalInitiatorHandshake2(hs *HandshakeState, message2 []byte) (*Session, error) {
+	noiseMsg2Len := dhLen + chacha20poly1305.Overhead // 48
+	if len(message2) != noiseMsg2Len {
+		return nil, fmt.Errorf("noise: classical message2 wrong size: got %d, want %d", len(message2), noiseMsg2Len)
+	}
+
+	ss := hs.ss
+
+	re := message2[:dhLen]
+	ss.mixHash(re)
+
+	reKey, err := ecdh.X25519().NewPublicKey(re)
+	if err != nil {
+		return nil, fmt.Errorf("noise: invalid responder ephemeral key: %w", err)
+	}
+	dhEE, err := hs.ePriv.ECDH(reKey)
+	if err != nil {
+		return nil, fmt.Errorf("noise: ee DH failed: %w", err)
+	}
+	ss.mixKey(dhEE)
+
+	if _, err = ss.decryptAndHash(message2[dhLen:]); err != nil {
+		return nil, fmt.Errorf("noise: decrypt message2 payload: %w", err)
+	}
+
+	cs1, cs2 := ss.split()
+	return &Session{Send: cs2, Receive: cs1}, nil
+}
+
 // ---- Crypto primitives ----
 
 func blake2bHash() hash.Hash {
@@ -579,5 +726,3 @@ func computeTranscript(handshakeHash, mlkemCT, mlkemSS []byte) []byte {
 	h.Write(mlkemSS)
 	return h.Sum(nil)
 }
-
-

--- a/internal/noise/noise_test.go
+++ b/internal/noise/noise_test.go
@@ -211,6 +211,52 @@ func TestNeedsRekey(t *testing.T) {
 	assert.False(t, session.NeedsRekey(), "NeedsRekey should be false at nonce 0")
 }
 
+func TestTamperedMlkemCiphertextCausesAEADFailure(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	_, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	// Tamper with the ML-KEM ciphertext portion of message1.
+	// The classical Noise part (first 48 bytes) is untouched.
+	tampered := make([]byte, len(msg1))
+	copy(tampered, msg1)
+	tampered[48] ^= 0xFF // flip one byte in the ML-KEM ciphertext
+
+	// Responder should fail because the tampered mlkemCT changes the handshake
+	// hash (via mixHash), causing the message2 AEAD to use a different AD than
+	// what the initiator expects. This proves mlkemCT is bound into the
+	// Noise state, not just the SLH-DSA transcript.
+	// Note: ML-KEM implicit rejection means Decapsulate doesn't error on
+	// tampered ciphertext — it produces a random shared secret instead.
+	// The failure comes from the divergent handshake hash.
+	_, _, err = ResponderHandshake(workerKey, tampered)
+	// The responder handshake itself succeeds (ML-KEM implicit rejection),
+	// but when the initiator tries to verify, the handshake hashes differ.
+	// Let's verify from the initiator's perspective instead:
+	require.NoError(t, err) // Responder doesn't detect the tampering
+
+	// Re-do the handshake properly and verify the initiator would fail.
+	hs, msg1Good, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	// Tamper with message1 before sending to responder.
+	tamperedMsg1 := make([]byte, len(msg1Good))
+	copy(tamperedMsg1, msg1Good)
+	tamperedMsg1[48] ^= 0xFF
+
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	msg2, _, err := ResponderHandshake(workerKey, tamperedMsg1)
+	require.NoError(t, err) // Responder succeeds due to ML-KEM implicit rejection
+
+	// Initiator fails because handshake hashes diverged (mixHash(mlkemCT) differs).
+	_, err = InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
+	require.Error(t, err, "initiator should detect tampered mlkemCT via handshake hash divergence")
+}
+
 func TestClassicalHandshakeRoundtrip(t *testing.T) {
 	// Worker generates composite keypair (only X25519 used for classical).
 	workerKey, err := GenerateCompositeKeypair()
@@ -364,4 +410,59 @@ func TestMessageSizes(t *testing.T) {
 	// message2 = noise_msg2 (48) + slhdsa_signature (49856) = 49904
 	assert.Equal(t, 48+SlhdsaSignatureSize, len(msg2), "message2 size")
 	_ = hs
+}
+
+func TestHandshakeStateZeroedAfterHybrid(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	// Verify sensitive material exists before completing handshake.
+	assert.NotNil(t, hs.ss, "symmetric state should exist before handshake2")
+	assert.NotEmpty(t, hs.mlkemSS, "mlkemSS should be set before handshake2")
+	assert.NotEmpty(t, hs.mlkemCT, "mlkemCT should be set before handshake2")
+
+	msg2, _, err := ResponderHandshake(workerKey, msg1)
+	require.NoError(t, err)
+
+	_, err = InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
+	require.NoError(t, err)
+
+	// After handshake2 completes, HandshakeState should be zeroed.
+	assert.Nil(t, hs.ss, "symmetric state should be nil after handshake2")
+	assert.Nil(t, hs.ePriv, "ephemeral private key should be nil after handshake2")
+	for _, b := range hs.mlkemSS {
+		if b != 0 {
+			t.Fatal("mlkemSS should be zeroed after handshake2")
+		}
+	}
+	for _, b := range hs.mlkemCT {
+		if b != 0 {
+			t.Fatal("mlkemCT should be zeroed after handshake2")
+		}
+	}
+}
+
+func TestHandshakeStateZeroedAfterClassical(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	hs, msg1, err := ClassicalInitiatorHandshake1(workerKey.X25519Public)
+	require.NoError(t, err)
+
+	assert.NotNil(t, hs.ss, "symmetric state should exist before handshake2")
+
+	msg2, _, err := ClassicalResponderHandshake(workerKey.X25519Public, workerKey.X25519Private, msg1)
+	require.NoError(t, err)
+
+	_, err = ClassicalInitiatorHandshake2(hs, msg2)
+	require.NoError(t, err)
+
+	assert.Nil(t, hs.ss, "symmetric state should be nil after classical handshake2")
+	assert.Nil(t, hs.ePriv, "ephemeral private key should be nil after classical handshake2")
 }

--- a/internal/noise/noise_test.go
+++ b/internal/noise/noise_test.go
@@ -9,27 +9,30 @@ import (
 )
 
 func TestHandshakeRoundtrip(t *testing.T) {
-	// Worker generates static key pair
-	workerKey, err := GenerateKeypair()
+	// Worker generates composite keypair.
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	// Initiator (Frontend) starts handshake with Worker's public key
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	// Initiator (Frontend) starts handshake.
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 	assert.NotEmpty(t, msg1)
 
-	// Worker (Responder) processes msg1 and returns msg2
+	// Worker (Responder) processes msg1 and returns msg2.
 	msg2, workerSession, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 	assert.NotEmpty(t, msg2)
 	assert.NotNil(t, workerSession)
 
-	// Initiator completes handshake
-	initiatorSession, err := InitiatorHandshake2(hs, msg2)
+	// Initiator completes handshake.
+	initiatorSession, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 	assert.NotNil(t, initiatorSession)
 
-	// Test bidirectional encryption
+	// Test bidirectional encryption.
 	t.Run("initiator_to_responder", func(t *testing.T) {
 		plaintext := []byte("hello from initiator")
 		ciphertext, err := initiatorSession.Encrypt(plaintext)
@@ -54,19 +57,21 @@ func TestHandshakeRoundtrip(t *testing.T) {
 }
 
 func TestMultipleMessages(t *testing.T) {
-	workerKey, err := GenerateKeypair()
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 
 	msg2, workerSession, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 
-	initiatorSession, err := InitiatorHandshake2(hs, msg2)
+	initiatorSession, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 
-	// Send multiple messages in each direction
 	for i := 0; i < 100; i++ {
 		msg := []byte(fmt.Sprintf("message %d from initiator", i))
 		ct, err := initiatorSession.Encrypt(msg)
@@ -84,45 +89,75 @@ func TestMultipleMessages(t *testing.T) {
 	}
 }
 
-func TestWrongKey(t *testing.T) {
-	workerKey, err := GenerateKeypair()
+func TestWrongMlkemKey(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	wrongKey, err := GenerateKeypair()
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
 	require.NoError(t, err)
 
-	// Initiator uses wrong public key
-	_, msg1, err := InitiatorHandshake1(wrongKey.Public)
+	// Generate a different ML-KEM key.
+	wrongKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	// Worker tries to complete handshake - should fail because
-	// initiator encrypted to wrong key
-	_, _, err = ResponderHandshake(workerKey, msg1)
-	// NK pattern: msg1 doesn't authenticate to the responder's key in a way
-	// that causes immediate failure. The handshake may complete but
-	// subsequent messages will fail to decrypt.
-	// Let's just verify the basic flow works with correct keys.
-	// The important thing is that wrong keys produce unusable sessions.
-	_ = err
+	// Initiator uses wrong ML-KEM public key — encapsulates to wrong key.
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, wrongKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	// Responder decapsulates with its own key. ML-KEM implicit rejection
+	// produces a random shared secret rather than an error, so the
+	// responder handshake itself succeeds.
+	msg2, _, err := ResponderHandshake(workerKey, msg1)
+	require.NoError(t, err)
+
+	// Initiator verification fails because the ML-KEM shared secrets differ,
+	// producing different transcripts and thus an SLH-DSA signature mismatch.
+	_, err = InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SLH-DSA")
+}
+
+func TestInvalidSlhdsaSignature(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	// Generate a different SLH-DSA key — use its public key for verification.
+	wrongKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+	wrongSlhdsaPubBytes, err := wrongKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	msg2, _, err := ResponderHandshake(workerKey, msg1)
+	require.NoError(t, err)
+
+	// Initiator uses wrong SLH-DSA public key — signature verification should fail.
+	_, err = InitiatorHandshake2(hs, msg2, wrongSlhdsaPubBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SLH-DSA")
 }
 
 func TestEmptyMessage(t *testing.T) {
-	workerKey, err := GenerateKeypair()
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 
 	msg2, workerSession, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 
-	initiatorSession, err := InitiatorHandshake2(hs, msg2)
+	initiatorSession, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 
-	// Empty plaintext should still work (authenticated empty message)
 	ct, err := initiatorSession.Encrypt([]byte{})
 	require.NoError(t, err)
-	assert.NotEmpty(t, ct) // Ciphertext includes auth tag
+	assert.NotEmpty(t, ct) // Ciphertext includes auth tag.
 
 	pt, err := workerSession.Decrypt(ct)
 	require.NoError(t, err)
@@ -130,16 +165,19 @@ func TestEmptyMessage(t *testing.T) {
 }
 
 func TestPlaintextSizeLimit(t *testing.T) {
-	workerKey, err := GenerateKeypair()
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 
 	msg2, _, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 
-	session, err := InitiatorHandshake2(hs, msg2)
+	session, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 
 	// Exactly at limit should succeed.
@@ -155,25 +193,44 @@ func TestPlaintextSizeLimit(t *testing.T) {
 }
 
 func TestNeedsRekey(t *testing.T) {
-	// NeedsRekey should be false initially.
-	workerKey, err := GenerateKeypair()
+	workerKey, err := GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	hs, msg1, err := InitiatorHandshake1(workerKey.Public)
+	slhdsaPubBytes, err := workerKey.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 
 	msg2, _, err := ResponderHandshake(workerKey, msg1)
 	require.NoError(t, err)
 
-	session, err := InitiatorHandshake2(hs, msg2)
+	session, err := InitiatorHandshake2(hs, msg2, slhdsaPubBytes)
 	require.NoError(t, err)
 
 	assert.False(t, session.NeedsRekey(), "NeedsRekey should be false at nonce 0")
 }
 
 func TestNonceLimitsConst(t *testing.T) {
-	// Verify the constant values match spec expectations.
 	assert.Equal(t, uint64(1<<31-1), SoftNonceLimit, "SoftNonceLimit should be 2^31-1")
 	assert.Equal(t, uint64(1<<32-1), HardNonceLimit, "HardNonceLimit should be 2^32-1")
 	assert.Equal(t, 65535-16, MaxPlaintextSize, "MaxPlaintextSize should be 65535-16")
+}
+
+func TestMessageSizes(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	hs, msg1, err := InitiatorHandshake1(workerKey.X25519Public, workerKey.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	// message1 = noise_msg1 (48) + mlkem_ciphertext (1568) = 1616
+	assert.Equal(t, 48+MlkemCiphertextSize, len(msg1), "message1 size")
+
+	msg2, _, err := ResponderHandshake(workerKey, msg1)
+	require.NoError(t, err)
+
+	// message2 = noise_msg2 (48) + slhdsa_signature (49856) = 49904
+	assert.Equal(t, 48+SlhdsaSignatureSize, len(msg2), "message2 size")
+	_ = hs
 }

--- a/internal/noise/noise_test.go
+++ b/internal/noise/noise_test.go
@@ -211,6 +211,137 @@ func TestNeedsRekey(t *testing.T) {
 	assert.False(t, session.NeedsRekey(), "NeedsRekey should be false at nonce 0")
 }
 
+func TestClassicalHandshakeRoundtrip(t *testing.T) {
+	// Worker generates composite keypair (only X25519 used for classical).
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	// Initiator starts classical handshake.
+	hs, msg1, err := ClassicalInitiatorHandshake1(workerKey.X25519Public)
+	require.NoError(t, err)
+	assert.Equal(t, 48, len(msg1), "classical message1 should be 48 bytes")
+
+	// Worker processes msg1 and returns msg2.
+	msg2, workerSession, err := ClassicalResponderHandshake(workerKey.X25519Public, workerKey.X25519Private, msg1)
+	require.NoError(t, err)
+	assert.Equal(t, 48, len(msg2), "classical message2 should be 48 bytes")
+	assert.NotNil(t, workerSession)
+
+	// Initiator completes handshake.
+	initiatorSession, err := ClassicalInitiatorHandshake2(hs, msg2)
+	require.NoError(t, err)
+	assert.NotNil(t, initiatorSession)
+
+	// Test bidirectional encryption.
+	t.Run("initiator_to_responder", func(t *testing.T) {
+		plaintext := []byte("hello from initiator (classical)")
+		ciphertext, err := initiatorSession.Encrypt(plaintext)
+		require.NoError(t, err)
+		assert.NotEqual(t, plaintext, ciphertext)
+
+		decrypted, err := workerSession.Decrypt(ciphertext)
+		require.NoError(t, err)
+		assert.Equal(t, plaintext, decrypted)
+	})
+
+	t.Run("responder_to_initiator", func(t *testing.T) {
+		plaintext := []byte("hello from responder (classical)")
+		ciphertext, err := workerSession.Encrypt(plaintext)
+		require.NoError(t, err)
+		assert.NotEqual(t, plaintext, ciphertext)
+
+		decrypted, err := initiatorSession.Decrypt(ciphertext)
+		require.NoError(t, err)
+		assert.Equal(t, plaintext, decrypted)
+	})
+}
+
+func TestClassicalMultipleMessages(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	hs, msg1, err := ClassicalInitiatorHandshake1(workerKey.X25519Public)
+	require.NoError(t, err)
+
+	msg2, workerSession, err := ClassicalResponderHandshake(workerKey.X25519Public, workerKey.X25519Private, msg1)
+	require.NoError(t, err)
+
+	initiatorSession, err := ClassicalInitiatorHandshake2(hs, msg2)
+	require.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		msg := []byte(fmt.Sprintf("classical message %d from initiator", i))
+		ct, err := initiatorSession.Encrypt(msg)
+		require.NoError(t, err)
+		pt, err := workerSession.Decrypt(ct)
+		require.NoError(t, err)
+		assert.Equal(t, msg, pt)
+
+		msg = []byte(fmt.Sprintf("classical message %d from responder", i))
+		ct, err = workerSession.Encrypt(msg)
+		require.NoError(t, err)
+		pt, err = initiatorSession.Decrypt(ct)
+		require.NoError(t, err)
+		assert.Equal(t, msg, pt)
+	}
+}
+
+func TestClassicalWrongKey(t *testing.T) {
+	workerKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	wrongKey, err := GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	// Initiator targets workerKey, but responder uses wrongKey's private key.
+	// The DH will produce different shared secrets, so decrypt fails.
+	hs, msg1, err := ClassicalInitiatorHandshake1(workerKey.X25519Public)
+	require.NoError(t, err)
+
+	msg2, _, err := ClassicalResponderHandshake(wrongKey.X25519Public, wrongKey.X25519Private, msg1)
+	// Responder decryption of message1 fails because DH(wrongPriv, initiatorEphemeral)
+	// produces a different key than DH(correctPriv, initiatorEphemeral).
+	require.Error(t, err)
+	_ = msg2
+	_ = hs
+}
+
+func TestPassthroughSession(t *testing.T) {
+	session := NewPassthroughSession()
+
+	t.Run("encrypt_is_copy", func(t *testing.T) {
+		plaintext := []byte("hello passthrough")
+		ciphertext, err := session.Encrypt(plaintext)
+		require.NoError(t, err)
+		assert.Equal(t, plaintext, ciphertext)
+		// Verify it's a copy, not the same slice.
+		ciphertext[0] = 0xFF
+		assert.NotEqual(t, plaintext[0], ciphertext[0])
+	})
+
+	t.Run("decrypt_is_copy", func(t *testing.T) {
+		data := []byte("hello passthrough decrypt")
+		decrypted, err := session.Decrypt(data)
+		require.NoError(t, err)
+		assert.Equal(t, data, decrypted)
+		decrypted[0] = 0xFF
+		assert.NotEqual(t, data[0], decrypted[0])
+	})
+
+	t.Run("needs_rekey_false", func(t *testing.T) {
+		assert.False(t, session.NeedsRekey())
+	})
+
+	t.Run("bidirectional", func(t *testing.T) {
+		msg := []byte("roundtrip through passthrough")
+		ct, err := session.Send.Encrypt(msg)
+		require.NoError(t, err)
+		pt, err := session.Receive.Decrypt(ct)
+		require.NoError(t, err)
+		assert.Equal(t, msg, pt)
+	})
+}
+
 func TestNonceLimitsConst(t *testing.T) {
 	assert.Equal(t, uint64(1<<31-1), SoftNonceLimit, "SoftNonceLimit should be 2^31-1")
 	assert.Equal(t, uint64(1<<32-1), HardNonceLimit, "HardNonceLimit should be 2^32-1")

--- a/internal/worker/channel/dispatcher_test.go
+++ b/internal/worker/channel/dispatcher_test.go
@@ -11,6 +11,28 @@ import (
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 )
 
+// setupTestSessions creates a composite keypair and performs a full hybrid handshake,
+// returning the worker and initiator sessions.
+func setupTestSessions(t *testing.T) (*noiseutil.Session, *noiseutil.Session) {
+	t.Helper()
+	ck, err := noiseutil.GenerateCompositeKeypair()
+	require.NoError(t, err)
+
+	slhdsaPub, err := ck.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
+	hs, msg1, err := noiseutil.InitiatorHandshake1(ck.X25519Public, ck.MlkemPublicKeyBytes())
+	require.NoError(t, err)
+
+	msg2, workerSession, err := noiseutil.ResponderHandshake(ck, msg1)
+	require.NoError(t, err)
+
+	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, msg2, slhdsaPub)
+	require.NoError(t, err)
+
+	return workerSession, initiatorSession
+}
+
 func TestDispatcher_RegisterAndDispatch(t *testing.T) {
 	d := NewDispatcher()
 
@@ -27,18 +49,7 @@ func TestDispatcher_RegisterAndDispatch(t *testing.T) {
 		})
 	})
 
-	// Create a channel sender backed by noise session.
-	kp, err := noiseutil.GenerateKeypair()
-	require.NoError(t, err)
-
-	hs, msg1, err := noiseutil.InitiatorHandshake1(kp.Public)
-	require.NoError(t, err)
-
-	msg2, workerSession, err := noiseutil.ResponderHandshake(kp, msg1)
-	require.NoError(t, err)
-
-	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, msg2)
-	require.NoError(t, err)
+	workerSession, initiatorSession := setupTestSessions(t)
 
 	sender := newCollectSender()
 	cs := &channelSender{
@@ -82,17 +93,7 @@ func TestDispatcher_PanicRecovery(t *testing.T) {
 		panic("test panic in handler")
 	})
 
-	kp, err := noiseutil.GenerateKeypair()
-	require.NoError(t, err)
-
-	hs, msg1, err := noiseutil.InitiatorHandshake1(kp.Public)
-	require.NoError(t, err)
-
-	msg2, workerSession, err := noiseutil.ResponderHandshake(kp, msg1)
-	require.NoError(t, err)
-
-	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, msg2)
-	require.NoError(t, err)
+	workerSession, initiatorSession := setupTestSessions(t)
 
 	sender := newCollectSender()
 	cs := &channelSender{
@@ -134,17 +135,7 @@ func TestDispatcher_UnknownMethod(t *testing.T) {
 	d := NewDispatcher()
 	d.Register("known", func(_ string, _ *leapmuxv1.InnerRpcRequest, _ *Sender) {})
 
-	kp, err := noiseutil.GenerateKeypair()
-	require.NoError(t, err)
-
-	hs, msg1, err := noiseutil.InitiatorHandshake1(kp.Public)
-	require.NoError(t, err)
-
-	msg2, workerSession, err := noiseutil.ResponderHandshake(kp, msg1)
-	require.NoError(t, err)
-
-	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, msg2)
-	require.NoError(t, err)
+	workerSession, initiatorSession := setupTestSessions(t)
 
 	sender := newCollectSender()
 	cs := &channelSender{

--- a/internal/worker/channel/session.go
+++ b/internal/worker/channel/session.go
@@ -35,8 +35,7 @@ type CloseCallback func(channelID string)
 type Manager struct {
 	mu                   sync.RWMutex
 	sessions             map[string]*channelSession // channelID -> session
-	privateKey           []byte                     // Worker's X25519 private key
-	publicKey            []byte                     // Worker's X25519 public key
+	compositeKey         *noise.CompositeKeypair    // Worker's composite keypair (X25519 + ML-KEM + SLH-DSA)
 	sendFn               SendFunc                   // Function to send messages to Hub
 	dispatcher           *Dispatcher                // Inner RPC dispatcher
 	closeCallback        CloseCallback              // Called when a channel is closed
@@ -45,11 +44,10 @@ type Manager struct {
 }
 
 // NewManager creates a new channel Manager.
-func NewManager(privateKey, publicKey []byte, sendFn SendFunc) *Manager {
+func NewManager(compositeKey *noise.CompositeKeypair, sendFn SendFunc) *Manager {
 	return &Manager{
 		sessions:             make(map[string]*channelSession),
-		privateKey:           privateKey,
-		publicKey:            publicKey,
+		compositeKey:         compositeKey,
 		sendFn:               sendFn,
 		maxMessageSize:       DefaultMaxMessageSize,
 		maxIncompleteChunked: DefaultMaxIncompleteChunked,
@@ -85,9 +83,8 @@ func (m *Manager) Dispatcher() *Dispatcher {
 // HandleOpen processes a ChannelOpenRequest from the Hub.
 // It performs the Noise_NK responder handshake and returns the response.
 func (m *Manager) HandleOpen(req *leapmuxv1.ChannelOpenRequest) *leapmuxv1.ChannelOpenResponse {
-	keypair := noise.Keypair{Private: m.privateKey, Public: m.publicKey}
 	handshakeResp, session, err := noise.ResponderHandshake(
-		keypair,
+		m.compositeKey,
 		req.GetHandshakePayload(),
 	)
 	if err != nil {

--- a/internal/worker/channel/session.go
+++ b/internal/worker/channel/session.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/noise"
+	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -20,7 +20,7 @@ type SendFunc func(msg *leapmuxv1.ConnectRequest) error
 type channelSession struct {
 	ChannelID              string
 	UserID                 string
-	Session                *noise.Session
+	Session                *noiseutil.Session
 	sender                 *channelSender          // shared sender for this channel (protects Encrypt+Send)
 	verified               bool                    // true after a valid UserIdClaim has been received
 	reassembly             map[uint32]*chunkBuffer // correlationID -> in-progress chunk reassembly
@@ -34,20 +34,22 @@ type CloseCallback func(channelID string)
 // Manager manages encrypted channel sessions on the Worker side.
 type Manager struct {
 	mu                   sync.RWMutex
-	sessions             map[string]*channelSession // channelID -> session
-	compositeKey         *noise.CompositeKeypair    // Worker's composite keypair (X25519 + ML-KEM + SLH-DSA)
-	sendFn               SendFunc                   // Function to send messages to Hub
-	dispatcher           *Dispatcher                // Inner RPC dispatcher
-	closeCallback        CloseCallback              // Called when a channel is closed
-	maxMessageSize       int                        // maximum reassembled message size
-	maxIncompleteChunked int                        // maximum in-flight chunked sequences per channel
+	sessions             map[string]*channelSession  // channelID -> session
+	compositeKey         *noiseutil.CompositeKeypair // Worker's composite keypair (X25519 + ML-KEM + SLH-DSA)
+	encryptionMode       leapmuxv1.EncryptionMode    // Encryption mode
+	sendFn               SendFunc                    // Function to send messages to Hub
+	dispatcher           *Dispatcher                 // Inner RPC dispatcher
+	closeCallback        CloseCallback               // Called when a channel is closed
+	maxMessageSize       int                         // maximum reassembled message size
+	maxIncompleteChunked int                         // maximum in-flight chunked sequences per channel
 }
 
 // NewManager creates a new channel Manager.
-func NewManager(compositeKey *noise.CompositeKeypair, sendFn SendFunc) *Manager {
+func NewManager(compositeKey *noiseutil.CompositeKeypair, encryptionMode leapmuxv1.EncryptionMode, sendFn SendFunc) *Manager {
 	return &Manager{
 		sessions:             make(map[string]*channelSession),
 		compositeKey:         compositeKey,
+		encryptionMode:       encryptionMode,
 		sendFn:               sendFn,
 		maxMessageSize:       DefaultMaxMessageSize,
 		maxIncompleteChunked: DefaultMaxIncompleteChunked,
@@ -83,10 +85,29 @@ func (m *Manager) Dispatcher() *Dispatcher {
 // HandleOpen processes a ChannelOpenRequest from the Hub.
 // It performs the Noise_NK responder handshake and returns the response.
 func (m *Manager) HandleOpen(req *leapmuxv1.ChannelOpenRequest) *leapmuxv1.ChannelOpenResponse {
-	handshakeResp, session, err := noise.ResponderHandshake(
-		m.compositeKey,
-		req.GetHandshakePayload(),
-	)
+	var handshakeResp []byte
+	var session *noiseutil.Session
+	var err error
+
+	switch m.encryptionMode {
+	case leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED:
+		// No encryption — use passthrough session.
+		session = noiseutil.NewPassthroughSession()
+	case leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC:
+		// Classical Noise_NK (X25519 only, no PQ).
+		handshakeResp, session, err = noiseutil.ClassicalResponderHandshake(
+			m.compositeKey.X25519Public,
+			m.compositeKey.X25519Private,
+			req.GetHandshakePayload(),
+		)
+	default:
+		// Post-quantum hybrid Noise_NK (X25519 + ML-KEM + SLH-DSA).
+		handshakeResp, session, err = noiseutil.ResponderHandshake(
+			m.compositeKey,
+			req.GetHandshakePayload(),
+		)
+	}
+
 	if err != nil {
 		slog.Error("channel handshake failed",
 			"channel_id", req.GetChannelId(),
@@ -123,6 +144,7 @@ func (m *Manager) HandleOpen(req *leapmuxv1.ChannelOpenRequest) *leapmuxv1.Chann
 	slog.Info("channel opened",
 		"channel_id", req.GetChannelId(),
 		"user_id", req.GetUserId(),
+		"encryption_mode", m.encryptionMode,
 	)
 
 	return &leapmuxv1.ChannelOpenResponse{
@@ -372,7 +394,7 @@ func (m *Manager) CloseAll() {
 type channelSender struct {
 	mu             sync.Mutex
 	channelID      string
-	session        *noise.Session
+	session        *noiseutil.Session
 	sendFn         SendFunc
 	maxMessageSize int
 }

--- a/internal/worker/channel/session_test.go
+++ b/internal/worker/channel/session_test.go
@@ -50,22 +50,25 @@ func (c *collectSender) waitForMessages(n int) []*leapmuxv1.ConnectRequest {
 	return append([]*leapmuxv1.ConnectRequest(nil), c.msgs...)
 }
 
-func setupTestManager(t *testing.T) (*Manager, noiseutil.Keypair, *collectSender) {
+func setupTestManager(t *testing.T) (*Manager, *noiseutil.CompositeKeypair, *collectSender) {
 	t.Helper()
-	kp, err := noiseutil.GenerateKeypair()
+	ck, err := noiseutil.GenerateCompositeKeypair()
 	require.NoError(t, err)
 
 	sender := newCollectSender()
-	mgr := NewManager(kp.Private, kp.Public, sender.send)
-	return mgr, kp, sender
+	mgr := NewManager(ck, sender.send)
+	return mgr, ck, sender
 }
 
-// performHandshake runs a full Noise_NK handshake between initiator and responder (Manager).
-func performHandshake(t *testing.T, mgr *Manager, kp noiseutil.Keypair, channelID, userID string) *noiseutil.Session {
+// performHandshake runs a full hybrid Noise_NK handshake between initiator and responder (Manager).
+func performHandshake(t *testing.T, mgr *Manager, ck *noiseutil.CompositeKeypair, channelID, userID string) *noiseutil.Session {
 	t.Helper()
 
+	slhdsaPub, err := ck.SlhdsaPublicKeyBytes()
+	require.NoError(t, err)
+
 	// Initiator creates msg1.
-	hs, msg1, err := noiseutil.InitiatorHandshake1(kp.Public)
+	hs, msg1, err := noiseutil.InitiatorHandshake1(ck.X25519Public, ck.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 
 	// Responder (Manager) handles open.
@@ -79,7 +82,7 @@ func performHandshake(t *testing.T, mgr *Manager, kp noiseutil.Keypair, channelI
 	assert.Equal(t, channelID, resp.GetChannelId())
 
 	// Initiator completes handshake.
-	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, resp.GetHandshakePayload())
+	initiatorSession, err := noiseutil.InitiatorHandshake2(hs, resp.GetHandshakePayload(), slhdsaPub)
 	require.NoError(t, err)
 
 	return initiatorSession
@@ -165,11 +168,11 @@ func decryptClaimResponse(t *testing.T, initiatorSession *noiseutil.Session, msg
 }
 
 // performHandshakeAndVerify performs handshake + UserIdClaim in one step.
-func performHandshakeAndVerify(t *testing.T, mgr *Manager, kp noiseutil.Keypair, sender *collectSender, channelID, userID string) *noiseutil.Session {
+func performHandshakeAndVerify(t *testing.T, mgr *Manager, ck *noiseutil.CompositeKeypair, sender *collectSender, channelID, userID string) *noiseutil.Session {
 	t.Helper()
 
 	msgsBefore := len(sender.messages())
-	session := performHandshake(t, mgr, kp, channelID, userID)
+	session := performHandshake(t, mgr, ck, channelID, userID)
 
 	// Send UserIdClaim.
 	sendUserIdClaim(t, mgr, session, channelID, userID)
@@ -466,10 +469,10 @@ func TestHandleMessage_NonBlocking(t *testing.T) {
 		return sender.send(msg)
 	}
 
-	kp, err := noiseutil.GenerateKeypair()
+	ck, err := noiseutil.GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	mgr := NewManager(kp.Private, kp.Public, blockingSend)
+	mgr := NewManager(ck, blockingSend)
 
 	// Set up a dispatcher with a handler that sends a response.
 	dispatcher := NewDispatcher()
@@ -481,7 +484,7 @@ func TestHandleMessage_NonBlocking(t *testing.T) {
 	mgr.SetDispatcher(dispatcher)
 
 	// Open channel and verify claim.
-	session := performHandshake(t, mgr, kp, "ch-block", "user-1")
+	session := performHandshake(t, mgr, ck, "ch-block", "user-1")
 
 	// Send the UserIdClaim. Since sends are now async, HandleMessage returns
 	// immediately and the claim response send happens in a goroutine.

--- a/internal/worker/channel/session_test.go
+++ b/internal/worker/channel/session_test.go
@@ -56,7 +56,7 @@ func setupTestManager(t *testing.T) (*Manager, *noiseutil.CompositeKeypair, *col
 	require.NoError(t, err)
 
 	sender := newCollectSender()
-	mgr := NewManager(ck, sender.send)
+	mgr := NewManager(ck, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, sender.send)
 	return mgr, ck, sender
 }
 
@@ -472,7 +472,7 @@ func TestHandleMessage_NonBlocking(t *testing.T) {
 	ck, err := noiseutil.GenerateCompositeKeypair()
 	require.NoError(t, err)
 
-	mgr := NewManager(ck, blockingSend)
+	mgr := NewManager(ck, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, blockingSend)
 
 	// Set up a dispatcher with a handler that sends a response.
 	dispatcher := NewDispatcher()

--- a/internal/worker/config/config.go
+++ b/internal/worker/config/config.go
@@ -49,38 +49,61 @@ func (c *Config) AgentStartupTimeout() time.Duration {
 
 // State holds the worker's persistent state (saved to disk after registration).
 type State struct {
-	WorkerID   string `json:"worker_id"`
-	AuthToken  string `json:"auth_token"`
-	OrgID      string `json:"org_id"`
-	PublicKey  string `json:"public_key,omitempty"`  // Base64-encoded X25519 public key
-	PrivateKey string `json:"private_key,omitempty"` // Base64-encoded X25519 private key
+	WorkerID        string `json:"worker_id"`
+	AuthToken       string `json:"auth_token"`
+	OrgID           string `json:"org_id"`
+	PublicKey       string `json:"public_key,omitempty"`        // Base64-encoded X25519 public key
+	PrivateKey      string `json:"private_key,omitempty"`       // Base64-encoded X25519 private key
+	MlkemPublicKey  string `json:"mlkem_public_key,omitempty"`  // Base64-encoded ML-KEM-1024 decapsulation key
+	SlhdsaPublicKey string `json:"slhdsa_public_key,omitempty"` // Base64-encoded SLH-DSA public key
+	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"` // Base64-encoded SLH-DSA private key
+	MlkemPrivateKey string `json:"mlkem_private_key,omitempty"` // Base64-encoded ML-KEM-1024 decapsulation key (serialized)
 }
 
-// PublicKeyBytes returns the decoded public key bytes.
-func (s *State) PublicKeyBytes() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(s.PublicKey)
-}
-
-// PrivateKeyBytes returns the decoded private key bytes.
-func (s *State) PrivateKeyBytes() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(s.PrivateKey)
-}
-
-// EnsureKeypair generates a keypair if one doesn't exist in the state.
+// EnsureCompositeKeypair generates a composite keypair if one doesn't exist.
 // Returns true if a new keypair was generated (state needs saving).
-func (s *State) EnsureKeypair() (bool, error) {
-	if s.PublicKey != "" && s.PrivateKey != "" {
+func (s *State) EnsureCompositeKeypair() (bool, error) {
+	if s.PublicKey != "" && s.PrivateKey != "" && s.MlkemPublicKey != "" && s.MlkemPrivateKey != "" && s.SlhdsaPublicKey != "" && s.SlhdsaPrivateKey != "" {
 		return false, nil
 	}
 
-	kp, err := noiseutil.GenerateKeypair()
+	ck, err := noiseutil.GenerateCompositeKeypair()
 	if err != nil {
-		return false, fmt.Errorf("generate keypair: %w", err)
+		return false, fmt.Errorf("generate composite keypair: %w", err)
 	}
 
-	s.PublicKey = base64.StdEncoding.EncodeToString(kp.Public)
-	s.PrivateKey = base64.StdEncoding.EncodeToString(kp.Private)
+	slhdsaPub, err := ck.SlhdsaPublicKeyBytes()
+	if err != nil {
+		return false, fmt.Errorf("marshal slhdsa public key: %w", err)
+	}
+	slhdsaPriv, err := ck.SlhdsaPrivateKey.MarshalBinary()
+	if err != nil {
+		return false, fmt.Errorf("marshal slhdsa private key: %w", err)
+	}
+
+	s.PublicKey = base64.StdEncoding.EncodeToString(ck.X25519Public)
+	s.PrivateKey = base64.StdEncoding.EncodeToString(ck.X25519Private)
+	s.MlkemPublicKey = base64.StdEncoding.EncodeToString(ck.MlkemPublicKeyBytes())
+	s.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
+	s.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
+	s.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
 	return true, nil
+}
+
+// CompositeKeypair reconstructs the CompositeKeypair from persisted state.
+func (s *State) CompositeKeypair() (*noiseutil.CompositeKeypair, error) {
+	return noiseutil.RestoreCompositeKeypair(
+		mustDecode(s.PublicKey),
+		mustDecode(s.PrivateKey),
+		mustDecode(s.MlkemPrivateKey),
+		mustDecode(s.SlhdsaPublicKey),
+		mustDecode(s.SlhdsaPrivateKey),
+	)
+}
+
+func mustDecode(s string) []byte {
+	b, _ := base64.StdEncoding.DecodeString(s)
+	return b
 }
 
 // Load parses worker configuration from defaults, config file, env vars, and CLI flags.

--- a/internal/worker/config/config.go
+++ b/internal/worker/config/config.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/knadh/koanf/v2"
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	internalconfig "github.com/leapmux/leapmux/internal/config"
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
@@ -36,6 +38,26 @@ type Config struct {
 	MaxMessageSize             int    `koanf:"max_message_size" json:"max_message_size"`
 	AgentStartupTimeoutSeconds int    `koanf:"agent_startup_timeout_seconds" json:"agent_startup_timeout_seconds"`
 	LogLevel                   string `koanf:"log_level" json:"log_level"`
+	EncryptionMode             string `koanf:"encryption_mode" json:"encryption_mode"`
+}
+
+// EncryptionModeProto returns the protobuf EncryptionMode value.
+func (c *Config) EncryptionModeProto() leapmuxv1.EncryptionMode {
+	return ParseEncryptionMode(c.EncryptionMode)
+}
+
+// ParseEncryptionMode parses a string encryption mode to its protobuf enum value.
+func ParseEncryptionMode(s string) leapmuxv1.EncryptionMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "disabled":
+		return leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED
+	case "classic":
+		return leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC
+	case "post-quantum", "post_quantum", "pq", "":
+		return leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
+	default:
+		return leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
+	}
 }
 
 // AgentStartupTimeout returns the agent startup timeout as a duration.
@@ -49,15 +71,15 @@ func (c *Config) AgentStartupTimeout() time.Duration {
 
 // State holds the worker's persistent state (saved to disk after registration).
 type State struct {
-	WorkerID        string `json:"worker_id"`
-	AuthToken       string `json:"auth_token"`
-	OrgID           string `json:"org_id"`
-	PublicKey       string `json:"public_key,omitempty"`        // Base64-encoded X25519 public key
-	PrivateKey      string `json:"private_key,omitempty"`       // Base64-encoded X25519 private key
-	MlkemPublicKey  string `json:"mlkem_public_key,omitempty"`  // Base64-encoded ML-KEM-1024 decapsulation key
-	SlhdsaPublicKey string `json:"slhdsa_public_key,omitempty"` // Base64-encoded SLH-DSA public key
+	WorkerID         string `json:"worker_id"`
+	AuthToken        string `json:"auth_token"`
+	OrgID            string `json:"org_id"`
+	PublicKey        string `json:"public_key,omitempty"`         // Base64-encoded X25519 public key
+	PrivateKey       string `json:"private_key,omitempty"`        // Base64-encoded X25519 private key
+	MlkemPublicKey   string `json:"mlkem_public_key,omitempty"`   // Base64-encoded ML-KEM-1024 decapsulation key
+	SlhdsaPublicKey  string `json:"slhdsa_public_key,omitempty"`  // Base64-encoded SLH-DSA public key
 	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"` // Base64-encoded SLH-DSA private key
-	MlkemPrivateKey string `json:"mlkem_private_key,omitempty"` // Base64-encoded ML-KEM-1024 decapsulation key (serialized)
+	MlkemPrivateKey  string `json:"mlkem_private_key,omitempty"`  // Base64-encoded ML-KEM-1024 decapsulation key (serialized)
 }
 
 // EnsureCompositeKeypair generates a composite keypair if one doesn't exist.
@@ -122,6 +144,7 @@ func Load(args []string) (*Config, bool, error) {
 	fs.Int("max-message-size", 0, "maximum reassembled channel message size in bytes (default 16 MiB)")
 	fs.Int("agent-startup-timeout-seconds", DefaultAgentStartupTimeoutSeconds, "agent startup timeout in seconds")
 	fs.String("log-level", defaultLogLevel, "log level (debug, info, warn, error)")
+	fs.String("encryption-mode", "post-quantum", "encryption mode (disabled, classic, post-quantum)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 
 	if err := fs.Parse(args); err != nil {
@@ -141,6 +164,7 @@ func Load(args []string) (*Config, bool, error) {
 		"max-message-size":              "max_message_size",
 		"agent-startup-timeout-seconds": "agent_startup_timeout_seconds",
 		"log-level":                     "log_level",
+		"encryption-mode":               "encryption_mode",
 	}
 
 	defaults := map[string]interface{}{
@@ -151,6 +175,7 @@ func Load(args []string) (*Config, bool, error) {
 		"max_message_size":              0,
 		"agent_startup_timeout_seconds": DefaultAgentStartupTimeoutSeconds,
 		"log_level":                     defaultLogLevel,
+		"encryption_mode":               "post-quantum",
 	}
 
 	k := koanf.New(".")

--- a/internal/worker/hub/client.go
+++ b/internal/worker/hub/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	// PublicKey is the Worker's X25519 public key for E2EE channels.
 	// Sent to the Hub with the initial heartbeat.
 	PublicKey []byte
+	// MlkemPublicKey is the Worker's ML-KEM-1024 public key.
+	MlkemPublicKey []byte
+	// SlhdsaPublicKey is the Worker's SLH-DSA-SHAKE-256f public key.
+	SlhdsaPublicKey []byte
 
 	// TabSyncProvider returns the current tab state for WorkspaceTabsSync
 	// on connect. Set by the runner after initializing the service context.
@@ -209,7 +213,11 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 	// ConnectRPC with gRPC protocol only sends HTTP/2 headers on the first Send().
 	if err := stream.Send(&leapmuxv1.ConnectRequest{
 		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
-			Heartbeat: &leapmuxv1.Heartbeat{PublicKey: c.PublicKey},
+			Heartbeat: &leapmuxv1.Heartbeat{
+				PublicKey:       c.PublicKey,
+				MlkemPublicKey:  c.MlkemPublicKey,
+				SlhdsaPublicKey: c.SlhdsaPublicKey,
+			},
 		},
 	}); err != nil {
 		return fmt.Errorf("initial heartbeat: %w", err)

--- a/internal/worker/hub/client.go
+++ b/internal/worker/hub/client.go
@@ -44,6 +44,8 @@ type Client struct {
 	MlkemPublicKey []byte
 	// SlhdsaPublicKey is the Worker's SLH-DSA-SHAKE-256f public key.
 	SlhdsaPublicKey []byte
+	// EncryptionMode is the Worker's encryption mode.
+	EncryptionMode leapmuxv1.EncryptionMode
 
 	// TabSyncProvider returns the current tab state for WorkspaceTabsSync
 	// on connect. Set by the runner after initializing the service context.
@@ -217,6 +219,7 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 				PublicKey:       c.PublicKey,
 				MlkemPublicKey:  c.MlkemPublicKey,
 				SlhdsaPublicKey: c.SlhdsaPublicKey,
+				EncryptionMode:  c.EncryptionMode,
 			},
 		},
 	}); err != nil {

--- a/internal/worker/hub/registration.go
+++ b/internal/worker/hub/registration.go
@@ -29,7 +29,7 @@ type RegistrationResult struct {
 // 3. Poll until the registration is approved or expires.
 //
 // If hubURL starts with "unix:", it creates a Unix domain socket transport automatically.
-func Register(ctx context.Context, hubURL, version string, publicKey []byte) (*RegistrationResult, error) {
+func Register(ctx context.Context, hubURL, version string, publicKey, mlkemPublicKey, slhdsaPublicKey []byte) (*RegistrationResult, error) {
 	var httpClient *http.Client
 	connectURL := hubURL
 	if strings.HasPrefix(hubURL, "unix:") {
@@ -44,14 +44,14 @@ func Register(ctx context.Context, hubURL, version string, publicKey []byte) (*R
 		connectURL,
 		connect.WithGRPC(),
 	)
-	return registerWithClient(ctx, client, hubURL, version, publicKey, newDefaultBackoff())
+	return registerWithClient(ctx, client, hubURL, version, publicKey, mlkemPublicKey, slhdsaPublicKey, newDefaultBackoff())
 }
 
 func registerWithClient(
 	ctx context.Context,
 	client leapmuxv1connect.WorkerConnectorServiceClient,
 	hubURL, version string,
-	publicKey []byte,
+	publicKey, mlkemPublicKey, slhdsaPublicKey []byte,
 	bo backoff.BackOff,
 ) (*RegistrationResult, error) {
 	// Step 1: Request registration with retry.
@@ -60,8 +60,10 @@ func registerWithClient(
 		var err error
 		reqResp, err = client.RequestRegistration(ctx, connect.NewRequest(
 			&leapmuxv1.RequestRegistrationRequest{
-				Version:   version,
-				PublicKey: publicKey,
+				Version:         version,
+				PublicKey:       publicKey,
+				MlkemPublicKey:  mlkemPublicKey,
+				SlhdsaPublicKey: slhdsaPublicKey,
 			},
 		))
 		if err == nil {

--- a/internal/worker/hub/registration_test.go
+++ b/internal/worker/hub/registration_test.go
@@ -64,7 +64,7 @@ func TestRegisterWithClient_RetriesUntilHubAvailable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, nil, nil, newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(failCount+1), attempts.Load(), "RequestRegistration call count")
@@ -91,7 +91,7 @@ func TestRegisterWithClient_StopsOnContextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	_, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, newFastBackoff())
+	_, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, nil, nil, newFastBackoff())
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.GreaterOrEqual(t, attempts.Load(), int32(1), "expected at least 1 attempt")
 }
@@ -128,7 +128,7 @@ func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, bo)
+	_, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, nil, nil, bo)
 	require.NoError(t, err, "registerWithClient failed")
 
 	// Verify gaps between retries are increasing.
@@ -169,7 +169,7 @@ func TestRegisterWithClient_LongPollPendingThenApproved(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, nil, nil, newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(3), pollCount.Load(), "PollRegistration call count")
@@ -205,7 +205,7 @@ func TestRegisterWithClient_PollErrorRetries(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, newFastBackoff())
+	result, err := registerWithClient(ctx, mock, "http://localhost:0", "0.0.1", nil, nil, nil, newFastBackoff())
 	require.NoError(t, err, "registerWithClient failed")
 
 	assert.Equal(t, int32(2), pollCount.Load(), "PollRegistration call count")

--- a/internal/worker/service/closed_tab_test.go
+++ b/internal/worker/service/closed_tab_test.go
@@ -62,11 +62,11 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 
 	// Set up a channel manager with a handshake so
 	// AccessibleWorkspaceIDs returns the desired workspaces.
-	kp, err := noiseutil.GenerateKeypair()
+	ck, err := noiseutil.GenerateCompositeKeypair()
 	require.NoError(t, err)
-	chmgr := channel.NewManager(kp.Private, kp.Public, func(*leapmuxv1.ConnectRequest) error { return nil })
+	chmgr := channel.NewManager(ck, func(*leapmuxv1.ConnectRequest) error { return nil })
 
-	_, msg1, err := noiseutil.InitiatorHandshake1(kp.Public)
+	_, msg1, err := noiseutil.InitiatorHandshake1(ck.X25519Public, ck.MlkemPublicKeyBytes())
 	require.NoError(t, err)
 	chmgr.HandleOpen(&leapmuxv1.ChannelOpenRequest{
 		ChannelId:              "test-ch",

--- a/internal/worker/service/closed_tab_test.go
+++ b/internal/worker/service/closed_tab_test.go
@@ -64,7 +64,7 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 	// AccessibleWorkspaceIDs returns the desired workspaces.
 	ck, err := noiseutil.GenerateCompositeKeypair()
 	require.NoError(t, err)
-	chmgr := channel.NewManager(ck, func(*leapmuxv1.ConnectRequest) error { return nil })
+	chmgr := channel.NewManager(ck, leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM, func(*leapmuxv1.ConnectRequest) error { return nil })
 
 	_, msg1, err := noiseutil.InitiatorHandshake1(ck.X25519Public, ck.MlkemPublicKeyBytes())
 	require.NoError(t, err)

--- a/proto/leapmux/v1/channel.proto
+++ b/proto/leapmux/v1/channel.proto
@@ -20,6 +20,8 @@ message GetWorkerPublicKeyRequest {
 
 message GetWorkerPublicKeyResponse {
   bytes public_key = 1;
+  bytes mlkem_public_key = 2;
+  bytes slhdsa_public_key = 3;
 }
 
 message OpenChannelRequest {

--- a/proto/leapmux/v1/channel.proto
+++ b/proto/leapmux/v1/channel.proto
@@ -6,6 +6,8 @@ package leapmux.v1;
 service ChannelService {
   // Get a Worker's static public key for Noise_NK handshake.
   rpc GetWorkerPublicKey(GetWorkerPublicKeyRequest) returns (GetWorkerPublicKeyResponse);
+  // Get a Worker's encryption mode from its live connection (not persisted).
+  rpc GetWorkerEncryptionMode(GetWorkerEncryptionModeRequest) returns (GetWorkerEncryptionModeResponse);
   // Open an encrypted channel to a Worker (triggers Noise_NK handshake via relay).
   rpc OpenChannel(OpenChannelRequest) returns (OpenChannelResponse);
   // Close an encrypted channel.
@@ -22,6 +24,24 @@ message GetWorkerPublicKeyResponse {
   bytes public_key = 1;
   bytes mlkem_public_key = 2;
   bytes slhdsa_public_key = 3;
+  // Field 4 (encryption_mode) removed — use GetWorkerEncryptionMode instead.
+  reserved 4;
+}
+
+message GetWorkerEncryptionModeRequest {
+  string worker_id = 1;
+}
+
+message GetWorkerEncryptionModeResponse {
+  EncryptionMode encryption_mode = 1;
+}
+
+// EncryptionMode specifies which E2EE handshake protocol the Worker uses.
+enum EncryptionMode {
+  ENCRYPTION_MODE_UNSPECIFIED = 0;    // Treated as POST_QUANTUM
+  ENCRYPTION_MODE_DISABLED = 1;       // No encryption (solo mode only)
+  ENCRYPTION_MODE_CLASSIC = 2;        // Classical Noise_NK (X25519 only)
+  ENCRYPTION_MODE_POST_QUANTUM = 3;   // Hybrid PQ Noise_NK (X25519 + ML-KEM + SLH-DSA)
 }
 
 message OpenChannelRequest {

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -206,6 +206,7 @@ message Heartbeat {
   bytes public_key = 2;  // Worker's X25519 public key for E2EE channels (sent with first heartbeat)
   bytes mlkem_public_key = 3;  // Worker's ML-KEM-1024 public key for post-quantum key encapsulation
   bytes slhdsa_public_key = 4;  // Worker's SLH-DSA-SHAKE-256f public key for post-quantum authentication
+  EncryptionMode encryption_mode = 5;  // Worker's encryption mode
 }
 
 // --- Inner RPC messages (E2EE channel, Frontend ↔ Worker) ---

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -36,6 +36,8 @@ service WorkerManagementService {
 message RequestRegistrationRequest {
   string version = 1;
   bytes public_key = 2;  // Worker's X25519 static public key for E2EE
+  bytes mlkem_public_key = 3;  // Worker's ML-KEM-1024 public key for post-quantum key encapsulation
+  bytes slhdsa_public_key = 4;  // Worker's SLH-DSA-SHAKE-256f public key for post-quantum authentication
 }
 
 message RequestRegistrationResponse {
@@ -202,6 +204,8 @@ message HubShuttingDownNotification {
 message Heartbeat {
   int64 timestamp_ms = 1;
   bytes public_key = 2;  // Worker's X25519 public key for E2EE channels (sent with first heartbeat)
+  bytes mlkem_public_key = 3;  // Worker's ML-KEM-1024 public key for post-quantum key encapsulation
+  bytes slhdsa_public_key = 4;  // Worker's SLH-DSA-SHAKE-256f public key for post-quantum authentication
 }
 
 // --- Inner RPC messages (E2EE channel, Frontend ↔ Worker) ---

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/noise"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -21,17 +22,16 @@ import (
 
 // RunConfig holds configuration for running the worker as a library.
 type RunConfig struct {
-	HubURL              string        // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
-	DataDir             string        // Directory for persistent state
-	AuthToken           string        // Pre-provisioned auth token (skip registration)
-	HTTPClient          *http.Client  // Custom HTTP client (e.g. for Unix socket transport)
-	PrivateKey          []byte        // Worker's X25519 private key for E2EE channels
-	PublicKey           []byte        // Worker's X25519 public key for E2EE channels
-	WorkerID            string        // Worker ID (from registration)
-	Name                string        // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
-	Version             string        // Build-time version string
-	DBMaxConns          int           // Maximum number of open database connections (0 = default)
-	AgentStartupTimeout time.Duration // Timeout for agent startup handshake (0 = 30s default)
+	HubURL              string                 // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
+	DataDir             string                 // Directory for persistent state
+	AuthToken           string                 // Pre-provisioned auth token (skip registration)
+	HTTPClient          *http.Client           // Custom HTTP client (e.g. for Unix socket transport)
+	CompositeKey        *noise.CompositeKeypair // Worker's composite keypair for E2EE channels
+	WorkerID            string                 // Worker ID (from registration)
+	Name                string                 // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
+	Version             string                 // Build-time version string
+	DBMaxConns          int                    // Maximum number of open database connections (0 = default)
+	AgentStartupTimeout time.Duration          // Timeout for agent startup handshake (0 = 30s default)
 }
 
 // Run starts the worker and blocks until ctx is cancelled.
@@ -62,9 +62,9 @@ func Run(ctx context.Context, cfg RunConfig) error {
 	}
 	defer client.Stop()
 
-	// Set up E2EE channel manager if keys are provided.
-	if len(cfg.PrivateKey) > 0 && len(cfg.PublicKey) > 0 {
-		channelMgr := channel.NewManager(cfg.PrivateKey, cfg.PublicKey, client.Send)
+	// Set up E2EE channel manager if composite key is provided.
+	if cfg.CompositeKey != nil {
+		channelMgr := channel.NewManager(cfg.CompositeKey, client.Send)
 
 		homeDir, _ := os.UserHomeDir()
 
@@ -105,7 +105,10 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		})
 
 		client.SetChannelMgr(channelMgr)
-		client.PublicKey = cfg.PublicKey
+		client.PublicKey = cfg.CompositeKey.X25519Public
+		client.MlkemPublicKey = cfg.CompositeKey.MlkemPublicKeyBytes()
+		slhdsaPub, _ := cfg.CompositeKey.SlhdsaPublicKeyBytes()
+		client.SlhdsaPublicKey = slhdsaPub
 
 		// Provide workspace tab sync data on connect.
 		queries := db.New(sqlDB)

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/noise"
+	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -22,16 +22,17 @@ import (
 
 // RunConfig holds configuration for running the worker as a library.
 type RunConfig struct {
-	HubURL              string                 // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
-	DataDir             string                 // Directory for persistent state
-	AuthToken           string                 // Pre-provisioned auth token (skip registration)
-	HTTPClient          *http.Client           // Custom HTTP client (e.g. for Unix socket transport)
-	CompositeKey        *noise.CompositeKeypair // Worker's composite keypair for E2EE channels
-	WorkerID            string                 // Worker ID (from registration)
-	Name                string                 // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
-	Version             string                 // Build-time version string
-	DBMaxConns          int                    // Maximum number of open database connections (0 = default)
-	AgentStartupTimeout time.Duration          // Timeout for agent startup handshake (0 = 30s default)
+	HubURL              string                      // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
+	DataDir             string                      // Directory for persistent state
+	AuthToken           string                      // Pre-provisioned auth token (skip registration)
+	HTTPClient          *http.Client                // Custom HTTP client (e.g. for Unix socket transport)
+	CompositeKey        *noiseutil.CompositeKeypair // Worker's composite keypair for E2EE channels
+	WorkerID            string                      // Worker ID (from registration)
+	Name                string                      // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
+	Version             string                      // Build-time version string
+	DBMaxConns          int                         // Maximum number of open database connections (0 = default)
+	AgentStartupTimeout time.Duration               // Timeout for agent startup handshake (0 = 30s default)
+	EncryptionMode      leapmuxv1.EncryptionMode    // Encryption mode (disabled, classic, post-quantum)
 }
 
 // Run starts the worker and blocks until ctx is cancelled.
@@ -64,7 +65,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 
 	// Set up E2EE channel manager if composite key is provided.
 	if cfg.CompositeKey != nil {
-		channelMgr := channel.NewManager(cfg.CompositeKey, client.Send)
+		channelMgr := channel.NewManager(cfg.CompositeKey, cfg.EncryptionMode, client.Send)
 
 		homeDir, _ := os.UserHomeDir()
 
@@ -105,10 +106,14 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		})
 
 		client.SetChannelMgr(channelMgr)
+		client.EncryptionMode = cfg.EncryptionMode
 		client.PublicKey = cfg.CompositeKey.X25519Public
-		client.MlkemPublicKey = cfg.CompositeKey.MlkemPublicKeyBytes()
-		slhdsaPub, _ := cfg.CompositeKey.SlhdsaPublicKeyBytes()
-		client.SlhdsaPublicKey = slhdsaPub
+		if cfg.EncryptionMode != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC &&
+			cfg.EncryptionMode != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_DISABLED {
+			client.MlkemPublicKey = cfg.CompositeKey.MlkemPublicKeyBytes()
+			slhdsaPub, _ := cfg.CompositeKey.SlhdsaPublicKeyBytes()
+			client.SlhdsaPublicKey = slhdsaPub
+		}
 
 		// Provide workspace tab sync data on connect.
 		queries := db.New(sqlDB)


### PR DESCRIPTION
## Motivation

The existing Noise_NK handshake used classical X25519 key exchange, which is vulnerable to "harvest now, decrypt later" attacks by a quantum-capable adversary. To protect session confidentiality long-term, the handshake needs to incorporate post-quantum algorithms so that security holds even if either the classical or PQ algorithm is broken in the future.

Additionally, the prior design stored the encryption mode in the database, which made it impossible for a worker to advertise its actual runtime capability without a schema migration per deployment. A runtime discovery mechanism was needed so that the hub and frontend can adapt to the mode each worker actually supports.

## Modifications

- **Hybrid PQ handshake**: Combined classical X25519 with ML-KEM-1024 (FIPS 203) for key encapsulation and SLH-DSA-SHAKE-256f (FIPS 205) for transcript authentication. Session keys are derived via `hybridSplit` from both shared secrets. The Go backend now uses `github.com/cloudflare/circl`; the frontend adds `@noble/post-quantum`.

- **Runtime encryption mode discovery**: Added `EncryptionMode` proto enum (`DISABLED`, `CLASSIC`, `POST_QUANTUM`). Workers advertise their mode via heartbeat; the hub caches it on the live connection and exposes it through a new `GetWorkerEncryptionMode` RPC. `ChannelManager.openChannel` branches on the discovered mode at channel-open time.

- **Composite key bundle**: Worker keys are now a typed `CompositeKeypair` (X25519 + ML-KEM-1024 + SLH-DSA). Registration, heartbeat, DB schema (`mlkem_public_key`, `slhdsa_public_key` columns), and all related queries and services have been updated. Key-pinning TOFU now hashes all three keys concatenated.

- **Security hardening**: ML-KEM ciphertext is mixed into the Noise handshake hash for defense-in-depth. DH shared secrets and all handshake state (private ephemeral key, chaining key, cipher key, hash) are zeroed after use. Message 2 size is validated with a strict equality check. `ENCRYPTION_MODE_DISABLED` is rejected by the hub's worker connector unless the server runs in solo mode.

- **Updated architecture diagram**: Removed the E2EE label from the solo mode diagram, since solo mode uses disabled encryption (browser and worker run in the same process on localhost).

- (Breaking) `RunConfig` fields `PrivateKey`/`PublicKey []byte` removed; replaced by `CompositeKey *noiseutil.CompositeKeypair`.
- (Breaking) `ChannelTransport.getWorkerPublicKey` now returns `Promise<WorkerKeyBundle>` instead of `Promise<Uint8Array>`.
- (Breaking) `ChannelTransport` gains a new required method `getWorkerEncryptionMode(workerId): Promise<EncryptionMode>`.
- (Breaking) `hub.Register` now requires three key arguments (X25519, ML-KEM, SLH-DSA).
- (Breaking) `State.EnsureKeypair`, `PublicKeyBytes`, and `PrivateKeyBytes` are removed.
- (Breaking) `channel.NewManager` signature changed.
- (Breaking) Handshake message sizes changed: message 1 grew from 48 to 1616 bytes; message 2 grew from 48 to 49904 bytes.

## Result

End-to-end encrypted channels between the frontend and worker are now protected by a hybrid post-quantum handshake. A quantum adversary who records today's traffic cannot decrypt it later by breaking X25519 alone. The encryption mode is discovered at runtime from each worker's live connection, so classic and PQ workers can coexist without any database migration. Solo mode continues to work unchanged with encryption disabled.

🤖 Generated with Claude Code
