### PR TITLE
Fix git base branch default, remote branch list, and dropdown reopen

### DIFF
--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -257,8 +257,11 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 		// Get remote tracking branches.
 		remoteOut, _ := gitOutput(ctx, repoRoot, "branch", "-r", "--list", "--format=%(refname:short)")
 		for _, b := range parseGitLines(remoteOut) {
-			// Skip HEAD pointers and branches that already have a local counterpart.
+			// Skip HEAD pointers, bare remote names, and branches that already have a local counterpart.
 			if strings.HasSuffix(b, "/HEAD") {
+				continue
+			}
+			if !strings.Contains(b, "/") {
 				continue
 			}
 			// e.g. "origin/main" -> check if "main" exists locally.

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -254,7 +254,10 @@ export function DropdownMenu(props: DropdownMenuProps) {
             ref={popoverRefCallback /* eslint-disable-line solid/reactivity -- ref callback, not a signal */}
             class={props.class}
             data-testid={props['data-testid']}
-            onClick={e => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              popoverEl?.hidePopover()
+            }}
           >
             {props.children}
           </menu>
@@ -266,7 +269,10 @@ export function DropdownMenu(props: DropdownMenuProps) {
           ref={popoverRefCallback /* eslint-disable-line solid/reactivity -- ref callback, not a signal */}
           class={props.class}
           data-testid={props['data-testid']}
-          onClick={e => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation()
+            popoverEl?.hidePopover()
+          }}
         >
           {props.children}
         </div>

--- a/frontend/src/components/shell/GitOptions.tsx
+++ b/frontend/src/components/shell/GitOptions.tsx
@@ -127,7 +127,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
         return
       setBranches(resp.branches)
       // Default the base branch to the current branch.
-      const cur = currentBranch() || resp.currentBranch
+      const cur = resp.currentBranch || currentBranch()
       if (!selectedBaseBranch() && cur) {
         setSelectedBaseBranch(cur)
       }


### PR DESCRIPTION
## Motivation

Three independent bugs were found in the git-related UI and backend logic:

1. Bare remote names (e.g. `origin` without a `/`) were appearing in the remote branch list shown in "Switch to branch", polluting the list with non-branch entries.
2. After opening a dialog from a dropdown menu item and dismissing it, the dropdown could not be reopened. The `showModal()` call auto-dismisses the popover without firing a `toggle` event, leaving `isOpen` in a stale state.
3. When creating a new worktree from within an existing worktree, the base branch defaulted to the worktree's own branch instead of the main repository's current branch.

## Modifications

- `backend/internal/worker/service/git.go`: Skip remote tracking entries that contain no `/` when building the remote branch list, filtering out bare remote names.
- `frontend/src/components/common/DropdownMenu.tsx`: Explicitly call `hidePopover()` when a dropdown item is clicked, so the open/closed state stays accurate even when `toggle` is not fired by the browser.
- `frontend/src/components/shell/GitOptions.tsx`: Swap priority so `resp.currentBranch` (from `ListGitBranches`, reflecting the main repo) takes precedence over `currentBranch()` (from `GetGitInfo`, reflecting the worktree) as the default base branch for new worktrees.

## Result

- The remote branch dropdown no longer shows bare remote names like `origin` alongside actual branch names.
- Dropdowns that open dialogs can be reopened after the dialog is dismissed.
- "Create new worktree" correctly defaults to the main repository's current branch rather than the active worktree's branch.

🤖 Generated with Claude Code
