### PR TITLE
Add show/hide hidden files toggle to file browser

### DIFF
--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -218,7 +218,7 @@ func fileInfoToProto(info os.FileInfo, absPath string) *leapmuxv1.FileInfo {
 		Size:        info.Size(),
 		ModTime:     info.ModTime().UTC().Format(time.RFC3339),
 		Permissions: fmt.Sprintf("%04o", info.Mode().Perm()),
-		Hidden:      isHidden(info.Name()),
+		Hidden:      isHidden(absPath, info.Name()),
 	}
 }
 

--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -218,6 +218,7 @@ func fileInfoToProto(info os.FileInfo, absPath string) *leapmuxv1.FileInfo {
 		Size:        info.Size(),
 		ModTime:     info.ModTime().UTC().Format(time.RFC3339),
 		Permissions: fmt.Sprintf("%04o", info.Mode().Perm()),
+		Hidden:      isHidden(info.Name()),
 	}
 }
 

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -173,6 +173,66 @@ func TestListDirectory_TruncationKeepsDirsFirst(t *testing.T) {
 	}
 }
 
+func TestFileInfoToProto_Hidden(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a hidden file and a regular file.
+	hiddenPath := filepath.Join(dir, ".hidden")
+	regularPath := filepath.Join(dir, "visible.txt")
+	if err := os.WriteFile(hiddenPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(regularPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hiddenInfo, err := os.Stat(hiddenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	regularInfo, err := os.Stat(regularPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hiddenProto := fileInfoToProto(hiddenInfo, hiddenPath)
+	if !hiddenProto.Hidden {
+		t.Errorf("expected Hidden=true for %q", hiddenPath)
+	}
+
+	regularProto := fileInfoToProto(regularInfo, regularPath)
+	if regularProto.Hidden {
+		t.Errorf("expected Hidden=false for %q", regularPath)
+	}
+}
+
+func TestListDirectory_HiddenField(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a mix of hidden and regular entries.
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, ".config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, _, err := listDirectory(dir, dir, 0, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range entries {
+		expectHidden := e.Name[0] == '.'
+		if e.Hidden != expectHidden {
+			t.Errorf("entry %q: Hidden=%v, want %v", e.Name, e.Hidden, expectHidden)
+		}
+	}
+}
+
 func TestListDirectory_DirsOnly(t *testing.T) {
 	t.Run("filters out files", func(t *testing.T) {
 		dir := t.TempDir()

--- a/backend/internal/worker/service/hidden.go
+++ b/backend/internal/worker/service/hidden.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package service
+
+import "strings"
+
+// isHidden reports whether the given file name should be considered hidden.
+// On Unix-like systems, files starting with "." are hidden.
+func isHidden(name string) bool {
+	return strings.HasPrefix(name, ".")
+}

--- a/backend/internal/worker/service/hidden.go
+++ b/backend/internal/worker/service/hidden.go
@@ -6,6 +6,7 @@ import "strings"
 
 // isHidden reports whether the given file name should be considered hidden.
 // On Unix-like systems, files starting with "." are hidden.
-func isHidden(name string) bool {
+// The absPath parameter is unused on Unix but required for the Windows implementation.
+func isHidden(absPath, name string) bool {
 	return strings.HasPrefix(name, ".")
 }

--- a/backend/internal/worker/service/hidden_windows.go
+++ b/backend/internal/worker/service/hidden_windows.go
@@ -7,15 +7,15 @@ import (
 	"syscall"
 )
 
-// isHidden reports whether the given file name should be considered hidden.
+// isHidden reports whether the given file should be considered hidden.
 // On Windows, a file is hidden if its name starts with "." or it has the
 // FILE_ATTRIBUTE_HIDDEN attribute set.
-func isHidden(name string) bool {
+func isHidden(absPath, name string) bool {
 	if strings.HasPrefix(name, ".") {
 		return true
 	}
-	// Check the Windows hidden attribute.
-	p, err := syscall.UTF16PtrFromString(name)
+	// Check the Windows hidden attribute using the full path.
+	p, err := syscall.UTF16PtrFromString(absPath)
 	if err != nil {
 		return false
 	}

--- a/backend/internal/worker/service/hidden_windows.go
+++ b/backend/internal/worker/service/hidden_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package service
+
+import (
+	"strings"
+	"syscall"
+)
+
+// isHidden reports whether the given file name should be considered hidden.
+// On Windows, a file is hidden if its name starts with "." or it has the
+// FILE_ATTRIBUTE_HIDDEN attribute set.
+func isHidden(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	// Check the Windows hidden attribute.
+	p, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return false
+	}
+	attrs, err := syscall.GetFileAttributes(p)
+	if err != nil {
+		return false
+	}
+	return attrs&syscall.FILE_ATTRIBUTE_HIDDEN != 0
+}

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -1,19 +1,40 @@
 import type { Component } from 'solid-js'
 import type { WorkerDialogState } from '~/hooks/createWorkerDialogState'
-import { Show } from 'solid-js'
+import Eye from 'lucide-solid/icons/eye'
+import EyeOff from 'lucide-solid/icons/eye-off'
+import { createEffect, createSignal, Show } from 'solid-js'
+import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
+import { safeGetJson, safeSetJson } from '~/lib/safeStorage'
 import { labelRow, treeContainer } from '~/styles/shared.css'
 
 interface DirectorySelectorProps {
   state: WorkerDialogState
 }
 
+const SHOW_HIDDEN_KEY = 'directorySelector:showHidden'
+
 export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
+  const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(SHOW_HIDDEN_KEY) ?? true)
+
+  createEffect(() => {
+    safeSetJson(SHOW_HIDDEN_KEY, showHiddenFiles())
+  })
+
   return (
     <div>
       <div class={labelRow}>
         Working Directory
+        <IconButton
+          icon={showHiddenFiles() ? Eye : EyeOff}
+          iconSize="xs"
+          size="sm"
+          title={showHiddenFiles() ? 'Hide hidden files' : 'Show hidden files'}
+          state={showHiddenFiles() ? IconButtonState.Enabled : IconButtonState.Active}
+          onClick={() => setShowHiddenFiles(prev => !prev)}
+          data-testid="directory-selector-show-hidden-toggle"
+        />
         <RefreshButton onClick={() => props.state.refreshTree()} title="Refresh directory tree" />
       </div>
       <Show when={props.state.workerId()}>
@@ -24,6 +45,7 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
             onSelect={props.state.setWorkingDir}
             rootPath="~"
             homeDir={props.state.workerInfoStore.getHomeDir(props.state.workerId())}
+            showHiddenFiles={showHiddenFiles()}
             ref={props.state.treeRef}
           />
         </div>

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -2,7 +2,7 @@ import type { Component } from 'solid-js'
 import type { WorkerDialogState } from '~/hooks/createWorkerDialogState'
 import Eye from 'lucide-solid/icons/eye'
 import EyeOff from 'lucide-solid/icons/eye-off'
-import { createEffect, createSignal, Show } from 'solid-js'
+import { createEffect, createSignal, on, Show } from 'solid-js'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
@@ -18,9 +18,9 @@ const SHOW_HIDDEN_KEY = 'directorySelector:showHidden'
 export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
   const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(SHOW_HIDDEN_KEY) ?? true)
 
-  createEffect(() => {
-    safeSetJson(SHOW_HIDDEN_KEY, showHiddenFiles())
-  })
+  createEffect(on(showHiddenFiles, (value) => {
+    safeSetJson(SHOW_HIDDEN_KEY, value)
+  }, { defer: true }))
 
   return (
     <div>

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -181,6 +181,8 @@ export function buildSectionDef(
           isFiltered={() => ctx.filesSectionHandle()?.isFiltered() ?? false}
           flatListMode={() => ctx.filesSectionHandle()?.flatListMode() ?? false}
           onToggleFlatList={() => ctx.filesSectionHandle()?.toggleFlatListMode()}
+          showHiddenFiles={() => ctx.filesSectionHandle()?.showHiddenFiles() ?? true}
+          onToggleShowHidden={() => ctx.filesSectionHandle()?.toggleShowHiddenFiles()}
         />
       ),
       content: () => (

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -284,13 +284,15 @@ const TreeNode: Component<{
   const isSelected = () => props.selectedPath === props.node.path
   const allChildren = () => tree.getChildren(props.node.path) ?? []
   const children = () => {
-    let result = allChildren()
-    if (!tree.showHiddenFiles)
-      result = result.filter(c => !c.hidden)
+    const all = allChildren()
+    const showHidden = tree.showHiddenFiles
     const visible = tree.visiblePaths()
-    if (visible)
-      result = result.filter(c => visible.has(c.path))
-    return result
+    if (showHidden && !visible)
+      return all
+    return all.filter(c =>
+      (showHidden || !c.hidden)
+      && (!visible || visible.has(c.path)),
+    )
   }
   const loaded = () => tree.getChildren(props.node.path) !== undefined
 
@@ -638,15 +640,17 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   // Root children derived from the centralized cache, optionally filtered.
   const showHidden = () => props.showHiddenFiles ?? true
   const rootChildren = () => {
-    let all = getChildren(rootPath())
+    const all = getChildren(rootPath())
     if (!all)
       return undefined
-    if (!showHidden())
-      all = all.filter(c => !c.hidden)
+    const sh = showHidden()
     const visible = props.visiblePaths
-    if (!visible)
+    if (sh && !visible)
       return all
-    return all.filter(c => visible.has(c.path))
+    return all.filter(c =>
+      (sh || !c.hidden)
+      && (!visible || visible.has(c.path)),
+    )
   }
 
   // Sync external selectedPath to input (tildified for display)

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -42,6 +42,8 @@ export interface DirectoryTreeProps {
   visiblePaths?: Set<string>
   /** Signal bumped on agent turn-end; drives directory tree refresh. */
   turnEndTrigger?: number
+  /** When false, entries with hidden=true are filtered out. Defaults to true. */
+  showHiddenFiles?: boolean
   /** Ref callback for imperative actions (collapse all, etc.). */
   ref?: (handle: DirectoryTreeHandle) => void
 }
@@ -50,6 +52,7 @@ interface TreeNodeData {
   path: string
   displayName: string
   isDir: boolean
+  hidden: boolean
 }
 
 // -------------------------------------------------------------------------
@@ -63,6 +66,7 @@ interface TreeContextValue {
   homeDir?: string
   scrollContainer?: HTMLDivElement
   gitStatusStore: () => ReturnType<typeof createGitFileStatusStore> | undefined
+  showHiddenFiles: boolean
   visiblePaths: () => Set<string> | undefined
   refreshVersion: () => number
   onSelect: (path: string) => void
@@ -142,6 +146,7 @@ async function loadChildren(
       path: entry.path,
       displayName: entry.name,
       isDir: entry.isDir,
+      hidden: entry.hidden,
     })),
     truncated: resp.truncated,
   }
@@ -279,10 +284,13 @@ const TreeNode: Component<{
   const isSelected = () => props.selectedPath === props.node.path
   const allChildren = () => tree.getChildren(props.node.path) ?? []
   const children = () => {
+    let result = allChildren()
+    if (!tree.showHiddenFiles)
+      result = result.filter(c => !c.hidden)
     const visible = tree.visiblePaths()
-    if (!visible)
-      return allChildren()
-    return allChildren().filter(c => visible.has(c.path))
+    if (visible)
+      result = result.filter(c => visible.has(c.path))
+    return result
   }
   const loaded = () => tree.getChildren(props.node.path) !== undefined
 
@@ -628,10 +636,13 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   }
 
   // Root children derived from the centralized cache, optionally filtered.
+  const showHidden = () => props.showHiddenFiles ?? true
   const rootChildren = () => {
-    const all = getChildren(rootPath())
+    let all = getChildren(rootPath())
     if (!all)
       return undefined
+    if (!showHidden())
+      all = all.filter(c => !c.hidden)
     const visible = props.visiblePaths
     if (!visible)
       return all
@@ -730,6 +741,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     get rootPath() { return rootPath() },
     get homeDir() { return props.homeDir },
     get scrollContainer() { return treeRef },
+    get showHiddenFiles() { return showHidden() },
     gitStatusStore: () => props.gitStatusStore,
     visiblePaths: () => props.visiblePaths,
     refreshVersion,

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -3,6 +3,8 @@ import type { DirectoryTreeHandle } from './DirectoryTree'
 import type { GitFileStatusEntry } from '~/generated/leapmux/v1/common_pb'
 import type { createGitFileStatusStore, GitFilterTab } from '~/stores/gitFileStatus.store'
 import ChevronsDownUp from 'lucide-solid/icons/chevrons-down-up'
+import Eye from 'lucide-solid/icons/eye'
+import EyeOff from 'lucide-solid/icons/eye-off'
 import FileIcon from 'lucide-solid/icons/file'
 import FolderTree from 'lucide-solid/icons/folder-tree'
 import List from 'lucide-solid/icons/list'
@@ -12,6 +14,7 @@ import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
+import { safeGetJson, safeSetJson } from '~/lib/safeStorage'
 import { DirectoryTree } from './DirectoryTree'
 import * as styles from './FilesSection.css'
 import { DiffStatsBadge, getGitFileIconClass } from './gitStatusUtils'
@@ -22,6 +25,8 @@ export interface FilesSectionHandle {
   isFiltered: () => boolean
   flatListMode: () => boolean
   toggleFlatListMode: () => void
+  showHiddenFiles: () => boolean
+  toggleShowHiddenFiles: () => void
 }
 
 export interface FilesSectionProps {
@@ -52,6 +57,8 @@ export interface FilesSectionHeaderActionsProps {
   isFiltered?: () => boolean
   flatListMode?: () => boolean
   onToggleFlatList?: () => void
+  showHiddenFiles?: () => boolean
+  onToggleShowHidden?: () => void
 }
 
 const FILTER_TABS: { key: GitFilterTab, label: string }[] = [
@@ -112,6 +119,15 @@ export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps
         onClick={() => props.onCollapseAll()}
         data-testid="files-collapse-all"
       />
+      <IconButton
+        icon={(props.showHiddenFiles?.() ?? true) ? Eye : EyeOff}
+        iconSize="xs"
+        size="sm"
+        title={(props.showHiddenFiles?.() ?? true) ? 'Hide hidden files' : 'Show hidden files'}
+        state={(props.showHiddenFiles?.() ?? true) ? IconButtonState.Enabled : IconButtonState.Active}
+        onClick={() => props.onToggleShowHidden?.()}
+        data-testid="files-show-hidden-toggle"
+      />
       <RefreshButton
         iconSize="xs"
         size="sm"
@@ -126,7 +142,14 @@ export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps
 export const FilesSection: Component<FilesSectionProps> = (props) => {
   const [activeFilter, setActiveFilter] = createSignal<GitFilterTab>('all')
   const [flatListMode, setFlatListMode] = createSignal(false)
+  const showHiddenStorageKey = () => `files:showHidden:${props.workerId}:${props.workingDir}`
+  const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(showHiddenStorageKey()) ?? true)
   let treeHandle: DirectoryTreeHandle | undefined
+
+  // Persist showHiddenFiles when it changes.
+  createEffect(() => {
+    safeSetJson(showHiddenStorageKey(), showHiddenFiles())
+  })
 
   const isFiltered = () => activeFilter() !== 'all'
 
@@ -138,6 +161,8 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
       isFiltered,
       flatListMode,
       toggleFlatListMode: () => setFlatListMode(prev => !prev),
+      showHiddenFiles,
+      toggleShowHiddenFiles: () => setShowHiddenFiles(prev => !prev),
     })
   })
 
@@ -215,6 +240,7 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
               homeDir={props.homeDir}
               gitStatusStore={props.gitStatusStore}
               visiblePaths={visiblePaths()}
+              showHiddenFiles={showHiddenFiles()}
               turnEndTrigger={props.turnEndTrigger}
               ref={(h) => { treeHandle = h }}
             />

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -9,7 +9,7 @@ import FileIcon from 'lucide-solid/icons/file'
 import FolderTree from 'lucide-solid/icons/folder-tree'
 import List from 'lucide-solid/icons/list'
 import LocateFixed from 'lucide-solid/icons/locate-fixed'
-import { createEffect, createSignal, For, Show } from 'solid-js'
+import { createEffect, createSignal, For, on, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
@@ -88,6 +88,7 @@ export const FileDiffStatsBadge: Component<{ entry: GitFileStatusEntry }> = (pro
 
 /** Toolbar buttons rendered in the section header. */
 export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps> = (props) => {
+  const showingHidden = () => props.showHiddenFiles?.() ?? true
   return (
     <>
       <Show when={props.isFiltered?.()}>
@@ -120,11 +121,11 @@ export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps
         data-testid="files-collapse-all"
       />
       <IconButton
-        icon={(props.showHiddenFiles?.() ?? true) ? Eye : EyeOff}
+        icon={showingHidden() ? Eye : EyeOff}
         iconSize="xs"
         size="sm"
-        title={(props.showHiddenFiles?.() ?? true) ? 'Hide hidden files' : 'Show hidden files'}
-        state={(props.showHiddenFiles?.() ?? true) ? IconButtonState.Enabled : IconButtonState.Active}
+        title={showingHidden() ? 'Hide hidden files' : 'Show hidden files'}
+        state={showingHidden() ? IconButtonState.Enabled : IconButtonState.Active}
         onClick={() => props.onToggleShowHidden?.()}
         data-testid="files-show-hidden-toggle"
       />
@@ -146,10 +147,15 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
   const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(showHiddenStorageKey()) ?? true)
   let treeHandle: DirectoryTreeHandle | undefined
 
-  // Persist showHiddenFiles when it changes.
-  createEffect(() => {
-    safeSetJson(showHiddenStorageKey(), showHiddenFiles())
-  })
+  // Re-read from localStorage when the storage key changes (workerId/workingDir changed).
+  createEffect(on(showHiddenStorageKey, (key) => {
+    setShowHiddenFiles(safeGetJson<boolean>(key) ?? true)
+  }, { defer: true }))
+
+  // Persist showHiddenFiles when it changes (skip initial mount).
+  createEffect(on(showHiddenFiles, (value) => {
+    safeSetJson(showHiddenStorageKey(), value)
+  }, { defer: true }))
 
   const isFiltered = () => activeFilter() !== 'all'
 

--- a/proto/leapmux/v1/file.proto
+++ b/proto/leapmux/v1/file.proto
@@ -46,4 +46,5 @@ message FileInfo {
   int64 size = 4;
   string mod_time = 5;
   string permissions = 6;
+  bool hidden = 7;
 }


### PR DESCRIPTION
## Motivation
The file browser had no way to control visibility of hidden files (dot-files on Unix/Linux, and files with the `FILE_ATTRIBUTE_HIDDEN` attribute on Windows). Users working in directories with many hidden files had no way to reduce clutter, and users who needed to access hidden files had no clear indication they existed. A persistent, per-location preference for hidden file visibility improves the usability of the file browser for both cases.

## Modifications
- Added a `hidden` boolean field to the `FileInfo` protobuf message (`proto/leapmux/v1/file.proto`) and populated it in `fileInfoToProto()`.
- Added platform-specific hidden file detection: a Unix implementation (`hidden.go`) using the dot-prefix convention and a Windows implementation (`hidden_windows.go`) checking both dot-prefix and `FILE_ATTRIBUTE_HIDDEN` via the Windows API.
- Added a `showHiddenFiles` prop and client-side filtering to `DirectoryTree`, so the tree only renders visible entries when the toggle is off.
- Added a show/hide toggle button (Eye/EyeOff icons) to both `FilesSection` and `DirectorySelector`, with the preference persisted to `localStorage` independently per workspace location.
- Added unit tests covering hidden file detection at the individual file level and at the directory listing level.

## Result
Users can now toggle hidden file visibility directly in the file browser. The preference is saved per workspace location, so it survives page reloads without affecting other open locations. On Unix systems, files starting with a dot are treated as hidden; on Windows, files with the system hidden attribute (or a dot prefix) are also hidden by default.

🤖 Generated with Claude Code
