### PR TITLE
feat(agent): Wrap Claude invocation in user's login shell

### DIFF
--- a/backend/cmd/leapmux/worker.go
+++ b/backend/cmd/leapmux/worker.go
@@ -142,6 +142,7 @@ func runWorker(args []string) error {
 	svcCtx.Name = cfg.Name
 	svcCtx.Version = version
 	svcCtx.AgentStartupTimeout = cfg.AgentStartupTimeout()
+	svcCtx.UseLoginShell = cfg.UseLoginShell
 	svcCtx.Send = client.Send
 	svcCtx.Channels = channelMgr
 	svcCtx.Init()

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -41,10 +41,14 @@ type Agent struct {
 	cmd         *exec.Cmd
 	stdin       io.WriteCloser
 	stderrBuf   *bytes.Buffer
+	stderrMu    sync.Mutex // protects stderrBuf when drained via goroutine
 	ctx         context.Context
 	cancel      context.CancelFunc
 	processDone chan struct{} // closed when the process exits
 	waitErr     error         // set before processDone is closed
+
+	preambleDelimiter string   // if set, readOutput skips lines until this delimiter
+	preambleOutput    []string // captured preamble lines (before delimiter)
 
 	mu      sync.Mutex
 	stopped bool
@@ -63,6 +67,7 @@ type Options struct {
 	ResumeSessionID string        // If set, uses --resume to resume a previous session
 	PermissionMode  string        // Permission mode to set on startup (default, acceptEdits, plan, bypassPermissions)
 	StartupTimeout  time.Duration // Timeout for the startup handshake (default: 30s)
+	LoginShell      string        // If non-empty, wraps claude invocation in this login shell
 }
 
 // Start spawns a new Claude Code process and begins reading its output.
@@ -101,10 +106,23 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		args = append(args, "--resume", opts.ResumeSessionID)
 	}
 
-	cmd := exec.CommandContext(ctx, "claude", args...)
-	cmd.Dir = opts.WorkingDir
+	var cmd *exec.Cmd
+	var preambleDelimiter string
+	if opts.LoginShell != "" {
+		cmd, preambleDelimiter = buildShellWrappedCommand(ctx, opts.LoginShell, args, opts.WorkingDir)
+	} else {
+		cmd = exec.CommandContext(ctx, "claude", args...)
+		cmd.Dir = opts.WorkingDir
+	}
+
 	cmd.Env = filterEnv(cmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
-	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts")
+	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1")
+	if opts.LoginShell != "" {
+		// Set CLAUDECODE=1 so the user's shell rc files can detect they are
+		// being sourced inside Claude Code and skip conflicting aliases.
+		// The inner command unsets it before invoking claude.
+		cmd.Env = append(cmd.Env, "CLAUDECODE=1")
+	}
 
 	// Send SIGTERM (instead of the default SIGKILL) when the context is
 	// cancelled, giving Claude Code a chance to persist its session state.
@@ -127,27 +145,45 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
 
-	// Capture stderr for debugging. If the process crashes, we want to know why.
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	// Capture stderr via a goroutine that actively drains the pipe. This
+	// prevents the process from blocking if stderr output exceeds the OS
+	// pipe buffer (~64KB). Buffer is capped at 1MB.
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
 
+	var stderrBuf bytes.Buffer
 	a := &Agent{
-		agentID:        opts.AgentID,
-		model:          opts.Model,
-		workingDir:     opts.WorkingDir,
-		cmd:            cmd,
-		stdin:          stdin,
-		ctx:            ctx,
-		cancel:         cancel,
-		stderrBuf:      &stderrBuf,
-		processDone:    make(chan struct{}),
-		pendingControl: make(map[string]chan<- controlResult),
+		agentID:           opts.AgentID,
+		model:             opts.Model,
+		workingDir:        opts.WorkingDir,
+		cmd:               cmd,
+		stdin:             stdin,
+		ctx:               ctx,
+		cancel:            cancel,
+		stderrBuf:         &stderrBuf,
+		preambleDelimiter: preambleDelimiter,
+		processDone:       make(chan struct{}),
+		pendingControl:    make(map[string]chan<- controlResult),
 	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
+
+	// Drain stderr in a background goroutine.
+	const maxStderrSize = 1 << 20 // 1MB
+	go func() {
+		limited := io.LimitReader(stderrPipe, maxStderrSize)
+		a.stderrMu.Lock()
+		_, _ = io.Copy(&stderrBuf, limited)
+		a.stderrMu.Unlock()
+		// Discard any remaining stderr beyond the limit.
+		_, _ = io.Copy(io.Discard, stderrPipe)
+	}()
 
 	// Read stdout in a background goroutine. Output will only arrive after
 	// the first message is sent to stdin (Claude Code behavior with
@@ -163,6 +199,19 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		_ = a.Wait()
 	}
 
+	// formatStartupError returns a descriptive error including stderr and
+	// preamble output (if any) for frontend diagnostics.
+	formatStartupError := func(phase string, err error) error {
+		parts := []string{fmt.Sprintf("%s: %s", phase, err)}
+		if stderr := strings.TrimSpace(a.Stderr()); stderr != "" {
+			parts = append(parts, "stderr: "+stderr)
+		}
+		if preamble := strings.TrimSpace(a.PreambleOutput()); preamble != "" {
+			parts = append(parts, "shell preamble: "+preamble)
+		}
+		return fmt.Errorf("%s", strings.Join(parts, "; "))
+	}
+
 	timeout := opts.startupTimeout()
 
 	// Send "initialize" as the first control request, matching the Agent SDK
@@ -170,7 +219,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 	// (which contains the session_id) and establishes the control protocol.
 	if _, err := a.sendControlAndWait(ctx, `{"subtype":"initialize"}`, timeout); err != nil {
 		cleanup()
-		return nil, fmt.Errorf("initialize: %w", err)
+		return nil, formatStartupError("initialize", err)
 	}
 
 	// Send set_permission_mode to configure the agent's permission mode.
@@ -184,7 +233,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, mode), timeout)
 	if err != nil {
 		cleanup()
-		return nil, fmt.Errorf("set_permission_mode: %w", err)
+		return nil, formatStartupError("set_permission_mode", err)
 	}
 	a.confirmedPermissionMode = resp.Mode
 
