### PR TITLE
Fix WebSocket read limit and add hidden messages toggle

### DIFF
--- a/backend/internal/hub/channelmgr/chunker.go
+++ b/backend/internal/hub/channelmgr/chunker.go
@@ -19,6 +19,11 @@ const (
 	// maxChunkCiphertext is the maximum ciphertext size for a single Noise
 	// transport message (65535 bytes = 65519 plaintext + 16 auth tag).
 	maxChunkCiphertext = 65535
+
+	// WSReadLimit is the WebSocket per-message read limit. It must exceed
+	// maxChunkCiphertext to accommodate the 4-byte length prefix and
+	// protobuf framing of a ChannelMessage.
+	WSReadLimit = maxChunkCiphertext + 4096
 )
 
 // chunkSequence tracks cumulative size for one in-flight chunked message.

--- a/backend/internal/hub/service/ws_channel_relay.go
+++ b/backend/internal/hub/service/ws_channel_relay.go
@@ -77,6 +77,8 @@ func (h *ChannelRelayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	wsConn.SetReadLimit(channelmgr.WSReadLimit)
+
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/channelmgr"
+)
+
+// TestWSReadLimit_AcceptsLargeChunk verifies that a WebSocket connection with
+// SetReadLimit(WSReadLimit) accepts messages up to the maximum chunk size
+// (maxChunkCiphertext + framing overhead), which would fail with the library's
+// default 32KB limit.
+func TestWSReadLimit_AcceptsLargeChunk(t *testing.T) {
+	// Build a ChannelMessage whose wire format (4-byte length prefix +
+	// protobuf) exceeds the default 32KB WebSocket read limit.
+	// Use 64KB of ciphertext — the maximum single Noise transport message.
+	ciphertext := []byte(strings.Repeat("X", 65535))
+	msg := &leapmuxv1.ChannelMessage{
+		ChannelId:     "test-channel",
+		CorrelationId: 1,
+		Ciphertext:    ciphertext,
+	}
+
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+
+	frame := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(data)))
+	copy(frame[4:], data)
+
+	// Sanity: the frame must exceed the default 32KB read limit.
+	require.Greater(t, len(frame), 32768, "test frame must exceed default WS read limit")
+
+	// Start a test server that reads one message using the relay's read limit.
+	received := make(chan *leapmuxv1.ChannelMessage, 1)
+	readErr := make(chan error, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		ws.SetReadLimit(channelmgr.WSReadLimit)
+
+		got, rerr := readChannelMessage(r.Context(), ws)
+		if rerr != nil {
+			readErr <- rerr
+			return
+		}
+		received <- got
+	}))
+	defer srv.Close()
+
+	// Connect and send the large message.
+	ctx := context.Background()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+	// Client also needs a higher write limit for large messages.
+	err = ws.Write(ctx, websocket.MessageBinary, frame)
+	require.NoError(t, err)
+
+	select {
+	case got := <-received:
+		assert.Equal(t, msg.GetChannelId(), got.GetChannelId())
+		assert.Equal(t, msg.GetCorrelationId(), got.GetCorrelationId())
+		assert.Equal(t, len(msg.GetCiphertext()), len(got.GetCiphertext()))
+	case rerr := <-readErr:
+		t.Fatalf("server read failed: %v", rerr)
+	}
+}
+
+// TestWSReadLimit_DefaultRejectsLargeChunk verifies that without SetReadLimit,
+// the default 32KB limit causes a read failure for large messages. This
+// confirms the fix is actually necessary.
+func TestWSReadLimit_DefaultRejectsLargeChunk(t *testing.T) {
+	ciphertext := []byte(strings.Repeat("X", 65535))
+	msg := &leapmuxv1.ChannelMessage{
+		ChannelId:     "test-channel",
+		CorrelationId: 1,
+		Ciphertext:    ciphertext,
+	}
+
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+
+	frame := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(data)))
+	copy(frame[4:], data)
+
+	// Server does NOT call SetReadLimit — uses library default (32KB).
+	readErr := make(chan error, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		// No SetReadLimit — default applies.
+		_, rerr := readChannelMessage(r.Context(), ws)
+		readErr <- rerr
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+	err = ws.Write(ctx, websocket.MessageBinary, frame)
+	require.NoError(t, err)
+
+	rerr := <-readErr
+	require.Error(t, rerr, "default read limit should reject large messages")
+}

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -84,7 +84,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
       return next
     })
   }
