### PR TITLE
Fix /reset alias, ThinkingIndicator stuck state, and muted hidden files

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -220,7 +220,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		// Check for leapmux-level slash commands (e.g. /clear) that
 		// Claude Code does not handle natively.
-		isSlashClear := strings.TrimSpace(content) == "/clear"
+		isSlashClear := trimmed == "/clear" || trimmed == "/reset"
 
 		// Attempt to send the message to the agent process (unless it's
 		// a command that leapmux handles itself).
@@ -1116,9 +1116,8 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 		slog.Warn("plan exec: no plan content found, broadcasting notification without restart",
 			"agent_id", agentID)
 		svc.Output.BroadcastNotification(agentID, map[string]interface{}{
-			"type":            "plan_execution",
-			"context_cleared": false,
-			"plan_file_path":  dbAgent.PlanFilePath,
+			"type":           "plan_execution",
+			"plan_file_path": dbAgent.PlanFilePath,
 		})
 		return
 	}
@@ -1132,11 +1131,13 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 	// StartAgent below doesn't fail with "agent already running".
 	svc.Agents.StopAndWaitAgent(agentID)
 
-	// Broadcast plan_execution notification.
+	// Broadcast context_cleared and plan_execution as separate notifications.
 	svc.Output.BroadcastNotification(agentID, map[string]interface{}{
-		"type":            "plan_execution",
-		"context_cleared": true,
-		"plan_file_path":  dbAgent.PlanFilePath,
+		"type": "context_cleared",
+	})
+	svc.Output.BroadcastNotification(agentID, map[string]interface{}{
+		"type":           "plan_execution",
+		"plan_file_path": dbAgent.PlanFilePath,
 	})
 
 	// Restart agent with plan content.

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"log/slog"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -970,6 +971,14 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 		case env.Type == "context_cleared":
 			contextClearedRaw = raw
 			contextClearedLastIdx = i
+			// context_cleared supersedes any earlier compaction boundaries.
+			keepAll = slices.DeleteFunc(keepAll, func(ir indexedRaw) bool {
+				var e envelope
+				if json.Unmarshal(ir.raw, &e) != nil {
+					return false
+				}
+				return e.Type == "system" && (e.Subtype == "compact_boundary" || e.Subtype == "microcompact_boundary")
+			})
 
 		case env.Type == "plan_execution":
 			planExecRaw = raw
@@ -992,6 +1001,11 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			statusLastIdx = i
 
 		case env.Type == "system" && (env.Subtype == "compact_boundary" || env.Subtype == "microcompact_boundary"):
