### PR TITLE
Fix hidden files toggle icon and directory merge behavior

### DIFF
--- a/backend/internal/worker/filebrowser/browser_test.go
+++ b/backend/internal/worker/filebrowser/browser_test.go
@@ -103,6 +103,31 @@ func TestListDirectory_MergeIgnoresFiles(t *testing.T) {
 	assert.Equal(t, "a", entries[0].Name)
 }
 
+func TestListDirectory_MergesHiddenDirs(t *testing.T) {
+	t.Run("hidden top-level dir is merged", func(t *testing.T) {
+		dir := t.TempDir()
+		// .github/workflows — hidden dir should be merged like any other.
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755))
+
+		_, entries, err := ListDirectory(dir, 5)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, ".github/workflows", entries[0].Name)
+		assert.True(t, entries[0].IsDir)
+	})
+
+	t.Run("hidden child is merged", func(t *testing.T) {
+		dir := t.TempDir()
+		// src/.internal/utils — all single-child, should merge through hidden.
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "src", ".internal", "utils"), 0o755))
+
+		_, entries, err := ListDirectory(dir, 5)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "src/.internal/utils", entries[0].Name)
+	})
+}
+
 func TestReadFile(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "test.txt")

--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -288,6 +288,7 @@ func listDirectory(dirPath, basePath string, maxDepth int32, currentDepth int32,
 
 		// Merge single-child directories: if the entry is a directory, max_depth > 0,
 		// and it has exactly one child that is also a directory, collapse them.
+		// The hidden flag is propagated so the frontend can still filter merged entries.
 		if fi.IsDir && maxDepth > 0 && currentDepth < maxDepth {
 			fi = mergeSingleChildDirs(fi, entryPath, maxDepth, currentDepth)
 		}
@@ -323,6 +324,11 @@ func mergeSingleChildDirs(fi *leapmuxv1.FileInfo, dirPath string, maxDepth int32
 
 	merged := fileInfoToProto(childInfo, childPath)
 	merged.Name = fi.Name + string(filepath.Separator) + child.Name()
+	// Propagate hidden flag so the frontend can filter merged entries
+	// even when a hidden directory has been merged into the path.
+	if fi.Hidden {
+		merged.Hidden = true
+	}
 
 	// Recursively merge if still a single child directory.
 	return mergeSingleChildDirs(merged, childPath, maxDepth, currentDepth+1)

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -233,6 +233,77 @@ func TestListDirectory_HiddenField(t *testing.T) {
 	}
 }
 
+func TestListDirectory_MergeHiddenDirs(t *testing.T) {
+	t.Run("hidden top-level dir is merged with hidden flag", func(t *testing.T) {
+		dir := t.TempDir()
+		// .github/workflows — hidden dir should be merged, with hidden flag propagated.
+		if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, _, err := listDirectory(dir, dir, 5, 0, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		expected := filepath.Join(".github", "workflows")
+		if entries[0].Name != expected {
+			t.Errorf("expected name %q, got %q", expected, entries[0].Name)
+		}
+		if !entries[0].Hidden {
+			t.Error("expected Hidden=true for merged .github/workflows")
+		}
+	})
+
+	t.Run("hidden child propagates hidden flag through merge", func(t *testing.T) {
+		dir := t.TempDir()
+		// src/.internal/utils — merge should go through .internal, propagating hidden.
+		if err := os.MkdirAll(filepath.Join(dir, "src", ".internal", "utils"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, _, err := listDirectory(dir, dir, 5, 0, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		expected := filepath.Join("src", ".internal", "utils")
+		if entries[0].Name != expected {
+			t.Errorf("expected name %q, got %q", expected, entries[0].Name)
+		}
+		if !entries[0].Hidden {
+			t.Error("expected Hidden=true when a hidden dir is in the merged path")
+		}
+	})
+
+	t.Run("non-hidden single-child dirs merge without hidden flag", func(t *testing.T) {
+		dir := t.TempDir()
+		// src/main/java — all visible, should merge normally, not hidden.
+		if err := os.MkdirAll(filepath.Join(dir, "src", "main", "java"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, _, err := listDirectory(dir, dir, 5, 0, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		expected := filepath.Join("src", "main", "java")
+		if entries[0].Name != expected {
+			t.Errorf("expected name %q, got %q", expected, entries[0].Name)
+		}
+		if entries[0].Hidden {
+			t.Error("expected Hidden=false for non-hidden merged path")
+		}
+	})
+}
+
 func TestListDirectory_DirsOnly(t *testing.T) {
 	t.Run("filters out files", func(t *testing.T) {
 		dir := t.TempDir()

--- a/frontend/src/components/common/Icon.test.tsx
+++ b/frontend/src/components/common/Icon.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@solidjs/testing-library'
+import Eye from 'lucide-solid/icons/eye'
+import EyeOff from 'lucide-solid/icons/eye-off'
+import { createSignal } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { Icon } from './Icon'
+
+describe('icon', () => {
+  it('reactively updates when the icon prop changes', () => {
+    const [icon, setIcon] = createSignal(Eye)
+
+    const { container } = render(() => (
+      <Icon icon={icon()} size="sm" />
+    ))
+
+    const svg = () => container.querySelector('svg')!
+
+    // Initial render should show the Eye icon.
+    expect(svg().classList.contains('lucide-eye')).toBe(true)
+    expect(svg().classList.contains('lucide-eye-off')).toBe(false)
+
+    // Switch to EyeOff — the rendered SVG should update.
+    setIcon(() => EyeOff)
+
+    expect(svg().classList.contains('lucide-eye-off')).toBe(true)
+    expect(svg().classList.contains('lucide-eye')).toBe(false)
+
+    // Switch back to Eye.
+    setIcon(() => Eye)
+
+    expect(svg().classList.contains('lucide-eye')).toBe(true)
+    expect(svg().classList.contains('lucide-eye-off')).toBe(false)
+  })
+})

--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon, LucideProps } from 'lucide-solid'
 import { splitProps } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
 import { iconSize } from '~/styles/tokens'
 
 export type IconSizeName = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
@@ -12,5 +13,5 @@ export interface IconProps extends Omit<LucideProps, 'size'> {
 export function Icon(props: IconProps) {
   const [local, rest] = splitProps(props, ['icon', 'size'])
   const px = () => iconSize[local.size]
-  return <local.icon size={px()} style={{ 'flex-shrink': '0', 'min-width': `${px()}px`, 'min-height': `${px()}px` }} {...rest} />
+  return <Dynamic component={local.icon} size={px()} style={{ 'flex-shrink': '0', 'min-width': `${px()}px`, 'min-height': `${px()}px` }} {...rest} />
 }


### PR DESCRIPTION
## Motivation

Two bugs were found in the hidden files toggle feature added in #127:

1. The file browser's hidden files toggle icon was not updating visually when toggled. The `Icon` component received an updated icon prop but did not re-render because it referenced the prop value directly rather than through Solid.js's reactive system.

2. When the file browser merges single-child directories into a combined path entry (e.g. `foo/bar/`), the `hidden` flag was not propagated to the merged entry. This caused the frontend to incorrectly display hidden directories that should have been filtered out, because the merged entry lacked the flag.

## Modifications

- Changed `Icon.tsx` to render via Solid.js `<Dynamic>` instead of calling the icon prop as a plain function, so the rendered SVG updates reactively when the prop changes.
- Updated `mergeSingleChildDirs` in `backend/internal/worker/service/file.go` to carry the `hidden` flag forward when collapsing single-child directory chains.
- Added backend tests covering hidden directory merging: hidden flag preserved at the top level and in nested merged paths.
- Added a frontend test verifying that `Icon` re-renders correctly when its prop changes.

## Result

- The hidden files toggle icon now switches appearance correctly when clicked.
- Hidden directories are no longer shown when the "show hidden files" option is off, even when those directories have been merged with their single child.

🤖 Generated with Claude Code
