### PR TITLE
Add max effort level and unify message retry with auto-start

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -58,7 +58,7 @@ type Agent struct {
 type Options struct {
 	AgentID         string
 	Model           string
-	Effort          string // Effort level (low, medium, high)
+	Effort          string // Effort level (low, medium, high, max)
 	WorkingDir      string
 	ResumeSessionID string        // If set, uses --resume to resume a previous session
 	PermissionMode  string        // Permission mode to set on startup (default, acceptEdits, plan, bypassPermissions)

--- a/backend/internal/worker/channel/session_test.go
+++ b/backend/internal/worker/channel/session_test.go
@@ -458,7 +458,7 @@ func TestCloseAll(t *testing.T) {
 // the send mutex and block the receive loop, causing a deadlock cascade.
 func TestHandleMessage_NonBlocking(t *testing.T) {
 	// Create a sendFn that blocks until explicitly released.
-	blockCh := make(chan struct{})
+	blockCh := make(chan struct{}, 1)
 	releaseCh := make(chan struct{})
 
 	sender := newCollectSender()

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -563,74 +563,6 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		sendProtoResponse(sender, &leapmuxv1.SendControlResponseResponse{})
 	})
 
-	d.Register("RetryAgentMessage", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
-		var r leapmuxv1.RetryAgentMessageRequest
-		if err := unmarshalRequest(req, &r); err != nil {
-			sendInvalidArgument(sender, "invalid request")
-			return
-		}
-
-		agentID := r.GetAgentId()
-		messageID := r.GetMessageId()
-
-		// Fetch the message to get its content.
-		msg, err := svc.Queries.GetMessageByAgentAndID(bgCtx(), db.GetMessageByAgentAndIDParams{
-			AgentID: agentID,
-			ID:      messageID,
-		})
-		if err != nil {
-			slog.Error("failed to fetch message for retry", "agent_id", agentID, "message_id", messageID, "error", err)
-			sendNotFoundError(sender, "message not found")
-			return
-		}
-
-		// Clear the delivery error.
-		if err := svc.Queries.SetMessageDeliveryError(bgCtx(), db.SetMessageDeliveryErrorParams{
-			DeliveryError: "",
-			ID:            messageID,
-			AgentID:       agentID,
-		}); err != nil {
-			slog.Error("failed to clear delivery error", "agent_id", agentID, "message_id", messageID, "error", err)
-			sendInternalError(sender, "failed to clear delivery error")
-			return
-		}
-
-		// Extract the original user text from the wrapped content envelope.
-		userText, err := extractUserText(msg.Content, leapmuxv1.ContentCompression(msg.ContentCompression))
-		if err != nil {
-			slog.Error("failed to extract user text for retry", "agent_id", agentID, "message_id", messageID, "error", err)
-			sendInternalError(sender, "failed to extract message content")
-			return
-		}
-
-		// Re-send the message to the agent.
-		var retryError string
-		if sendErr := svc.Agents.SendInput(agentID, userText); sendErr != nil {
-			slog.Error("failed to re-send message to agent", "agent_id", agentID, "error", sendErr)
-			retryError = sendErr.Error()
-			// Mark delivery error again.
-			_ = svc.Queries.SetMessageDeliveryError(bgCtx(), db.SetMessageDeliveryErrorParams{
-				DeliveryError: retryError,
-				ID:            messageID,
-				AgentID:       agentID,
-			})
-		}
-
-		sendProtoResponse(sender, &leapmuxv1.RetryAgentMessageResponse{})
-
-		// Broadcast the updated error state (cleared or new error).
-		svc.Watchers.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
-			AgentId: agentID,
-			Event: &leapmuxv1.AgentEvent_MessageError{
-				MessageError: &leapmuxv1.AgentMessageError{
-					AgentId:   agentID,
-					MessageId: messageID,
-					Error:     retryError, // empty = cleared
-				},
-			},
-		})
-	})
-
 	// WatchEvents registers the channel as a watcher for agent/terminal events.
 	// It replays messages since afterSeq, sends a statusChange marker,
 	// replays pending control requests, then streams live events.
