### PR TITLE
Fix Linux desktop packaging, window management, and menu bar handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: backend/go.mod
+          cache-dependency-path: |
+            backend/go.sum
+            desktop/go/go.sum
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /LeapMux*.app/
 /LeapMux*.dmg
 /LeapMux*.exe
+/LeapMux*.msi
+/leapmux-desktop*.deb
+/leapmux-desktop*.AppImage
 
 # Generated code
 generated/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /LeapMux*.dmg
 /LeapMux*.exe
 /LeapMux*.msi
+/leapmux-desktop
 /leapmux-desktop*.deb
 /leapmux-desktop*.AppImage
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ frontend/src/spinners/
 /desktop/go/bin/
 /desktop/rust/gen/
 /desktop/rust/icons/
+/desktop/rust/scripts/linuxdeploy-wrapper
 /desktop/rust/target/
 
 # IDE

--- a/README.md
+++ b/README.md
@@ -90,24 +90,26 @@ Run `leapmux` with no subcommand for a zero-config, single-user setup. Hub and W
 
 For multi-user and remote setups, run `leapmux hub` and `leapmux worker` separately. The Hub handles authentication and relays end-to-end encrypted traffic between the Frontend and Workers. Workers can be on different machines, behind NATs — they initiate outbound connections to the Hub.
 
+The Hub supports multiple database backends — **SQLite** (default), **PostgreSQL**, **MySQL**, **CockroachDB**, **YugabyteDB**, and **TiDB** — configured via the `storage.type` option. Workers always use SQLite locally.
+
 ```
-┌─────────────────┐              ┌──────────────────┐              ┌───────────────────┐
-│                 │  ConnectRPC  │                  │     gRPC     │  Worker 1         │
-│    Frontend     │◄────────────►│       Hub        │◄────────────►│  ┌─────────────┐  │
-│   (Browser /    │  WebSocket   │     (Relay)      │              │  │   Agents    │  │
-│   Desktop App)  │              │                  │              │  │ (multiple)  │  │
-│                 │              │    Go Service    │              │  └─────────────┘  │
-└─────────────────┘              │    + Database    │              │  + SQLite         │
-                                 │                  │              └───────────────────┘
-                                 └──────────────────┘                        ⋮
-                                                                   ┌───────────────────┐
-                                                                   │  Worker N         │
-                                                                   │  ┌─────────────┐  │
-                                                                   │  │   Agents    │  │
-                                                                   │  │ (multiple)  │  │
-                                                                   │  └─────────────┘  │
-                                                                   │  + SQLite         │
-                                                                   └───────────────────┘
+┌────────────────┐              ┌──────────────────┐              ┌──────────────────┐
+│                │  ConnectRPC  │                  │     gRPC     │  Worker 1        │
+│   Frontend     │◄────────────►│       Hub        │◄────────────►│  ┌────────────┐  │
+│  (Browser /    │  WebSocket   │     (Relay)      │              │  │   Agents   │  │
+│  Desktop App)  │              │                  │              │  │ (multiple) │  │
+│                │              │    Go Service    │              │  └────────────┘  │
+└────────────────┘              │  + Database      │              │  + SQLite        │
+                                │   (SQLite,       │              └──────────────────┘
+                                │    PostgreSQL,   │                        ⋮
+                                │    MySQL, ...)   │              ┌──────────────────┐
+                                └──────────────────┘              │  Worker N        │
+                                                                  │  ┌────────────┐  │
+                                                                  │  │   Agents   │  │
+                                                                  │  │ (multiple) │  │
+                                                                  │  └────────────┘  │
+                                                                  │  + SQLite        │
+                                                                  └──────────────────┘
 ```
 
 ### Modes
@@ -120,8 +122,9 @@ LeapMux is a single binary with these subcommands:
 | `leapmux hub` | Hub | Central service only (authentication, relay, database) |
 | `leapmux worker` | Worker | Connects to a remote Hub |
 | `leapmux dev` | Dev | Hub + Worker on `:4327` (all interfaces), login required, all features |
+| `leapmux admin` | Admin | CLI for managing orgs, users, sessions, workers, OAuth providers, encryption keys, and database |
 | `leapmux version` | — | Prints version and exits |
-| Desktop app | Solo | Native desktop app — runs solo mode in an embedded WebView |
+| Desktop app | — | Native desktop app — runs solo mode or connects to a remote hub in an embedded WebView |
 
 ### Components
 
@@ -135,7 +138,7 @@ LeapMux is a single binary with these subcommands:
 **Hub (Go)**
 - Authentication, workspace management, and worker registration service
 - Relays encrypted Frontend-Worker traffic without decrypting it
-- Stores persistent data in SQLite (users, workspaces, worker registry)
+- Pluggable storage backend: SQLite (default), PostgreSQL, MySQL, CockroachDB, YugabyteDB, or TiDB
 - No access to channel plaintext — acts as an authenticated relay
 
 **Worker (Go)**
