### PR TITLE
Fix settings changes targeting wrong agent in new tabs

### DIFF
--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -435,10 +435,10 @@ export function createTileRenderer(opts: TileRendererOpts) {
         focusRef={(fn) => { focusEditorRef.current = fn }}
         controlRequests={controlStore.getRequests(agentId())}
         onControlResponse={agentOps.handleControlResponse}
-        onPermissionModeChange={agentOps.handlePermissionModeChange}
-        onModelChange={v => agentOps.handleModelOrEffortChange('model', v)}
-        onEffortChange={v => agentOps.handleModelOrEffortChange('effort', v)}
-        onInterrupt={agentOps.handleInterrupt}
+        onPermissionModeChange={mode => agentOps.handlePermissionModeChange(agentId(), mode)}
+        onModelChange={v => agentOps.handleModelOrEffortChange(agentId(), 'model', v)}
+        onEffortChange={v => agentOps.handleModelOrEffortChange(agentId(), 'effort', v)}
+        onInterrupt={() => agentOps.handleInterrupt(agentId())}
         settingsLoading={settingsLoading.loading()}
         agentSessionInfo={agentSessionStore.getInfo(agentId())}
         agentWorking={agentStore.state.agents.find(a => a.id === agentId())?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId()))}

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -82,6 +82,7 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
           agentProvider: resp.agent.agentProvider,
         })
         props.tabStore.setActiveTabForTile(tileId, TabType.AGENT, resp.agent.id)
+        props.agentStore.setActiveAgent(resp.agent.id)
         props.persistLayout?.()
         // Register tab with hub.
         workspaceClient.addTab({
@@ -155,11 +156,8 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Change model or effort for the active agent (requires agent restart)
-  const handleModelOrEffortChange = async (field: 'model' | 'effort', value: string) => {
-    const agentId = props.agentStore.state.activeAgentId
-    if (!agentId)
-      return
+  // Change model or effort for the given agent (requires agent restart)
+  const handleModelOrEffortChange = async (agentId: string, field: 'model' | 'effort', value: string) => {
     const agent = props.agentStore.state.agents.find(a => a.id === agentId)
     if (!agent)
       return
@@ -184,11 +182,8 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Interrupt the active agent's current turn
-  const handleInterrupt = async () => {
-    const agentId = props.agentStore.state.activeAgentId
-    if (!agentId)
-      return
+  // Interrupt the given agent's current turn
+  const handleInterrupt = async (agentId: string) => {
     try {
       const workerId = getAgentWorkerId(agentId)
       await workerRpc.sendAgentMessage(workerId, {
@@ -201,11 +196,8 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Change permission mode for the active agent
-  const handlePermissionModeChange = async (mode: PermissionMode) => {
-    const agentId = props.agentStore.state.activeAgentId
-    if (!agentId)
-      return
+  // Change permission mode for the given agent
+  const handlePermissionModeChange = async (agentId: string, mode: PermissionMode) => {
     const agent = props.agentStore.state.agents.find(a => a.id === agentId)
     if (!agent)
       return

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test'
-import { lastAssistantBubble } from './helpers/ui'
+import { lastAssistantBubble, openAgentViaUI } from './helpers/ui'
 import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 /** Open the settings menu, retrying if it was caught mid-close animation. */
@@ -381,6 +381,39 @@ test.describe('Agent Settings', () => {
 
     // Direct check too
     await expect(page.locator('[data-testid="thinking-indicator"]')).not.toBeVisible()
+  })
+
+  test('permission mode change in new agent tab targets correct agent', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Verify first agent starts with Default mode
+    const firstTriggerText = await getTriggerText(page)
+    expect(firstTriggerText).toContain('Default')
+
+    // Open a second agent tab
+    await openAgentViaUI(page)
+
+    // The new tab should also start with Default mode
+    await expect(trigger).toContainText('Default')
+
+    // Switch the new agent to Plan Mode
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="permission-mode-plan"]').click()
+    await expect(trigger).toContainText('Plan Mode')
+    await waitForSettingsIdle(page)
+
+    // Verify the notification appears in the new agent's chat (not the first agent's)
+    await expect(page.getByText('Mode (Default → Plan Mode)')).toBeVisible()
+
+    // Switch back to the first agent tab
+    const agentTabs = page.locator('[data-testid="tab"][data-tab-type="agent"]')
+    await agentTabs.first().click()
+
+    // First agent should still be in Default mode
+    await expect(trigger).toContainText('Default')
+    // And should NOT have the permission mode notification
+    await expect(page.getByText('Mode (Default → Plan Mode)')).not.toBeVisible()
   })
 
   test('settings loading indicator on trigger', async ({ authenticatedWorkspace, page }) => {


### PR DESCRIPTION
## Motivation

When a user opened a second agent tab and changed settings (permission mode, model, or effort), the changes were incorrectly applied to the previously active agent rather than the agent in the new tab. This happened because `handlePermissionModeChange`, `handleModelOrEffortChange`, and `handleInterrupt` in `useAgentOperations.ts` read from the global `activeAgentId` store value instead of using the agent ID from the calling component. Additionally, `openAgentInWorkspace` did not call `setActiveAgent()`, so `activeAgentId` still pointed to the old agent after opening a new tab.

## Modifications

- Changed `handlePermissionModeChange`, `handleModelOrEffortChange`, and `handleInterrupt` in `useAgentOperations.ts` to accept an explicit `agentId` parameter instead of reading from the global `activeAgentId`.
- Updated `TileRenderer.tsx` so that `FocusedAgentEditorPanel` passes the correct `agentId()` to all settings and interrupt callbacks.
- Added `props.agentStore.setActiveAgent(resp.agent.id)` in `openAgentInWorkspace()` so that `activeAgentId` stays in sync for other consumers.
- Added an E2E test (`31-agent-settings.spec.ts`) that opens a second agent tab, changes its permission mode, and verifies the notification appears in the new agent's chat and that the first agent remains unaffected.

## Result

Settings changes (permission mode, model, effort) and interrupt made in a newly opened agent tab now correctly target that tab's agent. The notification appears in the correct chat, and switching back to the previous agent tab shows it is still in its original state.

🤖 Generated with Claude Code
