### PR TITLE
Roll back git setup when tab creation fails

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -65,6 +65,12 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			sendInternalError(sender, gmErr.Error())
 			return
 		}
+		openSucceeded := false
+		defer func() {
+			if !openSucceeded {
+				svc.rollbackGitMode(gm)
+			}
+		}()
 		workingDir = gm.WorkingDir
 		worktreeID := gm.WorktreeID
 
@@ -80,7 +86,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		resumed := ptrconv.BoolToInt64(r.GetAgentSessionId() != "")
 
 		// Create the agent record in the database.
-		if err := svc.Queries.CreateAgent(bgCtx(), db.CreateAgentParams{
+		if err := svc.createAgentRecord(bgCtx(), db.CreateAgentParams{
 			ID:            agentID,
 			WorkspaceID:   r.GetWorkspaceId(),
 			WorkingDir:    workingDir,
@@ -116,7 +122,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		sink := svc.Output.NewSink(agentID, agentProvider)
 
-		confirmedSettings, err := svc.Agents.StartAgent(bgCtx(), agentOpts, sink)
+		confirmedSettings, err := svc.startAgent(bgCtx(), agentOpts, sink)
 		if err != nil {
 			slog.Error("failed to start agent", "agent_id", agentID, "error", err)
 			// Mark the agent as closed since the process failed to start.
@@ -135,13 +141,14 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		svc.registerTabForWorktree(worktreeID, leapmuxv1.TabType_TAB_TYPE_AGENT, agentID)
 
 		// Fetch the created agent for the response.
-		dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+		dbAgent, err := svc.getAgentByID(bgCtx(), agentID)
 		if err != nil {
 			slog.Error("failed to fetch created agent", "error", err)
 			sendInternalError(sender, "failed to fetch created agent")
 			return
 		}
 
+		openSucceeded = true
 		sendProtoResponse(sender, &leapmuxv1.OpenAgentResponse{
 			Agent: agentToProto(&dbAgent, dbAgent.PermissionMode, svc.WorkerID, true, gitutil.GetGitStatus(dbAgent.WorkingDir), svc.Agents.AvailableModels(agentID, dbAgent.AgentProvider), svc.Agents.AvailableOptionGroups(agentID, dbAgent.AgentProvider)),
 		})

--- a/backend/internal/worker/service/open_rollback_test.go
+++ b/backend/internal/worker/service/open_rollback_test.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+	"github.com/leapmux/leapmux/internal/worker/terminal"
+)
+
+func TestOpenAgent_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initRepo(t)
+	branchName := "feature/agent-worktree"
+	worktreePath := expectedWorktreePath(repoDir, branchName)
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return nil, errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:    "ws-1",
+		WorkingDir:     repoDir,
+		CreateWorktree: true,
+		WorktreeBranch: branchName,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start agent: forced start failure", w.errors[0].message)
+	assert.NoDirExists(t, worktreePath)
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+
+	_, err := svc.Queries.GetWorktreeByPath(ctx, worktreePath)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestOpenAgent_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
+	repoDir := initRepo(t)
+	originalBranch := currentBranchName(t, repoDir)
+	branchName := "feature/agent-branch"
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return nil, errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:  "ws-1",
+		WorkingDir:   repoDir,
+		CreateBranch: branchName,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start agent: forced start failure", w.errors[0].message)
+	assert.Equal(t, originalBranch, currentBranchName(t, repoDir))
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+}
+
+func TestOpenAgent_RollsBackCreatedBranchToDetachedHEADOnStartFailure(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initRepo(t)
+	originalCommit := strings.TrimSpace(mustGitOutput(t, ctx, repoDir, "rev-parse", "HEAD"))
+	run(t, repoDir, "git", "checkout", "--detach", "HEAD")
+	branchName := "feature/detached-rollback"
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return nil, errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:  "ws-1",
+		WorkingDir:   repoDir,
+		CreateBranch: branchName,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start agent: forced start failure", w.errors[0].message)
+	assert.Equal(t, "HEAD", strings.TrimSpace(mustGitOutput(t, ctx, repoDir, "rev-parse", "--abbrev-ref", "HEAD")))
+	assert.Equal(t, originalCommit, strings.TrimSpace(mustGitOutput(t, ctx, repoDir, "rev-parse", "HEAD")))
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+}
+
+func TestOpenTerminal_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initRepo(t)
+	branchName := "feature/terminal-worktree"
+	worktreePath := expectedWorktreePath(repoDir, branchName)
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.startTerminalFn = func(terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
+		return errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
+		WorkspaceId:    "ws-1",
+		WorkingDir:     repoDir,
+		CreateWorktree: true,
+		WorktreeBranch: branchName,
+		Shell:          "/bin/sh",
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start terminal", w.errors[0].message)
+	assert.NoDirExists(t, worktreePath)
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+
+	_, err := svc.Queries.GetWorktreeByPath(ctx, worktreePath)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestOpenTerminal_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
+	repoDir := initRepo(t)
+	originalBranch := currentBranchName(t, repoDir)
+	branchName := "feature/terminal-branch"
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.startTerminalFn = func(terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
+		return errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
+		WorkspaceId:  "ws-1",
+		WorkingDir:   repoDir,
+		CreateBranch: branchName,
+		Shell:        "/bin/sh",
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start terminal", w.errors[0].message)
+	assert.Equal(t, originalBranch, currentBranchName(t, repoDir))
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+}
+
+func expectedWorktreePath(repoDir, branchName string) string {
+	return filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"-worktrees", branchName)
+}
+
+func currentBranchName(t *testing.T, repoDir string) string {
+	t.Helper()
+	out := mustGitOutput(t, context.Background(), repoDir, "rev-parse", "--abbrev-ref", "HEAD")
+	return strings.TrimSpace(out)
+}
+
+func localBranchExists(t *testing.T, repoDir, branchName string) bool {
+	t.Helper()
+	_, err := gitOutput(context.Background(), repoDir, "rev-parse", "--verify", "refs/heads/"+branchName)
+	return err == nil
+}
+
+func mustGitOutput(t *testing.T, ctx context.Context, repoDir string, args ...string) string {
+	t.Helper()
+	out, err := gitOutput(ctx, repoDir, args...)
+	require.NoError(t, err)
+	return out
+}
+
+func TestOpenAgent_RollsBackCreatedWorktreeOnCreateRecordFailure(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initRepo(t)
+	branchName := "feature/agent-create-failure"
+	worktreePath := expectedWorktreePath(repoDir, branchName)
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
+		return errors.New("forced create failure")
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:    "ws-1",
+		WorkingDir:     repoDir,
+		CreateWorktree: true,
+		WorktreeBranch: branchName,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to create agent", w.errors[0].message)
+	assert.NoDirExists(t, worktreePath)
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+
+	_, err := svc.Queries.GetWorktreeByPath(ctx, worktreePath)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestOpenAgent_RollsBackCreatedBranchOnCreateRecordFailure(t *testing.T) {
+	repoDir := initRepo(t)
+	originalBranch := currentBranchName(t, repoDir)
+	branchName := "feature/agent-create-branch"
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
+		return errors.New("forced create failure")
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:  "ws-1",
+		WorkingDir:   repoDir,
+		CreateBranch: branchName,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to create agent", w.errors[0].message)
+	assert.Equal(t, originalBranch, currentBranchName(t, repoDir))
+	assert.False(t, localBranchExists(t, repoDir, branchName))
+}
+
+func TestOpenTerminal_DoesNotRollBackSwitchBranchOnStartFailure(t *testing.T) {
+	repoDir := initRepo(t)
+	run(t, repoDir, "git", "checkout", "-b", "feature/existing")
+	run(t, repoDir, "git", "checkout", "-")
+
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.startTerminalFn = func(terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
+		return errors.New("forced start failure")
+	}
+
+	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
+		WorkspaceId:    "ws-1",
+		WorkingDir:     repoDir,
+		CheckoutBranch: "feature/existing",
+		Shell:          "/bin/sh",
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	require.Equal(t, "failed to start terminal", w.errors[0].message)
+	assert.Equal(t, "feature/existing", currentBranchName(t, repoDir))
+}

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -46,6 +46,11 @@ type Context struct {
 	UseLoginShell       bool                      // Wrap claude invocation in user's login shell
 	WakeLock            *wakelock.ActivityTracker // Keep-awake tracker (nil = disabled)
 	RegisteredBy        string                    // User ID who registered this worker (for tunnel authorization)
+
+	startAgentFn        func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error)
+	startTerminalFn     func(terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error
+	createAgentRecordFn func(context.Context, db.CreateAgentParams) error
+	getAgentByIDFn      func(context.Context, string) (db.Agent, error)
 }
 
 // agentStartupTimeout returns the configured agent startup timeout,
@@ -70,7 +75,7 @@ func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manage
 	queries := db.New(sqlDB)
 	watchers := NewWatcherManager()
 	output := NewOutputHandler(queries, watchers, agents, wl)
-	return &Context{
+	svc := &Context{
 		DB:        sqlDB,
 		Queries:   queries,
 		Agents:    agents,
@@ -81,6 +86,39 @@ func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manage
 		Output:    output,
 		WakeLock:  wl,
 	}
+	svc.startAgentFn = svc.Agents.StartAgent
+	svc.startTerminalFn = svc.Terminals.StartTerminal
+	svc.createAgentRecordFn = svc.Queries.CreateAgent
+	svc.getAgentByIDFn = svc.Queries.GetAgentByID
+	return svc
+}
+
+func (svc *Context) startAgent(ctx context.Context, opts agent.Options, sink agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+	if svc.startAgentFn != nil {
+		return svc.startAgentFn(ctx, opts, sink)
+	}
+	return svc.Agents.StartAgent(ctx, opts, sink)
+}
+
+func (svc *Context) startTerminal(opts terminal.Options, outputFn terminal.OutputHandler, exitFn terminal.ExitHandler) error {
+	if svc.startTerminalFn != nil {
+		return svc.startTerminalFn(opts, outputFn, exitFn)
+	}
+	return svc.Terminals.StartTerminal(opts, outputFn, exitFn)
+}
+
+func (svc *Context) createAgentRecord(ctx context.Context, params db.CreateAgentParams) error {
+	if svc.createAgentRecordFn != nil {
+		return svc.createAgentRecordFn(ctx, params)
+	}
+	return svc.Queries.CreateAgent(ctx, params)
+}
+
+func (svc *Context) getAgentByID(ctx context.Context, agentID string) (db.Agent, error) {
+	if svc.getAgentByIDFn != nil {
+		return svc.getAgentByIDFn(ctx, agentID)
+	}
+	return svc.Queries.GetAgentByID(ctx, agentID)
 }
 
 // Init performs one-time startup tasks such as clearing stale agent state

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -51,6 +51,12 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 			sendInternalError(sender, gmErr.Error())
 			return
 		}
+		openSucceeded := false
+		defer func() {
+			if !openSucceeded {
+				svc.rollbackGitMode(gm)
+			}
+		}()
 		workingDir = gm.WorkingDir
 		worktreeID := gm.WorktreeID
 
@@ -117,7 +123,7 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 			})
 		}
 