+			// Compaction supersedes any earlier context_cleared.
+			if contextClearedLastIdx >= 0 && i > contextClearedLastIdx {
+				contextClearedRaw = nil
+				contextClearedLastIdx = -1
+			}
 			keepAll = append(keepAll, indexedRaw{i, raw})
 
 		default:

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -908,14 +908,17 @@ func extractStatusValue(content []byte) (status string, ok bool) {
 // the last occurrence's data wins. Output is ordered by the position of each
 // type's last occurrence in the input.
 func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage {
-	type envelope struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-	}
-
 	type settingsChange struct {
 		Old string `json:"old"`
 		New string `json:"new"`
+	}
+
+	// Unified envelope — decoded once per message.
+	type envelope struct {
+		Type    string                       `json:"type"`
+		Subtype string                       `json:"subtype"`
+		Changes map[string]settingsChange    `json:"changes,omitempty"`
+		RLInfo  *struct{ RateLimitType string `json:"rateLimitType"` } `json:"rate_limit_info,omitempty"`
 	}
 
 	// Deduplication state — track the last-seen index for ordering.
@@ -953,16 +956,11 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 
 		switch {
 		case env.Type == "settings_changed":
-			var sc struct {
-				Changes map[string]settingsChange `json:"changes"`
-			}
-			if json.Unmarshal(raw, &sc) == nil {
-				for key, val := range sc.Changes {
-					if existing, ok := mergedChanges[key]; ok {
-						mergedChanges[key] = settingsChange{Old: existing.Old, New: val.New}
-					} else {
-						mergedChanges[key] = val
-					}
+			for key, val := range env.Changes {
+				if existing, ok := mergedChanges[key]; ok {
+					mergedChanges[key] = settingsChange{Old: existing.Old, New: val.New}
+				} else {
+					mergedChanges[key] = val
 				}
 			}
 			settingsLastIdx = i
@@ -972,15 +970,6 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			contextClearedLastIdx = i
 
 		case env.Type == "plan_execution":
-			// Strip context_cleared field — context clearing is always
-			// represented by a standalone context_cleared message.
-			var pe map[string]interface{}
-			if json.Unmarshal(raw, &pe) == nil {
-				delete(pe, "context_cleared")
-				if data, err := json.Marshal(pe); err == nil {
-					raw = data
-				}
-			}
 			planExecRaw = raw
 			planExecLastIdx = i
 
@@ -989,18 +978,11 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			interruptedLastIdx = i
 
 		case env.Type == "rate_limit":
-			var rl struct {
-				RateLimitInfo struct {
-					RateLimitType string `json:"rateLimitType"`
-				} `json:"rate_limit_info"`
+			key := "unknown"
+			if env.RLInfo != nil && env.RLInfo.RateLimitType != "" {
+				key = env.RLInfo.RateLimitType
 			}
-			if json.Unmarshal(raw, &rl) == nil {
-				key := rl.RateLimitInfo.RateLimitType
-				if key == "" {
-					key = "unknown"
-				}
-				rateLimitByType[key] = raw
-			}
+			rateLimitByType[key] = raw
 			rateLimitLastIdx = i
 
 		case env.Type == "system" && env.Subtype == "status":

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -915,10 +915,12 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 
 	// Unified envelope — decoded once per message.
 	type envelope struct {
-		Type    string                       `json:"type"`
-		Subtype string                       `json:"subtype"`
-		Changes map[string]settingsChange    `json:"changes,omitempty"`
-		RLInfo  *struct{ RateLimitType string `json:"rateLimitType"` } `json:"rate_limit_info,omitempty"`
+		Type    string                    `json:"type"`
+		Subtype string                    `json:"subtype"`
+		Changes map[string]settingsChange `json:"changes,omitempty"`
+		RLInfo  *struct {
+			RateLimitType string `json:"rateLimitType"`
+		} `json:"rate_limit_info,omitempty"`
 	}
 
 	// Deduplication state — track the last-seen index for ordering.

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -902,6 +903,10 @@ func extractStatusValue(content []byte) (status string, ok bool) {
 }
 
 // consolidateNotificationThread consolidates a notification thread's messages.
+// Each message type appears at most once in the output (except compaction
+// boundaries and unknown types, which are always kept). When duplicates exist,
+// the last occurrence's data wins. Output is ordered by the position of each
+// type's last occurrence in the input.
 func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage {
 	type envelope struct {
 		Type    string `json:"type"`
@@ -912,28 +917,44 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 		Old string `json:"old"`
 		New string `json:"new"`
 	}
-	mergedChanges := map[string]settingsChange{}
-	hasContextCleared := false
-	contextClearedRaw := json.RawMessage(nil)
-	hasInterrupted := false
-	interruptedRaw := json.RawMessage(nil)
-	var latestStatusRaw json.RawMessage
-	rateLimitByType := map[string]json.RawMessage{}
-	var compactionBoundaries []json.RawMessage
-	var planExecRaw json.RawMessage
 
-	for _, raw := range messages {
+	// Deduplication state — track the last-seen index for ordering.
+	mergedChanges := map[string]settingsChange{}
+	settingsLastIdx := -1
+
+	contextClearedRaw := json.RawMessage(nil)
+	contextClearedLastIdx := -1
+
+	interruptedRaw := json.RawMessage(nil)
+	interruptedLastIdx := -1
+
+	planExecRaw := json.RawMessage(nil)
+	planExecLastIdx := -1
+
+	rateLimitByType := map[string]json.RawMessage{}
+	rateLimitLastIdx := -1
+
+	var latestStatusRaw json.RawMessage
+	statusLastIdx := -1
+
+	// Compaction boundaries and unknown types: always kept, in order.
+	type indexedRaw struct {
+		idx int
+		raw json.RawMessage
+	}
+	var keepAll []indexedRaw
+
+	for i, raw := range messages {
 		var env envelope
 		if json.Unmarshal(raw, &env) != nil {
-			compactionBoundaries = append(compactionBoundaries, raw)
+			keepAll = append(keepAll, indexedRaw{i, raw})
 			continue
 		}
 
 		switch {
 		case env.Type == "settings_changed":
 			var sc struct {
-				Changes        map[string]settingsChange `json:"changes"`
-				ContextCleared bool                      `json:"contextCleared"`
+				Changes map[string]settingsChange `json:"changes"`
 			}
 			if json.Unmarshal(raw, &sc) == nil {
 				for key, val := range sc.Changes {
@@ -943,21 +964,29 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 						mergedChanges[key] = val
 					}
 				}
-				if sc.ContextCleared {
-					hasContextCleared = true
-				}
 			}
+			settingsLastIdx = i
 
 		case env.Type == "context_cleared":
-			hasContextCleared = true
 			contextClearedRaw = raw
+			contextClearedLastIdx = i
 
 		case env.Type == "plan_execution":
+			// Strip context_cleared field — context clearing is always
+			// represented by a standalone context_cleared message.
+			var pe map[string]interface{}
+			if json.Unmarshal(raw, &pe) == nil {
+				delete(pe, "context_cleared")
+				if data, err := json.Marshal(pe); err == nil {
+					raw = data
+				}
+			}
 			planExecRaw = raw
+			planExecLastIdx = i
 
 		case env.Type == "interrupted":
-			hasInterrupted = true
 			interruptedRaw = raw
+			interruptedLastIdx = i
 
 		case env.Type == "rate_limit":
 			var rl struct {
@@ -972,21 +1001,25 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 				}
 				rateLimitByType[key] = raw
 			}
+			rateLimitLastIdx = i
 
 		case env.Type == "system" && env.Subtype == "status":
 			latestStatusRaw = raw
+			statusLastIdx = i
 
 		case env.Type == "system" && (env.Subtype == "compact_boundary" || env.Subtype == "microcompact_boundary"):
-			compactionBoundaries = append(compactionBoundaries, raw)
+			keepAll = append(keepAll, indexedRaw{i, raw})
 
 		default:
-			compactionBoundaries = append(compactionBoundaries, raw)
+			keepAll = append(keepAll, indexedRaw{i, raw})
 		}
 	}
 
-	var result []json.RawMessage
+	// Build deduped entries with their ordering index.
+	var entries []indexedRaw
 
-	if len(mergedChanges) > 0 {
+	// settings_changed: merge all changes, drop if old==new for all keys.
+	if settingsLastIdx >= 0 {
 		effective := map[string]settingsChange{}
 		for key, val := range mergedChanges {
 			if val.Old != val.New {
@@ -998,67 +1031,44 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 				"type":    "settings_changed",
 				"changes": effective,
 			}
-			if hasContextCleared {
-				entry["contextCleared"] = true
-			}
 			if data, err := json.Marshal(entry); err == nil {
-				result = append(result, data)
+				entries = append(entries, indexedRaw{settingsLastIdx, data})
 			}
-		} else if hasContextCleared {
-			entry := map[string]interface{}{
-				"type": "context_cleared",
-			}
-			if data, err := json.Marshal(entry); err == nil {
-				result = append(result, data)
-			}
-			hasContextCleared = false
 		}
 	}
 
-	if hasContextCleared && contextClearedRaw != nil {
-		result = append(result, contextClearedRaw)
+	if contextClearedLastIdx >= 0 {
+		entries = append(entries, indexedRaw{contextClearedLastIdx, contextClearedRaw})
 	}
 
-	if planExecRaw != nil {
-		var pe struct {
-			ContextCleared bool `json:"context_cleared"`
-		}
-		if json.Unmarshal(planExecRaw, &pe) == nil && pe.ContextCleared {
-			filtered := result[:0]
-			for _, r := range result {
-				var e envelope
-				if json.Unmarshal(r, &e) == nil && e.Type == "context_cleared" {
-					continue
-				}
-				if json.Unmarshal(r, &e) == nil && e.Type == "settings_changed" {
-					var sc map[string]interface{}
-					if json.Unmarshal(r, &sc) == nil {
-						delete(sc, "contextCleared")
-						if data, err := json.Marshal(sc); err == nil {
-							r = data
-						}
-					}
-				}
-				filtered = append(filtered, r)
-			}
-			result = filtered
-		}
-		result = append(result, planExecRaw)
+	if planExecLastIdx >= 0 {
+		entries = append(entries, indexedRaw{planExecLastIdx, planExecRaw})
 	}
 
-	if hasInterrupted && interruptedRaw != nil {
-		result = append(result, interruptedRaw)
+	if interruptedLastIdx >= 0 {
+		entries = append(entries, indexedRaw{interruptedLastIdx, interruptedRaw})
 	}
 
 	for _, raw := range rateLimitByType {
-		result = append(result, raw)
+		entries = append(entries, indexedRaw{rateLimitLastIdx, raw})
 	}
 
-	if latestStatusRaw != nil {
-		result = append(result, latestStatusRaw)
+	if statusLastIdx >= 0 {
+		entries = append(entries, indexedRaw{statusLastIdx, latestStatusRaw})
 	}
 
-	result = append(result, compactionBoundaries...)
+	// Merge keepAll entries.
+	entries = append(entries, keepAll...)
+
+	// Sort by input index (ascending) to preserve chronological order.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].idx < entries[j].idx
+	})
+
+	result := make([]json.RawMessage, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, e.raw)
+	}
 
 	if len(result) == 0 {
 		return []json.RawMessage{}

--- a/backend/internal/worker/service/output_consolidate_test.go
+++ b/backend/internal/worker/service/output_consolidate_test.go
@@ -134,30 +134,12 @@ func TestConsolidateNotificationThread_SettingsMerged(t *testing.T) {
 }
 
 func TestConsolidateNotificationThread_PlanExecution(t *testing.T) {
-	t.Run("plan_execution with context_cleared both kept", func(t *testing.T) {
-		msgs := []json.RawMessage{
-			raw(t, map[string]interface{}{"type": "plan_execution", "plan_file_path": "/p.md"}),
-			raw(t, map[string]interface{}{"type": "context_cleared"}),
-		}
-		result := consolidateNotificationThread(msgs)
-		assert.Equal(t, []string{"plan_execution", "context_cleared"}, types(t, result))
-	})
-
-	t.Run("plan_execution strips context_cleared field", func(t *testing.T) {
-		msgs := []json.RawMessage{
-			raw(t, map[string]interface{}{
-				"type":            "plan_execution",
-				"context_cleared": true,
-				"plan_file_path":  "/p.md",
-			}),
-		}
-		result := consolidateNotificationThread(msgs)
-		require.Len(t, result, 1)
-		m := parseRaw(t, result[0])
-		assert.Equal(t, "plan_execution", m["type"])
-		assert.Nil(t, m["context_cleared"], "context_cleared field should be stripped")
-		assert.Equal(t, "/p.md", m["plan_file_path"])
-	})
+	msgs := []json.RawMessage{
+		raw(t, map[string]interface{}{"type": "plan_execution", "plan_file_path": "/p.md"}),
+		raw(t, map[string]interface{}{"type": "context_cleared"}),
+	}
+	result := consolidateNotificationThread(msgs)
+	assert.Equal(t, []string{"plan_execution", "context_cleared"}, types(t, result))
 }
 
 func TestConsolidateNotificationThread_NoContextClearedOnSettingsChanged(t *testing.T) {

--- a/backend/internal/worker/service/output_consolidate_test.go
+++ b/backend/internal/worker/service/output_consolidate_test.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper: build a json.RawMessage from an arbitrary value.
+func raw(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}
+
+// helper: parse a json.RawMessage back into a map.
+func parseRaw(t *testing.T, r json.RawMessage) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(r, &m))
+	return m
+}
+
+// helper: get the "type" string from a raw message.
+func msgType(t *testing.T, r json.RawMessage) string {
+	t.Helper()
+	m := parseRaw(t, r)
+	return m["type"].(string)
+}
+
+// helper: collect types from a slice of raw messages.
+func types(t *testing.T, msgs []json.RawMessage) []string {
+	t.Helper()
+	result := make([]string, len(msgs))
+	for i, m := range msgs {
+		result[i] = msgType(t, m)
+	}
+	return result
+}
+
+func settingsChanged(old, new string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "settings_changed",
+		"changes": map[string]interface{}{
+			"model": map[string]interface{}{"old": old, "new": new},
+		},
+	}
+}
+
+func TestConsolidateNotificationThread_OrderPreserved(t *testing.T) {
+	t.Run("context_cleared then settings_changed", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, settingsChanged("A", "B")),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"context_cleared", "settings_changed"}, types(t, result))
+	})
+
+	t.Run("settings_changed then context_cleared", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, settingsChanged("A", "B")),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"settings_changed", "context_cleared"}, types(t, result))
+	})
+}
+
+func TestConsolidateNotificationThread_Dedup(t *testing.T) {
+	t.Run("context_cleared deduped to last occurrence", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, settingsChanged("A", "B")),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"settings_changed", "context_cleared"}, types(t, result))
+	})
+
+	t.Run("settings_changed deduped to last occurrence", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, settingsChanged("A", "B")),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, settingsChanged("B", "C")),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"context_cleared", "settings_changed"}, types(t, result))
+		// Verify merged: old=A, new=C
+		changes := parseRaw(t, result[1])["changes"].(map[string]interface{})
+		model := changes["model"].(map[string]interface{})
+		assert.Equal(t, "A", model["old"])
+		assert.Equal(t, "C", model["new"])
+	})
+}
+
+func TestConsolidateNotificationThread_ChangesCancelOut(t *testing.T) {
+	t.Run("settings_changed cancels out when A->B then B->A", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, settingsChanged("A", "B")),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, settingsChanged("B", "A")),
+		}
+		result := consolidateNotificationThread(msgs)
+		// settings_changed drops because old==new; only context_cleared remains.
+		assert.Equal(t, []string{"context_cleared"}, types(t, result))
+	})
+
+	t.Run("settings_changed alone cancels out", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, settingsChanged("A", "B")),
+			raw(t, settingsChanged("B", "A")),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []json.RawMessage{}, result)
+	})
+}
+
+func TestConsolidateNotificationThread_SettingsMerged(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, settingsChanged("A", "B")),
+		raw(t, settingsChanged("B", "C")),
+	}
+	result := consolidateNotificationThread(msgs)
+	require.Len(t, result, 1)
+	assert.Equal(t, "settings_changed", msgType(t, result[0]))
+	changes := parseRaw(t, result[0])["changes"].(map[string]interface{})
+	model := changes["model"].(map[string]interface{})
+	assert.Equal(t, "A", model["old"])
+	assert.Equal(t, "C", model["new"])
+}
+
+func TestConsolidateNotificationThread_PlanExecution(t *testing.T) {
+	t.Run("plan_execution with context_cleared both kept", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "plan_execution", "plan_file_path": "/p.md"}),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"plan_execution", "context_cleared"}, types(t, result))
+	})
+
+	t.Run("plan_execution strips context_cleared field", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{
+				"type":            "plan_execution",
+				"context_cleared": true,
+				"plan_file_path":  "/p.md",
+			}),
+		}
+		result := consolidateNotificationThread(msgs)
+		require.Len(t, result, 1)
+		m := parseRaw(t, result[0])
+		assert.Equal(t, "plan_execution", m["type"])
+		assert.Nil(t, m["context_cleared"], "context_cleared field should be stripped")
+		assert.Equal(t, "/p.md", m["plan_file_path"])
+	})
+}
+
+func TestConsolidateNotificationThread_NoContextClearedOnSettingsChanged(t *testing.T) {
+	// Even if the input has contextCleared on settings_changed, output must not.
+	msgs := []json.RawMessage{
+		raw(t, map[string]interface{}{
+			"type":           "settings_changed",
+			"changes":        map[string]interface{}{"model": map[string]interface{}{"old": "A", "new": "B"}},
+			"contextCleared": true,
+		}),
+	}
+	result := consolidateNotificationThread(msgs)
+	require.Len(t, result, 1)
+	m := parseRaw(t, result[0])
+	assert.Nil(t, m["contextCleared"], "contextCleared should not appear in output")
+}
+
+func TestConsolidateNotificationThread_CompactionBoundariesKept(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
+		raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
+	}
+	result := consolidateNotificationThread(msgs)
+	assert.Len(t, result, 2)
+}
+
+func TestConsolidateNotificationThread_Interrupted(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, settingsChanged("A", "B")),
+		raw(t, map[string]interface{}{"type": "interrupted"}),
+	}
+	result := consolidateNotificationThread(msgs)
+	assert.Equal(t, []string{"settings_changed", "interrupted"}, types(t, result))
+}
+
+func TestConsolidateNotificationThread_RateLimit(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, map[string]interface{}{
+			"type":            "rate_limit",
+			"rate_limit_info": map[string]interface{}{"rateLimitType": "five_hour", "status": "exceeded"},
+		}),
+		raw(t, map[string]interface{}{
+			"type":            "rate_limit",
+			"rate_limit_info": map[string]interface{}{"rateLimitType": "five_hour", "status": "allowed"},
+		}),
+	}
+	result := consolidateNotificationThread(msgs)
+	require.Len(t, result, 1)
+	m := parseRaw(t, result[0])
+	info := m["rate_limit_info"].(map[string]interface{})
+	assert.Equal(t, "allowed", info["status"])
+}
+
+func TestConsolidateNotificationThread_SystemStatus(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, map[string]interface{}{"type": "system", "subtype": "status", "status": "compacting"}),
+		raw(t, map[string]interface{}{"type": "system", "subtype": "status", "status": "idle"}),
+	}
+	result := consolidateNotificationThread(msgs)
+	require.Len(t, result, 1)
+	m := parseRaw(t, result[0])
+	assert.Equal(t, "idle", m["status"])
+}
+
+func TestConsolidateNotificationThread_Empty(t *testing.T) {
+	result := consolidateNotificationThread(nil)
+	assert.Equal(t, []json.RawMessage{}, result)
+}

