### PR TITLE
Persist plans to disk and fix Codex rendering/retry issues

### DIFF
--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -106,7 +106,6 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 		a.turnToolUses = 0
 		a.turnSawPlan = false
 		a.turnPlanText = ""
-		a.turnAssistantText = ""
 		a.streamingPlan = false
 		threadID := a.threadID
 		a.mu.Unlock()
@@ -277,35 +276,30 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 
 	switch itemType {
 	case "agentMessage":
-		var messageItem struct {
-			Text string `json:"text"`
-		}
-		if json.Unmarshal(item, &messageItem) == nil && messageItem.Text != "" {
-			a.mu.Lock()
-			a.turnAssistantText = messageItem.Text
-			a.mu.Unlock()
-		}
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist agentMessage", "agent_id", a.agentID, "error", err)
 		}
 	case "plan":
+		a.mu.Lock()
+		a.turnSawPlan = true
+		wasStreamingPlan := a.streamingPlan
+		a.streamingPlan = false
+		a.mu.Unlock()
+		if wasStreamingPlan {
+			a.sink.BroadcastSessionInfo(map[string]interface{}{
+				"streamingType": "",
+			})
+		}
+
 		var planItem struct {
 			Text string `json:"text"`
 		}
 		if json.Unmarshal(item, &planItem) == nil && planItem.Text != "" {
 			a.mu.Lock()
-			a.turnSawPlan = true
 			a.turnPlanText = planItem.Text
-			wasStreamingPlan := a.streamingPlan
-			a.streamingPlan = false
 			a.mu.Unlock()
-			if wasStreamingPlan {
-				a.sink.BroadcastSessionInfo(map[string]interface{}{
-					"streamingType": "",
-				})
-			}
 		}
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
@@ -391,7 +385,6 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	numToolUses := a.turnToolUses
 	sawPlan := a.turnSawPlan
 	planText := a.turnPlanText
-	assistantText := a.turnAssistantText
 	collaborationMode := a.collaborationMode
 	a.mu.Unlock()
 
@@ -434,16 +427,10 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 				"error": "Codex turn failed",
 			})
 		}