@@ -295,10 +344,22 @@ func (a *Agent) AgentID() string {
 
 // Stderr returns the captured stderr output from the agent process.
 func (a *Agent) Stderr() string {
+	a.stderrMu.Lock()
+	defer a.stderrMu.Unlock()
 	if a.stderrBuf == nil {
 		return ""
 	}
 	return a.stderrBuf.String()
+}
+
+// PreambleOutput returns the captured stdout preamble lines (before the
+// delimiter) when running under a login shell wrapper. Returns empty string
+// if no preamble was captured.
+func (a *Agent) PreambleOutput() string {
+	if len(a.preambleOutput) == 0 {
+		return ""
+	}
+	return strings.Join(a.preambleOutput, "\n")
 }
 
 // ConfirmedPermissionMode returns the permission mode confirmed by the agent
@@ -400,6 +461,23 @@ func (a *Agent) handlePendingControlResponse(line []byte) bool {
 }
 
 func (a *Agent) readOutput(scanner *bufio.Scanner, outputFn OutputHandler) {
+	// If a preamble delimiter is set, skip lines until the delimiter is found.
+	// This handles shell login preamble (motd, .zshrc output, etc.) that
+	// appears before claude's NDJSON stream.
+	if a.preambleDelimiter != "" {
+		delimBytes := []byte(a.preambleDelimiter)
+		const maxPreambleLines = 50
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if bytes.Equal(bytes.TrimSpace(line), delimBytes) {
+				break
+			}
+			if len(a.preambleOutput) < maxPreambleLines {
+				a.preambleOutput = append(a.preambleOutput, string(line))
+			}
+		}
+	}
+
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {

--- a/backend/internal/worker/agent/agent_test.go
+++ b/backend/internal/worker/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -500,4 +501,178 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 		"error should include the stderr message from the crashed process")
 	assert.Less(t, elapsed, 2*time.Second,
 		"should detect early exit quickly, not wait for the full 5s timeout")
+}
+
+// TestHelperProcessWithPreamble is a test helper that outputs preamble lines
+// to both stdout and stderr, then a delimiter on stdout, then NDJSON.
+func TestHelperProcessWithPreamble(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_PREAMBLE") != "1" {
+		return
+	}
+
+	delimiter := os.Getenv("GO_PREAMBLE_DELIMITER")
+
+	// Output preamble to stdout.
+	_, _ = fmt.Fprintln(os.Stdout, "Welcome to my shell")
+	_, _ = fmt.Fprintln(os.Stdout, "Loading .zshrc ...")
+
+	// Output preamble to stderr.
+	_, _ = fmt.Fprintln(os.Stderr, "stderr preamble line 1")
+	_, _ = fmt.Fprintln(os.Stderr, "stderr preamble line 2")
+
+	// Output delimiter on stdout.
+	_, _ = fmt.Fprintln(os.Stdout, delimiter)
+
+	// Then echo stdin as NDJSON.
+	buf := make([]byte, 4096)
+	for {
+		n, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+		_, _ = os.Stdout.Write(buf[:n])
+	}
+	os.Exit(0)
+}
+
+func TestAgent_PreambleSkipping(t *testing.T) {
+	ctx := context.Background()
+
+	delimiter := "__LEAPMUX_READY_testdelimiter__"
+
+	var mu sync.Mutex
+	var lines []string
+	outputFn := func(line []byte) {
+		mu.Lock()
+		lines = append(lines, string(line))
+		mu.Unlock()
+	}
+
+	// Start process with preamble.
+	ctx2, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx2, os.Args[0], "-test.run=TestHelperProcessWithPreamble", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_PREAMBLE=1", "GO_PREAMBLE_DELIMITER="+delimiter)
+	cmd.Dir = t.TempDir()
+
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	stderrPipe, err := cmd.StderrPipe()
+	require.NoError(t, err)
+
+	var stderrBuf bytes.Buffer
+	a := &Agent{
+		agentID:           "preamble-test",
+		model:             "test",
+		workingDir:        t.TempDir(),
+		cmd:               cmd,
+		stdin:             stdin,
+		ctx:               ctx2,
+		cancel:            cancel,
+		stderrBuf:         &stderrBuf,
+		preambleDelimiter: delimiter,
+		processDone:       make(chan struct{}),
+		pendingControl:    make(map[string]chan<- controlResult),
+	}
+
+	require.NoError(t, cmd.Start())
+
+	// Drain stderr in background.
+	go func() {
+		a.stderrMu.Lock()
+		_, _ = fmt.Fprintf(&stderrBuf, "")
+		a.stderrMu.Unlock()
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := stderrPipe.Read(buf)
+			if n > 0 {
+				a.stderrMu.Lock()
+				stderrBuf.Write(buf[:n])
+				a.stderrMu.Unlock()
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutput(scanner, outputFn)
+
+	// Send some input to trigger output after delimiter.
+	require.NoError(t, a.SendInput("hello"))
+
+	// Wait for output to arrive.
+	testutil.AssertEventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(lines) > 0
+	}, "expected output after preamble")
+
+	// Verify preamble was captured.
+	preamble := a.PreambleOutput()
+	assert.Contains(t, preamble, "Welcome to my shell")
+	assert.Contains(t, preamble, "Loading .zshrc ...")
+
+	// Verify preamble lines were NOT forwarded to outputFn.
+	mu.Lock()
+	for _, line := range lines {
+		assert.NotContains(t, line, "Welcome to my shell")
+		assert.NotContains(t, line, "Loading .zshrc ...")
+	}
+	mu.Unlock()
+
+	// Verify stderr was captured.
+	testutil.AssertEventually(t, func() bool {
+		return strings.Contains(a.Stderr(), "stderr preamble line 1")
+	}, "expected stderr to be captured")
+
+	a.Stop()
+	_ = a.Wait()
+}
+
+func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
+	// Verify that LEAPMUX_WORKER=1 is always present in the environment
+	// when starting an agent (both with and without login shell).
+	ctx := context.Background()
+	args := []string{"--model", "test", "--output-format", "stream-json"}
+
+	// Without login shell.
+	cmd := exec.CommandContext(ctx, "echo", "test")
+	cmd.Dir = t.TempDir()
+	cmd.Env = filterEnv(cmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
+	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1")
+
+	foundWorker := false
+	foundClaudeCode := false
+	for _, e := range cmd.Env {
+		if e == "LEAPMUX_WORKER=1" {
+			foundWorker = true
+		}
+		if e == "CLAUDECODE=1" {
+			foundClaudeCode = true
+		}
+	}
+	assert.True(t, foundWorker, "LEAPMUX_WORKER=1 should be in env")
+	assert.False(t, foundClaudeCode, "CLAUDECODE=1 should NOT be in env without login shell")
+
+	// With login shell - verify the env is set on the command.
+	shellCmd, _ := buildShellWrappedCommand(ctx, "/bin/sh", args, t.TempDir())
+	shellCmd.Env = filterEnv(shellCmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
+	shellCmd.Env = append(shellCmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1", "CLAUDECODE=1")
+
+	foundWorker = false
+	foundClaudeCode = false
+	for _, e := range shellCmd.Env {
+		if e == "LEAPMUX_WORKER=1" {
+			foundWorker = true
+		}
+		if e == "CLAUDECODE=1" {
+			foundClaudeCode = true
+		}
+	}
+	assert.True(t, foundWorker, "LEAPMUX_WORKER=1 should be in shell-wrapped env")
+	assert.True(t, foundClaudeCode, "CLAUDECODE=1 should be in shell-wrapped env")
 }

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// buildShellWrappedCommand constructs an exec.Cmd that launches the claude
+// binary inside the user's login shell with interactive+login flags. This
+// ensures that shell profile scripts (e.g. .zshrc, .bash_profile) are sourced,
+// providing the correct PATH and environment variables.
+//
+// It returns the command and a unique delimiter string. The caller should scan
+// stdout for this delimiter: everything before it is shell preamble (motd,
+// profile output, etc.), and everything after is NDJSON from claude.
+func buildShellWrappedCommand(ctx context.Context, shellPath string, claudeArgs []string, workingDir string) (*exec.Cmd, string) {
+	delimiter := "__LEAPMUX_READY_" + generateRequestID() + "__"
+	shellName := filepath.Base(shellPath)
+
+	var cmdArgs []string
+	switch {
+	case isPwsh(shellName):
+		inner := buildPwshCommand(delimiter, claudeArgs)
+		cmdArgs = []string{"-Login", "-Command", inner}
+	case shellName == "tcsh" || shellName == "csh":
+		inner := buildPosixCommand(delimiter, claudeArgs, true)
+		cmdArgs = []string{"-ic", inner}
+	case shellName == "nu":
+		inner := buildNuCommand(delimiter, claudeArgs)
+		cmdArgs = []string{"-i", "-l", "-c", inner}
+	default:
+		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
+		inner := buildPosixCommand(delimiter, claudeArgs, true)
+		cmdArgs = []string{"-i", "-l", "-c", inner}
+	}
+
+	cmd := exec.CommandContext(ctx, shellPath, cmdArgs...)
+	cmd.Dir = workingDir
+	return cmd, delimiter
+}
+
+// buildPosixCommand builds the inner command string for POSIX-like shells.
+// If useExec is true, the command uses exec to replace the shell process.
+func buildPosixCommand(delimiter string, claudeArgs []string, useExec bool) string {
+	quoted := make([]string, len(claudeArgs))
+	for i, arg := range claudeArgs {
+		quoted[i] = posixQuote(arg)
+	}
+
+	if useExec {
+		return fmt.Sprintf("unset CLAUDECODE && echo '%s' && exec claude %s", delimiter, strings.Join(quoted, " "))
+	}
+	return fmt.Sprintf("unset CLAUDECODE && echo '%s' && claude %s", delimiter, strings.Join(quoted, " "))
+}
+
+// buildNuCommand builds the inner command string for Nushell.
+func buildNuCommand(delimiter string, claudeArgs []string) string {
+	quoted := make([]string, len(claudeArgs))
+	for i, arg := range claudeArgs {
+		quoted[i] = posixQuote(arg)
+	}
+	return fmt.Sprintf("hide-env CLAUDECODE; echo '%s'; ^claude %s", delimiter, strings.Join(quoted, " "))
+}
+
+// buildPwshCommand builds the inner command string for PowerShell.
+func buildPwshCommand(delimiter string, claudeArgs []string) string {
+	quoted := make([]string, len(claudeArgs))
+	for i, arg := range claudeArgs {
+		quoted[i] = pwshQuote(arg)
+	}
+	return fmt.Sprintf("Remove-Item Env:CLAUDECODE; Write-Output '%s'; & claude %s", delimiter, strings.Join(quoted, " "))
+}
+
+// posixQuote wraps a string in single quotes for POSIX shells.
+// Single quotes within the string are escaped as '\” (end quote, escaped
+// literal quote, start quote).
+func posixQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// pwshQuote wraps a string in single quotes for PowerShell.
+// Single quotes within the string are escaped by doubling them (”).
+func pwshQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
+
+// isPwsh returns true if the shell name matches PowerShell variants.
+func isPwsh(name string) bool {
+	return pwshPattern.MatchString(name)
+}

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildShellWrappedCommand_Bash(t *testing.T) {
+	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/bash", []string{"--model", "opus"}, "/tmp")
+	require.NotEmpty(t, delimiter)
+	assert.True(t, strings.HasPrefix(delimiter, "__LEAPMUX_READY_"))
+	assert.True(t, strings.HasSuffix(delimiter, "__"))
+
+	assert.Equal(t, "/bin/bash", cmd.Path)
+	assert.Equal(t, "/tmp", cmd.Dir)
+	require.Len(t, cmd.Args, 5) // bash -i -l -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-l", cmd.Args[2])
+	assert.Equal(t, "-c", cmd.Args[3])
+	assert.Contains(t, cmd.Args[4], "echo '"+delimiter+"'")
+	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[4], "exec claude")
+	assert.Contains(t, cmd.Args[4], "'--model'")
+	assert.Contains(t, cmd.Args[4], "'opus'")
+}
+
+func TestBuildShellWrappedCommand_Zsh(t *testing.T) {
+	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/zsh", []string{"--verbose"}, "/home/user")
+	assert.Equal(t, "/bin/zsh", cmd.Path)
+	require.Len(t, cmd.Args, 5) // zsh -i -l -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-l", cmd.Args[2])
+	assert.Equal(t, "-c", cmd.Args[3])
+	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[4], "exec claude")
+	assert.Contains(t, cmd.Args[4], delimiter)
+}
+
+func TestBuildShellWrappedCommand_Fish(t *testing.T) {
+	cmd, _ := buildShellWrappedCommand(context.Background(), "/usr/bin/fish", []string{"--model", "sonnet"}, "/tmp")
+	assert.Equal(t, "/usr/bin/fish", cmd.Path)
+	require.Len(t, cmd.Args, 5) // fish -i -l -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-l", cmd.Args[2])
+	assert.Equal(t, "-c", cmd.Args[3])
+	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[4], "exec claude")
+}
+
+func TestBuildShellWrappedCommand_Tcsh(t *testing.T) {
+	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/tcsh", []string{"--model", "opus"}, "/tmp")
+	assert.Equal(t, "/bin/tcsh", cmd.Path)
+	require.Len(t, cmd.Args, 3) // tcsh -ic <cmd>
+	assert.Equal(t, "-ic", cmd.Args[1])
+	assert.Contains(t, cmd.Args[2], "echo '"+delimiter+"'")
+	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[2], "exec claude")
+}
+
+func TestBuildShellWrappedCommand_Csh(t *testing.T) {
+	cmd, _ := buildShellWrappedCommand(context.Background(), "/bin/csh", []string{"--verbose"}, "/tmp")
+	assert.Equal(t, "/bin/csh", cmd.Path)
+	require.Len(t, cmd.Args, 3) // csh -ic <cmd>
+	assert.Equal(t, "-ic", cmd.Args[1])
+	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[2], "exec claude")
+}
+
+func TestBuildShellWrappedCommand_Nu(t *testing.T) {
+	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/usr/bin/nu", []string{"--model", "opus"}, "/tmp")
+	assert.Equal(t, "/usr/bin/nu", cmd.Path)
+	require.Len(t, cmd.Args, 5) // nu -i -l -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-l", cmd.Args[2])
+	assert.Equal(t, "-c", cmd.Args[3])
+	assert.Contains(t, cmd.Args[4], "echo '"+delimiter+"'")
+	assert.Contains(t, cmd.Args[4], "hide-env CLAUDECODE")
+	assert.Contains(t, cmd.Args[4], "^claude")
+	assert.NotContains(t, cmd.Args[4], "exec")
+}
+
+func TestBuildShellWrappedCommand_Pwsh(t *testing.T) {
+	for _, shell := range []string{"/usr/bin/pwsh", "/usr/bin/powershell", "/usr/bin/pwsh-preview", "/usr/bin/powershell-preview"} {
+		t.Run(shell, func(t *testing.T) {
+			cmd, delimiter := buildShellWrappedCommand(context.Background(), shell, []string{"--model", "opus"}, "/tmp")
+			assert.Equal(t, shell, cmd.Path)
+			require.Len(t, cmd.Args, 4) // pwsh -Login -Command <cmd>
+			assert.Equal(t, "-Login", cmd.Args[1])
+			assert.Equal(t, "-Command", cmd.Args[2])
+			assert.Contains(t, cmd.Args[3], "Write-Output '"+delimiter+"'")
+			assert.Contains(t, cmd.Args[3], "Remove-Item Env:CLAUDECODE")
+			assert.Contains(t, cmd.Args[3], "& claude")
+			assert.NotContains(t, cmd.Args[3], "exec")
+		})
+	}
+}
+
+func TestBuildShellWrappedCommand_UnknownShell(t *testing.T) {
+	cmd, _ := buildShellWrappedCommand(context.Background(), "/usr/bin/xonsh", []string{"--verbose"}, "/tmp")
+	assert.Equal(t, "/usr/bin/xonsh", cmd.Path)
+	require.Len(t, cmd.Args, 5) // defaults to -i -l -c
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-l", cmd.Args[2])
+	assert.Equal(t, "-c", cmd.Args[3])
+	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[4], "exec claude")
+}
+
+func TestPosixQuote(t *testing.T) {
+	assert.Equal(t, "'hello'", posixQuote("hello"))
+	assert.Equal(t, "'it'\\''s'", posixQuote("it's"))
+	assert.Equal(t, "''", posixQuote(""))
+}
+
+func TestPwshQuote(t *testing.T) {
+	assert.Equal(t, "'hello'", pwshQuote("hello"))
+	assert.Equal(t, "'it''s'", pwshQuote("it's"))
+	assert.Equal(t, "''", pwshQuote(""))
+}
+
+func TestIsPwsh(t *testing.T) {
+	assert.True(t, isPwsh("pwsh"))
+	assert.True(t, isPwsh("powershell"))
+	assert.True(t, isPwsh("pwsh-preview"))
+	assert.True(t, isPwsh("powershell-preview"))
+	assert.False(t, isPwsh("bash"))
+	assert.False(t, isPwsh("zsh"))
+	assert.False(t, isPwsh("pwsh-extra-stuff"))
+}

