### PR TITLE
Refactor shared tooltips and replace title attributes

### DIFF
--- a/frontend/src/components/chat/AgentInfoCard.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.tsx
@@ -28,7 +28,7 @@ function formatTokenCount(tokens: number): string {
 function CopyButton(props: { getText: () => string | undefined, title: string, testId?: string }) {
   const { copied, copy: handleCopy } = useCopyButton(() => props.getText())
   return (
-    <Tooltip text={props.title} targetAriaLabel>
+    <Tooltip text={props.title} ariaLabel>
       <button
         class={styles.infoCopyButton}
         onClick={handleCopy}

--- a/frontend/src/components/chat/AgentInfoCard.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.tsx
@@ -28,16 +28,18 @@ function formatTokenCount(tokens: number): string {
 function CopyButton(props: { getText: () => string | undefined, title: string, testId?: string }) {
   const { copied, copy: handleCopy } = useCopyButton(() => props.getText())
   return (
-    <button
-      class={styles.infoCopyButton}
-      onClick={handleCopy}
-      title={props.title}
-      data-testid={props.testId}
-    >
-      <Show when={copied()} fallback={<Icon icon={Copy} size="xs" />}>
-        <Icon icon={Check} size="xs" />
-      </Show>
-    </button>
+    <Tooltip text={props.title}>
+      <button
+        class={styles.infoCopyButton}
+        onClick={handleCopy}
+        aria-label={props.title}
+        data-testid={props.testId}
+      >
+        <Show when={copied()} fallback={<Icon icon={Copy} size="xs" />}>
+          <Icon icon={Check} size="xs" />
+        </Show>
+      </button>
+    </Tooltip>
   )
 }
 

--- a/frontend/src/components/chat/AgentInfoCard.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.tsx
@@ -28,11 +28,10 @@ function formatTokenCount(tokens: number): string {
 function CopyButton(props: { getText: () => string | undefined, title: string, testId?: string }) {
   const { copied, copy: handleCopy } = useCopyButton(() => props.getText())
   return (
-    <Tooltip text={props.title}>
+    <Tooltip text={props.title} targetAriaLabel>
       <button
         class={styles.infoCopyButton}
         onClick={handleCopy}
-        aria-label={props.title}
         data-testid={props.testId}
       >
         <Show when={copied()} fallback={<Icon icon={Copy} size="xs" />}>

--- a/frontend/src/components/chat/AttachmentStrip.tsx
+++ b/frontend/src/components/chat/AttachmentStrip.tsx
@@ -42,16 +42,18 @@ export const AttachmentStrip: Component<AttachmentStripProps> = (props) => {
                 />
               </span>
               <Tooltip text={attachment.filename}>
-                <span class={styles.pillFilename} title={attachment.filename}>{attachment.filename}</span>
+                <span class={styles.pillFilename}>{attachment.filename}</span>
               </Tooltip>
-              <button
-                class={styles.removeButton}
-                onClick={() => props.onRemove(attachment.id)}
-                data-testid="attachment-remove"
-                title="Remove attachment"
-              >
-                <Icon icon={X} size="xs" />
-              </button>
+              <Tooltip text="Remove attachment">
+                <button
+                  class={styles.removeButton}
+                  onClick={() => props.onRemove(attachment.id)}
+                  data-testid="attachment-remove"
+                  aria-label="Remove attachment"
+                >
+                  <Icon icon={X} size="xs" />
+                </button>
+              </Tooltip>
             </div>
           )}
         </For>

--- a/frontend/src/components/chat/AttachmentStrip.tsx
+++ b/frontend/src/components/chat/AttachmentStrip.tsx
@@ -44,7 +44,7 @@ export const AttachmentStrip: Component<AttachmentStripProps> = (props) => {
               <Tooltip text={attachment.filename}>
                 <span class={styles.pillFilename}>{attachment.filename}</span>
               </Tooltip>
-              <Tooltip text="Remove attachment" targetAriaLabel>
+              <Tooltip text="Remove attachment" ariaLabel>
                 <button
                   class={styles.removeButton}
                   onClick={() => props.onRemove(attachment.id)}

--- a/frontend/src/components/chat/AttachmentStrip.tsx
+++ b/frontend/src/components/chat/AttachmentStrip.tsx
@@ -44,12 +44,11 @@ export const AttachmentStrip: Component<AttachmentStripProps> = (props) => {
               <Tooltip text={attachment.filename}>
                 <span class={styles.pillFilename}>{attachment.filename}</span>
               </Tooltip>
-              <Tooltip text="Remove attachment">
+              <Tooltip text="Remove attachment" targetAriaLabel>
                 <button
                   class={styles.removeButton}
                   onClick={() => props.onRemove(attachment.id)}
                   data-testid="attachment-remove"
-                  aria-label="Remove attachment"
                 >
                   <Icon icon={X} size="xs" />
                 </button>

--- a/frontend/src/components/chat/ContextUsageGrid.tsx
+++ b/frontend/src/components/chat/ContextUsageGrid.tsx
@@ -97,13 +97,12 @@ export const ContextUsageGrid: Component<ContextUsageGridProps> = (props) => {
 
   return (
     <Show when={percentage() != null} fallback={<Info size={props.size} />}>
-      <Tooltip text={tooltip()}>
+      <Tooltip text={tooltip()} targetAriaLabel>
         <svg
           width={props.size}
           height={props.size}
           viewBox="0 0 11 11"
           fill="none"
-          aria-label={tooltip()}
         >
           <For each={fillOrder}>
             {([row, col], i) => (

--- a/frontend/src/components/chat/ContextUsageGrid.tsx
+++ b/frontend/src/components/chat/ContextUsageGrid.tsx
@@ -97,7 +97,7 @@ export const ContextUsageGrid: Component<ContextUsageGridProps> = (props) => {
 
   return (
     <Show when={percentage() != null} fallback={<Info size={props.size} />}>
-      <Tooltip text={tooltip()} targetAriaLabel>
+      <Tooltip text={tooltip()} ariaLabel>
         <svg
           width={props.size}
           height={props.size}

--- a/frontend/src/components/chat/controls/ACPControlRequest.tsx
+++ b/frontend/src/components/chat/controls/ACPControlRequest.tsx
@@ -100,7 +100,6 @@ export const ACPControlActions: Component<ActionsProps> = (props) => {
                 data-variant="secondary"
                 onClick={handleBypassPermissions}
                 data-testid="control-bypass-btn"
-                aria-label="Allow this request and stop asking for permissions"
               >
                 & Bypass Permissions
               </button>

--- a/frontend/src/components/chat/controls/ACPControlRequest.tsx
+++ b/frontend/src/components/chat/controls/ACPControlRequest.tsx
@@ -3,6 +3,7 @@ import type { ActionsProps, ContentProps } from './types'
 
 import { For, Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from '../ControlRequestBanner.css'
 import { toRpcId } from './CodexControlRequest'
 import { sendResponse } from './types'
@@ -94,14 +95,16 @@ export const ACPControlActions: Component<ActionsProps> = (props) => {
             )}
           </For>
           <Show when={props.bypassPermissionMode && defaultAllowOptionId(props.request.payload)}>
-            <button
-              data-variant="secondary"
-              onClick={handleBypassPermissions}
-              data-testid="control-bypass-btn"
-              title="Allow this request and stop asking for permissions"
-            >
-              & Bypass Permissions
-            </button>
+            <Tooltip text="Allow this request and stop asking for permissions">
+              <button
+                data-variant="secondary"
+                onClick={handleBypassPermissions}
+                data-testid="control-bypass-btn"
+                aria-label="Allow this request and stop asking for permissions"
+              >
+                & Bypass Permissions
+              </button>
+            </Tooltip>
           </Show>
         </ButtonGroup>
       </div>

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -5,6 +5,7 @@ import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createUniqueId, For, Show } from 'solid-js'
 import { agentLoadingTimeoutMs, apiLoadingTimeoutMs } from '~/api/transport'
 import { Icon } from '~/components/common/Icon'
+import { Tooltip } from '~/components/common/Tooltip'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { spinner } from '~/styles/animations.css'
 import { buildAllowResponse, buildDenyResponse, getToolInput } from '~/utils/controlResponse'
@@ -347,15 +348,17 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
           <Show when={stopping()}><Icon icon={LoaderCircle} size="sm" class={spinner} /></Show>
           {stopping() ? 'Stopping...' : 'Stop'}
         </button>
-        <button
-          class="outline"
-          onClick={handleYolo}
-          disabled={!anyUnanswered()}
-          data-testid="control-yolo-btn"
-          title="Auto-fill unanswered questions and submit"
-        >
-          YOLO
-        </button>
+        <Tooltip text="Auto-fill unanswered questions and submit">
+          <button
+            class="outline"
+            onClick={handleYolo}
+            disabled={!anyUnanswered()}
+            data-testid="control-yolo-btn"
+            aria-label="Auto-fill unanswered questions and submit"
+          >
+            YOLO
+          </button>
+        </Tooltip>
         {props.infoTrigger}
       </div>
       <Show when={questions().length > 1}>

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -354,7 +354,6 @@ export const AskUserQuestionActions: Component<ActionsProps> = (props) => {
             onClick={handleYolo}
             disabled={!anyUnanswered()}
             data-testid="control-yolo-btn"
-            aria-label="Auto-fill unanswered questions and submit"
           >
             YOLO
           </button>

--- a/frontend/src/components/chat/controls/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CodexControlRequest.tsx
@@ -282,7 +282,6 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                         data-variant="secondary"
                         onClick={handleBypassPermissions}
                         data-testid="control-bypass-btn"
-                        aria-label="Allow this request and stop asking for permissions"
                       >
                         & Bypass Permissions
                       </button>
@@ -310,7 +309,6 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                         data-variant="secondary"
                         onClick={handleBypassPermissions}
                         data-testid="control-bypass-btn"
-                        aria-label="Allow this request and stop asking for permissions"
                       >
                         & Bypass Permissions
                       </button>

--- a/frontend/src/components/chat/controls/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CodexControlRequest.tsx
@@ -3,6 +3,7 @@ import type { ActionsProps, AskQuestionState, ContentProps, Question } from './t
 
 import { For, Match, Show, Switch } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Tooltip } from '~/components/common/Tooltip'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { AskUserQuestionActions, AskUserQuestionContent } from './AskUserQuestionControl'
@@ -276,14 +277,16 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                   <button class="outline" onClick={() => handleDecision('cancel')} data-testid="control-deny-btn">Cancel</button>
                   <button onClick={() => handleDecision('accept')} data-testid="control-allow-btn">Allow</button>
                   <Show when={props.bypassPermissionMode}>
-                    <button
-                      data-variant="secondary"
-                      onClick={handleBypassPermissions}
-                      data-testid="control-bypass-btn"
-                      title="Allow this request and stop asking for permissions"
-                    >
-                      & Bypass Permissions
-                    </button>
+                    <Tooltip text="Allow this request and stop asking for permissions">
+                      <button
+                        data-variant="secondary"
+                        onClick={handleBypassPermissions}
+                        data-testid="control-bypass-btn"
+                        aria-label="Allow this request and stop asking for permissions"
+                      >
+                        & Bypass Permissions
+                      </button>
+                    </Tooltip>
                   </Show>
                 </ButtonGroup>
               )}
@@ -302,14 +305,16 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                     )}
                   </For>
                   <Show when={props.bypassPermissionMode}>
-                    <button
-                      data-variant="secondary"
-                      onClick={handleBypassPermissions}
-                      data-testid="control-bypass-btn"
-                      title="Allow this request and stop asking for permissions"
-                    >
-                      & Bypass Permissions
-                    </button>
+                    <Tooltip text="Allow this request and stop asking for permissions">
+                      <button
+                        data-variant="secondary"
+                        onClick={handleBypassPermissions}
+                        data-testid="control-bypass-btn"
+                        aria-label="Allow this request and stop asking for permissions"
+                      >
+                        & Bypass Permissions
+                      </button>
+                    </Tooltip>
                   </Show>
                 </ButtonGroup>
               )}

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -4,6 +4,7 @@ import type { ControlRequest } from '~/stores/control.store'
 
 import { Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Tooltip } from '~/components/common/Tooltip'
 import { buildAllowResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { CollapsibleText } from './CollapsibleText'
@@ -66,14 +67,16 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
             Allow
           </button>
           <Show when={props.bypassPermissionMode}>
-            <button
-              data-variant="secondary"
-              onClick={handleBypassPermissions}
-              data-testid="control-bypass-btn"
-              title="Allow this request and stop asking for permissions"
-            >
-              & Bypass Permissions
-            </button>
+            <Tooltip text="Allow this request and stop asking for permissions">
+              <button
+                data-variant="secondary"
+                onClick={handleBypassPermissions}
+                data-testid="control-bypass-btn"
+                aria-label="Allow this request and stop asking for permissions"
+              >
+                & Bypass Permissions
+              </button>
+            </Tooltip>
           </Show>
         </ButtonGroup>
       </Show>

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -72,7 +72,6 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
                 data-variant="secondary"
                 onClick={handleBypassPermissions}
                 data-testid="control-bypass-btn"
-                aria-label="Allow this request and stop asking for permissions"
               >
                 & Bypass Permissions
               </button>

--- a/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
@@ -3,6 +3,7 @@ import type { ActionsProps, AskQuestionState, ContentProps, Question } from './t
 
 import { For, Match, Show, Switch } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from '../ControlRequestBanner.css'
 import { AskUserQuestionActions, AskUserQuestionContent } from './AskUserQuestionControl'
 import { toRpcId } from './CodexControlRequest'
@@ -174,14 +175,16 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
                   <button class="outline" onClick={() => handleOption('reject')} data-testid="control-deny-btn">Reject</button>
                   <button onClick={() => handleOption('once')} data-testid="control-allow-btn">Allow once</button>
                   <Show when={props.bypassPermissionMode}>
-                    <button
-                      data-variant="secondary"
-                      onClick={handleBypassPermissions}
-                      data-testid="control-bypass-btn"
-                      title="Allow this request and stop asking for permissions"
-                    >
-                      & Bypass Permissions
-                    </button>
+                    <Tooltip text="Allow this request and stop asking for permissions">
+                      <button
+                        data-variant="secondary"
+                        onClick={handleBypassPermissions}
+                        data-testid="control-bypass-btn"
+                        aria-label="Allow this request and stop asking for permissions"
+                      >
+                        & Bypass Permissions
+                      </button>
+                    </Tooltip>
                   </Show>
                 </ButtonGroup>
               )}
@@ -199,14 +202,16 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
                   )}
                 </For>
                 <Show when={props.bypassPermissionMode}>
-                  <button
-                    data-variant="secondary"
-                    onClick={handleBypassPermissions}
-                    data-testid="control-bypass-btn"
-                    title="Allow this request and stop asking for permissions"
-                  >
-                    & Bypass Permissions
-                  </button>
+                  <Tooltip text="Allow this request and stop asking for permissions">
+                    <button
+                      data-variant="secondary"
+                      onClick={handleBypassPermissions}
+                      data-testid="control-bypass-btn"
+                      aria-label="Allow this request and stop asking for permissions"
+                    >
+                      & Bypass Permissions
+                    </button>
+                  </Tooltip>
                 </Show>
               </ButtonGroup>
             </Show>

--- a/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/controls/OpenCodeControlRequest.tsx
@@ -180,7 +180,6 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
                         data-variant="secondary"
                         onClick={handleBypassPermissions}
                         data-testid="control-bypass-btn"
-                        aria-label="Allow this request and stop asking for permissions"
                       >
                         & Bypass Permissions
                       </button>
@@ -207,7 +206,6 @@ export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
                       data-variant="secondary"
                       onClick={handleBypassPermissions}
                       data-testid="control-bypass-btn"
-                      aria-label="Allow this request and stop asking for permissions"
                     >
                       & Bypass Permissions
                     </button>

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -156,7 +156,7 @@ function CollapsibleMessage(props: { text: string, icon: LucideIcon, label: stri
   return (
     <>
       <div class={thinkingHeader} onClick={() => setExpanded(v => !v)}>
-        <Tooltip text={props.label} targetAriaLabel>
+        <Tooltip text={props.label} ariaLabel>
           <span class={inlineFlex}>
             <Icon icon={props.icon} size="md" class={toolUseIcon} />
           </span>
@@ -224,7 +224,7 @@ const taskStartedRenderer: MessageContentRenderer = {
     return (
       <div class={toolMessage}>
         <div class={toolUseHeader}>
-          <Tooltip text="Task Started" targetAriaLabel>
+          <Tooltip text="Task Started" ariaLabel>
             <span class={inlineFlex}>
               <Icon icon={Bot} size="md" class={toolUseIcon} />
             </span>

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -156,7 +156,7 @@ function CollapsibleMessage(props: { text: string, icon: LucideIcon, label: stri
   return (
     <>
       <div class={thinkingHeader} onClick={() => setExpanded(v => !v)}>
-        <Tooltip text={props.label}>
+        <Tooltip text={props.label} targetAriaLabel>
           <span class={inlineFlex}>
             <Icon icon={props.icon} size="md" class={toolUseIcon} />
           </span>
@@ -224,7 +224,7 @@ const taskStartedRenderer: MessageContentRenderer = {
     return (
       <div class={toolMessage}>
         <div class={toolUseHeader}>
-          <Tooltip text="Task Started">
+          <Tooltip text="Task Started" targetAriaLabel>
             <span class={inlineFlex}>
               <Icon icon={Bot} size="md" class={toolUseIcon} />
             </span>

--- a/frontend/src/components/chat/providers/codexRenderers.tsx
+++ b/frontend/src/components/chat/providers/codexRenderers.tsx
@@ -725,7 +725,7 @@ export function codexReasoningRenderer(parsed: unknown, _role: MessageRole, _con
   return (
     <div>
       <div class={thinkingHeader} onClick={() => setExpanded(v => !v)}>
-        <Tooltip text="Reasoning" targetAriaLabel>
+        <Tooltip text="Reasoning" ariaLabel>
           <span class={`${inlineFlex} ${toolUseIcon}`}>
             <Icon icon={Brain} size="md" />
           </span>

--- a/frontend/src/components/chat/providers/codexRenderers.tsx
+++ b/frontend/src/components/chat/providers/codexRenderers.tsx
@@ -725,7 +725,7 @@ export function codexReasoningRenderer(parsed: unknown, _role: MessageRole, _con
   return (
     <div>
       <div class={thinkingHeader} onClick={() => setExpanded(v => !v)}>
-        <Tooltip text="Reasoning">
+        <Tooltip text="Reasoning" targetAriaLabel>
           <span class={`${inlineFlex} ${toolUseIcon}`}>
             <Icon icon={Brain} size="md" />
           </span>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -104,7 +104,7 @@ export function ToolUseLayout(props: {
   return (
     <div class={toolMessage} data-tool-message>
       <div class={toolUseHeader}>
-        <Tooltip text={props.toolName} targetAriaLabel>
+        <Tooltip text={props.toolName} ariaLabel>
           <span class={`${inlineFlex} ${toolUseIcon}`}>
             <Icon icon={props.icon} size="md" />
           </span>

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -104,7 +104,7 @@ export function ToolUseLayout(props: {
   return (
     <div class={toolMessage} data-tool-message>
       <div class={toolUseHeader}>
-        <Tooltip text={props.toolName}>
+        <Tooltip text={props.toolName} targetAriaLabel>
           <span class={`${inlineFlex} ${toolUseIcon}`}>
             <Icon icon={props.icon} size="md" />
           </span>

--- a/frontend/src/components/common/IconButton.tsx
+++ b/frontend/src/components/common/IconButton.tsx
@@ -91,13 +91,12 @@ export const IconButton: Component<IconButtonProps> = (props) => {
   }
 
   return (
-    <Tooltip text={local.title}>
+    <Tooltip text={local.title} targetAriaLabel>
       <button
         type="button"
         class={classes()}
         style={local.style}
         disabled={isDisabled()}
-        aria-label={local.title}
         // eslint-disable-next-line solid/reactivity -- native event binding; onClick identity doesn't change at runtime
         onClick={local.onClick}
         {...rest}

--- a/frontend/src/components/common/IconButton.tsx
+++ b/frontend/src/components/common/IconButton.tsx
@@ -91,7 +91,7 @@ export const IconButton: Component<IconButtonProps> = (props) => {
   }
 
   return (
-    <Tooltip text={local.title} targetAriaLabel>
+    <Tooltip text={local.title} ariaLabel>
       <button
         type="button"
         class={classes()}

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { Tooltip } from './Tooltip'
+
+describe('tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    HTMLElement.prototype.showPopover = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('applies aria-describedby while visible', () => {
+    render(() => (
+      <Tooltip text="Tooltip text">
+        <button type="button">Trigger</button>
+      </Tooltip>
+    ))
+
+    const button = screen.getByRole('button', { name: 'Trigger' })
+    expect(button).not.toHaveAttribute('aria-describedby')
+
+    fireEvent.mouseEnter(button)
+    vi.advanceTimersByTime(700)
+
+    const tooltip = screen.getByRole('tooltip', { hidden: true })
+    expect(button).toHaveAttribute('aria-describedby', tooltip.id)
+
+    fireEvent.mouseLeave(button)
+    vi.advanceTimersByTime(100)
+    expect(button).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('uses tooltip text as aria-label when targetAriaLabel is true', () => {
+    render(() => (
+      <Tooltip text="Zoom in" targetAriaLabel>
+        <button type="button">
+          +
+        </button>
+      </Tooltip>
+    ))
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Zoom in')
+  })
+
+  it('uses the explicit targetAriaLabel when provided', () => {
+    render(() => (
+      <Tooltip text="Tooltip text" targetAriaLabel="Explicit label">
+        <button type="button">
+          +
+        </button>
+      </Tooltip>
+    ))
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Explicit label')
+  })
+
+  it('leaves visible text targets without an aria-label by default', () => {
+    render(() => (
+      <Tooltip text="Helpful details">
+        <button type="button">Visible label</button>
+      </Tooltip>
+    ))
+
+    expect(screen.getByRole('button', { name: 'Visible label' })).not.toHaveAttribute('aria-label')
+  })
+
+  it('warns and leaves invalid children unchanged', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { container } = render(() => (
+      <Tooltip text="Broken">
+        <>
+          <span>One</span>
+          <span>Two</span>
+        </>
+      </Tooltip>
+    ))
+
+    expect(warn).toHaveBeenCalled()
+    expect(container.textContent).toContain('OneTwo')
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+})

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -34,9 +34,9 @@ describe('tooltip', () => {
     expect(button).not.toHaveAttribute('aria-describedby')
   })
 
-  it('uses tooltip text as aria-label when targetAriaLabel is true', () => {
+  it('uses tooltip text as aria-label when ariaLabel is true', () => {
     render(() => (
-      <Tooltip text="Zoom in" targetAriaLabel>
+      <Tooltip text="Zoom in" ariaLabel>
         <button type="button">
           +
         </button>
@@ -46,9 +46,9 @@ describe('tooltip', () => {
     expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Zoom in')
   })
 
-  it('uses the explicit targetAriaLabel when provided', () => {
+  it('uses the explicit ariaLabel when provided', () => {
     render(() => (
-      <Tooltip text="Tooltip text" targetAriaLabel="Explicit label">
+      <Tooltip text="Tooltip text" ariaLabel="Explicit label">
         <button type="button">
           +
         </button>

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -19,7 +19,7 @@ export interface TooltipProps {
    * When set, applies an aria-label to the target element.
    * Use `true` to reuse `text`, or pass a string for an explicit label.
    */
-  targetAriaLabel?: string | true
+  ariaLabel?: string | true
   children: JSX.Element
 }
 
@@ -216,9 +216,9 @@ export function Tooltip(props: TooltipProps) {
     const originalAriaLabel = target.getAttribute('aria-label')
 
     createEffect(() => {
-      const nextAriaLabel = props.targetAriaLabel === true
+      const nextAriaLabel = props.ariaLabel === true
         ? props.text
-        : props.targetAriaLabel
+        : props.ariaLabel
       if (nextAriaLabel)
         target.setAttribute('aria-label', nextAriaLabel)
       else if (originalAriaLabel != null)

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'solid-js'
-import { createSignal, createUniqueId, onCleanup, Show } from 'solid-js'
+import { createEffect, createSignal, createUniqueId, onCleanup, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 import * as styles from './Tooltip.css'
 
@@ -7,6 +7,7 @@ const SHOW_DELAY_MS = 700
 const HIDE_DELAY_MS = 100
 /** Extra margin around trigger rect for the pointermove hit-test. */
 const HOVER_MARGIN_PX = 4
+const WHITESPACE_RE = /\s+/
 
 /** Dismiss callback of the currently visible tooltip (at most one). */
 let activeHide: (() => void) | undefined
@@ -14,7 +15,21 @@ let activeHide: (() => void) | undefined
 export interface TooltipProps {
   /** Tooltip text. When empty/undefined, the tooltip is disabled. */
   text: string | undefined
+  /**
+   * When set, applies an aria-label to the target element.
+   * Use `true` to reuse `text`, or pass a string for an explicit label.
+   */
+  targetAriaLabel?: string | true
   children: JSX.Element
+}
+
+type TooltipTarget = Element & {
+  addEventListener: Element['addEventListener']
+  removeEventListener: Element['removeEventListener']
+  getBoundingClientRect: Element['getBoundingClientRect']
+  getAttribute: Element['getAttribute']
+  setAttribute: Element['setAttribute']
+  removeAttribute: Element['removeAttribute']
 }
 
 /**
@@ -29,13 +44,27 @@ export interface TooltipProps {
  * via a SolidJS Portal and positioning it with getBoundingClientRect().
  */
 export function Tooltip(props: TooltipProps) {
-  let triggerEl: HTMLElement | undefined
+  let triggerWrapperEl: HTMLSpanElement | undefined
   let tooltipEl: HTMLDivElement | undefined
   const tooltipId = createUniqueId()
   const [visible, setVisible] = createSignal(false)
   const [pos, setPos] = createSignal({ top: 0, left: 0 })
+  const [targetEl, setTargetEl] = createSignal<TooltipTarget | undefined>()
   let showTimer: ReturnType<typeof setTimeout> | undefined
   let hideTimer: ReturnType<typeof setTimeout> | undefined
+  let warnedInvalidChild = false
+
+  const resolveTargetEl = (): TooltipTarget | undefined => {
+    const node = triggerWrapperEl?.firstElementChild
+    if (!(node instanceof Element) || triggerWrapperEl?.childElementCount !== 1) {
+      if (import.meta.env.DEV && !warnedInvalidChild) {
+        warnedInvalidChild = true
+        console.warn('Tooltip requires exactly one direct DOM element child.')
+      }
+      return undefined
+    }
+    return node as TooltipTarget
+  }
 
   const clearTimers = () => {
     clearTimeout(showTimer)
@@ -44,9 +73,7 @@ export function Tooltip(props: TooltipProps) {
     hideTimer = undefined
   }
 
-  /** The wrapper uses display:contents, so get the rect from the first child. */
-  const getTriggerRect = () =>
-    (triggerEl?.firstElementChild ?? triggerEl)?.getBoundingClientRect()
+  const getTriggerRect = () => targetEl()?.getBoundingClientRect()
 
   /** Dismiss this tooltip immediately. */
   const dismiss = () => {
@@ -127,18 +154,96 @@ export function Tooltip(props: TooltipProps) {
     hideTimer = setTimeout(dismiss, HIDE_DELAY_MS)
   }
 
+  onMount(() => {
+    setTargetEl(resolveTargetEl())
+  })
+
+  createEffect(() => {
+    const target = targetEl()
+    if (!target)
+      return
+
+    const handleShow = () => show()
+    const handleHide = () => hide()
+
+    target.addEventListener('mouseenter', handleShow)
+    target.addEventListener('mouseleave', handleHide)
+    target.addEventListener('focusin', handleShow)
+    target.addEventListener('focusout', handleHide)
+
+    onCleanup(() => {
+      target.removeEventListener('mouseenter', handleShow)
+      target.removeEventListener('mouseleave', handleHide)
+      target.removeEventListener('focusin', handleShow)
+      target.removeEventListener('focusout', handleHide)
+    })
+  })
+
+  createEffect(() => {
+    const target = targetEl()
+    if (!target)
+      return
+
+    const originalDescribedBy = target.getAttribute('aria-describedby')
+    const baseIds = (originalDescribedBy ?? '')
+      .split(WHITESPACE_RE)
+      .filter(Boolean)
+      .filter(id => id !== `tooltip-${tooltipId}`)
+
+    createEffect(() => {
+      const nextIds = visible() && props.text
+        ? [...baseIds, `tooltip-${tooltipId}`]
+        : baseIds
+      if (nextIds.length > 0)
+        target.setAttribute('aria-describedby', nextIds.join(' '))
+      else
+        target.removeAttribute('aria-describedby')
+    })
+
+    onCleanup(() => {
+      if (originalDescribedBy != null)
+        target.setAttribute('aria-describedby', originalDescribedBy)
+      else
+        target.removeAttribute('aria-describedby')
+    })
+  })
+
+  createEffect(() => {
+    const target = targetEl()
+    if (!target)
+      return
+
+    const originalAriaLabel = target.getAttribute('aria-label')
+
+    createEffect(() => {
+      const nextAriaLabel = props.targetAriaLabel === true
+        ? props.text
+        : props.targetAriaLabel
+      if (nextAriaLabel)
+        target.setAttribute('aria-label', nextAriaLabel)
+      else if (originalAriaLabel != null)
+        target.setAttribute('aria-label', originalAriaLabel)
+      else
+        target.removeAttribute('aria-label')
+    })
+
+    onCleanup(() => {
+      if (originalAriaLabel != null)
+        target.setAttribute('aria-label', originalAriaLabel)
+      else
+        target.removeAttribute('aria-label')
+    })
+  })
+
   onCleanup(dismiss)
 
   return (
     <>
       <span
-        ref={(el) => { triggerEl = el }}
+        ref={(el) => {
+          triggerWrapperEl = el
+        }}
         style={{ display: 'contents' }}
-        onMouseEnter={show}
-        onMouseLeave={hide}
-        onFocusIn={show}
-        onFocusOut={hide}
-        aria-describedby={visible() ? `tooltip-${tooltipId}` : undefined}
       >
         {props.children}
       </span>

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -275,11 +275,10 @@ export const FileViewer: Component<{
       </Show>
       <Show when={showOuterMention()}>
         <div class={styles.viewToggle}>
-          <Tooltip text="Mention in the chat">
+          <Tooltip text="Mention in the chat" targetAriaLabel>
             <button
               class={styles.viewToggleButton}
               onClick={() => props.onMention?.()}
-              aria-label="Mention in the chat"
               data-testid="file-mention-button"
             >
               <Icon icon={AtSign} size="sm" />

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -275,7 +275,7 @@ export const FileViewer: Component<{
       </Show>
       <Show when={showOuterMention()}>
         <div class={styles.viewToggle}>
-          <Tooltip text="Mention in the chat" targetAriaLabel>
+          <Tooltip text="Mention in the chat" ariaLabel>
             <button
               class={styles.viewToggleButton}
               onClick={() => props.onMention?.()}

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -8,6 +8,7 @@ import * as workerRpc from '~/api/workerRpc'
 import { diffAdded, diffRemoved } from '~/components/chat/diffStyles.css'
 import { DiffView, rawDiffToHunks } from '~/components/chat/diffUtils'
 import { Icon } from '~/components/common/Icon'
+import { Tooltip } from '~/components/common/Tooltip'
 import { GitFileRef } from '~/generated/leapmux/v1/git_pb'
 import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
 import { DiffModeToolbar } from './DiffModeToolbar'
@@ -274,14 +275,16 @@ export const FileViewer: Component<{
       </Show>
       <Show when={showOuterMention()}>
         <div class={styles.viewToggle}>
-          <button
-            class={styles.viewToggleButton}
-            onClick={() => props.onMention?.()}
-            title="Mention in the chat"
-            data-testid="file-mention-button"
-          >
-            <Icon icon={AtSign} size="sm" />
-          </button>
+          <Tooltip text="Mention in the chat">
+            <button
+              class={styles.viewToggleButton}
+              onClick={() => props.onMention?.()}
+              aria-label="Mention in the chat"
+              data-testid="file-mention-button"
+            >
+              <Icon icon={AtSign} size="sm" />
+            </button>
+          </Tooltip>
         </div>
       </Show>
       <div class={`${styles.content}${showToolbar() || showOuterMention() ? ` ${styles.hasFloatingToolbar}` : ''}`} ref={contentRef}>

--- a/frontend/src/components/fileviewer/ImageToolbar.tsx
+++ b/frontend/src/components/fileviewer/ImageToolbar.tsx
@@ -46,39 +46,35 @@ export function ImageToolbar(props: {
 }): JSX.Element {
   return (
     <div class={styles.imageToolbar}>
-      <Tooltip text="Zoom out">
+      <Tooltip text="Zoom out" targetAriaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
-          aria-label="Zoom out"
         >
           <Icon icon={ZoomOut} size="sm" />
         </button>
       </Tooltip>
       <span class={styles.imageToolbarLabel}>{zoomLabel(props.zoom, props.fitScale)}</span>
-      <Tooltip text="Zoom in">
+      <Tooltip text="Zoom in" targetAriaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
-          aria-label="Zoom in"
         >
           <Icon icon={ZoomIn} size="sm" />
         </button>
       </Tooltip>
-      <Tooltip text="Fit to view">
+      <Tooltip text="Fit to view" targetAriaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange('fit')}
-          aria-label="Fit to view"
         >
           <Icon icon={Maximize2} size="sm" />
         </button>
       </Tooltip>
-      <Tooltip text="Actual size (100%)">
+      <Tooltip text="Actual size (100%)" targetAriaLabel>
         <button
           class={styles.imageToolbarTextButton}
           onClick={() => props.onZoomChange('actual')}
-          aria-label="Actual size (100%)"
         >
           100%
         </button>

--- a/frontend/src/components/fileviewer/ImageToolbar.tsx
+++ b/frontend/src/components/fileviewer/ImageToolbar.tsx
@@ -3,6 +3,7 @@ import Maximize2 from 'lucide-solid/icons/maximize-2'
 import ZoomIn from 'lucide-solid/icons/zoom-in'
 import ZoomOut from 'lucide-solid/icons/zoom-out'
 import { Icon } from '~/components/common/Icon'
+import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from './FileViewer.css'
 
 export type ZoomMode = 'fit' | 'actual' | number
@@ -45,35 +46,43 @@ export function ImageToolbar(props: {
 }): JSX.Element {
   return (
     <div class={styles.imageToolbar}>
-      <button
-        class={styles.imageToolbarButton}
-        onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
-        title="Zoom out"
-      >
-        <Icon icon={ZoomOut} size="sm" />
-      </button>
+      <Tooltip text="Zoom out">
+        <button
+          class={styles.imageToolbarButton}
+          onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
+          aria-label="Zoom out"
+        >
+          <Icon icon={ZoomOut} size="sm" />
+        </button>
+      </Tooltip>
       <span class={styles.imageToolbarLabel}>{zoomLabel(props.zoom, props.fitScale)}</span>
-      <button
-        class={styles.imageToolbarButton}
-        onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
-        title="Zoom in"
-      >
-        <Icon icon={ZoomIn} size="sm" />
-      </button>
-      <button
-        class={styles.imageToolbarButton}
-        onClick={() => props.onZoomChange('fit')}
-        title="Fit to view"
-      >
-        <Icon icon={Maximize2} size="sm" />
-      </button>
-      <button
-        class={styles.imageToolbarTextButton}
-        onClick={() => props.onZoomChange('actual')}
-        title="Actual size (100%)"
-      >
-        100%
-      </button>
+      <Tooltip text="Zoom in">
+        <button
+          class={styles.imageToolbarButton}
+          onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
+          aria-label="Zoom in"
+        >
+          <Icon icon={ZoomIn} size="sm" />
+        </button>
+      </Tooltip>
+      <Tooltip text="Fit to view">
+        <button
+          class={styles.imageToolbarButton}
+          onClick={() => props.onZoomChange('fit')}
+          aria-label="Fit to view"
+        >
+          <Icon icon={Maximize2} size="sm" />
+        </button>
+      </Tooltip>
+      <Tooltip text="Actual size (100%)">
+        <button
+          class={styles.imageToolbarTextButton}
+          onClick={() => props.onZoomChange('actual')}
+          aria-label="Actual size (100%)"
+        >
+          100%
+        </button>
+      </Tooltip>
     </div>
   )
 }

--- a/frontend/src/components/fileviewer/ImageToolbar.tsx
+++ b/frontend/src/components/fileviewer/ImageToolbar.tsx
@@ -46,7 +46,7 @@ export function ImageToolbar(props: {
 }): JSX.Element {
   return (
     <div class={styles.imageToolbar}>
-      <Tooltip text="Zoom out" targetAriaLabel>
+      <Tooltip text="Zoom out" ariaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange(zoomOut(props.zoom, props.fitScale))}
@@ -55,7 +55,7 @@ export function ImageToolbar(props: {
         </button>
       </Tooltip>
       <span class={styles.imageToolbarLabel}>{zoomLabel(props.zoom, props.fitScale)}</span>
-      <Tooltip text="Zoom in" targetAriaLabel>
+      <Tooltip text="Zoom in" ariaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange(zoomIn(props.zoom, props.fitScale))}
@@ -63,7 +63,7 @@ export function ImageToolbar(props: {
           <Icon icon={ZoomIn} size="sm" />
         </button>
       </Tooltip>
-      <Tooltip text="Fit to view" targetAriaLabel>
+      <Tooltip text="Fit to view" ariaLabel>
         <button
           class={styles.imageToolbarButton}
           onClick={() => props.onZoomChange('fit')}
@@ -71,7 +71,7 @@ export function ImageToolbar(props: {
           <Icon icon={Maximize2} size="sm" />
         </button>
       </Tooltip>
-      <Tooltip text="Actual size (100%)" targetAriaLabel>
+      <Tooltip text="Actual size (100%)" ariaLabel>
         <button
           class={styles.imageToolbarTextButton}
           onClick={() => props.onZoomChange('actual')}

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -18,7 +18,7 @@ export function ViewToggle(props: {
 }): JSX.Element {
   return (
     <div class={styles.viewToggle}>
-      <Tooltip text="Rendered view" targetAriaLabel>
+      <Tooltip text="Rendered view" ariaLabel>
         <button
           class={styles.viewToggleButton}
           classList={{ [styles.viewToggleActive]: props.mode === 'render' }}
@@ -28,7 +28,7 @@ export function ViewToggle(props: {
         </button>
       </Tooltip>
       <Show when={props.showSplit}>
-        <Tooltip text="Side-by-side view" targetAriaLabel>
+        <Tooltip text="Side-by-side view" ariaLabel>
           <button
             class={styles.viewToggleButton}
             classList={{ [styles.viewToggleActive]: props.mode === 'split' }}
@@ -38,7 +38,7 @@ export function ViewToggle(props: {
           </button>
         </Tooltip>
       </Show>
-      <Tooltip text="Source view" targetAriaLabel>
+      <Tooltip text="Source view" ariaLabel>
         <button
           class={styles.viewToggleButton}
           classList={{ [styles.viewToggleActive]: props.mode === 'source' }}
@@ -49,7 +49,7 @@ export function ViewToggle(props: {
       </Tooltip>
       <Show when={props.onMention}>
         <div style={{ 'border-left': '1px solid var(--border)' }} />
-        <Tooltip text="Mention in the chat" targetAriaLabel>
+        <Tooltip text="Mention in the chat" ariaLabel>
           <button
             class={styles.viewToggleButton}
             onClick={() => props.onMention?.()}

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -5,6 +5,7 @@ import Columns2 from 'lucide-solid/icons/columns-2'
 import Eye from 'lucide-solid/icons/eye'
 import { Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
+import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from './FileViewer.css'
 
 export type ViewMode = 'render' | 'source' | 'split'
@@ -17,42 +18,50 @@ export function ViewToggle(props: {
 }): JSX.Element {
   return (
     <div class={styles.viewToggle}>
-      <button
-        class={styles.viewToggleButton}
-        classList={{ [styles.viewToggleActive]: props.mode === 'render' }}
-        onClick={() => props.onToggle('render')}
-        title="Rendered view"
-      >
-        <Icon icon={Eye} size="sm" />
-      </button>
-      <Show when={props.showSplit}>
+      <Tooltip text="Rendered view">
         <button
           class={styles.viewToggleButton}
-          classList={{ [styles.viewToggleActive]: props.mode === 'split' }}
-          onClick={() => props.onToggle('split')}
-          title="Side-by-side view"
+          classList={{ [styles.viewToggleActive]: props.mode === 'render' }}
+          onClick={() => props.onToggle('render')}
+          aria-label="Rendered view"
         >
-          <Icon icon={Columns2} size="sm" />
+          <Icon icon={Eye} size="sm" />
         </button>
+      </Tooltip>
+      <Show when={props.showSplit}>
+        <Tooltip text="Side-by-side view">
+          <button
+            class={styles.viewToggleButton}
+            classList={{ [styles.viewToggleActive]: props.mode === 'split' }}
+            onClick={() => props.onToggle('split')}
+            aria-label="Side-by-side view"
+          >
+            <Icon icon={Columns2} size="sm" />
+          </button>
+        </Tooltip>
       </Show>
-      <button
-        class={styles.viewToggleButton}
-        classList={{ [styles.viewToggleActive]: props.mode === 'source' }}
-        onClick={() => props.onToggle('source')}
-        title="Source view"
-      >
-        <Icon icon={Code} size="sm" />
-      </button>
+      <Tooltip text="Source view">
+        <button
+          class={styles.viewToggleButton}
+          classList={{ [styles.viewToggleActive]: props.mode === 'source' }}
+          onClick={() => props.onToggle('source')}
+          aria-label="Source view"
+        >
+          <Icon icon={Code} size="sm" />
+        </button>
+      </Tooltip>
       <Show when={props.onMention}>
         <div style={{ 'border-left': '1px solid var(--border)' }} />
-        <button
-          class={styles.viewToggleButton}
-          onClick={() => props.onMention?.()}
-          title="Mention in the chat"
-          data-testid="file-mention-button"
-        >
-          <Icon icon={AtSign} size="sm" />
-        </button>
+        <Tooltip text="Mention in the chat">
+          <button
+            class={styles.viewToggleButton}
+            onClick={() => props.onMention?.()}
+            aria-label="Mention in the chat"
+            data-testid="file-mention-button"
+          >
+            <Icon icon={AtSign} size="sm" />
+          </button>
+        </Tooltip>
       </Show>
     </div>
   )

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -18,45 +18,41 @@ export function ViewToggle(props: {
 }): JSX.Element {
   return (
     <div class={styles.viewToggle}>
-      <Tooltip text="Rendered view">
+      <Tooltip text="Rendered view" targetAriaLabel>
         <button
           class={styles.viewToggleButton}
           classList={{ [styles.viewToggleActive]: props.mode === 'render' }}
           onClick={() => props.onToggle('render')}
-          aria-label="Rendered view"
         >
           <Icon icon={Eye} size="sm" />
         </button>
       </Tooltip>
       <Show when={props.showSplit}>
-        <Tooltip text="Side-by-side view">
+        <Tooltip text="Side-by-side view" targetAriaLabel>
           <button
             class={styles.viewToggleButton}
             classList={{ [styles.viewToggleActive]: props.mode === 'split' }}
             onClick={() => props.onToggle('split')}
-            aria-label="Side-by-side view"
           >
             <Icon icon={Columns2} size="sm" />
           </button>
         </Tooltip>
       </Show>
-      <Tooltip text="Source view">
+      <Tooltip text="Source view" targetAriaLabel>
         <button
           class={styles.viewToggleButton}
           classList={{ [styles.viewToggleActive]: props.mode === 'source' }}
           onClick={() => props.onToggle('source')}
-          aria-label="Source view"
         >
           <Icon icon={Code} size="sm" />
         </button>
       </Tooltip>
       <Show when={props.onMention}>
         <div style={{ 'border-left': '1px solid var(--border)' }} />
-        <Tooltip text="Mention in the chat">
+        <Tooltip text="Mention in the chat" targetAriaLabel>
           <button
             class={styles.viewToggleButton}
             onClick={() => props.onMention?.()}
-            aria-label="Mention in the chat"
             data-testid="file-mention-button"
           >
             <Icon icon={AtSign} size="sm" />

--- a/frontend/src/components/settings/FontSettings.tsx
+++ b/frontend/src/components/settings/FontSettings.tsx
@@ -235,7 +235,7 @@ export const FontSettings: Component = () => {
                       </Show>
                     </div>
                   </Show>
-                  <Tooltip text="Remove">
+                  <Tooltip text="Remove" targetAriaLabel>
                     <button
                       class={styles.fontRemoveButton}
                       onClick={() => removeFont(list, i())}
@@ -261,7 +261,7 @@ export const FontSettings: Component = () => {
             }}
             disabled={fontSaving()}
           />
-          <Tooltip text={`Add ${label.toLowerCase()}`}>
+          <Tooltip text={`Add ${label.toLowerCase()}`} targetAriaLabel>
             <button
               class="small outline"
               onClick={() => addFont(list)}

--- a/frontend/src/components/settings/FontSettings.tsx
+++ b/frontend/src/components/settings/FontSettings.tsx
@@ -235,7 +235,7 @@ export const FontSettings: Component = () => {
                       </Show>
                     </div>
                   </Show>
-                  <Tooltip text="Remove" targetAriaLabel>
+                  <Tooltip text="Remove" ariaLabel>
                     <button
                       class={styles.fontRemoveButton}
                       onClick={() => removeFont(list, i())}
@@ -261,7 +261,7 @@ export const FontSettings: Component = () => {
             }}
             disabled={fontSaving()}
           />
-          <Tooltip text={`Add ${label.toLowerCase()}`} targetAriaLabel>
+          <Tooltip text={`Add ${label.toLowerCase()}`} ariaLabel>
             <button
               class="small outline"
               onClick={() => addFont(list)}

--- a/frontend/tests/unit/components/AttachmentStrip.test.tsx
+++ b/frontend/tests/unit/components/AttachmentStrip.test.tsx
@@ -1,5 +1,5 @@
 import type { FileAttachment } from '~/components/chat/attachments'
-import { render, screen } from '@solidjs/testing-library'
+import { render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { AttachmentStrip } from '~/components/chat/AttachmentStrip'

--- a/frontend/tests/unit/components/AttachmentStrip.test.tsx
+++ b/frontend/tests/unit/components/AttachmentStrip.test.tsx
@@ -1,5 +1,5 @@
 import type { FileAttachment } from '~/components/chat/attachments'
-import { render } from '@solidjs/testing-library'
+import { render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { AttachmentStrip } from '~/components/chat/AttachmentStrip'
@@ -60,9 +60,8 @@ describe('attachmentStrip', () => {
     const { container } = render(() => (
       <AttachmentStrip attachments={attachments} onRemove={() => {}} />
     ))
-    const filename = container.querySelector('[data-testid="attachment-pill"] span[title]') as HTMLSpanElement
+    const filename = container.querySelector('[data-testid="attachment-pill"] > span:nth-of-type(2)') as HTMLSpanElement
     expect(filename).toBeInTheDocument()
-    expect(filename.title).toBe('very/long/nested/path/to/screenshot.png')
     expect(filename).toHaveTextContent('very/long/nested/path/to/screenshot.png')
   })
 

--- a/frontend/tests/unit/components/AttachmentStrip.test.tsx
+++ b/frontend/tests/unit/components/AttachmentStrip.test.tsx
@@ -60,7 +60,7 @@ describe('attachmentStrip', () => {
     const { container } = render(() => (
       <AttachmentStrip attachments={attachments} onRemove={() => {}} />
     ))
-    const filename = container.querySelector('[data-testid="attachment-pill"] > span:nth-of-type(2)') as HTMLSpanElement
+    const filename = container.querySelector('[data-testid="attachment-pill"] > span:nth-of-type(2) > span') as HTMLSpanElement
     expect(filename).toBeInTheDocument()
     expect(filename).toHaveTextContent('very/long/nested/path/to/screenshot.png')
   })

--- a/frontend/tests/unit/components/GenericToolControl.test.tsx
+++ b/frontend/tests/unit/components/GenericToolControl.test.tsx
@@ -23,6 +23,16 @@ function makeAskState(): AskQuestionState {
 }
 
 describe('genericToolActions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    HTMLElement.prototype.showPopover = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
   it('shows Reject, Allow, and Bypass Permissions when no editor content', () => {
     render(() => (
       <GenericToolActions
@@ -133,7 +143,11 @@ describe('genericToolActions', () => {
       />
     ))
 
-    expect(screen.getByTestId('control-bypass-btn'))
-      .toHaveAttribute('title', 'Allow this request and stop asking for permissions')
+    const button = screen.getByTestId('control-bypass-btn')
+    fireEvent.mouseEnter(button)
+    vi.advanceTimersByTime(700)
+
+    expect(screen.getByRole('tooltip', { hidden: true }))
+      .toHaveTextContent('Allow this request and stop asking for permissions')
   })
 })


### PR DESCRIPTION
## Motivation
Several frontend controls were still using native `title` attributes instead of the shared tooltip component, and the shared `Tooltip` abstraction itself did not have a built-in way to label icon-only targets consistently.

## Modifications
Refactored the shared `Tooltip` component to resolve a single direct child element, attach hover and focus behavior to that target, manage `aria-describedby` on the target while the tooltip is visible, and support an opt-in `targetAriaLabel` prop for icon-only or otherwise unlabeled controls. Added focused tests for tooltip visibility, target labeling, and invalid child usage. Migrated tooltip-backed icon-only controls such as `IconButton`, file viewer controls, message/tool header icons, font action buttons, attachment removal, agent info copy actions, and the context usage grid to use `targetAriaLabel`. Left text-bearing tooltip targets as tooltip-only so their visible text remains the accessible name, and updated the attachment strip test to match the new structure.

## Result
Tooltip behavior is now centralized in the shared component for the affected controls, accessible labeling for icon-only targets can be declared through `Tooltip` instead of repeated per-callsite `aria-label` props, and the branch no longer relies on native `title` tooltips for those UI interactions.
