### PR TITLE
feat(terminal): Open terminal tabs as interactive login shells

### DIFF
--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
+
+	"github.com/leapmux/leapmux/internal/worker/terminal"
 )
 
 // buildShellWrappedCommand constructs an exec.Cmd that launches the claude
@@ -36,24 +37,24 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 
 	var cmdArgs []string
 	switch {
-	case isPwsh(shellName):
+	case terminal.IsPwsh(shellName):
 		inner := buildPwshCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs)
 		if interactive {
-			cmdArgs = []string{"-Login", "-Command", inner}
+			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-Command", inner)
 		} else {
 			cmdArgs = []string{"-Command", inner}
 		}
 	case shellName == "tcsh" || shellName == "csh":
 		inner := buildPosixCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
 		if interactive {
-			cmdArgs = []string{"-ic", inner}
+			cmdArgs = []string{"-i", "-c", inner} // tcsh: -l must be the only flag
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
 	case shellName == "nu":
 		inner := buildNuCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs)
 		if interactive {
-			cmdArgs = []string{"-i", "-l", "-c", inner}
+			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-c", inner)
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
@@ -61,7 +62,7 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
 		inner := buildPosixCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
 		if interactive {
-			cmdArgs = []string{"-i", "-l", "-c", inner}
+			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-c", inner)
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
@@ -233,11 +234,4 @@ func posixQuote(s string) string {
 // Single quotes within the string are escaped by doubling them (").
 func pwshQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
-}
-
-var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
-
-// isPwsh returns true if the shell name matches PowerShell variants.
-func isPwsh(name string) bool {
-	return pwshPattern.MatchString(name)
 }

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -47,7 +47,7 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 	case shellName == "tcsh" || shellName == "csh":
 		inner := buildPosixCommand(delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
 		if interactive {
-			cmdArgs = []string{"-i", "-c", inner} // tcsh: -l must be the only flag
+			cmdArgs = []string{"-ic", inner} // tcsh: -l must be the only flag
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/leapmux/leapmux/internal/worker/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -87,11 +88,12 @@ func TestBuildShellWrappedCommand_Tcsh_Interactive(t *testing.T) {
 		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
 	)
 	assert.Equal(t, "/bin/tcsh", cmd.Path)
-	require.Len(t, cmd.Args, 3) // tcsh -ic <cmd>
-	assert.Equal(t, "-ic", cmd.Args[1])
-	assert.Contains(t, cmd.Args[2], "echo '"+delimiter+"'")
-	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
-	assert.Contains(t, cmd.Args[2], "exec claude")
+	require.Len(t, cmd.Args, 4) // tcsh -i -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-c", cmd.Args[2])
+	assert.Contains(t, cmd.Args[3], "echo '"+delimiter+"'")
+	assert.Contains(t, cmd.Args[3], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[3], "exec claude")
 }
 
 func TestBuildShellWrappedCommand_Tcsh_NonInteractive(t *testing.T) {
@@ -110,10 +112,11 @@ func TestBuildShellWrappedCommand_Csh(t *testing.T) {
 		[]string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
 	)
 	assert.Equal(t, "/bin/csh", cmd.Path)
-	require.Len(t, cmd.Args, 3) // csh -ic <cmd>
-	assert.Equal(t, "-ic", cmd.Args[1])
-	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
-	assert.Contains(t, cmd.Args[2], "exec claude")
+	require.Len(t, cmd.Args, 4) // csh -i -c <cmd>
+	assert.Equal(t, "-i", cmd.Args[1])
+	assert.Equal(t, "-c", cmd.Args[2])
+	assert.Contains(t, cmd.Args[3], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[3], "exec claude")
 }
 
 func TestBuildShellWrappedCommand_Nu_Interactive(t *testing.T) {
@@ -318,11 +321,11 @@ func TestPwshQuote(t *testing.T) {
 }
 
 func TestIsPwsh(t *testing.T) {
-	assert.True(t, isPwsh("pwsh"))
-	assert.True(t, isPwsh("powershell"))
-	assert.True(t, isPwsh("pwsh-preview"))
-	assert.True(t, isPwsh("powershell-preview"))
-	assert.False(t, isPwsh("bash"))
-	assert.False(t, isPwsh("zsh"))
-	assert.False(t, isPwsh("pwsh-extra-stuff"))
+	assert.True(t, terminal.IsPwsh("pwsh"))
+	assert.True(t, terminal.IsPwsh("powershell"))
+	assert.True(t, terminal.IsPwsh("pwsh-preview"))
+	assert.True(t, terminal.IsPwsh("powershell-preview"))
+	assert.False(t, terminal.IsPwsh("bash"))
+	assert.False(t, terminal.IsPwsh("zsh"))
+	assert.False(t, terminal.IsPwsh("pwsh-extra-stuff"))
 }

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -88,12 +88,11 @@ func TestBuildShellWrappedCommand_Tcsh_Interactive(t *testing.T) {
 		[]string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
 	)
 	assert.Equal(t, "/bin/tcsh", cmd.Path)
-	require.Len(t, cmd.Args, 4) // tcsh -i -c <cmd>
-	assert.Equal(t, "-i", cmd.Args[1])
-	assert.Equal(t, "-c", cmd.Args[2])
-	assert.Contains(t, cmd.Args[3], "echo '"+delimiter+"'")
-	assert.Contains(t, cmd.Args[3], "unset CLAUDECODE")
-	assert.Contains(t, cmd.Args[3], "exec claude")
+	require.Len(t, cmd.Args, 3) // tcsh -ic <cmd>
+	assert.Equal(t, "-ic", cmd.Args[1])
+	assert.Contains(t, cmd.Args[2], "echo '"+delimiter+"'")
+	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[2], "exec claude")
 }
 
 func TestBuildShellWrappedCommand_Tcsh_NonInteractive(t *testing.T) {
@@ -112,11 +111,10 @@ func TestBuildShellWrappedCommand_Csh(t *testing.T) {
 		[]string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
 	)
 	assert.Equal(t, "/bin/csh", cmd.Path)
-	require.Len(t, cmd.Args, 4) // csh -i -c <cmd>
-	assert.Equal(t, "-i", cmd.Args[1])
-	assert.Equal(t, "-c", cmd.Args[2])
-	assert.Contains(t, cmd.Args[3], "unset CLAUDECODE")
-	assert.Contains(t, cmd.Args[3], "exec claude")
+	require.Len(t, cmd.Args, 3) // csh -ic <cmd>
+	assert.Equal(t, "-ic", cmd.Args[1])
+	assert.Contains(t, cmd.Args[2], "unset CLAUDECODE")
+	assert.Contains(t, cmd.Args[2], "exec claude")
 }
 
 func TestBuildShellWrappedCommand_Nu_Interactive(t *testing.T) {

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -1,0 +1,33 @@
+package terminal
+
+import (
+	"path/filepath"
+	"regexp"
+)
+
+var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
+
+// IsPwsh returns true if the shell name matches PowerShell variants
+// (pwsh, powershell, pwsh-preview, powershell-preview).
+func IsPwsh(name string) bool {
+	return pwshPattern.MatchString(name)
+}
+
+// LoginShellArgs returns the flags needed to start the given shell as an
+// interactive login shell (no -c command). The returned slice is safe to
+// append to.
+//
+//   - pwsh/powershell: ["-Login"]
+//   - tcsh/csh:        ["-l"]  — tcsh requires -l as the only flag
+//   - all others:      ["-i", "-l"]
+func LoginShellArgs(shellPath string) []string {
+	name := filepath.Base(shellPath)
+	switch {
+	case IsPwsh(name):
+		return []string{"-Login"}
+	case name == "tcsh" || name == "csh":
+		return []string{"-l"}
+	default:
+		return []string{"-i", "-l"}
+	}
+}

--- a/backend/internal/worker/terminal/login_shell_test.go
+++ b/backend/internal/worker/terminal/login_shell_test.go
@@ -1,0 +1,46 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoginShellArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		shellPath string
+		want      []string
+	}{
+		{"bash", "/bin/bash", []string{"-i", "-l"}},
+		{"zsh", "/bin/zsh", []string{"-i", "-l"}},
+		{"fish", "/usr/bin/fish", []string{"-i", "-l"}},
+		{"sh", "/bin/sh", []string{"-i", "-l"}},
+		{"nu", "/usr/bin/nu", []string{"-i", "-l"}},
+		{"tcsh", "/bin/tcsh", []string{"-l"}},
+		{"csh", "/bin/csh", []string{"-l"}},
+		{"pwsh", "/usr/bin/pwsh", []string{"-Login"}},
+		{"powershell", "/usr/bin/powershell", []string{"-Login"}},
+		{"pwsh-preview", "/usr/bin/pwsh-preview", []string{"-Login"}},
+		{"unknown", "/usr/bin/xonsh", []string{"-i", "-l"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LoginShellArgs(tt.shellPath))
+		})
+	}
+}
+
+func TestIsPwsh(t *testing.T) {
+	// Positive cases
+	assert.True(t, IsPwsh("pwsh"))
+	assert.True(t, IsPwsh("powershell"))
+	assert.True(t, IsPwsh("pwsh-preview"))
+	assert.True(t, IsPwsh("powershell-preview"))
+
+	// Negative cases
+	assert.False(t, IsPwsh("bash"))
+	assert.False(t, IsPwsh("zsh"))
+	assert.False(t, IsPwsh("fish"))
+	assert.False(t, IsPwsh("pwsh-extra-stuff"))
+}

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -93,7 +93,8 @@ func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 		shell = ResolveDefaultShell()
 	}
 
