### PR TITLE
feat(desktop): Forward Go slog messages to Web Inspector console

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/leapmux/leapmux/solo"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -100,6 +99,13 @@ func (a *App) domReady(_ context.Context) {
 	}, true);
 })();
 `, inspectorMsg))
+
+	// Flush buffered log records to the WebView console now that the
+	// navigated page's DOM is ready and WindowExecJS calls will land.
+	// On the initial launcher page load logHandler is nil (no-op).
+	if a.logHandler != nil {
+		a.logHandler.SetReady()
+	}
 }
 
 // bringToFront shows and raises the window so it appears above other windows.
@@ -178,18 +184,6 @@ func (a *App) ConnectSolo() (string, error) {
 	}
 
 	a.connected = true
-
-	// Give the WebView time to navigate to the frontend before flushing
-	// buffered log records. WindowExecJS calls during navigation may be
-	// lost, so we wait a few seconds.
-	if a.logHandler != nil {
-		h := a.logHandler
-		go func() {
-			time.Sleep(3 * time.Second)
-			h.SetReady()
-		}()
-	}
-
 	return "http://127.0.0.1:4327", nil
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/leapmux/leapmux/solo"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -14,11 +15,12 @@ import (
 
 // App is the main application struct bound to the frontend via Wails.
 type App struct {
-	ctx       context.Context
-	version   string
-	config    *DesktopConfig
-	solo      *solo.Instance
-	connected bool // true after a successful Connect call
+	ctx        context.Context
+	version    string
+	config     *DesktopConfig
+	solo       *solo.Instance
+	logHandler *webviewHandler
+	connected  bool // true after a successful Connect call
 }
 
 // NewApp creates a new App instance.
@@ -176,6 +178,18 @@ func (a *App) ConnectSolo() (string, error) {
 	}
 
 	a.connected = true
+
+	// Give the WebView time to navigate to the frontend before flushing
+	// buffered log records. WindowExecJS calls during navigation may be
+	// lost, so we wait a few seconds.
+	if a.logHandler != nil {
+		h := a.logHandler
+		go func() {
+			time.Sleep(3 * time.Second)
+			h.SetReady()
+		}()
+	}
+
 	return "http://127.0.0.1:4327", nil
 }
 

--- a/desktop/solo.go
+++ b/desktop/solo.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/leapmux/leapmux/solo"
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // startSolo launches a Hub and Worker in-process via the solo package.
@@ -18,6 +20,15 @@ func (a *App) startSolo() error {
 		return err
 	}
 	a.solo = inst
+
+	// Wrap the default slog handler so log records are also forwarded
+	// to the WebView console (for Web Inspector / F12).
+	a.logHandler = newWebviewHandler(
+		slog.Default().Handler(),
+		func(js string) { wailsRuntime.WindowExecJS(a.ctx, js) },
+	)
+	slog.SetDefault(slog.New(a.logHandler))
+
 	return nil
 }
 
@@ -25,6 +36,11 @@ func (a *App) startSolo() error {
 func (a *App) stopSolo() {
 	if a.solo == nil {
 		return
+	}
+	// Restore the original inner handler before stopping.
+	if a.logHandler != nil {
+		slog.SetDefault(slog.New(a.logHandler.inner))
+		a.logHandler = nil
 	}
 	a.solo.Stop()
 	a.solo = nil

--- a/desktop/webview_log_handler.go
+++ b/desktop/webview_log_handler.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxBufferedRecords = 500
+
+// webviewHandler is a slog.Handler that wraps an inner handler and
+// additionally forwards log records to a WebView console via execJS.
+// Before the WebView is ready, JS strings are buffered (capped at
+// maxBufferedRecords). After SetReady is called, buffered strings are
+// flushed and subsequent records are forwarded directly.
+type webviewHandler struct {
+	inner  slog.Handler
+	shared *webviewHandlerShared
+	attrs  []slog.Attr
+	group  string
+}
+
+type webviewHandlerShared struct {
+	mu     sync.Mutex
+	execJS func(string)
+	ready  bool
+	buffer []string
+}
+
+func newWebviewHandler(inner slog.Handler, execJS func(string)) *webviewHandler {
+	return &webviewHandler{
+		inner: inner,
+		shared: &webviewHandlerShared{
+			execJS: execJS,
+		},
+	}
+}
+
+func (h *webviewHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *webviewHandler) Handle(ctx context.Context, r slog.Record) error {
+	err := h.inner.Handle(ctx, r)
+
+	js := h.formatConsoleJS(r)
+
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	if h.shared.ready {
+		h.shared.execJS(js)
+	} else {
+		if len(h.shared.buffer) >= maxBufferedRecords {
+			// Drop oldest to make room.
+			h.shared.buffer = h.shared.buffer[1:]
+		}
+		h.shared.buffer = append(h.shared.buffer, js)
+	}
+
+	return err
+}
+
+func (h *webviewHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &webviewHandler{
+		inner:  h.inner.WithAttrs(attrs),
+		shared: h.shared,
+		attrs:  append(h.attrs, attrs...),
+		group:  h.group,
+	}
+}
+
+func (h *webviewHandler) WithGroup(name string) slog.Handler {
+	prefix := name
+	if h.group != "" {
+		prefix = h.group + "." + name
+	}
+	return &webviewHandler{
+		inner:  h.inner.WithGroup(name),
+		shared: h.shared,
+		attrs:  h.attrs,
+		group:  prefix,
+	}
+}
+
+// SetReady flushes the buffer and marks the handler as ready for direct
+// forwarding.
+func (h *webviewHandler) SetReady() {
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	for _, js := range h.shared.buffer {
+		h.shared.execJS(js)
+	}
+	h.shared.buffer = nil
+	h.shared.ready = true
+}
+
+func (h *webviewHandler) formatConsoleJS(r slog.Record) string {
+	method := "info"
+	switch {
+	case r.Level >= slog.LevelError:
+		method = "error"
+	case r.Level >= slog.LevelWarn:
+		method = "warn"
+	case r.Level < slog.LevelInfo:
+		method = "debug"
+	}
+
+	var args []string
+	args = append(args, jsonString(r.Time.Format(time.TimeOnly)))
+	args = append(args, jsonString(r.Message))
+
+	// Include pre-set attrs from WithAttrs.
+	for _, a := range h.attrs {
+		args = append(args, jsonString(h.formatAttr(a)))
+	}
+
+	// Include record-level attrs.
+	r.Attrs(func(a slog.Attr) bool {
+		args = append(args, jsonString(h.formatAttr(a)))
+		return true
+	})
+
+	return fmt.Sprintf("console.%s(%s)", method, strings.Join(args, ","))
+}
+
+func (h *webviewHandler) formatAttr(a slog.Attr) string {
+	key := a.Key
+	if h.group != "" {
+		key = h.group + "." + key
+	}
+	return key + "=" + a.Value.String()
+}
+
+// jsonString returns s as a JSON-encoded string literal (valid JS).
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/desktop/webview_log_handler.go
+++ b/desktop/webview_log_handler.go
@@ -69,7 +69,7 @@ func (h *webviewHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &webviewHandler{
 		inner:  h.inner.WithAttrs(attrs),
 		shared: h.shared,
-		attrs:  append(h.attrs, attrs...),
+		attrs:  append(append([]slog.Attr(nil), h.attrs...), attrs...),
 		group:  h.group,
 	}
 }

--- a/desktop/webview_log_handler_test.go
+++ b/desktop/webview_log_handler_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockExecJS collects all JS strings passed to it.
+type mockExecJS struct {
+	mu   sync.Mutex
+	calls []string
+}
+
+func (m *mockExecJS) fn(js string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, js)
+}
+
+func (m *mockExecJS) getCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.calls...)
+}
+
+// noopHandler is a minimal slog.Handler that records whether Handle was called.
+type noopHandler struct {
+	mu      sync.Mutex
+	handled int
+}
+
+func (h *noopHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *noopHandler) Handle(_ context.Context, _ slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.handled++
+	return nil
+}
+func (h *noopHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *noopHandler) WithGroup(name string) slog.Handler       { return h }
+func (h *noopHandler) getHandled() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.handled
+}
+
+func newTestRecord(level slog.Level, msg string, attrs ...slog.Attr) slog.Record {
+	r := slog.NewRecord(time.Date(2026, 3, 16, 14, 30, 45, 0, time.UTC), level, msg, 0)
+	r.AddAttrs(attrs...)
+	return r
+}
+
+func TestBufferingBeforeReady(t *testing.T) {
+	mock := &mockExecJS{}
+	inner := &noopHandler{}
+	h := newWebviewHandler(inner, mock.fn)
+
+	r := newTestRecord(slog.LevelInfo, "starting")
+	_ = h.Handle(context.TODO(), r)
+
+	if got := mock.getCalls(); len(got) != 0 {
+		t.Fatalf("expected no execJS calls before ready, got %d", len(got))
+	}
+	if inner.getHandled() != 1 {
+		t.Fatal("inner handler should have been called")
+	}
+}
+
+func TestFlushOnSetReady(t *testing.T) {
+	mock := &mockExecJS{}
+	inner := &noopHandler{}
+	h := newWebviewHandler(inner, mock.fn)
+
+	_ = h.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "msg1"))
+	_ = h.Handle(context.TODO(), newTestRecord(slog.LevelWarn, "msg2"))
+
+	h.SetReady()
+
+	calls := mock.getCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 flushed calls, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "console.info") {
+		t.Errorf("first flushed call should be console.info, got %s", calls[0])
+	}
+	if !strings.Contains(calls[1], "console.warn") {
+		t.Errorf("second flushed call should be console.warn, got %s", calls[1])
+	}
+}
+
+func TestDirectForwardingAfterReady(t *testing.T) {
+	mock := &mockExecJS{}
+	h := newWebviewHandler(&noopHandler{}, mock.fn)
+	h.SetReady()
+
+	_ = h.Handle(context.TODO(), newTestRecord(slog.LevelError, "boom"))
+
+	calls := mock.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "console.error") {
+		t.Errorf("expected console.error, got %s", calls[0])
+	}
+}
+
+func TestBufferCap(t *testing.T) {
+	mock := &mockExecJS{}
+	h := newWebviewHandler(&noopHandler{}, mock.fn)
+
+	// Fill buffer beyond cap.
+	for i := range maxBufferedRecords + 50 {
+		r := newTestRecord(slog.LevelInfo, "msg", slog.Int("i", i))
+		_ = h.Handle(context.TODO(), r)
+	}
+
+	h.SetReady()
+
+	calls := mock.getCalls()
+	if len(calls) != maxBufferedRecords {
+		t.Fatalf("expected %d buffered calls, got %d", maxBufferedRecords, len(calls))
+	}
+	// Oldest should have been dropped; first flushed should be i=50.
+	if !strings.Contains(calls[0], "i=50") {
+		t.Errorf("expected first flushed record to have i=50, got %s", calls[0])
+	}
+}
+
+func TestJSEscaping(t *testing.T) {
+	mock := &mockExecJS{}
+	h := newWebviewHandler(&noopHandler{}, mock.fn)
+	h.SetReady()
+
+	r := newTestRecord(slog.LevelInfo, "line1\nline2\"quote")
+	_ = h.Handle(context.TODO(), r)
+
+	calls := mock.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	// json.Marshal escapes newlines and quotes.
+	if strings.Contains(calls[0], "\n") {
+		t.Error("newline should be escaped in JS output")
+	}
+	if !strings.Contains(calls[0], `\n`) {
+		t.Error("expected escaped newline (\\n) in output")
+	}
+	if !strings.Contains(calls[0], `\"`) {
+		t.Error("expected escaped quote in output")
+	}
+}
+
+func TestLevelMapping(t *testing.T) {
+	tests := []struct {
+		level  slog.Level
+		method string
+	}{
+		{slog.LevelDebug, "console.debug"},
+		{slog.LevelInfo, "console.info"},
+		{slog.LevelWarn, "console.warn"},
+		{slog.LevelError, "console.error"},
+	}
+
+	for _, tt := range tests {
+		mock := &mockExecJS{}
+		h := newWebviewHandler(&noopHandler{}, mock.fn)
+		h.SetReady()
+
+		_ = h.Handle(context.TODO(), newTestRecord(tt.level, "test"))
+
+		calls := mock.getCalls()
+		if len(calls) != 1 {
+			t.Fatalf("level %v: expected 1 call, got %d", tt.level, len(calls))
+		}
+		if !strings.HasPrefix(calls[0], tt.method+"(") {
+			t.Errorf("level %v: expected %s, got %s", tt.level, tt.method, calls[0])
+		}
+	}
+}
+
+func TestInnerHandlerAlwaysCalled(t *testing.T) {
+	inner := &noopHandler{}
+	h := newWebviewHandler(inner, (&mockExecJS{}).fn)
+
+	// Before ready.
+	_ = h.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "a"))
+	// After ready.
+	h.SetReady()
+	_ = h.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "b"))
+
+	if inner.getHandled() != 2 {
+		t.Fatalf("expected inner handler called 2 times, got %d", inner.getHandled())
+	}
+}
+
+func TestWithAttrsAppearsInOutput(t *testing.T) {
+	mock := &mockExecJS{}
+	h := newWebviewHandler(&noopHandler{}, mock.fn)
+	h.SetReady()
+
+	h2 := h.WithAttrs([]slog.Attr{slog.String("component", "hub")})
+	_ = h2.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "ready"))
+
+	calls := mock.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "component=hub") {
+		t.Errorf("expected component=hub in output, got %s", calls[0])
+	}
+}
+
+func TestWithGroupAppearsInOutput(t *testing.T) {
+	mock := &mockExecJS{}
+	h := newWebviewHandler(&noopHandler{}, mock.fn)
+	h.SetReady()
+
+	h2 := h.WithGroup("server").WithAttrs([]slog.Attr{slog.String("addr", ":8080")})
+	_ = h2.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "listening"))
+
+	calls := mock.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "server.addr=:8080") {
+		t.Errorf("expected server.addr=:8080 in output, got %s", calls[0])
+	}
+}