-		promptText := planText
-		if promptText == "" {
-			promptText = assistantText
-		}
-		if turnStatus == "completed" && collaborationMode == CodexCollaborationPlan && (sawPlan || promptText != "") {
+		if turnStatus == "completed" && collaborationMode == CodexCollaborationPlan && sawPlan && planText != "" {
 			// Persist plan content so initiatePlanExecution can use it.
-			if promptText != "" {
-				compressed, compression := msgcodec.Compress([]byte(promptText))
-				a.sink.UpdatePlan("", compressed, compression, extractPlanTitle(promptText))
-			}
+			compressed, compression := msgcodec.Compress([]byte(planText))
+			a.sink.UpdatePlan("", compressed, compression, extractPlanTitle(planText))
 			requestID := fmt.Sprintf("codex-plan-prompt-%s", turnID)
 			payload, err := json.Marshal(map[string]interface{}{
 				"type":       "control_request",
@@ -464,7 +451,6 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	a.turnID = ""
 	a.turnSawPlan = false
 	a.turnPlanText = ""
-	a.turnAssistantText = ""
 	a.mu.Unlock()
 
 	// Clear the turn ID in session info.

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
 )
+
+const codexRetryableDisconnectPrefix = "stream disconnected before completion:"
 
 // handleCodexOutput processes a single parsed JSONL notification from the Codex app-server.
 // Codex messages are stored in their native JSON-RPC format.
@@ -390,7 +393,7 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 
 	// Parse once: enrich with num_tool_uses and extract turn data
 	// from the same map to avoid a second json.Unmarshal.
-	var turnStatus, turnID string
+	var turnStatus, turnID, turnErrorMessage string
 	parsed := make(map[string]json.RawMessage)
 	if err := json.Unmarshal(params, &parsed); err == nil {
 		if b, err := json.Marshal(numToolUses); err == nil {
@@ -400,10 +403,14 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 			var turn struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
+				Error  struct {
+					Message string `json:"message"`
+				} `json:"error"`
 			}
 			if json.Unmarshal(turnRaw, &turn) == nil {
 				turnStatus = turn.Status
 				turnID = turn.ID
+				turnErrorMessage = turn.Error.Message
 			}
 		}
 		if b, err := json.Marshal(parsed); err == nil {
@@ -422,10 +429,17 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 
 	if turnStatus != "" {
 		if turnStatus == "failed" {
-			a.sink.BroadcastNotification(map[string]interface{}{
-				"type":  "agent_error",
-				"error": "Codex turn failed",
-			})
+			if isRetryableCodexTurnFailure(turnErrorMessage) {
+				a.sink.ScheduleAutoContinue(AutoContinueSchedule{
+					Reason:        AutoContinueReasonAPIError,
+					DueAt:         time.Now().UTC(),
+					SourcePayload: append([]byte(nil), params...),
+				})
+			} else {
+				a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
+			}
+		} else {
+			a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
 		}
 		if turnStatus == "completed" && collaborationMode == CodexCollaborationPlan && sawPlan && planText != "" {
 			// Persist plan content so initiatePlanExecution can use it.
@@ -457,6 +471,10 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	a.sink.BroadcastSessionInfo(map[string]interface{}{
 		"codexTurnId": "",
 	})
+}
+
+func isRetryableCodexTurnFailure(message string) bool {
+	return strings.HasPrefix(message, codexRetryableDisconnectPrefix)
 }
 
 // handleTokenUsageUpdated processes thread/tokenUsage/updated notifications.

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -327,6 +327,70 @@ func TestHandleCodexOutput_RateLimitClearCancelsResume(t *testing.T) {
 	}
 }
 
+func TestHandleCodexOutput_TurnCompletedFailedRetryableSchedulesAPIError(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	input := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"failed","items":[],"error":{"message":"stream disconnected before completion: An error occurred while processing your request.","codexErrorInfo":"other","additionalDetails":null}}}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.MessageCount() != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", sink.MessageCount())
+	}
+	if sink.AutoScheduleCount() != 1 {
+		t.Fatalf("expected 1 auto-continue schedule, got %d", sink.AutoScheduleCount())
+	}
+	schedule := sink.LastAutoSchedule()
+	if schedule.Reason != AutoContinueReasonAPIError {
+		t.Fatalf("expected api_error reason, got %q", schedule.Reason)
+	}
+	if string(schedule.SourcePayload) != string(sink.Messages()[0].Content) {
+		t.Fatalf("expected source payload to match persisted turn/completed payload")
+	}
+	if sink.AutoCancelCount() != 0 {
+		t.Fatalf("expected 0 auto-continue cancels, got %d", sink.AutoCancelCount())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedFailedNonRetryableCancelsAPIError(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	input := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"failed","items":[],"error":{"message":"Request was aborted by the user.","codexErrorInfo":"other","additionalDetails":null}}}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.AutoScheduleCount() != 0 {
+		t.Fatalf("expected 0 auto-continue schedules, got %d", sink.AutoScheduleCount())
+	}
+	if sink.AutoCancelCount() != 1 {
+		t.Fatalf("expected 1 auto-continue cancel, got %d", sink.AutoCancelCount())
+	}
+	if sink.LastAutoCancel() != AutoContinueReasonAPIError {
+		t.Fatalf("expected api_error cancel, got %q", sink.LastAutoCancel())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedSuccessCancelsAPIError(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	input := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`
+	handleCodexOutput(agent, parseLine([]byte(input)))
+
+	if sink.AutoScheduleCount() != 0 {
+		t.Fatalf("expected 0 auto-continue schedules, got %d", sink.AutoScheduleCount())
+	}
+	if sink.AutoCancelCount() != 1 {
+		t.Fatalf("expected 1 auto-continue cancel, got %d", sink.AutoCancelCount())
+	}
+	if sink.LastAutoCancel() != AutoContinueReasonAPIError {
+		t.Fatalf("expected api_error cancel, got %q", sink.LastAutoCancel())
+	}
+}
+
 func TestHandleCodexOutput_SpawnAgentStartedOpensSubagentSpan(t *testing.T) {
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -7,12 +7,20 @@ import (
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/msgcodec"
 )
 
 // controlRequestRecord captures a single PersistControlRequest / BroadcastControlRequest call.
 type controlRequestRecord struct {
 	RequestID string
 	Payload   []byte
+}
+
+type planUpdateRecord struct {
+	FilePath    string
+	Content     []byte
+	Compression leapmuxv1.ContentCompression
+	Title       string
 }
 
 // controlTestSink extends testSink to also record control request calls.
@@ -22,6 +30,7 @@ type controlTestSink struct {
 	crMu              sync.Mutex
 	persistedControls []controlRequestRecord
 	broadcastControls []controlRequestRecord
+	planUpdates       []planUpdateRecord
 }
 
 type startupStatusGuardSink struct {
@@ -74,6 +83,29 @@ func (s *controlTestSink) LastBroadcastControl() controlRequestRecord {
 	s.crMu.Lock()
 	defer s.crMu.Unlock()
 	return s.broadcastControls[len(s.broadcastControls)-1]
+}
+
+func (s *controlTestSink) UpdatePlan(filePath string, content []byte, compression leapmuxv1.ContentCompression, title string) {
+	s.crMu.Lock()
+	defer s.crMu.Unlock()
+	s.planUpdates = append(s.planUpdates, planUpdateRecord{
+		FilePath:    filePath,
+		Content:     append([]byte(nil), content...),
+		Compression: compression,
+		Title:       title,
+	})
+}
+
+func (s *controlTestSink) PlanUpdateCount() int {
+	s.crMu.Lock()
+	defer s.crMu.Unlock()
+	return len(s.planUpdates)
+}
+
+func (s *controlTestSink) LastPlanUpdate() planUpdateRecord {
+	s.crMu.Lock()
+	defer s.crMu.Unlock()
+	return s.planUpdates[len(s.planUpdates)-1]
 }
 
 func newCodexAgentWithSink(sink OutputSink) *CodexAgent {
@@ -848,5 +880,95 @@ func TestHandleCodexOutput_TurnCompletedIgnoresSubagentThreads(t *testing.T) {
 	}
 	if sink.SessionInfoCount() != 0 {
 		t.Fatalf("expected 0 session info broadcasts, got %d", sink.SessionInfoCount())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedPlanModePersistsRealPlanAndPrompts(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+	agent.collaborationMode = CodexCollaborationPlan
+
+	planStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn-1","item":{"type":"plan","id":"plan-1"}}}`
+	planCompleted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn-1","item":{"type":"plan","id":"plan-1","text":"# Design Doc: Rendering fixes\n\n- first\n"}}}`
+	turnCompleted := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(planStarted)))
+	handleCodexOutput(agent, parseLine([]byte(planCompleted)))
+	handleCodexOutput(agent, parseLine([]byte(turnCompleted)))
+
+	if sink.PlanUpdateCount() != 1 {
+		t.Fatalf("expected 1 plan update, got %d", sink.PlanUpdateCount())
+	}
+	plan := sink.LastPlanUpdate()
+	decoded, err := msgcodec.Decompress(plan.Content, plan.Compression)
+	if err != nil {
+		t.Fatalf("failed to decompress persisted plan content: %v", err)
+	}
+	if got := string(decoded); got != "# Design Doc: Rendering fixes\n\n- first\n" {
+		t.Fatalf("unexpected persisted plan content: %q", got)
+	}
+	if plan.Title != "Rendering fixes" {
+		t.Fatalf("expected normalized title, got %q", plan.Title)
+	}
+	if sink.PersistedControlCount() != 1 || sink.BroadcastControlCount() != 1 {
+		t.Fatalf("expected one control request, got persisted=%d broadcast=%d", sink.PersistedControlCount(), sink.BroadcastControlCount())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedPlanModeIgnoresAssistantTextWithoutPlanItem(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+	agent.collaborationMode = CodexCollaborationPlan
+
+	assistantCompleted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn-1","item":{"type":"agentMessage","id":"msg-1","text":"Revised plan:\n- not a real plan item"}}}`
+	turnCompleted := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(assistantCompleted)))
+	handleCodexOutput(agent, parseLine([]byte(turnCompleted)))
+
+	if sink.PlanUpdateCount() != 0 {
+		t.Fatalf("expected no plan update, got %d", sink.PlanUpdateCount())
+	}
+	if sink.PersistedControlCount() != 0 || sink.BroadcastControlCount() != 0 {
+		t.Fatalf("expected no control request, got persisted=%d broadcast=%d", sink.PersistedControlCount(), sink.BroadcastControlCount())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedPlanModeWithoutRealPlanDoesNotPrompt(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+	agent.collaborationMode = CodexCollaborationPlan
+
+	turnCompleted := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`
+	handleCodexOutput(agent, parseLine([]byte(turnCompleted)))
+
+	if sink.PlanUpdateCount() != 0 {
+		t.Fatalf("expected no plan update, got %d", sink.PlanUpdateCount())
+	}
+	if sink.PersistedControlCount() != 0 || sink.BroadcastControlCount() != 0 {
+		t.Fatalf("expected no control request, got persisted=%d broadcast=%d", sink.PersistedControlCount(), sink.BroadcastControlCount())
+	}
+}
+
+func TestHandleCodexOutput_TurnCompletedPlanModeWithEmptyPlanTextDoesNotPersist(t *testing.T) {
+	sink := &controlTestSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+	agent.collaborationMode = CodexCollaborationPlan
+
+	planCompleted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn-1","item":{"type":"plan","id":"plan-1"}}}`
+	turnCompleted := `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(planCompleted)))
+	handleCodexOutput(agent, parseLine([]byte(turnCompleted)))
+
+	if sink.PlanUpdateCount() != 0 {
+		t.Fatalf("expected no plan update, got %d", sink.PlanUpdateCount())
+	}
+	if sink.PersistedControlCount() != 0 || sink.BroadcastControlCount() != 0 {
+		t.Fatalf("expected no control request, got persisted=%d broadcast=%d", sink.PersistedControlCount(), sink.BroadcastControlCount())
 	}
 }

--- a/backend/internal/worker/agent/plan_title.go
+++ b/backend/internal/worker/agent/plan_title.go
@@ -19,9 +19,10 @@ var (
 	reLink          = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
 	reWikiLink      = regexp.MustCompile(`\[\[(.+?)\]\]`)
 
-	// rePlanPrefix matches common "plan" prefixes in titles, e.g.
-	// "Plan:", "Plan -", "[Plan]", "(Plan)", "*Plan*", etc.
-	rePlanPrefix = regexp.MustCompile(`(?i)^[\[({<*]*plan[\])}>*]*[\s:\-–—]+`)
+	// rePlanPrefix matches common plan/design prefixes in titles, e.g.
+	// "Plan:", "Design:", "Design Doc -", "[Plan]", "(Design Doc)", etc.
+	// The longer "Design Doc" prefix appears first so it wins over "Design".
+	rePlanPrefix = regexp.MustCompile(`(?i)^[\[({<*]*(design\s+doc|design|plan)[\])}>*]*[\s:\-–—]+`)
 
 	htmlPolicy = bluemonday.StrictPolicy()
 )
@@ -87,4 +88,31 @@ func extractPlanTitle(content string) string {
 	}
 
 	return line
+}
+
+// SanitizePlanFilenameTitle converts a plan title into a safe, readable
+// filename stem while preserving Unicode text where possible.
+func SanitizePlanFilenameTitle(title string) string {
+	title = strings.Map(func(r rune) rune {
+		switch {
+		case r == '/' || r == '\\':
+			return -1
+		case strings.ContainsRune(`<>:"|?*`, r):
+			return -1
+		case unicode.IsControl(r):
+			return -1
+		case unicode.IsSpace(r):
+			return ' '
+		default:
+			return r
+		}
+	}, title)
+
+	title = strings.TrimSpace(title)
+	title = strings.Join(strings.Fields(title), " ")
+	title = strings.TrimRight(title, ". ")
+	if title == "" {
+		return "Untitled Plan"
+	}
+	return title
 }

