### PR TITLE
Centralize ACP settings management and fix ClearContext reapplication

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -219,8 +219,18 @@ func (b *acpBase) ClearContext() (string, bool) {
 	return session.SessionID, true
 }
 
+// reapplyModelAndPermissionMode re-applies the current model and permission
+// mode after a session/new. Used as the default reapplySettings callback by
+// agents that track permission mode (Copilot, Gemini, Goose).
+func (b *acpBase) reapplyModelAndPermissionMode() {
+	b.mu.Lock()
+	model, mode := b.model, b.permissionMode
+	b.mu.Unlock()
+	acpApplySetting(b.providerName, b.agentID, "model", model, b.setModel)
+	acpApplySetting(b.providerName, b.agentID, "mode", mode, b.setPermissionMode)
+}
+
 // setPermissionMode sends a session/set_mode RPC and updates the local field.
-// Used by Copilot, Cursor, Gemini, and Goose agents.
 func (b *acpBase) setPermissionMode(mode string) error {
 	b.mu.Lock()
 	available := b.availableModes
@@ -235,36 +245,37 @@ func (b *acpBase) setPermissionMode(mode string) error {
 	return nil
 }
 
+// CurrentSettings returns the current model and permission mode.
+// Concrete types that track additional settings (e.g. primaryAgent)
+// should override this method.
+func (b *acpBase) CurrentSettings() *leapmuxv1.AgentSettings {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return &leapmuxv1.AgentSettings{
+		Model:          b.model,
+		PermissionMode: b.permissionMode,
+	}
+}
+
 // UpdateSettings applies model and permission-mode changes to a running
 // ACP agent. Concrete types that use different settings (e.g. primaryAgent
 // instead of permissionMode) should override this method.
 func (b *acpBase) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpUpdateSetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
-		acpUpdateSetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode)
+	return acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
+		acpApplySetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode)
 }
 
-// acpUpdateSetting applies a single setting extracted from AgentSettings,
-// logging a warning and returning false on failure. Skips empty values.
-func acpUpdateSetting(providerName, agentID, name, value string, apply func(string) error) bool {
+// acpApplySetting applies a single setting, logging a warning and returning
+// false on failure. Skips empty values.
+func acpApplySetting(providerName, agentID, name, value string, apply func(string) error) bool {
 	if value == "" {
 		return true
 	}
 	if err := apply(value); err != nil {
-		slog.Warn("UpdateSettings: failed to set "+name, "provider", providerName, "agent_id", agentID, "error", err)
+		slog.Warn("failed to apply "+name, "provider", providerName, "agent_id", agentID, "error", err)
 		return false
 	}
 	return true
-}
-
-// acpReapplySetting re-applies a single setting after a session/new,
-// logging a warning on failure.
-func acpReapplySetting(providerName, agentID, name, value string, apply func(string) error) {
-	if value == "" {
-		return
-	}
-	if err := apply(value); err != nil {
-		slog.Warn("ClearContext: failed to re-apply "+name, "provider", providerName, "agent_id", agentID, "error", err)
-	}
 }
 
 // buildACPSessionRequest builds a newSession or loadSession JSON-RPC request.

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -246,7 +246,6 @@ func (b *acpBase) setPermissionMode(mode string) error {
 	return nil
 }
 
-// CurrentSettings returns the current model and permission mode.
 // Concrete types that track additional settings (e.g. primaryAgent)
 // should override this method.
 func (b *acpBase) CurrentSettings() *leapmuxv1.AgentSettings {
@@ -258,17 +257,16 @@ func (b *acpBase) CurrentSettings() *leapmuxv1.AgentSettings {
 	}
 }
 
-// UpdateSettings applies model and permission-mode changes to a running
-// ACP agent. Concrete types that use different settings (e.g. primaryAgent
-// instead of permissionMode) should override this method.
+// Concrete types that use different settings (e.g. primaryAgent instead
+// of permissionMode) should override this method.
 func (b *acpBase) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
-		acpApplySetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode)
+	ok := acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel)
+	ok = acpApplySetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode) && ok
+	return ok
 }
 
-// setPrimaryAgent sends a session/set_mode RPC for a primary-agent value
-// and updates the local field. Used by agents that track primaryAgent
-// instead of permissionMode (Kilo, OpenCode).
+// Used by agents that track primaryAgent instead of permissionMode
+// (Kilo, OpenCode).
 func (b *acpBase) setPrimaryAgent(agent string) error {
 	b.mu.Lock()
 	available := b.availablePrimaryAgents
@@ -325,9 +323,8 @@ func (b *acpBase) primaryAgentOptionGroups(fallback []*leapmuxv1.AvailableOption
 	}}
 }
 
-// primaryAgentCurrentSettings returns settings including primaryAgent in
-// ExtraSettings. Used by agents that track primaryAgent instead of
-// permissionMode (Kilo, OpenCode).
+// Used by agents that track primaryAgent instead of permissionMode
+// (Kilo, OpenCode).
 func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -341,16 +338,16 @@ func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
 	}
 }
 
-// primaryAgentUpdateSettings applies model and primary-agent changes to a
-// running ACP agent. Used by agents that track primaryAgent instead of
-// permissionMode (Kilo, OpenCode).
+// Used by agents that track primaryAgent instead of permissionMode
+// (Kilo, OpenCode).
 func (b *acpBase) primaryAgentUpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
-		acpApplySetting(b.providerName, b.agentID, "primary agent", s.GetExtraSettings()[OptionGroupKeyPrimaryAgent], b.setPrimaryAgent)
+	ok := acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel)
+	ok = acpApplySetting(b.providerName, b.agentID, "primary agent", s.GetExtraSettings()[OptionGroupKeyPrimaryAgent], b.setPrimaryAgent) && ok
+	return ok
 }
 
-// acpApplySetting applies a single setting, logging a warning and returning
-// false on failure. Skips empty values.
+// acpApplySetting logs a warning and returns false on failure. Skips
+// empty values.
 func acpApplySetting(providerName, agentID, name, value string, apply func(string) error) bool {
 	if value == "" {
 		return true

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -293,6 +293,62 @@ func (b *acpBase) reapplyModelAndPrimaryAgent() {
 	acpApplySetting(b.providerName, b.agentID, "primary agent", primaryAgent, b.setPrimaryAgent)
 }
 
+// permissionModeOptionGroups returns AvailableOptionGroups for agents that
+// use permission-mode (e.g. Copilot, Cursor, Gemini, Goose).
+func (b *acpBase) permissionModeOptionGroups(label string, fallback []*leapmuxv1.AvailableOption) []*leapmuxv1.AvailableOptionGroup {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	options := b.availableModes
+	if len(options) == 0 {
+		options = fallback
+	}
+	return []*leapmuxv1.AvailableOptionGroup{{
+		Key:     OptionGroupKeyPermissionMode,
+		Label:   label,
+		Options: options,
+	}}
+}
+
+// primaryAgentOptionGroups returns AvailableOptionGroups for agents that
+// use primary-agent selection (e.g. Kilo, OpenCode).
+func (b *acpBase) primaryAgentOptionGroups(fallback []*leapmuxv1.AvailableOption) []*leapmuxv1.AvailableOptionGroup {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	options := b.availablePrimaryAgents
+	if len(options) == 0 {
+		options = fallback
+	}
+	return []*leapmuxv1.AvailableOptionGroup{{
+		Key:     OpenCodeExtraPrimaryAgent,
+		Label:   "Primary Agent",
+		Options: options,
+	}}
+}
+
+// primaryAgentCurrentSettings returns settings including primaryAgent in
+// ExtraSettings. Used by agents that track primaryAgent instead of
+// permissionMode (Kilo, OpenCode).
+func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	extra := map[string]string{}
+	if b.currentPrimaryAgent != "" {
+		extra[OpenCodeExtraPrimaryAgent] = b.currentPrimaryAgent
+	}
+	return &leapmuxv1.AgentSettings{
+		Model:         b.model,
+		ExtraSettings: extra,
+	}
+}
+
+// primaryAgentUpdateSettings applies model and primary-agent changes to a
+// running ACP agent. Used by agents that track primaryAgent instead of
+// permissionMode (Kilo, OpenCode).
+func (b *acpBase) primaryAgentUpdateSettings(s *leapmuxv1.AgentSettings) bool {
+	return acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
+		acpApplySetting(b.providerName, b.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], b.setPrimaryAgent)
+}
+
 // acpApplySetting applies a single setting, logging a warning and returning
 // false on failure. Skips empty values.
 func acpApplySetting(providerName, agentID, name, value string, apply func(string) error) bool {

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -178,9 +178,11 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 	}
 }
 
-// ClearContext sends a session/new request on the running ACP process,
-// replacing the current session with a fresh one.
-func (b *acpBase) ClearContext() (string, bool) {
+// clearSession sends a session/new request on the running ACP process,
+// replacing the current session with a fresh one and re-applying the
+// current model. Concrete providers should override ClearContext() to
+// call this and then re-apply their own settings (e.g. permission mode).
+func (b *acpBase) clearSession() (string, bool) {
 	_, params := buildACPSessionRequest("", b.workingDir, acpMethodSessionNew, "")
 	resp, err := b.sendRequest(acpMethodSessionNew, json.RawMessage(params), b.APITimeout())
 	if err != nil {

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -333,7 +333,7 @@ func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
 	defer b.mu.Unlock()
 	var extra map[string]string
 	if b.currentPrimaryAgent != "" {
-		extra = map[string]string{OpenCodeExtraPrimaryAgent: b.currentPrimaryAgent}
+		extra = map[string]string{OptionGroupKeyPrimaryAgent: b.currentPrimaryAgent}
 	}
 	return &leapmuxv1.AgentSettings{
 		Model:         b.model,
@@ -346,7 +346,7 @@ func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
 // permissionMode (Kilo, OpenCode).
 func (b *acpBase) primaryAgentUpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return acpApplySetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
-		acpApplySetting(b.providerName, b.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], b.setPrimaryAgent)
+		acpApplySetting(b.providerName, b.agentID, "primary agent", s.GetExtraSettings()[OptionGroupKeyPrimaryAgent], b.setPrimaryAgent)
 }
 
 // acpApplySetting applies a single setting, logging a warning and returning

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -319,7 +319,7 @@ func (b *acpBase) primaryAgentOptionGroups(fallback []*leapmuxv1.AvailableOption
 		options = fallback
 	}
 	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OpenCodeExtraPrimaryAgent,
+		Key:     OptionGroupKeyPrimaryAgent,
 		Label:   "Primary Agent",
 		Options: options,
 	}}