-		err := svc.Terminals.StartTerminal(terminal.Options{
+		err := svc.startTerminal(terminal.Options{
 			ID:            terminalID,
 			WorkspaceID:   workspaceID,
 			Shell:         shell,
@@ -161,6 +167,7 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 			resp.GitBranch = gs.Branch
 			resp.GitOriginUrl = gs.OriginUrl
 		}
+		openSucceeded = true
 		sendProtoResponse(sender, resp)
 	})
 

--- a/backend/internal/worker/service/worktree.go
+++ b/backend/internal/worker/service/worktree.go
@@ -15,6 +15,26 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
 )
 
+type rollbackWorktree struct {
+	WorktreeID   string
+	WorktreePath string
+	RepoRoot     string
+	BranchName   string
+}
+
+type rollbackBranch struct {
+	WorkingDir       string
+	CreatedBranch    string
+	OriginalBranch   string
+	OriginalCommit   string
+	OriginalDetached bool
+}
+
+type gitModeRollback struct {
+	CreatedWorktree *rollbackWorktree
+	CreatedBranch   *rollbackBranch
+}
+
 // createWorktreeIfRequested creates a git worktree on the local filesystem if
 // requested. Returns the final working directory (which may be the worktree
 // path) and the DB worktree ID (empty if no worktree was created/reused).