--- a/backend/internal/worker/agent/plan_title_test.go
+++ b/backend/internal/worker/agent/plan_title_test.go
@@ -53,6 +53,41 @@ func TestExtractPlanTitle(t *testing.T) {
 			want:    "Fix login bug",
 		},
 		{
+			name:    "Design prefix",
+			content: "# Design: Renderer fixes",
+			want:    "Renderer fixes",
+		},
+		{
+			name:    "Design Doc prefix",
+			content: "# Design Doc: Renderer fixes",
+			want:    "Renderer fixes",
+		},
+		{
+			name:    "Design Doc stripped before Design",
+			content: "# Design Doc: API changes",
+			want:    "API changes",
+		},
+		{
+			name:    "design doc mixed case",
+			content: "# dEsIgN dOc - API changes",
+			want:    "API changes",
+		},
+		{
+			name:    "wrapped Design Doc prefix",
+			content: "# [Design Doc] API changes",
+			want:    "API changes",
+		},
+		{
+			name:    "wrapped Design prefix",
+			content: "# (Design) Renderer fixes",
+			want:    "Renderer fixes",
+		},
+		{
+			name:    "Design with em dash",
+			content: "# Design — Migrate renderer",
+			want:    "Migrate renderer",
+		},
+		{
 			name:    "Plan with em dash",
 			content: "# Plan — Migrate to new API",
 			want:    "Migrate to new API",
@@ -112,6 +147,46 @@ func TestExtractPlanTitle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, extractPlanTitle(tt.content))
+		})
+	}
+}
+
+func TestSanitizePlanFilenameTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "removes invalid characters",
+			title: `A/B\C:D*E?F"G<H>I|J`,
+			want:  "ABCDEFGHIJ",
+		},
+		{
+			name:  "trims trailing dots and spaces",
+			title: "Plan Name.  ",
+			want:  "Plan Name",
+		},
+		{
+			name:  "falls back when empty",
+			title: " \t\r\n ",
+			want:  "Untitled Plan",
+		},
+		{
+			name:  "retains unicode",
+			title: "설계 문서 渲染修复",
+			want:  "설계 문서 渲染修复",
+		},
+		{
+			name:  "collapses whitespace and strips controls",
+			title: "Plan\t\x00  Name\n\r",
+			want:  "Plan Name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SanitizePlanFilenameTitle(tt.title))
 		})
 	}
 }

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -87,6 +87,7 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 		Terminals: terminal.NewManager(),
 	}
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.Output.DataDir = svc.DataDir
 
 	d := channel.NewDispatcher()
 	RegisterAll(d, svc)

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -360,6 +360,7 @@ type OutputHandler struct {
 	queries *db.Queries
 	watcher *WatcherManager
 	agents  *agent.Manager
+	DataDir string
 
 	// Per-agent notification threading state (concurrent access).
 	notifMu         sync.Map // agentID -> *sync.Mutex
@@ -380,6 +381,8 @@ type OutputHandler struct {
 
 	// wakeLock prevents system sleep while there is agent/terminal activity.
 	wakeLock *wakelock.ActivityTracker
+
+	now func() time.Time
 }
 
 // NewOutputHandler creates a new OutputHandler.
@@ -389,6 +392,7 @@ func NewOutputHandler(queries *db.Queries, watcher *WatcherManager, agents *agen
 		watcher:  watcher,
 		agents:   agents,
 		wakeLock: wl,
+		now:      time.Now,
 	}
 }
 
