### PR TITLE
fix(agent): Improve error messages and deduplicate e2e test selectors

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -41,7 +41,8 @@ type Agent struct {
 	cmd         *exec.Cmd
 	stdin       io.WriteCloser
 	stderrBuf   *bytes.Buffer
-	stderrMu    sync.Mutex // protects stderrBuf when drained via goroutine
+	stderrMu    sync.Mutex    // protects stderrBuf when drained via goroutine
+	stderrDone  chan struct{} // closed when the stderr goroutine finishes
 	ctx         context.Context
 	cancel      context.CancelFunc
 	processDone chan struct{} // closed when the process exits
@@ -169,6 +170,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		ctx:                ctx,
 		cancel:             cancel,
 		stderrBuf:          &stderrBuf,
+		stderrDone:         make(chan struct{}),
 		preambleDelimiter:  preambleDelimiter,
 		preambleMetaPrefix: metaPrefix,
 		preambleMeta:       make(map[string]string),
@@ -184,6 +186,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 	// Drain stderr in a background goroutine.
 	const maxStderrSize = 1 << 20 // 1MB
 	go func() {
+		defer close(a.stderrDone)
 		limited := io.LimitReader(stderrPipe, maxStderrSize)
 		a.stderrMu.Lock()
 		_, _ = io.Copy(&stderrBuf, limited)
@@ -206,19 +209,6 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		_ = a.Wait()
 	}
 
-	// formatStartupError returns a descriptive error including stderr and
-	// preamble output (if any) for frontend diagnostics.
-	formatStartupError := func(phase string, err error) error {
-		parts := []string{fmt.Sprintf("%s: %s", phase, err)}
-		if stderr := strings.TrimSpace(a.Stderr()); stderr != "" {
-			parts = append(parts, "stderr: "+stderr)
-		}
-		if preamble := strings.TrimSpace(a.PreambleOutput()); preamble != "" {
-			parts = append(parts, "shell preamble: "+preamble)
-		}
-		return fmt.Errorf("%s", strings.Join(parts, "; "))
-	}
-
 	timeout := opts.startupTimeout()
 
 	// Send "initialize" as the first control request, matching the Agent SDK
@@ -226,7 +216,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 	// (which contains the session_id) and establishes the control protocol.
 	if _, err := a.sendControlAndWait(ctx, `{"subtype":"initialize"}`, timeout); err != nil {
 		cleanup()
-		return nil, formatStartupError("initialize", err)
+		return nil, a.formatStartupError("initialize", err)
 	}
 
 	// Send set_permission_mode to configure the agent's permission mode.
@@ -240,7 +230,7 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, e
 		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, mode), timeout)
 	if err != nil {
 		cleanup()
-		return nil, formatStartupError("set_permission_mode", err)
+		return nil, a.formatStartupError("set_permission_mode", err)
 	}
 	a.confirmedPermissionMode = resp.Mode
 
@@ -350,7 +340,13 @@ func (a *Agent) AgentID() string {
 }
 
 // Stderr returns the captured stderr output from the agent process.
