### PR TITLE
Add git remote URL and branch to git status response

### DIFF
--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -150,10 +150,17 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		sendProtoResponse(sender, &leapmuxv1.GetGitFileStatusResponse{
+		resp := &leapmuxv1.GetGitFileStatusResponse{
 			RepoRoot: repoRoot,
 			Files:    files,
-		})
+		}
+		if branch, err := gitOutput(ctx, repoRoot, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+			resp.CurrentBranch = strings.TrimSpace(branch)
+		}
+		if originURL, err := gitOutput(ctx, repoRoot, "config", "--get", "remote.origin.url"); err == nil {
+			resp.OriginUrl = strings.TrimSpace(originURL)
+		}
+		sendProtoResponse(sender, resp)
 	})
 
 	d.Register("ReadGitFile", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {

--- a/backend/internal/worker/service/git_test.go
+++ b/backend/internal/worker/service/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -115,6 +116,42 @@ func TestGetGitFileStatusEntries_NonGitDir(t *testing.T) {
 	files, err := getGitFileStatusEntries(context.Background(), dir)
 	require.NoError(t, err)
 	assert.Nil(t, files)
+}
+
+func TestGetGitFileStatus_ReturnsOriginUrlAndCurrentBranch(t *testing.T) {
+	dir := initRepo(t)
+	ctx := context.Background()
+
+	// Set a remote origin URL.
+	run(t, dir, "git", "remote", "add", "origin", "https://github.com/test/repo.git")
+
+	// Create a file so there's something in the status.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello\n"), 0o644))
+
+	// Resolve repo root (matches what the handler does).
+	repoRoot, err := gitOutput(ctx, dir, "rev-parse", "--show-toplevel")
+	require.NoError(t, err)
+	repoRoot = strings.TrimSpace(repoRoot)
+
+	// Simulate what the handler does: get files, then branch/origin.
+	files, err := getGitFileStatusEntries(ctx, repoRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	resp := &leapmuxv1.GetGitFileStatusResponse{
+		RepoRoot: repoRoot,
+		Files:    files,
+	}
+	if branch, err := gitOutput(ctx, repoRoot, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		resp.CurrentBranch = strings.TrimSpace(branch)
+	}
+	if originURL, err := gitOutput(ctx, repoRoot, "config", "--get", "remote.origin.url"); err == nil {
+		resp.OriginUrl = strings.TrimSpace(originURL)
+	}
+
+	// The default branch name depends on git config; just verify it's non-empty.
+	assert.NotEmpty(t, resp.CurrentBranch)
+	assert.Equal(t, "https://github.com/test/repo.git", resp.OriginUrl)
 }
 
 func TestResolveMainRepoRoot_RegularRepo(t *testing.T) {

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -338,6 +338,8 @@ export const AppShell: ParentComponent = (props) => {
   createEffect(() => {
     const files = gitFileStatusStore.state.files
     const repoRoot = gitFileStatusStore.state.repoRoot
+    const originUrl = gitFileStatusStore.state.originUrl
+    const currentBranch = gitFileStatusStore.state.currentBranch
     if (!repoRoot)
       return
     let added = 0
@@ -352,14 +354,29 @@ export const AppShell: ParentComponent = (props) => {
         deleted += f.linesDeleted + f.stagedLinesDeleted
       }
     }
+    const gitFields = {
+      gitDiffAdded: added,
+      gitDiffDeleted: deleted,
+      gitDiffUntracked: untracked,
+      gitOriginUrl: originUrl || undefined,
+      gitBranch: currentBranch || undefined,
+    }
     for (const tab of untrack(() => tabStore.state.tabs)) {
-      if (tab.type !== TabType.AGENT)
-        continue
-      const agent = untrack(() => agentStore.state.agents.find(a => a.id === tab.id))
-      if (!agent?.workingDir)
-        continue
-      if (agent.workingDir === repoRoot || agent.workingDir.startsWith(`${repoRoot}/`)) {
-        tabStore.updateTab(TabType.AGENT, tab.id, { gitDiffAdded: added, gitDiffDeleted: deleted, gitDiffUntracked: untracked })
+      if (tab.type === TabType.AGENT) {
+        const agent = untrack(() => agentStore.state.agents.find(a => a.id === tab.id))
+        if (!agent?.workingDir)
+          continue
+        if (agent.workingDir === repoRoot || agent.workingDir.startsWith(`${repoRoot}/`)) {
+          tabStore.updateTab(TabType.AGENT, tab.id, gitFields)
+        }
+      }
+      else if (tab.type === TabType.TERMINAL) {
+        const workingDir = tab.workingDir
+        if (!workingDir)
+          continue
+        if (workingDir === repoRoot || workingDir.startsWith(`${repoRoot}/`)) {
+          tabStore.updateTab(TabType.TERMINAL, tab.id, gitFields)
+        }
       }
     }
   })

--- a/frontend/src/stores/gitFileStatus.store.ts
+++ b/frontend/src/stores/gitFileStatus.store.ts
@@ -12,6 +12,8 @@ export type GitFilterTab = 'all' | 'changed' | 'staged' | 'unstaged'
 interface GitFileStatusState {
   isGitRepo: boolean
   repoRoot: string
+  originUrl: string
+  currentBranch: string
   files: GitFileStatusEntry[]
 }
 
@@ -19,6 +21,8 @@ export function createGitFileStatusStore() {
   const [state, setState] = createStore<GitFileStatusState>({
     isGitRepo: false,
     repoRoot: '',
+    originUrl: '',
+    currentBranch: '',
     files: [],
   })
 
@@ -33,6 +37,8 @@ export function createGitFileStatusStore() {
       setState(produce((s) => {
         s.isGitRepo = true
         s.repoRoot = resp.repoRoot
+        s.originUrl = resp.originUrl
+        s.currentBranch = resp.currentBranch
         s.files = resp.files
       }))
     }
@@ -40,6 +46,8 @@ export function createGitFileStatusStore() {
       setState(produce((s) => {
         s.isGitRepo = false
         s.repoRoot = ''
+        s.originUrl = ''
+        s.currentBranch = ''
         s.files = []
       }))
     }
@@ -49,7 +57,7 @@ export function createGitFileStatusStore() {
   }
 
   const clear = () => {
-    setState({ isGitRepo: false, repoRoot: '', files: [] })
+    setState({ isGitRepo: false, repoRoot: '', originUrl: '', currentBranch: '', files: [] })
   }
 
   const getFileStatus = (absPath: string): GitFileStatusEntry | undefined => {

--- a/frontend/tests/unit/stores/gitFileStatus.store.test.ts
+++ b/frontend/tests/unit/stores/gitFileStatus.store.test.ts
@@ -118,6 +118,52 @@ describe('gitFileStatusStore', () => {
     })
   })
 
+  describe('originUrl and currentBranch', () => {
+    it('stores originUrl and currentBranch after successful refresh', async () => {
+      await createRoot(async (dispose) => {
+        const store = createGitFileStatusStore()
+
+        mockGetGitFileStatus.mockResolvedValueOnce({
+          repoRoot: '/repo',
+          originUrl: 'https://github.com/test/repo.git',
+          currentBranch: 'main',
+          files: [],
+        })
+
+        await store.refresh('worker1', '/repo')
+
+        expect(store.state.originUrl).toBe('https://github.com/test/repo.git')
+        expect(store.state.currentBranch).toBe('main')
+
+        dispose()
+      })
+    })
+
+    it('clears originUrl and currentBranch on refresh error', async () => {
+      await createRoot(async (dispose) => {
+        const store = createGitFileStatusStore()
+
+        // First, populate with valid data.
+        mockGetGitFileStatus.mockResolvedValueOnce({
+          repoRoot: '/repo',
+          originUrl: 'https://github.com/test/repo.git',
+          currentBranch: 'main',
+          files: [],
+        })
+        await store.refresh('worker1', '/repo')
+
+        // Now simulate an error.
+        mockGetGitFileStatus.mockRejectedValueOnce(new Error('network error'))
+        await store.refresh('worker1', '/repo')
+
+        expect(store.state.originUrl).toBe('')
+        expect(store.state.currentBranch).toBe('')
+
+        dispose()
+      })
+    })
+  })
+
   describe('getChangedFiles', () => {
     it('includes untracked files in changed and unstaged filters', async () => {
       await createRoot(async (dispose) => {

--- a/proto/leapmux/v1/git.proto
+++ b/proto/leapmux/v1/git.proto
@@ -56,7 +56,9 @@ message GetGitFileStatusRequest {
 
 message GetGitFileStatusResponse {
   string repo_root = 1;
-  repeated GitFileStatusEntry files = 2;  // Paths are relative to repo root
+  string origin_url = 2;
+  string current_branch = 3;
+  repeated GitFileStatusEntry files = 4;  // Paths are relative to repo root
 }
 
 // GitFileRef specifies which version of a file to read.


### PR DESCRIPTION
## Motivation

The frontend had no reliable way to keep the git branch and remote origin URL up to date after initial tab creation. These values were only populated from `statusChange` events or at tab creation time, so changes (e.g., `git remote set-url origin ...` or branch switches) were not reflected until a status change event happened to arrive.

## Modifications

- Extended `GetGitFileStatusResponse` in `proto/leapmux/v1/git.proto` to include `origin_url` (field 2) and `current_branch` (field 3); the `files` array was renumbered to field 4
- Updated the backend git handler in `backend/internal/worker/service/git.go` to populate the new fields by running `git config --get remote.origin.url` and `git rev-parse --abbrev-ref HEAD` on each status refresh
- Updated `frontend/src/stores/gitFileStatus.store.ts` to track and persist `originUrl` and `currentBranch` in store state, with proper initialization and clearing on refresh
- Refactored `frontend/src/components/shell/AppShell.tsx` to distribute git metadata to both Agent and Terminal tabs, unifying the update logic across tab types
- Added backend test in `git_test.go` covering origin URL and branch population, and frontend unit tests in `gitFileStatus.store.test.ts` covering store persistence and error-handling for the new fields

## Result

After this change, git status refreshes now return the active branch name and remote origin URL alongside the file status list. Both Agent and Terminal tabs in AppShell receive this metadata, keeping the UI current after manual refreshes (refresh icon) and automatic refreshes (after each agent turn).

🤖 Generated with Claude Code