@@ -937,6 +941,25 @@ func (h *OutputHandler) updatePlan(agentID, filePath string, compressed []byte, 
 		title = agentRow.PlanTitle
 	}
 
+	canonicalPath := agentRow.PlanFilePath
+	if len(compressed) > 0 {
+		content, err := msgcodec.Decompress(compressed, compression)
+		if err != nil {
+			slog.Warn("failed to decompress plan content", "agent_id", agentID, "error", err)
+		} else if len(content) > 0 {
+			materializedPath, err := h.materializePlanFile(title, content, h.now())
+			if err != nil {
+				slog.Warn("failed to materialize plan file", "agent_id", agentID, "error", err)
+			} else {
+				canonicalPath = materializedPath
+			}
+		}
+	}
+
+	if filePath != "" && canonicalPath == "" {
+		slog.Debug("ignoring provider-native plan path in favor of worker materialization", "agent_id", agentID, "provider_path", filePath)
+	}
+
 	shouldAutoRename := title != "" &&
 		title != agentRow.Title &&
 		(agentRow.Title == agentRow.PlanTitle ||
@@ -944,7 +967,7 @@ func (h *OutputHandler) updatePlan(agentID, filePath string, compressed []byte, 
 
 	if shouldAutoRename {
 		if err := h.queries.UpdateAgentPlanAndTitle(bgCtx(), db.UpdateAgentPlanAndTitleParams{
-			PlanFilePath:           filePath,
+			PlanFilePath:           canonicalPath,
 			PlanContent:            compressed,
 			PlanContentCompression: compression,
 			PlanTitle:              title,
@@ -960,7 +983,7 @@ func (h *OutputHandler) updatePlan(agentID, filePath string, compressed []byte, 
 		}
 	} else {
 		if err := h.queries.UpdateAgentPlan(bgCtx(), db.UpdateAgentPlanParams{
-			PlanFilePath:           filePath,
+			PlanFilePath:           canonicalPath,
 			PlanContent:            compressed,
 			PlanContentCompression: compression,
 			PlanTitle:              title,

--- a/backend/internal/worker/service/output_plan.go
+++ b/backend/internal/worker/service/output_plan.go
@@ -25,7 +25,8 @@ func (h *OutputHandler) materializePlanFile(title string, content []byte, now ti
 	}
 
 	base := agent.SanitizePlanFilenameTitle(title)
-	for counter := 0; ; counter++ {
+	const maxCollisions = 1000
+	for counter := 0; counter <= maxCollisions; counter++ {
 		filename := base
 		if counter > 0 {
 			filename = fmt.Sprintf("%s (%d)", base, counter)
@@ -47,4 +48,5 @@ func (h *OutputHandler) materializePlanFile(title string, content []byte, now ti
 		}
 		return path, nil
 	}
+	return "", fmt.Errorf("too many plan file collisions for %q", base)
 }

--- a/backend/internal/worker/service/output_plan.go
+++ b/backend/internal/worker/service/output_plan.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/worker/agent"
+)
+
+func (h *OutputHandler) materializePlanFile(title string, content []byte, now time.Time) (string, error) {
+	if h.DataDir == "" {
+		return "", fmt.Errorf("missing data dir")
+	}
+
+	rootDir, err := filepath.Abs(h.DataDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve data dir: %w", err)
+	}
+	dir := filepath.Join(rootDir, "plans", fmt.Sprintf("%04d", now.Year()), fmt.Sprintf("%02d", int(now.Month())))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir plan dir: %w", err)
+	}
+
+	base := agent.SanitizePlanFilenameTitle(title)
+	for counter := 0; ; counter++ {
+		filename := base
+		if counter > 0 {
+			filename = fmt.Sprintf("%s (%d)", base, counter)
+		}
+		path := filepath.Join(dir, filename+".md")
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			if errors.Is(err, os.ErrExist) {
+				continue
+			}
+			return "", fmt.Errorf("create plan file: %w", err)
+		}
+		if _, err := f.Write(content); err != nil {
+			_ = f.Close()
+			return "", fmt.Errorf("write plan file: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("close plan file: %w", err)
+		}
+		return path, nil
+	}
+}

--- a/backend/internal/worker/service/output_plan.go
+++ b/backend/internal/worker/service/output_plan.go
@@ -41,6 +41,7 @@ func (h *OutputHandler) materializePlanFile(title string, content []byte, now ti
 		}
 		if _, err := f.Write(content); err != nil {
 			_ = f.Close()
+			_ = os.Remove(path)
 			return "", fmt.Errorf("write plan file: %w", err)
 		}
 		if err := f.Close(); err != nil {

--- a/backend/internal/worker/service/output_plan_test.go
+++ b/backend/internal/worker/service/output_plan_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/util/msgcodec"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func TestOutputHandlerUpdatePlan_MaterializesPlanFileAndStoresCanonicalPath(t *testing.T) {
+	_, queries := setupTestDB(t)
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	watchers := NewWatcherManager()
+	h := NewOutputHandler(queries, watchers, nil, nil)
+	h.DataDir = dataDir
+	h.now = func() time.Time { return time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC) }
+
+	require.NoError(t, queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Title:       "Agent 1",
+	}))
+
+	content := []byte("# Design: Rendering fixes\n\n- item\n")
+	compressed, compression := msgcodec.Compress(content)
+	h.updatePlan("agent-1", "/provider/path.md", compressed, compression, "Rendering fixes")
+
+	row, err := queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+
+	wantPath := filepath.Join(dataDir, "plans", "2026", "04", "Rendering fixes.md")
+	assert.Equal(t, wantPath, row.PlanFilePath)
+	assert.Equal(t, "Rendering fixes", row.PlanTitle)
+
+	got, err := os.ReadFile(row.PlanFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, string(content), string(got))
+}
+
+func TestOutputHandlerUpdatePlan_CollisionAppendsCounterSuffix(t *testing.T) {
+	_, queries := setupTestDB(t)
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	h := NewOutputHandler(queries, NewWatcherManager(), nil, nil)
+	h.DataDir = dataDir
+	h.now = func() time.Time { return time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC) }
+
+	require.NoError(t, queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Title:       "Agent 1",
+	}))
+
+	dir := filepath.Join(dataDir, "plans", "2026", "04")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Some Plan.md"), []byte("existing"), 0o644))
+
+	compressed, compression := msgcodec.Compress([]byte("# Plan: Some Plan\n"))
+	h.updatePlan("agent-1", "", compressed, compression, "Some Plan")
+
+	row, err := queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "Some Plan (1).md"), row.PlanFilePath)
+}
+
+func TestOutputHandlerUpdatePlan_StoresUntitledFallback(t *testing.T) {
+	_, queries := setupTestDB(t)
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	h := NewOutputHandler(queries, NewWatcherManager(), nil, nil)
+	h.DataDir = dataDir
+	h.now = func() time.Time { return time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC) }
+
+	require.NoError(t, queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Title:       "Agent 1",
+	}))
+
+	compressed, compression := msgcodec.Compress([]byte("- item\n"))
+	h.updatePlan("agent-1", "", compressed, compression, "")
+
+	row, err := queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dataDir, "plans", "2026", "04", "Untitled Plan.md"), row.PlanFilePath)
+}
+
+func TestOutputHandlerMaterializePlanFile_PicksFirstFreeCounter(t *testing.T) {
+	dataDir := t.TempDir()
+	h := NewOutputHandler(nil, nil, nil, nil)
+	h.DataDir = dataDir
+	now := time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC)
+	dir := filepath.Join(dataDir, "plans", "2026", "04")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	for _, name := range []string{"Some Plan.md", "Some Plan (1).md"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644))
+	}
+
+	path, err := h.materializePlanFile("Some Plan", []byte("content"), now)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "Some Plan (2).md"), path)
+}
+
+func TestOutputHandlerUpdatePlan_PreservesCompressedContentInDB(t *testing.T) {
+	_, queries := setupTestDB(t)
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	h := NewOutputHandler(queries, NewWatcherManager(), nil, nil)
+	h.DataDir = dataDir
+	h.now = func() time.Time { return time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC) }
+
+	require.NoError(t, queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Title:       "Agent 1",
+	}))
+
+	content := []byte(fmt.Sprintf("# Plan: %s\n", "Canonical Plan"))
+	compressed, compression := msgcodec.Compress(content)
+	h.updatePlan("agent-1", "", compressed, compression, "Canonical Plan")
+
+	row, err := queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	decompressed, err := msgcodec.Decompress(row.PlanContent, row.PlanContentCompression)
+	require.NoError(t, err)
+	assert.Equal(t, string(content), string(decompressed))
+}

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -75,6 +75,7 @@ func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manage
 	queries := db.New(sqlDB)
 	watchers := NewWatcherManager()
 	output := NewOutputHandler(queries, watchers, agents, wl)