+// It waits for the stderr goroutine to finish draining the pipe (up to
+// 3 seconds) to avoid racing with the goroutine after process exit.
 func (a *Agent) Stderr() string {
+	select {
+	case <-a.stderrDone:
+	case <-time.After(3 * time.Second):
+	}
 	a.stderrMu.Lock()
 	defer a.stderrMu.Unlock()
 	if a.stderrBuf == nil {
@@ -367,6 +363,32 @@ func (a *Agent) PreambleOutput() string {
 		return ""
 	}
 	return strings.Join(a.preambleOutput, "\n")
+}
+
+// processExitError returns a descriptive error for a process that exited
+// unexpectedly. It includes the exit code when available. Callers that
+// need stderr and preamble details should read them separately (e.g. via
+// a.formatStartupError).
+func (a *Agent) processExitError() error {
+	if a.waitErr != nil {
+		if exitErr, ok := a.waitErr.(*exec.ExitError); ok {
+			return fmt.Errorf("agent process exited with code %d", exitErr.ExitCode())
+		}
+	}
+	return fmt.Errorf("agent process exited unexpectedly")
+}
+
+// formatStartupError returns a descriptive error including stderr and
+// preamble output (if any) for frontend diagnostics.
+func (a *Agent) formatStartupError(phase string, err error) error {
+	parts := []string{fmt.Sprintf("%s: %s", phase, err)}
+	if stderr := strings.TrimSpace(a.Stderr()); stderr != "" {
+		parts = append(parts, "stderr: "+stderr)
+	}
+	if preamble := strings.TrimSpace(a.PreambleOutput()); preamble != "" {
+		parts = append(parts, "shell preamble: "+preamble)
+	}
+	return fmt.Errorf("%s", strings.Join(parts, "; "))
 }
 
 // SupportsModelEffort returns whether the agent supports --model/--effort CLI args.
@@ -408,11 +430,7 @@ func (a *Agent) sendControlAndWait(ctx context.Context, requestBody string, time
 		return resp, nil
 	case <-a.processDone:
 		a.unregisterPendingControl(requestID)
-		stderr := strings.TrimSpace(a.Stderr())
-		if stderr != "" {
-			return controlResult{}, fmt.Errorf("agent process exited: %s", stderr)
-		}
-		return controlResult{}, fmt.Errorf("agent process exited unexpectedly")
+		return controlResult{}, a.processExitError()
 	case <-ctx.Done():
 		a.unregisterPendingControl(requestID)
 		return controlResult{}, ctx.Err()

--- a/backend/internal/worker/agent/agent_test.go
+++ b/backend/internal/worker/agent/agent_test.go
@@ -450,6 +450,9 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 		var stderrBuf bytes.Buffer
 		cmd.Stderr = &stderrBuf
 
+		stderrDone := make(chan struct{})
+		close(stderrDone) // stderr is captured synchronously via cmd.Stderr
+
 		a := &Agent{
 			agentID:        opts.AgentID,
 			model:          opts.Model,
@@ -459,6 +462,7 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 			ctx:            ctx2,
 			cancel:         cancel,
 			stderrBuf:      &stderrBuf,
+			stderrDone:     stderrDone,
 			processDone:    make(chan struct{}),
 			pendingControl: make(map[string]chan<- controlResult),
 		}
@@ -480,7 +484,7 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 		// Attempt the initialize handshake — should detect early exit.
 		if _, err := a.sendControlAndWait(ctx2, `{"subtype":"initialize"}`, opts.startupTimeout()); err != nil {
 			cleanup()
-			return nil, fmt.Errorf("initialize: %w", err)
+			return nil, a.formatStartupError("initialize", err)
 		}
 
 		return a, nil
@@ -497,6 +501,8 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 
 	assert.Nil(t, agent, "agent should be nil on early exit")
 	require.Error(t, err, "expected error from early exit")
+	assert.Contains(t, err.Error(), "agent process exited with code",
+		"error should include the exit code")
 	assert.Contains(t, err.Error(), "cannot be launched inside another Claude Code session",
 		"error should include the stderr message from the crashed process")
 	assert.Less(t, elapsed, 2*time.Second,
@@ -562,6 +568,7 @@ func TestAgent_PreambleSkipping(t *testing.T) {
 	require.NoError(t, err)
 
 	var stderrBuf bytes.Buffer
+	stderrDone := make(chan struct{})
 	a := &Agent{
 		agentID:           "preamble-test",
 		model:             "test",
@@ -571,6 +578,7 @@ func TestAgent_PreambleSkipping(t *testing.T) {
 		ctx:               ctx2,
 		cancel:            cancel,
 		stderrBuf:         &stderrBuf,
+		stderrDone:        stderrDone,
 		preambleDelimiter: delimiter,
 		preambleMeta:      make(map[string]string),
 		processDone:       make(chan struct{}),
@@ -581,6 +589,7 @@ func TestAgent_PreambleSkipping(t *testing.T) {
 
 	// Drain stderr in background.
 	go func() {
+		defer close(stderrDone)
 		a.stderrMu.Lock()
 		_, _ = fmt.Fprintf(&stderrBuf, "")
 		a.stderrMu.Unlock()

--- a/frontend/tests/e2e/03-workspace-chat.spec.ts
+++ b/frontend/tests/e2e/03-workspace-chat.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { lastAssistantBubble } from './helpers/ui'
 
 /**
  * Ensure at least one agent tab exists after workspace creation
@@ -35,12 +36,8 @@ test.describe('Workspace Chat', () => {
     // Editor should be cleared after sending
     await expect(editor).toHaveText('')
 
-    // Wait for Claude's response: the page should contain "4" (the answer)
-    // and the empty state should be gone.
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('4') && !body.includes('Send a message to start')
-    })
+    // Wait for Claude's response in the last assistant message bubble.
+    await expect(lastAssistantBubble(page)).toContainText('4', { timeout: 30000 })
   })
 
   test('should show workspace in sidebar after creation', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/23-agent-resume.spec.ts
+++ b/frontend/tests/e2e/23-agent-resume.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, loginViaToken, waitForWorkspaceReady } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 /**
@@ -9,13 +9,13 @@ import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as t
  */
 async function waitForAssistantMessage(page: import('@playwright/test').Page, text: string) {
   await page.waitForFunction(
-    (t: string) => {
+    ({ t, sel }: { t: string, sel: string }) => {
       const msgs = document.querySelectorAll(
-        '[data-testid="message-bubble"][data-role="assistant"] [data-testid="message-content"]',
+        `${sel} [data-testid="message-content"]`,
       )
       return [...msgs].some(m => m.textContent?.includes(t))
     },
-    text,
+    { t: text, sel: ASSISTANT_BUBBLE_SELECTOR },
     { timeout: 60_000 },
   )
 }

--- a/frontend/tests/e2e/24-full-restart.spec.ts
+++ b/frontend/tests/e2e/24-full-restart.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, waitForLayoutSave, waitForWorkspaceReady } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, assistantBubbles, loginViaToken, waitForLayoutSave, waitForWorkspaceReady } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartHub, restartWorker, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Full Hub+Worker Restart', () => {
@@ -24,14 +24,14 @@ test.describe('Full Hub+Worker Restart', () => {
       await expect(editor).toHaveText('')
 
       // Wait for the assistant's response containing "4"
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         for (const b of bubbles) {
           if (b.textContent?.includes('4'))
             return true
         }
         return false
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
 
       // Verify the user message is also visible
       const userBubbles = page.locator('[data-testid="message-bubble"][data-role="user"]')
@@ -55,21 +55,21 @@ test.describe('Full Hub+Worker Restart', () => {
       await expect(editor).toBeVisible()
 
       // Verify the first conversation is still visible after restart (loaded from DB)
-      await page.waitForFunction(() => {
+      await page.waitForFunction((sel: string) => {
         const userBubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="user"]')
-        const assistantBubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+        const asstBubbles = document.querySelectorAll(sel)
         let hasUserMsg = false
         let hasAssistantResp = false
         for (const b of userBubbles) {
           if (b.textContent?.includes('2+2'))
             hasUserMsg = true
         }
-        for (const b of assistantBubbles) {
+        for (const b of asstBubbles) {
           if (b.textContent?.includes('4'))
             hasAssistantResp = true
         }
         return hasUserMsg && hasAssistantResp
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
 
       // Step 4: Send another message and wait for response.
       await editor.click()
@@ -77,14 +77,14 @@ test.describe('Full Hub+Worker Restart', () => {
       await page.keyboard.press('Meta+Enter')
 
       // Wait for the assistant's response containing "6"
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         for (const b of bubbles) {
           if (b.textContent?.includes('6'))
             return true
         }
         return false
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
 
       // Step 5: Verify both conversations are visible in chat history.
       await page.waitForFunction(() => {
@@ -102,11 +102,11 @@ test.describe('Full Hub+Worker Restart', () => {
       })
 
       // Verify both assistant responses are present
-      await page.waitForFunction(() => {
-        const assistantBubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const asstBubbles = document.querySelectorAll(sel)
         let has4 = false
         let has6 = false
-        for (const b of assistantBubbles) {
+        for (const b of asstBubbles) {
           const text = b.textContent || ''
           if (text.includes('4'))
             has4 = true
@@ -114,7 +114,7 @@ test.describe('Full Hub+Worker Restart', () => {
             has6 = true
         }
         return has4 && has6
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
@@ -247,7 +247,7 @@ test.describe('Full Hub+Worker Restart', () => {
 
       // Wait for the thinking indicator or streaming to appear (agent is processing)
       const thinkingIndicator = page.locator('[data-testid="thinking-indicator"]')
-      const streamingText = page.locator('[data-testid="message-bubble"][data-role="assistant"]')
+      const streamingText = assistantBubbles(page)
       await expect(thinkingIndicator.or(streamingText)).toBeVisible({ timeout: 30_000 })
 
       // Remember the workspace URL so we can navigate back after restart

--- a/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
+++ b/frontend/tests/e2e/24-worker-restart-thinking-indicator.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, assistantBubbles, loginViaToken, waitForWorkspaceReady } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Worker Restart Thinking Indicator', () => {
@@ -25,7 +25,7 @@ test.describe('Worker Restart Thinking Indicator', () => {
 
       // Wait for thinking indicator or streaming to appear (agent is processing)
       const thinkingIndicator = page.locator('[data-testid="thinking-indicator"]')
-      const streamingText = page.locator('[data-testid="message-bubble"][data-role="assistant"]')
+      const streamingText = assistantBubbles(page)
       await expect(thinkingIndicator.or(streamingText)).toBeVisible({ timeout: 30_000 })
 
       // Stop the worker while agent is working
@@ -64,14 +64,14 @@ test.describe('Worker Restart Thinking Indicator', () => {
       await page.keyboard.press('Meta+Enter')
 
       // Wait for the assistant's response
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         for (const b of bubbles) {
           if (b.textContent?.includes('4'))
             return true
         }
         return false
-      }, { timeout: 60_000 })
+      }, ASSISTANT_BUBBLE_SELECTOR, { timeout: 60_000 })
 
       // Stop the worker
       await stopWorker()
@@ -111,14 +111,14 @@ test.describe('Worker Restart Thinking Indicator', () => {
       await page.keyboard.press('Meta+Enter')
 
       // Wait for the assistant's response containing "6"
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         for (const b of bubbles) {
           if (b.textContent?.includes('6'))
             return true
         }
         return false
-      }, { timeout: 60_000 })
+      }, ASSISTANT_BUBBLE_SELECTOR, { timeout: 60_000 })
 
       // Verify that the thinking indicator was shown at some point during
       // the turn, even if only briefly before streaming began.

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { assistantBubbles, firstAssistantBubble } from './helpers/ui'
 
 async function sendAndWaitForReply(page: Page, message: string) {
   const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
@@ -9,9 +10,7 @@ async function sendAndWaitForReply(page: Page, message: string) {
   await page.keyboard.press('Meta+Enter')
 
   // Wait for at least one assistant bubble to appear
-  await expect(
-    page.locator('[data-testid="message-bubble"][data-role="assistant"]').first(),
-  ).toBeVisible()
+  await expect(firstAssistantBubble(page)).toBeVisible()
 }
 
 test.describe('Chat Message Rendering', () => {
@@ -34,9 +33,7 @@ test.describe('Chat Message Rendering', () => {
 
     // Find an assistant bubble whose message-content contains <p> tags
     // (skip thinking bubbles and turn-end indicators which have no <p>)
-    const assistantBubble = page.locator(
-      '[data-testid="message-bubble"][data-role="assistant"]',
-    ).filter({
+    const assistantBubble = assistantBubbles(page).filter({
       has: page.locator('[data-testid="message-content"] p'),
     }).first()
 

--- a/frontend/tests/e2e/25-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/25-no-worker-settings.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, loginViaToken, waitForWorkspaceReady } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Settings and /clear after Worker restart', () => {
@@ -25,14 +25,14 @@ test.describe('Settings and /clear after Worker restart', () => {
       await expect(editor).toHaveText('')
 
       // Wait for the assistant's response containing "4"
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         for (const b of bubbles) {
           if (b.textContent?.includes('4'))
             return true
         }
         return false
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
 
       // Step 2: Restart the Worker (stop + start). All persistent data
       // (workspaces, agents, messages) is stored on the Worker's SQLite DB,
@@ -43,9 +43,9 @@ test.describe('Settings and /clear after Worker restart', () => {
 
       // Wait for the E2EE channels to reconnect and messages to reload.
       // The original conversation should be visible (loaded from Worker DB).
-      await page.waitForFunction(() => {
+      await page.waitForFunction((sel: string) => {
         const userBubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="user"]')
-        const assistantBubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+        const assistantBubbles = document.querySelectorAll(sel)
         let hasUserMsg = false
         let hasAssistantResp = false
         for (const b of userBubbles) {
@@ -57,7 +57,7 @@ test.describe('Settings and /clear after Worker restart', () => {
             hasAssistantResp = true
         }
         return hasUserMsg && hasAssistantResp
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
 
       // Helper: wait for a notification bubble to contain the expected text.
       const waitForNotification = (text: string) =>

--- a/frontend/tests/e2e/26-message-delivery-error.spec.ts
+++ b/frontend/tests/e2e/26-message-delivery-error.spec.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, loginViaUI, waitForWorkspaceReady } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, firstAssistantBubble, loginViaToken, loginViaUI, waitForWorkspaceReady } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
 test.describe('Message Delivery Error', () => {
@@ -24,9 +24,7 @@ test.describe('Message Delivery Error', () => {
       await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
-      await expect(
-        page.locator('[data-testid="message-bubble"][data-role="assistant"]').first(),
-      ).toBeVisible()
+      await expect(firstAssistantBubble(page)).toBeVisible()
 
       // Stop the worker and wait for the hub to confirm it's offline.
       await stopWorker()
@@ -57,10 +55,10 @@ test.describe('Message Delivery Error', () => {
       await expect(errorIndicator).not.toBeVisible()
 
       // Wait for agent response (confirming message was delivered)
-      await page.waitForFunction(() => {
-        const bubbles = document.querySelectorAll('[data-testid="message-bubble"][data-role="assistant"]')
+      await page.waitForFunction((sel: string) => {
+        const bubbles = document.querySelectorAll(sel)
         return bubbles.length >= 2
-      })
+      }, ASSISTANT_BUBBLE_SELECTOR)
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
@@ -86,9 +84,7 @@ test.describe('Message Delivery Error', () => {
       await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
-      await expect(
-        page.locator('[data-testid="message-bubble"][data-role="assistant"]').first(),
-      ).toBeVisible()
+      await expect(firstAssistantBubble(page)).toBeVisible()
 
       // Stop the worker and wait for the hub to confirm it's offline
       await stopWorker()
@@ -145,9 +141,7 @@ test.describe('Message Delivery Error', () => {
       await page.keyboard.press('Meta+Enter')
       await expect(editor).toHaveText('')
 
-      await expect(
-        page.locator('[data-testid="message-bubble"][data-role="assistant"]').first(),
-      ).toBeVisible()
+      await expect(firstAssistantBubble(page)).toBeVisible()
 
       // Stop the worker and wait for the hub to confirm it's offline
       await stopWorker()

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import { lastAssistantBubble } from './helpers/ui'
 import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 /** Open the settings menu, retrying if it was caught mid-close animation. */
@@ -70,6 +71,30 @@ test.describe('Agent Settings', () => {
     await openSettingsMenu(page)
     await page.locator('[data-testid="model-haiku"]').click()
     await expect(trigger).toContainText('Haiku')
+  })
+
+  test('switch to model with bracket characters', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Switch to Sonnet[1m] — model name contains brackets that must be
+    // properly escaped in the shell command when spawning Claude Code.
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="model-sonnet\\[1m\\]"]').click()
+    await expect(trigger).toContainText('Sonnet[1m]')
+    await waitForSettingsIdle(page)
+
+    // Verify agent restarted successfully by sending a message
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+    await editor.click()
+    await page.keyboard.type('What is 3+4? Reply with just the number, nothing else.')
+    await page.keyboard.press('Meta+Enter')
+
+    // Wait for an assistant response — if the agent failed to start, we
+    // would see an error notification instead.
+    const lastAssistant = lastAssistantBubble(page)
+    await expect(lastAssistant).toContainText('7', { timeout: 30000 })
   })
 
   test('switch effort', async ({ authenticatedWorkspace, page }) => {
@@ -190,10 +215,8 @@ test.describe('Agent Settings', () => {
     await page.keyboard.press('Meta+Enter')
 
     // Wait for a response (ensures init message and session ID are stored)
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('2') && !body.includes('Send a message to start')
-    })
+    const lastAssistant1 = lastAssistantBubble(page)
+    await expect(lastAssistant1).toContainText('2', { timeout: 30000 })
 
     // Switch to Plan Mode (dropdown auto-closes on select)
     await openSettingsMenu(page)
@@ -219,10 +242,8 @@ test.describe('Agent Settings', () => {
     await page.keyboard.press('Meta+Enter')
 
     // Wait for a response (agent resumed successfully)
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('4') && !body.includes('Send a message to start')
-    })
+    const lastAssistant2 = lastAssistantBubble(page)
+    await expect(lastAssistant2).toContainText('4', { timeout: 30000 })
 
     // Verify Plan Mode is still selected after worker restart
     await expect(trigger).toContainText('Plan Mode')
@@ -236,19 +257,15 @@ test.describe('Agent Settings', () => {
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
     await page.keyboard.press('Meta+Enter')
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('2') && !body.includes('Send a message to start')
-    })
+    const lastAssistant1 = lastAssistantBubble(page)
+    await expect(lastAssistant1).toContainText('2', { timeout: 30000 })
 
     // Verify the agent is still responsive after interrupt by sending another message
     await editor.click()
     await page.keyboard.type('What is 2+2? Reply with just the number, nothing else.')
     await page.keyboard.press('Meta+Enter')
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('4')
-    })
+    const lastAssistant2 = lastAssistantBubble(page)
+    await expect(lastAssistant2).toContainText('4', { timeout: 30000 })
   })
 
   test('model/effort items not disabled when idle', async ({ authenticatedWorkspace, page }) => {

--- a/frontend/tests/e2e/32-clear-command.spec.ts
+++ b/frontend/tests/e2e/32-clear-command.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { lastAssistantBubble } from './helpers/ui'
 
 test.describe('Clear Command', () => {
   test('slash clear clears context and shows notification', async ({ page, authenticatedWorkspace }) => {
@@ -9,10 +10,8 @@ test.describe('Clear Command', () => {
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
     await page.keyboard.press('Meta+Enter')
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('2') && !body.includes('Send a message to start')
-    })
+    const lastAssistant1 = lastAssistantBubble(page)
+    await expect(lastAssistant1).toContainText('2', { timeout: 30000 })
 
     // Send /clear
     await editor.click()
@@ -26,10 +25,8 @@ test.describe('Clear Command', () => {
     await editor.click()
     await page.keyboard.type('What is 3+3? Reply with just the number, nothing else.')
     await page.keyboard.press('Meta+Enter')
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('6')
-    })
+    const lastAssistant2 = lastAssistantBubble(page)
+    await expect(lastAssistant2).toContainText('6', { timeout: 30000 })
 
     // Verify context usage indicator shows the fallback info icon (cleared).
     // The ContextUsageGrid falls back to an <Info> icon when contextUsage is null.

--- a/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
+++ b/frontend/tests/e2e/33-clear-resets-context-usage.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { lastAssistantBubble } from './helpers/ui'
 
 const CONTEXT_PERCENTAGE_RE = /(\d+)%/
 
@@ -12,10 +13,8 @@ test.describe('Clear Command – Context Usage Reset', () => {
     await editor.click()
     await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
     await page.keyboard.press('Meta+Enter')
-    await page.waitForFunction(() => {
-      const body = document.body.textContent || ''
-      return body.includes('2') && !body.includes('Send a message to start')
-    })
+    const lastAssistant = lastAssistantBubble(page)
+    await expect(lastAssistant).toContainText('2', { timeout: 30000 })
 
     // Wait for the ContextUsageGrid to show the 3x3 SVG grid (non-zero
     // context usage), confirming the agent has sent context info.

--- a/frontend/tests/e2e/41-chat-pagination.spec.ts
+++ b/frontend/tests/e2e/41-chat-pagination.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { firstAssistantBubble } from './helpers/ui'
 
 /**
  * Wait for an agent tab to be present. If none exists, create one.
@@ -25,9 +26,7 @@ async function sendMessage(page: Page, message: string) {
 }
 
 async function waitForAssistantReply(page: Page) {
-  await expect(
-    page.locator('[data-testid="message-bubble"][data-role="assistant"]').first(),
-  ).toBeVisible({ timeout: 30_000 })
+  await expect(firstAssistantBubble(page)).toBeVisible({ timeout: 30_000 })
 }
 
 /** Wait for the agent to finish its turn (no more streaming/thinking indicators). */

--- a/frontend/tests/e2e/56-dropdown-popover.spec.ts
+++ b/frontend/tests/e2e/56-dropdown-popover.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures'
-import { openAgentViaUI } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, openAgentViaUI } from './helpers/ui'
 
 const HAS_TEXT_RE = /.+/
 
@@ -28,7 +28,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
 
     // Wait for the assistant response in the active chat view
     await expect(
-      page.locator('[data-testid="message-bubble"][data-role="assistant"] [data-testid="message-content"]')
+      page.locator(`${ASSISTANT_BUBBLE_SELECTOR} [data-testid="message-content"]`)
         .filter({ hasText: '2' }),
     ).toBeVisible({ timeout: 60_000 })
 
@@ -108,7 +108,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
 
     // Wait for the assistant response in the active chat view
     await expect(
-      page.locator('[data-testid="message-bubble"][data-role="assistant"] [data-testid="message-content"]')
+      page.locator(`${ASSISTANT_BUBBLE_SELECTOR} [data-testid="message-content"]`)
         .filter({ hasText: '2' }),
     ).toBeVisible({ timeout: 60_000 })
 

--- a/frontend/tests/e2e/61-quote-and-mention.spec.ts
+++ b/frontend/tests/e2e/61-quote-and-mention.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, sendMessage, waitForAgentIdle, waitForWorkspaceReady } from './helpers/ui'
+import { firstAssistantBubble, loginViaToken, sendMessage, waitForAgentIdle, waitForWorkspaceReady } from './helpers/ui'
 
 const frontendDir = path.resolve(import.meta.dirname, '../..')
 
@@ -16,7 +16,7 @@ test.describe('Quote and Mention', () => {
     await waitForAgentIdle(page)
 
     // Find an assistant bubble row
-    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    const assistantBubble = firstAssistantBubble(page)
     await expect(assistantBubble).toBeVisible()
 
     // Hover the row to reveal the reply button (it's hidden by default via opacity: 0)
@@ -43,7 +43,7 @@ test.describe('Quote and Mention', () => {
     await waitForAgentIdle(page)
 
     // Find an assistant bubble and click the quote button
-    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    const assistantBubble = firstAssistantBubble(page)
     await expect(assistantBubble).toBeVisible()
     const messageRow = assistantBubble.locator('..')
     await messageRow.hover()
@@ -75,7 +75,7 @@ test.describe('Quote and Mention', () => {
     await waitForAgentIdle(page)
 
     // Find the assistant message content
-    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    const assistantBubble = firstAssistantBubble(page)
     await expect(assistantBubble).toBeVisible()
 
     const messageContent = assistantBubble.locator('[data-testid="message-content"]')
@@ -105,7 +105,7 @@ test.describe('Quote and Mention', () => {
     await waitForAgentIdle(page)
 
     // Find the assistant message content
-    const assistantBubble = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first()
+    const assistantBubble = firstAssistantBubble(page)
     await expect(assistantBubble).toBeVisible()
 
     const messageContent = assistantBubble.locator('[data-testid="message-content"]')

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -28,6 +28,24 @@ export async function waitForControlBanner(page: Page) {
   return banner
 }
 
+/** CSS selector for assistant message bubbles. Exported for use in browser-context code (e.g. waitForFunction). */
+export const ASSISTANT_BUBBLE_SELECTOR = '[data-testid="message-bubble"][data-role="assistant"]'
+
+/** Return a locator for all assistant message bubbles. */
+export function assistantBubbles(page: Page) {
+  return page.locator(ASSISTANT_BUBBLE_SELECTOR)
+}
+
+/** Return a locator for the first assistant message bubble. */
+export function firstAssistantBubble(page: Page) {
+  return page.locator(ASSISTANT_BUBBLE_SELECTOR).first()
+}
+
+/** Return a locator for the last assistant message bubble. */
+export function lastAssistantBubble(page: Page) {
+  return page.locator(ASSISTANT_BUBBLE_SELECTOR).last()
+}
+
 /** Wait for the agent to finish its current turn (thinking indicator gone). */
 export async function waitForAgentIdle(page: Page, timeoutMs = 120_000) {
   // Brief delay so the thinking indicator has time to appear before we


### PR DESCRIPTION
## Motivation

Two independent issues needed to be addressed in the agent infrastructure and e2e test suite.

First, when the agent process exited unexpectedly during startup (e.g. due to an invalid model name or misconfiguration), the error message returned to the caller was generic and did not include the actual process exit code. This made it difficult to diagnose startup failures from logs alone.

Second, the agent process's `Stderr()` method had a race condition: after the process exited, the background goroutine draining stderr might not have finished writing to the buffer before `Stderr()` read from it, leading to incomplete or corrupted output in error messages.

Finally, across 13 e2e test files the CSS selector string `[data-testid="message-bubble"][data-role="assistant"]` was inlined as a literal, and several tests used brittle `page.waitForFunction()` calls that searched the entire `document.body` text rather than targeting specific elements.

## Modifications

**Backend (`backend/internal/worker/agent/agent.go`):**
- Added `stderrDone chan struct{}` to `Agent`, closed when the stderr-draining goroutine finishes. `Stderr()` now waits on this channel (up to 3 seconds) before reading the buffer, eliminating the race condition.
- Extracted `processExitError()` method that returns `"agent process exited with code <N>"` when an `*exec.ExitError` is available, rather than the previous generic message.
- Refactored the `formatStartupError` local closure into a proper method `(a *Agent) formatStartupError()` for reuse across both startup control requests.
- `sendControlAndWait` now calls `a.processExitError()` when `processDone` fires, so startup errors carry the actual exit code.

**E2E tests (`frontend/tests/e2e/`):**
- Added `ASSISTANT_BUBBLE_SELECTOR` constant and three helper functions — `assistantBubbles()`, `firstAssistantBubble()`, `lastAssistantBubble()` — to `helpers/ui.ts`.
- Replaced all 13 occurrences of the inline selector string across test files with calls to the new helpers.
- Replaced `page.waitForFunction()` body-text searches with `expect(lastAssistantBubble(page)).toContainText(...)` assertions.
- Added a test in `31-agent-settings.spec.ts` verifying that agent restart succeeds when the model name contains bracket characters (e.g., `Sonnet[1m]`).

## Result

- Startup error messages for failed agent launches now include the exit code, e.g. `"initialize: agent process exited with code 1; stderr: ..."`, making failures easier to diagnose.
- The race condition between the stderr goroutine and `Stderr()` reads is eliminated; callers consistently see the complete stderr output.
- E2e tests that assert on assistant message content are more reliable and scoped to specific message bubbles rather than the whole page body.
- The assistant-bubble selector is now maintained in a single place (`ASSISTANT_BUBBLE_SELECTOR`), reducing the risk of selector drift across the test suite.

🤖 Generated with Claude Code
