### PR TITLE
Persist auto-continue schedules for Claude and Codex

### DIFF
--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -363,9 +363,8 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// Auto-continue on synthetic API 5xx errors; reset on normal results.
 		if env.IsError && hasSyntheticAPI5xxPrefix(env.Result) {
 			a.sink.ScheduleAutoContinue(AutoContinueSchedule{
-				Reason:  AutoContinueReasonAPIError,
-				DueAt:   time.Now().UTC(),
-				Content: "Continue.",
+				Reason: AutoContinueReasonAPIError,
+				DueAt:  time.Now().UTC(),
 			})
 		} else {
 			a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
@@ -445,18 +444,21 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 		return
 	}
 
-	var rlType struct {
+	var rlInfo struct {
 		RateLimitType string `json:"rateLimitType"`
+		Status        string `json:"status"`
+		ResetsAt      *int64 `json:"resetsAt"`
 	}
-	if err := json.Unmarshal(rle.RateLimitInfo, &rlType); err != nil {
+	if err := json.Unmarshal(rle.RateLimitInfo, &rlInfo); err != nil {
 		slog.Warn("claude rate limit info unmarshal failed", "agent_id", a.agentID, "error", err)
+		return
 	}
-	if rlType.RateLimitType == "" {
-		rlType.RateLimitType = "unknown"
+	if rlInfo.RateLimitType == "" {
+		rlInfo.RateLimitType = "unknown"
 	}
 
 	rateLimits := map[string]json.RawMessage{
-		rlType.RateLimitType: rle.RateLimitInfo,
+		rlInfo.RateLimitType: rle.RateLimitInfo,
 	}
 	a.sink.BroadcastSessionInfo(map[string]interface{}{
 		"rateLimits": rateLimits,
@@ -474,26 +476,17 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 		slog.Error("persist rate_limit notification", "agent_id", a.agentID, "error", err)
 	}
 
-	var scheduleInfo struct {
-		Status   string `json:"status"`
-		ResetsAt *int64 `json:"resetsAt"`
-	}
-	if err := json.Unmarshal(rle.RateLimitInfo, &scheduleInfo); err != nil {
-		slog.Warn("claude rate limit scheduling parse failed", "agent_id", a.agentID, "error", err)
-		return
-	}
-	if scheduleInfo.Status == "allowed" {
+	if rlInfo.Status == "allowed" {
 		a.sink.CancelAutoContinue(AutoContinueReasonRateLimit)
 		return
 	}
-	if scheduleInfo.ResetsAt == nil {
+	if rlInfo.ResetsAt == nil {
 		return
 	}
 
 	a.sink.ScheduleAutoContinue(AutoContinueSchedule{
 		Reason:        AutoContinueReasonRateLimit,
-		DueAt:         time.Unix(*scheduleInfo.ResetsAt, 0).UTC(),
-		Content:       "Continue.",
+		DueAt:         time.Unix(*rlInfo.ResetsAt, 0).UTC(),
 		SourcePayload: append([]byte(nil), rle.RateLimitInfo...),
 	})
 }

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -362,9 +362,13 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	if msgType == "result" {
 		// Auto-continue on synthetic API 5xx errors; reset on normal results.
 		if env.IsError && hasSyntheticAPI5xxPrefix(env.Result) {
-			a.sink.ScheduleAutoContinue()
+			a.sink.ScheduleAutoContinue(AutoContinueSchedule{
+				Reason:  AutoContinueReasonAPIError,
+				DueAt:   time.Now().UTC(),
+				Content: "Continue.",
+			})
 		} else {
-			a.sink.ResetAutoContinue()
+			a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
 		}
 
 		// Reset all span tracking so the next turn starts clean.
@@ -469,6 +473,29 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 	if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, notifContent); err != nil {
 		slog.Error("persist rate_limit notification", "agent_id", a.agentID, "error", err)
 	}
+
+	var scheduleInfo struct {
+		Status   string `json:"status"`
+		ResetsAt *int64 `json:"resetsAt"`
+	}
+	if err := json.Unmarshal(rle.RateLimitInfo, &scheduleInfo); err != nil {
+		slog.Warn("claude rate limit scheduling parse failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+	if scheduleInfo.Status == "allowed" {
+		a.sink.CancelAutoContinue(AutoContinueReasonRateLimit)
+		return
+	}
+	if scheduleInfo.ResetsAt == nil {
+		return
+	}
+
+	a.sink.ScheduleAutoContinue(AutoContinueSchedule{
+		Reason:        AutoContinueReasonRateLimit,
+		DueAt:         time.Unix(*scheduleInfo.ResetsAt, 0).UTC(),
+		Content:       "Continue.",
+		SourcePayload: append([]byte(nil), rle.RateLimitInfo...),
+	})
 }
 
 // extractAndBroadcastUsage extracts token usage from assistant/result messages.

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/stretchr/testify/assert"
@@ -196,6 +197,68 @@ func TestHandleOutput_AssistantNoToolUse(t *testing.T) {
 	// No spans opened.
 	assert.Empty(t, sink.OpenedSpans())
 	assert.Equal(t, 0, agent.turnToolUses)
+}
+
+func TestClaudeRateLimitEvent_SchedulesResumeWhenBlocked(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	agent.HandleOutput([]byte(`{
+		"type":"rate_limit_event",
+		"rate_limit_info":{
+			"rateLimitType":"five_hour",
+			"status":"exceeded",
+			"resetsAt":1893456000
+		}
+	}`))
+
+	require.Equal(t, 1, sink.AutoScheduleCount())
+	schedule := sink.LastAutoSchedule()
+	assert.Equal(t, AutoContinueReasonRateLimit, schedule.Reason)
+	assert.Equal(t, "Continue.", schedule.Content)
+	assert.Equal(t, time.Unix(1893456000, 0).UTC(), schedule.DueAt)
+	assert.JSONEq(t, `{"rateLimitType":"five_hour","status":"exceeded","resetsAt":1893456000}`, string(schedule.SourcePayload))
+}
+
+func TestClaudeRateLimitEvent_AllowedCancelsResume(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	agent.HandleOutput([]byte(`{
+		"type":"rate_limit_event",
+		"rate_limit_info":{
+			"rateLimitType":"five_hour",
+			"status":"allowed",
+			"resetsAt":1893456000
+		}
+	}`))
+
+	require.Equal(t, 1, sink.AutoCancelCount())
+	assert.Equal(t, AutoContinueReasonRateLimit, sink.LastAutoCancel())
+	assert.Equal(t, 0, sink.AutoScheduleCount())
+}
+
+func TestClaudeResult_APIErrorUsesAPIErrorReason(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	agent.HandleOutput([]byte(`{
+		"type":"result",
+		"is_error":true,
+		"result":"API Error: 500 Internal Server Error"
+	}`))
+
+	require.Equal(t, 1, sink.AutoScheduleCount())
+	assert.Equal(t, AutoContinueReasonAPIError, sink.LastAutoSchedule().Reason)
+
+	agent.HandleOutput([]byte(`{
+		"type":"result",
+		"is_error":false,
+		"result":"ok"
+	}`))
+
+	require.Equal(t, 1, sink.AutoCancelCount())
+	assert.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
 }
 
 func TestHandleOutput_MalformedJSON(t *testing.T) {

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -215,7 +215,6 @@ func TestClaudeRateLimitEvent_SchedulesResumeWhenBlocked(t *testing.T) {
 	require.Equal(t, 1, sink.AutoScheduleCount())
 	schedule := sink.LastAutoSchedule()
 	assert.Equal(t, AutoContinueReasonRateLimit, schedule.Reason)
-	assert.Equal(t, "Continue.", schedule.Content)
 	assert.Equal(t, time.Unix(1893456000, 0).UTC(), schedule.DueAt)
 	assert.JSONEq(t, `{"rateLimitType":"five_hour","status":"exceeded","resetsAt":1893456000}`, string(schedule.SourcePayload))
 }

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
@@ -601,6 +602,7 @@ func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMess
 	}
 
 	rateLimits := map[string]interface{}{}
+	var latestExceededReset *time.Time
 	for _, tier := range []*codexRateLimitTier{notif.RateLimits.Primary, notif.RateLimits.Secondary} {
 		if tier == nil {
 			continue
@@ -619,6 +621,12 @@ func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMess
 		}
 		if tier.ResetsAt != nil {
 			info["resetsAt"] = *tier.ResetsAt
+			if status == "exceeded" {
+				resetAt := time.Unix(*tier.ResetsAt, 0).UTC()
+				if latestExceededReset == nil || resetAt.After(*latestExceededReset) {
+					latestExceededReset = &resetAt
+				}
+			}
 		}
 		rateLimits[rlType] = info
 	}
@@ -626,6 +634,17 @@ func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMess
 		a.sink.BroadcastSessionInfo(map[string]interface{}{
 			"rateLimits": rateLimits,
 		})
+	}
+
+	if latestExceededReset != nil {
+		a.sink.ScheduleAutoContinue(AutoContinueSchedule{
+			Reason:        AutoContinueReasonRateLimit,
+			DueAt:         *latestExceededReset,
+			Content:       "Continue.",
+			SourcePayload: append([]byte(nil), content...),
+		})
+	} else {
+		a.sink.CancelAutoContinue(AutoContinueReasonRateLimit)
 	}
 }
 

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -640,7 +640,6 @@ func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMess
 		a.sink.ScheduleAutoContinue(AutoContinueSchedule{
 			Reason:        AutoContinueReasonRateLimit,
 			DueAt:         *latestExceededReset,
-			Content:       "Continue.",
 			SourcePayload: append([]byte(nil), content...),
 		})
 	} else {

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
@@ -257,6 +258,43 @@ func TestHandleCodexOutput_McpStartupStatusPersistsNotification(t *testing.T) {
 	}
 	if string(sink.LastNotification().Content) != input {
 		t.Fatalf("expected raw startup status notification to be preserved, got %s", string(sink.LastNotification().Content))
+	}
+}
+
+func TestHandleCodexOutput_RateLimitExceededSchedulesResume(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"account/rateLimits/updated","params":{"rateLimits":{"primary":{"usedPercent":100,"windowDurationMins":300,"resetsAt":1893456000},"secondary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":1894000000}}}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.AutoScheduleCount() != 1 {
+		t.Fatalf("expected 1 auto-continue schedule, got %d", sink.AutoScheduleCount())
+	}
+	schedule := sink.LastAutoSchedule()
+	if schedule.Reason != AutoContinueReasonRateLimit {
+		t.Fatalf("expected rate_limit reason, got %q", schedule.Reason)
+	}
+	if schedule.Content != "Continue." {
+		t.Fatalf("expected Continue. content, got %q", schedule.Content)
+	}
+	if !schedule.DueAt.Equal(time.Unix(1893456000, 0).UTC()) {
+		t.Fatalf("expected reset time dueAt, got %v", schedule.DueAt)
+	}
+}
+
+func TestHandleCodexOutput_RateLimitClearCancelsResume(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	input := `{"method":"account/rateLimits/updated","params":{"rateLimits":{"primary":{"usedPercent":75,"windowDurationMins":300,"resetsAt":1893456000},"secondary":{"usedPercent":10,"windowDurationMins":10080,"resetsAt":1894000000}}}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.AutoCancelCount() != 1 {
+		t.Fatalf("expected 1 auto-continue cancel, got %d", sink.AutoCancelCount())
+	}
+	if sink.LastAutoCancel() != AutoContinueReasonRateLimit {
+		t.Fatalf("expected rate_limit cancel, got %q", sink.LastAutoCancel())
 	}
 }
 

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -275,9 +275,6 @@ func TestHandleCodexOutput_RateLimitExceededSchedulesResume(t *testing.T) {
 	if schedule.Reason != AutoContinueReasonRateLimit {
 		t.Fatalf("expected rate_limit reason, got %q", schedule.Reason)
 	}
-	if schedule.Content != "Continue." {
-		t.Fatalf("expected Continue. content, got %q", schedule.Content)
-	}
 	if !schedule.DueAt.Equal(time.Unix(1893456000, 0).UTC()) {
 		t.Fatalf("expected reset time dueAt, got %v", schedule.DueAt)
 	}

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -32,7 +32,6 @@ const (
 type AutoContinueSchedule struct {
 	Reason        AutoContinueReason
 	DueAt         time.Time
-	Content       string
 	SourcePayload []byte
 }
 

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
@@ -19,6 +20,20 @@ type SpanInfo struct {
 	SpanType        string
 	SpanColor       int32
 	Closing         bool
+}
+
+type AutoContinueReason string
+
+const (
+	AutoContinueReasonAPIError  AutoContinueReason = "api_error"
+	AutoContinueReasonRateLimit AutoContinueReason = "rate_limit"
+)
+
+type AutoContinueSchedule struct {
+	Reason        AutoContinueReason
+	DueAt         time.Time
+	Content       string
+	SourcePayload []byte
 }
 
 // OutputSink provides generic primitives for persisting and broadcasting
@@ -46,8 +61,8 @@ type OutputSink interface {
 	StorePlanModeToolUse(toolUseID, targetMode string)
 	LoadAndDeletePlanModeToolUse(toolUseID string) (targetMode string, ok bool)
 	UpdatePlan(filePath string, content []byte, compression leapmuxv1.ContentCompression, title string)
-	ScheduleAutoContinue()
-	ResetAutoContinue()
+	ScheduleAutoContinue(schedule AutoContinueSchedule)
+	CancelAutoContinue(reason AutoContinueReason)
 }
 
 // Provider is the interface that all coding agent providers must implement.

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -20,6 +20,8 @@ type testSink struct {
 	openSpans        []testSinkSpanOpen
 	closedSpans      []string
 	resetSpanCount   int
+	autoSchedules    []AutoContinueSchedule
+	autoCancels      []AutoContinueReason
 	planModeToolUses sync.Map
 }
 
@@ -145,8 +147,16 @@ func (s *testSink) LoadAndDeletePlanModeToolUse(toolUseID string) (string, bool)
 }
 
 func (s *testSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string) {}
-func (s *testSink) ScheduleAutoContinue()                                           {}
-func (s *testSink) ResetAutoContinue()                                              {}
+func (s *testSink) ScheduleAutoContinue(schedule AutoContinueSchedule) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.autoSchedules = append(s.autoSchedules, schedule)
+}
+func (s *testSink) CancelAutoContinue(reason AutoContinueReason) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.autoCancels = append(s.autoCancels, reason)
+}
 
 // MessageCount returns the number of persisted messages.
 func (s *testSink) MessageCount() int {
@@ -272,6 +282,30 @@ func (s *testSink) ResetSpanCount() int {
 	return s.resetSpanCount
 }
 
+func (s *testSink) AutoScheduleCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.autoSchedules)
+}
+
+func (s *testSink) LastAutoSchedule() AutoContinueSchedule {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.autoSchedules[len(s.autoSchedules)-1]
+}
+
+func (s *testSink) AutoCancelCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.autoCancels)
+}
+
+func (s *testSink) LastAutoCancel() AutoContinueReason {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.autoCancels[len(s.autoCancels)-1]
+}
+
 // noopSink is a no-op implementation of OutputSink for tests that don't
 // need to verify output.
 type noopSink struct{}
@@ -300,5 +334,5 @@ func (noopSink) BroadcastNotification(map[string]interface{})                   
 func (noopSink) StorePlanModeToolUse(string, string)                             {}
 func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)              { return "", false }
 func (noopSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string) {}
-func (noopSink) ScheduleAutoContinue()                                           {}
-func (noopSink) ResetAutoContinue()                                              {}
+func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                       {}
+func (noopSink) CancelAutoContinue(AutoContinueReason)                           {}

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -57,6 +57,22 @@ CREATE TABLE control_requests (
     PRIMARY KEY (agent_id, request_id)
 );
 
+-- Scheduled synthetic auto-continue messages
+CREATE TABLE auto_continue_schedules (
+    agent_id        TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    reason          TEXT NOT NULL,
+    content         TEXT NOT NULL DEFAULT 'Continue.',
+    due_at          DATETIME NOT NULL,
+    jitter_ms       INTEGER NOT NULL DEFAULT 0,
+    next_backoff_ms INTEGER NOT NULL DEFAULT 0,
+    state           TEXT NOT NULL DEFAULT 'active',
+    source_payload  BLOB NOT NULL DEFAULT x'',
+    created_at      DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (agent_id, reason)
+);
+CREATE INDEX idx_auto_continue_schedules_state_due_at ON auto_continue_schedules(state, due_at);
+
 -- Worktrees created by LeapMux (for lifecycle tracking)
 CREATE TABLE worktrees (
     id              TEXT PRIMARY KEY,
@@ -100,6 +116,7 @@ CREATE INDEX idx_worktree_tabs_tab ON worktree_tabs(tab_type, tab_id);
 DROP TABLE IF EXISTS terminals;
 DROP TABLE IF EXISTS worktree_tabs;
 DROP TABLE IF EXISTS worktrees;
+DROP TABLE IF EXISTS auto_continue_schedules;
 DROP TABLE IF EXISTS control_requests;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS agents;

--- a/backend/internal/worker/db/queries/auto_continue_schedules.sql
+++ b/backend/internal/worker/db/queries/auto_continue_schedules.sql
@@ -1,0 +1,61 @@
+-- name: UpsertAutoContinueSchedule :exec
+INSERT INTO auto_continue_schedules (
+  agent_id,
+  reason,
+  content,
+  due_at,
+  jitter_ms,
+  next_backoff_ms,
+  state,
+  source_payload
+) VALUES (
+  sqlc.arg(agent_id),
+  sqlc.arg(reason),
+  sqlc.arg(content),
+  sqlc.arg(due_at),
+  sqlc.arg(jitter_ms),
+  sqlc.arg(next_backoff_ms),
+  'active',
+  sqlc.arg(source_payload)
+)
+ON CONFLICT(agent_id, reason) DO UPDATE SET
+  content = excluded.content,
+  due_at = excluded.due_at,
+  jitter_ms = excluded.jitter_ms,
+  next_backoff_ms = excluded.next_backoff_ms,
+  state = 'active',
+  source_payload = excluded.source_payload,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+
+-- name: GetAutoContinueSchedule :one
+SELECT * FROM auto_continue_schedules
+WHERE agent_id = ? AND reason = ?;
+
+-- name: ListActiveAutoContinueSchedules :many
+SELECT * FROM auto_continue_schedules
+WHERE state = 'active'
+ORDER BY due_at ASC;
+
+-- name: CancelAutoContinueSchedule :exec
+UPDATE auto_continue_schedules
+SET state = 'cancelled',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE agent_id = ? AND reason = ? AND state = 'active';
+
+-- name: CancelAllAutoContinueSchedulesByAgent :exec
+UPDATE auto_continue_schedules
+SET state = 'cancelled',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE agent_id = ? AND state = 'active';
+
+-- name: MarkAutoContinueScheduleFired :exec
+UPDATE auto_continue_schedules
+SET state = 'fired',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE agent_id = ? AND reason = ? AND state = 'active';
+
+-- name: IsAgentOpen :one
+SELECT EXISTS(
+  SELECT 1 FROM agents
+  WHERE id = ? AND closed_at IS NULL
+);

--- a/backend/internal/worker/service/auto_continue.go
+++ b/backend/internal/worker/service/auto_continue.go
@@ -1,10 +1,16 @@
 package service
 
 import (
+	"database/sql"
+	"errors"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"sync"
 	"time"
+
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
 const (
@@ -12,106 +18,266 @@ const (
 	autoContinueMaxDelay     = 180 * time.Second
 	autoContinueMultiplier   = 2.0
 	autoContinueJitterFrac   = 0.2
+
+	autoContinueContent = "Continue."
+
+	autoContinueStateActive    = "active"
+	autoContinueStateCancelled = "cancelled"
+	autoContinueStateFired     = "fired"
+
+	rateLimitJitterMin = 5 * time.Second
+	rateLimitJitterMax = 30 * time.Second
+	rateLimitJitterPct = 0.05
 )
 
-// autoContinueState tracks exponential-backoff retry state for a single agent.
-// Note: hub/backoff.go serves WebSocket reconnection (a blocking retry loop),
-// whereas this is a timer-based scheduler with generation tracking — different
-// enough that sharing code would add complexity without benefit.
-type autoContinueState struct {
-	mu         sync.Mutex
-	timer      *time.Timer
-	generation int
-	backoff    time.Duration
+type autoContinueKey struct {
+	AgentID string
+	Reason  agent.AutoContinueReason
 }
 
-// scheduleAutoContinue schedules a "Continue." message for the given agent
-// after an exponentially increasing delay. Each call resets the timer.
-func (h *OutputHandler) scheduleAutoContinue(agentID string) {
-	v, ok := h.autoContinue.Load(agentID)
-	if !ok {
-		v, _ = h.autoContinue.LoadOrStore(agentID, &autoContinueState{
-			backoff: autoContinueInitialDelay,
-		})
+type autoContinueTimerState struct {
+	mu    sync.Mutex
+	timer *time.Timer
+	dueAt time.Time
+}
+
+func (h *OutputHandler) restoreAutoContinueSchedules() {
+	schedules, err := h.queries.ListActiveAutoContinueSchedules(bgCtx())
+	if err != nil {
+		slog.Error("auto-continue restore failed", "error", err)
+		return
 	}
-	st := v.(*autoContinueState)
+	for _, schedule := range schedules {
+		key := autoContinueKey{AgentID: schedule.AgentID, Reason: agent.AutoContinueReason(schedule.Reason)}
+		h.armAutoContinueTimer(key, schedule.DueAt)
+	}
+}
 
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	if st.timer != nil {
-		st.timer.Stop()
+func (h *OutputHandler) scheduleAutoContinue(agentID string, schedule agent.AutoContinueSchedule) {
+	now := time.Now().UTC()
+	if schedule.Content == "" {
+		schedule.Content = autoContinueContent
 	}
 
-	st.generation++
-	gen := st.generation
+	record, err := h.buildAutoContinueRecord(agentID, schedule, now)
+	if err != nil {
+		slog.Error("auto-continue schedule build failed", "agent_id", agentID, "reason", schedule.Reason, "error", err)
+		return
+	}
 
-	delay := st.backoff
+	if err := h.queries.UpsertAutoContinueSchedule(bgCtx(), record); err != nil {
+		slog.Error("auto-continue schedule persist failed", "agent_id", agentID, "reason", schedule.Reason, "error", err)
+		return
+	}
+
+	key := autoContinueKey{AgentID: agentID, Reason: schedule.Reason}
+	h.armAutoContinueTimer(key, record.DueAt)
+}
+
+func (h *OutputHandler) cancelAutoContinue(agentID string, reason agent.AutoContinueReason) {
+	if err := h.queries.CancelAutoContinueSchedule(bgCtx(), db.CancelAutoContinueScheduleParams{
+		AgentID: agentID,
+		Reason:  string(reason),
+	}); err != nil {
+		slog.Error("auto-continue cancel failed", "agent_id", agentID, "reason", reason, "error", err)
+	}
+	h.stopAutoContinueTimer(autoContinueKey{AgentID: agentID, Reason: reason}, false)
+}
+
+func (h *OutputHandler) cleanupAutoContinue(agentID string) {
+	if err := h.queries.CancelAllAutoContinueSchedulesByAgent(bgCtx(), agentID); err != nil {
+		slog.Error("auto-continue cleanup failed", "agent_id", agentID, "error", err)
+	}
+	for _, reason := range []agent.AutoContinueReason{
+		agent.AutoContinueReasonAPIError,
+		agent.AutoContinueReasonRateLimit,
+	} {
+		h.stopAutoContinueTimer(autoContinueKey{AgentID: agentID, Reason: reason}, true)
+	}
+}
+
+func (h *OutputHandler) buildAutoContinueRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, error) {
+	switch schedule.Reason {
+	case agent.AutoContinueReasonAPIError:
+		return h.buildAPIErrorScheduleRecord(agentID, schedule, now)
+	case agent.AutoContinueReasonRateLimit:
+		return h.buildRateLimitScheduleRecord(agentID, schedule, now), nil
+	default:
+		return db.UpsertAutoContinueScheduleParams{}, errors.New("unknown auto-continue reason")
+	}
+}
+
+func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, error) {
+	delay := autoContinueInitialDelay
+	nextBackoff := time.Duration(float64(autoContinueInitialDelay) * autoContinueMultiplier)
+
+	existing, err := h.queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: agentID,
+		Reason:  string(schedule.Reason),
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return db.UpsertAutoContinueScheduleParams{}, err
+	}
+	if err == nil && existing.State == autoContinueStateActive && existing.NextBackoffMs > 0 {
+		delay = time.Duration(existing.NextBackoffMs) * time.Millisecond
+		nextBackoff = time.Duration(float64(delay) * autoContinueMultiplier)
+	}
+
 	if delay > autoContinueMaxDelay {
 		delay = autoContinueMaxDelay
 	}
+	if nextBackoff > autoContinueMaxDelay {
+		nextBackoff = autoContinueMaxDelay
+	}
 
-	// Apply jitter: +-20%.
-	jitter := time.Duration(float64(delay) * autoContinueJitterFrac * (2*rand.Float64() - 1))
-	delay += jitter
+	jitter := symmetricJitter(delay, autoContinueJitterFrac)
+	dueAt := now.Add(delay + jitter)
+	return db.UpsertAutoContinueScheduleParams{
+		AgentID:       agentID,
+		Reason:        string(schedule.Reason),
+		Content:       schedule.Content,
+		DueAt:         dueAt,
+		JitterMs:      jitter.Milliseconds(),
+		NextBackoffMs: nextBackoff.Milliseconds(),
+		SourcePayload: cloneBytes(schedule.SourcePayload),
+	}, nil
+}
 
-	// Advance backoff for next invocation.
-	st.backoff = time.Duration(float64(st.backoff) * autoContinueMultiplier)
+func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) db.UpsertAutoContinueScheduleParams {
+	jitter := positiveRateLimitJitter(schedule.DueAt.Sub(now))
+	dueAt := schedule.DueAt.UTC().Add(jitter)
+	return db.UpsertAutoContinueScheduleParams{
+		AgentID:       agentID,
+		Reason:        string(schedule.Reason),
+		Content:       schedule.Content,
+		DueAt:         dueAt,
+		JitterMs:      jitter.Milliseconds(),
+		NextBackoffMs: 0,
+		SourcePayload: cloneBytes(schedule.SourcePayload),
+	}
+}
+
+func (h *OutputHandler) armAutoContinueTimer(key autoContinueKey, dueAt time.Time) {
+	v, _ := h.autoContinue.LoadOrStore(key, &autoContinueTimerState{})
+	state := v.(*autoContinueTimerState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.timer != nil {
+		state.timer.Stop()
+	}
+	state.dueAt = dueAt
+
+	delay := time.Until(dueAt)
+	if delay < 0 {
+		delay = 0
+	}
+
+	state.timer = time.AfterFunc(delay, func() {
+		h.fireAutoContinue(key, dueAt)
+	})
 
 	slog.Info("auto-continue scheduled",
-		"agent_id", agentID,
-		"delay", delay,
-		"generation", gen)
+		"agent_id", key.AgentID,
+		"reason", key.Reason,
+		"due_at", dueAt,
+	)
+}
 
-	st.timer = time.AfterFunc(delay, func() {
-		st.mu.Lock()
-		if st.generation != gen {
-			st.mu.Unlock()
-			return
-		}
-		st.mu.Unlock()
+func (h *OutputHandler) stopAutoContinueTimer(key autoContinueKey, remove bool) {
+	v, ok := h.autoContinue.Load(key)
+	if !ok {
+		return
+	}
+	state := v.(*autoContinueTimerState)
+	state.mu.Lock()
+	if state.timer != nil {
+		state.timer.Stop()
+		state.timer = nil
+	}
+	state.mu.Unlock()
+	if remove {
+		h.autoContinue.Delete(key)
+	}
+}
 
-		if h.sendMessageFunc == nil {
-			slog.Warn("auto-continue: sendMessageFunc not set", "agent_id", agentID)
-			return
-		}
+func (h *OutputHandler) fireAutoContinue(key autoContinueKey, dueAt time.Time) {
+	defer h.stopAutoContinueTimer(key, false)
 
-		slog.Info("auto-continue firing", "agent_id", agentID)
-		h.sendMessageFunc(agentID, "Continue.")
+	schedule, err := h.queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: key.AgentID,
+		Reason:  string(key.Reason),
 	})
-}
-
-// resetAutoContinue cancels any pending auto-continue timer and resets
-// the backoff to the initial delay.
-func (h *OutputHandler) resetAutoContinue(agentID string) {
-	v, ok := h.autoContinue.Load(agentID)
-	if !ok {
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			slog.Error("auto-continue fire read failed", "agent_id", key.AgentID, "reason", key.Reason, "error", err)
+		}
 		return
 	}
-	st := v.(*autoContinueState)
-
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	if st.timer != nil {
-		st.timer.Stop()
-		st.timer = nil
-	}
-	st.generation++
-	st.backoff = autoContinueInitialDelay
-}
-
-// cleanupAutoContinue stops any pending timer and removes the state.
-func (h *OutputHandler) cleanupAutoContinue(agentID string) {
-	v, ok := h.autoContinue.LoadAndDelete(agentID)
-	if !ok {
+	if schedule.State != autoContinueStateActive || !schedule.DueAt.Equal(dueAt) {
 		return
 	}
-	st := v.(*autoContinueState)
-	st.mu.Lock()
-	defer st.mu.Unlock()
-	if st.timer != nil {
-		st.timer.Stop()
-		st.timer = nil
+
+	isOpen, err := h.queries.IsAgentOpen(bgCtx(), key.AgentID)
+	if err != nil {
+		slog.Error("auto-continue fire open-check failed", "agent_id", key.AgentID, "reason", key.Reason, "error", err)
+		return
 	}
+	if isOpen == 0 {
+		_ = h.queries.CancelAutoContinueSchedule(bgCtx(), db.CancelAutoContinueScheduleParams{
+			AgentID: key.AgentID,
+			Reason:  string(key.Reason),
+		})
+		return
+	}
+
+	if err := h.queries.MarkAutoContinueScheduleFired(bgCtx(), db.MarkAutoContinueScheduleFiredParams{
+		AgentID: key.AgentID,
+		Reason:  string(key.Reason),
+	}); err != nil {
+		slog.Error("auto-continue fire mark failed", "agent_id", key.AgentID, "reason", key.Reason, "error", err)
+		return
+	}
+	if h.sendMessageFunc == nil {
+		slog.Warn("auto-continue: sendMessageFunc not set", "agent_id", key.AgentID, "reason", key.Reason)
+		return
+	}
+
+	slog.Info("auto-continue firing", "agent_id", key.AgentID, "reason", key.Reason)
+	h.sendMessageFunc(key.AgentID, schedule.Content)
+}
+
+func symmetricJitter(delay time.Duration, frac float64) time.Duration {
+	if delay <= 0 || frac <= 0 {
+		return 0
+	}
+	window := float64(delay) * frac
+	return time.Duration(window * (2*rand.Float64() - 1))
+}
+
+func positiveRateLimitJitter(remaining time.Duration) time.Duration {
+	if remaining < 0 {
+		remaining = 0
+	}
+	target := time.Duration(math.Round(float64(remaining) * rateLimitJitterPct))
+	if target < rateLimitJitterMin {
+		target = rateLimitJitterMin
+	}
+	if target > rateLimitJitterMax {
+		target = rateLimitJitterMax
+	}
+	if target <= 0 {
+		return rateLimitJitterMin
+	}
+	return time.Duration(rand.Int64N(int64(target))) + 1
+}
+
+func cloneBytes(src []byte) []byte {
+	if len(src) == 0 {
+		return []byte{}
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
 }

--- a/backend/internal/worker/service/auto_continue.go
+++ b/backend/internal/worker/service/auto_continue.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
 	"log/slog"
@@ -38,7 +39,6 @@ type autoContinueKey struct {
 type autoContinueTimerState struct {
 	mu    sync.Mutex
 	timer *time.Timer
-	dueAt time.Time
 }
 
 func (h *OutputHandler) restoreAutoContinueSchedules() {
@@ -55,9 +55,6 @@ func (h *OutputHandler) restoreAutoContinueSchedules() {
 
 func (h *OutputHandler) scheduleAutoContinue(agentID string, schedule agent.AutoContinueSchedule) {
 	now := time.Now().UTC()
-	if schedule.Content == "" {
-		schedule.Content = autoContinueContent
-	}
 
 	record, err := h.buildAutoContinueRecord(agentID, schedule, now)
 	if err != nil {
@@ -135,11 +132,11 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
-		Content:       schedule.Content,
+		Content:       autoContinueContent,
 		DueAt:         dueAt,
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: nextBackoff.Milliseconds(),
-		SourcePayload: cloneBytes(schedule.SourcePayload),
+		SourcePayload: cloneOrEmpty(schedule.SourcePayload),
 	}, nil
 }
 
@@ -149,11 +146,11 @@ func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule ag
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
-		Content:       schedule.Content,
+		Content:       autoContinueContent,
 		DueAt:         dueAt,
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: 0,
-		SourcePayload: cloneBytes(schedule.SourcePayload),
+		SourcePayload: cloneOrEmpty(schedule.SourcePayload),
 	}
 }
 
@@ -167,7 +164,6 @@ func (h *OutputHandler) armAutoContinueTimer(key autoContinueKey, dueAt time.Tim
 	if state.timer != nil {
 		state.timer.Stop()
 	}
-	state.dueAt = dueAt
 
 	delay := time.Until(dueAt)
 	if delay < 0 {
@@ -267,17 +263,12 @@ func positiveRateLimitJitter(remaining time.Duration) time.Duration {
 	if target > rateLimitJitterMax {
 		target = rateLimitJitterMax
 	}
-	if target <= 0 {
-		return rateLimitJitterMin
-	}
 	return time.Duration(rand.Int64N(int64(target))) + 1
 }
 
-func cloneBytes(src []byte) []byte {
+func cloneOrEmpty(src []byte) []byte {
 	if len(src) == 0 {
 		return []byte{}
 	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
+	return bytes.Clone(src)
 }

--- a/backend/internal/worker/service/auto_continue_service_test.go
+++ b/backend/internal/worker/service/auto_continue_service_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func TestCloseAgent_CancelsPendingSchedules(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+
+	require.NoError(t, svc.Queries.CreateAgent(bgCtx(), db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  "/tmp",
+		HomeDir:     "/tmp",
+	}))
+	require.NoError(t, svc.Queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
+		AgentID:       "agent-1",
+		Reason:        "rate_limit",
+		Content:       autoContinueContent,
+		DueAt:         time.Now().UTC().Add(time.Hour),
+		JitterMs:      0,
+		NextBackoffMs: 0,
+		SourcePayload: []byte{},
+	}))
+
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{AgentId: "agent-1"}, w)
+	require.Empty(t, w.errors)
+
+	row, err := svc.Queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: "agent-1",
+		Reason:  "rate_limit",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, autoContinueStateCancelled, row.State)
+}
+
+func TestCleanupWorkspace_CancelsPendingSchedules(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+
+	require.NoError(t, svc.Queries.CreateAgent(bgCtx(), db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  "/tmp",
+		HomeDir:     "/tmp",
+	}))
+	require.NoError(t, svc.Queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
+		AgentID:       "agent-1",
+		Reason:        "api_error",
+		Content:       autoContinueContent,
+		DueAt:         time.Now().UTC().Add(time.Hour),
+		JitterMs:      0,
+		NextBackoffMs: 20000,
+		SourcePayload: []byte{},
+	}))
+
+	dispatch(d, "CleanupWorkspace", &leapmuxv1.CleanupWorkspaceRequest{WorkspaceId: "ws-1"}, w)
+	require.Empty(t, w.errors)
+
+	row, err := svc.Queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: "agent-1",
+		Reason:  "api_error",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, autoContinueStateCancelled, row.State)
+}

--- a/backend/internal/worker/service/auto_continue_service_test.go
+++ b/backend/internal/worker/service/auto_continue_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -22,7 +23,7 @@ func TestCloseAgent_CancelsPendingSchedules(t *testing.T) {
 	}))
 	require.NoError(t, svc.Queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
 		AgentID:       "agent-1",
-		Reason:        "rate_limit",
+		Reason:        string(agent.AutoContinueReasonRateLimit),
 		Content:       autoContinueContent,
 		DueAt:         time.Now().UTC().Add(time.Hour),
 		JitterMs:      0,
@@ -35,7 +36,7 @@ func TestCloseAgent_CancelsPendingSchedules(t *testing.T) {
 
 	row, err := svc.Queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
 		AgentID: "agent-1",
-		Reason:  "rate_limit",
+		Reason:  string(agent.AutoContinueReasonRateLimit),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, autoContinueStateCancelled, row.State)
@@ -52,7 +53,7 @@ func TestCleanupWorkspace_CancelsPendingSchedules(t *testing.T) {
 	}))
 	require.NoError(t, svc.Queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
 		AgentID:       "agent-1",
-		Reason:        "api_error",
+		Reason:        string(agent.AutoContinueReasonAPIError),
 		Content:       autoContinueContent,
 		DueAt:         time.Now().UTC().Add(time.Hour),
 		JitterMs:      0,
@@ -65,7 +66,7 @@ func TestCleanupWorkspace_CancelsPendingSchedules(t *testing.T) {
 
 	row, err := svc.Queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
 		AgentID: "agent-1",
-		Reason:  "api_error",
+		Reason:  string(agent.AutoContinueReasonAPIError),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, autoContinueStateCancelled, row.State)

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -7,93 +7,168 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
-func TestScheduleAutoContinue_FiresAfterDelay(t *testing.T) {
-	h := &OutputHandler{}
-
-	var called atomic.Int32
-
-	h.sendMessageFunc = func(agentID, content string) {
-		called.Add(1)
-	}
-
-	h.scheduleAutoContinue("agent-1")
-
-	// Should not fire immediately.
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, int32(0), called.Load())
-
-	// Wait for the initial delay (10s) + some margin.
-	// We can't wait that long in a unit test, so we test via
-	// the internal state instead: verify the state was created.
-	v, ok := h.autoContinue.Load("agent-1")
-	require.True(t, ok)
-	st := v.(*autoContinueState)
-	st.mu.Lock()
-	assert.NotNil(t, st.timer, "timer should be set")
-	assert.Equal(t, 1, st.generation)
-	// Backoff should have doubled from initial 10s to 20s.
-	assert.Equal(t, time.Duration(float64(autoContinueInitialDelay)*autoContinueMultiplier), st.backoff)
-	st.mu.Unlock()
-
-	// Cleanup.
-	h.cleanupAutoContinue("agent-1")
+func createAutoContinueTestAgent(t *testing.T, queries *db.Queries, agentID string) {
+	t.Helper()
+	require.NoError(t, queries.CreateAgent(bgCtx(), db.CreateAgentParams{
+		ID:          agentID,
+		WorkspaceID: "ws-1",
+		WorkingDir:  "/tmp",
+		HomeDir:     "/tmp",
+	}))
 }
 
-func TestResetAutoContinue_StopsTimer(t *testing.T) {
-	h := &OutputHandler{}
-	h.sendMessageFunc = func(string, string) {}
+func TestAutoContinueSchedule_SurvivesRestart(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	h.scheduleAutoContinue("agent-1")
+	require.NoError(t, queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
+		AgentID:       "agent-1",
+		Reason:        string(agent.AutoContinueReasonRateLimit),
+		Content:       autoContinueContent,
+		DueAt:         time.Now().UTC().Add(100 * time.Millisecond),
+		JitterMs:      0,
+		NextBackoffMs: 0,
+		SourcePayload: []byte{},
+	}))
 
-	v, ok := h.autoContinue.Load("agent-1")
-	require.True(t, ok)
-	st := v.(*autoContinueState)
+	var fired atomic.Int32
+	h2 := NewOutputHandler(queries, nil, nil, nil)
+	h2.SetSendMessageFunc(func(agentID, content string) {
+		if agentID == "agent-1" && content == autoContinueContent {
+			fired.Add(1)
+		}
+	})
+	h2.restoreAutoContinueSchedules()
 
-	h.resetAutoContinue("agent-1")
+	require.Eventually(t, func() bool { return fired.Load() == 1 }, 2*time.Second, 25*time.Millisecond)
 
-	st.mu.Lock()
-	assert.Nil(t, st.timer, "timer should be nil after reset")
-	assert.Equal(t, autoContinueInitialDelay, st.backoff, "backoff should be reset to initial")
-	st.mu.Unlock()
+	row, err := queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: "agent-1",
+		Reason:  string(agent.AutoContinueReasonRateLimit),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, autoContinueStateFired, row.State)
 }
 
-func TestResetAutoContinue_NoopWhenNoState(t *testing.T) {
-	h := &OutputHandler{}
-	// Should not panic.
-	h.resetAutoContinue("nonexistent")
+func TestAutoContinueSchedule_RescheduleUpdatesSingleRow(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
+
+	h := NewOutputHandler(queries, nil, nil, nil)
+	firstDueAt := time.Now().UTC().Add(10 * time.Minute)
+	secondDueAt := firstDueAt.Add(20 * time.Minute)
+
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonRateLimit,
+		DueAt:   firstDueAt,
+		Content: autoContinueContent,
+	})
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonRateLimit,
+		DueAt:   secondDueAt,
+		Content: autoContinueContent,
+	})
+	t.Cleanup(func() { h.cleanupAutoContinue("agent-1") })
+
+	rows, err := queries.ListActiveAutoContinueSchedules(bgCtx())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "agent-1", rows[0].AgentID)
+	assert.Equal(t, string(agent.AutoContinueReasonRateLimit), rows[0].Reason)
+	assert.True(t, rows[0].DueAt.After(firstDueAt))
 }
 
-func TestCleanupAutoContinue_RemovesState(t *testing.T) {
-	h := &OutputHandler{}
-	h.sendMessageFunc = func(string, string) {}
+func TestAutoContinueSchedule_ReasonsCanCoexist(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	h.scheduleAutoContinue("agent-1")
-	_, ok := h.autoContinue.Load("agent-1")
-	require.True(t, ok)
+	h := NewOutputHandler(queries, nil, nil, nil)
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonAPIError,
+		DueAt:   time.Now().UTC(),
+		Content: autoContinueContent,
+	})
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonRateLimit,
+		DueAt:   time.Now().UTC().Add(time.Hour),
+		Content: autoContinueContent,
+	})
+	t.Cleanup(func() { h.cleanupAutoContinue("agent-1") })
 
-	h.cleanupAutoContinue("agent-1")
-	_, ok = h.autoContinue.Load("agent-1")
-	assert.False(t, ok, "state should be removed after cleanup")
+	rows, err := queries.ListActiveAutoContinueSchedules(bgCtx())
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
 }
 
-func TestScheduleAutoContinue_BackoffIncreases(t *testing.T) {
-	h := &OutputHandler{}
-	h.sendMessageFunc = func(string, string) {}
+func TestAutoContinueSchedule_CancelOneReasonLeavesOtherIntact(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	// Schedule twice to see backoff increase.
-	h.scheduleAutoContinue("agent-1")
-	h.scheduleAutoContinue("agent-1")
+	h := NewOutputHandler(queries, nil, nil, nil)
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonAPIError,
+		DueAt:   time.Now().UTC(),
+		Content: autoContinueContent,
+	})
+	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
+		Reason:  agent.AutoContinueReasonRateLimit,
+		DueAt:   time.Now().UTC().Add(time.Hour),
+		Content: autoContinueContent,
+	})
 
-	v, _ := h.autoContinue.Load("agent-1")
-	st := v.(*autoContinueState)
-	st.mu.Lock()
-	// After two schedules: initial 10s -> 20s (first) -> 40s (second).
-	expected := time.Duration(float64(autoContinueInitialDelay) * autoContinueMultiplier * autoContinueMultiplier)
-	assert.Equal(t, expected, st.backoff)
-	assert.Equal(t, 2, st.generation, "generation should increment on each schedule")
-	st.mu.Unlock()
+	h.cancelAutoContinue("agent-1", agent.AutoContinueReasonAPIError)
+	t.Cleanup(func() { h.cleanupAutoContinue("agent-1") })
 
-	h.cleanupAutoContinue("agent-1")
+	rows, err := queries.ListActiveAutoContinueSchedules(bgCtx())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, string(agent.AutoContinueReasonRateLimit), rows[0].Reason)
+
+	apiRow, err := queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+		AgentID: "agent-1",
+		Reason:  string(agent.AutoContinueReasonAPIError),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, autoContinueStateCancelled, apiRow.State)
+}
+
+func TestAutoContinueSchedule_FiresOnceAndDoesNotRefireAfterRestart(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
+
+	require.NoError(t, queries.UpsertAutoContinueSchedule(bgCtx(), db.UpsertAutoContinueScheduleParams{
+		AgentID:       "agent-1",
+		Reason:        string(agent.AutoContinueReasonRateLimit),
+		Content:       autoContinueContent,
+		DueAt:         time.Now().UTC().Add(100 * time.Millisecond),
+		JitterMs:      0,
+		NextBackoffMs: 0,
+		SourcePayload: []byte{},
+	}))
+
+	var fired atomic.Int32
+	h1 := NewOutputHandler(queries, nil, nil, nil)
+	h1.SetSendMessageFunc(func(agentID, content string) {
+		if agentID == "agent-1" && content == autoContinueContent {
+			fired.Add(1)
+		}
+	})
+	h1.restoreAutoContinueSchedules()
+	require.Eventually(t, func() bool { return fired.Load() == 1 }, 2*time.Second, 25*time.Millisecond)
+
+	h2 := NewOutputHandler(queries, nil, nil, nil)
+	h2.SetSendMessageFunc(func(agentID, content string) {
+		if agentID == "agent-1" && content == autoContinueContent {
+			fired.Add(1)
+		}
+	})
+	h2.restoreAutoContinueSchedules()
+	time.Sleep(250 * time.Millisecond)
+
+	assert.Equal(t, int32(1), fired.Load())
 }

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -64,14 +64,12 @@ func TestAutoContinueSchedule_RescheduleUpdatesSingleRow(t *testing.T) {
 	secondDueAt := firstDueAt.Add(20 * time.Minute)
 
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonRateLimit,
-		DueAt:   firstDueAt,
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonRateLimit,
+		DueAt:  firstDueAt,
 	})
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonRateLimit,
-		DueAt:   secondDueAt,
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonRateLimit,
+		DueAt:  secondDueAt,
 	})
 	t.Cleanup(func() { h.cleanupAutoContinue("agent-1") })
 
@@ -89,14 +87,12 @@ func TestAutoContinueSchedule_ReasonsCanCoexist(t *testing.T) {
 
 	h := NewOutputHandler(queries, nil, nil, nil)
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonAPIError,
-		DueAt:   time.Now().UTC(),
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonAPIError,
+		DueAt:  time.Now().UTC(),
 	})
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonRateLimit,
-		DueAt:   time.Now().UTC().Add(time.Hour),
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonRateLimit,
+		DueAt:  time.Now().UTC().Add(time.Hour),
 	})
 	t.Cleanup(func() { h.cleanupAutoContinue("agent-1") })
 
@@ -111,14 +107,12 @@ func TestAutoContinueSchedule_CancelOneReasonLeavesOtherIntact(t *testing.T) {
 
 	h := NewOutputHandler(queries, nil, nil, nil)
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonAPIError,
-		DueAt:   time.Now().UTC(),
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonAPIError,
+		DueAt:  time.Now().UTC(),
 	})
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
-		Reason:  agent.AutoContinueReasonRateLimit,
-		DueAt:   time.Now().UTC().Add(time.Hour),
-		Content: autoContinueContent,
+		Reason: agent.AutoContinueReasonRateLimit,
+		DueAt:  time.Now().UTC().Add(time.Hour),
 	})
 
 	h.cancelAutoContinue("agent-1", agent.AutoContinueReasonAPIError)

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -86,6 +86,7 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 		Watchers:  NewWatcherManager(),
 		Terminals: terminal.NewManager(),
 	}
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	d := channel.NewDispatcher()
 	RegisterAll(d, svc)

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -371,8 +371,8 @@ type OutputHandler struct {
 	// Plan mode tool_use tracking (shared across agents).
 	planModeToolUse sync.Map // tool_use_id -> target mode string ("plan" or "default")
 
-	// Auto-continue state (per-agent).
-	autoContinue sync.Map // agentID -> *autoContinueState
+	// Auto-continue timers keyed by agent_id + reason.
+	autoContinue sync.Map // scheduleKey -> *autoContinueTimerState
 
 	// sendMessageFunc is called by auto-continue to inject a synthetic
 	// user message. Set via SetSendMessageFunc during service Init.
@@ -669,12 +669,12 @@ func (s *agentOutputSink) UpdatePlan(filePath string, content []byte, compressio
 	s.h.updatePlan(s.agentID, filePath, content, compression, title)
 }
 
-func (s *agentOutputSink) ScheduleAutoContinue() {
-	s.h.scheduleAutoContinue(s.agentID)
+func (s *agentOutputSink) ScheduleAutoContinue(schedule agent.AutoContinueSchedule) {
+	s.h.scheduleAutoContinue(s.agentID, schedule)
 }
 
-func (s *agentOutputSink) ResetAutoContinue() {
-	s.h.resetAutoContinue(s.agentID)
+func (s *agentOutputSink) CancelAutoContinue(reason agent.AutoContinueReason) {
+	s.h.cancelAutoContinue(s.agentID, reason)
 }
 
 // --- Internal helpers ---

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -138,6 +138,7 @@ func (svc *Context) Init() {
 
 	// Wire auto-continue so OutputHandler can send synthetic user messages.
 	svc.Output.SetSendMessageFunc(svc.sendSyntheticUserMessage)
+	svc.Output.restoreAutoContinueSchedules()
 
 	// No need to deactivate agents/terminals on startup — status is now
 	// derived from runtime state (HasAgent/HasTerminal), not from the DB.

--- a/backend/internal/worker/service/workspace_cleanup.go
+++ b/backend/internal/worker/service/workspace_cleanup.go
@@ -37,6 +37,7 @@ func handleCleanupWorkspace(svc *Context) channel.HandlerFunc {
 		}
 		for _, row := range agentIDs {
 			svc.Agents.StopAgent(row)
+			svc.Output.CleanupAgent(row)
 			_ = svc.Queries.CloseAgent(bgCtx(), row)
 
 			svc.unregisterTabAndCleanup(leapmuxv1.TabType_TAB_TYPE_AGENT, row)


### PR DESCRIPTION
## Motivation
Codex and Claude auto-continue behavior only lived in worker memory, so pending resumes were lost across worker restarts and could not track independent retry reasons for the same agent. We also needed to add rate-limit auto-resume for Claude Code and Codex without expanding the provider runtime surface or applying the behavior to ACP agents yet.

## Modifications
Added a reason-aware auto-continue contract to the agent output sink with `api_error` and `rate_limit` schedule reasons, absolute due times, and optional provider source payloads for diagnostics.
Replaced the in-memory worker auto-continue timer state with a persistent scheduler backed by a dedicated `auto_continue_schedules` table and new queries for upsert, restore, cancel, fire, and agent-open checks. The scheduler now restores active timers during worker init, updates existing `(agent_id, reason)` schedules in place, guards on fire before sending a synthetic `Continue.`, and cancels schedules during agent close and workspace cleanup.
Migrated Claude’s existing synthetic API 5xx retry path onto the persistent scheduler under `api_error`, and added rate-limit scheduling for Claude Code from structured `rate_limit_event` notifications and for Codex from `account/rateLimits/updated` notifications when a tier is exceeded with a reset time.
Updated sink implementations and test coverage across provider, scheduler, and service layers, and folded the new auto-continue schema into the initial worker migration instead of shipping a separate follow-up migration.

## Result
Claude API-error retries now survive worker restarts, Claude Code and Codex can auto-resume after rate limits using persistent per-reason schedules, and the worker can manage concurrent `api_error` and `rate_limit` resumes for the same agent without duplicate timers.
The sink API is now the provider-facing extension point for future auto-continue adopters, while ACP-based agents remain unchanged in this PR.
Backend verification passed with `task test-backend`.
