### PR TITLE
Auto-focus chat editor on printable keypress

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -213,6 +213,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   // Editor content ref for programmatic get/set of editor markdown.
   let editorContentRef: EditorContentRef | undefined
   let editorFocusFn: (() => void) | undefined
+  let editorInsertFn: ((text: string) => void) | undefined
   // Whether the MarkdownEditor has fully initialized (draft loaded, cursor restored).
   let editorReady = false
 
@@ -225,7 +226,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   /** Register the editor ref if the editor is ready and both refs are available. */
   const tryRegisterEditorRef = (agentId: string) => {
     if (editorReady && editorContentRef && editorFocusFn) {
-      registerEditorRef(agentId, { get: editorContentRef.get, set: editorContentRef.set, focus: editorFocusFn })
+      registerEditorRef(agentId, { get: editorContentRef.get, set: editorContentRef.set, focus: editorFocusFn, insert: text => editorInsertFn?.(text) })
       registeredAgentId = agentId
     }
   }
@@ -426,6 +427,9 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           }}
           contentRef={(get, set) => {
             editorContentRef = { get, set }
+          }}
+          insertRef={(fn) => {
+            editorInsertFn = fn
           }}
           onReady={() => {
             editorReady = true

--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -35,6 +35,7 @@ interface MarkdownEditorProps {
   banner?: JSX.Element
   footer?: JSX.Element
   contentRef?: (get: () => string, set: (text: string) => void) => void
+  insertRef?: (insert: (text: string) => void) => void
   /** Called once the editor is fully initialized with draft content. */
   onReady?: () => void
   placeholder?: string
@@ -306,6 +307,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       sendRef: props.sendRef,
       focusRef: props.focusRef,
       contentRef: props.contentRef,
+      insertRef: props.insertRef,
       handleSend,
     })
 

--- a/frontend/src/components/chat/editorRefHandlers.ts
+++ b/frontend/src/components/chat/editorRefHandlers.ts
@@ -83,7 +83,6 @@ export function setupEditorRefHandlers(opts: EditorRefHandlersOptions): void {
     catch { /* editor may not be ready */ }
   })
 