--- a/desktop/webview_log_handler_test.go
+++ b/desktop/webview_log_handler_test.go
@@ -230,3 +230,30 @@ func TestWithGroupAppearsInOutput(t *testing.T) {
 		t.Errorf("expected server.addr=:8080 in output, got %s", calls[0])
 	}
 }
+
+func TestWithAttrsSiblingIsolation(t *testing.T) {
+	mock := &mockExecJS{}
+	parent := newWebviewHandler(&noopHandler{}, mock.fn)
+	parent.SetReady()
+
+	// Create two children from the same parent with different attrs.
+	child1 := parent.WithAttrs([]slog.Attr{slog.String("child", "1")})
+	child2 := parent.WithAttrs([]slog.Attr{slog.String("child", "2")})
+
+	_ = child1.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "from1"))
+	_ = child2.Handle(context.TODO(), newTestRecord(slog.LevelInfo, "from2"))
+
+	calls := mock.getCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "child=1") {
+		t.Errorf("child1 should have child=1, got %s", calls[0])
+	}
+	if strings.Contains(calls[0], "child=2") {
+		t.Errorf("child1 should NOT have child=2, got %s", calls[0])
+	}
+	if !strings.Contains(calls[1], "child=2") {
+		t.Errorf("child2 should have child=2, got %s", calls[1])
+	}
+}


### PR DESCRIPTION
## Motivation
When developing or debugging the desktop application, Go server-side log messages were only visible in the terminal. Developers inspecting the application via the browser's Web Inspector (DevTools) had no visibility into backend logs, making it difficult to correlate frontend behavior with server-side activity in a single pane of glass.

## Modifications
- Add `webviewHandler`, a new `slog.Handler` implementation that wraps the default handler and forwards log records to the WebView console via JavaScript execution.
- Map Go slog levels to the appropriate browser console methods: `debug`, `info`, `warn`, and `error`.
- Buffer up to 500 log records before the WebView is ready, then flush them 3 seconds after the WebView connects to avoid losing messages during navigation startup.
- Restore the original inner handler when the solo instance stops, preventing log duplication and memory leaks.
- Apply proper JSON escaping for special characters in log messages and attributes before injecting them into JavaScript.
- Add comprehensive tests (232 lines) covering buffering, deferred flushing, level mapping, attribute and group handling, and JS escaping.

## Result
Go `slog` messages are now visible in the browser's Web Inspector console (F12 / DevTools) alongside frontend logs. Developers no longer need to switch between the terminal and DevTools to correlate backend and frontend activity when building or debugging the desktop application.

🤖 Generated with Claude Code
