### PR TITLE
Fix WKWebView binding loss on macOS sleep/wake and disable refresh shortcuts

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -98,6 +98,12 @@ func (a *App) domReady(_ context.Context) {
 		if (e.key === 'F12') {
 			if (__post) __post('%s');
 		}
+		if (e.key === 'F5') {
+			e.preventDefault();
+		}
+		if ((e.key === 'r' || e.key === 'R') && (e.ctrlKey || e.metaKey)) {
+			e.preventDefault();
+		}
 		if (e.key === 'q' && (e.ctrlKey || e.metaKey)) {
 			e.preventDefault();
 			if (__post) __post('Q');

--- a/frontend/src/entry-server.tsx
+++ b/frontend/src/entry-server.tsx
@@ -7,6 +7,13 @@ export default createHandler(() => (
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
+          {/* Disable Wails auto-injection so we can inject explicitly.
+              This ensures bindings survive WKWebView content process
+              termination (macOS sleep/wake). In non-Wails contexts the
+              meta tag is ignored and the scripts 404 harmlessly. */}
+          <meta name="wails-options" content="noautoinject" />
+          <script src="/wails/ipc.js" />
+          <script src="/wails/runtime.js" />
           <link rel="icon" href="/leapmux-icon-corners.ico" sizes="48x48" />
           <link rel="icon" href="/leapmux-icon-corners.svg" type="image/svg+xml" />
           <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Motivation
On macOS, the WKWebView content process can be terminated by the OS during sleep/wake cycles. When this happens, the Wails IPC and runtime bindings injected automatically by the framework are lost, breaking the desktop application until the user manually restarts the app.

Additionally, users could accidentally trigger a full page reload via F5 or Ctrl/Cmd+R, which would also lose application state in the desktop context where a page reload is never the right recovery action.

## Modifications
- Added a `<meta name="wails-options" content="noautoinject" />` tag and explicit `<script>` tags for `/wails/ipc.js` and `/wails/runtime.js` in `frontend/src/entry-server.tsx`, so the browser re-fetches and re-executes them on any page reload — ensuring bindings are re-established after WKWebView content process termination
- Disabled F5 and Ctrl/Cmd+R keyboard shortcuts in `desktop/app.go` to prevent accidental page reloads

## Result
The desktop application no longer loses its Wails IPC and runtime bindings after the Mac wakes from sleep. Users also cannot accidentally reload the page via keyboard shortcuts, preventing unexpected loss of application state.

🤖 Generated with Claude Code
