### PR TITLE
fix(agent): Fix model switch failures and stale session ID after restart

### DIFF
--- a/backend/internal/worker/agent/testing.go
+++ b/backend/internal/worker/agent/testing.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// MockStartAgent registers a mock agent process in the manager for testing.
+// The mock process is a simple echo process that reads stdin and writes to
+// stdout. It does not implement the Claude Code protocol.
+//
+// This is intended for use in tests outside the agent package that need a
+// running agent registered in the manager (e.g. to make HasAgent return true).
+func (m *Manager) MockStartAgent(ctx context.Context, opts Options, outputFn OutputHandler) (string, error) {
+	return m.startAgentWith(ctx, opts, outputFn, mockStartForTest)
+}
+
+// mockStartForTest spawns a test helper process (simple cat) instead of the
+// real claude binary. Unlike the internal mockStart used in agent_test.go,
+// this does not depend on TestHelperProcess and uses a plain "cat" command.
+func mockStartForTest(ctx context.Context, opts Options, outputFn OutputHandler) (*Agent, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(ctx, "cat")
+	cmd.Dir = opts.WorkingDir
+	cmd.Env = os.Environ()
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	cmd.Stderr = nil
+
+	a := &Agent{
+		agentID:        opts.AgentID,
+		model:          opts.Model,
+		workingDir:     opts.WorkingDir,
+		cmd:            cmd,
+		stdin:          stdin,
+		ctx:            ctx,
+		cancel:         cancel,
+		processDone:    make(chan struct{}),
+		pendingControl: make(map[string]chan<- controlResult),
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutput(scanner, outputFn)
+
+	return a, nil
+}

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -502,17 +502,20 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		if svc.Agents.HasAgent(agentID) {
 			svc.Agents.StopAndWaitAgent(agentID)
 
+			// Don't resume the old session — it may not have been persisted
+			// (e.g. no user messages were sent before the settings change).
+			// On success, handleSystemInit will overwrite the session ID with
+			// the new one. On failure, we clear it below.
 			agentOpts := agent.Options{
-				AgentID:         agentID,
-				Model:           newModel,
-				Effort:          newEffort,
-				WorkingDir:      dbAgent.WorkingDir,
-				ResumeSessionID: dbAgent.AgentSessionID,
-				PermissionMode:  dbAgent.PermissionMode,
-				StartupTimeout:  svc.agentStartupTimeout(),
-				Shell:           svc.agentShell(),
-				LoginShell:      svc.agentLoginShell(),
-				HomeDir:         svc.HomeDir,
+				AgentID:        agentID,
+				Model:          newModel,
+				Effort:         newEffort,
+				WorkingDir:     dbAgent.WorkingDir,
+				PermissionMode: dbAgent.PermissionMode,
+				StartupTimeout: svc.agentStartupTimeout(),
+				Shell:          svc.agentShell(),
+				LoginShell:     svc.agentLoginShell(),
+				HomeDir:        svc.HomeDir,
 			}
 
 			outputFn := agentOutputFn(svc.Output, agentID, dbAgent.WorkspaceID, dbAgent.WorkingDir)
@@ -520,6 +523,12 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			if _, err := svc.Agents.StartAgent(bgCtx(), agentOpts, outputFn); err != nil {
 				slog.Error("failed to restart agent with new settings",
 					"agent_id", agentID, "error", err)
+				// Clear stale session ID so ensureAgentRunning won't try
+				// to resume a non-existent session on the next message.
+				_ = svc.Queries.UpdateAgentSessionID(bgCtx(), db.UpdateAgentSessionIDParams{
+					AgentSessionID: "",
+					ID:             agentID,
+				})
 				svc.Output.BroadcastNotification(agentID, map[string]interface{}{
 					"type":  "agent_error",
 					"error": "Failed to restart agent with new settings: " + err.Error(),

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func TestUpdateAgentSettings_ClearsSessionIDOnRestartFailure(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+
+	workDir := t.TempDir()
+
+	// Create an agent in the DB with a session ID already set
+	// (simulates a previously running agent that established a session).
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  workDir,
+		HomeDir:     t.TempDir(),
+		Model:       "opus",
+	}))
+	require.NoError(t, svc.Queries.UpdateAgentSessionID(ctx, db.UpdateAgentSessionIDParams{
+		AgentSessionID: "old-session-id",
+		ID:             "agent-1",
+	}))
+
+	// Register a mock agent so HasAgent returns true and the restart
+	// path is entered. The subsequent StartAgent call will fail because
+	// the mock agent doesn't implement the Claude Code initialization
+	// protocol (sendControlAndWait will time out or fail).
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Model:      "opus",
+		WorkingDir: workDir,
+	}, func([]byte) {})
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// Switch model — StopAndWaitAgent will kill the mock agent, then
+	// StartAgent will try to start a real claude process which will fail
+	// during the initialization handshake (startup timeout).
+	// Use a very short startup timeout to speed up the test.
+	svc.AgentStartupTimeout = 1 * time.Nanosecond // forces immediate timeout
+
+	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
+		AgentId: "agent-1",
+		Model:   "sonnet",
+	}, w)
+
+	// Verify the session ID was cleared from the DB.
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Empty(t, dbAgent.AgentSessionID,
+		"session ID should be cleared after failed restart")
+
+	// Verify the model was still updated in the DB.
+	assert.Equal(t, "sonnet", dbAgent.Model,
+		"model should be updated even when restart fails")
+}
+
+func TestUpdateAgentSettings_DoesNotResumeSessionOnRestart(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+
+	// Create an agent with a session ID.
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Model:       "opus",
+	}))
+	require.NoError(t, svc.Queries.UpdateAgentSessionID(ctx, db.UpdateAgentSessionIDParams{
+		AgentSessionID: "old-session-id",
+		ID:             "agent-1",
+	}))
+
+	// Agent is NOT running (HasAgent returns false), so the restart
+	// block is skipped. Verify the DB update works correctly.
+	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
+		AgentId: "agent-1",
+		Model:   "sonnet",
+	}, w)
+
+	// Verify the response was successful (no errors).
+	require.Empty(t, w.errors, "expected no errors")
+	require.Len(t, w.responses, 1, "expected one response")
+
+	var resp leapmuxv1.UpdateAgentSettingsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+
+	// Verify the model was updated.
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, "sonnet", dbAgent.Model)
+
+	// Session ID should remain unchanged when no restart was attempted.
+	assert.Equal(t, "old-session-id", dbAgent.AgentSessionID,
+		"session ID should not change when agent is not running")
+}


### PR DESCRIPTION
## Motivation
When switching models or effort settings on a fresh tab (before sending any messages), the agent would crash with "agent process exited with code 1". This happened because `UpdateAgentSettings` unconditionally passed the existing `ResumeSessionID` to the restarted agent, but Claude Code may not have persisted that session yet if no user messages were sent.

A related problem could also occur after a failed restart: the stale session ID remained in the database, causing subsequent messages to fail with "No conversation found with session ID" when `ensureAgentRunning` tried to resume a session that never existed.

## Modifications
- Removed `ResumeSessionID` from `agent.Options` in `UpdateAgentSettings` so that restarting the agent for a model or effort change never attempts to resume a potentially unpersisted session.
- Added a `UpdateAgentSessionID("", agentID)` call in the error path of `StartAgent` inside `UpdateAgentSettings` to clear the stale session ID from the database when a restart fails, preventing resume attempts on non-existent sessions.

## Result
Switching models or effort level on a fresh tab (before sending any messages) no longer fails with an "agent process exited with code 1" error. If a restart does fail for another reason, the stale session ID is cleared so the next user message can start a clean session instead of hitting a "No conversation found with session ID" error.

🤖 Generated with Claude Code