--- a/backend/internal/worker/service/output_consolidate_test.go
+++ b/backend/internal/worker/service/output_consolidate_test.go
@@ -204,6 +204,54 @@ func TestConsolidateNotificationThread_SystemStatus(t *testing.T) {
 	assert.Equal(t, "idle", m["status"])
 }
 
+func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *testing.T) {
+	t.Run("compact_boundary after context_cleared drops context_cleared", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"system"}, types(t, result))
+	})
+
+	t.Run("microcompact_boundary after context_cleared drops context_cleared", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"system"}, types(t, result))
+	})
+
+	t.Run("context_cleared after compact_boundary drops compact_boundary", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"context_cleared"}, types(t, result))
+	})
+
+	t.Run("context_cleared after microcompact_boundary drops microcompact_boundary", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"context_cleared"}, types(t, result))
+	})
+
+	t.Run("settings_changed preserved when compaction supersedes context_cleared", func(t *testing.T) {
+		msgs := []json.RawMessage{
+			raw(t, settingsChanged("A", "B")),
+			raw(t, map[string]interface{}{"type": "context_cleared"}),
+			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
+		}
+		result := consolidateNotificationThread(msgs)
+		assert.Equal(t, []string{"settings_changed", "system"}, types(t, result))
+	})
+}
+
 func TestConsolidateNotificationThread_Empty(t *testing.T) {
 	result := consolidateNotificationThread(nil)
 	assert.Equal(t, []json.RawMessage{}, result)

--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -24,7 +24,10 @@ function renderedContains(messages: unknown[], text: string): boolean {
   return renderText(messages).includes(text)
 }
 
-describe('renderNotificationThread: compaction vs context_cleared ordering', () => {
+describe('renderNotificationThread: compaction and context_cleared rendering', () => {
+  // Note: The backend consolidation handles mutual exclusion between
+  // compaction and context_cleared. The frontend simply renders what it receives.
+
   const contextClearedMsg = { type: 'context_cleared' }
   const compactBoundaryMsg = {
     type: 'system',
@@ -37,35 +40,6 @@ describe('renderNotificationThread: compaction vs context_cleared ordering', () 
     status: 'compacting',
   }
 
-  it('compaction AFTER context_cleared: shows compaction, hides "Context cleared"', () => {
-    const messages = [contextClearedMsg, compactBoundaryMsg]
-    expect(renderedContains(messages, 'Context compacted')).toBe(true)
-    expect(renderedContains(messages, 'Context cleared')).toBe(false)
-  })
-
-  it('compaction BEFORE context_cleared: hides compaction, shows "Context cleared"', () => {
-    const messages = [compactBoundaryMsg, contextClearedMsg]
-    expect(renderedContains(messages, 'Context compacted')).toBe(false)
-    expect(renderedContains(messages, 'Context cleared')).toBe(true)
-  })
-
-  it('plan_execution renders together with compaction', () => {
-    const planExecMsg = {
-      type: 'plan_execution',
-      plan_file_path: '/path/plan.md',
-    }
-    const messages = [contextClearedMsg, planExecMsg, compactBoundaryMsg]
-    const text = renderText(messages)
-    expect(text).toContain('Executing plan')
-    expect(text).toContain('Context compacted')
-  })
-
-  it('compacting spinner AFTER context_cleared: shows spinner, hides "Context cleared"', () => {
-    const messages = [contextClearedMsg, compactingStatusMsg]
-    expect(renderedContains(messages, 'Compacting context...')).toBe(true)
-    expect(renderedContains(messages, 'Context cleared')).toBe(false)
-  })
-
   it('context_cleared alone: shows "Context cleared"', () => {
     const messages = [contextClearedMsg]
     expect(renderedContains(messages, 'Context cleared')).toBe(true)
@@ -77,28 +51,72 @@ describe('renderNotificationThread: compaction vs context_cleared ordering', () 
     expect(renderedContains(messages, 'Context cleared')).toBe(false)
   })
 
-  it('settings_changed + context_cleared BEFORE compaction: shows compaction, hides "Context cleared"', () => {
-    const settingsMsg = {
-      type: 'settings_changed',
-      changes: { model: { old: 'A', new: 'B' } },
-    }
-    const messages = [settingsMsg, contextClearedMsg, compactBoundaryMsg]
-    const text = renderText(messages)
-    expect(text).toContain('Context compacted')
-    expect(text).not.toContain('Context cleared')
-    expect(text).toContain('Model')
+  it('compacting spinner: shows spinner', () => {
+    const messages = [compactingStatusMsg]
+    expect(renderedContains(messages, 'Compacting context...')).toBe(true)
   })
 
-  it('compaction BEFORE settings_changed + context_cleared: hides compaction, shows "Context cleared"', () => {
+  it('plan_execution renders together with compaction', () => {
+    const planExecMsg = {
+      type: 'plan_execution',
+      plan_file_path: '/path/plan.md',
+    }
+    const messages = [planExecMsg, compactBoundaryMsg]
+    const text = renderText(messages)
+    expect(text).toContain('Executing plan')
+    expect(text).toContain('Context compacted')
+  })
+
+  it('settings_changed with compaction renders both', () => {
     const settingsMsg = {
       type: 'settings_changed',
       changes: { model: { old: 'A', new: 'B' } },
     }
-    const messages = [compactBoundaryMsg, settingsMsg, contextClearedMsg]
+    const messages = [settingsMsg, compactBoundaryMsg]
     const text = renderText(messages)
-    expect(text).not.toContain('Context compacted')
-    expect(text).toContain('Context cleared')
+    expect(text).toContain('Context compacted')
     expect(text).toContain('Model')
+  })
+})
+
+describe('renderNotificationThread: message ordering', () => {
+  it('context_cleared before settings_changed preserves order', () => {
+    const messages = [
+      { type: 'context_cleared' },
+      { type: 'settings_changed', changes: { permissionMode: { old: 'default', new: 'plan' } } },
+    ]
+    const text = renderText(messages)
+    const clearedIdx = text.indexOf('Context cleared')
+    const modeIdx = text.indexOf('Mode')
+    expect(clearedIdx).toBeGreaterThanOrEqual(0)
+    expect(modeIdx).toBeGreaterThan(clearedIdx)
+  })
+
+  it('settings_changed before context_cleared preserves order', () => {
+    const messages = [
+      { type: 'settings_changed', changes: { permissionMode: { old: 'default', new: 'plan' } } },
+      { type: 'context_cleared' },
+    ]
+    const text = renderText(messages)
+    const modeIdx = text.indexOf('Mode')
+    const clearedIdx = text.indexOf('Context cleared')
+    expect(modeIdx).toBeGreaterThanOrEqual(0)
+    expect(clearedIdx).toBeGreaterThan(modeIdx)
+  })
+
+  it('interrupted appears in order among other messages', () => {
+    const messages = [
+      { type: 'context_cleared' },
+      { type: 'interrupted' },
+      { type: 'settings_changed', changes: { model: { old: 'A', new: 'B' } } },
+    ]
+    const text = renderText(messages)
+    const clearedIdx = text.indexOf('Context cleared')
+    const interruptedIdx = text.indexOf('Interrupted')
+    const modelIdx = text.indexOf('Model')
+    expect(clearedIdx).toBeGreaterThanOrEqual(0)
+    expect(interruptedIdx).toBeGreaterThan(clearedIdx)
+    expect(modelIdx).toBeGreaterThan(interruptedIdx)
   })
 })
 

--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -52,12 +52,11 @@ describe('renderNotificationThread: compaction vs context_cleared ordering', () 
   it('plan_execution renders together with compaction', () => {
     const planExecMsg = {
       type: 'plan_execution',
-      context_cleared: true,
       plan_file_path: '/path/plan.md',
     }
-    const messages = [planExecMsg, compactBoundaryMsg]
+    const messages = [contextClearedMsg, planExecMsg, compactBoundaryMsg]
     const text = renderText(messages)
-    expect(text).toContain('Executing plan with clean context')
+    expect(text).toContain('Executing plan')
     expect(text).toContain('Context compacted')
   })
 
@@ -78,26 +77,24 @@ describe('renderNotificationThread: compaction vs context_cleared ordering', () 
     expect(renderedContains(messages, 'Context cleared')).toBe(false)
   })
 
-  it('settings_changed with contextCleared BEFORE compaction: shows compaction, hides "Context cleared"', () => {
+  it('settings_changed + context_cleared BEFORE compaction: shows compaction, hides "Context cleared"', () => {
     const settingsMsg = {
       type: 'settings_changed',
       changes: { model: { old: 'A', new: 'B' } },
-      contextCleared: true,
     }
-    const messages = [settingsMsg, compactBoundaryMsg]
+    const messages = [settingsMsg, contextClearedMsg, compactBoundaryMsg]
     const text = renderText(messages)
     expect(text).toContain('Context compacted')
     expect(text).not.toContain('Context cleared')
     expect(text).toContain('Model')
   })
 
-  it('compaction BEFORE settings_changed with contextCleared: hides compaction, shows "Context cleared"', () => {
+  it('compaction BEFORE settings_changed + context_cleared: hides compaction, shows "Context cleared"', () => {
     const settingsMsg = {
       type: 'settings_changed',
       changes: { model: { old: 'A', new: 'B' } },
-      contextCleared: true,
     }
-    const messages = [compactBoundaryMsg, settingsMsg]
+    const messages = [compactBoundaryMsg, settingsMsg, contextClearedMsg]
     const text = renderText(messages)
     expect(text).not.toContain('Context compacted')
     expect(text).toContain('Context cleared')

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -39,7 +39,7 @@ function displayValue(key: string, value: string): string {
   return DISPLAY_VALUE_MAPS[key]?.[value] ?? value
 }
 
-/** Handles settings change notifications: {"type":"settings_changed","changes":{...},"contextCleared"?:true} */
+/** Handles settings change notifications: {"type":"settings_changed","changes":{...}} */
 export const settingsChangedRenderer: MessageContentRenderer = {
   render(parsed, _role, _context) {
     if (!isObject(parsed) || parsed.type !== 'settings_changed')
@@ -52,9 +52,6 @@ export const settingsChangedRenderer: MessageContentRenderer = {
       if (val.old !== val.new) {
         parts.push(`${displayLabel(key)} (${displayValue(key, val.old)} → ${displayValue(key, val.new)})`)
       }
-    }
-    if (parsed.contextCleared) {
-      parts.push('Context cleared')
     }
     if (parts.length === 0)
       return null
@@ -272,7 +269,6 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   // Accumulate state across all messages in the thread.
   const settingsParts: string[] = []
   let contextCleared = false
-  let planExecContextCleared = false
   let interrupted = false
   let compacting = false
   let compactLabel: string | null = null
@@ -309,23 +305,13 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
             settingsParts.push(`${displayLabel(key)} (${displayValue(key, val.old)} → ${displayValue(key, val.new)})`)
         }
       }
-      if (m.contextCleared) {
-        contextCleared = true
-        lastContextEventIsCompaction = false
-      }
     }
     else if (t === 'context_cleared') {
       contextCleared = true
       lastContextEventIsCompaction = false
     }
     else if (t === 'plan_execution') {
-      if (m.context_cleared === true) {
-        planExecContextCleared = true
-        settingsParts.push('Executing plan with clean context')
-      }
-      else {
-        settingsParts.push('Executing plan retaining context')
-      }
+      settingsParts.push('Executing plan')
     }
     else if (t === 'agent_error') {
       const error = typeof m.error === 'string' ? m.error : 'Unknown error'
@@ -362,7 +348,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
     }
   }
 
-  if (contextCleared && !planExecContextCleared && !lastContextEventIsCompaction)
+  if (contextCleared && !lastContextEventIsCompaction)
     settingsParts.push('Context cleared')
   if (interrupted)
     settingsParts.push('Interrupted')

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -268,8 +268,6 @@ function formatCompactionTokens(preTokens: number | undefined, tokensSaved: numb
 export function renderNotificationThread(messages: unknown[]): JSXElement {
   // Accumulate state across all messages in the thread.
   const settingsParts: string[] = []
-  let contextCleared = false
-  let interrupted = false
   let compacting = false
   let compactLabel: string | null = null
   let compactPreTokens: number | undefined
@@ -278,9 +276,6 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   let microcompactPreTokens: number | undefined
   let microcompactTokensSaved: number | undefined
   const rateLimitByType: Record<string, Record<string, unknown>> = {}
-  // Track whether the most recent context-affecting event is compaction or context_cleared.
-  // true = compaction came last, false = context_cleared came last.
-  let lastContextEventIsCompaction = false
 
   for (const msg of messages) {
     if (!isObject(msg))
@@ -307,8 +302,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
       }
     }
     else if (t === 'context_cleared') {
-      contextCleared = true
-      lastContextEventIsCompaction = false
+      settingsParts.push('Context cleared')
     }
     else if (t === 'plan_execution') {
       settingsParts.push('Executing plan')
@@ -318,7 +312,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
       settingsParts.push(error)
     }
     else if (t === 'interrupted') {
-      interrupted = true
+      settingsParts.push('Interrupted')
     }
     else if (t === 'agent_renamed') {
       const title = typeof m.title === 'string' ? m.title : ''
@@ -327,12 +321,9 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
     }
     else if (t === 'system' && st === 'status') {
       compacting = m.status === 'compacting'
-      if (compacting)
-        lastContextEventIsCompaction = true
     }
     else if (t === 'system' && st === 'compact_boundary') {
       compacting = false
-      lastContextEventIsCompaction = true
       const meta = (isObject(m.compact_metadata) ? m.compact_metadata : m.compactMetadata) as Record<string, unknown> | undefined
       compactPreTokens = (typeof meta?.pre_tokens === 'number' ? meta.pre_tokens : meta?.preTokens) as number | undefined
       compactTokensSaved = (typeof meta?.tokens_saved === 'number' ? meta.tokens_saved : meta?.tokensSaved) as number | undefined
@@ -340,18 +331,12 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
     }
     else if (t === 'system' && st === 'microcompact_boundary') {
       compacting = false
-      lastContextEventIsCompaction = true
       const meta = (isObject(m.microcompactMetadata) ? m.microcompactMetadata : m.microcompact_metadata) as Record<string, unknown> | undefined
       microcompactPreTokens = (typeof meta?.preTokens === 'number' ? meta.preTokens : meta?.pre_tokens) as number | undefined
       microcompactTokensSaved = (typeof meta?.tokensSaved === 'number' ? meta.tokensSaved : meta?.tokens_saved) as number | undefined
       microcompactLabel = `Context microcompacted${formatCompactionTokens(microcompactPreTokens, microcompactTokensSaved)}`
     }
   }
-
-  if (contextCleared && !lastContextEventIsCompaction)
-    settingsParts.push('Context cleared')
-  if (interrupted)
-    settingsParts.push('Interrupted')
 
   // Add rate limit messages (one per rateLimitType), skipping "allowed" status.
   for (const info of Object.values(rateLimitByType)) {
@@ -361,13 +346,10 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
 
   const settingsLine = settingsParts.length > 0 ? settingsParts.join(', ') : null
 
-  // Show compaction when there's no context_cleared, or when compaction came after context_cleared.
-  const showCompaction = !contextCleared || lastContextEventIsCompaction
-
   const elements: JSXElement[] = []
 
   // Compaction in progress (spinner).
-  if (showCompaction && compacting && !compactLabel && !microcompactLabel) {
+  if (compacting && !compactLabel && !microcompactLabel) {
     elements.push(
       <div class={resultDivider}>
         <Icon icon={LoaderCircle} size="sm" class={spinner} />
@@ -377,7 +359,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   }
 
   // Compact boundary result.
-  if (showCompaction && compactLabel) {
+  if (compactLabel) {
     elements.push(
       <div class={resultDivider}>
         <Icon icon={ArrowDownToLine} size="sm" />
@@ -387,7 +369,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   }
 
   // Microcompact boundary result.
-  if (showCompaction && microcompactLabel) {
+  if (microcompactLabel) {
     elements.push(
       <div class={resultDivider}>
         <Icon icon={ArrowDownToLine} size="sm" />

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -157,8 +157,9 @@ export const AppShell: ParentComponent = (props) => {
   const handleTurnEnd = (agentId: string, numTurns?: number) => {
     if (isAgentClosing(agentId))
       return
+    // Always bump the trigger (drives git status and directory tree refresh),
+    // but skip the audible notification for trivial single-exchange turns.
     setTurnEndTrigger(v => v + 1)
-    // Skip sound for trivial turns (single exchange or less).
     if (numTurns !== undefined && numTurns <= 1)
       return
     const now = Date.now()

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -154,10 +154,13 @@ export const AppShell: ParentComponent = (props) => {
   const turnEndAudio = new Audio('/sounds/benkirb-electronic-doorbell-262895.mp3')
   // Late-bound ref: set once useTabOperations is initialized (after useWorkspaceConnection).
   let isAgentClosing: (agentId: string) => boolean = () => false
-  const handleTurnEnd = (agentId: string) => {
+  const handleTurnEnd = (agentId: string, numTurns?: number) => {
     if (isAgentClosing(agentId))
       return
     setTurnEndTrigger(v => v + 1)
+    // Skip sound for trivial turns (single exchange or less).
+    if (numTurns !== undefined && numTurns <= 1)
+      return
     const now = Date.now()
     if (now - lastSoundPlayedAt < TURN_END_SOUND_COOLDOWN_MS)
       return

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -52,6 +52,11 @@ export const nodeName = style({
   whiteSpace: 'nowrap',
 })
 
+export const nodeNameMuted = style({
+  whiteSpace: 'nowrap',
+  color: 'var(--muted-foreground)',
+})
+
 export const loadingState = style({
   display: 'flex',
   alignItems: 'center',

--- a/frontend/src/components/tree/DirectoryTree.css.ts
+++ b/frontend/src/components/tree/DirectoryTree.css.ts
@@ -52,10 +52,9 @@ export const nodeName = style({
   whiteSpace: 'nowrap',
 })
 
-export const nodeNameMuted = style({
-  whiteSpace: 'nowrap',
+export const nodeNameMuted = style([nodeName, {
   color: 'var(--muted-foreground)',
-})
+}])
 
 export const loadingState = style({
   display: 'flex',

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -468,7 +468,7 @@ const TreeNode: Component<{
             <Icon icon={FolderOpen} size="sm" class={gitIcon().class || styles.folderIcon} data-testid={gitIcon().testId} />
           </Show>
         </Show>
-        <span class={styles.nodeName}>{props.node.displayName}</span>
+        <span class={props.node.hidden ? styles.nodeNameMuted : styles.nodeName}>{props.node.displayName}</span>
         {renderNodeDiffStats(props.node, tree.gitStatusStore())}
         <div class={styles.nodeActions}>
           <TreeContextMenu

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -108,7 +108,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
               break
 
             // Ephemeral (unwrapped) agent_session_info — not persisted, skip addMessage.
-            if (!parsed.isWrapped && parsed.topLevel.type === 'agent_session_info') {
+            if (!parsed.wrapper && parsed.topLevel.type === 'agent_session_info') {
               const info = parsed.topLevel.info as Record<string, unknown> | undefined
               const updates: Record<string, unknown> = {}
               if (info?.total_cost_usd !== undefined)

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -33,7 +33,7 @@ export interface WorkspaceConnectionParams {
   /** Returns the worker ID for the active workspace. */
   getWorkerId: () => string
   /** Called when an agent turn ends (turn completed or control request received). */
-  onTurnEnd?: (agentId: string) => void
+  onTurnEnd?: (agentId: string, numTurns?: number) => void
 }
 
 export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
@@ -168,7 +168,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             const meta = extractResultMetadata(parseMessageContent(msg))
             if (meta) {
               if (meta.subtype && catchUpPhase === 'live')
-                params.onTurnEnd?.(agentId)
+                params.onTurnEnd?.(agentId, meta.numTurns)
               if (meta.contextWindow !== undefined) {
                 const existingUsage = agentSessionStore.getInfo(agentId).contextUsage
                 if (existingUsage) {

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -399,6 +399,17 @@ describe('extractResultMetadata', () => {
     const msg = makeMsg(MessageRole.RESULT, wrap(content))
     expect(extractResultMetadata(parseMessageContent(msg))).toBeNull()
   })
+
+  it('extracts numTurns from result message', () => {
+    const content = {
+      type: 'result',
+      subtype: 'turn_end',
+      num_turns: 5,
+    }
+    const msg = makeMsg(MessageRole.RESULT, wrap(content))
+    const result = extractResultMetadata(parseMessageContent(msg))
+    expect(result).toEqual({ subtype: 'turn_end', numTurns: 5 })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -527,7 +538,6 @@ describe('extractPlanFilePath', () => {
   it('extracts plan file path from wrapped plan_execution message', () => {
     const content = {
       type: 'plan_execution',
-      context_cleared: true,
       plan_file_path: '/home/user/.claude/plans/plan.md',
     }
     const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
@@ -538,7 +548,6 @@ describe('extractPlanFilePath', () => {
     const ccMsg = { type: 'context_cleared' }
     const peMsg = {
       type: 'plan_execution',
-      context_cleared: true,
       plan_file_path: '/path/to/plan.md',
     }
     const msg = makeMsg(MessageRole.LEAPMUX, wrap(ccMsg, peMsg))
@@ -548,7 +557,6 @@ describe('extractPlanFilePath', () => {
   it('extracts plan file path from unwrapped plan_execution message', () => {
     const content = {
       type: 'plan_execution',
-      context_cleared: false,
       plan_file_path: '/path/plan.md',
     }
     const msg = makeMsg(MessageRole.LEAPMUX, content)
@@ -558,7 +566,6 @@ describe('extractPlanFilePath', () => {
   it('returns undefined when plan_file_path is empty', () => {
     const content = {
       type: 'plan_execution',
-      context_cleared: false,
       plan_file_path: '',
     }
     const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -48,9 +48,8 @@ describe('parseMessageContent', () => {
     const msg = makeMsg(MessageRole.ASSISTANT, wrap(inner))
     const result = parseMessageContent(msg)
 
-    expect(result.isWrapped).toBe(true)
-    expect(result.parentObject).toEqual(inner)
     expect(result.wrapper).not.toBeNull()
+    expect(result.parentObject).toEqual(inner)
     expect(result.children).toEqual([])
     expect(result.rawText).toBeTruthy()
   })
@@ -69,7 +68,7 @@ describe('parseMessageContent', () => {
     const msg = makeMsg(MessageRole.ASSISTANT, wrap())
     const result = parseMessageContent(msg)
 
-    expect(result.isWrapped).toBe(true)
+    expect(result.wrapper).not.toBeNull()
     expect(result.parentObject).toBeUndefined()
     expect(result.children).toEqual([])
   })
@@ -79,7 +78,7 @@ describe('parseMessageContent', () => {
     const msg = makeMsg(MessageRole.LEAPMUX, content)
     const result = parseMessageContent(msg)
 
-    expect(result.isWrapped).toBe(false)
+    expect(result.wrapper).toBeNull()
     expect(result.parentObject).toEqual(content)
     expect(result.topLevel).toEqual(content)
     expect(result.wrapper).toBeNull()

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -13,8 +13,6 @@ export interface ParsedMessageContent {
   rawText: string
   /** The top-level parsed JSON object, or null on parse failure. */
   topLevel: Record<string, unknown> | null
-  /** Whether topLevel is a thread-wrapper envelope ({messages: [...]}) */
-  isWrapped: boolean
   /** The first (parent) inner message object, or undefined. */
   parentObject: Record<string, unknown> | undefined
   /** Thread children (messages after the first), empty array if none. */
@@ -26,7 +24,6 @@ export interface ParsedMessageContent {
 const EMPTY_PARSED: ParsedMessageContent = {
   rawText: '',
   topLevel: null,
-  isWrapped: false,
   parentObject: undefined,
   children: [],
   wrapper: null,
@@ -48,7 +45,7 @@ export function parseMessageContent(message: AgentChatMessage): ParsedMessageCon
       // An empty messages array can occur when notification consolidation
       // cancels out all changes (e.g. plan mode toggled back).
       if (obj.messages.length === 0)
-        return { rawText: text, topLevel: obj, isWrapped: true, parentObject: undefined, children: [], wrapper: obj }
+        return { rawText: text, topLevel: obj, parentObject: undefined, children: [], wrapper: obj }
 
       const first = obj.messages[0]
       const parent = (typeof first === 'object' && first !== null && !Array.isArray(first))
@@ -57,7 +54,6 @@ export function parseMessageContent(message: AgentChatMessage): ParsedMessageCon
       return {
         rawText: text,
         topLevel: obj,
-        isWrapped: true,
         parentObject: parent,
         children: obj.messages.length > 1 ? obj.messages.slice(1) : [],
         wrapper: obj,
@@ -67,10 +63,10 @@ export function parseMessageContent(message: AgentChatMessage): ParsedMessageCon
     const parent = (typeof obj === 'object' && obj !== null && !Array.isArray(obj))
       ? obj as Record<string, unknown>
       : undefined
-    return { rawText: text, topLevel: obj, isWrapped: false, parentObject: parent, children: [], wrapper: null }
+    return { rawText: text, topLevel: obj, parentObject: parent, children: [], wrapper: null }
   }
   catch {
-    return { rawText: text, topLevel: null, isWrapped: false, parentObject: undefined, children: [], wrapper: null }
+    return { rawText: text, topLevel: null, parentObject: undefined, children: [], wrapper: null }
   }
 }
 

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -162,11 +162,12 @@ export function extractAssistantUsage(parsed: ParsedMessageContent): {
   return Object.keys(result).length > 0 ? result : null
 }
 
-/** Extract result-message metadata: subtype, contextWindow, totalCostUsd. */
+/** Extract result-message metadata: subtype, contextWindow, totalCostUsd, numTurns. */
 export function extractResultMetadata(parsed: ParsedMessageContent): {
   subtype?: string
   contextWindow?: number
   totalCostUsd?: number
+  numTurns?: number
 } | null {
   const inner = getInnerMessage(parsed)
   if (!inner)
@@ -175,7 +176,7 @@ export function extractResultMetadata(parsed: ParsedMessageContent): {
   if (inner.parent_tool_use_id)
     return null
 
-  const result: { subtype?: string, contextWindow?: number, totalCostUsd?: number } = {}
+  const result: { subtype?: string, contextWindow?: number, totalCostUsd?: number, numTurns?: number } = {}
 
   if (inner.subtype)
     result.subtype = inner.subtype as string
@@ -192,6 +193,9 @@ export function extractResultMetadata(parsed: ParsedMessageContent): {
 
   if (typeof inner.total_cost_usd === 'number')
     result.totalCostUsd = inner.total_cost_usd as number
+
+  if (typeof inner.num_turns === 'number')
+    result.numTurns = inner.num_turns as number
 
   return Object.keys(result).length > 0 ? result : null
 }

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -20,9 +20,17 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     // context_cleared is a turn boundary: the agent restarted with a fresh
     // context and is now idle, so stop scanning into the old history.
     if (msg.role === MessageRole.LEAPMUX) {
-      const innerType = getInnerMessageType(parseMessageContent(msg))
+      const parsed = parseMessageContent(msg)
+      const innerType = getInnerMessageType(parsed)
       if (innerType === 'context_cleared')
         return false
+      // Check if context_cleared is in a notification thread wrapper.
+      if (parsed.isWrapped && parsed.wrapper) {
+        for (const m of parsed.wrapper.messages) {
+          if (typeof m === 'object' && m !== null && (m as Record<string, unknown>).type === 'context_cleared')
+            return false
+        }
+      }
       continue
     }
     if (msg.role !== MessageRole.RESULT)

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -25,7 +25,7 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
       if (innerType === 'context_cleared')
         return false
       // Check if context_cleared is in a notification thread wrapper.
-      if (parsed.isWrapped && parsed.wrapper) {
+      if (parsed.wrapper) {
         for (const m of parsed.wrapper.messages) {
           if (typeof m === 'object' && m !== null && (m as Record<string, unknown>).type === 'context_cleared')
             return false

--- a/frontend/tests/e2e/32-clear-command.spec.ts
+++ b/frontend/tests/e2e/32-clear-command.spec.ts
@@ -2,6 +2,33 @@ import { expect, test } from './fixtures'
 import { lastAssistantBubble } from './helpers/ui'
 
 test.describe('Clear Command', () => {
+  test('slash reset clears context (alias for /clear)', async ({ page, authenticatedWorkspace }) => {
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+
+    // Send a message to establish a session
+    await editor.click()
+    await page.keyboard.type('What is 1+1? Reply with just the number, nothing else.')
+    await page.keyboard.press('Meta+Enter')
+    const lastAssistant1 = lastAssistantBubble(page)
+    await expect(lastAssistant1).toContainText('2', { timeout: 30000 })
+
+    // Send /reset (alias for /clear)
+    await editor.click()
+    await page.keyboard.type('/reset')
+    await page.keyboard.press('Meta+Enter')
+
+    // Verify notification bubble appears
+    await expect(page.getByText('Context cleared')).toBeVisible()
+
+    // Verify agent is still responsive (new session)
+    await editor.click()
+    await page.keyboard.type('What is 4+4? Reply with just the number, nothing else.')
+    await page.keyboard.press('Meta+Enter')
+    const lastAssistant2 = lastAssistantBubble(page)
+    await expect(lastAssistant2).toContainText('8', { timeout: 30000 })
+  })
+
   test('slash clear clears context and shows notification', async ({ page, authenticatedWorkspace }) => {
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()

--- a/frontend/tests/unit/utils/agentState.test.ts
+++ b/frontend/tests/unit/utils/agentState.test.ts
@@ -168,4 +168,18 @@ describe('isAgentWorking', () => {
       makeMsg(MessageRole.LEAPMUX, wrap([{ type: 'context_cleared' }])),
     ])).toBe(false)
   })
+
+  it('treats LEAPMUX wrapper with [settings_changed, context_cleared] as turn boundary', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.LEAPMUX, wrap([{ type: 'settings_changed' }, { type: 'context_cleared' }])),
+    ])).toBe(false)
+  })
+
+  it('treats LEAPMUX wrapper with [context_cleared, settings_changed] as turn boundary', () => {
+    expect(isAgentWorking([
+      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageRole.LEAPMUX, wrap([{ type: 'context_cleared' }, { type: 'settings_changed' }])),
+    ])).toBe(false)
+  })
 })


### PR DESCRIPTION
## Motivation

The notification consolidation logic was split between the backend and frontend, making it difficult to reason about and test. The frontend had to apply its own mutual exclusion rules (e.g., hiding `context_cleared` when a compaction boundary arrived), duplicating logic that properly belongs in the backend's consolidation pass.

Additionally, `context_cleared` was bundled with `plan_execution` inside a single notification type via a boolean field, coupling two unrelated events. Several minor UI issues also needed fixing: `/reset` was not recognized as an alias for `/clear`, the `ThinkingIndicator` could get stuck after `/clear` followed by a plan mode toggle, and hidden directory entries in the file tree were not visually distinguished.

## Modifications

- **Breaking change**: The `context_cleared` field has been removed from `settings_changed` and `plan_execution` notification types. These are now emitted as independent `context_cleared` events.
- Rewrote `consolidateNotificationThread()` to use index-based deduplication: each message type appears at most once, with the last occurrence winning, and output is ordered by the chronological position of each type's last occurrence.
- Moved `context_cleared` / compaction mutual exclusion entirely into backend consolidation. `context_cleared` suppresses earlier compaction boundaries in the same thread; a later compaction boundary suppresses `context_cleared`.
- Removed `isWrapped` from `ParsedMessageContent` — the `wrapper` field (null vs object) already encodes this information.
- Added `/reset` as a backend-level alias for `/clear`.
- Fixed `ThinkingIndicator` bug: `isAgentWorking` now inspects `context_cleared` events inside notification thread wrappers, so the indicator clears correctly after `/clear` + plan mode toggle.
- Applied `nodeNameMuted` CSS class to hidden directory entries in the file tree for visual distinction.
- Added 258 lines of backend tests covering deduplication, ordering, settings merging, compaction boundary interactions, and edge cases.

## Result

- Notification consolidation rules have a single source of truth in the backend, making the frontend rendering logic simpler and straightforward: it renders messages in the order they are received.
- You no longer see the `ThinkingIndicator` get stuck after running `/clear` and then toggling plan mode.
- Typing `/reset` now works identically to `/clear`.
- Hidden files in the directory tree are rendered in a muted color, matching the visual treatment used elsewhere for de-emphasized entries.

🤖 Generated with Claude Code
