### PR TITLE
Introduce extensible notification consolidation per provider

### DIFF
--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -685,13 +685,6 @@ func extractToolUseResultMessage(raw json.RawMessage) string {
 
 // --- Notification threading helpers ---
 
-var notificationThreadableSubtypes = map[string]bool{
-	"status":                true,
-	"compact_boundary":      true,
-	"microcompact_boundary": true,
-	"api_retry":             true,
-}
-
 func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
 	switch role {
 	case leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX:
@@ -704,14 +697,7 @@ func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
 		}
 		return msg.Type == "settings_changed" || msg.Type == "context_cleared" || msg.Type == "interrupted" || msg.Type == "rate_limit" || msg.Type == "agent_error" || msg.Type == "compacting"
 	case leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM:
-		var msg struct {
-			Subtype string `json:"subtype"`
-		}
-		if err := json.Unmarshal(content, &msg); err != nil {
-			slog.Warn("notification threadable unmarshal failed", "role", "system", "error", err)
-			return false
-		}
-		return notificationThreadableSubtypes[msg.Subtype]
+		return NotificationConsolidatorForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE).Classify(content).Consolidatable()
 	default:
 		return false
 	}

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -75,6 +75,11 @@ func handleCodexOutput(a *CodexAgent, line *parsedLine) {
 	case "account/rateLimits/updated":
 		a.handleRateLimitsUpdated(line.Raw, line.Params)
 
+	case "mcpServer/startupStatus/updated":
+		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, line.Raw); err != nil {
+			slog.Error("codex persist startup status notification", "agent_id", a.agentID, "error", err)
+		}
+
 	case "error":
 		a.handleErrorNotification(line.Params)
 

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 // controlRequestRecord captures a single PersistControlRequest / BroadcastControlRequest call.
@@ -19,6 +21,16 @@ type controlTestSink struct {
 	crMu              sync.Mutex
 	persistedControls []controlRequestRecord
 	broadcastControls []controlRequestRecord
+}
+
+type startupStatusGuardSink struct {
+	testSink
+	t *testing.T
+}
+
+func (s *startupStatusGuardSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, span SpanInfo) error {
+	s.t.Fatalf("startup status notification must not be persisted as a regular message: role=%v content=%s", role, string(content))
+	return nil
 }
 
 func (s *controlTestSink) PersistControlRequest(requestID string, payload []byte) {
@@ -227,6 +239,24 @@ func TestHandleCodexOutput_ContextCompactionStartPersistsCompactingNotification(
 	}
 	if sink.MessageCount() != 0 {
 		t.Fatalf("expected 0 assistant messages, got %d", sink.MessageCount())
+	}
+}
+
+func TestHandleCodexOutput_McpStartupStatusPersistsNotification(t *testing.T) {
+	sink := &startupStatusGuardSink{t: t}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"mcpServer/startupStatus/updated","params":{"name":"codex_apps","status":"ready"}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.NotificationCount() != 1 {
+		t.Fatalf("expected 1 notification, got %d", sink.NotificationCount())
+	}
+	if sink.MessageCount() != 0 {
+		t.Fatalf("expected 0 persisted messages, got %d", sink.MessageCount())
+	}
+	if string(sink.LastNotification().Content) != input {
+		t.Fatalf("expected raw startup status notification to be preserved, got %s", string(sink.LastNotification().Content))
 	}
 }
 