@@ -331,9 +331,9 @@ func (b *acpBase) primaryAgentOptionGroups(fallback []*leapmuxv1.AvailableOption
 func (b *acpBase) primaryAgentCurrentSettings() *leapmuxv1.AgentSettings {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	extra := map[string]string{}
+	var extra map[string]string
 	if b.currentPrimaryAgent != "" {
-		extra[OpenCodeExtraPrimaryAgent] = b.currentPrimaryAgent
+		extra = map[string]string{OpenCodeExtraPrimaryAgent: b.currentPrimaryAgent}
 	}
 	return &leapmuxv1.AgentSettings{
 		Model:         b.model,

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -71,19 +71,21 @@ type jsonrpcBase struct {
 // agents (GeminiCLIAgent, OpenCodeAgent, CopilotCLIAgent) but not CodexAgent.
 type acpBase struct {
 	jsonrpcBase
-	sink               OutputSink
-	providerName       string                  // e.g. "copilot", "gemini", "opencode" — used in log messages
-	extraSessionUpdate acpSessionUpdateHandler // optional provider-specific session update handler
-	extraMethod        acpMethodHandler        // optional provider-specific request/notification handler
-	reapplySettings    func()                  // called by ClearContext after session/new to re-apply model, mode, etc.
-	sessionID          string
-	workingDir         string
-	model              string
-	permissionMode     string
-	availableModels    []*leapmuxv1.AvailableModel
-	availableModes     []*leapmuxv1.AvailableOption
-	turnAssistantText  strings.Builder
-	turnThinkingText   strings.Builder
+	sink                   OutputSink
+	providerName           string                  // e.g. "copilot", "gemini", "opencode" — used in log messages
+	extraSessionUpdate     acpSessionUpdateHandler // optional provider-specific session update handler
+	extraMethod            acpMethodHandler        // optional provider-specific request/notification handler
+	reapplySettings        func()                  // called by ClearContext after session/new to re-apply model, mode, etc.
+	sessionID              string
+	workingDir             string
+	model                  string
+	permissionMode         string
+	currentPrimaryAgent    string
+	availableModels        []*leapmuxv1.AvailableModel
+	availableModes         []*leapmuxv1.AvailableOption
+	availablePrimaryAgents []*leapmuxv1.AvailableOption
+	turnAssistantText      strings.Builder
+	turnThinkingText       strings.Builder
 }
 
 // handleACPPromptResponse extracts accumulated turn text, calls the optional
@@ -220,8 +222,7 @@ func (b *acpBase) ClearContext() (string, bool) {
 }
 
 // reapplyModelAndPermissionMode re-applies the current model and permission
-// mode after a session/new. Used as the default reapplySettings callback by
-// agents that track permission mode (Copilot, Gemini, Goose).
+// mode after a session/new.
 func (b *acpBase) reapplyModelAndPermissionMode() {
 	b.mu.Lock()
 	model, mode := b.model, b.permissionMode
@@ -265,6 +266,33 @@ func (b *acpBase) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		acpApplySetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode)
 }
 
+// setPrimaryAgent sends a session/set_mode RPC for a primary-agent value
+// and updates the local field. Used by agents that track primaryAgent
+// instead of permissionMode (Kilo, OpenCode).
+func (b *acpBase) setPrimaryAgent(agent string) error {
+	b.mu.Lock()
+	available := b.availablePrimaryAgents
+	b.mu.Unlock()
+
+	if err := b.acpSetMode(agent, available); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	b.currentPrimaryAgent = agent
+	b.mu.Unlock()
+	return nil
+}
+
+// reapplyModelAndPrimaryAgent re-applies the current model and primary
+// agent after a session/new.
+func (b *acpBase) reapplyModelAndPrimaryAgent() {
+	b.mu.Lock()
+	model, primaryAgent := b.model, b.currentPrimaryAgent
+	b.mu.Unlock()
+	acpApplySetting(b.providerName, b.agentID, "model", model, b.setModel)
+	acpApplySetting(b.providerName, b.agentID, "primary agent", primaryAgent, b.setPrimaryAgent)
+}
+
 // acpApplySetting applies a single setting, logging a warning and returning
 // false on failure. Skips empty values.
 func acpApplySetting(providerName, agentID, name, value string, apply func(string) error) bool {
@@ -272,7 +300,7 @@ func acpApplySetting(providerName, agentID, name, value string, apply func(strin
 		return true
 	}
 	if err := apply(value); err != nil {
-		slog.Warn("failed to apply "+name, "provider", providerName, "agent_id", agentID, "error", err)
+		slog.Warn("failed to apply setting", "setting", name, "provider", providerName, "agent_id", agentID, "error", err)
 		return false
 	}
 	return true

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -75,10 +75,13 @@ type acpBase struct {
 	providerName       string                  // e.g. "copilot", "gemini", "opencode" — used in log messages
 	extraSessionUpdate acpSessionUpdateHandler // optional provider-specific session update handler
 	extraMethod        acpMethodHandler        // optional provider-specific request/notification handler
+	reapplySettings    func()                  // called by ClearContext after session/new to re-apply model, mode, etc.
 	sessionID          string
 	workingDir         string
 	model              string
+	permissionMode     string
 	availableModels    []*leapmuxv1.AvailableModel
+	availableModes     []*leapmuxv1.AvailableOption
 	turnAssistantText  strings.Builder
 	turnThinkingText   strings.Builder
 }
@@ -178,11 +181,11 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 	}
 }
 
-// clearSession sends a session/new request on the running ACP process,
-// replacing the current session with a fresh one and re-applying the
-// current model. Concrete providers should override ClearContext() to
-// call this and then re-apply their own settings (e.g. permission mode).
-func (b *acpBase) clearSession() (string, bool) {
+// ClearContext sends a session/new request on the running ACP process,
+// replacing the current session with a fresh one. After the session is
+// created, the reapplySettings callback (if set) re-applies provider-
+// specific settings such as model and permission mode.
+func (b *acpBase) ClearContext() (string, bool) {
 	_, params := buildACPSessionRequest("", b.workingDir, acpMethodSessionNew, "")
 	resp, err := b.sendRequest(acpMethodSessionNew, json.RawMessage(params), b.APITimeout())
 	if err != nil {
@@ -209,7 +212,59 @@ func (b *acpBase) clearSession() (string, bool) {
 	b.mu.Unlock()
 
 	b.sink.UpdateSessionID(session.SessionID)
+
+	if b.reapplySettings != nil {
+		b.reapplySettings()
+	}
 	return session.SessionID, true
+}
+
+// setPermissionMode sends a session/set_mode RPC and updates the local field.
+// Used by Copilot, Cursor, Gemini, and Goose agents.
+func (b *acpBase) setPermissionMode(mode string) error {
+	b.mu.Lock()
+	available := b.availableModes
+	b.mu.Unlock()
+
+	if err := b.acpSetMode(mode, available); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	b.permissionMode = mode
+	b.mu.Unlock()
+	return nil
+}
+
+// UpdateSettings applies model and permission-mode changes to a running
+// ACP agent. Concrete types that use different settings (e.g. primaryAgent
+// instead of permissionMode) should override this method.
+func (b *acpBase) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
+	return acpUpdateSetting(b.providerName, b.agentID, "model", s.GetModel(), b.setModel) &&
+		acpUpdateSetting(b.providerName, b.agentID, "mode", s.GetPermissionMode(), b.setPermissionMode)
+}
+
+// acpUpdateSetting applies a single setting extracted from AgentSettings,
+// logging a warning and returning false on failure. Skips empty values.
+func acpUpdateSetting(providerName, agentID, name, value string, apply func(string) error) bool {
+	if value == "" {
+		return true
+	}
+	if err := apply(value); err != nil {
+		slog.Warn("UpdateSettings: failed to set "+name, "provider", providerName, "agent_id", agentID, "error", err)
+		return false
+	}
+	return true
+}
+
+// acpReapplySetting re-applies a single setting after a session/new,
+// logging a warning on failure.
+func acpReapplySetting(providerName, agentID, name, value string, apply func(string) error) {
+	if value == "" {
+		return
+	}
+	if err := apply(value); err != nil {
+		slog.Warn("ClearContext: failed to re-apply "+name, "provider", providerName, "agent_id", agentID, "error", err)
+	}
 }
 
 // buildACPSessionRequest builds a newSession or loadSession JSON-RPC request.

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -34,6 +34,11 @@ const (
 // to identify the permission-mode option group across all providers.
 const OptionGroupKeyPermissionMode = "permissionMode"
 
+// OptionGroupKeyPrimaryAgent is the key used in AvailableOptionGroup
+// to identify the primary-agent option group across providers that
+// support agent selection (e.g. Kilo, OpenCode).
+const OptionGroupKeyPrimaryAgent = "primaryAgent"
+
 // DefaultAPITimeout is the fallback timeout for JSON-RPC requests to the
 // agent process, used when no configured value is provided.
 const DefaultAPITimeout = time.Duration(config.DefaultAPITimeoutSeconds) * time.Second

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -167,6 +167,28 @@ func (a *CopilotCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return true
 }
 
+func (a *CopilotCLIAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	mode := a.permissionMode
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setModel(model); err != nil {
+			slog.Warn("copilot ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if mode != "" {
+		if err := a.setPermissionMode(mode); err != nil {
+			slog.Warn("copilot ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
+}
+
 func (a *CopilotCLIAgent) setPermissionMode(mode string) error {
 	a.mu.Lock()
 	available := a.availableModes

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -57,13 +57,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, mode := a.model, a.permissionMode
-		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
-	}
+	a.reapplySettings = a.reapplyModelAndPermissionMode
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -129,15 +123,6 @@ func (a *CopilotCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.
 	a.doSendACPPrompt(content, attachments, func(resp json.RawMessage) {
 		a.handleACPPromptResponse(resp, nil)
 	})
-}
-
-func (a *CopilotCLIAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return &leapmuxv1.AgentSettings{
-		Model:          a.model,
-		PermissionMode: a.permissionMode,
-	}
 }
 
 func (a *CopilotCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -126,17 +126,7 @@ func (a *CopilotCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.
 }
 
 func (a *CopilotCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availableModes
-	if len(options) == 0 {
-		options = fallbackCopilotCLIModes()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OptionGroupKeyPermissionMode,
-		Label:   "Mode",
-		Options: options,
-	}}
+	return a.permissionModeOptionGroups("Mode", fallbackCopilotCLIModes())
 }
 
 func init() {

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -19,9 +18,6 @@ const (
 // CopilotCLIAgent manages a single Copilot CLI ACP process.
 type CopilotCLIAgent struct {
 	acpBase
-
-	permissionMode string
-	availableModes []*leapmuxv1.AvailableOption
 }
 
 // StartCopilotCLI starts a Copilot CLI ACP agent process and performs the handshake.
@@ -61,6 +57,13 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, mode := a.model, a.permissionMode
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -101,13 +104,13 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	if requested := StringOrDefault(opts.PermissionMode, ""); requested != "" && requested != a.permissionMode {
 		if err := a.setPermissionMode(requested); err != nil {
 			cleanup()
-			return nil, a.formatStartupError("session/set_mode", err)
+			return nil, a.formatStartupError(acpMethodSessionSetMode, err)
 		}
 	}
 	if requested := StringOrDefault(opts.Model, ""); requested != "" && requested != a.model {
 		if err := a.setModel(requested); err != nil {
 			cleanup()
-			return nil, a.formatStartupError("session/set_model", err)
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
 		}
 	}
 
@@ -149,58 +152,6 @@ func (a *CopilotCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		Label:   "Mode",
 		Options: options,
 	}}
-}
-
-func (a *CopilotCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if model := s.GetModel(); model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("copilot session/set_model failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if mode := s.GetPermissionMode(); mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("copilot session/set_mode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *CopilotCLIAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	mode := a.permissionMode
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("copilot ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("copilot ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
-}
-
-func (a *CopilotCLIAgent) setPermissionMode(mode string) error {
-	a.mu.Lock()
-	available := a.availableModes
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(mode, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.permissionMode = mode
-	a.mu.Unlock()
-	return nil
 }
 
 func init() {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -61,13 +61,7 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.extraMethod = a.handleExtraMethod
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, mode := a.model, a.permissionMode
-		a.mu.Unlock()
-		acpApplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
-		acpApplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
-	}
+	a.reapplySettings = a.reapplyModelAndMode
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -174,6 +168,16 @@ func (a *CursorCLIAgent) setCursorModel(model string) error {
 	a.model = model
 	a.mu.Unlock()
 	return nil
+}
+
+// reapplyModelAndMode re-applies the current model and permission mode
+// after a session/new. Uses setCursorModel for the model-ID wire format.
+func (a *CursorCLIAgent) reapplyModelAndMode() {
+	a.mu.Lock()
+	model, mode := a.model, a.permissionMode
+	a.mu.Unlock()
+	acpApplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
+	acpApplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
 }
 
 var cursorCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -65,8 +65,8 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 		a.mu.Lock()
 		model, mode := a.model, a.permissionMode
 		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
-		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+		acpApplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
+		acpApplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -146,15 +146,6 @@ func (a *CursorCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.A
 	})
 }
 
-func (a *CursorCLIAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return &leapmuxv1.AgentSettings{
-		Model:          a.model,
-		PermissionMode: a.permissionMode,
-	}
-}
-
 func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -170,8 +161,8 @@ func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGro
 }
 
 func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpUpdateSetting(a.providerName, a.agentID, "model", normalizeCursorModelID(s.GetModel()), a.setCursorModel) &&
-		acpUpdateSetting(a.providerName, a.agentID, "mode", s.GetPermissionMode(), a.setPermissionMode)
+	return acpApplySetting(a.providerName, a.agentID, "model", normalizeCursorModelID(s.GetModel()), a.setCursorModel) &&
+		acpApplySetting(a.providerName, a.agentID, "mode", s.GetPermissionMode(), a.setPermissionMode)
 }
 
 func (a *CursorCLIAgent) setCursorModel(model string) error {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -182,6 +182,28 @@ func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return true
 }
 
+func (a *CursorCLIAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	mode := a.permissionMode
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setCursorModel(model); err != nil {
+			slog.Warn("cursor ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if mode != "" {
+		if err := a.setPermissionMode(mode); err != nil {
+			slog.Warn("cursor ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
+}
+
 func (a *CursorCLIAgent) setCursorModel(model string) error {
 	wireModel := cursorModelIDForWire(model)
 	if err := a.setModel(wireModel); err != nil {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -22,9 +21,6 @@ const (
 // CursorCLIAgent manages a single Cursor CLI ACP process.
 type CursorCLIAgent struct {
 	acpBase
-
-	permissionMode string
-	availableModes []*leapmuxv1.AvailableOption
 }
 
 // StartCursorCLI starts a Cursor CLI ACP agent process and performs the handshake.
@@ -65,6 +61,13 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.extraMethod = a.handleExtraMethod
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, mode := a.model, a.permissionMode
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
+		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -167,41 +170,8 @@ func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGro
 }
 
 func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if model := normalizeCursorModelID(s.GetModel()); model != "" {
-		if err := a.setCursorModel(model); err != nil {
-			slog.Warn("cursor session/set_model failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if mode := s.GetPermissionMode(); mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("cursor session/set_mode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *CursorCLIAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	mode := a.permissionMode
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setCursorModel(model); err != nil {
-			slog.Warn("cursor ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("cursor ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
+	return acpUpdateSetting(a.providerName, a.agentID, "model", normalizeCursorModelID(s.GetModel()), a.setCursorModel) &&
+		acpUpdateSetting(a.providerName, a.agentID, "mode", s.GetPermissionMode(), a.setPermissionMode)
 }
 
 func (a *CursorCLIAgent) setCursorModel(model string) error {
@@ -211,20 +181,6 @@ func (a *CursorCLIAgent) setCursorModel(model string) error {
 	}
 	a.mu.Lock()
 	a.model = model
-	a.mu.Unlock()
-	return nil
-}
-
-func (a *CursorCLIAgent) setPermissionMode(mode string) error {
-	a.mu.Lock()
-	available := a.availableModes
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(mode, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.permissionMode = mode
 	a.mu.Unlock()
 	return nil
 }

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -145,8 +145,9 @@ func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGro
 }
 
 func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpApplySetting(a.providerName, a.agentID, "model", normalizeCursorModelID(s.GetModel()), a.setCursorModel) &&
-		acpApplySetting(a.providerName, a.agentID, "mode", s.GetPermissionMode(), a.setPermissionMode)
+	ok := acpApplySetting(a.providerName, a.agentID, "model", normalizeCursorModelID(s.GetModel()), a.setCursorModel)
+	ok = acpApplySetting(a.providerName, a.agentID, "mode", s.GetPermissionMode(), a.setPermissionMode) && ok
+	return ok
 }
 
 func (a *CursorCLIAgent) setCursorModel(model string) error {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -141,17 +141,7 @@ func (a *CursorCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.A
 }
 
 func (a *CursorCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availableModes
-	if len(options) == 0 {
-		options = fallbackCursorCLIModes()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OptionGroupKeyPermissionMode,
-		Label:   "Mode",
-		Options: options,
-	}}
+	return a.permissionModeOptionGroups("Mode", fallbackCursorCLIModes())
 }
 
 func (a *CursorCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -23,6 +23,11 @@ type cursorRecordedRequest struct {
 
 func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []cursorRecordedRequest) {
 	t.Helper()
+	return newCursorAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+}
+
+func newCursorAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CursorCLIAgent, func() []cursorRecordedRequest) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	readPipe, writePipe, err := os.Pipe()
@@ -63,7 +68,11 @@ func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []cursorRecorde
 			mu.Unlock()
 			if req.ID != 0 {
 				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+					body := json.RawMessage(`{}`)
+					if respond != nil {
+						body = respond(req.Method)
+					}
+					ch.(chan json.RawMessage) <- body
 				}
 			}
 		}
@@ -213,6 +222,38 @@ func TestCursorUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 	assert.Equal(t, cursorCLIModelAutoWire, recorded[0].Params["modelId"])
 	assert.Equal(t, "session/set_mode", recorded[1].Method)
 	assert.Equal(t, CursorCLIModePlan, recorded[1].Params["modeId"])
+}
+
+func TestCursorClearContextReappliesModelAndMode(t *testing.T) {
+	agent, requests := newCursorAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{"sessionId":"session-2"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "auto"
+	agent.permissionMode = CursorCLIModePlan
+	agent.availableModes = []*leapmuxv1.AvailableOption{
+		{Id: CursorCLIModeAgent, Name: "Agent", IsDefault: true},
+		{Id: CursorCLIModePlan, Name: "Plan"},
+	}
+	agent.sink = &testSink{}
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "session-2", agent.sessionID)
+
+	// Verify model is preserved with wire format conversion.
+	assert.Equal(t, "auto", agent.model)
+
+	recorded := requests()
+	require.Len(t, recorded, 3)
+	assert.Equal(t, acpMethodSessionNew, recorded[0].Method)
+	assert.Equal(t, acpMethodSessionSetModel, recorded[1].Method)
+	assert.Equal(t, cursorCLIModelAutoWire, recorded[1].Params["modelId"])
+	assert.Equal(t, acpMethodSessionSetMode, recorded[2].Method)
+	assert.Equal(t, CursorCLIModePlan, recorded[2].Params["modeId"])
 }
 
 func TestBuildCursorCLIModelsNormalizesAuto(t *testing.T) {

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -242,8 +242,8 @@ func TestCursorClearContextReappliesModelAndMode(t *testing.T) {
 		agent.mu.Lock()
 		model, mode := agent.model, agent.permissionMode
 		agent.mu.Unlock()
-		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setCursorModel)
-		acpReapplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
+		acpApplySetting(agent.providerName, agent.agentID, "model", model, agent.setCursorModel)
+		acpApplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
 	}
 
 	sessionID, ok := agent.ClearContext()

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -218,9 +218,9 @@ func TestCursorUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 
 	recorded := requests()
 	require.Len(t, recorded, 2)
-	assert.Equal(t, "session/set_model", recorded[0].Method)
+	assert.Equal(t, acpMethodSessionSetModel, recorded[0].Method)
 	assert.Equal(t, cursorCLIModelAutoWire, recorded[0].Params["modelId"])
-	assert.Equal(t, "session/set_mode", recorded[1].Method)
+	assert.Equal(t, acpMethodSessionSetMode, recorded[1].Method)
 	assert.Equal(t, CursorCLIModePlan, recorded[1].Params["modeId"])
 }
 

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -238,13 +238,7 @@ func TestCursorClearContextReappliesModelAndMode(t *testing.T) {
 		{Id: CursorCLIModePlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
-	agent.reapplySettings = func() {
-		agent.mu.Lock()
-		model, mode := agent.model, agent.permissionMode
-		agent.mu.Unlock()
-		acpApplySetting(agent.providerName, agent.agentID, "model", model, agent.setCursorModel)
-		acpApplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
-	}
+	agent.reapplySettings = agent.reapplyModelAndMode
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -238,6 +238,13 @@ func TestCursorClearContextReappliesModelAndMode(t *testing.T) {
 		{Id: CursorCLIModePlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
+	agent.reapplySettings = func() {
+		agent.mu.Lock()
+		model, mode := agent.model, agent.permissionMode
+		agent.mu.Unlock()
+		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setCursorModel)
+		acpReapplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
+	}
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -99,10 +99,19 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 		a.permissionMode = GeminiCLIModeDefault
 	}
 
+	cleanup := func() {
+		a.Stop()
+		_ = a.Wait()
+	}
+	if requested := StringOrDefault(opts.Model, ""); requested != "" && requested != a.model {
+		if err := a.setModel(requested); err != nil {
+			cleanup()
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
+		}
+	}
 	if requested := StringOrDefault(opts.PermissionMode, ""); requested != "" && requested != a.permissionMode {
 		if err := a.setPermissionMode(requested); err != nil {
-			a.Stop()
-			_ = a.Wait()
+			cleanup()
 			return nil, a.formatStartupError("session/set_mode", err)
 		}
 	}
@@ -216,6 +225,28 @@ func (a *GeminiCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		}
 	}
 	return true
+}
+
+func (a *GeminiCLIAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	mode := a.permissionMode
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setModel(model); err != nil {
+			slog.Warn("gemini ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if mode != "" {
+		if err := a.setPermissionMode(mode); err != nil {
+			slog.Warn("gemini ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
 }
 
 func (a *GeminiCLIAgent) setPermissionMode(mode string) error {

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -19,9 +19,6 @@ const (
 // GeminiCLIAgent manages a single Gemini CLI ACP process.
 type GeminiCLIAgent struct {
 	acpBase
-
-	permissionMode string
-	availableModes []*leapmuxv1.AvailableOption
 }
 
 // StartGeminiCLI starts a Gemini CLI ACP agent process and performs the handshake.
@@ -65,6 +62,13 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	}
 	a.extraSessionUpdate = a.handleExtraSessionUpdate
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, mode := a.model, a.permissionMode
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -112,7 +116,7 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	if requested := StringOrDefault(opts.PermissionMode, ""); requested != "" && requested != a.permissionMode {
 		if err := a.setPermissionMode(requested); err != nil {
 			cleanup()
-			return nil, a.formatStartupError("session/set_mode", err)
+			return nil, a.formatStartupError(acpMethodSessionSetMode, err)
 		}
 	}
 
@@ -209,58 +213,6 @@ func (a *GeminiCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGro
 		Label:   "Permission Mode",
 		Options: options,
 	}}
-}
-
-func (a *GeminiCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if model := s.GetModel(); model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("gemini unstable_setSessionModel failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if mode := s.GetPermissionMode(); mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("gemini setSessionMode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *GeminiCLIAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	mode := a.permissionMode
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("gemini ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("gemini ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
-}
-
-func (a *GeminiCLIAgent) setPermissionMode(mode string) error {
-	a.mu.Lock()
-	available := a.availableModes
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(mode, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.permissionMode = mode
-	a.mu.Unlock()
-	return nil
 }
 
 var geminiCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -187,17 +187,7 @@ func broadcastGeminiQuotaSessionInfo(sink OutputSink, resp json.RawMessage) {
 }
 
 func (a *GeminiCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availableModes
-	if len(options) == 0 {
-		options = fallbackGeminiCLIModes()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OptionGroupKeyPermissionMode,
-		Label:   "Permission Mode",
-		Options: options,
-	}}
+	return a.permissionModeOptionGroups("Permission Mode", fallbackGeminiCLIModes())
 }
 
 var geminiCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -62,13 +62,7 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	}
 	a.extraSessionUpdate = a.handleExtraSessionUpdate
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, mode := a.model, a.permissionMode
-		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
-	}
+	a.reapplySettings = a.reapplyModelAndPermissionMode
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -190,15 +184,6 @@ func broadcastGeminiQuotaSessionInfo(sink OutputSink, resp json.RawMessage) {
 			"outputTokens":             outputTokens,
 		},
 	})
-}
-
-func (a *GeminiCLIAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return &leapmuxv1.AgentSettings{
-		Model:          a.model,
-		PermissionMode: a.permissionMode,
-	}
 }
 
 func (a *GeminiCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/gemini_output_test.go
+++ b/backend/internal/worker/agent/gemini_output_test.go
@@ -188,8 +188,7 @@ func TestBuildGeminiCLIModels_withoutAutoEmptyCurrentModel(t *testing.T) {
 
 func TestGeminiCurrentSettingsIncludesPermissionMode(t *testing.T) {
 	agent := &GeminiCLIAgent{
-		acpBase:        acpBase{model: "auto"},
-		permissionMode: GeminiCLIModePlan,
+		acpBase: acpBase{model: "auto", permissionMode: GeminiCLIModePlan},
 	}
 
 	settings := agent.CurrentSettings()

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -197,6 +197,32 @@ func TestStartGeminiCLI_NewSessionHandshake(t *testing.T) {
 	assert.Equal(t, "default", agent.permissionMode)
 }
 
+func TestStartGeminiCLI_NewSessionAppliesRequestedModelAndMode(t *testing.T) {
+	installFakeGeminiCLI(t, "new")
+
+	// The fake CLI's session/new returns model="gemini-2.5-pro" and mode="default".
+	// Pass different requested values so that setModel and setPermissionMode are sent.
+	provider, err := StartGeminiCLI(context.Background(), Options{
+		AgentID:        "gemini-settings",
+		WorkingDir:     t.TempDir(),
+		Shell:          "/bin/sh",
+		LoginShell:     false,
+		Model:          "gemini-2.5-flash",
+		PermissionMode: GeminiCLIModePlan,
+		AgentProvider:  leapmuxv1.AgentProvider_AGENT_PROVIDER_GEMINI_CLI,
+	}, &testSink{})
+	require.NoError(t, err)
+
+	agent := provider.(*GeminiCLIAgent)
+	t.Cleanup(func() {
+		agent.Stop()
+		_ = agent.Wait()
+	})
+
+	assert.Equal(t, "gemini-2.5-flash", agent.model)
+	assert.Equal(t, GeminiCLIModePlan, agent.permissionMode)
+}
+
 func TestStartGeminiCLI_LoadSessionUsesResumeID(t *testing.T) {
 	installFakeGeminiCLI(t, "load")
 
@@ -242,6 +268,35 @@ func TestGeminiUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 	assert.Equal(t, "gemini-2.5-flash", recorded[0].Params["modelId"])
 	assert.Equal(t, "session/set_mode", recorded[1].Method)
 	assert.Equal(t, GeminiCLIModePlan, recorded[1].Params["modeId"])
+}
+
+func TestGeminiClearContextReappliesModelAndMode(t *testing.T) {
+	agent, requests := newGeminiAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{"sessionId":"session-2"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gemini-2.5-flash"
+	agent.permissionMode = GeminiCLIModePlan
+	agent.availableModes = []*leapmuxv1.AvailableOption{
+		{Id: GeminiCLIModeDefault, Name: "Default", IsDefault: true},
+		{Id: GeminiCLIModePlan, Name: "Plan"},
+	}
+	agent.sink = &testSink{}
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "session-2", agent.sessionID)
+
+	recorded := requests()
+	require.Len(t, recorded, 3)
+	assert.Equal(t, acpMethodSessionNew, recorded[0].Method)
+	assert.Equal(t, acpMethodSessionSetModel, recorded[1].Method)
+	assert.Equal(t, "gemini-2.5-flash", recorded[1].Params["modelId"])
+	assert.Equal(t, acpMethodSessionSetMode, recorded[2].Method)
+	assert.Equal(t, GeminiCLIModePlan, recorded[2].Params["modeId"])
 }
 
 func TestGeminiCancelSessionSendsACPMethod(t *testing.T) {

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -284,13 +284,7 @@ func TestGeminiClearContextReappliesModelAndMode(t *testing.T) {
 		{Id: GeminiCLIModePlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
-	agent.reapplySettings = func() {
-		agent.mu.Lock()
-		model, mode := agent.model, agent.permissionMode
-		agent.mu.Unlock()
-		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
-		acpReapplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
-	}
+	agent.reapplySettings = agent.reapplyModelAndPermissionMode
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -135,15 +135,15 @@ func TestHelperProcessGeminiCLI(t *testing.T) {
 		}
 
 		switch req.Method {
-		case "initialize":
+		case acpMethodInitialize:
 			writeResponse(req.ID, `{}`, false)
-		case "session/new":
+		case acpMethodSessionNew:
 			writeResponse(req.ID, `{"sessionId":"session-new","models":{"currentModelId":"gemini-2.5-pro","availableModels":[{"modelId":"auto","name":"Auto","description":"Automatic"},{"modelId":"gemini-2.5-pro","name":"Gemini 2.5 Pro","description":"Detailed"}]},"modes":{"currentModeId":"default","availableModes":[{"id":"default","name":"Default"},{"id":"plan","name":"Plan"}]}}`, false)
-		case "session/load":
+		case acpMethodSessionLoad:
 			if scenario == "load" {
 				writeResponse(req.ID, `{"models":{"currentModelId":"gemini-2.5-flash","availableModels":[{"modelId":"auto","name":"Auto"},{"modelId":"gemini-2.5-flash","name":"Gemini 2.5 Flash"}]},"modes":{"currentModeId":"plan","availableModes":[{"id":"default","name":"Default"},{"id":"plan","name":"Plan"}]}}`, false)
 			}
-		case "session/set_mode", "session/set_model", "session/prompt":
+		case acpMethodSessionSetMode, acpMethodSessionSetModel, acpMethodSessionPrompt:
 			writeResponse(req.ID, `{}`, false)
 		}
 	}
@@ -264,9 +264,9 @@ func TestGeminiUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 
 	recorded := requests()
 	require.Len(t, recorded, 2)
-	assert.Equal(t, "session/set_model", recorded[0].Method)
+	assert.Equal(t, acpMethodSessionSetModel, recorded[0].Method)
 	assert.Equal(t, "gemini-2.5-flash", recorded[0].Params["modelId"])
-	assert.Equal(t, "session/set_mode", recorded[1].Method)
+	assert.Equal(t, acpMethodSessionSetMode, recorded[1].Method)
 	assert.Equal(t, GeminiCLIModePlan, recorded[1].Params["modeId"])
 }
 

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -284,6 +284,13 @@ func TestGeminiClearContextReappliesModelAndMode(t *testing.T) {
 		{Id: GeminiCLIModePlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
+	agent.reapplySettings = func() {
+		agent.mu.Lock()
+		model, mode := agent.model, agent.permissionMode
+		agent.mu.Unlock()
+		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
+		acpReapplySetting(agent.providerName, agent.agentID, "mode", mode, agent.setPermissionMode)
+	}
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -58,13 +58,7 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, mode := a.model, a.permissionMode
-		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
-	}
+	a.reapplySettings = a.reapplyModelAndPermissionMode
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -131,15 +125,6 @@ func (a *GooseCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.At
 	a.doSendACPPrompt(content, attachments, func(resp json.RawMessage) {
 		a.handleACPPromptResponse(resp, nil)
 	})
-}
-
-func (a *GooseCLIAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return &leapmuxv1.AgentSettings{
-		Model:          a.model,
-		PermissionMode: a.permissionMode,
-	}
 }
 
 func (a *GooseCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -20,9 +19,6 @@ const (
 // GooseCLIAgent manages a single Goose CLI ACP process.
 type GooseCLIAgent struct {
 	acpBase
-
-	permissionMode string
-	availableModes []*leapmuxv1.AvailableOption
 }
 
 // StartGooseCLI starts a Goose CLI ACP agent process and performs the handshake.
@@ -62,6 +58,13 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, mode := a.model, a.permissionMode
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpReapplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -102,13 +105,13 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 	if requested := StringOrDefault(opts.PermissionMode, ""); requested != "" && requested != a.permissionMode {
 		if err := a.setPermissionMode(requested); err != nil {
 			cleanup()
-			return nil, a.formatStartupError("session/set_mode", err)
+			return nil, a.formatStartupError(acpMethodSessionSetMode, err)
 		}
 	}
 	if requested := StringOrDefault(opts.Model, ""); requested != "" && requested != a.model {
 		if err := a.setModel(requested); err != nil {
 			cleanup()
-			return nil, a.formatStartupError("session/set_model", err)
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
 		}
 	}
 
@@ -151,58 +154,6 @@ func (a *GooseCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGrou
 		Label:   "Mode",
 		Options: options,
 	}}
-}
-
-func (a *GooseCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if model := s.GetModel(); model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("goose session/set_model failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if mode := s.GetPermissionMode(); mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("goose session/set_mode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *GooseCLIAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	mode := a.permissionMode
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("goose ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if mode != "" {
-		if err := a.setPermissionMode(mode); err != nil {
-			slog.Warn("goose ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
-}
-
-func (a *GooseCLIAgent) setPermissionMode(mode string) error {
-	a.mu.Lock()
-	available := a.availableModes
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(mode, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.permissionMode = mode
-	a.mu.Unlock()
-	return nil
 }
 
 func init() {

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -169,6 +169,28 @@ func (a *GooseCLIAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return true
 }
 
+func (a *GooseCLIAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	mode := a.permissionMode
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setModel(model); err != nil {
+			slog.Warn("goose ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if mode != "" {
+		if err := a.setPermissionMode(mode); err != nil {
+			slog.Warn("goose ClearContext: failed to re-apply mode", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
+}
+
 func (a *GooseCLIAgent) setPermissionMode(mode string) error {
 	a.mu.Lock()
 	available := a.availableModes

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -128,17 +128,7 @@ func (a *GooseCLIAgent) doSendPrompt(content string, attachments []*leapmuxv1.At
 }
 
 func (a *GooseCLIAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availableModes
-	if len(options) == 0 {
-		options = fallbackGooseCLIModes()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OptionGroupKeyPermissionMode,
-		Label:   "Mode",
-		Options: options,
-	}}
+	return a.permissionModeOptionGroups("Mode", fallbackGooseCLIModes())
 }
 
 func init() {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -14,9 +14,6 @@ const KiloPrimaryAgentCode = "code"
 // KiloAgent manages a single Kilo ACP process.
 type KiloAgent struct {
 	acpBase
-
-	currentPrimaryAgent    string
-	availablePrimaryAgents []*leapmuxv1.AvailableOption
 }
 
 // StartKilo starts a Kilo ACP agent process and performs the handshake.
@@ -168,30 +165,6 @@ func (a *KiloAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 func (a *KiloAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
 		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
-}
-
-func (a *KiloAgent) setPrimaryAgent(agent string) error {
-	a.mu.Lock()
-	available := a.availablePrimaryAgents
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(agent, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.currentPrimaryAgent = agent
-	a.mu.Unlock()
-	return nil
-}
-
-// reapplyModelAndPrimaryAgent re-applies the current model and primary
-// agent after a session/new.
-func (a *KiloAgent) reapplyModelAndPrimaryAgent() {
-	a.mu.Lock()
-	model, primaryAgent := a.model, a.currentPrimaryAgent
-	a.mu.Unlock()
-	acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-	acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 }
 
 func (a *KiloAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -146,39 +146,15 @@ func (a *KiloAgent) doSendPrompt(content string, attachments []*leapmuxv1.Attach
 }
 
 func (a *KiloAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	extra := map[string]string{}
-	if a.currentPrimaryAgent != "" {
-		extra[OpenCodeExtraPrimaryAgent] = a.currentPrimaryAgent
-	}
-	return &leapmuxv1.AgentSettings{
-		Model:         a.model,
-		ExtraSettings: extra,
-	}
+	return a.primaryAgentCurrentSettings()
 }
 
 func (a *KiloAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	return a.availablePrimaryAgentGroup()
+	return a.primaryAgentOptionGroups(fallbackKiloPrimaryAgents())
 }
 
 func (a *KiloAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
-		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
-}
-
-func (a *KiloAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availablePrimaryAgents
-	if len(options) == 0 {
-		options = fallbackKiloPrimaryAgents()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OpenCodeExtraPrimaryAgent,
-		Label:   "Primary Agent",
-		Options: options,
-	}}
+	return a.primaryAgentUpdateSettings(s)
 }
 
 func init() {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -94,7 +94,7 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 	}
 	var requestedPrimaryAgent string
 	if opts.ExtraSettings != nil {
-		requestedPrimaryAgent = opts.ExtraSettings[OpenCodeExtraPrimaryAgent]
+		requestedPrimaryAgent = opts.ExtraSettings[OptionGroupKeyPrimaryAgent]
 	}
 	if err := a.configurePrimaryAgents(handshake.Modes, handshake.CurrentModeID, requestedPrimaryAgent); err != nil {
 		cleanup()
@@ -165,7 +165,7 @@ func init() {
 		},
 		nil, // models discovered dynamically from newSession
 		[]*leapmuxv1.AvailableOptionGroup{{
-			Key:   OpenCodeExtraPrimaryAgent,
+			Key:   OptionGroupKeyPrimaryAgent,
 			Label: "Primary Agent",
 			Options: []*leapmuxv1.AvailableOption{
 				{Id: KiloPrimaryAgentCode, Name: "Code", IsDefault: true},

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -59,13 +59,7 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 		},
 	}
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, primaryAgent := a.model, a.currentPrimaryAgent
-		a.mu.Unlock()
-		acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
-	}
+	a.reapplySettings = a.reapplyModelAndPrimaryAgent
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -188,6 +182,16 @@ func (a *KiloAgent) setPrimaryAgent(agent string) error {
 	a.currentPrimaryAgent = agent
 	a.mu.Unlock()
 	return nil
+}
+
+// reapplyModelAndPrimaryAgent re-applies the current model and primary
+// agent after a session/new.
+func (a *KiloAgent) reapplyModelAndPrimaryAgent() {
+	a.mu.Lock()
+	model, primaryAgent := a.model, a.currentPrimaryAgent
+	a.mu.Unlock()
+	acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+	acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 }
 
 func (a *KiloAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -63,8 +63,8 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 		a.mu.Lock()
 		model, primaryAgent := a.model, a.currentPrimaryAgent
 		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpReapplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
+		acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -172,8 +172,8 @@ func (a *KiloAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 }
 
 func (a *KiloAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpUpdateSetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
-		acpUpdateSetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
+	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
+		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
 }
 
 func (a *KiloAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -89,6 +89,12 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 		a.Stop()
 		_ = a.Wait()
 	}
+	if requested := StringOrDefault(opts.Model, ""); requested != "" && requested != a.model {
+		if err := a.setModel(requested); err != nil {
+			cleanup()
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
+		}
+	}
 	var requestedPrimaryAgent string
 	if opts.ExtraSettings != nil {
 		requestedPrimaryAgent = opts.ExtraSettings[OpenCodeExtraPrimaryAgent]
@@ -173,6 +179,28 @@ func (a *KiloAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		}
 	}
 	return true
+}
+
+func (a *KiloAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	primaryAgent := a.currentPrimaryAgent
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setModel(model); err != nil {
+			slog.Warn("kilo ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if primaryAgent != "" {
+		if err := a.setPrimaryAgent(primaryAgent); err != nil {
+			slog.Warn("kilo ClearContext: failed to re-apply primary agent", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
 }
 
 func (a *KiloAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -60,6 +59,13 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 		},
 	}
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, primaryAgent := a.model, a.currentPrimaryAgent
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpReapplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -166,41 +172,8 @@ func (a *KiloAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 }
 
 func (a *KiloAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if m := s.GetModel(); m != "" {
-		if err := a.setModel(m); err != nil {
-			slog.Warn("kilo session/set_model failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if primaryAgent := s.GetExtraSettings()[OpenCodeExtraPrimaryAgent]; primaryAgent != "" {
-		if err := a.setPrimaryAgent(primaryAgent); err != nil {
-			slog.Warn("kilo session/set_mode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *KiloAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	primaryAgent := a.currentPrimaryAgent
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("kilo ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if primaryAgent != "" {
-		if err := a.setPrimaryAgent(primaryAgent); err != nil {
-			slog.Warn("kilo ClearContext: failed to re-apply primary agent", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
+	return acpUpdateSetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
+		acpUpdateSetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
 }
 
 func (a *KiloAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -200,7 +200,7 @@ func TestKiloCurrentSettingsExposesPrimaryAgent(t *testing.T) {
 
 func TestKiloAvailablePrimaryAgentGroupFallsBack(t *testing.T) {
 	agent := &KiloAgent{}
-	groups := agent.availablePrimaryAgentGroup()
+	groups := agent.AvailableOptionGroups()
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 option group, got %d", len(groups))
 	}

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -138,8 +138,8 @@ func TestKiloConfigurePrimaryAgentsRestoresSavedPrimaryAgent(t *testing.T) {
 	if len(recorded) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(recorded))
 	}
-	if recorded[0].Method != "session/set_mode" {
-		t.Fatalf("expected session/set_mode, got %q", recorded[0].Method)
+	if recorded[0].Method != acpMethodSessionSetMode {
+		t.Fatalf("expected %s, got %q", acpMethodSessionSetMode, recorded[0].Method)
 	}
 	if got := recorded[0].Params["modeId"]; got != OpenCodePrimaryAgentPlan {
 		t.Fatalf("expected modeId %q, got %#v", OpenCodePrimaryAgentPlan, got)
@@ -182,8 +182,8 @@ func TestKiloUpdateSettingsSendsSessionSetMode(t *testing.T) {
 		t.Fatalf("expected current primary agent %q, got %q", OpenCodePrimaryAgentPlan, agent.currentPrimaryAgent)
 	}
 	recorded := requests()
-	if len(recorded) != 1 || recorded[0].Method != "session/set_mode" {
-		t.Fatalf("expected one session/set_mode request, got %#v", recorded)
+	if len(recorded) != 1 || recorded[0].Method != acpMethodSessionSetMode {
+		t.Fatalf("expected one %s request, got %#v", acpMethodSessionSetMode, recorded)
 	}
 }
 

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -173,7 +173,7 @@ func TestKiloUpdateSettingsSendsSessionSetMode(t *testing.T) {
 	agent.currentPrimaryAgent = KiloPrimaryAgentCode
 
 	updated := agent.UpdateSettings(&leapmuxv1.AgentSettings{
-		ExtraSettings: map[string]string{OpenCodeExtraPrimaryAgent: OpenCodePrimaryAgentPlan},
+		ExtraSettings: map[string]string{OptionGroupKeyPrimaryAgent: OpenCodePrimaryAgentPlan},
 	})
 	if !updated {
 		t.Fatalf("expected update to succeed")
@@ -193,7 +193,7 @@ func TestKiloCurrentSettingsExposesPrimaryAgent(t *testing.T) {
 	if settings.GetModel() != "openai/gpt-5" {
 		t.Fatalf("expected model to round-trip")
 	}
-	if got := settings.GetExtraSettings()[OpenCodeExtraPrimaryAgent]; got != OpenCodePrimaryAgentPlan {
+	if got := settings.GetExtraSettings()[OptionGroupKeyPrimaryAgent]; got != OpenCodePrimaryAgentPlan {
 		t.Fatalf("expected primaryAgent %q, got %q", OpenCodePrimaryAgentPlan, got)
 	}
 }
@@ -204,8 +204,8 @@ func TestKiloAvailablePrimaryAgentGroupFallsBack(t *testing.T) {
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 option group, got %d", len(groups))
 	}
-	if groups[0].Key != OpenCodeExtraPrimaryAgent {
-		t.Fatalf("expected key %q, got %q", OpenCodeExtraPrimaryAgent, groups[0].Key)
+	if groups[0].Key != OptionGroupKeyPrimaryAgent {
+		t.Fatalf("expected key %q, got %q", OptionGroupKeyPrimaryAgent, groups[0].Key)
 	}
 	if len(groups[0].Options) != 2 {
 		t.Fatalf("expected 2 fallback options, got %d", len(groups[0].Options))

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -188,7 +188,7 @@ func TestKiloUpdateSettingsSendsSessionSetMode(t *testing.T) {
 }
 
 func TestKiloCurrentSettingsExposesPrimaryAgent(t *testing.T) {
-	agent := &KiloAgent{acpBase: acpBase{model: "openai/gpt-5"}, currentPrimaryAgent: OpenCodePrimaryAgentPlan}
+	agent := &KiloAgent{acpBase: acpBase{model: "openai/gpt-5", currentPrimaryAgent: OpenCodePrimaryAgentPlan}}
 	settings := agent.CurrentSettings()
 	if settings.GetModel() != "openai/gpt-5" {
 		t.Fatalf("expected model to round-trip")

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -212,7 +212,7 @@ func TestManager_AgentExitCleanup(t *testing.T) {
 func TestManager_AvailableOptionGroupsPrefersRuntimeGroups(t *testing.T) {
 	m := NewManager(nil)
 	runtimeGroups := []*leapmuxv1.AvailableOptionGroup{{
-		Key:   OpenCodeExtraPrimaryAgent,
+		Key:   OptionGroupKeyPrimaryAgent,
 		Label: "Primary Agent",
 		Options: []*leapmuxv1.AvailableOption{
 			{Id: "build", Name: "build"},
@@ -228,7 +228,7 @@ func TestManager_AvailableOptionGroupsPrefersRuntimeGroups(t *testing.T) {
 
 	staticGroups := m.AvailableOptionGroups("missing-agent", leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE)
 	require.Len(t, staticGroups, 1)
-	assert.Equal(t, OpenCodeExtraPrimaryAgent, staticGroups[0].Key)
+	assert.Equal(t, OptionGroupKeyPrimaryAgent, staticGroups[0].Key)
 	assert.Equal(t, OpenCodePrimaryAgentBuild, staticGroups[0].Options[0].Id)
 }
 

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -76,8 +76,8 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		a.mu.Lock()
 		model, primaryAgent := a.model, a.currentPrimaryAgent
 		a.mu.Unlock()
-		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpReapplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
+		acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -261,8 +261,8 @@ func (a *OpenCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGrou
 
 // UpdateSettings applies setting changes to a running agent.
 func (a *OpenCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpUpdateSetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
-		acpUpdateSetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
+	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
+		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
 }
 
 func (a *OpenCodeAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	OpenCodeExtraPrimaryAgent = OptionGroupKeyPrimaryAgent
 	OpenCodePrimaryAgentBuild = "build"
 	OpenCodePrimaryAgentPlan  = "plan"
 	openCodeHiddenCompaction  = "compaction"
@@ -107,7 +106,7 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 	}
 	var requestedPrimaryAgent string
 	if opts.ExtraSettings != nil {
-		requestedPrimaryAgent = opts.ExtraSettings[OpenCodeExtraPrimaryAgent]
+		requestedPrimaryAgent = opts.ExtraSettings[OptionGroupKeyPrimaryAgent]
 	}
 	if err := a.configurePrimaryAgents(handshake.Modes, handshake.CurrentModeID, requestedPrimaryAgent); err != nil {
 		cleanup()
@@ -251,7 +250,7 @@ func init() {
 		},
 		nil, // models discovered dynamically from newSession
 		[]*leapmuxv1.AvailableOptionGroup{{
-			Key:   OpenCodeExtraPrimaryAgent,
+			Key:   OptionGroupKeyPrimaryAgent,
 			Label: "Primary Agent",
 			Options: []*leapmuxv1.AvailableOption{
 				{Id: OpenCodePrimaryAgentBuild, Name: "Build", IsDefault: true},

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -72,13 +72,7 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		},
 	}
 	a.promptFunc = a.doSendPrompt
-	a.reapplySettings = func() {
-		a.mu.Lock()
-		model, primaryAgent := a.model, a.currentPrimaryAgent
-		a.mu.Unlock()
-		acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-		acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
-	}
+	a.reapplySettings = a.reapplyModelAndPrimaryAgent
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -277,6 +271,16 @@ func (a *OpenCodeAgent) setPrimaryAgent(agent string) error {
 	a.currentPrimaryAgent = agent
 	a.mu.Unlock()
 	return nil
+}
+
+// reapplyModelAndPrimaryAgent re-applies the current model and primary
+// agent after a session/new.
+func (a *OpenCodeAgent) reapplyModelAndPrimaryAgent() {
+	a.mu.Lock()
+	model, primaryAgent := a.model, a.currentPrimaryAgent
+	a.mu.Unlock()
+	acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+	acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 }
 
 func (a *OpenCodeAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	OpenCodeExtraPrimaryAgent = "primaryAgent"
+	OpenCodeExtraPrimaryAgent = OptionGroupKeyPrimaryAgent
 	OpenCodePrimaryAgentBuild = "build"
 	OpenCodePrimaryAgentPlan  = "plan"
 	openCodeHiddenCompaction  = "compaction"

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -27,9 +27,6 @@ const (
 // OpenCodeAgent manages a single OpenCode ACP process.
 type OpenCodeAgent struct {
 	acpBase
-
-	currentPrimaryAgent    string
-	availablePrimaryAgents []*leapmuxv1.AvailableOption
 }
 
 // StartOpenCode starts an OpenCode ACP agent process and performs the handshake.
@@ -257,30 +254,6 @@ func (a *OpenCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGrou
 func (a *OpenCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
 		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
-}
-
-func (a *OpenCodeAgent) setPrimaryAgent(agent string) error {
-	a.mu.Lock()
-	available := a.availablePrimaryAgents
-	a.mu.Unlock()
-
-	if err := a.acpSetMode(agent, available); err != nil {
-		return err
-	}
-	a.mu.Lock()
-	a.currentPrimaryAgent = agent
-	a.mu.Unlock()
-	return nil
-}
-
-// reapplyModelAndPrimaryAgent re-applies the current model and primary
-// agent after a session/new.
-func (a *OpenCodeAgent) reapplyModelAndPrimaryAgent() {
-	a.mu.Lock()
-	model, primaryAgent := a.model, a.currentPrimaryAgent
-	a.mu.Unlock()
-	acpApplySetting(a.providerName, a.agentID, "model", model, a.setModel)
-	acpApplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
 }
 
 func (a *OpenCodeAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -102,6 +102,12 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		a.Stop()
 		_ = a.Wait()
 	}
+	if requested := StringOrDefault(opts.Model, ""); requested != "" && requested != a.model {
+		if err := a.setModel(requested); err != nil {
+			cleanup()
+			return nil, a.formatStartupError(acpMethodSessionSetModel, err)
+		}
+	}
 	var requestedPrimaryAgent string
 	if opts.ExtraSettings != nil {
 		requestedPrimaryAgent = opts.ExtraSettings[OpenCodeExtraPrimaryAgent]
@@ -262,6 +268,28 @@ func (a *OpenCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		}
 	}
 	return true
+}
+
+func (a *OpenCodeAgent) ClearContext() (string, bool) {
+	sessionID, ok := a.clearSession()
+	if !ok {
+		return "", false
+	}
+	a.mu.Lock()
+	model := a.model
+	primaryAgent := a.currentPrimaryAgent
+	a.mu.Unlock()
+	if model != "" {
+		if err := a.setModel(model); err != nil {
+			slog.Warn("opencode ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
+		}
+	}
+	if primaryAgent != "" {
+		if err := a.setPrimaryAgent(primaryAgent); err != nil {
+			slog.Warn("opencode ClearContext: failed to re-apply primary agent", "agent_id", a.agentID, "error", err)
+		}
+	}
+	return sessionID, true
 }
 
 func (a *OpenCodeAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -73,6 +72,13 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		},
 	}
 	a.promptFunc = a.doSendPrompt
+	a.reapplySettings = func() {
+		a.mu.Lock()
+		model, primaryAgent := a.model, a.currentPrimaryAgent
+		a.mu.Unlock()
+		acpReapplySetting(a.providerName, a.agentID, "model", model, a.setModel)
+		acpReapplySetting(a.providerName, a.agentID, "primary agent", primaryAgent, a.setPrimaryAgent)
+	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -255,41 +261,8 @@ func (a *OpenCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGrou
 
 // UpdateSettings applies setting changes to a running agent.
 func (a *OpenCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	if m := s.GetModel(); m != "" {
-		if err := a.setModel(m); err != nil {
-			slog.Warn("opencode session/set_model failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	if primaryAgent := s.GetExtraSettings()[OpenCodeExtraPrimaryAgent]; primaryAgent != "" {
-		if err := a.setPrimaryAgent(primaryAgent); err != nil {
-			slog.Warn("opencode session/set_mode failed", "agent_id", a.agentID, "error", err)
-			return false
-		}
-	}
-	return true
-}
-
-func (a *OpenCodeAgent) ClearContext() (string, bool) {
-	sessionID, ok := a.clearSession()
-	if !ok {
-		return "", false
-	}
-	a.mu.Lock()
-	model := a.model
-	primaryAgent := a.currentPrimaryAgent
-	a.mu.Unlock()
-	if model != "" {
-		if err := a.setModel(model); err != nil {
-			slog.Warn("opencode ClearContext: failed to re-apply model", "agent_id", a.agentID, "error", err)
-		}
-	}
-	if primaryAgent != "" {
-		if err := a.setPrimaryAgent(primaryAgent); err != nil {
-			slog.Warn("opencode ClearContext: failed to re-apply primary agent", "agent_id", a.agentID, "error", err)
-		}
-	}
-	return sessionID, true
+	return acpUpdateSetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
+		acpUpdateSetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
 }
 
 func (a *OpenCodeAgent) setPrimaryAgent(agent string) error {

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -231,43 +231,16 @@ func buildACPPromptBlocks(content string, classified []classifiedAttachment) []m
 	return prompt
 }
 
-// CurrentSettings returns the current settings for this agent.
 func (a *OpenCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	extra := map[string]string{}
-	if a.currentPrimaryAgent != "" {
-		extra[OpenCodeExtraPrimaryAgent] = a.currentPrimaryAgent
-	}
-	return &leapmuxv1.AgentSettings{
-		Model:         a.model,
-		ExtraSettings: extra,
-	}
+	return a.primaryAgentCurrentSettings()
 }
 
-// AvailableOptionGroups returns the available primary-agent group.
 func (a *OpenCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	return a.availablePrimaryAgentGroup()
+	return a.primaryAgentOptionGroups(fallbackOpenCodePrimaryAgents())
 }
 
-// UpdateSettings applies setting changes to a running agent.
 func (a *OpenCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
-	return acpApplySetting(a.providerName, a.agentID, "model", s.GetModel(), a.setModel) &&
-		acpApplySetting(a.providerName, a.agentID, "primary agent", s.GetExtraSettings()[OpenCodeExtraPrimaryAgent], a.setPrimaryAgent)
-}
-
-func (a *OpenCodeAgent) availablePrimaryAgentGroup() []*leapmuxv1.AvailableOptionGroup {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	options := a.availablePrimaryAgents
-	if len(options) == 0 {
-		options = fallbackOpenCodePrimaryAgents()
-	}
-	return []*leapmuxv1.AvailableOptionGroup{{
-		Key:     OpenCodeExtraPrimaryAgent,
-		Label:   "Primary Agent",
-		Options: options,
-	}}
+	return a.primaryAgentUpdateSettings(s)
 }
 
 func init() {

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -214,8 +214,8 @@ func TestOpenCodeClearContextReappliesModelAndPrimaryAgent(t *testing.T) {
 		agent.mu.Lock()
 		model, primaryAgent := agent.model, agent.currentPrimaryAgent
 		agent.mu.Unlock()
-		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
-		acpReapplySetting(agent.providerName, agent.agentID, "primary agent", primaryAgent, agent.setPrimaryAgent)
+		acpApplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
+		acpApplySetting(agent.providerName, agent.agentID, "primary agent", primaryAgent, agent.setPrimaryAgent)
 	}
 
 	sessionID, ok := agent.ClearContext()

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -147,8 +147,8 @@ func TestOpenCodeConfigurePrimaryAgentsRestoresSavedPrimaryAgent(t *testing.T) {
 	if len(recorded) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(recorded))
 	}
-	if recorded[0].Method != "session/set_mode" {
-		t.Fatalf("expected session/set_mode, got %q", recorded[0].Method)
+	if recorded[0].Method != acpMethodSessionSetMode {
+		t.Fatalf("expected %s, got %q", acpMethodSessionSetMode, recorded[0].Method)
 	}
 	if got := recorded[0].Params["modeId"]; got != OpenCodePrimaryAgentPlan {
 		t.Fatalf("expected modeId %q, got %#v", OpenCodePrimaryAgentPlan, got)
@@ -182,7 +182,7 @@ func TestOpenCodeUpdateSettingsSendsSessionSetMode(t *testing.T) {
 	agent.currentPrimaryAgent = OpenCodePrimaryAgentBuild
 
 	updated := agent.UpdateSettings(&leapmuxv1.AgentSettings{
-		ExtraSettings: map[string]string{OpenCodeExtraPrimaryAgent: OpenCodePrimaryAgentPlan},
+		ExtraSettings: map[string]string{OptionGroupKeyPrimaryAgent: OpenCodePrimaryAgentPlan},
 	})
 	if !updated {
 		t.Fatalf("expected update to succeed")
@@ -191,8 +191,8 @@ func TestOpenCodeUpdateSettingsSendsSessionSetMode(t *testing.T) {
 		t.Fatalf("expected current primary agent %q, got %q", OpenCodePrimaryAgentPlan, agent.currentPrimaryAgent)
 	}
 	recorded := requests()
-	if len(recorded) != 1 || recorded[0].Method != "session/set_mode" {
-		t.Fatalf("expected one session/set_mode request, got %#v", recorded)
+	if len(recorded) != 1 || recorded[0].Method != acpMethodSessionSetMode {
+		t.Fatalf("expected one %s request, got %#v", acpMethodSessionSetMode, recorded)
 	}
 }
 
@@ -232,7 +232,7 @@ func TestOpenCodeCurrentSettingsExposesPrimaryAgent(t *testing.T) {
 	if settings.GetModel() != "openai/gpt-5" {
 		t.Fatalf("expected model to round-trip")
 	}
-	if got := settings.GetExtraSettings()[OpenCodeExtraPrimaryAgent]; got != OpenCodePrimaryAgentPlan {
+	if got := settings.GetExtraSettings()[OptionGroupKeyPrimaryAgent]; got != OpenCodePrimaryAgentPlan {
 		t.Fatalf("expected primaryAgent %q, got %q", OpenCodePrimaryAgentPlan, got)
 	}
 }
@@ -243,8 +243,8 @@ func TestOpenCodeAvailablePrimaryAgentGroupFallsBack(t *testing.T) {
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 option group, got %d", len(groups))
 	}
-	if groups[0].Key != OpenCodeExtraPrimaryAgent {
-		t.Fatalf("expected key %q, got %q", OpenCodeExtraPrimaryAgent, groups[0].Key)
+	if groups[0].Key != OptionGroupKeyPrimaryAgent {
+		t.Fatalf("expected key %q, got %q", OptionGroupKeyPrimaryAgent, groups[0].Key)
 	}
 	if len(groups[0].Options) != 2 {
 		t.Fatalf("expected 2 fallback options, got %d", len(groups[0].Options))

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -227,7 +227,7 @@ func TestOpenCodeClearContextReappliesModelAndPrimaryAgent(t *testing.T) {
 }
 
 func TestOpenCodeCurrentSettingsExposesPrimaryAgent(t *testing.T) {
-	agent := &OpenCodeAgent{acpBase: acpBase{model: "openai/gpt-5"}, currentPrimaryAgent: OpenCodePrimaryAgentPlan}
+	agent := &OpenCodeAgent{acpBase: acpBase{model: "openai/gpt-5", currentPrimaryAgent: OpenCodePrimaryAgentPlan}}
 	settings := agent.CurrentSettings()
 	if settings.GetModel() != "openai/gpt-5" {
 		t.Fatalf("expected model to round-trip")

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -210,6 +210,13 @@ func TestOpenCodeClearContextReappliesModelAndPrimaryAgent(t *testing.T) {
 		{Id: OpenCodePrimaryAgentPlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
+	agent.reapplySettings = func() {
+		agent.mu.Lock()
+		model, primaryAgent := agent.model, agent.currentPrimaryAgent
+		agent.mu.Unlock()
+		acpReapplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
+		acpReapplySetting(agent.providerName, agent.agentID, "primary agent", primaryAgent, agent.setPrimaryAgent)
+	}
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -21,6 +21,11 @@ type openCodeRecordedRequest struct {
 
 func newOpenCodeAgentForRPC(t *testing.T) (*OpenCodeAgent, func() []openCodeRecordedRequest) {
 	t.Helper()
+	return newOpenCodeAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+}
+
+func newOpenCodeAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*OpenCodeAgent, func() []openCodeRecordedRequest) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	readPipe, writePipe, err := os.Pipe()
@@ -62,7 +67,11 @@ func newOpenCodeAgentForRPC(t *testing.T) (*OpenCodeAgent, func() []openCodeReco
 			requests = append(requests, openCodeRecordedRequest{Method: req.Method, Params: req.Params})
 			mu.Unlock()
 			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-				ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+				body := json.RawMessage(`{}`)
+				if respond != nil {
+					body = respond(req.Method)
+				}
+				ch.(chan json.RawMessage) <- body
 			}
 		}
 	}()
@@ -185,6 +194,35 @@ func TestOpenCodeUpdateSettingsSendsSessionSetMode(t *testing.T) {
 	if len(recorded) != 1 || recorded[0].Method != "session/set_mode" {
 		t.Fatalf("expected one session/set_mode request, got %#v", recorded)
 	}
+}
+
+func TestOpenCodeClearContextReappliesModelAndPrimaryAgent(t *testing.T) {
+	agent, requests := newOpenCodeAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{"sessionId":"session-2"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "openai/gpt-5"
+	agent.currentPrimaryAgent = OpenCodePrimaryAgentPlan
+	agent.availablePrimaryAgents = []*leapmuxv1.AvailableOption{
+		{Id: OpenCodePrimaryAgentBuild, Name: "Build", IsDefault: true},
+		{Id: OpenCodePrimaryAgentPlan, Name: "Plan"},
+	}
+	agent.sink = &testSink{}
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "session-2", agent.sessionID)
+
+	recorded := requests()
+	require.Len(t, recorded, 3)
+	assert.Equal(t, acpMethodSessionNew, recorded[0].Method)
+	assert.Equal(t, acpMethodSessionSetModel, recorded[1].Method)
+	assert.Equal(t, "openai/gpt-5", recorded[1].Params["modelId"])
+	assert.Equal(t, acpMethodSessionSetMode, recorded[2].Method)
+	assert.Equal(t, OpenCodePrimaryAgentPlan, recorded[2].Params["modeId"])
 }
 
 func TestOpenCodeCurrentSettingsExposesPrimaryAgent(t *testing.T) {

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -210,13 +210,7 @@ func TestOpenCodeClearContextReappliesModelAndPrimaryAgent(t *testing.T) {
 		{Id: OpenCodePrimaryAgentPlan, Name: "Plan"},
 	}
 	agent.sink = &testSink{}
-	agent.reapplySettings = func() {
-		agent.mu.Lock()
-		model, primaryAgent := agent.model, agent.currentPrimaryAgent
-		agent.mu.Unlock()
-		acpApplySetting(agent.providerName, agent.agentID, "model", model, agent.setModel)
-		acpApplySetting(agent.providerName, agent.agentID, "primary agent", primaryAgent, agent.setPrimaryAgent)
-	}
+	agent.reapplySettings = agent.reapplyModelAndPrimaryAgent
 
 	sessionID, ok := agent.ClearContext()
 	require.True(t, ok)

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -239,7 +239,7 @@ func TestOpenCodeCurrentSettingsExposesPrimaryAgent(t *testing.T) {
 
 func TestOpenCodeAvailablePrimaryAgentGroupFallsBack(t *testing.T) {
 	agent := &OpenCodeAgent{}
-	groups := agent.availablePrimaryAgentGroup()
+	groups := agent.AvailableOptionGroups()
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 option group, got %d", len(groups))
 	}

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1282,7 +1282,7 @@ func (svc *Context) setAgentPermissionModeWithAgent(dbAgent db.Agent, mode strin
 
 	svc.broadcastSettingsStatusChange(dbAgent, nil)
 
-	if oldMode != "" && oldMode != mode {
+	if oldMode != "" {
 		svc.Output.BroadcastNotification(agentID, dbAgent.AgentProvider, map[string]interface{}{
 			"type": "settings_changed",
 			"changes": map[string]interface{}{
@@ -1954,6 +1954,9 @@ func (svc *Context) initiatePlanExecutionRestart(agentID, targetMode string, dbA
 // parseSetPermissionMode checks if a control_request is a set_permission_mode
 // request and returns the requested mode. Returns ("", false) if not a match.
 func parseSetPermissionMode(content string) (string, bool) {
+	if !strings.Contains(content, "set_permission_mode") {
+		return "", false
+	}
 	var msg struct {
 		Request struct {
 			Subtype string `json:"subtype"`

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1183,10 +1183,19 @@ func (svc *Context) ensureAgentRunning(agentID string) error {
 // These payloads are forwarded directly to the agent's stdin and are not
 // wrapped in a user message envelope or persisted as chat messages.
 func (svc *Context) handleControlRequestMessage(agentID, content string) {
+	// Persist set_permission_mode to the DB eagerly so that /clear
+	// (which reads the DB) always sees the latest mode. Some providers
+	// (e.g. Claude Code) don't echo the mode back in their
+	// control_response, so relying on the output handler alone would
+	// leave the DB stale.
+	mode, isSetMode := parseSetPermissionMode(content)
+	if isSetMode {
+		svc.setAgentPermissionMode(agentID, mode)
+	}
+
 	// If agent is not running, handle special cases locally.
 	if !svc.Agents.HasAgent(agentID) {
-		if mode, ok := parseSetPermissionMode(content); ok {
-			svc.setAgentPermissionMode(agentID, mode)
+		if isSetMode {
 			return
 		}
 		if isInterruptRequest(content) {
@@ -1198,15 +1207,6 @@ func (svc *Context) handleControlRequestMessage(agentID, content string) {
 			slog.Error("failed to start agent for control request", "agent_id", agentID, "error", err)
 			return
 		}
-	}
-
-	// Persist set_permission_mode to the DB eagerly so that /clear
-	// (which reads the DB) always sees the latest mode. Some providers
-	// (e.g. Claude Code) don't echo the mode back in their
-	// control_response, so relying on the output handler alone would
-	// leave the DB stale.
-	if mode, ok := parseSetPermissionMode(content); ok {
-		svc.setAgentPermissionMode(agentID, mode)
 	}
 
 	// Send as raw input to the agent's stdin.

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1267,6 +1267,9 @@ func (svc *Context) setAgentPermissionMode(agentID, mode string) {
 func (svc *Context) setAgentPermissionModeWithAgent(dbAgent db.Agent, mode string) db.Agent {
 	agentID := dbAgent.ID
 	oldMode := dbAgent.PermissionMode
+	if oldMode == mode {
+		return dbAgent
+	}
 	if err := svc.Queries.SetAgentPermissionMode(bgCtx(), db.SetAgentPermissionModeParams{
 		PermissionMode: mode,
 		ID:             agentID,

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1312,6 +1312,9 @@ func (svc *Context) setAgentCollaborationModeWithAgent(dbAgent db.Agent, mode st
 	agentID := dbAgent.ID
 	extras := loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider)
 	oldMode := extras[agent.CodexExtraCollaborationMode]
+	if oldMode == mode {
+		return dbAgent
+	}
 	extras[agent.CodexExtraCollaborationMode] = mode
 	newExtraSettings := marshalExtraSettings(extras)
 	if err := svc.Queries.SetAgentExtraSettings(bgCtx(), db.SetAgentExtraSettingsParams{
@@ -1332,18 +1335,16 @@ func (svc *Context) setAgentCollaborationModeWithAgent(dbAgent db.Agent, mode st
 
 	svc.broadcastSettingsStatusChange(dbAgent, extras)
 
-	if oldMode != mode {
-		svc.Output.BroadcastNotification(agentID, dbAgent.AgentProvider, map[string]interface{}{
-			"type": "settings_changed",
-			"changes": map[string]interface{}{
-				agent.CodexExtraCollaborationMode: map[string]string{
-					"old": oldMode, "new": mode,
-					"label":    svc.optionGroupLabel(agentID, agent.CodexExtraCollaborationMode, dbAgent.AgentProvider),
-					"oldLabel": svc.optionLabel(agentID, agent.CodexExtraCollaborationMode, oldMode, dbAgent.AgentProvider), "newLabel": svc.optionLabel(agentID, agent.CodexExtraCollaborationMode, mode, dbAgent.AgentProvider),
-				},
+	svc.Output.BroadcastNotification(agentID, dbAgent.AgentProvider, map[string]interface{}{
+		"type": "settings_changed",
+		"changes": map[string]interface{}{
+			agent.CodexExtraCollaborationMode: map[string]string{
+				"old": oldMode, "new": mode,
+				"label":    svc.optionGroupLabel(agentID, agent.CodexExtraCollaborationMode, dbAgent.AgentProvider),
+				"oldLabel": svc.optionLabel(agentID, agent.CodexExtraCollaborationMode, oldMode, dbAgent.AgentProvider), "newLabel": svc.optionLabel(agentID, agent.CodexExtraCollaborationMode, mode, dbAgent.AgentProvider),
 			},
-		})
-	}
+		},
+	})
 
 	return dbAgent
 }

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1200,6 +1200,15 @@ func (svc *Context) handleControlRequestMessage(agentID, content string) {
 		}
 	}
 
+	// Persist set_permission_mode to the DB eagerly so that /clear
+	// (which reads the DB) always sees the latest mode. Some providers
+	// (e.g. Claude Code) don't echo the mode back in their
+	// control_response, so relying on the output handler alone would
+	// leave the DB stale.
+	if mode, ok := parseSetPermissionMode(content); ok {
+		svc.setAgentPermissionMode(agentID, mode)
+	}
+
 	// Send as raw input to the agent's stdin.
 	if err := svc.Agents.SendRawInput(agentID, []byte(content)); err != nil {
 		slog.Error("failed to send control request to agent", "agent_id", agentID, "error", err)

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -487,3 +487,44 @@ func TestUpdateAgentSettings_BroadcastsGeminiPermissionModeLabels(t *testing.T) 
 	assert.Equal(t, "Default", change["oldLabel"])
 	assert.Equal(t, "YOLO", change["newLabel"])
 }
+
+func TestSendAgentRawMessage_SetPermissionModePersistsToDBWhileRunning(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.SetAgentPermissionMode(ctx, db.SetAgentPermissionModeParams{
+		PermissionMode: "default",
+		ID:             "agent-1",
+	}))
+
+	// Register a mock agent so HasAgent returns true.
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// Send set_permission_mode via SendAgentRawMessage while the agent
+	// is running. The DB should be updated eagerly, even if the agent
+	// doesn't echo the mode back in its control_response.
+	dispatch(d, "SendAgentRawMessage", &leapmuxv1.SendAgentRawMessageRequest{
+		AgentId: "agent-1",
+		Content: `{"type":"control_request","request_id":"r1","request":{"subtype":"set_permission_mode","mode":"bypassPermissions"}}`,
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, "bypassPermissions", dbAgent.PermissionMode,
+		"permission mode should be persisted to DB when set_permission_mode is sent while agent is running")
+}

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -7,20 +7,18 @@ import { labelRow, treeContainer } from '~/components/common/Dialog.css'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
-import { safeGetJson, safeSetJson } from '~/lib/browserStorage'
+import { KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN, safeGetJson, safeSetJson } from '~/lib/browserStorage'
 import { emptyState } from '~/styles/shared.css'
 
 interface DirectorySelectorProps {
   state: WorkerDialogState
 }
 
-const SHOW_HIDDEN_KEY = 'directorySelector:showHidden'
-
 export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
-  const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(SHOW_HIDDEN_KEY) ?? true)
+  const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN) ?? true)
 
   createEffect(on(showHiddenFiles, (value) => {
-    safeSetJson(SHOW_HIDDEN_KEY, value)
+    safeSetJson(KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN, value)
   }, { defer: true }))
 
   return (

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -14,7 +14,7 @@ import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
-import { safeGetJson, safeSetJson } from '~/lib/browserStorage'
+import { PREFIX_FILES_SHOW_HIDDEN, safeGetJson, safeSetJson } from '~/lib/browserStorage'
 import { DirectoryTree } from './DirectoryTree'
 import * as styles from './FilesSection.css'
 import { DiffStatsBadge, getGitFileIconClass } from './gitStatusUtils'
@@ -143,7 +143,7 @@ export const FilesSectionHeaderActions: Component<FilesSectionHeaderActionsProps
 export const FilesSection: Component<FilesSectionProps> = (props) => {
   const [activeFilter, setActiveFilter] = createSignal<GitFilterTab>('all')
   const [flatListMode, setFlatListMode] = createSignal(false)
-  const showHiddenStorageKey = () => `files:showHidden:${props.workerId}:${props.workingDir}`
+  const showHiddenStorageKey = () => `${PREFIX_FILES_SHOW_HIDDEN}${props.workerId}:${props.workingDir}`
   const [showHiddenFiles, setShowHiddenFiles] = createSignal(safeGetJson<boolean>(showHiddenStorageKey()) ?? true)
   let treeHandle: DirectoryTreeHandle | undefined
 

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -52,6 +52,7 @@ export const PREFIX_AGENT_SESSION = 'leapmux:agent-session:'
 export const PREFIX_ASK_STATE = 'leapmux:ask-state:'
 export const PREFIX_WORKER_INFO = 'leapmux:worker-info:'
 export const PREFIX_LOCAL_MESSAGES = 'leapmux:local-messages:'
+export const PREFIX_FILES_SHOW_HIDDEN = 'leapmux:files-show-hidden:'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const HOUR_MS = 60 * 60 * 1000
@@ -66,6 +67,7 @@ export const DYNAMIC_KEY_TTLS: ReadonlyArray<{ prefix: string, ttlMs: number }> 
   { prefix: PREFIX_ASK_STATE, ttlMs: 1 * DAY_MS },
   { prefix: PREFIX_WORKER_INFO, ttlMs: 7 * DAY_MS },
   { prefix: PREFIX_LOCAL_MESSAGES, ttlMs: 7 * DAY_MS },
+  { prefix: PREFIX_FILES_SHOW_HIDDEN, ttlMs: 7 * DAY_MS },
 ]
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -37,12 +37,14 @@ export interface BrowserPreferences {
 export const KEY_BROWSER_PREFS = 'leapmux:browser-prefs'
 export const KEY_MRU_AGENT_PROVIDERS = 'leapmux:mru-agent-providers'
 export const KEY_KEY_PINS = 'leapmux:key-pins'
+export const KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN = 'leapmux:directory-selector-show-hidden'
 
 /** Keys that are never cleaned up and stored without wrapping. */
 export const STATIC_KEYS = new Set([
   KEY_BROWSER_PREFS,
   KEY_MRU_AGENT_PROVIDERS,
   KEY_KEY_PINS,
+  KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN,
 ])
 
 /** Dynamic key prefixes — single source of truth for all consumers. */


### PR DESCRIPTION
## Motivation
Each ACP-based agent (Copilot, Cursor, Gemini, Goose, Kilo, OpenCode) had its
own copy of `CurrentSettings()`, `UpdateSettings()`, and logic for handling
permission modes and primary-agent option groups. This duplication made it
easy for one agent's implementation to drift from the others. There was also a
correctness bug: after `ClearContext()` issued `session/new` to start a fresh
session, the previously saved settings (model, permission mode, primary agent)
were never re-applied, so the agent would revert to defaults. Additionally,
some providers (e.g., Claude Code) do not echo the permission mode back in
control responses, meaning a `/clear` that followed a `set_permission_mode`
request could lose the latest mode.

## Modifications
- Moved `CurrentSettings()`, `UpdateSettings()`, and all permission/primary-agent
  handling into the shared `acpBase` struct, removing the per-agent duplicates in
  Copilot, Cursor, Gemini, Goose, Kilo, and OpenCode.
- Added a `reapplySettings` callback to `acpBase` that is invoked by
  `ClearContext()` after `session/new`, re-applying the saved model, permission
  mode, and primary-agent selection to the new session.
- Extracted shared helper functions: `permissionModeOptionGroups()`,
  `primaryAgentOptionGroups()`, `primaryAgentCurrentSettings()`,
  `primaryAgentUpdateSettings()`, and `acpApplySetting()`.
- (Breaking) Removed the `OpenCodeExtraPrimaryAgent` constant. Use the new
  `OptionGroupKeyPrimaryAgent` constant (defined in `agent.go`) instead.
- In the service layer, `handleControlRequestMessage` now persists
  `set_permission_mode` requests to the database immediately rather than waiting
  for a provider echo, so `/clear` always reads the latest mode.
- Added idempotency guards to `setAgentPermissionModeWithAgent` and
  `setAgentCollaborationModeWithAgent` to skip redundant DB writes and
  notifications when the value has not changed.
- Added `ClearContext` reapplication tests for Cursor, Gemini, and OpenCode
  agents; refactored test helpers to accept flexible response handlers.
- Centralized `KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN` and `PREFIX_FILES_SHOW_HIDDEN`
  localStorage key constants in `browserStorage.ts`.

## Result
After `ClearContext()` (e.g., the `/clear` command), agents now correctly
restore their previously configured model, permission mode, and primary agent
instead of resetting to defaults. The permission mode is also reliably preserved
across `/clear` for providers that do not echo it back. Callers that referenced
`OpenCodeExtraPrimaryAgent` must migrate to `OptionGroupKeyPrimaryAgent`.