--- a/backend/internal/worker/config/config.go
+++ b/backend/internal/worker/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	AgentStartupTimeoutSeconds int    `koanf:"agent_startup_timeout_seconds" json:"agent_startup_timeout_seconds"`
 	LogLevel                   string `koanf:"log_level" json:"log_level"`
 	EncryptionMode             string `koanf:"encryption_mode" json:"encryption_mode"`
+	UseLoginShell              bool   `koanf:"use_login_shell" json:"use_login_shell"`
 }
 
 // EncryptionModeProto returns the protobuf EncryptionMode value.
@@ -145,6 +146,7 @@ func Load(args []string) (*Config, bool, error) {
 	fs.Int("agent-startup-timeout-seconds", DefaultAgentStartupTimeoutSeconds, "agent startup timeout in seconds")
 	fs.String("log-level", defaultLogLevel, "log level (debug, info, warn, error)")
 	fs.String("encryption-mode", "post-quantum", "encryption mode (classic, post-quantum)")
+	fs.Bool("use-login-shell", true, "wrap claude invocation in user's login shell")
 	showVersion := fs.Bool("version", false, "print version and exit")
 
 	if err := fs.Parse(args); err != nil {
@@ -166,6 +168,7 @@ func Load(args []string) (*Config, bool, error) {
 		"agent-startup-timeout-seconds": "agent_startup_timeout_seconds",
 		"log-level":                     "log_level",
 		"encryption-mode":               "encryption_mode",
+		"use-login-shell":               "use_login_shell",
 	}
 
 	defaults := map[string]interface{}{
@@ -178,6 +181,7 @@ func Load(args []string) (*Config, bool, error) {
 		"agent_startup_timeout_seconds": DefaultAgentStartupTimeoutSeconds,
 		"log_level":                     defaultLogLevel,
 		"encryption_mode":               "post-quantum",
+		"use_login_shell":               true,
 	}
 
 	k := koanf.New(".")

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -19,9 +19,19 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
+	"github.com/leapmux/leapmux/internal/worker/terminal"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
+
+// loginShell returns the user's default login shell path if UseLoginShell is
+// enabled, or an empty string otherwise.
+func (svc *Context) loginShell() string {
+	if !svc.UseLoginShell {
+		return ""
+	}
+	return terminal.ResolveDefaultShell()
+}
 
 // registerAgentHandlers registers all agent-related inner RPC handlers.
 func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
@@ -85,6 +95,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			WorkingDir:      workingDir,
 			ResumeSessionID: r.GetAgentSessionId(),
 			StartupTimeout:  svc.agentStartupTimeout(),
+			LoginShell:      svc.loginShell(),
 		}
 
 		outputFn := agentOutputFn(svc.Output, agentID, r.GetWorkspaceId(), workingDir)
@@ -502,6 +513,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 				ResumeSessionID: dbAgent.AgentSessionID,
 				PermissionMode:  dbAgent.PermissionMode,
 				StartupTimeout:  svc.agentStartupTimeout(),
+				LoginShell:      svc.loginShell(),
 			}
 
 			outputFn := agentOutputFn(svc.Output, agentID, dbAgent.WorkspaceID, dbAgent.WorkingDir)
@@ -832,6 +844,7 @@ func (svc *Context) handleClearContext(agentID string) {
 		WorkingDir:     dbAgent.WorkingDir,
 		PermissionMode: dbAgent.PermissionMode,
 		StartupTimeout: svc.agentStartupTimeout(),
+		LoginShell:     svc.loginShell(),
 	}, outputFn); err != nil {
 		slog.Error("clear context: failed to restart agent", "agent_id", agentID, "error", err)
 		_ = svc.Queries.UpdateAgentSessionID(bgCtx(), db.UpdateAgentSessionIDParams{
@@ -875,6 +888,7 @@ func (svc *Context) ensureAgentRunning(agentID string) error {
 		ResumeSessionID: dbAgent.AgentSessionID,
 		PermissionMode:  dbAgent.PermissionMode,
 		StartupTimeout:  svc.agentStartupTimeout(),
+		LoginShell:      svc.loginShell(),
 	}, outputFn); err != nil {
 		slog.Error("ensureAgentRunning: failed to start agent", "agent_id", agentID, "error", err)
 		return err
@@ -1128,6 +1142,7 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 		WorkingDir:     dbAgent.WorkingDir,
 		PermissionMode: targetMode,
 		StartupTimeout: svc.agentStartupTimeout(),
+		LoginShell:     svc.loginShell(),
 	}, outputFn); err != nil {
 		slog.Error("plan exec: failed to restart agent", "agent_id", agentID, "error", err)
 		_ = svc.Queries.UpdateAgentSessionID(bgCtx(), db.UpdateAgentSessionIDParams{

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -41,6 +41,7 @@ type Context struct {
 	Watchers            *WatcherManager // Fan-out manager for event broadcasting
 	Output              *OutputHandler  // Agent output NDJSON processor
 	AgentStartupTimeout time.Duration   // Timeout for agent startup handshake (default: 30s)
+	UseLoginShell       bool            // Wrap claude invocation in user's login shell
 }
 
 // agentStartupTimeout returns the configured agent startup timeout,

--- a/backend/internal/worker/terminal/shells.go
+++ b/backend/internal/worker/terminal/shells.go
@@ -14,12 +14,12 @@ var shellCache struct {
 	defaultShell string
 }
 
-// resolveDefaultShell returns the user's default shell.  It checks the
+// ResolveDefaultShell returns the user's default shell.  It checks the
 // LEAPMUX_DEFAULT_SHELL environment variable first (accepting either a bare
 // command name like "zsh" or an absolute path like "/bin/zsh"), then the SHELL
 // environment variable, and finally falls back to platform-specific detection
 // (e.g. dscl on macOS, /etc/passwd on Linux).
-func resolveDefaultShell() string {
+func ResolveDefaultShell() string {
 	if shell := resolveShellEnv("LEAPMUX_DEFAULT_SHELL"); shell != "" {
 		slog.Info("default shell from LEAPMUX_DEFAULT_SHELL", "shell", shell)
 		return shell
@@ -62,7 +62,7 @@ func resolveShellEnv(name string) string {
 // invoking as "sh" activates POSIX mode.
 func ListAvailableShells() (shells []string, defaultShell string) {
 	shellCache.once.Do(func() {
-		shellCache.defaultShell = resolveDefaultShell()
+		shellCache.defaultShell = ResolveDefaultShell()
 
 		// Place the default shell first so it appears at the top of
 		// the UI dropdown.

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -90,7 +90,7 @@ type Options struct {
 func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 	shell := opts.Shell
 	if shell == "" {
-		shell = resolveDefaultShell()
+		shell = ResolveDefaultShell()
 	}
 
 	cmd := exec.Command(shell)

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -512,14 +512,14 @@ func TestDetectDefaultShell(t *testing.T) {
 func TestResolveDefaultShell_PrefersLeapmuxEnv(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "/bin/test-leapmux-shell")
 	t.Setenv("SHELL", "/bin/other-shell")
-	shell := resolveDefaultShell()
+	shell := ResolveDefaultShell()
 	assert.Equal(t, "/bin/test-leapmux-shell", shell)
 }
 
 func TestResolveDefaultShell_LeapmuxEnvBareName(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "sh")
 	t.Setenv("SHELL", "/bin/other-shell")
-	shell := resolveDefaultShell()
+	shell := ResolveDefaultShell()
 	assert.NotEmpty(t, shell, "bare name should be resolved")
 	assert.True(t, strings.HasPrefix(shell, "/"), "resolved path should be absolute")
 	assert.True(t, strings.HasSuffix(shell, "/sh"), "resolved path should end with /sh")
@@ -528,23 +528,23 @@ func TestResolveDefaultShell_LeapmuxEnvBareName(t *testing.T) {
 func TestResolveDefaultShell_LeapmuxEnvInvalidBareName(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "nonexistent-shell-xyz")
 	t.Setenv("SHELL", "/bin/fallback-shell")
-	shell := resolveDefaultShell()
+	shell := ResolveDefaultShell()
 	assert.Equal(t, "/bin/fallback-shell", shell, "should fall back to $SHELL when LEAPMUX_DEFAULT_SHELL is unresolvable")
 }
 
 func TestResolveDefaultShell_UsesEnvWhenSet(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
 	t.Setenv("SHELL", "/bin/test-shell")
-	shell := resolveDefaultShell()
-	assert.Equal(t, "/bin/test-shell", shell, "resolveDefaultShell should prefer $SHELL")
+	shell := ResolveDefaultShell()
+	assert.Equal(t, "/bin/test-shell", shell, "ResolveDefaultShell should prefer $SHELL")
 }
 
 func TestResolveDefaultShell_FallsBackWhenEnvUnset(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
 	t.Setenv("SHELL", "")
-	shell := resolveDefaultShell()
-	assert.NotEmpty(t, shell, "resolveDefaultShell should return a shell even without $SHELL")
-	assert.True(t, strings.HasPrefix(shell, "/"), "resolveDefaultShell should return an absolute path")
+	shell := ResolveDefaultShell()
+	assert.NotEmpty(t, shell, "ResolveDefaultShell should return a shell even without $SHELL")
+	assert.True(t, strings.HasPrefix(shell, "/"), "ResolveDefaultShell should return an absolute path")
 }
 
 func TestResolveShellEnv_Empty(t *testing.T) {

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -89,7 +90,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 
 	cliFlags := cfg.CLIFlags
 	if cliFlags == nil {
-		cliFlags = []string{"addr", "data-dir", "dev-frontend", "db-max-conns", "max-message-size", "max-incomplete-chunked", "api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds", "log-level"}
+		cliFlags = []string{"addr", "data-dir", "dev-frontend", "db-max-conns", "max-message-size", "max-incomplete-chunked", "api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds", "log-level", "use-login-shell"}
 	}
 
 	hubCfg, _, err := hubconfig.LoadWithOptions(cfg.Args, hubconfig.LoadOptions{
@@ -100,6 +101,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		CLIFlags:          cliFlags,
 		ExtraFlags: []hubconfig.ExtraFlagDef{
 			{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
+			{Name: "use-login-shell", KoanfKey: "use_login_shell", Usage: "wrap claude invocation in user's login shell", StrDefault: "true"},
 		},
 		SoloMode: !cfg.DevMode,
 	})
@@ -219,6 +221,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 			MaxIncompleteChunked: hubCfg.MaxIncompleteChunked,
 			AgentStartupTimeout:  hubCfg.AgentStartupTimeout(),
 			EncryptionMode:       workerconfig.ParseEncryptionMode(hubCfg.Extras["encryption_mode"]),
+			UseLoginShell:        parseBool(hubCfg.Extras["use_login_shell"], true),
 		}); wErr != nil {
 			slog.Error("worker error", "error", wErr)
 		}
@@ -314,4 +317,17 @@ func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath,
 func mustDecode64(s string) []byte {
 	b, _ := base64.StdEncoding.DecodeString(s)
 	return b
+}
+
+// parseBool parses a string as a boolean, returning defaultVal if the string
+// is empty or not recognized.
+func parseBool(s string, defaultVal bool) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultVal
+	}
 }

--- a/backend/worker/runner.go
+++ b/backend/worker/runner.go
@@ -35,6 +35,7 @@ type RunConfig struct {
 	MaxIncompleteChunked int                         // Maximum in-flight chunked sequences per channel (0 = 4 default)
 	AgentStartupTimeout  time.Duration               // Timeout for agent startup handshake (0 = 30s default)
 	EncryptionMode       leapmuxv1.EncryptionMode    // Encryption mode (classic, post-quantum)
+	UseLoginShell        bool                        // Wrap claude invocation in user's login shell
 }
 
 // Run starts the worker and blocks until ctx is cancelled.
@@ -96,6 +97,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		}
 		svcCtx.Version = cfg.Version
 		svcCtx.AgentStartupTimeout = cfg.AgentStartupTimeout
+		svcCtx.UseLoginShell = cfg.UseLoginShell
 		svcCtx.Send = client.Send
 		svcCtx.Channels = channelMgr
 		svcCtx.Init()


### PR DESCRIPTION
## Motivation

Claude Code agents were previously launched as bare processes, bypassing the user's shell initialization files (`.zshrc`, `.bash_profile`, etc.). This caused the agent to inherit an incomplete environment — missing PATH entries, aliases, and tool configurations that users depend on — leading to failures when Claude tried to invoke tools that were only available through their shell setup.

## Modifications

- Added `Options.LoginShell` field to the agent `Options` struct. When non-empty, the Claude invocation is wrapped in the specified login shell using interactive and login flags (`-i -l`).
- Added `backend/internal/worker/agent/shell.go` with `buildShellWrappedCommand()` and shell-specific command builders for POSIX shells, PowerShell (`pwsh`/`powershell`), and Nushell. Each builder handles shell-appropriate quoting and command construction.
- Implemented preamble detection: a unique delimiter is emitted to stdout before Claude starts, so the agent can skip shell login output (motd, profile script noise) without forwarding it to the NDJSON output stream. Up to 50 preamble lines are captured and exposed via the new `Agent.PreambleOutput()` method for inclusion in startup error messages.
- Fixed a blocking bug where processes that emit more than ~64KB of stderr would stall. Stderr is now drained by a background goroutine with a 1MB cap.
- Added two environment variables set on the agent process: `LEAPMUX_WORKER=1` (always set) and `CLAUDECODE=1` (set only when a login shell is used, then unset before Claude is exec'd) to let shell rc files detect the Claude Code context and skip conflicting aliases.
- Added `UseLoginShell` configuration flag (default: `true`) in `RunConfig`, `Config`, and the service `Context`. All five agent startup paths (`OpenAgent`, `ResumeSession`, `HandleClearContext`, `ensureAgentRunning`, `initiatePlanExecution`) now pass the resolved shell path to `Options`.
- Exported `ResolveDefaultShell()` from the terminal package (previously `resolveDefaultShell()`) so the agent service can retrieve the user's default shell.
- Added `use-login-shell` flag support to the CLI and solo mode configuration loaders.

## Result

Claude Code agents now run inside the user's login shell, ensuring their full environment — PATH, tool aliases, version managers, and other shell-configured utilities — is available during task execution. Users whose tools are only reachable via shell initialization files will no longer see "command not found" errors from the agent.

🤖 Generated with Claude Code
