### PR TITLE
Add Copy Markdown and Quote reply actions to plan and tool renderers

### DIFF
--- a/frontend/src/components/chat/AgentInfoCard.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.tsx
@@ -6,6 +6,7 @@ import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js'
 import { AgentProviderIcon, agentProviderLabel } from '~/components/common/AgentProviderIcon'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
+import { useCopyButton } from '~/hooks/useCopyButton'
 import { formatCountdown, formatResetTimestamp, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_POPOVER_LABELS } from '~/lib/rateLimitUtils'
 import * as styles from './ChatView.css'
 import { computePercentage, contextBufferPct, contextSize, resolveContextWindow } from './ContextUsageGrid'
@@ -24,26 +25,8 @@ function formatTokenCount(tokens: number): string {
   return String(tokens)
 }
 
-function useCopyButton(getText: () => string | undefined) {
-  const [copied, setCopied] = createSignal(false)
-  const handleCopy = async () => {
-    const text = getText()
-    if (!text)
-      return
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(setCopied, 2000, false)
-    }
-    catch {
-      // ignore clipboard errors
-    }
-  }
-  return { copied, handleCopy }
-}
-
 function CopyButton(props: { getText: () => string | undefined, title: string, testId?: string }) {
-  const { copied, handleCopy } = useCopyButton(() => props.getText())
+  const { copied, copy: handleCopy } = useCopyButton(() => props.getText())
   return (
     <button
       class={styles.infoCopyButton}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -440,11 +440,14 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   const toggleDiffView = () => props.onSetLocalDiffView?.(diffView() === 'unified' ? 'split' : 'unified')
 
   // Build render context for message renderers.
+  // eslint-disable-next-line solid/reactivity -- onReply is a stable callback prop
+  const contextReply: RenderContext['onReply'] = props.onReply ? text => props.onReply!(formatChatQuote(text)) : undefined
   const renderContext = (): RenderContext => ({
     createdAt: props.message.createdAt,
     workingDir: props.workingDir,
     homeDir: props.homeDir,
     diffView: diffView(),
+    onReply: contextReply,
     onCopyJson: copyJson,
     jsonCopied: jsonCopied(),
     toolUseMessage: toolUseMessage(),

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -14,12 +14,13 @@ import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import Terminal from 'lucide-solid/icons/terminal'
 import Wrench from 'lucide-solid/icons/wrench'
-import { createEffect, createSignal, For, Show } from 'solid-js'
+import { createEffect, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { TodoList } from '~/components/todo/TodoList'
 import { DiffStatsBadge } from '~/components/tree/gitStatusUtils'
-import { codexPlanToTodos } from '~/lib/messageParser'
+import { useCopyButton } from '~/hooks/useCopyButton'
+import { codexPlanToTodos, todosToMarkdown } from '~/lib/messageParser'
 import { renderMarkdown, shikiHighlighter } from '~/lib/renderMarkdown'
 import { getCachedSettingsLabel } from '~/lib/settingsLabelCache'
 import { inlineFlex } from '~/styles/shared.css'
@@ -332,12 +333,7 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
   const text = (item.text as string) || ''
   if (!text)
     return null
-  const [copied, setCopied] = createSignal(false)
-  const copyMarkdown = () => {
-    void navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(setCopied, 2000, false)
-  }
+  const { copied, copy } = useCopyButton(() => text)
   const reply = context?.onReply ? () => context.onReply!(text) : undefined
   return (
     <ToolUseLayout
@@ -348,7 +344,7 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
       bordered={false}
       context={context}
       onReply={reply}
-      onCopyMarkdown={copyMarkdown}
+      onCopyMarkdown={copy}
       markdownCopied={copied()}
     >
       <hr />
@@ -373,14 +369,9 @@ export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, conte
   const explanation = typeof params.explanation === 'string' ? params.explanation.trim() : ''
   const label = `${todos.length} task${todos.length === 1 ? '' : 's'}${explanation ? ` - ${explanation}` : ''}`
 
-  const todosToMarkdown = () => todos.map(t => `- [${t.status === 'completed' ? 'x' : ' '}] ${t.content}`).join('\n')
-  const [copied, setCopied] = createSignal(false)
-  const copyMarkdown = () => {
-    void navigator.clipboard.writeText(todosToMarkdown())
-    setCopied(true)
-    setTimeout(setCopied, 2000, false)
-  }
-  const reply = context?.onReply ? () => context.onReply!(todosToMarkdown()) : undefined
+  const md = todosToMarkdown(todos)
+  const { copied, copy } = useCopyButton(() => md)
+  const reply = context?.onReply ? () => context.onReply!(md) : undefined
 
   return (
     <ToolUseLayout
@@ -390,7 +381,7 @@ export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, conte
       alwaysVisible={true}
       context={context}
       onReply={reply}
-      onCopyMarkdown={copyMarkdown}
+      onCopyMarkdown={copy}
       markdownCopied={copied()}
     >
       <TodoList todos={todos} />

--- a/frontend/src/components/chat/codexRenderers.tsx
+++ b/frontend/src/components/chat/codexRenderers.tsx
@@ -14,7 +14,7 @@ import ListTodo from 'lucide-solid/icons/list-todo'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import Terminal from 'lucide-solid/icons/terminal'
 import Wrench from 'lucide-solid/icons/wrench'
-import { createEffect, For, Show } from 'solid-js'
+import { createEffect, createSignal, For, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { TodoList } from '~/components/todo/TodoList'
@@ -332,6 +332,13 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
   const text = (item.text as string) || ''
   if (!text)
     return null
+  const [copied, setCopied] = createSignal(false)
+  const copyMarkdown = () => {
+    void navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(setCopied, 2000, false)
+  }
+  const reply = context?.onReply ? () => context.onReply!(text) : undefined
   return (
     <ToolUseLayout
       icon={PlaneTakeoff}
@@ -340,6 +347,9 @@ export function codexPlanRenderer(parsed: unknown, _role: MessageRole, context?:
       alwaysVisible={true}
       bordered={false}
       context={context}
+      onReply={reply}
+      onCopyMarkdown={copyMarkdown}
+      markdownCopied={copied()}
     >
       <hr />
       <div class={markdownContent} style={{ 'font-size': 'var(--text-regular)' }} innerHTML={renderMarkdown(text)} />
@@ -363,6 +373,15 @@ export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, conte
   const explanation = typeof params.explanation === 'string' ? params.explanation.trim() : ''
   const label = `${todos.length} task${todos.length === 1 ? '' : 's'}${explanation ? ` - ${explanation}` : ''}`
 
+  const todosToMarkdown = () => todos.map(t => `- [${t.status === 'completed' ? 'x' : ' '}] ${t.content}`).join('\n')
+  const [copied, setCopied] = createSignal(false)
+  const copyMarkdown = () => {
+    void navigator.clipboard.writeText(todosToMarkdown())
+    setCopied(true)
+    setTimeout(setCopied, 2000, false)
+  }
+  const reply = context?.onReply ? () => context.onReply!(todosToMarkdown()) : undefined
+
   return (
     <ToolUseLayout
       icon={ListTodo}
@@ -370,6 +389,9 @@ export function codexTurnPlanRenderer(parsed: unknown, _role: MessageRole, conte
       title={label}
       alwaysVisible={true}
       context={context}
+      onReply={reply}
+      onCopyMarkdown={copyMarkdown}
+      markdownCopied={copied()}
     >
       <TodoList todos={todos} />
     </ToolUseLayout>

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -70,6 +70,8 @@ export interface RenderContext {
   homeDir?: string
   /** User's preferred diff view. */
   diffView?: DiffViewPreference
+  /** Reply/quote callback — inserts quoted text into the editor. */
+  onReply?: (quotedText: string) => void
   /** Copy raw JSON to clipboard. */
   onCopyJson?: () => void
   /** Whether JSON was just copied (for feedback). */

--- a/frontend/src/components/chat/opencodeRenderers.tsx
+++ b/frontend/src/components/chat/opencodeRenderers.tsx
@@ -352,7 +352,7 @@ export function opencodeResultDividerRenderer(parsed: unknown): JSX.Element | nu
 }
 
 /** Render an OpenCode plan (todo list). */
-export function opencodePlanRenderer(toolUse: Record<string, unknown>, _role: MessageRole, _context?: RenderContext): JSX.Element {
+export function opencodePlanRenderer(toolUse: Record<string, unknown>, _role: MessageRole, context?: RenderContext): JSX.Element {
   const entries = toolUse.entries as Array<{ priority?: string, status?: string, content: string }> | undefined
 
   if (!entries || entries.length === 0)
@@ -363,11 +363,24 @@ export function opencodePlanRenderer(toolUse: Record<string, unknown>, _role: Me
     status: e.status === 'completed' ? 'completed' as const : 'pending' as const,
   }))
 
+  const entriesToMarkdown = () => entries.map(e => `- [${e.status === 'completed' ? 'x' : ' '}] ${e.content}`).join('\n')
+  const [copied, setCopied] = createSignal(false)
+  const copyMarkdown = () => {
+    void navigator.clipboard.writeText(entriesToMarkdown())
+    setCopied(true)
+    setTimeout(setCopied, 2000, false)
+  }
+  const reply = context?.onReply ? () => context.onReply!(entriesToMarkdown()) : undefined
+
   return (
     <ToolUseLayout
       icon={ListTodo}
       toolName="Plan"
       title="Plan"
+      context={context}
+      onReply={reply}
+      onCopyMarkdown={copyMarkdown}
+      markdownCopied={copied()}
     >
       <TodoList items={todos} />
     </ToolUseLayout>

--- a/frontend/src/components/chat/opencodeRenderers.tsx
+++ b/frontend/src/components/chat/opencodeRenderers.tsx
@@ -13,6 +13,8 @@ import Wrench from 'lucide-solid/icons/wrench'
 import { createSignal, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { TodoList } from '~/components/todo/TodoList'
+import { useCopyButton } from '~/hooks/useCopyButton'
+import { todosToMarkdown } from '~/lib/messageParser'
 import { containsAnsi, renderAnsi } from '~/lib/renderAnsi'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { inlineFlex } from '~/styles/shared.css'
@@ -363,14 +365,9 @@ export function opencodePlanRenderer(toolUse: Record<string, unknown>, _role: Me
     status: e.status === 'completed' ? 'completed' as const : 'pending' as const,
   }))
 
-  const entriesToMarkdown = () => entries.map(e => `- [${e.status === 'completed' ? 'x' : ' '}] ${e.content}`).join('\n')
-  const [copied, setCopied] = createSignal(false)
-  const copyMarkdown = () => {
-    void navigator.clipboard.writeText(entriesToMarkdown())
-    setCopied(true)
-    setTimeout(setCopied, 2000, false)
-  }
-  const reply = context?.onReply ? () => context.onReply!(entriesToMarkdown()) : undefined
+  const md = todosToMarkdown(todos)
+  const { copied, copy } = useCopyButton(() => md)
+  const reply = context?.onReply ? () => context.onReply!(md) : undefined
 
   return (
     <ToolUseLayout
@@ -379,7 +376,7 @@ export function opencodePlanRenderer(toolUse: Record<string, unknown>, _role: Me
       title="Plan"
       context={context}
       onReply={reply}
-      onCopyMarkdown={copyMarkdown}
+      onCopyMarkdown={copy}
       markdownCopied={copied()}
     >
       <TodoList items={todos} />

--- a/frontend/src/components/chat/planModeRenderers.tsx
+++ b/frontend/src/components/chat/planModeRenderers.tsx
@@ -2,7 +2,8 @@
 import type { JSX } from 'solid-js'
 import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
-import { createSignal, Show } from 'solid-js'
+import { Show } from 'solid-js'
+import { useCopyButton } from '~/hooks/useCopyButton'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { markdownContent } from './markdownContent.css'
 import { getAssistantContent, isObject } from './messageUtils'
@@ -12,14 +13,7 @@ import { ToolUseLayout } from './toolRenderers'
 export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
   const input = toolUse.input
   const planText = isObject(input) ? String((input as Record<string, unknown>).plan || '') : ''
-  const [copied, setCopied] = createSignal(false)
-  const copyMarkdown = planText
-    ? () => {
-        void navigator.clipboard.writeText(planText)
-        setCopied(true)
-        setTimeout(setCopied, 2000, false)
-      }
-    : undefined
+  const { copied, copy } = useCopyButton(() => planText || undefined)
   const reply = planText && context?.onReply ? () => context.onReply!(planText) : undefined
 
   return (
@@ -31,7 +25,7 @@ export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: R
       bordered={false}
       context={context}
       onReply={reply}
-      onCopyMarkdown={copyMarkdown}
+      onCopyMarkdown={planText ? copy : undefined}
       markdownCopied={copied()}
     >
       <Show when={planText}>

--- a/frontend/src/components/chat/planModeRenderers.tsx
+++ b/frontend/src/components/chat/planModeRenderers.tsx
@@ -2,7 +2,7 @@
 import type { JSX } from 'solid-js'
 import type { MessageContentRenderer, RenderContext } from './messageRenderers'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
-import { Show } from 'solid-js'
+import { createSignal, Show } from 'solid-js'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import { markdownContent } from './markdownContent.css'
 import { getAssistantContent, isObject } from './messageUtils'
@@ -12,6 +12,15 @@ import { ToolUseLayout } from './toolRenderers'
 export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
   const input = toolUse.input
   const planText = isObject(input) ? String((input as Record<string, unknown>).plan || '') : ''
+  const [copied, setCopied] = createSignal(false)
+  const copyMarkdown = planText
+    ? () => {
+        void navigator.clipboard.writeText(planText)
+        setCopied(true)
+        setTimeout(setCopied, 2000, false)
+      }
+    : undefined
+  const reply = planText && context?.onReply ? () => context.onReply!(planText) : undefined
 
   return (
     <ToolUseLayout
@@ -21,6 +30,9 @@ export function renderExitPlanMode(toolUse: Record<string, unknown>, context?: R
       alwaysVisible={true}
       bordered={false}
       context={context}
+      onReply={reply}
+      onCopyMarkdown={copyMarkdown}
+      markdownCopied={copied()}
     >
       <Show when={planText}>
         <hr />

--- a/frontend/src/components/chat/taskRenderers.tsx
+++ b/frontend/src/components/chat/taskRenderers.tsx
@@ -5,8 +5,10 @@ import type { TodoItem } from '~/stores/chat.store'
 import Check from 'lucide-solid/icons/check'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import Vote from 'lucide-solid/icons/vote'
-import { createSignal, For, Show } from 'solid-js'
+import { For, Show } from 'solid-js'
 import { TodoList } from '~/components/todo/TodoList'
+import { useCopyButton } from '~/hooks/useCopyButton'
+import { todosToMarkdown } from '~/lib/messageParser'
 import { getAssistantContent, isObject } from './messageUtils'
 import { ToolUseLayout } from './toolRenderers'
 import {
@@ -28,15 +30,9 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
   const count = todos.length
   const label = `${count} task${count === 1 ? '' : 's'}`
 
-  const statusMark = (s: TodoItem['status']) => s === 'completed' ? 'x' : s === 'in_progress' ? '~' : ' '
-  const todosToMarkdown = () => todos.map(t => `- [${statusMark(t.status)}] ${t.content}`).join('\n')
-  const [copied, setCopied] = createSignal(false)
-  const copyMarkdown = () => {
-    void navigator.clipboard.writeText(todosToMarkdown())
-    setCopied(true)
-    setTimeout(setCopied, 2000, false)
-  }
-  const reply = context?.onReply ? () => context.onReply!(todosToMarkdown()) : undefined
+  const md = todosToMarkdown(todos)
+  const { copied, copy } = useCopyButton(() => md)
+  const reply = context?.onReply ? () => context.onReply!(md) : undefined
 
   return (
     <ToolUseLayout
@@ -46,7 +42,7 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
       alwaysVisible={true}
       context={context}
       onReply={reply}
-      onCopyMarkdown={copyMarkdown}
+      onCopyMarkdown={copy}
       markdownCopied={copied()}
     >
       <TodoList todos={todos} />

--- a/frontend/src/components/chat/taskRenderers.tsx
+++ b/frontend/src/components/chat/taskRenderers.tsx
@@ -5,7 +5,7 @@ import type { TodoItem } from '~/stores/chat.store'
 import Check from 'lucide-solid/icons/check'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import Vote from 'lucide-solid/icons/vote'
-import { For, Show } from 'solid-js'
+import { createSignal, For, Show } from 'solid-js'
 import { TodoList } from '~/components/todo/TodoList'
 import { getAssistantContent, isObject } from './messageUtils'
 import { ToolUseLayout } from './toolRenderers'
@@ -28,6 +28,16 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
   const count = todos.length
   const label = `${count} task${count === 1 ? '' : 's'}`
 
+  const statusMark = (s: TodoItem['status']) => s === 'completed' ? 'x' : s === 'in_progress' ? '~' : ' '
+  const todosToMarkdown = () => todos.map(t => `- [${statusMark(t.status)}] ${t.content}`).join('\n')
+  const [copied, setCopied] = createSignal(false)
+  const copyMarkdown = () => {
+    void navigator.clipboard.writeText(todosToMarkdown())
+    setCopied(true)
+    setTimeout(setCopied, 2000, false)
+  }
+  const reply = context?.onReply ? () => context.onReply!(todosToMarkdown()) : undefined
+
   return (
     <ToolUseLayout
       icon={ListTodo}
@@ -35,6 +45,9 @@ export function renderTodoWrite(toolUse: Record<string, unknown>, context?: Rend
       title={label}
       alwaysVisible={true}
       context={context}
+      onReply={reply}
+      onCopyMarkdown={copyMarkdown}
+      markdownCopied={copied()}
     >
       <TodoList todos={todos} />
     </ToolUseLayout>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -125,10 +125,8 @@ export function ToolUseLayout(props: {
   onCopyContent?: () => void
   contentCopied?: boolean
   copyContentLabel?: string
-  /** Copy markdown callback. */
   onCopyMarkdown?: () => void
   markdownCopied?: boolean
-  /** Reply/quote callback. */
   onReply?: () => void
 }): JSX.Element {
   const expanded = () => props.expanded ?? false

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -125,9 +125,14 @@ export function ToolUseLayout(props: {
   onCopyContent?: () => void
   contentCopied?: boolean
   copyContentLabel?: string
+  /** Copy markdown callback. */
+  onCopyMarkdown?: () => void
+  markdownCopied?: boolean
+  /** Reply/quote callback. */
+  onReply?: () => void
 }): JSX.Element {
   const expanded = () => props.expanded ?? false
-  const hasActions = () => !!props.onToggleExpand || !!props.context?.onCopyJson || !!props.hasDiff || !!props.onCopyContent
+  const hasActions = () => !!props.onToggleExpand || !!props.context?.onCopyJson || !!props.hasDiff || !!props.onCopyContent || !!props.onCopyMarkdown || !!props.onReply
   return (
     <div class={toolMessage} data-tool-message>
       <div class={toolUseHeader}>
@@ -139,17 +144,21 @@ export function ToolUseLayout(props: {
         {typeof props.title === 'string'
           ? <span class={toolInputText}>{props.title}</span>
           : props.title}
-        <Show when={props.context && hasActions()}>
+        <Show when={hasActions()}>
           <ToolHeaderActions
-            createdAt={props.context!.createdAt}
+            inline
+            createdAt={props.context?.createdAt}
             expanded={expanded()}
             onToggleExpand={props.onToggleExpand}
             expandLabel={props.expandLabel}
             onCopyContent={props.onCopyContent}
             contentCopied={props.contentCopied}
             copyContentLabel={props.copyContentLabel}
-            onCopyJson={props.context!.onCopyJson}
-            jsonCopied={props.context!.jsonCopied ?? false}
+            onReply={props.onReply}
+            onCopyMarkdown={props.onCopyMarkdown}
+            markdownCopied={props.markdownCopied}
+            onCopyJson={props.context?.onCopyJson}
+            jsonCopied={props.context?.jsonCopied ?? false}
             hasDiff={props.hasDiff}
             diffView={props.diffView}
             onToggleDiffView={props.onDiffViewChange ? () => props.onDiffViewChange!(props.diffView === 'unified' ? 'split' : 'unified') : undefined}
@@ -226,51 +235,84 @@ export function ToolHeaderActions(props: {
   /** Copy markdown callback — when provided, shows a copy markdown button. */
   onCopyMarkdown?: () => void
   markdownCopied?: boolean
+  /** When true, use inline tool header order; when false (default), use bubble order. */
+  inline?: boolean
 }): JSX.Element {
   const timestamp = () => props.createdAt
+
+  const replyButton = (
+    <Show when={props.onReply}>
+      <IconButton
+        icon={Quote}
+        size="sm"
+        data-testid="message-quote"
+        onClick={() => props.onReply?.()}
+        title="Quote"
+      />
+    </Show>
+  )
+  const timestampEl = (
+    <Show when={timestamp()}>
+      <RelativeTime
+        timestamp={timestamp()!}
+        class={toolHeaderTimestamp}
+      />
+    </Show>
+  )
+  const copyJsonButton = (
+    <Show when={props.onCopyJson}>
+      <IconButton
+        icon={props.jsonCopied ? Check : Braces}
+        size="sm"
+        data-testid="message-copy-json"
+        onClick={() => props.onCopyJson?.()}
+        title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
+      />
+    </Show>
+  )
+  const copyMarkdownButton = (
+    <Show when={props.onCopyMarkdown}>
+      <IconButton
+        icon={props.markdownCopied ? Check : Copy}
+        size="sm"
+        data-testid="message-copy-markdown"
+        onClick={() => props.onCopyMarkdown?.()}
+        title={props.markdownCopied ? 'Copied' : 'Copy Markdown'}
+      />
+    </Show>
+  )
+  const copyContentButton = (
+    <Show when={props.onCopyContent}>
+      <IconButton
+        icon={props.contentCopied ? Check : Copy}
+        size="sm"
+        onClick={() => props.onCopyContent?.()}
+        title={props.contentCopied ? 'Copied' : (props.copyContentLabel || 'Copy')}
+      />
+    </Show>
+  )
+
   return (
     <div class={toolHeaderActions} data-testid="message-toolbar">
-      <Show when={props.onReply}>
-        <IconButton
-          icon={Quote}
-          size="sm"
-          data-testid="message-quote"
-          onClick={() => props.onReply?.()}
-          title="Quote"
-        />
-      </Show>
-      <Show when={timestamp()}>
-        <RelativeTime
-          timestamp={timestamp()!}
-          class={toolHeaderTimestamp}
-        />
-      </Show>
-      <Show when={props.onCopyMarkdown}>
-        <IconButton
-          icon={props.markdownCopied ? Check : Copy}
-          size="sm"
-          data-testid="message-copy-markdown"
-          onClick={() => props.onCopyMarkdown?.()}
-          title={props.markdownCopied ? 'Copied' : 'Copy Markdown'}
-        />
-      </Show>
-      <Show when={props.onCopyJson}>
-        <IconButton
-          icon={props.jsonCopied ? Check : Braces}
-          size="sm"
-          data-testid="message-copy-json"
-          onClick={() => props.onCopyJson?.()}
-          title={props.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
-        />
-      </Show>
-      <Show when={props.onCopyContent}>
-        <IconButton
-          icon={props.contentCopied ? Check : Copy}
-          size="sm"
-          onClick={() => props.onCopyContent?.()}
-          title={props.contentCopied ? 'Copied' : (props.copyContentLabel || 'Copy')}
-        />
-      </Show>
+      {props.inline
+        ? (
+            <>
+              {timestampEl}
+              {copyJsonButton}
+              {copyMarkdownButton}
+              {copyContentButton}
+              {replyButton}
+            </>
+          )
+        : (
+            <>
+              {replyButton}
+              {timestampEl}
+              {copyMarkdownButton}
+              {copyJsonButton}
+              {copyContentButton}
+            </>
+          )}
       <Show when={props.hasDiff && props.onToggleDiffView}>
         <IconButton
           icon={props.diffView === 'unified' ? Columns2 : Rows2}

--- a/frontend/src/hooks/useCopyButton.ts
+++ b/frontend/src/hooks/useCopyButton.ts
@@ -1,0 +1,20 @@
+import { createSignal } from 'solid-js'
+
+/** Reusable clipboard-copy-with-feedback hook. Returns a `copied` signal and a `copy` handler. */
+export function useCopyButton(getText: () => string | undefined) {
+  const [copied, setCopied] = createSignal(false)
+  const copy = async () => {
+    const text = getText()
+    if (!text)
+      return
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(setCopied, 2000, false)
+    }
+    catch {
+      // ignore clipboard errors
+    }
+  }
+  return { copied, copy }
+}

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -101,6 +101,14 @@ export function getInnerMessageType(parsed: ParsedMessageContent): string | unde
 // Domain-specific extractors
 // ---------------------------------------------------------------------------
 
+/** Convert todo items to a markdown checklist string. */
+export function todosToMarkdown(items: ReadonlyArray<{ status: string, content: string }>): string {
+  return items.map((t) => {
+    const mark = t.status === 'completed' ? 'x' : t.status === 'in_progress' ? '~' : ' '
+    return `- [${mark}] ${t.content}`
+  }).join('\n')
+}
+
 /** Convert a Codex plan array (from turn/plan/updated) to TodoItem[]. */
 export function codexPlanToTodos(plan: unknown[]): TodoItem[] {
   return plan.flatMap((entry) => {


### PR DESCRIPTION
## Motivation

Plan-mode and task-related messages (Codex plans, OpenCode plans, todo lists, etc.) had no way to copy their content as markdown or quote them in a reply. Users who want to reference or reuse structured plan output had to manually select and copy text. Additionally, the copy-to-clipboard logic was duplicated across components with no shared abstraction.

## Modifications

- Added a new `useCopyButton` hook (`frontend/src/hooks/useCopyButton.ts`) that encapsulates copy-to-clipboard state and logic. The hook exposes `{ copied, copy }` (note: this replaces the previous `{ copied, handleCopy }` shape in `AgentInfoCard`).
- Removed the duplicate copy logic from `AgentInfoCard.tsx` in favor of the new hook.
- Added `todosToMarkdown` utility in `messageParser.ts` to serialize todo items into a markdown checklist string.
- Extended `RenderContext` with an `onReply` callback to support quote/reply actions across renderers.
- Updated `ToolUseLayout` and `ToolHeaderActions` with new props: `onCopyMarkdown`, `markdownCopied`, `onReply`, and `inline` (controls action ordering for inline vs. bubble contexts).
- Wired Copy Markdown and Quote buttons into all plan and task renderers: Codex plan, Codex turn plan, OpenCode plan, `ExitPlanMode`, and `TodoWrite`.

## Result

Users can now copy the markdown representation of any plan or todo list directly from the message bubble using a Copy Markdown button, and can quote plan messages into a reply using the Quote button. The copy-to-clipboard behavior is now handled by a single shared hook rather than duplicated per component.

🤖 Generated with Claude Code
