### PR TITLE
fix(backend): Include symlinked directories in workspace directory tree

### DIFF
--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -221,6 +221,19 @@ func fileInfoToProto(info os.FileInfo, absPath string) *leapmuxv1.FileInfo {
 	}
 }
 
+// isDirEntry reports whether de is a directory or a symlink to a directory
+// under parentDir. It follows symlinks, unlike de.IsDir().
+func isDirEntry(de os.DirEntry, parentDir string) bool {
+	if de.IsDir() {
+		return true
+	}
+	if de.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(parentDir, de.Name()))
+	return err == nil && info.IsDir()
+}
+
 // listDirectory reads directory entries, sorts them (directories first, then
 // alphabetically), truncates to maxDirEntries, and optionally merges
 // single-child directories. Sorting and truncating happen on the lightweight
@@ -237,7 +250,7 @@ func listDirectory(dirPath, basePath string, maxDepth int32, currentDepth int32,
 	if dirsOnly {
 		n := 0
 		for _, de := range dirEntries {
-			if de.IsDir() {
+			if isDirEntry(de, dirPath) {
 				dirEntries[n] = de
 				n++
 			}
@@ -247,7 +260,7 @@ func listDirectory(dirPath, basePath string, maxDepth int32, currentDepth int32,
 
 	// Sort using DirEntry metadata (no extra syscalls).
 	sort.Slice(dirEntries, func(i, j int) bool {
-		iDir, jDir := dirEntries[i].IsDir(), dirEntries[j].IsDir()
+		iDir, jDir := isDirEntry(dirEntries[i], dirPath), isDirEntry(dirEntries[j], dirPath)
 		if iDir != jDir {
 			return iDir
 		}

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -238,4 +238,76 @@ func TestListDirectory_DirsOnly(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("includes symlinked directories", func(t *testing.T) {
+		dir := t.TempDir()
+		// Create a real directory and a symlink pointing to it.
+		realDir := filepath.Join(dir, "realdir")
+		if err := os.Mkdir(realDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realDir, filepath.Join(dir, "linkdir")); err != nil {
+			t.Fatal(err)
+		}
+		// Also create a regular file and a symlink to a file (both should be excluded).
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		fileTarget := filepath.Join(dir, "file.txt")
+		if err := os.Symlink(fileTarget, filepath.Join(dir, "linkfile")); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, _, err := listDirectory(dir, dir, 0, 0, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries (realdir + linkdir), got %d", len(entries))
+		}
+		for _, e := range entries {
+			if !e.IsDir {
+				t.Errorf("expected only directories, got non-dir %q", e.Name)
+			}
+		}
+	})
+
+	t.Run("symlinked directories sort with real directories", func(t *testing.T) {
+		dir := t.TempDir()
+		// Create: aaa_file (file), bbb_dir (dir), ccc_link (symlink->dir), ddd_file (file).
+		if err := os.WriteFile(filepath.Join(dir, "aaa_file"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(dir, "bbb_dir"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(dir, "bbb_dir")
+		if err := os.Symlink(target, filepath.Join(dir, "ccc_link")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "ddd_file"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, _, err := listDirectory(dir, dir, 0, 0, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Directories (real + symlinked) should come first.
+		if len(entries) < 2 {
+			t.Fatalf("expected at least 2 entries, got %d", len(entries))
+		}
+		// First two entries should be directories (bbb_dir and ccc_link, both dirs).
+		for _, e := range entries[:2] {
+			if !e.IsDir {
+				t.Errorf("expected directory in first two entries, got file %q", e.Name)
+			}
+		}
+		// Last two entries should be files.
+		for _, e := range entries[2:] {
+			if e.IsDir {
+				t.Errorf("expected file in last two entries, got dir %q", e.Name)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Motivation
The workspace directory tree listing excluded symlinked directories because the standard `IsDir()` method returns `false` for symlinks without following them. This meant that any directory reachable via a symlink was invisible in the workspace tree, which is unexpected and limits usability in workspaces that rely on symlinks.

## Modifications
- Added an internal `isDirEntry()` helper in `backend/internal/worker/service/file.go` that uses `os.Stat()` to follow symlinks before checking whether an entry is a directory
- Updated `listDirectory()` to use `isDirEntry()` instead of `IsDir()` in both the directory-filter path (when `dirsOnly=true`) and the sort-order path
- Added two new test cases in `file_test.go` covering: symlinked directories appearing in `dirsOnly` listings, and symlinked directories sorting correctly alongside real directories

## Result
Symlinked directories are now included in workspace directory tree listings. If your workspace contains a directory symlink, it will appear in the tree just like a regular directory.

🤖 Generated with Claude Code