@@ -872,30 +804,6 @@ func gitStatusToProto(gs *gitutil.GitStatus) *leapmuxv1.AgentGitStatus {
 		Untracked:   gs.Untracked,
 		OriginUrl:   gs.OriginURL,
 	}
-}
-
-// extractUserText extracts the original user text from a persisted user
-// message. The content is stored as a compressed threadWrapper envelope
-// containing {"content":"..."} inner JSON.
-func extractUserText(data []byte, compression leapmuxv1.ContentCompression) (string, error) {
-	decompressed, err := msgcodec.Decompress(data, compression)
-	if err != nil {
-		return "", fmt.Errorf("decompress: %w", err)
-	}
-
-	wrapper, err := unwrapContent(decompressed)
-	if err != nil || len(wrapper.Messages) == 0 {
-		// Fallback: treat raw content as the user text (legacy format).
-		return string(decompressed), nil
-	}
-
-	var inner struct {
-		Content string `json:"content"`
-	}
-	if err := json.Unmarshal(wrapper.Messages[0], &inner); err != nil {
-		return "", fmt.Errorf("parse inner message: %w", err)
-	}
-	return inner.Content, nil
 }
 
 // handleClearContext implements the /clear command by restarting the agent

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -15,7 +15,6 @@ import type {
   ListAgentsResponse,
   OpenAgentResponse,
   RenameAgentResponse,
-  RetryAgentMessageResponse,
   SendAgentMessageResponse,
   SendControlResponseResponse,
   UpdateAgentSettingsResponse,
@@ -68,8 +67,6 @@ import {
   OpenAgentResponseSchema,
   RenameAgentRequestSchema,
   RenameAgentResponseSchema,
-  RetryAgentMessageRequestSchema,
-  RetryAgentMessageResponseSchema,
   SendAgentMessageRequestSchema,
   SendAgentMessageResponseSchema,
   SendControlResponseRequestSchema,
@@ -279,10 +276,6 @@ export function renameAgent(workerId: string, req: MessageInitShape<typeof Renam
 
 export function sendControlResponse(workerId: string, req: MessageInitShape<typeof SendControlResponseRequestSchema>): Promise<SendControlResponseResponse> {
   return callWorker(workerId, 'SendControlResponse', SendControlResponseRequestSchema, SendControlResponseResponseSchema, req)
-}
-
-export function retryAgentMessage(workerId: string, req: MessageInitShape<typeof RetryAgentMessageRequestSchema>): Promise<RetryAgentMessageResponse> {
-  return callWorker(workerId, 'RetryAgentMessage', RetryAgentMessageRequestSchema, RetryAgentMessageResponseSchema, req)
 }
 
 export function deleteAgentMessage(workerId: string, req: MessageInitShape<typeof DeleteAgentMessageRequestSchema>): Promise<DeleteAgentMessageResponse> {

--- a/frontend/src/components/chat/EditorSettingsDropdown.tsx
+++ b/frontend/src/components/chat/EditorSettingsDropdown.tsx
@@ -5,6 +5,7 @@ import ChevronsDown from 'lucide-solid/icons/chevrons-down'
 import ChevronsUp from 'lucide-solid/icons/chevrons-up'
 import Dot from 'lucide-solid/icons/dot'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
+import Zap from 'lucide-solid/icons/zap'
 import { createUniqueId, For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
@@ -35,6 +36,39 @@ export interface EditorSettingsDropdownProps {
   onPermissionModeChange?: (mode: PermissionMode) => void
 }
 
+function RadioGroup(props: {
+  label: string
+  items: { label: string, value: string }[]
+  testIdPrefix: string
+  name: string
+  current: string
+  onChange: (value: string) => void
+}): JSX.Element {
+  return (
+    <fieldset>
+      <legend class={styles.settingsGroupLabel}>{props.label}</legend>
+      <For each={props.items}>
+        {item => (
+          <label
+            role="menuitemradio"
+            class={styles.settingsRadioItem}
+            data-testid={`${props.testIdPrefix}-${item.value}`}
+          >
+            <input
+              type="radio"
+              name={props.name}
+              value={item.value}
+              checked={props.current === item.value}
+              onChange={() => props.onChange(item.value)}
+            />
+            {item.label}
+          </label>
+        )}
+      </For>
+    </fieldset>
+  )
+}
+
 export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.Element {
   let settingsPopoverEl: HTMLElement | undefined
   const menuId = createUniqueId()
@@ -47,6 +81,7 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
     switch (currentEffort()) {
       case 'low': return <Icon icon={ChevronsDown} size="xs" />
       case 'high': return <Icon icon={ChevronsUp} size="xs" />
+      case 'max': return <Icon icon={Zap} size="xs" />
       default: return <Icon icon={Dot} size="xs" />
     }
   }
@@ -72,83 +107,39 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
       class={styles.settingsMenu}
       data-testid="agent-settings-menu"
     >
-      {/* Effort */}
-      <fieldset>
-        <legend class={styles.settingsGroupLabel}>Effort</legend>
-        <For each={EFFORTS}>
-          {effort => (
-            <label
-              role="menuitemradio"
-              class={styles.settingsRadioItem}
-              data-testid={`effort-${effort.value}`}
-            >
-              <input
-                type="radio"
-                name={`${menuId}-effort`}
-                value={effort.value}
-                checked={currentEffort() === effort.value}
-                onChange={() => {
-                  props.onEffortChange?.(effort.value)
-                  settingsPopoverEl?.hidePopover()
-                }}
-              />
-              {effort.label}
-            </label>
-          )}
-        </For>
-      </fieldset>
-
-      {/* Model */}
-      <fieldset>
-        <legend class={styles.settingsGroupLabel}>Model</legend>
-        <For each={MODELS}>
-          {model => (
-            <label
-              role="menuitemradio"
-              class={styles.settingsRadioItem}
-              data-testid={`model-${model.value}`}
-            >
-              <input
-                type="radio"
-                name={`${menuId}-model`}
-                value={model.value}
-                checked={currentModel() === model.value}
-                onChange={() => {
-                  props.onModelChange?.(model.value)
-                  settingsPopoverEl?.hidePopover()
-                }}
-              />
-              {model.label}
-            </label>
-          )}
-        </For>
-      </fieldset>
-
-      {/* Permission Mode */}
-      <fieldset>
-        <legend class={styles.settingsGroupLabel}>Permission Mode</legend>
-        <For each={PERMISSION_MODES}>
-          {mode => (
-            <label
-              role="menuitemradio"
-              class={styles.settingsRadioItem}
-              data-testid={`permission-mode-${mode.value}`}
-            >
-              <input
-                type="radio"
-                name={`${menuId}-mode`}
-                value={mode.value}
-                checked={currentMode() === mode.value}
-                onChange={() => {
-                  props.onPermissionModeChange?.(mode.value as PermissionMode)
-                  settingsPopoverEl?.hidePopover()
-                }}
-              />
-              {mode.label}
-            </label>
-          )}
-        </For>
-      </fieldset>
+      <RadioGroup
+        label="Effort"
+        items={EFFORTS}
+        testIdPrefix="effort"
+        name={`${menuId}-effort`}
+        current={currentEffort()}
+        onChange={(v) => {
+          props.onEffortChange?.(v)
+          settingsPopoverEl?.hidePopover()
+        }}
+      />
+      <RadioGroup
+        label="Model"
+        items={MODELS}
+        testIdPrefix="model"
+        name={`${menuId}-model`}
+        current={currentModel()}
+        onChange={(v) => {
+          props.onModelChange?.(v)
+          settingsPopoverEl?.hidePopover()
+        }}
+      />
+      <RadioGroup
+        label="Permission Mode"
+        items={PERMISSION_MODES}
+        testIdPrefix="permission-mode"
+        name={`${menuId}-mode`}
+        current={currentMode()}
+        onChange={(v) => {
+          props.onPermissionModeChange?.(v as PermissionMode)
+          settingsPopoverEl?.hidePopover()
+        }}
+      />
     </DropdownMenu>
   )
 }

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -107,7 +107,6 @@ export const AppShell: ParentComponent = (props) => {
       try {
         const resp = await workerClient.listWorkers({ orgId })
         setWorkers(resp.workers)
-        workerChannelStatusStore.setWorkerIds(resp.workers.map(w => w.id))
         for (const w of resp.workers) {
           if (w.online) {
             workerInfoStore.fetchWorkerInfo(w.id)
@@ -1086,7 +1085,6 @@ export const AppShell: ParentComponent = (props) => {
             onClose={() => setDeregisterTarget(null)}
             onDeregistered={() => {
               setWorkers(prev => prev.filter(w => w.id !== target().id))
-              workerChannelStatusStore.setWorkerIds(workers().map(w => w.id))
               setDeregisterTarget(null)
             }}
           />

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -223,28 +223,29 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Retry a failed message delivery
+  // Retry a failed message delivery.
+  // Always re-sends via sendAgentMessage (which auto-starts the agent
+  // if needed), then removes the old failed message.
   const handleRetryMessage = async (agentId: string, messageId: string) => {
     try {
       const workerId = getAgentWorkerId(agentId)
+      const message = props.chatStore.getMessages(agentId).find(m => m.id === messageId)
+      if (!message)
+        return
+      const parsed = parseMessageContent(message)
+      const inner = getInnerMessage(parsed)
+      const content = inner?.content
+      if (typeof content !== 'string')
+        return
+
+      await workerRpc.sendAgentMessage(workerId, { agentId, content })
+      // Success: delete the old failed message. The new one arrives via WatchEvents.
       if (messageId.startsWith('local-')) {
-        // Local optimistic message was never stored on the Worker.
-        // Extract the original content and re-send it.
-        const message = props.chatStore.getMessages(agentId).find(m => m.id === messageId)
-        if (!message)
-          return
-        const parsed = parseMessageContent(message)
-        const inner = getInnerMessage(parsed)
-        const content = inner?.content
-        if (typeof content !== 'string')
-          return
-        await workerRpc.sendAgentMessage(workerId, { agentId, content })
-        // Success: remove local message; the real one arrives via WatchEvents.
         props.chatStore.removeMessage(agentId, messageId)
       }
       else {
-        await workerRpc.retryAgentMessage(workerId, { agentId, messageId })
-        props.chatStore.clearMessageError(messageId)
+        await workerRpc.deleteAgentMessage(workerId, { agentId, messageId })
+        props.chatStore.removeMessage(agentId, messageId)
       }
     }
     catch (err) {

--- a/frontend/src/components/workers/WorkerSectionContent.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.tsx
@@ -16,7 +16,6 @@ export interface WorkerSectionContentProps {
 
 const statusClass: Record<ChannelStatus, string> = {
   connected: styles.statusConnected,
-  warning: styles.statusWarning,
   disconnected: styles.statusDisconnected,
 }
 

--- a/frontend/src/components/workers/workerSection.css.ts
+++ b/frontend/src/components/workers/workerSection.css.ts
@@ -11,10 +11,6 @@ export const statusConnected = style({
   background: 'var(--success)',
 })
 
-export const statusWarning = style({
-  background: 'var(--warning)',
-})
-
 export const statusDisconnected = style({
   background: 'var(--danger)',
 })

--- a/frontend/src/stores/workerChannelStatus.store.test.ts
+++ b/frontend/src/stores/workerChannelStatus.store.test.ts
@@ -1,12 +1,10 @@
 import { createRoot } from 'solid-js'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ChannelError } from '~/lib/channel'
+import { describe, expect, it } from 'vitest'
 import { createWorkerChannelStatusStore } from './workerChannelStatus.store'
 
 // Minimal mock ChannelManager with observability hooks
 function createMockChannelManager() {
   const stateCallbacks = new Set<() => void>()
-  const errorCallbacks = new Set<(workerId: string, error: ChannelError) => void>()
   const openChannels = new Set<string>()
 
   return {
@@ -14,12 +12,6 @@ function createMockChannelManager() {
       stateCallbacks.add(cb)
       return () => {
         stateCallbacks.delete(cb)
-      }
-    },
-    onChannelError(cb: (workerId: string, error: ChannelError) => void) {
-      errorCallbacks.add(cb)
-      return () => {
-        errorCallbacks.delete(cb)
       }
     },
     hasOpenChannel(workerId: string) {
@@ -34,27 +26,14 @@ function createMockChannelManager() {
       openChannels.delete(workerId)
       for (const cb of stateCallbacks) cb()
     },
-    _emitError(workerId: string) {
-      const err = new ChannelError('rpc', 'test error')
-      for (const cb of errorCallbacks) cb(workerId, err)
-    },
   }
 }
 
 describe('workerChannelStatusStore', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('should start workers as disconnected', () => {
+  it('should report disconnected when no channel is open', () => {
     createRoot((dispose) => {
       const cm = createMockChannelManager()
       const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1', 'w2'])
 
       expect(store.getStatus('w1')).toBe('disconnected')
       expect(store.getStatus('w2')).toBe('disconnected')
@@ -66,7 +45,6 @@ describe('workerChannelStatusStore', () => {
     createRoot((dispose) => {
       const cm = createMockChannelManager()
       const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1'])
 
       cm._setOpen('w1')
       expect(store.getStatus('w1')).toBe('connected')
@@ -78,62 +56,11 @@ describe('workerChannelStatusStore', () => {
     createRoot((dispose) => {
       const cm = createMockChannelManager()
       const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1'])
 
       cm._setOpen('w1')
       expect(store.getStatus('w1')).toBe('connected')
 
       cm._setClosed('w1')
-      expect(store.getStatus('w1')).toBe('disconnected')
-      dispose()
-    })
-  })
-
-  it('should transition to warning on non-transport error', () => {
-    createRoot((dispose) => {
-      const cm = createMockChannelManager()
-      const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1'])
-
-      cm._setOpen('w1')
-      cm._emitError('w1')
-      expect(store.getStatus('w1')).toBe('warning')
-      dispose()
-    })
-  })
-
-  it('should expire warning back to connected after 10s', () => {
-    createRoot((dispose) => {
-      const cm = createMockChannelManager()
-      const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1'])
-
-      cm._setOpen('w1')
-      cm._emitError('w1')
-      expect(store.getStatus('w1')).toBe('warning')
-
-      vi.advanceTimersByTime(10_000)
-      expect(store.getStatus('w1')).toBe('connected')
-      dispose()
-    })
-  })
-
-  it('should expire warning to disconnected if channel closed', () => {
-    createRoot((dispose) => {
-      const cm = createMockChannelManager()
-      const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1'])
-
-      cm._setOpen('w1')
-      cm._emitError('w1')
-      cm._setClosed('w1')
-      // Still warning because error hasn't expired yet
-      // (but channel is closed, so after expiry it should be disconnected)
-      // Actually after _setClosed, the state refresh happens and
-      // since there's still a warning entry, it stays 'warning'
-      expect(store.getStatus('w1')).toBe('warning')
-
-      vi.advanceTimersByTime(10_000)
       expect(store.getStatus('w1')).toBe('disconnected')
       dispose()
     })
@@ -143,7 +70,6 @@ describe('workerChannelStatusStore', () => {
     createRoot((dispose) => {
       const cm = createMockChannelManager()
       const store = createWorkerChannelStatusStore(cm as any)
-      store.setWorkerIds(['w1', 'w2'])
 
       cm._setOpen('w1')
       expect(store.getStatus('w1')).toBe('connected')
@@ -151,10 +77,6 @@ describe('workerChannelStatusStore', () => {
 
       cm._setOpen('w2')
       expect(store.getStatus('w1')).toBe('connected')
-      expect(store.getStatus('w2')).toBe('connected')
-
-      cm._emitError('w1')
-      expect(store.getStatus('w1')).toBe('warning')
       expect(store.getStatus('w2')).toBe('connected')
       dispose()
     })

--- a/frontend/src/stores/workerChannelStatus.store.ts
+++ b/frontend/src/stores/workerChannelStatus.store.ts
@@ -1,75 +1,27 @@
 import type { ChannelManager } from '~/lib/channel'
 import { createSignal, onCleanup } from 'solid-js'
 
-export type ChannelStatus = 'connected' | 'warning' | 'disconnected'
-
-interface WarningState {
-  lastErrorAt: number
-}
-
-const WARNING_EXPIRY_MS = 10_000
+export type ChannelStatus = 'connected' | 'disconnected'
 
 export function createWorkerChannelStatusStore(cm: ChannelManager) {
-  const [statusMap, setStatusMap] = createSignal<Record<string, ChannelStatus>>({})
-  const warnings = new Map<string, WarningState>()
-
-  function refreshAll(workerIds: string[]) {
-    setStatusMap(() => {
-      const map: Record<string, ChannelStatus> = {}
-      for (const id of workerIds) {
-        if (warnings.has(id)) {
-          map[id] = 'warning'
-        }
-        else {
-          map[id] = cm.hasOpenChannel(id) ? 'connected' : 'disconnected'
-        }
-      }
-      return map
-    })
-  }
-
-  let trackedWorkerIds: string[] = []
-
-  function setWorkerIds(ids: string[]) {
-    trackedWorkerIds = ids
-    refreshAll(ids)
-  }
+  // Version counter — bumped on channel state changes to trigger
+  // SolidJS reactivity in getStatus() callers.
+  const [version, setVersion] = createSignal(0)
 
   const unsubState = cm.onStateChange(() => {
-    refreshAll(trackedWorkerIds)
+    setVersion(v => v + 1)
   })
-
-  const unsubError = cm.onChannelError((workerId) => {
-    warnings.set(workerId, { lastErrorAt: Date.now() })
-    refreshAll(trackedWorkerIds)
-  })
-
-  const interval = setInterval(() => {
-    let changed = false
-    const now = Date.now()
-    for (const [workerId, state] of warnings) {
-      if (now - state.lastErrorAt >= WARNING_EXPIRY_MS) {
-        warnings.delete(workerId)
-        changed = true
-      }
-    }
-    if (changed) {
-      refreshAll(trackedWorkerIds)
-    }
-  }, WARNING_EXPIRY_MS)
 
   onCleanup(() => {
     unsubState()
-    unsubError()
-    clearInterval(interval)
   })
 
   function getStatus(workerId: string): ChannelStatus {
-    return statusMap()[workerId] ?? 'disconnected'
+    version() // subscribe to changes
+    return cm.hasOpenChannel(workerId) ? 'connected' : 'disconnected'
   }
 
   return {
     getStatus,
-    setWorkerIds,
   }
 }

--- a/frontend/src/utils/controlResponse.ts
+++ b/frontend/src/utils/controlResponse.ts
@@ -81,6 +81,7 @@ export const MODEL_LABELS: Record<string, string> = {
 }
 
 export const EFFORT_LABELS: Record<string, string> = {
+  max: 'Max',
   high: 'High',
   medium: 'Medium',
   low: 'Low',

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -242,6 +242,7 @@ test.describe('Agent Settings', () => {
     await expect(page.locator('[data-testid="effort-low"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-medium"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-high"]')).not.toHaveAttribute('data-disabled', '')
+    await expect(page.locator('[data-testid="effort-max"]')).not.toHaveAttribute('data-disabled', '')
 
     // Verify permission mode items are enabled when idle
     await expect(page.locator('[data-testid="permission-mode-default"]')).not.toHaveAttribute('data-disabled', '')

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -49,7 +49,7 @@ export default async function globalSetup() {
   console.log('[e2e] Building leapmux...')
   execSync('task build-backend', { cwd: ROOT, stdio: 'inherit' })
 
-  const binaryPath = join(ROOT, 'leapmux')
+  const binaryPath = join(ROOT, 'backend', 'leapmux')
 
   // Save minimal state for fixtures and teardown
   const state: E2EGlobalState = {

--- a/frontend/tests/e2e/helpers/e2e-channel.ts
+++ b/frontend/tests/e2e/helpers/e2e-channel.ts
@@ -7,6 +7,7 @@
 
 import type { ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '../../../src/lib/channel'
 import { Buffer } from 'node:buffer'
+import { EncryptionMode } from '../../../src/generated/leapmux/v1/channel_pb'
 import { ChannelManager } from '../../../src/lib/channel'
 
 // ---- Base64 helpers for JSON ↔ bytes conversion ----
@@ -49,6 +50,27 @@ class FetchChannelTransport implements ChannelTransport {
       mlkemPublicKey: base64ToBytes(data.mlkemPublicKey),
       slhdsaPublicKey: base64ToBytes(data.slhdsaPublicKey),
     }
+  }
+
+  async getWorkerEncryptionMode(workerId: string): Promise<EncryptionMode> {
+    const resp = await fetch(`${this.hubUrl}/leapmux.v1.ChannelService/GetWorkerEncryptionMode`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({ workerId }),
+    })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`GetWorkerEncryptionMode failed: ${resp.status} ${body}`)
+    }
+    const data = await resp.json() as { encryptionMode: string }
+    // Map string enum to numeric value.
+    if (data.encryptionMode === 'ENCRYPTION_MODE_CLASSIC')
+      return EncryptionMode.CLASSIC
+    // UNSPECIFIED and POST_QUANTUM both use hybrid PQ.
+    return EncryptionMode.POST_QUANTUM
   }
 
   async openChannel(workerId: string, handshakePayload: Uint8Array): Promise<{ channelId: string, handshakePayload: Uint8Array }> {

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -197,13 +197,6 @@ message AgentMessageDeleted {
   string message_id = 2;
 }
 
-message RetryAgentMessageRequest {
-  string agent_id = 1;
-  string message_id = 2;
-}
-
-message RetryAgentMessageResponse {}
-
 message DeleteAgentMessageRequest {
   string agent_id = 1;
   string message_id = 2;


### PR DESCRIPTION
## Motivation

Two independent issues were addressed in this PR:

1. **Missing "max" effort level**: The agent effort configuration only supported low, medium, and high levels; a "max" level was needed for users who want maximum model effort.

2. **Broken message retry after worker restart**: When a worker restarted, retrying a failed message would result in an "agent not found" error. The retry logic had two separate code paths — one via the now-removed `RetryAgentMessage` RPC and one via `sendAgentMessage` — and the dedicated retry path did not auto-start the worker before sending, unlike the main send path.

Additionally, the worker status dot showed an orange warning state during normal channel re-establishment (e.g., after a `WatchEvents` stream restart), causing false visual feedback to users.

## Modifications

- Added "max" as a supported effort level in the agent settings UI (with a Zap icon) and in the backend proto/documentation.
- (Breaking) Removed the `RetryAgentMessage` RPC and its associated `RetryAgentMessageRequest` / `RetryAgentMessageResponse` proto messages. Retry now goes through `sendAgentMessage`, which handles worker auto-start transparently.
- Removed the `retryAgentMessage` RPC function from the frontend API client.
- Replaced the error-based warning state in `createWorkerChannelStatusStore` with a simpler version-counter pattern; the status type is now `'connected' | 'disconnected'` only, eliminating the transient `'warning'` state.
- Refactored `EditorSettingsDropdown` to extract a reusable `RadioGroup` component, removing duplication across effort, model, and permission mode selectors.
- Fixed E2E global setup to reference the correct binary path (`backend/leapmux`) after the backend directory reorganization in #105.

## Result

- The agent settings panel now exposes a "max" effort option alongside low, medium, and high.
- Retrying a failed message no longer produces an "agent not found" error when the worker has been restarted; the retry flow auto-starts the worker as needed before re-sending the message.
- The worker status dot no longer flickers orange during normal channel re-establishment; it shows only connected or disconnected states.

🤖 Generated with Claude Code