@@ -23,26 +43,26 @@ func (svc *Context) createWorktreeIfRequested(
 	createWorktree bool,
 	branchName string,
 	baseBranch string,
-) (finalWorkingDir string, worktreeID string, err error) {
+) (finalWorkingDir string, worktreeID string, rollback *rollbackWorktree, err error) {
 	if !createWorktree {
-		return workingDir, "", nil
+		return workingDir, "", nil, nil
 	}
 
 	if err := gitutil.ValidateBranchName(branchName); err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 
 	ctx := bgCtx()
 
 	// Fail early if a local branch with this name already exists.
 	if branchExists(ctx, workingDir, branchName) {
-		return "", "", fmt.Errorf("branch %q already exists", branchName)
+		return "", "", nil, fmt.Errorf("branch %q already exists", branchName)
 	}
 
 	// Resolve to the main repo root (handles linked worktrees).
 	repoRoot, err := resolveMainRepoRoot(ctx, workingDir)
 	if err != nil {
-		return "", "", errNotGitRepo
+		return "", "", nil, errNotGitRepo
 	}
 
 	repoDirName := filepath.Base(repoRoot)
@@ -59,19 +79,26 @@ func (svc *Context) createWorktreeIfRequested(
 
 	// Compute worktree path.
 	worktreePath := filepath.Join(filepath.Dir(repoRoot), repoDirName+"-worktrees", branchName)
+	rollback = &rollbackWorktree{
+		WorktreePath: worktreePath,
+		RepoRoot:     repoRoot,
+		BranchName:   branchName,
+	}
 
 	// Create the worktree on disk.
 	if err := gitCommand(ctx, repoRoot, "worktree", "add", "-b", branchName, worktreePath, startPoint); err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 
 	slog.Info("worktree created", "worktree_path", worktreePath, "branch_name", branchName)
 
 	wtID, err := svc.ensureTrackedWorktree(ctx, worktreePath)
 	if err != nil {
-		return "", "", err
+		svc.rollbackCreatedWorktree(*rollback)
+		return "", "", nil, err
 	}
-	return worktreePath, wtID, nil
+	rollback.WorktreeID = wtID
+	return worktreePath, wtID, rollback, nil
 }
 
 // registerTabForWorktree associates a tab with a worktree.
@@ -152,6 +179,86 @@ func (svc *Context) removeWorktreeFromDisk(wt db.Worktree, force bool) {
 	if err := svc.Queries.DeleteWorktree(ctx, wt.ID); err != nil {
 		slog.Warn("failed to delete worktree record",
 			"worktree_id", wt.ID, "error", err)
+	}
+}
+
+func currentCheckoutTarget(ctx context.Context, workingDir string) (*rollbackBranch, error) {
+	branchName, err := currentLocalBranchForPath(ctx, workingDir)
+	if err == nil && branchName != "" {
+		return &rollbackBranch{
+			WorkingDir:     workingDir,
+			OriginalBranch: branchName,
+		}, nil
+	}
+
+	commitSHA, err := gitOutput(ctx, workingDir, "rev-parse", "HEAD")
+	if err != nil {
+		return nil, err
+	}
+	commitSHA = strings.TrimSpace(commitSHA)
+	if commitSHA == "" {
+		return nil, errors.New("failed to resolve current HEAD")
+	}
+
+	return &rollbackBranch{
+		WorkingDir:       workingDir,
+		OriginalCommit:   commitSHA,
+		OriginalDetached: true,
+	}, nil
+}
+
+func (svc *Context) rollbackGitMode(result gitModeResult) {
+	if result.Rollback.CreatedBranch != nil {
+		svc.rollbackCreatedBranch(*result.Rollback.CreatedBranch)
+	}
+	if result.Rollback.CreatedWorktree != nil {
+		svc.rollbackCreatedWorktree(*result.Rollback.CreatedWorktree)
+	}
+}
+
+func (svc *Context) rollbackCreatedWorktree(r rollbackWorktree) {
+	ctx := bgCtx()
+
+	if err := gitCommand(ctx, r.RepoRoot, "worktree", "remove", "--force", r.WorktreePath); err != nil {
+		slog.Warn("failed to roll back worktree",
+			"worktree_path", r.WorktreePath, "repo_root", r.RepoRoot, "error", err)
+	}
+
+	if r.BranchName != "" {
+		if err := gitCommand(ctx, r.RepoRoot, "branch", "-D", r.BranchName); err != nil {
+			slog.Warn("failed to roll back worktree branch",
+				"branch", r.BranchName, "repo_root", r.RepoRoot, "error", err)
+		}
+	}
+
+	if r.WorktreeID != "" {
+		if err := svc.Queries.DeleteWorktree(ctx, r.WorktreeID); err != nil {
+			slog.Warn("failed to roll back tracked worktree",
+				"worktree_id", r.WorktreeID, "error", err)
+		}
+	}
+}
+
+func (svc *Context) rollbackCreatedBranch(r rollbackBranch) {
+	ctx := bgCtx()
+
+	if r.OriginalDetached {
+		if err := gitCommand(ctx, r.WorkingDir, "checkout", "--detach", r.OriginalCommit); err != nil {
+			slog.Warn("failed to restore detached HEAD before deleting branch",
+				"working_dir", r.WorkingDir, "commit", r.OriginalCommit, "error", err)
+			return
+		}
+	} else {
+		if err := gitCommand(ctx, r.WorkingDir, "checkout", r.OriginalBranch); err != nil {
+			slog.Warn("failed to restore branch before deleting branch",
+				"working_dir", r.WorkingDir, "branch", r.OriginalBranch, "error", err)
+			return
+		}
+	}
+
+	if err := gitCommand(ctx, r.WorkingDir, "branch", "-D", r.CreatedBranch); err != nil {
+		slog.Warn("failed to roll back branch creation",
+			"working_dir", r.WorkingDir, "branch", r.CreatedBranch, "error", err)
 	}
 }
 
@@ -332,16 +439,18 @@ type gitModeRequest interface {
 type gitModeResult struct {
 	WorkingDir string
 	WorktreeID string
+	Rollback   gitModeRollback
 }
 
 // applyGitMode applies the git-mode options from a request to the working
 // directory, returning the (possibly changed) working directory and worktree ID.
 func (svc *Context) applyGitMode(workingDir string, r gitModeRequest) (gitModeResult, error) {
 	var worktreeID string
+	var rollback gitModeRollback
 
 	// Create a worktree if requested.
 	if r.GetCreateWorktree() {
-		finalDir, wtID, err := svc.createWorktreeIfRequested(
+		finalDir, wtID, wtRollback, err := svc.createWorktreeIfRequested(
 			workingDir, true, r.GetWorktreeBranch(), r.GetWorktreeBaseBranch(),
 		)
 		if err != nil {
@@ -349,6 +458,7 @@ func (svc *Context) applyGitMode(workingDir string, r gitModeRequest) (gitModeRe
 		}
 		workingDir = finalDir
 		worktreeID = wtID
+		rollback.CreatedWorktree = wtRollback
 	}
 
 	// Checkout branch if requested.
@@ -360,9 +470,15 @@ func (svc *Context) applyGitMode(workingDir string, r gitModeRequest) (gitModeRe
 
 	// Create new branch if requested.
 	if branch := r.GetCreateBranch(); branch != "" {
+		currentTarget, err := currentCheckoutTarget(bgCtx(), workingDir)
+		if err != nil {
+			return gitModeResult{}, fmt.Errorf("failed to capture current checkout: %w", err)
+		}
 		if err := svc.createBranchIfRequested(workingDir, branch, r.GetCreateBranchBase()); err != nil {
 			return gitModeResult{}, fmt.Errorf("failed to create branch: %w", err)
 		}
+		currentTarget.CreatedBranch = branch
+		rollback.CreatedBranch = currentTarget
 	}
 
 	// Use existing worktree if requested.
@@ -388,7 +504,11 @@ func (svc *Context) applyGitMode(workingDir string, r gitModeRequest) (gitModeRe
 		}
 	}
 
-	return gitModeResult{WorkingDir: workingDir, WorktreeID: worktreeID}, nil
+	return gitModeResult{
+		WorkingDir: workingDir,
+		WorktreeID: worktreeID,
+		Rollback:   rollback,
+	}, nil
 }
 
 var errNotGitRepo = errors.New("path is not inside a git repository")


### PR DESCRIPTION
## Motivation
Creating an agent or terminal tab can mutate git state before the tab is fully opened. When a later step fails, LeapMux was leaving behind the just-created worktree or branch, which causes the user's next retry to fail with an "already exists" error.

## Modifications
- Extended worker git-mode handling to carry rollback metadata for newly created worktrees and branches.
- Added best-effort rollback in `OpenAgent` and `OpenTerminal` so failures after git setup restore the previous state before returning an error.
- Restored the original checkout before deleting a created branch, including detached `HEAD` cases.
- Added narrow internal startup hooks on the worker service to force deterministic agent and terminal start failures in tests.
- Added worker service tests covering worktree rollback, branch rollback, detached-HEAD restoration, create-record failure, and the non-rollback `switch-branch` path.

## Result
Failed tab creation no longer leaves stale worktrees or branches behind. Retries after fixing the underlying problem can succeed without manual git cleanup, and the rollback behavior is covered by deterministic service-level tests.