-  const getLocalDiffView = (messageId: string) => diffViewOverrides().get(messageId) ?? null
+  const getLocalDiffView = (messageId: string) => diffViewOverrides().get(messageId)
   const setLocalDiffView = (messageId: string, view: 'unified' | 'split') => {
     setDiffViewOverrides((prev) => {
       const next = new Map(prev)

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -8,6 +8,7 @@ import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show, untrack } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
+import { usePreferences } from '~/context/PreferencesContext'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { renderMarkdown } from '~/lib/renderMarkdown'
@@ -65,6 +66,8 @@ interface ChatViewProps {
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
+  const prefs = usePreferences()
+
   // Lifted expand/collapse state keyed by message ID so that it survives
   // <For> re-renders when new messages are added to the list.
   const [expandedMessages, setExpandedMessages] = createSignal<Set<string>>(new Set())
@@ -193,6 +196,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   })
 
   const visibleEntries = createMemo(() => {
+    const showHidden = prefs.showHiddenMessages()
     return props.messages.map((msg) => {
       let classified = classifyParsedMessage(msg)
       if (
@@ -205,7 +209,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         classified = { ...classified, category: { kind: 'assistant_thinking' } }
       }
       return { msg, ...classified }
-    }).filter(entry => entry.category.kind !== 'hidden')
+    }).filter(entry => showHidden || entry.category.kind !== 'hidden')
   })
 
   const scrollToBottom = () => {

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -65,6 +65,31 @@ interface ChatViewProps {
 }
 
 export const ChatView: Component<ChatViewProps> = (props) => {
+  // Lifted expand/collapse state keyed by message ID so that it survives
+  // <For> re-renders when new messages are added to the list.
+  const [expandedMessages, setExpandedMessages] = createSignal<Set<string>>(new Set())
+  const [diffViewOverrides, setDiffViewOverrides] = createSignal<Map<string, 'unified' | 'split'>>(new Map())
+
+  const isMessageExpanded = (messageId: string) => expandedMessages().has(messageId)
+  const toggleMessageExpanded = (messageId: string) => {
+    setExpandedMessages((prev) => {
+      const next = new Set(prev)
+      if (next.has(messageId))
+        next.delete(messageId)
+      else
+        next.add(messageId)
+      return next
+    })
+  }
+  const getLocalDiffView = (messageId: string) => diffViewOverrides().get(messageId) ?? null
+  const setLocalDiffView = (messageId: string, view: 'unified' | 'split') => {
+    setDiffViewOverrides((prev) => {
+      const next = new Map(prev)
+      next.set(messageId, view)
+      return next
+    })
+  }
+
   // Throttle streaming text markdown rendering to animation frames to avoid
   // running the full remark+shiki pipeline on every streaming chunk.
   const [renderedStreamHtml, setRenderedStreamHtml] = createSignal('')
@@ -362,6 +387,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                         onReply={props.onReply}
                         getMessageBySpanId={props.getMessageBySpanId}
                         commandStream={props.getCommandStreamBySpanId?.(msg.spanId)}
+                        toolResultExpanded={isMessageExpanded(msg.id)}
+                        onToggleToolResultExpanded={() => toggleMessageExpanded(msg.id)}
+                        localDiffView={getLocalDiffView(msg.id)}
+                        onSetLocalDiffView={view => setLocalDiffView(msg.id, view)}
                       />
                     )
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -150,7 +150,7 @@ interface MessageBubbleProps {
   /** Toggle the expand/collapse state for this message's tool result. */
   onToggleToolResultExpanded?: () => void
   /** Lifted per-message diff view override, managed by ChatView. */
-  localDiffView?: 'unified' | 'split' | null
+  localDiffView?: 'unified' | 'split'
   /** Set the per-message diff view override. */
   onSetLocalDiffView?: (view: 'unified' | 'split') => void
 }
@@ -160,7 +160,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   const [jsonCopied, setJsonCopied] = createSignal(false)
   const [markdownCopied, setMarkdownCopied] = createSignal(false)
   const toolResultExpanded = () => props.toolResultExpanded ?? false
-  const localDiffView = () => props.localDiffView ?? null
+  const localDiffView = () => props.localDiffView
   let contentRef: HTMLDivElement | undefined
 
   // Use pre-computed values from ChatView when available, otherwise compute on demand.

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -145,14 +145,22 @@ interface MessageBubbleProps {
   /** Look up a message by its spanId (for tool_use ↔ tool_result linking). */
   getMessageBySpanId?: (spanId: string) => AgentChatMessage | undefined
   commandStream?: CommandStreamSegment[]
+  /** Lifted expand/collapse state for tool results, managed by ChatView. */
+  toolResultExpanded?: boolean
+  /** Toggle the expand/collapse state for this message's tool result. */
+  onToggleToolResultExpanded?: () => void
+  /** Lifted per-message diff view override, managed by ChatView. */
+  localDiffView?: 'unified' | 'split' | null
+  /** Set the per-message diff view override. */
+  onSetLocalDiffView?: (view: 'unified' | 'split') => void
 }
 
 export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   const prefs = usePreferences()
   const [jsonCopied, setJsonCopied] = createSignal(false)
   const [markdownCopied, setMarkdownCopied] = createSignal(false)
-  const [toolResultExpanded, setToolResultExpanded] = createSignal(false)
-  const [localDiffView, setLocalDiffView] = createSignal<'unified' | 'split' | null>(null)
+  const toolResultExpanded = () => props.toolResultExpanded ?? false
+  const localDiffView = () => props.localDiffView ?? null
   let contentRef: HTMLDivElement | undefined
 
   // Use pre-computed values from ChatView when available, otherwise compute on demand.
@@ -425,7 +433,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   }
 
   const diffView = () => localDiffView() ?? prefs.diffView()
