### PR TITLE
Refactor sidebar logic and polish UI animations and scrollbars

### DIFF
--- a/frontend/src/components/chat/ThinkingIndicator.css.ts
+++ b/frontend/src/components/chat/ThinkingIndicator.css.ts
@@ -27,5 +27,12 @@ export const compass = style({
 
 export const verb = style({
   fontSize: 'var(--text-7)',
+  fontWeight: 600,
   userSelect: 'none',
+})
+
+export const char = style({
+  display: 'inline-block',
+  whiteSpace: 'pre',
+  transition: 'transform 0.5s ease-out',
 })

--- a/frontend/src/components/chat/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/ThinkingIndicator.tsx
@@ -4,11 +4,11 @@ import { createCompassSimulation } from './compassPhysics'
 import { getRandomVerb } from './spinnerVerbs'
 import * as styles from './ThinkingIndicator.css'
 
-function charWeight(index: number, total: number, highlightPos: number): number {
+function charElevation(index: number, total: number, highlightPos: number): number {
   const dist = Math.abs(index - highlightPos)
   const wrappedDist = Math.min(dist, total - dist)
-  const falloff = Math.max(0, 1 - (wrappedDist / total) * 2)
-  return 400 + 300 * falloff
+  const falloff = Math.max(0, 1 - wrappedDist / 1.5)
+  return -4 * falloff
 }
 
 export interface ThinkingIndicatorProps {
@@ -127,7 +127,7 @@ export const ThinkingIndicator: Component<ThinkingIndicatorProps> = (props) => {
           <span class={styles.verb}>
             <For each={chars()}>
               {(char, i) => (
-                <span style={{ 'font-weight': charWeight(i(), chars().length, highlightPos()) }}>
+                <span class={styles.char} style={{ transform: `translateY(${charElevation(i(), chars().length, highlightPos())}px)` }}>
                   {char}
                 </span>
               )}

--- a/frontend/src/components/shell/CollapsibleSidebar.css.ts
+++ b/frontend/src/components/shell/CollapsibleSidebar.css.ts
@@ -86,8 +86,21 @@ export const collapsibleTrigger = style({
   'borderBottom': '1px solid var(--border)',
   'flexShrink': 0,
   'position': 'relative',
+  'cursor': 'pointer',
+  'userSelect': 'none',
   ':hover': {
     backgroundColor: 'var(--card)',
+  },
+  '::after': {
+    content: '""',
+    width: '1em',
+    height: '1em',
+    flexShrink: 0,
+    backgroundColor: 'currentColor',
+    maskImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
+    maskSize: 'contain',
+    maskRepeat: 'no-repeat',
+    transition: 'transform var(--transition-fast)',
   },
 })
 
@@ -119,8 +132,13 @@ globalStyle(`${collapsibleTrigger} > ${sidebarTitle}`, {
   flex: 1,
 })
 
+/** Rotate chevron when the pane is expanded. */
+globalStyle(`${collapsiblePaneExpanded} > ${collapsibleTrigger}::after`, {
+  transform: 'rotate(180deg)',
+})
+
 /** Hide bottom border on collapsed pane triggers. */
-globalStyle(`${collapsiblePane}:not([open]) > ${collapsibleTrigger}`, {
+globalStyle(`${collapsiblePane}:not(${collapsiblePaneExpanded}) > ${collapsibleTrigger}`, {
   borderBottom: 'none',
 })
 

--- a/frontend/src/components/shell/CollapsibleSidebar.test.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.test.tsx
@@ -116,7 +116,7 @@ describe('collapsibleSidebar', () => {
 
     // Click the summary of section B to collapse it
     const summaries = screen.getAllByText('Section B')
-    const summary = summaries[0].closest('summary')
+    const summary = summaries[0].closest('[role="button"]')
     if (summary) {
       fireEvent.click(summary)
     }
@@ -215,7 +215,7 @@ describe('collapsibleSidebar', () => {
     expect(screen.getAllByTestId('pane-resize-handle')).toHaveLength(2)
 
     // Collapse section B by clicking its summary
-    const summary = screen.getByText('Section B').closest('summary')
+    const summary = screen.getByText('Section B').closest('[role="button"]')
     if (summary) {
       fireEvent.click(summary)
     }

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -4,7 +4,7 @@ import { createDraggable, createDroppable, useDragDropContext } from '@thisbeyon
 import GripVertical from 'lucide-solid/icons/grip-vertical'
 import PanelLeftClose from 'lucide-solid/icons/panel-left-close'
 import PanelRightClose from 'lucide-solid/icons/panel-right-close'
-import { createEffect, createMemo, createSignal, For, Show } from 'solid-js'
+import { createMemo, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { IconButton } from '~/components/common/IconButton'
 import * as styles from './CollapsibleSidebar.css'
@@ -50,7 +50,7 @@ export interface SidebarSectionDef {
   railElement?: JSX.Element
   /** Rail position: 'top' (default) or 'bottom'. */
   railPosition?: 'top' | 'bottom'
-  /** data-testid for the section details element. */
+  /** data-testid for the section container element. */
   testId?: string
   /** Whether the section can be dragged/reordered. Default: false. */
   draggable?: boolean
@@ -309,15 +309,6 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
               return -1
             }
 
-            // Use a ref + createEffect to fully control the <details> open
-            // state.  This prevents the browser's session-history restoration
-            // from overriding our persisted collapsed preferences on reload.
-            let detailsRef!: HTMLDetailsElement
-            createEffect(() => {
-              if (detailsRef)
-                detailsRef.open = sectionOpen()
-            })
-
             return (
               <>
                 {/* Resize handle between expanded panes */}
@@ -335,9 +326,8 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                   <div class={styles.dropIndicatorLine} data-testid="drop-indicator" />
                 </Show>
 
-                <details
+                <div
                   ref={(el) => {
-                    detailsRef = el
                     // Attach draggable + droppable refs for DnD
                     if (draggable)
                       draggable.ref(el)
@@ -347,15 +337,13 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                   class={`${styles.collapsiblePane} ${sectionOpen() ? styles.collapsiblePaneExpanded : ''} ${draggable?.isActiveDraggable ? styles.collapsiblePaneDragging : ''}`}
                   style={flexStyle()}
                   data-testid={section().testId}
+                  data-closed={sectionOpen() ? undefined : ''}
                 >
-                  <summary
+                  <div
+                    role="button"
                     class={`${styles.collapsibleTrigger} ${props.side === 'right' ? styles.collapsibleTriggerRight : ''} ${isStatic() || !canCollapse() ? styles.collapsibleTriggerStatic : ''} ${index() === 0 && props.side === 'right' ? styles.collapsibleTriggerNoChevron : ''}`}
                     data-testid={section().testId ? `${section().testId}-summary` : undefined}
-                    onClick={(e) => {
-                      // Prevent native <details> toggle -- we control state
-                      // entirely via signals to avoid browser auto-restoration
-                      // issues on page reload.
-                      e.preventDefault()
+                    onClick={() => {
                       if (sectionOpen() && !canCollapse())
                         return
                       handleToggle(id, section().collapsible, !sectionOpen())
@@ -416,7 +404,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                         }}
                       />
                     </Show>
-                  </summary>
+                  </div>
                   <div class={`${styles.collapsibleContent}${sectionOpen() ? ` ${styles.collapsibleContentExpanded}` : ''}`}>
                     <div class={styles.collapsibleContentInner}>
                       <div class={styles.sidebarContent}>
@@ -424,7 +412,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                       </div>
                     </div>
                   </div>
-                </details>
+                </div>
 
                 {/* Drop indicator: after this section */}
                 <Show when={currentDropIndicator()?.targetSectionId === id && currentDropIndicator()?.position === 'after'}>

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -1,130 +1,33 @@
 import type { Component } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
-import type { FilesSectionHandle } from '~/components/tree/FilesSection'
-import type { Worker } from '~/generated/leapmux/v1/worker_pb'
-import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
-import type { WorkerInfo } from '~/lib/workerInfoCache'
-import type { TodoItem } from '~/stores/chat.store'
-import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
-import type { createSectionStore } from '~/stores/section.store'
-import type { createTabStore, Tab } from '~/stores/tab.store'
-import type { ChannelStatus } from '~/stores/workerChannelStatus.store'
-import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry'
+import type { SidebarCommonProps } from './useSidebarCore'
 
 import CircleUser from 'lucide-solid/icons/circle-user'
-import Plus from 'lucide-solid/icons/plus'
 import Settings from 'lucide-solid/icons/settings'
-import { createMemo, createSignal, onCleanup, Show } from 'solid-js'
+import { onCleanup } from 'solid-js'
 import { IconButton } from '~/components/common/IconButton'
-import { TodoList } from '~/components/todo/TodoList'
-import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
-import { WorkerSectionContent } from '~/components/workers/WorkerSectionContent'
-import { emptySection as emptySectionStyle, dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
-import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
-import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
+import { dragOverlay as wsDragOverlay } from '~/components/workspace/workspaceList.css'
 import { useAuth } from '~/context/AuthContext'
-import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { Sidebar } from '~/generated/leapmux/v1/section_pb'
 import { isSoloMode } from '~/lib/systemInfo'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 import * as csStyles from './CollapsibleSidebar.css'
 import { useSectionDrag } from './SectionDragContext'
-import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
 import { UserMenu } from './UserMenu'
-import { useWorkspaceOperations } from './useWorkspaceOperations'
+import { useSidebarCore } from './useSidebarCore'
 
-interface LeftSidebarProps {
-  workspaces: Workspace[]
-  activeWorkspaceId: string | null
-  sectionStore: ReturnType<typeof createSectionStore>
-  loadSections: () => Promise<void>
-  onSelectWorkspace: (id: string) => void
-  onNewWorkspace: (sectionId: string | null) => void
-  onRefreshWorkspaces: () => void | Promise<void>
-  onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
-  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
-  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
-  onPostArchiveWorkspace?: (workspaceId: string) => void
-  isCollapsed: boolean
-  onExpand: () => void
-  onCollapse?: () => void
-  initialOpenSections?: Record<string, boolean>
-  initialSectionSizes?: Record<string, number>
-  onSectionStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
-  // File/todo props for rendering FILES/TODOS sections moved to this sidebar
-  workerId: string
-  workingDir: string
-  homeDir: string
-  fileTreePath: string
-  onFileSelect: (path: string) => void
-  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
-  onFileMention?: (path: string) => void
-  onOpenTerminal?: (dirPath: string) => void
-  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
-  activeFilePath?: string
-  hasActiveFileTab?: boolean
-  showTodos: boolean
-  activeTodos: TodoItem[]
-  /** Signal bumped on agent turn-end; drives directory tree refresh. */
-  turnEndTrigger?: number
-  // Worker section props
-  workers: Worker[]
-  workerInfoFn: (id: string) => WorkerInfo | null
-  channelStatusFn: (id: string) => ChannelStatus
-  onDeregisterWorker: (worker: Worker) => void
-  tabStore: ReturnType<typeof createTabStore>
-  registry?: WorkspaceStoreRegistryType
-  onTabClick: (type: number, id: string) => void
-  onTabRename?: (tab: Tab, title: string) => void
-  onExpandWorkspace: (workspaceId: string) => void
-}
+type LeftSidebarProps = SidebarCommonProps
 
 export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   const auth = useAuth()
-  // eslint-disable-next-line solid/reactivity -- stable store reference for component lifetime
-  const store = props.sectionStore
   const { addExternalDragHandler, addExternalOverlayRenderer } = useSectionDrag()
 
-  // Captured from CollapsibleSidebar's expandSectionRef callback.
-  let expandSection: ((sectionId: string) => void) | undefined
-
-  // Handle for the FilesSection imperative API (e.g., collapseAll).
-  // Declared as a signal so reactive reads (e.g., isFiltered in header
-  // actions) re-evaluate when the handle is assigned after FilesSection mounts.
-  const [filesSectionHandle, setFilesSectionHandle] = createSignal<FilesSectionHandle | undefined>()
-
-  /* eslint-disable solid/reactivity -- callbacks are stable references */
-  const wsOps = useWorkspaceOperations({
-    workspaces: () => props.workspaces,
-    activeWorkspaceId: () => props.activeWorkspaceId,
-    sectionStore: store,
-    loadSections: props.loadSections,
-    onSelectWorkspace: props.onSelectWorkspace,
-    onNewWorkspace: props.onNewWorkspace,
-    onRefreshWorkspaces: props.onRefreshWorkspaces,
-    onDeleteWorkspace: props.onDeleteWorkspace,
-    onConfirmDelete: props.onConfirmDelete,
-    onConfirmArchive: props.onConfirmArchive,
-    onPostArchiveWorkspace: (workspaceId) => {
-      const archivedSection = store.getArchivedSection()
-      if (archivedSection && expandSection)
-        expandSection(archivedSection.id)
-      props.onPostArchiveWorkspace?.(workspaceId)
-    },
-  })
-  /* eslint-enable solid/reactivity */
-
-  // ---------------------------------------------------------------------------
-  // Workspace grouping
-  // ---------------------------------------------------------------------------
-
-  /** Get sections for the left sidebar, sorted by position. */
-  const leftSections = createMemo(() =>
-    store.getSectionsForSidebar(Sidebar.LEFT),
-  )
-
-  const sectionGroups = createMemo(() =>
-    wsOps.buildSectionGroups(leftSections()),
-  )
+  const {
+    wsOps,
+    buildSectionDefs,
+    renderSharingDialog,
+    expandSectionRef,
+  } = useSidebarCore(props, Sidebar.LEFT)
 
   // ---------------------------------------------------------------------------
   // DnD
@@ -153,189 +56,11 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   })
 
   // ---------------------------------------------------------------------------
-  // Reactive helpers for content factories.
-  // ---------------------------------------------------------------------------
-
-  const getWorkspacesForGroup = (sectionId: string): Workspace[] =>
-    wsOps.getWorkspacesForGroup(sectionId, sectionGroups())
-
-  const isGroupShared = (sectionId: string): boolean =>
-    wsOps.isGroupShared(sectionId, sectionGroups())
-
-  // ---------------------------------------------------------------------------
   // Build sidebar section definitions
   // ---------------------------------------------------------------------------
 
   const sidebarSections = (): SidebarSectionDef[] => {
-    const groups = sectionGroups()
-    const sections: SidebarSectionDef[] = []
-
-    for (const group of groups) {
-      const sectionId = group.section.id
-      const sectionType = group.section.sectionType
-      const isShared = sectionType === SectionType.WORKSPACES_SHARED
-
-      if (isWorkspaceSection(sectionType)) {
-        sections.push({
-          id: sectionId,
-          title: group.section.name,
-          railIcon: getSectionIcon(group.section),
-          railTitle: group.section.name,
-          defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
-          collapsible: true,
-          draggable: true,
-          visible: !isShared || wsOps.sharedWorkspaces().length > 0,
-          headerActions: wsOps.canAddToSection(group.section)
-            ? (
-                <IconButton
-                  icon={Plus}
-                  iconSize="sm"
-                  size="md"
-                  title={`New workspace in ${group.section.name}`}
-                  data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    e.preventDefault()
-                    props.onNewWorkspace(sectionId)
-                  }}
-                />
-              )
-            : undefined,
-          testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          content: () => (
-            <WorkspaceSectionContent
-              workspaces={getWorkspacesForGroup(sectionId)}
-              sectionId={sectionId}
-              activeWorkspaceId={props.activeWorkspaceId}
-              currentUserId={wsOps.currentUserId()}
-              isVirtual={isGroupShared(sectionId)}
-              sections={store.state.sections}
-              onSelect={props.onSelectWorkspace}
-              onRename={wsOps.startRename}
-              onMoveTo={wsOps.moveWorkspace}
-              onShare={id => wsOps.setSharingWorkspaceId(id)}
-              onArchive={wsOps.archiveWorkspace}
-              onUnarchive={wsOps.unarchiveWorkspace}
-              onDelete={wsOps.deleteWorkspace}
-              isArchived={wsOps.isWorkspaceArchived}
-              renamingWorkspaceId={wsOps.renamingWorkspaceId()}
-              renameValue={wsOps.renameValue()}
-              onRenameInput={wsOps.onRenameInput}
-              onRenameCommit={wsOps.commitRename}
-              onRenameCancel={wsOps.cancelRename}
-              isWorkspaceLoading={wsOps.isWorkspaceLoading}
-              tabs={props.tabStore.state.tabs}
-              activeTabKey={props.tabStore.state.activeTabKey}
-              getTabsForWorkspace={(wsId: string) => {
-                const snap = props.registry?.get(wsId)
-                return snap?.tabs.tabs ?? []
-              }}
-              getActiveTabKeyForWorkspace={(wsId: string) => {
-                const snap = props.registry?.get(wsId)
-                return snap?.tabs.activeTabKey ?? null
-              }}
-              onTabClick={props.onTabClick}
-              onTabRename={props.onTabRename}
-              onExpandWorkspace={props.onExpandWorkspace}
-            />
-          ),
-        })
-      }
-      else if (sectionType === SectionType.FILES) {
-        // FILES section moved to the left sidebar — render FilesSection
-        sections.push({
-          id: sectionId,
-          title: group.section.name,
-          railIcon: getSectionIcon(group.section),
-          railTitle: group.section.name,
-          defaultOpen: true,
-          collapsible: true,
-          draggable: true,
-          testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          headerActions: (
-            <FilesSectionHeaderActions
-              onCollapseAll={() => filesSectionHandle()?.collapseAll()}
-              onLocateFile={() => {
-                if (props.activeFilePath)
-                  props.onFileSelect(props.activeFilePath)
-              }}
-              onRefresh={() => {
-                if (props.workerId && props.workingDir)
-                  props.gitStatusStore?.refresh(props.workerId, props.workingDir)
-                filesSectionHandle()?.refresh()
-              }}
-              hasActiveFileTab={props.hasActiveFileTab ?? false}
-              isFiltered={() => filesSectionHandle()?.isFiltered() ?? false}
-              flatListMode={() => filesSectionHandle()?.flatListMode() ?? false}
-              onToggleFlatList={() => filesSectionHandle()?.toggleFlatListMode()}
-            />
-          ),
-          content: () => (
-            <Show
-              when={props.workerId}
-              fallback={<div class={emptySectionStyle}>No tab selected</div>}
-            >
-              <FilesSection
-                workerId={props.workerId}
-                workingDir={props.workingDir}
-                homeDir={props.homeDir}
-                fileTreePath={props.fileTreePath}
-                onFileSelect={props.onFileSelect}
-                onFileOpen={props.onFileOpen}
-                onMention={props.onFileMention}
-                onOpenTerminal={props.onOpenTerminal}
-                gitStatusStore={props.gitStatusStore!}
-                activeFilePath={props.activeFilePath}
-                hasActiveFileTab={props.hasActiveFileTab ?? false}
-                turnEndTrigger={props.turnEndTrigger}
-                ref={setFilesSectionHandle}
-              />
-            </Show>
-          ),
-        })
-      }
-      else if (sectionType === SectionType.TODOS) {
-        // TODOS section moved to the left sidebar — render TodoList
-        sections.push({
-          id: sectionId,
-          title: group.section.name,
-          railIcon: getSectionIcon(group.section),
-          railTitle: group.section.name,
-          visible: props.showTodos,
-          draggable: true,
-          testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          railBadge: () => (
-            <span class={csStyles.railBadgeText}>
-              {props.activeTodos.filter(t => t.status === 'completed').length}
-              /
-              {props.activeTodos.length}
-            </span>
-          ),
-          content: () => <TodoList todos={props.activeTodos} />,
-        })
-      }
-      else if (sectionType === SectionType.WORKERS) {
-        sections.push({
-          id: sectionId,
-          title: group.section.name,
-          railIcon: getSectionIcon(group.section),
-          railTitle: group.section.name,
-          defaultOpen: true,
-          collapsible: true,
-          draggable: true,
-          defaultSize: 0.15,
-          testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          content: () => (
-            <WorkerSectionContent
-              workers={props.workers}
-              workerInfo={props.workerInfoFn}
-              channelStatus={props.channelStatusFn}
-              onDeregister={props.onDeregisterWorker}
-            />
-          ),
-        })
-      }
-    }
+    const sections = buildSectionDefs()
 
     // User Menu section (rail-only in collapsed, rendered at bottom in expanded)
     const solo = isSoloMode()
@@ -381,21 +106,10 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
         initialOpenSections={props.initialOpenSections}
         initialSectionSizes={props.initialSectionSizes}
         onStateChange={props.onSectionStateChange}
-        expandSectionRef={fn => expandSection = fn}
+        expandSectionRef={expandSectionRef}
       />
 
-      <Show when={wsOps.sharingWorkspaceId()}>
-        {workspaceId => (
-          <WorkspaceSharingDialog
-            workspaceId={workspaceId()}
-            onClose={() => wsOps.setSharingWorkspaceId(null)}
-            onSaved={() => {
-              wsOps.setSharingWorkspaceId(null)
-              props.onRefreshWorkspaces()
-            }}
-          />
-        )}
-      </Show>
+      {renderSharingDialog()}
     </>
   )
 }

--- a/frontend/src/components/shell/RightSidebar.tsx
+++ b/frontend/src/components/shell/RightSidebar.tsx
@@ -1,283 +1,23 @@
 import type { Component } from 'solid-js'
-import type { SidebarSectionDef } from './CollapsibleSidebar'
-import type { FilesSectionHandle } from '~/components/tree/FilesSection'
-import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
-import type { TodoItem } from '~/stores/chat.store'
-import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
-import type { createSectionStore } from '~/stores/section.store'
-import type { createTabStore, Tab } from '~/stores/tab.store'
-import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry'
+import type { SidebarCommonProps } from './useSidebarCore'
 
-import Plus from 'lucide-solid/icons/plus'
-import { createMemo, createSignal, Show } from 'solid-js'
-import { IconButton } from '~/components/common/IconButton'
-import { TodoList } from '~/components/todo/TodoList'
-import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
-import * as swlStyles from '~/components/workspace/workspaceList.css'
-import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
-import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
-import { SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { Sidebar } from '~/generated/leapmux/v1/section_pb'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
-import * as csStyles from './CollapsibleSidebar.css'
-import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
-import { useWorkspaceOperations } from './useWorkspaceOperations'
+import { useSidebarCore } from './useSidebarCore'
 
-interface RightSidebarProps {
-  workspaceId: string
-  workerId: string
-  workingDir: string
-  homeDir: string
-  showTodos: boolean
-  activeTodos: TodoItem[]
-  fileTreePath: string
-  onFileSelect: (path: string) => void
-  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
-  onFileMention?: (path: string) => void
-  onOpenTerminal?: (dirPath: string) => void
-  gitStatusStore: ReturnType<typeof createGitFileStatusStore>
-  activeFilePath?: string
-  hasActiveFileTab: boolean
-  sectionStore: ReturnType<typeof createSectionStore>
-  isCollapsed: boolean
-  onExpand: () => void
-  onCollapse?: () => void
-  initialOpenSections?: Record<string, boolean>
-  initialSectionSizes?: Record<string, number>
-  onSectionStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
-  // Workspace props for rendering workspace sections moved to this sidebar
-  workspaces: Workspace[]
-  activeWorkspaceId: string | null
-  loadSections: () => Promise<void>
-  onSelectWorkspace: (id: string) => void
-  onNewWorkspace: (sectionId: string | null) => void
-  onRefreshWorkspaces: () => void | Promise<void>
-  onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
-  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
-  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
-  onPostArchiveWorkspace?: (workspaceId: string) => void
-  /** Signal bumped on agent turn-end; drives directory tree refresh. */
-  turnEndTrigger?: number
-  tabStore?: ReturnType<typeof createTabStore>
-  registry?: WorkspaceStoreRegistryType
-  onTabClick?: (type: number, id: string) => void
-  onTabRename?: (tab: Tab, title: string) => void
-  onExpandWorkspace?: (workspaceId: string) => void
-}
+type RightSidebarProps = SidebarCommonProps
 
 export const RightSidebar: Component<RightSidebarProps> = (props) => {
-  // eslint-disable-next-line solid/reactivity -- stable store reference for component lifetime
-  const store = props.sectionStore
-
-  // Captured from CollapsibleSidebar's expandSectionRef callback.
-  let expandSection: ((sectionId: string) => void) | undefined
-
-  // Handle for the FilesSection imperative API (e.g., collapseAll).
-  // Declared as a signal so reactive reads (e.g., isFiltered in header
-  // actions) re-evaluate when the handle is assigned after FilesSection mounts.
-  const [filesSectionHandle, setFilesSectionHandle] = createSignal<FilesSectionHandle | undefined>()
-
-  /* eslint-disable solid/reactivity -- callbacks are stable references */
-  const wsOps = useWorkspaceOperations({
-    workspaces: () => props.workspaces,
-    activeWorkspaceId: () => props.activeWorkspaceId,
-    sectionStore: store,
-    loadSections: props.loadSections,
-    onSelectWorkspace: props.onSelectWorkspace,
-    onNewWorkspace: props.onNewWorkspace,
-    onRefreshWorkspaces: props.onRefreshWorkspaces,
-    onDeleteWorkspace: props.onDeleteWorkspace,
-    onConfirmDelete: props.onConfirmDelete,
-    onConfirmArchive: props.onConfirmArchive,
-    onPostArchiveWorkspace: (workspaceId) => {
-      const archivedSection = store.getArchivedSection()
-      if (archivedSection && expandSection)
-        expandSection(archivedSection.id)
-      props.onPostArchiveWorkspace?.(workspaceId)
-    },
-  })
-  /* eslint-enable solid/reactivity */
-
-  /** Get sections assigned to the right sidebar, sorted by position. */
-  const rightSections = createMemo(() =>
-    store.getSectionsForSidebar(Sidebar.RIGHT),
-  )
-
-  const sectionGroups = createMemo(() =>
-    wsOps.buildSectionGroups(rightSections()),
-  )
-
-  const getWorkspacesForGroup = (sectionId: string): Workspace[] =>
-    wsOps.getWorkspacesForGroup(sectionId, sectionGroups())
-
-  const isGroupShared = (sectionId: string): boolean =>
-    wsOps.isGroupShared(sectionId, sectionGroups())
-
-  // Build section definitions reactively from the store
-  const sections = (): SidebarSectionDef[] => {
-    const secs = rightSections()
-    return secs.map((section): SidebarSectionDef => {
-      const sectionType = section.sectionType
-
-      if (sectionType === SectionType.FILES) {
-        return {
-          id: section.id,
-          title: section.name,
-          railIcon: getSectionIcon(section),
-          railTitle: section.name,
-          collapsible: secs.length > 1,
-          draggable: true,
-          testId: 'section-header-files',
-          headerActions: (
-            <FilesSectionHeaderActions
-              onCollapseAll={() => filesSectionHandle()?.collapseAll()}
-              onLocateFile={() => {
-                if (props.activeFilePath)
-                  props.onFileSelect(props.activeFilePath)
-              }}
-              onRefresh={() => {
-                if (props.workerId && props.workingDir)
-                  props.gitStatusStore.refresh(props.workerId, props.workingDir)
-                filesSectionHandle()?.refresh()
-              }}
-              hasActiveFileTab={props.hasActiveFileTab}
-              isFiltered={() => filesSectionHandle()?.isFiltered() ?? false}
-              flatListMode={() => filesSectionHandle()?.flatListMode() ?? false}
-              onToggleFlatList={() => filesSectionHandle()?.toggleFlatListMode()}
-            />
-          ),
-          content: () => (
-            <Show
-              when={props.workerId}
-              fallback={<div class={swlStyles.emptySection}>No tab selected</div>}
-            >
-              <FilesSection
-                workerId={props.workerId}
-                workingDir={props.workingDir}
-                homeDir={props.homeDir}
-                fileTreePath={props.fileTreePath}
-                onFileSelect={props.onFileSelect}
-                onFileOpen={props.onFileOpen}
-                onMention={props.onFileMention}
-                onOpenTerminal={props.onOpenTerminal}
-                gitStatusStore={props.gitStatusStore}
-                activeFilePath={props.activeFilePath}
-                hasActiveFileTab={props.hasActiveFileTab}
-                turnEndTrigger={props.turnEndTrigger}
-                ref={setFilesSectionHandle}
-              />
-            </Show>
-          ),
-        }
-      }
-
-      if (sectionType === SectionType.TODOS) {
-        return {
-          id: section.id,
-          title: section.name,
-          railIcon: getSectionIcon(section),
-          railTitle: section.name,
-          visible: props.showTodos,
-          draggable: true,
-          testId: 'section-header-todos',
-          railBadge: () => (
-            <span class={csStyles.railBadgeText}>
-              {props.activeTodos.filter(t => t.status === 'completed').length}
-              /
-              {props.activeTodos.length}
-            </span>
-          ),
-          content: () => <TodoList todos={props.activeTodos} />,
-        }
-      }
-
-      if (isWorkspaceSection(sectionType)) {
-        // Workspace section moved to the right sidebar — render full workspace content
-        const isShared = sectionType === SectionType.WORKSPACES_SHARED
-        const sectionId = section.id
-        return {
-          id: sectionId,
-          title: section.name,
-          railIcon: getSectionIcon(section),
-          railTitle: section.name,
-          defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
-          collapsible: true,
-          draggable: true,
-          visible: !isShared || wsOps.sharedWorkspaces().length > 0,
-          headerActions: wsOps.canAddToSection(section)
-            ? (
-                <IconButton
-                  icon={Plus}
-                  iconSize="sm"
-                  size="md"
-                  title={`New workspace in ${section.name}`}
-                  data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    e.preventDefault()
-                    props.onNewWorkspace(sectionId)
-                  }}
-                />
-              )
-            : undefined,
-          testId: `section-header-${sectionTypeTestId(sectionType)}`,
-          content: () => (
-            <WorkspaceSectionContent
-              workspaces={getWorkspacesForGroup(sectionId)}
-              sectionId={sectionId}
-              activeWorkspaceId={props.activeWorkspaceId}
-              currentUserId={wsOps.currentUserId()}
-              isVirtual={isGroupShared(sectionId)}
-              sections={store.state.sections}
-              onSelect={props.onSelectWorkspace}
-              onRename={wsOps.startRename}
-              onMoveTo={wsOps.moveWorkspace}
-              onShare={id => wsOps.setSharingWorkspaceId(id)}
-              onArchive={wsOps.archiveWorkspace}
-              onUnarchive={wsOps.unarchiveWorkspace}
-              onDelete={wsOps.deleteWorkspace}
-              isArchived={wsOps.isWorkspaceArchived}
-              renamingWorkspaceId={wsOps.renamingWorkspaceId()}
-              renameValue={wsOps.renameValue()}
-              onRenameInput={wsOps.onRenameInput}
-              onRenameCommit={wsOps.commitRename}
-              onRenameCancel={wsOps.cancelRename}
-              isWorkspaceLoading={wsOps.isWorkspaceLoading}
-              tabs={props.tabStore?.state.tabs ?? []}
-              activeTabKey={props.tabStore?.state.activeTabKey ?? null}
-              getTabsForWorkspace={(wsId: string) => {
-                const snap = props.registry?.get(wsId)
-                return snap?.tabs.tabs ?? []
-              }}
-              getActiveTabKeyForWorkspace={(wsId: string) => {
-                const snap = props.registry?.get(wsId)
-                return snap?.tabs.activeTabKey ?? null
-              }}
-              onTabClick={props.onTabClick ?? (() => {})}
-              onTabRename={props.onTabRename}
-              onExpandWorkspace={props.onExpandWorkspace}
-            />
-          ),
-        }
-      }
-
-      // Unknown section type — empty fallback
-      return {
-        id: section.id,
-        title: section.name,
-        railIcon: getSectionIcon(section),
-        railTitle: section.name,
-        collapsible: true,
-        draggable: true,
-        testId: `section-header-${sectionTypeTestId(sectionType)}`,
-        content: () => <></>,
-      }
-    })
-  }
+  const {
+    buildSectionDefs,
+    renderSharingDialog,
+    expandSectionRef,
+  } = useSidebarCore(props, Sidebar.RIGHT)
 
   return (
     <>
       <CollapsibleSidebar
-        sections={sections()}
+        sections={buildSectionDefs()}
         side="right"
         isCollapsed={props.isCollapsed}
         onExpand={props.onExpand}
@@ -285,21 +25,10 @@ export const RightSidebar: Component<RightSidebarProps> = (props) => {
         initialOpenSections={props.initialOpenSections}
         initialSectionSizes={props.initialSectionSizes}
         onStateChange={props.onSectionStateChange}
-        expandSectionRef={fn => expandSection = fn}
+        expandSectionRef={expandSectionRef}
       />
 
-      <Show when={wsOps.sharingWorkspaceId()}>
-        {workspaceId => (
-          <WorkspaceSharingDialog
-            workspaceId={workspaceId()}
-            onClose={() => wsOps.setSharingWorkspaceId(null)}
-            onSaved={() => {
-              wsOps.setSharingWorkspaceId(null)
-              props.onRefreshWorkspaces()
-            }}
-          />
-        )}
-      </Show>
+      {renderSharingDialog()}
     </>
   )
 }

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -120,7 +120,6 @@ export function createLeftSidebarElement(opts: SidebarElementsOpts, display?: Si
 export function createRightSidebarElement(opts: SidebarElementsOpts, display?: SidebarDisplayOpts): JSX.Element {
   return (
     <RightSidebar
-      workspaceId={opts.activeWorkspaceId ?? ''}
       workerId={opts.getCurrentTabContext().workerId}
       workingDir={opts.getCurrentTabContext().workingDir}
       homeDir={opts.getCurrentTabContext().homeDir}
@@ -164,6 +163,10 @@ export function createRightSidebarElement(opts: SidebarElementsOpts, display?: S
       onTabClick={opts.onTabClick}
       onTabRename={opts.onTabRename}
       onExpandWorkspace={opts.onExpandWorkspace}
+      workers={opts.workers}
+      workerInfoFn={opts.workerInfoFn}
+      channelStatusFn={opts.channelStatusFn}
+      onDeregisterWorker={opts.onDeregisterWorker}
     />
   )
 }

--- a/frontend/src/components/shell/TabBar.css.ts
+++ b/frontend/src/components/shell/TabBar.css.ts
@@ -28,6 +28,10 @@ export const tabList = style({
   borderRadius: 0,
 })
 
+globalStyle(`${tabList}::-webkit-scrollbar`, {
+  display: 'none',
+})
+
 export const tab = style({
   'all': 'unset',
   'display': 'flex',

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -1,0 +1,264 @@
+import type { Accessor } from 'solid-js'
+import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { WorkspaceOperations } from './useWorkspaceOperations'
+import type { FilesSectionHandle } from '~/components/tree/FilesSection'
+import type { Section } from '~/generated/leapmux/v1/section_pb'
+import type { Worker } from '~/generated/leapmux/v1/worker_pb'
+import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { TodoItem } from '~/stores/chat.store'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
+import type { createSectionStore } from '~/stores/section.store'
+import type { createTabStore, Tab } from '~/stores/tab.store'
+import type { ChannelStatus } from '~/stores/workerChannelStatus.store'
+import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry'
+
+import Plus from 'lucide-solid/icons/plus'
+import { Show } from 'solid-js'
+import { IconButton } from '~/components/common/IconButton'
+import { TodoList } from '~/components/todo/TodoList'
+import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
+import { WorkerSectionContent } from '~/components/workers/WorkerSectionContent'
+import { emptySection as emptySectionStyle } from '~/components/workspace/workspaceList.css'
+import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
+import { SectionType } from '~/generated/leapmux/v1/section_pb'
+import * as csStyles from './CollapsibleSidebar.css'
+import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
+
+/**
+ * All dependencies needed to build a `SidebarSectionDef` for any section type.
+ * Both LeftSidebar and RightSidebar populate this from their props.
+ */
+export interface SectionDefContext {
+  // Section store
+  sectionStore: ReturnType<typeof createSectionStore>
+
+  // Workspace operations
+  wsOps: WorkspaceOperations
+  getWorkspacesForGroup: (sectionId: string) => Workspace[]
+  isGroupShared: (sectionId: string) => boolean
+  activeWorkspaceId: string | null
+  onNewWorkspace: (sectionId: string | null) => void
+  onSelectWorkspace: (id: string) => void
+  tabStore?: ReturnType<typeof createTabStore>
+  registry?: WorkspaceStoreRegistryType
+  onTabClick?: (type: number, id: string) => void
+  onTabRename?: (tab: Tab, title: string) => void
+  onExpandWorkspace?: (workspaceId: string) => void
+
+  // Files section
+  workerId: string
+  workingDir: string
+  homeDir: string
+  fileTreePath: string
+  onFileSelect: (path: string) => void
+  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
+  onFileMention?: (path: string) => void
+  onOpenTerminal?: (dirPath: string) => void
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
+  activeFilePath?: string
+  hasActiveFileTab?: boolean
+  turnEndTrigger?: number
+  filesSectionHandle: Accessor<FilesSectionHandle | undefined>
+  setFilesSectionHandle: (handle: FilesSectionHandle | undefined) => void
+
+  // Todos section
+  showTodos: boolean
+  activeTodos: TodoItem[]
+
+  // Workers section
+  workers: Worker[]
+  workerInfoFn: (id: string) => WorkerInfo | null
+  channelStatusFn: (id: string) => ChannelStatus
+  onDeregisterWorker: (worker: Worker) => void
+}
+
+/**
+ * Maps a section to a `SidebarSectionDef`.
+ *
+ * This is the single source of truth for section-type → content mapping.
+ * Both sidebars use this function, so adding or changing a section type
+ * only requires updating this one place.
+ */
+export function buildSectionDef(
+  section: Section,
+  ctx: SectionDefContext,
+): SidebarSectionDef {
+  const sectionType = section.sectionType
+  const sectionId = section.id
+
+  if (isWorkspaceSection(sectionType)) {
+    const isShared = sectionType === SectionType.WORKSPACES_SHARED
+    return {
+      id: sectionId,
+      title: section.name,
+      railIcon: getSectionIcon(section),
+      railTitle: section.name,
+      defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
+      collapsible: true,
+      draggable: true,
+      visible: !isShared || ctx.wsOps.sharedWorkspaces().length > 0,
+      headerActions: ctx.wsOps.canAddToSection(section)
+        ? (
+            <IconButton
+              icon={Plus}
+              iconSize="sm"
+              size="md"
+              title={`New workspace in ${section.name}`}
+              data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                ctx.onNewWorkspace(sectionId)
+              }}
+            />
+          )
+        : undefined,
+      testId: `section-header-${sectionTypeTestId(sectionType)}`,
+      content: () => (
+        <WorkspaceSectionContent
+          workspaces={ctx.getWorkspacesForGroup(sectionId)}
+          sectionId={sectionId}
+          activeWorkspaceId={ctx.activeWorkspaceId}
+          currentUserId={ctx.wsOps.currentUserId()}
+          isVirtual={ctx.isGroupShared(sectionId)}
+          sections={ctx.sectionStore.state.sections}
+          onSelect={ctx.onSelectWorkspace}
+          onRename={ctx.wsOps.startRename}
+          onMoveTo={ctx.wsOps.moveWorkspace}
+          onShare={id => ctx.wsOps.setSharingWorkspaceId(id)}
+          onArchive={ctx.wsOps.archiveWorkspace}
+          onUnarchive={ctx.wsOps.unarchiveWorkspace}
+          onDelete={ctx.wsOps.deleteWorkspace}
+          isArchived={ctx.wsOps.isWorkspaceArchived}
+          renamingWorkspaceId={ctx.wsOps.renamingWorkspaceId()}
+          renameValue={ctx.wsOps.renameValue()}
+          onRenameInput={ctx.wsOps.onRenameInput}
+          onRenameCommit={ctx.wsOps.commitRename}
+          onRenameCancel={ctx.wsOps.cancelRename}
+          isWorkspaceLoading={ctx.wsOps.isWorkspaceLoading}
+          tabs={ctx.tabStore?.state.tabs ?? []}
+          activeTabKey={ctx.tabStore?.state.activeTabKey ?? null}
+          getTabsForWorkspace={(wsId: string) => {
+            const snap = ctx.registry?.get(wsId)
+            return snap?.tabs.tabs ?? []
+          }}
+          getActiveTabKeyForWorkspace={(wsId: string) => {
+            const snap = ctx.registry?.get(wsId)
+            return snap?.tabs.activeTabKey ?? null
+          }}
+          onTabClick={ctx.onTabClick ?? (() => {})}
+          onTabRename={ctx.onTabRename}
+          onExpandWorkspace={ctx.onExpandWorkspace}
+        />
+      ),
+    }
+  }
+
+  if (sectionType === SectionType.FILES) {
+    return {
+      id: sectionId,
+      title: section.name,
+      railIcon: getSectionIcon(section),
+      railTitle: section.name,
+      defaultOpen: true,
+      collapsible: true,
+      draggable: true,
+      testId: `section-header-${sectionTypeTestId(sectionType)}`,
+      headerActions: (
+        <FilesSectionHeaderActions
+          onCollapseAll={() => ctx.filesSectionHandle()?.collapseAll()}
+          onLocateFile={() => {
+            if (ctx.activeFilePath)
+              ctx.onFileSelect(ctx.activeFilePath)
+          }}
+          onRefresh={() => {
+            if (ctx.workerId && ctx.workingDir)
+              ctx.gitStatusStore?.refresh(ctx.workerId, ctx.workingDir)
+            ctx.filesSectionHandle()?.refresh()
+          }}
+          hasActiveFileTab={ctx.hasActiveFileTab ?? false}
+          isFiltered={() => ctx.filesSectionHandle()?.isFiltered() ?? false}
+          flatListMode={() => ctx.filesSectionHandle()?.flatListMode() ?? false}
+          onToggleFlatList={() => ctx.filesSectionHandle()?.toggleFlatListMode()}
+        />
+      ),
+      content: () => (
+        <Show
+          when={ctx.workerId}
+          fallback={<div class={emptySectionStyle}>No tab selected</div>}
+        >
+          <FilesSection
+            workerId={ctx.workerId}
+            workingDir={ctx.workingDir}
+            homeDir={ctx.homeDir}
+            fileTreePath={ctx.fileTreePath}
+            onFileSelect={ctx.onFileSelect}
+            onFileOpen={ctx.onFileOpen}
+            onMention={ctx.onFileMention}
+            onOpenTerminal={ctx.onOpenTerminal}
+            gitStatusStore={ctx.gitStatusStore!}
+            activeFilePath={ctx.activeFilePath}
+            hasActiveFileTab={ctx.hasActiveFileTab ?? false}
+            turnEndTrigger={ctx.turnEndTrigger}
+            ref={ctx.setFilesSectionHandle}
+          />
+        </Show>
+      ),
+    }
+  }
+
+  if (sectionType === SectionType.TODOS) {
+    return {
+      id: sectionId,
+      title: section.name,
+      railIcon: getSectionIcon(section),
+      railTitle: section.name,
+      visible: ctx.showTodos,
+      draggable: true,
+      testId: `section-header-${sectionTypeTestId(sectionType)}`,
+      railBadge: () => (
+        <span class={csStyles.railBadgeText}>
+          {ctx.activeTodos.filter(t => t.status === 'completed').length}
+          /
+          {ctx.activeTodos.length}
+        </span>
+      ),
+      content: () => <TodoList todos={ctx.activeTodos} />,
+    }
+  }
+
+  if (sectionType === SectionType.WORKERS) {
+    return {
+      id: sectionId,
+      title: section.name,
+      railIcon: getSectionIcon(section),
+      railTitle: section.name,
+      defaultOpen: true,
+      collapsible: true,
+      draggable: true,
+      defaultSize: 0.15,
+      testId: `section-header-${sectionTypeTestId(sectionType)}`,
+      content: () => (
+        <WorkerSectionContent
+          workers={ctx.workers}
+          workerInfo={ctx.workerInfoFn}
+          channelStatus={ctx.channelStatusFn}
+          onDeregister={ctx.onDeregisterWorker}
+        />
+      ),
+    }
+  }
+
+  // Unknown section type — empty fallback
+  return {
+    id: sectionId,
+    title: section.name,
+    railIcon: getSectionIcon(section),
+    railTitle: section.name,
+    collapsible: true,
+    draggable: true,
+    testId: `section-header-${sectionTypeTestId(sectionType)}`,
+    content: () => <></>,
+  }
+}

--- a/frontend/src/components/shell/useSidebarCore.tsx
+++ b/frontend/src/components/shell/useSidebarCore.tsx
@@ -1,0 +1,204 @@
+import type { JSX } from 'solid-js'
+import type { SectionDefContext } from './buildSectionDef'
+import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { FilesSectionHandle } from '~/components/tree/FilesSection'
+import type { Sidebar } from '~/generated/leapmux/v1/section_pb'
+import type { Worker } from '~/generated/leapmux/v1/worker_pb'
+import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { TodoItem } from '~/stores/chat.store'
+import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
+import type { createSectionStore } from '~/stores/section.store'
+import type { createTabStore, Tab } from '~/stores/tab.store'
+import type { ChannelStatus } from '~/stores/workerChannelStatus.store'
+import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry'
+
+import { createMemo, createSignal, Show } from 'solid-js'
+import { WorkspaceSharingDialog } from '~/components/workspace/WorkspaceSharingDialog'
+import { buildSectionDef } from './buildSectionDef'
+import { useWorkspaceOperations } from './useWorkspaceOperations'
+
+// ---------------------------------------------------------------------------
+// Shared sidebar props
+// ---------------------------------------------------------------------------
+
+/**
+ * Props shared by both LeftSidebar and RightSidebar.
+ * Each sidebar extends this with its own extras.
+ */
+export interface SidebarCommonProps {
+  // Section store
+  sectionStore: ReturnType<typeof createSectionStore>
+
+  // Workspace operations
+  workspaces: Workspace[]
+  activeWorkspaceId: string | null
+  loadSections: () => Promise<void>
+  onSelectWorkspace: (id: string) => void
+  onNewWorkspace: (sectionId: string | null) => void
+  onRefreshWorkspaces: () => void | Promise<void>
+  onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
+  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
+  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
+  onPostArchiveWorkspace?: (workspaceId: string) => void
+
+  // Display
+  isCollapsed: boolean
+  onExpand: () => void
+  onCollapse?: () => void
+  initialOpenSections?: Record<string, boolean>
+  initialSectionSizes?: Record<string, number>
+  onSectionStateChange?: (openSections: Record<string, boolean>, sectionSizes: Record<string, number>) => void
+
+  // Content
+  workerId: string
+  workingDir: string
+  homeDir: string
+  fileTreePath: string
+  onFileSelect: (path: string) => void
+  onFileOpen?: (path: string, openSource?: GitFilterTab) => void
+  onFileMention?: (path: string) => void
+  onOpenTerminal?: (dirPath: string) => void
+  gitStatusStore?: ReturnType<typeof createGitFileStatusStore>
+  activeFilePath?: string
+  hasActiveFileTab?: boolean
+  showTodos: boolean
+  activeTodos: TodoItem[]
+  /** Signal bumped on agent turn-end; drives directory tree refresh. */
+  turnEndTrigger?: number
+
+  // Tabs
+  tabStore?: ReturnType<typeof createTabStore>
+  registry?: WorkspaceStoreRegistryType
+  onTabClick?: (type: number, id: string) => void
+  onTabRename?: (tab: Tab, title: string) => void
+  onExpandWorkspace?: (workspaceId: string) => void
+
+  // Workers
+  workers: Worker[]
+  workerInfoFn: (id: string) => WorkerInfo | null
+  channelStatusFn: (id: string) => ChannelStatus
+  onDeregisterWorker: (worker: Worker) => void
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared setup for both sidebars: workspace operations, section grouping,
+ * section definition context, and the sharing dialog.
+ */
+export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
+  const store = props.sectionStore
+
+  // Captured from CollapsibleSidebar's expandSectionRef callback.
+  let expandSection: ((sectionId: string) => void) | undefined
+
+  // Handle for the FilesSection imperative API (e.g., collapseAll).
+  // Declared as a signal so reactive reads (e.g., isFiltered in header
+  // actions) re-evaluate when the handle is assigned after FilesSection mounts.
+  const [filesSectionHandle, setFilesSectionHandle] = createSignal<FilesSectionHandle | undefined>()
+
+  const wsOps = useWorkspaceOperations({
+    workspaces: () => props.workspaces,
+    activeWorkspaceId: () => props.activeWorkspaceId,
+    sectionStore: store,
+    loadSections: props.loadSections,
+    onSelectWorkspace: props.onSelectWorkspace,
+    onNewWorkspace: props.onNewWorkspace,
+    onRefreshWorkspaces: props.onRefreshWorkspaces,
+    onDeleteWorkspace: props.onDeleteWorkspace,
+    onConfirmDelete: props.onConfirmDelete,
+    onConfirmArchive: props.onConfirmArchive,
+    onPostArchiveWorkspace: (workspaceId) => {
+      const archivedSection = store.getArchivedSection()
+      if (archivedSection && expandSection)
+        expandSection(archivedSection.id)
+      props.onPostArchiveWorkspace?.(workspaceId)
+    },
+  })
+
+  const sections = createMemo(() =>
+    store.getSectionsForSidebar(side),
+  )
+
+  const sectionGroups = createMemo(() =>
+    wsOps.buildSectionGroups(sections()),
+  )
+
+  /**
+   * Creates a `SectionDefContext` from the SolidJS component props, using
+   * property getters to preserve reactivity through the SolidJS proxy chain.
+   */
+  const createCtx = (): SectionDefContext => ({
+    sectionStore: store,
+    wsOps,
+    getWorkspacesForGroup: sectionId =>
+      wsOps.getWorkspacesForGroup(sectionId, sectionGroups()),
+    isGroupShared: sectionId =>
+      wsOps.isGroupShared(sectionId, sectionGroups()),
+    get activeWorkspaceId() { return props.activeWorkspaceId },
+    onNewWorkspace: props.onNewWorkspace,
+    onSelectWorkspace: props.onSelectWorkspace,
+    get tabStore() { return props.tabStore },
+    get registry() { return props.registry },
+    get onTabClick() { return props.onTabClick },
+    get onTabRename() { return props.onTabRename },
+    get onExpandWorkspace() { return props.onExpandWorkspace },
+    get workerId() { return props.workerId },
+    get workingDir() { return props.workingDir },
+    get homeDir() { return props.homeDir },
+    get fileTreePath() { return props.fileTreePath },
+    onFileSelect: props.onFileSelect,
+    get onFileOpen() { return props.onFileOpen },
+    get onFileMention() { return props.onFileMention },
+    get onOpenTerminal() { return props.onOpenTerminal },
+    get gitStatusStore() { return props.gitStatusStore },
+    get activeFilePath() { return props.activeFilePath },
+    get hasActiveFileTab() { return props.hasActiveFileTab },
+    get turnEndTrigger() { return props.turnEndTrigger },
+    filesSectionHandle,
+    setFilesSectionHandle,
+    get showTodos() { return props.showTodos },
+    get activeTodos() { return props.activeTodos },
+    get workers() { return props.workers },
+    workerInfoFn: props.workerInfoFn,
+    channelStatusFn: props.channelStatusFn,
+    onDeregisterWorker: props.onDeregisterWorker,
+  })
+
+  /** Build `SidebarSectionDef[]` from the current section groups. */
+  const buildSectionDefs = (): SidebarSectionDef[] => {
+    const ctx = createCtx()
+    return sectionGroups().map(group =>
+      buildSectionDef(group.section, ctx),
+    )
+  }
+
+  /** Render the workspace sharing dialog (used by both sidebars). */
+  const renderSharingDialog = (): JSX.Element => (
+    <Show when={wsOps.sharingWorkspaceId()}>
+      {workspaceId => (
+        <WorkspaceSharingDialog
+          workspaceId={workspaceId()}
+          onClose={() => wsOps.setSharingWorkspaceId(null)}
+          onSaved={() => {
+            wsOps.setSharingWorkspaceId(null)
+            props.onRefreshWorkspaces()
+          }}
+        />
+      )}
+    </Show>
+  )
+
+  return {
+    store,
+    wsOps,
+    sections,
+    sectionGroups,
+    buildSectionDefs,
+    renderSharingDialog,
+    expandSectionRef: (fn: (sectionId: string) => void) => { expandSection = fn },
+  }
+}

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { node, nodeSelected } from './sharedTree.css'
+import { node } from './sharedTree.css'
 
 export {
   chevron,
@@ -98,6 +98,12 @@ export const nodeActions = style({
   flexShrink: 0,
   position: 'sticky',
   right: 'var(--space-2)',
+  backgroundColor: 'transparent',
+})
+
+/** Give nodeActions a background on hover so it covers scrolled text underneath. */
+globalStyle(`${node}:hover ${nodeActions}`, {
+  backgroundColor: 'inherit',
 })
 
 export const nodeMenuTrigger = style({
@@ -107,21 +113,6 @@ export const nodeMenuTrigger = style({
     [`${node}:hover &`]: { opacity: 1 },
     '&[aria-expanded="true"]': { opacity: 1 },
   },
-})
-
-/** Give nodeActions a background on hover so it covers scrolled text underneath. */
-globalStyle(`${node}:hover ${nodeActions}`, {
-  backgroundColor: 'var(--card)',
-})
-
-/** Match selected node background. */
-globalStyle(`${node}${nodeSelected} ${nodeActions}`, {
-  backgroundColor: 'var(--secondary)',
-})
-
-/** Match selected + hover node background. */
-globalStyle(`${node}${nodeSelected}:hover ${nodeActions}`, {
-  backgroundColor: 'var(--muted)',
 })
 
 export const pathInput = style({

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -171,21 +171,12 @@ export const itemActions = style({
   marginLeft: 'auto',
   position: 'sticky',
   right: 'var(--space-2)',
+  backgroundColor: 'transparent',
 })
 
 /** Give itemActions a background on hover so it covers scrolled text underneath. */
 globalStyle(`${item}:hover:not(${itemDropTarget}) ${itemActions}`, {
-  backgroundColor: 'var(--card)',
-})
-
-/** Match active item background. */
-globalStyle(`${item}${itemActive}:not(${itemDropTarget}) ${itemActions}`, {
-  backgroundColor: 'var(--secondary)',
-})
-
-/** Match active + hover item background. */
-globalStyle(`${item}${itemActive}:hover:not(${itemDropTarget}) ${itemActions}`, {
-  backgroundColor: 'var(--muted)',
+  backgroundColor: 'inherit',
 })
 
 export const itemMenuTrigger = style({

--- a/frontend/src/styles/global.css.ts
+++ b/frontend/src/styles/global.css.ts
@@ -80,6 +80,11 @@ globalStyle(':root', {
     '--input': 'rgb(213 209 203)',
     '--ring': 'rgb(13 148 136)',
 
+    // Scrollbar
+    '--scrollbar-thumb': 'rgb(from var(--muted-foreground) r g b / 0.35)',
+    '--scrollbar-thumb-hover': 'rgb(from var(--muted-foreground) r g b / 0.55)',
+    '--scrollbar-track': 'transparent',
+
     // LeapMux-specific custom variables
     '--lm-bg-translucent': 'rgba(255, 255, 255, 0.5)',
     '--lm-danger-subtle': 'rgb(253 235 233)',
@@ -130,6 +135,11 @@ globalStyle('[data-theme="dark"]', {
     '--input': 'rgb(61 58 54)',
     '--ring': 'rgb(20 184 166)',
 
+    // Scrollbar
+    '--scrollbar-thumb': 'rgb(from var(--muted-foreground) r g b / 0.35)',
+    '--scrollbar-thumb-hover': 'rgb(from var(--muted-foreground) r g b / 0.55)',
+    '--scrollbar-track': 'transparent',
+
     // LeapMux-specific custom variables
     '--lm-bg-translucent': 'rgba(26, 25, 23, 0.5)',
     '--lm-danger-subtle': 'rgb(50 30 28)',
@@ -167,4 +177,35 @@ globalStyle('button, [role="button"]', {
       transition: 'none',
     },
   },
+})
+
+// Consistent thin scrollbars across browsers (standard CSS — Firefox & Chrome 121+).
+globalStyle('*', {
+  scrollbarWidth: 'thin',
+  scrollbarColor: 'var(--scrollbar-thumb) var(--scrollbar-track)',
+})
+
+// WebKit scrollbar styling (Safari & older Chrome).
+globalStyle('*::-webkit-scrollbar', {
+  width: '8px',
+  height: '8px',
+})
+
+globalStyle('*::-webkit-scrollbar-track', {
+  background: 'transparent',
+})
+
+globalStyle('*::-webkit-scrollbar-thumb', {
+  backgroundColor: 'var(--scrollbar-thumb)',
+  borderRadius: '4px',
+  border: '2px solid transparent',
+  backgroundClip: 'content-box',
+})
+
+globalStyle('*::-webkit-scrollbar-thumb:hover', {
+  backgroundColor: 'var(--scrollbar-thumb-hover)',
+})
+
+globalStyle('*::-webkit-scrollbar-corner', {
+  background: 'transparent',
 })

--- a/frontend/tests/e2e/09-worker-management.spec.ts
+++ b/frontend/tests/e2e/09-worker-management.spec.ts
@@ -7,9 +7,9 @@ test.describe('Worker Management', () => {
     await expect(workersSection).toBeVisible()
 
     // Expand the section if collapsed
-    const isOpen = await workersSection.evaluate((el: HTMLDetailsElement) => el.open)
+    const isOpen = await workersSection.evaluate(el => !el.hasAttribute('data-closed'))
     if (!isOpen)
-      await workersSection.locator('> summary').click()
+      await workersSection.locator('> [role="button"]').click()
 
     // Should contain the worker named "Local" (dev mode sets LEAPMUX_WORKER_NAME=Local)
     await expect(workersSection.getByText('Local')).toBeVisible()
@@ -19,9 +19,9 @@ test.describe('Worker Management', () => {
     const workersSection = page.getByTestId('section-header-workers')
     await expect(workersSection).toBeVisible()
 
-    const isOpen = await workersSection.evaluate((el: HTMLDetailsElement) => el.open)
+    const isOpen = await workersSection.evaluate(el => !el.hasAttribute('data-closed'))
     if (!isOpen)
-      await workersSection.locator('> summary').click()
+      await workersSection.locator('> [role="button"]').click()
 
     // The status dot should indicate "connected"
     await expect(workersSection.locator('[data-status="connected"]')).toBeVisible()

--- a/frontend/tests/e2e/13-workspace-sections.spec.ts
+++ b/frontend/tests/e2e/13-workspace-sections.spec.ts
@@ -18,13 +18,13 @@ test.describe('Workspace Sections', () => {
     await expect(wsItem).toBeVisible()
 
     // Click the section header summary to collapse it
-    await page.locator('[data-testid="section-header-workspaces_in_progress"] > summary').click()
+    await page.locator('[data-testid="section-header-workspaces_in_progress"] > [role="button"]').click()
 
     // Workspace should be hidden
     await expect(wsItem).not.toBeVisible()
 
     // Click the section header summary again to expand
-    await page.locator('[data-testid="section-header-workspaces_in_progress"] > summary').click()
+    await page.locator('[data-testid="section-header-workspaces_in_progress"] > [role="button"]').click()
 
     // Workspace should be visible again
     await expect(wsItem).toBeVisible()
@@ -53,7 +53,7 @@ test.describe('Workspace Sections', () => {
     const wsItem = page.locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`)
 
     // Collapse the section
-    await page.locator('[data-testid="section-header-workspaces_in_progress"] > summary').click()
+    await page.locator('[data-testid="section-header-workspaces_in_progress"] > [role="button"]').click()
     await expect(wsItem).not.toBeVisible()
 
     // Reload the page
@@ -66,6 +66,6 @@ test.describe('Workspace Sections', () => {
     await expect(wsItem).not.toBeVisible()
 
     // Expand it again for cleanup
-    await page.locator('[data-testid="section-header-workspaces_in_progress"] > summary').click()
+    await page.locator('[data-testid="section-header-workspaces_in_progress"] > [role="button"]').click()
   })
 })

--- a/frontend/tests/e2e/15-resizable-sidebars.spec.ts
+++ b/frontend/tests/e2e/15-resizable-sidebars.spec.ts
@@ -68,20 +68,20 @@ test.describe('Pane Resize Handles', () => {
       const testId = await section.getAttribute('data-testid')
       if (testId === 'section-header-workspaces_in_progress' || testId === 'section-header-workspaces_archived')
         continue
-      const isOpen = await section.evaluate((el: HTMLDetailsElement) => el.open)
+      const isOpen = await section.evaluate(el => !el.hasAttribute('data-closed'))
       if (isOpen)
-        await section.locator('> summary').click()
+        await section.locator('> [role="button"]').click()
     }
 
     // Ensure In Progress is expanded (it should be by default, but check)
-    const inProgressIsOpen = await inProgress.evaluate((el: HTMLDetailsElement) => el.open)
+    const inProgressIsOpen = await inProgress.evaluate(el => !el.hasAttribute('data-closed'))
     if (!inProgressIsOpen)
-      await inProgress.locator('> summary').click()
+      await inProgress.locator('> [role="button"]').click()
 
     // Ensure Archived is expanded
-    const archivedIsOpen = await archived.evaluate((el: HTMLDetailsElement) => el.open)
+    const archivedIsOpen = await archived.evaluate(el => !el.hasAttribute('data-closed'))
     if (!archivedIsOpen)
-      await archived.locator('> summary').click()
+      await archived.locator('> [role="button"]').click()
 
     // Wait for exactly one resize handle between the two sections
     await expect(page.locator('[data-testid="pane-resize-handle"]')).toHaveCount(1)
@@ -127,7 +127,7 @@ test.describe('Pane Resize Handles', () => {
     await ensureOnlyTwoSectionsExpanded(page)
 
     // Collapse Archived section
-    await page.locator('[data-testid="section-header-workspaces_archived"] > summary').click()
+    await page.locator('[data-testid="section-header-workspaces_archived"] > [role="button"]').click()
 
     // Pane resize handle should disappear
     await expect(page.locator('[data-testid="pane-resize-handle"]')).toHaveCount(0)
@@ -184,9 +184,9 @@ test.describe('Pane Resize Handles', () => {
       const testId = await section.getAttribute('data-testid')
       if (testId === 'section-header-workspaces_in_progress')
         continue
-      const isOpen = await section.evaluate((el: HTMLDetailsElement) => el.open)
+      const isOpen = await section.evaluate(el => !el.hasAttribute('data-closed'))
       if (isOpen)
-        await section.locator('> summary').click()
+        await section.locator('> [role="button"]').click()
     }
     await page.waitForTimeout(200)
 

--- a/frontend/tests/e2e/20-section-reorder.spec.ts
+++ b/frontend/tests/e2e/20-section-reorder.spec.ts
@@ -16,8 +16,8 @@ function waitForMoveSection(page: import('@playwright/test').Page) {
  * If `side` is given, only returns sections within that sidebar.
  */
 async function getSectionOrder(page: import('@playwright/test').Page, side?: 'left' | 'right') {
-  // Each section has a data-testid on the <details> element (section-header-*).
-  // The <summary> also has a data-testid ending with "-summary", so we
+  // Each section has a data-testid on the container element (section-header-*).
+  // The trigger also has a data-testid ending with "-summary", so we
   // exclude those to avoid double-counting.
   const root = side
     ? page.locator(`[data-testid="sidebar-${side}"]`)

--- a/frontend/tests/e2e/99-worker-deregistration.spec.ts
+++ b/frontend/tests/e2e/99-worker-deregistration.spec.ts
@@ -30,9 +30,9 @@ async function openWorkersSidebar(page: import('@playwright/test').Page) {
   const workersSection = page.getByTestId('section-header-workers')
   await expect(workersSection).toBeVisible()
   // Expand the section if collapsed by checking the DOM open property
-  const isOpen = await workersSection.evaluate((el: HTMLDetailsElement) => el.open)
+  const isOpen = await workersSection.evaluate(el => !el.hasAttribute('data-closed'))
   if (!isOpen)
-    await workersSection.locator('> summary').click()
+    await workersSection.locator('> [role="button"]').click()
   // Wait for content to be visible
   await expect(workersSection.locator('[class*="sectionItems"]')).toBeVisible()
   return workersSection
@@ -215,9 +215,9 @@ test.describe('Worker Status Indicator', () => {
     await page.reload()
     const refreshedSection = page.getByTestId('section-header-workers')
     await expect(refreshedSection).toBeVisible()
-    const reopened = await refreshedSection.evaluate((el: HTMLDetailsElement) => el.open)
+    const reopened = await refreshedSection.evaluate(el => !el.hasAttribute('data-closed'))
     if (!reopened)
-      await refreshedSection.locator('> summary').click()
+      await refreshedSection.locator('> [role="button"]').click()
 
     // Status dot should change back to connected (green)
     await expect(refreshedSection.locator('[data-status="connected"]')).toBeVisible({ timeout: 15_000 })


### PR DESCRIPTION
## Motivation

`LeftSidebar` and `RightSidebar` contained nearly identical logic for
building section definitions and managing workspace operations, leading
to ~600 lines of duplicated code across the two components. Additionally,
the `details`/`summary` HTML elements used for collapsible sidebar
sections created cross-browser inconsistencies and styling limitations.
Several visual rough edges also needed addressing: the `ThinkingIndicator`
animation was weight-based rather than position-based, sidebar action
buttons had a visible background on hover, and scrollbar appearance varied
across browsers.

## Modifications

- Extract `useSidebarCore` hook that consolidates all shared sidebar setup
  (workspace operations, section grouping, section definition context, and
  the sharing dialog) so both `LeftSidebar` and `RightSidebar` delegate to
  a single implementation.
- Extract `buildSectionDef` into a new `buildSectionDef.tsx` module that
  maps each `SectionType` to its `SidebarSectionDef`. This is now the
  single source of truth for section-type-to-content mapping, eliminating
  duplication between the two sidebars.
- Replace `details`/`summary` elements in `CollapsibleSidebar` with plain
  `div`s to gain full style control over the collapsible header and content
  regions.
- Replace the font-weight wave animation in `ThinkingIndicator` with a
  vertical bounce (`translateY`) elevation effect driven by the compass
  physics simulation's highlight position.
- Fix the visible background on sidebar item action containers by scoping
  the hover style more precisely.
- Add consistent thin scrollbar styling for both Firefox (via
  `scrollbar-width`/`scrollbar-color`) and WebKit (via `::-webkit-scrollbar`
  pseudo-elements) using CSS custom properties (`--scrollbar-thumb`,
  `--scrollbar-track`) defined for both light and dark themes.
- Update E2E tests to use `div`-based selectors in place of the removed
  `details`/`summary` elements.

## Result

- `LeftSidebar` and `RightSidebar` are each reduced by ~300 lines; adding
  or modifying a section type now only requires changing `buildSectionDef`.
- Scrollbars render consistently across Chrome, Firefox, and Safari using
  the app's theme colors.
- The `ThinkingIndicator` text animates with a smooth bouncing wave tied to
  the compass needle position instead of a font-weight pulse.
- Sidebar item action buttons no longer show an unwanted background
  highlight.

🤖 Generated with Claude Code
