### PR TITLE
Consolidate user preferences into users table and fix channel race

### DIFF
--- a/backend/internal/hub/bootstrap/bootstrap.go
+++ b/backend/internal/hub/bootstrap/bootstrap.go
@@ -82,12 +82,6 @@ func Run(ctx context.Context, q *db.Queries, soloMode bool) error {
 		return fmt.Errorf("create org member: %w", err)
 	}
 
-	if err := q.UpsertUserPreferences(ctx, db.UpsertUserPreferencesParams{
-		UserID: userID,
-	}); err != nil {
-		return fmt.Errorf("create user preferences: %w", err)
-	}
-
 	slog.Info("bootstrap: created personal org and admin user",
 		"org_id", orgID,
 		"user_id", userID,

--- a/backend/internal/hub/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/db/migrations/00001_initial.sql
@@ -18,6 +18,7 @@ CREATE TABLE users (
     email          TEXT NOT NULL DEFAULT '',
     email_verified INTEGER NOT NULL DEFAULT 0,
     is_admin       INTEGER NOT NULL DEFAULT 0,
+    prefs          TEXT NOT NULL DEFAULT '{}',
     created_at     DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at     DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
@@ -119,13 +120,6 @@ CREATE TABLE workspace_section_items (
 );
 CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(section_id);
 
--- User preferences
-CREATE TABLE user_preferences (
-    user_id    TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
-    prefs      TEXT NOT NULL DEFAULT '{}',
-    updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
 -- Cross-user Worker access grants (for workspace sharing)
 CREATE TABLE worker_access_grants (
     worker_id  TEXT NOT NULL REFERENCES workers(id) ON DELETE CASCADE,
@@ -179,7 +173,6 @@ DROP TABLE IF EXISTS workspace_layouts;
 DROP TABLE IF EXISTS workspace_tabs;
 DROP TABLE IF EXISTS workspace_access;
 DROP TABLE IF EXISTS worker_access_grants;
-DROP TABLE IF EXISTS user_preferences;
 DROP TABLE IF EXISTS email_verifications;
 DROP TABLE IF EXISTS workspace_section_items;
 DROP TABLE IF EXISTS workspace_sections;

--- a/backend/internal/hub/db/queries/user_preferences.sql
+++ b/backend/internal/hub/db/queries/user_preferences.sql
@@ -1,9 +1,0 @@
--- name: GetUserPreferences :one
-SELECT * FROM user_preferences WHERE user_id = ?;
-
--- name: UpsertUserPreferences :exec
-INSERT INTO user_preferences (user_id, prefs, updated_at)
-VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-ON CONFLICT (user_id) DO UPDATE SET
-  prefs = excluded.prefs,
-  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/backend/internal/hub/db/queries/users.sql
+++ b/backend/internal/hub/db/queries/users.sql
@@ -44,5 +44,12 @@ WHERE id = ?;
 -- name: DeleteUser :exec
 DELETE FROM users WHERE id = ?;
 
+-- name: GetUserPrefs :one
+SELECT prefs FROM users WHERE id = ?;
+
+-- name: UpdateUserPrefs :exec
+UPDATE users SET prefs = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = ?;
+
 -- name: CountUsers :one
 SELECT count(*) FROM users;

--- a/backend/internal/hub/service/admin_service.go
+++ b/backend/internal/hub/service/admin_service.go
@@ -185,13 +185,6 @@ func (s *AdminService) CreateUser(ctx context.Context, req *connect.Request[leap
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create org member: %w", err))
 	}
 
-	// Create default user preferences.
-	if err := s.queries.UpsertUserPreferences(ctx, db.UpsertUserPreferencesParams{
-		UserID: userID,
-	}); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create user preferences: %w", err))
-	}
-
 	// Fetch the created user to get timestamps.
 	user, err := s.queries.GetUserByID(ctx, userID)
 	if err != nil {

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -139,13 +139,6 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create org member: %w", err))
 	}
 
-	// Create default preferences.
-	if err := s.queries.UpsertUserPreferences(ctx, db.UpsertUserPreferencesParams{
-		UserID: userID,
-	}); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create preferences: %w", err))
-	}
-
 	user, err := s.queries.GetUserByID(ctx, userID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -140,18 +140,13 @@ func (s *UserService) GetPreferences(ctx context.Context, req *connect.Request[l
 		return nil, err
 	}
 
-	row, err := s.queries.GetUserPreferences(ctx, userInfo.ID)
+	prefs, err := s.queries.GetUserPrefs(ctx, userInfo.ID)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return connect.NewResponse(&leapmuxv1.GetPreferencesResponse{
-				Preferences: &leapmuxv1.UserPreferences{},
-			}), nil
-		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
 	var sp storedPreferences
-	if err := json.Unmarshal([]byte(row.Prefs), &sp); err != nil {
+	if err := json.Unmarshal([]byte(prefs), &sp); err != nil {
 		sp = storedPreferences{}
 	}
 
@@ -225,9 +220,9 @@ func (s *UserService) UpdatePreferences(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("marshal prefs: %w", err))
 	}
 
-	if err := s.queries.UpsertUserPreferences(ctx, db.UpsertUserPreferencesParams{
-		UserID: userInfo.ID,
-		Prefs:  string(prefsJSON),
+	if err := s.queries.UpdateUserPrefs(ctx, db.UpdateUserPrefsParams{
+		Prefs: string(prefsJSON),
+		ID:    userInfo.ID,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}

--- a/backend/tunnel/channel.go
+++ b/backend/tunnel/channel.go
@@ -172,7 +172,7 @@ func OpenChannel(ctx context.Context, hubURL, token, userID, workerID string, op
 	ch.mu.Unlock()
 
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		ch.Close()
 		return nil, fmt.Errorf("user id claim timeout")
 	case <-chCtx.Done():

--- a/backend/tunnel/channel.go
+++ b/backend/tunnel/channel.go
@@ -150,9 +150,15 @@ func OpenChannel(ctx context.Context, hubURL, token, userID, workerID string, op
 		reassembly: make(map[uint32]*chunkBuffer),
 	}
 
+	// 7. Send UserIdClaim.
+	// Register the pending response handler before starting recvLoop and
+	// sending the claim to avoid a race where the response arrives before
+	// pending[0] is registered and gets silently dropped.
+	claimRespCh := make(chan *leapmuxv1.InnerRpcResponse, 1)
+	ch.pending[0] = claimRespCh
+
 	go ch.recvLoop()
 
-	// 7. Send UserIdClaim.
 	claim := &leapmuxv1.UserIdClaim{
 		UserId:      userID,
 		TimestampMs: time.Now().UnixMilli(),
@@ -165,14 +171,8 @@ func OpenChannel(ctx context.Context, hubURL, token, userID, workerID string, op
 		return nil, fmt.Errorf("send user id claim: %w", err)
 	}
 
-	// Wait for UserIdClaimResponse.
-	claimRespCh := make(chan *leapmuxv1.InnerRpcResponse, 1)
-	ch.mu.Lock()
-	ch.pending[0] = claimRespCh
-	ch.mu.Unlock()
-
 	select {
-	case <-time.After(30 * time.Second):
+	case <-time.After(10 * time.Second):
 		ch.Close()
 		return nil, fmt.Errorf("user id claim timeout")
 	case <-chCtx.Done():


### PR DESCRIPTION
## Motivation

User preferences were stored in a separate `user_preferences` table with a one-to-one relationship to `users`, adding unnecessary database complexity. Additionally, a race condition existed in `OpenChannel` where a `UserIdClaimResponse` could arrive before the pending response handler was registered, causing it to be silently dropped.

## Modifications

- Merged the `user_preferences` table into the `users` table as a JSON `prefs` column with a default of `'{}'`, removing the separate table entirely
- Replaced `GetUserPreferences` and `UpsertUserPreferences` queries with `GetUserPrefs` and `UpdateUserPrefs` that operate directly on the `users` table
- Removed explicit `UpsertUserPreferences` initialization calls from `bootstrap.go`, `admin_service.go`, and `auth_service.go` - preferences are now initialized by the schema default
- Simplified `GetPreferences` in `user_service.go` by removing the special case for missing preferences, since a preferences record always exists in the `users` row
- Fixed race condition in `channel.go`: moved `ch.pending[0] = claimRespCh` to before the receive goroutine starts, ensuring the handler is registered before any response can arrive

**Breaking change**: The `user_preferences` table and its `GetUserPreferences`/`UpsertUserPreferences` queries have been removed. Any external tooling or migrations that reference them will need to be updated.

## Result

The database schema is simpler with one fewer table to join or manage. Preference initialization is implicit via the schema default rather than requiring explicit upserts at multiple call sites. The `OpenChannel` race condition is resolved, preventing silent message drops during channel setup.

🤖 Generated with Claude Code
