### PR TITLE
fix(terminal): Skip redundant PTY resize to prevent prompt duplication

### DIFF
--- a/backend/internal/worker/terminal/manager.go
+++ b/backend/internal/worker/terminal/manager.go
@@ -98,6 +98,7 @@ func (m *Manager) SendInput(terminalID string, data []byte) error {
 func (m *Manager) Resize(terminalID string, cols, rows uint16) error {
 	m.mu.RLock()
 	t, ok := m.terminals[terminalID]
+	meta := m.meta[terminalID]
 	m.mu.RUnlock()
 
 	if !ok {
@@ -105,6 +106,13 @@ func (m *Manager) Resize(terminalID string, cols, rows uint16) error {
 	}
 	if t.IsExited() {
 		return fmt.Errorf("terminal exited: %s", terminalID)
+	}
+
+	// Skip if dimensions haven't changed to avoid a spurious SIGWINCH
+	// that causes shells (e.g. zsh with starship) to redraw the prompt,
+	// leaving the old prompt visible on screen.
+	if meta.Cols == uint32(cols) && meta.Rows == uint32(rows) {
+		return nil
 	}
 
 	if err := t.Resize(cols, rows); err != nil {

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -232,6 +232,28 @@ func TestManager_Resize_UnknownTerminal(t *testing.T) {
 	assert.Contains(t, err.Error(), "no terminal", "error should indicate unknown terminal")
 }
 
+func TestManager_Resize_SameDimensions(t *testing.T) {
+	m := NewManager()
+	err := m.StartTerminal(Options{
+		ID:         "tm-resize-noop",
+		Shell:      "/bin/sh",
+		WorkingDir: t.TempDir(),
+		Cols:       80,
+		Rows:       24,
+	}, func([]byte) {}, nil)
+	require.NoError(t, err)
+	defer m.StopAll()
+
+	// Resize to same dimensions should be a no-op (no spurious SIGWINCH).
+	assert.NoError(t, m.Resize("tm-resize-noop", 80, 24))
+
+	// Resize to different dimensions should succeed.
+	assert.NoError(t, m.Resize("tm-resize-noop", 120, 40))
+
+	// Resize to same (new) dimensions should be a no-op again.
+	assert.NoError(t, m.Resize("tm-resize-noop", 120, 40))
+}
+
 func TestManager_ScreenSnapshot(t *testing.T) {
 	m := NewManager()
 	var mu sync.Mutex


### PR DESCRIPTION
## Motivation

When a terminal resize request arrives with the same dimensions as the current terminal size, the PTY still receives a SIGWINCH signal. This causes shells like zsh (especially with prompt frameworks like starship) to redraw the prompt, leaving a duplicate old prompt visible on screen.

## Modifications

- Added a dimension comparison check in `Manager.Resize()` that compares the incoming columns/rows against the stored metadata and returns early when they match
- Added `TestManager_Resize_SameDimensions` test covering:
  - Same-dimension resize is a no-op
  - Different-dimension resize succeeds
  - Repeated same-dimension resize after a real resize is again a no-op

## Result

Redundant PTY resize calls are skipped, preventing spurious SIGWINCH signals and eliminating the prompt duplication artifact in shells that redraw on window-change events.

🤖 Generated with Claude Code