-  const toggleDiffView = () => setLocalDiffView(diffView() === 'unified' ? 'split' : 'unified')
+  const toggleDiffView = () => props.onSetLocalDiffView?.(diffView() === 'unified' ? 'split' : 'unified')
 
   // Build render context for message renderers.
   const renderContext = (): RenderContext => ({
@@ -543,7 +551,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
             onCopyContent={copyableResultContent() ? copyResultContent : undefined}
             contentCopied={resultCopied()}
             expanded={toolResultExpanded()}
-            onToggleExpand={isCollapsibleToolResult() ? () => setToolResultExpanded(v => !v) : undefined}
+            onToggleExpand={isCollapsibleToolResult() ? props.onToggleToolResultExpanded : undefined}
             hasDiff={hasToolResultDiff()}
             diffView={diffView()}
             onToggleDiffView={hasToolResultDiff() ? toggleDiffView : undefined}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -537,9 +537,11 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
         >
           <div ref={contentRef} data-testid="message-content">
             <ErrorBoundary fallback={renderErrorFallback('Failed to render message:')}>
-              {category().kind === 'notification_thread'
-                ? renderNotificationThread((category() as { kind: 'notification_thread', messages: unknown[] }).messages)
-                : renderMessageContent(parsed().parentObject ?? parsed().rawText, props.message.role, renderContext(), category(), props.message.agentProvider)}
+              {category().kind === 'hidden'
+                ? <pre class={chatStyles.hiddenMessageJson}>{prettifyJson(rawJson())}</pre>
+                : category().kind === 'notification_thread'
+                  ? renderNotificationThread((category() as { kind: 'notification_thread', messages: unknown[] }).messages)
+                  : renderMessageContent(parsed().parentObject ?? parsed().rawText, props.message.role, renderContext(), category(), props.message.agentProvider)}
             </ErrorBoundary>
           </div>
         </div>

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -117,6 +117,23 @@ export const resultDivider = style({
   },
 })
 
+// Hidden message rendered as raw JSON (developer mode)
+export const hiddenMessageJson = style({
+  margin: 0,
+  padding: 'var(--space-2) var(--space-3)',
+  fontSize: 'var(--text-7)',
+  fontFamily: 'var(--font-mono)',
+  fontVariantLigatures: 'none',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+  color: 'var(--muted-foreground)',
+  backgroundColor: 'var(--card)',
+  border: '1px dashed var(--border)',
+  borderRadius: 'var(--radius-small)',
+  maxHeight: '300px',
+  overflow: 'auto',
+})
+
 // Control response message (compact)
 export const controlResponseMessage = style({
   display: 'flex',

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -19,6 +19,7 @@ import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { Tooltip } from '~/components/common/Tooltip'
+import { usePreferences } from '~/context/PreferencesContext'
 import { tabKey, TabType } from '~/stores/tab.store'
 import { menuSectionHeader, monoFont } from '~/styles/shared.css'
 import * as styles from './TabBar.css'
@@ -90,6 +91,7 @@ interface TabBarProps {
 }
 
 export const TabBar: Component<TabBarProps> = (props) => {
+  const prefs = usePreferences()
   const newTerminalLabel = () => props.hasActiveTabContext ? 'New terminal at the current working directory' : 'New terminal...'
 
   const [editingTabKey, setEditingTabKey] = createSignal<string | null>(null)
@@ -276,6 +278,18 @@ export const TabBar: Component<TabBarProps> = (props) => {
           </button>
         )}
       </For>
+      <hr />
+      <li class={menuSectionHeader}>Developer</li>
+      <button
+        role="menuitem"
+        onClick={(e) => {
+          e.preventDefault()
+          prefs.setShowHiddenMessages(!prefs.showHiddenMessages())
+        }}
+      >
+        {prefs.showHiddenMessages() ? '\u2713 ' : '\u2003 '}
+        Show hidden messages
+      </button>
     </>
   )
 

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -25,6 +25,9 @@ import { menuSectionHeader, monoFont } from '~/styles/shared.css'
 import * as styles from './TabBar.css'
 import { TABBAR_ZONE_PREFIX, useTabDrag } from './TabDragContext'
 
+const MENU_CHECK = '\u2713 ' // ✓ + space
+const MENU_NOCHECK = '\u2003 ' // em-space placeholder
+
 const TabBarTooltip: Component<{ text: string, children: JSX.Element }> = tipProps => (
   <Tooltip text={tipProps.text}>
     <span class={styles.tooltipTrigger}>
@@ -287,7 +290,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           prefs.setShowHiddenMessages(!prefs.showHiddenMessages())
         }}
       >
-        {prefs.showHiddenMessages() ? '\u2713 ' : '\u2003 '}
+        {prefs.showHiddenMessages() ? MENU_CHECK : MENU_NOCHECK}
         Show hidden messages
       </button>
     </>

--- a/frontend/src/context/PreferencesContext.tsx
+++ b/frontend/src/context/PreferencesContext.tsx
@@ -39,6 +39,9 @@ interface PreferencesState {
   turnEndSound: () => TurnEndSoundPreference
   /** Resolved turn end sound volume (0-100). */
   turnEndSoundVolume: () => number
+  /** Whether hidden messages are shown in the chat view (developer feature). */
+  showHiddenMessages: () => boolean
+  setShowHiddenMessages: (value: boolean) => void
 
   // --- Browser-level overrides (localStorage) ---
   /** Raw browser-level theme override. null means "use account default". */
@@ -182,6 +185,15 @@ export const PreferencesProvider: ParentComponent = (props) => {
     writeLocalStorage('leapmux-turn-end-sound-volume', value !== null ? String(value) : null)
   }
 
+  // --- Browser-only developer preferences ---
+  const [showHiddenMessages, setShowHiddenMessages] = createSignal(
+    readLocalStorage('leapmux-show-hidden-messages') === 'true',
+  )
+  const setShowHiddenMessagesWrapped = (value: boolean) => {
+    setShowHiddenMessages(value)
+    writeLocalStorage('leapmux-show-hidden-messages', value ? 'true' : null)
+  }
+
   // --- Resolved values (browser override → account default → hardcoded) ---
   const theme = (): ThemePreference => browserTheme() ?? accountTheme()
   const terminalTheme = (): TerminalThemePreference => browserTerminalTheme() ?? accountTerminalTheme()
@@ -248,6 +260,8 @@ export const PreferencesProvider: ParentComponent = (props) => {
     <PreferencesContext.Provider value={{
       theme,
       terminalTheme,
+      showHiddenMessages,
+      setShowHiddenMessages: setShowHiddenMessagesWrapped,
       uiFontCustomEnabled,
       monoFontCustomEnabled,
       uiFonts,

--- a/frontend/src/context/PreferencesContext.tsx
+++ b/frontend/src/context/PreferencesContext.tsx
@@ -186,11 +186,11 @@ export const PreferencesProvider: ParentComponent = (props) => {
   }
 
   // --- Browser-only developer preferences ---
-  const [showHiddenMessages, setShowHiddenMessages] = createSignal(
+  const [showHiddenMessages, setShowHiddenMessagesSignal] = createSignal(
     readLocalStorage('leapmux-show-hidden-messages') === 'true',
   )
-  const setShowHiddenMessagesWrapped = (value: boolean) => {
-    setShowHiddenMessages(value)
+  const setShowHiddenMessages = (value: boolean) => {
+    setShowHiddenMessagesSignal(value)
     writeLocalStorage('leapmux-show-hidden-messages', value ? 'true' : null)
   }
 
@@ -261,7 +261,7 @@ export const PreferencesProvider: ParentComponent = (props) => {
       theme,
       terminalTheme,
       showHiddenMessages,
-      setShowHiddenMessages: setShowHiddenMessagesWrapped,
+      setShowHiddenMessages,
       uiFontCustomEnabled,
       monoFontCustomEnabled,
       uiFonts,

--- a/frontend/tests/unit/components/TabBar.test.tsx
+++ b/frontend/tests/unit/components/TabBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { TabBar } from '~/components/shell/TabBar'
+import { PreferencesProvider } from '~/context/PreferencesContext'
 import { TabType } from '~/stores/tab.store'
 
 // Mock solid-dnd to avoid DragDropProvider context requirement
@@ -84,11 +85,13 @@ describe('tabBar readOnly prop', () => {
       makeTab(TabType.FILE, 'f1', 'File 1'),
     ]
     render(() => (
-      <TabBar
-        {...defaultProps}
-        tabs={tabs}
-        readOnly={false}
-      />
+      <PreferencesProvider>
+        <TabBar
+          {...defaultProps}
+          tabs={tabs}
+          readOnly={false}
+        />
+      </PreferencesProvider>
     ))
     const closeButtons = screen.getAllByTestId('tab-close')
     expect(closeButtons).toHaveLength(3)
@@ -100,11 +103,13 @@ describe('tabBar readOnly prop', () => {
       makeTab(TabType.TERMINAL, 't1', 'Terminal 1'),
     ]
     render(() => (
-      <TabBar
-        {...defaultProps}
-        tabs={tabs}
-        readOnly={true}
-      />
+      <PreferencesProvider>
+        <TabBar
+          {...defaultProps}
+          tabs={tabs}
+          readOnly={true}
+        />
+      </PreferencesProvider>
     ))
     const closeButtons = screen.queryAllByTestId('tab-close')
     expect(closeButtons).toHaveLength(0)
@@ -115,11 +120,13 @@ describe('tabBar readOnly prop', () => {
       makeTab(TabType.FILE, 'f1', 'readme.md'),
     ]
     render(() => (
-      <TabBar
-        {...defaultProps}
-        tabs={tabs}
-        readOnly={true}
-      />
+      <PreferencesProvider>
+        <TabBar
+          {...defaultProps}
+          tabs={tabs}
+          readOnly={true}
+        />
+      </PreferencesProvider>
     ))
     const closeButtons = screen.getAllByTestId('tab-close')
     expect(closeButtons).toHaveLength(1)
@@ -132,11 +139,13 @@ describe('tabBar readOnly prop', () => {
       makeTab(TabType.FILE, 'f1', 'readme.md'),
     ]
     render(() => (
-      <TabBar
-        {...defaultProps}
-        tabs={tabs}
-        readOnly={true}
-      />
+      <PreferencesProvider>
+        <TabBar
+          {...defaultProps}
+          tabs={tabs}
+          readOnly={true}
+        />
+      </PreferencesProvider>
     ))
     // Only the file tab should have a close button
     const closeButtons = screen.getAllByTestId('tab-close')
@@ -145,12 +154,14 @@ describe('tabBar readOnly prop', () => {
 
   it('hides add-tab buttons when readOnly is true', () => {
     render(() => (
-      <TabBar
-        {...defaultProps}
-        tabs={[makeTab(TabType.AGENT, 'a1', 'Agent')]}
-        readOnly={true}
-        showAddButton={false}
-      />
+      <PreferencesProvider>
+        <TabBar
+          {...defaultProps}
+          tabs={[makeTab(TabType.AGENT, 'a1', 'Agent')]}
+          readOnly={true}
+          showAddButton={false}
+        />
+      </PreferencesProvider>
     ))
     expect(screen.queryByTestId('new-agent-button')).toBeNull()
     expect(screen.queryByTestId('new-terminal-button')).toBeNull()


### PR DESCRIPTION
## Motivation

Two separate issues are addressed in this PR:

1. The channel relay WebSocket was using the `coder/websocket` library's default 32KB read limit. A full Noise transport message can carry up to 65535 bytes of ciphertext, which — once wrapped in the 4-byte length prefix and protobuf framing — exceeds 32KB. This caused large agent messages to be silently dropped with a read error at the hub.

2. There was no way for developers to inspect hidden messages (internal plumbing messages filtered from the chat view) without modifying code.

## Modifications

- Added `WSReadLimit` constant to `channelmgr` (`maxChunkCiphertext + 4096`) as the canonical WebSocket per-message read limit for the channel relay, centralizing the value alongside the Noise size constants.
- Applied `wsConn.SetReadLimit(channelmgr.WSReadLimit)` in `ChannelRelayHandler.ServeHTTP` to allow full-size Noise transport messages through.
- Added `TestWSReadLimit_AcceptsLargeChunk` and `TestWSReadLimit_DefaultRejectsLargeChunk` to verify the fix and confirm the default 32KB limit was insufficient.
- Added `showHiddenMessages` preference (localStorage-backed, browser-only) to `PreferencesContext` with a getter and setter.
- Added a "Show hidden messages" toggle to the Developer section of the TabBar More Options menu.
- Lifted tool-result expand/collapse state and per-message diff view override from `MessageBubble` up into `ChatView`, keyed by message ID, so state survives `<For>` list re-renders when new messages arrive.
- Updated `TabBar` unit tests to wrap the component in `PreferencesProvider`, which is now required because `TabBar` reads from the preferences context.

## Result

- Large agent messages (up to the full 65535-byte Noise transport limit) are no longer dropped by the hub's WebSocket read limit.
- Developers can toggle "Show hidden messages" from the TabBar More Options menu under Developer, causing hidden internal messages (e.g. `ToolSearch` plumbing) to appear as raw JSON in the chat view for inspection.
- Expand/collapse and diff view state on tool result messages is now preserved when new messages arrive, eliminating unwanted resets during an active agent session.

🤖 Generated with Claude Code
