### PR TITLE
Move sidecar binary to MacOS/ dir in app bundle

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -292,6 +292,9 @@ tasks:
       - task: prepare-desktop
       - task: build-desktop-sidecar
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --bundles app --config '{"version":"{{.VERSION}}"}'
+      # Move sidecar from Resources/_up_/go/bin/ to MacOS/ for a cleaner bundle layout.
+      - mv "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/Resources/_up_/go/bin/"* "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/MacOS/"
+      - rm -rf "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/Resources/_up_"
       - rsync -a --delete "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/" "LeapMux Desktop.app/"
       - cd frontend/node_modules/macos-alias && npx node-gyp rebuild 2>/dev/null || true
       - mkdir -p desktop/rust/target/release/bundle/dmg

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -811,8 +811,7 @@ fn capabilities_for(state: &ShellState) -> PlatformCapabilities {
 fn resolve_sidecar_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
     let sidecar_name = sidecar_binary_name();
 
-    // Prefer the dev-mode path next to the Cargo project; fall back to the
-    // bundled resource directory used in release builds.
+    // Dev-mode path next to the Cargo project.
     let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("_up_")
         .join("go")
@@ -822,6 +821,20 @@ fn resolve_sidecar_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
         return Ok(dev_path);
     }
 
+    // Production: on macOS the sidecar lives in Contents/MacOS/.
+    #[cfg(target_os = "macos")]
+    {
+        let exe = std::env::current_exe()
+            .map_err(|err| format!("resolve current exe: {err}"))?;
+        if let Some(dir) = exe.parent() {
+            let path = dir.join(&sidecar_name);
+            if path.exists() {
+                return Ok(path);
+            }
+        }
+    }
+
+    // Fallback: resource directory (Linux, Windows).
     let resource_dir = app_handle
         .path()
         .resource_dir()


### PR DESCRIPTION
## Motivation

The sidecar binary was placed under `Contents/Resources/_up_/go/bin/` inside the macOS app bundle, which created an unnecessarily deep and non-standard directory hierarchy within the Resources folder. macOS convention places co-located executables in the `Contents/MacOS/` directory alongside the main binary.

## Modifications

- Updated `Taskfile.yaml` to move the sidecar binary into `Contents/MacOS/` instead of `Contents/Resources/_up_/go/bin/`, and removed the now-empty resource directory hierarchy.
- Refactored `resolve_sidecar_path()` in `desktop/rust/src/main.rs` to check `Contents/MacOS/` (the directory containing the current executable) as the production path before falling back to the cross-platform resource directory path used on Linux and Windows.
- Clarified inline comments to explicitly document the three-tier resolution order: dev-mode path → macOS production path (`Contents/MacOS/`) → cross-platform fallback (resource directory for Linux/Windows).

## Result

The macOS app bundle now follows a cleaner, more conventional layout with the sidecar binary residing in `Contents/MacOS/` alongside the main executable. The path resolution logic in the Rust desktop host correctly locates the sidecar binary under the new layout without affecting dev-mode or non-macOS builds.
