### PR TITLE
fix(frontend): Reuse Audio object for turn-end sound

### DIFF
--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -151,6 +151,7 @@ export const AppShell: ParentComponent = (props) => {
   // Debounced turn-end handler
   const TURN_END_SOUND_COOLDOWN_MS = 60_000
   let lastSoundPlayedAt = 0
+  const turnEndAudio = new Audio('/sounds/benkirb-electronic-doorbell-262895.mp3')
   // Late-bound ref: set once useTabOperations is initialized (after useWorkspaceConnection).
   let isAgentClosing: (agentId: string) => boolean = () => false
   const handleTurnEnd = (agentId: string) => {
@@ -163,9 +164,9 @@ export const AppShell: ParentComponent = (props) => {
     const sound = preferences.turnEndSound()
     if (sound === 'ding-dong') {
       lastSoundPlayedAt = now
-      const audio = new Audio('/sounds/benkirb-electronic-doorbell-262895.mp3')
-      audio.volume = preferences.turnEndSoundVolume() / 100
-      audio.play().catch(() => {})
+      turnEndAudio.currentTime = 0
+      turnEndAudio.volume = preferences.turnEndSoundVolume() / 100
+      turnEndAudio.play().catch(() => {})
     }
   }
 


### PR DESCRIPTION
## Motivation
Each time a turn ended, `handleTurnEnd` instantiated a new `Audio` object to play the notification sound. Rapid or overlapping turn-end events could create multiple simultaneous Audio instances, causing audio distortion or unexpected playback behavior.

## Modifications
- Extract `turnEndAudio` as a single `Audio` instance created once outside `handleTurnEnd`, rather than constructing a new object on every invocation.
- Reset `turnEndAudio.currentTime = 0` before each `.play()` call so the sound restarts cleanly if triggered while still playing.

## Result
The turn-end sound plays correctly without audio distortion even when turn-end events occur in rapid succession. Only one Audio object is allocated for the lifetime of the component, reducing unnecessary object churn.

🤖 Generated with Claude Code