-  // Expose insert-at-cursor function (e.g. for auto-focus keystroke forwarding)
   opts.insertRef?.((text: string) => {
     try {
       editor.action((ctx: Ctx) => {

--- a/frontend/src/components/chat/editorRefHandlers.ts
+++ b/frontend/src/components/chat/editorRefHandlers.ts
@@ -13,6 +13,7 @@ export interface EditorRefHandlersOptions {
   sendRef?: (send: () => void) => void
   focusRef?: (focus: () => void) => void
   contentRef?: (get: () => string, set: (text: string) => void) => void
+  insertRef?: (insert: (text: string) => void) => void
   handleSend: () => void
 }
 
@@ -77,6 +78,18 @@ export function setupEditorRefHandlers(opts: EditorRefHandlersOptions): void {
     try {
       editor.action((ctx: Ctx) => {
         ctx.get(editorViewCtx).focus()
+      })
+    }
+    catch { /* editor may not be ready */ }
+  })
+
+  // Expose insert-at-cursor function (e.g. for auto-focus keystroke forwarding)
+  opts.insertRef?.((text: string) => {
+    try {
+      editor.action((ctx: Ctx) => {
+        const view = ctx.get(editorViewCtx)
+        const tr = view.state.tr.insertText(text)
+        view.dispatch(tr)
       })
     }
     catch { /* editor may not be ready */ }

--- a/frontend/src/components/chat/editorRefHandlers.ts
+++ b/frontend/src/components/chat/editorRefHandlers.ts
@@ -87,8 +87,8 @@ export function setupEditorRefHandlers(opts: EditorRefHandlersOptions): void {
     try {
       editor.action((ctx: Ctx) => {
         const view = ctx.get(editorViewCtx)
-        const tr = view.state.tr.insertText(text)
-        view.dispatch(tr)
+        view.focus()
+        view.dispatch(view.state.tr.insertText(text))
       })
     }
     catch { /* editor may not be ready */ }

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -23,6 +23,7 @@ import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { SectionType } from '~/generated/leapmux/v1/section_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
+import { useChatAutoFocus } from '~/hooks/useChatAutoFocus'
 import { useIsMobile } from '~/hooks/useIsMobile'
 import { useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
 import { createLogger } from '~/lib/logger'
@@ -986,6 +987,10 @@ export const AppShell: ParentComponent = (props) => {
     isFloatingWindowTile: (tileId: string) => !!floatingWindowStore.getWindowForTile(tileId),
     onDetachTab: handleDetachTab,
   })
+
+  // Auto-focus the chat editor when the user types a printable character
+  // and the focus is not on a meaningful interactive element.
+  useChatAutoFocus(() => tileRenderer.focusedAgentId())
 
   // Sidebar element factories
   // Use getters for reactive values so that LeftSidebar/RightSidebar props

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -988,8 +988,6 @@ export const AppShell: ParentComponent = (props) => {
     onDetachTab: handleDetachTab,
   })
 
-  // Auto-focus the chat editor when the user types a printable character
-  // and the focus is not on a meaningful interactive element.
   useChatAutoFocus(() => tileRenderer.focusedAgentId())
 
   // Sidebar element factories

--- a/frontend/src/hooks/useChatAutoFocus.ts
+++ b/frontend/src/hooks/useChatAutoFocus.ts
@@ -3,24 +3,16 @@ import { getEditorRef } from '~/stores/editorRef.store'
 
 export function useChatAutoFocus(getFocusedAgentId: () => string | null): void {
   function handleKeyDown(e: KeyboardEvent) {
-    // Skip modifier combos (shortcuts like Ctrl+C, Cmd+V, Alt+p)
     if (e.ctrlKey || e.metaKey || e.altKey)
       return
-
-    // Only handle single printable characters (filters out Escape, Tab,
-    // Enter, Backspace, Delete, ArrowUp, F1, Shift, Control, Alt, etc.)
     if (e.key.length !== 1)
       return
-
-    // Skip space to avoid hijacking scroll-with-space behavior
+    // Preserve scroll-with-space behavior
     if (e.key === ' ')
       return
-
-    // Don't steal focus from meaningful interactive elements
     if (isMeaningfulElement(document.activeElement))
       return
 
-    // Only auto-focus when an agent tab is active
     const agentId = getFocusedAgentId()
     if (!agentId)
       return
@@ -29,7 +21,6 @@ export function useChatAutoFocus(getFocusedAgentId: () => string | null): void {
     if (!ref)
       return
 
-    ref.focus()
     ref.insert(e.key)
     e.preventDefault()
   }

--- a/frontend/src/hooks/useChatAutoFocus.ts
+++ b/frontend/src/hooks/useChatAutoFocus.ts
@@ -1,0 +1,72 @@
+import { onCleanup, onMount } from 'solid-js'
+import { getEditorRef } from '~/stores/editorRef.store'
+
+/**
+ * Auto-focus the active agent tab's chat editor when the user types a printable
+ * character and the focus is not on a meaningful interactive element.
+ *
+ * Trigger: any single printable character key (letters, numbers, symbols),
+ * excluding modifier combos (Ctrl/Cmd+*), space, and non-printable keys.
+ */
+export function useChatAutoFocus(getFocusedAgentId: () => string | null): void {
+  function handleKeyDown(e: KeyboardEvent) {
+    // Skip modifier combos (shortcuts like Ctrl+C, Cmd+V)
+    if (e.ctrlKey || e.metaKey)
+      return
+
+    // Only handle single printable characters (filters out Escape, Tab,
+    // Enter, Backspace, Delete, ArrowUp, F1, Shift, Control, Alt, etc.)
+    if (e.key.length !== 1)
+      return
+
+    // Skip space to avoid hijacking scroll-with-space behavior
+    if (e.key === ' ')
+      return
+
+    // Don't steal focus from meaningful interactive elements
+    if (isMeaningfulElement(document.activeElement))
+      return
+
+    // Only auto-focus when an agent tab is active
+    const agentId = getFocusedAgentId()
+    if (!agentId)
+      return
+
+    const ref = getEditorRef(agentId)
+    if (!ref)
+      return
+
+    ref.focus()
+    ref.insert(e.key)
+    e.preventDefault()
+  }
+
+  onMount(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
+  })
+}
+
+/** Returns true if the element is an interactive control that should retain focus. */
+function isMeaningfulElement(el: Element | null): boolean {
+  if (!el)
+    return false
+
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT')
+    return true
+
+  if (el.getAttribute('contenteditable') === 'true')
+    return true
+
+  if (el.closest('dialog[open]'))
+    return true
+
+  if (el.closest('[popover]:popover-open'))
+    return true
+
+  if (el.closest('[role="menu"], [role="listbox"], [role="dialog"]'))
+    return true
+
+  return false
+}

--- a/frontend/src/hooks/useChatAutoFocus.ts
+++ b/frontend/src/hooks/useChatAutoFocus.ts
@@ -1,17 +1,10 @@
 import { onCleanup, onMount } from 'solid-js'
 import { getEditorRef } from '~/stores/editorRef.store'
 
-/**
- * Auto-focus the active agent tab's chat editor when the user types a printable
- * character and the focus is not on a meaningful interactive element.
- *
- * Trigger: any single printable character key (letters, numbers, symbols),
- * excluding modifier combos (Ctrl/Cmd+*), space, and non-printable keys.
- */
 export function useChatAutoFocus(getFocusedAgentId: () => string | null): void {
   function handleKeyDown(e: KeyboardEvent) {
-    // Skip modifier combos (shortcuts like Ctrl+C, Cmd+V)
-    if (e.ctrlKey || e.metaKey)
+    // Skip modifier combos (shortcuts like Ctrl+C, Cmd+V, Alt+p)
+    if (e.ctrlKey || e.metaKey || e.altKey)
       return
 
     // Only handle single printable characters (filters out Escape, Tab,
@@ -59,13 +52,7 @@ function isMeaningfulElement(el: Element | null): boolean {
   if (el.getAttribute('contenteditable') === 'true')
     return true
 
-  if (el.closest('dialog[open]'))
-    return true
-
-  if (el.closest('[popover]:popover-open'))
-    return true
-
-  if (el.closest('[role="menu"], [role="listbox"], [role="dialog"]'))
+  if (el.closest('dialog[open], [popover]:popover-open, [role="menu"], [role="listbox"], [role="dialog"]'))
     return true
 
   return false

--- a/frontend/src/stores/editorRef.store.ts
+++ b/frontend/src/stores/editorRef.store.ts
@@ -5,6 +5,7 @@ export interface EditorRef {
   get: () => string
   set: (value: string) => void
   focus: () => void
+  insert: (text: string) => void
 }
 
 const registry = new Map<string, EditorRef>()


### PR DESCRIPTION
## Motivation
When a user starts typing anywhere on the page, keystrokes were lost unless
the chat editor already had focus. This created friction in the interaction
flow, requiring users to explicitly click the editor before typing a message.

## Modifications
- Add a new `useChatAutoFocus` hook that listens for printable key presses
  on the page and redirects focus and input to the active chat editor, while
  correctly ignoring keypresses in form elements, dialogs, and menus.
- Add an `insert` method to the `EditorRef` interface and implement it in
  `editorRefHandlers.ts` using the Milkdown editor API to programmatically
  inject the triggering character into the editor.
- Add an `insertRef` callback prop to `MarkdownEditor` and propagate it
  through `AgentEditorPanel` to wire up the insertion handler.
- Integrate `useChatAutoFocus` globally in `AppShell`, passing the focused
  agent ID getter to scope the behavior to the active chat panel.

## Result
Users can start typing a message immediately without first clicking the chat
editor. The first typed character is inserted into the editor and focus
follows automatically, making the interaction feel seamless and keyboard-first.

🤖 Generated with Claude Code