--- a/backend/internal/worker/agent/notification_consolidator.go
+++ b/backend/internal/worker/agent/notification_consolidator.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"encoding/json"
+	"sync"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+type NotificationKind string
+
+const (
+	NotificationKindNone               NotificationKind = ""
+	NotificationKindStatus             NotificationKind = "status"
+	NotificationKindAPIRetry           NotificationKind = "api_retry"
+	NotificationKindCompactionBoundary NotificationKind = "compaction_boundary"
+	NotificationKindProviderScoped     NotificationKind = "provider_scoped"
+)
+
+type NotificationClassification struct {
+	Kind NotificationKind
+	Key  string
+}
+
+func (c NotificationClassification) Consolidatable() bool {
+	return c.Kind != NotificationKindNone
+}
+
+type NotificationConsolidator interface {
+	Classify(raw json.RawMessage) NotificationClassification
+	Merge(class NotificationClassification, previous, next json.RawMessage) (json.RawMessage, error)
+}
+
+type noopNotificationConsolidator struct{}
+
+func (noopNotificationConsolidator) Classify(json.RawMessage) NotificationClassification {
+	return NotificationClassification{}
+}
+
+func (noopNotificationConsolidator) Merge(class NotificationClassification, previous, next json.RawMessage) (json.RawMessage, error) {
+	return next, nil
+}
+
+var (
+	notificationConsolidatorMu       sync.RWMutex
+	notificationConsolidatorRegistry = map[leapmuxv1.AgentProvider]NotificationConsolidator{}
+)
+
+func RegisterNotificationConsolidator(provider leapmuxv1.AgentProvider, consolidator NotificationConsolidator) {
+	notificationConsolidatorMu.Lock()
+	defer notificationConsolidatorMu.Unlock()
+	notificationConsolidatorRegistry[provider] = consolidator
+}
+
+func NotificationConsolidatorForProvider(provider leapmuxv1.AgentProvider) NotificationConsolidator {
+	notificationConsolidatorMu.RLock()
+	defer notificationConsolidatorMu.RUnlock()
+	if consolidator := notificationConsolidatorRegistry[provider]; consolidator != nil {
+		return consolidator
+	}
+	return noopNotificationConsolidator{}
+}
+
+type codexNotificationConsolidator struct{}
+
+func (codexNotificationConsolidator) Classify(raw json.RawMessage) NotificationClassification {
+	var env struct {
+		Method string `json:"method"`
+		Params *struct {
+			Name string `json:"name,omitempty"`
+		} `json:"params,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return NotificationClassification{}
+	}
+	switch env.Method {
+	case "account/rateLimits/updated":
+		return NotificationClassification{
+			Kind: NotificationKindProviderScoped,
+			Key:  "codex:account/rateLimits/updated",
+		}
+	case "mcpServer/startupStatus/updated":
+		name := "unknown"
+		if env.Params != nil && env.Params.Name != "" {
+			name = env.Params.Name
+		}
+		return NotificationClassification{
+			Kind: NotificationKindProviderScoped,
+			Key:  "codex:mcpServer/startupStatus/updated:" + name,
+		}
+	default:
+		return NotificationClassification{}
+	}
+}
+
+func (codexNotificationConsolidator) Merge(class NotificationClassification, previous, next json.RawMessage) (json.RawMessage, error) {
+	return next, nil
+}
+
+type claudeNotificationConsolidator struct{}
+
+func (claudeNotificationConsolidator) Classify(raw json.RawMessage) NotificationClassification {
+	var env struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return NotificationClassification{}
+	}
+	if env.Type != "system" {
+		return NotificationClassification{}
+	}
+	switch env.Subtype {
+	case "status":
+		return NotificationClassification{Kind: NotificationKindStatus, Key: "claude:system:status"}
+	case "api_retry":
+		return NotificationClassification{Kind: NotificationKindAPIRetry, Key: "claude:system:api_retry"}
+	case "compact_boundary", "microcompact_boundary":
+		return NotificationClassification{Kind: NotificationKindCompactionBoundary, Key: "claude:system:" + env.Subtype}
+	default:
+		return NotificationClassification{}
+	}
+}
+
+func (claudeNotificationConsolidator) Merge(class NotificationClassification, previous, next json.RawMessage) (json.RawMessage, error) {
+	return next, nil
+}
+
+func init() {
+	RegisterNotificationConsolidator(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, codexNotificationConsolidator{})
+	RegisterNotificationConsolidator(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, claudeNotificationConsolidator{})
+}

--- a/backend/internal/worker/agent/notification_consolidator_test.go
+++ b/backend/internal/worker/agent/notification_consolidator_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+func TestNotificationConsolidatorForProvider_CodexClassification(t *testing.T) {
+	consolidator := NotificationConsolidatorForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+
+	rateLimit := json.RawMessage(`{"method":"account/rateLimits/updated","params":{"foo":"bar"}}`)
+	startup := json.RawMessage(`{"method":"mcpServer/startupStatus/updated","params":{"name":"codex_apps","status":"ready"}}`)
+
+	assert.Equal(t, NotificationClassification{
+		Kind: NotificationKindProviderScoped,
+		Key:  "codex:account/rateLimits/updated",
+	}, consolidator.Classify(rateLimit))
+
+	assert.Equal(t, NotificationClassification{
+		Kind: NotificationKindProviderScoped,
+		Key:  "codex:mcpServer/startupStatus/updated:codex_apps",
+	}, consolidator.Classify(startup))
+}
+
+func TestNotificationConsolidatorForProvider_ClaudeClassification(t *testing.T) {
+	consolidator := NotificationConsolidatorForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	assert.Equal(t,
+		NotificationClassification{Kind: NotificationKindStatus, Key: "claude:system:status"},
+		consolidator.Classify(json.RawMessage(`{"type":"system","subtype":"status","status":"idle"}`)),
+	)
+	assert.Equal(t,
+		NotificationClassification{Kind: NotificationKindAPIRetry, Key: "claude:system:api_retry"},
+		consolidator.Classify(json.RawMessage(`{"type":"system","subtype":"api_retry","attempt":2}`)),
+	)
+	assert.Equal(t,
+		NotificationClassification{Kind: NotificationKindCompactionBoundary, Key: "claude:system:compact_boundary"},
+		consolidator.Classify(json.RawMessage(`{"type":"system","subtype":"compact_boundary"}`)),
+	)
+}
+
+func TestNotificationConsolidatorForProvider_DefaultFallback(t *testing.T) {
+	consolidator := NotificationConsolidatorForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE)
+	class := consolidator.Classify(json.RawMessage(`{"method":"mcpServer/startupStatus/updated","params":{"name":"codex_apps"}}`))
+	assert.False(t, class.Consolidatable())
+
+	merged, err := consolidator.Merge(NotificationClassification{}, json.RawMessage(`{"a":1}`), json.RawMessage(`{"a":2}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"a":2}`, string(merged))
+}
+
+func TestIsNotificationThreadable_ClaudeSystemUsesConsolidator(t *testing.T) {
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"idle"}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"api_retry","attempt":1}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+	assert.False(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"other"}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -428,19 +428,21 @@ func (h *OutputHandler) spanTracker(agentID string) *SpanTracker {
 // NewSink creates a per-agent OutputSink backed by this OutputHandler.
 func (h *OutputHandler) NewSink(agentID string, agentProvider leapmuxv1.AgentProvider) agent.OutputSink {
 	return &agentOutputSink{
-		h:             h,
-		agentID:       agentID,
-		agentProvider: agentProvider,
-		tracker:       h.spanTracker(agentID),
+		h:                        h,
+		agentID:                  agentID,
+		agentProvider:            agentProvider,
+		notificationConsolidator: agent.NotificationConsolidatorForProvider(agentProvider),
+		tracker:                  h.spanTracker(agentID),
 	}
 }
 
 // agentOutputSink implements agent.OutputSink for a single agent.
 type agentOutputSink struct {
-	h             *OutputHandler
-	agentID       string
-	agentProvider leapmuxv1.AgentProvider
-	tracker       *SpanTracker
+	h                        *OutputHandler
+	agentID                  string
+	agentProvider            leapmuxv1.AgentProvider
+	notificationConsolidator agent.NotificationConsolidator
+	tracker                  *SpanTracker
 }
 
 // --- OutputSink interface implementation ---
@@ -450,7 +452,7 @@ func (s *agentOutputSink) PersistMessage(role leapmuxv1.MessageRole, content []b
 }
 
 func (s *agentOutputSink) PersistNotification(role leapmuxv1.MessageRole, content []byte) error {
-	return s.h.persistNotificationThreaded(s.agentID, s.agentProvider, role, content)
+	return s.h.persistNotificationThreaded(s.agentID, s.agentProvider, s.notificationConsolidator, role, content)
 }
 
 func (s *agentOutputSink) OpenSpan(spanID, parentSpanID string) {
@@ -760,7 +762,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 
 // persistNotificationThreaded persists a notification message, appending it
 // to the current notification thread if one exists.
-func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, role leapmuxv1.MessageRole, contentJSON []byte) error {
+func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, consolidator agent.NotificationConsolidator, role leapmuxv1.MessageRole, contentJSON []byte) error {
 	if h.wakeLock != nil {
 		h.wakeLock.RecordActivity()
 	}
@@ -770,7 +772,7 @@ func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvide
 
 	if ref, ok := h.lastNotifThread.Load(agentID); ok {
 		threadRef := ref.(*notifThreadRef)
-		if err := h.appendToNotificationThread(agentID, agentProvider, threadRef, role, contentJSON); err == nil {
+		if err := h.appendToNotificationThread(agentID, agentProvider, consolidator, threadRef, role, contentJSON); err == nil {
 			return nil
 		}
 	}
@@ -779,7 +781,7 @@ func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvide
 }
 
 // appendToNotificationThread appends a message to an existing notification thread.
-func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, threadRef *notifThreadRef, role leapmuxv1.MessageRole, contentJSON []byte) error {
+func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, consolidator agent.NotificationConsolidator, threadRef *notifThreadRef, role leapmuxv1.MessageRole, contentJSON []byte) error {
 	parentRow, err := h.queries.GetMessageByAgentAndID(bgCtx(), db.GetMessageByAgentAndIDParams{
 		ID:      threadRef.msgID,
 		AgentID: agentID,
@@ -803,7 +805,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		wrapper.OldSeqs = wrapper.OldSeqs[len(wrapper.OldSeqs)-16:]
 	}
 	wrapper.Messages = append(wrapper.Messages, contentJSON)
-	wrapper.Messages = consolidateNotificationThread(wrapper.Messages)
+	wrapper.Messages = consolidateNotificationThread(wrapper.Messages, consolidator)
 
 	merged, err := json.Marshal(wrapper)
 	if err != nil {
@@ -917,7 +919,7 @@ func (h *OutputHandler) BroadcastNotification(agentID string, agentProvider leap
 		slog.Warn("marshal notification content", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := h.persistNotificationThreaded(agentID, agentProvider, leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, contentJSON); err != nil {
+	if err := h.persistNotificationThreaded(agentID, agentProvider, agent.NotificationConsolidatorForProvider(agentProvider), leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, contentJSON); err != nil {
 		slog.Warn("failed to persist notification", "agent_id", agentID, "error", err)
 	}
 }
@@ -970,31 +972,28 @@ func (h *OutputHandler) updatePlan(agentID, filePath string, compressed []byte, 
 }
 
 // consolidateNotificationThread consolidates a notification thread's messages.
-// Each message type appears at most once in the output (except compaction
-// boundaries and unknown types, which are always kept). When duplicates exist,
-// the last occurrence's data wins. Output is ordered by the position of each
-// type's last occurrence in the input.
-func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage {
+// Service-owned LeapMux notification types are merged centrally, while
+// provider-owned raw payloads are classified through the injected consolidator.
+// Ordering is preserved by the last occurrence index of each retained entry.
+func consolidateNotificationThread(messages []json.RawMessage, providerConsolidator agent.NotificationConsolidator) []json.RawMessage {
+	if providerConsolidator == nil {
+		providerConsolidator = agent.NotificationConsolidatorForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_UNSPECIFIED)
+	}
+
 	type settingsChange struct {
 		Old string `json:"old"`
 		New string `json:"new"`
 	}
 
-	// Unified envelope — decoded once per message.
 	type envelope struct {
 		Type    string                    `json:"type"`
 		Subtype string                    `json:"subtype"`
-		Method  string                    `json:"method"`
 		Changes map[string]settingsChange `json:"changes,omitempty"`
-		Params  *struct {
-			Name string `json:"name,omitempty"`
-		} `json:"params,omitempty"`
-		RLInfo *struct {
+		RLInfo  *struct {
 			RateLimitType string `json:"rateLimitType"`
 		} `json:"rate_limit_info,omitempty"`
 	}
 
-	// Deduplication state — track the last-seen index for ordering.
 	mergedChanges := map[string]settingsChange{}
 	settingsLastIdx := -1
 
@@ -1007,37 +1006,33 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 	planExecRaw := json.RawMessage(nil)
 	planExecLastIdx := -1
 
-	rateLimitByType := map[string]json.RawMessage{}
-	rateLimitLastIdx := -1
+	type indexedRaw struct {
+		idx  int
+		raw  json.RawMessage
+		kind agent.NotificationKind
+	}
 
-	var codexRateLimitRaw json.RawMessage
-	codexRateLimitLastIdx := -1
+	rateLimitByType := map[string]indexedRaw{}
+	providerEntries := map[string]indexedRaw{}
 
-	var latestStatusRaw json.RawMessage
+	var latestStatus indexedRaw
 	statusLastIdx := -1
 
-	var latestApiRetryRaw json.RawMessage
+	var latestAPIRetry indexedRaw
 	apiRetryLastIdx := -1
 
-	// Compaction boundaries and unknown types: always kept, in order.
-	type indexedRaw struct {
-		idx int
-		raw json.RawMessage
-	}
 	var keepAll []indexedRaw
-
-	startupStatusByServer := map[string]indexedRaw{}
 
 	for i, raw := range messages {
 		var env envelope
 		if err := json.Unmarshal(raw, &env); err != nil {
 			slog.Warn("consolidate notification unmarshal failed", "error", err)
-			keepAll = append(keepAll, indexedRaw{i, raw})
+			keepAll = append(keepAll, indexedRaw{idx: i, raw: raw})
 			continue
 		}
 
-		switch {
-		case env.Type == "settings_changed":
+		switch env.Type {
+		case "settings_changed":
 			for key, val := range env.Changes {
 				if existing, ok := mergedChanges[key]; ok {
 					mergedChanges[key] = settingsChange{Old: existing.Old, New: val.New}
@@ -1047,79 +1042,68 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 			}
 			settingsLastIdx = i
 
-		case env.Type == "context_cleared":
+		case "context_cleared":
 			contextClearedRaw = raw
 			contextClearedLastIdx = i
-			// context_cleared supersedes any earlier compaction boundaries.
 			keepAll = slices.DeleteFunc(keepAll, func(ir indexedRaw) bool {
-				var e envelope
-				if err := json.Unmarshal(ir.raw, &e); err != nil {
-					slog.Warn("consolidate context_cleared filter unmarshal failed", "error", err)
-					return false
-				}
-				return e.Type == "system" && (e.Subtype == "compact_boundary" || e.Subtype == "microcompact_boundary")
+				return ir.kind == agent.NotificationKindCompactionBoundary
 			})
 
-		case env.Type == "plan_execution":
+		case "plan_execution":
 			planExecRaw = raw
 			planExecLastIdx = i
 
-		case env.Type == "interrupted":
+		case "interrupted":
 			interruptedRaw = raw
 			interruptedLastIdx = i
 
-		case env.Type == "rate_limit":
+		case "rate_limit":
 			key := "unknown"
 			if env.RLInfo != nil && env.RLInfo.RateLimitType != "" {
 				key = env.RLInfo.RateLimitType
 			}
-			rateLimitByType[key] = raw
-			rateLimitLastIdx = i
-
-		case env.Method == "account/rateLimits/updated":
-			// Codex native rate limit notification: deduplicate, keep last.
-			codexRateLimitRaw = raw
-			codexRateLimitLastIdx = i
-
-		case env.Method == "mcpServer/startupStatus/updated":
-			key := "unknown"
-			if env.Params != nil && env.Params.Name != "" {
-				key = env.Params.Name
-			}
-			startupStatusByServer[key] = indexedRaw{idx: i, raw: raw}
-
-		case env.Type == "compacting":
-			latestStatusRaw = raw
+			rateLimitByType[key] = indexedRaw{idx: i, raw: raw}
+		case "compacting":
+			latestStatus = indexedRaw{idx: i, raw: raw, kind: agent.NotificationKindStatus}
 			statusLastIdx = i
-
-		case env.Type == "system" && env.Subtype == "status":
-			latestStatusRaw = raw
-			statusLastIdx = i
-
-		case env.Type == "system" && env.Subtype == "api_retry":
-			latestApiRetryRaw = raw
-			apiRetryLastIdx = i
-
-		case env.Type == "system" && (env.Subtype == "compact_boundary" || env.Subtype == "microcompact_boundary"):
-			// Compaction result supersedes any earlier compacting status.
-			latestStatusRaw = nil
-			statusLastIdx = -1
-			// Compaction supersedes any earlier context_cleared.
-			if contextClearedLastIdx >= 0 && i > contextClearedLastIdx {
-				contextClearedRaw = nil
-				contextClearedLastIdx = -1
-			}
-			keepAll = append(keepAll, indexedRaw{i, raw})
 
 		default:
-			keepAll = append(keepAll, indexedRaw{i, raw})
+			class := providerConsolidator.Classify(raw)
+			switch class.Kind {
+			case agent.NotificationKindStatus:
+				latestStatus = indexedRaw{idx: i, raw: raw, kind: class.Kind}
+				statusLastIdx = i
+			case agent.NotificationKindAPIRetry:
+				latestAPIRetry = indexedRaw{idx: i, raw: raw, kind: class.Kind}
+				apiRetryLastIdx = i
+			case agent.NotificationKindCompactionBoundary:
+				statusLastIdx = -1
+				latestStatus = indexedRaw{}
+				if contextClearedLastIdx >= 0 && i > contextClearedLastIdx {
+					contextClearedRaw = nil
+					contextClearedLastIdx = -1
+				}
+				keepAll = append(keepAll, indexedRaw{idx: i, raw: raw, kind: class.Kind})
+			case agent.NotificationKindProviderScoped:
+				prev, ok := providerEntries[class.Key]
+				if ok {
+					merged, err := providerConsolidator.Merge(class, prev.raw, raw)
+					if err != nil {
+						slog.Warn("consolidate provider notification merge failed", "key", class.Key, "error", err)
+						merged = raw
+					}
+					providerEntries[class.Key] = indexedRaw{idx: i, raw: merged, kind: class.Kind}
+				} else {
+					providerEntries[class.Key] = indexedRaw{idx: i, raw: raw, kind: class.Kind}
+				}
+			default:
+				keepAll = append(keepAll, indexedRaw{idx: i, raw: raw})
+			}
 		}
 	}
 
-	// Build deduped entries with their ordering index.
 	var entries []indexedRaw
 
-	// settings_changed: merge all changes, drop if old==new for all keys.
 	if settingsLastIdx >= 0 {
 		effective := map[string]settingsChange{}
 		for key, val := range mergedChanges {
@@ -1133,47 +1117,41 @@ func consolidateNotificationThread(messages []json.RawMessage) []json.RawMessage
 				"changes": effective,
 			}
 			if data, err := json.Marshal(entry); err == nil {
-				entries = append(entries, indexedRaw{settingsLastIdx, data})
+				entries = append(entries, indexedRaw{idx: settingsLastIdx, raw: data})
 			}
 		}
 	}
 
 	if contextClearedLastIdx >= 0 {
-		entries = append(entries, indexedRaw{contextClearedLastIdx, contextClearedRaw})
+		entries = append(entries, indexedRaw{idx: contextClearedLastIdx, raw: contextClearedRaw})
 	}
 
 	if planExecLastIdx >= 0 {
-		entries = append(entries, indexedRaw{planExecLastIdx, planExecRaw})
+		entries = append(entries, indexedRaw{idx: planExecLastIdx, raw: planExecRaw})
 	}
 
 	if interruptedLastIdx >= 0 {
-		entries = append(entries, indexedRaw{interruptedLastIdx, interruptedRaw})
+		entries = append(entries, indexedRaw{idx: interruptedLastIdx, raw: interruptedRaw})
 	}
 
-	for _, raw := range rateLimitByType {
-		entries = append(entries, indexedRaw{rateLimitLastIdx, raw})
+	for _, rateLimit := range rateLimitByType {
+		entries = append(entries, rateLimit)
 	}
 
-	if codexRateLimitLastIdx >= 0 {
-		entries = append(entries, indexedRaw{codexRateLimitLastIdx, codexRateLimitRaw})
-	}
-
-	for _, startupRaw := range startupStatusByServer {
-		entries = append(entries, startupRaw)
+	for _, providerEntry := range providerEntries {
+		entries = append(entries, providerEntry)
 	}
 
 	if statusLastIdx >= 0 {
-		entries = append(entries, indexedRaw{statusLastIdx, latestStatusRaw})
+		entries = append(entries, latestStatus)
 	}
 
 	if apiRetryLastIdx >= 0 {
-		entries = append(entries, indexedRaw{apiRetryLastIdx, latestApiRetryRaw})
+		entries = append(entries, latestAPIRetry)
 	}
 
-	// Merge keepAll entries.
 	entries = append(entries, keepAll...)
 
-	// Sort by input index (ascending) to preserve chronological order.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].idx < entries[j].idx
 	})

--- a/backend/internal/worker/service/output_consolidate_test.go
+++ b/backend/internal/worker/service/output_consolidate_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 )
 
 // helper: build a json.RawMessage from an arbitrary value.
@@ -66,13 +69,17 @@ func codexStartupStatus(name, status string, errorText interface{}) map[string]i
 	}
 }
 
+func consolidateForProvider(provider leapmuxv1.AgentProvider, msgs []json.RawMessage) []json.RawMessage {
+	return consolidateNotificationThread(msgs, agent.NotificationConsolidatorForProvider(provider))
+}
+
 func TestConsolidateNotificationThread_OrderPreserved(t *testing.T) {
 	t.Run("context_cleared then settings_changed", func(t *testing.T) {
 		msgs := []json.RawMessage{
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, settingsChanged("A", "B")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"context_cleared", "settings_changed"}, types(t, result))
 	})
 
@@ -81,7 +88,7 @@ func TestConsolidateNotificationThread_OrderPreserved(t *testing.T) {
 			raw(t, settingsChanged("A", "B")),
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"settings_changed", "context_cleared"}, types(t, result))
 	})
 
@@ -90,7 +97,7 @@ func TestConsolidateNotificationThread_OrderPreserved(t *testing.T) {
 			raw(t, map[string]interface{}{"type": "system", "subtype": "api_retry", "attempt": 1, "max_retries": 3}),
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		require.Len(t, result, 2)
 		first := parseRaw(t, result[0])
 		second := parseRaw(t, result[1])
@@ -107,7 +114,7 @@ func TestConsolidateNotificationThread_Dedup(t *testing.T) {
 			raw(t, settingsChanged("A", "B")),
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"settings_changed", "context_cleared"}, types(t, result))
 	})
 
@@ -117,7 +124,7 @@ func TestConsolidateNotificationThread_Dedup(t *testing.T) {
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, settingsChanged("B", "C")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"context_cleared", "settings_changed"}, types(t, result))
 		// Verify merged: old=A, new=C
 		changes := parseRaw(t, result[1])["changes"].(map[string]interface{})
@@ -132,7 +139,7 @@ func TestConsolidateNotificationThread_Dedup(t *testing.T) {
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "api_retry", "attempt": 2, "max_retries": 3}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		require.Len(t, result, 2)
 		first := parseRaw(t, result[0])
 		second := parseRaw(t, result[1])
@@ -150,7 +157,7 @@ func TestConsolidateNotificationThread_ChangesCancelOut(t *testing.T) {
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, settingsChanged("B", "A")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		// settings_changed drops because old==new; only context_cleared remains.
 		assert.Equal(t, []string{"context_cleared"}, types(t, result))
 	})
@@ -160,7 +167,7 @@ func TestConsolidateNotificationThread_ChangesCancelOut(t *testing.T) {
 			raw(t, settingsChanged("A", "B")),
 			raw(t, settingsChanged("B", "A")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []json.RawMessage{}, result)
 	})
 }
@@ -170,7 +177,7 @@ func TestConsolidateNotificationThread_SettingsMerged(t *testing.T) {
 		raw(t, settingsChanged("A", "B")),
 		raw(t, settingsChanged("B", "C")),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	require.Len(t, result, 1)
 	assert.Equal(t, "settings_changed", msgType(t, result[0]))
 	changes := parseRaw(t, result[0])["changes"].(map[string]interface{})
@@ -184,7 +191,7 @@ func TestConsolidateNotificationThread_PlanExecution(t *testing.T) {
 		raw(t, map[string]interface{}{"type": "plan_execution", "plan_file_path": "/p.md"}),
 		raw(t, map[string]interface{}{"type": "context_cleared"}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	assert.Equal(t, []string{"plan_execution", "context_cleared"}, types(t, result))
 }
 
@@ -197,7 +204,7 @@ func TestConsolidateNotificationThread_NoContextClearedOnSettingsChanged(t *test
 			"contextCleared": true,
 		}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	require.Len(t, result, 1)
 	m := parseRaw(t, result[0])
 	assert.Nil(t, m["contextCleared"], "contextCleared should not appear in output")
@@ -208,7 +215,7 @@ func TestConsolidateNotificationThread_CompactionBoundariesKept(t *testing.T) {
 		raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 		raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	assert.Len(t, result, 2)
 }
 
@@ -217,7 +224,7 @@ func TestConsolidateNotificationThread_Interrupted(t *testing.T) {
 		raw(t, settingsChanged("A", "B")),
 		raw(t, map[string]interface{}{"type": "interrupted"}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	assert.Equal(t, []string{"settings_changed", "interrupted"}, types(t, result))
 }
 
@@ -232,7 +239,7 @@ func TestConsolidateNotificationThread_RateLimit(t *testing.T) {
 			"rate_limit_info": map[string]interface{}{"rateLimitType": "five_hour", "status": "allowed"},
 		}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	require.Len(t, result, 1)
 	m := parseRaw(t, result[0])
 	info := m["rate_limit_info"].(map[string]interface{})
@@ -244,7 +251,7 @@ func TestConsolidateNotificationThread_SystemStatus(t *testing.T) {
 		raw(t, map[string]interface{}{"type": "system", "subtype": "status", "status": "compacting"}),
 		raw(t, map[string]interface{}{"type": "system", "subtype": "status", "status": "idle"}),
 	}
-	result := consolidateNotificationThread(msgs)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 	require.Len(t, result, 1)
 	m := parseRaw(t, result[0])
 	assert.Equal(t, "idle", m["status"])
@@ -256,7 +263,7 @@ func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *te
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"system"}, types(t, result))
 	})
 
@@ -265,7 +272,7 @@ func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *te
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"system"}, types(t, result))
 	})
 
@@ -274,7 +281,7 @@ func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *te
 			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"context_cleared"}, types(t, result))
 	})
 
@@ -283,7 +290,7 @@ func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *te
 			raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"context_cleared"}, types(t, result))
 	})
 
@@ -293,7 +300,7 @@ func TestConsolidateNotificationThread_CompactionSupersedes_ContextCleared(t *te
 			raw(t, map[string]interface{}{"type": "context_cleared"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"settings_changed", "system"}, types(t, result))
 	})
 }
@@ -304,7 +311,7 @@ func TestConsolidateNotificationThread_CompactingDroppedByBoundary(t *testing.T)
 			raw(t, map[string]interface{}{"type": "compacting"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		require.Len(t, result, 1)
 		m := parseRaw(t, result[0])
 		assert.Equal(t, "system", m["type"])
@@ -316,7 +323,7 @@ func TestConsolidateNotificationThread_CompactingDroppedByBoundary(t *testing.T)
 			raw(t, map[string]interface{}{"type": "compacting"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "microcompact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		require.Len(t, result, 1)
 		m := parseRaw(t, result[0])
 		assert.Equal(t, "system", m["type"])
@@ -327,7 +334,7 @@ func TestConsolidateNotificationThread_CompactingDroppedByBoundary(t *testing.T)
 		msgs := []json.RawMessage{
 			raw(t, map[string]interface{}{"type": "compacting"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		assert.Equal(t, []string{"compacting"}, types(t, result))
 	})
 
@@ -337,7 +344,7 @@ func TestConsolidateNotificationThread_CompactingDroppedByBoundary(t *testing.T)
 			raw(t, map[string]interface{}{"type": "compacting"}),
 			raw(t, map[string]interface{}{"type": "system", "subtype": "compact_boundary"}),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs)
 		require.Len(t, result, 2)
 		assert.Equal(t, "settings_changed", msgType(t, result[0]))
 		m := parseRaw(t, result[1])
@@ -347,7 +354,7 @@ func TestConsolidateNotificationThread_CompactingDroppedByBoundary(t *testing.T)
 }
 
 func TestConsolidateNotificationThread_Empty(t *testing.T) {
-	result := consolidateNotificationThread(nil)
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, nil)
 	assert.Equal(t, []json.RawMessage{}, result)
 }
 
@@ -357,7 +364,7 @@ func TestConsolidateNotificationThread_CodexMcpStartupStatus(t *testing.T) {
 			raw(t, codexStartupStatus("codex_apps", "starting", nil)),
 			raw(t, codexStartupStatus("codex_apps", "ready", nil)),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, msgs)
 		require.Len(t, result, 1)
 		m := parseRaw(t, result[0])
 		assert.Equal(t, "mcpServer/startupStatus/updated", m["method"])
@@ -371,7 +378,7 @@ func TestConsolidateNotificationThread_CodexMcpStartupStatus(t *testing.T) {
 			raw(t, codexStartupStatus("codex_apps", "starting", nil)),
 			raw(t, codexStartupStatus("codex_apps", "failed", "boom")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, msgs)
 		require.Len(t, result, 1)
 		params := parseRaw(t, result[0])["params"].(map[string]interface{})
 		assert.Equal(t, "failed", params["status"])
@@ -383,7 +390,7 @@ func TestConsolidateNotificationThread_CodexMcpStartupStatus(t *testing.T) {
 			raw(t, codexStartupStatus("codex_apps", "starting", nil)),
 			raw(t, codexStartupStatus("codex_apps", "cancelled", nil)),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, msgs)
 		require.Len(t, result, 1)
 		params := parseRaw(t, result[0])["params"].(map[string]interface{})
 		assert.Equal(t, "cancelled", params["status"])
@@ -397,7 +404,7 @@ func TestConsolidateNotificationThread_CodexMcpStartupStatus(t *testing.T) {
 			raw(t, codexStartupStatus("codex_apps", "ready", nil)),
 			raw(t, codexStartupStatus("other", "failed", "boom")),
 		}
-		result := consolidateNotificationThread(msgs)
+		result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, msgs)
 		assert.Equal(t, []string{"context_cleared", "mcpServer/startupStatus/updated", "mcpServer/startupStatus/updated"}, types(t, result))
 
 		firstParams := parseRaw(t, result[1])["params"].(map[string]interface{})
@@ -408,4 +415,15 @@ func TestConsolidateNotificationThread_CodexMcpStartupStatus(t *testing.T) {
 		assert.Equal(t, "failed", secondParams["status"])
 		assert.Equal(t, "boom", secondParams["error"])
 	})
+}
+
+func TestConsolidateNotificationThread_DefaultProviderKeepsUnknownProviderNotifications(t *testing.T) {
+	msgs := []json.RawMessage{
+		raw(t, codexStartupStatus("codex_apps", "starting", nil)),
+		raw(t, codexStartupStatus("codex_apps", "ready", nil)),
+	}
+
+	result := consolidateForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, msgs)
+	require.Len(t, result, 2)
+	assert.Equal(t, []string{"mcpServer/startupStatus/updated", "mcpServer/startupStatus/updated"}, types(t, result))
 }

--- a/backend/internal/worker/service/output_thread_test.go
+++ b/backend/internal/worker/service/output_thread_test.go
@@ -104,3 +104,57 @@ func TestNotificationThreading_NonNotificationBreaksAdjacency(t *testing.T) {
 	assert.Equal(t, "context_cleared", msgType(t, firstWrapper.Messages[0]))
 	assert.Equal(t, "interrupted", msgType(t, secondWrapper.Messages[0]))
 }
+
+func TestNotificationThreading_CodexStartupStatusConsolidatesInWrapper(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+	starting, err := json.Marshal(map[string]any{
+		"method": "mcpServer/startupStatus/updated",
+		"params": map[string]any{"name": "codex_apps", "status": "starting", "error": nil},
+	})
+	require.NoError(t, err)
+	ready, err := json.Marshal(map[string]any{
+		"method": "mcpServer/startupStatus/updated",
+		"params": map[string]any{"name": "codex_apps", "status": "ready", "error": nil},
+	})
+	require.NoError(t, err)
+	settingsChanged, err := json.Marshal(map[string]any{
+		"type": "settings_changed",
+		"changes": map[string]any{
+			"permissionMode": map[string]any{"old": "on-request", "new": "never"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, starting))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, ready))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, settingsChanged))
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1",
+		Seq:     0,
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	wrapper := decodeNotifWrapper(t, rows[0].Content, rows[0].ContentCompression)
+	require.Len(t, wrapper.Messages, 2)
+	assert.Equal(t, []string{"mcpServer/startupStatus/updated", "settings_changed"}, types(t, wrapper.Messages))
+
+	startup := parseRaw(t, wrapper.Messages[0])
+	params := startup["params"].(map[string]interface{})
+	assert.Equal(t, "codex_apps", params["name"])
+	assert.Equal(t, "ready", params["status"])
+}


### PR DESCRIPTION
## Motivation

Notification consolidation logic was previously hard-coded inside `consolidateNotificationThread()` in the service layer, with provider-specific classification scattered across multiple functions (`isNotificationThreadable()`, inline switch statements). This made it difficult to add new provider-specific notification types without modifying the core consolidation function, and it coupled the service layer to provider implementation details.

Additionally, Codex `mcpServer/startupStatus/updated` events were not being persisted as notifications at all, causing them to be silently dropped.

## Modifications

- Added `NotificationConsolidator` interface in a new `notification_consolidator.go` file, with `Classify()` and `Merge()` methods, along with `NotificationKind` constants (`NotificationKindStatus`, `NotificationKindAPIRetry`, `NotificationKindCompactionBoundary`, `NotificationKindProviderScoped`) and `NotificationClassification` struct for structured results.
- Added `RegisterNotificationConsolidator()` and `NotificationConsolidatorForProvider()` registry functions, allowing each agent package to register its own consolidation strategy at `init()` time without service-layer coupling.
- Refactored `consolidateNotificationThread()` to accept an injectable `NotificationConsolidator` and delegate provider-specific classification to it, replacing inline provider logic.
- Implemented `claudeNotificationConsolidator` to centralize Claude Code system message classification that was previously split between `isNotificationThreadable()` and the consolidation function.
- Implemented `codexNotificationConsolidator` to handle `account/rateLimits/updated` and `mcpServer/startupStatus/updated` as provider-scoped notifications, with per-server deduplication keyed by server name.
- Added handling for `mcpServer/startupStatus/updated` in `codex_output.go` to persist the event as a notification via `PersistNotification`.

## Result

Provider agents can now register their own `NotificationConsolidator` implementations without touching the service layer. Adding a new provider-specific notification type requires only adding a case to that provider's consolidator.

Codex MCP server startup status notifications are now properly persisted and consolidated in the notification thread instead of being silently dropped. Separate MCP servers produce separate notification entries (deduplication is per server name), so status updates for `server-a` and `server-b` are tracked independently.

🤖 Generated with Claude Code
