### PR TITLE
fix(desktop): Improve desktop UX and fix backend warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 
 # Build output
 /backend/bin/
+/backend/leapmux
 /desktop/bin/
+/desktop/leapmux-desktop
 /desktop/build/appicon.png
 /desktop/build/windows/icon.ico
 .task/

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,10 @@
 *~
 
 # Build output
-/backend/leapmux
-/desktop/build/bin/
+/backend/bin/
+/desktop/bin/
 /desktop/build/appicon.png
 /desktop/build/windows/icon.ico
-/desktop/leapmux-desktop
 .task/
 
 # Generated code

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ task build-frontend   # Build frontend assets
 task build-desktop    # Build desktop app for current platform (requires wails)
 ```
 
-The `leapmux` binary is output to `backend/leapmux`. The desktop app is output to `desktop/build/bin/`. On macOS, a `.dmg` installer is also created.
+The `leapmux` binary is output to `backend/bin/`. The desktop app is output to `desktop/bin/`. On macOS, a `.dmg` installer is also created.
 
 `task build` skips the desktop build automatically if `wails` is not installed.
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -448,7 +448,7 @@ tasks:
       - wails build -tags devtools -o leapmux-desktop -platform linux/amd64 -ldflags "-X main.version={{.VERSION}}"
       - cp build/linux/leapmux-desktop.desktop build/bin/
       - cp build/appicon.png build/bin/leapmux-desktop.png
-      - cp ../icons/leapmux-icon.svg build/bin/leapmux-desktop.svg
+      - cp ../icons/leapmux-icon-light.svg build/bin/leapmux-desktop.svg
 
   build-desktop-linux-arm64:
     desc: Build LeapMux desktop app for Linux (arm64)
@@ -470,7 +470,7 @@ tasks:
       - wails build -tags devtools -o leapmux-desktop -platform linux/arm64 -ldflags "-X main.version={{.VERSION}}"
       - cp build/linux/leapmux-desktop.desktop build/bin/
       - cp build/appicon.png build/bin/leapmux-desktop.png
-      - cp ../icons/leapmux-icon.svg build/bin/leapmux-desktop.svg
+      - cp ../icons/leapmux-icon-light.svg build/bin/leapmux-desktop.svg
 
   build-desktop-windows:
     desc: Build LeapMux desktop app for Windows

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -515,9 +515,9 @@ tasks:
   clean:
     desc: Remove all build artifacts and generated code
     cmds:
-      - rm -rf backend/bin/
+      - rm -rf backend/bin/ backend/leapmux
       - rm -rf backend/generated/ backend/*/generated/ backend/*/*/generated/
       - rm -rf frontend/.output/ frontend/.vinxi/ frontend/node_modules/
       - rm -rf frontend/src/spinners/
-      - rm -rf desktop/bin/ desktop/build/appicon.png desktop/build/windows/icon.ico
+      - rm -rf desktop/bin/ desktop/leapmux-desktop desktop/build/appicon.png desktop/build/windows/icon.ico
       - rm -rf .task/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -145,9 +145,10 @@ tasks:
       - backend/worker/**/*
       - "backend/**/*.go"
     generates:
-      - backend/leapmux
+      - backend/bin/leapmux
     cmds:
-      - go build -ldflags "-X main.version={{.VERSION}}" -o ./leapmux ./cmd/leapmux
+      - mkdir -p bin
+      - go build -ldflags "-X main.version={{.VERSION}}" -o ./bin/leapmux ./cmd/leapmux
 
   generate-web-icons:
     desc: Generate web favicon and PNG icons from SVG sources
@@ -406,9 +407,10 @@ tasks:
       - backend/go.sum
       - "backend/**/*.go"
     generates:
-      - desktop/build/bin/LeapMux.app/Contents/MacOS/LeapMux
+      - desktop/bin/LeapMux.app/Contents/MacOS/LeapMux
     cmds:
       - wails build -tags devtools -platform darwin/universal -ldflags "-X main.version={{.VERSION}}"
+      - rm -rf bin && mv build/bin bin
       - task: package-desktop-dmg
 
   package-desktop-dmg:
@@ -416,17 +418,17 @@ tasks:
     platforms: [darwin]
     deps: [prepare-frontend]
     sources:
-      - desktop/build/bin/LeapMux.app/Contents/MacOS/LeapMux
+      - desktop/bin/LeapMux.app/Contents/MacOS/LeapMux
       - desktop/scripts/create-dmg.sh
     generates:
-      - desktop/build/bin/LeapMux-{{.VERSION}}.dmg
+      - desktop/bin/LeapMux-{{.VERSION}}.dmg
     cmds:
       - cd frontend && npm rebuild macos-alias 2>/dev/null || true
       - >-
         desktop/scripts/create-dmg.sh
         "{{.VERSION}}"
-        desktop/build/bin/LeapMux.app
-        desktop/build/bin/LeapMux-{{.VERSION}}.dmg
+        desktop/bin/LeapMux.app
+        desktop/bin/LeapMux-{{.VERSION}}.dmg
 
   build-desktop-linux-amd64:
     desc: Build LeapMux desktop app for Linux (amd64)
@@ -443,12 +445,13 @@ tasks:
       - backend/go.sum
       - "backend/**/*.go"
     generates:
-      - desktop/build/bin/leapmux-desktop
+      - desktop/bin/leapmux-desktop
     cmds:
       - wails build -tags devtools -o leapmux-desktop -platform linux/amd64 -ldflags "-X main.version={{.VERSION}}"
-      - cp build/linux/leapmux-desktop.desktop build/bin/
-      - cp build/appicon.png build/bin/leapmux-desktop.png
-      - cp ../icons/leapmux-icon-light.svg build/bin/leapmux-desktop.svg
+      - rm -rf bin && mv build/bin bin
+      - cp build/linux/leapmux-desktop.desktop bin/
+      - cp build/appicon.png bin/leapmux-desktop.png
+      - cp ../icons/leapmux-icon-light.svg bin/leapmux-desktop.svg
 
   build-desktop-linux-arm64:
     desc: Build LeapMux desktop app for Linux (arm64)
@@ -465,12 +468,13 @@ tasks:
       - backend/go.sum
       - "backend/**/*.go"
     generates:
-      - desktop/build/bin/leapmux-desktop
+      - desktop/bin/leapmux-desktop
     cmds:
       - wails build -tags devtools -o leapmux-desktop -platform linux/arm64 -ldflags "-X main.version={{.VERSION}}"
-      - cp build/linux/leapmux-desktop.desktop build/bin/
-      - cp build/appicon.png build/bin/leapmux-desktop.png
-      - cp ../icons/leapmux-icon-light.svg build/bin/leapmux-desktop.svg
+      - rm -rf bin && mv build/bin bin
+      - cp build/linux/leapmux-desktop.desktop bin/
+      - cp build/appicon.png bin/leapmux-desktop.png
+      - cp ../icons/leapmux-icon-light.svg bin/leapmux-desktop.svg
 
   build-desktop-windows:
     desc: Build LeapMux desktop app for Windows
@@ -487,9 +491,10 @@ tasks:
       - backend/go.sum
       - "backend/**/*.go"
     generates:
-      - desktop/build/bin/LeapMux.exe
+      - desktop/bin/LeapMux.exe
     cmds:
       - wails build -tags devtools -platform windows/amd64 -ldflags "-X main.version={{.VERSION}}"
+      - rm -rf bin && mv build/bin bin
 
   lint-desktop:
     desc: Lint desktop Go code
@@ -510,9 +515,9 @@ tasks:
   clean:
     desc: Remove all build artifacts and generated code
     cmds:
-      - rm -f backend/leapmux
+      - rm -rf backend/bin/
       - rm -rf backend/generated/ backend/*/generated/ backend/*/*/generated/
       - rm -rf frontend/.output/ frontend/.vinxi/ frontend/node_modules/
       - rm -rf frontend/src/spinners/
-      - rm -rf desktop/build/bin/ desktop/build/appicon.png desktop/build/windows/icon.ico
+      - rm -rf desktop/bin/ desktop/build/appicon.png desktop/build/windows/icon.ico
       - rm -rf .task/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -378,6 +378,16 @@ tasks:
 
   build-desktop:
     desc: Build LeapMux desktop app for current platform
+    sources:
+      - desktop/go.mod
+      - desktop/go.sum
+      - "desktop/**/*.go"
+      - desktop/frontend/**/*
+      - desktop/build/appicon.png
+      - desktop/build/windows/icon.ico
+      - backend/go.mod
+      - backend/go.sum
+      - "backend/**/*.go"
     cmds:
       - task: build-desktop-{{if eq OS "darwin"}}darwin{{else if eq OS "windows"}}windows{{else}}{{OS}}-{{ARCH}}{{end}}
 
@@ -385,13 +395,13 @@ tasks:
     desc: Build LeapMux desktop app for macOS
     dir: desktop
     deps: [prepare-desktop]
-    method: timestamp
     sources:
       - desktop/go.mod
       - desktop/go.sum
       - "desktop/**/*.go"
       - desktop/frontend/**/*
       - desktop/build/appicon.png
+      - desktop/build/windows/icon.ico
       - backend/go.mod
       - backend/go.sum
       - "backend/**/*.go"
@@ -405,7 +415,6 @@ tasks:
     desc: Package LeapMux.app into a .dmg (macOS only)
     platforms: [darwin]
     deps: [prepare-frontend]
-    method: timestamp
     sources:
       - desktop/build/bin/LeapMux.app/Contents/MacOS/LeapMux
       - desktop/scripts/create-dmg.sh
@@ -423,12 +432,13 @@ tasks:
     desc: Build LeapMux desktop app for Linux (amd64)
     dir: desktop
     deps: [prepare-desktop]
-    method: timestamp
     sources:
       - desktop/go.mod
       - desktop/go.sum
       - "desktop/**/*.go"
       - desktop/frontend/**/*
+      - desktop/build/appicon.png
+      - desktop/build/windows/icon.ico
       - backend/go.mod
       - backend/go.sum
       - "backend/**/*.go"
@@ -436,17 +446,21 @@ tasks:
       - desktop/build/bin/leapmux-desktop
     cmds:
       - wails build -tags devtools -o leapmux-desktop -platform linux/amd64 -ldflags "-X main.version={{.VERSION}}"
+      - cp build/linux/leapmux-desktop.desktop build/bin/
+      - cp build/appicon.png build/bin/leapmux-desktop.png
+      - cp ../icons/leapmux-icon.svg build/bin/leapmux-desktop.svg
 
   build-desktop-linux-arm64:
     desc: Build LeapMux desktop app for Linux (arm64)
     dir: desktop
     deps: [prepare-desktop]
-    method: timestamp
     sources:
       - desktop/go.mod
       - desktop/go.sum
       - "desktop/**/*.go"
       - desktop/frontend/**/*
+      - desktop/build/appicon.png
+      - desktop/build/windows/icon.ico
       - backend/go.mod
       - backend/go.sum
       - "backend/**/*.go"
@@ -454,17 +468,20 @@ tasks:
       - desktop/build/bin/leapmux-desktop
     cmds:
       - wails build -tags devtools -o leapmux-desktop -platform linux/arm64 -ldflags "-X main.version={{.VERSION}}"
+      - cp build/linux/leapmux-desktop.desktop build/bin/
+      - cp build/appicon.png build/bin/leapmux-desktop.png
+      - cp ../icons/leapmux-icon.svg build/bin/leapmux-desktop.svg
 
   build-desktop-windows:
     desc: Build LeapMux desktop app for Windows
     dir: desktop
     deps: [prepare-desktop]
-    method: timestamp
     sources:
       - desktop/go.mod
       - desktop/go.sum
       - "desktop/**/*.go"
       - desktop/frontend/**/*
+      - desktop/build/appicon.png
       - desktop/build/windows/icon.ico
       - backend/go.mod
       - backend/go.sum

--- a/backend/internal/hub/db/db.go
+++ b/backend/internal/hub/db/db.go
@@ -2,18 +2,12 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
-	"log/slog"
-	"os"
 
-	_ "modernc.org/sqlite"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 )
 
 // DefaultMaxConns is the default maximum number of open database connections.
-// SQLite in WAL mode supports concurrent readers alongside a single writer,
-// so we allow multiple connections to avoid serializing all DB operations
-// (reads included) through a single connection.
-const DefaultMaxConns = 4
+const DefaultMaxConns = sqlitedb.DefaultMaxConns
 
 // Open opens a SQLite database at the given path and configures it for
 // concurrent use (WAL mode, foreign keys enabled).
@@ -21,37 +15,5 @@ const DefaultMaxConns = 4
 // If maxConns is provided, it sets the maximum number of open connections;
 // otherwise DefaultMaxConns is used.
 func Open(path string, maxConns ...int) (*sql.DB, error) {
-	// Use _pragma DSN parameters so they are applied to every new
-	// connection from the pool (not just the first one).
-	dsn := path
-	if path == ":memory:" {
-		dsn = path + "?_pragma=foreign_keys(1)"
-	} else {
-		dsn = path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
-	}
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
-	}
-
-	// Restrict file permissions to owner-only (0600).
-	if path != ":memory:" {
-		if err := os.Chmod(path, 0o600); err != nil {
-			slog.Warn("failed to chmod database file", "path", path, "error", err)
-		}
-	}
-
-	// In-memory databases must use a single connection because each
-	// connection gets its own isolated database instance.
-	if path == ":memory:" {
-		db.SetMaxOpenConns(1)
-	} else {
-		n := DefaultMaxConns
-		if len(maxConns) > 0 && maxConns[0] > 0 {
-			n = maxConns[0]
-		}
-		db.SetMaxOpenConns(n)
-	}
-
-	return db, nil
+	return sqlitedb.Open(path, maxConns...)
 }

--- a/backend/internal/hub/db/db.go
+++ b/backend/internal/hub/db/db.go
@@ -21,9 +21,13 @@ const DefaultMaxConns = 4
 // If maxConns is provided, it sets the maximum number of open connections;
 // otherwise DefaultMaxConns is used.
 func Open(path string, maxConns ...int) (*sql.DB, error) {
+	// Use _pragma DSN parameters so they are applied to every new
+	// connection from the pool (not just the first one).
 	dsn := path
-	if path != ":memory:" {
-		dsn = path + "?_busy_timeout=5000"
+	if path == ":memory:" {
+		dsn = path + "?_pragma=foreign_keys(1)"
+	} else {
+		dsn = path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -35,18 +39,6 @@ func Open(path string, maxConns ...int) (*sql.DB, error) {
 		if err := os.Chmod(path, 0o600); err != nil {
 			slog.Warn("failed to chmod database file", "path", path, "error", err)
 		}
-	}
-
-	// Enable WAL mode for better concurrent read performance.
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("set WAL mode: %w", err)
-	}
-
-	// Enable foreign key enforcement.
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	// In-memory databases must use a single connection because each

--- a/backend/internal/hub/service/worker_connector_service.go
+++ b/backend/internal/hub/service/worker_connector_service.go
@@ -319,7 +319,7 @@ func (s *WorkerConnectorService) processWorkerMessage(
 ) error {
 	// Update last seen periodically on heartbeats.
 	if hb := msg.GetHeartbeat(); hb != nil {
-		if err := s.queries.UpdateWorkerLastSeen(ctx, workerID); err != nil {
+		if err := s.queries.UpdateWorkerLastSeen(ctx, workerID); err != nil && ctx.Err() == nil {
 			slog.Warn("failed to update worker last seen on heartbeat", "worker_id", workerID, "error", err)
 		}
 		// Cache encryption mode on the live connection (not persisted to DB).

--- a/backend/internal/util/sqlitedb/open.go
+++ b/backend/internal/util/sqlitedb/open.go
@@ -1,0 +1,80 @@
+package sqlitedb
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+
+	_ "modernc.org/sqlite"
+)
+
+// DefaultMaxConns is the default maximum number of open database connections.
+// SQLite in WAL mode supports concurrent readers alongside a single writer,
+// so we allow multiple connections to avoid serializing all DB operations
+// (reads included) through a single connection.
+const DefaultMaxConns = 4
+
+// Open opens a SQLite database at the given path and configures it for
+// concurrent use (WAL mode, foreign keys enabled).
+// Use ":memory:" for an in-memory database (useful for testing).
+// If maxConns is provided, it sets the maximum number of open connections;
+// otherwise DefaultMaxConns is used.
+func Open(path string, maxConns ...int) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", buildDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	// In-memory databases must use a single connection because each
+	// connection gets its own isolated database instance.
+	if path == ":memory:" {
+		db.SetMaxOpenConns(1)
+	} else {
+		n := DefaultMaxConns
+		if len(maxConns) > 0 && maxConns[0] > 0 {
+			n = maxConns[0]
+		}
+		db.SetMaxOpenConns(n)
+	}
+
+	// Force a connection to ensure the file is created before chmod.
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	// Restrict file permissions to owner-only (0600).
+	if path != ":memory:" {
+		if err := os.Chmod(path, 0o600); err != nil {
+			slog.Warn("failed to chmod database file", "path", path, "error", err)
+		}
+	}
+
+	return db, nil
+}
+
+// buildDSN constructs a SQLite DSN with pragma parameters applied via the
+// connection string so they take effect on every pooled connection.
+// It uses the file: URI scheme to safely separate the path from query
+// parameters, avoiding issues if the path contains special characters.
+func buildDSN(path string) string {
+	// 60s busy_timeout: high enough to never trigger during normal
+	// operation, but still acts as a safety net against stuck transactions.
+	// Request-scoped contexts provide the real timeout boundary.
+	const filePragmas = "_pragma=busy_timeout(60000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+	const memoryPragmas = "_pragma=foreign_keys(1)"
+
+	if path == ":memory:" {
+		return ":memory:?" + memoryPragmas
+	}
+
+	u := &url.URL{
+		Scheme:   "file",
+		OmitHost: true,
+		Path:     path,
+		RawQuery: filePragmas,
+	}
+	return u.String()
+}

--- a/backend/internal/util/sqlitedb/open_test.go
+++ b/backend/internal/util/sqlitedb/open_test.go
@@ -1,0 +1,57 @@
+package sqlitedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen_InMemory(t *testing.T) {
+	db, err := Open(":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	require.NoError(t, db.Ping())
+
+	var fk int
+	require.NoError(t, db.QueryRow("PRAGMA foreign_keys").Scan(&fk))
+	assert.Equal(t, 1, fk)
+}
+
+func TestOpen_File(t *testing.T) {
+	path := t.TempDir() + "/test.db"
+	db, err := Open(path)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	require.NoError(t, db.Ping())
+
+	var fk int
+	require.NoError(t, db.QueryRow("PRAGMA foreign_keys").Scan(&fk))
+	assert.Equal(t, 1, fk)
+
+	var journal string
+	require.NoError(t, db.QueryRow("PRAGMA journal_mode").Scan(&journal))
+	assert.Equal(t, "wal", journal)
+
+	var timeout int
+	require.NoError(t, db.QueryRow("PRAGMA busy_timeout").Scan(&timeout))
+	assert.Equal(t, 60000, timeout)
+}
+
+func TestBuildDSN_Memory(t *testing.T) {
+	dsn := buildDSN(":memory:")
+	assert.Equal(t, ":memory:?_pragma=foreign_keys(1)", dsn)
+}
+
+func TestBuildDSN_AbsolutePath(t *testing.T) {
+	dsn := buildDSN("/home/user/data.db")
+	assert.Equal(t, "file:/home/user/data.db?_pragma=busy_timeout(60000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)", dsn)
+}
+
+func TestBuildDSN_SpecialCharsInPath(t *testing.T) {
+	dsn := buildDSN("/home/user/my?data&file.db")
+	assert.Contains(t, dsn, "file:/home/user/my%3Fdata&file.db")
+	assert.Contains(t, dsn, "_pragma=foreign_keys(1)")
+}

--- a/backend/internal/worker/db/db.go
+++ b/backend/internal/worker/db/db.go
@@ -2,18 +2,12 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
-	"log/slog"
-	"os"
 
-	_ "modernc.org/sqlite"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 )
 
 // DefaultMaxConns is the default maximum number of open database connections.
-// SQLite in WAL mode supports concurrent readers alongside a single writer,
-// so we allow multiple connections to avoid serializing all DB operations
-// (reads included) through a single connection.
-const DefaultMaxConns = 4
+const DefaultMaxConns = sqlitedb.DefaultMaxConns
 
 // Open opens a SQLite database at the given path and configures it for
 // concurrent use (WAL mode, foreign keys enabled).
@@ -21,37 +15,5 @@ const DefaultMaxConns = 4
 // If maxConns is provided, it sets the maximum number of open connections;
 // otherwise DefaultMaxConns is used.
 func Open(path string, maxConns ...int) (*sql.DB, error) {
-	// Use _pragma DSN parameters so they are applied to every new
-	// connection from the pool (not just the first one).
-	dsn := path
-	if path == ":memory:" {
-		dsn = path + "?_pragma=foreign_keys(1)"
-	} else {
-		dsn = path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
-	}
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
-	}
-
-	// Restrict file permissions to owner-only (0600).
-	if path != ":memory:" {
-		if err := os.Chmod(path, 0o600); err != nil {
-			slog.Warn("failed to chmod database file", "path", path, "error", err)
-		}
-	}
-
-	// In-memory databases must use a single connection because each
-	// connection gets its own isolated database instance.
-	if path == ":memory:" {
-		db.SetMaxOpenConns(1)
-	} else {
-		n := DefaultMaxConns
-		if len(maxConns) > 0 && maxConns[0] > 0 {
-			n = maxConns[0]
-		}
-		db.SetMaxOpenConns(n)
-	}
-
-	return db, nil
+	return sqlitedb.Open(path, maxConns...)
 }

--- a/backend/internal/worker/db/db.go
+++ b/backend/internal/worker/db/db.go
@@ -21,9 +21,13 @@ const DefaultMaxConns = 4
 // If maxConns is provided, it sets the maximum number of open connections;
 // otherwise DefaultMaxConns is used.
 func Open(path string, maxConns ...int) (*sql.DB, error) {
+	// Use _pragma DSN parameters so they are applied to every new
+	// connection from the pool (not just the first one).
 	dsn := path
-	if path != ":memory:" {
-		dsn = path + "?_busy_timeout=5000"
+	if path == ":memory:" {
+		dsn = path + "?_pragma=foreign_keys(1)"
+	} else {
+		dsn = path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -35,18 +39,6 @@ func Open(path string, maxConns ...int) (*sql.DB, error) {
 		if err := os.Chmod(path, 0o600); err != nil {
 			slog.Warn("failed to chmod database file", "path", path, "error", err)
 		}
-	}
-
-	// Enable WAL mode for better concurrent read performance.
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("set WAL mode: %w", err)
-	}
-
-	// Enable foreign key enforcement.
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	// In-memory databases must use a single connection because each

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -58,7 +58,7 @@ func (a *App) domReady(_ context.Context) {
 	// manager ("external" handler) is attached to the webview, so
 	// webkit.messageHandlers.external.postMessage is always available,
 	// even on pages not served via the wails:// scheme.
-	var post = (function() {
+	window.__lm_post = (function() {
 		// Windows (WebView2)
 		if (window.chrome && window.chrome.webview && window.chrome.webview.postMessage)
 			return function(m) { window.chrome.webview.postMessage(m); };
@@ -81,16 +81,16 @@ func (a *App) domReady(_ context.Context) {
 		if (href && /^https?:\/\//.test(href)) {
 			e.preventDefault();
 			e.stopPropagation();
-			if (post) post('BO:' + href);
+			if (window.__lm_post) window.__lm_post('BO:' + href);
 		}
 	}, true);
 	document.addEventListener('keydown', function(e) {
 		if (e.key === 'F12') {
-			if (post) post('%s');
+			if (window.__lm_post) window.__lm_post('%s');
 		}
 		if (e.key === 'q' && (e.ctrlKey || e.metaKey)) {
 			e.preventDefault();
-			if (post) post('Q');
+			if (window.__lm_post) window.__lm_post('Q');
 		}
 	}, true);
 })();

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -95,6 +95,17 @@ func (a *App) domReady(_ context.Context) {
 `, inspectorMsg))
 }
 
