### PR TITLE
Fix result text shown as error when subtype is success

### DIFF
--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -8,7 +8,7 @@ vi.mock('./messageRenderers', () => ({
     typeof v === 'object' && v !== null && !Array.isArray(v),
 }))
 
-const { renderNotificationThread } = await import('./notificationRenderers')
+const { renderNotificationThread, resultRenderer } = await import('./notificationRenderers')
 
 /** Extract all text content from the rendered container, trimmed. */
 function renderText(messages: unknown[]): string {
@@ -154,5 +154,55 @@ describe('renderNotificationThread: agent_renamed', () => {
     const text = renderText(messages)
     expect(text).toContain('Renamed to Test Plan')
     expect(text).toContain('Interrupted')
+  })
+})
+
+/** Render a result message via resultRenderer and return its text and style. */
+function renderResult(parsed: Record<string, unknown>): { text: string, color: string } {
+  const el = resultRenderer.render(parsed, 'assistant')
+  if (el === null)
+    return { text: '', color: '' }
+  const { container } = render(() => el)
+  const div = container.querySelector('div')
+  return {
+    text: div?.textContent?.trim() ?? '',
+    color: div?.style.color ?? '',
+  }
+}
+
+describe('resultRenderer: stop_reason null handling', () => {
+  it('success subtype with context stats does not show as error', () => {
+    const { text, color } = renderResult({
+      type: 'result',
+      subtype: 'success',
+      stop_reason: null,
+      result: 'Context usage: 50k tokens',
+      duration_ms: 1000,
+    })
+    expect(color).toBe('')
+    expect(text).toContain('Took')
+  })
+
+  it('success subtype with known error prefix shows as error', () => {
+    const { text, color } = renderResult({
+      type: 'result',
+      subtype: 'success',
+      stop_reason: null,
+      result: 'Unknown skill: foo',
+      duration_ms: 500,
+    })
+    expect(color).toBe('var(--danger)')
+    expect(text).toBe('Unknown skill: foo')
+  })
+
+  it('missing subtype with result text shows as error', () => {
+    const { text, color } = renderResult({
+      type: 'result',
+      stop_reason: null,
+      result: 'Something went wrong',
+      duration_ms: 200,
+    })
+    expect(color).toBe('var(--danger)')
+    expect(text).toBe('Something went wrong')
   })
 })

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -246,10 +246,21 @@ export const resultRenderer: MessageContentRenderer = {
     const resultText = typeof parsed.result === 'string' ? parsed.result : ''
     const durationStr = formatDuration(durationMs)
 
-    // When stop_reason is absent (agent never produced output), show the result
-    // text as an error — e.g. "Unknown skill: update-pr".
+    // When stop_reason is absent (agent never produced output), the result text
+    // may be an error or just a repetition of the last assistant message.
     if (!parsed.stop_reason && resultText) {
-      return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{resultText}</div>
+      if (parsed.subtype === 'success') {
+        // For success results, only show known error prefixes (e.g. "Unknown skill:").
+        const knownErrorPrefixes = ['Unknown skill:']
+        const isKnownError = knownErrorPrefixes.some(p => resultText.startsWith(p))
+        if (isKnownError) {
+          return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{resultText}</div>
+        }
+        // Fall through to normal display logic below
+      }
+      else {
+        return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{resultText}</div>
+      }
     }
 
     // For non-success subtypes, show result text with duration.


### PR DESCRIPTION
## Motivation

When a tool result message had `subtype === 'success'` and a null `stop_reason`, the chat renderer was incorrectly displaying the result text using error styling. This caused normal output such as context usage statistics to appear as error messages, which was misleading to users.

## Modifications

- Updated `resultRenderer` in `notificationRenderers.tsx` to check for known error prefixes (currently `"Unknown skill:"`) before applying error styling when `subtype === 'success'` and `stop_reason` is null. Results that do not match a known error prefix are now rendered normally with duration information.
- Added three test cases to `notificationRenderers.test.tsx` covering: success subtypes with context stats, success subtypes with known error prefixes, and results with missing subtypes.

## Result

Success result text such as context usage stats is no longer displayed with error styling. Only result messages that match known error prefixes (e.g. `"Unknown skill:"`) continue to be shown as errors when `stop_reason` is null.

🤖 Generated with Claude Code
