### PR TITLE
Add Codex live streaming, control persistence, and chat rendering

### DIFF
--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -86,7 +86,7 @@ func (a *ClaudeCodeAgent) HandleOutput(content []byte) {
 		a.claudeCodeHandleRateLimitEvent(content)
 
 	default:
-		a.sink.BroadcastStreamChunk(content)
+		a.sink.BroadcastStreamChunk(content, "", "")
 	}
 }
 

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -57,6 +57,9 @@ func handleCodexOutput(a *CodexAgent, content []byte) {
 	case "item/completed":
 		a.handleItemCompleted(envelope.Params)
 
+	case "thread/compacted":
+		a.handleThreadCompacted(envelope.Params)
+
 	case "turn/completed":
 		a.handleTurnCompleted(envelope.Params)
 
@@ -226,6 +229,10 @@ func (a *CodexAgent) handleItemStarted(params json.RawMessage) {
 	switch itemType {
 	case "agentMessage":
 		// No-op for started — wait for completed to persist.
+	case "contextCompaction":
+		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, []byte(`{"type":"compacting"}`)); err != nil {
+			slog.Error("codex persist compacting notification", "agent_id", a.agentID, "error", err)
+		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
 		// Pre-peek the span color before persisting so it is recorded with the message.
 		spanColor := a.sink.PeekNextSpanColor()
@@ -331,12 +338,37 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 			slog.Error("codex persist reasoning", "agent_id", a.agentID, "error", err)
 		}
 		a.sink.BroadcastStreamEnd(itemID)
+	case "contextCompaction":
+		// No-op: completion is represented by thread/compacted, which is emitted as
+		// a LEAPMUX notification-thread boundary instead of an assistant message.
 	default:
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist unknown item", "agent_id", a.agentID, "type", itemType, "error", err)
 		}
+	}
+}
+
+func (a *CodexAgent) handleThreadCompacted(params json.RawMessage) {
+	var notif struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+	}
+	if json.Unmarshal(params, &notif) != nil {
+		return
+	}
+	content, err := json.Marshal(map[string]interface{}{
+		"type":     "system",
+		"subtype":  "compact_boundary",
+		"threadId": notif.ThreadID,
+		"turnId":   notif.TurnID,
+	})
+	if err != nil {
+		return
+	}
+	if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, content); err != nil {
+		slog.Error("codex persist compacted notification", "agent_id", a.agentID, "error", err)
 	}
 }
 

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -33,6 +33,24 @@ func handleCodexOutput(a *CodexAgent, content []byte) {
 	case "item/plan/delta":
 		a.handlePlanDelta(envelope.Params)
 
+	case "item/reasoning/summaryTextDelta":
+		a.handleReasoningSummaryTextDelta(envelope.Params)
+
+	case "item/reasoning/summaryPartAdded":
+		a.handleReasoningSummaryPartAdded(envelope.Params)
+
+	case "item/reasoning/textDelta":
+		a.handleReasoningTextDelta(envelope.Params)
+
+	case "item/commandExecution/outputDelta":
+		a.handleCommandExecutionOutputDelta(envelope.Params)
+
+	case "item/commandExecution/terminalInteraction":
+		a.handleCommandExecutionTerminalInteraction(envelope.Params)
+
+	case "item/fileChange/outputDelta":
+		a.handleFileChangeOutputDelta(envelope.Params)
+
 	case "item/started":
 		a.handleItemStarted(envelope.Params)
 
@@ -113,7 +131,7 @@ func (a *CodexAgent) handleAgentMessageDelta(params json.RawMessage) {
 		Delta string `json:"delta"`
 	}
 	if json.Unmarshal(params, &delta) == nil && delta.Delta != "" {
-		a.sink.BroadcastStreamChunk([]byte(delta.Delta))
+		a.sink.BroadcastStreamChunk([]byte(delta.Delta), "", "item/agentMessage/delta")
 	}
 }
 
@@ -133,7 +151,66 @@ func (a *CodexAgent) handlePlanDelta(params json.RawMessage) {
 		} else {
 			a.mu.Unlock()
 		}
-		a.sink.BroadcastStreamChunk([]byte(delta.Delta))
+		a.sink.BroadcastStreamChunk([]byte(delta.Delta), "", "item/plan/delta")
+	}
+}
+
+func (a *CodexAgent) handleReasoningSummaryTextDelta(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+		Delta  string `json:"delta"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
+		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/reasoning/summaryTextDelta")
+	}
+}
+
+func (a *CodexAgent) handleReasoningSummaryPartAdded(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" {
+		a.sink.BroadcastStreamChunk(nil, notif.ItemID, "item/reasoning/summaryPartAdded")
+	}
+}
+
+func (a *CodexAgent) handleReasoningTextDelta(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+		Delta  string `json:"delta"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
+		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/reasoning/textDelta")
+	}
+}
+
+func (a *CodexAgent) handleCommandExecutionOutputDelta(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+		Delta  string `json:"delta"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
+		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/commandExecution/outputDelta")
+	}
+}
+
+func (a *CodexAgent) handleCommandExecutionTerminalInteraction(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+		Stdin  string `json:"stdin"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Stdin != "" {
+		a.sink.BroadcastStreamChunk([]byte(notif.Stdin), notif.ItemID, "item/commandExecution/terminalInteraction")
+	}
+}
+
+func (a *CodexAgent) handleFileChangeOutputDelta(params json.RawMessage) {
+	var notif struct {
+		ItemID string `json:"itemId"`
+		Delta  string `json:"delta"`
+	}
+	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
+		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/fileChange/outputDelta")
 	}
 }
 
@@ -234,6 +311,9 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		}); err != nil {
 			slog.Error("codex persist item/completed", "agent_id", a.agentID, "type", itemType, "error", err)
 		}
+		if itemType == "commandExecution" || itemType == "fileChange" || itemType == "reasoning" {
+			a.sink.BroadcastStreamEnd(itemID)
+		}
 		a.sink.CloseSpan(itemID)
 	case "collabAgentToolCall":
 		// Close receiver thread spans first so the completed message
@@ -250,6 +330,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		}); err != nil {
 			slog.Error("codex persist reasoning", "agent_id", a.agentID, "error", err)
 		}
+		a.sink.BroadcastStreamEnd(itemID)
 	default:
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -207,6 +207,53 @@ func TestHandleCodexOutput_PlanDelta(t *testing.T) {
 	}
 }
 
