### PR TITLE
Fix multi-question provider flows for Codex and OpenCode

### DIFF
--- a/backend/internal/worker/service/codex_control.go
+++ b/backend/internal/worker/service/codex_control.go
@@ -11,10 +11,14 @@ import (
 
 func codexControlResponseRequestID(content []byte) string {
 	var rpc struct {
-		ID *json.Number `json:"id"`
+		ID json.RawMessage `json:"id"`
 	}
-	if err := json.Unmarshal(content, &rpc); err == nil && rpc.ID != nil {
-		return rpc.ID.String()
+	if err := json.Unmarshal(content, &rpc); err == nil && len(rpc.ID) > 0 && string(rpc.ID) != "null" {
+		var str string
+		if json.Unmarshal(rpc.ID, &str) == nil {
+			return str
+		}
+		return strings.TrimSpace(string(rpc.ID))
 	}
 
 	var cr struct {
@@ -125,12 +129,58 @@ func codexFeedbackMessageText(responseContent []byte) string {
 	return message
 }
 
+func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Properties struct {
+			Questions []struct {
+				Header   string `json:"header"`
+				Question string `json:"question"`
+			} `json:"questions"`
+		} `json:"properties"`
+	}
+	var resp struct {
+		Result struct {
+			Answers [][]string `json:"answers"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+		return ""
+	}
+
+	lines := make([]string, 0, len(resp.Result.Answers))
+	for i, answers := range resp.Result.Answers {
+		if len(answers) == 0 {
+			continue
+		}
+		parts := make([]string, 0, len(answers))
+		for _, answer := range answers {
+			if text := strings.TrimSpace(answer); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) == 0 {
+			continue
+		}
+
+		label := fmt.Sprintf("Question %d", i+1)
+		if i < len(req.Properties.Questions) {
+			if header := strings.TrimSpace(req.Properties.Questions[i].Header); header != "" {
+				label = header
+			} else if question := strings.TrimSpace(req.Properties.Questions[i].Question); question != "" {
+				label = question
+			}
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", label, strings.Join(parts, ", ")))
+	}
+	return strings.Join(lines, "\n")
+}
+
 func (svc *Context) codexControlResponseDisplayText(agentID string, provider leapmuxv1.AgentProvider, content []byte) string {
 	switch provider {
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX:
 		// handled below
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE:
-		return opencodeControlResponseDisplayText(content)
+		// handled below
 	default:
 		return ""
 	}
@@ -150,16 +200,26 @@ func (svc *Context) codexControlResponseDisplayText(agentID string, provider lea
 
 	var payload struct {
 		Method string `json:"method"`
+		Type   string `json:"type"`
 	}
 	if json.Unmarshal(cr.Payload, &payload) != nil {
 		return ""
 	}
 
-	if payload.Method == "item/tool/requestUserInput" {
-		return codexUserInputAnswersText(cr.Payload, content)
+	switch provider {
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX:
+		if payload.Method == "item/tool/requestUserInput" {
+			return codexUserInputAnswersText(cr.Payload, content)
+		}
+		return codexFeedbackMessageText(content)
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE:
+		if payload.Type == "question.asked" {
+			return opencodeQuestionAnswersText(cr.Payload, content)
+		}
+		return opencodeControlResponseDisplayText(content)
+	default:
+		return ""
 	}
-
-	return codexFeedbackMessageText(content)
 }
 
 // opencodeControlResponseDisplayText extracts a human-readable display text

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -149,6 +149,65 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	assert.Equal(t, "Please add tests before exiting plan mode.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
 }
 
+func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+	}))
+
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "que-1",
+		Payload: []byte(`{
+			"type":"question.asked",
+			"properties":{
+				"questions":[
+					{"header":"Task","question":"Pick a task"},
+					{"header":"Env","question":"Pick an environment"}
+				]
+			}
+		}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Model:      "opus",
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"jsonrpc":"2.0",
+			"id":"que-1",
+			"result":{
+				"answers":[["Build"],["Dev"]]
+			}
+		}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1",
+		Seq:     0,
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, "Task: Build\nEnv: Dev", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+}
+
 func TestExtractControlResponseRequestID(t *testing.T) {
 	// Claude Code format: response.request_id
 	assert.Equal(t, "req-1", extractControlResponseRequestID(

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -304,6 +304,15 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   const modelContextWindow = createMemo(() =>
     Number(props.agent?.availableModels?.find(m => m.id === props.agent?.model)?.contextWindow) || undefined,
   )
+  const activeDraftKey = createMemo(() => {
+    if (!props.agentId)
+      return undefined
+    const request = ctrl.activeControlRequest()
+    if (!request)
+      return props.agentId
+    const pageSuffix = ctrl.isAskUserQuestion() ? `-q-${askCurrentPage()}` : ''
+    return `${props.agentId}-ctrl-${request.requestId}${pageSuffix}`
+  })
 
   let triggerSend: (() => void) | undefined
 
@@ -384,6 +393,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         />
         <MarkdownEditor
           agentId={props.agentId}
+          draftKey={activeDraftKey()}
           controlRequestId={ctrl.activeControlRequest()?.requestId}
           onSend={ctrl.activeControlRequest() ? ctrl.handleControlSend : ctrl.handleSend}
           disabled={props.disabled}

--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -20,6 +20,8 @@ export { clearDraft }
 interface MarkdownEditorProps {
   /** Agent ID for per-tab draft persistence. */
   agentId?: string
+  /** Full draft key override. When set, takes precedence over agent/control request keys. */
+  draftKey?: string
   /** When set, drafts are stored under a control-request-specific key instead of the agentId key. */
   controlRequestId?: string
   onSend: (markdown: string) => boolean | void
@@ -57,6 +59,8 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
 
   /** Compute the localStorage draft key, incorporating controlRequestId when present. */
   const getDraftKey = () => {
+    if (props.draftKey)
+      return props.draftKey
     if (!props.agentId)
       return undefined
     return props.controlRequestId
@@ -357,40 +361,34 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     }
   })
 
-  // Swap editor content when agentId changes (per-tab draft isolation)
-  let prevAgentId: string | undefined
-  let prevCtrlReqIdForAgentSwap: string | undefined
+  // Swap editor content when the effective draft key changes. This covers
+  // agent switches, control-request switches, and per-question draft scopes.
+  let prevDraftKey: string | null | undefined
   createEffect(on(
-    () => props.agentId,
-    (newAgentId) => {
-      // On first run, prevAgentId is undefined — just record the initial agentId.
+    getDraftKey,
+    (newDraftKeyRaw) => {
+      const newDraftKey = newDraftKeyRaw ?? null
+      // On first run, just record the initial key.
       // onMount already loaded the draft for this agentId, so no swap needed.
-      // Note: editorInstance may not exist yet (onMount is async), so we must
-      // set prevAgentId unconditionally to avoid skipping the first real swap.
-      if (prevAgentId === undefined) {
-        prevAgentId = newAgentId
-        prevCtrlReqIdForAgentSwap = props.controlRequestId
+      if (prevDraftKey === undefined) {
+        prevDraftKey = newDraftKey
         return
       }
-      if (newAgentId === prevAgentId)
+      if (newDraftKey === prevDraftKey)
         return
       if (!editorInstance)
         return
 
-      // Save current content as draft for the old agent (under composite key)
-      if (prevAgentId) {
-        const oldKey = prevCtrlReqIdForAgentSwap
-          ? `${prevAgentId}-ctrl-${prevCtrlReqIdForAgentSwap}`
-          : prevAgentId
+      // Save current content under the previous draft key.
+      if (prevDraftKey) {
         try {
-          saveDraftFromEditor(editorInstance, oldKey)
+          saveDraftFromEditor(editorInstance, prevDraftKey)
         }
         catch { /* editor may not be ready */ }
       }
 
-      // Load draft for the new agent and replace editor content
-      const newKey = getDraftKey()
-      const draft = newKey ? loadDraft(newKey) : { content: '', cursor: -1 }
+      // Load draft for the new key and replace editor content.
+      const draft = newDraftKey ? loadDraft(newDraftKey) : { content: '', cursor: -1 }
       try {
         editorInstance.action(replaceAll(draft.content))
         restoreCursor(editorInstance, draft.cursor)
@@ -399,50 +397,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       }
       catch { /* editor may not be ready */ }
 
-      prevAgentId = newAgentId
-      prevCtrlReqIdForAgentSwap = props.controlRequestId
-    },
-  ))
-
-  // Swap editor content when controlRequestId changes (control request draft isolation)
-  let prevControlRequestId: string | null | undefined // sentinel for first run
-  createEffect(on(
-    () => props.controlRequestId,
-    (newCtrlId) => {
-      const newCtrlIdNorm = newCtrlId ?? null
-      // On first run, just record the initial value. onMount handles initial draft.
-      if (prevControlRequestId === undefined) {
-        prevControlRequestId = newCtrlIdNorm
-        return
-      }
-      if (newCtrlIdNorm === prevControlRequestId)
-        return
-      if (!editorInstance || !props.agentId)
-        return
-
-      // Save current content under the old key
-      const oldKey = prevControlRequestId
-        ? `${props.agentId}-ctrl-${prevControlRequestId}`
-        : props.agentId
-      try {
-        saveDraftFromEditor(editorInstance, oldKey)
-      }
-      catch { /* editor may not be ready */ }
-
-      // Load draft for the new key
-      const newKey = newCtrlIdNorm
-        ? `${props.agentId}-ctrl-${newCtrlIdNorm}`
-        : props.agentId
-      const draft = loadDraft(newKey)
-      try {
-        editorInstance.action(replaceAll(draft.content))
-        restoreCursor(editorInstance, draft.cursor)
-        setMarkdown(draft.content)
-        props.onContentChange?.(draft.content.trim().length > 0)
-      }
-      catch { /* editor may not be ready */ }
-
-      prevControlRequestId = newCtrlIdNorm
+      prevDraftKey = newDraftKey
     },
   ))
 

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -4,6 +4,7 @@ import type { AskQuestionState } from './controls/types'
 import type { ControlRequest } from '~/stores/control.store'
 import { createRoot, createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { useControlResponseHandling } from './controlResponseHandling'
 
 function createMinimalAskState(): AskQuestionState {
@@ -63,8 +64,8 @@ function makeAttachment(overrides: Partial<FileAttachment> = {}): FileAttachment
   }
 }
 
-function makeControlRequest(requestId: string, agentId: string): ControlRequest {
-  return { requestId, agentId, payload: { tool_name: 'Bash', tool_input: {} } }
+function makeControlRequest(requestId: string, agentId: string, payload: Record<string, unknown> = { tool_name: 'Bash', tool_input: {} }): ControlRequest {
+  return { requestId, agentId, payload }
 }
 
 describe('handleSend', () => {
@@ -201,5 +202,163 @@ describe('handleControlSend', () => {
     expect(onSendMessage).not.toHaveBeenCalled()
     // onControlResponse should have been called (the allow response).
     expect(onControlResponse).toHaveBeenCalled()
+  })
+
+  it('uses Codex-native request_user_input responses', () => {
+    createRoot((dispose) => {
+      const onControlResponse = vi.fn().mockResolvedValue(undefined)
+      const askState = createMinimalAskState()
+      askState.setSelections({ 0: ['Build'] })
+      const props: ControlResponseHandlingProps = {
+        agentId: 'test-agent',
+        agent: { agentProvider: AgentProvider.CODEX },
+        controlRequests: [makeControlRequest('7', 'test-agent', {
+          method: 'item/tool/requestUserInput',
+          params: {
+            questions: [
+              { id: 'q1', header: 'Action', question: 'What next?', options: [{ label: 'Build' }] },
+            ],
+          },
+        })],
+        onControlResponse,
+        onSendMessage: vi.fn(),
+      }
+      const result = useControlResponseHandling(
+        props,
+        askState,
+        () => undefined,
+        vi.fn(),
+      )
+
+      result.handleControlSend('')
+
+      expect(onControlResponse).toHaveBeenCalledOnce()
+      const [, bytes] = onControlResponse.mock.calls[0]
+      const parsed = JSON.parse(new TextDecoder().decode(bytes as Uint8Array))
+      expect(parsed).toMatchObject({
+        jsonrpc: '2.0',
+        id: 7,
+        result: {
+          answers: {
+            q1: { answers: ['Build'] },
+          },
+        },
+      })
+      dispose()
+    })
+  })
+
+  it('advances Codex multi-question requests instead of submitting incomplete answers', () => {
+    createRoot((dispose) => {
+      const onControlResponse = vi.fn().mockResolvedValue(undefined)
+      const askState = createMinimalAskState()
+      const editorContentRef = {
+        get: () => 'Build',
+        set: vi.fn(),
+      }
+      const props: ControlResponseHandlingProps = {
+        agentId: 'test-agent',
+        agent: { agentProvider: AgentProvider.CODEX },
+        controlRequests: [makeControlRequest('7', 'test-agent', {
+          method: 'item/tool/requestUserInput',
+          params: {
+            questions: [
+              { id: 'q1', header: 'Action', question: 'What next?', options: [{ label: 'Build' }] },
+              { id: 'q2', header: 'Env', question: 'Where?', options: [{ label: 'Dev' }] },
+            ],
+          },
+        })],
+        onControlResponse,
+        onSendMessage: vi.fn(),
+      }
+      const result = useControlResponseHandling(
+        props,
+        askState,
+        () => editorContentRef,
+        vi.fn(),
+      )
+
+      const submitted = result.handleControlSend('Build')
+
+      expect(submitted).toBe(false)
+      expect(askState.currentPage()).toBe(1)
+      expect(editorContentRef.set).toHaveBeenCalledWith('')
+      expect(onControlResponse).not.toHaveBeenCalled()
+      dispose()
+    })
+  })
+
+  it('uses OpenCode-native question responses', () => {
+    createRoot((dispose) => {
+      const onControlResponse = vi.fn().mockResolvedValue(undefined)
+      const askState = createMinimalAskState()
+      askState.setSelections({ 0: ['Build'] })
+      askState.setCustomTexts({ 1: 'Dev' })
+      const props: ControlResponseHandlingProps = {
+        agentId: 'test-agent',
+        agent: { agentProvider: AgentProvider.OPENCODE },
+        controlRequests: [makeControlRequest('que-1', 'test-agent', {
+          type: 'question.asked',
+          properties: {
+            questions: [
+              { header: 'Task', question: 'Pick a task', options: [{ label: 'Build' }] },
+              { header: 'Env', question: 'Pick an env', options: [{ label: 'Dev' }], custom: true },
+            ],
+          },
+        })],
+        onControlResponse,
+        onSendMessage: vi.fn(),
+      }
+      const result = useControlResponseHandling(props, askState, () => undefined, vi.fn())
+
+      result.handleControlSend('')
+
+      expect(onControlResponse).toHaveBeenCalledOnce()
+      const [, bytes] = onControlResponse.mock.calls[0]
+      const parsed = JSON.parse(new TextDecoder().decode(bytes as Uint8Array))
+      expect(parsed).toMatchObject({
+        jsonrpc: '2.0',
+        id: 'que-1',
+        result: {
+          answers: [['Build'], ['Dev']],
+        },
+      })
+      dispose()
+    })
+  })
+
+  it('advances OpenCode multi-question requests instead of submitting incomplete answers', () => {
+    createRoot((dispose) => {
+      const onControlResponse = vi.fn().mockResolvedValue(undefined)
+      const askState = createMinimalAskState()
+      const editorContentRef = {
+        get: () => 'Build',
+        set: vi.fn(),
+      }
+      const props: ControlResponseHandlingProps = {
+        agentId: 'test-agent',
+        agent: { agentProvider: AgentProvider.OPENCODE },
+        controlRequests: [makeControlRequest('que-1', 'test-agent', {
+          type: 'question.asked',
+          properties: {
+            questions: [
+              { header: 'Task', question: 'Pick a task', options: [{ label: 'Build' }] },
+              { header: 'Env', question: 'Pick an env', options: [{ label: 'Dev' }] },
+            ],
+          },
+        })],
+        onControlResponse,
+        onSendMessage: vi.fn(),
+      }
+      const result = useControlResponseHandling(props, askState, () => editorContentRef, vi.fn())
+
+      const submitted = result.handleControlSend('Build')
+
+      expect(submitted).toBe(false)
+      expect(askState.currentPage()).toBe(1)
+      expect(editorContentRef.set).toHaveBeenCalledWith('')
+      expect(onControlResponse).not.toHaveBeenCalled()
+      dispose()
+    })
   })
 })

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -162,69 +162,45 @@ export function useControlResponseHandling(
       return
     if (isAskUserQuestion()) {
       const provider = props.agent?.agentProvider
-      const normalizedRequest = (() => {
+      // Extract and normalize questions once for both page navigation and response building.
+      const normalizedQuestions: Question[] = (() => {
         switch (provider) {
           case AgentProvider.CODEX: {
             const params = req.payload.params as Record<string, unknown> | undefined
-            return {
-              ...req,
-              payload: {
-                ...req.payload,
-                request: {
-                  tool_name: 'AskUserQuestion',
-                  input: { questions: params?.questions ?? [] },
-                },
-              },
-            }
+            return (params?.questions as Question[] | undefined) ?? []
           }
           case AgentProvider.OPENCODE: {
             const properties = req.payload.properties as Record<string, unknown> | undefined
             const rawQuestions = (properties?.questions as Array<Record<string, unknown>> | undefined) ?? []
-            return {
-              ...req,
-              payload: {
-                ...req.payload,
-                request: {
-                  tool_name: 'AskUserQuestion',
-                  input: {
-                    questions: rawQuestions.map(question => ({
-                      ...question,
-                      multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
-                    })),
-                  },
-                },
-              },
-            }
-          }
-          default:
-            return req
-        }
-      })()
-      const sendAskResponse = () => {
-        switch (provider) {
-          case AgentProvider.CODEX: {
-            const params = req.payload.params as Record<string, unknown> | undefined
-            const questions = (params?.questions as Question[] | undefined) ?? []
-            void sendCodexUserInputResponse(req.agentId, sendControlResponse, req.requestId, questions, askState)
-            break
-          }
-          case AgentProvider.OPENCODE: {
-            const properties = req.payload.properties as Record<string, unknown> | undefined
-            const rawQuestions = (properties?.questions as Array<Record<string, unknown>> | undefined) ?? []
-            const questions = rawQuestions.map(question => ({
+            return rawQuestions.map(question => ({
               ...question,
               multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
             })) as Question[]
-            void sendOpenCodeQuestionResponse(req.agentId, sendControlResponse, req.requestId, questions, askState)
-            break
           }
+          default:
+            return (getToolInput(req.payload).questions as Question[] | undefined) ?? []
+        }
+      })()
+      const normalizedRequest: ControlRequest = {
+        ...req,
+        payload: {
+          ...req.payload,
+          request: {
+            tool_name: 'AskUserQuestion',
+            input: { questions: normalizedQuestions },
+          },
+        },
+      }
+      const sendAskResponse = () => {
+        switch (provider) {
+          case AgentProvider.CODEX:
+            void sendCodexUserInputResponse(req.agentId, sendControlResponse, req.requestId, normalizedQuestions, askState)
+            break
+          case AgentProvider.OPENCODE:
+            void sendOpenCodeQuestionResponse(req.agentId, sendControlResponse, req.requestId, normalizedQuestions, askState)
+            break
           default: {
-            const response = buildAskAnswers(
-              askState,
-              ((getToolInput(req.payload).questions as Question[] | undefined) ?? []),
-              getToolInput(req.payload),
-              req.requestId,
-            )
+            const response = buildAskAnswers(askState, normalizedQuestions, getToolInput(req.payload), req.requestId)
             void sendControlResponse(req.agentId, new TextEncoder().encode(JSON.stringify(response)))
           }
         }

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -1,14 +1,16 @@
 import type { Accessor } from 'solid-js'
 import type { FileAttachment } from './attachments'
-import type { AskQuestionState, EditorContentRef } from './controls/types'
-import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import type { AskQuestionState, EditorContentRef, Question } from './controls/types'
 import type { ControlRequest } from '~/stores/control.store'
 import type { PermissionMode } from '~/utils/controlResponse'
 import { createEffect, createMemo, on } from 'solid-js'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { clearDraft } from '~/lib/editor/draftPersistence'
 import { safeGetJson, safeRemoveItem, safeSetJson } from '~/lib/safeStorage'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
-import { trySubmitAskUserQuestion } from './controls/AskUserQuestionControl'
+import { buildAskAnswers, trySubmitAskUserQuestion } from './controls/AskUserQuestionControl'
+import { sendCodexUserInputResponse } from './controls/CodexControlRequest'
+import { sendOpenCodeQuestionResponse } from './controls/OpenCodeControlRequest'
 import { getProviderPlugin } from './providers'
 
 export interface ControlResponseHandlingProps {
@@ -146,6 +148,11 @@ export function useControlResponseHandling(
     if (!props.agentId)
       return
     clearDraft(`${props.agentId}-ctrl-${requestId}`)
+    // Ask-user-question drafts may be scoped per page; clear a reasonable
+    // range of page keys for this one-shot request.
+    for (let page = 0; page < 20; page++) {
+      clearDraft(`${props.agentId}-ctrl-${requestId}-q-${page}`)
+    }
     safeRemoveItem(`leapmux-ask-state-${props.agentId}-${requestId}`)
   }
 
@@ -154,11 +161,79 @@ export function useControlResponseHandling(
     if (!req)
       return
     if (isAskUserQuestion()) {
+      const provider = props.agent?.agentProvider
+      const normalizedRequest = (() => {
+        switch (provider) {
+          case AgentProvider.CODEX: {
+            const params = req.payload.params as Record<string, unknown> | undefined
+            return {
+              ...req,
+              payload: {
+                ...req.payload,
+                request: {
+                  tool_name: 'AskUserQuestion',
+                  input: { questions: params?.questions ?? [] },
+                },
+              },
+            }
+          }
+          case AgentProvider.OPENCODE: {
+            const properties = req.payload.properties as Record<string, unknown> | undefined
+            const rawQuestions = (properties?.questions as Array<Record<string, unknown>> | undefined) ?? []
+            return {
+              ...req,
+              payload: {
+                ...req.payload,
+                request: {
+                  tool_name: 'AskUserQuestion',
+                  input: {
+                    questions: rawQuestions.map(question => ({
+                      ...question,
+                      multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
+                    })),
+                  },
+                },
+              },
+            }
+          }
+          default:
+            return req
+        }
+      })()
+      const sendAskResponse = () => {
+        switch (provider) {
+          case AgentProvider.CODEX: {
+            const params = req.payload.params as Record<string, unknown> | undefined
+            const questions = (params?.questions as Question[] | undefined) ?? []
+            void sendCodexUserInputResponse(req.agentId, sendControlResponse, req.requestId, questions, askState)
+            break
+          }
+          case AgentProvider.OPENCODE: {
+            const properties = req.payload.properties as Record<string, unknown> | undefined
+            const rawQuestions = (properties?.questions as Array<Record<string, unknown>> | undefined) ?? []
+            const questions = rawQuestions.map(question => ({
+              ...question,
+              multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
+            })) as Question[]
+            void sendOpenCodeQuestionResponse(req.agentId, sendControlResponse, req.requestId, questions, askState)
+            break
+          }
+          default: {
+            const response = buildAskAnswers(
+              askState,
+              ((getToolInput(req.payload).questions as Question[] | undefined) ?? []),
+              getToolInput(req.payload),
+              req.requestId,
+            )
+            void sendControlResponse(req.agentId, new TextEncoder().encode(JSON.stringify(response)))
+          }
+        }
+      }
       const submitted = trySubmitAskUserQuestion(
         askState,
-        req,
+        normalizedRequest,
         content,
-        sendControlResponse,
+        sendAskResponse,
         editorContentRefAccessor(),
       )
       if (!submitted)

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.test.ts
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.test.ts
@@ -1,0 +1,81 @@
+import type { AskQuestionState, Question } from './types'
+import type { ControlRequest } from '~/stores/control.store'
+import { createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { buildAskAnswers, trySubmitAskUserQuestion } from './AskUserQuestionControl'
+
+function makeAskState(overrides: {
+  selections?: Record<number, string[]>
+  customTexts?: Record<number, string>
+  currentPage?: number
+} = {}): AskQuestionState {
+  const [selections, setSelections] = createSignal<Record<number, string[]>>(overrides.selections ?? {})
+  const [customTexts, setCustomTexts] = createSignal<Record<number, string>>(overrides.customTexts ?? {})
+  const [currentPage, setCurrentPage] = createSignal(overrides.currentPage ?? 0)
+  return { selections, setSelections, customTexts, setCustomTexts, currentPage, setCurrentPage }
+}
+
+function makeRequest(questions: Question[]): ControlRequest {
+  return {
+    requestId: 'req-1',
+    agentId: 'agent-1',
+    payload: {
+      request: {
+        tool_name: 'AskUserQuestion',
+        input: { questions },
+      },
+    },
+  }
+}
+
+describe('trySubmitAskUserQuestion', () => {
+  it('saves the current page draft and navigates to the next unanswered page', () => {
+    const state = makeAskState({
+      currentPage: 0,
+    })
+    const editorContentRef = { set: vi.fn(), get: vi.fn() }
+    const submitted = trySubmitAskUserQuestion(
+      state,
+      makeRequest([
+        { header: 'Task', question: 'Pick a task', options: [{ label: 'Build' }] },
+        { header: 'Env', question: 'Pick an env', options: [{ label: 'Dev' }] },
+      ]),
+      'typed first answer',
+      vi.fn(),
+      editorContentRef,
+    )
+
+    expect(submitted).toBe(false)
+    expect(state.customTexts()[0]).toBe('typed first answer')
+    expect(state.currentPage()).toBe(1)
+    expect(editorContentRef.set).toHaveBeenCalledWith('')
+  })
+})
+
+describe('buildAskAnswers', () => {
+  it('prefers selected options over custom text for the same question', () => {
+    const state = makeAskState({
+      selections: { 0: ['Build'] },
+      customTexts: { 0: 'typed answer' },
+    })
+    const result = buildAskAnswers(
+      state,
+      [{ header: 'Task', question: 'Pick a task', options: [{ label: 'Build' }] }],
+      { questions: [] },
+      'req-1',
+    )
+
+    expect(result).toMatchObject({
+      response: {
+        request_id: 'req-1',
+        response: {
+          updatedInput: {
+            answers: {
+              Task: 'Build',
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -17,6 +17,11 @@ import { sendResponse } from './types'
 // ---------------------------------------------------------------------------
 
 function toggleSelection(state: AskQuestionState, qIdx: number, label: string, multiSelect: boolean, totalQuestions: number) {
+  state.setCustomTexts((prev) => {
+    if (!(qIdx in prev))
+      return prev
+    return { ...prev, [qIdx]: '' }
+  })
   state.setSelections((prev) => {
     const current = prev[qIdx] ?? []
     if (multiSelect) {
@@ -49,7 +54,7 @@ function isPageAnsweredWithOption(state: AskQuestionState, qIdx: number): boolea
   return !!customText
 }
 
-function buildAskAnswers(
+export function buildAskAnswers(
   state: AskQuestionState,
   questions: Question[],
   input: Record<string, unknown>,
@@ -89,7 +94,7 @@ export function trySubmitAskUserQuestion(
   state: AskQuestionState,
   request: ControlRequest,
   currentContent: string,
-  onRespond: (agentId: string, content: Uint8Array) => void,
+  onSubmit: () => void,
   editorContentRef?: EditorContentRef,
 ): boolean {
   const input = getToolInput(request.payload)
@@ -97,8 +102,8 @@ export function trySubmitAskUserQuestion(
 
   // Save current editor text to the current page.
   const page = state.currentPage()
+  state.setCustomTexts(prev => ({ ...prev, [page]: currentContent }))
   if (currentContent) {
-    state.setCustomTexts(prev => ({ ...prev, [page]: currentContent }))
     state.setSelections(prev => ({ ...prev, [page]: [] }))
   }
 
@@ -128,9 +133,7 @@ export function trySubmitAskUserQuestion(
     return false
 
   // Build and send the response.
-  const response = buildAskAnswers(state, questions, input, request.requestId)
-  const bytes = new TextEncoder().encode(JSON.stringify(response))
-  onRespond(request.agentId, bytes)
+  onSubmit()
   return true
 }
 
@@ -269,9 +272,9 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
     if (!props.editorContentRef)
       return
     const text = props.editorContentRef.get()
+    const page = props.askState.currentPage()
+    props.askState.setCustomTexts(prev => ({ ...prev, [page]: text }))
     if (text) {
-      const page = props.askState.currentPage()
-      props.askState.setCustomTexts(prev => ({ ...prev, [page]: text }))
       // Clear selections for this page since custom text overrides
       props.askState.setSelections(prev => ({ ...prev, [page]: [] }))
     }

--- a/frontend/src/components/chat/controls/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CodexControlRequest.tsx
@@ -134,7 +134,25 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
   }
 
   return (
-    <Switch>
+    <Switch
+      fallback={(
+        <>
+          <div class={styles.controlBannerTitle}>{title()}</div>
+          <Show when={reason()}>
+            <div class={styles.codexReason}>{reason()}</div>
+          </Show>
+          <Show when={command()}>
+            <CollapsibleText text={command()!} maxLines={6} class={styles.toolSummary} />
+          </Show>
+          <Show when={cwd()}>
+            <div class={styles.codexCwd}>
+              {'cwd: '}
+              {cwd()}
+            </div>
+          </Show>
+        </>
+      )}
+    >
       <Match when={toolName() === 'CodexPlanModePrompt'}>
         <div class={styles.controlBannerTitle}>Implement the proposed plan?</div>
       </Match>
@@ -144,21 +162,6 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
           askState={props.askState}
           optionsDisabled={props.optionsDisabled}
         />
-      </Match>
-      <Match when={true}>
-        <div class={styles.controlBannerTitle}>{title()}</div>
-        <Show when={reason()}>
-          <div class={styles.codexReason}>{reason()}</div>
-        </Show>
-        <Show when={command()}>
-          <CollapsibleText text={command()!} maxLines={6} class={styles.toolSummary} />
-        </Show>
-        <Show when={cwd()}>
-          <div class={styles.codexCwd}>
-            {'cwd: '}
-            {cwd()}
-          </div>
-        </Show>
       </Match>
     </Switch>
   )
@@ -215,45 +218,8 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   }
 
   return (
-    <Switch>
-      <Match when={toolName() === 'CodexPlanModePrompt'}>
-        <div class={styles.controlFooter}>
-          <div class={styles.controlFooterLeft}>
-            {props.infoTrigger}
-          </div>
-          <div class={styles.controlFooterRight}>
-            <ButtonGroup>
-              <button
-                class="outline"
-                onClick={() => {
-                  if (props.hasEditorContent) {
-                    props.onTriggerSend()
-                    return
-                  }
-                  sendCodexPlanPromptResponse(props.request.agentId, props.onRespond, buildDenyResponse(props.request.requestId, ''))
-                }}
-                data-testid="control-deny-btn"
-              >
-                {props.hasEditorContent ? 'Send Feedback' : 'Stay in Plan Mode'}
-              </button>
-              <button
-                onClick={() => sendCodexPlanPromptResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId, getToolInput(props.request.payload)))}
-                data-testid="control-allow-btn"
-              >
-                Implement Plan
-              </button>
-            </ButtonGroup>
-          </div>
-        </div>
-      </Match>
-      <Match when={method() === 'item/tool/requestUserInput'}>
-        <AskUserQuestionActions
-          {...props}
-          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
-          onRespond={userInputOnRespond}
-        />
-      </Match>
-      <Match when={true}>
+    <Switch
+      fallback={(
         <div class={styles.controlFooter}>
           <div class={styles.controlFooterLeft}>
             {props.infoTrigger}
@@ -306,6 +272,44 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
             </Show>
           </div>
         </div>
+      )}
+    >
+      <Match when={toolName() === 'CodexPlanModePrompt'}>
+        <div class={styles.controlFooter}>
+          <div class={styles.controlFooterLeft}>
+            {props.infoTrigger}
+          </div>
+          <div class={styles.controlFooterRight}>
+            <ButtonGroup>
+              <button
+                class="outline"
+                onClick={() => {
+                  if (props.hasEditorContent) {
+                    props.onTriggerSend()
+                    return
+                  }
+                  sendCodexPlanPromptResponse(props.request.agentId, props.onRespond, buildDenyResponse(props.request.requestId, ''))
+                }}
+                data-testid="control-deny-btn"
+              >
+                {props.hasEditorContent ? 'Send Feedback' : 'Stay in Plan Mode'}
+              </button>
+              <button
+                onClick={() => sendCodexPlanPromptResponse(props.request.agentId, props.onRespond, buildAllowResponse(props.request.requestId, getToolInput(props.request.payload)))}
+                data-testid="control-allow-btn"
+              >
+                Implement Plan
+              </button>
+            </ButtonGroup>
+          </div>
+        </div>
+      </Match>
+      <Match when={method() === 'item/tool/requestUserInput'}>
+        <AskUserQuestionActions
+          {...props}
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          onRespond={userInputOnRespond}
+        />
       </Match>
     </Switch>
   )

--- a/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
@@ -1,9 +1,10 @@
 import type { Component } from 'solid-js'
-import type { ActionsProps, ContentProps } from './types'
+import type { ActionsProps, AskQuestionState, ContentProps, Question } from './types'
 
-import { For, Show } from 'solid-js'
+import { For, Match, Show, Switch } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import * as styles from '../ControlRequestBanner.css'
+import { AskUserQuestionActions, AskUserQuestionContent } from './AskUserQuestionControl'
 import { toRpcId } from './CodexControlRequest'
 import { sendResponse } from './types'
 
@@ -24,6 +25,33 @@ function getOptions(payload: Record<string, unknown>): Array<{ optionId: string,
   return (params?.options as Array<{ optionId: string, kind: string, name: string }>) ?? []
 }
 
+function getQuestionProperties(payload: Record<string, unknown>): Record<string, unknown> | undefined {
+  return payload.properties as Record<string, unknown> | undefined
+}
+
+function isOpenCodeQuestionPayload(payload: Record<string, unknown>): boolean {
+  return payload.type === 'question.asked' && Array.isArray(getQuestionProperties(payload)?.questions)
+}
+
+function wrapAsAskUserQuestion(payload: Record<string, unknown>): Record<string, unknown> {
+  const properties = getQuestionProperties(payload)
+  const questions = (properties?.questions as Array<Record<string, unknown>> | undefined) ?? []
+  return {
+    ...payload,
+    request: {
+      tool_name: 'AskUserQuestion',
+      input: {
+        questions: questions.map((question) => {
+          const mapped = { ...question }
+          if ('multiple' in mapped && !('multiSelect' in mapped))
+            mapped.multiSelect = mapped.multiple
+          return mapped
+        }),
+      },
+    },
+  }
+}
+
 /**
  * Sends an OpenCode permission response as a JSON-RPC response.
  */
@@ -40,6 +68,41 @@ export function sendOpenCodePermissionResponse(
   })
 }
 
+export function sendOpenCodeQuestionResponse(
+  agentId: string,
+  onRespond: (agentId: string, content: Uint8Array) => Promise<void>,
+  requestId: string,
+  questions: Question[],
+  askState: AskQuestionState,
+): Promise<void> {
+  const answers: string[][] = questions.map((_, index) => {
+    const selected = askState.selections()[index] ?? []
+    const customText = askState.customTexts()[index]?.trim()
+    if (selected.length > 0)
+      return selected
+    if (customText)
+      return [customText]
+    return []
+  })
+  return sendResponse(agentId, onRespond, {
+    jsonrpc: '2.0',
+    id: toRpcId(requestId),
+    result: { answers },
+  })
+}
+
+export function sendOpenCodeQuestionRejectResponse(
+  agentId: string,
+  onRespond: (agentId: string, content: Uint8Array) => Promise<void>,
+  requestId: string,
+): Promise<void> {
+  return sendResponse(agentId, onRespond, {
+    jsonrpc: '2.0',
+    id: toRpcId(requestId),
+    result: { rejected: true },
+  })
+}
+
 /** OpenCode-specific control request content. */
 export const OpenCodeControlContent: Component<ContentProps> = (props) => {
   const toolCall = () => getToolCall(props.request.payload)
@@ -47,18 +110,33 @@ export const OpenCodeControlContent: Component<ContentProps> = (props) => {
   const kind = () => toolCall()?.kind as string | undefined
 
   return (
-    <>
-      <div class={styles.controlBannerTitle}>{title()}</div>
-      <Show when={kind()}>
-        <div class={styles.codexCwd}>{kind()}</div>
-      </Show>
-    </>
+    <Switch>
+      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
+        <AskUserQuestionContent
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          askState={props.askState}
+          optionsDisabled={props.optionsDisabled}
+        />
+      </Match>
+      <Match when={true}>
+        <>
+          <div class={styles.controlBannerTitle}>{title()}</div>
+          <Show when={kind()}>
+            <div class={styles.codexCwd}>{kind()}</div>
+          </Show>
+        </>
+      </Match>
+    </Switch>
   )
 }
 
 /** OpenCode-specific control request action buttons. */
 export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
   const options = () => getOptions(props.request.payload)
+  const questions = () => ((getQuestionProperties(props.request.payload)?.questions as Question[] | undefined) ?? []).map(question => ({
+    ...question,
+    multiSelect: question.multiSelect ?? (question as Question & { multiple?: boolean }).multiple,
+  }))
 
   const handleOption = (optionId: string) => {
     sendOpenCodePermissionResponse(props.request.agentId, props.onRespond, props.request.requestId, optionId)
@@ -71,56 +149,76 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
       props.onPermissionModeChange?.(props.bypassPermissionMode)
   }
 
+  const userInputOnRespond = async (_agentId: string, content: Uint8Array) => {
+    const parsed = JSON.parse(new TextDecoder().decode(content))
+    if (parsed?.response?.response?.behavior === 'deny') {
+      await sendOpenCodeQuestionRejectResponse(props.request.agentId, props.onRespond, props.request.requestId)
+      return
+    }
+    await sendOpenCodeQuestionResponse(props.request.agentId, props.onRespond, props.request.requestId, questions(), props.askState)
+  }
+
   return (
-    <div class={styles.controlFooter}>
-      <div class={styles.controlFooterLeft}>
-        {props.infoTrigger}
-      </div>
-      <div class={styles.controlFooterRight}>
-        <Show
-          when={options().length > 0}
-          fallback={(
-            <ButtonGroup>
-              <button class="outline" onClick={() => handleOption('reject')} data-testid="control-deny-btn">Reject</button>
-              <button onClick={() => handleOption('once')} data-testid="control-allow-btn">Allow once</button>
-              <Show when={props.bypassPermissionMode}>
-                <button
-                  data-variant="secondary"
-                  onClick={handleBypassPermissions}
-                  data-testid="control-bypass-btn"
-                  title="Allow this request and stop asking for permissions"
-                >
-                  & Bypass Permissions
-                </button>
-              </Show>
-            </ButtonGroup>
-          )}
-        >
-          <ButtonGroup>
-            <For each={options()}>
-              {option => (
-                <button
-                  class={option.kind === 'reject_once' ? 'outline' : undefined}
-                  onClick={() => handleOption(option.optionId)}
-                  data-testid={`control-decision-${option.optionId}`}
-                >
-                  {option.name}
-                </button>
+    <Switch>
+      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
+        <AskUserQuestionActions
+          {...props}
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          onRespond={userInputOnRespond}
+        />
+      </Match>
+      <Match when={true}>
+        <div class={styles.controlFooter}>
+          <div class={styles.controlFooterLeft}>
+            {props.infoTrigger}
+          </div>
+          <div class={styles.controlFooterRight}>
+            <Show
+              when={options().length > 0}
+              fallback={(
+                <ButtonGroup>
+                  <button class="outline" onClick={() => handleOption('reject')} data-testid="control-deny-btn">Reject</button>
+                  <button onClick={() => handleOption('once')} data-testid="control-allow-btn">Allow once</button>
+                  <Show when={props.bypassPermissionMode}>
+                    <button
+                      data-variant="secondary"
+                      onClick={handleBypassPermissions}
+                      data-testid="control-bypass-btn"
+                      title="Allow this request and stop asking for permissions"
+                    >
+                      & Bypass Permissions
+                    </button>
+                  </Show>
+                </ButtonGroup>
               )}
-            </For>
-            <Show when={props.bypassPermissionMode}>
-              <button
-                data-variant="secondary"
-                onClick={handleBypassPermissions}
-                data-testid="control-bypass-btn"
-                title="Allow this request and stop asking for permissions"
-              >
-                & Bypass Permissions
-              </button>
+            >
+              <ButtonGroup>
+                <For each={options()}>
+                  {option => (
+                    <button
+                      class={option.kind === 'reject_once' ? 'outline' : undefined}
+                      onClick={() => handleOption(option.optionId)}
+                      data-testid={`control-decision-${option.optionId}`}
+                    >
+                      {option.name}
+                    </button>
+                  )}
+                </For>
+                <Show when={props.bypassPermissionMode}>
+                  <button
+                    data-variant="secondary"
+                    onClick={handleBypassPermissions}
+                    data-testid="control-bypass-btn"
+                    title="Allow this request and stop asking for permissions"
+                  >
+                    & Bypass Permissions
+                  </button>
+                </Show>
+              </ButtonGroup>
             </Show>
-          </ButtonGroup>
-        </Show>
-      </div>
-    </div>
+          </div>
+        </div>
+      </Match>
+    </Switch>
   )
 }

--- a/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
@@ -110,21 +110,22 @@ export const OpenCodeControlContent: Component<ContentProps> = (props) => {
   const kind = () => toolCall()?.kind as string | undefined
 
   return (
-    <Switch>
-      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
-        <AskUserQuestionContent
-          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
-          askState={props.askState}
-          optionsDisabled={props.optionsDisabled}
-        />
-      </Match>
-      <Match when={true}>
+    <Switch
+      fallback={(
         <>
           <div class={styles.controlBannerTitle}>{title()}</div>
           <Show when={kind()}>
             <div class={styles.codexCwd}>{kind()}</div>
           </Show>
         </>
+      )}
+    >
+      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
+        <AskUserQuestionContent
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          askState={props.askState}
+          optionsDisabled={props.optionsDisabled}
+        />
       </Match>
     </Switch>
   )
@@ -159,15 +160,8 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
   }
 
   return (
-    <Switch>
-      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
-        <AskUserQuestionActions
-          {...props}
-          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
-          onRespond={userInputOnRespond}
-        />
-      </Match>
-      <Match when={true}>
+    <Switch
+      fallback={(
         <div class={styles.controlFooter}>
           <div class={styles.controlFooterLeft}>
             {props.infoTrigger}
@@ -218,6 +212,14 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
             </Show>
           </div>
         </div>
+      )}
+    >
+      <Match when={isOpenCodeQuestionPayload(props.request.payload)}>
+        <AskUserQuestionActions
+          {...props}
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          onRespond={userInputOnRespond}
+        />
       </Match>
     </Switch>
   )

--- a/frontend/src/components/chat/providers/opencode.test.ts
+++ b/frontend/src/components/chat/providers/opencode.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
-import { sendOpenCodePermissionResponse } from '../controls/OpenCodeControlRequest'
+import { sendOpenCodePermissionResponse, sendOpenCodeQuestionResponse } from '../controls/OpenCodeControlRequest'
 import { opencodeResultDividerRenderer } from '../opencodeRenderers'
 import { getProviderPlugin } from './registry'
 
@@ -474,6 +474,14 @@ describe('opencode tool_call_update renderer', () => {
 describe('opencode isAskUserQuestion', () => {
   const plugin = getProviderPlugin(AgentProvider.OPENCODE)!
 
+  it('returns true for question requests', () => {
+    const payload = {
+      type: 'question.asked',
+      properties: { questions: [] },
+    }
+    expect(plugin.isAskUserQuestion!(payload)).toBe(true)
+  })
+
   it('returns false for permission requests', () => {
     const payload = {
       method: 'requestPermission',
@@ -572,6 +580,44 @@ describe('sendOpenCodePermissionResponse', () => {
       jsonrpc: '2.0',
       id: 'abc',
       result: { outcome: { outcome: 'selected', optionId: 'once' } },
+    })
+  })
+})
+
+describe('sendOpenCodeQuestionResponse', () => {
+  function decode(bytes: Uint8Array): Record<string, unknown> {
+    return JSON.parse(new TextDecoder().decode(bytes))
+  }
+
+  function makeAskState() {
+    return {
+      selections: () => ({ 0: ['Build'], 1: [] }),
+      setSelections: vi.fn(),
+      customTexts: () => ({ 1: 'Dev' }),
+      setCustomTexts: vi.fn(),
+      currentPage: () => 0,
+      setCurrentPage: vi.fn(),
+    }
+  }
+
+  it('sends ordered answer arrays for each question', async () => {
+    let captured: Uint8Array | undefined
+    const onRespond = vi.fn(async (_id: string, content: Uint8Array) => {
+      captured = content
+    })
+
+    await sendOpenCodeQuestionResponse('agent1', onRespond, 'que_1', [
+      { question: 'Action?', options: [{ label: 'Build' }] },
+      { question: 'Env?', options: [{ label: 'Dev' }] },
+    ], makeAskState())
+
+    const parsed = decode(captured!)
+    expect(parsed).toMatchObject({
+      jsonrpc: '2.0',
+      id: 'que_1',
+      result: {
+        answers: [['Build'], ['Dev']],
+      },
     })
   })
 })

--- a/frontend/src/components/chat/providers/opencode.tsx
+++ b/frontend/src/components/chat/providers/opencode.tsx
@@ -211,8 +211,8 @@ const opencodePlugin: ProviderPlugin = {
     })
   },
 
-  isAskUserQuestion(): boolean {
-    return false
+  isAskUserQuestion(payload?: Record<string, unknown>): boolean {
+    return payload?.type === 'question.asked'
   },
 
   async changePermissionMode(workerId: string, agentId: string, mode: PermissionMode): Promise<void> {

--- a/frontend/tests/e2e/30-control-request.spec.ts
+++ b/frontend/tests/e2e/30-control-request.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { openAgentViaUI } from './helpers/ui'
 
 /** Send a message via the ProseMirror editor. */
 async function sendMessage(page: Page, text: string) {
@@ -188,5 +189,51 @@ test.describe('Control Request - AskUserQuestion', () => {
 
     // Verify control banner disappears
     await expect(page.locator('[data-testid="control-banner"]')).not.toBeVisible()
+  })
+
+  test('multi-question control request stays on the correct agent tab', async ({ page, authenticatedWorkspace }) => {
+    const agentTabs = page.locator('[data-testid="tab"][data-tab-type="agent"]')
+    await expect(agentTabs).toHaveCount(1)
+
+    // Open a second agent tab; the new tab becomes active.
+    await openAgentViaUI(page)
+    await expect(agentTabs).toHaveCount(2)
+
+    const firstAgentTab = agentTabs.first()
+    const secondAgentTab = agentTabs.nth(1)
+
+    // Trigger AskUserQuestion only on the second agent.
+    await secondAgentTab.click()
+    await sendMessage(
+      page,
+      `Use AskUserQuestion and tell me what I answered: {"questions":[${COLOR_Q_2},${SIZE_Q}]}`,
+    )
+
+    const secondBanner = await waitForControlBanner(page)
+    await expect(secondBanner.getByText('Pick a color')).toBeVisible()
+
+    // Switch to the first agent and verify the control request did not leak there.
+    await firstAgentTab.click()
+    await expect(firstAgentTab).toHaveAttribute('aria-selected', 'true')
+    await expect(page.locator('[data-testid="control-banner"]')).not.toBeVisible()
+
+    // Switch back to the second agent and complete the request there.
+    await secondAgentTab.click()
+    await expect(secondAgentTab).toHaveAttribute('aria-selected', 'true')
+    await expect(page.locator('[data-testid="control-banner"]')).toBeVisible()
+    await expect(page.locator('[data-testid="control-banner"]').getByText('Pick a color')).toBeVisible()
+
+    await clickOption(page, 'Red')
+    await expect(page.locator('[data-testid="control-banner"]').getByText('Pick a size')).toBeVisible()
+    await clickOption(page, 'Large')
+
+    const submitBtn = page.locator('[data-testid="control-submit-btn"]')
+    await expect(submitBtn).toBeEnabled()
+    await submitBtn.click()
+
+    await page.waitForFunction(() => {
+      const body = document.body.textContent || ''
+      return body.includes('Red') && body.includes('Large')
+    })
   })
 })


### PR DESCRIPTION
## Motivation

Multi-question `AskUserQuestion` control requests sent by Codex and OpenCode agents were not handled correctly end-to-end. Two categories of bugs existed:

1. **Wrong response format.** When `handleControlSend` dispatched a Codex `item/tool/requestUserInput` or an OpenCode `question.asked` request, it fell through to the generic Claude Code response builder and sent a Claude Code-format payload instead of the provider-native JSON-RPC format expected by each backend.

2. **Multi-question pagination not enforced.** On requests with more than one question, pressing Send before all questions were answered would submit an incomplete response rather than advancing the paginator to the next unanswered question.

Additionally, the backend lacked a display-text helper for OpenCode question responses, so answered questions were not persisted as readable chat messages.

## Modifications

**Frontend (`controlResponseHandling.ts`)**
- `handleControlSend` now detects the active provider and, for `AgentProvider.CODEX` and `AgentProvider.OPENCODE` question requests, calls `sendCodexUserInputResponse` / `sendOpenCodeQuestionResponse` directly instead of the generic `buildAskAnswers` path.
- Multi-question requests are routed through `trySubmitAskUserQuestion`, which advances the paginator when not all questions are answered and only submits once every question has a response.

**Frontend (`CodexControlRequest.tsx` / `OpenCodeControlRequest.tsx`)**
- Extracted `sendCodexUserInputResponse` and `sendOpenCodeQuestionResponse` as standalone exported helpers so `controlResponseHandling.ts` can call them without going through the banner component's `onRespond` interception chain.
- `sendOpenCodeQuestionRejectResponse` added for the deny path of OpenCode question flows.
- Replaced `<Match when={true}>` with idiomatic `<Switch fallback>` in both components.

**Frontend (`AskUserQuestionControl.tsx`)**
- `trySubmitAskUserQuestion` navigation logic made provider-agnostic: it reads questions from the (already-normalised) `ControlRequest.payload.request.input.questions`, making it reusable for Codex and OpenCode question normalization done in `handleControlSend`.

**Frontend (`MarkdownEditor.tsx` / `AgentEditorPanel.tsx`)**
- Consolidated two separate draft-swap effects (agent switch + control request switch) into a single effect driven by a computed `draftKey`, which also covers per-question pagination scope.

**Backend (`codex_control.go` / `control_response_test.go`)**
- Added `opencodeQuestionAnswersText` to format OpenCode `question.asked` answers for message persistence.
- `codexControlResponseDisplayText` now dispatches to the appropriate handler based on the request method/type looked up from the stored control request payload, with provider-aware routing for Codex vs OpenCode.
- Fixed `codexControlResponseRequestID` to handle string JSON-RPC IDs using `json.RawMessage` instead of `*json.Number`.
- New backend integration test verifying that `SendControlResponse` persists the correct user-role message for OpenCode question answer flows.

**E2E tests (`30-control-request.spec.ts`)**
- Added Playwright test verifying multi-question requests stay isolated to the correct agent tab when multiple agents are open simultaneously.

## Result

- Codex `item/tool/requestUserInput` and OpenCode `question.asked` control requests now send provider-native JSON-RPC responses, so agents receive answers in the format they expect.
- Pressing Send on a multi-question request with unanswered pages navigates to the next unanswered question instead of submitting incomplete data.
- Answered questions are persisted as readable user messages in the chat history for both Codex and OpenCode providers.
- Control request banners remain scoped to the correct agent tab when multiple agents are open simultaneously.

🤖 Generated with Claude Code