+	output.DataDir = dataDir
 	svc := &Context{
 		DB:        sqlDB,
 		Queries:   queries,

--- a/frontend/src/components/chat/providers/codex.test.ts
+++ b/frontend/src/components/chat/providers/codex.test.ts
@@ -265,6 +265,24 @@ describe('codex result divider', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'result_divider' })
   })
 
+  it('hides synthetic Codex turn failed notifications', () => {
+    const parent = {
+      type: 'agent_error',
+      error: 'Codex turn failed',
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
+  })
+
+  it('hides notification threads containing only synthetic Codex turn failed notifications', () => {
+    const wrapper = {
+      old_seqs: [],
+      messages: [
+        { type: 'agent_error', error: 'Codex turn failed' },
+      ],
+    }
+    expect(plugin.classify(input(undefined, wrapper))).toEqual({ kind: 'hidden' })
+  })
+
   it('renders result_divider via renderMessage', () => {
     const parsed = {
       turn: { id: 'turn-1', status: 'completed' },

--- a/frontend/src/components/chat/providers/codex.tsx
+++ b/frontend/src/components/chat/providers/codex.tsx
@@ -40,6 +40,7 @@ export const CODEX_EXTRA_COLLABORATION_MODE = 'collaboration_mode'
 export const CODEX_EXTRA_SANDBOX_POLICY = 'sandbox_policy'
 export const CODEX_EXTRA_NETWORK_ACCESS = 'network_access'
 export const CODEX_EXTRA_SERVICE_TIER = 'service_tier'
+const CODEX_TURN_FAILED_NOTIFICATION = 'Codex turn failed'
 
 let codexReqIdCounter = 1000
 
@@ -142,6 +143,8 @@ function isCodexHiddenNotificationThreadMessage(m: unknown): boolean {
     return false
   const msg = m as Record<string, unknown>
   if (msg.method === 'thread/tokenUsage/updated')
+    return true
+  if (msg.type === 'agent_error' && msg.error === CODEX_TURN_FAILED_NOTIFICATION)
     return true
   return isCodexRateLimitAllAllowed(msg)
 }
@@ -361,6 +364,9 @@ const codexPlugin: ProviderPlugin = {
         return { kind: 'hidden' }
       return { kind: 'notification' }
     }
+
+    if (type === 'agent_error' && parent.error === CODEX_TURN_FAILED_NOTIFICATION)
+      return { kind: 'hidden' }
 
     if (parent.method === 'turn/plan/updated' && isObject(parent.params))
       return { kind: 'tool_use', toolName: 'turnPlan', toolUse: parent, content: [] }

--- a/frontend/src/components/chat/providers/codexRenderers.tsx
+++ b/frontend/src/components/chat/providers/codexRenderers.tsx
@@ -7,6 +7,7 @@ import type { CommandStreamSegment } from '~/stores/chat.store'
 import Bot from 'lucide-solid/icons/bot'
 import Brain from 'lucide-solid/icons/brain'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
+import File from 'lucide-solid/icons/file'
 import FileEdit from 'lucide-solid/icons/file-pen-line'
 import FilePlus from 'lucide-solid/icons/file-plus'
 import Globe from 'lucide-solid/icons/globe'
@@ -36,7 +37,7 @@ import {
 } from '../messageStyles.css'
 import { isObject, relativizePath } from '../messageUtils'
 import { formatDuration } from '../rendererUtils'
-import { renderAgentDetail, renderBashDetail, renderEditDetail, renderQueryDetail, renderUrlDetail, renderWriteDetail } from '../toolDetailRenderers'
+import { renderAgentDetail, renderBashDetail, renderDeleteDetail, renderEditDetail, renderQueryDetail, renderUrlDetail, renderWriteDetail } from '../toolDetailRenderers'
 import { EmptyTodoLayout, renderBashHighlight, ToolResultMessage, ToolUseLayout } from '../toolRenderers'
 import {
   commandStreamContainer,
@@ -160,6 +161,10 @@ function isSimpleEditChange(change: Record<string, unknown>): boolean {
 
 function isSimpleAddChange(change: Record<string, unknown>): boolean {
   return codexChangeKind(change) === 'add' && typeof change.diff === 'string' && (change.diff as string).length > 0
+}
+
+function isSimpleDeleteChange(change: Record<string, unknown>): boolean {
+  return codexChangeKind(change) === 'delete'
 }
 
 function completedFileChangeEntries(changes: Array<Record<string, unknown>>): Array<
@@ -549,8 +554,10 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
   const hasLiveStream = () => liveStream().length > 0
   const completedEntries = completedFileChangeEntries(changes)
   const simpleAdd = changes.length === 1 && isSimpleAddChange(changes[0]) ? changes[0] : null
+  const simpleDelete = changes.length === 1 && isSimpleDeleteChange(changes[0]) ? changes[0] : null
   const simpleAddPath = simpleAdd ? ((simpleAdd.path as string) || '') : ''
   const simpleAddContent = simpleAdd ? ((simpleAdd.diff as string) || '') : ''
+  const simpleDeletePath = simpleDelete ? ((simpleDelete.path as string) || '') : ''
 
   if (status === 'completed' && simpleAdd) {
     return (
@@ -562,6 +569,21 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
         oldStr=""
         newStr={simpleAddContent}
         filePath={simpleAddPath}
+        context={context}
+      />
+    )
+  }
+
+  if (status === 'completed' && simpleDelete) {
+    return (
+      <ToolResultMessage
+        toolName="Delete"
+        resultContent={`Deleted \`${relativizePath(simpleDeletePath, context?.workingDir, context?.homeDir)}\``}
+        isPreText={false}
+        structuredPatch={null}
+        oldStr=""
+        newStr=""
+        filePath={simpleDeletePath}
         context={context}
       />
     )
@@ -614,9 +636,11 @@ export function codexFileChangeRenderer(parsed: unknown, _role: MessageRole, con
   const homeDir = context?.homeDir
   const inProgressDetail = simpleAdd
     ? { icon: FilePlus, title: renderWriteDetail(simpleAddPath, simpleAddContent, cwd, homeDir), path: simpleAddPath }
-    : simpleEdit && parsedDiff
-      ? { icon: FileEdit, title: renderEditDetail((simpleEdit.path as string) || '', parsedDiff.oldText, parsedDiff.newText, cwd, homeDir), path: (simpleEdit.path as string) || '' }
-      : null
+    : simpleDelete
+      ? { icon: File, title: renderDeleteDetail(simpleDeletePath, cwd, homeDir), path: simpleDeletePath }
+      : simpleEdit && parsedDiff
+        ? { icon: FileEdit, title: renderEditDetail((simpleEdit.path as string) || '', parsedDiff.oldText, parsedDiff.newText, cwd, homeDir), path: (simpleEdit.path as string) || '' }
+        : null
 
   if (inProgressDetail) {
     const title = inProgressDetail.title || (

--- a/frontend/src/components/chat/toolDetailRenderers.tsx
+++ b/frontend/src/components/chat/toolDetailRenderers.tsx
@@ -48,6 +48,12 @@ export function renderWriteDetail(path?: string, content?: string, cwd?: string,
   )
 }
 
+export function renderDeleteDetail(path?: string, cwd?: string, homeDir?: string): JSX.Element | null {
+  if (!path)
+    return null
+  return <span class={toolInputPath}>{relativizePath(path, cwd, homeDir)}</span>
+}
+
 export function renderEditDetail(path?: string, oldStr?: string, newStr?: string, cwd?: string, homeDir?: string): JSX.Element | null {
   if (!path)
     return null

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -949,6 +949,49 @@ describe('chatView', () => {
     expect(screen.getByTestId('message-toolbar')).toBeInTheDocument()
   })
 
+  it('renders a simple codex delete fileChange start message as file deletion', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-start',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'in_progress',
+        changes: [{ path: '/repo/src/old-file.ts', kind: { type: 'delete' }, diff: 'export const old = true\n' }],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container).toHaveTextContent('old-file.ts')
+    expect(view.container).not.toHaveTextContent('export const old = true')
+  })
+
+  it('renders a simple codex delete fileChange completion as file deletion', () => {
+    const messages = [
+      makeCodexFileChangeMessage({
+        id: 'fc-done',
+        seq: 1n,
+        spanId: 'fc-1',
+        status: 'completed',
+        changes: [{ path: '/repo/src/old-file.ts', kind: { type: 'delete' }, diff: 'export const old = true\n' }],
+      }),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    expect(view.container).toHaveTextContent('Deleted /repo/src/old-file.ts')
+    expect(view.container).not.toHaveTextContent('1 file changed')
+    expect(screen.getByTestId('message-toolbar')).toBeInTheDocument()
+  })
+
   it('renders multi-file codex fileChange entries with per-file labels including adds', () => {
     const messages = [
       makeCodexFileChangeMessage({


### PR DESCRIPTION
## Motivation

Several related gaps existed in the Codex integration:

1. Plan content was streamed and displayed in chat but never written to disk, making plans ephemeral and unavailable for later reference.
2. When Codex emitted a `turn/completed` with `status: "failed"` due to a transient stream disconnection, the backend broadcast an `agent_error` notification that appeared in chat, creating noisy and confusing UX - especially because the backend was already scheduling an auto-continue retry for these cases.
3. The plan-detection logic used a fallback to assistant message text when no explicit plan content was present, which could trigger plan execution incorrectly on empty-content turns.
4. Codex file deletions were not rendered distinctly in the chat UI; they lacked icons, labels, and the dedicated detail view that add and edit operations already had.

## Modifications

**Backend**

- Introduced `output_plan.go` with `materializePlanFile()` that writes plan content as timestamped markdown files under `plans/YYYY/MM/` in the configured data directory, using `O_EXCL` creation and a collision-avoidance loop (bounded at 1000) to prevent overwriting existing files; partially-written files are cleaned up on failure.
- Extracted plan-title utilities into a dedicated `plan_title.go` module: `extractPlanTitle()` strips YAML frontmatter, heading markers, all inline markdown formatting, and HTML tags to derive a readable title, then truncates to 128 characters; `SanitizePlanFilenameTitle()` converts the title to a filesystem-safe stem, removing path separators and control characters.
- Tightened Codex plan detection: plan execution now requires both `sawPlan == true` and non-empty `planText`; the previous fallback that used assistant message text when plan content was absent has been removed.
- Added `isRetryableCodexTurnFailure()` that detects transient `"stream disconnected before completion:"` errors; failing turns matching this predicate now schedule an auto-continue retry instead of broadcasting an `agent_error` notification; non-retryable failures cancel auto-continue as before.
- Removed the `turnAssistantText` field and its associated fallback plan-detection logic from `CodexAgent`.

**Frontend**

- Added `renderDeleteDetail()` to `toolDetailRenderers.tsx` that renders the deleted file path using the standard `toolInputPath` style.
- Updated `codexFileChangeRenderer` in `codexRenderers.tsx` to detect single-file delete operations (`kind: "delete"`), select the `File` icon, and pass the path to `renderDeleteDetail()` for consistent in-progress and completed display.
- Added logic in the Codex provider classifier (`codex.tsx`) to return `{ kind: 'hidden' }` for `agent_error` messages whose `error` field equals `"Codex turn failed"`, and for notification thread wrappers whose only messages are of that type.

## Result

- Plans are now automatically saved as `plans/YYYY/MM/<title>.md` files in the LeapMux data directory across all providers, making them available for review after a session ends.
- Transient stream-disconnection failures no longer surface as "Codex turn failed" error banners in chat; the backend silently retries instead.
- Codex file deletions are now rendered with a file icon and the deleted path in the chat UI, consistent with how add and edit operations appear.
- Incorrect plan execution on turns with no actual plan content is prevented by the stricter detection logic.