-	cmd := exec.Command(shell)
+	args := LoginShellArgs(shell)
+	cmd := exec.Command(shell, args...)
 	cmd.Dir = opts.WorkingDir
 	cmd.Env = append(os.Environ(),
 		"TERM=xterm-256color",
@@ -136,6 +137,7 @@ func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 	slog.Info("terminal started",
 		"terminal_id", opts.ID,
 		"shell", shell,
+		"args", args,
 		"pid", cmd.Process.Pid,
 	)
 


### PR DESCRIPTION
## Motivation

Terminal tabs were not launched as interactive login shells, which meant
user shell profiles (e.g., `~/.bash_profile`, `~/.zprofile`) were never
sourced. This caused missing environment variables, aliases, and other
per-user configuration when opening a terminal in the UI.

Additionally, the logic for deriving the correct shell flags was
duplicated between the agent and terminal packages with no shared
abstraction, making it error-prone to keep in sync.

## Modifications

- Added `backend/internal/worker/terminal/login_shell.go` with two new
  public functions:
  - `IsPwsh(name string) bool` — detects PowerShell variants
    (`pwsh`, `powershell`, `pwsh-preview`, `powershell-preview`)
  - `LoginShellArgs(shellPath string) []string` — returns the
    shell-appropriate flags for starting an interactive login shell
    (`-Login` for pwsh, `-l` for tcsh/csh, `-i -l` for all others)
- Updated `terminal.Start()` to call `LoginShellArgs()` when constructing
  the shell command, replacing the previous bare invocation with no flags
- Moved `IsPwsh()` out of `agent/shell.go` into the new shared module and
  updated `agent/shell.go` to use `LoginShellArgs()` from the terminal
  package, removing the duplicated flag logic
- tcsh/csh retains the combined `-ic` flag in the agent shell-wrapping
  context (where a command is passed via `-c`), with a comment explaining
  that `-l` must be the only flag when tcsh starts without a `-c` command

## Result

Terminal tabs now launch as interactive login shells, so shell profiles
are sourced automatically. Users will see their environment variables,
aliases, and prompt customisations loaded correctly when opening a new
terminal tab — the same experience as opening a native terminal.

Shell flag handling for interactive login shells is now centralised in
`terminal.LoginShellArgs()`, reducing duplication and making future
shell-compatibility fixes easier to apply in one place.

🤖 Generated with Claude Code
