### PR TITLE
Add new models, auto effort, and model-specific effort restrictions

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -113,10 +113,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 
 	var modelEffortArgs []string
 	if !thirdPartyFromSettings {
-		modelEffortArgs = []string{"--model", opts.Model}
-		if opts.Effort != "" {
-			modelEffortArgs = append(modelEffortArgs, "--effort", opts.Effort)
-		}
+		modelEffortArgs = buildModelEffortArgs(opts.Model, opts.Effort)
 	}
 
 	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
@@ -568,4 +565,19 @@ func filterEnv(environ []string, keys ...string) []string {
 		}
 	}
 	return filtered
+}
+
+// buildModelEffortArgs constructs the --model and --effort CLI arguments for
+// Claude Code. Haiku does not support effort levels, and max effort is only
+// supported for opus models (falls back to high for others).
+func buildModelEffortArgs(model, effort string) []string {
+	args := []string{"--model", model}
+	if effort != "" && model != "haiku" {
+		// Max effort is only supported for opus models; fall back to high.
+		if effort == "max" && !strings.HasPrefix(model, "opus") {
+			effort = "high"
+		}
+		args = append(args, "--effort", effort)
+	}
+	return args
 }

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -235,6 +235,76 @@ func TestBuildShellWrappedCommand_ModelEffortInElseBranch(t *testing.T) {
 	assert.NotContains(t, parts[0], "'--effort'")
 }
 