+// bringToFront shows and raises the window so it appears above other windows.
+func (a *App) bringToFront() {
+	if a.ctx == nil {
+		return
+	}
+	wailsRuntime.WindowUnminimise(a.ctx)
+	wailsRuntime.WindowShow(a.ctx)
+	wailsRuntime.WindowSetAlwaysOnTop(a.ctx, true)
+	wailsRuntime.WindowSetAlwaysOnTop(a.ctx, false)
+}
+
 // shutdown is called when the app is closing.
 func (a *App) shutdown(_ context.Context) {
 	// Save the current window size if the user has connected at least once.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -37,15 +37,10 @@ func (a *App) startup(ctx context.Context) {
 // so it takes effect after the window is fully laid out.
 func (a *App) domReady(_ context.Context) {
 	wailsRuntime.WindowCenter(a.ctx)
+	installTabKeyHandler()
 
 	// Intercept clicks on external links and open them in the default browser
 	// instead of navigating inside the WebView.
-	//
-	// Prevent WebKitGTK from intercepting Tab/Shift+Tab for native focus
-	// traversal when the user is typing in the ProseMirror editor. Without
-	// this, the keydown event never reaches ProseMirror's handleKeyDown on
-	// Linux, so Shift+Tab (plan mode toggle) and Tab (heading conversion)
-	// do not work.
 	// The inspector message differs per platform:
 	//   macOS:   "wails:openInspector"
 	//   Linux:   "wails:showInspector"
@@ -88,16 +83,6 @@ func (a *App) domReady(_ context.Context) {
 		}
 	}, true);
 	document.addEventListener('keydown', function(e) {
-		if (e.key === 'Tab') {
-			var el = e.target;
-			while (el) {
-				if (el.classList && el.classList.contains('ProseMirror')) {
-					e.preventDefault();
-					return;
-				}
-				el = el.parentElement;
-			}
-		}
 		if (e.key === 'F12') {
 			if (post) post('%s');
 		}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/leapmux/leapmux/solo"
@@ -45,8 +46,34 @@ func (a *App) domReady(_ context.Context) {
 	// this, the keydown event never reaches ProseMirror's handleKeyDown on
 	// Linux, so Shift+Tab (plan mode toggle) and Tab (heading conversion)
 	// do not work.
-	wailsRuntime.WindowExecJS(a.ctx, `
+	// The inspector message differs per platform:
+	//   macOS:   "wails:openInspector"
+	//   Linux:   "wails:showInspector"
+	//   Windows: handled natively by WebView2 (F12 key), no message needed
+	inspectorMsg := "wails:showInspector"
+	if runtime.GOOS == "darwin" {
+		inspectorMsg = "wails:openInspector"
+	}
+
+	wailsRuntime.WindowExecJS(a.ctx, fmt.Sprintf(`
 (function() {
+	// Build a postMessage helper that works whether or not the Wails
+	// runtime JS has been loaded into this page. The WebKit user-content
+	// manager ("external" handler) is attached to the webview, so
+	// webkit.messageHandlers.external.postMessage is always available,
+	// even on pages not served via the wails:// scheme.
+	var post = (function() {
+		// Windows (WebView2)
+		if (window.chrome && window.chrome.webview && window.chrome.webview.postMessage)
+			return function(m) { window.chrome.webview.postMessage(m); };
+		// macOS / Linux (WebKit)
+		if (window.webkit && window.webkit.messageHandlers &&
+		    window.webkit.messageHandlers.external &&
+		    window.webkit.messageHandlers.external.postMessage)
+			return function(m) { window.webkit.messageHandlers.external.postMessage(m); };
+		return null;
+	})();
+
 	document.addEventListener('click', function(e) {
 		var el = e.target;
 		while (el && el.tagName !== 'A') {
@@ -57,7 +84,7 @@ func (a *App) domReady(_ context.Context) {
 		if (href && /^https?:\/\//.test(href)) {
 			e.preventDefault();
 			e.stopPropagation();
-			window.runtime.BrowserOpenURL(href);
+			if (post) post('BO:' + href);
 		}
 	}, true);
 	document.addEventListener('keydown', function(e) {
@@ -72,16 +99,15 @@ func (a *App) domReady(_ context.Context) {
 			}
 		}
 		if (e.key === 'F12') {
-			window.WailsInvoke('wails:openInspector');
-			window.WailsInvoke('wails:showInspector');
+			if (post) post('%s');
 		}
 		if (e.key === 'q' && (e.ctrlKey || e.metaKey)) {
 			e.preventDefault();
-			window.runtime.Quit();
+			if (post) post('Q');
 		}
 	}, true);
 })();
-`)
+`, inspectorMsg))
 }
 
 // shutdown is called when the app is closing.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -39,8 +39,9 @@ func (a *App) domReady(_ context.Context) {
 	wailsRuntime.WindowCenter(a.ctx)
 	installTabKeyHandler()
 
-	// Intercept clicks on external links and open them in the default browser
-	// instead of navigating inside the WebView.
+	// Inject JS handlers for external links, keyboard shortcuts (F12, Ctrl+Q),
+	// using native postMessage since Wails runtime JS is unavailable after
+	// the WebView navigates away from the wails:// launcher page.
 	// The inspector message differs per platform:
 	//   macOS:   "wails:openInspector"
 	//   Linux:   "wails:showInspector"
@@ -69,6 +70,7 @@ func (a *App) domReady(_ context.Context) {
 		return null;
 	})();
 
+	// Intercept clicks on external links and open them in the default browser.
 	document.addEventListener('click', function(e) {
 		var el = e.target;
 		while (el && el.tagName !== 'A') {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -36,6 +36,48 @@ func (a *App) startup(ctx context.Context) {
 // so it takes effect after the window is fully laid out.
 func (a *App) domReady(_ context.Context) {
 	wailsRuntime.WindowCenter(a.ctx)
+
+	// Intercept clicks on external links and open them in the default browser
+	// instead of navigating inside the WebView.
+	//
+	// Prevent WebKitGTK from intercepting Tab/Shift+Tab for native focus
+	// traversal when the user is typing in the ProseMirror editor. Without
+	// this, the keydown event never reaches ProseMirror's handleKeyDown on
+	// Linux, so Shift+Tab (plan mode toggle) and Tab (heading conversion)
+	// do not work.
+	wailsRuntime.WindowExecJS(a.ctx, `
+(function() {
+	document.addEventListener('click', function(e) {
+		var el = e.target;
+		while (el && el.tagName !== 'A') {
+			el = el.parentElement;
+		}
+		if (!el) return;
+		var href = el.getAttribute('href');
+		if (href && /^https?:\/\//.test(href)) {
+			e.preventDefault();
+			e.stopPropagation();
+			window.runtime.BrowserOpenURL(href);
+		}
+	}, true);
+	document.addEventListener('keydown', function(e) {
+		if (e.key === 'Tab') {
+			var el = e.target;
+			while (el) {
+				if (el.classList && el.classList.contains('ProseMirror')) {
+					e.preventDefault();
+					return;
+				}
+				el = el.parentElement;
+			}
+		}
+		if (e.key === 'F12') {
+			window.WailsInvoke('wails:openInspector');
+			window.WailsInvoke('wails:showInspector');
+		}
+	}, true);
+})();
+`)
 }
 
 // shutdown is called when the app is closing.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -75,6 +75,10 @@ func (a *App) domReady(_ context.Context) {
 			window.WailsInvoke('wails:openInspector');
 			window.WailsInvoke('wails:showInspector');
 		}
+		if (e.key === 'q' && (e.ctrlKey || e.metaKey)) {
+			e.preventDefault();
+			window.runtime.Quit();
+		}
 	}, true);
 })();
 `)

--- a/desktop/build/linux/leapmux-desktop.desktop
+++ b/desktop/build/linux/leapmux-desktop.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=LeapMux
+Comment=LeapMux Desktop
+Exec=leapmux-desktop
+Icon=leapmux-desktop
+Type=Application
+Categories=Development;

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -32,7 +32,14 @@ func main() {
 		appMenu.Append(menu.EditMenu())
 		viewMenu := appMenu.AddSubmenu("View")
 		viewMenu.AddText("Toggle Developer Tools", keys.Key("f12"), func(_ *menu.CallbackData) {
-			wailsRuntime.WindowExecJS(app.ctx, "window.WailsInvoke('wails:openInspector')")
+			wailsRuntime.WindowExecJS(app.ctx, `
+				(function() {
+					if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.external)
+						window.webkit.messageHandlers.external.postMessage('wails:openInspector');
+					else if (window.WailsInvoke)
+						window.WailsInvoke('wails:openInspector');
+				})();
+			`)
 		})
 		appMenu.Append(menu.WindowMenu())
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"embed"
+	"runtime"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -15,19 +17,29 @@ import (
 //go:embed all:frontend
 var assets embed.FS
 
+//go:embed build/appicon.png
+var appIcon []byte
+
 var version = "dev"
 
 func main() {
 	app := NewApp(version)
 
-	appMenu := menu.NewMenu()
-	appMenu.Append(menu.AppMenu())
-	appMenu.Append(menu.EditMenu())
-	viewMenu := appMenu.AddSubmenu("View")
-	viewMenu.AddText("Toggle Developer Tools", keys.Combo("i", keys.OptionOrAltKey, keys.CmdOrCtrlKey), func(_ *menu.CallbackData) {
-		wailsRuntime.WindowExecJS(app.ctx, "window.WailsInvoke('wails:openInspector');window.WailsInvoke('wails:showInspector')")
-	})
-	appMenu.Append(menu.WindowMenu())
+	// Build the application menu. On macOS the menu lives in the system
+	// menu bar and costs no window space. On Windows and Linux the menu
+	// bar consumes vertical space, so we omit it entirely and handle the
+	// Dev Tools shortcut via JS instead (see domReady).
+	var appMenu *menu.Menu
+	if runtime.GOOS == "darwin" {
+		appMenu = menu.NewMenu()
+		appMenu.Append(menu.AppMenu())
+		appMenu.Append(menu.EditMenu())
+		viewMenu := appMenu.AddSubmenu("View")
+		viewMenu.AddText("Toggle Developer Tools", keys.Key("f12"), func(_ *menu.CallbackData) {
+			wailsRuntime.WindowExecJS(app.ctx, "window.WailsInvoke('wails:openInspector')")
+		})
+		appMenu.Append(menu.WindowMenu())
+	}
 
 	if err := wails.Run(&options.App{
 		Title:     "LeapMux",
@@ -42,6 +54,9 @@ func main() {
 		OnStartup:  app.startup,
 		OnDomReady: app.domReady,
 		OnShutdown: app.shutdown,
+		Linux: &linux.Options{
+			Icon: appIcon,
+		},
 		Mac: &mac.Options{
 			Preferences: &mac.Preferences{
 				FullscreenEnabled: mac.Enabled,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -58,7 +58,7 @@ func main() {
 		// page to the real frontend (e.g. http://127.0.0.1:4327). Allow
 		// that origin so JS→Go IPC (keyboard shortcuts, external links)
 		// continues to work on the navigated page.
-		BindingsAllowedOrigins: "http://127.0.0.1:*,http://*,https://*",
+		BindingsAllowedOrigins: "http://*,https://*",
 		OnStartup:              app.startup,
 		OnDomReady:             app.domReady,
 		OnShutdown:             app.shutdown,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -9,16 +9,12 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
-	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 //go:embed all:frontend
 var assets embed.FS
-
-//go:embed build/appicon.png
-var appIcon []byte
 
 var version = "dev"
 
@@ -54,9 +50,6 @@ func main() {
 		OnStartup:  app.startup,
 		OnDomReady: app.domReady,
 		OnShutdown: app.shutdown,
-		Linux: &linux.Options{
-			Icon: appIcon,
-		},
 		Mac: &mac.Options{
 			Preferences: &mac.Preferences{
 				FullscreenEnabled: mac.Enabled,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"embed"
+	"errors"
+	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/wailsapp/wails/v2"
@@ -20,6 +23,17 @@ var version = "dev"
 
 func main() {
 	app := NewApp(version)
+
+	release, err := acquireSingleInstance(app.bringToFront)
+	if errors.Is(err, errAlreadyRunning) {
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "single instance check: %v\n", err)
+	}
+	if release != nil {
+		defer release()
+	}
 
 	// Build the application menu. On macOS the menu lives in the system
 	// menu bar and costs no window space. On Windows and Linux the menu

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -46,14 +46,7 @@ func main() {
 		appMenu.Append(menu.EditMenu())
 		viewMenu := appMenu.AddSubmenu("View")
 		viewMenu.AddText("Toggle Developer Tools", keys.Key("f12"), func(_ *menu.CallbackData) {
-			wailsRuntime.WindowExecJS(app.ctx, `
-				(function() {
-					if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.external)
-						window.webkit.messageHandlers.external.postMessage('wails:openInspector');
-					else if (window.WailsInvoke)
-						window.WailsInvoke('wails:openInspector');
-				})();
-			`)
+			wailsRuntime.WindowExecJS(app.ctx, `if (window.__lm_post) window.__lm_post('wails:openInspector');`)
 		})
 		appMenu.Append(menu.WindowMenu())
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -54,9 +54,14 @@ func main() {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		OnStartup:  app.startup,
-		OnDomReady: app.domReady,
-		OnShutdown: app.shutdown,
+		// After connecting, the WebView navigates from the wails:// launcher
+		// page to the real frontend (e.g. http://127.0.0.1:4327). Allow
+		// that origin so JS→Go IPC (keyboard shortcuts, external links)
+		// continues to work on the navigated page.
+		BindingsAllowedOrigins: "http://127.0.0.1:*,https://*",
+		OnStartup:              app.startup,
+		OnDomReady:             app.domReady,
+		OnShutdown:             app.shutdown,
 		Mac: &mac.Options{
 			Preferences: &mac.Preferences{
 				FullscreenEnabled: mac.Enabled,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -58,7 +58,7 @@ func main() {
 		// page to the real frontend (e.g. http://127.0.0.1:4327). Allow
 		// that origin so JS→Go IPC (keyboard shortcuts, external links)
 		// continues to work on the navigated page.
-		BindingsAllowedOrigins: "http://127.0.0.1:*,https://*",
+		BindingsAllowedOrigins: "http://127.0.0.1:*,http://*,https://*",
 		OnStartup:              app.startup,
 		OnDomReady:             app.domReady,
 		OnShutdown:             app.shutdown,

--- a/desktop/singleinstance.go
+++ b/desktop/singleinstance.go
@@ -3,15 +3,12 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 )
-
-var errAlreadyRunning = errors.New("another instance is already running")
 
 func socketPath() string {
 	if runtime.GOOS == "linux" {

--- a/desktop/singleinstance.go
+++ b/desktop/singleinstance.go
@@ -1,0 +1,83 @@
+//go:build linux || windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var errAlreadyRunning = errors.New("another instance is already running")
+
+func socketPath() string {
+	if runtime.GOOS == "linux" {
+		if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+			return filepath.Join(dir, "leapmux-desktop.sock")
+		}
+		return filepath.Join(os.TempDir(), fmt.Sprintf("leapmux-desktop-%d.sock", os.Getuid()))
+	}
+
+	// Windows: use LocalAppData for a short, user-specific path.
+	if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
+		return filepath.Join(dir, "leapmux", "instance.sock")
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, "leapmux", "instance.sock")
+}
+
+// acquireSingleInstance ensures only one instance of the desktop app runs at a
+// time. If another instance is already running, it signals that instance to
+// bring its window to the front and returns errAlreadyRunning. Otherwise it
+// starts a background listener that invokes onActivate when a subsequent
+// instance tries to start, and returns a release function to clean up.
+func acquireSingleInstance(onActivate func()) (release func(), err error) {
+	path := socketPath()
+
+	// Try connecting to an existing instance.
+	conn, err := net.Dial("unix", path)
+	if err == nil {
+		_, _ = conn.Write([]byte("activate"))
+		conn.Close()
+		return nil, errAlreadyRunning
+	}
+
+	// No existing instance — clean up any stale socket and start listening.
+	_ = os.Remove(path)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return func() {}, nil
+	}
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		// Cannot listen (e.g. permission error) — proceed without
+		// single-instance enforcement rather than blocking the user.
+		return func() {}, nil
+	}
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			buf := make([]byte, 32)
+			n, _ := c.Read(buf)
+			c.Close()
+			if string(buf[:n]) == "activate" && onActivate != nil {
+				onActivate()
+			}
+		}
+	}()
+
+	return func() {
+		ln.Close()
+		_ = os.Remove(path)
+	}, nil
+}

--- a/desktop/singleinstance_common.go
+++ b/desktop/singleinstance_common.go
@@ -1,0 +1,5 @@
+package main
+
+import "errors"
+
+var errAlreadyRunning = errors.New("another instance is already running")

--- a/desktop/singleinstance_other.go
+++ b/desktop/singleinstance_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !windows
+
+package main
+
+import "errors"
+
+var errAlreadyRunning = errors.New("another instance is already running")
+
+func acquireSingleInstance(_ func()) (func(), error) {
+	return func() {}, nil
+}

--- a/desktop/singleinstance_other.go
+++ b/desktop/singleinstance_other.go
@@ -2,10 +2,6 @@
 
 package main
 
-import "errors"
-
-var errAlreadyRunning = errors.New("another instance is already running")
-
 func acquireSingleInstance(_ func()) (func(), error) {
 	return func() {}, nil
 }

--- a/desktop/tabfix_linux.go
+++ b/desktop/tabfix_linux.go
@@ -3,7 +3,8 @@
 package main
 
 /*
-#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1
+#cgo linux !webkit2_41 pkg-config: gtk+-3.0 webkit2gtk-4.0
+#cgo linux webkit2_41 pkg-config: gtk+-3.0 webkit2gtk-4.1
 
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>

--- a/desktop/tabfix_linux.go
+++ b/desktop/tabfix_linux.go
@@ -3,11 +3,46 @@
 package main
 
 /*
-#cgo linux !webkit2_41 pkg-config: gtk+-3.0 webkit2gtk-4.0
-#cgo linux webkit2_41 pkg-config: gtk+-3.0 webkit2gtk-4.1
+#cgo linux pkg-config: gtk+-3.0
+#cgo LDFLAGS: -ldl
 
+#include <dlfcn.h>
 #include <gtk/gtk.h>
-#include <webkit2/webkit2.h>
+
+// Resolve WebKitGTK symbols at runtime via dlsym(RTLD_DEFAULT, ...) so we
+// don't need to pkg-config webkit2gtk ourselves (which causes libsoup2/3
+// conflicts when the webkit2_41 build tag doesn't match Wails).
+// The symbols are already loaded by Wails.
+
+typedef void (*evaluate_js_fn)(void *web_view, const char *script,
+	gssize length, const char *world_name, const char *source_uri,
+	GCancellable *cancellable, GAsyncReadyCallback callback,
+	gpointer user_data);
+
+static GType get_webkit_web_view_type() {
+	static GType cached = 0;
+	if (cached) return cached;
+	GType (*fn)(void) = dlsym(RTLD_DEFAULT, "webkit_web_view_get_type");
+	if (fn) cached = fn();
+	return cached;
+}
+
+static void eval_js(void *web_view, const char *script) {
+	static evaluate_js_fn fn = NULL;
+	static int resolved = 0;
+	if (!resolved) {
+		resolved = 1;
+		// Try the newer API first, fall back to the deprecated one.
+		fn = (evaluate_js_fn)dlsym(RTLD_DEFAULT, "webkit_web_view_evaluate_javascript");
+		if (!fn) {
+			// webkit_web_view_run_javascript has a simpler signature:
+			// (WebKitWebView*, const char*, GCancellable*, GAsyncReadyCallback, gpointer)
+			// We can cast safely because extra trailing NULLs are harmless in the C ABI.
+			fn = (evaluate_js_fn)dlsym(RTLD_DEFAULT, "webkit_web_view_run_javascript");
+		}
+	}
+	if (fn) fn(web_view, script, -1, NULL, NULL, NULL, NULL, NULL);
+}
 
 // Intercept Tab/Shift+Tab at the GTK level to prevent focus traversal,
 // then inject a synthetic JS KeyboardEvent so ProseMirror can handle it.
@@ -26,8 +61,11 @@ static gboolean on_tab_key_press(GtkWidget *widget, GdkEventKey *event, gpointer
 	if (event->keyval != GDK_KEY_Tab && event->keyval != GDK_KEY_ISO_Left_Tab)
 		return FALSE;
 
+	GType wv_type = get_webkit_web_view_type();
+	if (!wv_type) return FALSE;
+
 	GtkWidget *focus = gtk_window_get_focus(GTK_WINDOW(widget));
-	if (!focus || !WEBKIT_IS_WEB_VIEW(focus))
+	if (!focus || !G_TYPE_CHECK_INSTANCE_TYPE(focus, wv_type))
 		return FALSE;
 
 	gboolean shift = (event->state & GDK_SHIFT_MASK) != 0;
@@ -57,7 +95,7 @@ static gboolean on_tab_key_press(GtkWidget *widget, GdkEventKey *event, gpointer
 		"}"
 		"})()";
 
-	webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW(focus), js, -1, NULL, NULL, NULL, NULL, NULL);
+	eval_js(focus, js);
 	return TRUE;
 }
 

--- a/desktop/tabfix_linux.go
+++ b/desktop/tabfix_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package main
+
+/*
+#cgo linux pkg-config: gtk+-3.0
+
+#include <gtk/gtk.h>
+
+// Intercept Tab/Shift+Tab at the GTK level to prevent focus traversal.
+//
+// In GTK3, the GtkWindow's default key-press-event handler first propagates
+// the event to the focused widget (WebKitWebView), then does focus traversal
+// for Tab if the event wasn't consumed. WebKitGTK returns FALSE for Tab,
+// so GTK moves focus away from the WebView.
+//
+// This handler runs before the default handler (G_SIGNAL_RUN_LAST).
+// It manually propagates Tab to the focused widget so WebKitGTK generates
+// the JS keydown event for ProseMirror, then returns TRUE to suppress
+// GTK's focus traversal.
+static gboolean on_tab_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data) {
+	if (event->keyval == GDK_KEY_Tab || event->keyval == GDK_KEY_ISO_Left_Tab) {
+		gtk_window_propagate_key_event(GTK_WINDOW(widget), event);
+		return TRUE;
+	}
+	return FALSE;
+}
+
+static int tab_handler_installed = 0;
+
+static gboolean install_tab_handler_idle(gpointer data) {
+	if (tab_handler_installed) return G_SOURCE_REMOVE;
+	tab_handler_installed = 1;
+
+	GList *toplevels = gtk_window_list_toplevels();
+	for (GList *l = toplevels; l != NULL; l = l->next) {
+		if (GTK_IS_WINDOW(l->data)) {
+			g_signal_connect(l->data, "key-press-event",
+				G_CALLBACK(on_tab_key_press), NULL);
+		}
+	}
+	g_list_free(toplevels);
+	return G_SOURCE_REMOVE;
+}
+
+void doInstallTabKeyHandler() {
+	g_idle_add(install_tab_handler_idle, NULL);
+}
+*/
+import "C"
+
+func installTabKeyHandler() {
+	C.doInstallTabKeyHandler()
+}

--- a/desktop/tabfix_linux.go
+++ b/desktop/tabfix_linux.go
@@ -3,27 +3,61 @@
 package main
 
 /*
-#cgo linux pkg-config: gtk+-3.0
+#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1
 
 #include <gtk/gtk.h>
+#include <webkit2/webkit2.h>
 
-// Intercept Tab/Shift+Tab at the GTK level to prevent focus traversal.
+// Intercept Tab/Shift+Tab at the GTK level to prevent focus traversal,
+// then inject a synthetic JS KeyboardEvent so ProseMirror can handle it.
 //
-// In GTK3, the GtkWindow's default key-press-event handler first propagates
-// the event to the focused widget (WebKitWebView), then does focus traversal
-// for Tab if the event wasn't consumed. WebKitGTK returns FALSE for Tab,
-// so GTK moves focus away from the WebView.
+// We cannot use gtk_window_propagate_key_event() because it walks up the
+// widget hierarchy, and each parent's GtkWidget base handler checks key
+// bindings — the Tab binding triggers move-focus, causing focus traversal
+// despite our handler returning TRUE.
 //
-// This handler runs before the default handler (G_SIGNAL_RUN_LAST).
-// It manually propagates Tab to the focused widget so WebKitGTK generates
-// the JS keydown event for ProseMirror, then returns TRUE to suppress
-// GTK's focus traversal.
+// Instead, we suppress the GTK event entirely and dispatch a synthetic
+// keydown event to document.activeElement via JS. If ProseMirror is
+// focused, it handles Tab (heading convert, list indent, plan mode toggle,
+// etc.). If not, we manually move focus to the next/previous focusable
+// HTML element.
 static gboolean on_tab_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data) {
-	if (event->keyval == GDK_KEY_Tab || event->keyval == GDK_KEY_ISO_Left_Tab) {
-		gtk_window_propagate_key_event(GTK_WINDOW(widget), event);
-		return TRUE;
-	}
-	return FALSE;
+	if (event->keyval != GDK_KEY_Tab && event->keyval != GDK_KEY_ISO_Left_Tab)
+		return FALSE;
+
+	GtkWidget *focus = gtk_window_get_focus(GTK_WINDOW(widget));
+	if (!focus || !WEBKIT_IS_WEB_VIEW(focus))
+		return FALSE;
+
+	gboolean shift = (event->state & GDK_SHIFT_MASK) != 0;
+
+	const char *js = shift ?
+		"(function(){"
+		"var e=new KeyboardEvent('keydown',{key:'Tab',code:'Tab',shiftKey:true,bubbles:true,cancelable:true});"
+		"if(document.activeElement.dispatchEvent(e)){"
+		"var f=Array.from(document.querySelectorAll("
+		"'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),"
+		"textarea:not([disabled]),[tabindex]:not([tabindex=\"-1\"]),[contenteditable]'"
+		")).filter(function(x){return x.offsetParent!==null});"
+		"var i=f.indexOf(document.activeElement);"
+		"if(i>0)f[i-1].focus();"
+		"}"
+		"})()"
+		:
+		"(function(){"
+		"var e=new KeyboardEvent('keydown',{key:'Tab',code:'Tab',shiftKey:false,bubbles:true,cancelable:true});"
+		"if(document.activeElement.dispatchEvent(e)){"
+		"var f=Array.from(document.querySelectorAll("
+		"'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),"
+		"textarea:not([disabled]),[tabindex]:not([tabindex=\"-1\"]),[contenteditable]'"
+		")).filter(function(x){return x.offsetParent!==null});"
+		"var i=f.indexOf(document.activeElement);"
+		"if(i>=0&&i<f.length-1)f[i+1].focus();"
+		"}"
+		"})()";
+
+	webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW(focus), js, -1, NULL, NULL, NULL, NULL, NULL);
+	return TRUE;
 }
 
 static int tab_handler_installed = 0;

--- a/desktop/tabfix_other.go
+++ b/desktop/tabfix_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func installTabKeyHandler() {}


### PR DESCRIPTION
## Motivation

The desktop application had several usability issues on Linux and Windows that made it difficult to use as a first-class native application. Tab/Shift+Tab focus traversal was broken in the ProseMirror editor on Linux due to WebKitGTK intercepting key events before they reached the web content. Keyboard shortcuts like F12 and Ctrl+Q stopped working after in-app navigation because the JS bindings were not re-injected. There was no mechanism to prevent multiple instances from running simultaneously. The app also lacked proper Linux desktop integration (`.desktop` file, icons) and the SQLite initialization code was duplicated across the hub and worker packages with an inadequate busy timeout and no proper file URI encoding.

## Modifications

- Add single-instance enforcement on Linux and Windows using a Unix socket lock; a second launch activates the existing window and exits.
- Add `desktop/tabfix_linux.go`: native GTK/WebKitGTK integration via `dlsym` to intercept Tab and Shift+Tab key events and forward them to the ProseMirror editor, bypassing WebKit's default focus traversal.
- Inject keyboard shortcut and external-link JS handlers via Wails `OnDomReady`, using native `postMessage` so they work after the WebView navigates away from the `wails://` launcher page.
- Add `desktop/build/linux/leapmux-desktop.desktop` file and icons for proper Linux desktop integration.
- Extract `backend/internal/util/sqlitedb.Open()` to eliminate duplicated SQLite initialization in `hub/db` and `worker/db`, fix DSN path encoding to use the `file:` URI scheme, and increase `busy_timeout` from 5s to 60s.
- Reorganize build output: backend binaries move to `backend/bin/`, desktop binaries move to `desktop/bin/`.
- Fix worker heartbeat update to check context cancellation before logging a warning, eliminating spurious log noise on shutdown.
- Use `dlsym` for WebKitGTK symbol resolution to avoid link-time libsoup2/3 conflicts.
- Simplify allowed origins to `http://*,https://*` so IPC works after navigation to the frontend server.

## Result

- Running a second instance of the desktop app now activates the already-running window instead of opening a duplicate.
- Tab and Shift+Tab work correctly inside the ProseMirror editor on Linux.
- Keyboard shortcuts (Ctrl+Q, F12) continue to work after navigating between pages in the frontend.
- The app appears correctly in Linux application launchers with its icon.
- SQLite databases opened by the hub and worker correctly handle file paths containing special characters, and lock contention is tolerated for up to 60 seconds instead of 5.
- Worker shutdown no longer emits spurious "failed to update heartbeat" warnings.

🤖 Generated with Claude Code
