### PR TITLE
feat(agent): Hide model/effort options for third-party LLM providers

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -47,8 +47,10 @@ type Agent struct {
 	processDone chan struct{} // closed when the process exits
 	waitErr     error         // set before processDone is closed
 
-	preambleDelimiter string   // if set, readOutput skips lines until this delimiter
-	preambleOutput    []string // captured preamble lines (before delimiter)
+	preambleDelimiter  string            // if set, readOutput skips lines until this delimiter
+	preambleMetaPrefix string            // prefix for metadata lines (before delimiter)
+	preambleMeta       map[string]string // parsed key=value metadata from preamble
+	preambleOutput     []string          // captured preamble lines (before delimiter)
 
 	mu      sync.Mutex
 	stopped bool
@@ -67,7 +69,9 @@ type Options struct {
 	ResumeSessionID string        // If set, uses --resume to resume a previous session
 	PermissionMode  string        // Permission mode to set on startup (default, acceptEdits, plan, bypassPermissions)
 	StartupTimeout  time.Duration // Timeout for the startup handshake (default: 30s)
-	LoginShell      string        // If non-empty, wraps claude invocation in this login shell
+	Shell           string        // Default shell path (always set when using shell wrapper)
+	LoginShell      bool          // If true, use interactive+login shell flags
+	HomeDir         string        // User's home directory (for reading Claude Code settings)
 }
 
 // Start spawns a new Claude Code process and begins reading its output.
@@ -88,8 +92,13 @@ func (o Options) startupTimeout() time.Duration {
 func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	args := []string{
-		"--model", opts.Model,
+	// Check Claude Code settings files for third-party LLM provider env vars.
+	// If detected, we omit --model/--effort entirely (simple command).
+	// If not detected, we use a conditional shell command that checks env
+	// vars at runtime (the user may have them in their shell profile).
+	thirdPartyFromSettings := detectThirdPartyProvider(opts.HomeDir, opts.WorkingDir)
+
+	baseArgs := []string{
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
@@ -98,26 +107,25 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		"--setting-sources", "user,project,local",
 	}
 
-	if opts.Effort != "" {
-		args = append(args, "--effort", opts.Effort)
-	}
-
 	if opts.ResumeSessionID != "" {
-		args = append(args, "--resume", opts.ResumeSessionID)
+		baseArgs = append(baseArgs, "--resume", opts.ResumeSessionID)
 	}
 
-	var cmd *exec.Cmd
-	var preambleDelimiter string
-	if opts.LoginShell != "" {
-		cmd, preambleDelimiter = buildShellWrappedCommand(ctx, opts.LoginShell, args, opts.WorkingDir)
-	} else {
-		cmd = exec.CommandContext(ctx, "claude", args...)
-		cmd.Dir = opts.WorkingDir
+	var modelEffortArgs []string
+	if !thirdPartyFromSettings {
+		modelEffortArgs = []string{"--model", opts.Model}
+		if opts.Effort != "" {
+			modelEffortArgs = append(modelEffortArgs, "--effort", opts.Effort)
+		}
 	}
+
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
+		ctx, opts.Shell, opts.LoginShell, baseArgs, modelEffortArgs, opts.WorkingDir,
+	)
 
 	cmd.Env = filterEnv(cmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
 	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1")
-	if opts.LoginShell != "" {
+	if opts.LoginShell {
 		// Set CLAUDECODE=1 so the user's shell rc files can detect they are
 		// being sourced inside Claude Code and skip conflicting aliases.
 		// The inner command unsets it before invoking claude.
@@ -156,17 +164,19 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 
 	var stderrBuf bytes.Buffer
 	a := &Agent{
-		agentID:           opts.AgentID,
-		model:             opts.Model,
-		workingDir:        opts.WorkingDir,
-		cmd:               cmd,
-		stdin:             stdin,
-		ctx:               ctx,
-		cancel:            cancel,
-		stderrBuf:         &stderrBuf,
-		preambleDelimiter: preambleDelimiter,
-		processDone:       make(chan struct{}),
-		pendingControl:    make(map[string]chan<- controlResult),
+		agentID:            opts.AgentID,
+		model:              opts.Model,
+		workingDir:         opts.WorkingDir,
+		cmd:                cmd,
+		stdin:              stdin,
+		ctx:                ctx,
+		cancel:             cancel,
+		stderrBuf:          &stderrBuf,
+		preambleDelimiter:  preambleDelimiter,
+		preambleMetaPrefix: metaPrefix,
+		preambleMeta:       make(map[string]string),
+		processDone:        make(chan struct{}),
+		pendingControl:     make(map[string]chan<- controlResult),
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -362,6 +372,15 @@ func (a *Agent) PreambleOutput() string {
 	return strings.Join(a.preambleOutput, "\n")
 }
 
+// SupportsModelEffort returns whether the agent supports --model/--effort CLI args.
+// When a third-party provider was detected from settings files at startup,
+// the shell wrapper runs without conditional logic and no metadata is emitted,
+// so this returns false. Otherwise, the shell wrapper checks env vars at
+// runtime and reports the result via preamble metadata.
+func (a *Agent) SupportsModelEffort() bool {
+	return a.preambleMeta["supports_model_effort"] == "true"
+}
+
 // ConfirmedPermissionMode returns the permission mode confirmed by the agent
 // during the startup handshake.
 func (a *Agent) ConfirmedPermissionMode() string {
@@ -466,11 +485,21 @@ func (a *Agent) readOutput(scanner *bufio.Scanner, outputFn OutputHandler) {
 	// appears before claude's NDJSON stream.
 	if a.preambleDelimiter != "" {
 		delimBytes := []byte(a.preambleDelimiter)
+		metaPrefixBytes := []byte(a.preambleMetaPrefix)
 		const maxPreambleLines = 50
 		for scanner.Scan() {
 			line := scanner.Bytes()
-			if bytes.Equal(bytes.TrimSpace(line), delimBytes) {
+			trimmed := bytes.TrimSpace(line)
+			if bytes.Equal(trimmed, delimBytes) {
 				break
+			}
+			// Parse metadata lines (e.g. "__LEAPMUX_META_xxx__ key=value").
+			if len(metaPrefixBytes) > 0 && bytes.HasPrefix(trimmed, metaPrefixBytes) {
+				kv := string(trimmed[len(metaPrefixBytes):])
+				if eqIdx := strings.IndexByte(kv, '='); eqIdx >= 0 {
+					a.preambleMeta[kv[:eqIdx]] = kv[eqIdx+1:]
+				}
+				continue
 			}
 			if len(a.preambleOutput) < maxPreambleLines {
 				a.preambleOutput = append(a.preambleOutput, string(line))

--- a/backend/internal/worker/agent/agent_test.go
+++ b/backend/internal/worker/agent/agent_test.go
@@ -572,6 +572,7 @@ func TestAgent_PreambleSkipping(t *testing.T) {
 		cancel:            cancel,
 		stderrBuf:         &stderrBuf,
 		preambleDelimiter: delimiter,
+		preambleMeta:      make(map[string]string),
 		processDone:       make(chan struct{}),
 		pendingControl:    make(map[string]chan<- controlResult),
 	}
@@ -633,11 +634,139 @@ func TestAgent_PreambleSkipping(t *testing.T) {
 	_ = a.Wait()
 }
 
+// TestHelperProcessWithPreambleMeta is a test helper that outputs metadata lines,
+// preamble, delimiter, then echoes stdin.
+func TestHelperProcessWithPreambleMeta(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_PREAMBLE_META") != "1" {
+		return
+	}
+
+	delimiter := os.Getenv("GO_PREAMBLE_DELIMITER")
+	metaPrefix := os.Getenv("GO_META_PREFIX")
+
+	// Output preamble
+	_, _ = fmt.Fprintln(os.Stdout, "shell preamble line")
+	// Output metadata line
+	_, _ = fmt.Fprintln(os.Stdout, metaPrefix+"supports_model_effort=false")
+	// Output delimiter
+	_, _ = fmt.Fprintln(os.Stdout, delimiter)
+
+	// Echo stdin
+	buf := make([]byte, 4096)
+	for {
+		n, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+		_, _ = os.Stdout.Write(buf[:n])
+	}
+	os.Exit(0)
+}
+
+func TestAgent_PreambleMetaParsing(t *testing.T) {
+	ctx := context.Background()
+
+	delimiter := "__LEAPMUX_READY_testmeta__"
+	metaPrefix := "__LEAPMUX_META_testmeta__ "
+
+	var mu sync.Mutex
+	var lines []string
+	outputFn := func(line []byte) {
+		mu.Lock()
+		lines = append(lines, string(line))
+		mu.Unlock()
+	}
+
+	ctx2, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx2, os.Args[0], "-test.run=TestHelperProcessWithPreambleMeta", "--")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS_PREAMBLE_META=1",
+		"GO_PREAMBLE_DELIMITER="+delimiter,
+		"GO_META_PREFIX="+metaPrefix,
+	)
+	cmd.Dir = t.TempDir()
+
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+
+	a := &Agent{
+		agentID:            "meta-test",
+		model:              "test",
+		workingDir:         t.TempDir(),
+		cmd:                cmd,
+		stdin:              stdin,
+		ctx:                ctx2,
+		cancel:             cancel,
+		preambleDelimiter:  delimiter,
+		preambleMetaPrefix: metaPrefix,
+		preambleMeta:       make(map[string]string),
+		processDone:        make(chan struct{}),
+		pendingControl:     make(map[string]chan<- controlResult),
+	}
+
+	require.NoError(t, cmd.Start())
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutput(scanner, outputFn)
+
+	// Send input to trigger post-preamble output.
+	require.NoError(t, a.SendInput("hello"))
+
+	testutil.AssertEventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(lines) > 0
+	}, "expected output after preamble")
+
+	// Verify metadata was parsed.
+	assert.False(t, a.SupportsModelEffort(), "should be false when env var set")
+	assert.Equal(t, "false", a.preambleMeta["supports_model_effort"])
+
+	// Verify preamble output does NOT contain the metadata line.
+	preamble := a.PreambleOutput()
+	assert.Contains(t, preamble, "shell preamble line")
+	assert.NotContains(t, preamble, "supports_model_effort")
+
+	// Verify metadata was NOT forwarded to outputFn.
+	mu.Lock()
+	for _, line := range lines {
+		assert.NotContains(t, line, "supports_model_effort")
+	}
+	mu.Unlock()
+
+	a.Stop()
+	_ = a.Wait()
+}
+
+func TestAgent_SupportsModelEffortDefaultFalse(t *testing.T) {
+	a := &Agent{preambleMeta: make(map[string]string)}
+	assert.False(t, a.SupportsModelEffort())
+}
+
+func TestAgent_SupportsModelEffortTrue(t *testing.T) {
+	a := &Agent{preambleMeta: map[string]string{"supports_model_effort": "true"}}
+	assert.True(t, a.SupportsModelEffort())
+}
+
+func TestAgent_SupportsModelEffortFalseFromShell(t *testing.T) {
+	// Shell detected third-party provider env var at runtime.
+	a := &Agent{preambleMeta: map[string]string{"supports_model_effort": "false"}}
+	assert.False(t, a.SupportsModelEffort())
+}
+
+func TestAgent_SupportsModelEffortFalseNoMeta(t *testing.T) {
+	// Settings detected third-party → no metadata emitted → empty map.
+	a := &Agent{preambleMeta: make(map[string]string)}
+	assert.False(t, a.SupportsModelEffort())
+}
+
 func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	// Verify that LEAPMUX_WORKER=1 is always present in the environment
 	// when starting an agent (both with and without login shell).
 	ctx := context.Background()
-	args := []string{"--model", "test", "--output-format", "stream-json"}
 
 	// Without login shell.
 	cmd := exec.CommandContext(ctx, "echo", "test")
@@ -659,7 +788,7 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	assert.False(t, foundClaudeCode, "CLAUDECODE=1 should NOT be in env without login shell")
 
 	// With login shell - verify the env is set on the command.
-	shellCmd, _ := buildShellWrappedCommand(ctx, "/bin/sh", args, t.TempDir())
+	shellCmd, _, _ := buildShellWrappedCommand(ctx, "/bin/sh", true, []string{"--output-format", "stream-json"}, []string{"--model", "test"}, t.TempDir())
 	shellCmd.Env = filterEnv(shellCmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
 	shellCmd.Env = append(shellCmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1", "CLAUDECODE=1")
 

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -164,6 +164,20 @@ func (m *Manager) StopAndWaitAgent(agentID string) bool {
 	return true
 }
 
+// SupportsModelEffort returns whether the agent supports --model/--effort CLI args.
+// Returns true as default (agent not found = safe fallback for Anthropic API).
+func (m *Manager) SupportsModelEffort(agentID string) bool {
+	m.mu.RLock()
+	a, ok := m.agents[agentID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return true
+	}
+
+	return a.SupportsModelEffort()
+}
+
 // HasAgent returns true if an agent is running with the given agent ID.
 func (m *Manager) HasAgent(agentID string) bool {
 	m.mu.RLock()

--- a/backend/internal/worker/agent/settings.go
+++ b/backend/internal/worker/agent/settings.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// thirdPartyProviderEnvVars are the env vars that indicate a third-party LLM
+// provider is in use, meaning --model/--effort args should not be passed.
+var thirdPartyProviderEnvVars = []string{
+	"CLAUDE_CODE_USE_BEDROCK",
+	"CLAUDE_CODE_USE_FOUNDRY",
+	"CLAUDE_CODE_USE_VERTEX",
+}
+
+// detectThirdPartyProvider checks whether any third-party LLM provider env
+// vars are configured, either in Claude Code settings files or in the process
+// environment. Settings are merged in priority order per Claude Code docs:
+// User (lowest) < Project < Local < Managed (highest).
+func detectThirdPartyProvider(homeDir, workingDir string) bool {
+	// Merge env vars from settings files (lowest to highest priority).
+	merged := make(map[string]string)
+
+	// 1. User settings (lowest priority).
+	mergeSettingsEnv(merged, filepath.Join(homeDir, ".claude", "settings.json"))
+
+	// 2. Project settings.
+	mergeSettingsEnv(merged, filepath.Join(workingDir, ".claude", "settings.json"))
+
+	// 3. Local project settings.
+	mergeSettingsEnv(merged, filepath.Join(workingDir, ".claude", "settings.local.json"))
+
+	// 4. Managed settings (highest priority).
+	if path := managedSettingsPath(); path != "" {
+		mergeSettingsEnv(merged, path)
+	}
+
+	// Check merged settings for third-party provider vars.
+	for _, key := range thirdPartyProviderEnvVars {
+		if v, ok := merged[key]; ok && v != "" {
+			return true
+		}
+	}
+
+	// Also check process environment as fallback (someone may have
+	// exported these vars in their shell profile).
+	for _, key := range thirdPartyProviderEnvVars {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mergeSettingsEnv reads a Claude Code settings JSON file and merges its "env"
+// entries into dst. Later calls override earlier values for the same key.
+func mergeSettingsEnv(dst map[string]string, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // File doesn't exist or unreadable — skip silently.
+	}
+
+	var settings struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return // Malformed JSON — skip silently.
+	}
+
+	for k, v := range settings.Env {
+		dst[k] = v
+	}
+}
+
+// managedSettingsPath returns the OS-specific path for managed settings.
+func managedSettingsPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/ClaudeCode/managed-settings.json"
+	case "linux":
+		return "/etc/claude-code/managed-settings.json"
+	case "windows":
+		return `C:\Program Files\ClaudeCode\managed-settings.json`
+	default:
+		return ""
+	}
+}

--- a/backend/internal/worker/agent/settings_test.go
+++ b/backend/internal/worker/agent/settings_test.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectThirdPartyProvider_NoSettings(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	assert.False(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_UserSettings_Bedrock(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": "true"}
+	}`), 0o644))
+
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_UserSettings_Vertex(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_VERTEX": "1"}
+	}`), 0o644))
+
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_UserSettings_Foundry(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_FOUNDRY": "true"}
+	}`), 0o644))
+
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_ProjectSettings(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(workingDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": "true"}
+	}`), 0o644))
+
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_LocalSettings(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(workingDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_VERTEX": "true"}
+	}`), 0o644))
+
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_EmptyValue(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": ""}
+	}`), 0o644))
+
+	assert.False(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_MalformedJSON(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`not json`), 0o644))
+
+	assert.False(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_NoEnvSection(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{
+		"permissions": {"allow": []}
+	}`), 0o644))
+
+	assert.False(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_ProcessEnv(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_Precedence_HigherOverrides(t *testing.T) {
+	// User sets BEDROCK=true, but local project settings clears it.
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	userDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(userDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": "true"}
+	}`), 0o644))
+
+	localDir := filepath.Join(workingDir, ".claude")
+	require.NoError(t, os.MkdirAll(localDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "settings.local.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": ""}
+	}`), 0o644))
+
+	// Local settings override user settings — empty string means not set.
+	assert.False(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestDetectThirdPartyProvider_Precedence_LowerSetHigherAbsent(t *testing.T) {
+	// User sets BEDROCK=true, project settings don't mention it.
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	userDir := filepath.Join(homeDir, ".claude")
+	require.NoError(t, os.MkdirAll(userDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, "settings.json"), []byte(`{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": "true"}
+	}`), 0o644))
+
+	// Project settings exist but don't mention BEDROCK.
+	projDir := filepath.Join(workingDir, ".claude")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projDir, "settings.json"), []byte(`{
+		"env": {"OTHER_VAR": "value"}
+	}`), 0o644))
+
+	// User setting persists since project doesn't override it.
+	assert.True(t, detectThirdPartyProvider(homeDir, workingDir))
+}
+
+func TestMergeSettingsEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+		"env": {"KEY1": "val1", "KEY2": "val2"}
+	}`), 0o644))
+
+	dst := make(map[string]string)
+	mergeSettingsEnv(dst, path)
+	assert.Equal(t, "val1", dst["KEY1"])
+	assert.Equal(t, "val2", dst["KEY2"])
+}
+
+func TestMergeSettingsEnv_Override(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+		"env": {"KEY1": "new"}
+	}`), 0o644))
+
+	dst := map[string]string{"KEY1": "old", "KEY2": "keep"}
+	mergeSettingsEnv(dst, path)
+	assert.Equal(t, "new", dst["KEY1"])
+	assert.Equal(t, "keep", dst["KEY2"])
+}
+
+func TestMergeSettingsEnv_MissingFile(t *testing.T) {
+	dst := make(map[string]string)
+	mergeSettingsEnv(dst, "/nonexistent/path/settings.json")
+	assert.Empty(t, dst)
+}
+
+func TestManagedSettingsPath(t *testing.T) {
+	path := managedSettingsPath()
+	// Should return a non-empty path on supported OSes.
+	assert.NotEmpty(t, path)
+}

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -10,80 +10,227 @@ import (
 )
 
 // buildShellWrappedCommand constructs an exec.Cmd that launches the claude
-// binary inside the user's login shell with interactive+login flags. This
-// ensures that shell profile scripts (e.g. .zshrc, .bash_profile) are sourced,
-// providing the correct PATH and environment variables.
+// binary inside the user's shell. When interactive is true, the shell is
+// invoked with interactive+login flags (e.g. -i -l -c) so that profile
+// scripts are sourced. When false, only -c is used (no profile sourcing).
 //
-// It returns the command and a unique delimiter string. The caller should scan
-// stdout for this delimiter: everything before it is shell preamble (motd,
-// profile output, etc.), and everything after is NDJSON from claude.
-func buildShellWrappedCommand(ctx context.Context, shellPath string, claudeArgs []string, workingDir string) (*exec.Cmd, string) {
-	delimiter := "__LEAPMUX_READY_" + generateRequestID() + "__"
+// baseArgs are always passed to claude. modelEffortArgs (--model/--effort)
+// are conditionally included only when no third-party LLM provider env vars
+// are detected at shell runtime (CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_FOUNDRY,
+// CLAUDE_CODE_USE_VERTEX). When modelEffortArgs is empty, no conditional
+// logic is emitted (the caller already determined third-party provider use).
+//
+// It returns the command, a unique delimiter string, and a metadata line prefix.
+// The caller should scan stdout for lines starting with metaPrefix to extract
+// key=value metadata, then for the delimiter to detect the end of preamble.
+func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive bool,
+	baseArgs []string, modelEffortArgs []string, workingDir string) (*exec.Cmd, string, string) {
+
+	id := generateRequestID()
+	delimiter := "__LEAPMUX_READY_" + id + "__"
+	metaPrefix := ""
+	if len(modelEffortArgs) > 0 {
+		metaPrefix = "__LEAPMUX_META_" + id + "__ "
+	}
 	shellName := filepath.Base(shellPath)
 
 	var cmdArgs []string
 	switch {
 	case isPwsh(shellName):
-		inner := buildPwshCommand(delimiter, claudeArgs)
-		cmdArgs = []string{"-Login", "-Command", inner}
+		inner := buildPwshCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs)
+		if interactive {
+			cmdArgs = []string{"-Login", "-Command", inner}
+		} else {
+			cmdArgs = []string{"-Command", inner}
+		}
 	case shellName == "tcsh" || shellName == "csh":
-		inner := buildPosixCommand(delimiter, claudeArgs, true)
-		cmdArgs = []string{"-ic", inner}
+		inner := buildPosixCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
+		if interactive {
+			cmdArgs = []string{"-ic", inner}
+		} else {
+			cmdArgs = []string{"-c", inner}
+		}
 	case shellName == "nu":
-		inner := buildNuCommand(delimiter, claudeArgs)
-		cmdArgs = []string{"-i", "-l", "-c", inner}
+		inner := buildNuCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs)
+		if interactive {
+			cmdArgs = []string{"-i", "-l", "-c", inner}
+		} else {
+			cmdArgs = []string{"-c", inner}
+		}
 	default:
 		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
-		inner := buildPosixCommand(delimiter, claudeArgs, true)
-		cmdArgs = []string{"-i", "-l", "-c", inner}
+		inner := buildPosixCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
+		if interactive {
+			cmdArgs = []string{"-i", "-l", "-c", inner}
+		} else {
+			cmdArgs = []string{"-c", inner}
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, shellPath, cmdArgs...)
 	cmd.Dir = workingDir
-	return cmd, delimiter
+	return cmd, delimiter, metaPrefix
 }
 
 // buildPosixCommand builds the inner command string for POSIX-like shells.
 // If useExec is true, the command uses exec to replace the shell process.
-func buildPosixCommand(delimiter string, claudeArgs []string, useExec bool) string {
-	quoted := make([]string, len(claudeArgs))
-	for i, arg := range claudeArgs {
-		quoted[i] = posixQuote(arg)
+// When modelEffortArgs is non-empty, a conditional is emitted to check for
+// third-party provider env vars at runtime.
+func buildPosixCommand(delimiter, metaPrefix string, baseArgs, modelEffortArgs []string, useExec bool) string {
+	quotedBase := make([]string, len(baseArgs))
+	for i, arg := range baseArgs {
+		quotedBase[i] = posixQuote(arg)
 	}
 
+	execPrefix := ""
 	if useExec {
-		return fmt.Sprintf("unset CLAUDECODE && echo '%s' && exec claude %s", delimiter, strings.Join(quoted, " "))
+		execPrefix = "exec "
 	}
-	return fmt.Sprintf("unset CLAUDECODE && echo '%s' && claude %s", delimiter, strings.Join(quoted, " "))
+
+	baseArgsStr := strings.Join(quotedBase, " ")
+
+	// Simple path: no model/effort args (third-party detected from settings).
+	if len(modelEffortArgs) == 0 {
+		return fmt.Sprintf("unset CLAUDECODE && echo '%s' && %sclaude %s",
+			delimiter, execPrefix, baseArgsStr)
+	}
+
+	// Conditional path: check env vars at runtime.
+	quotedME := make([]string, len(modelEffortArgs))
+	for i, arg := range modelEffortArgs {
+		quotedME[i] = posixQuote(arg)
+	}
+	meArgsStr := strings.Join(quotedME, " ")
+
+	return fmt.Sprintf(
+		"unset CLAUDECODE && "+
+			"if "+posixEnvCondition()+"; then "+
+			"echo '%ssupports_model_effort=false' && "+
+			"echo '%s' && %sclaude %s; "+
+			"else "+
+			"echo '%ssupports_model_effort=true' && "+
+			"echo '%s' && %sclaude %s %s; "+
+			"fi",
+		metaPrefix, delimiter, execPrefix, baseArgsStr,
+		metaPrefix, delimiter, execPrefix, baseArgsStr, meArgsStr,
+	)
 }
 
 // buildNuCommand builds the inner command string for Nushell.
-func buildNuCommand(delimiter string, claudeArgs []string) string {
-	quoted := make([]string, len(claudeArgs))
-	for i, arg := range claudeArgs {
-		quoted[i] = posixQuote(arg)
+func buildNuCommand(delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
+	quotedBase := make([]string, len(baseArgs))
+	for i, arg := range baseArgs {
+		quotedBase[i] = posixQuote(arg)
 	}
-	return fmt.Sprintf("hide-env CLAUDECODE; echo '%s'; ^claude %s", delimiter, strings.Join(quoted, " "))
+
+	baseArgsStr := strings.Join(quotedBase, " ")
+
+	// Simple path: no model/effort args.
+	if len(modelEffortArgs) == 0 {
+		return fmt.Sprintf("hide-env CLAUDECODE; echo '%s'; ^claude %s",
+			delimiter, baseArgsStr)
+	}
+
+	// Conditional path.
+	quotedME := make([]string, len(modelEffortArgs))
+	for i, arg := range modelEffortArgs {
+		quotedME[i] = posixQuote(arg)
+	}
+	meArgsStr := strings.Join(quotedME, " ")
+
+	return fmt.Sprintf(
+		"hide-env CLAUDECODE; "+
+			"if ("+nuEnvCondition()+") { "+
+			"echo '%ssupports_model_effort=false'; "+
+			"echo '%s'; ^claude %s "+
+			"} else { "+
+			"echo '%ssupports_model_effort=true'; "+
+			"echo '%s'; ^claude %s %s "+
+			"}",
+		metaPrefix, delimiter, baseArgsStr,
+		metaPrefix, delimiter, baseArgsStr, meArgsStr,
+	)
 }
 
 // buildPwshCommand builds the inner command string for PowerShell.
-func buildPwshCommand(delimiter string, claudeArgs []string) string {
-	quoted := make([]string, len(claudeArgs))
-	for i, arg := range claudeArgs {
-		quoted[i] = pwshQuote(arg)
+func buildPwshCommand(delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
+	quotedBase := make([]string, len(baseArgs))
+	for i, arg := range baseArgs {
+		quotedBase[i] = pwshQuote(arg)
 	}
-	return fmt.Sprintf("Remove-Item Env:CLAUDECODE; Write-Output '%s'; & claude %s", delimiter, strings.Join(quoted, " "))
+
+	baseArgsStr := strings.Join(quotedBase, " ")
+
+	// Simple path: no model/effort args.
+	if len(modelEffortArgs) == 0 {
+		return fmt.Sprintf("Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; "+
+			"Write-Output '%s'; & claude %s",
+			delimiter, baseArgsStr)
+	}
+
+	// Conditional path.
+	quotedME := make([]string, len(modelEffortArgs))
+	for i, arg := range modelEffortArgs {
+		quotedME[i] = pwshQuote(arg)
+	}
+	meArgsStr := strings.Join(quotedME, " ")
+
+	return fmt.Sprintf(
+		"Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; "+
+			"if ("+pwshEnvCondition()+") { "+
+			"Write-Output '%ssupports_model_effort=false'; "+
+			"Write-Output '%s'; & claude %s "+
+			"} else { "+
+			"Write-Output '%ssupports_model_effort=true'; "+
+			"Write-Output '%s'; & claude %s %s "+
+			"}",
+		metaPrefix, delimiter, baseArgsStr,
+		metaPrefix, delimiter, baseArgsStr, meArgsStr,
+	)
+}
+
+// posixEnvCondition builds a POSIX shell conditional expression that checks
+// whether any third-party provider env var is set.
+// e.g. `[ -n "$VAR1" ] || [ -n "$VAR2" ] || [ -n "$VAR3" ]`
+func posixEnvCondition() string {
+	parts := make([]string, len(thirdPartyProviderEnvVars))
+	for i, v := range thirdPartyProviderEnvVars {
+		parts[i] = fmt.Sprintf(`[ -n "$%s" ]`, v)
+	}
+	return strings.Join(parts, " || ")
+}
+
+// nuEnvCondition builds a Nushell conditional expression that checks
+// whether any third-party provider env var is set.
+// e.g. `($env | get -i VAR1 | default ”) != ” or ...`
+func nuEnvCondition() string {
+	parts := make([]string, len(thirdPartyProviderEnvVars))
+	for i, v := range thirdPartyProviderEnvVars {
+		parts[i] = fmt.Sprintf("($env | get -i %s | default '') != ''", v)
+	}
+	return strings.Join(parts, " or ")
+}
+
+// pwshEnvCondition builds a PowerShell conditional expression that checks
+// whether any third-party provider env var is set.
+// e.g. `$env:VAR1 -or $env:VAR2 -or $env:VAR3`
+func pwshEnvCondition() string {
+	parts := make([]string, len(thirdPartyProviderEnvVars))
+	for i, v := range thirdPartyProviderEnvVars {
+		parts[i] = "$env:" + v
+	}
+	return strings.Join(parts, " -or ")
 }
 
 // posixQuote wraps a string in single quotes for POSIX shells.
-// Single quotes within the string are escaped as '\” (end quote, escaped
+// Single quotes within the string are escaped as '\" (end quote, escaped
 // literal quote, start quote).
 func posixQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // pwshQuote wraps a string in single quotes for PowerShell.
-// Single quotes within the string are escaped by doubling them (”).
+// Single quotes within the string are escaped by doubling them (").
 func pwshQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildShellWrappedCommand_Bash(t *testing.T) {
-	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/bash", []string{"--model", "opus"}, "/tmp")
+func TestBuildShellWrappedCommand_Bash_Interactive(t *testing.T) {
+	cmd, delimiter, metaPrefix := buildShellWrappedCommand(
+		context.Background(), "/bin/bash", true,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
 	require.NotEmpty(t, delimiter)
 	assert.True(t, strings.HasPrefix(delimiter, "__LEAPMUX_READY_"))
 	assert.True(t, strings.HasSuffix(delimiter, "__"))
+	require.NotEmpty(t, metaPrefix)
+	assert.True(t, strings.HasPrefix(metaPrefix, "__LEAPMUX_META_"))
 
 	assert.Equal(t, "/bin/bash", cmd.Path)
 	assert.Equal(t, "/tmp", cmd.Dir)
@@ -24,12 +29,32 @@ func TestBuildShellWrappedCommand_Bash(t *testing.T) {
 	assert.Contains(t, cmd.Args[4], "echo '"+delimiter+"'")
 	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
 	assert.Contains(t, cmd.Args[4], "exec claude")
+	assert.Contains(t, cmd.Args[4], "'--output-format'")
 	assert.Contains(t, cmd.Args[4], "'--model'")
 	assert.Contains(t, cmd.Args[4], "'opus'")
+	// Verify conditional structure
+	assert.Contains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
+	assert.Contains(t, cmd.Args[4], "supports_model_effort=false")
+	assert.Contains(t, cmd.Args[4], "supports_model_effort=true")
+	assert.Contains(t, cmd.Args[4], metaPrefix+"supports_model_effort=")
+}
+
+func TestBuildShellWrappedCommand_Bash_NonInteractive(t *testing.T) {
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/bin/bash", false,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
+	assert.Equal(t, "/bin/bash", cmd.Path)
+	require.Len(t, cmd.Args, 3) // bash -c <cmd>
+	assert.Equal(t, "-c", cmd.Args[1])
+	assert.Contains(t, cmd.Args[2], "exec claude")
 }
 
 func TestBuildShellWrappedCommand_Zsh(t *testing.T) {
-	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/zsh", []string{"--verbose"}, "/home/user")
+	cmd, delimiter, _ := buildShellWrappedCommand(
+		context.Background(), "/bin/zsh", true,
+		[]string{"--verbose"}, []string{"--model", "sonnet"}, "/home/user",
+	)
 	assert.Equal(t, "/bin/zsh", cmd.Path)
 	require.Len(t, cmd.Args, 5) // zsh -i -l -c <cmd>
 	assert.Equal(t, "-i", cmd.Args[1])
@@ -41,7 +66,10 @@ func TestBuildShellWrappedCommand_Zsh(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Fish(t *testing.T) {
-	cmd, _ := buildShellWrappedCommand(context.Background(), "/usr/bin/fish", []string{"--model", "sonnet"}, "/tmp")
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/fish", true,
+		[]string{"--model", "sonnet"}, []string{}, "/tmp",
+	)
 	assert.Equal(t, "/usr/bin/fish", cmd.Path)
 	require.Len(t, cmd.Args, 5) // fish -i -l -c <cmd>
 	assert.Equal(t, "-i", cmd.Args[1])
@@ -49,10 +77,15 @@ func TestBuildShellWrappedCommand_Fish(t *testing.T) {
 	assert.Equal(t, "-c", cmd.Args[3])
 	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
 	assert.Contains(t, cmd.Args[4], "exec claude")
+	// No conditional (empty modelEffortArgs)
+	assert.NotContains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
 }
 
-func TestBuildShellWrappedCommand_Tcsh(t *testing.T) {
-	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/bin/tcsh", []string{"--model", "opus"}, "/tmp")
+func TestBuildShellWrappedCommand_Tcsh_Interactive(t *testing.T) {
+	cmd, delimiter, _ := buildShellWrappedCommand(
+		context.Background(), "/bin/tcsh", true,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
 	assert.Equal(t, "/bin/tcsh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // tcsh -ic <cmd>
 	assert.Equal(t, "-ic", cmd.Args[1])
@@ -61,8 +94,21 @@ func TestBuildShellWrappedCommand_Tcsh(t *testing.T) {
 	assert.Contains(t, cmd.Args[2], "exec claude")
 }
 
+func TestBuildShellWrappedCommand_Tcsh_NonInteractive(t *testing.T) {
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/bin/tcsh", false,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
+	assert.Equal(t, "/bin/tcsh", cmd.Path)
+	require.Len(t, cmd.Args, 3) // tcsh -c <cmd>
+	assert.Equal(t, "-c", cmd.Args[1])
+}
+
 func TestBuildShellWrappedCommand_Csh(t *testing.T) {
-	cmd, _ := buildShellWrappedCommand(context.Background(), "/bin/csh", []string{"--verbose"}, "/tmp")
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/bin/csh", true,
+		[]string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
+	)
 	assert.Equal(t, "/bin/csh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // csh -ic <cmd>
 	assert.Equal(t, "-ic", cmd.Args[1])
@@ -70,8 +116,11 @@ func TestBuildShellWrappedCommand_Csh(t *testing.T) {
 	assert.Contains(t, cmd.Args[2], "exec claude")
 }
 
-func TestBuildShellWrappedCommand_Nu(t *testing.T) {
-	cmd, delimiter := buildShellWrappedCommand(context.Background(), "/usr/bin/nu", []string{"--model", "opus"}, "/tmp")
+func TestBuildShellWrappedCommand_Nu_Interactive(t *testing.T) {
+	cmd, delimiter, _ := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/nu", true,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
 	assert.Equal(t, "/usr/bin/nu", cmd.Path)
 	require.Len(t, cmd.Args, 5) // nu -i -l -c <cmd>
 	assert.Equal(t, "-i", cmd.Args[1])
@@ -81,12 +130,26 @@ func TestBuildShellWrappedCommand_Nu(t *testing.T) {
 	assert.Contains(t, cmd.Args[4], "hide-env CLAUDECODE")
 	assert.Contains(t, cmd.Args[4], "^claude")
 	assert.NotContains(t, cmd.Args[4], "exec")
+	assert.Contains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
 }
 
-func TestBuildShellWrappedCommand_Pwsh(t *testing.T) {
+func TestBuildShellWrappedCommand_Nu_NonInteractive(t *testing.T) {
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/nu", false,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
+	assert.Equal(t, "/usr/bin/nu", cmd.Path)
+	require.Len(t, cmd.Args, 3) // nu -c <cmd>
+	assert.Equal(t, "-c", cmd.Args[1])
+}
+
+func TestBuildShellWrappedCommand_Pwsh_Interactive(t *testing.T) {
 	for _, shell := range []string{"/usr/bin/pwsh", "/usr/bin/powershell", "/usr/bin/pwsh-preview", "/usr/bin/powershell-preview"} {
 		t.Run(shell, func(t *testing.T) {
-			cmd, delimiter := buildShellWrappedCommand(context.Background(), shell, []string{"--model", "opus"}, "/tmp")
+			cmd, delimiter, _ := buildShellWrappedCommand(
+				context.Background(), shell, true,
+				[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+			)
 			assert.Equal(t, shell, cmd.Path)
 			require.Len(t, cmd.Args, 4) // pwsh -Login -Command <cmd>
 			assert.Equal(t, "-Login", cmd.Args[1])
@@ -95,12 +158,26 @@ func TestBuildShellWrappedCommand_Pwsh(t *testing.T) {
 			assert.Contains(t, cmd.Args[3], "Remove-Item Env:CLAUDECODE")
 			assert.Contains(t, cmd.Args[3], "& claude")
 			assert.NotContains(t, cmd.Args[3], "exec")
+			assert.Contains(t, cmd.Args[3], "CLAUDE_CODE_USE_BEDROCK")
 		})
 	}
 }
 
+func TestBuildShellWrappedCommand_Pwsh_NonInteractive(t *testing.T) {
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/pwsh", false,
+		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+	)
+	assert.Equal(t, "/usr/bin/pwsh", cmd.Path)
+	require.Len(t, cmd.Args, 3) // pwsh -Command <cmd>
+	assert.Equal(t, "-Command", cmd.Args[1])
+}
+
 func TestBuildShellWrappedCommand_UnknownShell(t *testing.T) {
-	cmd, _ := buildShellWrappedCommand(context.Background(), "/usr/bin/xonsh", []string{"--verbose"}, "/tmp")
+	cmd, _, _ := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/xonsh", true,
+		[]string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
+	)
 	assert.Equal(t, "/usr/bin/xonsh", cmd.Path)
 	require.Len(t, cmd.Args, 5) // defaults to -i -l -c
 	assert.Equal(t, "-i", cmd.Args[1])
@@ -108,6 +185,54 @@ func TestBuildShellWrappedCommand_UnknownShell(t *testing.T) {
 	assert.Equal(t, "-c", cmd.Args[3])
 	assert.Contains(t, cmd.Args[4], "unset CLAUDECODE")
 	assert.Contains(t, cmd.Args[4], "exec claude")
+}
+
+func TestBuildShellWrappedCommand_NoModelEffort(t *testing.T) {
+	// When third-party provider was detected from settings, modelEffortArgs is nil.
+	// No conditional logic should be generated.
+	cmd, _, metaPrefix := buildShellWrappedCommand(
+		context.Background(), "/bin/bash", true,
+		[]string{"--output-format", "stream-json"}, nil, "/tmp",
+	)
+	assert.Empty(t, metaPrefix)
+	assert.Contains(t, cmd.Args[4], "'--output-format'")
+	assert.NotContains(t, cmd.Args[4], "'--model'")
+	assert.NotContains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
+	assert.NotContains(t, cmd.Args[4], "supports_model_effort")
+}
+
+func TestBuildShellWrappedCommand_NoModelEffort_Nu(t *testing.T) {
+	cmd, _, metaPrefix := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/nu", true,
+		[]string{"--output-format", "stream-json"}, nil, "/tmp",
+	)
+	assert.Empty(t, metaPrefix)
+	assert.NotContains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
+}
+
+func TestBuildShellWrappedCommand_NoModelEffort_Pwsh(t *testing.T) {
+	cmd, _, metaPrefix := buildShellWrappedCommand(
+		context.Background(), "/usr/bin/pwsh", true,
+		[]string{"--output-format", "stream-json"}, nil, "/tmp",
+	)
+	assert.Empty(t, metaPrefix)
+	assert.NotContains(t, cmd.Args[3], "CLAUDE_CODE_USE_BEDROCK")
+}
+
+func TestBuildShellWrappedCommand_ModelEffortInElseBranch(t *testing.T) {
+	inner := buildPosixCommand("__DELIM__", "__META__ ", []string{"--output-format", "stream-json"}, []string{"--model", "opus", "--effort", "high"}, true)
+
+	// The else branch should contain model/effort args
+	parts := strings.SplitN(inner, "else", 2)
+	require.Len(t, parts, 2, "expected if/else structure")
+	assert.Contains(t, parts[1], "'--model'")
+	assert.Contains(t, parts[1], "'--effort'")
+	assert.Contains(t, parts[1], "'opus'")
+	assert.Contains(t, parts[1], "'high'")
+
+	// The if branch (third-party provider) should NOT contain model/effort args
+	assert.NotContains(t, parts[0], "'--model'")
+	assert.NotContains(t, parts[0], "'--effort'")
 }
 
 func TestPosixQuote(t *testing.T) {

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -24,13 +24,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// loginShell returns the user's default login shell path if UseLoginShell is
-// enabled, or an empty string otherwise.
-func (svc *Context) loginShell() string {
-	if !svc.UseLoginShell {
-		return ""
-	}
+// agentShell returns the resolved default shell path for agent options.
+func (svc *Context) agentShell() string {
 	return terminal.ResolveDefaultShell()
+}
+
+// agentLoginShell returns whether the agent should use interactive+login shell flags.
+func (svc *Context) agentLoginShell() bool {
+	return svc.UseLoginShell
 }
 
 // registerAgentHandlers registers all agent-related inner RPC handlers.
@@ -95,7 +96,9 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			WorkingDir:      workingDir,
 			ResumeSessionID: r.GetAgentSessionId(),
 			StartupTimeout:  svc.agentStartupTimeout(),
-			LoginShell:      svc.loginShell(),
+			Shell:           svc.agentShell(),
+			LoginShell:      svc.agentLoginShell(),
+			HomeDir:         svc.HomeDir,
 		}
 
 		outputFn := agentOutputFn(svc.Output, agentID, r.GetWorkspaceId(), workingDir)
@@ -136,7 +139,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		}
 
 		sendProtoResponse(sender, &leapmuxv1.OpenAgentResponse{
-			Agent: agentToProto(&dbAgent, permissionMode, svc.WorkerID, true, gitutil.GetGitStatus(dbAgent.WorkingDir)),
+			Agent: agentToProto(&dbAgent, permissionMode, svc.WorkerID, true, gitutil.GetGitStatus(dbAgent.WorkingDir), svc.Agents.SupportsModelEffort(agentID)),
 		})
 	})
 
@@ -329,7 +332,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			if accessibleWsIDs != nil && !accessibleWsIDs[agents[i].WorkspaceID] {
 				continue
 			}
-			protoAgents = append(protoAgents, agentToProto(&agents[i], agents[i].PermissionMode, svc.WorkerID, svc.Agents.HasAgent(agents[i].ID), gitStatuses[i]))
+			protoAgents = append(protoAgents, agentToProto(&agents[i], agents[i].PermissionMode, svc.WorkerID, svc.Agents.HasAgent(agents[i].ID), gitStatuses[i], svc.Agents.SupportsModelEffort(agents[i].ID)))
 		}
 
 		sendProtoResponse(sender, &leapmuxv1.ListAgentsResponse{
@@ -513,7 +516,9 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 				ResumeSessionID: dbAgent.AgentSessionID,
 				PermissionMode:  dbAgent.PermissionMode,
 				StartupTimeout:  svc.agentStartupTimeout(),
-				LoginShell:      svc.loginShell(),
+				Shell:           svc.agentShell(),
+				LoginShell:      svc.agentLoginShell(),
+				HomeDir:         svc.HomeDir,
 			}
 
 			outputFn := agentOutputFn(svc.Output, agentID, dbAgent.WorkspaceID, dbAgent.WorkingDir)
@@ -685,14 +690,15 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 					status = leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE
 				}
 				sc := &leapmuxv1.AgentStatusChange{
-					AgentId:        agentID,
-					Status:         status,
-					AgentSessionId: dbAgent.AgentSessionID,
-					WorkerOnline:   true,
-					PermissionMode: dbAgent.PermissionMode,
-					Model:          modelOrDefault(dbAgent.Model),
-					Effort:         dbAgent.Effort,
-					GitStatus:      gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+					AgentId:             agentID,
+					Status:              status,
+					AgentSessionId:      dbAgent.AgentSessionID,
+					WorkerOnline:        true,
+					PermissionMode:      dbAgent.PermissionMode,
+					Model:               modelOrDefault(dbAgent.Model),
+					Effort:              dbAgent.Effort,
+					GitStatus:           gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+					SupportsModelEffort: svc.Agents.SupportsModelEffort(agentID),
 				}
 				broadcastWatchEvent(sender, &leapmuxv1.WatchEventsResponse{
 					Event: &leapmuxv1.WatchEventsResponse_AgentEvent{
@@ -768,25 +774,26 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 }
 
 // agentToProto converts a DB Agent to a proto AgentInfo.
-func agentToProto(a *db.Agent, permissionMode, workerID string, isRunning bool, gs *gitutil.GitStatus) *leapmuxv1.AgentInfo {
+func agentToProto(a *db.Agent, permissionMode, workerID string, isRunning bool, gs *gitutil.GitStatus, supportsModelEffort bool) *leapmuxv1.AgentInfo {
 	status := leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE
 	if isRunning {
 		status = leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE
 	}
 	info := &leapmuxv1.AgentInfo{
-		Id:             a.ID,
-		WorkspaceId:    a.WorkspaceID,
-		Title:          a.Title,
-		Model:          modelOrDefault(a.Model),
-		Status:         status,
-		WorkingDir:     a.WorkingDir,
-		PermissionMode: permissionMode,
-		Effort:         a.Effort,
-		AgentSessionId: a.AgentSessionID,
-		HomeDir:        a.HomeDir,
-		WorkerId:       workerID,
-		CreatedAt:      timefmt.Format(a.CreatedAt),
-		GitStatus:      gitStatusToProto(gs),
+		Id:                  a.ID,
+		WorkspaceId:         a.WorkspaceID,
+		Title:               a.Title,
+		Model:               modelOrDefault(a.Model),
+		Status:              status,
+		WorkingDir:          a.WorkingDir,
+		PermissionMode:      permissionMode,
+		Effort:              a.Effort,
+		AgentSessionId:      a.AgentSessionID,
+		HomeDir:             a.HomeDir,
+		WorkerId:            workerID,
+		CreatedAt:           timefmt.Format(a.CreatedAt),
+		GitStatus:           gitStatusToProto(gs),
+		SupportsModelEffort: supportsModelEffort,
 	}
 
 	if a.ClosedAt.Valid {
@@ -844,7 +851,9 @@ func (svc *Context) handleClearContext(agentID string) {
 		WorkingDir:     dbAgent.WorkingDir,
 		PermissionMode: dbAgent.PermissionMode,
 		StartupTimeout: svc.agentStartupTimeout(),
-		LoginShell:     svc.loginShell(),
+		Shell:          svc.agentShell(),
+		LoginShell:     svc.agentLoginShell(),
+		HomeDir:        svc.HomeDir,
 	}, outputFn); err != nil {
 		slog.Error("clear context: failed to restart agent", "agent_id", agentID, "error", err)
 		_ = svc.Queries.UpdateAgentSessionID(bgCtx(), db.UpdateAgentSessionIDParams{
@@ -888,7 +897,9 @@ func (svc *Context) ensureAgentRunning(agentID string) error {
 		ResumeSessionID: dbAgent.AgentSessionID,
 		PermissionMode:  dbAgent.PermissionMode,
 		StartupTimeout:  svc.agentStartupTimeout(),
-		LoginShell:      svc.loginShell(),
+		Shell:           svc.agentShell(),
+		LoginShell:      svc.agentLoginShell(),
+		HomeDir:         svc.HomeDir,
 	}, outputFn); err != nil {
 		slog.Error("ensureAgentRunning: failed to start agent", "agent_id", agentID, "error", err)
 		return err
@@ -949,14 +960,15 @@ func (svc *Context) setAgentPermissionMode(agentID, mode string) {
 		AgentId: agentID,
 		Event: &leapmuxv1.AgentEvent_StatusChange{
 			StatusChange: &leapmuxv1.AgentStatusChange{
-				AgentId:        agentID,
-				Status:         leapmuxv1.AgentStatus_AGENT_STATUS_UNSPECIFIED,
-				AgentSessionId: dbAgent.AgentSessionID,
-				WorkerOnline:   true,
-				PermissionMode: mode,
-				Model:          modelOrDefault(dbAgent.Model),
-				Effort:         dbAgent.Effort,
-				GitStatus:      gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+				AgentId:             agentID,
+				Status:              leapmuxv1.AgentStatus_AGENT_STATUS_UNSPECIFIED,
+				AgentSessionId:      dbAgent.AgentSessionID,
+				WorkerOnline:        true,
+				PermissionMode:      mode,
+				Model:               modelOrDefault(dbAgent.Model),
+				Effort:              dbAgent.Effort,
+				GitStatus:           gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+				SupportsModelEffort: svc.Agents.SupportsModelEffort(agentID),
 			},
 		},
 	})
@@ -1142,7 +1154,9 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 		WorkingDir:     dbAgent.WorkingDir,
 		PermissionMode: targetMode,
 		StartupTimeout: svc.agentStartupTimeout(),
-		LoginShell:     svc.loginShell(),
+		Shell:          svc.agentShell(),
+		LoginShell:     svc.agentLoginShell(),
+		HomeDir:        svc.HomeDir,
 	}, outputFn); err != nil {
 		slog.Error("plan exec: failed to restart agent", "agent_id", agentID, "error", err)
 		_ = svc.Queries.UpdateAgentSessionID(bgCtx(), db.UpdateAgentSessionIDParams{

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
 )
@@ -71,6 +72,7 @@ type notifThreadRef struct {
 type OutputHandler struct {
 	queries *db.Queries
 	watcher *WatcherManager
+	agents  *agent.Manager
 
 	// Per-agent state (concurrent access from agent goroutines).
 	notifMu         sync.Map // agentID -> *sync.Mutex
@@ -92,10 +94,11 @@ type contextUsageSnapshot struct {
 }
 
 // NewOutputHandler creates a new OutputHandler.
-func NewOutputHandler(queries *db.Queries, watcher *WatcherManager) *OutputHandler {
+func NewOutputHandler(queries *db.Queries, watcher *WatcherManager, agents *agent.Manager) *OutputHandler {
 	return &OutputHandler{
 		queries: queries,
 		watcher: watcher,
+		agents:  agents,
 	}
 }
 
@@ -291,14 +294,15 @@ func (h *OutputHandler) handleSystemInit(agentID string, content []byte) {
 	// Always broadcast ACTIVE so the frontend learns the agent is running
 	// (even on resume where the session ID hasn't changed).
 	sc := &leapmuxv1.AgentStatusChange{
-		AgentId:        agentID,
-		Status:         leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
-		AgentSessionId: initMsg.SessionID,
-		WorkerOnline:   true,
-		PermissionMode: existingAgent.PermissionMode,
-		Model:          existingAgent.Model,
-		Effort:         existingAgent.Effort,
-		GitStatus:      gitStatusToProto(gitutil.GetGitStatus(existingAgent.WorkingDir)),
+		AgentId:             agentID,
+		Status:              leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
+		AgentSessionId:      initMsg.SessionID,
+		WorkerOnline:        true,
+		PermissionMode:      existingAgent.PermissionMode,
+		Model:               existingAgent.Model,
+		Effort:              existingAgent.Effort,
+		GitStatus:           gitStatusToProto(gitutil.GetGitStatus(existingAgent.WorkingDir)),
+		SupportsModelEffort: h.agents.SupportsModelEffort(agentID),
 	}
 	h.watcher.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
@@ -404,14 +408,15 @@ func (h *OutputHandler) handleControlResponse(agentID string, content []byte) {
 					AgentId: agentID,
 					Event: &leapmuxv1.AgentEvent_StatusChange{
 						StatusChange: &leapmuxv1.AgentStatusChange{
-							AgentId:        agentID,
-							Status:         leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
-							AgentSessionId: dbAgent.AgentSessionID,
-							WorkerOnline:   true,
-							PermissionMode: newMode,
-							Model:          dbAgent.Model,
-							Effort:         dbAgent.Effort,
-							GitStatus:      gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+							AgentId:             agentID,
+							Status:              leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
+							AgentSessionId:      dbAgent.AgentSessionID,
+							WorkerOnline:        true,
+							PermissionMode:      newMode,
+							Model:               dbAgent.Model,
+							Effort:              dbAgent.Effort,
+							GitStatus:           gitStatusToProto(gitutil.GetGitStatus(dbAgent.WorkingDir)),
+							SupportsModelEffort: h.agents.SupportsModelEffort(agentID),
 						},
 					},
 				})

--- a/backend/internal/worker/service/plan_mode.go
+++ b/backend/internal/worker/service/plan_mode.go
@@ -224,13 +224,14 @@ func (h *OutputHandler) detectPlanModeFromToolResult(agentID string, content []b
 			// Broadcast statusChange so frontends update their permission mode display.
 			if fetchErr == nil {
 				sc := &leapmuxv1.AgentStatusChange{
-					AgentId:        agentID,
-					Status:         leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
-					AgentSessionId: dbAgent.AgentSessionID,
-					WorkerOnline:   true,
-					PermissionMode: targetMode,
-					Model:          dbAgent.Model,
-					Effort:         dbAgent.Effort,
+					AgentId:             agentID,
+					Status:              leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE,
+					AgentSessionId:      dbAgent.AgentSessionID,
+					WorkerOnline:        true,
+					PermissionMode:      targetMode,
+					Model:               dbAgent.Model,
+					Effort:              dbAgent.Effort,
+					SupportsModelEffort: h.agents.SupportsModelEffort(agentID),
 				}
 				h.watcher.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
 					AgentId: agentID,

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -57,7 +57,7 @@ func (svc *Context) agentStartupTimeout() time.Duration {
 func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manager, homeDir, dataDir string) *Context {
 	queries := db.New(sqlDB)
 	watchers := NewWatcherManager()
-	output := NewOutputHandler(queries, watchers)
+	output := NewOutputHandler(queries, watchers, agents)
 	return &Context{
 		DB:        sqlDB,
 		Queries:   queries,

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -341,6 +341,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                         model={props.agent?.model}
                         effort={props.agent?.effort}
                         permissionMode={props.agent?.permissionMode}
+                        supportsModelEffort={props.agent?.supportsModelEffort}
                         onModelChange={props.onModelChange}
                         onEffortChange={props.onEffortChange}
                         onPermissionModeChange={props.onPermissionModeChange}

--- a/frontend/src/components/chat/EditorSettingsDropdown.tsx
+++ b/frontend/src/components/chat/EditorSettingsDropdown.tsx
@@ -31,6 +31,7 @@ export interface EditorSettingsDropdownProps {
   model?: string
   effort?: string
   permissionMode?: string
+  supportsModelEffort?: boolean
   onModelChange?: (model: string) => void
   onEffortChange?: (effort: string) => void
   onPermissionModeChange?: (mode: PermissionMode) => void
@@ -95,8 +96,10 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
           disabled={props.disabled}
           {...triggerProps}
         >
-          {modelLabel(currentModel())}
-          {effortIcon()}
+          <Show when={props.supportsModelEffort !== false}>
+            {modelLabel(currentModel())}
+            {effortIcon()}
+          </Show>
           {modeLabel(currentMode())}
           <Show when={props.settingsLoading} fallback={<Icon icon={ChevronDown} size="xs" />}>
             <Icon icon={LoaderCircle} size="xs" class={spinner} data-testid="settings-loading-spinner" />
@@ -107,28 +110,30 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
       class={styles.settingsMenu}
       data-testid="agent-settings-menu"
     >
-      <RadioGroup
-        label="Effort"
-        items={EFFORTS}
-        testIdPrefix="effort"
-        name={`${menuId}-effort`}
-        current={currentEffort()}
-        onChange={(v) => {
-          props.onEffortChange?.(v)
-          settingsPopoverEl?.hidePopover()
-        }}
-      />
-      <RadioGroup
-        label="Model"
-        items={MODELS}
-        testIdPrefix="model"
-        name={`${menuId}-model`}
-        current={currentModel()}
-        onChange={(v) => {
-          props.onModelChange?.(v)
-          settingsPopoverEl?.hidePopover()
-        }}
-      />
+      <Show when={props.supportsModelEffort !== false}>
+        <RadioGroup
+          label="Effort"
+          items={EFFORTS}
+          testIdPrefix="effort"
+          name={`${menuId}-effort`}
+          current={currentEffort()}
+          onChange={(v) => {
+            props.onEffortChange?.(v)
+            settingsPopoverEl?.hidePopover()
+          }}
+        />
+        <RadioGroup
+          label="Model"
+          items={MODELS}
+          testIdPrefix="model"
+          name={`${menuId}-model`}
+          current={currentModel()}
+          onChange={(v) => {
+            props.onModelChange?.(v)
+            settingsPopoverEl?.hidePopover()
+          }}
+        />
+      </Show>
       <RadioGroup
         label="Permission Mode"
         items={PERMISSION_MODES}

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -160,6 +160,8 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     const agent = props.agentStore.state.agents.find(a => a.id === agentId)
     if (!agent)
       return
+    if (agent.supportsModelEffort === false)
+      return
     const previous = agent[field] || (field === 'model' ? DEFAULT_MODEL : DEFAULT_EFFORT)
     // Optimistic update
     props.agentStore.updateAgent(agentId, { [field]: value })

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -222,6 +222,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
                 ...(sc.effort ? { effort: sc.effort } : {}),
               }),
           gitStatus: sc.gitStatus,
+          supportsModelEffort: sc.supportsModelEffort,
         })
         if (sc.gitStatus) {
           const gs = sc.gitStatus

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -85,6 +85,7 @@ message AgentInfo {
   string working_dir = 13;      // Working directory on the worker
   AgentGitStatus git_status = 14; // Git status for the agent's working directory
   string home_dir = 15;         // Worker's home directory for tilde path display
+  bool supports_model_effort = 16; // Whether the agent supports --model/--effort CLI args
 }
 
 // --- Agent Messaging ---
@@ -129,6 +130,7 @@ message AgentStatusChange {
   string model = 6;
   string effort = 7;
   AgentGitStatus git_status = 8; // Git status for the agent's working directory
+  bool supports_model_effort = 9; // Whether the agent supports --model/--effort CLI args
 }
 
 // AgentGitStatus holds git repository status for an agent's working directory.


### PR DESCRIPTION
## Motivation

When users configure Claude Code to use a third-party LLM provider (AWS Bedrock, Azure Foundry, or Google Vertex), passing `--model` and `--effort` flags to the `claude` CLI causes errors because those providers manage model selection through their own configuration. Previously, the agent always passed these flags regardless of provider configuration, breaking setups that relied on third-party providers.

## Modifications

- Added `settings.go` with a `detectThirdPartyProvider()` function that reads Claude Code settings files (`settings.json`, `settings.local.json`, and managed settings) in priority order to check for `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_FOUNDRY`, or `CLAUDE_CODE_USE_VERTEX` environment variable declarations, with cross-platform managed settings paths for macOS, Linux, and Windows.
- The agent now generates shell-wrapped commands that conditionally include `--model`/`--effort` flags at runtime based on whether third-party provider environment variables are set. This supports bash/zsh, PowerShell, Nushell, tcsh/csh, and fish shells.
- Added a `__LEAPMUX_META_` prefix protocol to parse metadata from shell preamble output; agents report their `supports_model_effort` status at startup via this mechanism.
- Replaced the `LoginShell` string field in the shell configuration with separate `Shell` (binary path), `LoginShell` (boolean), and `HomeDir` fields to support provider detection against the user's home directory.
- Added `SupportsModelEffort(agentID string)` to the agent `Manager` interface.
- Added `supports_model_effort` field to `AgentInfo` (field 16) and `AgentStatusChange` (field 9) protobuf messages.
- Propagated the `supports_model_effort` flag through the service layer into `OutputHandler` and RPC responses.
- The frontend hides model and effort controls in the editor settings dropdown when `supportsModelEffort` is `false`.

## Result

Users running Claude Code against AWS Bedrock, Azure Foundry, or Google Vertex no longer see CLI errors caused by unsupported `--model`/`--effort` flags. The model and effort settings controls are hidden from the UI when the connected agent does not support them, preventing confusion. Detection is based on the actual runtime environment, so users can switch providers by updating their Claude Code settings without reconfiguring the agent.

🤖 Generated with Claude Code