+func TestBuildModelEffortArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		effort   string
+		expected []string
+	}{
+		{
+			name:     "opus with max effort",
+			model:    "opus",
+			effort:   "max",
+			expected: []string{"--model", "opus", "--effort", "max"},
+		},
+		{
+			name:     "opus[1m] with max effort",
+			model:    "opus[1m]",
+			effort:   "max",
+			expected: []string{"--model", "opus[1m]", "--effort", "max"},
+		},
+		{
+			name:     "sonnet with max effort falls back to high",
+			model:    "sonnet",
+			effort:   "max",
+			expected: []string{"--model", "sonnet", "--effort", "high"},
+		},
+		{
+			name:     "sonnet[1m] with max effort falls back to high",
+			model:    "sonnet[1m]",
+			effort:   "max",
+			expected: []string{"--model", "sonnet[1m]", "--effort", "high"},
+		},
+		{
+			name:     "sonnet with high effort unchanged",
+			model:    "sonnet",
+			effort:   "high",
+			expected: []string{"--model", "sonnet", "--effort", "high"},
+		},
+		{
+			name:     "haiku omits effort entirely",
+			model:    "haiku",
+			effort:   "high",
+			expected: []string{"--model", "haiku"},
+		},
+		{
+			name:     "haiku omits max effort",
+			model:    "haiku",
+			effort:   "max",
+			expected: []string{"--model", "haiku"},
+		},
+		{
+			name:     "empty effort omitted",
+			model:    "sonnet",
+			effort:   "",
+			expected: []string{"--model", "sonnet"},
+		},
+		{
+			name:     "auto effort",
+			model:    "sonnet",
+			effort:   "auto",
+			expected: []string{"--model", "sonnet", "--effort", "auto"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildModelEffortArgs(tt.model, tt.effort)
+			assert.Equal(t, tt.expected, args)
+		})
+	}
+}
+
 func TestPosixQuote(t *testing.T) {
 	assert.Equal(t, "'hello'", posixQuote("hello"))
 	assert.Equal(t, "'it'\\''s'", posixQuote("it's"))

--- a/frontend/scripts/resolve-task-bin.ts
+++ b/frontend/scripts/resolve-task-bin.ts
@@ -1,0 +1,13 @@
+import { execFileSync } from 'node:child_process'
+
+/** Resolve the `task` binary, which may be installed as `go-task`. */
+export function resolveTaskBin(): string {
+  for (const name of ['task', 'go-task']) {
+    try {
+      execFileSync('which', [name], { stdio: 'pipe' })
+      return name
+    }
+    catch {}
+  }
+  throw new Error('Neither "task" nor "go-task" found in $PATH')
+}

--- a/frontend/scripts/run-e2e.ts
+++ b/frontend/scripts/run-e2e.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
+import { resolveTaskBin } from './resolve-task-bin'
 
 function run(cmd: string, args: string[]): Promise<number> {
   return new Promise((resolve) => {
@@ -16,7 +17,8 @@ function run(cmd: string, args: string[]): Promise<number> {
 
 async function main() {
   // Always clean and build before running e2e tests
-  const buildCode = await run('task', ['build-frontend', 'build-backend'])
+  const taskBin = resolveTaskBin()
+  const buildCode = await run(taskBin, ['build-frontend', 'build-backend'])
   if (buildCode !== 0) {
     console.error('`task clean build` failed with exit code', buildCode)
     process.exit(buildCode)

--- a/frontend/src/components/chat/EditorSettingsDropdown.tsx
+++ b/frontend/src/components/chat/EditorSettingsDropdown.tsx
@@ -5,6 +5,7 @@ import ChevronsDown from 'lucide-solid/icons/chevrons-down'
 import ChevronsUp from 'lucide-solid/icons/chevrons-up'
 import Dot from 'lucide-solid/icons/dot'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
+import Sparkles from 'lucide-solid/icons/sparkles'
 import Zap from 'lucide-solid/icons/zap'
 import { createUniqueId, For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
@@ -78,8 +79,12 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
   const currentEffort = () => props.effort || DEFAULT_EFFORT
   const currentMode = () => props.permissionMode || 'default'
 
+  const isOpus = () => currentModel().startsWith('opus')
+  const availableEfforts = () => isOpus() ? EFFORTS : EFFORTS.filter(e => e.value !== 'max')
+
   const effortIcon = () => {
     switch (currentEffort()) {
+      case 'auto': return <Icon icon={Sparkles} size="xs" />
       case 'low': return <Icon icon={ChevronsDown} size="xs" />
       case 'high': return <Icon icon={ChevronsUp} size="xs" />
       case 'max': return <Icon icon={Zap} size="xs" />
@@ -98,7 +103,7 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
         >
           <Show when={props.supportsModelEffort !== false}>
             {modelLabel(currentModel())}
-            {effortIcon()}
+            <Show when={currentModel() !== 'haiku'}>{effortIcon()}</Show>
           </Show>
           {modeLabel(currentMode())}
           <Show when={props.settingsLoading} fallback={<Icon icon={ChevronDown} size="xs" />}>
@@ -111,17 +116,19 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
       data-testid="agent-settings-menu"
     >
       <Show when={props.supportsModelEffort !== false}>
-        <RadioGroup
-          label="Effort"
-          items={EFFORTS}
-          testIdPrefix="effort"
-          name={`${menuId}-effort`}
-          current={currentEffort()}
-          onChange={(v) => {
-            props.onEffortChange?.(v)
-            settingsPopoverEl?.hidePopover()
-          }}
-        />
+        <Show when={currentModel() !== 'haiku'}>
+          <RadioGroup
+            label="Effort"
+            items={availableEfforts()}
+            testIdPrefix="effort"
+            name={`${menuId}-effort`}
+            current={currentEffort()}
+            onChange={(v) => {
+              props.onEffortChange?.(v)
+              settingsPopoverEl?.hidePopover()
+            }}
+          />
+        </Show>
         <RadioGroup
           label="Model"
           items={MODELS}
@@ -130,6 +137,10 @@ export function EditorSettingsDropdown(props: EditorSettingsDropdownProps): JSX.
           current={currentModel()}
           onChange={(v) => {
             props.onModelChange?.(v)
+            // Fall back from max to high when switching away from opus
+            if (!v.startsWith('opus') && currentEffort() === 'max') {
+              props.onEffortChange?.('high')
+            }
             settingsPopoverEl?.hidePopover()
           }}
         />

--- a/frontend/src/utils/controlResponse.ts
+++ b/frontend/src/utils/controlResponse.ts
@@ -75,12 +75,15 @@ export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {
 }
 
 export const MODEL_LABELS: Record<string, string> = {
-  opus: 'Opus',
-  sonnet: 'Sonnet',
-  haiku: 'Haiku',
+  'opus': 'Opus',
+  'opus[1m]': 'Opus[1m]',
+  'sonnet': 'Sonnet',
+  'sonnet[1m]': 'Sonnet[1m]',
+  'haiku': 'Haiku',
 }
 
 export const EFFORT_LABELS: Record<string, string> = {
+  auto: 'Auto',
   max: 'Max',
   high: 'High',
   medium: 'Medium',

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -85,6 +85,31 @@ test.describe('Agent Settings', () => {
     await page.keyboard.press('Escape')
   })
 
+  test('effort hidden when haiku selected', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Default model is Sonnet — effort section should be visible; switch to Haiku
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-high"]')).toBeVisible()
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
+    await waitForSettingsIdle(page)
+
+    // Effort section should be hidden for Haiku
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-high"]')).not.toBeVisible()
+
+    // Switch back to Sonnet — effort should reappear
+    await page.locator('[data-testid="model-sonnet"]').click()
+    await expect(trigger).toContainText('Sonnet')
+    await waitForSettingsIdle(page)
+
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-high"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+
   test('permission mode persistence across refresh', async ({ authenticatedWorkspace, page }) => {
     // Wait for the editor to be ready (agent is started)
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
@@ -236,13 +261,17 @@ test.describe('Agent Settings', () => {
     // Verify all model items are enabled (not disabled) when idle
     await expect(page.locator('[data-testid="model-haiku"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="model-sonnet"]')).not.toHaveAttribute('data-disabled', '')
+    await expect(page.locator('[data-testid="model-sonnet\\[1m\\]"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="model-opus"]')).not.toHaveAttribute('data-disabled', '')
+    await expect(page.locator('[data-testid="model-opus\\[1m\\]"]')).not.toHaveAttribute('data-disabled', '')
 
-    // Verify all effort items are enabled when idle
+    // Verify effort items are enabled when idle (max is only shown for opus)
+    await expect(page.locator('[data-testid="effort-auto"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-low"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-medium"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-high"]')).not.toHaveAttribute('data-disabled', '')
-    await expect(page.locator('[data-testid="effort-max"]')).not.toHaveAttribute('data-disabled', '')
+    // Max effort is hidden for non-opus models (default is Sonnet)
+    await expect(page.locator('[data-testid="effort-max"]')).not.toBeVisible()
 
     // Verify permission mode items are enabled when idle
     await expect(page.locator('[data-testid="permission-mode-default"]')).not.toHaveAttribute('data-disabled', '')
@@ -307,15 +336,15 @@ test.describe('Agent Settings', () => {
     await expect(trigger).toContainText('Plan Mode')
     await waitForSettingsIdle(page)
 
-    // Switch model to Haiku
-    await openSettingsMenu(page)
-    await page.locator('[data-testid="model-haiku"]').click()
-    await expect(trigger).toContainText('Haiku')
-    await waitForSettingsIdle(page)
-
     // Switch effort to High
     await openSettingsMenu(page)
     await page.locator('[data-testid="effort-high"]').click()
+    await waitForSettingsIdle(page)
+
+    // Switch model to Haiku (effort section hidden for Haiku)
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
     await waitForSettingsIdle(page)
 
     // Wait a moment for any delayed status events

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { resolveTaskBin } from '../../scripts/resolve-task-bin'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..', '..', '..')
@@ -47,7 +48,7 @@ export default async function globalSetup() {
 
   // Build the leapmux binary (includes embedded frontend)
   console.log('[e2e] Building leapmux...')
-  execSync('task build-backend', { cwd: ROOT, stdio: 'inherit' })
+  execSync(`${resolveTaskBin()} build-backend`, { cwd: ROOT, stdio: 'inherit' })
 
   const binaryPath = join(ROOT, 'backend', 'leapmux')
 


### PR DESCRIPTION
## Motivation

As new Claude model variants become available and effort control behavior
needs to vary by model, the agent settings UI requires updates to reflect
which models support which effort levels. Previously, effort options were
presented uniformly regardless of the selected model, which could lead to
invalid or unsupported configurations (e.g., selecting max effort on a
non-opus model, or showing effort controls for haiku which does not
support them at all).

## Modifications

- Add `opus[1m]` and `sonnet[1m]` as selectable model variants in the
  agent settings dropdown
- Add an `auto` effort level that lets the system determine the
  appropriate effort for each request
- Restrict the `max` effort option to opus models only; when a user
  switches away from an opus model while `max` is selected, effort
  automatically downgrades to `high`
- Hide the effort selector entirely when `haiku` is the selected model,
  since haiku does not support effort configuration
- Add `frontend/scripts/resolve-task-bin.ts` to locate either the `task`
  or `go-task` binary in PATH, improving compatibility across different
  installation methods

## Result

Users can now select `opus[1m]` and `sonnet[1m]` model variants from the
agent settings panel. The effort selector adapts dynamically to the
chosen model: only opus models expose the `max` effort option, haiku hides
the effort selector entirely, and switching models with an incompatible
effort level automatically falls back to a valid value. The `auto` effort
level is available for models that support it, allowing the system to
decide the appropriate effort without manual selection.

The build system now reliably locates the task runner binary regardless
of whether it is installed as `task` or `go-task`.

🤖 Generated with Claude Code
