### PR TITLE
Add keep-awake and auto-continue on API errors

### DIFF
--- a/backend/cmd/leapmux/worker.go
+++ b/backend/cmd/leapmux/worker.go
@@ -15,6 +15,7 @@ import (
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
 	"github.com/leapmux/leapmux/internal/worker/hub"
 	"github.com/leapmux/leapmux/internal/worker/service"
+	"github.com/leapmux/leapmux/internal/worker/wakelock"
 	"github.com/leapmux/leapmux/util/version"
 )
 
@@ -121,6 +122,9 @@ func runWorker(args []string) error {
 
 	homeDir, _ := os.UserHomeDir()
 
+	wakeLockTracker := wakelock.NewActivityTracker()
+	defer wakeLockTracker.Close()
+
 	// Set up E2EE channel manager with service handlers.
 	encMode := cfg.EncryptionModeProto()
 
@@ -131,6 +135,7 @@ func runWorker(args []string) error {
 		client.TerminalManager(),
 		homeDir,
 		cfg.DataDir,
+		wakeLockTracker,
 	)
 
 	channelMgr := channel.NewManager(

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -122,6 +122,8 @@ type messageEnvelope struct {
 	ToolUseResult json.RawMessage            `json:"tool_use_result"`
 	CostUSD       *float64                   `json:"total_cost_usd"`
 	ModelUsage    map[string]json.RawMessage `json:"modelUsage"`
+	IsError       bool                       `json:"is_error"`
+	Result        string                     `json:"result"`
 
 	// contentBlocks is lazily populated from RawContent.
 	contentBlocks []contentBlock
@@ -347,8 +349,15 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		}
 	}
 
-	// Reset all span tracking at turn-end so the next turn starts clean.
 	if msgType == "result" {
+		// Auto-continue on synthetic API 5xx errors; reset on normal results.
+		if env.IsError && hasSyntheticAPI5xxPrefix(env.Result) {
+			a.sink.ScheduleAutoContinue()
+		} else {
+			a.sink.ResetAutoContinue()
+		}
+
+		// Reset all span tracking so the next turn starts clean.
 		a.sink.ResetSpans()
 	}
 }
@@ -603,6 +612,7 @@ var notificationThreadableSubtypes = map[string]bool{
 	"status":                true,
 	"compact_boundary":      true,
 	"microcompact_boundary": true,
+	"api_retry":             true,
 }
 
 func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
@@ -640,6 +650,38 @@ func extractStatusValue(content []byte) (status string, ok bool) {
 		return *msg.Status, true
 	}
 	return "", true
+}
+
+// syntheticAPIErrorPrefix is the prefix Claude Code uses for synthetic API error results.
+const syntheticAPIErrorPrefix = "API Error: "
+
+// hasSyntheticAPI5xxPrefix reports whether s starts with "API Error: 5XX"
+// where XX are two digits (i.e. exactly a 3-digit 5xx HTTP status code).
+func hasSyntheticAPI5xxPrefix(s string) bool {
+	// "API Error: 5XX ..." — prefix is 11 chars, then 5, then two digits.
+	if !strings.HasPrefix(s, syntheticAPIErrorPrefix) {
+		return false
+	}
+	rest := s[len(syntheticAPIErrorPrefix):]
+	return len(rest) >= 3 &&
+		rest[0] == '5' &&
+		rest[1] >= '0' && rest[1] <= '9' &&
+		rest[2] >= '0' && rest[2] <= '9' &&
+		(len(rest) == 3 || rest[3] < '0' || rest[3] > '9')
+}
+
+// isSyntheticAPIError checks whether a result message is a synthetic API 5xx error
+// injected by Claude Code (e.g. "API Error: 500 ..."). These trigger auto-continue.
+func isSyntheticAPIError(content []byte) bool {
+	var msg struct {
+		Type    string `json:"type"`
+		IsError bool   `json:"is_error"`
+		Result  string `json:"result"`
+	}
+	if json.Unmarshal(content, &msg) != nil || msg.Type != "result" || !msg.IsError {
+		return false
+	}
+	return hasSyntheticAPI5xxPrefix(msg.Result)
 }
 
 // isSimpleUserTextEcho returns true if the NDJSON line is a user message echo

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -359,6 +359,34 @@ func TestHandleOutput_TopLevelAssistantBroadcastsContextUsage(t *testing.T) {
 	assert.Equal(t, int64(30), usage["cacheReadInputTokens"])
 }
 