+func TestHandleCodexOutput_ContextCompactionStartPersistsCompactingNotification(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/started","params":{"item":{"type":"contextCompaction","id":"compact-1"},"threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.NotificationCount() != 1 {
+		t.Fatalf("expected 1 notification, got %d", sink.NotificationCount())
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(sink.LastNotification().Content, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal notification: %v", err)
+	}
+	if parsed["type"] != "compacting" {
+		t.Fatalf("expected compacting notification, got %+v", parsed)
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected 0 assistant messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_ThreadCompactedPersistsBoundaryNotification(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"thread/compacted","params":{"threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.NotificationCount() != 1 {
+		t.Fatalf("expected 1 notification, got %d", sink.NotificationCount())
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(sink.LastNotification().Content, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal notification: %v", err)
+	}
+	if parsed["type"] != "system" || parsed["subtype"] != "compact_boundary" {
+		t.Fatalf("expected compact boundary notification, got %+v", parsed)
+	}
+	if parsed["threadId"] != "t1" || parsed["turnId"] != "turn1" {
+		t.Fatalf("expected thread/turn ids to be preserved, got %+v", parsed)
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected 0 assistant messages, got %d", sink.MessageCount())
+	}
+}
+
 func TestHandleCodexOutput_CommandExecutionOutputDelta(t *testing.T) {
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -177,6 +177,9 @@ func TestHandleCodexOutput_PlanDelta(t *testing.T) {
 	if sink.StreamChunkCount() != 1 {
 		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
 	}
+	if got := sink.LastStreamChunk(); got.Method != "item/plan/delta" || got.SpanID != "" || string(got.Content) != "# Plan\n" {
+		t.Fatalf("unexpected stream chunk: %+v", got)
+	}
 
 	// Verify the session info was broadcast with streamingType "plan".
 	if sink.SessionInfoCount() != 1 {
@@ -201,6 +204,156 @@ func TestHandleCodexOutput_PlanDelta(t *testing.T) {
 	// Should NOT be persisted as a regular message.
 	if sink.MessageCount() != 0 {
 		t.Errorf("expected 0 messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_CommandExecutionOutputDelta(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/commandExecution/outputDelta","params":{"itemId":"cmd-1","delta":"hello\n","threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "cmd-1" {
+		t.Fatalf("expected spanID cmd-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/commandExecution/outputDelta" {
+		t.Fatalf("expected command output method, got %q", got.Method)
+	}
+	if string(got.Content) != "hello\n" {
+		t.Fatalf("unexpected content %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_ReasoningSummaryTextDelta(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"reason-1","delta":"thinking...","summaryIndex":0,"threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "reason-1" {
+		t.Fatalf("expected spanID reason-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/reasoning/summaryTextDelta" {
+		t.Fatalf("expected reasoning summary method, got %q", got.Method)
+	}
+	if string(got.Content) != "thinking..." {
+		t.Fatalf("unexpected content %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_ReasoningSummaryPartAdded(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/reasoning/summaryPartAdded","params":{"itemId":"reason-1","summaryIndex":1,"threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "reason-1" {
+		t.Fatalf("expected spanID reason-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/reasoning/summaryPartAdded" {
+		t.Fatalf("expected reasoning summary part method, got %q", got.Method)
+	}
+	if len(got.Content) != 0 {
+		t.Fatalf("expected empty content, got %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_ReasoningTextDelta(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/reasoning/textDelta","params":{"itemId":"reason-1","delta":"raw chain","contentIndex":0,"threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "reason-1" {
+		t.Fatalf("expected spanID reason-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/reasoning/textDelta" {
+		t.Fatalf("expected reasoning text method, got %q", got.Method)
+	}
+	if string(got.Content) != "raw chain" {
+		t.Fatalf("unexpected content %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_CommandExecutionTerminalInteraction(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/commandExecution/terminalInteraction","params":{"itemId":"cmd-1","processId":"123","stdin":"y\n","threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "cmd-1" {
+		t.Fatalf("expected spanID cmd-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/commandExecution/terminalInteraction" {
+		t.Fatalf("expected command interaction method, got %q", got.Method)
+	}
+	if string(got.Content) != "y\n" {
+		t.Fatalf("unexpected content %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_FileChangeOutputDelta(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"item/fileChange/outputDelta","params":{"itemId":"fc-1","delta":"diff --git a.txt b.txt\n","threadId":"t1","turnId":"turn1"}}`
+	handleCodexOutput(agent, []byte(input))
+
+	if sink.StreamChunkCount() != 1 {
+		t.Fatalf("expected 1 stream chunk, got %d", sink.StreamChunkCount())
+	}
+	got := sink.LastStreamChunk()
+	if got.SpanID != "fc-1" {
+		t.Fatalf("expected spanID fc-1, got %q", got.SpanID)
+	}
+	if got.Method != "item/fileChange/outputDelta" {
+		t.Fatalf("expected file change output method, got %q", got.Method)
+	}
+	if string(got.Content) != "diff --git a.txt b.txt\n" {
+		t.Fatalf("unexpected content %q", string(got.Content))
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected no persisted messages, got %d", sink.MessageCount())
 	}
 }
 
@@ -244,6 +397,60 @@ func TestHandleCodexOutput_PlanDeltaThenCompleted(t *testing.T) {
 	info2 := sink.LastSessionInfo()
 	if info2["streamingType"] != "plan" {
 		t.Errorf("expected streamingType 'plan', got %v", info2["streamingType"])
+	}
+}
+
+func TestHandleCodexOutput_CommandExecutionCompletedBroadcastsStreamEnd(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	completed := `{"method":"item/completed","params":{"threadId":"t1","item":{"type":"commandExecution","id":"cmd-1","status":"completed","aggregatedOutput":"done"}}}`
+	handleCodexOutput(agent, []byte(completed))
+
+	if sink.MessageCount() != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", sink.MessageCount())
+	}
+	if sink.StreamEndCount() != 1 {
+		t.Fatalf("expected 1 stream end, got %d", sink.StreamEndCount())
+	}
+	if got := sink.LastStreamEnd(); got != "cmd-1" {
+		t.Fatalf("expected stream end for cmd-1, got %q", got)
+	}
+}
+
+func TestHandleCodexOutput_FileChangeCompletedBroadcastsStreamEnd(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	completed := `{"method":"item/completed","params":{"threadId":"t1","item":{"type":"fileChange","id":"fc-1","status":"completed","changes":[{"path":"a.txt","kind":"update","diff":"@@ -1 +1 @@\n-old\n+new"}]}}}`
+	handleCodexOutput(agent, []byte(completed))
+
+	if sink.MessageCount() != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", sink.MessageCount())
+	}
+	if sink.StreamEndCount() != 1 {
+		t.Fatalf("expected 1 stream end, got %d", sink.StreamEndCount())
+	}
+	if got := sink.LastStreamEnd(); got != "fc-1" {
+		t.Fatalf("expected stream end for fc-1, got %q", got)
+	}
+}
+
+func TestHandleCodexOutput_ReasoningCompletedBroadcastsStreamEnd(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	completed := `{"method":"item/completed","params":{"threadId":"t1","item":{"type":"reasoning","id":"reason-1","summary":["done"]}}}`
+	handleCodexOutput(agent, []byte(completed))
+
+	if sink.MessageCount() != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", sink.MessageCount())
+	}
+	if sink.StreamEndCount() != 1 {
+		t.Fatalf("expected 1 stream end, got %d", sink.StreamEndCount())
+	}
+	if got := sink.LastStreamEnd(); got != "reason-1" {
+		t.Fatalf("expected stream end for reason-1, got %q", got)
 	}
 }
 

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -22,7 +22,8 @@ type OutputSink interface {
 	SetSpanType(spanID, spanType string)
 	GetSpanType(spanID string) string
 	PeekNextSpanColor() int32
-	BroadcastStreamChunk(content []byte)
+	BroadcastStreamChunk(content []byte, spanID string, method string)
+	BroadcastStreamEnd(spanID string)
 	PersistControlRequest(requestID string, payload []byte)
 	DeleteControlRequest(requestID string)
 	BroadcastControlRequest(requestID string, payload []byte)

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -10,7 +10,8 @@ import (
 type testSink struct {
 	mu               sync.Mutex
 	messages         []testSinkMessage
-	streamChunks     [][]byte
+	streamChunks     []testSinkStreamChunk
+	streamEnds       []string
 	sessionIDs       []string
 	sessionInfos     []map[string]interface{}
 	spanTypes        map[string]string
@@ -25,6 +26,12 @@ type testSinkMessage struct {
 	ParentSpanID string
 	SpanID       string
 	SpanType     string
+}
+
+type testSinkStreamChunk struct {
+	Content []byte
+	SpanID  string
+	Method  string
 }
 
 func (s *testSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, span SpanInfo) error {
@@ -64,10 +71,20 @@ func (s *testSink) GetSpanType(spanID string) string {
 
 func (s *testSink) PeekNextSpanColor() int32 { return 0 }
 
-func (s *testSink) BroadcastStreamChunk(content []byte) {
+func (s *testSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.streamChunks = append(s.streamChunks, append([]byte(nil), content...))
+	s.streamChunks = append(s.streamChunks, testSinkStreamChunk{
+		Content: append([]byte(nil), content...),
+		SpanID:  spanID,
+		Method:  method,
+	})
+}
+
+func (s *testSink) BroadcastStreamEnd(spanID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streamEnds = append(s.streamEnds, spanID)
 }
 
 func (s *testSink) PersistControlRequest(string, []byte)   {}
@@ -127,6 +144,27 @@ func (s *testSink) StreamChunkCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.streamChunks)
+}
+
+func (s *testSink) LastStreamChunk() testSinkStreamChunk {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streamChunks[len(s.streamChunks)-1]
+}
+
+func (s *testSink) StreamEndCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.streamEnds)
+}
+
+func (s *testSink) LastStreamEnd() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.streamEnds) == 0 {
+		return ""
+	}
+	return s.streamEnds[len(s.streamEnds)-1]
 }
 
 // SessionIDCount returns the number of UpdateSessionID calls.
@@ -198,7 +236,8 @@ func (noopSink) ResetSpans()                                                    
 func (noopSink) SetSpanType(string, string)                                      {}
 func (noopSink) GetSpanType(string) string                                       { return "" }
 func (noopSink) PeekNextSpanColor() int32                                        { return 0 }
-func (noopSink) BroadcastStreamChunk([]byte)                                     {}
+func (noopSink) BroadcastStreamChunk([]byte, string, string)                     {}
+func (noopSink) BroadcastStreamEnd(string)                                       {}
 func (noopSink) PersistControlRequest(string, []byte)                            {}
 func (noopSink) DeleteControlRequest(string)                                     {}
 func (noopSink) BroadcastControlRequest(string, []byte)                          {}

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -10,6 +10,7 @@ import (
 type testSink struct {
 	mu               sync.Mutex
 	messages         []testSinkMessage
+	notifications    []testSinkMessage
 	streamChunks     []testSinkStreamChunk
 	streamEnds       []string
 	sessionIDs       []string
@@ -41,7 +42,12 @@ func (s *testSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, sp
 	return nil
 }
 
-func (s *testSink) PersistNotification(leapmuxv1.MessageRole, []byte) error { return nil }
+func (s *testSink) PersistNotification(role leapmuxv1.MessageRole, content []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifications = append(s.notifications, testSinkMessage{Role: role, Content: append([]byte(nil), content...)})
+	return nil
+}
 
 func (s *testSink) OpenSpan(spanID string, _ string) {
 	s.mu.Lock()
@@ -130,6 +136,18 @@ func (s *testSink) MessageCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.messages)
+}
+
+func (s *testSink) NotificationCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.notifications)
+}
+
+func (s *testSink) LastNotification() testSinkMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notifications[len(s.notifications)-1]
 }
 
 // Messages returns a copy of all persisted messages.

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -686,7 +686,14 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		persistedCodexText := svc.codexControlResponseDisplayText(agentID, content)
+		dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+		if err != nil {
+			slog.Error("failed to look up agent for control response", "agent_id", agentID, "error", err)
+			sendNotFoundError(sender, "agent not found")
+			return
+		}
+
+		persistedCodexText := svc.codexControlResponseDisplayText(agentID, dbAgent.AgentProvider, content)
 
 		// Detect plan mode changes from the control response before
 		// forwarding to the agent. This mirrors the main-branch Hub logic
@@ -694,7 +701,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// approval or rejection.
 		svc.handleControlResponsePlanMode(agentID, content)
 
-		svc.persistSyntheticUserMessage(agentID, persistedCodexText)
+		svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, persistedCodexText)
 
 		if err := svc.Agents.SendRawInput(agentID, content); err != nil {
 			slog.Error("failed to send control response to agent",
@@ -1080,20 +1087,14 @@ func (svc *Context) handleControlRequestMessage(agentID, content string) {
 	}
 }
 
-func (svc *Context) persistSyntheticUserMessage(agentID, content string) {
+func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmuxv1.AgentProvider, content string) {
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return
 	}
 
-	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
-	if err != nil {
-		slog.Error("synthetic user message: agent not found", "agent_id", agentID, "error", err)
-		return
-	}
-
 	innerJSON, _ := json.Marshal(map[string]string{"content": content})
-	if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
 		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -686,11 +686,15 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
+		persistedCodexText := svc.codexControlResponseDisplayText(agentID, content)
+
 		// Detect plan mode changes from the control response before
 		// forwarding to the agent. This mirrors the main-branch Hub logic
 		// that updated permission mode based on EnterPlanMode/ExitPlanMode
 		// approval or rejection.
 		svc.handleControlResponsePlanMode(agentID, content)
+
+		svc.persistSyntheticUserMessage(agentID, persistedCodexText)
 
 		if err := svc.Agents.SendRawInput(agentID, content); err != nil {
 			slog.Error("failed to send control response to agent",
@@ -1073,6 +1077,24 @@ func (svc *Context) handleControlRequestMessage(agentID, content string) {
 	// Send as raw input to the agent's stdin.
 	if err := svc.Agents.SendRawInput(agentID, []byte(content)); err != nil {
 		slog.Error("failed to send control request to agent", "agent_id", agentID, "error", err)
+	}
+}
+
+func (svc *Context) persistSyntheticUserMessage(agentID, content string) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return
+	}
+
+	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+	if err != nil {
+		slog.Error("synthetic user message: agent not found", "agent_id", agentID, "error", err)
+		return
+	}
+
+	innerJSON, _ := json.Marshal(map[string]string{"content": content})
+	if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
+		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
 	}
 }
 

--- a/backend/internal/worker/service/codex_control.go
+++ b/backend/internal/worker/service/codex_control.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func codexControlResponseRequestID(content []byte) string {
+	var rpc struct {
+		ID *json.Number `json:"id"`
+	}
+	if err := json.Unmarshal(content, &rpc); err == nil && rpc.ID != nil {
+		return rpc.ID.String()
+	}
+
+	var cr struct {
+		Response struct {
+			RequestID string `json:"request_id"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(content, &cr); err == nil {
+		return cr.Response.RequestID
+	}
+
+	return ""
+}
+
+func codexUserInputAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Params struct {
+			Questions []struct {
+				ID     string `json:"id"`
+				Header string `json:"header"`
+			} `json:"questions"`
+		} `json:"params"`
+	}
+	var resp struct {
+		Result struct {
+			Answers map[string]struct {
+				Answers []string `json:"answers"`
+			} `json:"answers"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+		return ""
+	}
+
+	if len(resp.Result.Answers) == 0 {
+		return ""
+	}
+
+	labels := make(map[string]string, len(req.Params.Questions))
+	order := make([]string, 0, len(req.Params.Questions))
+	for _, q := range req.Params.Questions {
+		key := strings.TrimSpace(q.ID)
+		if key == "" {
+			key = strings.TrimSpace(q.Header)
+		}
+		if key == "" {
+			continue
+		}
+		label := strings.TrimSpace(q.Header)
+		if label == "" {
+			label = key
+		}
+		labels[key] = label
+		order = append(order, key)
+	}
+
+	lines := make([]string, 0, len(resp.Result.Answers))
+	seen := make(map[string]bool, len(resp.Result.Answers))
+	appendLine := func(key string) {
+		answer, ok := resp.Result.Answers[key]
+		if !ok || seen[key] {
+			return
+		}
+		parts := make([]string, 0, len(answer.Answers))
+		for _, entry := range answer.Answers {
+			if text := strings.TrimSpace(entry); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) == 0 {
+			return
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", labels[key], strings.Join(parts, ", ")))
+		seen[key] = true
+	}
+
+	for _, key := range order {
+		appendLine(key)
+	}
+	for key := range resp.Result.Answers {
+		if seen[key] {
+			continue
+		}
+		if _, ok := labels[key]; !ok {
+			labels[key] = key
+		}
+		appendLine(key)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func codexFeedbackMessageText(responseContent []byte) string {
+	var cr struct {
+		Response struct {
+			Response struct {
+				Message string `json:"message"`
+			} `json:"response"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(responseContent, &cr); err != nil {
+		return ""
+	}
+	message := strings.TrimSpace(cr.Response.Response.Message)
+	if message == "" || message == "Rejected by user." {
+		return ""
+	}
+	return message
+}
+
+func (svc *Context) codexControlResponseDisplayText(agentID string, content []byte) string {
+	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+	if err != nil || dbAgent.AgentProvider != leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX {
+		return ""
+	}
+
+	reqID := codexControlResponseRequestID(content)
+	if reqID == "" {
+		return ""
+	}
+
+	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
+		AgentID:   agentID,
+		RequestID: reqID,
+	})
+	if err != nil {
+		return ""
+	}
+
+	var payload struct {
+		Method string `json:"method"`
+	}
+	if json.Unmarshal(cr.Payload, &payload) != nil {
+		return ""
+	}
+
+	if payload.Method == "item/tool/requestUserInput" {
+		return codexUserInputAnswersText(cr.Payload, content)
+	}
+
+	return codexFeedbackMessageText(content)
+}

--- a/backend/internal/worker/service/codex_control.go
+++ b/backend/internal/worker/service/codex_control.go
@@ -125,9 +125,8 @@ func codexFeedbackMessageText(responseContent []byte) string {
 	return message
 }
 
-func (svc *Context) codexControlResponseDisplayText(agentID string, content []byte) string {
-	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
-	if err != nil || dbAgent.AgentProvider != leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX {
+func (svc *Context) codexControlResponseDisplayText(agentID string, provider leapmuxv1.AgentProvider, content []byte) string {
+	if provider != leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX {
 		return ""
 	}
 

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/msgcodec"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func decodeMessageContent(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) string {
+	t.Helper()
+	raw, err := msgcodec.Decompress(content, compression)
+	require.NoError(t, err)
+
+	var body struct {
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body))
+	return body.Content
+}
+
+func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "7",
+		Payload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"method":"item/tool/requestUserInput",
+			"params":{
+				"questions":[
+					{"header":"Task","id":"task"},
+					{"header":"Reason","id":"reason"}
+				]
+			}
+		}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Model:      "opus",
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"result":{
+				"answers":{
+					"task":{"answers":["Inspect the renderer"]},
+					"reason":{"answers":["Need parity with Claude Code"]}
+				}
+			}
+		}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1",
+		Seq:     0,
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, "Task: Inspect the renderer\nReason: Need parity with Claude Code", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+}
+
+func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "req-1",
+		Payload: []byte(`{
+			"type":"control_request",
+			"request_id":"req-1",
+			"request":{"tool_name":"ExitPlanMode"}
+		}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Model:      "opus",
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"type":"control_response",
+			"response":{
+				"subtype":"success",
+				"request_id":"req-1",
+				"response":{
+					"behavior":"deny",
+					"message":"Please add tests before exiting plan mode."
+				}
+			}
+		}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1",
+		Seq:     0,
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, "Please add tests before exiting plan mode.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -434,7 +434,7 @@ func (s *agentOutputSink) PeekNextSpanColor() int32 {
 	return s.tracker.PeekNextColor()
 }
 
-func (s *agentOutputSink) BroadcastStreamChunk(content []byte) {
+func (s *agentOutputSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
 	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
 		AgentId: s.agentID,
 		Event: &leapmuxv1.AgentEvent_StreamChunk{
@@ -442,6 +442,20 @@ func (s *agentOutputSink) BroadcastStreamChunk(content []byte) {
 				MessageId:     s.agentID,
 				Delta:         content,
 				AgentProvider: s.agentProvider,
+				SpanId:        spanID,
+				Method:        method,
+			},
+		},
+	})
+}
+
+func (s *agentOutputSink) BroadcastStreamEnd(spanID string) {
+	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
+		AgentId: s.agentID,
+		Event: &leapmuxv1.AgentEvent_StreamEnd{
+			StreamEnd: &leapmuxv1.AgentStreamEnd{
+				MessageId: s.agentID,
+				SpanId:    spanID,
 			},
 		},
 	})

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { CommandStreamSegment } from '~/stores/chat.store'
 
 import ArrowDown from 'lucide-solid/icons/arrow-down'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
@@ -7,6 +8,7 @@ import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show, untrack } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { spinner } from '~/styles/animations.css'
@@ -57,9 +59,12 @@ interface ChatViewProps {
   streamingType?: string
   /** Look up a message by its spanId (for tool_use ↔ tool_result linking). */
   getMessageBySpanId?: (spanId: string) => AgentChatMessage | undefined
+  /** Look up live Codex span stream segments by span id. */
+  getCommandStreamBySpanId?: (spanId: string) => CommandStreamSegment[]
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
+  const coalescedCodexSpanTypes = new Set(['commandExecution', 'fileChange', 'reasoning'])
   // Throttle streaming text markdown rendering to animation frames to avoid
   // running the full remark+shiki pipeline on every streaming chunk.
   const [renderedStreamHtml, setRenderedStreamHtml] = createSignal('')
@@ -160,6 +165,52 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   onMount(() => {
     props.scrollStateRef?.(getScrollState)
     props.scrollToBottomRef?.(forceScrollToBottom)
+  })
+
+  const visibleEntries = createMemo(() => {
+    const entries = props.messages.map((msg) => {
+      let classified = classifyParsedMessage(msg)
+      if (
+        classified.category.kind === 'hidden'
+        && msg.agentProvider === AgentProvider.CODEX
+        && msg.spanType === 'reasoning'
+        && msg.spanId
+        && (props.getCommandStreamBySpanId?.(msg.spanId).length ?? 0) > 0
+      ) {
+        classified = { ...classified, category: { kind: 'assistant_thinking' } }
+      }
+      return { msg, ...classified }
+    })
+
+    const latestCodexCommandSeqBySpan = new Map<string, bigint>()
+    for (const entry of entries) {
+      if (
+        entry.msg.agentProvider === AgentProvider.CODEX
+        && !!entry.msg.spanType
+        && coalescedCodexSpanTypes.has(entry.msg.spanType)
+        && entry.msg.spanId
+        && (entry.category.kind === 'tool_use' || entry.category.kind === 'assistant_thinking')
+      ) {
+        const prev = latestCodexCommandSeqBySpan.get(entry.msg.spanId)
+        if (prev === undefined || entry.msg.seq > prev)
+          latestCodexCommandSeqBySpan.set(entry.msg.spanId, entry.msg.seq)
+      }
+    }
+
+    return entries.filter((entry) => {
+      if (entry.category.kind === 'hidden')
+        return false
+      if (
+        entry.msg.agentProvider === AgentProvider.CODEX
+        && !!entry.msg.spanType
+        && coalescedCodexSpanTypes.has(entry.msg.spanType)
+        && entry.msg.spanId
+        && (entry.category.kind === 'tool_use' || entry.category.kind === 'assistant_thinking')
+      ) {
+        return latestCodexCommandSeqBySpan.get(entry.msg.spanId) === entry.msg.seq
+      }
+      return true
+    })
   })
 
   const scrollToBottom = () => {
@@ -315,12 +366,8 @@ export const ChatView: Component<ChatViewProps> = (props) => {
               onQuote={text => props.onQuote?.(formatChatQuote(text))}
             >
               <div ref={contentRef} class={styles.messageListContent}>
-                <For each={props.messages}>
-                  {(msg) => {
-                    const { parsed, category } = classifyParsedMessage(msg)
-                    if (category.kind === 'hidden')
-                      return null
-
+                <For each={visibleEntries()}>
+                  {({ msg, parsed, category }) => {
                     const spanLines = createMemo(() => {
                       if (!msg.spanLines || msg.spanLines === '[]')
                         return []
@@ -344,6 +391,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                         homeDir={props.homeDir}
                         onReply={props.onReply}
                         getMessageBySpanId={props.getMessageBySpanId}
+                        commandStream={props.getCommandStreamBySpanId?.(msg.spanId)}
                       />
                     )
 

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -64,7 +64,6 @@ interface ChatViewProps {
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
-  const coalescedCodexSpanTypes = new Set(['commandExecution', 'fileChange', 'reasoning'])
   // Throttle streaming text markdown rendering to animation frames to avoid
   // running the full remark+shiki pipeline on every streaming chunk.
   const [renderedStreamHtml, setRenderedStreamHtml] = createSignal('')
@@ -168,7 +167,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   })
 
   const visibleEntries = createMemo(() => {
-    const entries = props.messages.map((msg) => {
+    return props.messages.map((msg) => {
       let classified = classifyParsedMessage(msg)
       if (
         classified.category.kind === 'hidden'
@@ -180,37 +179,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         classified = { ...classified, category: { kind: 'assistant_thinking' } }
       }
       return { msg, ...classified }
-    })
-
-    const latestCodexCommandSeqBySpan = new Map<string, bigint>()
-    for (const entry of entries) {
-      if (
-        entry.msg.agentProvider === AgentProvider.CODEX
-        && !!entry.msg.spanType
-        && coalescedCodexSpanTypes.has(entry.msg.spanType)
-        && entry.msg.spanId
-        && (entry.category.kind === 'tool_use' || entry.category.kind === 'assistant_thinking')
-      ) {
-        const prev = latestCodexCommandSeqBySpan.get(entry.msg.spanId)
-        if (prev === undefined || entry.msg.seq > prev)
-          latestCodexCommandSeqBySpan.set(entry.msg.spanId, entry.msg.seq)
-      }
-    }
-
-    return entries.filter((entry) => {
-      if (entry.category.kind === 'hidden')
-        return false
-      if (
-        entry.msg.agentProvider === AgentProvider.CODEX
-        && !!entry.msg.spanType
-        && coalescedCodexSpanTypes.has(entry.msg.spanType)
-        && entry.msg.spanId
-        && (entry.category.kind === 'tool_use' || entry.category.kind === 'assistant_thinking')
-      ) {
-        return latestCodexCommandSeqBySpan.get(entry.msg.spanId) === entry.msg.seq
-      }
-      return true
-    })
+    }).filter(entry => entry.category.kind !== 'hidden')
   })
 
   const scrollToBottom = () => {

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -11,7 +11,7 @@ import { createMemo, createSignal, ErrorBoundary, onMount, Show } from 'solid-js
 import { render } from 'solid-js/web'
 import { IconButton } from '~/components/common/IconButton'
 import { usePreferences } from '~/context/PreferencesContext'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { createLogger } from '~/lib/logger'
 import { parseMessageContent } from '~/lib/messageParser'
 import { formatChatQuote } from '~/lib/quoteUtils'
@@ -91,6 +91,24 @@ function injectCopyButtons(container: HTMLElement) {
   }
 }
 
+function isCodexEmptyCompletedWebSearch(message: AgentChatMessage, parsed: ParsedMessageContent): boolean {
+  if (message.agentProvider !== AgentProvider.CODEX || message.spanType !== 'webSearch')
+    return false
+
+  const item = parsed.parentObject?.item as Record<string, unknown> | undefined
+  if (!isObject(item) || item.type !== 'webSearch')
+    return false
+
+  const query = typeof item.query === 'string' ? item.query.trim() : ''
+  const action = isObject(item.action) ? item.action as Record<string, unknown> : null
+  const actionType = typeof action?.type === 'string' ? action.type as string : ''
+
+  if (actionType !== 'other')
+    return false
+
+  return query.length === 0
+}
+
 /** Classify a message, returning both the parsed content and category. */
 export function classifyParsedMessage(message: AgentChatMessage) {
   const parsed = parseMessageContent(message)
@@ -106,6 +124,9 @@ export function classifyParsedMessage(message: AgentChatMessage) {
   }
   // Hide TodoWrite tool_result — the tool_use already shows the full todo list.
   if (category.kind === 'tool_result' && message.spanType === 'TodoWrite') {
+    category = { kind: 'hidden' }
+  }
+  if ((category.kind === 'tool_use' || category.kind === 'tool_result') && isCodexEmptyCompletedWebSearch(message, parsed)) {
     category = { kind: 'hidden' }
   }
   return { parsed, category }
@@ -212,9 +233,33 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     return text || null
   }
 
+  const isCodexTerminalCommandResult = createMemo(() => {
+    if (props.message.agentProvider !== AgentProvider.CODEX)
+      return false
+    if (category().kind !== 'tool_use' || props.message.spanType !== 'commandExecution')
+      return false
+    const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+    const status = typeof item?.status === 'string' ? item.status : ''
+    return status === 'completed' || status === 'failed'
+  })
+
+  const isCodexCompletedFileChangeResult = createMemo(() => {
+    if (props.message.agentProvider !== AgentProvider.CODEX)
+      return false
+    if (category().kind !== 'tool_use' || props.message.spanType !== 'fileChange')
+      return false
+    const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+    return item?.status === 'completed'
+  })
+
   // Whether the message is rendered by a renderer that has its own internal ToolHeaderActions.
-  // tool_use and agent_prompt render their own ToolHeaderActions inside ToolUseLayout.
-  const hasInternalActions = () => category().kind === 'tool_use' || category().kind === 'agent_prompt'
+  // tool_use and agent_prompt render their own ToolHeaderActions inside ToolUseLayout,
+  // except Codex terminal command results, which should use the shared result toolbar.
+  const hasInternalActions = () => {
+    if (isCodexTerminalCommandResult() || isCodexCompletedFileChangeResult())
+      return false
+    return category().kind === 'tool_use' || category().kind === 'agent_prompt'
+  }
 
   // Shared derivation for tool_result messages: extract toolName and toolUseResult once.
   const toolResultInfo = createMemo(() => {
@@ -230,6 +275,12 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
 
   // Determine if this tool_result is collapsible (enough lines/items to warrant collapse).
   const isCollapsibleToolResult = createMemo(() => {
+    if (isCodexTerminalCommandResult()) {
+      const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+      const output = typeof item?.aggregatedOutput === 'string' ? item.aggregatedOutput : ''
+      return output.split('\n').length > COLLAPSED_RESULT_ROWS
+    }
+
     const info = toolResultInfo()
     if (!info)
       return false
@@ -288,6 +339,12 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
 
   // Determine if this tool_result has a diff (Edit/Write with structuredPatch or old/new strings).
   const hasToolResultDiff = createMemo(() => {
+    if (isCodexCompletedFileChangeResult()) {
+      const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+      const changes = Array.isArray(item?.changes) ? item.changes as Array<Record<string, unknown>> : []
+      return changes.some(change => typeof change.diff === 'string' && change.diff.includes('@@ '))
+    }
+
     const info = toolResultInfo()
     if (!info)
       return false
@@ -303,6 +360,20 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
 
   // Extract copyable content for tool_result messages (Read/Write/Edit/Bash/etc.).
   const copyableResultContent = createMemo((): string | null => {
+    if (isCodexTerminalCommandResult()) {
+      const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+      return typeof item?.aggregatedOutput === 'string' ? item.aggregatedOutput : null
+    }
+
+    if (isCodexCompletedFileChangeResult()) {
+      const item = parsed().parentObject?.item as Record<string, unknown> | undefined
+      const changes = Array.isArray(item?.changes) ? item.changes as Array<Record<string, unknown>> : []
+      const diffs = changes
+        .map(change => typeof change.diff === 'string' ? change.diff : '')
+        .filter(Boolean)
+      return diffs.length > 0 ? diffs.join('\n\n') : null
+    }
+
     const info = toolResultInfo()
     if (!info)
       return null

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -3,6 +3,7 @@ import type { MessageCategory } from './messageClassification'
 import type { RenderContext } from './messageRenderers'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
+import type { CommandStreamSegment } from '~/stores/chat.store'
 
 import Check from 'lucide-solid/icons/check'
 import Copy from 'lucide-solid/icons/copy'
@@ -122,6 +123,7 @@ interface MessageBubbleProps {
   onReply?: (quotedText: string) => void
   /** Look up a message by its spanId (for tool_use ↔ tool_result linking). */
   getMessageBySpanId?: (spanId: string) => AgentChatMessage | undefined
+  commandStream?: CommandStreamSegment[]
 }
 
 export const MessageBubble: Component<MessageBubbleProps> = (props) => {
@@ -365,7 +367,9 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     toolUseMessage: toolUseMessage(),
     spanColor: props.message.spanColor,
     spanType: props.message.spanType,
+    spanId: props.message.spanId,
     toolResultExpanded: toolResultExpanded(),
+    commandStream: props.commandStream,
   })
 
   // Extract assistant text for the reply button.

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -25,6 +25,8 @@ import {
 import { isObject } from './messageUtils'
 import { ToolUseLayout } from './toolRenderers'
 import {
+  commandStreamContainer,
+  commandStreamInteraction,
   toolInputPath,
   toolInputSummary,
   toolResultContentPre,
@@ -100,7 +102,9 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
   const durationMs = item.durationMs as number | null | undefined
   const isCompleted = status === 'completed'
   const hasError = isCompleted && exitCode != null && exitCode !== 0
-  const [expanded, setExpanded] = createSignal(hasError || !isCompleted)
+  const liveStream = () => context?.commandStream ?? []
+  const hasLiveStream = () => liveStream().length > 0
+  const [expanded, setExpanded] = createSignal(hasError || !isCompleted || hasLiveStream())
 
   const statusParts = (): string => {
     const parts: string[] = []
@@ -130,8 +134,19 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
           {cwd}
         </div>
       </Show>
-      <Show when={output}>
-        <div class={toolResultContentPre}>{output}</div>
+      <Show
+        when={hasLiveStream()}
+        fallback={<Show when={output}><div class={toolResultContentPre}>{output}</div></Show>}
+      >
+        <div class={commandStreamContainer}>
+          <For each={liveStream()}>
+            {segment => (
+              <div class={segment.kind === 'interaction' ? commandStreamInteraction : toolResultContentPre}>
+                {segment.kind === 'interaction' ? `> ${segment.text}` : segment.text}
+              </div>
+            )}
+          </For>
+        </div>
       </Show>
     </ToolUseLayout>
   )
@@ -145,6 +160,8 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
 
   const changes = (item.changes as Array<Record<string, unknown>>) || []
   const status = (item.status as string) || ''
+  const liveStream = () => context?.commandStream ?? []
+  const hasLiveStream = () => liveStream().length > 0
   const [expanded, setExpanded] = createSignal(true)
 
   const titleEl = (
@@ -167,6 +184,15 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
       expanded={expanded()}
       onToggleExpand={() => setExpanded(v => !v)}
     >
+      <Show when={hasLiveStream()}>
+        <div class={commandStreamContainer}>
+          <For each={liveStream()}>
+            {segment => (
+              <div class={toolResultContentPre}>{segment.text}</div>
+            )}
+          </For>
+        </div>
+      </Show>
       <For each={changes}>
         {(change) => {
           const path = (change.path as string) || '(unknown)'
@@ -202,8 +228,38 @@ export function codexReasoningRenderer(parsed: unknown, _role: MessageRole, _con
 
   const summary = (item.summary as string[]) || []
   const content = (item.content as string[]) || []
-  const text = summary.join('\n') || content.join('\n') || ''
-  if (!text)
+  const liveStream = () => _context?.commandStream ?? []
+  const liveSummary = () => {
+    const parts: string[] = []
+    let current = ''
+    for (const segment of liveStream()) {
+      if (segment.kind === 'reasoning_summary_break') {
+        if (current) {
+          parts.push(current)
+          current = ''
+        }
+        continue
+      }
+      if (segment.kind === 'reasoning_summary')
+        current += segment.text
+    }
+    if (current)
+      parts.push(current)
+    return parts
+  }
+  const liveContent = () => liveStream()
+    .filter(segment => segment.kind === 'reasoning_content')
+    .map(segment => segment.text)
+  const text = () => {
+    const streamedSummary = liveSummary()
+    if (streamedSummary.length > 0)
+      return streamedSummary.join('\n\n')
+    const streamedContent = liveContent()
+    if (streamedContent.length > 0)
+      return streamedContent.join('\n')
+    return summary.join('\n') || content.join('\n') || ''
+  }
+  if (!text())
     return null
 
   const [expanded, setExpanded] = createSignal(false)
@@ -223,7 +279,7 @@ export function codexReasoningRenderer(parsed: unknown, _role: MessageRole, _con
       </div>
       <Show when={expanded()}>
         <div class={thinkingContent}>
-          <div class={markdownContent} innerHTML={renderMarkdown(text)} />
+          <div class={markdownContent} innerHTML={renderMarkdown(text())} />
         </div>
       </Show>
     </div>

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'solid-js'
 import type { StructuredPatchHunk } from './diffUtils'
 import type { RenderContext } from './messageRenderers'
 import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
-import type { TodoItem } from '~/stores/chat.store'
+import type { CommandStreamSegment, TodoItem } from '~/stores/chat.store'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
@@ -53,6 +53,18 @@ const CODEX_DIFF_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
 const DIV_OPEN_RE = /<div\b/g
 const DIV_CLOSE_RE = /<\/div>/g
 const TOOL_USE_HEADER_CLASS_FRAGMENT = 'toolUseHeader__'
+
+function LiveStreamOutput(props: { stream: () => CommandStreamSegment[] }): JSX.Element {
+  return (
+    <div class={commandStreamContainer}>
+      <For each={props.stream()}>
+        {segment => (
+          <div class={toolResultContentPre}>{segment.text}</div>
+        )}
+      </For>
+    </div>
+  )
+}
 
 interface ParsedCodexDiff {
   hunks: StructuredPatchHunk[]
@@ -476,7 +488,6 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
       title={title}
       summary={(
         <>
-          { }
           <div class={toolInputSummary} innerHTML={renderBashHighlight(displayCommand)} />
           <Show when={statusParts()}>
             <div class={toolInputSummary}>{statusParts()}</div>
@@ -589,13 +600,7 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
         alwaysVisible={true}
       >
         <Show when={hasLiveStream()}>
-          <div class={commandStreamContainer}>
-            <For each={liveStream()}>
-              {segment => (
-                <div class={toolResultContentPre}>{segment.text}</div>
-              )}
-            </For>
-          </div>
+          <LiveStreamOutput stream={liveStream} />
         </Show>
       </ToolUseLayout>
     )
@@ -620,26 +625,18 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
         alwaysVisible={true}
       >
         <Show when={hasLiveStream()}>
-          <div class={commandStreamContainer}>
-            <For each={liveStream()}>
-              {segment => (
-                <div class={toolResultContentPre}>{segment.text}</div>
-              )}
-            </For>
-          </div>
+          <LiveStreamOutput stream={liveStream} />
         </Show>
       </ToolUseLayout>
     )
   }
 
   const titleEl = (
-    <>
-      <span class={toolInputSummary}>
-        {changes.length === 1
-          ? relativizePath(String(changes[0].path || 'file'), context?.workingDir, context?.homeDir)
-          : `${changes.length} files`}
-      </span>
-    </>
+    <span class={toolInputSummary}>
+      {changes.length === 1
+        ? relativizePath(String(changes[0].path || 'file'), context?.workingDir, context?.homeDir)
+        : `${changes.length} files`}
+    </span>
   )
 
   return (
@@ -651,29 +648,21 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
       alwaysVisible={true}
     >
       <Show when={hasLiveStream()}>
-        <div class={commandStreamContainer}>
-          <For each={liveStream()}>
-            {segment => (
-              <div class={toolResultContentPre}>{segment.text}</div>
-            )}
-          </For>
-        </div>
+        <LiveStreamOutput stream={liveStream} />
       </Show>
       <For each={changes.length === 1 ? [] : changes}>
         {(change) => {
           const path = relativizePath((change.path as string) || '(unknown)', context?.workingDir, context?.homeDir)
           const kind = codexChangeKind(change)
           return (
-            <div>
-              <div class={toolInputPath}>
-                {path}
-                {' '}
-                <span class={toolInputSummary}>
-                  (
-                  {kind}
-                  )
-                </span>
-              </div>
+            <div class={toolInputPath}>
+              {path}
+              {' '}
+              <span class={toolInputSummary}>
+                (
+                {kind}
+                )
+              </span>
             </div>
           )
         }}

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'solid-js'
 import type { StructuredPatchHunk } from './diffUtils'
 import type { RenderContext } from './messageRenderers'
 import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import type { TodoItem } from '~/stores/chat.store'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
@@ -15,10 +16,9 @@ import Terminal from 'lucide-solid/icons/terminal'
 import Wrench from 'lucide-solid/icons/wrench'
 import { createEffect, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
-import { TodoList } from '~/components/todo/TodoList'
 import { Tooltip } from '~/components/common/Tooltip'
+import { TodoList } from '~/components/todo/TodoList'
 import { renderMarkdown, shikiHighlighter } from '~/lib/renderMarkdown'
-import type { TodoItem } from '~/stores/chat.store'
 import { inlineFlex } from '~/styles/shared.css'
 import { DiffView, rawDiffToHunks } from './diffUtils'
 import { markdownContent } from './markdownContent.css'
@@ -35,8 +35,8 @@ import { renderToolDetail } from './toolDetailRenderers'
 import { ToolResultMessage, ToolUseLayout } from './toolRenderers'
 import {
   commandStreamContainer,
-  toolInputCode,
   commandStreamInteraction,
+  toolInputCode,
   toolInputPath,
   toolInputSummary,
   toolInputText,
@@ -50,6 +50,8 @@ import {
 /** Regex to strip shell wrappers like `/bin/zsh -lc '...'` from commands. */
 const SHELL_WRAPPER_RE = /^\/bin\/(?:ba|z)?sh\s+-lc\s+'(.+)'$/
 const CODEX_DIFF_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+const DIV_OPEN_RE = /<div\b/g
+const DIV_CLOSE_RE = /<\/div>/g
 const TOOL_USE_HEADER_CLASS_FRAGMENT = 'toolUseHeader__'
 
 interface ParsedCodexDiff {
@@ -173,14 +175,14 @@ function stripToolUseHeaderFromOutput(output: string): string {
       continue
     }
 
-    if (kept.length > 0 && kept[kept.length - 1].includes('<div'))
+    if (kept.length > 0 && kept.at(-1).includes('<div'))
       kept.pop()
 
     let depth = 1
     while (++i < lines.length) {
       const current = lines[i]
-      depth += (current.match(/<div\b/g) || []).length
-      depth -= (current.match(/<\/div>/g) || []).length
+      depth += (current.match(DIV_OPEN_RE) || []).length
+      depth -= (current.match(DIV_CLOSE_RE) || []).length
       if (depth <= 0)
         break
     }
@@ -472,15 +474,15 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
       icon={Terminal}
       toolName="Command Execution"
       title={title}
-      summary={
+      summary={(
         <>
-          {/* eslint-disable-next-line solid/no-innerhtml -- shiki output is safe */}
+          { }
           <div class={toolInputSummary} innerHTML={renderBashHighlight(displayCommand)} />
           <Show when={statusParts()}>
             <div class={toolInputSummary}>{statusParts()}</div>
           </Show>
         </>
-      }
+      )}
       context={context}
       expanded={expanded()}
       onToggleExpand={() => setExpanded(v => !v)}
@@ -668,9 +670,9 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
                 {' '}
                 <span class={toolInputSummary}>
                   (
-                    {kind}
-                    )
-                  </span>
+                  {kind}
+                  )
+                </span>
               </div>
             </div>
           )

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -7,6 +7,7 @@ import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import FileEdit from 'lucide-solid/icons/file-pen-line'
+import FilePlus from 'lucide-solid/icons/file-plus'
 import Globe from 'lucide-solid/icons/globe'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
@@ -19,7 +20,7 @@ import { Tooltip } from '~/components/common/Tooltip'
 import { renderMarkdown, shikiHighlighter } from '~/lib/renderMarkdown'
 import type { TodoItem } from '~/stores/chat.store'
 import { inlineFlex } from '~/styles/shared.css'
-import { DiffView } from './diffUtils'
+import { DiffView, rawDiffToHunks } from './diffUtils'
 import { markdownContent } from './markdownContent.css'
 import {
   resultDivider,
@@ -142,6 +143,10 @@ function codexChangeKind(change: Record<string, unknown>): string {
 
 function isSimpleEditChange(change: Record<string, unknown>): boolean {
   return codexChangeKind(change) === 'update' && typeof change.diff === 'string' && !!parseCodexUnifiedDiff(change.diff as string)
+}
+
+function isSimpleAddChange(change: Record<string, unknown>): boolean {
+  return codexChangeKind(change) === 'add' && typeof change.diff === 'string' && (change.diff as string).length > 0
 }
 
 function parsedChangeDiffs(changes: Array<Record<string, unknown>>): Array<{ path: string, diff: ParsedCodexDiff }> {
@@ -418,7 +423,6 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
   const output = stripToolUseHeaderFromOutput((item.aggregatedOutput as string) || '')
   const exitCode = item.exitCode as number | null | undefined
   const durationMs = item.durationMs as number | null | undefined
-  const processId = item.processId as string | null | undefined
   const isTerminal = status === 'completed' || status === 'failed'
   const hasError = status === 'failed' || (isTerminal && exitCode != null && exitCode !== 0)
   const liveStream = () => context?.commandStream ?? []
@@ -441,8 +445,6 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
   }
   const resultStatusDetail = (): string => {
     const parts: string[] = []
-    if (processId)
-      parts.push(`process ID: ${processId}`)
     if (exitCode != null && exitCode !== 0)
       parts.push(`exit code: ${exitCode}`)
     return parts.join(' · ')
@@ -519,6 +521,24 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
   const liveStream = () => context?.commandStream ?? []
   const hasLiveStream = () => liveStream().length > 0
   const completedDiffs = parsedChangeDiffs(changes)
+  const simpleAdd = changes.length === 1 && isSimpleAddChange(changes[0]) ? changes[0] : null
+  const simpleAddPath = simpleAdd ? ((simpleAdd.path as string) || '') : ''
+  const simpleAddContent = simpleAdd ? ((simpleAdd.diff as string) || '') : ''
+
+  if (status === 'completed' && simpleAdd) {
+    return (
+      <ToolResultMessage
+        toolName="Write"
+        resultContent=""
+        isPreText={false}
+        structuredPatch={rawDiffToHunks('', simpleAddContent)}
+        oldStr=""
+        newStr={simpleAddContent}
+        filePath={simpleAddPath}
+        context={context}
+      />
+    )
+  }
 
   if (status === 'completed' && completedDiffs.length > 0) {
     return (
@@ -550,6 +570,35 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
 
   const simpleEdit = changes.length === 1 && isSimpleEditChange(changes[0]) ? changes[0] : null
   const parsedDiff = simpleEdit ? parseCodexUnifiedDiff(simpleEdit.diff as string) : null
+  if (simpleAdd) {
+    const title = renderToolDetail('Write', {
+      file_path: simpleAddPath,
+      content: simpleAddContent,
+    }, context) || (
+      <span class={toolInputPath}>{relativizePath(simpleAddPath, context?.workingDir, context?.homeDir)}</span>
+    )
+
+    return (
+      <ToolUseLayout
+        icon={FilePlus}
+        toolName="File Change"
+        title={title}
+        context={context}
+        alwaysVisible={true}
+      >
+        <Show when={hasLiveStream()}>
+          <div class={commandStreamContainer}>
+            <For each={liveStream()}>
+              {segment => (
+                <div class={toolResultContentPre}>{segment.text}</div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </ToolUseLayout>
+    )
+  }
+
   if (simpleEdit && parsedDiff) {
     const path = (simpleEdit.path as string) || ''
     const title = renderToolDetail('Edit', {

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -314,10 +314,8 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
       bordered={false}
       context={context}
     >
-      <>
-        <hr />
-        <div class={markdownContent} style={{ 'font-size': 'var(--text-regular)' }} innerHTML={renderMarkdown(text)} />
-      </>
+      <hr />
+      <div class={markdownContent} style={{ 'font-size': 'var(--text-regular)' }} innerHTML={renderMarkdown(text)} />
     </ToolUseLayout>
   )
 }
@@ -563,42 +561,20 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
 
   const simpleEdit = changes.length === 1 && isSimpleEditChange(changes[0]) ? changes[0] : null
   const parsedDiff = simpleEdit ? parseCodexUnifiedDiff(simpleEdit.diff as string) : null
-  if (simpleAdd) {
-    const title = renderToolDetail('Write', {
-      file_path: simpleAddPath,
-      content: simpleAddContent,
-    }, context) || (
-      <span class={toolInputPath}>{relativizePath(simpleAddPath, context?.workingDir, context?.homeDir)}</span>
+  const inProgressDetail = simpleAdd
+    ? { icon: FilePlus, title: renderToolDetail('Write', { file_path: simpleAddPath, content: simpleAddContent }, context), path: simpleAddPath }
+    : simpleEdit && parsedDiff
+      ? { icon: FileEdit, title: renderToolDetail('Edit', { file_path: (simpleEdit.path as string) || '', old_string: parsedDiff.oldText, new_string: parsedDiff.newText }, context), path: (simpleEdit.path as string) || '' }
+      : null
+
+  if (inProgressDetail) {
+    const title = inProgressDetail.title || (
+      <span class={toolInputPath}>{relativizePath(inProgressDetail.path, context?.workingDir, context?.homeDir)}</span>
     )
 
     return (
       <ToolUseLayout
-        icon={FilePlus}
-        toolName="File Change"
-        title={title}
-        context={context}
-        alwaysVisible={true}
-      >
-        <Show when={hasLiveStream()}>
-          <LiveStreamOutput stream={liveStream} />
-        </Show>
-      </ToolUseLayout>
-    )
-  }
-
-  if (simpleEdit && parsedDiff) {
-    const path = (simpleEdit.path as string) || ''
-    const title = renderToolDetail('Edit', {
-      file_path: path,
-      old_string: parsedDiff.oldText,
-      new_string: parsedDiff.newText,
-    }, context) || (
-      <span class={toolInputPath}>{relativizePath(path, context?.workingDir, context?.homeDir)}</span>
-    )
-
-    return (
-      <ToolUseLayout
-        icon={FileEdit}
+        icon={inProgressDetail.icon}
         toolName="File Change"
         title={title}
         context={context}

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -1,19 +1,25 @@
 /* eslint-disable solid/no-innerhtml -- HTML is produced via remark, not arbitrary user input */
 import type { JSX } from 'solid-js'
+import type { StructuredPatchHunk } from './diffUtils'
 import type { RenderContext } from './messageRenderers'
 import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import FileEdit from 'lucide-solid/icons/file-pen-line'
+import Globe from 'lucide-solid/icons/globe'
+import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
-import SquareTerminal from 'lucide-solid/icons/square-terminal'
+import Terminal from 'lucide-solid/icons/terminal'
 import Wrench from 'lucide-solid/icons/wrench'
-import { createSignal, For, Show } from 'solid-js'
+import { createEffect, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
+import { TodoList } from '~/components/todo/TodoList'
 import { Tooltip } from '~/components/common/Tooltip'
-import { renderMarkdown } from '~/lib/renderMarkdown'
+import { renderMarkdown, shikiHighlighter } from '~/lib/renderMarkdown'
+import type { TodoItem } from '~/stores/chat.store'
 import { inlineFlex } from '~/styles/shared.css'
+import { DiffView } from './diffUtils'
 import { markdownContent } from './markdownContent.css'
 import {
   resultDivider,
@@ -22,20 +28,34 @@ import {
   thinkingContent,
   thinkingHeader,
 } from './messageStyles.css'
-import { isObject } from './messageUtils'
-import { ToolUseLayout } from './toolRenderers'
+import { isObject, relativizePath } from './messageUtils'
+import { formatDuration } from './rendererUtils'
+import { renderToolDetail } from './toolDetailRenderers'
+import { ToolResultMessage, ToolUseLayout } from './toolRenderers'
 import {
   commandStreamContainer,
+  toolInputCode,
   commandStreamInteraction,
   toolInputPath,
   toolInputSummary,
+  toolInputText,
+  toolMessage,
   toolResultContentPre,
   toolResultError,
+  toolResultPrompt,
   toolUseIcon,
 } from './toolStyles.css'
 
 /** Regex to strip shell wrappers like `/bin/zsh -lc '...'` from commands. */
 const SHELL_WRAPPER_RE = /^\/bin\/(?:ba|z)?sh\s+-lc\s+'(.+)'$/
+const CODEX_DIFF_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+const TOOL_USE_HEADER_CLASS_FRAGMENT = 'toolUseHeader__'
+
+interface ParsedCodexDiff {
+  hunks: StructuredPatchHunk[]
+  oldText: string
+  newText: string
+}
 
 /** Extract the item from Codex native params: {item: {...}, threadId, turnId} */
 function extractItem(parsed: unknown): Record<string, unknown> | null {
@@ -48,6 +68,226 @@ function extractItem(parsed: unknown): Record<string, unknown> | null {
   if (parsed.type && typeof parsed.type === 'string')
     return parsed
   return null
+}
+
+function firstCommandLine(command: string): string {
+  return command.split('\n').find(line => line.trim()) || command
+}
+
+function renderBashHighlight(code: string): string {
+  return shikiHighlighter.codeToHtml(code, {
+    lang: 'bash',
+    themes: { light: 'github-light', dark: 'github-dark' },
+    defaultColor: false,
+  })
+}
+
+function parseCodexUnifiedDiff(diff: string): ParsedCodexDiff | null {
+  if (!diff.trim())
+    return null
+
+  const lines = diff.split('\n')
+  const hunks: StructuredPatchHunk[] = []
+  const oldLines: string[] = []
+  const newLines: string[] = []
+  let current: StructuredPatchHunk | null = null
+
+  for (const line of lines) {
+    const header = line.match(CODEX_DIFF_HEADER_RE)
+    if (header) {
+      current = {
+        oldStart: Number.parseInt(header[1], 10),
+        oldLines: header[2] ? Number.parseInt(header[2], 10) : 1,
+        newStart: Number.parseInt(header[3], 10),
+        newLines: header[4] ? Number.parseInt(header[4], 10) : 1,
+        lines: [],
+      }
+      hunks.push(current)
+      continue
+    }
+    if (!current)
+      continue
+    if (line.startsWith('\\ No newline at end of file'))
+      continue
+    if (!line.startsWith('+') && !line.startsWith('-') && !line.startsWith(' '))
+      continue
+
+    current.lines.push(line)
+    const prefix = line[0]
+    const text = line.slice(1)
+    if (prefix === '+' || prefix === ' ')
+      newLines.push(text)
+    if (prefix === '-' || prefix === ' ')
+      oldLines.push(text)
+  }
+
+  if (hunks.length === 0)
+    return null
+
+  return {
+    hunks,
+    oldText: oldLines.join('\n'),
+    newText: newLines.join('\n'),
+  }
+}
+
+function codexChangeKind(change: Record<string, unknown>): string {
+  const kind = change.kind
+  if (typeof kind === 'string')
+    return kind
+  if (isObject(kind) && typeof kind.type === 'string')
+    return kind.type as string
+  return ''
+}
+
+function isSimpleEditChange(change: Record<string, unknown>): boolean {
+  return codexChangeKind(change) === 'update' && typeof change.diff === 'string' && !!parseCodexUnifiedDiff(change.diff as string)
+}
+
+function parsedChangeDiffs(changes: Array<Record<string, unknown>>): Array<{ path: string, diff: ParsedCodexDiff }> {
+  return changes.flatMap((change) => {
+    const diffText = typeof change.diff === 'string' ? change.diff : ''
+    const parsed = parseCodexUnifiedDiff(diffText)
+    if (!parsed)
+      return []
+    return [{ path: typeof change.path === 'string' ? change.path : '', diff: parsed }]
+  })
+}
+
+function stripToolUseHeaderFromOutput(output: string): string {
+  if (!output.includes(TOOL_USE_HEADER_CLASS_FRAGMENT))
+    return output
+
+  const lines = output.split('\n')
+  const kept: string[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line.includes(TOOL_USE_HEADER_CLASS_FRAGMENT)) {
+      kept.push(line)
+      continue
+    }
+
+    if (kept.length > 0 && kept[kept.length - 1].includes('<div'))
+      kept.pop()
+
+    let depth = 1
+    while (++i < lines.length) {
+      const current = lines[i]
+      depth += (current.match(/<div\b/g) || []).length
+      depth -= (current.match(/<\/div>/g) || []).length
+      if (depth <= 0)
+        break
+    }
+  }
+
+  return kept.join('\n')
+}
+
+function extractPlanParams(parsed: unknown): Record<string, unknown> | null {
+  if (!isObject(parsed))
+    return null
+  if (parsed.method === 'turn/plan/updated' && isObject(parsed.params))
+    return parsed.params as Record<string, unknown>
+  if (Array.isArray(parsed.plan))
+    return parsed
+  return null
+}
+
+function codexPlanTodos(plan: unknown): TodoItem[] {
+  if (!Array.isArray(plan))
+    return []
+  return plan.flatMap((entry) => {
+    if (!isObject(entry))
+      return []
+    const content = typeof entry.step === 'string' ? entry.step : ''
+    if (!content)
+      return []
+    const rawStatus = entry.status
+    const status: TodoItem['status']
+      = rawStatus === 'completed'
+        ? 'completed'
+        : rawStatus === 'inProgress'
+          ? 'in_progress'
+          : 'pending'
+    return [{
+      content,
+      status,
+      activeForm: content,
+    }]
+  })
+}
+
+function codexWebSearchAction(parsed: unknown): Record<string, unknown> | null {
+  if (!isObject(parsed))
+    return null
+  return isObject(parsed.action) ? parsed.action as Record<string, unknown> : null
+}
+
+function codexWebSearchActionType(action: Record<string, unknown> | null): string {
+  return typeof action?.type === 'string' ? action.type as string : ''
+}
+
+function codexWebSearchQueries(action: Record<string, unknown> | null): string[] {
+  if (codexWebSearchActionType(action) !== 'search')
+    return []
+  const direct = typeof action?.query === 'string' ? action.query.trim() : ''
+  const listed = Array.isArray(action?.queries)
+    ? action.queries.filter(q => typeof q === 'string').map(q => (q as string).trim()).filter(Boolean)
+    : []
+  const merged = direct ? [direct, ...listed] : listed
+  return merged.filter((query, index) => merged.indexOf(query) === index)
+}
+
+function codexWebSearchActionDetail(action: Record<string, unknown> | null, query: string): string {
+  const actionType = codexWebSearchActionType(action)
+  if (actionType === 'search') {
+    const queries = codexWebSearchQueries(action)
+    if (queries.length > 0)
+      return queries[0]
+    return query
+  }
+  if (actionType === 'openPage')
+    return typeof action?.url === 'string' ? action.url : query
+  if (actionType === 'findInPage') {
+    const url = typeof action?.url === 'string' ? action.url : ''
+    const pattern = typeof action?.pattern === 'string' ? action.pattern : ''
+    if (pattern && url)
+      return `'${pattern}' in ${url}`
+    if (pattern)
+      return `'${pattern}'`
+    if (url)
+      return url
+  }
+  return query
+}
+
+function renderCodexWebSearchTitle(action: Record<string, unknown> | null, detail: string, context?: RenderContext): JSX.Element | string {
+  const actionType = codexWebSearchActionType(action)
+  if (actionType === 'openPage') {
+    return renderToolDetail('WebFetch', { url: detail }, context) || detail || 'Open page'
+  }
+  if (actionType === 'search') {
+    return renderToolDetail('WebSearch', { query: detail }, context) || detail || 'Web search'
+  }
+  if (actionType === 'findInPage') {
+    const url = typeof action?.url === 'string' ? action.url : ''
+    const pattern = typeof action?.pattern === 'string' ? action.pattern : ''
+    if (pattern && url) {
+      return (
+        <>
+          <span class={toolInputCode}>{`"${pattern}"`}</span>
+          <span class={toolInputText}>{' in '}</span>
+          {renderToolDetail('WebFetch', { url }, context) || <span class={toolInputText}>{url}</span>}
+        </>
+      )
+    }
+    if (pattern)
+      return <span class={toolInputCode}>{`"${pattern}"`}</span>
+    if (url)
+      return renderToolDetail('WebFetch', { url }, context) || url
+  }
+  return detail || 'Searching the web'
 }
 
 /** Renders Codex agentMessage items as markdown. */
@@ -86,6 +326,84 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
   )
 }
 
+/** Renders Codex turn/plan/updated notifications with the same todo-list UI pattern as TodoWrite. */
+export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, context?: RenderContext): JSX.Element | null {
+  const params = extractPlanParams(parsed)
+  if (!params)
+    return null
+
+  const todos = codexPlanTodos(params.plan)
+  if (todos.length === 0)
+    return null
+
+  const explanation = typeof params.explanation === 'string' ? params.explanation.trim() : ''
+  const label = `${todos.length} task${todos.length === 1 ? '' : 's'}${explanation ? ` - ${explanation}` : ''}`
+
+  return (
+    <ToolUseLayout
+      icon={ListTodo}
+      toolName="Plan Update"
+      title={label}
+      alwaysVisible={true}
+      context={context}
+    >
+      <TodoList todos={todos} />
+    </ToolUseLayout>
+  )
+}
+
+/** Renders Codex webSearch items using WebSearch/WebFetch-style tool cards. */
+export function codexWebSearchRenderer(parsed: unknown, _role: MessageRole, context?: RenderContext): JSX.Element | null {
+  const item = extractItem(parsed)
+  if (!item || item.type !== 'webSearch')
+    return null
+
+  const query = typeof item.query === 'string' ? item.query : ''
+  const action = codexWebSearchAction(item)
+  const actionType = codexWebSearchActionType(action)
+  const detail = codexWebSearchActionDetail(action, query)
+  const queries = codexWebSearchQueries(action)
+  const isStartMessage = actionType === 'other' && !query.trim()
+  const [expanded, setExpanded] = createSignal(false)
+
+  if (isStartMessage) {
+    return (
+      <ToolUseLayout
+        icon={Globe}
+        toolName="WebSearch"
+        title="Searching the web"
+        alwaysVisible={true}
+        context={context}
+      />
+    )
+  }
+
+  if (!detail.trim())
+    return null
+
+  return (
+    <ToolUseLayout
+      icon={Globe}
+      toolName={actionType === 'openPage' ? 'WebFetch' : 'WebSearch'}
+      title={renderCodexWebSearchTitle(action, detail, context)}
+      context={context}
+      expanded={expanded()}
+      onToggleExpand={queries.length > 1 ? () => setExpanded(v => !v) : undefined}
+      alwaysVisible={queries.length <= 1}
+    >
+      <Show when={queries.length > 1}>
+        <For each={queries.slice(1)}>
+          {extraQuery => (
+            <div class={toolInputSummary}>
+              {renderToolDetail('WebSearch', { query: extraQuery }, context) || extraQuery}
+            </div>
+          )}
+        </For>
+      </Show>
+    </ToolUseLayout>
+  )
+}
+
 /** Renders Codex commandExecution items using shared ToolUseLayout. */
 export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRole, context?: RenderContext): JSX.Element | null {
   const item = extractItem(parsed)
@@ -97,32 +415,70 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
   const command = rawCommand.replace(SHELL_WRAPPER_RE, '$1')
   const cwd = (item.cwd as string) || ''
   const status = (item.status as string) || ''
-  const output = (item.aggregatedOutput as string) || ''
+  const output = stripToolUseHeaderFromOutput((item.aggregatedOutput as string) || '')
   const exitCode = item.exitCode as number | null | undefined
   const durationMs = item.durationMs as number | null | undefined
-  const isCompleted = status === 'completed'
-  const hasError = isCompleted && exitCode != null && exitCode !== 0
+  const processId = item.processId as string | null | undefined
+  const isTerminal = status === 'completed' || status === 'failed'
+  const hasError = status === 'failed' || (isTerminal && exitCode != null && exitCode !== 0)
   const liveStream = () => context?.commandStream ?? []
   const hasLiveStream = () => liveStream().length > 0
-  const [expanded, setExpanded] = createSignal(hasError || !isCompleted || hasLiveStream())
+  const [expanded, setExpanded] = createSignal(false)
+  createEffect(() => {
+    if (hasLiveStream())
+      setExpanded(true)
+  })
+  const displayCommand = firstCommandLine(command)
+  const title = renderToolDetail('Bash', { description: 'Run command', command }, context) || 'Run command'
 
   const statusParts = (): string => {
     const parts: string[] = []
-    if (!isCompleted && status)
-      parts.push(status)
     if (exitCode != null)
       parts.push(`exit ${exitCode}`)
     if (durationMs != null)
-      parts.push(`${(durationMs / 1000).toFixed(1)}s`)
+      parts.push(formatDuration(durationMs))
     return parts.join(' · ')
+  }
+  const resultStatusDetail = (): string => {
+    const parts: string[] = []
+    if (processId)
+      parts.push(`process ID: ${processId}`)
+    if (exitCode != null && exitCode !== 0)
+      parts.push(`exit code: ${exitCode}`)
+    return parts.join(' · ')
+  }
+
+  if (isTerminal) {
+    return (
+      <ToolResultMessage
+        toolName="Bash"
+        resultContent={output}
+        isPreText={true}
+        structuredPatch={null}
+        oldStr=""
+        newStr=""
+        filePath=""
+        isError={hasError}
+        statusDetail={resultStatusDetail()}
+        context={context}
+      />
+    )
   }
 
   return (
     <ToolUseLayout
-      icon={SquareTerminal}
+      icon={Terminal}
       toolName="Command Execution"
-      title={command}
-      summary={statusParts() ? <div class={toolInputSummary}>{statusParts()}</div> : undefined}
+      title={title}
+      summary={
+        <>
+          {/* eslint-disable-next-line solid/no-innerhtml -- shiki output is safe */}
+          <div class={toolInputSummary} innerHTML={renderBashHighlight(displayCommand)} />
+          <Show when={statusParts()}>
+            <div class={toolInputSummary}>{statusParts()}</div>
+          </Show>
+        </>
+      }
       context={context}
       expanded={expanded()}
       onToggleExpand={() => setExpanded(v => !v)}
@@ -131,7 +487,7 @@ export function codexCommandExecutionRenderer(parsed: unknown, _role: MessageRol
         <div class={toolInputSummary}>
           cwd:
           {' '}
-          {cwd}
+          {relativizePath(cwd, context?.workingDir, context?.homeDir)}
         </div>
       </Show>
       <Show
@@ -162,16 +518,76 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
   const status = (item.status as string) || ''
   const liveStream = () => context?.commandStream ?? []
   const hasLiveStream = () => liveStream().length > 0
-  const [expanded, setExpanded] = createSignal(true)
+  const completedDiffs = parsedChangeDiffs(changes)
+
+  if (status === 'completed' && completedDiffs.length > 0) {
+    return (
+      <div class={toolMessage}>
+        <For each={completedDiffs}>
+          {entry => (
+            <DiffView
+              hunks={entry.diff.hunks}
+              view={context?.diffView ?? 'unified'}
+              filePath={entry.path}
+            />
+          )}
+        </For>
+      </div>
+    )
+  }
+
+  if (status === 'completed') {
+    return (
+      <div class={toolMessage}>
+        <Show when={changes.length > 0 && completedDiffs.length === 0}>
+          <div class={toolResultPrompt}>
+            {changes.length === 1 ? '1 file changed' : `${changes.length} files changed`}
+          </div>
+        </Show>
+      </div>
+    )
+  }
+
+  const simpleEdit = changes.length === 1 && isSimpleEditChange(changes[0]) ? changes[0] : null
+  const parsedDiff = simpleEdit ? parseCodexUnifiedDiff(simpleEdit.diff as string) : null
+  if (simpleEdit && parsedDiff) {
+    const path = (simpleEdit.path as string) || ''
+    const title = renderToolDetail('Edit', {
+      file_path: path,
+      old_string: parsedDiff.oldText,
+      new_string: parsedDiff.newText,
+    }, context) || (
+      <span class={toolInputPath}>{relativizePath(path, context?.workingDir, context?.homeDir)}</span>
+    )
+
+    return (
+      <ToolUseLayout
+        icon={FileEdit}
+        toolName="File Change"
+        title={title}
+        context={context}
+        alwaysVisible={true}
+      >
+        <Show when={hasLiveStream()}>
+          <div class={commandStreamContainer}>
+            <For each={liveStream()}>
+              {segment => (
+                <div class={toolResultContentPre}>{segment.text}</div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </ToolUseLayout>
+    )
+  }
 
   const titleEl = (
     <>
       <span class={toolInputSummary}>
-        {changes.length === 1 ? String(changes[0].path || 'file') : `${changes.length} files`}
+        {changes.length === 1
+          ? relativizePath(String(changes[0].path || 'file'), context?.workingDir, context?.homeDir)
+          : `${changes.length} files`}
       </span>
-      <Show when={status}>
-        <span class={toolInputSummary}>{status}</span>
-      </Show>
     </>
   )
 
@@ -181,8 +597,7 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
       toolName="File Change"
       title={titleEl}
       context={context}
-      expanded={expanded()}
-      onToggleExpand={() => setExpanded(v => !v)}
+      alwaysVisible={true}
     >
       <Show when={hasLiveStream()}>
         <div class={commandStreamContainer}>
@@ -193,11 +608,10 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
           </For>
         </div>
       </Show>
-      <For each={changes}>
+      <For each={changes.length === 1 ? [] : changes}>
         {(change) => {
-          const path = (change.path as string) || '(unknown)'
-          const kind = (change.kind as string) || ''
-          const diff = (change.diff as string) || ''
+          const path = relativizePath((change.path as string) || '(unknown)', context?.workingDir, context?.homeDir)
+          const kind = codexChangeKind(change)
           return (
             <div>
               <div class={toolInputPath}>
@@ -205,13 +619,10 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
                 {' '}
                 <span class={toolInputSummary}>
                   (
-                  {kind}
-                  )
-                </span>
+                    {kind}
+                    )
+                  </span>
               </div>
-              <Show when={diff}>
-                <div class={toolResultContentPre}>{diff}</div>
-              </Show>
             </div>
           )
         }}
@@ -314,6 +725,28 @@ export function codexMcpToolCallRenderer(parsed: unknown, _role: MessageRole, co
 
   const titleEl = codexStatusTitle(server ? `${server}/${tool}` : tool, status)
 
+  if (status === 'completed' || status === 'failed') {
+    return (
+      <div class={toolMessage}>
+        <Show when={result}>
+          <div>
+            <div class={toolResultPrompt}>Result</div>
+            <div class={toolResultContentPre}>{JSON.stringify(result, null, 2)}</div>
+          </div>
+        </Show>
+        <Show when={error}>
+          <div>
+            <div class={toolResultPrompt}>Error</div>
+            <div class={toolResultError}>{JSON.stringify(error, null, 2)}</div>
+          </div>
+        </Show>
+        <Show when={!result && !error && status}>
+          <div class={toolResultPrompt}>{status}</div>
+        </Show>
+      </div>
+    )
+  }
+
   return (
     <ToolUseLayout
       icon={Wrench}
@@ -354,14 +787,22 @@ export function codexCollabAgentToolCallRenderer(parsed: unknown, _role: Message
   const tool = (item.tool as string) || 'SpawnAgent'
   const status = (item.status as string) || ''
   const displayName = tool === 'spawnAgent' ? 'SpawnAgent' : tool
+  const titleEl = renderToolDetail('Agent', { description: displayName }, context) || codexStatusTitle(displayName, status)
 
-  const titleEl = codexStatusTitle(displayName, status)
+  if (status === 'completed' || status === 'failed') {
+    return (
+      <div class={toolMessage}>
+        <div class={toolResultPrompt}>{`${displayName} ${status}`}</div>
+      </div>
+    )
+  }
 
   return (
     <ToolUseLayout
       icon={Bot}
       toolName={displayName}
       title={titleEl}
+      summary={status ? <div class={toolInputSummary}>{status}</div> : undefined}
       context={context}
     />
   )

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'solid-js'
 import type { StructuredPatchHunk } from './diffUtils'
 import type { RenderContext } from './messageRenderers'
 import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
-import type { CommandStreamSegment, TodoItem } from '~/stores/chat.store'
+import type { CommandStreamSegment } from '~/stores/chat.store'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
@@ -18,6 +18,7 @@ import { createEffect, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { TodoList } from '~/components/todo/TodoList'
+import { codexPlanToTodos } from '~/lib/messageParser'
 import { renderMarkdown, shikiHighlighter } from '~/lib/renderMarkdown'
 import { inlineFlex } from '~/styles/shared.css'
 import { DiffView, rawDiffToHunks } from './diffUtils'
@@ -213,30 +214,6 @@ function extractPlanParams(parsed: unknown): Record<string, unknown> | null {
   return null
 }
 
-function codexPlanTodos(plan: unknown): TodoItem[] {
-  if (!Array.isArray(plan))
-    return []
-  return plan.flatMap((entry) => {
-    if (!isObject(entry))
-      return []
-    const content = typeof entry.step === 'string' ? entry.step : ''
-    if (!content)
-      return []
-    const rawStatus = entry.status
-    const status: TodoItem['status']
-      = rawStatus === 'completed'
-        ? 'completed'
-        : rawStatus === 'inProgress'
-          ? 'in_progress'
-          : 'pending'
-    return [{
-      content,
-      status,
-      activeForm: content,
-    }]
-  })
-}
-
 function codexWebSearchAction(parsed: unknown): Record<string, unknown> | null {
   if (!isObject(parsed))
     return null
@@ -351,7 +328,10 @@ export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, conte
   if (!params)
     return null
 
-  const todos = codexPlanTodos(params.plan)
+  const plan = params.plan
+  if (!Array.isArray(plan))
+    return null
+  const todos = codexPlanToTodos(plan)
   if (todos.length === 0)
     return null
 

--- a/frontend/src/components/chat/diffUtils.test.tsx
+++ b/frontend/src/components/chat/diffUtils.test.tsx
@@ -301,7 +301,10 @@ describe('groupByHunk', () => {
   })
 })
 
-describe('DiffView gap rendering without original file', () => {
+const EXPAND_RE = /expand/i
+const COLLAPSE_RE = /collapse/i
+
+describe('diffView gap rendering without original file', () => {
   const hunks: StructuredPatchHunk[] = [
     { oldStart: 4, oldLines: 2, newStart: 4, newLines: 2, lines: [' line 4', '-line 5', '+line 5 mod'] },
     { oldStart: 9, oldLines: 1, newStart: 9, newLines: 1, lines: ['-line 9', '+line 9 mod'] },
@@ -313,8 +316,8 @@ describe('DiffView gap rendering without original file', () => {
     ))
 
     expect(getAllByText('3 lines hidden')).toHaveLength(1)
-    expect(queryByRole('button', { name: /expand/i })).toBeNull()
-    expect(queryByRole('button', { name: /collapse/i })).toBeNull()
+    expect(queryByRole('button', { name: EXPAND_RE })).toBeNull()
+    expect(queryByRole('button', { name: COLLAPSE_RE })).toBeNull()
   })
 
   it('renders non-clickable hidden-line gaps in split view', () => {
@@ -323,7 +326,7 @@ describe('DiffView gap rendering without original file', () => {
     ))
 
     expect(getAllByText('3 lines hidden')).toHaveLength(1)
-    expect(queryByRole('button', { name: /expand/i })).toBeNull()
-    expect(queryByRole('button', { name: /collapse/i })).toBeNull()
+    expect(queryByRole('button', { name: EXPAND_RE })).toBeNull()
+    expect(queryByRole('button', { name: COLLAPSE_RE })).toBeNull()
   })
 })

--- a/frontend/src/components/chat/diffUtils.test.tsx
+++ b/frontend/src/components/chat/diffUtils.test.tsx
@@ -2,7 +2,7 @@ import type { StructuredPatchHunk } from './diffUtils'
 import { render } from '@solidjs/testing-library'
 import { diffWordsWithSpace } from 'diff'
 import { describe, expect, it } from 'vitest'
-import { computeGapMap, DiffView, groupByHunk, rawDiffToHunks } from './diffUtils'
+import { computeGapMap, computeSyntheticGapMap, DiffView, groupByHunk, rawDiffToHunks } from './diffUtils'
 
 /**
  * Reconstruct one side of a word-diff using the same filtering logic
@@ -244,6 +244,30 @@ describe('computeGapMap', () => {
   })
 })
 
+describe('computeSyntheticGapMap', () => {
+  it('computes only inter-hunk gaps without original file content', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 4, oldLines: 2, newStart: 4, newLines: 2, lines: [' line 4', '-line 5', '+line 5 mod'] },
+      { oldStart: 9, oldLines: 1, newStart: 9, newLines: 1, lines: ['-line 9', '+line 9 mod'] },
+    ]
+
+    const gaps = computeSyntheticGapMap(hunks)
+
+    expect(gaps.get(1)).toEqual({ startLineNumber: 6, lineCount: 3 })
+    expect(gaps.size).toBe(1)
+  })
+
+  it('does not infer outer gaps without original file length', () => {
+    const hunks: StructuredPatchHunk[] = [
+      { oldStart: 2, oldLines: 1, newStart: 2, newLines: 1, lines: ['-line 2', '+line 2 mod'] },
+    ]
+
+    const gaps = computeSyntheticGapMap(hunks)
+
+    expect(gaps.size).toBe(0)
+  })
+})
+
 describe('groupByHunk', () => {
   it('groups entries by hunkIndex', () => {
     const entries = [
@@ -274,5 +298,32 @@ describe('groupByHunk', () => {
     const groups = groupByHunk(entries)
     expect(groups).toHaveLength(1)
     expect(groups[0]).toHaveLength(2)
+  })
+})
+
+describe('DiffView gap rendering without original file', () => {
+  const hunks: StructuredPatchHunk[] = [
+    { oldStart: 4, oldLines: 2, newStart: 4, newLines: 2, lines: [' line 4', '-line 5', '+line 5 mod'] },
+    { oldStart: 9, oldLines: 1, newStart: 9, newLines: 1, lines: ['-line 9', '+line 9 mod'] },
+  ]
+
+  it('renders non-clickable hidden-line gaps in unified view', () => {
+    const { getAllByText, queryByRole } = render(() => (
+      <DiffView hunks={hunks} view="unified" />
+    ))
+
+    expect(getAllByText('3 lines hidden')).toHaveLength(1)
+    expect(queryByRole('button', { name: /expand/i })).toBeNull()
+    expect(queryByRole('button', { name: /collapse/i })).toBeNull()
+  })
+
+  it('renders non-clickable hidden-line gaps in split view', () => {
+    const { getAllByText, queryByRole } = render(() => (
+      <DiffView hunks={hunks} view="split" />
+    ))
+
+    expect(getAllByText('3 lines hidden')).toHaveLength(1)
+    expect(queryByRole('button', { name: /expand/i })).toBeNull()
+    expect(queryByRole('button', { name: /collapse/i })).toBeNull()
   })
 })

--- a/frontend/src/components/chat/diffUtils.tsx
+++ b/frontend/src/components/chat/diffUtils.tsx
@@ -1021,8 +1021,7 @@ function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string,
           <For each={groupByHunk(splitLines().left)}>
             {(leftGroup, groupIdx) => {
               const hi = () => leftGroup[0]?.hunkIndex ?? groupIdx()
-              const rightGroups = () => groupByHunk(splitLines().right)
-              const rightGroup = () => rightGroups()[groupIdx()] ?? []
+              const rightGroup = () => groupByHunk(splitLines().right)[groupIdx()] ?? []
               const gapBefore = () => syntheticGaps().get(hi())
               return (
                 <>

--- a/frontend/src/components/chat/diffUtils.tsx
+++ b/frontend/src/components/chat/diffUtils.tsx
@@ -270,6 +270,14 @@ export interface DiffGap {
   startLineNumber: number
 }
 
+/** A synthetic gap computed from hunk coordinates when original file content is unavailable. */
+export interface DiffGapSummary {
+  /** Number of hidden old-file lines between hunks. */
+  lineCount: number
+  /** 1-based line number of the first hidden line. */
+  startLineNumber: number
+}
+
 /**
  * Compute a map of gaps between hunks using the original file content.
  * Returns a Map keyed by hunk index (gap *before* that hunk) plus an optional trailing gap.
@@ -323,6 +331,37 @@ export function computeGapMap(
   }
 
   return { gaps, trailing }
+}
+
+/**
+ * Compute synthetic gap summaries from hunk coordinates only.
+ * This supports non-expandable "N lines hidden" separators even when the
+ * original file content is not available.
+ *
+ * Gap at key N = lines between hunk N-1 and hunk N.
+ * Leading and trailing gaps are intentionally omitted without original file
+ * content because they only indicate omitted outer context around the diff.
+ */
+export function computeSyntheticGapMap(hunks: StructuredPatchHunk[]): Map<number, DiffGapSummary> {
+  const gaps = new Map<number, DiffGapSummary>()
+
+  if (hunks.length === 0)
+    return gaps
+
+  for (let i = 1; i < hunks.length; i++) {
+    const prev = hunks[i - 1]
+    const curr = hunks[i]
+    const gapStart = prev.oldStart + prev.oldLines
+    const gapEnd = curr.oldStart - 1
+    if (gapEnd >= gapStart) {
+      gaps.set(i, {
+        lineCount: gapEnd - gapStart + 1,
+        startLineNumber: gapStart,
+      })
+    }
+  }
+
+  return gaps
 }
 
 /**
@@ -534,6 +573,32 @@ function DiffGapSeparator(props: {
         )}
       </For>
     </>
+  )
+}
+
+/** Render a non-interactive gap separator when only the hidden line count is known. */
+function DiffGapSummarySeparator(props: {
+  gap: DiffGapSummary
+  splitView?: boolean
+  isFirst?: boolean
+  isLast?: boolean
+}): JSX.Element {
+  const separatorClass = () => {
+    let cls = diffGapSeparator
+    if (props.splitView)
+      cls += ` ${diffGapSeparatorSplit}`
+    if (props.isFirst)
+      cls += ` ${diffGapSeparatorFirst}`
+    if (props.isLast)
+      cls += ` ${diffGapSeparatorLast}`
+    return cls
+  }
+  const hiddenLabel = () => `${props.gap.lineCount} line${props.gap.lineCount === 1 ? '' : 's'} hidden`
+
+  return (
+    <div class={separatorClass()}>
+      {hiddenLabel()}
+    </div>
   )
 }
 
@@ -771,6 +836,7 @@ function UnifiedDiffView(props: { hunks: StructuredPatchHunk[], filePath?: strin
       return null
     return computeGapMap(props.hunks, ofl)
   }
+  const syntheticGaps = createMemo(() => computeSyntheticGapMap(props.hunks))
 
   const [gapReveals, setGapReveals] = createSignal<Map<string, { top: number, bottom: number }>>(new Map())
   const getReveal = (key: string) => gapReveals().get(key) ?? { top: 0, bottom: 0 }
@@ -805,8 +871,26 @@ function UnifiedDiffView(props: { hunks: StructuredPatchHunk[], filePath?: strin
       <Show
         when={gapData()}
         fallback={(
-          <For each={lines()}>
-            {line => <UnifiedDiffLine line={line} />}
+          <For each={groupByHunk(lines())}>
+            {(group, groupIdx) => {
+              const hi = () => group[0]?.hunkIndex ?? groupIdx()
+              const gapBefore = () => syntheticGaps().get(hi())
+              return (
+                <>
+                  <Show when={gapBefore()}>
+                    {gap => (
+                      <DiffGapSummarySeparator
+                        gap={gap()}
+                        isFirst={groupIdx() === 0}
+                      />
+                    )}
+                  </Show>
+                  <For each={group}>
+                    {line => <UnifiedDiffLine line={line} />}
+                  </For>
+                </>
+              )
+            }}
           </For>
         )}
       >
@@ -899,6 +983,7 @@ function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string,
       return null
     return computeGapMap(props.hunks, ofl)
   }
+  const syntheticGaps = createMemo(() => computeSyntheticGapMap(props.hunks))
 
   const [gapReveals, setGapReveals] = createSignal<Map<string, { top: number, bottom: number }>>(new Map())
   const getReveal = (key: string) => gapReveals().get(key) ?? { top: 0, bottom: 0 }
@@ -933,10 +1018,31 @@ function SplitDiffView(props: { hunks: StructuredPatchHunk[], filePath?: string,
       <Show
         when={gapData()}
         fallback={(
-          <For each={splitLines().left}>
-            {(leftLine, i) => {
-              const rightLine = () => splitLines().right[i()]
-              return <SplitDiffRow left={leftLine} right={rightLine()} />
+          <For each={groupByHunk(splitLines().left)}>
+            {(leftGroup, groupIdx) => {
+              const hi = () => leftGroup[0]?.hunkIndex ?? groupIdx()
+              const rightGroups = () => groupByHunk(splitLines().right)
+              const rightGroup = () => rightGroups()[groupIdx()] ?? []
+              const gapBefore = () => syntheticGaps().get(hi())
+              return (
+                <>
+                  <Show when={gapBefore()}>
+                    {gap => (
+                      <DiffGapSummarySeparator
+                        gap={gap()}
+                        splitView
+                        isFirst={groupIdx() === 0}
+                      />
+                    )}
+                  </Show>
+                  <For each={leftGroup}>
+                    {(leftLine, i) => {
+                      const rightLine = () => rightGroup()[i()] ?? { content: '', type: 'empty' as const, num: null, hunkIndex: hi() }
+                      return <SplitDiffRow left={leftLine} right={rightLine()} />
+                    }}
+                  </For>
+                </>
+              )
             }}
           </For>
         )}

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -4,6 +4,7 @@ import type { JSX } from 'solid-js'
 import type { MessageCategory } from './messageClassification'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { AgentChatMessage, AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import type { CommandStreamSegment } from '~/stores/chat.store'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
@@ -80,8 +81,12 @@ export interface RenderContext {
   spanColor?: number
   /** Tool name or item type from span_type column (reliable, always set for span messages). */
   spanType?: string
+  /** Current message span id. */
+  spanId?: string
   /** Whether the Bash/TaskOutput tool result is expanded (controlled by MessageBubble). */
   toolResultExpanded?: boolean
+  /** Live streamed Codex span content for command, fileChange, and reasoning items. */
+  commandStream?: CommandStreamSegment[]
 }
 
 export interface MessageContentRenderer {

--- a/frontend/src/components/chat/providers/codex.test.ts
+++ b/frontend/src/components/chat/providers/codex.test.ts
@@ -66,6 +66,50 @@ describe('codex classify', () => {
     const result = plugin.classify(parent, null)
     expect(result).toEqual({ kind: 'notification' })
   })
+
+  it('classifies compacting as notification', () => {
+    const parent = { type: 'compacting' }
+    const result = plugin.classify(parent, null)
+    expect(result).toEqual({ kind: 'notification' })
+  })
+
+  it('classifies compact_boundary system messages as notification', () => {
+    const parent = { type: 'system', subtype: 'compact_boundary' }
+    const result = plugin.classify(parent, null)
+    expect(result).toEqual({ kind: 'notification' })
+  })
+
+  it('classifies turn/plan/updated as a Codex tool-use message', () => {
+    const parent = {
+      method: 'turn/plan/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: null,
+        plan: [
+          { step: 'Inspect messages', status: 'inProgress' },
+          { step: 'Update renderer', status: 'pending' },
+        ],
+      },
+    }
+    const result = plugin.classify(parent, null)
+    expect(result).toEqual({ kind: 'tool_use', toolName: 'turnPlan', toolUse: parent, content: [] })
+  })
+
+  it('classifies webSearch items as Codex tool-use messages', () => {
+    const parent = {
+      item: {
+        type: 'webSearch',
+        id: 'ws-1',
+        query: 'https://example.com',
+        action: { type: 'openPage', url: 'https://example.com' },
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    }
+    const result = plugin.classify(parent, null)
+    expect(result).toEqual({ kind: 'tool_use', toolName: 'webSearch', toolUse: parent.item, content: [] })
+  })
 })
 
 describe('codex isAskUserQuestion', () => {

--- a/frontend/src/components/chat/providers/codex.tsx
+++ b/frontend/src/components/chat/providers/codex.tsx
@@ -20,8 +20,8 @@ import {
   codexMcpToolCallRenderer,
   codexPlanRenderer,
   codexReasoningRenderer,
-  codexTurnPlanRenderer,
   codexTurnCompletedRenderer,
+  codexTurnPlanRenderer,
   codexWebSearchRenderer,
 } from '../codexRenderers'
 import { CodexControlActions, CodexControlContent } from '../controls/CodexControlRequest'
@@ -54,8 +54,9 @@ function buildCodexInterruptRequest(threadId: string, turnId: string): string {
 const CODEX_EXTRA_NOTIF_TYPES = new Set(['agent_error'])
 function isCodexNotifThread(wrapper: { messages: unknown[] } | null): wrapper is { messages: unknown[] } {
   if (isNotificationThreadWrapper(wrapper, CODEX_EXTRA_NOTIF_TYPES, (t, st) =>
-    t === 'system' && st !== 'init' && st !== 'task_notification'))
+    t === 'system' && st !== 'init' && st !== 'task_notification')) {
     return true
+  }
   // Codex method-based notifications (e.g. account/rateLimits/updated)
   if (!wrapper || wrapper.messages.length < 1)
     return false

--- a/frontend/src/components/chat/providers/codex.tsx
+++ b/frontend/src/components/chat/providers/codex.tsx
@@ -20,7 +20,9 @@ import {
   codexMcpToolCallRenderer,
   codexPlanRenderer,
   codexReasoningRenderer,
+  codexTurnPlanRenderer,
   codexTurnCompletedRenderer,
+  codexWebSearchRenderer,
 } from '../codexRenderers'
 import { CodexControlActions, CodexControlContent } from '../controls/CodexControlRequest'
 import { isNotificationThreadWrapper, isObject } from '../messageUtils'
@@ -51,7 +53,8 @@ function buildCodexInterruptRequest(threadId: string, turnId: string): string {
 /** Extra notification types for Codex (agent_error). */
 const CODEX_EXTRA_NOTIF_TYPES = new Set(['agent_error'])
 function isCodexNotifThread(wrapper: { messages: unknown[] } | null): wrapper is { messages: unknown[] } {
-  if (isNotificationThreadWrapper(wrapper, CODEX_EXTRA_NOTIF_TYPES))
+  if (isNotificationThreadWrapper(wrapper, CODEX_EXTRA_NOTIF_TYPES, (t, st) =>
+    t === 'system' && st !== 'init' && st !== 'task_notification'))
     return true
   // Codex method-based notifications (e.g. account/rateLimits/updated)
   if (!wrapper || wrapper.messages.length < 1)
@@ -236,10 +239,26 @@ const codexPlugin: ProviderPlugin = {
     if (!parent)
       return { kind: 'unknown' }
 
+    const type = parent.type as string | undefined
+    const subtype = parent.subtype as string | undefined
+
     // Startup and status notifications are transient lifecycle signals.
     // Persist them if needed, but keep them out of chat rendering.
     if (parent.method === 'thread/started' || parent.method === 'turn/started' || parent.method === 'thread/status/changed')
       return { kind: 'hidden' }
+
+    if (type === 'system') {
+      if (subtype === 'init')
+        return { kind: 'hidden' }
+      if (subtype === 'status' && parent.status !== 'compacting')
+        return { kind: 'hidden' }
+      if (subtype === 'task_notification')
+        return { kind: 'hidden' }
+      return { kind: 'notification' }
+    }
+
+    if (parent.method === 'turn/plan/updated' && isObject(parent.params))
+      return { kind: 'tool_use', toolName: 'turnPlan', toolUse: parent, content: [] }
 
     // Each item is now its own message (no more merging).
     const effective = parent
@@ -283,6 +302,10 @@ const codexPlugin: ProviderPlugin = {
       if (itemType === 'collabAgentToolCall')
         return { kind: 'tool_use', toolName: 'collabAgentToolCall', toolUse: item, content: [] }
 
+      // webSearch → tool use / result-like native codex message
+      if (itemType === 'webSearch')
+        return { kind: 'tool_use', toolName: 'webSearch', toolUse: item, content: [] }
+
       // reasoning → thinking (hide if both summary and content are empty)
       if (itemType === 'reasoning') {
         const summary = item.summary as unknown[] | undefined
@@ -312,9 +335,8 @@ const codexPlugin: ProviderPlugin = {
     }
 
     // LeapMux notification types
-    const type = parent.type as string | undefined
     if (type === 'settings_changed' || type === 'context_cleared'
-      || type === 'interrupted' || type === 'agent_error' || type === 'agent_renamed') {
+      || type === 'interrupted' || type === 'agent_error' || type === 'agent_renamed' || type === 'compacting') {
       return { kind: 'notification' }
     }
 
@@ -331,12 +353,16 @@ const codexPlugin: ProviderPlugin = {
     if (category.kind === 'tool_use') {
       // Use the item stored in category.toolUse (resolved to final state in classify).
       const cat = category as { toolName: string, toolUse: Record<string, unknown> }
+      if (cat.toolName === 'turnPlan')
+        return codexTurnPlanRenderer(cat.toolUse, role, context)
       if (cat.toolName === 'plan')
         return codexPlanRenderer(cat.toolUse, role, context)
       if (cat.toolName === 'commandExecution')
         return codexCommandExecutionRenderer(cat.toolUse, role, context)
       if (cat.toolName === 'fileChange')
         return codexFileChangeRenderer(cat.toolUse, role, context)
+      if (cat.toolName === 'webSearch')
+        return codexWebSearchRenderer(cat.toolUse, role, context)
       if (cat.toolName === 'collabAgentToolCall')
         return codexCollabAgentToolCallRenderer(cat.toolUse, role, context)
       return codexMcpToolCallRenderer(cat.toolUse, role, context)

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -495,11 +495,16 @@ const PRE_TEXT_TOOLS = new Set(['Bash', 'Grep', 'Glob', 'Read', 'TaskOutput'])
 export const COLLAPSED_RESULT_ROWS = 3
 
 const TOOL_USE_ERROR_RE = /<tool_use_error>([\s\S]*?)<\/tool_use_error>/
+const LEADING_BLANK_LINES_RE = /^(?:\s*\n)+/
 
 /** Extract error text from <tool_use_error> tags in tool result content. */
 function extractToolUseError(content: string): string | null {
   const match = content.match(TOOL_USE_ERROR_RE)
   return match ? match[1].trim() : null
+}
+
+function stripLeadingBlankLines(content: string): string {
+  return content.replace(LEADING_BLANK_LINES_RE, '')
 }
 
 /**
@@ -1100,7 +1105,7 @@ function ExitPlanModeResultView(props: {
 }
 
 /** Inner component for tool_result messages with structuredPatch — owns local diff view state. */
-function ToolResultMessage(props: {
+export function ToolResultMessage(props: {
   toolName: string
   resultContent: string
   isPreText: boolean
@@ -1113,6 +1118,8 @@ function ToolResultMessage(props: {
   readFilePath?: string
   /** Whether the tool result is an error (from is_error field). */
   isError?: boolean
+  /** Optional status detail shown inline with the Bash-like result header. */
+  statusDetail?: string
   context?: RenderContext
 }): JSX.Element {
   const diffView = () => props.context?.diffView ?? 'unified'
@@ -1124,8 +1131,9 @@ function ToolResultMessage(props: {
   // Bash/TaskOutput/Read: collapsible via expand/collapse button in MessageBubble toolbar.
   const isRead = () => props.toolName === 'Read'
   const isBashLike = () => props.toolName === 'Bash' || props.toolName === 'TaskOutput' || props.toolName === ''
+  const normalizedResultContent = () => isBashLike() ? stripLeadingBlankLines(props.resultContent) : props.resultContent
   const expanded = () => props.context?.toolResultExpanded ?? false
-  const resultLines = () => props.resultContent.split('\n')
+  const resultLines = () => normalizedResultContent().split('\n')
   const isCollapsed = () => {
     if (!isBashLike() || expanded())
       return false
@@ -1133,20 +1141,25 @@ function ToolResultMessage(props: {
   }
   const displayContent = () => {
     if (!isCollapsed())
-      return props.resultContent
+      return normalizedResultContent()
     return resultLines().slice(0, COLLAPSED_RESULT_ROWS).join('\n')
   }
 
   const statusIcon = () => props.isError ? CircleAlert : Check
 
   return (
-    <div class={toolMessage}>
+    <div class={toolMessage} data-tool-message>
       <Show when={isBashLike() && props.isError !== undefined}>
         <div class={toolUseHeader}>
           <span class={`${inlineFlex} ${toolUseIcon}`}>
             <Icon icon={statusIcon()} size="md" />
           </span>
-          <span class={toolInputText}>{props.isError ? 'Error' : 'Success'}</span>
+          <span class={toolInputText}>
+            {props.isError ? 'Error' : 'Success'}
+            <Show when={props.statusDetail}>
+              {detail => ` (${detail()})`}
+            </Show>
+          </span>
         </div>
       </Show>
       <Show
@@ -1158,7 +1171,7 @@ function ToolResultMessage(props: {
           fallback={
             props.isPreText
               ? isBashLike()
-                ? containsAnsi(props.resultContent)
+                ? containsAnsi(normalizedResultContent())
                   /* eslint-disable-next-line solid/no-innerhtml -- HTML from renderAnsi, not user input */
                   ? <div class={`${toolResultContentAnsi}${isCollapsed() ? ` ${toolResultCollapsed}` : ''}`} innerHTML={renderAnsi(displayContent())} />
                   : <div class={`${toolResultContentPre}${isCollapsed() ? ` ${toolResultCollapsed}` : ''}`}>{displayContent()}</div>

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -42,6 +42,21 @@ export const toolResultContentPre = style({
   wordBreak: 'break-all',
 })
 
+export const commandStreamContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+})
+
+export const commandStreamInteraction = style([
+  toolResultContentPre,
+  {
+    color: 'var(--muted-foreground)',
+    paddingLeft: 'var(--space-2)',
+    borderLeft: '2px solid var(--border)',
+  },
+])
+
 // Tool result error message (subtle styling for transient, auto-recovered errors)
 export const toolResultError = style({
   color: 'var(--muted-foreground)',

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -21,13 +21,13 @@ import { Icon } from '~/components/common/Icon'
 import { showWarnToast } from '~/components/common/Toast'
 import { FileViewer } from '~/components/fileviewer/FileViewer'
 import { TerminalView } from '~/components/terminal/TerminalView'
-import { AgentStatus, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { formatFileMention, formatFileQuote } from '~/lib/quoteUtils'
 import { appendText, insertIntoMruAgentEditor } from '~/stores/editorRef.store'
 import { tabKey } from '~/stores/tab.store'
-import { isAgentWorking } from '~/utils/agentState'
+import { shouldShowThinkingIndicator } from '~/utils/agentState'
 import * as styles from './AppShell.css'
 import { TabBar } from './TabBar'
 import { Tile } from './Tile'
@@ -115,6 +115,14 @@ export function createTileRenderer(opts: TileRendererOpts) {
       return null
     return tabStore.state.tabs.find(t => tabKey(t) === key) ?? null
   }
+
+  const agentThinking = (agentId: string) => shouldShowThinkingIndicator(
+    agentStore.state.agents.find(a => a.id === agentId),
+    agentSessionStore.getInfo(agentId),
+    chatStore.getMessages(agentId),
+    chatStore.state.streamingText[agentId],
+    controlStore.getRequests(agentId).length,
+  )
 
   const createTabBarForTile = (tileId: string) => (
     <TabBar
@@ -233,7 +241,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                     messageVersion={chatStore.getMessageVersion(agentId)}
                     streamingText={chatStore.state.streamingText[agentId] ?? ''}
                     streamingType={agentSessionStore.getInfo(agentId).streamingType}
-                    agentWorking={agentStore.state.agents.find(a => a.id === agentId)?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId)) && controlStore.getRequests(agentId).length === 0}
+                    agentWorking={agentThinking(agentId)}
                     messageErrors={chatStore.state.messageErrors}
                     onRetryMessage={messageId => agentOps.handleRetryMessage(agentId, messageId)}
                     onDeleteMessage={messageId => agentOps.handleDeleteMessage(agentId, messageId)}
@@ -256,6 +264,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                         forceScrollToBottomRef.current = fn
                     }}
                     getMessageBySpanId={spanId => chatStore.getMessageBySpanId(agentId, spanId)}
+                    getCommandStreamBySpanId={spanId => chatStore.getCommandStream(agentId, spanId)}
                     onQuote={isActiveWorkspaceArchived()
                       ? undefined
                       : (text) => {
@@ -446,7 +455,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
         onInterrupt={() => agentOps.handleInterrupt(agentId())}
         settingsLoading={settingsLoading.loading()}
         agentSessionInfo={agentSessionStore.getInfo(agentId())}
-        agentWorking={agentStore.state.agents.find(a => a.id === agentId())?.status === AgentStatus.ACTIVE && isAgentWorking(chatStore.getMessages(agentId()))}
+        agentWorking={agentThinking(agentId())}
         containerHeight={props.containerHeight}
       />
     )

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -416,6 +416,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
           if (!id)
             return
           forceScrollToBottomRef.current?.()
+          const sendAgent = agentStore.state.agents.find(a => a.id === id)
 
           // Create an optimistic local message so it appears immediately in the chat.
           const localId = `local-${crypto.randomUUID()}`
@@ -429,15 +430,14 @@ export function createTileRenderer(opts: TileRendererOpts) {
             createdAt: new Date().toISOString(),
             deliveryError: '',
             updatedAt: '',
+            agentProvider: sendAgent?.agentProvider,
           }
           chatStore.addMessage(id, localMsg)
 
           try {
-            const sendAgent = agentStore.state.agents.find(a => a.id === id)
             await workerRpc.sendAgentMessage(sendAgent?.workerId ?? '', { agentId: id, content })
-            // Success: remove the optimistic message. The real message
-            // will arrive via the WatchEvents stream from the Worker.
-            chatStore.removeMessage(id, localId)
+            // Keep the optimistic message until the persisted message arrives.
+            // chatStore.addMessage() reconciles the matching server echo in place.
           }
           catch {
             chatStore.setMessageError(localId, 'Failed to deliver')

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -157,6 +157,22 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         chatStore.addMessage(agentId, msg)
         chatStore.clearStreamingText(agentId)
 
+        if (msg.spanId && (msg.spanType === 'commandExecution' || msg.spanType === 'fileChange' || msg.spanType === 'reasoning') && msg.role === MessageRole.ASSISTANT) {
+          try {
+            const parsed = parseMessageContent(msg)
+            const item = parsed.parentObject?.item as Record<string, unknown> | undefined
+            const isCompletedReasoning = item?.type === 'reasoning'
+              && (((item.summary as unknown[] | undefined)?.length ?? 0) > 0 || ((item.content as unknown[] | undefined)?.length ?? 0) > 0)
+            if ((item?.type === 'commandExecution' || item?.type === 'fileChange') && item.status === 'completed') {
+              chatStore.clearCommandStream(agentId, msg.spanId)
+            }
+            else if (isCompletedReasoning) {
+              chatStore.clearCommandStream(agentId, msg.spanId)
+            }
+          }
+          catch { /* ignore parse errors */ }
+        }
+
         // Extract context usage from assistant messages (rehydrates on reconnect).
         if (msg.role === MessageRole.ASSISTANT) {
           try {
@@ -195,11 +211,24 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       }
       case 'streamChunk': {
         const text = new TextDecoder().decode(inner.value.delta)
-        chatStore.setStreamingText(agentId, (chatStore.state.streamingText[agentId] ?? '') + text)
+        if (inner.value.spanId) {
+          chatStore.appendCommandStream(
+            agentId,
+            inner.value.spanId,
+            inner.value.method,
+            text,
+          )
+        }
+        else {
+          chatStore.setStreamingText(agentId, (chatStore.state.streamingText[agentId] ?? '') + text)
+        }
         break
       }
       case 'streamEnd':
-        chatStore.clearStreamingText(agentId)
+        if (inner.value.spanId)
+          chatStore.clearCommandStream(agentId, inner.value.spanId)
+        else
+          chatStore.clearStreamingText(agentId)
         if (tabStore.state.activeTabKey !== `agent:${agentId}`) {
           tabStore.setNotification(TabType.AGENT, agentId, true)
         }
@@ -586,6 +615,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     }
     for (const a of agentStore.state.agents) {
       chatStore.clearStreamingText(a.id)
+      const streams = chatStore.state.commandStreamsByAgent[a.id]
+      if (streams) {
+        for (const spanId of Object.keys(streams))
+          chatStore.clearCommandStream(a.id, spanId)
+      }
       controlStore.clearAgent(a.id)
       if (a.status === AgentStatus.ACTIVE) {
         agentStore.updateAgent(a.id, { status: AgentStatus.INACTIVE })

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -207,6 +207,30 @@ describe('extractTodos', () => {
     const todos = extractTodos(msg, parsed)
     expect(todos![0].status).toBe('pending')
   })
+
+  it('extracts todos from a Codex turn/plan/updated message', () => {
+    const msg = makeMsg(MessageRole.ASSISTANT, {
+      method: 'turn/plan/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: 'Need a plan',
+        plan: [
+          { step: 'Inspect messages', status: 'inProgress' },
+          { step: 'Patch renderer', status: 'pending' },
+          { step: 'Run tests', status: 'completed' },
+        ],
+      },
+    })
+    const parsed = parseMessageContent(msg)
+    const todos = extractTodos(msg, parsed)
+
+    expect(todos).toEqual([
+      { content: 'Inspect messages', status: 'in_progress', activeForm: 'Inspect messages' },
+      { content: 'Patch renderer', status: 'pending', activeForm: 'Patch renderer' },
+      { content: 'Run tests', status: 'completed', activeForm: 'Run tests' },
+    ])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -248,6 +272,23 @@ describe('findLatestTodos', () => {
 
   it('returns null for empty array', () => {
     expect(findLatestTodos([])).toBeNull()
+  })
+
+  it('finds the latest Codex turn/plan/updated scanning backward', () => {
+    const messages = [
+      makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
+      makeMsg(MessageRole.ASSISTANT, {
+        method: 'turn/plan/updated',
+        params: {
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          explanation: null,
+          plan: [{ step: 'New Codex task', status: 'inProgress' }],
+        },
+      }, { seq: 4n }),
+    ]
+    const todos = findLatestTodos(messages)
+    expect(todos).toEqual([{ content: 'New Codex task', status: 'in_progress', activeForm: 'New Codex task' }])
   })
 })
 

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -103,22 +103,48 @@ export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageCon
   if (message.role !== MessageRole.ASSISTANT)
     return null
   const parent = parsed.parentObject
-  if (!parent || parent.type !== 'assistant')
+  if (!parent)
     return null
-  const msg = parent.message as Record<string, unknown> | undefined
-  const content = msg?.content
-  if (!Array.isArray(content))
-    return null
-  const toolUse = content.find(
-    (c: Record<string, unknown>) => typeof c === 'object' && c !== null && c.type === 'tool_use' && c.name === 'TodoWrite',
-  )
-  if (!toolUse?.input?.todos || !Array.isArray(toolUse.input.todos))
-    return null
-  return toolUse.input.todos.map((t: Record<string, unknown>) => ({
-    content: String(t.content || ''),
-    status: t.status === 'in_progress' ? 'in_progress' as const : t.status === 'completed' ? 'completed' as const : 'pending' as const,
-    activeForm: String(t.activeForm || ''),
-  }))
+
+  if (parent.type === 'assistant') {
+    const msg = parent.message as Record<string, unknown> | undefined
+    const content = msg?.content
+    if (!Array.isArray(content))
+      return null
+    const toolUse = content.find(
+      (c: Record<string, unknown>) => typeof c === 'object' && c !== null && c.type === 'tool_use' && c.name === 'TodoWrite',
+    )
+    if (!toolUse?.input?.todos || !Array.isArray(toolUse.input.todos))
+      return null
+    return toolUse.input.todos.map((t: Record<string, unknown>) => ({
+      content: String(t.content || ''),
+      status: t.status === 'in_progress' ? 'in_progress' as const : t.status === 'completed' ? 'completed' as const : 'pending' as const,
+      activeForm: String(t.activeForm || ''),
+    }))
+  }
+
+  if (parent.method === 'turn/plan/updated') {
+    const params = parent.params as Record<string, unknown> | undefined
+    const plan = params?.plan
+    if (!Array.isArray(plan))
+      return null
+    const todos = plan.flatMap((entry) => {
+      if (typeof entry !== 'object' || entry === null)
+        return []
+      const step = String((entry as Record<string, unknown>).step || '')
+      if (!step)
+        return []
+      const status = (entry as Record<string, unknown>).status
+      return [{
+        content: step,
+        status: status === 'inProgress' ? 'in_progress' as const : status === 'completed' ? 'completed' as const : 'pending' as const,
+        activeForm: step,
+      }]
+    })
+    return todos.length > 0 ? todos : null
+  }
+
+  return null
 }
 
 /** Scan messages backward for the latest TodoWrite, returning todos or null. */

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -98,6 +98,23 @@ export function getInnerMessageType(parsed: ParsedMessageContent): string | unde
 // Domain-specific extractors
 // ---------------------------------------------------------------------------
 
+/** Convert a Codex plan array (from turn/plan/updated) to TodoItem[]. */
+export function codexPlanToTodos(plan: unknown[]): TodoItem[] {
+  return plan.flatMap((entry) => {
+    if (typeof entry !== 'object' || entry === null)
+      return []
+    const step = String((entry as Record<string, unknown>).step || '')
+    if (!step)
+      return []
+    const status = (entry as Record<string, unknown>).status
+    return [{
+      content: step,
+      status: status === 'inProgress' ? 'in_progress' as const : status === 'completed' ? 'completed' as const : 'pending' as const,
+      activeForm: step,
+    }]
+  })
+}
+
 /** Extract TodoWrite todos from a parsed assistant message. Returns null if not applicable. */
 export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageContent): TodoItem[] | null {
   if (message.role !== MessageRole.ASSISTANT)
@@ -128,19 +145,7 @@ export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageCon
     const plan = params?.plan
     if (!Array.isArray(plan))
       return null
-    const todos = plan.flatMap((entry) => {
-      if (typeof entry !== 'object' || entry === null)
-        return []
-      const step = String((entry as Record<string, unknown>).step || '')
-      if (!step)
-        return []
-      const status = (entry as Record<string, unknown>).status
-      return [{
-        content: step,
-        status: status === 'inProgress' ? 'in_progress' as const : status === 'completed' ? 'completed' as const : 'pending' as const,
-        activeForm: step,
-      }]
-    })
+    const todos = codexPlanToTodos(plan)
     return todos.length > 0 ? todos : null
   }
 

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -41,6 +41,21 @@ function removePersistedLocalMessage(agentId: string, messageId: string) {
   safeSetJson(LOCAL_MSG_KEY, all)
 }
 
+function extractUserMessageText(message: AgentChatMessage): string | null {
+  if (message.role !== MessageRole.USER)
+    return null
+  const parsed = parseMessageContent(message)
+  const parent = parsed.parentObject
+  if (!parent)
+    return null
+  if (typeof parent.content === 'string')
+    return parent.content
+  const msg = parent.message as Record<string, unknown> | undefined
+  if (msg && typeof msg.content === 'string')
+    return msg.content
+  return null
+}
+
 /** Reconstruct an AgentChatMessage from a persisted local message. */
 function hydrateLocalMessage(p: PersistedLocalMessage): AgentChatMessage {
   const contentJson = JSON.stringify({ content: p.contentText })
@@ -180,6 +195,22 @@ export function createChatStore() {
       }
       else {
         setState('messagesByAgent', agentId, (prev = []) => {
+          if (message.role === MessageRole.USER) {
+            const incomingText = extractUserMessageText(message)
+            if (incomingText) {
+              const localIdx = prev.findIndex(candidate =>
+                candidate.id.startsWith('local-')
+                && candidate.role === MessageRole.USER
+                && !candidate.deliveryError
+                && extractUserMessageText(candidate) === incomingText,
+              )
+              if (localIdx !== -1) {
+                removePersistedLocalMessage(agentId, prev[localIdx].id)
+                return [...prev.slice(0, localIdx), message, ...prev.slice(localIdx + 1)]
+              }
+            }
+          }
+
           // Local (optimistic) messages have seq === 0n and always go at the end.
           if (message.seq === 0n) {
             return [...prev, message]

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -66,9 +66,15 @@ export interface TodoItem {
   activeForm: string
 }
 
+export interface CommandStreamSegment {
+  kind: 'output' | 'interaction' | 'reasoning_summary' | 'reasoning_content' | 'reasoning_summary_break'
+  text: string
+}
+
 interface ChatStoreState {
   messagesByAgent: Record<string, AgentChatMessage[]>
   streamingText: Record<string, string>
+  commandStreamsByAgent: Record<string, Record<string, CommandStreamSegment[]>>
   messageErrors: Record<string, string>
   /** Latest TodoWrite todos per agent, updated incrementally as messages arrive. */
   todosByAgent: Record<string, TodoItem[]>
@@ -89,6 +95,7 @@ export function createChatStore() {
   const [state, setState] = createStore<ChatStoreState>({
     messagesByAgent: {},
     streamingText: {},
+    commandStreamsByAgent: {},
     messageErrors: {},
     todosByAgent: {},
     loading: false,
@@ -288,6 +295,47 @@ export function createChatStore() {
 
     clearStreamingText(agentId: string) {
       setState('streamingText', agentId, '')
+    },
+
+    appendCommandStream(agentId: string, spanId: string, method: string, text: string) {
+      if (!spanId)
+        return
+      const segmentKind: CommandStreamSegment['kind']
+        = method === 'item/commandExecution/terminalInteraction'
+          ? 'interaction'
+          : method === 'item/reasoning/summaryTextDelta'
+            ? 'reasoning_summary'
+            : method === 'item/reasoning/textDelta'
+              ? 'reasoning_content'
+              : method === 'item/reasoning/summaryPartAdded'
+                ? 'reasoning_summary_break'
+                : 'output'
+      if (!text && segmentKind !== 'reasoning_summary_break')
+        return
+      setState('commandStreamsByAgent', agentId, spanId, (prev = []) => {
+        const last = prev.at(-1)
+        if (segmentKind !== 'reasoning_summary_break' && last && last.kind === segmentKind) {
+          return [
+            ...prev.slice(0, -1),
+            { kind: segmentKind, text: last.text + text },
+          ]
+        }
+        return [...prev, { kind: segmentKind, text }]
+      })
+      setState('messageVersion', agentId, (prev = 0) => prev + 1)
+    },
+
+    getCommandStream(agentId: string, spanId: string): CommandStreamSegment[] {
+      if (!spanId)
+        return []
+      return state.commandStreamsByAgent[agentId]?.[spanId] ?? []
+    },
+
+    clearCommandStream(agentId: string, spanId: string) {
+      if (!spanId)
+        return
+      setState('commandStreamsByAgent', agentId, spanId, undefined!)
+      setState('messageVersion', agentId, (prev = 0) => prev + 1)
     },
 
     getTodos(agentId: string): TodoItem[] {

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -201,21 +201,31 @@ export function createChatStore() {
         setState('messagesByAgent', agentId, existingIdx, message)
       }
       else {
+        // Reconcile optimistic local user messages before updating the store,
+        // so the localStorage side-effect stays outside the setState updater.
+        let reconciledLocalId: string | undefined
+        if (message.role === MessageRole.USER) {
+          const incomingText = extractUserMessageText(message)
+          if (incomingText) {
+            const current = state.messagesByAgent[agentId] ?? []
+            const local = current.find(candidate =>
+              candidate.id.startsWith('local-')
+              && candidate.role === MessageRole.USER
+              && !candidate.deliveryError
+              && extractUserMessageText(candidate) === incomingText,
+            )
+            if (local)
+              reconciledLocalId = local.id
+          }
+        }
+        if (reconciledLocalId)
+          removePersistedLocalMessage(agentId, reconciledLocalId)
+
         setState('messagesByAgent', agentId, (prev = []) => {
-          if (message.role === MessageRole.USER) {
-            const incomingText = extractUserMessageText(message)
-            if (incomingText) {
-              const localIdx = prev.findIndex(candidate =>
-                candidate.id.startsWith('local-')
-                && candidate.role === MessageRole.USER
-                && !candidate.deliveryError
-                && extractUserMessageText(candidate) === incomingText,
-              )
-              if (localIdx !== -1) {
-                removePersistedLocalMessage(agentId, prev[localIdx].id)
-                return [...prev.slice(0, localIdx), message, ...prev.slice(localIdx + 1)]
-              }
-            }
+          if (reconciledLocalId) {
+            const localIdx = prev.findIndex(m => m.id === reconciledLocalId)
+            if (localIdx !== -1)
+              return [...prev.slice(0, localIdx), message, ...prev.slice(localIdx + 1)]
           }
 
           // Local (optimistic) messages have seq === 0n and always go at the end.

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -86,6 +86,13 @@ export interface CommandStreamSegment {
   text: string
 }
 
+const METHOD_TO_SEGMENT_KIND: Record<string, CommandStreamSegment['kind']> = {
+  'item/commandExecution/terminalInteraction': 'interaction',
+  'item/reasoning/summaryTextDelta': 'reasoning_summary',
+  'item/reasoning/textDelta': 'reasoning_content',
+  'item/reasoning/summaryPartAdded': 'reasoning_summary_break',
+}
+
 interface ChatStoreState {
   messagesByAgent: Record<string, AgentChatMessage[]>
   streamingText: Record<string, string>
@@ -331,16 +338,7 @@ export function createChatStore() {
     appendCommandStream(agentId: string, spanId: string, method: string, text: string) {
       if (!spanId)
         return
-      const segmentKind: CommandStreamSegment['kind']
-        = method === 'item/commandExecution/terminalInteraction'
-          ? 'interaction'
-          : method === 'item/reasoning/summaryTextDelta'
-            ? 'reasoning_summary'
-            : method === 'item/reasoning/textDelta'
-              ? 'reasoning_content'
-              : method === 'item/reasoning/summaryPartAdded'
-                ? 'reasoning_summary_break'
-                : 'output'
+      const segmentKind: CommandStreamSegment['kind'] = METHOD_TO_SEGMENT_KIND[method] ?? 'output'
       if (!text && segmentKind !== 'reasoning_summary_break')
         return
       setState('commandStreamsByAgent', agentId, spanId, (prev = []) => {

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -1,5 +1,6 @@
-import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentChatMessage, AgentInfo } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentSessionInfo } from '~/stores/agentSession.store'
+import { AgentProvider, AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 
 /** RESULT-role messages with these inner types are mid-turn notifications, not turn ends. */
@@ -42,4 +43,28 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     return false // real turn-end RESULT
   }
   return false // no messages or all notifications
+}
+
+/**
+ * Whether the chat-level thinking indicator should be shown for an agent.
+ * Codex exposes an explicit turn ID for active turns; prefer that over the
+ * generic message-history heuristic so idle-but-running Codex tabs don't show
+ * as thinking on creation.
+ */
+export function shouldShowThinkingIndicator(
+  agent: AgentInfo | undefined,
+  sessionInfo: AgentSessionInfo | undefined,
+  msgs: AgentChatMessage[],
+  streamingText: string | undefined,
+  pendingControlRequests = 0,
+): boolean {
+  if (!agent || agent.status !== AgentStatus.ACTIVE)
+    return false
+  if (pendingControlRequests > 0)
+    return false
+  if (streamingText)
+    return true
+  if (agent.agentProvider === AgentProvider.CODEX)
+    return Boolean(sessionInfo?.codexTurnId)
+  return isAgentWorking(msgs)
 }

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -6,13 +6,22 @@ import { ChatView } from '~/components/chat/ChatView'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 
-// jsdom does not provide ResizeObserver
+// jsdom does not provide ResizeObserver or Worker
 beforeAll(() => {
   globalThis.ResizeObserver ??= class {
     observe() {}
     unobserve() {}
     disconnect() {}
   } as unknown as typeof ResizeObserver
+  globalThis.Worker ??= class {
+    onmessage: ((e: MessageEvent) => void) | null = null
+    onerror: ((e: ErrorEvent) => void) | null = null
+    postMessage() {}
+    terminate() {}
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() { return false }
+  } as unknown as typeof Worker
 })
 
 function makeMessage(role: string, text: string, id: string = '1'): AgentChatMessage {
@@ -344,7 +353,7 @@ describe('chatView', () => {
       </PreferencesProvider>
     ))
 
-    expect(view.container.textContent).toContain('Error (process ID: 63628 · exit code: 1)')
+    expect(view.container.textContent).toContain('Error (exit code: 1)')
   })
 
   it('renders live fileChange stream inside the matching codex fileChange bubble', () => {
@@ -421,6 +430,48 @@ describe('chatView', () => {
     expect(screen.queryByText('completed')).toBeNull()
     expect(screen.getByText('old')).toBeTruthy()
     expect(screen.getByText('new')).toBeTruthy()
+  })
+
+  it('renders a simple codex add fileChange start message like Write tool_use', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-start',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'in_progress',
+        changes: [{ path: '/repo/src/new-file.ts', kind: { type: 'add' }, diff: 'export const hello = "world"\n' }],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('new-file.ts')
+    expect(view.container.textContent).not.toContain('export const hello = "world"')
+  })
+
+  it('renders a simple codex add fileChange completion like Write tool_use_result', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-done',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'completed',
+        changes: [{ path: '/repo/src/new-file.ts', kind: { type: 'add' }, diff: 'export const hello = "world"\n' }],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('export const hello = "world"')
+    expect(screen.getByTestId('message-toolbar')).toBeTruthy()
   })
 
   it('shows shared toolbar actions for completed codex fileChange messages', () => {

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -1,9 +1,10 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { CommandStreamSegment } from '~/stores/chat.store'
 import { render, screen, waitFor } from '@solidjs/testing-library'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { ChatView } from '~/components/chat/ChatView'
 import { PreferencesProvider } from '~/context/PreferencesContext'
-import { ContentCompression } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 
 // jsdom does not provide ResizeObserver
 beforeAll(() => {
@@ -29,6 +30,101 @@ function makeMessage(role: string, text: string, id: string = '1'): AgentChatMes
     seq: 1n,
     createdAt: '',
   }
+}
+
+function makeCodexCommandMessage(params: {
+  id: string
+  seq: bigint
+  spanId: string
+  status: string
+  command?: string
+  aggregatedOutput?: string
+}): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage',
+    id: params.id,
+    role: MessageRole.ASSISTANT,
+    content: new TextEncoder().encode(JSON.stringify({
+      item: {
+        type: 'commandExecution',
+        id: params.spanId,
+        command: params.command ?? 'echo hi',
+        cwd: '/tmp',
+        status: params.status,
+        aggregatedOutput: params.aggregatedOutput ?? '',
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    })),
+    contentCompression: ContentCompression.NONE,
+    seq: params.seq,
+    createdAt: '',
+    agentProvider: AgentProvider.CODEX,
+    spanId: params.spanId,
+    spanType: 'commandExecution',
+  } as AgentChatMessage
+}
+
+function makeCodexFileChangeMessage(params: {
+  id: string
+  seq: bigint
+  spanId: string
+  status: string
+  diff?: string
+}): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage',
+    id: params.id,
+    role: MessageRole.ASSISTANT,
+    content: new TextEncoder().encode(JSON.stringify({
+      item: {
+        type: 'fileChange',
+        id: params.spanId,
+        status: params.status,
+        changes: params.status === 'completed'
+          ? [{ path: 'a.txt', kind: 'update', diff: params.diff ?? '@@ -1 +1 @@\n-old\n+new' }]
+          : [],
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    })),
+    contentCompression: ContentCompression.NONE,
+    seq: params.seq,
+    createdAt: '',
+    agentProvider: AgentProvider.CODEX,
+    spanId: params.spanId,
+    spanType: 'fileChange',
+  } as AgentChatMessage
+}
+
+function makeCodexReasoningMessage(params: {
+  id: string
+  seq: bigint
+  spanId: string
+  summary?: string[]
+  content?: string[]
+}): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage',
+    id: params.id,
+    role: MessageRole.ASSISTANT,
+    content: new TextEncoder().encode(JSON.stringify({
+      item: {
+        type: 'reasoning',
+        id: params.spanId,
+        summary: params.summary ?? [],
+        content: params.content ?? [],
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    })),
+    contentCompression: ContentCompression.NONE,
+    seq: params.seq,
+    createdAt: '',
+    agentProvider: AgentProvider.CODEX,
+    spanId: params.spanId,
+    spanType: 'reasoning',
+  } as AgentChatMessage
 }
 
 describe('chatView', () => {
@@ -72,5 +168,120 @@ describe('chatView', () => {
       </PreferencesProvider>
     ))
     expect(screen.getByTestId('chat-container')).toBeTruthy()
+  })
+
+  it('renders live command stream inside the matching codex command bubble', () => {
+    const messages = [
+      makeCodexCommandMessage({ id: 'cmd-start', seq: 1n, spanId: 'cmd-1', status: 'in_progress' }),
+    ]
+    const commandStream: CommandStreamSegment[] = [
+      { kind: 'output', text: 'building...\n' },
+      { kind: 'interaction', text: 'y\n' },
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView
+          messages={messages}
+          streamingText=""
+          getCommandStreamBySpanId={() => commandStream}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByText('building...')).toBeTruthy()
+    expect(screen.getByText('> y')).toBeTruthy()
+  })
+
+  it('hides stale codex commandExecution start message once completed message exists for the same span', () => {
+    const messages = [
+      makeCodexCommandMessage({ id: 'cmd-start', seq: 1n, spanId: 'cmd-1', status: 'in_progress' }),
+      makeCodexCommandMessage({ id: 'cmd-done', seq: 2n, spanId: 'cmd-1', status: 'completed', aggregatedOutput: 'done\n' }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getAllByText('echo hi')).toHaveLength(1)
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+  })
+
+  it('renders live fileChange stream inside the matching codex fileChange bubble', () => {
+    const messages = [
+      makeCodexFileChangeMessage({ id: 'fc-start', seq: 1n, spanId: 'fc-1', status: 'in_progress' }),
+    ]
+    const fileStream: CommandStreamSegment[] = [
+      { kind: 'output', text: 'updating a.txt\n' },
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView
+          messages={messages}
+          streamingText=""
+          getCommandStreamBySpanId={() => fileStream}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByText('updating a.txt')).toBeTruthy()
+  })
+
+  it('hides stale codex fileChange start message once completed message exists for the same span', () => {
+    const messages = [
+      makeCodexFileChangeMessage({ id: 'fc-start', seq: 1n, spanId: 'fc-1', status: 'in_progress' }),
+      makeCodexFileChangeMessage({ id: 'fc-done', seq: 2n, spanId: 'fc-1', status: 'completed' }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+  })
+
+  it('renders live reasoning stream inside the matching codex reasoning bubble', () => {
+    const messages = [
+      makeCodexReasoningMessage({ id: 'reason-start', seq: 1n, spanId: 'reason-1' }),
+    ]
+    const reasoningStream: CommandStreamSegment[] = [
+      { kind: 'reasoning_summary', text: 'first summary' },
+      { kind: 'reasoning_summary_break', text: '' },
+      { kind: 'reasoning_summary', text: 'second summary' },
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView
+          messages={messages}
+          streamingText=""
+          getCommandStreamBySpanId={() => reasoningStream}
+        />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+    expect(screen.getByText('Thinking')).toBeTruthy()
+  })
+
+  it('hides stale codex reasoning start message once completed message exists for the same span', () => {
+    const messages = [
+      makeCodexReasoningMessage({ id: 'reason-start', seq: 1n, spanId: 'reason-1' }),
+      makeCodexReasoningMessage({ id: 'reason-done', seq: 2n, spanId: 'reason-1', summary: ['done'] }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+    expect(screen.getByText('Thinking')).toBeTruthy()
   })
 })

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -1,6 +1,6 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { CommandStreamSegment } from '~/stores/chat.store'
-import { render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { ChatView } from '~/components/chat/ChatView'
 import { PreferencesProvider } from '~/context/PreferencesContext'
@@ -39,6 +39,8 @@ function makeCodexCommandMessage(params: {
   status: string
   command?: string
   aggregatedOutput?: string
+  processId?: string
+  exitCode?: number
 }): AgentChatMessage {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
@@ -50,8 +52,10 @@ function makeCodexCommandMessage(params: {
         id: params.spanId,
         command: params.command ?? 'echo hi',
         cwd: '/tmp',
+        processId: params.processId,
         status: params.status,
         aggregatedOutput: params.aggregatedOutput ?? '',
+        exitCode: params.exitCode,
       },
       threadId: 'thread-1',
       turnId: 'turn-1',
@@ -71,6 +75,7 @@ function makeCodexFileChangeMessage(params: {
   spanId: string
   status: string
   diff?: string
+  changes?: Array<Record<string, unknown>>
 }): AgentChatMessage {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
@@ -81,9 +86,9 @@ function makeCodexFileChangeMessage(params: {
         type: 'fileChange',
         id: params.spanId,
         status: params.status,
-        changes: params.status === 'completed'
+        changes: params.changes ?? (params.status === 'completed'
           ? [{ path: 'a.txt', kind: 'update', diff: params.diff ?? '@@ -1 +1 @@\n-old\n+new' }]
-          : [],
+          : []),
       },
       threadId: 'thread-1',
       turnId: 'turn-1',
@@ -124,6 +129,64 @@ function makeCodexReasoningMessage(params: {
     agentProvider: AgentProvider.CODEX,
     spanId: params.spanId,
     spanType: 'reasoning',
+  } as AgentChatMessage
+}
+
+function makeCodexTurnPlanMessage(params: {
+  id: string
+  seq: bigint
+  explanation?: string | null
+  plan: Array<{ step: string, status: string }>
+}): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage',
+    id: params.id,
+    role: MessageRole.ASSISTANT,
+    content: new TextEncoder().encode(JSON.stringify({
+      method: 'turn/plan/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: params.explanation ?? null,
+        plan: params.plan,
+      },
+    })),
+    contentCompression: ContentCompression.NONE,
+    seq: params.seq,
+    createdAt: '',
+    agentProvider: AgentProvider.CODEX,
+  } as AgentChatMessage
+}
+
+function makeCodexWebSearchMessage(params: {
+  id: string
+  seq: bigint
+  spanId: string
+  query?: string
+  action?: Record<string, unknown>
+  completed?: boolean
+}): AgentChatMessage {
+  return {
+    $typeName: 'leapmux.v1.AgentChatMessage',
+    id: params.id,
+    role: MessageRole.ASSISTANT,
+    content: new TextEncoder().encode(JSON.stringify({
+      item: {
+        type: 'webSearch',
+        id: params.spanId,
+        query: params.query ?? '',
+        action: params.action ?? { type: 'other' },
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    })),
+    contentCompression: ContentCompression.NONE,
+    seq: params.seq,
+    createdAt: '',
+    agentProvider: AgentProvider.CODEX,
+    spanId: params.spanId,
+    spanType: 'webSearch',
+    spanLines: params.completed ? JSON.stringify([{ span_id: params.spanId, color: 1, type: 'connector_end' }]) : '[]',
   } as AgentChatMessage
 }
 
@@ -193,20 +256,95 @@ describe('chatView', () => {
     expect(screen.getByText('> y')).toBeTruthy()
   })
 
-  it('hides stale codex commandExecution start message once completed message exists for the same span', () => {
+  it('keeps both codex commandExecution start and completed messages in history', () => {
     const messages = [
       makeCodexCommandMessage({ id: 'cmd-start', seq: 1n, spanId: 'cmd-1', status: 'in_progress' }),
       makeCodexCommandMessage({ id: 'cmd-done', seq: 2n, spanId: 'cmd-1', status: 'completed', aggregatedOutput: 'done\n' }),
     ]
 
-    render(() => (
+    const view = render(() => (
       <PreferencesProvider>
         <ChatView messages={messages} streamingText="" />
       </PreferencesProvider>
     ))
 
-    expect(screen.getAllByText('echo hi')).toHaveLength(1)
-    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(2)
+    expect(screen.getByText('done')).toBeTruthy()
+    expect(view.container.textContent).toContain('echo hi')
+  })
+
+  it('renders long completed codex command output with the shared collapsed result UI', () => {
+    const messages = [
+      makeCodexCommandMessage({
+        id: 'cmd-done',
+        seq: 1n,
+        spanId: 'cmd-1',
+        status: 'completed',
+        aggregatedOutput: 'line1\nline2\nline3\nline4\n',
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByTestId('message-toolbar')).toBeTruthy()
+    expect(view.container.textContent).toContain('line1')
+    expect(view.container.textContent).toContain('line3')
+    expect(screen.queryByText('line4')).toBeNull()
+  })
+
+  it('strips tool use header DOM from completed codex command output', () => {
+    const messages = [
+      makeCodexCommandMessage({
+        id: 'cmd-done',
+        seq: 1n,
+        spanId: 'cmd-1',
+        status: 'failed',
+        aggregatedOutput: [
+          'TestingLibraryElementError',
+          '  <div',
+          '    class="toolStyles_toolUseHeader__174i4tc1"',
+          '  >',
+          '    <span>0 files</span>',
+          '  </div>',
+          'real failure output',
+        ].join('\n'),
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('real failure output')
+    expect(screen.queryByText('0 files')).toBeNull()
+  })
+
+  it('renders process ID and exit code in completed codex command failures without output', () => {
+    const messages = [
+      makeCodexCommandMessage({
+        id: 'cmd-failed',
+        seq: 1n,
+        spanId: 'cmd-1',
+        status: 'failed',
+        aggregatedOutput: '',
+        processId: '63628',
+        exitCode: 1,
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('Error (process ID: 63628 · exit code: 1)')
   })
 
   it('renders live fileChange stream inside the matching codex fileChange bubble', () => {
@@ -230,7 +368,7 @@ describe('chatView', () => {
     expect(screen.getByText('updating a.txt')).toBeTruthy()
   })
 
-  it('hides stale codex fileChange start message once completed message exists for the same span', () => {
+  it('keeps both codex fileChange start and completed messages in history', () => {
     const messages = [
       makeCodexFileChangeMessage({ id: 'fc-start', seq: 1n, spanId: 'fc-1', status: 'in_progress' }),
       makeCodexFileChangeMessage({ id: 'fc-done', seq: 2n, spanId: 'fc-1', status: 'completed' }),
@@ -242,7 +380,89 @@ describe('chatView', () => {
       </PreferencesProvider>
     ))
 
-    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(2)
+    expect(screen.getByText('0 files')).toBeTruthy()
+    expect(screen.getByText('old')).toBeTruthy()
+  })
+
+  it('does not render a diff in the codex fileChange start message', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-start',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'in_progress',
+        changes: [{ path: 'a.txt', kind: 'update', diff: '@@ -1 +1 @@\n-old\n+new' }],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('a.txt')
+    expect(view.container.textContent).not.toContain('old')
+    expect(view.container.textContent).not.toContain('new')
+  })
+
+  it('renders a simple codex fileChange with Edit-style diff content', () => {
+    const messages = [
+      makeCodexFileChangeMessage({ id: 'fc-done', seq: 1n, spanId: 'fc-1', status: 'completed' }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.queryByText('completed')).toBeNull()
+    expect(screen.getByText('old')).toBeTruthy()
+    expect(screen.getByText('new')).toBeTruthy()
+  })
+
+  it('shows shared toolbar actions for completed codex fileChange messages', () => {
+    const messages = [
+      makeCodexFileChangeMessage({ id: 'fc-done', seq: 1n, spanId: 'fc-1', status: 'completed' }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    const toolbar = screen.getByTestId('message-toolbar')
+    expect(toolbar).toBeTruthy()
+    expect(screen.getByTestId('message-copy-json')).toBeTruthy()
+    expect(view.container.querySelectorAll('[data-testid="message-toolbar"] button').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('falls back to codex fileChange summary for mixed changes', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-done',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'completed',
+        changes: [
+          { path: 'a.txt', kind: 'create', diff: '' },
+          { path: 'b.txt', kind: 'delete', diff: '' },
+        ],
+      }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByText('2 files changed')).toBeTruthy()
+    expect(screen.queryByText(/a\.txt/)).toBeNull()
+    expect(screen.queryByText(/b\.txt/)).toBeNull()
   })
 
   it('renders live reasoning stream inside the matching codex reasoning bubble', () => {
@@ -269,7 +489,7 @@ describe('chatView', () => {
     expect(screen.getByText('Thinking')).toBeTruthy()
   })
 
-  it('hides stale codex reasoning start message once completed message exists for the same span', () => {
+  it('keeps completed codex reasoning visible while empty start reasoning remains hidden', () => {
     const messages = [
       makeCodexReasoningMessage({ id: 'reason-start', seq: 1n, spanId: 'reason-1' }),
       makeCodexReasoningMessage({ id: 'reason-done', seq: 2n, spanId: 'reason-1', summary: ['done'] }),
@@ -283,5 +503,167 @@ describe('chatView', () => {
 
     expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
     expect(screen.getByText('Thinking')).toBeTruthy()
+  })
+
+  it('renders turn/plan/updated with the TodoWrite-style todo list UI', () => {
+    const messages = [
+      makeCodexTurnPlanMessage({
+        id: 'plan-1',
+        seq: 1n,
+        plan: [
+          { step: 'Inspect message filtering', status: 'inProgress' },
+          { step: 'Implement renderer', status: 'pending' },
+          { step: 'Run tests', status: 'completed' },
+        ],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('3 tasks')
+    expect(view.container.textContent).toContain('Inspect message filtering')
+    expect(view.container.textContent).toContain('Implement renderer')
+    expect(view.container.textContent).toContain('Run tests')
+  })
+
+  it('renders turn/plan/updated explanation in the title when present', () => {
+    const messages = [
+      makeCodexTurnPlanMessage({
+        id: 'plan-1',
+        seq: 1n,
+        explanation: 'Need to keep start and complete messages visible',
+        plan: [
+          { step: 'Inspect message filtering', status: 'inProgress' },
+          { step: 'Implement renderer', status: 'pending' },
+        ],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('2 tasks - Need to keep start and complete messages visible')
+  })
+
+  it('renders codex webSearch start and completed search messages separately', () => {
+    const messages = [
+      makeCodexWebSearchMessage({ id: 'ws-start', seq: 1n, spanId: 'ws-1' }),
+      makeCodexWebSearchMessage({
+        id: 'ws-done',
+        seq: 2n,
+        spanId: 'ws-1',
+        query: 'codex app server',
+        action: {
+          type: 'search',
+          query: 'codex app server',
+          queries: [
+            'codex app server',
+            'site:github.com openai codex "turn/plan/updated"',
+            'site:github.com "turn/plan/updated" codex app server',
+          ],
+        },
+        completed: true,
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getAllByTestId('message-bubble')).toHaveLength(1)
+    expect(view.container.textContent).not.toContain('Searching the web')
+    expect(view.container.textContent).toContain('codex app server')
+    expect(view.container.textContent).not.toContain('site:github.com openai codex')
+    expect(view.container.textContent).not.toContain('site:github.com "turn/plan/updated" codex app server')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }))
+
+    expect(view.container.textContent).toContain('site:github.com openai codex "turn/plan/updated"')
+    expect(view.container.textContent).toContain('site:github.com "turn/plan/updated" codex app server')
+  })
+
+  it('renders codex webSearch openPage messages like a fetch/opened-page result', () => {
+    const messages = [
+      makeCodexWebSearchMessage({
+        id: 'ws-open',
+        seq: 1n,
+        spanId: 'ws-1',
+        query: 'https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md',
+        action: {
+          type: 'openPage',
+          url: 'https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md',
+        },
+        completed: true,
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md')
+    expect(screen.getByTestId('message-toolbar')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Expand' })).toBeNull()
+  })
+
+  it('renders codex webSearch findInPage messages with pattern and URL', () => {
+    const messages = [
+      makeCodexWebSearchMessage({
+        id: 'ws-find',
+        seq: 1n,
+        spanId: 'ws-1',
+        query: 'README',
+        action: {
+          type: 'findInPage',
+          url: 'https://example.com/readme',
+          pattern: 'turn/plan/updated',
+        },
+        completed: true,
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container.textContent).toContain('turn/plan/updated')
+    expect(view.container.textContent).toContain('https://example.com/readme')
+    expect(screen.getByTestId('message-toolbar')).toBeTruthy()
+  })
+
+  it('hides empty completed codex webSearch messages with no query or detail', () => {
+    const messages = [
+      makeCodexWebSearchMessage({
+        id: 'ws-empty',
+        seq: 1n,
+        spanId: 'ws-1',
+        query: '',
+        action: { type: 'other' },
+        completed: true,
+      }),
+    ]
+
+    render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.queryByText('Searched')).toBeNull()
+    expect(screen.queryByText('Searching the web')).toBeNull()
+    expect(screen.queryByTestId('message-bubble')).toBeNull()
   })
 })

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -6,6 +6,9 @@ import { ChatView } from '~/components/chat/ChatView'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 
+const A_TXT_RE = /a\.txt/
+const B_TXT_RE = /b\.txt/
+
 // jsdom does not provide ResizeObserver or Worker
 beforeAll(() => {
   globalThis.ResizeObserver ??= class {
@@ -512,8 +515,8 @@ describe('chatView', () => {
     ))
 
     expect(screen.getByText('2 files changed')).toBeTruthy()
-    expect(screen.queryByText(/a\.txt/)).toBeNull()
-    expect(screen.queryByText(/b\.txt/)).toBeNull()
+    expect(screen.queryByText(A_TXT_RE)).toBeNull()
+    expect(screen.queryByText(B_TXT_RE)).toBeNull()
   })
 
   it('renders live reasoning stream inside the matching codex reasoning bubble', () => {

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -1,7 +1,7 @@
 import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentChatMessageSchema, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { createChatStore } from '~/stores/chat.store'
 
 // Mock workerRpc for loadInitialMessages / loadOlderMessages / loadNewerMessages
@@ -17,6 +17,18 @@ function makeMessage(id: string, seq: bigint, deliveryError = '') {
     content: new TextEncoder().encode(`{"content":"test"}`),
     seq,
     deliveryError,
+  })
+}
+
+function makeUserMessage(id: string, seq: bigint, content: string, deliveryError = '', agentProvider?: AgentProvider) {
+  return create(AgentChatMessageSchema, {
+    id,
+    role: MessageRole.USER,
+    content: new TextEncoder().encode(JSON.stringify({ content })),
+    contentCompression: ContentCompression.NONE,
+    seq,
+    deliveryError,
+    agentProvider,
   })
 }
 
@@ -147,6 +159,21 @@ describe('createChatStore', () => {
       store.removeMessage('agent1', 'msg1')
       expect(store.getMessages('agent1')).toHaveLength(0)
       expect(store.state.messageErrors.msg1).toBeUndefined()
+      dispose()
+    })
+  })
+
+  it('should replace a matching optimistic local user message with the persisted server message', () => {
+    createRoot((dispose) => {
+      const store = createChatStore()
+      store.addMessage('agent1', makeUserMessage('local-1', 0n, 'hello', '', AgentProvider.CODEX))
+      store.addMessage('agent1', makeUserMessage('server-1', 5n, 'hello', '', AgentProvider.CODEX))
+
+      const msgs = store.getMessages('agent1')
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].id).toBe('server-1')
+      expect(msgs[0].seq).toBe(5n)
+      expect(msgs[0].agentProvider).toBe(AgentProvider.CODEX)
       dispose()
     })
   })

--- a/frontend/tests/unit/utils/agentState.test.ts
+++ b/frontend/tests/unit/utils/agentState.test.ts
@@ -1,10 +1,38 @@
+import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentSessionInfo } from '~/stores/agentSession.store'
 import { describe, expect, it } from 'vitest'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
-import { isAgentWorking } from '~/utils/agentState'
+import { AgentProvider, AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { isAgentWorking, shouldShowThinkingIndicator } from '~/utils/agentState'
 import { makeMessage, rawContent, wrapContent } from '../helpers/messageFactory'
 
 function makeMsg(role: MessageRole, content?: Uint8Array, deliveryError?: string) {
   return makeMessage({ role, content, deliveryError })
+}
+
+function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    $typeName: 'leapmux.v1.AgentInfo' as const,
+    id: 'agent-1',
+    workspaceId: 'ws-1',
+    title: 'Agent 1',
+    model: '',
+    status: AgentStatus.ACTIVE,
+    workingDir: '/tmp',
+    permissionMode: '',
+    effort: '',
+    agentSessionId: '',
+    homeDir: '/tmp',
+    workerId: 'worker-1',
+    createdAt: '2025-01-15T10:00:00.000Z',
+    gitStatus: undefined,
+    agentProvider: AgentProvider.CLAUDE_CODE,
+    availableModels: [],
+    availableOptionGroups: [],
+    codexSandboxPolicy: '',
+    codexNetworkAccess: '',
+    codexCollaborationMode: '',
+    ...overrides,
+  } as AgentInfo
 }
 
 describe('isAgentWorking', () => {
@@ -160,5 +188,64 @@ describe('isAgentWorking', () => {
       makeMsg(MessageRole.ASSISTANT),
       makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }, { type: 'settings_changed' }])),
     ])).toBe(false)
+  })
+})
+
+describe('shouldShowThinkingIndicator', () => {
+  it('returns false for an inactive agent', () => {
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ status: AgentStatus.INACTIVE }),
+      {},
+      [makeMsg(MessageRole.USER)],
+      '',
+    )).toBe(false)
+  })
+
+  it('returns false when a control request is pending', () => {
+    expect(shouldShowThinkingIndicator(
+      makeAgent(),
+      {},
+      [makeMsg(MessageRole.USER)],
+      '',
+      1,
+    )).toBe(false)
+  })
+
+  it('returns true when streaming text is present', () => {
+    expect(shouldShowThinkingIndicator(
+      makeAgent(),
+      {},
+      [],
+      'streaming...',
+    )).toBe(true)
+  })
+
+  it('uses codexTurnId for Codex instead of chat-history heuristics', () => {
+    const sessionInfo: AgentSessionInfo = {}
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ agentProvider: AgentProvider.CODEX }),
+      sessionInfo,
+      [makeMsg(MessageRole.ASSISTANT)],
+      '',
+    )).toBe(false)
+  })
+
+  it('shows thinking for Codex when codexTurnId is set', () => {
+    const sessionInfo: AgentSessionInfo = { codexTurnId: 'turn-123' }
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ agentProvider: AgentProvider.CODEX }),
+      sessionInfo,
+      [],
+      '',
+    )).toBe(true)
+  })
+
+  it('falls back to chat-history heuristics for non-Codex agents', () => {
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ agentProvider: AgentProvider.CLAUDE_CODE }),
+      {},
+      [makeMsg(MessageRole.USER)],
+      '',
+    )).toBe(true)
   })
 })

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -173,16 +173,18 @@ message AgentChatMessage {
   string span_lines = 14; // JSON array of active span lines at this message's position
 }
 
-// AgentStreamChunk provides token-by-token streaming.
 message AgentStreamChunk {
   string message_id = 1;
   bytes delta = 2; // Verbatim NDJSON line (stream_event from Claude Code)
   AgentProvider agent_provider = 3; // Provider that produced this chunk
+  string span_id = 4; // Optional target tool/item span for inline streaming
+  string method = 5; // Original provider notification method for classifying the stream
 }
 
 // AgentStreamEnd signals that streaming for a message is complete.
 message AgentStreamEnd {
   string message_id = 1;
+  string span_id = 2; // Optional target tool/item span for inline streaming
 }
 
 // AgentStatusChange notifies of agent status transitions.


### PR DESCRIPTION
## Motivation

Codex agent interactions were missing real-time visibility into what the
agent was doing. Command execution output, file changes, and reasoning
summaries streamed from the Codex app-server were discarded rather than
forwarded to connected clients. Additionally, when Codex agents answered
user input prompts or sent feedback messages (tool approval/rejection),
those responses were never written to the message history, leaving gaps
in the dialogue record. The frontend also lacked renderers for several
Codex-native message types (turn plans, web search operations, live
terminal output), and the "thinking" indicator could appear falsely on
idle Codex tabs when other heuristics misfired.

## Modifications

**Backend – Agent Layer**

- Extended `BroadcastStreamChunk` to accept `spanID` and `method`
  parameters so the frontend can associate streamed content with the
  correct item span and original Codex method.
- Added `BroadcastStreamEnd(spanID string)` to `OutputSink` to signal
  when a command execution, file change, or reasoning item finishes
  streaming; all callers updated including `claude_output.go`.
- Implemented handlers for `item/reasoning/summaryTextDelta`,
  `item/reasoning/textDelta`, `item/commandExecution/outputDelta`,
  `item/commandExecution/terminalInteraction`, and
  `item/fileChange/outputDelta`, forwarding each to the appropriate span
  stream.
- Added context compaction event handling: `item/started` for
  `contextCompaction` emits a `compacting` notification; `thread/compacted`
  emits a `compact_boundary` system notification to mark the boundary in
  the message timeline.
- (Breaking change) `BroadcastStreamChunk` signature changed from one
  parameter (content) to three (content, spanID, method).

**Backend – Service Layer**

- Added `codex_control.go` with parsers that extract human-readable text
  from `requestUserInput` answers and tool approval/rejection feedback
  messages.
- When a Codex control response arrives, the extracted text is now
  persisted as a user-role message, creating a complete dialogue record
  alongside the agent's messages.
- Updated `AgentStreamChunk` and `AgentStreamEnd` protobuf messages with
  `span_id` and `method` fields to carry streaming metadata to the
  frontend.

**Frontend – Chat Components**

- Added `codexTurnPlanRenderer` and `codexWebSearchRenderer` for
  first-class display of plan and web search message types.
- Implemented native rendering for Codex terminal command output and file
  change results with diff display, collapsible sections, and formatting
  that treats them as tool results.
- Surfaced reasoning messages that have associated live command streams,
  even when they would otherwise be hidden, to expose agent thinking
  alongside execution data.
- Hidden empty/completed web search operations that produce no meaningful
  results to reduce UI clutter.

**Frontend – Infrastructure**

- Added `CommandStreamSegment` interface and `commandStreamsByAgent` state
  in `chat.store.ts` to track streamed output per message span ID.
- Introduced `shouldShowThinkingIndicator()` that uses `codexTurnId` for
  Codex agents instead of message-history heuristics, preventing false
  "thinking" indicators on idle Codex tabs.
- Extended `extractTodos()` to recognise `turn/plan/updated` messages
  from Codex agents, converting plan steps into `TodoItem` objects.
- Optimistic user messages sent before server confirmation are now
  reconciled by content comparison with persisted server messages,
  replacing local placeholders instead of duplicating them.
- Command streams are cleared when their corresponding item completes,
  preventing stale output from persisting across turns.

## Result

Codex command execution, file changes, and reasoning now stream in real
time inside the chat view, providing live feedback on what the agent is
doing. User responses to Codex prompts and approval flows are recorded
in the conversation history so the full dialogue is preserved. Turn plans
and web search operations are rendered as dedicated UI elements rather
than raw JSON. The "thinking" spinner no longer appears on idle Codex
tabs, and optimistic user messages no longer duplicate when the server
confirms them.

🤖 Generated with Claude Code