@@ -176,11 +179,17 @@ Before you begin, ensure you have the following installed:
 
 Install [Bun](https://bun.sh/) by following the instructions at https://bun.sh/.
 
+Install the [Rust toolchain](https://rustup.rs/) for desktop app builds:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+```
+
 Install the remaining dependencies with [Homebrew](https://brew.sh/):
 
 ```bash
 brew install buf go go-task golangci-lint mprocs sqlc yq
-rustup default stable
 ```
 
 ### Arch Linux
@@ -203,6 +212,12 @@ Install the remaining dependencies from the [AUR](https://wiki.archlinux.org/tit
 ```bash
 yay -S mprocs-bin
 rustup default stable
+```
+
+For desktop app builds, install the [Tauri prerequisites for Arch Linux](https://v2.tauri.app/start/prerequisites/#linux):
+
+```bash
+sudo pacman -S webkit2gtk-4.1 libappindicator-gtk3 librsvg patchelf
 ```
 
 ### Operating System
@@ -239,6 +254,11 @@ To run in solo mode (localhost-only, no login) instead of dev mode during develo
 task dev-solo
 ```
 
+To develop the desktop app (Tauri + Go sidecar):
+```bash
+task dev-desktop
+```
+
 ## Development
 
 ### Building
@@ -255,7 +275,7 @@ task build-frontend   # Build frontend assets
 task build-desktop    # Build desktop app for current platform (Tauri v2 + Rust)
 ```
 
-The `leapmux` binary is output to `backend/build/bin/`. The Tauri desktop bundle is emitted under `desktop/src-tauri/target/`.
+The `leapmux` binary is output to the repository root. The Tauri desktop bundle is emitted under `desktop/rust/target/`.
 
 ### Testing
 
@@ -268,6 +288,7 @@ Run specific test suites:
 ```bash
 task test-backend       # Backend tests
 task test-frontend      # Frontend tests (Vitest)
+task test-desktop       # Desktop sidecar tests
 task test-e2e           # End-to-end tests (Playwright)
 ```
 
@@ -296,7 +317,7 @@ Run specific linters:
 task lint-proto      # Lint Protocol Buffer definitions
 task lint-backend    # Lint Go code (hub + worker)
 task lint-frontend   # Lint frontend code (ESLint)
-task lint-desktop    # Lint desktop Go sidecar + Tauri Rust shell
+task lint-desktop    # Lint desktop Go sidecar + Tauri Rust shell (clippy)
 ```
 
 Auto-fix lint violations:
@@ -304,14 +325,14 @@ Auto-fix lint violations:
 task lint-fix            # Fix all (Go, frontend, desktop)
 task lint-fix-backend    # Fix Go code (golangci-lint --fix)
 task lint-fix-frontend   # Fix frontend code (ESLint --fix)
-task lint-fix-desktop    # Fix desktop Go code + format Tauri Rust shell
+task lint-fix-desktop    # Fix desktop Go code + Tauri Rust code (clippy --fix)
 ```
 
 ### Desktop and Mobile Prerequisites
 
-Desktop builds use Tauri v2:
+Desktop builds use [Tauri v2](https://v2.tauri.app/start/prerequisites/):
 - macOS: Xcode Command Line Tools, Rust, WebKit (system)
-- Linux: Rust plus the WebKitGTK/Tauri native dependencies for your distro
+- Linux: Rust plus the WebKitGTK/Tauri native dependencies for your distro (see [Tauri Linux prerequisites](https://v2.tauri.app/start/prerequisites/#linux))
 - Windows: Rust MSVC toolchain plus WebView2
 
 Future mobile builds use Tauri mobile tooling:
@@ -334,7 +355,7 @@ task generate-sqlc    # Generate type-safe SQL code (hub and worker)
 Task uses checksums to skip generation when source files haven't changed. To force regeneration, use `task --force generate`.
 
 Always run `task generate-proto` after modifying `.proto` files in `/proto/leapmux/v1/`.
-Always run `task generate-sqlc` after modifying `.sql` files in `/backend/internal/hub/db/queries/` or `/backend/internal/worker/db/queries/`.
+Always run `task generate-sqlc` after modifying `.sql` files in `/backend/internal/hub/store/*/db/queries/` or `/backend/internal/worker/db/queries/`.
 
 ### Preparation
 
@@ -436,8 +457,8 @@ Tool and base image versions are centralized in the `versions.yaml` file at the 
 - **[Goose](https://pressly.github.io/goose/)** - Database migrations
 - **[gRPC](https://grpc.io/)** - Standard gRPC (Worker communication)
 - **[Protocol Buffers](https://protobuf.dev/)** - Service and message definitions
-- **[SQLite](https://sqlite.org/)** - Embedded database
-- **[sqlc](https://sqlc.dev/)** - Type-safe SQL code generation
+- **Pluggable database** - SQLite (default), PostgreSQL, MySQL, CockroachDB, YugabyteDB, or TiDB
+- **[sqlc](https://sqlc.dev/)** - Type-safe SQL code generation (per-backend: SQLite, PostgreSQL, MySQL)
 
 ### Worker (Agent Wrapper)
 
@@ -449,7 +470,7 @@ Tool and base image versions are centralized in the `versions.yaml` file at the 
 
 ### Desktop (optional)
 
-- **[Tauri](https://tauri.app/)** - Desktop application framework (Rust + native WebView)
+- **[Tauri v2](https://v2.tauri.app/)** - Desktop application framework (Rust + native WebView)
 - **Go desktop sidecar** - Desktop-only service for Solo startup, local proxying, tunnels, and OS integrations
 
 ### Build Tools
@@ -467,11 +488,12 @@ leapmux/
 ├── .github/workflows/       # CI, Docker, and release workflows
 │
 ├── backend/                 # Go backend module
-│   ├── build/               # Build output (gitignored)
+│   ├── channelwire/         # E2EE channel wire format definitions
 │   │
 │   ├── cmd/leapmux/         # Unified binary entry point
+│   │   ├── admin*.go        # Admin CLI (org, user, session, worker, oauth, encryption, db)
 │   │   ├── hub.go           # Hub mode
-│   │   ├── main.go          # Subcommand routing (hub, worker, solo, dev)
+│   │   ├── main.go          # Subcommand routing (hub, worker, solo, dev, admin)
 │   │   ├── solo.go          # Solo/dev mode (hub + worker, default)
 │   │   └── worker.go        # Worker mode
 │   │
@@ -487,24 +509,37 @@ leapmux/
 │   │   │   ├── auth/        # Session-based authentication
 │   │   │   ├── bootstrap/   # Database initialization and seeding
 │   │   │   ├── channelmgr/  # E2EE channel routing and chunk validation
-│   │   │   ├── config/      # Hub configuration
-│   │   │   ├── db/          # Database driver, migrations, and queries
+│   │   │   ├── cleanup/     # Periodic cleanup of expired data
+│   │   │   ├── config/      # Hub configuration (incl. storage backend selection)
 │   │   │   ├── frontend/    # Frontend asset embedding and dev proxy
+│   │   │   ├── keystore/    # Encryption key management and rotation
 │   │   │   ├── layout/      # Workspace tiling layout management
 │   │   │   ├── notifier/    # Worker notification queue (persistent delivery with retries)
+│   │   │   ├── oauth/       # OAuth/OIDC provider integrations (GitHub, OIDC)
+│   │   │   ├── password/    # Password hashing and verification
 │   │   │   ├── service/     # RPC service implementations (auth, workspace, channel relay)
+│   │   │   ├── store/       # Storage abstraction and backend implementations
+│   │   │   │   ├── sqlite/      # SQLite backend (default)
+│   │   │   │   ├── postgres/    # PostgreSQL backend (also used by CockroachDB, YugabyteDB)
+│   │   │   │   ├── mysql/       # MySQL backend (also used by TiDB)
+│   │   │   │   ├── cockroachdb/ # CockroachDB integration tests
+│   │   │   │   ├── yugabytedb/  # YugabyteDB integration tests
+│   │   │   │   ├── tidb/        # TiDB integration tests
+│   │   │   │   ├── sqlutil/     # Shared SQL helpers (migrations, bulk ops, converters)
+│   │   │   │   └── storetest/   # Backend-agnostic test suite
+│   │   │   ├── storeopen/   # Store factory (opens backend from config)
 │   │   │   └── workermgr/   # Worker connection registry and pending approvals
 │   │   │
 │   │   ├── logging/         # Structured logging and middleware
 │   │   ├── metrics/         # Prometheus metrics and interceptors
 │   │   ├── noise/           # Noise_NK protocol and key fingerprinting
-│   │   ├── util/            # Shared utilities (id, lexorank, msgcodec, timefmt, testutil)
+│   │   ├── util/            # Shared utilities (id, lexorank, msgcodec, ptrconv, sqlitedb, timefmt, validate, testutil)
 │   │   │
 │   │   └── worker/          # Worker implementation
 │   │       ├── agent/       # Agent process management
 │   │       ├── channel/     # E2EE channel session management and dispatch
 │   │       ├── config/      # Worker configuration
-│   │       ├── db/          # Worker database driver, migrations, and queries
+│   │       ├── db/          # Worker database (SQLite-only), migrations, and queries
 │   │       ├── filebrowser/ # File system access
 │   │       ├── gitutil/     # Git repository utilities
 │   │       ├── hub/         # gRPC client to Hub (with auto-reconnect)
@@ -513,17 +548,22 @@ leapmux/
 │   │       └── wakelock/    # System wake lock management
 │   │
 │   ├── solo/                # Shared solo mode startup logic
+│   ├── spautil/             # SPA HTTP handler utilities
+│   ├── tunnel/              # Tunnel channel and connection management
+│   ├── util/version/        # Build version information
 │   │
 │   └── worker/              # Worker public API (thin wrapper)
 │       └── runner.go        # Run(), RunConfig
 │
-├── desktop/                 # Tauri desktop app + Go desktop sidecar
-│   ├── src-tauri/           # Tauri v2 Rust shell
-│   └── scripts/             # Packaging helpers
+├── desktop/                 # Tauri v2 desktop app + Go desktop sidecar
+│   ├── go/                  # Go desktop sidecar (solo startup, proxy, tunnels, OS integrations)
+│   └── rust/                # Tauri v2 Rust shell (WebView, packaging, icons)
+│       └── scripts/         # Packaging helpers (DMG creation, icon generation)
 │
 ├── docker/                  # Dockerfile and s6-overlay service definitions
 │
 ├── frontend/                # SolidJS web application
+│   ├── scripts/             # Build and development scripts
 │   ├── src/
 │   │   ├── api/             # ConnectRPC client setup
 │   │   ├── components/      # UI components (chat, terminal, filebrowser, shell, etc.)
@@ -532,11 +572,14 @@ leapmux/
 │   │   ├── hooks/           # Custom hooks
 │   │   ├── lib/             # Utility libraries
 │   │   ├── routes/          # Route definitions
+│   │   ├── spinners/        # Spinner verb JSON files (generated, gitignored)
 │   │   ├── stores/          # State management (agents, chat, terminals, etc.)
 │   │   ├── styles/          # Global styles and themes
 │   │   ├── types/           # TypeScript type definitions
 │   │   └── utils/           # Shared utility functions
-│   └── tests/               # Unit tests (Vitest) and E2E tests (Playwright)
+│   └── tests/
+│       ├── e2e/             # End-to-end tests (Playwright)
+│       └── unit/            # Unit tests (Vitest)
 │
 ├── icons/                   # SVG icons (app logo and agent provider icons)
 │
@@ -544,13 +587,15 @@ leapmux/
 │   └── leapmux/v1/          # Service and message definitions
 │
 ├── scripts/                 # Utility scripts
-│   ├── license-overrides/   # Vendored licenses for packages missing them
-│   └── generate-notice.mjs  # License collection and NOTICE.md/HTML generation
+│   ├── build-ico.mjs        # ICO file builder
+│   ├── generate-notice.mjs  # License collection and NOTICE.md/HTML generation
+│   └── license-overrides/   # Vendored licenses for packages missing them
 │
 ├── buf.gen.yaml             # Protocol Buffer code generation targets
 ├── buf.yaml                 # Protocol Buffer linting configuration
-├── go.work                  # Go workspace (backend + desktop modules)
+├── go.work                  # Go workspace (backend + desktop/go modules)
 ├── mprocs.yaml              # Dev mode process configuration (task dev)
+├── mprocs-desktop.yaml      # Desktop dev mode process configuration (task dev-desktop)
 ├── mprocs-solo.yaml         # Solo mode process configuration (task dev-solo)
 ├── NOTICE.md                # Third-party dependency licenses (generated)
 ├── README.md                # This file

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,6 +159,9 @@ tasks:
 
   prepare-desktop:
     desc: Prepare desktop for builds
+    preconditions:
+      - sh: '[ "{{OS}}" = "darwin" ] || [ "{{OS}}" = "linux" ] || [ "{{OS}}" = "windows" ]'
+        msg: "Unsupported OS: {{OS}}. Desktop builds require macOS, Linux, or Windows."
     sources:
       - icons/leapmux-icon.svg
       - icons/leapmux-icon-corners.svg
@@ -176,7 +179,7 @@ tasks:
       - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon.svg icons/leapmux-icon-corners.svg desktop/rust/icons/icon.png desktop/rust/icons/icon.ico opaque
         if: '[ "{{OS}}" = "darwin" ]'
       - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon-corners.svg icons/leapmux-icon-corners.svg desktop/rust/icons/icon.png desktop/rust/icons/icon.ico transparent
-        if: '[ "{{OS}}" != "darwin" ]'
+        if: '[ "{{OS}}" = "linux" ] || [ "{{OS}}" = "windows" ]'
 
   # --- Build ---
 
@@ -236,11 +239,16 @@ tasks:
 
   build-desktop:
     desc: Build desktop
+    preconditions:
+      - sh: '[ "{{OS}}" = "darwin" ] || [ "{{OS}}" = "linux" ] || [ "{{OS}}" = "windows" ]'
+        msg: "Unsupported OS: {{OS}}. Desktop builds require macOS, Linux, or Windows."
     cmds:
       - task: build-desktop-darwin
         if: '[ "{{OS}}" = "darwin" ]'
-      - task: build-desktop-not-darwin
-        if: '[ "{{OS}}" != "darwin" ]'
+      - task: build-desktop-linux
+        if: '[ "{{OS}}" = "linux" ]'
+      - task: build-desktop-windows
+        if: '[ "{{OS}}" = "windows" ]'
 
   build-desktop-darwin:
     desc: Build desktop for macOS
@@ -256,9 +264,8 @@ tasks:
       - desktop/rust/src/**/*
       - desktop/rust/Cargo.*
       - desktop/rust/capabilities/**/*
-      - desktop/rust/tauri*.conf.json
+      - desktop/rust/tauri.conf.json
       - desktop/rust/icons/icon.png
-      - desktop/rust/icons/icon.ico
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
@@ -279,8 +286,8 @@ tasks:
         "desktop/rust/target/release/bundle/dmg/LeapMux Desktop {{.VERSION}} ({{ARCH}}).dmg"
       - cp -f "desktop/rust/target/release/bundle/dmg/LeapMux Desktop {{.VERSION}} ({{ARCH}}).dmg" "LeapMux Desktop {{.VERSION}} ({{ARCH}}).dmg"
 
-  build-desktop-not-darwin:
-    desc: Build desktop for Windows and linux
+  build-desktop-linux:
+    desc: Build desktop for Linux
     sources:
       - backend/go.mod
       - backend/go.sum
@@ -293,19 +300,52 @@ tasks:
       - desktop/rust/src/**/*
       - desktop/rust/Cargo.*
       - desktop/rust/capabilities/**/*
-      - desktop/rust/tauri*.conf.json
+      - desktop/rust/tauri.conf.json
+      - desktop/rust/tauri.linux.conf.json
+      - desktop/rust/desktop-template.desktop
       - desktop/rust/icons/icon.png
-      - desktop/rust/icons/icon.ico
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
     generates:
-      - desktop/go/bin/leapmux-desktop-service-*
+      - leapmux-desktop*.deb
+      - leapmux-desktop*.AppImage
     cmds:
       - task: prepare-desktop
       - task: build-desktop-sidecar
       - desktop/rust/scripts/patch-linuxdeploy.sh
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
+      - cp -f desktop/rust/target/release/bundle/deb/leapmux-desktop*.deb .
+      - cp -f desktop/rust/target/release/bundle/appimage/leapmux-desktop*.AppImage .
+
+  build-desktop-windows:
+    desc: Build desktop for Windows
+    sources:
+      - backend/go.mod
+      - backend/go.sum
+      - backend/**/*.go
+      - desktop/go/go.mod
+      - desktop/go/go.sum
+      - desktop/go/**/*.go
+      - exclude: desktop/go/bin/**/*
+      - desktop/rust/*.rs
+      - desktop/rust/src/**/*
+      - desktop/rust/Cargo.*
+      - desktop/rust/capabilities/**/*
+      - desktop/rust/tauri.conf.json
+      - desktop/rust/icons/icon.ico
+      - desktop/rust/scripts/**/*
+      - frontend/.output/**/*
+      - backend/internal/hub/generated/frontend/public/**/*
+    generates:
+      - LeapMux*.exe
+      - LeapMux*.msi
+    cmds:
+      - task: prepare-desktop
+      - task: build-desktop-sidecar
+      - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
+      - cp -f desktop/rust/target/release/bundle/nsis/LeapMux*.exe .
+      - cp -f desktop/rust/target/release/bundle/msi/LeapMux*.msi .
 
   # --- Testing ---
 
@@ -591,6 +631,9 @@ tasks:
     cmds:
       - rm -f  LeapMux*.dmg
       - rm -rf LeapMux*.app
+      - rm -f  leapmux-desktop*.deb
+      - rm -f  leapmux-desktop*.AppImage
+      - rm -f  LeapMux*.msi
       - rm -f  desktop/go/leapmux-desktop
       - rm -rf desktop/go/bin/
       - rm -rf desktop/rust/gen/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -304,6 +304,7 @@ tasks:
     cmds:
       - task: prepare-desktop
       - task: build-desktop-sidecar
+      - desktop/rust/scripts/patch-linuxdeploy.sh
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
 
   # --- Testing ---

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -308,6 +308,7 @@ tasks:
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
     generates:
+      - leapmux-desktop
       - leapmux-desktop*.deb
       - leapmux-desktop*.AppImage
     cmds:
@@ -315,6 +316,7 @@ tasks:
       - task: build-desktop-sidecar
       - desktop/rust/scripts/patch-linuxdeploy.sh
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
+      - cp -f desktop/rust/target/release/leapmux-desktop .
       - cp -f desktop/rust/target/release/bundle/deb/leapmux-desktop*.deb .
       - cp -f desktop/rust/target/release/bundle/appimage/leapmux-desktop*.AppImage .
 
@@ -631,6 +633,7 @@ tasks:
     cmds:
       - rm -f  LeapMux*.dmg
       - rm -rf LeapMux*.app
+      - rm -f  leapmux-desktop
       - rm -f  leapmux-desktop*.deb
       - rm -f  leapmux-desktop*.AppImage
       - rm -f  LeapMux*.msi

--- a/desktop/rust/capabilities/default.json
+++ b/desktop/rust/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-set-size",
+    "core:window:allow-show",
     "core:window:allow-center",
     "core:window:allow-maximize",
     "core:webview:allow-create-webview-window"

--- a/desktop/rust/desktop-template.desktop
+++ b/desktop/rust/desktop-template.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Categories=
+Exec=leapmux-desktop
+StartupWMClass=leapmux-desktop
+Icon=leapmux-desktop
+Name=LeapMux Desktop
+Terminal=false
+Type=Application

--- a/desktop/rust/scripts/linuxdeploy-wrapper.c
+++ b/desktop/rust/scripts/linuxdeploy-wrapper.c
@@ -1,0 +1,57 @@
+/*
+ * ELF wrapper for linuxdeploy that runs the extracted (patched) copy.
+ *
+ * Tauri writes to bytes 8-10 of the cached linuxdeploy binary (ELF header
+ * padding), which corrupts shell script shebangs. This compiled wrapper
+ * is a proper ELF binary, so those writes are harmless.
+ *
+ * Build:  gcc -static -O2 -o linuxdeploy-wrapper linuxdeploy-wrapper.c
+ */
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    /* Resolve the directory containing this binary. */
+    char self[4096];
+    ssize_t n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+    if (n < 0) {
+        perror("readlink /proc/self/exe");
+        return 1;
+    }
+    self[n] = '\0';
+    char *dir = dirname(self);
+
+    /* Path to the extracted AppRun. */
+    char apprun[4096];
+    snprintf(apprun, sizeof(apprun), "%s/linuxdeploy-extracted/AppRun", dir);
+
+    /* Prepend cache dir to PATH so linuxdeploy discovers its plugins. */
+    const char *old_path = getenv("PATH");
+    char new_path[8192];
+    snprintf(new_path, sizeof(new_path), "%s:%s", dir, old_path ? old_path : "");
+    setenv("PATH", new_path, 1);
+
+    /*
+     * Build new argv, filtering out --appimage-extract-and-run which is
+     * an AppImage-runtime flag that the raw binary does not understand.
+     */
+    char **new_argv = calloc(argc + 1, sizeof(char *));
+    if (!new_argv) {
+        perror("calloc");
+        return 1;
+    }
+    int j = 0;
+    new_argv[j++] = apprun;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--appimage-extract-and-run") != 0)
+            new_argv[j++] = argv[i];
+    }
+    new_argv[j] = NULL;
+
+    execv(apprun, new_argv);
+    perror("execv");
+    return 1;
+}

--- a/desktop/rust/scripts/patch-linuxdeploy.sh
+++ b/desktop/rust/scripts/patch-linuxdeploy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Patches the cached linuxdeploy AppImage so that it uses the system's `strip`
+# instead of its bundled one (binutils 2.35), which cannot handle the
+# `.relr.dyn` sections produced by modern toolchains (binutils >= 2.36).
+#
+# Also patches the GTK plugin to exclude VMware's bundled libraries from
+# recursive find, preventing deployment failures caused by VMware's old
+# libgdk_pixbuf depending on the missing libcroco-0.6.so.3.
+#
+# This script is idempotent — it only patches once and skips subsequent runs.
+#
+set -euo pipefail
+
+CACHE_DIR="${HOME}/.cache/tauri"
+APPIMAGE="${CACHE_DIR}/linuxdeploy-x86_64.AppImage"
+EXTRACTED="${CACHE_DIR}/linuxdeploy-extracted"
+GTK_PLUGIN="${CACHE_DIR}/linuxdeploy-plugin-gtk.sh"
+
+LINUXDEPLOY_URL="https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage"
+GTK_PLUGIN_URL="https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
+
+# Download linuxdeploy if not cached yet.
+mkdir -p "$CACHE_DIR"
+if [[ ! -f "$APPIMAGE" ]]; then
+    echo "patch-linuxdeploy: downloading linuxdeploy ..."
+    curl -fsSL -o "$APPIMAGE" "$LINUXDEPLOY_URL"
+    chmod +x "$APPIMAGE"
+fi
+
+# Already patched — the .orig backup and extracted directory only exist
+# after a successful patching run.
+if [[ -f "${APPIMAGE}.orig" ]] && [[ -d "$EXTRACTED" ]] && [[ -x "$EXTRACTED/AppRun" ]]; then
+    echo "patch-linuxdeploy: already patched; skipping."
+    exit 0
+fi
+
+echo "patch-linuxdeploy: extracting linuxdeploy AppImage ..."
+rm -rf "${CACHE_DIR}/squashfs-root" "$EXTRACTED"
+(cd "$CACHE_DIR" && "$APPIMAGE" --appimage-extract >/dev/null 2>&1)
+mv "${CACHE_DIR}/squashfs-root" "$EXTRACTED"
+
+echo "patch-linuxdeploy: replacing bundled strip with system strip ..."
+ln -sf /usr/bin/strip "$EXTRACTED/usr/bin/strip"
+
+echo "patch-linuxdeploy: installing compiled wrapper binary ..."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/linuxdeploy-wrapper"
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "patch-linuxdeploy: compiling wrapper ..."
+    gcc -static -O2 -o "$WRAPPER" "$SCRIPT_DIR/linuxdeploy-wrapper.c"
+fi
+mv "$APPIMAGE" "${APPIMAGE}.orig"
+cp "$WRAPPER" "$APPIMAGE"
+chmod +x "$APPIMAGE"
+
+# Download and patch the GTK plugin to exclude VMware's bundled libraries
+# from the recursive find, preventing deployment failures caused by
+# VMware's old libgdk_pixbuf depending on the missing libcroco-0.6.so.3.
+if [[ ! -f "$GTK_PLUGIN" ]]; then
+    echo "patch-linuxdeploy: downloading GTK plugin ..."
+    curl -fsSL -o "$GTK_PLUGIN" "$GTK_PLUGIN_URL"
+    chmod +x "$GTK_PLUGIN"
+fi
+if ! grep -q 'vmware' "$GTK_PLUGIN"; then
+    echo "patch-linuxdeploy: patching GTK plugin to exclude VMware libraries ..."
+    sed -i 's|find "$directory" \\( -type l -o -type f \\)|find "$directory" -not -path "*/vmware/*" \\( -type l -o -type f \\)|' "$GTK_PLUGIN"
+fi
+
+echo "patch-linuxdeploy: done."

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+compile_error!("LeapMux Desktop only supports macOS, Linux, and Windows");
+
 mod proto {
   include!(concat!(env!("OUT_DIR"), "/leapmux.desktop.v1.rs"));
 }
@@ -449,7 +452,7 @@ fn sidecar_binary_name() -> String {
   {
     format!("{name}.exe")
   }
-  #[cfg(not(target_os = "windows"))]
+  #[cfg(any(target_os = "macos", target_os = "linux"))]
   {
     name
   }
@@ -728,7 +731,7 @@ fn quit_app(app: AppHandle) {
 
 #[tauri::command]
 fn hide_menu_bar(app: AppHandle) {
-  #[cfg(not(target_os = "macos"))]
+  #[cfg(any(target_os = "linux", target_os = "windows"))]
   if let Some(w) = app.get_webview_window("main") {
     let _ = w.hide_menu();
   }
@@ -737,7 +740,7 @@ fn hide_menu_bar(app: AppHandle) {
 
 #[tauri::command]
 fn toggle_menu_bar(app: AppHandle) {
-  #[cfg(not(target_os = "macos"))]
+  #[cfg(any(target_os = "linux", target_os = "windows"))]
   if let Some(w) = app.get_webview_window("main") {
     if w.is_menu_visible().unwrap_or(false) {
       let _ = w.hide_menu();
@@ -833,15 +836,9 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     "File",
     true,
     &[
-      #[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-      )))]
+      #[cfg(any(target_os = "macos", target_os = "windows"))]
       &PredefinedMenuItem::close_window(app, None)?,
-      #[cfg(not(target_os = "macos"))]
+      #[cfg(any(target_os = "linux", target_os = "windows"))]
       &MenuItem::with_id(app, "quit", "Quit", true, Some("Ctrl+Q"))?,
     ],
   )?;
@@ -885,7 +882,7 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     "Help",
     true,
     &[
-      #[cfg(not(target_os = "macos"))]
+      #[cfg(any(target_os = "linux", target_os = "windows"))]
       &show_about,
       &open_web_inspector,
     ],
@@ -943,7 +940,7 @@ fn main() {
         }
       }
       // Re-hide the menu bar after a menu item is selected (Linux/Windows).
-      #[cfg(not(target_os = "macos"))]
+      #[cfg(any(target_os = "linux", target_os = "windows"))]
       if let Some(w) = app.get_webview_window("main") {
         let _ = w.hide_menu();
       }

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -38,8 +38,10 @@ use tokio::sync::oneshot;
 
 const SHOW_ABOUT_MENU_ID: &str = "show-about";
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
+const QUIT_MENU_ID: &str = "quit";
+const MINIMIZE_MENU_ID: &str = "minimize";
+const MAXIMIZE_MENU_ID: &str = "maximize";
 const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024; // 16 MB
-
 
 // --- Frame read/write utilities ---
 
@@ -391,8 +393,6 @@ fn handle_sidecar_event(app_handle: &AppHandle, event: proto::Event) {
 }
 
 // --- Static helpers ---
-
-
 
 fn capabilities_for(state: &ShellState) -> PlatformCapabilities {
   match state.shell_mode {
@@ -839,7 +839,7 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
       #[cfg(any(target_os = "macos", target_os = "windows"))]
       &PredefinedMenuItem::close_window(app, None)?,
       #[cfg(any(target_os = "linux", target_os = "windows"))]
-      &MenuItem::with_id(app, "quit", "Quit", true, Some("Ctrl+Q"))?,
+      &MenuItem::with_id(app, QUIT_MENU_ID, "Quit", true, Some("Ctrl+Q"))?,
     ],
   )?;
 
@@ -871,8 +871,8 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     "Window",
     true,
     &[
-      &MenuItem::with_id(app, "minimize", "Minimize", true, None::<&str>)?,
-      &MenuItem::with_id(app, "maximize", "Maximize", true, None::<&str>)?,
+      &MenuItem::with_id(app, MINIMIZE_MENU_ID, "Minimize", true, None::<&str>)?,
+      &MenuItem::with_id(app, MAXIMIZE_MENU_ID, "Maximize", true, None::<&str>)?,
     ],
   )?;
 
@@ -927,13 +927,13 @@ fn main() {
         let _ = app.emit("menu:show-about", ());
       } else if event.id() == OPEN_WEB_INSPECTOR_MENU_ID {
         open_main_web_inspector(app);
-      } else if event.id() == "quit" {
+      } else if event.id() == QUIT_MENU_ID {
         app.exit(0);
-      } else if event.id() == "minimize" {
+      } else if event.id() == MINIMIZE_MENU_ID {
         if let Some(w) = app.get_webview_window("main") {
           let _ = w.minimize();
         }
-      } else if event.id() == "maximize" {
+      } else if event.id() == MAXIMIZE_MENU_ID {
         if let Some(w) = app.get_webview_window("main") {
           let is_max = w.is_maximized().unwrap_or(false);
           if is_max { let _ = w.unmaximize(); } else { let _ = w.maximize(); }

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -18,7 +18,6 @@ use std::{
     Arc, Mutex,
   },
   thread,
-  time::Duration,
 };
 use tauri::{
   menu::{Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID},
@@ -37,6 +36,7 @@ use tokio::sync::oneshot;
 const SHOW_ABOUT_MENU_ID: &str = "show-about";
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
 const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024; // 16 MB
+
 
 // --- Frame read/write utilities ---
 
@@ -212,8 +212,6 @@ struct DesktopShell {
   close_in_progress: AtomicBool,
   exit_in_progress: AtomicBool,
   state: Mutex<ShellState>,
-  resize_debounce_tx: tokio::sync::mpsc::Sender<(u32, u32, bool)>,
-  resize_debounce_rx: Mutex<Option<tokio::sync::mpsc::Receiver<(u32, u32, bool)>>>,
 }
 
 impl DesktopShell {
@@ -260,10 +258,6 @@ impl DesktopShell {
       }
     });
 
-    // Debounce resize events: persist via sidecar RPC only after
-    // 500ms of inactivity instead of on every pixel during a drag.
-    let (resize_tx, resize_rx) = tokio::sync::mpsc::channel::<(u32, u32, bool)>(4);
-
     Ok(Self {
       app_handle,
       sidecar: SidecarProcess {
@@ -280,13 +274,7 @@ impl DesktopShell {
         hub_url: String::new(),
         local_app_url,
       }),
-      resize_debounce_tx: resize_tx,
-      resize_debounce_rx: Mutex::new(Some(resize_rx)),
     })
-  }
-
-  fn take_resize_rx(&self) -> tokio::sync::mpsc::Receiver<(u32, u32, bool)> {
-    self.resize_debounce_rx.lock().unwrap().take().expect("resize_rx already taken")
   }
 
   async fn send_request_async(&self, method: proto::request::Method) -> Result<proto::Response, String> {
@@ -401,17 +389,6 @@ fn handle_sidecar_event(app_handle: &AppHandle, event: proto::Event) {
 
 // --- Static helpers ---
 
-/// Extract logical window geometry (width, height, maximized) from any
-/// Tauri window type that provides inner_size, scale_factor, and is_maximized.
-macro_rules! window_geometry {
-  ($window:expr) => {{
-    let size = $window.inner_size().map_err(|err| format!("read window size: {err}"))?;
-    let scale_factor = $window.scale_factor().map_err(|err| format!("read scale factor: {err}"))?;
-    let size = size.to_logical::<u32>(scale_factor);
-    let maximized = $window.is_maximized().map_err(|err| format!("read maximized state: {err}"))?;
-    (size.width, size.height, maximized)
-  }};
-}
 
 
 fn capabilities_for(state: &ShellState) -> PlatformCapabilities {
@@ -712,8 +689,6 @@ fn proto_to_tunnel_info(info: &proto::TunnelInfo) -> TunnelInfoResponse {
 
 #[tauri::command]
 async fn switch_mode(shell: State<'_, Arc<DesktopShell>>, window: WebviewWindow) -> Result<(), String> {
-  let (w, h, m) = window_geometry!(&window);
-  shell.save_window_size(w, h, m).await?;
   check_response(
     shell.send_request_async(proto::request::Method::SwitchMode(proto::SwitchModeRequest {})).await?,
   )?;
@@ -732,15 +707,45 @@ async fn switch_mode(shell: State<'_, Arc<DesktopShell>>, window: WebviewWindow)
 }
 
 #[tauri::command]
-async fn restart_app(shell: State<'_, Arc<DesktopShell>>, window: WebviewWindow) -> Result<(), String> {
-  let (w, h, m) = window_geometry!(&window);
-  shell.save_window_size(w, h, m).await?;
+async fn restart_app(shell: State<'_, Arc<DesktopShell>>, _window: WebviewWindow) -> Result<(), String> {
   let current_exe = std::env::current_exe().map_err(|err| format!("resolve current exe: {err}"))?;
   Command::new(current_exe)
     .spawn()
     .map_err(|err| format!("restart app: {err}"))?;
   shell.app_handle.exit(0);
   Ok(())
+}
+
+#[tauri::command]
+async fn save_window_geometry(shell: State<'_, Arc<DesktopShell>>, width: u32, height: u32, maximized: bool) -> Result<(), String> {
+  shell.save_window_size(width, height, maximized).await
+}
+
+#[tauri::command]
+fn quit_app(app: AppHandle) {
+  app.exit(0);
+}
+
+#[tauri::command]
+fn hide_menu_bar(app: AppHandle) {
+  #[cfg(not(target_os = "macos"))]
+  if let Some(w) = app.get_webview_window("main") {
+    let _ = w.hide_menu();
+  }
+  let _ = app;
+}
+
+#[tauri::command]
+fn toggle_menu_bar(app: AppHandle) {
+  #[cfg(not(target_os = "macos"))]
+  if let Some(w) = app.get_webview_window("main") {
+    if w.is_menu_visible().unwrap_or(false) {
+      let _ = w.hide_menu();
+    } else {
+      let _ = w.show_menu();
+    }
+  }
+  let _ = app;
 }
 
 // --- Window/app helpers ---
@@ -759,13 +764,6 @@ fn open_main_web_inspector(app: &AppHandle) {
   }
 }
 
-macro_rules! try_save_window_geometry {
-  ($shell:expr, $window:expr) => {
-    if let Ok((w, h, m)) = (|| -> Result<(u32, u32, bool), String> { Ok(window_geometry!($window)) })() {
-      let _ = $shell.save_window_size(w, h, m).await;
-    }
-  };
-}
 
 fn handle_main_window_close(shell: Arc<DesktopShell>, window: Window) {
   if shell
@@ -777,7 +775,6 @@ fn handle_main_window_close(shell: Arc<DesktopShell>, window: Window) {
   }
 
   tauri::async_runtime::spawn(async move {
-    try_save_window_geometry!(&shell, &window);
     let _ = window.close();
   });
 }
@@ -792,20 +789,16 @@ fn handle_app_exit(shell: Arc<DesktopShell>) {
   }
 
   tauri::async_runtime::spawn(async move {
-    if let Some(window) = shell.app_handle.get_webview_window("main") {
-      try_save_window_geometry!(&shell, &window);
-    }
     shell.app_handle.exit(0);
   });
 }
 
 fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
-  let pkg_info = app.package_info();
 
   let show_about = MenuItem::with_id(
     app,
     SHOW_ABOUT_MENU_ID,
-    format!("About {}", pkg_info.name),
+    "About LeapMux Desktop...",
     true,
     None::<&str>,
   )?;
@@ -821,7 +814,7 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
   #[cfg(target_os = "macos")]
   let app_menu = Submenu::with_items(
     app,
-    pkg_info.name.clone(),
+    "LeapMux Desktop",
     true,
     &[
       &show_about,
@@ -835,21 +828,21 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     ],
   )?;
 
-  #[cfg(not(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-  )))]
   let file_menu = Submenu::with_items(
     app,
     "File",
     true,
     &[
+      #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+      )))]
       &PredefinedMenuItem::close_window(app, None)?,
       #[cfg(not(target_os = "macos"))]
-      &PredefinedMenuItem::quit(app, None)?,
+      &MenuItem::with_id(app, "quit", "Quit", true, Some("Ctrl+Q"))?,
     ],
   )?;
 
@@ -881,11 +874,8 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     "Window",
     true,
     &[
-      &PredefinedMenuItem::minimize(app, None)?,
-      &PredefinedMenuItem::maximize(app, None)?,
-      #[cfg(target_os = "macos")]
-      &PredefinedMenuItem::separator(app)?,
-      &PredefinedMenuItem::close_window(app, None)?,
+      &MenuItem::with_id(app, "minimize", "Minimize", true, None::<&str>)?,
+      &MenuItem::with_id(app, "maximize", "Maximize", true, None::<&str>)?,
     ],
   )?;
 
@@ -906,13 +896,6 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     &[
       #[cfg(target_os = "macos")]
       &app_menu,
-      #[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-      )))]
       &file_menu,
       &edit_menu,
       #[cfg(target_os = "macos")]
@@ -924,6 +907,18 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
 }
 
 fn main() {
+  // Work around known WebKitGTK issues on Linux:
+  // - DMA-BUF renderer fails with "Failed to create GBM buffer"
+  // - Hardware compositing can trigger Wayland protocol errors
+  //   (tauri-apps/tauri#8541)
+  // Disabling both avoids GPU buffer management issues while
+  // keeping native Wayland support.
+  #[cfg(target_os = "linux")]
+  {
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+  }
+
   tauri::Builder::default()
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -935,6 +930,22 @@ fn main() {
         let _ = app.emit("menu:show-about", ());
       } else if event.id() == OPEN_WEB_INSPECTOR_MENU_ID {
         open_main_web_inspector(app);
+      } else if event.id() == "quit" {
+        app.exit(0);
+      } else if event.id() == "minimize" {
+        if let Some(w) = app.get_webview_window("main") {
+          let _ = w.minimize();
+        }
+      } else if event.id() == "maximize" {
+        if let Some(w) = app.get_webview_window("main") {
+          let is_max = w.is_maximized().unwrap_or(false);
+          if is_max { let _ = w.unmaximize(); } else { let _ = w.maximize(); }
+        }
+      }
+      // Re-hide the menu bar after a menu item is selected (Linux/Windows).
+      #[cfg(not(target_os = "macos"))]
+      if let Some(w) = app.get_webview_window("main") {
+        let _ = w.hide_menu();
       }
     })
     .on_window_event(|window, event| {
@@ -942,54 +953,27 @@ fn main() {
         return;
       }
 
-      match event {
-        WindowEvent::Resized(_) => {
-          if let Some(shell) = window.app_handle().try_state::<Arc<DesktopShell>>() {
-            if let Ok((w, h, m)) = (|| -> Result<(u32, u32, bool), String> { Ok(window_geometry!(window)) })() {
-              let _ = shell.resize_debounce_tx.try_send((w, h, m));
-            }
+      if let WindowEvent::CloseRequested { api, .. } = event {
+        if let Some(shell) = window.app_handle().try_state::<Arc<DesktopShell>>() {
+          if !shell.close_in_progress.load(Ordering::SeqCst) {
+            api.prevent_close();
+            handle_main_window_close(shell.inner().clone(), window.clone());
           }
         }
-        WindowEvent::CloseRequested { api, .. } => {
-          if let Some(shell) = window.app_handle().try_state::<Arc<DesktopShell>>() {
-            if !shell.close_in_progress.load(Ordering::SeqCst) {
-              api.prevent_close();
-              handle_main_window_close(shell.inner().clone(), window.clone());
-            }
-          }
-        }
-        _ => {}
       }
     })
     .setup(|app| {
-      let shell = Arc::new(DesktopShell::new(app.handle().clone())?);
-      let shell_for_debounce = shell.clone();
-      let mut resize_rx = shell.take_resize_rx();
-      tauri::async_runtime::spawn(async move {
-        let mut latest: Option<(u32, u32, bool)> = None;
-        let mut persisted: Option<(u32, u32, bool)> = None;
-        loop {
-          tokio::select! {
-            msg = resize_rx.recv() => {
-              match msg {
-                Some(state) => { latest = Some(state); }
-                None => break,
-              }
-            }
-            _ = tokio::time::sleep(Duration::from_millis(500)), if latest.is_some() => {
-              if let Some(state) = latest.take() {
-                if persisted != Some(state) {
-                  if let Err(err) = shell_for_debounce.save_window_size(state.0, state.1, state.2).await {
-                    eprintln!("save desktop window state on resize: {err}");
-                  } else {
-                    persisted = Some(state);
-                  }
-                }
-              }
-            }
-          }
+      // Safety net: if the frontend doesn't show the window within 5s
+      // (e.g. JS error), show it anyway to avoid an invisible app.
+      let handle = app.handle().clone();
+      std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        if let Some(w) = handle.get_webview_window("main") {
+          let _ = w.show();
         }
       });
+
+      let shell = Arc::new(DesktopShell::new(app.handle().clone())?);
       app.manage(shell);
       Ok(())
     })
@@ -1009,6 +993,10 @@ fn main() {
       list_tunnels,
       switch_mode,
       restart_app,
+      save_window_geometry,
+      quit_app,
+      hide_menu_bar,
+      toggle_menu_bar,
     ])
     .build(tauri::generate_context!())
     .expect("error while building LeapMux desktop")

--- a/desktop/rust/tauri.conf.json
+++ b/desktop/rust/tauri.conf.json
@@ -15,12 +15,13 @@
       {
         "label": "main",
         "title": "LeapMux Desktop",
-        "width": 900,
-        "height": 680,
+        "width": 1280,
+        "height": 800,
         "minWidth": 800,
         "minHeight": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "visible": false
       }
     ]
   },

--- a/desktop/rust/tauri.linux.conf.json
+++ b/desktop/rust/tauri.linux.conf.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "mainBinaryName": "leapmux-desktop"
+  "productName": "leapmux-desktop",
+  "mainBinaryName": "leapmux-desktop",
+  "bundle": {
+    "targets": ["deb", "appimage"],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "desktop-template.desktop"
+      }
+    }
+  }
 }

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -122,9 +122,6 @@ const DISTRIBUTED_DESKTOP_CAPABILITIES = caps('tauri-desktop-distributed', {
   systemPermissions: true,
 })
 
-/** Default launcher window dimensions (must match tauri.conf.json). */
-export const LAUNCHER_WINDOW_SIZE = { width: 900, height: 680 }
-
 export function isTauriApp(): boolean {
   return typeof window.__TAURI_INTERNALS__ !== 'undefined'
 }
@@ -237,86 +234,94 @@ export async function refreshRuntimeState(): Promise<DesktopRuntimeState> {
   return getRuntimeState()
 }
 
-export async function animateWindowResize(targetW: number, targetH: number, durationMs = 400): Promise<void> {
+/**
+ * Restore the window to the saved geometry on startup and install a
+ * resize listener that debounces and saves via the Rust sidecar.
+ *
+ * Uses `window.innerWidth/Height` (CSS viewport) which matches what
+ * Tauri's `setSize()` expects — this avoids the GTK CSD offset issue
+ * where `appWindow.innerSize()` includes shadow + header bar.
+ */
+export async function restoreWindowGeometry(width: number, height: number, maximized: boolean): Promise<void> {
   if (!isTauriApp())
     return
 
   try {
     const { LogicalSize } = await loadTauriDpi()
-    const { getCurrentWindow, currentMonitor } = await loadTauriWindow()
+    const { getCurrentWindow } = await loadTauriWindow()
     const appWindow = getCurrentWindow()
 
-    // Fetch scale factor, current size, and monitor info in parallel
-    // to minimize IPC round-trips before the first animation frame.
-    const [scaleFactor, innerSize, monitor] = await Promise.all([
-      appWindow.scaleFactor(),
-      appWindow.innerSize(),
-      currentMonitor().catch(() => null),
-    ])
-
-    // Clamp target to the current monitor size.
-    if (monitor) {
-      const monitorSize = monitor.size.toLogical(scaleFactor)
-      if (monitorSize.width > 0 && monitorSize.height > 0) {
-        targetW = Math.min(targetW, monitorSize.width)
-        targetH = Math.min(targetH, monitorSize.height)
-      }
+    if (maximized) {
+      await appWindow.maximize()
+    }
+    else if (width > 0 && height > 0) {
+      await appWindow.setSize(new LogicalSize(width, height))
     }
 
-    const cur = innerSize.toLogical(scaleFactor)
-    if (durationMs <= 0) {
-      await appWindow.setSize(new LogicalSize(targetW, targetH))
-      await appWindow.center()
-      return
+    // Show the window now that it's at the correct size.
+    // The window starts hidden (visible: false in tauri.conf.json) so
+    // the Wayland compositor sees the final size at first map.
+    await appWindow.show()
+
+    // Hide the menu bar on Linux/Windows — toggled with ALT.
+    // Must be done after show() due to a GTK bug (tao#1201).
+    await tauriInvoke('hide_menu_bar').catch(() => {})
+
+    // Save window geometry on resize / maximize / unmaximize, debounced.
+    let saveTimer: ReturnType<typeof setTimeout> | null = null
+    const saveGeometry = () => {
+      if (saveTimer)
+        clearTimeout(saveTimer)
+      saveTimer = setTimeout(async () => {
+        try {
+          const isMax = await appWindow.isMaximized()
+          tauriInvoke('save_window_geometry', {
+            width: window.innerWidth,
+            height: window.innerHeight,
+            maximized: isMax,
+          }).catch(() => {})
+        }
+        catch { /* best-effort */ }
+      }, 500)
     }
-
-    if (cur.width === targetW && cur.height === targetH)
-      return
-
-    const startW = cur.width
-    const startH = cur.height
-    const steps = Math.max(Math.round(durationMs / 8), 1)
-    const stepDelayMs = durationMs / steps
-
-    for (let step = 1; step <= steps; step += 1) {
-      const t = step / steps
-      const eased = 1 - (1 - t) ** 3
-      const w = Math.round(startW + (targetW - startW) * eased)
-      const h = Math.round(startH + (targetH - startH) * eased)
-      await appWindow.setSize(new LogicalSize(w, h))
-      await appWindow.center()
-      if (step < steps)
-        await new Promise(resolve => setTimeout(resolve, stepDelayMs))
-    }
-    await appWindow.setSize(new LogicalSize(targetW, targetH))
-    await appWindow.center()
+    window.addEventListener('resize', saveGeometry)
   }
   catch (err) {
-    log.warn('animateWindowResize fallback', err)
-    try {
-      const { LogicalSize } = await loadTauriDpi()
-      const { getCurrentWindow } = await loadTauriWindow()
-      const appWindow = getCurrentWindow()
-      await appWindow.setSize(new LogicalSize(targetW, targetH))
-      await appWindow.center()
-    }
-    catch (fallbackErr) {
-      log.warn('animateWindowResize failed', fallbackErr)
-    }
+    log.warn('restoreWindowGeometry failed', err)
   }
 }
 
-export async function maximizeWindow(): Promise<void> {
+/**
+ * Install a global ALT key listener that toggles the menu bar on
+ * Linux/Windows.  Fires on ALT release only if no other key was
+ * pressed between ALT-down and ALT-up (standard desktop behavior).
+ */
+export function installMenuBarToggle(): void {
   if (!isTauriApp())
     return
 
-  try {
-    const { getCurrentWindow } = await loadTauriWindow()
-    await getCurrentWindow().maximize()
-  }
-  catch (err) {
-    log.warn('maximizeWindow failed', err)
-  }
+  let altDown = false
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Alt') {
+      altDown = true
+    }
+    else {
+      altDown = false
+    }
+
+    // Handle menu shortcuts directly — GTK disables accelerators
+    // when the menu bar is hidden.
+    if (e.key === 'q' && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
+      e.preventDefault()
+      tauriInvoke('quit_app').catch(() => {})
+    }
+  })
+  window.addEventListener('keyup', (e) => {
+    if (e.key === 'Alt' && altDown) {
+      altDown = false
+      tauriInvoke('toggle_menu_bar').catch(() => {})
+    }
+  })
 }
 
 export const platformBridge = {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -2,7 +2,7 @@ import type { ParentComponent } from 'solid-js'
 import { Router } from '@solidjs/router'
 import { FileRoutes } from '@solidjs/start/router'
 import { createEffect, createResource, createSignal, ErrorBoundary, Match, onCleanup, onMount, Show, Suspense, Switch } from 'solid-js'
-import { getRuntimeState, isTauriApp, platformBridge, refreshRuntimeState } from '~/api/platformBridge'
+import { getRuntimeState, installMenuBarToggle, isTauriApp, platformBridge, refreshRuntimeState } from '~/api/platformBridge'
 import { channelManager } from '~/api/workerRpc'
 import { showInfoToast } from '~/components/common/Toast'
 import { LauncherView } from '~/components/desktop/LauncherView'
@@ -189,11 +189,17 @@ export default function App() {
     onCleanup(() => document.removeEventListener('focusin', handleFocusIn, true))
 
     if (isTauriApp()) {
+      installMenuBarToggle()
       platformBridge.onEvent('menu:show-about', () => setShowAboutDialog(true))
         .then(unlisten => onCleanup(unlisten))
 
+      // Always go through the launcher on startup / refresh.
+      // The LauncherView's auto-connect logic will silently re-establish
+      // the sidecar connection and transition to the workspace.  Going
+      // directly to 'connected' would break after a WebView refresh
+      // because the channel relays and RPC streams are lost.
       getRuntimeState()
-        .then(state => setDesktopState(state.connected ? 'connected' : 'launcher'))
+        .then(() => setDesktopState('launcher'))
         .catch(() => setDesktopState('launcher'))
     }
   })

--- a/frontend/src/components/desktop/LauncherView.tsx
+++ b/frontend/src/components/desktop/LauncherView.tsx
@@ -1,6 +1,6 @@
 import type { Component } from 'solid-js'
 import { createSignal, onCleanup, onMount } from 'solid-js'
-import { animateWindowResize, getRuntimeState, LAUNCHER_WINDOW_SIZE, maximizeWindow, platformBridge } from '~/api/platformBridge'
+import { getRuntimeState, platformBridge, restoreWindowGeometry } from '~/api/platformBridge'
 import { createLogger } from '~/lib/logger'
 import { formatVersionLine } from '~/lib/systemInfo'
 import * as styles from './LauncherView.css'
@@ -24,8 +24,6 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
   const [visible, setVisible] = createSignal(false)
   let fdaPollTimer: ReturnType<typeof setInterval> | null = null
   let containerRef: HTMLDivElement | undefined
-  let resizedToWorkspace = false
-  let savedGeometry = { width: 0, height: 0, maximized: false }
 
   const isValidHubUrl = (value: string): boolean => {
     let s = value.trim()
@@ -99,18 +97,6 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
     })
   }
 
-  const resizeToWorkspace = async () => {
-    if (resizedToWorkspace)
-      return
-    resizedToWorkspace = true
-    if (savedGeometry.maximized)
-      await maximizeWindow()
-    else if (savedGeometry.width > 0 && savedGeometry.height > 0)
-      await animateWindowResize(savedGeometry.width, savedGeometry.height)
-    else
-      await animateWindowResize(1280, 800)
-  }
-
   const connect = async () => {
     setLoading(true)
     setError('')
@@ -118,12 +104,10 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
       if (mode() === 'solo') {
         await platformBridge.connectSolo()
         await fadeOut()
-        await resizeToWorkspace()
         props.onConnected()
       }
       else {
         await fadeOut()
-        await resizeToWorkspace()
         await platformBridge.connectDistributed(hubUrl().trim())
       }
     }
@@ -143,13 +127,8 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
       if (buildInfo.version)
         setVersionLine(formatVersionLine(buildInfo))
 
-      // Remember saved window geometry for resizeToWorkspace().
-      savedGeometry = { width: config.window_width, height: config.window_height, maximized: config.window_maximized }
-
-      // Ensure the window starts at the default launcher size.
-      // On first launch it's already 900×680 (from tauri.conf.json).
-      // After Switch Mode it may be larger — shrink it back.
-      await animateWindowResize(LAUNCHER_WINDOW_SIZE.width, LAUNCHER_WINDOW_SIZE.height)
+      // Restore saved window geometry on startup.
+      await restoreWindowGeometry(config.window_width, config.window_height, config.window_maximized)
 
       if (config.mode === 'distributed' && config.hub_url) {
         setHubUrl(config.hub_url)
@@ -168,9 +147,6 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
             return
           }
         }
-
-        // Resize to the saved workspace size before connecting.
-        await resizeToWorkspace()
 
         // Auto-connect silently — don't fade in unless it takes > 1s.
         const showTimer = setTimeout(setVisible, 1000, true)

--- a/frontend/src/components/shell/UserMenu.tsx
+++ b/frontend/src/components/shell/UserMenu.tsx
@@ -1,7 +1,7 @@
 import type { Component, JSX } from 'solid-js'
 import { useNavigate } from '@solidjs/router'
 import { createSignal, For, Show } from 'solid-js'
-import { animateWindowResize, LAUNCHER_WINDOW_SIZE, platformBridge } from '~/api/platformBridge'
+import { platformBridge } from '~/api/platformBridge'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { PreferencesDialog } from '~/components/settings/PreferencesDialog'
 import { ProfileDialog } from '~/components/settings/ProfileDialog'
@@ -62,10 +62,6 @@ export const UserMenu: Component<UserMenuProps> = (props) => {
     })
 
     await platformBridge.switchMode()
-
-    // Resize back to the default launcher size while the overlay hides
-    // the transition. The LauncherView will handle its own fade-in.
-    await animateWindowResize(LAUNCHER_WINDOW_SIZE.width, LAUNCHER_WINDOW_SIZE.height)
 
     overlay.remove()
     ;(window as any).__leapmux_disconnectDesktop?.()


### PR DESCRIPTION
## Motivation

The Linux desktop app had several critical issues preventing reliable distribution and use: WebKitGTK crashed due to DMA-BUF renderer incompatibilities, Wayland produced protocol errors from hardware compositing, and the linuxdeploy toolchain was corrupting binaries during AppImage packaging. Additionally, VMware environments exposed GTK plugin failures with bundled libraries. Beyond these bugs, the Linux platform lacked a proper distribution pipeline and the window management logic had grown complex and fragile across platforms.

## Modifications

**Linux distribution pipeline:**
- Added AppImage and Debian package build targets to `Taskfile.yaml`, with separate `build-desktop-linux` and `build-desktop-windows` tasks replacing the former `build-desktop-not-darwin` target
- Introduced `linuxdeploy-wrapper.c` and `patch-linuxdeploy.sh` to work around Tauri's ELF header writes corrupting the linuxdeploy binary and to fix GTK plugin failures in VMware environments
- Added `desktop-template.desktop` for Linux application entry metadata

**Rust desktop app (`desktop/rust/src/main.rs`):**
- Replaced all `not(target_os = "macos")` cfg guards with explicit `any(target_os = "linux", target_os = "windows")` guards; added `compile_error!` for unsupported platforms
- Disabled DMA-BUF renderer and hardware compositing via environment variables to fix WebKitGTK crashes on Wayland
- Added native menu bar for Linux/Windows with Quit (Ctrl+Q), Minimize, and Maximize items
- Added a 5-second window visibility safety net in case frontend JavaScript fails to show the window
- Set initial window visibility to `false` to give the frontend explicit control; increased default window size to 1280x800
- Added new Tauri commands: `save_window_geometry()`, `quit_app()`, `hide_menu_bar()`, `toggle_menu_bar()`

**Frontend window management:**
- Replaced `animateWindowResize()` and `maximizeWindow()` with `restoreWindowGeometry(width, height, maximized)`, which restores saved window state on startup and manages visibility initialization
- Added `installMenuBarToggle()` to handle global ALT key events for toggling the native menu bar on Linux/Windows, with debounced geometry saving on resize/maximize
- Simplified `LauncherView.tsx` by removing manual `resizeToWorkspace()` calls and local geometry state; window restoration now happens automatically in `onMount()`
- Modified `app.tsx` to always route through the launcher on startup, allowing the LauncherView's auto-connect logic to re-establish the sidecar connection correctly after a WebView refresh

**Configuration and documentation:**
- Added `core:window:allow-show` Tauri capability
- Updated `README.md` with Rust, Bun, and Tauri installation instructions, database backend details, and a revised directory structure reflecting Go/Rust separation

**Removed from `platformBridge.ts` public API:** `animateWindowResize()`, `maximizeWindow()`, `LAUNCHER_WINDOW_SIZE`

## Result

The Linux desktop app now builds and packages correctly as AppImage and Debian packages. WebKitGTK no longer crashes due to DMA-BUF or Wayland compositing issues, and linuxdeploy binary corruption is prevented during packaging. The window management flow is simplified: the window starts hidden and is shown by the frontend after geometry is restored, with a safety net ensuring the window always becomes visible. On Linux and Windows, users get a native menu bar with keyboard shortcuts (Alt to toggle, Ctrl+Q to quit) and proper window controls.