+func TestIsSyntheticAPIError(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"500 error", `{"type":"result","is_error":true,"result":"API Error: 500 Internal Server Error"}`, true},
+		{"502 error", `{"type":"result","is_error":true,"result":"API Error: 502 Bad Gateway"}`, true},
+		{"529 overloaded", `{"type":"result","is_error":true,"result":"API Error: 529 Overloaded"}`, true},
+		{"599 bare", `{"type":"result","is_error":true,"result":"API Error: 599"}`, true},
+		{"400 not matched", `{"type":"result","is_error":true,"result":"API Error: 400 Bad Request"}`, false},
+		{"single digit 5", `{"type":"result","is_error":true,"result":"API Error: 5"}`, false},
+		{"two digit 50", `{"type":"result","is_error":true,"result":"API Error: 50"}`, false},
+		{"four digit 5000", `{"type":"result","is_error":true,"result":"API Error: 5000"}`, false},
+		{"not error", `{"type":"result","is_error":false,"result":"done"}`, false},
+		{"not result type", `{"type":"assistant","is_error":true,"result":"API Error: 500"}`, false},
+		{"normal result", `{"type":"result","subtype":"success","result":"All done","duration_ms":1234}`, false},
+		{"invalid json", `{invalid`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSyntheticAPIError([]byte(tt.input))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestHandleOutput_SubagentAssistantDoesNotOverwriteContextUsage(t *testing.T) {
 	sink := &outputTestSink{}
 	agent := newTestAgent(sink)

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -38,6 +38,8 @@ type OutputSink interface {
 	StorePlanModeToolUse(toolUseID, targetMode string)
 	LoadAndDeletePlanModeToolUse(toolUseID string) (targetMode string, ok bool)
 	UpdatePlan(filePath string, content []byte, compression leapmuxv1.ContentCompression, title string)
+	ScheduleAutoContinue()
+	ResetAutoContinue()
 }
 
 // Provider is the interface that all coding agent providers must implement.

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -142,6 +142,8 @@ func (s *testSink) LoadAndDeletePlanModeToolUse(toolUseID string) (string, bool)
 }
 
 func (s *testSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string) {}
+func (s *testSink) ScheduleAutoContinue()                                           {}
+func (s *testSink) ResetAutoContinue()                                              {}
 
 // MessageCount returns the number of persisted messages.
 func (s *testSink) MessageCount() int {
@@ -287,3 +289,5 @@ func (noopSink) SoftClearNotifThread()                                          
 func (noopSink) StorePlanModeToolUse(string, string)                             {}
 func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)              { return "", false }
 func (noopSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string) {}
+func (noopSink) ScheduleAutoContinue()                                           {}
+func (noopSink) ResetAutoContinue()                                              {}

--- a/backend/internal/worker/service/agent_clear_test.go
+++ b/backend/internal/worker/service/agent_clear_test.go
@@ -72,7 +72,7 @@ func decodeAgentChatMessageContent(t *testing.T, msg *leapmuxv1.AgentChatMessage
 func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-1",
@@ -129,7 +129,7 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-codex",
@@ -161,7 +161,7 @@ func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testin
 func TestSendAgentRawMessage_ClaudeInterruptDoesNotPersistSyntheticUserMarker(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-claude",

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -20,7 +20,7 @@ import (
 func TestUpdateAgentSettings_ClearsSessionIDOnRestartFailure(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	workDir := t.TempDir()
 
@@ -171,7 +171,7 @@ func TestUpdateAgentSettings_DoesNotResumeSessionOnRestart(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Create an agent with a session ID.
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -213,7 +213,7 @@ func TestUpdateAgentSettings_DoesNotResumeSessionOnRestart(t *testing.T) {
 func TestUpdateAgentSettings_BroadcastsGenericExtraSettingChanges(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/auto_continue.go
+++ b/backend/internal/worker/service/auto_continue.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"log/slog"
+	"math/rand/v2"
+	"sync"
+	"time"
+)
+
+const (
+	autoContinueInitialDelay = 10 * time.Second
+	autoContinueMaxDelay     = 180 * time.Second
+	autoContinueMultiplier   = 2.0
+	autoContinueJitterFrac   = 0.2
+)
+
+// autoContinueState tracks exponential-backoff retry state for a single agent.
+type autoContinueState struct {
+	mu         sync.Mutex
+	timer      *time.Timer
+	generation int
+	backoff    time.Duration
+}
+
+// scheduleAutoContinue schedules a "Continue." message for the given agent
+// after an exponentially increasing delay. Each call resets the timer.
+func (h *OutputHandler) scheduleAutoContinue(agentID string) {
+	v, _ := h.autoContinue.LoadOrStore(agentID, &autoContinueState{
+		backoff: autoContinueInitialDelay,
+	})
+	st := v.(*autoContinueState)
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if st.timer != nil {
+		st.timer.Stop()
+	}
+
+	st.generation++
+	gen := st.generation
+
+	delay := st.backoff
+	if delay > autoContinueMaxDelay {
+		delay = autoContinueMaxDelay
+	}
+
+	// Apply jitter: +-20%.
+	jitter := time.Duration(float64(delay) * autoContinueJitterFrac * (2*rand.Float64() - 1))
+	delay += jitter
+
+	// Advance backoff for next invocation.
+	st.backoff = time.Duration(float64(st.backoff) * autoContinueMultiplier)
+
+	slog.Info("auto-continue scheduled",
+		"agent_id", agentID,
+		"delay", delay,
+		"generation", gen)
+
+	st.timer = time.AfterFunc(delay, func() {
+		st.mu.Lock()
+		if st.generation != gen {
+			st.mu.Unlock()
+			return
+		}
+		st.mu.Unlock()
+
+		if h.sendMessageFunc == nil {
+			slog.Warn("auto-continue: sendMessageFunc not set", "agent_id", agentID)
+			return
+		}
+
+		slog.Info("auto-continue firing", "agent_id", agentID)
+		h.sendMessageFunc(agentID, "Continue.")
+	})
+}
+
+// resetAutoContinue cancels any pending auto-continue timer and resets
+// the backoff to the initial delay.
+func (h *OutputHandler) resetAutoContinue(agentID string) {
+	v, ok := h.autoContinue.Load(agentID)
+	if !ok {
+		return
+	}
+	st := v.(*autoContinueState)
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if st.timer != nil {
+		st.timer.Stop()
+		st.timer = nil
+	}
+	st.generation++
+	st.backoff = autoContinueInitialDelay
+}
+
+// cleanupAutoContinue stops any pending timer and removes the state.
+func (h *OutputHandler) cleanupAutoContinue(agentID string) {
+	v, ok := h.autoContinue.LoadAndDelete(agentID)
+	if !ok {
+		return
+	}
+	st := v.(*autoContinueState)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.timer != nil {
+		st.timer.Stop()
+		st.timer = nil
+	}
+}

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleAutoContinue_FiresAfterDelay(t *testing.T) {
+	h := &OutputHandler{}
+
+	var called atomic.Int32
+
+	h.sendMessageFunc = func(agentID, content string) {
+		called.Add(1)
+	}
+
+	h.scheduleAutoContinue("agent-1")
+
+	// Should not fire immediately.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(0), called.Load())
+
+	// Wait for the initial delay (10s) + some margin.
+	// We can't wait that long in a unit test, so we test via
+	// the internal state instead: verify the state was created.
+	v, ok := h.autoContinue.Load("agent-1")
+	require.True(t, ok)
+	st := v.(*autoContinueState)
+	st.mu.Lock()
+	assert.NotNil(t, st.timer, "timer should be set")
+	assert.Equal(t, 1, st.generation)
+	// Backoff should have doubled from initial 10s to 20s.
+	assert.Equal(t, time.Duration(float64(autoContinueInitialDelay)*autoContinueMultiplier), st.backoff)
+	st.mu.Unlock()
+
+	// Cleanup.
+	h.cleanupAutoContinue("agent-1")
+}
+
+func TestResetAutoContinue_StopsTimer(t *testing.T) {
+	h := &OutputHandler{}
+	h.sendMessageFunc = func(string, string) {}
+
+	h.scheduleAutoContinue("agent-1")
+
+	v, ok := h.autoContinue.Load("agent-1")
+	require.True(t, ok)
+	st := v.(*autoContinueState)
+
+	h.resetAutoContinue("agent-1")
+
+	st.mu.Lock()
+	assert.Nil(t, st.timer, "timer should be nil after reset")
+	assert.Equal(t, autoContinueInitialDelay, st.backoff, "backoff should be reset to initial")
+	st.mu.Unlock()
+}
+
+func TestResetAutoContinue_NoopWhenNoState(t *testing.T) {
+	h := &OutputHandler{}
+	// Should not panic.
+	h.resetAutoContinue("nonexistent")
+}
+
+func TestCleanupAutoContinue_RemovesState(t *testing.T) {
+	h := &OutputHandler{}
+	h.sendMessageFunc = func(string, string) {}
+
+	h.scheduleAutoContinue("agent-1")
+	_, ok := h.autoContinue.Load("agent-1")
+	require.True(t, ok)
+
+	h.cleanupAutoContinue("agent-1")
+	_, ok = h.autoContinue.Load("agent-1")
+	assert.False(t, ok, "state should be removed after cleanup")
+}
+
+func TestScheduleAutoContinue_BackoffIncreases(t *testing.T) {
+	h := &OutputHandler{}
+	h.sendMessageFunc = func(string, string) {}
+
+	// Schedule twice to see backoff increase.
+	h.scheduleAutoContinue("agent-1")
+	h.scheduleAutoContinue("agent-1")
+
+	v, _ := h.autoContinue.Load("agent-1")
+	st := v.(*autoContinueState)
+	st.mu.Lock()
+	// After two schedules: initial 10s -> 20s (first) -> 40s (second).
+	expected := time.Duration(float64(autoContinueInitialDelay) * autoContinueMultiplier * autoContinueMultiplier)
+	assert.Equal(t, expected, st.backoff)
+	assert.Equal(t, 2, st.generation, "generation should increment on each schedule")
+	st.mu.Unlock()
+
+	h.cleanupAutoContinue("agent-1")
+}

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -29,7 +29,7 @@ func decodeMessageContent(t *testing.T, content []byte, compression leapmuxv1.Co
 func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -93,7 +93,7 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents)
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
+	"github.com/leapmux/leapmux/internal/worker/wakelock"
 )
 
 // notifThreadGracePeriod is how long a soft-cleared notification thread
@@ -365,14 +366,25 @@ type OutputHandler struct {
 
 	// Plan mode tool_use tracking (shared across agents).
 	planModeToolUse sync.Map // tool_use_id -> target mode string ("plan" or "default")
+
+	// Auto-continue state (per-agent).
+	autoContinue sync.Map // agentID -> *autoContinueState
+
+	// sendMessageFunc is called by auto-continue to inject a synthetic
+	// user message. Set via SetSendMessageFunc during service Init.
+	sendMessageFunc func(agentID, content string)
+
+	// wakeLock prevents system sleep while there is agent/terminal activity.
+	wakeLock *wakelock.ActivityTracker
 }
 
 // NewOutputHandler creates a new OutputHandler.
-func NewOutputHandler(queries *db.Queries, watcher *WatcherManager, agents *agent.Manager) *OutputHandler {
+func NewOutputHandler(queries *db.Queries, watcher *WatcherManager, agents *agent.Manager, wl *wakelock.ActivityTracker) *OutputHandler {
 	return &OutputHandler{
-		queries: queries,
-		watcher: watcher,
-		agents:  agents,
+		queries:  queries,
+		watcher:  watcher,
+		agents:   agents,
+		wakeLock: wl,
 	}
 }
 
@@ -384,12 +396,20 @@ func (h *OutputHandler) ResetSpanTracker(agentID string) {
 	}
 }
 
+// SetSendMessageFunc sets the callback used by auto-continue to inject
+// a synthetic user message into an agent. Must be called before any
+// agent output is processed.
+func (h *OutputHandler) SetSendMessageFunc(fn func(agentID, content string)) {
+	h.sendMessageFunc = fn
+}
+
 // CleanupAgent removes all per-agent state from the handler's maps.
 // Call this when an agent is permanently closed.
 func (h *OutputHandler) CleanupAgent(agentID string) {
 	h.notifMu.Delete(agentID)
 	h.lastNotifThread.Delete(agentID)
 	h.spanTrackers.Delete(agentID)
+	h.cleanupAutoContinue(agentID)
 }
 
 // spanTracker returns the per-agent SpanTracker, creating one if needed.
@@ -647,6 +667,14 @@ func (s *agentOutputSink) UpdatePlan(filePath string, content []byte, compressio
 	s.h.updatePlan(s.agentID, filePath, content, compression, title)
 }
 
+func (s *agentOutputSink) ScheduleAutoContinue() {
+	s.h.scheduleAutoContinue(s.agentID)
+}
+
+func (s *agentOutputSink) ResetAutoContinue() {
+	s.h.resetAutoContinue(s.agentID)
+}
+
 // --- Internal helpers ---
 
 // notifMutex returns a per-agent mutex for notification threading.
@@ -671,6 +699,9 @@ func (h *OutputHandler) softClearNotifThread(agentID string) {
 // persistAndBroadcast persists a message and broadcasts it to watchers.
 // tracker may be nil, in which case it is resolved from the agentID.
 func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmuxv1.AgentProvider, role leapmuxv1.MessageRole, contentJSON []byte, span agent.SpanInfo, tracker *SpanTracker) error {
+	if h.wakeLock != nil {
+		h.wakeLock.RecordActivity()
+	}
 	if tracker == nil {
 		tracker = h.spanTracker(agentID)
 	}
@@ -728,6 +759,9 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 // persistNotificationThreaded persists a notification message, appending it
 // to the current notification thread if one exists.
 func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, role leapmuxv1.MessageRole, contentJSON []byte) error {
+	if h.wakeLock != nil {
+		h.wakeLock.RecordActivity()
+	}
 	mu := h.notifMutex(agentID)
 	mu.Lock()
 	defer mu.Unlock()
@@ -968,6 +1002,9 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 	var latestStatusRaw json.RawMessage
 	statusLastIdx := -1
 
+	var latestApiRetryRaw json.RawMessage
+	apiRetryLastIdx := -1
+
 	// Compaction boundaries and unknown types: always kept, in order.
 	type indexedRaw struct {
 		idx int
@@ -1034,6 +1071,10 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			latestStatusRaw = raw
 			statusLastIdx = i
 
+		case env.Type == "system" && env.Subtype == "api_retry":
+			latestApiRetryRaw = raw
+			apiRetryLastIdx = i
+
 		case env.Type == "system" && (env.Subtype == "compact_boundary" || env.Subtype == "microcompact_boundary"):
 			// Compaction result supersedes any earlier compacting status.
 			latestStatusRaw = nil
@@ -1094,6 +1135,10 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 
 	if statusLastIdx >= 0 {
 		entries = append(entries, indexedRaw{statusLastIdx, latestStatusRaw})
+	}
+
+	if apiRetryLastIdx >= 0 {
+		entries = append(entries, indexedRaw{apiRetryLastIdx, latestApiRetryRaw})
 	}
 
 	// Merge keepAll entries.

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
+	"github.com/leapmux/leapmux/internal/worker/wakelock"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -34,13 +35,14 @@ type Context struct {
 	Channels            *channel.Manager // E2EE channel manager (for workspace access lookups)
 	HomeDir             string
 	DataDir             string
-	WorkerID            string          // This worker's ID (set after registration)
-	Name                string          // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
-	Send                SendFunc        // Forwards messages to the Hub via WebSocket
-	Watchers            *WatcherManager // Fan-out manager for event broadcasting
-	Output              *OutputHandler  // Agent output NDJSON processor
-	AgentStartupTimeout time.Duration   // Timeout for agent startup handshake (default: 30s)
-	UseLoginShell       bool            // Wrap claude invocation in user's login shell
+	WorkerID            string                    // This worker's ID (set after registration)
+	Name                string                    // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
+	Send                SendFunc                  // Forwards messages to the Hub via WebSocket
+	Watchers            *WatcherManager           // Fan-out manager for event broadcasting
+	Output              *OutputHandler            // Agent output NDJSON processor
+	AgentStartupTimeout time.Duration             // Timeout for agent startup handshake (default: 30s)
+	UseLoginShell       bool                      // Wrap claude invocation in user's login shell
+	WakeLock            *wakelock.ActivityTracker // Keep-awake tracker (nil = disabled)
 }
 
 // agentStartupTimeout returns the configured agent startup timeout,
@@ -53,10 +55,10 @@ func (svc *Context) agentStartupTimeout() time.Duration {
 }
 
 // NewContext creates a new service context with all dependencies.
-func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manager, homeDir, dataDir string) *Context {
+func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manager, homeDir, dataDir string, wl *wakelock.ActivityTracker) *Context {
 	queries := db.New(sqlDB)
 	watchers := NewWatcherManager()
-	output := NewOutputHandler(queries, watchers, agents)
+	output := NewOutputHandler(queries, watchers, agents, wl)
 	return &Context{
 		DB:        sqlDB,
 		Queries:   queries,
@@ -66,6 +68,7 @@ func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manage
 		DataDir:   dataDir,
 		Watchers:  watchers,
 		Output:    output,
+		WakeLock:  wl,
 	}
 }
 
@@ -83,6 +86,9 @@ func (svc *Context) Init() {
 	if svc.Send == nil {
 		panic("service.Context.Init: Send must be set before calling Init")
 	}
+
+	// Wire auto-continue so OutputHandler can send synthetic user messages.
+	svc.Output.SetSendMessageFunc(svc.sendSyntheticUserMessage)
 
 	// No need to deactivate agents/terminals on startup — status is now
 	// derived from runtime state (HasAgent/HasTerminal), not from the DB.

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -57,6 +57,9 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 		terminalID := id.Generate()
 
 		outputFn := func(data []byte) {
+			if svc.WakeLock != nil {
+				svc.WakeLock.RecordActivity()
+			}
 			svc.Watchers.BroadcastTerminalEvent(terminalID, &leapmuxv1.TerminalEvent{
 				TerminalId: terminalID,
 				Event: &leapmuxv1.TerminalEvent_Data{
@@ -201,6 +204,10 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 		if terminalID == "" {
 			sendInvalidArgument(sender, "terminal_id is required")
 			return
+		}
+
+		if svc.WakeLock != nil {
+			svc.WakeLock.RecordActivity()
 		}
 
 		if err := svc.Terminals.SendInput(terminalID, r.GetData()); err != nil {

--- a/backend/internal/worker/wakelock/wakelock.go
+++ b/backend/internal/worker/wakelock/wakelock.go
@@ -1,0 +1,96 @@
+// Package wakelock provides a platform-agnostic mechanism to prevent
+// system sleep while the worker has stdio activity. An ActivityTracker
+// acquires a wakelock on the first activity and releases it after an
+// idle timeout (default 60s).
+package wakelock
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// WakeLock is the platform-specific sleep inhibitor.
+type WakeLock interface {
+	Acquire() error
+	Release()
+}
+
+const defaultIdleTimeout = 60 * time.Second
+
+// ActivityTracker holds a WakeLock while there is recent activity and
+// releases it after an idle period.
+type ActivityTracker struct {
+	wl           WakeLock
+	mu           sync.Mutex
+	held         bool
+	timer        *time.Timer
+	timeout      time.Duration
+	lastActivity time.Time
+}
+
+// NewActivityTracker creates a tracker with the platform WakeLock and
+// the default 60-second idle timeout.
+func NewActivityTracker() *ActivityTracker {
+	return &ActivityTracker{
+		wl:      newPlatformWakeLock(),
+		timeout: defaultIdleTimeout,
+	}
+}
+
+// RecordActivity acquires the wakelock if not held and resets the idle
+// timer. To avoid excessive timer churn on hot paths (e.g. terminal
+// output), the timer is only reset when at least half the timeout has
+// elapsed since the last reset.
+func (t *ActivityTracker) RecordActivity() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.held {
+		if err := t.wl.Acquire(); err != nil {
+			slog.Warn("failed to acquire wakelock", "error", err)
+			return
+		}
+		t.held = true
+		t.lastActivity = time.Now()
+		t.timer = time.AfterFunc(t.timeout, t.releaseOnIdle)
+		return
+	}
+
+	// Throttle timer resets: only reset when half the timeout has elapsed.
+	now := time.Now()
+	if now.Sub(t.lastActivity) < t.timeout/2 {
+		return
+	}
+	t.lastActivity = now
+
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+	t.timer = time.AfterFunc(t.timeout, t.releaseOnIdle)
+}
+
+func (t *ActivityTracker) releaseOnIdle() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.held {
+		t.wl.Release()
+		t.held = false
+	}
+}
+
+// Close releases the wakelock unconditionally. Safe to call multiple
+// times.
+func (t *ActivityTracker) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.timer != nil {
+		t.timer.Stop()
+		t.timer = nil
+	}
+	if t.held {
+		t.wl.Release()
+		t.held = false
+	}
+}

--- a/backend/internal/worker/wakelock/wakelock_darwin.go
+++ b/backend/internal/worker/wakelock/wakelock_darwin.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package wakelock
+
+import (
+	"log/slog"
+	"os/exec"
+)
+
+type darwinWakeLock struct {
+	cmd *exec.Cmd
+}
+
+func newPlatformWakeLock() WakeLock {
+	return &darwinWakeLock{}
+}
+
+func (w *darwinWakeLock) Acquire() error {
+	w.cmd = exec.Command("caffeinate", "-i")
+	if err := w.cmd.Start(); err != nil {
+		return err
+	}
+	slog.Debug("wakelock acquired (caffeinate -i)", "pid", w.cmd.Process.Pid)
+	return nil
+}
+
+func (w *darwinWakeLock) Release() {
+	if w.cmd != nil && w.cmd.Process != nil {
+		_ = w.cmd.Process.Kill()
+		_ = w.cmd.Wait()
+		slog.Debug("wakelock released (caffeinate killed)")
+		w.cmd = nil
+	}
+}

--- a/backend/internal/worker/wakelock/wakelock_linux.go
+++ b/backend/internal/worker/wakelock/wakelock_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package wakelock
+
+import (
+	"log/slog"
+	"os/exec"
+)
+
+type linuxWakeLock struct {
+	cmd *exec.Cmd
+}
+
+func newPlatformWakeLock() WakeLock {
+	return &linuxWakeLock{}
+}
+
+func (w *linuxWakeLock) Acquire() error {
+	w.cmd = exec.Command(
+		"systemd-inhibit",
+		"--what=idle",
+		"--who=leapmux",
+		"--why=Worker active",
+		"--mode=block",
+		"cat",
+	)
+	if err := w.cmd.Start(); err != nil {
+		return err
+	}
+	slog.Debug("wakelock acquired (systemd-inhibit)", "pid", w.cmd.Process.Pid)
+	return nil
+}
+
+func (w *linuxWakeLock) Release() {
+	if w.cmd != nil && w.cmd.Process != nil {
+		_ = w.cmd.Process.Kill()
+		_ = w.cmd.Wait()
+		slog.Debug("wakelock released (systemd-inhibit killed)")
+		w.cmd = nil
+	}
+}

--- a/backend/internal/worker/wakelock/wakelock_other.go
+++ b/backend/internal/worker/wakelock/wakelock_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package wakelock
+
+type noopWakeLock struct{}
+
+func newPlatformWakeLock() WakeLock {
+	return &noopWakeLock{}
+}
+
+func (w *noopWakeLock) Acquire() error { return nil }
+func (w *noopWakeLock) Release()       {}

--- a/backend/internal/worker/wakelock/wakelock_windows.go
+++ b/backend/internal/worker/wakelock/wakelock_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package wakelock
+
+import (
+	"log/slog"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32                    = syscall.NewLazyDLL("kernel32.dll")
+	procSetThreadExecutionState = kernel32.NewProc("SetThreadExecutionState")
+)
+
+const (
+	esSystemRequired = 0x00000001
+	esContinuous     = 0x80000000
+)
+
+type windowsWakeLock struct{}
+
+func newPlatformWakeLock() WakeLock {
+	return &windowsWakeLock{}
+}
+
+func (w *windowsWakeLock) Acquire() error {
+	ret, _, _ := procSetThreadExecutionState.Call(uintptr(esSystemRequired | esContinuous))
+	if ret == 0 {
+		return syscall.GetLastError()
+	}
+	slog.Debug("wakelock acquired (SetThreadExecutionState)")
+	return nil
+}
+
+func (w *windowsWakeLock) Release() {
+	_, _, _ = procSetThreadExecutionState.Call(uintptr(esContinuous))
+	slog.Debug("wakelock released (SetThreadExecutionState)")
+}
+
+// Ensure unsafe is referenced for the syscall.
+var _ unsafe.Pointer

--- a/backend/worker/runner.go
+++ b/backend/worker/runner.go
@@ -76,6 +76,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 			client.TerminalManager(),
 			homeDir,
 			cfg.DataDir,
+			nil, // no wakelock in embedded runner
 		)
 
 		channelMgr := channel.NewManager(

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -20,6 +20,7 @@ import { isObject } from './messageUtils'
 import {
   agentErrorRenderer,
   agentRenamedRenderer,
+  apiRetryRenderer,
   compactBoundaryRenderer,
   compactingRenderer,
   contextClearedRenderer,
@@ -280,6 +281,7 @@ const KIND_RENDERERS: Record<string, (parsed: unknown, role: MessageRole, contex
       ?? agentErrorRenderer.render(parsed, role, context)
       ?? agentRenamedRenderer.render(parsed, role, context)
       ?? rateLimitRenderer.render(parsed, role, context)
+      ?? apiRetryRenderer.render(parsed, role, context)
       ?? compactBoundaryRenderer.render(parsed, role, context)
       ?? microcompactBoundaryRenderer.render(parsed, role, context)
       ?? systemInitRenderer.render(parsed, role, context)
@@ -343,6 +345,7 @@ function getFallbackRenderers(): MessageContentRenderer[] {
       agentErrorRenderer,
       agentRenamedRenderer,
       rateLimitRenderer,
+      apiRetryRenderer,
       compactBoundaryRenderer,
       microcompactBoundaryRenderer,
       systemInitRenderer,

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -117,12 +117,38 @@ export const agentRenamedRenderer: MessageContentRenderer = {
   },
 }
 
+/**
+ * Cleans up synthetic API error messages from Claude Code.
+ * Extracts a human-readable message from the embedded JSON body, e.g.:
+ *   "API Error: 529 {\"type\":\"error\",...,\"message\":\"Overloaded...\"}"
+ * becomes:
+ *   "API Error: 529 · Overloaded..."
+ */
+const apiErrorPattern = /^API Error: (\d+) (.*)$/
+function cleanAPIErrorMessage(msg: string): string {
+  const match = apiErrorPattern.exec(msg)
+  if (!match)
+    return msg
+  const [, statusCode, body] = match
+  if (body.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(body)
+      const message = parsed?.error?.message
+      if (typeof message === 'string')
+        return `API Error: ${statusCode} ${message}`
+    }
+    catch { /* not parseable JSON */ }
+    return `API Error: ${statusCode}`
+  }
+  return msg
+}
+
 function formatApiRetryLabel(data: Record<string, unknown>): string {
   const attempt = typeof data.attempt === 'number' ? data.attempt : '?'
   const maxRetries = typeof data.max_retries === 'number' ? data.max_retries : '?'
   const errorStatus = data.error_status != null ? String(data.error_status) : null
   const error = typeof data.error === 'string' ? data.error : null
-  const detail = [errorStatus, error].filter(Boolean).join(' \u00B7 ')
+  const detail = [errorStatus, error].filter(Boolean).join(' ')
   return detail
     ? `API Retry ${attempt}/${maxRetries} (${detail})`
     : `API Retry ${attempt}/${maxRetries}`
@@ -248,7 +274,10 @@ export const resultRenderer: MessageContentRenderer = {
       const errors = Array.isArray(parsed.errors) ? parsed.errors as string[] : []
       const resultText = typeof parsed.result === 'string' ? parsed.result : ''
       const errorMsg = errors.length > 0 ? errors.join('; ') : resultText || 'Unknown error'
-      return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{errorMsg}</div>
+      const durationMs = typeof parsed.duration_ms === 'number' ? parsed.duration_ms : 0
+      const durationSuffix = durationMs > 0 ? ` (${formatDuration(durationMs)})` : ''
+      const label = cleanAPIErrorMessage(errorMsg) + durationSuffix
+      return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{label}</div>
     }
 
     const durationMs = typeof parsed.duration_ms === 'number' ? parsed.duration_ms : 0

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -117,6 +117,26 @@ export const agentRenamedRenderer: MessageContentRenderer = {
   },
 }
 
+function formatApiRetryLabel(data: Record<string, unknown>): string {
+  const attempt = typeof data.attempt === 'number' ? data.attempt : '?'
+  const maxRetries = typeof data.max_retries === 'number' ? data.max_retries : '?'
+  const errorStatus = data.error_status != null ? String(data.error_status) : null
+  const error = typeof data.error === 'string' ? data.error : null
+  const detail = [errorStatus, error].filter(Boolean).join(' \u00B7 ')
+  return detail
+    ? `API Retry ${attempt}/${maxRetries} (${detail})`
+    : `API Retry ${attempt}/${maxRetries}`
+}
+
+/** Handles api_retry notifications: {"type":"system","subtype":"api_retry","attempt":N,"max_retries":N,...} */
+export const apiRetryRenderer: MessageContentRenderer = {
+  render(parsed, _role, _context) {
+    if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'api_retry')
+      return null
+    return <div class={controlResponseMessage}>{formatApiRetryLabel(parsed as Record<string, unknown>)}</div>
+  },
+}
+
 /** Handles rate limit notifications: {"type":"rate_limit","rate_limit_info":{...}} or Codex native format */
 export const rateLimitRenderer: MessageContentRenderer = {
   render(parsed, _role, _context) {
@@ -313,6 +333,7 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
   let microcompactPreTokens: number | undefined
   let microcompactTokensSaved: number | undefined
   const rateLimitByType: Record<string, Record<string, unknown>> = {}
+  let latestApiRetry: Record<string, unknown> | null = null
 
   for (const msg of messages) {
     if (!isObject(msg))
@@ -367,6 +388,9 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
       const title = typeof m.title === 'string' ? m.title : ''
       if (title)
         settingsParts.push(`Renamed to ${title}`)
+    }
+    else if (t === 'system' && st === 'api_retry') {
+      latestApiRetry = m
     }
     else if (t === 'compacting' || (t === 'system' && st === 'status' && m.status === 'compacting')) {
       compacting = true
@@ -427,6 +451,13 @@ export function renderNotificationThread(messages: unknown[]): JSXElement {
         <Icon icon={ArrowDownToLine} size="sm" />
         {` ${microcompactLabel}`}
       </div>,
+    )
+  }
+
+  // API retry (latest only).
+  if (latestApiRetry) {
+    elements.push(
+      <div class={controlResponseMessage}>{formatApiRetryLabel(latestApiRetry)}</div>,
     )
   }
 


### PR DESCRIPTION
## Motivation

Two related reliability problems affected long-running agent sessions:

1. The host system could sleep during extended agent runs, interrupting active work mid-session. There was no mechanism to hold a wakelock while the worker was busy.

2. Claude Code occasionally returns synthetic API 5xx errors (e.g. 529 Overloaded) that require a "Continue." prompt to recover. This logic existed previously but was removed during the E2EE migration (commit 529a392) because the Hub can no longer read encrypted agent messages. The retry logic needs to live in the Worker layer instead.

## Modifications

- Added a new `wakelock` package with a platform-agnostic `ActivityTracker` that acquires a sleep inhibitor on first I/O activity and releases it after 60 seconds of idle time. Timer resets are throttled to avoid overhead on hot paths like terminal output. Platform implementations:
  - macOS: `caffeinate`
  - Linux: `systemd-inhibit`
  - Windows: `SetThreadExecutionState`
  - Other: no-op fallback
- Added `auto_continue.go` with an exponential backoff retry mechanism that automatically sends "Continue." when Claude Code reports a synthetic API 5xx error. Initial delay is 10s, max 180s, 2x multiplier, ±20% jitter. Backoff resets on successful completion.
- Extended the message envelope parser in `claude_output.go` to capture `is_error` and `result` fields for detecting synthetic API errors. `hasSyntheticAPI5xxPrefix()` strictly matches only 3-digit 5xx status codes to avoid false positives.
- Extended `OutputSink` with `ScheduleAutoContinue()` and `ResetAutoContinue()` methods. Wakelock activity tracking is wired into terminal and agent I/O paths via the service context.
- Added `api_retry` to notification threadable subtypes with dedup-to-latest consolidation.
- Added `apiRetryRenderer` on the frontend displaying attempt count, max retries, and error details (e.g. "API Retry 2/5 (529 Overloaded)").
- Added `cleanAPIErrorMessage()` on the frontend to extract a human-readable message from the JSON body embedded in Claude Code's synthetic API error strings. Error results now show duration alongside the cleaned message (e.g. "API Error: 529 Overloaded (3m 25s)").

## Result

- The host machine no longer sleeps while an agent session is active. The wakelock is acquired automatically on first activity and released 60 seconds after the last observed I/O.
- Agent sessions that hit transient API 5xx errors (e.g. 529 Overloaded) automatically recover by sending "Continue." with exponential backoff, rather than stalling indefinitely.
- The chat UI displays clean, human-readable API error messages and retry notifications instead of raw JSON blobs.

🤖 Generated with Claude Code
