### PR TITLE
Add Cursor CLI agent provider support

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -614,7 +614,9 @@ func jsonRPCResultError(resp json.RawMessage) error {
 	return fmt.Errorf("json-rpc error %d: %s", code, message)
 }
 
-func extractJSONRPCID(content []byte) (json.RawMessage, string, bool) {
+// ExtractJSONRPCID extracts the JSON-RPC "id" field from a raw JSON payload,
+// returning the raw bytes, its string representation, and whether extraction succeeded.
+func ExtractJSONRPCID(content []byte) (json.RawMessage, string, bool) {
 	var payload struct {
 		ID json.RawMessage `json:"id"`
 	}

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -110,8 +110,6 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(
 // the shared dispatcher. Return true if the update was consumed.
 type acpSessionUpdateHandler func(sessionUpdate string, update json.RawMessage) bool
 
-// configOptionSessionUpdateHandler returns an acpSessionUpdateHandler that
-// dispatches config_option_update events to the given handler.
 func configOptionSessionUpdateHandler(handler func(json.RawMessage)) acpSessionUpdateHandler {
 	return func(sessionUpdate string, update json.RawMessage) bool {
 		if sessionUpdate == acpUpdateConfigOptionUpdate {
@@ -131,7 +129,11 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 	var wrapper struct {
 		Update json.RawMessage `json:"update"`
 	}
-	if json.Unmarshal(params, &wrapper) != nil || len(wrapper.Update) == 0 {
+	if err := json.Unmarshal(params, &wrapper); err != nil {
+		slog.Warn("acp session update unmarshal wrapper failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
+		return
+	}
+	if len(wrapper.Update) == 0 {
 		return
 	}
 	update := wrapper.Update
@@ -141,7 +143,8 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 		Role          string          `json:"role"`
 		Content       json.RawMessage `json:"content"`
 	}
-	if json.Unmarshal(update, &header) != nil {
+	if err := json.Unmarshal(update, &header); err != nil {
+		slog.Warn("acp session update unmarshal header failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
 		return
 	}
 
@@ -185,7 +188,10 @@ func buildACPSessionRequest(resumeSessionID, workingDir, newMethod, resumeMethod
 		p["sessionId"] = resumeSessionID
 		method = resumeMethod
 	}
-	params, _ = json.Marshal(p)
+	params, err := json.Marshal(p)
+	if err != nil {
+		slog.Warn("acp session request marshal failed", "error", err)
+	}
 	return method, params
 }
 
@@ -440,7 +446,11 @@ func (b *acpBase) broadcastACPChunk(content json.RawMessage, builder *strings.Bu
 	var c struct {
 		Text string `json:"text"`
 	}
-	if json.Unmarshal(content, &c) != nil || c.Text == "" {
+	if err := json.Unmarshal(content, &c); err != nil {
+		slog.Warn("acp broadcast chunk unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
+		return
+	}
+	if c.Text == "" {
 		return
 	}
 	b.mu.Lock()
@@ -496,7 +506,11 @@ func unwrapACPResult(resp json.RawMessage) json.RawMessage {
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
 	}
-	if json.Unmarshal(resp, &wrapper) != nil || wrapper.Role != "result" || len(wrapper.Content) == 0 {
+	if err := json.Unmarshal(resp, &wrapper); err != nil {
+		slog.Warn("acp unwrap result unmarshal failed", "error", err)
+		return resp
+	}
+	if wrapper.Role != "result" || len(wrapper.Content) == 0 {
 		return resp
 	}
 	return wrapper.Content
@@ -509,7 +523,11 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 		Kind       string `json:"kind"`
 		Status     string `json:"status"`
 	}
-	if json.Unmarshal(update, &tc) != nil || tc.ToolCallID == "" {
+	if err := json.Unmarshal(update, &tc); err != nil {
+		slog.Warn("acp tool_call unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
+		return
+	}
+	if tc.ToolCallID == "" {
 		return
 	}
 
@@ -544,7 +562,11 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 		ToolCallID string `json:"toolCallId"`
 		Status     string `json:"status"`
 	}
-	if json.Unmarshal(update, &tcu) != nil || tcu.ToolCallID == "" {
+	if err := json.Unmarshal(update, &tcu); err != nil {
+		slog.Warn("acp tool_call_update unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
+		return
+	}
+	if tcu.ToolCallID == "" {
 		return
 	}
 
@@ -579,7 +601,8 @@ func (b *acpBase) handleUsageUpdate(update json.RawMessage) {
 			Currency string  `json:"currency"`
 		} `json:"cost"`
 	}
-	if json.Unmarshal(update, &usage) != nil {
+	if err := json.Unmarshal(update, &usage); err != nil {
+		slog.Warn("acp usage update unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
 		return
 	}
 
@@ -632,7 +655,11 @@ func ExtractJSONRPCID(content []byte) (json.RawMessage, string, bool) {
 	var payload struct {
 		ID json.RawMessage `json:"id"`
 	}
-	if json.Unmarshal(content, &payload) != nil || len(payload.ID) == 0 || string(payload.ID) == "null" {
+	if err := json.Unmarshal(content, &payload); err != nil {
+		slog.Warn("json-rpc id unmarshal failed", "error", err)
+		return nil, "", false
+	}
+	if len(payload.ID) == 0 || string(payload.ID) == "null" {
 		return nil, "", false
 	}
 
@@ -797,17 +824,29 @@ type acpConfigOptionValue struct {
 }
 
 // buildACPModels converts a list of acpModelInfo into proto AvailableModel messages.
-func buildACPModels(models []acpModelInfo, currentModelID string) []*leapmuxv1.AvailableModel {
+// If normalize is non-nil, it is applied to each model ID (and the currentModelID) before use.
+func buildACPModels(models []acpModelInfo, currentModelID string, normalize func(string) string) []*leapmuxv1.AvailableModel {
+	if normalize != nil {
+		currentModelID = normalize(currentModelID)
+	}
 	result := make([]*leapmuxv1.AvailableModel, 0, len(models))
 	for _, m := range models {
-		if m.ModelID == "" {
+		id := m.ModelID
+		if normalize != nil {
+			id = normalize(id)
+		}
+		if id == "" {
 			continue
 		}
+		name := m.Name
+		if name == "" {
+			name = id
+		}
 		result = append(result, &leapmuxv1.AvailableModel{
-			Id:          m.ModelID,
-			DisplayName: m.Name,
+			Id:          id,
+			DisplayName: name,
 			Description: m.Description,
-			IsDefault:   m.ModelID == currentModelID,
+			IsDefault:   id == currentModelID,
 		})
 	}
 	return result
@@ -842,7 +881,8 @@ func parseACPConfigOptions(raw json.RawMessage) []acpConfigOption {
 	var payload struct {
 		ConfigOptions []acpConfigOption `json:"configOptions"`
 	}
-	if json.Unmarshal(raw, &payload) != nil {
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		slog.Warn("acp config options unmarshal failed", "error", err)
 		return nil
 	}
 	return payload.ConfigOptions

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -110,6 +110,18 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(
 // the shared dispatcher. Return true if the update was consumed.
 type acpSessionUpdateHandler func(sessionUpdate string, update json.RawMessage) bool
 
+// configOptionSessionUpdateHandler returns an acpSessionUpdateHandler that
+// dispatches config_option_update events to the given handler.
+func configOptionSessionUpdateHandler(handler func(json.RawMessage)) acpSessionUpdateHandler {
+	return func(sessionUpdate string, update json.RawMessage) bool {
+		if sessionUpdate == acpUpdateConfigOptionUpdate {
+			handler(update)
+			return true
+		}
+		return false
+	}
+}
+
 // acpMethodHandler is called for JSON-RPC methods not handled by the shared
 // ACP dispatcher. Return true if the method was consumed.
 type acpMethodHandler func(line *parsedLine) bool

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -74,6 +74,7 @@ type acpBase struct {
 	sink               OutputSink
 	providerName       string                  // e.g. "copilot", "gemini", "opencode" — used in log messages
 	extraSessionUpdate acpSessionUpdateHandler // optional provider-specific session update handler
+	extraMethod        acpMethodHandler        // optional provider-specific request/notification handler
 	sessionID          string
 	model              string
 	availableModels    []*leapmuxv1.AvailableModel
@@ -108,6 +109,10 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(
 // acpSessionUpdateHandler is called for session update types not handled by
 // the shared dispatcher. Return true if the update was consumed.
 type acpSessionUpdateHandler func(sessionUpdate string, update json.RawMessage) bool
+
+// acpMethodHandler is called for JSON-RPC methods not handled by the shared
+// ACP dispatcher. Return true if the method was consumed.
+type acpMethodHandler func(line *parsedLine) bool
 
 // handleACPSessionUpdate dispatches ACP sessionUpdate notifications by type.
 func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessionUpdateHandler) {
@@ -182,6 +187,13 @@ type jsonrpcMessage struct {
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
+type jsonrpcResponseMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   any             `json:"error,omitempty"`
+}
+
 func (b *jsonrpcBase) sendRequest(method string, params json.RawMessage, timeout time.Duration) (json.RawMessage, error) {
 	reqID := b.nextReqID.Add(1)
 
@@ -234,6 +246,37 @@ func (b *jsonrpcBase) sendNotification(method string, params json.RawMessage) er
 		return fmt.Errorf("write notification: %w", err)
 	}
 
+	return nil
+}
+
+func (b *jsonrpcBase) sendResponse(id json.RawMessage, result any) error {
+	return b.writeJSONRPCResponse(jsonrpcResponseMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
+func (b *jsonrpcBase) sendErrorResponse(id json.RawMessage, code int, message string) error {
+	return b.writeJSONRPCResponse(jsonrpcResponseMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: map[string]interface{}{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+func (b *jsonrpcBase) writeJSONRPCResponse(resp jsonrpcResponseMessage) error {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := b.stdin.Write(data); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
 	return nil
 }
 
@@ -571,6 +614,26 @@ func jsonRPCResultError(resp json.RawMessage) error {
 	return fmt.Errorf("json-rpc error %d: %s", code, message)
 }
 
+func extractJSONRPCID(content []byte) (json.RawMessage, string, bool) {
+	var payload struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if json.Unmarshal(content, &payload) != nil || len(payload.ID) == 0 || string(payload.ID) == "null" {
+		return nil, "", false
+	}
+
+	var text string
+	if json.Unmarshal(payload.ID, &text) == nil {
+		return payload.ID, text, true
+	}
+
+	text = strings.TrimSpace(string(payload.ID))
+	if text == "" {
+		return nil, "", false
+	}
+	return payload.ID, text, true
+}
+
 // acpSessionConfig describes the session methods for a specific ACP provider.
 type acpSessionConfig struct {
 	newMethod    string // e.g. "session/new"
@@ -590,6 +653,7 @@ type acpSessionResult struct {
 	Models         []acpModelInfo
 	CurrentModeID  string
 	Modes          []acpModeInfo
+	ConfigOptions  []acpConfigOption
 	Raw            json.RawMessage // full session response for provider-specific parsing
 }
 
@@ -657,6 +721,7 @@ func (b *acpBase) startACPHandshake(
 			CurrentModeID  string        `json:"currentModeId"`
 			AvailableModes []acpModeInfo `json:"availableModes"`
 		} `json:"modes"`
+		ConfigOptions []acpConfigOption `json:"configOptions"`
 	}
 	if err := json.Unmarshal(sessionResp, &session); err != nil {
 		cleanup()
@@ -678,6 +743,7 @@ func (b *acpBase) startACPHandshake(
 		SessionID:      session.SessionID,
 		CurrentModelID: session.Models.CurrentModelID,
 		Models:         session.Models.AvailableModels,
+		ConfigOptions:  session.ConfigOptions,
 		Raw:            sessionResp,
 	}
 	if session.Modes != nil {
@@ -698,6 +764,20 @@ type acpModeInfo struct {
 // acpModelInfo is the JSON shape shared by all ACP providers for model metadata.
 type acpModelInfo struct {
 	ModelID     string `json:"modelId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type acpConfigOption struct {
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	CurrentValue string                 `json:"currentValue"`
+	Options      []acpConfigOptionValue `json:"options"`
+}
+
+type acpConfigOptionValue struct {
+	Value       string `json:"value"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }
@@ -742,6 +822,94 @@ func buildACPModes(modes []acpModeInfo, currentModeID string, filter func(id str
 		})
 	}
 	return result
+}
+
+func parseACPConfigOptions(raw json.RawMessage) []acpConfigOption {
+	var payload struct {
+		ConfigOptions []acpConfigOption `json:"configOptions"`
+	}
+	if json.Unmarshal(raw, &payload) != nil {
+		return nil
+	}
+	return payload.ConfigOptions
+}
+
+func syncACPConfigOptions(
+	model *string,
+	mode *string,
+	availableModels *[]*leapmuxv1.AvailableModel,
+	availableModes *[]*leapmuxv1.AvailableOption,
+	options []acpConfigOption,
+	normalize func(configID, value string) string,
+) string {
+	if len(options) == 0 {
+		return ""
+	}
+	if normalize == nil {
+		normalize = func(_ string, value string) string { return value }
+	}
+
+	var updatedMode string
+	for _, option := range options {
+		switch option.ID {
+		case "model":
+			currentValue := normalize(option.ID, option.CurrentValue)
+			if currentValue != "" {
+				*model = currentValue
+			}
+			if len(option.Options) > 0 {
+				models := make([]*leapmuxv1.AvailableModel, 0, len(option.Options))
+				for _, candidate := range option.Options {
+					value := normalize(option.ID, candidate.Value)
+					if value == "" {
+						continue
+					}
+					name := candidate.Name
+					if name == "" {
+						name = value
+					}
+					models = append(models, &leapmuxv1.AvailableModel{
+						Id:          value,
+						DisplayName: name,
+						Description: candidate.Description,
+						IsDefault:   value == currentValue,
+					})
+				}
+				if len(models) > 0 {
+					*availableModels = models
+				}
+			}
+		case "mode":
+			currentValue := normalize(option.ID, option.CurrentValue)
+			if currentValue != "" {
+				*mode = currentValue
+				updatedMode = currentValue
+			}
+			if len(option.Options) > 0 {
+				modes := make([]*leapmuxv1.AvailableOption, 0, len(option.Options))
+				for _, candidate := range option.Options {
+					value := normalize(option.ID, candidate.Value)
+					if value == "" {
+						continue
+					}
+					name := candidate.Name
+					if name == "" {
+						name = value
+					}
+					modes = append(modes, &leapmuxv1.AvailableOption{
+						Id:          value,
+						Name:        name,
+						Description: candidate.Description,
+						IsDefault:   value == currentValue,
+					})
+				}
+				if len(modes) > 0 {
+					*availableModes = modes
+				}
+			}
+		}
+	}
+	return updatedMode
 }
 
 // AvailableModels returns the models reported by the ACP provider.
@@ -852,7 +1020,7 @@ func (b *acpBase) handleRequestPermission(id *json.Number, content []byte) {
 // extraSessionUpdate handler. Used as the outputHandler for readOutputLoop.
 func (b *acpBase) handleOutput(line *parsedLine) {
 	slog.Debug("acp HandleOutput", "provider", b.providerName, "agent_id", b.agentID, "method", line.Method, "len", len(line.Raw))
-	b.handleACPOutput(line, b.extraSessionUpdate)
+	b.handleACPOutput(line, b.extraSessionUpdate, b.extraMethod)
 }
 
 // HandleOutput processes a single JSONL notification from an ACP provider.
@@ -862,13 +1030,16 @@ func (b *acpBase) HandleOutput(content []byte) {
 
 // handleACPOutput is the shared output dispatcher for all ACP providers.
 // It routes session updates and permission requests, persisting anything else.
-func (b *acpBase) handleACPOutput(line *parsedLine, extraSessionUpdate acpSessionUpdateHandler) {
+func (b *acpBase) handleACPOutput(line *parsedLine, extraSessionUpdate acpSessionUpdateHandler, extraMethod acpMethodHandler) {
 	switch line.Method {
 	case acpMethodSessionUpdate:
 		b.handleACPSessionUpdate(line.Params, extraSessionUpdate)
 	case acpMethodSessionRequestPermission:
 		b.handleRequestPermission(line.ID, line.Raw)
 	default:
+		if extraMethod != nil && extraMethod(line) {
+			return
+		}
 		if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, line.Raw, SpanInfo{}); err != nil {
 			slog.Error("acp persist notification", "agent_id", b.agentID, "method", line.Method, "error", err)
 		}

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -147,7 +147,9 @@ func (e *messageEnvelope) ContentBlocks() []contentBlock {
 		e.contentParsed = true
 		raw := e.Message.RawContent
 		if len(raw) > 0 && raw[0] == '[' {
-			_ = json.Unmarshal(raw, &e.contentBlocks)
+			if err := json.Unmarshal(raw, &e.contentBlocks); err != nil {
+				slog.Warn("claude content blocks unmarshal failed", "error", err)
+			}
 		}
 	}
 	return e.contentBlocks
@@ -189,7 +191,8 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 				OldString string `json:"old_string"`
 				NewString string `json:"new_string"`
 			}
-			if json.Unmarshal(block.Input, &input) != nil {
+			if err := json.Unmarshal(block.Input, &input); err != nil {
+				slog.Warn("claude tool input unmarshal failed", "agent_id", a.agentID, "tool", block.Name, "error", err)
 				continue
 			}
 			filePath := input.FilePath
@@ -441,7 +444,9 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 	var rlType struct {
 		RateLimitType string `json:"rateLimitType"`
 	}
-	_ = json.Unmarshal(rle.RateLimitInfo, &rlType)
+	if err := json.Unmarshal(rle.RateLimitInfo, &rlType); err != nil {
+		slog.Warn("claude rate limit info unmarshal failed", "agent_id", a.agentID, "error", err)
+	}
 	if rlType.RateLimitType == "" {
 		rlType.RateLimitType = "unknown"
 	}
@@ -628,7 +633,8 @@ func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
 		var msg struct {
 			Type string `json:"type"`
 		}
-		if json.Unmarshal(content, &msg) != nil {
+		if err := json.Unmarshal(content, &msg); err != nil {
+			slog.Warn("notification threadable unmarshal failed", "role", "leapmux", "error", err)
 			return false
 		}
 		return msg.Type == "settings_changed" || msg.Type == "context_cleared" || msg.Type == "interrupted" || msg.Type == "rate_limit" || msg.Type == "agent_error" || msg.Type == "compacting"
@@ -636,7 +642,8 @@ func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
 		var msg struct {
 			Subtype string `json:"subtype"`
 		}
-		if json.Unmarshal(content, &msg) != nil {
+		if err := json.Unmarshal(content, &msg); err != nil {
+			slog.Warn("notification threadable unmarshal failed", "role", "system", "error", err)
 			return false
 		}
 		return notificationThreadableSubtypes[msg.Subtype]
@@ -650,7 +657,11 @@ func extractStatusValue(content []byte) (status string, ok bool) {
 		Subtype string  `json:"subtype"`
 		Status  *string `json:"status"`
 	}
-	if json.Unmarshal(content, &msg) != nil || msg.Subtype != "status" {
+	if err := json.Unmarshal(content, &msg); err != nil {
+		slog.Warn("extract status value unmarshal failed", "error", err)
+		return "", false
+	}
+	if msg.Subtype != "status" {
 		return "", false
 	}
 	if msg.Status != nil {
@@ -686,7 +697,11 @@ func isSimpleUserTextEcho(content []byte) bool {
 			Content json.RawMessage `json:"content"`
 		} `json:"message"`
 	}
-	if json.Unmarshal(content, &msg) != nil || msg.Type != "user" {
+	if err := json.Unmarshal(content, &msg); err != nil {
+		slog.Warn("user text echo unmarshal failed", "error", err)
+		return false
+	}
+	if msg.Type != "user" {
 		return false
 	}
 	trimmed := bytes.TrimSpace(msg.Message.Content)

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -351,7 +351,8 @@ func (a *CodexAgent) handleThreadCompacted(params json.RawMessage) {
 		ThreadID string `json:"threadId"`
 		TurnID   string `json:"turnId"`
 	}
-	if json.Unmarshal(params, &notif) != nil {
+	if err := json.Unmarshal(params, &notif); err != nil {
+		slog.Warn("codex thread_compacted unmarshal failed", "agent_id", a.agentID, "error", err)
 		return
 	}
 	content, err := json.Marshal(map[string]interface{}{
@@ -474,7 +475,8 @@ func (a *CodexAgent) handleTokenUsageUpdated(content []byte, params json.RawMess
 			ModelContextWindow *int64 `json:"modelContextWindow"`
 		} `json:"tokenUsage"`
 	}
-	if json.Unmarshal(params, &notif) != nil {
+	if err := json.Unmarshal(params, &notif); err != nil {
+		slog.Warn("codex token_usage_updated unmarshal failed", "agent_id", a.agentID, "error", err)
 		return
 	}
 	if !a.isMainThreadID(notif.ThreadID) {
@@ -582,7 +584,8 @@ func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMess
 			Secondary *codexRateLimitTier `json:"secondary"`
 		} `json:"rateLimits"`
 	}
-	if json.Unmarshal(params, &notif) != nil {
+	if err := json.Unmarshal(params, &notif); err != nil {
+		slog.Warn("codex rate limit unmarshal failed", "agent_id", a.agentID, "error", err)
 		return
 	}
 
@@ -728,7 +731,8 @@ func isTerminalCollabAgentStatus(status string) bool {
 
 func parseCollabToolCall(item json.RawMessage) *codexCollabAgentToolCall {
 	var collab codexCollabAgentToolCall
-	if json.Unmarshal(item, &collab) != nil {
+	if err := json.Unmarshal(item, &collab); err != nil {
+		slog.Warn("codex collab tool call unmarshal failed", "error", err)
 		return nil
 	}
 	return &collab
@@ -910,7 +914,11 @@ func extractCodexItem(params json.RawMessage) (item json.RawMessage, itemType, i
 		Item     json.RawMessage `json:"item"`
 		ThreadID string          `json:"threadId"`
 	}
-	if json.Unmarshal(params, &wrapper) != nil || len(wrapper.Item) == 0 {
+	if err := json.Unmarshal(params, &wrapper); err != nil {
+		slog.Warn("codex extract item wrapper unmarshal failed", "error", err)
+		return nil, "", "", ""
+	}
+	if len(wrapper.Item) == 0 {
 		return nil, "", "", ""
 	}
 
@@ -918,7 +926,8 @@ func extractCodexItem(params json.RawMessage) (item json.RawMessage, itemType, i
 		Type string `json:"type"`
 		ID   string `json:"id"`
 	}
-	if json.Unmarshal(wrapper.Item, &header) != nil {
+	if err := json.Unmarshal(wrapper.Item, &header); err != nil {
+		slog.Warn("codex extract item header unmarshal failed", "error", err)
 		return nil, "", "", ""
 	}
 

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -58,7 +58,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 			model:        opts.Model,
 		},
 	}
-	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
 
 	if err := cmd.Start(); err != nil {

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -76,7 +76,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 		return nil, err
 	}
 
-	a.availableModels = buildACPModels(handshake.Models, handshake.CurrentModelID)
+	a.availableModels = buildACPModels(handshake.Models, handshake.CurrentModelID, nil)
 	if a.model == "" && handshake.CurrentModelID != "" {
 		a.model = handshake.CurrentModelID
 	}

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -16,16 +16,6 @@ const (
 	CopilotCLIModeAutopilot = "https://agentclientprotocol.com/protocol/session-modes#autopilot"
 )
 
-type copilotCLIConfigOption struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	CurrentValue string `json:"currentValue"`
-	Options      []struct {
-		Value string `json:"value"`
-		Name  string `json:"name"`
-	} `json:"options"`
-}
-
 // CopilotCLIAgent manages a single Copilot CLI ACP process.
 type CopilotCLIAgent struct {
 	acpBase
@@ -98,11 +88,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	}
 
 	// Parse Copilot-specific configOptions from the raw session response.
-	var copilotSession struct {
-		ConfigOptions []copilotCLIConfigOption `json:"configOptions"`
-	}
-	_ = json.Unmarshal(handshake.Raw, &copilotSession)
-	a.syncConfigOptions(copilotSession.ConfigOptions)
+	a.syncConfigOptions(handshake.ConfigOptions)
 
 	cleanup := func() {
 		a.Stop()

--- a/backend/internal/worker/agent/copilot_output.go
+++ b/backend/internal/worker/agent/copilot_output.go
@@ -2,14 +2,6 @@ package agent
 
 import "encoding/json"
 
-func (a *CopilotCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update json.RawMessage) bool {
-	if sessionUpdate == acpUpdateConfigOptionUpdate {
-		a.handleConfigOptionUpdate(update)
-		return true
-	}
-	return false
-}
-
 func (a *CopilotCLIAgent) handleConfigOptionUpdate(update json.RawMessage) {
 	options := parseACPConfigOptions(update)
 	if len(options) == 0 {

--- a/backend/internal/worker/agent/copilot_output.go
+++ b/backend/internal/worker/agent/copilot_output.go
@@ -1,10 +1,6 @@
 package agent
 
-import (
-	"encoding/json"
-
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-)
+import "encoding/json"
 
 func (a *CopilotCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update json.RawMessage) bool {
 	if sessionUpdate == acpUpdateConfigOptionUpdate {
@@ -15,81 +11,24 @@ func (a *CopilotCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update 
 }
 
 func (a *CopilotCLIAgent) handleConfigOptionUpdate(update json.RawMessage) {
-	var payload struct {
-		ConfigOptions []copilotCLIConfigOption `json:"configOptions"`
-	}
-	if json.Unmarshal(update, &payload) != nil || len(payload.ConfigOptions) == 0 {
+	options := parseACPConfigOptions(update)
+	if len(options) == 0 {
 		return
 	}
 
-	if mode := a.syncConfigOptions(payload.ConfigOptions); mode != "" {
+	if mode := a.syncConfigOptions(options); mode != "" {
 		a.sink.UpdatePermissionMode(mode)
 	}
 }
 
 // syncConfigOptions updates the agent's model and mode from the given config options.
 // It returns the updated mode value, or "" if no mode was found.
-func (a *CopilotCLIAgent) syncConfigOptions(options []copilotCLIConfigOption) string {
+func (a *CopilotCLIAgent) syncConfigOptions(options []acpConfigOption) string {
 	if len(options) == 0 {
 		return ""
 	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
-	var updatedMode string
-	for _, option := range options {
-		switch option.ID {
-		case "model":
-			if option.CurrentValue != "" {
-				a.model = option.CurrentValue
-			}
-			if len(option.Options) > 0 {
-				models := make([]*leapmuxv1.AvailableModel, 0, len(option.Options))
-				for _, candidate := range option.Options {
-					if candidate.Value == "" {
-						continue
-					}
-					name := candidate.Name
-					if name == "" {
-						name = candidate.Value
-					}
-					models = append(models, &leapmuxv1.AvailableModel{
-						Id:          candidate.Value,
-						DisplayName: name,
-						IsDefault:   candidate.Value == option.CurrentValue,
-					})
-				}
-				if len(models) > 0 {
-					a.availableModels = models
-				}
-			}
-		case "mode":
-			if option.CurrentValue != "" {
-				a.permissionMode = option.CurrentValue
-				updatedMode = option.CurrentValue
-			}
-			if len(option.Options) > 0 {
-				modes := make([]*leapmuxv1.AvailableOption, 0, len(option.Options))
-				for _, candidate := range option.Options {
-					if candidate.Value == "" {
-						continue
-					}
-					name := candidate.Name
-					if name == "" {
-						name = candidate.Value
-					}
-					modes = append(modes, &leapmuxv1.AvailableOption{
-						Id:        candidate.Value,
-						Name:      name,
-						IsDefault: candidate.Value == option.CurrentValue,
-					})
-				}
-				if len(modes) > 0 {
-					a.availableModes = modes
-				}
-			}
-		}
-	}
-	return updatedMode
+	return syncACPConfigOptions(&a.model, &a.permissionMode, &a.availableModels, &a.availableModes, options, nil)
 }

--- a/backend/internal/worker/agent/copilot_output_test.go
+++ b/backend/internal/worker/agent/copilot_output_test.go
@@ -13,7 +13,7 @@ func newCopilotAgentWithSink(sink OutputSink) *CopilotCLIAgent {
 			sessionID:    "test-session",
 		},
 	}
-	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	return a
 }
 

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -80,7 +80,7 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 		return nil, err
 	}
 
-	a.availableModels = buildCursorCLIModels(handshake.Models, handshake.CurrentModelID)
+	a.availableModels = buildACPModels(handshake.Models, handshake.CurrentModelID, normalizeCursorModelID)
 	if a.model == "" && handshake.CurrentModelID != "" {
 		a.model = normalizeCursorModelID(handshake.CurrentModelID)
 	}
@@ -123,28 +123,6 @@ func cursorModelIDForWire(model string) string {
 		return cursorCLIModelAutoWire
 	}
 	return model
-}
-
-func buildCursorCLIModels(models []acpModelInfo, currentModelID string) []*leapmuxv1.AvailableModel {
-	currentModelID = normalizeCursorModelID(currentModelID)
-	result := make([]*leapmuxv1.AvailableModel, 0, len(models))
-	for _, model := range models {
-		id := normalizeCursorModelID(model.ModelID)
-		if id == "" {
-			continue
-		}
-		name := model.Name
-		if name == "" {
-			name = id
-		}
-		result = append(result, &leapmuxv1.AvailableModel{
-			Id:          id,
-			DisplayName: name,
-			Description: model.Description,
-			IsDefault:   id == currentModelID,
-		})
-	}
-	return result
 }
 
 func fallbackCursorCLIModes() []*leapmuxv1.AvailableOption {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -1,0 +1,252 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/util/version"
+)
+
+const (
+	CursorCLIModeAgent = "agent"
+	CursorCLIModePlan  = "plan"
+	CursorCLIModeAsk   = "ask"
+
+	cursorCLIModelAuto     = "auto"
+	cursorCLIModelAutoWire = "default[]"
+)
+
+// CursorCLIAgent manages a single Cursor CLI ACP process.
+type CursorCLIAgent struct {
+	acpBase
+
+	permissionMode string
+	availableModes []*leapmuxv1.AvailableOption
+}
+
+// StartCursorCLI starts a Cursor CLI ACP agent process and performs the handshake.
+func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provider, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
+		ctx, opts.Shell, opts.LoginShell, "cursor-agent", nil, []string{"acp"}, nil, opts.WorkingDir,
+	)
+
+	cmd.Env = append(cmd.Environ(), "LEAPMUX_WORKER=1")
+
+	stdin, stdout, stderrPipe, err := setupProcessPipes(cmd, cancel)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &CursorCLIAgent{
+		acpBase: acpBase{
+			jsonrpcBase: jsonrpcBase{processBase: processBase{
+				agentID:            opts.AgentID,
+				cmd:                cmd,
+				stdin:              stdin,
+				ctx:                ctx,
+				cancel:             cancel,
+				stderrDone:         make(chan struct{}),
+				processDone:        make(chan struct{}),
+				preambleDelimiter:  preambleDelimiter,
+				preambleMetaPrefix: metaPrefix,
+				preambleMeta:       make(map[string]string),
+			}},
+			sink:         sink,
+			providerName: "cursor",
+			model:        normalizeCursorModelID(opts.Model),
+		},
+	}
+	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraMethod = a.handleExtraMethod
+	a.promptFunc = a.doSendPrompt
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start cursor-agent: %w", err)
+	}
+
+	initParams, _ := json.Marshal(map[string]interface{}{
+		"protocolVersion": 1,
+		"clientInfo":      map[string]string{"name": "leapmux", "title": "LeapMux", "version": version.Value},
+		"capabilities":    map[string]interface{}{},
+	})
+	handshake, err := a.startACPHandshake(stdout, stderrPipe, opts, initParams, acpDefaultSessionConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	a.availableModels = buildCursorCLIModels(handshake.Models, handshake.CurrentModelID)
+	if a.model == "" && handshake.CurrentModelID != "" {
+		a.model = normalizeCursorModelID(handshake.CurrentModelID)
+	}
+
+	a.availableModes = buildACPModes(handshake.Modes, handshake.CurrentModeID, nil)
+	a.permissionMode = handshake.CurrentModeID
+	if a.permissionMode == "" {
+		a.permissionMode = CursorCLIModeAgent
+	}
+
+	cleanup := func() {
+		a.Stop()
+		_ = a.Wait()
+	}
+	if requested := normalizeCursorModelID(StringOrDefault(opts.Model, "")); requested != "" && requested != a.model {
+		if err := a.setCursorModel(requested); err != nil {
+			cleanup()
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
+		}
+	}
+	if requested := StringOrDefault(opts.PermissionMode, ""); requested != "" && requested != a.permissionMode {
+		if err := a.setPermissionMode(requested); err != nil {
+			cleanup()
+			return nil, a.formatStartupError(acpMethodSessionSetMode, err)
+		}
+	}
+
+	return a, nil
+}
+
+func normalizeCursorModelID(model string) string {
+	switch model {
+	case "", cursorCLIModelAuto:
+		return model
+	case cursorCLIModelAutoWire:
+		return cursorCLIModelAuto
+	default:
+		return model
+	}
+}
+
+func cursorModelIDForWire(model string) string {
+	if model == cursorCLIModelAuto {
+		return cursorCLIModelAutoWire
+	}
+	return model
+}
+
+func buildCursorCLIModels(models []acpModelInfo, currentModelID string) []*leapmuxv1.AvailableModel {
+	currentModelID = normalizeCursorModelID(currentModelID)
+	result := make([]*leapmuxv1.AvailableModel, 0, len(models))
+	for _, model := range models {
+		id := normalizeCursorModelID(model.ModelID)
+		if id == "" {
+			continue
+		}
+		name := model.Name
+		if name == "" {
+			name = id
+		}
+		result = append(result, &leapmuxv1.AvailableModel{
+			Id:          id,
+			DisplayName: name,
+			Description: model.Description,
+			IsDefault:   id == currentModelID,
+		})
+	}
+	return result
+}
+
+func fallbackCursorCLIModes() []*leapmuxv1.AvailableOption {
+	return []*leapmuxv1.AvailableOption{
+		{Id: CursorCLIModeAgent, Name: "Agent", IsDefault: true},
+		{Id: CursorCLIModePlan, Name: "Plan"},
+		{Id: CursorCLIModeAsk, Name: "Ask"},
+	}
+}
+
+func (a *CursorCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.Attachment) {
+	a.doSendACPPrompt(content, attachments, func(resp json.RawMessage) {
+		a.handleACPPromptResponse(resp, nil)
+	})
+}
+
+func (a *CursorCLIAgent) CurrentSettings() *leapmuxv1.AgentSettings {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return &leapmuxv1.AgentSettings{
+		Model:          a.model,
+		PermissionMode: a.permissionMode,
+	}
+}
+
+func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	options := a.availableModes
+	if len(options) == 0 {
+		options = fallbackCursorCLIModes()
+	}
+	return []*leapmuxv1.AvailableOptionGroup{{
+		Key:     "permissionMode",
+		Label:   "Mode",
+		Options: options,
+	}}
+}
+
+func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
+	if model := normalizeCursorModelID(s.GetModel()); model != "" {
+		if err := a.setCursorModel(model); err != nil {
+			slog.Warn("cursor session/set_model failed", "agent_id", a.agentID, "error", err)
+			return false
+		}
+	}
+	if mode := s.GetPermissionMode(); mode != "" {
+		if err := a.setPermissionMode(mode); err != nil {
+			slog.Warn("cursor session/set_mode failed", "agent_id", a.agentID, "error", err)
+			return false
+		}
+	}
+	return true
+}
+
+func (a *CursorCLIAgent) setCursorModel(model string) error {
+	wireModel := cursorModelIDForWire(model)
+	if err := a.setModel(wireModel); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.model = model
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *CursorCLIAgent) setPermissionMode(mode string) error {
+	a.mu.Lock()
+	available := a.availableModes
+	a.mu.Unlock()
+
+	if err := a.acpSetMode(mode, available); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.permissionMode = mode
+	a.mu.Unlock()
+	return nil
+}
+
+var cursorCLIAvailableModels = []*leapmuxv1.AvailableModel{
+	{Id: cursorCLIModelAuto, DisplayName: "Auto", Description: "Automatically selects the best available Cursor model", IsDefault: true},
+}
+
+func init() {
+	registerProvider(
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI,
+		func(ctx context.Context, opts Options, sink OutputSink) (Provider, error) {
+			return StartCursorCLI(ctx, opts, sink)
+		},
+		cursorCLIAvailableModels,
+		[]*leapmuxv1.AvailableOptionGroup{{
+			Key:     "permissionMode",
+			Label:   "Mode",
+			Options: fallbackCursorCLIModes(),
+		}},
+		"LEAPMUX_CURSOR_DEFAULT_MODEL",
+		"",
+		"cursor-agent",
+	)
+}

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -112,14 +112,10 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 }
 
 func normalizeCursorModelID(model string) string {
-	switch model {
-	case "", cursorCLIModelAuto:
-		return model
-	case cursorCLIModelAutoWire:
+	if model == cursorCLIModelAutoWire {
 		return cursorCLIModelAuto
-	default:
-		return model
 	}
+	return model
 }
 
 func cursorModelIDForWire(model string) string {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -61,7 +61,7 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 			model:        normalizeCursorModelID(opts.Model),
 		},
 	}
-	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.extraMethod = a.handleExtraMethod
 	a.promptFunc = a.doSendPrompt
 

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -14,14 +14,6 @@ const (
 	cursorMethodGenerateImage = "cursor/generate_image"
 )
 
-func (a *CursorCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update json.RawMessage) bool {
-	if sessionUpdate == acpUpdateConfigOptionUpdate {
-		a.handleConfigOptionUpdate(update)
-		return true
-	}
-	return false
-}
-
 func (a *CursorCLIAgent) handleConfigOptionUpdate(update json.RawMessage) {
 	options := parseACPConfigOptions(update)
 	if len(options) == 0 {

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+)
+
+const (
+	cursorMethodAskQuestion   = "cursor/ask_question"
+	cursorMethodCreatePlan    = "cursor/create_plan"
+	cursorMethodUpdateTodos   = "cursor/update_todos"
+	cursorMethodTask          = "cursor/task"
+	cursorMethodGenerateImage = "cursor/generate_image"
+)
+
+func (a *CursorCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update json.RawMessage) bool {
+	if sessionUpdate == acpUpdateConfigOptionUpdate {
+		a.handleConfigOptionUpdate(update)
+		return true
+	}
+	return false
+}
+
+func (a *CursorCLIAgent) handleConfigOptionUpdate(update json.RawMessage) {
+	options := parseACPConfigOptions(update)
+	if len(options) == 0 {
+		return
+	}
+
+	a.mu.Lock()
+	mode := syncACPConfigOptions(&a.model, &a.permissionMode, &a.availableModels, &a.availableModes, options, func(configID, value string) string {
+		if configID == "model" {
+			return normalizeCursorModelID(value)
+		}
+		return value
+	})
+	a.mu.Unlock()
+
+	if mode != "" {
+		a.sink.UpdatePermissionMode(mode)
+	}
+}
+
+func (a *CursorCLIAgent) handleExtraMethod(line *parsedLine) bool {
+	if !strings.HasPrefix(line.Method, "cursor/") {
+		return false
+	}
+
+	idRaw, requestID, ok := extractJSONRPCID(line.Raw)
+	if !ok {
+		return true
+	}
+
+	switch line.Method {
+	case cursorMethodAskQuestion:
+		a.handleAskQuestionRequest(line.Raw, requestID)
+		return true
+	case cursorMethodCreatePlan:
+		a.handleCreatePlanRequest(line.Raw, requestID)
+		return true
+	case cursorMethodUpdateTodos, cursorMethodTask, cursorMethodGenerateImage:
+		if err := a.sendResponse(idRaw, map[string]interface{}{}); err != nil {
+			slog.Warn("cursor extension ack failed", "agent_id", a.agentID, "method", line.Method, "error", err)
+		}
+		return true
+	default:
+		if err := a.sendErrorResponse(idRaw, -32601, "Method not supported: "+line.Method); err != nil {
+			slog.Warn("cursor extension method-not-found failed", "agent_id", a.agentID, "method", line.Method, "error", err)
+		}
+		return true
+	}
+}
+
+func (a *CursorCLIAgent) handleAskQuestionRequest(raw []byte, requestID string) {
+	payload, ok := a.buildAskQuestionPayload(raw)
+	if !ok {
+		return
+	}
+	a.sink.PersistControlRequest(requestID, payload)
+	a.sink.BroadcastControlRequest(requestID, payload)
+}
+
+func (a *CursorCLIAgent) buildAskQuestionPayload(raw []byte) ([]byte, bool) {
+	var payload map[string]interface{}
+	if json.Unmarshal(raw, &payload) != nil {
+		return nil, false
+	}
+
+	params, _ := payload["params"].(map[string]interface{})
+	rawQuestions, _ := params["questions"].([]interface{})
+	questions := make([]map[string]interface{}, 0, len(rawQuestions))
+	for _, item := range rawQuestions {
+		q, _ := item.(map[string]interface{})
+		if q == nil {
+			continue
+		}
+		rawOptions, _ := q["options"].([]interface{})
+		options := make([]map[string]interface{}, 0, len(rawOptions))
+		for _, rawOption := range rawOptions {
+			option, _ := rawOption.(map[string]interface{})
+			if option == nil {
+				continue
+			}
+			mapped := map[string]interface{}{}
+			if id, _ := option["id"].(string); id != "" {
+				mapped["id"] = id
+			}
+			if label, _ := option["label"].(string); label != "" {
+				mapped["label"] = label
+			}
+			options = append(options, mapped)
+		}
+
+		mapped := map[string]interface{}{
+			"question": q["prompt"],
+			"options":  options,
+		}
+		if id, _ := q["id"].(string); id != "" {
+			mapped["id"] = id
+		}
+		if prompt, _ := q["prompt"].(string); prompt != "" {
+			mapped["header"] = prompt
+		}
+		if allowMultiple, ok := q["allowMultiple"].(bool); ok {
+			mapped["multiSelect"] = allowMultiple
+		}
+		questions = append(questions, mapped)
+	}
+
+	payload["request"] = map[string]interface{}{
+		"tool_name": "AskUserQuestion",
+		"input": map[string]interface{}{
+			"questions": questions,
+		},
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}
+
+func (a *CursorCLIAgent) handleCreatePlanRequest(raw []byte, requestID string) {
+	var payload map[string]interface{}
+	if json.Unmarshal(raw, &payload) != nil {
+		return
+	}
+
+	payload["type"] = "cursor.create_plan"
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	a.sink.PersistControlRequest(requestID, encoded)
+	a.sink.BroadcastControlRequest(requestID, encoded)
+}

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -75,7 +75,8 @@ func (a *CursorCLIAgent) handleAskQuestionRequest(raw []byte, requestID string) 
 
 func (a *CursorCLIAgent) buildAskQuestionPayload(raw []byte) ([]byte, bool) {
 	var payload map[string]interface{}
-	if json.Unmarshal(raw, &payload) != nil {
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		slog.Warn("cursor ask_question unmarshal failed", "agent_id", a.agentID, "error", err)
 		return nil, false
 	}
 
@@ -129,6 +130,7 @@ func (a *CursorCLIAgent) buildAskQuestionPayload(raw []byte) ([]byte, bool) {
 
 	encoded, err := json.Marshal(payload)
 	if err != nil {
+		slog.Warn("cursor ask_question marshal failed", "agent_id", a.agentID, "error", err)
 		return nil, false
 	}
 	return encoded, true
@@ -136,13 +138,15 @@ func (a *CursorCLIAgent) buildAskQuestionPayload(raw []byte) ([]byte, bool) {
 
 func (a *CursorCLIAgent) handleCreatePlanRequest(raw []byte, requestID string) {
 	var payload map[string]interface{}
-	if json.Unmarshal(raw, &payload) != nil {
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		slog.Warn("cursor create_plan unmarshal failed", "agent_id", a.agentID, "error", err)
 		return
 	}
 
 	payload["type"] = "cursor.create_plan"
 	encoded, err := json.Marshal(payload)
 	if err != nil {
+		slog.Warn("cursor create_plan marshal failed", "agent_id", a.agentID, "error", err)
 		return
 	}
 

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	cursorMethodAskQuestion   = "cursor/ask_question"
-	cursorMethodCreatePlan    = "cursor/create_plan"
+	CursorMethodAskQuestion   = "cursor/ask_question"
+	CursorMethodCreatePlan    = "cursor/create_plan"
 	cursorMethodUpdateTodos   = "cursor/update_todos"
 	cursorMethodTask          = "cursor/task"
 	cursorMethodGenerateImage = "cursor/generate_image"
@@ -45,10 +45,10 @@ func (a *CursorCLIAgent) handleExtraMethod(line *parsedLine) bool {
 	}
 
 	switch line.Method {
-	case cursorMethodAskQuestion:
+	case CursorMethodAskQuestion:
 		a.handleAskQuestionRequest(line.Raw, requestID)
 		return true
-	case cursorMethodCreatePlan:
+	case CursorMethodCreatePlan:
 		a.handleCreatePlanRequest(line.Raw, requestID)
 		return true
 	case cursorMethodUpdateTodos, cursorMethodTask, cursorMethodGenerateImage:

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -47,7 +47,7 @@ func (a *CursorCLIAgent) handleExtraMethod(line *parsedLine) bool {
 		return false
 	}
 
-	idRaw, requestID, ok := extractJSONRPCID(line.Raw)
+	idRaw, requestID, ok := ExtractJSONRPCID(line.Raw)
 	if !ok {
 		return true
 	}

--- a/backend/internal/worker/agent/cursor_output_test.go
+++ b/backend/internal/worker/agent/cursor_output_test.go
@@ -19,7 +19,7 @@ func newCursorAgentWithSink(sink OutputSink) *CursorCLIAgent {
 			sessionID:    "test-session",
 		},
 	}
-	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.extraMethod = a.handleExtraMethod
 	return a
 }

--- a/backend/internal/worker/agent/cursor_output_test.go
+++ b/backend/internal/worker/agent/cursor_output_test.go
@@ -79,7 +79,7 @@ func TestHandleCursorOutput_AskQuestionPersistsControlRequest(t *testing.T) {
 	if err := json.Unmarshal(sink.LastPersistedControl().Payload, &payload); err != nil {
 		t.Fatalf("failed to unmarshal control payload: %v", err)
 	}
-	if payload.Method != cursorMethodAskQuestion {
+	if payload.Method != CursorMethodAskQuestion {
 		t.Fatalf("expected cursor ask method, got %q", payload.Method)
 	}
 	if payload.Request.ToolName != "AskUserQuestion" {
@@ -108,7 +108,7 @@ func TestHandleCursorOutput_CreatePlanPersistsControlRequest(t *testing.T) {
 	if err := json.Unmarshal(sink.LastPersistedControl().Payload, &payload); err != nil {
 		t.Fatalf("failed to unmarshal create-plan payload: %v", err)
 	}
-	if payload.Type != "cursor.create_plan" || payload.Method != cursorMethodCreatePlan {
+	if payload.Type != "cursor.create_plan" || payload.Method != CursorMethodCreatePlan {
 		t.Fatalf("expected cursor create-plan payload, got %#v", payload)
 	}
 }

--- a/backend/internal/worker/agent/cursor_output_test.go
+++ b/backend/internal/worker/agent/cursor_output_test.go
@@ -1,0 +1,164 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func newCursorAgentWithSink(sink OutputSink) *CursorCLIAgent {
+	a := &CursorCLIAgent{
+		acpBase: acpBase{
+			jsonrpcBase: jsonrpcBase{processBase: processBase{
+				agentID: "test-agent",
+			}},
+			sink:         sink,
+			providerName: "cursor",
+			sessionID:    "test-session",
+		},
+	}
+	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.extraMethod = a.handleExtraMethod
+	return a
+}
+
+func TestHandleCursorOutput_ConfigOptionUpdateBroadcastsPermissionMode(t *testing.T) {
+	sink := &testSink{}
+	agent := newCursorAgentWithSink(sink)
+
+	input := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"config_option_update","configOptions":[{"id":"mode","currentValue":"plan","options":[{"value":"agent","name":"Agent"},{"value":"plan","name":"Plan"}]},{"id":"model","currentValue":"default[]","options":[{"value":"default[]","name":"Auto"},{"value":"gpt-5.4[reasoning=medium]","name":"GPT-5.4"}]}]}}}`
+	agent.HandleOutput([]byte(input))
+
+	if agent.permissionMode != CursorCLIModePlan {
+		t.Fatalf("expected mode plan, got %q", agent.permissionMode)
+	}
+	if agent.model != "auto" {
+		t.Fatalf("expected model auto, got %q", agent.model)
+	}
+	if got := sink.PermissionMode(); got != CursorCLIModePlan {
+		t.Fatalf("expected sink permission mode plan, got %q", got)
+	}
+	if len(agent.availableModels) != 2 {
+		t.Fatalf("expected 2 available models, got %d", len(agent.availableModels))
+	}
+	if agent.availableModels[0].GetId() != "auto" {
+		t.Fatalf("expected normalized auto model, got %q", agent.availableModels[0].GetId())
+	}
+}
+
+func TestHandleCursorOutput_AskQuestionPersistsControlRequest(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCursorAgentWithSink(sink)
+
+	input := `{"jsonrpc":"2.0","id":7,"method":"cursor/ask_question","params":{"toolCallId":"tc-1","title":"Need input","questions":[{"id":"q1","prompt":"Pick one","allowMultiple":false,"options":[{"id":"a","label":"Alpha"},{"id":"b","label":"Beta"}]}]}}`
+	agent.HandleOutput([]byte(input))
+
+	if sink.PersistedControlCount() != 1 {
+		t.Fatalf("expected 1 persisted control request, got %d", sink.PersistedControlCount())
+	}
+	if got := sink.LastPersistedControl().RequestID; got != "7" {
+		t.Fatalf("expected control request id 7, got %q", got)
+	}
+
+	var payload struct {
+		Method  string `json:"method"`
+		Request struct {
+			ToolName string `json:"tool_name"`
+			Input    struct {
+				Questions []struct {
+					ID          string `json:"id"`
+					Question    string `json:"question"`
+					Header      string `json:"header"`
+					MultiSelect bool   `json:"multiSelect"`
+				} `json:"questions"`
+			} `json:"input"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(sink.LastPersistedControl().Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal control payload: %v", err)
+	}
+	if payload.Method != cursorMethodAskQuestion {
+		t.Fatalf("expected cursor ask method, got %q", payload.Method)
+	}
+	if payload.Request.ToolName != "AskUserQuestion" {
+		t.Fatalf("expected AskUserQuestion wrapper, got %q", payload.Request.ToolName)
+	}
+	if len(payload.Request.Input.Questions) != 1 || payload.Request.Input.Questions[0].ID != "q1" {
+		t.Fatalf("expected wrapped cursor question, got %#v", payload.Request.Input.Questions)
+	}
+}
+
+func TestHandleCursorOutput_CreatePlanPersistsControlRequest(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCursorAgentWithSink(sink)
+
+	input := `{"jsonrpc":"2.0","id":8,"method":"cursor/create_plan","params":{"toolCallId":"plan-1","name":"Migration","overview":"Review the generated plan"}}`
+	agent.HandleOutput([]byte(input))
+
+	if sink.PersistedControlCount() != 1 {
+		t.Fatalf("expected 1 persisted control request, got %d", sink.PersistedControlCount())
+	}
+
+	var payload struct {
+		Type   string `json:"type"`
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(sink.LastPersistedControl().Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal create-plan payload: %v", err)
+	}
+	if payload.Type != "cursor.create_plan" || payload.Method != cursorMethodCreatePlan {
+		t.Fatalf("expected cursor create-plan payload, got %#v", payload)
+	}
+}
+
+func TestHandleCursorOutput_UpdateTodosAcknowledgesRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() {
+		cancel()
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	}()
+
+	agent := &CursorCLIAgent{
+		acpBase: acpBase{
+			jsonrpcBase: jsonrpcBase{processBase: processBase{
+				agentID:     "test-agent",
+				stdin:       writePipe,
+				ctx:         ctx,
+				cancel:      cancel,
+				processDone: make(chan struct{}),
+				stderrDone:  make(chan struct{}),
+			}},
+			sink:         &testSink{},
+			providerName: "cursor",
+			sessionID:    "test-session",
+		},
+	}
+	agent.extraMethod = agent.handleExtraMethod
+
+	done := make(chan map[string]interface{}, 1)
+	go func() {
+		scanner := bufio.NewScanner(readPipe)
+		if scanner.Scan() {
+			var payload map[string]interface{}
+			_ = json.Unmarshal(scanner.Bytes(), &payload)
+			done <- payload
+		}
+	}()
+
+	agent.HandleOutput([]byte(`{"jsonrpc":"2.0","id":9,"method":"cursor/update_todos","params":{"toolCallId":"todo-1","todos":[]}}`))
+
+	resp := <-done
+	if got := int(resp["id"].(float64)); got != 9 {
+		t.Fatalf("expected id 9, got %d", got)
+	}
+	if _, ok := resp["result"]; !ok {
+		t.Fatalf("expected result response, got %#v", resp)
+	}
+}

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+type cursorRecordedRequest struct {
+	Method string
+	Params map[string]interface{}
+}
+
+func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []cursorRecordedRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readPipe, writePipe, err := os.Pipe()
+	require.NoError(t, err)
+
+	agent := &CursorCLIAgent{
+		acpBase: acpBase{
+			jsonrpcBase: jsonrpcBase{processBase: processBase{
+				agentID:     "test-agent",
+				stdin:       writePipe,
+				ctx:         ctx,
+				cancel:      cancel,
+				processDone: make(chan struct{}),
+				stderrDone:  make(chan struct{}),
+			}},
+			sessionID: "session-1",
+		},
+	}
+	close(agent.stderrDone)
+
+	var (
+		mu       sync.Mutex
+		requests []cursorRecordedRequest
+	)
+	go func() {
+		scanner := bufio.NewScanner(readPipe)
+		for scanner.Scan() {
+			var req struct {
+				ID     int64                  `json:"id"`
+				Method string                 `json:"method"`
+				Params map[string]interface{} `json:"params"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				continue
+			}
+			mu.Lock()
+			requests = append(requests, cursorRecordedRequest{Method: req.Method, Params: req.Params})
+			mu.Unlock()
+			if req.ID != 0 {
+				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
+					ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+				}
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+
+	return agent, func() []cursorRecordedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]cursorRecordedRequest, len(requests))
+		copy(out, requests)
+		return out
+	}
+}
+
+func installFakeCursorCLI(t *testing.T, scenario string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	launcher := filepath.Join(dir, "cursor-agent")
+	script := fmt.Sprintf("#!/bin/sh\nLEAPMUX_CURSOR_TEST_SCENARIO=%q exec %q -test.run=TestHelperProcessCursorCLI -- \"$@\"\n", scenario, os.Args[0])
+	require.NoError(t, os.WriteFile(launcher, []byte(script), 0o755))
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GO_WANT_HELPER_PROCESS_CURSOR", "1")
+}
+
+func TestHelperProcessCursorCLI(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_CURSOR") != "1" {
+		return
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer func() { _ = writer.Flush() }()
+
+	scenario := os.Getenv("LEAPMUX_CURSOR_TEST_SCENARIO")
+
+	writeResponse := func(id json.RawMessage, body string, isError bool) {
+		field := "result"
+		if isError {
+			field = "error"
+		}
+		_, _ = fmt.Fprintf(writer, `{"jsonrpc":"2.0","id":%s,"%s":%s}`+"\n", string(id), field, body)
+		_ = writer.Flush()
+	}
+
+	for scanner.Scan() {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case acpMethodInitialize:
+			writeResponse(req.ID, `{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}`, false)
+		case acpMethodSessionNew:
+			writeResponse(req.ID, `{"sessionId":"cursor-new","models":{"currentModelId":"default[]","availableModels":[{"modelId":"default[]","name":"Auto"},{"modelId":"gpt-5.4[reasoning=medium]","name":"GPT-5.4"}]},"modes":{"currentModeId":"agent","availableModes":[{"id":"agent","name":"Agent"},{"id":"plan","name":"Plan"},{"id":"ask","name":"Ask"}]},"configOptions":[{"id":"mode","currentValue":"agent","options":[{"value":"agent","name":"Agent"},{"value":"plan","name":"Plan"},{"value":"ask","name":"Ask"}]},{"id":"model","currentValue":"default[]","options":[{"value":"default[]","name":"Auto"},{"value":"gpt-5.4[reasoning=medium]","name":"GPT-5.4"}]}]}`, false)
+		case acpMethodSessionLoad:
+			if scenario == "load" {
+				writeResponse(req.ID, `{"models":{"currentModelId":"gpt-5.4[reasoning=medium]","availableModels":[{"modelId":"default[]","name":"Auto"},{"modelId":"gpt-5.4[reasoning=medium]","name":"GPT-5.4"}]},"modes":{"currentModeId":"plan","availableModes":[{"id":"agent","name":"Agent"},{"id":"plan","name":"Plan"},{"id":"ask","name":"Ask"}]}}`, false)
+			}
+		case acpMethodSessionSetModel, acpMethodSessionSetMode, acpMethodSessionPrompt:
+			writeResponse(req.ID, `{}`, false)
+		}
+	}
+	os.Exit(0)
+}
+
+func TestStartCursorCLI_NewSessionHandshake(t *testing.T) {
+	installFakeCursorCLI(t, "new")
+
+	provider, err := StartCursorCLI(context.Background(), Options{
+		AgentID:       "cursor-new",
+		WorkingDir:    t.TempDir(),
+		Shell:         "/bin/sh",
+		LoginShell:    false,
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI,
+	}, &testSink{})
+	require.NoError(t, err)
+
+	agent := provider.(*CursorCLIAgent)
+	t.Cleanup(func() {
+		agent.Stop()
+		_ = agent.Wait()
+	})
+
+	assert.Equal(t, "cursor-new", agent.sessionID)
+	assert.Equal(t, "auto", agent.model)
+	assert.Equal(t, CursorCLIModeAgent, agent.permissionMode)
+	require.Len(t, agent.AvailableModels(), 2)
+	assert.Equal(t, "auto", agent.AvailableModels()[0].GetId())
+	require.Len(t, agent.AvailableOptionGroups(), 1)
+	assert.Equal(t, "permissionMode", agent.AvailableOptionGroups()[0].GetKey())
+}
+
+func TestStartCursorCLI_LoadSessionUsesResumeID(t *testing.T) {
+	installFakeCursorCLI(t, "load")
+
+	provider, err := StartCursorCLI(context.Background(), Options{
+		AgentID:         "cursor-load",
+		WorkingDir:      t.TempDir(),
+		ResumeSessionID: "cursor-resume",
+		Shell:           "/bin/sh",
+		LoginShell:      false,
+		AgentProvider:   leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI,
+	}, &testSink{})
+	require.NoError(t, err)
+
+	agent := provider.(*CursorCLIAgent)
+	t.Cleanup(func() {
+		agent.Stop()
+		_ = agent.Wait()
+	})
+
+	assert.Equal(t, "cursor-resume", agent.sessionID)
+	assert.Equal(t, "gpt-5.4[reasoning=medium]", agent.model)
+	assert.Equal(t, CursorCLIModePlan, agent.permissionMode)
+}
+
+func TestCursorUpdateSettingsSendsLiveACPRequests(t *testing.T) {
+	agent, requests := newCursorAgentForRPC(t)
+	agent.availableModes = []*leapmuxv1.AvailableOption{
+		{Id: CursorCLIModeAgent, Name: "Agent", IsDefault: true},
+		{Id: CursorCLIModePlan, Name: "Plan"},
+	}
+
+	updated := agent.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:          "auto",
+		PermissionMode: CursorCLIModePlan,
+	})
+	require.True(t, updated)
+	assert.Equal(t, "auto", agent.model)
+	assert.Equal(t, CursorCLIModePlan, agent.permissionMode)
+
+	recorded := requests()
+	require.Len(t, recorded, 2)
+	assert.Equal(t, "session/set_model", recorded[0].Method)
+	assert.Equal(t, cursorCLIModelAutoWire, recorded[0].Params["modelId"])
+	assert.Equal(t, "session/set_mode", recorded[1].Method)
+	assert.Equal(t, CursorCLIModePlan, recorded[1].Params["modeId"])
+}
+
+func TestBuildCursorCLIModelsNormalizesAuto(t *testing.T) {
+	models := []acpModelInfo{
+		{ModelID: cursorCLIModelAutoWire, Name: "Auto"},
+		{ModelID: "gpt-5.4[reasoning=medium]", Name: "GPT-5.4"},
+	}
+	result := buildCursorCLIModels(models, cursorCLIModelAutoWire)
+	require.Len(t, result, 2)
+	assert.Equal(t, "auto", result[0].Id)
+	assert.True(t, result[0].IsDefault)
+}
+
+func TestCursorDefaultModelIsAuto(t *testing.T) {
+	assert.Equal(t, "auto", DefaultModel(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI))
+}

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -220,7 +220,7 @@ func TestBuildCursorCLIModelsNormalizesAuto(t *testing.T) {
 		{ModelID: cursorCLIModelAutoWire, Name: "Auto"},
 		{ModelID: "gpt-5.4[reasoning=medium]", Name: "GPT-5.4"},
 	}
-	result := buildCursorCLIModels(models, cursorCLIModelAutoWire)
+	result := buildACPModels(models, cursorCLIModelAutoWire, normalizeCursorModelID)
 	require.Len(t, result, 2)
 	assert.Equal(t, "auto", result[0].Id)
 	assert.True(t, result[0].IsDefault)

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -114,7 +114,7 @@ func buildGeminiCLIModels(models []acpModelInfo, currentModelID string) []*leapm
 			break
 		}
 	}
-	result := buildACPModels(models, currentModelID)
+	result := buildACPModels(models, currentModelID, nil)
 	if !hasAuto {
 		result = append([]*leapmuxv1.AvailableModel{{
 			Id:          "auto",
@@ -154,7 +154,8 @@ func broadcastGeminiQuotaSessionInfo(sink OutputSink, resp json.RawMessage) {
 			} `json:"quota"`
 		} `json:"_meta"`
 	}
-	if json.Unmarshal(resp, &result) != nil {
+	if err := json.Unmarshal(resp, &result); err != nil {
+		slog.Warn("gemini quota session info unmarshal failed", "error", err)
 		return
 	}
 

--- a/backend/internal/worker/agent/gemini_output.go
+++ b/backend/internal/worker/agent/gemini_output.go
@@ -1,6 +1,9 @@
 package agent
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"log/slog"
+)
 
 func (a *GeminiCLIAgent) handleExtraSessionUpdate(sessionUpdate string, update json.RawMessage) bool {
 	if sessionUpdate == acpUpdateCurrentModeUpdate {
@@ -14,7 +17,11 @@ func (a *GeminiCLIAgent) handleCurrentModeUpdate(update json.RawMessage) {
 	var mode struct {
 		CurrentModeID string `json:"currentModeId"`
 	}
-	if json.Unmarshal(update, &mode) != nil || mode.CurrentModeID == "" {
+	if err := json.Unmarshal(update, &mode); err != nil {
+		slog.Warn("gemini current mode update unmarshal failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+	if mode.CurrentModeID == "" {
 		return
 	}
 

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -89,7 +89,7 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		return nil, err
 	}
 
-	a.availableModels = buildACPModels(handshake.Models, handshake.CurrentModelID)
+	a.availableModels = buildACPModels(handshake.Models, handshake.CurrentModelID, nil)
 	if a.model == "" && handshake.CurrentModelID != "" {
 		a.model = handshake.CurrentModelID
 	}

--- a/backend/internal/worker/agent/process.go
+++ b/backend/internal/worker/agent/process.go
@@ -233,7 +233,9 @@ type parsedLine struct {
 // that accept []byte (e.g. for tests) to bridge into the single-parse pipeline.
 func parseLine(content []byte) *parsedLine {
 	line := &parsedLine{Raw: content}
-	_ = json.Unmarshal(content, line)
+	if err := json.Unmarshal(content, line); err != nil {
+		slog.Warn("parse line unmarshal failed", "error", err)
+	}
 	return line
 }
 

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -234,9 +234,15 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			for i, a := range attachments {
 				meta[i] = attachmentMeta{Filename: a.GetFilename(), MimeType: a.GetMimeType()}
 			}
-			innerJSON, _ = json.Marshal(map[string]interface{}{"content": content, "attachments": meta})
+			innerJSON, err = json.Marshal(map[string]interface{}{"content": content, "attachments": meta})
+			if err != nil {
+				slog.Warn("user message marshal failed", "agent_id", agentID, "error", err)
+			}
 		} else {
-			innerJSON, _ = json.Marshal(map[string]string{"content": content})
+			innerJSON, err = json.Marshal(map[string]string{"content": content})
+			if err != nil {
+				slog.Warn("user message marshal failed", "agent_id", agentID, "error", err)
+			}
 		}
 		compressed, compressionType := msgcodec.Compress(innerJSON)
 
@@ -1427,7 +1433,11 @@ func (svc *Context) handleCodexPlanModePromptResponse(agentID string, content []
 			ToolName string `json:"tool_name"`
 		} `json:"request"`
 	}
-	if json.Unmarshal(cr.Payload, &crBody) != nil || crBody.Request.ToolName != "CodexPlanModePrompt" {
+	if err := json.Unmarshal(cr.Payload, &crBody); err != nil {
+		slog.Warn("codex plan mode prompt unmarshal failed", "agent_id", agentID, "error", err)
+		return false
+	}
+	if crBody.Request.ToolName != "CodexPlanModePrompt" {
 		return false
 	}
 
@@ -1498,7 +1508,8 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 	var req struct {
 		Method string `json:"method"`
 	}
-	if json.Unmarshal(cr.Payload, &req) != nil {
+	if err := json.Unmarshal(cr.Payload, &req); err != nil {
+		slog.Warn("cursor control response unmarshal method failed", "agent_id", agentID, "error", err)
 		return nil, false
 	}
 	if req.Method != "cursor/create_plan" {
@@ -1510,34 +1521,26 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 		return nil, false
 	}
 
-	outcome := "accepted"
-	response := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      json.RawMessage(idRaw),
-		"result": map[string]interface{}{
-			"outcome": map[string]interface{}{
-				"outcome": outcome,
-			},
-		},
+	outcomeBody := map[string]interface{}{
+		"outcome": "accepted",
 	}
-
 	if crPayload.Response.Response.Behavior == agent.ControlBehaviorDeny {
-		outcome = "rejected"
-		result := response["result"].(map[string]interface{})
-		outcomeBody := result["outcome"].(map[string]interface{})
-		outcomeBody["outcome"] = outcome
+		outcomeBody["outcome"] = "rejected"
 		if reason := strings.TrimSpace(crPayload.Response.Response.Message); reason != "" && reason != "Rejected by user." {
 			outcomeBody["reason"] = reason
 		}
 	}
 
-	encoded, err := json.Marshal(response)
+	encoded, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(idRaw),
+		"result":  map[string]interface{}{"outcome": outcomeBody},
+	})
 	if err != nil {
 		return nil, false
 	}
 	return encoded, true
 }
-
 
 // extractControlResponseRequestID extracts the control request ID from a
 // control response's raw JSON content.  It supports both Claude Code format
@@ -1551,7 +1554,8 @@ func extractControlResponseRequestID(content []byte) string {
 		// OpenCode / ACP JSON-RPC format (id can be number or string)
 		ID json.RawMessage `json:"id"`
 	}
-	if json.Unmarshal(content, &parsed) != nil {
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		slog.Warn("extract control response request ID unmarshal failed", "error", err)
 		return ""
 	}
 	if parsed.Response.RequestID != "" {
@@ -1607,7 +1611,8 @@ func (svc *Context) handleControlResponsePlanMode(agentID string, content []byte
 			ToolUseID string `json:"tool_use_id"`
 		} `json:"request"`
 	}
-	if json.Unmarshal(cr.Payload, &crBody) != nil {
+	if err := json.Unmarshal(cr.Payload, &crBody); err != nil {
+		slog.Warn("codex cancel request unmarshal failed", "agent_id", agentID, "error", err)
 		return
 	}
 	toolName := crBody.Request.ToolName

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -725,8 +725,11 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		content = svc.normalizeProviderControlResponse(agentID, dbAgent.AgentProvider, content)
-		displayText := svc.controlResponseDisplayText(agentID, dbAgent.AgentProvider, content)
+		var displayText string
+		content, displayText = svc.normalizeProviderControlResponse(agentID, dbAgent.AgentProvider, content)
+		if displayText == "" {
+			displayText = svc.controlResponseDisplayText(agentID, dbAgent.AgentProvider, content)
+		}
 
 		// Detect plan mode changes from the control response before
 		// forwarding to the agent. This mirrors the main-branch Hub logic
@@ -1468,17 +1471,22 @@ func (svc *Context) handleCodexPlanModePromptResponse(agentID string, content []
 	return true
 }
 
-func (svc *Context) normalizeProviderControlResponse(agentID string, provider leapmuxv1.AgentProvider, content []byte) []byte {
+// normalizeProviderControlResponse transforms provider-specific control
+// responses into the wire format expected by the agent process.  It returns
+// the (possibly transformed) content and, when the transform already computed
+// the display text, a non-empty displayText so the caller can skip a second
+// DB lookup in controlResponseDisplayText.
+func (svc *Context) normalizeProviderControlResponse(agentID string, provider leapmuxv1.AgentProvider, content []byte) (normalized []byte, displayText string) {
 	switch provider {
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI:
-		if transformed, ok := svc.transformCursorControlResponse(agentID, content); ok {
-			return transformed
+		if transformed, text, ok := svc.transformCursorControlResponse(agentID, content); ok {
+			return transformed, text
 		}
 	}
-	return content
+	return content, ""
 }
 
-func (svc *Context) transformCursorControlResponse(agentID string, content []byte) ([]byte, bool) {
+func (svc *Context) transformCursorControlResponse(agentID string, content []byte) ([]byte, string, bool) {
 	var crPayload struct {
 		Response struct {
 			RequestID string `json:"request_id"`
@@ -1489,12 +1497,12 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 		} `json:"response"`
 	}
 	if err := json.Unmarshal(content, &crPayload); err != nil {
-		return nil, false
+		return nil, "", false
 	}
 
 	reqID := strings.TrimSpace(crPayload.Response.RequestID)
 	if reqID == "" {
-		return nil, false
+		return nil, "", false
 	}
 
 	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
@@ -1502,7 +1510,7 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 		RequestID: reqID,
 	})
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
 
 	var req struct {
@@ -1510,15 +1518,15 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 	}
 	if err := json.Unmarshal(cr.Payload, &req); err != nil {
 		slog.Warn("cursor control response unmarshal method failed", "agent_id", agentID, "error", err)
-		return nil, false
+		return nil, "", false
 	}
-	if req.Method != "cursor/create_plan" {
-		return nil, false
+	if req.Method != agent.CursorMethodCreatePlan {
+		return nil, "", false
 	}
 
 	idRaw, _, ok := agent.ExtractJSONRPCID(cr.Payload)
 	if !ok {
-		return nil, false
+		return nil, "", false
 	}
 
 	outcomeBody := map[string]interface{}{
@@ -1537,9 +1545,9 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 		"result":  map[string]interface{}{"outcome": outcomeBody},
 	})
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
-	return encoded, true
+	return encoded, cursorCreatePlanResponseDisplayText(encoded), true
 }
 
 // extractControlResponseRequestID extracts the control request ID from a

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -719,6 +719,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
+		content = svc.normalizeProviderControlResponse(agentID, dbAgent.AgentProvider, content)
 		displayText := svc.controlResponseDisplayText(agentID, dbAgent.AgentProvider, content)
 
 		// Detect plan mode changes from the control response before
@@ -1455,6 +1456,104 @@ func (svc *Context) handleCodexPlanModePromptResponse(agentID string, content []
 	}
 
 	return true
+}
+
+func (svc *Context) normalizeProviderControlResponse(agentID string, provider leapmuxv1.AgentProvider, content []byte) []byte {
+	switch provider {
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI:
+		if transformed, ok := svc.transformCursorControlResponse(agentID, content); ok {
+			return transformed
+		}
+	}
+	return content
+}
+
+func (svc *Context) transformCursorControlResponse(agentID string, content []byte) ([]byte, bool) {
+	var crPayload struct {
+		Response struct {
+			RequestID string `json:"request_id"`
+			Response  struct {
+				Behavior string `json:"behavior"`
+				Message  string `json:"message"`
+			} `json:"response"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(content, &crPayload); err != nil {
+		return nil, false
+	}
+
+	reqID := strings.TrimSpace(crPayload.Response.RequestID)
+	if reqID == "" {
+		return nil, false
+	}
+
+	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
+		AgentID:   agentID,
+		RequestID: reqID,
+	})
+	if err != nil {
+		return nil, false
+	}
+
+	var req struct {
+		Method string `json:"method"`
+	}
+	if json.Unmarshal(cr.Payload, &req) != nil {
+		return nil, false
+	}
+	if req.Method != "cursor/create_plan" {
+		return nil, false
+	}
+
+	idRaw, _, ok := controlResponseRPCID(cr.Payload)
+	if !ok {
+		return nil, false
+	}
+
+	outcome := "accepted"
+	response := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(idRaw),
+		"result": map[string]interface{}{
+			"outcome": map[string]interface{}{
+				"outcome": outcome,
+			},
+		},
+	}
+
+	if crPayload.Response.Response.Behavior == agent.ControlBehaviorDeny {
+		outcome = "rejected"
+		result := response["result"].(map[string]interface{})
+		outcomeBody := result["outcome"].(map[string]interface{})
+		outcomeBody["outcome"] = outcome
+		if reason := strings.TrimSpace(crPayload.Response.Response.Message); reason != "" && reason != "Rejected by user." {
+			outcomeBody["reason"] = reason
+		}
+	}
+
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}
+
+func controlResponseRPCID(content []byte) ([]byte, string, bool) {
+	var payload struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if json.Unmarshal(content, &payload) != nil || len(payload.ID) == 0 || string(payload.ID) == "null" {
+		return nil, "", false
+	}
+	var text string
+	if json.Unmarshal(payload.ID, &text) == nil {
+		return payload.ID, text, true
+	}
+	text = strings.TrimSpace(string(payload.ID))
+	if text == "" {
+		return nil, "", false
+	}
+	return payload.ID, text, true
 }
 
 // extractControlResponseRequestID extracts the control request ID from a

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1505,7 +1505,7 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 		return nil, false
 	}
 
-	idRaw, _, ok := controlResponseRPCID(cr.Payload)
+	idRaw, _, ok := agent.ExtractJSONRPCID(cr.Payload)
 	if !ok {
 		return nil, false
 	}
@@ -1538,23 +1538,6 @@ func (svc *Context) transformCursorControlResponse(agentID string, content []byt
 	return encoded, true
 }
 
-func controlResponseRPCID(content []byte) ([]byte, string, bool) {
-	var payload struct {
-		ID json.RawMessage `json:"id"`
-	}
-	if json.Unmarshal(content, &payload) != nil || len(payload.ID) == 0 || string(payload.ID) == "null" {
-		return nil, "", false
-	}
-	var text string
-	if json.Unmarshal(payload.ID, &text) == nil {
-		return payload.ID, text, true
-	}
-	text = strings.TrimSpace(string(payload.ID))
-	if text == "" {
-		return nil, "", false
-	}
-	return payload.ID, text, true
-}
 
 // extractControlResponseRequestID extracts the control request ID from a
 // control response's raw JSON content.  It supports both Claude Code format

--- a/backend/internal/worker/service/control_response.go
+++ b/backend/internal/worker/service/control_response.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -375,9 +376,9 @@ func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv
 		return acpPermissionResponseDisplayText(cr.Payload, content)
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI:
 		switch payload.Method {
-		case "cursor/ask_question":
+		case agent.CursorMethodAskQuestion:
 			return cursorQuestionAnswersText(cr.Payload, content)
-		case "cursor/create_plan":
+		case agent.CursorMethodCreatePlan:
 			return cursorCreatePlanResponseDisplayText(content)
 		default:
 			return ""

--- a/backend/internal/worker/service/control_response.go
+++ b/backend/internal/worker/service/control_response.go
@@ -175,6 +175,135 @@ func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string 
 	return strings.Join(lines, "\n")
 }
 
+func cursorQuestionAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Params struct {
+			Questions []struct {
+				ID      string `json:"id"`
+				Prompt  string `json:"prompt"`
+				Options []struct {
+					ID    string `json:"id"`
+					Label string `json:"label"`
+				} `json:"options"`
+			} `json:"questions"`
+		} `json:"params"`
+	}
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+				Answers []struct {
+					QuestionID        string   `json:"questionId"`
+					SelectedOptionIDs []string `json:"selectedOptionIds"`
+				} `json:"answers"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+		return ""
+	}
+
+	switch resp.Result.Outcome.Outcome {
+	case "answered":
+		labels := make(map[string]string, len(req.Params.Questions))
+		optionLabels := make(map[string]map[string]string, len(req.Params.Questions))
+		order := make([]string, 0, len(req.Params.Questions))
+		for _, q := range req.Params.Questions {
+			if strings.TrimSpace(q.ID) == "" {
+				continue
+			}
+			labels[q.ID] = strings.TrimSpace(q.Prompt)
+			options := make(map[string]string, len(q.Options))
+			for _, option := range q.Options {
+				if strings.TrimSpace(option.ID) == "" {
+					continue
+				}
+				label := strings.TrimSpace(option.Label)
+				if label == "" {
+					label = option.ID
+				}
+				options[option.ID] = label
+			}
+			optionLabels[q.ID] = options
+			order = append(order, q.ID)
+		}
+
+		answerByQuestion := make(map[string][]string, len(resp.Result.Outcome.Answers))
+		for _, answer := range resp.Result.Outcome.Answers {
+			if strings.TrimSpace(answer.QuestionID) == "" {
+				continue
+			}
+			mapped := make([]string, 0, len(answer.SelectedOptionIDs))
+			for _, optionID := range answer.SelectedOptionIDs {
+				optionID = strings.TrimSpace(optionID)
+				if optionID == "" {
+					continue
+				}
+				label := optionID
+				if options := optionLabels[answer.QuestionID]; options != nil {
+					if mappedLabel := strings.TrimSpace(options[optionID]); mappedLabel != "" {
+						label = mappedLabel
+					}
+				}
+				mapped = append(mapped, label)
+			}
+			if len(mapped) > 0 {
+				answerByQuestion[answer.QuestionID] = mapped
+			}
+		}
+
+		lines := make([]string, 0, len(answerByQuestion))
+		for _, questionID := range order {
+			mapped := answerByQuestion[questionID]
+			if len(mapped) == 0 {
+				continue
+			}
+			label := strings.TrimSpace(labels[questionID])
+			if label == "" {
+				label = questionID
+			}
+			lines = append(lines, fmt.Sprintf("%s: %s", label, strings.Join(mapped, ", ")))
+		}
+		return strings.Join(lines, "\n")
+	case "cancelled", "skipped":
+		return strings.TrimSpace(resp.Result.Outcome.Reason)
+	default:
+		return ""
+	}
+}
+
+func cursorCreatePlanResponseDisplayText(responseContent []byte) string {
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(responseContent, &resp) != nil {
+		return ""
+	}
+
+	switch resp.Result.Outcome.Outcome {
+	case "accepted":
+		return "Accept"
+	case "rejected":
+		if reason := strings.TrimSpace(resp.Result.Outcome.Reason); reason != "" {
+			return reason
+		}
+		return "Reject"
+	case "cancelled":
+		if reason := strings.TrimSpace(resp.Result.Outcome.Reason); reason != "" {
+			return reason
+		}
+		return "Cancel"
+	default:
+		return ""
+	}
+}
+
 func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv1.AgentProvider, content []byte) string {
 	switch provider {
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX:
@@ -184,6 +313,8 @@ func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_GEMINI_CLI:
 		// handled below
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_COPILOT_CLI:
+		// handled below
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI:
 		// handled below
 	default:
 		return ""
@@ -224,6 +355,15 @@ func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv
 	case leapmuxv1.AgentProvider_AGENT_PROVIDER_GEMINI_CLI,
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_COPILOT_CLI:
 		return acpPermissionResponseDisplayText(cr.Payload, content)
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR_CLI:
+		switch payload.Method {
+		case "cursor/ask_question":
+			return cursorQuestionAnswersText(cr.Payload, content)
+		case "cursor/create_plan":
+			return cursorCreatePlanResponseDisplayText(content)
+		default:
+			return ""
+		}
 	default:
 		return ""
 	}

--- a/backend/internal/worker/service/control_response.go
+++ b/backend/internal/worker/service/control_response.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -49,7 +50,12 @@ func codexUserInputAnswersText(requestPayload, responseContent []byte) string {
 			} `json:"answers"`
 		} `json:"result"`
 	}
-	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+	if err := json.Unmarshal(requestPayload, &req); err != nil {
+		slog.Warn("codex user input request unmarshal failed", "error", err)
+		return ""
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		slog.Warn("codex user input response unmarshal failed", "error", err)
 		return ""
 	}
 
@@ -143,7 +149,12 @@ func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string 
 			Answers [][]string `json:"answers"`
 		} `json:"result"`
 	}
-	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+	if err := json.Unmarshal(requestPayload, &req); err != nil {
+		slog.Warn("opencode question request unmarshal failed", "error", err)
+		return ""
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		slog.Warn("opencode question response unmarshal failed", "error", err)
 		return ""
 	}
 
@@ -200,7 +211,12 @@ func cursorQuestionAnswersText(requestPayload, responseContent []byte) string {
 			} `json:"outcome"`
 		} `json:"result"`
 	}
-	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+	if err := json.Unmarshal(requestPayload, &req); err != nil {
+		slog.Warn("cursor question request unmarshal failed", "error", err)
+		return ""
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		slog.Warn("cursor question response unmarshal failed", "error", err)
 		return ""
 	}
 
@@ -282,7 +298,8 @@ func cursorCreatePlanResponseDisplayText(responseContent []byte) string {
 			} `json:"outcome"`
 		} `json:"result"`
 	}
-	if json.Unmarshal(responseContent, &resp) != nil {
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		slog.Warn("cursor create plan response unmarshal failed", "error", err)
 		return ""
 	}
 
@@ -337,7 +354,8 @@ func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv
 		Method string `json:"method"`
 		Type   string `json:"type"`
 	}
-	if json.Unmarshal(cr.Payload, &payload) != nil {
+	if err := json.Unmarshal(cr.Payload, &payload); err != nil {
+		slog.Warn("control response display text unmarshal failed", "agent_id", agentID, "error", err)
 		return ""
 	}
 
@@ -388,7 +406,12 @@ func acpPermissionResponseDisplayText(requestPayload, responseContent []byte) st
 			} `json:"outcome"`
 		} `json:"result"`
 	}
-	if json.Unmarshal(requestPayload, &req) != nil || json.Unmarshal(responseContent, &resp) != nil {
+	if err := json.Unmarshal(requestPayload, &req); err != nil {
+		slog.Warn("acp permission request unmarshal failed", "error", err)
+		return ""
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		slog.Warn("acp permission response unmarshal failed", "error", err)
 		return ""
 	}
 

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -1005,7 +1005,8 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 
 	for i, raw := range messages {
 		var env envelope
-		if json.Unmarshal(raw, &env) != nil {
+		if err := json.Unmarshal(raw, &env); err != nil {
+			slog.Warn("consolidate notification unmarshal failed", "error", err)
 			keepAll = append(keepAll, indexedRaw{i, raw})
 			continue
 		}
@@ -1027,7 +1028,8 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			// context_cleared supersedes any earlier compaction boundaries.
 			keepAll = slices.DeleteFunc(keepAll, func(ir indexedRaw) bool {
 				var e envelope
-				if json.Unmarshal(ir.raw, &e) != nil {
+				if err := json.Unmarshal(ir.raw, &e); err != nil {
+					slog.Warn("consolidate context_cleared filter unmarshal failed", "error", err)
 					return false
 				}
 				return e.Type == "system" && (e.Subtype == "compact_boundary" || e.Subtype == "microcompact_boundary")

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -10,6 +10,7 @@ import { safeGetJson, safeRemoveItem, safeSetJson } from '~/lib/safeStorage'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import { buildAskAnswers, trySubmitAskUserQuestion } from './controls/AskUserQuestionControl'
 import { sendCodexUserInputResponse } from './controls/CodexControlRequest'
+import { sendCursorQuestionResponse } from './controls/CursorControlRequest'
 import { sendOpenCodeQuestionResponse } from './controls/OpenCodeControlRequest'
 import { getProviderPlugin } from './providers'
 
@@ -177,6 +178,20 @@ export function useControlResponseHandling(
               multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
             })) as Question[]
           }
+          case AgentProvider.CURSOR_CLI: {
+            const params = req.payload.params as Record<string, unknown> | undefined
+            const rawQuestions = (params?.questions as Array<Record<string, unknown>> | undefined) ?? []
+            return rawQuestions.map(question => ({
+              id: question.id as string | undefined,
+              question: (question.prompt as string | undefined) ?? '',
+              header: (question.prompt as string | undefined) ?? (question.id as string | undefined),
+              multiSelect: (question.allowMultiple as boolean | undefined) ?? false,
+              options: ((question.options as Array<Record<string, unknown>> | undefined) ?? []).map(option => ({
+                id: option.id as string | undefined,
+                label: (option.label as string | undefined) ?? (option.id as string | undefined) ?? '',
+              })),
+            })) as Question[]
+          }
           default:
             return (getToolInput(req.payload).questions as Question[] | undefined) ?? []
         }
@@ -198,6 +213,9 @@ export function useControlResponseHandling(
             break
           case AgentProvider.OPENCODE:
             void sendOpenCodeQuestionResponse(req.agentId, sendControlResponse, req.requestId, normalizedQuestions, askState)
+            break
+          case AgentProvider.CURSOR_CLI:
+            void sendCursorQuestionResponse(req.agentId, sendControlResponse, req.requestId, normalizedQuestions, askState)
             break
           default: {
             const response = buildAskAnswers(askState, normalizedQuestions, getToolInput(req.payload), req.requestId)

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -10,7 +10,7 @@ import { safeGetJson, safeRemoveItem, safeSetJson } from '~/lib/safeStorage'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import { buildAskAnswers, trySubmitAskUserQuestion } from './controls/AskUserQuestionControl'
 import { sendCodexUserInputResponse } from './controls/CodexControlRequest'
-import { sendCursorQuestionResponse } from './controls/CursorControlRequest'
+import { getCursorQuestions, sendCursorQuestionResponse } from './controls/CursorControlRequest'
 import { sendOpenCodeQuestionResponse } from './controls/OpenCodeControlRequest'
 import { getProviderPlugin } from './providers'
 
@@ -178,20 +178,8 @@ export function useControlResponseHandling(
               multiSelect: (question.multiSelect as boolean | undefined) ?? (question.multiple as boolean | undefined),
             })) as Question[]
           }
-          case AgentProvider.CURSOR_CLI: {
-            const params = req.payload.params as Record<string, unknown> | undefined
-            const rawQuestions = (params?.questions as Array<Record<string, unknown>> | undefined) ?? []
-            return rawQuestions.map(question => ({
-              id: question.id as string | undefined,
-              question: (question.prompt as string | undefined) ?? '',
-              header: (question.prompt as string | undefined) ?? (question.id as string | undefined),
-              multiSelect: (question.allowMultiple as boolean | undefined) ?? false,
-              options: ((question.options as Array<Record<string, unknown>> | undefined) ?? []).map(option => ({
-                id: option.id as string | undefined,
-                label: (option.label as string | undefined) ?? (option.id as string | undefined) ?? '',
-              })),
-            })) as Question[]
-          }
+          case AgentProvider.CURSOR_CLI:
+            return getCursorQuestions(req.payload)
           default:
             return (getToolInput(req.payload).questions as Question[] | undefined) ?? []
         }

--- a/frontend/src/components/chat/controls/CursorControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CursorControlRequest.tsx
@@ -21,7 +21,7 @@ function isCursorCreatePlanPayload(payload: Record<string, unknown>): boolean {
   return payload.method === 'cursor/create_plan'
 }
 
-function getCursorQuestions(payload: Record<string, unknown>): Question[] {
+export function getCursorQuestions(payload: Record<string, unknown>): Question[] {
   const params = getCursorParams(payload)
   const rawQuestions = (params?.questions as Array<Record<string, unknown>> | undefined) ?? []
   return rawQuestions.map(question => ({
@@ -112,14 +112,12 @@ export const CursorControlContent: Component<ContentProps> = (props) => {
         />
       </Match>
       <Match when={isCursorCreatePlanPayload(props.request.payload)}>
-        <>
-          <div class={styles.controlBannerTitle}>
-            {planName() ? `Create Plan: ${planName()}` : 'Create Plan'}
-          </div>
-          <Show when={overview()}>
-            <div class={styles.codexReason}>{overview()}</div>
-          </Show>
-        </>
+        <div class={styles.controlBannerTitle}>
+          {planName() ? `Create Plan: ${planName()}` : 'Create Plan'}
+        </div>
+        <Show when={overview()}>
+          <div class={styles.codexReason}>{overview()}</div>
+        </Show>
       </Match>
     </Switch>
   )

--- a/frontend/src/components/chat/controls/CursorControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CursorControlRequest.tsx
@@ -13,12 +13,16 @@ function getCursorParams(payload: Record<string, unknown>): Record<string, unkno
   return payload.params as Record<string, unknown> | undefined
 }
 
-function isCursorAskQuestionPayload(payload: Record<string, unknown>): boolean {
+export function isCursorAskQuestionPayload(payload: Record<string, unknown>): boolean {
   return payload.method === 'cursor/ask_question'
 }
 
-function isCursorCreatePlanPayload(payload: Record<string, unknown>): boolean {
+export function isCursorCreatePlanPayload(payload: Record<string, unknown>): boolean {
   return payload.method === 'cursor/create_plan'
+}
+
+export function isCursorControlPayload(payload: Record<string, unknown>): boolean {
+  return isCursorAskQuestionPayload(payload) || isCursorCreatePlanPayload(payload)
 }
 
 export function getCursorQuestions(payload: Record<string, unknown>): Question[] {

--- a/frontend/src/components/chat/controls/CursorControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CursorControlRequest.tsx
@@ -1,0 +1,177 @@
+import type { Component } from 'solid-js'
+import type { ActionsProps, AskQuestionState, ContentProps, Question } from './types'
+
+import { Match, Show, Switch } from 'solid-js'
+import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { buildAllowResponse, buildDenyResponse } from '~/utils/controlResponse'
+import * as styles from '../ControlRequestBanner.css'
+import { AskUserQuestionActions, AskUserQuestionContent } from './AskUserQuestionControl'
+import { toRpcId } from './CodexControlRequest'
+import { sendResponse } from './types'
+
+function getCursorParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
+  return payload.params as Record<string, unknown> | undefined
+}
+
+function isCursorAskQuestionPayload(payload: Record<string, unknown>): boolean {
+  return payload.method === 'cursor/ask_question'
+}
+
+function isCursorCreatePlanPayload(payload: Record<string, unknown>): boolean {
+  return payload.method === 'cursor/create_plan'
+}
+
+function getCursorQuestions(payload: Record<string, unknown>): Question[] {
+  const params = getCursorParams(payload)
+  const rawQuestions = (params?.questions as Array<Record<string, unknown>> | undefined) ?? []
+  return rawQuestions.map(question => ({
+    id: question.id as string | undefined,
+    question: (question.prompt as string | undefined) ?? '',
+    header: (question.prompt as string | undefined) ?? (question.id as string | undefined),
+    multiSelect: (question.allowMultiple as boolean | undefined) ?? false,
+    options: ((question.options as Array<Record<string, unknown>> | undefined) ?? []).map(option => ({
+      id: option.id as string | undefined,
+      label: (option.label as string | undefined) ?? (option.id as string | undefined) ?? '',
+    })),
+  }))
+}
+
+function wrapAsAskUserQuestion(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...payload,
+    request: {
+      tool_name: 'AskUserQuestion',
+      input: { questions: getCursorQuestions(payload) },
+    },
+  }
+}
+
+export function sendCursorQuestionResponse(
+  agentId: string,
+  onRespond: (agentId: string, content: Uint8Array) => Promise<void>,
+  requestId: string,
+  questions: Question[],
+  askState: AskQuestionState,
+): Promise<void> {
+  const answers = questions.map((question, index) => {
+    const selected = askState.selections()[index] ?? []
+    const selectedOptionIds = selected.map((selectedLabel) => {
+      const match = question.options.find(option => option.label === selectedLabel)
+      return match?.id || selectedLabel
+    })
+    return {
+      questionId: question.id || `q${index}`,
+      selectedOptionIds,
+    }
+  }).filter(answer => answer.selectedOptionIds.length > 0)
+
+  return sendResponse(agentId, onRespond, {
+    jsonrpc: '2.0',
+    id: toRpcId(requestId),
+    result: {
+      outcome: {
+        outcome: 'answered',
+        answers,
+      },
+    },
+  })
+}
+
+export function sendCursorQuestionRejectResponse(
+  agentId: string,
+  onRespond: (agentId: string, content: Uint8Array) => Promise<void>,
+  requestId: string,
+  reason?: string,
+): Promise<void> {
+  return sendResponse(agentId, onRespond, {
+    jsonrpc: '2.0',
+    id: toRpcId(requestId),
+    result: {
+      outcome: {
+        outcome: 'cancelled',
+        ...(reason ? { reason } : {}),
+      },
+    },
+  })
+}
+
+export const CursorControlContent: Component<ContentProps> = (props) => {
+  const params = () => getCursorParams(props.request.payload)
+  const planName = () => params()?.name as string | undefined
+  const overview = () => params()?.overview as string | undefined
+
+  return (
+    <Switch
+      fallback={<div class={styles.controlBannerTitle}>Cursor Request</div>}
+    >
+      <Match when={isCursorAskQuestionPayload(props.request.payload)}>
+        <AskUserQuestionContent
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          askState={props.askState}
+          optionsDisabled={props.optionsDisabled}
+        />
+      </Match>
+      <Match when={isCursorCreatePlanPayload(props.request.payload)}>
+        <>
+          <div class={styles.controlBannerTitle}>
+            {planName() ? `Create Plan: ${planName()}` : 'Create Plan'}
+          </div>
+          <Show when={overview()}>
+            <div class={styles.codexReason}>{overview()}</div>
+          </Show>
+        </>
+      </Match>
+    </Switch>
+  )
+}
+
+export const CursorControlActions: Component<ActionsProps> = (props) => {
+  const questions = () => getCursorQuestions(props.request.payload)
+
+  const createPlanAllow = () => sendResponse(
+    props.request.agentId,
+    props.onRespond,
+    buildAllowResponse(props.request.requestId, {}),
+  )
+
+  const createPlanReject = () => sendResponse(
+    props.request.agentId,
+    props.onRespond,
+    buildDenyResponse(props.request.requestId, 'Rejected by user.'),
+  )
+
+  const userInputOnRespond = async (_agentId: string, content: Uint8Array) => {
+    const parsed = JSON.parse(new TextDecoder().decode(content))
+    if (parsed?.response?.response?.behavior === 'deny') {
+      await sendCursorQuestionRejectResponse(props.request.agentId, props.onRespond, props.request.requestId, parsed?.response?.response?.message as string | undefined)
+      return
+    }
+    await sendCursorQuestionResponse(props.request.agentId, props.onRespond, props.request.requestId, questions(), props.askState)
+  }
+
+  return (
+    <Switch
+      fallback={(
+        <div class={styles.controlFooter}>
+          <div class={styles.controlFooterLeft}>
+            {props.infoTrigger}
+          </div>
+          <div class={styles.controlFooterRight}>
+            <ButtonGroup>
+              <button class="outline" onClick={createPlanReject} data-testid="control-deny-btn">Reject</button>
+              <button onClick={createPlanAllow} data-testid="control-allow-btn">Allow</button>
+            </ButtonGroup>
+          </div>
+        </div>
+      )}
+    >
+      <Match when={isCursorAskQuestionPayload(props.request.payload)}>
+        <AskUserQuestionActions
+          {...props}
+          request={{ ...props.request, payload: wrapAsAskUserQuestion(props.request.payload) }}
+          onRespond={userInputOnRespond}
+        />
+      </Match>
+    </Switch>
+  )
+}

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -4,6 +4,7 @@ import type { ControlRequest } from '~/stores/control.store'
 import type { PermissionMode } from '~/utils/controlResponse'
 
 interface QuestionOption {
+  id?: string
   label: string
   description?: string
 }

--- a/frontend/src/components/chat/providers/cursor.test.ts
+++ b/frontend/src/components/chat/providers/cursor.test.ts
@@ -1,0 +1,108 @@
+import { create } from '@bufbuild/protobuf'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import * as workerRpc from '~/api/workerRpc'
+import { AgentProvider, AvailableModelSchema, AvailableOptionGroupSchema, AvailableOptionSchema } from '~/generated/leapmux/v1/agent_pb'
+import { getProviderPlugin } from './registry'
+import { input } from './testUtils'
+
+import './cursor'
+
+vi.mock('~/api/workerRpc', () => ({
+  updateAgentSettings: vi.fn(),
+}))
+
+describe('cursor provider', () => {
+  const plugin = getProviderPlugin(AgentProvider.CURSOR_CLI)!
+
+  it('exposes attachment capabilities', () => {
+    expect(plugin.attachments).toEqual({
+      text: true,
+      image: true,
+      pdf: true,
+      binary: true,
+    })
+  })
+
+  it('classifies agent_message_chunk as assistant_text', () => {
+    const parent = {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'Hello Cursor' },
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'assistant_text' })
+  })
+
+  it('hides config_option_update', () => {
+    const parent = {
+      sessionUpdate: 'config_option_update',
+      configOptions: [],
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
+  })
+
+  it('maps plan mode to agent/plan values', () => {
+    expect(plugin.planMode?.currentMode({ permissionMode: 'plan' })).toBe('plan')
+    expect(plugin.planMode?.currentMode({ permissionMode: '' })).toBe('agent')
+  })
+
+  it('recognizes cursor ask-question control payloads', () => {
+    expect(plugin.isAskUserQuestion?.({ method: 'cursor/ask_question' })).toBe(true)
+    expect(plugin.isAskUserQuestion?.({ method: 'cursor/create_plan' })).toBe(false)
+  })
+
+  it('changes permission mode through UpdateAgentSettings', async () => {
+    await plugin.changePermissionMode?.('worker-1', 'agent-1', 'plan')
+    expect(workerRpc.updateAgentSettings).toHaveBeenCalledWith('worker-1', {
+      agentId: 'agent-1',
+      settings: { permissionMode: 'plan' },
+    })
+  })
+})
+
+describe('cursor settings panel', () => {
+  const plugin = getProviderPlugin(AgentProvider.CURSOR_CLI)!
+
+  it('renders runtime modes and updates via permission-mode callback', async () => {
+    const onPermissionModeChange = vi.fn()
+    render(() => plugin.SettingsPanel!({
+      model: 'auto',
+      permissionMode: 'agent',
+      availableModels: [
+        create(AvailableModelSchema, { id: 'auto', displayName: 'Auto', isDefault: true }),
+        create(AvailableModelSchema, { id: 'gpt-5.4', displayName: 'GPT-5.4' }),
+      ],
+      availableOptionGroups: [create(AvailableOptionGroupSchema, {
+        key: 'permissionMode',
+        label: 'Mode',
+        options: [
+          create(AvailableOptionSchema, { id: 'agent', name: 'Agent', isDefault: true }),
+          create(AvailableOptionSchema, { id: 'plan', name: 'Plan' }),
+          create(AvailableOptionSchema, { id: 'ask', name: 'Ask' }),
+        ],
+      })],
+      onPermissionModeChange,
+    }))
+
+    expect(screen.getByText('Mode')).toBeTruthy()
+    await fireEvent.click(screen.getByDisplayValue('plan'))
+    expect(onPermissionModeChange).toHaveBeenCalledWith('plan')
+  })
+
+  it('includes the selected mode in the trigger label', () => {
+    render(() => plugin.settingsTriggerLabel!({
+      model: 'auto',
+      permissionMode: 'plan',
+      availableModels: [create(AvailableModelSchema, { id: 'auto', displayName: 'Auto', isDefault: true })],
+      availableOptionGroups: [create(AvailableOptionGroupSchema, {
+        key: 'permissionMode',
+        label: 'Mode',
+        options: [
+          create(AvailableOptionSchema, { id: 'agent', name: 'Agent', isDefault: true }),
+          create(AvailableOptionSchema, { id: 'plan', name: 'Plan' }),
+        ],
+      })],
+    }))
+
+    expect(screen.getByText('Auto \u00B7 Plan')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/chat/providers/cursor.tsx
+++ b/frontend/src/components/chat/providers/cursor.tsx
@@ -3,7 +3,7 @@ import type { PermissionMode } from '~/utils/controlResponse'
 import { createMemo, Show } from 'solid-js'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { ACPControlActions, ACPControlContent } from '../controls/ACPControlRequest'
-import { CursorControlActions, CursorControlContent } from '../controls/CursorControlRequest'
+import { CursorControlActions, CursorControlContent, isCursorAskQuestionPayload, isCursorControlPayload } from '../controls/CursorControlRequest'
 import { PERMISSION_MODE_KEY } from '../settingsShared'
 import {
   buildACPInterruptContent,
@@ -42,27 +42,21 @@ registerProvider(AgentProvider.CURSOR_CLI, {
   changePermissionMode: changeACPPermissionMode,
 
   isAskUserQuestion(payload?: Record<string, unknown>): boolean {
-    return payload?.method === 'cursor/ask_question'
+    return !!payload && isCursorAskQuestionPayload(payload)
   },
 
   ControlContent: (props) => {
-    const isCursorControl = createMemo(() => (
-      props.request.payload.method === 'cursor/ask_question'
-      || props.request.payload.method === 'cursor/create_plan'
-    ))
+    const isCursor = createMemo(() => isCursorControlPayload(props.request.payload))
     return (
-      <Show when={isCursorControl()} fallback={<ACPControlContent {...props} />}>
+      <Show when={isCursor()} fallback={<ACPControlContent {...props} />}>
         <CursorControlContent {...props} />
       </Show>
     )
   },
   ControlActions: (props) => {
-    const isCursorControl = createMemo(() => (
-      props.request.payload.method === 'cursor/ask_question'
-      || props.request.payload.method === 'cursor/create_plan'
-    ))
+    const isCursor = createMemo(() => isCursorControlPayload(props.request.payload))
     return (
-      <Show when={isCursorControl()} fallback={<ACPControlActions {...props} />}>
+      <Show when={isCursor()} fallback={<ACPControlActions {...props} />}>
         <CursorControlActions {...props} />
       </Show>
     )

--- a/frontend/src/components/chat/providers/cursor.tsx
+++ b/frontend/src/components/chat/providers/cursor.tsx
@@ -1,0 +1,72 @@
+import type { ACPSettingsPanelConfig } from './acpShared'
+import type { PermissionMode } from '~/utils/controlResponse'
+import { createMemo, Show } from 'solid-js'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { ACPControlActions, ACPControlContent } from '../controls/ACPControlRequest'
+import { CursorControlActions, CursorControlContent } from '../controls/CursorControlRequest'
+import { PERMISSION_MODE_KEY } from '../settingsShared'
+import {
+  buildACPInterruptContent,
+  changeACPPermissionMode,
+  classifyACPMessage,
+  createACPSettingsPanel,
+  createACPTriggerLabel,
+  renderACPMessage,
+} from './acpShared'
+import { registerProvider } from './registry'
+
+const DEFAULT_CURSOR_MODEL = import.meta.env.LEAPMUX_CURSOR_DEFAULT_MODEL || 'auto'
+
+const settingsConfig: ACPSettingsPanelConfig = {
+  defaultModel: DEFAULT_CURSOR_MODEL,
+  optionGroupKey: PERMISSION_MODE_KEY,
+  defaultOptionValue: 'agent',
+  fallbackLabel: 'Mode',
+  testIdPrefix: 'permission-mode',
+}
+
+registerProvider(AgentProvider.CURSOR_CLI, {
+  defaultModel: DEFAULT_CURSOR_MODEL,
+  defaultPermissionMode: 'agent' as PermissionMode,
+  attachments: { text: true, image: true, pdf: true, binary: true },
+  planMode: {
+    currentMode: agent => agent.permissionMode || 'agent',
+    planValue: 'plan',
+    defaultValue: 'agent',
+    setMode: (mode, cb) => cb.onPermissionModeChange?.(mode as PermissionMode),
+  },
+
+  classify: classifyACPMessage({ extraHiddenSessionUpdates: new Set(['config_option_update']) }),
+  renderMessage: renderACPMessage,
+  buildInterruptContent: buildACPInterruptContent,
+  changePermissionMode: changeACPPermissionMode,
+
+  isAskUserQuestion(payload?: Record<string, unknown>): boolean {
+    return payload?.method === 'cursor/ask_question'
+  },
+
+  ControlContent: (props) => {
+    const isCursorControl = createMemo(() => (
+      props.request.payload.method === 'cursor/ask_question'
+      || props.request.payload.method === 'cursor/create_plan'
+    ))
+    return (
+      <Show when={isCursorControl()} fallback={<ACPControlContent {...props} />}>
+        <CursorControlContent {...props} />
+      </Show>
+    )
+  },
+  ControlActions: (props) => {
+    const isCursorControl = createMemo(() => (
+      props.request.payload.method === 'cursor/ask_question'
+      || props.request.payload.method === 'cursor/create_plan'
+    ))
+    return (
+      <Show when={isCursorControl()} fallback={<ACPControlActions {...props} />}>
+        <CursorControlActions {...props} />
+      </Show>
+    )
+  },
+  SettingsPanel: createACPSettingsPanel(settingsConfig),
+  settingsTriggerLabel: createACPTriggerLabel(settingsConfig),
+})

--- a/frontend/src/components/chat/providers/index.ts
+++ b/frontend/src/components/chat/providers/index.ts
@@ -2,6 +2,7 @@
 import './claude'
 import './copilot'
 import './codex'
+import './cursor'
 import './gemini'
 import './opencode'
 import './stubs'

--- a/frontend/src/components/common/AgentProviderIcon.tsx
+++ b/frontend/src/components/common/AgentProviderIcon.tsx
@@ -10,6 +10,7 @@ export function agentProviderLabel(provider?: AgentProvider): string {
     case AgentProvider.GEMINI_CLI: return 'Gemini CLI'
     case AgentProvider.OPENCODE: return 'OpenCode'
     case AgentProvider.COPILOT_CLI: return 'Copilot CLI'
+    case AgentProvider.CURSOR_CLI: return 'Cursor CLI'
     default: return 'Unknown'
   }
 }
@@ -127,6 +128,24 @@ function CopilotCliIcon(props: { size: number, class?: string }): JSX.Element {
   )
 }
 
+function CursorCliIcon(props: { size: number, class?: string }): JSX.Element {
+  return (
+    <svg
+      fill="#000"
+      fill-rule="evenodd"
+      height={props.size}
+      width={props.size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      class={props.class}
+      style={iconStyle(props.size)}
+    >
+      <title>Cursor</title>
+      <path d="M22.106 5.68 12.5.135a.998.998 0 0 0-.998 0L1.893 5.68a.84.84 0 0 0-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 0 0 .998 0l9.608-5.547a.84.84 0 0 0 .42-.727V6.407a.84.84 0 0 0-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 0 0-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z" />
+    </svg>
+  )
+}
+
 export interface AgentProviderIconProps {
   provider?: AgentProvider
   size: number
@@ -150,6 +169,9 @@ export function AgentProviderIcon(props: AgentProviderIconProps): JSX.Element {
       </Match>
       <Match when={props.provider === AgentProvider.COPILOT_CLI}>
         <CopilotCliIcon size={props.size} class={props.class} />
+      </Match>
+      <Match when={props.provider === AgentProvider.CURSOR_CLI}>
+        <CursorCliIcon size={props.size} class={props.class} />
       </Match>
     </Switch>
   )

--- a/frontend/src/components/shell/AgentProviderSelector.tsx
+++ b/frontend/src/components/shell/AgentProviderSelector.tsx
@@ -5,7 +5,7 @@ import { RefreshButton } from '~/components/common/RefreshButton'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { labelRow } from '~/styles/shared.css'
 
-const allProviders = [AgentProvider.CLAUDE_CODE, AgentProvider.CODEX, AgentProvider.GEMINI_CLI, AgentProvider.OPENCODE, AgentProvider.COPILOT_CLI]
+const allProviders = [AgentProvider.CLAUDE_CODE, AgentProvider.CODEX, AgentProvider.GEMINI_CLI, AgentProvider.OPENCODE, AgentProvider.COPILOT_CLI, AgentProvider.CURSOR_CLI]
 
 interface AgentProviderSelectorProps {
   value: Accessor<AgentProvider>

--- a/frontend/tests/e2e/112-cursor-basic-chat.spec.ts
+++ b/frontend/tests/e2e/112-cursor-basic-chat.spec.ts
@@ -1,0 +1,18 @@
+import { CURSOR_E2E_SKIP_REASON, cursorTest, expect } from './cursor-fixtures'
+import { lastAssistantBubble, sendMessage, waitForAgentIdle } from './helpers/ui'
+
+const QUOTA_OR_LIMIT_ERROR_RE = /quota|limit|too many requests/i
+
+cursorTest.skip(!!CURSOR_E2E_SKIP_REASON, CURSOR_E2E_SKIP_REASON || '')
+
+cursorTest.describe('Cursor Basic Chat', () => {
+  cursorTest('send message and receive response', async ({ authenticatedCursorWorkspace, page }) => {
+    void authenticatedCursorWorkspace
+    await sendMessage(page, 'What is 2+2? Reply with just the number.')
+    await waitForAgentIdle(page, 120_000)
+
+    const bubble = await lastAssistantBubble(page)
+    const text = await bubble.textContent()
+    expect(text === null || QUOTA_OR_LIMIT_ERROR_RE.test(text) || text.includes('4')).toBe(true)
+  })
+})

--- a/frontend/tests/e2e/113-cursor-settings.spec.ts
+++ b/frontend/tests/e2e/113-cursor-settings.spec.ts
@@ -1,0 +1,22 @@
+import { CURSOR_E2E_SKIP_REASON, cursorTest, expect } from './cursor-fixtures'
+import { openSettingsMenu, waitForSettingsIdle } from './helpers/ui'
+
+cursorTest.skip(!!CURSOR_E2E_SKIP_REASON, CURSOR_E2E_SKIP_REASON || '')
+
+cursorTest.describe('Cursor Settings', () => {
+  cursorTest('mode and model can be changed live', async ({ authenticatedCursorWorkspace, page }) => {
+    void authenticatedCursorWorkspace
+
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="permission-mode-plan"]').click()
+    await expect(trigger).toContainText('Plan')
+    await waitForSettingsIdle(page)
+
+    await openSettingsMenu(page)
+    await page.locator('[data-testid^="model-auto"]').first().click()
+    await expect(trigger).toContainText('Auto')
+  })
+})

--- a/frontend/tests/e2e/114-cursor-agent-type-selector.spec.ts
+++ b/frontend/tests/e2e/114-cursor-agent-type-selector.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from './fixtures'
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+
+test.describe('cursor agent type selector', () => {
+  test('Cursor CLI appears in the provider selector', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, adminOrgId, workerId } = leapmuxServer
+
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, `selector-cursor-${Date.now()}`, adminOrgId)
+    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
+
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+
+      const newAgentBtn = page.locator('[data-testid="new-agent-btn"]')
+      if (await newAgentBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await newAgentBtn.click()
+
+        const dialog = page.locator('[role="dialog"]')
+        await expect(dialog).toBeVisible({ timeout: 5000 })
+
+        const select = dialog.locator('select').filter({ hasText: 'Claude Code' })
+        if (await select.isVisible({ timeout: 3000 }).catch(() => false)) {
+          const options = await select.locator('option').allTextContents()
+          expect(options).toContain('Cursor CLI')
+        }
+      }
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
+})

--- a/frontend/tests/e2e/51-cross-tile-tabs.spec.ts
+++ b/frontend/tests/e2e/51-cross-tile-tabs.spec.ts
@@ -30,12 +30,46 @@ async function splitHorizontal(page: Page, tile?: Locator) {
   }
 }
 
-/** Simulate a drag-and-drop from one element to another using mouse events. */
+/**
+ * Compute the visible bounding box of an element, clipped to its scroll parent.
+ * Returns the intersection of the element's box with the nearest ancestor that
+ * has `overflow` scrolling enabled, so the drag starts on a point the user can
+ * actually see (and that receives pointer events).
+ */
+async function visibleBox(locator: Locator) {
+  return locator.evaluate((el: HTMLElement) => {
+    const rect = el.getBoundingClientRect()
+    // Walk up to find the nearest scrollable ancestor
+    let parent = el.parentElement
+    while (parent) {
+      const style = getComputedStyle(parent)
+      if (style.overflowX === 'auto' || style.overflowX === 'scroll'
+        || style.overflowY === 'auto' || style.overflowY === 'scroll') {
+        const parentRect = parent.getBoundingClientRect()
+        // Clip to the scroll parent
+        return {
+          x: Math.max(rect.x, parentRect.x),
+          y: Math.max(rect.y, parentRect.y),
+          width: Math.min(rect.right, parentRect.right) - Math.max(rect.x, parentRect.x),
+          height: Math.min(rect.bottom, parentRect.bottom) - Math.max(rect.y, parentRect.y),
+        }
+      }
+      parent = parent.parentElement
+    }
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+  })
+}
+
+/** Simulate a drag-and-drop from one element to another using pointer events. */
 async function dragTo(page: Page, source: Locator, target: Locator) {
-  const sourceBox = await source.boundingBox()
+  // Scroll the source into view so it's not clipped by its scroll parent
+  await source.scrollIntoViewIfNeeded()
+
+  // Use the visible portion of the source to avoid clicking on overlapping elements
+  const sourceBox = await visibleBox(source)
   const targetBox = await target.boundingBox()
-  if (!sourceBox || !targetBox)
-    throw new Error('Could not get bounding boxes for drag operation')
+  if (sourceBox.width <= 0 || sourceBox.height <= 0 || !targetBox)
+    throw new Error('Could not get valid bounding boxes for drag operation')
 
   const srcX = sourceBox.x + sourceBox.width / 2
   const srcY = sourceBox.y + sourceBox.height / 2
@@ -43,17 +77,11 @@ async function dragTo(page: Page, source: Locator, target: Locator) {
   const tgtY = targetBox.y + targetBox.height / 2
 
   await page.mouse.move(srcX, srcY)
+  await page.waitForTimeout(100)
   await page.mouse.down()
-  // Move in steps to trigger DnD sensors
-  const steps = 5
-  for (let i = 1; i <= steps; i++) {
-    await page.mouse.move(
-      srcX + (tgtX - srcX) * (i / steps),
-      srcY + (tgtY - srcY) * (i / steps),
-      { steps: 1 },
-    )
-    await page.waitForTimeout(30)
-  }
+  await page.waitForTimeout(100)
+  await page.mouse.move(tgtX, tgtY, { steps: 15 })
+  await page.waitForTimeout(100)
   await page.mouse.up()
 }
 
@@ -159,6 +187,7 @@ test.describe('Cross-Tile Tabs', () => {
     // Drag terminal tab from tile 1 to tile 2's tab bar
     const terminalTab = tile1.locator('[data-testid="tab"][data-tab-type="terminal"]')
     const tile2TabList = tile2.locator('[data-testid="tab-list"]')
+
     await dragTo(page, terminalTab, tile2TabList)
 
     // Wait for the move to settle

--- a/frontend/tests/e2e/65-attachment-support.spec.ts
+++ b/frontend/tests/e2e/65-attachment-support.spec.ts
@@ -16,10 +16,10 @@ function createTestPng(name = 'test.png'): string {
   return path
 }
 
-/** Create a minimal text file (unsupported type) for rejection testing. */
-function createTestTxt(name = 'test.txt'): string {
+/** Create a minimal binary file (unsupported for the default provider) for rejection testing. */
+function createTestBinary(name = 'test.bin'): string {
   const path = join(tmpdir(), `leapmux-e2e-${Date.now()}-${name}`)
-  writeFileSync(path, 'hello world')
+  writeFileSync(path, Buffer.from([0x00, 0xFF, 0x01, 0xFE]))
   return path
 }
 
@@ -128,16 +128,16 @@ test.describe('Attachment Support', () => {
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
-    // Upload a .txt file (unsupported type).
+    // Upload a binary file (unsupported type for the default provider).
     const fileInput = page.locator('[data-testid="file-input"]')
-    await fileInput.setInputFiles(createTestTxt())
+    await fileInput.setInputFiles(createTestBinary())
 
     // No attachment pill should appear.
     await expect(page.locator('[data-testid="attachment-pill"]')).toHaveCount(0)
 
     // A toast should have been shown in the DOM (output element with .toast-message).
     const toast = page.locator('output .toast-message')
-    await expect(toast).toContainText('unsupported', { timeout: 5000 })
+    await expect(toast).toContainText('binary', { timeout: 5000 })
   })
 
   test('attachment-only message (no text) can be sent', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/acp-fixture-factory.ts
+++ b/frontend/tests/e2e/acp-fixture-factory.ts
@@ -20,6 +20,8 @@ export interface ACPFixtureConfig {
   skipMessage?: string
   /** Prefix for workspace names (e.g. 'copilot-e2e', 'gemini-e2e', 'opencode-e2e'). */
   workspacePrefix: string
+  /** Optional explicit model to use when opening the agent. */
+  model?: string
 }
 
 export interface WorkspaceFixture {
@@ -53,6 +55,7 @@ export async function createACPWorkspace(
   )
   await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, undefined, {
     agentProvider: config.agentProvider,
+    model: config.model,
   })
   const workspaceUrl = `/o/admin/workspace/${workspaceId}`
 

--- a/frontend/tests/e2e/cursor-fixtures.ts
+++ b/frontend/tests/e2e/cursor-fixtures.ts
@@ -1,0 +1,28 @@
+import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
+import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
+import { test as base, expect } from './fixtures'
+
+const cursorConfig: ACPFixtureConfig = {
+  agentProvider: AgentProvider.CURSOR_CLI,
+  cliBinary: 'cursor-agent',
+  skipMessage: 'Cursor E2E requires a cursor-agent CLI on PATH',
+  workspacePrefix: 'cursor-e2e',
+  model: 'auto',
+}
+
+export const CURSOR_E2E_SKIP_REASON = detectACPSkipReason(cursorConfig)
+
+export const cursorTest = base.extend<{
+  cursorWorkspace: WorkspaceFixture
+  authenticatedCursorWorkspace: WorkspaceFixture
+}>({
+  cursorWorkspace: async ({ leapmuxServer }, use) => {
+    await createACPWorkspace(leapmuxServer, cursorConfig, use)
+  },
+
+  authenticatedCursorWorkspace: async ({ page, cursorWorkspace, leapmuxServer }, use) => {
+    await authenticateACPWorkspace(page, cursorWorkspace, leapmuxServer.adminToken, use)
+  },
+})
+
+export { expect }

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -224,6 +224,7 @@ export async function openAgentViaAPI(
   workspaceId: string,
   workingDir?: string,
   options?: {
+    model?: string
     createWorktree?: boolean
     worktreeBranch?: string
     worktreeBaseBranch?: string
@@ -243,6 +244,7 @@ export async function openAgentViaAPI(
       workspaceId,
       workerId,
       workingDir: workingDir ?? '',
+      ...(options?.model ? { model: options.model } : {}),
       ...(options?.agentProvider ? { agentProvider: options.agentProvider } : {}),
       ...(options?.createWorktree ? { createWorktree: true, worktreeBranch: options.worktreeBranch ?? '' } : {}),
       ...(options?.worktreeBaseBranch ? { worktreeBaseBranch: options.worktreeBaseBranch } : {}),

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -11,6 +11,7 @@ enum AgentProvider {
   AGENT_PROVIDER_GEMINI_CLI = 3;
   AGENT_PROVIDER_OPENCODE = 4;
   AGENT_PROVIDER_COPILOT_CLI = 5;
+  AGENT_PROVIDER_CURSOR_CLI = 6;
 }
 
 // AgentStatus tracks the lifecycle state of an agent.


### PR DESCRIPTION
## Motivation

LeapMux supports multiple AI coding agent providers (Claude Code, Codex, Copilot, Gemini, OpenCode). This PR adds support for the Cursor CLI agent, which communicates over the ACP (Agent Communication Protocol) using JSON-RPC. Cursor introduces a distinct interaction model with three permission modes (Agent, Plan, Ask) and custom JSON-RPC methods (`cursor/ask_question`, `cursor/create_plan`) that required new request/response infrastructure beyond the original notification-only ACP design.

## Modifications

- Added `CursorCLIAgent` backend provider (`cursor.go`, `cursor_output.go`) that launches `cursor-agent acp`, handles the ACP handshake, normalizes the "auto" model to the wire value `default[]`, and manages Agent/Plan/Ask permission modes.
- Extended `acpBase` with an `extraMethod` hook so providers can handle custom JSON-RPC methods without modifying shared infrastructure.
- Added `sendResponse`/`sendErrorResponse`/`writeJSONRPCResponse` methods to the ACP layer to support request/response patterns, enabling Cursor's interactive `ask_question` and `create_plan` flows.
- Introduced shared ACP helpers (`configOptionSessionUpdateHandler`, `syncACPConfigOptions`, `parseACPConfigOptions`, `ExtractJSONRPCID`) and refactored Copilot to use them, eliminating duplicated config-option handling code.
- Added `AGENT_PROVIDER_CURSOR_CLI = 6` to the proto `AgentProvider` enum and wired up `transformCursorControlResponse()` and `normalizeProviderControlResponse()` in the control-response service layer.
- Added frontend Cursor provider (`cursor.tsx`) registered under `AgentProvider.CURSOR_CLI` with full attachment support (text, image, PDF, binary) and a `CursorControlRequest` component that maps Cursor-specific question payloads to the internal `Question` format.
- Extended the `Question` type with an optional `id` field to carry Cursor option IDs.
- Improved JSON unmarshal error reporting across all ACP providers (previously silent).
- Added E2E test suite for Cursor: basic chat (`112`), settings (`113`), and agent type selector (`114`), plus shared `cursor-fixtures.ts`.
- Fixed drag-and-drop test reliability in `51-cross-tile-tabs.spec.ts` by clipping coordinates to the visible scroll-parent region.
- Fixed unsupported attachment E2E test to use actual binary content instead of plain text.

## Result

Users can now create and use Cursor CLI agents in LeapMux. The Cursor provider appears in the agent provider selector with its icon, supports Agent/Plan/Ask mode switching, and handles Cursor's interactive question and plan-creation prompts natively in the chat UI. All attachment types (text, image, PDF, binary) are supported.

🤖 Generated with Claude Code
