### PR TITLE
Add live settings sync, Claude output style, and Codex refresh

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -76,6 +76,7 @@ type acpBase struct {
 	extraSessionUpdate     acpSessionUpdateHandler // optional provider-specific session update handler
 	extraMethod            acpMethodHandler        // optional provider-specific request/notification handler
 	reapplySettings        func()                  // called by ClearContext after session/new to re-apply model, mode, etc.
+	refreshFromSession     func(json.RawMessage)   // called by ClearContext after reapplySettings to sync state from the session response
 	sessionID              string
 	workingDir             string
 	model                  string
@@ -218,6 +219,9 @@ func (b *acpBase) ClearContext() (string, bool) {
 	if b.reapplySettings != nil {
 		b.reapplySettings()
 	}
+	if b.refreshFromSession != nil {
+		b.refreshFromSession(resp)
+	}
 	return session.SessionID, true
 }
 
@@ -289,6 +293,73 @@ func (b *acpBase) reapplyModelAndPrimaryAgent() {
 	b.mu.Unlock()
 	acpApplySetting(b.providerName, b.agentID, "model", model, b.setModel)
 	acpApplySetting(b.providerName, b.agentID, "primary agent", primaryAgent, b.setPrimaryAgent)
+}
+
+// refreshModelAndPermissionModeFromSession parses the session response and
+// updates the model and permission mode fields. Used by agents that track
+// permissionMode (Gemini, Copilot, Goose).
+func (b *acpBase) refreshModelAndPermissionModeFromSession(resp json.RawMessage) {
+	model, mode := parseSessionModelAndMode(resp)
+	b.mu.Lock()
+	if model != "" {
+		b.model = model
+	}
+	if mode != "" {
+		b.permissionMode = mode
+	}
+	b.mu.Unlock()
+	slog.Info("acp agent settings refreshed from session",
+		"provider", b.providerName,
+		"agent_id", b.agentID,
+		"model", b.model,
+		"mode", b.permissionMode,
+	)
+	b.sink.BroadcastSettingsRefreshed(b.model, "", b.permissionMode, nil)
+}
+
+// refreshModelAndPrimaryAgentFromSession parses the session response and
+// updates the model and primary agent fields. Used by agents that track
+// currentPrimaryAgent (OpenCode, Kilo).
+func (b *acpBase) refreshModelAndPrimaryAgentFromSession(resp json.RawMessage) {
+	model, mode := parseSessionModelAndMode(resp)
+	b.mu.Lock()
+	if model != "" {
+		b.model = model
+	}
+	if mode != "" {
+		b.currentPrimaryAgent = mode
+	}
+	b.mu.Unlock()
+	slog.Info("acp agent settings refreshed from session",
+		"provider", b.providerName,
+		"agent_id", b.agentID,
+		"model", b.model,
+		"primaryAgent", b.currentPrimaryAgent,
+	)
+	b.sink.BroadcastSettingsRefreshed(b.model, "", "", map[string]string{
+		OptionGroupKeyPrimaryAgent: b.currentPrimaryAgent,
+	})
+}
+
+// parseSessionModelAndMode extracts currentModelId and currentModeId from
+// an ACP session response.
+func parseSessionModelAndMode(resp json.RawMessage) (model, mode string) {
+	var session struct {
+		Models struct {
+			CurrentModelID string `json:"currentModelId"`
+		} `json:"models"`
+		Modes *struct {
+			CurrentModeID string `json:"currentModeId"`
+		} `json:"modes"`
+	}
+	if err := json.Unmarshal(resp, &session); err != nil {
+		return "", ""
+	}
+	mode = ""
+	if session.Modes != nil {
+		mode = session.Modes.CurrentModeID
+	}
+	return session.Models.CurrentModelID, mode
 }
 
 // permissionModeOptionGroups returns AvailableOptionGroups for agents that

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -295,51 +295,55 @@ func (b *acpBase) reapplyModelAndPrimaryAgent() {
 	acpApplySetting(b.providerName, b.agentID, "primary agent", primaryAgent, b.setPrimaryAgent)
 }
 
-// refreshModelAndPermissionModeFromSession parses the session response and
-// updates the model and permission mode fields. Used by agents that track
-// permissionMode (Gemini, Copilot, Goose).
-func (b *acpBase) refreshModelAndPermissionModeFromSession(resp json.RawMessage) {
-	model, mode := parseSessionModelAndMode(resp)
+// applySessionRefresh parses the session response, updates b.model (optionally
+// normalized via `normalizeModel`) and the field pointed to by `secondary`,
+// then logs and broadcasts. `secondaryLogKey` is the slog attribute name for
+// the secondary field (e.g. "mode", "primaryAgent").
+func (b *acpBase) applySessionRefresh(
+	resp json.RawMessage,
+	normalizeModel func(string) string,
+	secondary *string,
+	secondaryLogKey string,
+	broadcast func(model, secondary string),
+) {
+	model, secondaryVal := parseSessionModelAndMode(resp)
 	b.mu.Lock()
 	if model != "" {
+		if normalizeModel != nil {
+			model = normalizeModel(model)
+		}
 		b.model = model
 	}
-	if mode != "" {
-		b.permissionMode = mode
+	if secondaryVal != "" {
+		*secondary = secondaryVal
 	}
-	snapshotModel, snapshotMode := b.model, b.permissionMode
+	snapshotModel := b.model
+	snapshotSecondary := *secondary
 	b.mu.Unlock()
 	slog.Info("acp agent settings refreshed from session",
 		"provider", b.providerName,
 		"agent_id", b.agentID,
 		"model", snapshotModel,
-		"mode", snapshotMode,
+		secondaryLogKey, snapshotSecondary,
 	)
-	b.sink.BroadcastSettingsRefreshed(snapshotModel, "", snapshotMode, nil)
+	broadcast(snapshotModel, snapshotSecondary)
 }
 
-// refreshModelAndPrimaryAgentFromSession parses the session response and
-// updates the model and primary agent fields. Used by agents that track
+// refreshModelAndPermissionModeFromSession is used by agents that track
+// permissionMode (Gemini, Copilot, Goose).
+func (b *acpBase) refreshModelAndPermissionModeFromSession(resp json.RawMessage) {
+	b.applySessionRefresh(resp, nil, &b.permissionMode, "mode", func(model, mode string) {
+		b.sink.BroadcastSettingsRefreshed(model, "", mode, nil)
+	})
+}
+
+// refreshModelAndPrimaryAgentFromSession is used by agents that track
 // currentPrimaryAgent (OpenCode, Kilo).
 func (b *acpBase) refreshModelAndPrimaryAgentFromSession(resp json.RawMessage) {
-	model, mode := parseSessionModelAndMode(resp)
-	b.mu.Lock()
-	if model != "" {
-		b.model = model
-	}
-	if mode != "" {
-		b.currentPrimaryAgent = mode
-	}
-	snapshotModel, snapshotAgent := b.model, b.currentPrimaryAgent
-	b.mu.Unlock()
-	slog.Info("acp agent settings refreshed from session",
-		"provider", b.providerName,
-		"agent_id", b.agentID,
-		"model", snapshotModel,
-		"primaryAgent", snapshotAgent,
-	)
-	b.sink.BroadcastSettingsRefreshed(snapshotModel, "", "", map[string]string{
-		OptionGroupKeyPrimaryAgent: snapshotAgent,
+	b.applySessionRefresh(resp, nil, &b.currentPrimaryAgent, "primaryAgent", func(model, agent string) {
+		b.sink.BroadcastSettingsRefreshed(model, "", "", map[string]string{
+			OptionGroupKeyPrimaryAgent: agent,
+		})
 	})
 }
 

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -307,14 +307,15 @@ func (b *acpBase) refreshModelAndPermissionModeFromSession(resp json.RawMessage)
 	if mode != "" {
 		b.permissionMode = mode
 	}
+	snapshotModel, snapshotMode := b.model, b.permissionMode
 	b.mu.Unlock()
 	slog.Info("acp agent settings refreshed from session",
 		"provider", b.providerName,
 		"agent_id", b.agentID,
-		"model", b.model,
-		"mode", b.permissionMode,
+		"model", snapshotModel,
+		"mode", snapshotMode,
 	)
-	b.sink.BroadcastSettingsRefreshed(b.model, "", b.permissionMode, nil)
+	b.sink.BroadcastSettingsRefreshed(snapshotModel, "", snapshotMode, nil)
 }
 
 // refreshModelAndPrimaryAgentFromSession parses the session response and
@@ -329,15 +330,16 @@ func (b *acpBase) refreshModelAndPrimaryAgentFromSession(resp json.RawMessage) {
 	if mode != "" {
 		b.currentPrimaryAgent = mode
 	}
+	snapshotModel, snapshotAgent := b.model, b.currentPrimaryAgent
 	b.mu.Unlock()
 	slog.Info("acp agent settings refreshed from session",
 		"provider", b.providerName,
 		"agent_id", b.agentID,
-		"model", b.model,
-		"primaryAgent", b.currentPrimaryAgent,
+		"model", snapshotModel,
+		"primaryAgent", snapshotAgent,
 	)
-	b.sink.BroadcastSettingsRefreshed(b.model, "", "", map[string]string{
-		OptionGroupKeyPrimaryAgent: b.currentPrimaryAgent,
+	b.sink.BroadcastSettingsRefreshed(snapshotModel, "", "", map[string]string{
+		OptionGroupKeyPrimaryAgent: snapshotAgent,
 	})
 }
 
@@ -355,7 +357,6 @@ func parseSessionModelAndMode(resp json.RawMessage) (model, mode string) {
 	if err := json.Unmarshal(resp, &session); err != nil {
 		return "", ""
 	}
-	mode = ""
 	if session.Modes != nil {
 		mode = session.Modes.CurrentModeID
 	}

--- a/backend/internal/worker/agent/acp_refresh_test.go
+++ b/backend/internal/worker/agent/acp_refresh_test.go
@@ -1,0 +1,221 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit tests for parseSessionModelAndMode ---
+
+func TestParseSessionModelAndMode(t *testing.T) {
+	resp := json.RawMessage(`{
+		"sessionId": "session-1",
+		"models": {"currentModelId": "gemini-2.5-pro", "availableModels": []},
+		"modes":  {"currentModeId": "plan", "availableModes": []}
+	}`)
+	model, mode := parseSessionModelAndMode(resp)
+	assert.Equal(t, "gemini-2.5-pro", model)
+	assert.Equal(t, "plan", mode)
+}
+
+func TestParseSessionModelAndMode_NoModes(t *testing.T) {
+	resp := json.RawMessage(`{
+		"sessionId": "session-1",
+		"models": {"currentModelId": "gpt-5.4"}
+	}`)
+	model, mode := parseSessionModelAndMode(resp)
+	assert.Equal(t, "gpt-5.4", model)
+	assert.Equal(t, "", mode)
+}
+
+func TestParseSessionModelAndMode_InvalidJSON(t *testing.T) {
+	model, mode := parseSessionModelAndMode(json.RawMessage(`invalid`))
+	assert.Equal(t, "", model)
+	assert.Equal(t, "", mode)
+}
+
+// --- Tests for refreshFromSession via ClearContext ---
+
+func TestGeminiClearContextRefreshesFromSession(t *testing.T) {
+	agent, _ := newGeminiAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "gemini-2.5-flash"},
+				"modes":  {"currentModeId": "plan"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gemini-2.5-pro"
+	agent.permissionMode = "default"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndPermissionMode
+	agent.refreshFromSession = agent.refreshModelAndPermissionModeFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "gemini-2.5-flash", agent.model)
+	assert.Equal(t, "plan", agent.permissionMode)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "gemini-2.5-flash", refresh.Model)
+	assert.Equal(t, "plan", refresh.PermissionMode)
+}
+
+func TestCopilotClearContextRefreshesFromSession(t *testing.T) {
+	agent, _ := newCopilotAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "gpt-5.4"},
+				"modes":  {"currentModeId": "plan"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gpt-4o"
+	agent.permissionMode = "agent"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndPermissionMode
+	agent.refreshFromSession = agent.refreshModelAndPermissionModeFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "gpt-5.4", agent.model)
+	assert.Equal(t, "plan", agent.permissionMode)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "gpt-5.4", refresh.Model)
+	assert.Equal(t, "plan", refresh.PermissionMode)
+}
+
+func TestCursorClearContextRefreshesWithNormalization(t *testing.T) {
+	agent, _ := newCursorAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			// Cursor returns the wire format "default[]" for auto model.
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "default[]"},
+				"modes":  {"currentModeId": "agent"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "some-model"
+	agent.permissionMode = "plan"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndMode
+	agent.refreshFromSession = agent.refreshCursorFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "auto", agent.model)
+	assert.Equal(t, "agent", agent.permissionMode)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "auto", refresh.Model)
+	assert.Equal(t, "agent", refresh.PermissionMode)
+}
+
+func TestOpenCodeClearContextRefreshesPrimaryAgent(t *testing.T) {
+	agent, _ := newOpenCodeAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "openai/gpt-5"},
+				"modes":  {"currentModeId": "plan"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "openai/gpt-4o"
+	agent.currentPrimaryAgent = "build"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndPrimaryAgent
+	agent.refreshFromSession = agent.refreshModelAndPrimaryAgentFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "openai/gpt-5", agent.model)
+	assert.Equal(t, "plan", agent.currentPrimaryAgent)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "openai/gpt-5", refresh.Model)
+	assert.Equal(t, "plan", refresh.ExtraSettings[OptionGroupKeyPrimaryAgent])
+}
+
+func TestKiloClearContextRefreshesPrimaryAgent(t *testing.T) {
+	agent, _ := newKiloAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "anthropic/claude-sonnet-4"},
+				"modes":  {"currentModeId": "code"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "anthropic/claude-opus-4"
+	agent.currentPrimaryAgent = "plan"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndPrimaryAgent
+	agent.refreshFromSession = agent.refreshModelAndPrimaryAgentFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "anthropic/claude-sonnet-4", agent.model)
+	assert.Equal(t, "code", agent.currentPrimaryAgent)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "anthropic/claude-sonnet-4", refresh.Model)
+	assert.Equal(t, "code", refresh.ExtraSettings[OptionGroupKeyPrimaryAgent])
+}
+
+func TestGooseClearContextRefreshesFromSession(t *testing.T) {
+	agent, _ := newGooseAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{
+				"sessionId": "session-2",
+				"models": {"currentModelId": "claude-sonnet-4"},
+				"modes":  {"currentModeId": "approve"}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gpt-5.4"
+	agent.permissionMode = "auto"
+	sink := &testSink{}
+	agent.sink = sink
+	agent.reapplySettings = agent.reapplyModelAndPermissionMode
+	agent.refreshFromSession = agent.refreshModelAndPermissionModeFromSession
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	assert.Equal(t, "session-2", sessionID)
+	assert.Equal(t, "claude-sonnet-4", agent.model)
+	assert.Equal(t, "approve", agent.permissionMode)
+
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "claude-sonnet-4", refresh.Model)
+	assert.Equal(t, "approve", refresh.PermissionMode)
+}

--- a/backend/internal/worker/agent/acp_test_helpers.go
+++ b/backend/internal/worker/agent/acp_test_helpers.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordedRequest captures a JSON-RPC request written to an ACP agent's stdin
+// in tests.
+type recordedRequest struct {
+	Method string
+	Params map[string]interface{}
+}
+
+// newACPAgentForRPC constructs an ACP agent of type T for tests and starts a
+// fake peer that echoes `{}` for every request. construct returns a
+// zero-value agent; accessBase returns a pointer to its embedded acpBase so
+// the helper can populate shared fields in-place (avoiding copylocks
+// violations) and so the peer can look up pendingReqs.
+func newACPAgentForRPC[T any](
+	t *testing.T,
+	construct func() *T,
+	accessBase func(*T) *acpBase,
+) (*T, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t, construct, accessBase, func(string) json.RawMessage {
+		return json.RawMessage(`{}`)
+	})
+}
+
+// newACPAgentForRPCWithResponder is like newACPAgentForRPC but the caller
+// supplies the response body for each inbound method.
+func newACPAgentForRPCWithResponder[T any](
+	t *testing.T,
+	construct func() *T,
+	accessBase func(*T) *acpBase,
+	respond func(method string) json.RawMessage,
+) (*T, func() []recordedRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readPipe, writePipe, err := os.Pipe()
+	require.NoError(t, err)
+
+	agent := construct()
+	ab := accessBase(agent)
+	ab.agentID = "test-agent"
+	ab.stdin = writePipe
+	ab.ctx = ctx
+	ab.cancel = cancel
+	ab.processDone = make(chan struct{})
+	ab.stderrDone = make(chan struct{})
+	ab.sessionID = "session-1"
+	close(ab.stderrDone)
+
+	var (
+		mu       sync.Mutex
+		requests []recordedRequest
+	)
+	go func() {
+		scanner := bufio.NewScanner(readPipe)
+		for scanner.Scan() {
+			var req struct {
+				ID     int64                  `json:"id"`
+				Method string                 `json:"method"`
+				Params map[string]interface{} `json:"params"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				continue
+			}
+			mu.Lock()
+			requests = append(requests, recordedRequest{Method: req.Method, Params: req.Params})
+			mu.Unlock()
+			if ch, ok := ab.pendingReqs.Load(req.ID); ok {
+				body := json.RawMessage(`{}`)
+				if respond != nil {
+					body = respond(req.Method)
+				}
+				ch.(chan json.RawMessage) <- body
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+
+	return agent, func() []recordedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]recordedRequest, len(requests))
+		copy(out, requests)
+		return out
+	}
+}

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -226,18 +227,10 @@ func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[
 		fs["outputStyle"] = v
 	}
 	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
-		if v == "on" {
-			fs["fastMode"] = true
-		} else {
-			fs["fastMode"] = nil
-		}
+		fs["fastMode"] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
-		if v == "off" {
-			fs["alwaysThinkingEnabled"] = false
-		} else {
-			fs["alwaysThinkingEnabled"] = nil
-		}
+		fs["alwaysThinkingEnabled"] = flagSettingOffOn(v)
 	}
 	return fs
 }
@@ -413,24 +406,16 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 
 	extra := s.ExtraSettings
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
-		if !sliceContains(a.availableOutputStyles, v) {
+		if !slices.Contains(a.availableOutputStyles, v) {
 			return false
 		}
 		flagSettings["outputStyle"] = v
 	}
 	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
-		if v == "on" {
-			flagSettings["fastMode"] = true
-		} else {
-			flagSettings["fastMode"] = nil
-		}
+		flagSettings["fastMode"] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
-		if v == "off" {
-			flagSettings["alwaysThinkingEnabled"] = false
-		} else {
-			flagSettings["alwaysThinkingEnabled"] = nil
-		}
+		flagSettings["alwaysThinkingEnabled"] = flagSettingOffOn(v)
 	}
 
 	if len(flagSettings) == 0 {
@@ -518,13 +503,24 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 	})
 }
 
-func sliceContains(s []string, v string) bool {
-	for _, item := range s {
-		if item == v {
-			return true
-		}
+// flagSettingOnOff maps an "on"/"off" string to a boolean flag setting value
+// for apply_flag_settings. "on" → true, anything else → nil (which resets
+// the flag to its default).
+func flagSettingOnOff(v string) interface{} {
+	if v == "on" {
+		return true
 	}
-	return false
+	return nil
+}
+
+// flagSettingOffOn maps an "off"/"on" string to a boolean flag setting value
+// for apply_flag_settings. "off" → false, anything else → nil (which resets
+// the flag to its default).
+func flagSettingOffOn(v string) interface{} {
+	if v == "off" {
+		return false
+	}
+	return nil
 }
 
 // claudeCodeEfforts shared across models (except haiku gets none, and only opus gets max).

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -63,7 +63,6 @@ type ClaudeCodeAgent struct {
 	// Settings state from initialize response and runtime updates.
 	outputStyle           string
 	availableOutputStyles []string
-	fastModeAvailable     bool
 	fastMode              string // "on" / "off"
 	alwaysThinking        string // "on" / "off"
 }
@@ -185,13 +184,10 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.outputStyle = initResp.OutputStyle
 	}
 	a.availableOutputStyles = initResp.AvailableOutputStyles
-	if initResp.FastModeState != "" {
-		a.fastModeAvailable = true
-		if initResp.FastModeState == "on" || initResp.FastModeState == "cooldown" {
-			a.fastMode = "on"
-		} else {
-			a.fastMode = "off"
-		}
+	if initResp.FastModeState == "on" || initResp.FastModeState == "cooldown" {
+		a.fastMode = "on"
+	} else {
+		a.fastMode = "off"
 	}
 
 	// Send set_permission_mode to configure the agent's permission mode.
@@ -370,7 +366,7 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		for _, s := range a.availableOutputStyles {
 			opts = append(opts, &leapmuxv1.AvailableOption{
 				Id:        s,
-				Name:      s,
+				Name:      titleCaseID(s, ""),
 				IsDefault: s == a.outputStyle,
 			})
 		}
@@ -381,16 +377,14 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		})
 	}
 
-	if a.fastModeAvailable {
-		groups = append(groups, &leapmuxv1.AvailableOptionGroup{
-			Key:   ExtraKeyFastMode,
-			Label: "Fast Mode",
-			Options: []*leapmuxv1.AvailableOption{
-				{Id: "off", Name: "Off", IsDefault: a.fastMode != "on"},
-				{Id: "on", Name: "On", IsDefault: a.fastMode == "on"},
-			},
-		})
-	}
+	groups = append(groups, &leapmuxv1.AvailableOptionGroup{
+		Key:   ExtraKeyFastMode,
+		Label: "Fast Mode",
+		Options: []*leapmuxv1.AvailableOption{
+			{Id: "on", Name: "On", IsDefault: a.fastMode == "on"},
+			{Id: "off", Name: "Off", IsDefault: a.fastMode != "on"},
+		},
+	})
 
 	groups = append(groups, &leapmuxv1.AvailableOptionGroup{
 		Key:   ExtraKeyAlwaysThinking,
@@ -517,6 +511,15 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 			a.alwaysThinking = "off"
 		}
 	}
+
+	slog.Info("agent settings refreshed",
+		"agent_id", a.agentID,
+		"model", a.model,
+		"effort", a.effort,
+		"outputStyle", a.outputStyle,
+		"fastMode", a.fastMode,
+		"alwaysThinking", a.alwaysThinking,
+	)
 }
 
 func sliceContains(s []string, v string) bool {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -224,13 +224,13 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[string]interface{} {
 	fs := map[string]interface{}{}
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
-		fs["outputStyle"] = v
+		fs[ExtraKeyOutputStyle] = v
 	}
 	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
-		fs["fastMode"] = flagSettingOnOff(v)
+		fs[ExtraKeyFastMode] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
-		fs["alwaysThinkingEnabled"] = flagSettingOffOn(v)
+		fs[ExtraKeyAlwaysThinking] = flagSettingOffOn(v)
 	}
 	return fs
 }
@@ -425,13 +425,13 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		if !slices.Contains(availStyles, v) {
 			return false
 		}
-		flagSettings["outputStyle"] = v
+		flagSettings[ExtraKeyOutputStyle] = v
 	}
 	if v := extra[ExtraKeyFastMode]; v != "" && v != curFastMode {
-		flagSettings["fastMode"] = flagSettingOnOff(v)
+		flagSettings[ExtraKeyFastMode] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != curThinking {
-		flagSettings["alwaysThinkingEnabled"] = flagSettingOffOn(v)
+		flagSettings[ExtraKeyAlwaysThinking] = flagSettingOffOn(v)
 	}
 
 	if len(flagSettings) == 0 {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -510,6 +510,12 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 		"fastMode", a.fastMode,
 		"alwaysThinking", a.alwaysThinking,
 	)
+
+	a.sink.BroadcastSettingsRefreshed(a.model, a.effort, a.confirmedPermissionMode, map[string]string{
+		ExtraKeyOutputStyle:    a.outputStyle,
+		ExtraKeyFastMode:       a.fastMode,
+		ExtraKeyAlwaysThinking: a.alwaysThinking,
+	})
 }
 
 func sliceContains(s []string, v string) bool {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -450,16 +450,6 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	return true
 }
 
-// ClearContext sends /clear to Claude Code, clearing the conversation context
-// without restarting the process. The new session ID arrives asynchronously
-// via the system init message on the next turn.
-func (a *ClaudeCodeAgent) ClearContext() (string, bool) {
-	if err := a.SendInput("/clear", nil); err != nil {
-		return "", false
-	}
-	return "", true
-}
-
 // refreshSettingsFromAgent sends get_settings and updates internal state with
 // the actual applied values from Claude Code.
 func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"strings"
 	"sync"
@@ -24,16 +25,28 @@ const (
 
 // claudeCodeControlResult holds the outcome of a pending control request.
 type claudeCodeControlResult struct {
-	Success bool
-	Mode    string
-	Error   string
+	Success               bool
+	Mode                  string
+	Error                 string
+	OutputStyle           string
+	AvailableOutputStyles []string
+	FastModeState         string // "off", "cooldown", "on", or "" (unavailable)
+	RawResponse           json.RawMessage
 }
+
+// Extra settings keys for Claude Code option groups.
+const (
+	ExtraKeyOutputStyle    = "outputStyle"
+	ExtraKeyFastMode       = "fastMode"
+	ExtraKeyAlwaysThinking = "alwaysThinkingEnabled"
+)
 
 // ClaudeCodeAgent manages a single Claude Code process.
 type ClaudeCodeAgent struct {
 	processBase // shared process lifecycle (Stop, Wait, Stderr, etc.)
 
 	model      string
+	effort     string
 	workingDir string
 	homeDir    string
 	sink       OutputSink
@@ -46,6 +59,13 @@ type ClaudeCodeAgent struct {
 	pendingControlMu        sync.Mutex
 	pendingControl          map[string]chan<- claudeCodeControlResult
 	confirmedPermissionMode string
+
+	// Settings state from initialize response and runtime updates.
+	outputStyle           string
+	availableOutputStyles []string
+	fastModeAvailable     bool
+	fastMode              string // "on" / "off"
+	alwaysThinking        string // "on" / "off"
 }
 
 // StartClaudeCode spawns a new Claude Code process and begins reading its output.
@@ -118,11 +138,13 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 			apiTimeout:         opts.apiTimeout(),
 		},
 		model:                  opts.Model,
+		effort:                 opts.Effort,
 		workingDir:             opts.WorkingDir,
 		homeDir:                opts.HomeDir,
 		sink:                   sink,
 		thirdPartyFromSettings: thirdPartyFromSettings,
 		pendingControl:         make(map[string]chan<- claudeCodeControlResult),
+		alwaysThinking:         "on", // default
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -152,9 +174,24 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	// Send "initialize" as the first control request, matching the Agent SDK
 	// protocol. This triggers Claude Code to emit the init system message
 	// (which contains the session_id) and establishes the control protocol.
-	if _, err := a.sendControlAndWait(ctx, `{"subtype":"initialize"}`, timeout); err != nil {
+	initResp, err := a.sendControlAndWait(ctx, `{"subtype":"initialize"}`, timeout)
+	if err != nil {
 		cleanup()
 		return nil, a.formatStartupError("initialize", err)
+	}
+
+	// Extract settings from the initialize response.
+	if initResp.OutputStyle != "" {
+		a.outputStyle = initResp.OutputStyle
+	}
+	a.availableOutputStyles = initResp.AvailableOutputStyles
+	if initResp.FastModeState != "" {
+		a.fastModeAvailable = true
+		if initResp.FastModeState == "on" || initResp.FastModeState == "cooldown" {
+			a.fastMode = "on"
+		} else {
+			a.fastMode = "off"
+		}
 	}
 
 	// Send set_permission_mode to configure the agent's permission mode.
@@ -169,7 +206,44 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	}
 	a.confirmedPermissionMode = resp.Mode
 
+	// Apply persisted extra settings that differ from initialized defaults.
+	if flagSettings := a.buildStartupFlagSettings(opts.ExtraSettings); len(flagSettings) > 0 {
+		body, _ := json.Marshal(map[string]interface{}{
+			"subtype":  "apply_flag_settings",
+			"settings": flagSettings,
+		})
+		if _, err := a.sendControlAndWait(ctx, string(body), timeout); err != nil {
+			slog.Warn("apply_flag_settings at startup failed", "agent_id", a.agentID, "error", err)
+		} else {
+			a.refreshSettingsFromAgent(timeout)
+		}
+	}
+
 	return a, nil
+}
+
+// buildStartupFlagSettings builds an apply_flag_settings payload for extra
+// settings that differ from the initialized defaults.
+func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[string]interface{} {
+	fs := map[string]interface{}{}
+	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
+		fs["outputStyle"] = v
+	}
+	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
+		if v == "on" {
+			fs["fastMode"] = true
+		} else {
+			fs["fastMode"] = nil
+		}
+	}
+	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
+		if v == "off" {
+			fs["alwaysThinkingEnabled"] = false
+		} else {
+			fs["alwaysThinkingEnabled"] = nil
+		}
+	}
+	return fs
 }
 
 // SendInput writes a user message to the agent's stdin.
@@ -253,9 +327,21 @@ func buildClaudeContentBlocks(content string, classified []classifiedAttachment)
 
 // CurrentSettings returns the current settings for this agent.
 func (a *ClaudeCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
+	extra := map[string]string{}
+	if a.outputStyle != "" {
+		extra[ExtraKeyOutputStyle] = a.outputStyle
+	}
+	if a.fastMode != "" {
+		extra[ExtraKeyFastMode] = a.fastMode
+	}
+	if a.alwaysThinking != "" {
+		extra[ExtraKeyAlwaysThinking] = a.alwaysThinking
+	}
 	return &leapmuxv1.AgentSettings{
 		Model:          a.model,
+		Effort:         a.effort,
 		PermissionMode: a.confirmedPermissionMode,
+		ExtraSettings:  extra,
 	}
 }
 
@@ -271,13 +357,174 @@ func (a *ClaudeCodeAgent) AvailableModels() []*leapmuxv1.AvailableModel {
 	return claudeCodeAvailableModels
 }
 
-// AvailableOptionGroups returns the static Claude Code option groups.
+// AvailableOptionGroups returns dynamic option groups including output style,
+// fast mode (when available), and extended thinking, in addition to the
+// static permission mode group.
 func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	return AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	groups := []*leapmuxv1.AvailableOptionGroup{
+		AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0], // permission mode
+	}
+
+	if len(a.availableOutputStyles) > 0 {
+		opts := make([]*leapmuxv1.AvailableOption, 0, len(a.availableOutputStyles))
+		for _, s := range a.availableOutputStyles {
+			opts = append(opts, &leapmuxv1.AvailableOption{
+				Id:        s,
+				Name:      s,
+				IsDefault: s == a.outputStyle,
+			})
+		}
+		groups = append(groups, &leapmuxv1.AvailableOptionGroup{
+			Key:     ExtraKeyOutputStyle,
+			Label:   "Output Style",
+			Options: opts,
+		})
+	}
+
+	if a.fastModeAvailable {
+		groups = append(groups, &leapmuxv1.AvailableOptionGroup{
+			Key:   ExtraKeyFastMode,
+			Label: "Fast Mode",
+			Options: []*leapmuxv1.AvailableOption{
+				{Id: "off", Name: "Off", IsDefault: a.fastMode != "on"},
+				{Id: "on", Name: "On", IsDefault: a.fastMode == "on"},
+			},
+		})
+	}
+
+	groups = append(groups, &leapmuxv1.AvailableOptionGroup{
+		Key:   ExtraKeyAlwaysThinking,
+		Label: "Extended Thinking",
+		Options: []*leapmuxv1.AvailableOption{
+			{Id: "on", Name: "On", IsDefault: a.alwaysThinking != "off"},
+			{Id: "off", Name: "Off", IsDefault: a.alwaysThinking == "off"},
+		},
+	})
+
+	return groups
 }
 
-// UpdateSettings is a no-op for Claude Code — settings changes require a restart.
-func (a *ClaudeCodeAgent) UpdateSettings(_ *leapmuxv1.AgentSettings) bool {
+// UpdateSettings applies settings changes via the apply_flag_settings control
+// request, avoiding a process restart. Returns true if the update was handled
+// (or nothing changed), false if a restart is needed.
+func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
+	flagSettings := map[string]interface{}{}
+
+	if s.Model != "" && s.Model != a.model {
+		flagSettings["model"] = s.Model
+	}
+	if s.Effort != "" && s.Effort != a.effort {
+		flagSettings["effortLevel"] = s.Effort
+	}
+
+	extra := s.ExtraSettings
+	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
+		if !sliceContains(a.availableOutputStyles, v) {
+			return false
+		}
+		flagSettings["outputStyle"] = v
+	}
+	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
+		if v == "on" {
+			flagSettings["fastMode"] = true
+		} else {
+			flagSettings["fastMode"] = nil
+		}
+	}
+	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
+		if v == "off" {
+			flagSettings["alwaysThinkingEnabled"] = false
+		} else {
+			flagSettings["alwaysThinkingEnabled"] = nil
+		}
+	}
+
+	if len(flagSettings) == 0 {
+		return true
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"subtype":  "apply_flag_settings",
+		"settings": flagSettings,
+	})
+	if _, err := a.sendControlAndWait(a.ctx, string(body), a.APITimeout()); err != nil {
+		slog.Error("apply_flag_settings failed", "agent_id", a.agentID, "error", err)
+		return false
+	}
+
+	a.refreshSettingsFromAgent(a.APITimeout())
+	return true
+}
+
+// ClearContext sends /clear to Claude Code, clearing the conversation context
+// without restarting the process. The new session ID arrives asynchronously
+// via the system init message on the next turn.
+func (a *ClaudeCodeAgent) ClearContext() (string, bool) {
+	if err := a.SendInput("/clear", nil); err != nil {
+		return "", false
+	}
+	return "", true
+}
+
+// refreshSettingsFromAgent sends get_settings and updates internal state with
+// the actual applied values from Claude Code.
+func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
+	resp, err := a.sendControlAndWait(a.ctx, `{"subtype":"get_settings"}`, timeout)
+	if err != nil {
+		slog.Warn("get_settings failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+	if len(resp.RawResponse) == 0 {
+		return
+	}
+
+	var settings struct {
+		Effective struct {
+			OutputStyle           string `json:"outputStyle"`
+			FastMode              *bool  `json:"fastMode"`
+			AlwaysThinkingEnabled *bool  `json:"alwaysThinkingEnabled"`
+		} `json:"effective"`
+		Applied struct {
+			Model  string  `json:"model"`
+			Effort *string `json:"effort"`
+		} `json:"applied"`
+	}
+	if err := json.Unmarshal(resp.RawResponse, &settings); err != nil {
+		slog.Warn("get_settings response parse failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+
+	if settings.Applied.Model != "" {
+		a.model = settings.Applied.Model
+	}
+	if settings.Applied.Effort != nil {
+		a.effort = *settings.Applied.Effort
+	}
+	if settings.Effective.OutputStyle != "" {
+		a.outputStyle = settings.Effective.OutputStyle
+	}
+	if settings.Effective.FastMode != nil {
+		if *settings.Effective.FastMode {
+			a.fastMode = "on"
+		} else {
+			a.fastMode = "off"
+		}
+	}
+	if settings.Effective.AlwaysThinkingEnabled != nil {
+		if *settings.Effective.AlwaysThinkingEnabled {
+			a.alwaysThinking = "on"
+		} else {
+			a.alwaysThinking = "off"
+		}
+	}
+}
+
+func sliceContains(s []string, v string) bool {
+	for _, item := range s {
+		if item == v {
+			return true
+		}
+	}
 	return false
 }
 
@@ -362,12 +609,10 @@ func (a *ClaudeCodeAgent) handlePendingControlResponse(line *parsedLine) bool {
 
 	var envelope struct {
 		Response struct {
-			Subtype   string `json:"subtype"`
-			RequestID string `json:"request_id"`
-			Response  struct {
-				Mode string `json:"mode"`
-			} `json:"response"`
-			Error string `json:"error"`
+			Subtype   string          `json:"subtype"`
+			RequestID string          `json:"request_id"`
+			Response  json.RawMessage `json:"response"`
+			Error     string          `json:"error"`
 		} `json:"response"`
 	}
 	if err := json.Unmarshal(line.Raw, &envelope); err != nil {
@@ -383,10 +628,25 @@ func (a *ClaudeCodeAgent) handlePendingControlResponse(line *parsedLine) bool {
 		return false
 	}
 
+	// Parse known fields from the inner response object.
+	var innerResponse struct {
+		Mode                  string   `json:"mode"`
+		OutputStyle           string   `json:"output_style"`
+		AvailableOutputStyles []string `json:"available_output_styles"`
+		FastModeState         string   `json:"fast_mode_state"`
+	}
+	if len(envelope.Response.Response) > 0 {
+		_ = json.Unmarshal(envelope.Response.Response, &innerResponse)
+	}
+
 	result := claudeCodeControlResult{
-		Success: envelope.Response.Subtype == "success",
-		Mode:    envelope.Response.Response.Mode,
-		Error:   envelope.Response.Error,
+		Success:               envelope.Response.Subtype == "success",
+		Mode:                  innerResponse.Mode,
+		Error:                 envelope.Response.Error,
+		OutputStyle:           innerResponse.OutputStyle,
+		AvailableOutputStyles: innerResponse.AvailableOutputStyles,
+		FastModeState:         innerResponse.FastModeState,
+		RawResponse:           envelope.Response.Response,
 	}
 	ch <- result
 	return true

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -316,20 +316,25 @@ func buildClaudeContentBlocks(content string, classified []classifiedAttachment)
 
 // CurrentSettings returns the current settings for this agent.
 func (a *ClaudeCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
+	a.mu.Lock()
+	model, effort, mode := a.model, a.effort, a.confirmedPermissionMode
+	outputStyle, fastMode, thinking := a.outputStyle, a.fastMode, a.alwaysThinking
+	a.mu.Unlock()
+
 	extra := map[string]string{}
-	if a.outputStyle != "" {
-		extra[ExtraKeyOutputStyle] = a.outputStyle
+	if outputStyle != "" {
+		extra[ExtraKeyOutputStyle] = outputStyle
 	}
-	if a.fastMode != "" {
-		extra[ExtraKeyFastMode] = a.fastMode
+	if fastMode != "" {
+		extra[ExtraKeyFastMode] = fastMode
 	}
-	if a.alwaysThinking != "" {
-		extra[ExtraKeyAlwaysThinking] = a.alwaysThinking
+	if thinking != "" {
+		extra[ExtraKeyAlwaysThinking] = thinking
 	}
 	return &leapmuxv1.AgentSettings{
-		Model:          a.model,
-		Effort:         a.effort,
-		PermissionMode: a.confirmedPermissionMode,
+		Model:          model,
+		Effort:         effort,
+		PermissionMode: mode,
 		ExtraSettings:  extra,
 	}
 }
@@ -350,17 +355,22 @@ func (a *ClaudeCodeAgent) AvailableModels() []*leapmuxv1.AvailableModel {
 // fast mode (when available), and extended thinking, in addition to the
 // static permission mode group.
 func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
+	a.mu.Lock()
+	outputStyle, fastMode, thinking := a.outputStyle, a.fastMode, a.alwaysThinking
+	availStyles := a.availableOutputStyles
+	a.mu.Unlock()
+
 	groups := []*leapmuxv1.AvailableOptionGroup{
 		AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0], // permission mode
 	}
 
-	if len(a.availableOutputStyles) > 0 {
-		opts := make([]*leapmuxv1.AvailableOption, 0, len(a.availableOutputStyles))
-		for _, s := range a.availableOutputStyles {
+	if len(availStyles) > 0 {
+		opts := make([]*leapmuxv1.AvailableOption, 0, len(availStyles))
+		for _, s := range availStyles {
 			opts = append(opts, &leapmuxv1.AvailableOption{
 				Id:        s,
 				Name:      titleCaseID(s, ""),
-				IsDefault: s == a.outputStyle,
+				IsDefault: s == outputStyle,
 			})
 		}
 		groups = append(groups, &leapmuxv1.AvailableOptionGroup{
@@ -374,8 +384,8 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		Key:   ExtraKeyFastMode,
 		Label: "Fast Mode",
 		Options: []*leapmuxv1.AvailableOption{
-			{Id: "on", Name: "On", IsDefault: a.fastMode == "on"},
-			{Id: "off", Name: "Off", IsDefault: a.fastMode != "on"},
+			{Id: "on", Name: "On", IsDefault: fastMode == "on"},
+			{Id: "off", Name: "Off", IsDefault: fastMode != "on"},
 		},
 	})
 
@@ -383,8 +393,8 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		Key:   ExtraKeyAlwaysThinking,
 		Label: "Extended Thinking",
 		Options: []*leapmuxv1.AvailableOption{
-			{Id: "on", Name: "On", IsDefault: a.alwaysThinking != "off"},
-			{Id: "off", Name: "Off", IsDefault: a.alwaysThinking == "off"},
+			{Id: "on", Name: "On", IsDefault: thinking != "off"},
+			{Id: "off", Name: "Off", IsDefault: thinking == "off"},
 		},
 	})
 
@@ -395,26 +405,32 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 // request, avoiding a process restart. Returns true if the update was handled
 // (or nothing changed), false if a restart is needed.
 func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
+	a.mu.Lock()
+	curModel, curEffort := a.model, a.effort
+	curOutputStyle, curFastMode, curThinking := a.outputStyle, a.fastMode, a.alwaysThinking
+	availStyles := a.availableOutputStyles
+	a.mu.Unlock()
+
 	flagSettings := map[string]interface{}{}
 
-	if s.Model != "" && s.Model != a.model {
+	if s.Model != "" && s.Model != curModel {
 		flagSettings["model"] = s.Model
 	}
-	if s.Effort != "" && s.Effort != a.effort {
+	if s.Effort != "" && s.Effort != curEffort {
 		flagSettings["effortLevel"] = s.Effort
 	}
 
 	extra := s.ExtraSettings
-	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
-		if !slices.Contains(a.availableOutputStyles, v) {
+	if v := extra[ExtraKeyOutputStyle]; v != "" && v != curOutputStyle {
+		if !slices.Contains(availStyles, v) {
 			return false
 		}
 		flagSettings["outputStyle"] = v
 	}
-	if v := extra[ExtraKeyFastMode]; v != "" && v != a.fastMode {
+	if v := extra[ExtraKeyFastMode]; v != "" && v != curFastMode {
 		flagSettings["fastMode"] = flagSettingOnOff(v)
 	}
-	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
+	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != curThinking {
 		flagSettings["alwaysThinkingEnabled"] = flagSettingOffOn(v)
 	}
 
@@ -463,6 +479,7 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 		return
 	}
 
+	a.mu.Lock()
 	if settings.Applied.Model != "" {
 		a.model = settings.Applied.Model
 	}
@@ -486,20 +503,23 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 			a.alwaysThinking = "off"
 		}
 	}
+	model, effort, mode := a.model, a.effort, a.confirmedPermissionMode
+	outputStyle, fastMode, thinking := a.outputStyle, a.fastMode, a.alwaysThinking
+	a.mu.Unlock()
 
 	slog.Info("agent settings refreshed",
 		"agent_id", a.agentID,
-		"model", a.model,
-		"effort", a.effort,
-		"outputStyle", a.outputStyle,
-		"fastMode", a.fastMode,
-		"alwaysThinking", a.alwaysThinking,
+		"model", model,
+		"effort", effort,
+		"outputStyle", outputStyle,
+		"fastMode", fastMode,
+		"alwaysThinking", thinking,
 	)
 
-	a.sink.BroadcastSettingsRefreshed(a.model, a.effort, a.confirmedPermissionMode, map[string]string{
-		ExtraKeyOutputStyle:    a.outputStyle,
-		ExtraKeyFastMode:       a.fastMode,
-		ExtraKeyAlwaysThinking: a.alwaysThinking,
+	a.sink.BroadcastSettingsRefreshed(model, effort, mode, map[string]string{
+		ExtraKeyOutputStyle:    outputStyle,
+		ExtraKeyFastMode:       fastMode,
+		ExtraKeyAlwaysThinking: thinking,
 	})
 }
 

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -1,0 +1,592 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit tests for AvailableOptionGroups ---
+
+func TestAvailableOptionGroups_IncludesOutputStyles(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		availableOutputStyles: []string{"default", "Explanatory", "Learning"},
+		outputStyle:           "Explanatory",
+		alwaysThinking:        "on",
+	}
+	groups := a.AvailableOptionGroups()
+
+	var styleGroup *leapmuxv1.AvailableOptionGroup
+	for _, g := range groups {
+		if g.Key == ExtraKeyOutputStyle {
+			styleGroup = g
+			break
+		}
+	}
+	require.NotNil(t, styleGroup, "output style group should be present")
+	assert.Equal(t, "Output Style", styleGroup.Label)
+	assert.Len(t, styleGroup.Options, 3)
+
+	for _, opt := range styleGroup.Options {
+		if opt.Id == "Explanatory" {
+			assert.True(t, opt.IsDefault, "Explanatory should be marked as default")
+		} else {
+			assert.False(t, opt.IsDefault, "%s should not be default", opt.Id)
+		}
+	}
+}
+
+func TestAvailableOptionGroups_NoOutputStylesWhenEmpty(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		alwaysThinking: "on",
+	}
+	groups := a.AvailableOptionGroups()
+	for _, g := range groups {
+		assert.NotEqual(t, ExtraKeyOutputStyle, g.Key, "should not have output style group when empty")
+	}
+}
+
+func TestAvailableOptionGroups_FastModeWhenAvailable(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		fastModeAvailable: true,
+		fastMode:          "on",
+		alwaysThinking:    "on",
+	}
+	groups := a.AvailableOptionGroups()
+
+	var fastGroup *leapmuxv1.AvailableOptionGroup
+	for _, g := range groups {
+		if g.Key == ExtraKeyFastMode {
+			fastGroup = g
+			break
+		}
+	}
+	require.NotNil(t, fastGroup, "fast mode group should be present when available")
+	assert.Len(t, fastGroup.Options, 2)
+
+	for _, opt := range fastGroup.Options {
+		if opt.Id == "on" {
+			assert.True(t, opt.IsDefault)
+		} else {
+			assert.False(t, opt.IsDefault)
+		}
+	}
+}
+
+func TestAvailableOptionGroups_NoFastModeWhenUnavailable(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		alwaysThinking: "on",
+	}
+	groups := a.AvailableOptionGroups()
+	for _, g := range groups {
+		assert.NotEqual(t, ExtraKeyFastMode, g.Key, "should not have fast mode group when unavailable")
+	}
+}
+
+func TestAvailableOptionGroups_AlwaysIncludesThinking(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		alwaysThinking: "off",
+	}
+	groups := a.AvailableOptionGroups()
+
+	var thinkingGroup *leapmuxv1.AvailableOptionGroup
+	for _, g := range groups {
+		if g.Key == ExtraKeyAlwaysThinking {
+			thinkingGroup = g
+			break
+		}
+	}
+	require.NotNil(t, thinkingGroup, "thinking group should always be present")
+	for _, opt := range thinkingGroup.Options {
+		if opt.Id == "off" {
+			assert.True(t, opt.IsDefault)
+		} else {
+			assert.False(t, opt.IsDefault)
+		}
+	}
+}
+
+// --- Unit tests for CurrentSettings ---
+
+func TestCurrentSettings_IncludesExtraSettings(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		processBase:             processBase{agentID: "test"},
+		model:                   "sonnet",
+		effort:                  "low",
+		confirmedPermissionMode: "default",
+		outputStyle:             "Explanatory",
+		fastMode:                "on",
+		alwaysThinking:          "off",
+	}
+	s := a.CurrentSettings()
+	assert.Equal(t, "sonnet", s.Model)
+	assert.Equal(t, "low", s.Effort)
+	assert.Equal(t, "Explanatory", s.ExtraSettings[ExtraKeyOutputStyle])
+	assert.Equal(t, "on", s.ExtraSettings[ExtraKeyFastMode])
+	assert.Equal(t, "off", s.ExtraSettings[ExtraKeyAlwaysThinking])
+}
+
+// --- Unit tests for UpdateSettings logic (no-op / validation) ---
+
+func TestUpdateSettings_NothingChanged(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyOutputStyle:    a.outputStyle,
+			ExtraKeyFastMode:       a.fastMode,
+			ExtraKeyAlwaysThinking: a.alwaysThinking,
+		},
+	})
+	assert.True(t, result, "should return true when nothing changed")
+}
+
+func TestUpdateSettings_OutputStyleInvalid(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.availableOutputStyles = []string{"default", "Explanatory"}
+	a.outputStyle = "default"
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyOutputStyle: "NonExistent",
+		},
+	})
+	assert.False(t, result, "should return false for invalid output style")
+	assert.Equal(t, "default", a.outputStyle, "output style should not change")
+}
+
+func TestUpdateSettings_ModelChange(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  "sonnet",
+		Effort: a.effort,
+	})
+	assert.True(t, result, "should return true for model change via apply_flag_settings")
+	assert.Equal(t, "sonnet", a.model, "model should be updated from get_settings response")
+}
+
+func TestUpdateSettings_EffortChange(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: "low",
+	})
+	assert.True(t, result, "should return true for effort change")
+	assert.Equal(t, "low", a.effort, "effort should be updated from get_settings response")
+}
+
+func TestUpdateSettings_OutputStyleChange(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.availableOutputStyles = []string{"default", "Explanatory", "Learning"}
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyOutputStyle: "Explanatory",
+		},
+	})
+	assert.True(t, result, "should return true for output style change")
+	assert.Equal(t, "Explanatory", a.outputStyle, "output style should be updated")
+}
+
+func TestUpdateSettings_FastModeOn(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.fastMode = "off"
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyFastMode: "on",
+		},
+	})
+	assert.True(t, result)
+	assert.Equal(t, "on", a.fastMode)
+}
+
+func TestUpdateSettings_AlwaysThinkingOff(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyAlwaysThinking: "off",
+		},
+	})
+	assert.True(t, result)
+	assert.Equal(t, "off", a.alwaysThinking)
+}
+
+func TestUpdateSettings_FastModeOff(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.fastMode = "on"
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyFastMode: "off",
+		},
+	})
+	assert.True(t, result)
+	assert.Equal(t, "off", a.fastMode)
+}
+
+func TestUpdateSettings_AlwaysThinkingOn(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.alwaysThinking = "off"
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  a.model,
+		Effort: a.effort,
+		ExtraSettings: map[string]string{
+			ExtraKeyAlwaysThinking: "on",
+		},
+	})
+	assert.True(t, result)
+	assert.Equal(t, "on", a.alwaysThinking)
+}
+
+func TestUpdateSettings_ApplyFlagSettingsFails(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	// Stop the mock process so apply_flag_settings will fail.
+	a.Stop()
+	_ = a.Wait()
+
+	// Re-mark as not stopped so UpdateSettings proceeds to sendControlAndWait.
+	a.mu.Lock()
+	a.stopped = false
+	a.mu.Unlock()
+
+	originalModel := a.model
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  "sonnet",
+		Effort: a.effort,
+	})
+	assert.False(t, result, "should return false when apply_flag_settings fails")
+	assert.Equal(t, originalModel, a.model, "model should not change on failure")
+}
+
+func TestUpdateSettings_MultipleChanges(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	a.availableOutputStyles = []string{"default", "Learning"}
+	a.fastMode = "off"
+
+	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:  "sonnet",
+		Effort: "low",
+		ExtraSettings: map[string]string{
+			ExtraKeyOutputStyle: "Learning",
+			ExtraKeyFastMode:    "on",
+		},
+	})
+	assert.True(t, result, "should return true for multiple changes")
+	assert.Equal(t, "sonnet", a.model)
+	assert.Equal(t, "low", a.effort)
+	assert.Equal(t, "Learning", a.outputStyle)
+	assert.Equal(t, "on", a.fastMode)
+}
+
+// --- Unit tests for ClearContext ---
+
+func TestClearContext_SendsClearCommand(t *testing.T) {
+	a := newTestAgentWithControlProtocol(t)
+	defer stopTestAgent(a)
+
+	sessionID, ok := a.ClearContext()
+	assert.True(t, ok, "ClearContext should return true for a running agent")
+	assert.Empty(t, sessionID, "session ID should be empty (updated asynchronously)")
+}
+
+func TestClearContext_FailsWhenStopped(t *testing.T) {
+	ctx := context.Background()
+	agent, err := mockStart(ctx, Options{
+		AgentID:    "clear-stop-test",
+		Model:      "test",
+		WorkingDir: t.TempDir(),
+	}, noopSink{})
+	require.NoError(t, err)
+
+	agent.Stop()
+	_ = agent.Wait()
+
+	_, ok := agent.ClearContext()
+	assert.False(t, ok, "ClearContext should return false when agent is stopped")
+}
+
+// --- Unit tests for handlePendingControlResponse parsing ---
+
+func TestHandlePendingControlResponse_ParsesInitializeFields(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		processBase:    processBase{agentID: "test"},
+		pendingControl: make(map[string]chan<- claudeCodeControlResult),
+	}
+
+	ch := make(chan claudeCodeControlResult, 1)
+	a.registerPendingControl("req-1", ch)
+
+	raw := []byte(`{"type":"control_response","response":{` +
+		`"subtype":"success","request_id":"req-1","response":{` +
+		`"output_style":"Explanatory",` +
+		`"available_output_styles":["default","Explanatory","Learning"],` +
+		`"fast_mode_state":"on",` +
+		`"mode":"default"` +
+		`}}}`)
+
+	line := &parsedLine{Type: "control_response", Raw: raw}
+	consumed := a.handlePendingControlResponse(line)
+	assert.True(t, consumed)
+
+	result := <-ch
+	assert.True(t, result.Success)
+	assert.Equal(t, "Explanatory", result.OutputStyle)
+	assert.Equal(t, []string{"default", "Explanatory", "Learning"}, result.AvailableOutputStyles)
+	assert.Equal(t, "on", result.FastModeState)
+	assert.Equal(t, "default", result.Mode)
+	assert.NotEmpty(t, result.RawResponse)
+}
+
+func TestHandlePendingControlResponse_ParsesGetSettingsResponse(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		processBase:    processBase{agentID: "test"},
+		pendingControl: make(map[string]chan<- claudeCodeControlResult),
+	}
+
+	ch := make(chan claudeCodeControlResult, 1)
+	a.registerPendingControl("req-2", ch)
+
+	raw := []byte(`{"type":"control_response","response":{` +
+		`"subtype":"success","request_id":"req-2","response":{` +
+		`"effective":{"outputStyle":"Learning","fastMode":true,"alwaysThinkingEnabled":false},` +
+		`"applied":{"model":"sonnet","effort":"low"}` +
+		`}}}`)
+
+	line := &parsedLine{Type: "control_response", Raw: raw}
+	consumed := a.handlePendingControlResponse(line)
+	assert.True(t, consumed)
+
+	result := <-ch
+	assert.True(t, result.Success)
+	assert.NotEmpty(t, result.RawResponse)
+
+	// Verify the raw response can be parsed for get_settings fields.
+	var settings struct {
+		Effective struct {
+			OutputStyle           string `json:"outputStyle"`
+			FastMode              *bool  `json:"fastMode"`
+			AlwaysThinkingEnabled *bool  `json:"alwaysThinkingEnabled"`
+		} `json:"effective"`
+		Applied struct {
+			Model  string  `json:"model"`
+			Effort *string `json:"effort"`
+		} `json:"applied"`
+	}
+	require.NoError(t, json.Unmarshal(result.RawResponse, &settings))
+	assert.Equal(t, "Learning", settings.Effective.OutputStyle)
+	assert.NotNil(t, settings.Effective.FastMode)
+	assert.True(t, *settings.Effective.FastMode)
+	assert.NotNil(t, settings.Effective.AlwaysThinkingEnabled)
+	assert.False(t, *settings.Effective.AlwaysThinkingEnabled)
+	assert.Equal(t, "sonnet", settings.Applied.Model)
+	assert.NotNil(t, settings.Applied.Effort)
+	assert.Equal(t, "low", *settings.Applied.Effort)
+}
+
+// --- Test helper: mock process with control protocol ---
+
+// TestHelperProcessWithControlProtocol is a test helper that responds to
+// control_request messages. It tracks settings state from apply_flag_settings
+// and returns it in get_settings responses.
+func TestHelperProcessWithControlProtocol(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_CONTROL") != "1" {
+		return
+	}
+
+	// Track current settings state.
+	state := map[string]interface{}{
+		"model":                 "opus[1m]",
+		"effort":                "high",
+		"outputStyle":           "default",
+		"fastMode":              nil,
+		"alwaysThinkingEnabled": nil,
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		var msg struct {
+			Type      string `json:"type"`
+			RequestID string `json:"request_id"`
+			Request   struct {
+				Subtype  string                 `json:"subtype"`
+				Settings map[string]interface{} `json:"settings"`
+			} `json:"request"`
+		}
+		if err := json.Unmarshal([]byte(line), &msg); err != nil || msg.Type != "control_request" {
+			_, _ = fmt.Fprintln(os.Stdout, line)
+			continue
+		}
+
+		var responseBody interface{}
+		switch msg.Request.Subtype {
+		case "apply_flag_settings":
+			for k, v := range msg.Request.Settings {
+				if v == nil {
+					delete(state, k)
+				} else {
+					state[k] = v
+				}
+			}
+			responseBody = map[string]interface{}{}
+		case "get_settings":
+			// Build effective settings from state, applying defaults for
+			// absent (null-deleted) boolean settings.
+			effective := map[string]interface{}{}
+			if v, ok := state["outputStyle"]; ok && v != nil {
+				effective["outputStyle"] = v
+			}
+			if v, ok := state["fastMode"]; ok && v != nil {
+				effective["fastMode"] = v
+			} else {
+				effective["fastMode"] = false // default: off
+			}
+			if v, ok := state["alwaysThinkingEnabled"]; ok && v != nil {
+				effective["alwaysThinkingEnabled"] = v
+			} else {
+				effective["alwaysThinkingEnabled"] = true // default: on
+			}
+
+			model := "opus[1m]"
+			if v, ok := state["model"].(string); ok {
+				model = v
+			}
+			effort := "high"
+			if v, ok := state["effortLevel"].(string); ok {
+				effort = v
+			}
+
+			responseBody = map[string]interface{}{
+				"effective": effective,
+				"applied": map[string]interface{}{
+					"model":  model,
+					"effort": effort,
+				},
+				"sources": []interface{}{},
+			}
+		default:
+			responseBody = map[string]interface{}{}
+		}
+
+		resp := map[string]interface{}{
+			"type": "control_response",
+			"response": map[string]interface{}{
+				"subtype":    "success",
+				"request_id": msg.RequestID,
+				"response":   responseBody,
+			},
+		}
+		data, _ := json.Marshal(resp)
+		_, _ = fmt.Fprintln(os.Stdout, string(data))
+		_ = os.Stdout.Sync()
+	}
+
+	os.Exit(0)
+}
+
+// newTestAgentWithControlProtocol creates a ClaudeCodeAgent backed by a mock
+// process that handles control_request messages. The agent has sensible
+// defaults set for testing UpdateSettings.
+func newTestAgentWithControlProtocol(t *testing.T) *ClaudeCodeAgent {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcessWithControlProtocol", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_CONTROL=1")
+	cmd.Dir = t.TempDir()
+
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+
+	cmd.Stderr = nil
+
+	a := &ClaudeCodeAgent{
+		processBase: processBase{
+			agentID:     "test-ctrl",
+			cmd:         cmd,
+			stdin:       stdin,
+			ctx:         ctx,
+			cancel:      cancel,
+			processDone: make(chan struct{}),
+			stderrDone:  make(chan struct{}),
+			apiTimeout:  5 * time.Second,
+		},
+		model:                 "opus[1m]",
+		effort:                "high",
+		outputStyle:           "default",
+		availableOutputStyles: []string{"default", "Explanatory", "Learning"},
+		fastMode:              "off",
+		alwaysThinking:        "on",
+		workingDir:            t.TempDir(),
+		sink:                  noopSink{},
+		pendingControl:        make(map[string]chan<- claudeCodeControlResult),
+	}
+	close(a.stderrDone)
+
+	require.NoError(t, cmd.Start())
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutputLoop(scanner)
+
+	return a
+}
+
+func stopTestAgent(a *ClaudeCodeAgent) {
+	a.Stop()
+	_ = a.Wait()
+}

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -56,11 +56,10 @@ func TestAvailableOptionGroups_NoOutputStylesWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestAvailableOptionGroups_FastModeWhenAvailable(t *testing.T) {
+func TestAvailableOptionGroups_FastModeOn(t *testing.T) {
 	a := &ClaudeCodeAgent{
-		fastModeAvailable: true,
-		fastMode:          "on",
-		alwaysThinking:    "on",
+		fastMode:       "on",
+		alwaysThinking: "on",
 	}
 	groups := a.AvailableOptionGroups()
 
@@ -71,7 +70,7 @@ func TestAvailableOptionGroups_FastModeWhenAvailable(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, fastGroup, "fast mode group should be present when available")
+	require.NotNil(t, fastGroup, "fast mode group should always be present")
 	assert.Len(t, fastGroup.Options, 2)
 
 	for _, opt := range fastGroup.Options {
@@ -83,13 +82,26 @@ func TestAvailableOptionGroups_FastModeWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestAvailableOptionGroups_NoFastModeWhenUnavailable(t *testing.T) {
+func TestAvailableOptionGroups_FastModeDefaultsToOff(t *testing.T) {
 	a := &ClaudeCodeAgent{
 		alwaysThinking: "on",
 	}
 	groups := a.AvailableOptionGroups()
+
+	var fastGroup *leapmuxv1.AvailableOptionGroup
 	for _, g := range groups {
-		assert.NotEqual(t, ExtraKeyFastMode, g.Key, "should not have fast mode group when unavailable")
+		if g.Key == ExtraKeyFastMode {
+			fastGroup = g
+			break
+		}
+	}
+	require.NotNil(t, fastGroup, "fast mode group should always be present")
+	for _, opt := range fastGroup.Options {
+		if opt.Id == "off" {
+			assert.True(t, opt.IsDefault, "off should be default")
+		} else {
+			assert.False(t, opt.IsDefault, "on should not be default")
+		}
 	}
 }
 

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -335,33 +335,6 @@ func TestUpdateSettings_MultipleChanges(t *testing.T) {
 	assert.Equal(t, "on", a.fastMode)
 }
 
-// --- Unit tests for ClearContext ---
-
-func TestClearContext_SendsClearCommand(t *testing.T) {
-	a := newTestAgentWithControlProtocol(t)
-	defer stopTestAgent(a)
-
-	sessionID, ok := a.ClearContext()
-	assert.True(t, ok, "ClearContext should return true for a running agent")
-	assert.Empty(t, sessionID, "session ID should be empty (updated asynchronously)")
-}
-
-func TestClearContext_FailsWhenStopped(t *testing.T) {
-	ctx := context.Background()
-	agent, err := mockStart(ctx, Options{
-		AgentID:    "clear-stop-test",
-		Model:      "test",
-		WorkingDir: t.TempDir(),
-	}, noopSink{})
-	require.NoError(t, err)
-
-	agent.Stop()
-	_ = agent.Wait()
-
-	_, ok := agent.ClearContext()
-	assert.False(t, ok, "ClearContext should return false when agent is stopped")
-}
-
 // --- Unit tests for handlePendingControlResponse parsing ---
 
 func TestHandlePendingControlResponse_ParsesInitializeFields(t *testing.T) {

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -788,8 +788,8 @@ func init() {
 				Key:   CodexExtraServiceTier,
 				Label: "Fast Mode",
 				Options: []*leapmuxv1.AvailableOption{
-					{Id: CodexDefaultServiceTier, Name: "Off", Description: "Use the normal/default service tier", IsDefault: true},
 					{Id: CodexServiceTierFast, Name: "On", Description: "Use Codex fast mode for future turns"},
+					{Id: CodexDefaultServiceTier, Name: "Off", Description: "Use the normal/default service tier", IsDefault: true},
 				},
 			},
 			{

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -562,10 +562,10 @@ func (a *CodexAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 	return AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
 }
 
-// UpdateSettings stores new settings so the next turn/start picks them up.
+// UpdateSettings stores new settings so the next turn/start picks them up,
+// then refreshes from the Codex server to confirm the effective state.
 func (a *CodexAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if s.GetModel() != "" {
 		a.model = s.GetModel()
 	}
@@ -588,7 +588,84 @@ func (a *CodexAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	if v := extras[CodexExtraServiceTier]; v != "" {
 		a.serviceTier = v
 	}
+	a.mu.Unlock()
+
+	a.refreshSettingsFromAgent()
 	return true
+}
+
+// refreshSettingsFromAgent sends a config/read RPC to the Codex server and
+// updates internal state with the effective config values.
+func (a *CodexAgent) refreshSettingsFromAgent() {
+	resp, err := a.sendRequest("config/read", json.RawMessage(`{"includeLayers":false}`), a.APITimeout())
+	if err != nil {
+		slog.Warn("codex config/read failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+
+	var result struct {
+		Config struct {
+			Model                json.RawMessage `json:"model"`
+			ModelReasoningEffort json.RawMessage `json:"model_reasoning_effort"`
+			ApprovalPolicy       json.RawMessage `json:"approval_policy"`
+			SandboxMode          json.RawMessage `json:"sandbox_mode"`
+			ServiceTier          json.RawMessage `json:"service_tier"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		slog.Warn("codex config/read unmarshal failed", "agent_id", a.agentID, "error", err)
+		return
+	}
+
+	a.mu.Lock()
+	// Each field may be null or a string; only update if it's a non-empty string.
+	if s := jsonString(result.Config.Model); s != "" {
+		a.model = s
+	}
+	if s := jsonString(result.Config.ModelReasoningEffort); s != "" {
+		a.effort = s
+	}
+	// approval_policy can be a string ("on-request") or an object ({"granular":...}).
+	// Only update for the simple string case that LeapMux models.
+	if s := jsonString(result.Config.ApprovalPolicy); s != "" {
+		a.approvalPolicy = s
+	}
+	if s := jsonString(result.Config.SandboxMode); s != "" {
+		a.sandboxPolicy = s
+	}
+	if s := jsonString(result.Config.ServiceTier); s != "" {
+		a.serviceTier = s
+	}
+	a.mu.Unlock()
+
+	slog.Info("codex agent settings refreshed",
+		"agent_id", a.agentID,
+		"model", a.model,
+		"effort", a.effort,
+		"approvalPolicy", a.approvalPolicy,
+		"sandboxPolicy", a.sandboxPolicy,
+		"serviceTier", a.serviceTier,
+	)
+
+	a.sink.BroadcastSettingsRefreshed(a.model, a.effort, a.approvalPolicy, map[string]string{
+		CodexExtraSandboxPolicy:     a.sandboxPolicy,
+		CodexExtraNetworkAccess:     a.networkAccess,
+		CodexExtraCollaborationMode: a.collaborationMode,
+		CodexExtraServiceTier:       a.serviceTier,
+	})
+}
+
+// jsonString attempts to unmarshal a JSON value as a plain string.
+// Returns "" if the value is null, not a string, or empty.
+func jsonString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
 }
 
 // queryAvailableModels sends a model/list request and converts the response.

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -636,22 +636,24 @@ func (a *CodexAgent) refreshSettingsFromAgent() {
 	if s := jsonString(result.Config.ServiceTier); s != "" {
 		a.serviceTier = s
 	}
+	model, effort, approval := a.model, a.effort, a.approvalPolicy
+	sandbox, network, collab, tier := a.sandboxPolicy, a.networkAccess, a.collaborationMode, a.serviceTier
 	a.mu.Unlock()
 
 	slog.Info("codex agent settings refreshed",
 		"agent_id", a.agentID,
-		"model", a.model,
-		"effort", a.effort,
-		"approvalPolicy", a.approvalPolicy,
-		"sandboxPolicy", a.sandboxPolicy,
-		"serviceTier", a.serviceTier,
+		"model", model,
+		"effort", effort,
+		"approvalPolicy", approval,
+		"sandboxPolicy", sandbox,
+		"serviceTier", tier,
 	)
 
-	a.sink.BroadcastSettingsRefreshed(a.model, a.effort, a.approvalPolicy, map[string]string{
-		CodexExtraSandboxPolicy:     a.sandboxPolicy,
-		CodexExtraNetworkAccess:     a.networkAccess,
-		CodexExtraCollaborationMode: a.collaborationMode,
-		CodexExtraServiceTier:       a.serviceTier,
+	a.sink.BroadcastSettingsRefreshed(model, effort, approval, map[string]string{
+		CodexExtraSandboxPolicy:     sandbox,
+		CodexExtraNetworkAccess:     network,
+		CodexExtraCollaborationMode: collab,
+		CodexExtraServiceTier:       tier,
 	})
 }
 

--- a/backend/internal/worker/agent/codex_settings_test.go
+++ b/backend/internal/worker/agent/codex_settings_test.go
@@ -1,0 +1,229 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type codexRecordedRequest struct {
+	Method string
+	Params map[string]interface{}
+}
+
+func newCodexAgentForRPC(t *testing.T, respond func(method string) json.RawMessage) (*CodexAgent, *testSink, func() []codexRecordedRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readPipe, writePipe, err := os.Pipe()
+	require.NoError(t, err)
+
+	sink := &testSink{}
+	agent := &CodexAgent{
+		jsonrpcBase: jsonrpcBase{processBase: processBase{
+			agentID:     "test-codex",
+			stdin:       writePipe,
+			ctx:         ctx,
+			cancel:      cancel,
+			processDone: make(chan struct{}),
+			stderrDone:  make(chan struct{}),
+		}},
+		model:             "gpt-5.4",
+		effort:            "high",
+		approvalPolicy:    CodexDefaultApprovalPolicy,
+		sandboxPolicy:     CodexDefaultSandboxPolicy,
+		networkAccess:     CodexDefaultNetworkAccess,
+		collaborationMode: CodexDefaultCollaborationMode,
+		serviceTier:       CodexDefaultServiceTier,
+		sink:              sink,
+	}
+	close(agent.stderrDone)
+
+	var (
+		mu       sync.Mutex
+		requests []codexRecordedRequest
+	)
+
+	go func() {
+		scanner := bufio.NewScanner(readPipe)
+		for scanner.Scan() {
+			var req struct {
+				ID     int64                  `json:"id"`
+				Method string                 `json:"method"`
+				Params map[string]interface{} `json:"params"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				continue
+			}
+			mu.Lock()
+			requests = append(requests, codexRecordedRequest{Method: req.Method, Params: req.Params})
+			mu.Unlock()
+			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
+				ch.(chan json.RawMessage) <- respond(req.Method)
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+
+	return agent, sink, func() []codexRecordedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]codexRecordedRequest, len(requests))
+		copy(out, requests)
+		return out
+	}
+}
+
+func TestCodexRefreshSettingsFromAgent(t *testing.T) {
+	agent, sink, requests := newCodexAgentForRPC(t, func(method string) json.RawMessage {
+		if method == "config/read" {
+			return json.RawMessage(`{
+				"config": {
+					"model": "gpt-5.2",
+					"model_reasoning_effort": "medium",
+					"approval_policy": "never",
+					"sandbox_mode": "danger-full-access",
+					"service_tier": "fast"
+				},
+				"origins": {}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+
+	agent.refreshSettingsFromAgent()
+
+	assert.Equal(t, "gpt-5.2", agent.model)
+	assert.Equal(t, "medium", agent.effort)
+	assert.Equal(t, "never", agent.approvalPolicy)
+	assert.Equal(t, "danger-full-access", agent.sandboxPolicy)
+	assert.Equal(t, "fast", agent.serviceTier)
+
+	recorded := requests()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "config/read", recorded[0].Method)
+
+	// Verify settings were broadcast.
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "gpt-5.2", refresh.Model)
+	assert.Equal(t, "medium", refresh.Effort)
+	assert.Equal(t, "never", refresh.PermissionMode)
+	assert.Equal(t, "danger-full-access", refresh.ExtraSettings[CodexExtraSandboxPolicy])
+	assert.Equal(t, "fast", refresh.ExtraSettings[CodexExtraServiceTier])
+}
+
+func TestCodexRefreshSettingsFromAgent_NullFields(t *testing.T) {
+	agent, _, _ := newCodexAgentForRPC(t, func(method string) json.RawMessage {
+		if method == "config/read" {
+			return json.RawMessage(`{
+				"config": {
+					"model": null,
+					"model_reasoning_effort": null,
+					"approval_policy": null,
+					"sandbox_mode": null,
+					"service_tier": null
+				},
+				"origins": {}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+
+	// Set initial values.
+	agent.model = "gpt-5.4"
+	agent.effort = "high"
+	agent.approvalPolicy = "on-request"
+	agent.sandboxPolicy = "workspace-write"
+	agent.serviceTier = "default"
+
+	agent.refreshSettingsFromAgent()
+
+	// Null fields should not overwrite existing values.
+	assert.Equal(t, "gpt-5.4", agent.model)
+	assert.Equal(t, "high", agent.effort)
+	assert.Equal(t, "on-request", agent.approvalPolicy)
+	assert.Equal(t, "workspace-write", agent.sandboxPolicy)
+	assert.Equal(t, "default", agent.serviceTier)
+}
+
+func TestCodexRefreshSettingsFromAgent_GranularApprovalPolicy(t *testing.T) {
+	agent, _, _ := newCodexAgentForRPC(t, func(method string) json.RawMessage {
+		if method == "config/read" {
+			return json.RawMessage(`{
+				"config": {
+					"model": "gpt-5.4",
+					"approval_policy": {"granular": {"sandbox_approval": true, "rules": true}}
+				},
+				"origins": {}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+
+	agent.approvalPolicy = "on-request"
+	agent.refreshSettingsFromAgent()
+
+	// Granular object should not overwrite the simple string.
+	assert.Equal(t, "on-request", agent.approvalPolicy)
+}
+
+func TestCodexUpdateSettingsCallsRefresh(t *testing.T) {
+	agent, sink, requests := newCodexAgentForRPC(t, func(method string) json.RawMessage {
+		if method == "config/read" {
+			return json.RawMessage(`{
+				"config": {
+					"model": "gpt-5.2",
+					"model_reasoning_effort": "low",
+					"approval_policy": "never",
+					"sandbox_mode": "read-only",
+					"service_tier": "fast"
+				},
+				"origins": {}
+			}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+
+	updated := agent.UpdateSettings(&leapmuxv1.AgentSettings{
+		Model:          "gpt-5.2",
+		Effort:         "low",
+		PermissionMode: "never",
+		ExtraSettings: map[string]string{
+			CodexExtraSandboxPolicy: "read-only",
+			CodexExtraServiceTier:   "fast",
+		},
+	})
+	require.True(t, updated)
+
+	// After UpdateSettings, refreshSettingsFromAgent should have been called.
+	recorded := requests()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "config/read", recorded[0].Method)
+
+	// Values should reflect the config/read response.
+	assert.Equal(t, "gpt-5.2", agent.model)
+	assert.Equal(t, "low", agent.effort)
+	assert.Equal(t, "never", agent.approvalPolicy)
+	assert.Equal(t, "read-only", agent.sandboxPolicy)
+	assert.Equal(t, "fast", agent.serviceTier)
+
+	// Verify settings were broadcast.
+	require.Equal(t, 1, sink.SettingsRefreshCount())
+	refresh := sink.LastSettingsRefresh()
+	assert.Equal(t, "gpt-5.2", refresh.Model)
+	assert.Equal(t, "low", refresh.Effort)
+	assert.Equal(t, "never", refresh.PermissionMode)
+}

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -58,6 +58,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPermissionMode
+	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/leapmux/leapmux/internal/util/testutil"
@@ -17,81 +16,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type copilotRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []copilotRecordedRequest) {
-	t.Helper()
-	return newCopilotAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newCopilotAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CopilotCLIAgent, func() []copilotRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-
-	agent := &CopilotCLIAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []copilotRecordedRequest
+func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *CopilotCLIAgent { return &CopilotCLIAgent{} },
+		func(a *CopilotCLIAgent) *acpBase { return &a.acpBase },
 	)
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, copilotRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if req.ID != 0 {
-				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					body := json.RawMessage(`{}`)
-					if respond != nil {
-						body = respond(req.Method)
-					}
-					ch.(chan json.RawMessage) <- body
-				}
-			}
-		}
-	}()
+}
 
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []copilotRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]copilotRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newCopilotAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CopilotCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *CopilotCLIAgent { return &CopilotCLIAgent{} },
+		func(a *CopilotCLIAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func installFakeCopilotCLI(t *testing.T, scenario string) {

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -24,6 +24,11 @@ type copilotRecordedRequest struct {
 
 func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []copilotRecordedRequest) {
 	t.Helper()
+	return newCopilotAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+}
+
+func newCopilotAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CopilotCLIAgent, func() []copilotRecordedRequest) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	readPipe, writePipe, err := os.Pipe()
@@ -64,7 +69,11 @@ func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []copilotReco
 			mu.Unlock()
 			if req.ID != 0 {
 				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+					body := json.RawMessage(`{}`)
+					if respond != nil {
+						body = respond(req.Method)
+					}
+					ch.(chan json.RawMessage) <- body
 				}
 			}
 		}

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -173,26 +172,12 @@ func (a *CursorCLIAgent) reapplyModelAndMode() {
 	acpApplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
 }
 
-// refreshCursorFromSession parses the session response and updates model
-// (with Cursor-specific normalization) and permission mode.
+// refreshCursorFromSession refreshes model (with Cursor-specific
+// normalization) and permission mode.
 func (a *CursorCLIAgent) refreshCursorFromSession(resp json.RawMessage) {
-	model, mode := parseSessionModelAndMode(resp)
-	a.mu.Lock()
-	if model != "" {
-		a.model = normalizeCursorModelID(model)
-	}
-	if mode != "" {
-		a.permissionMode = mode
-	}
-	snapshotModel, snapshotMode := a.model, a.permissionMode
-	a.mu.Unlock()
-	slog.Info("acp agent settings refreshed from session",
-		"provider", a.providerName,
-		"agent_id", a.agentID,
-		"model", snapshotModel,
-		"mode", snapshotMode,
-	)
-	a.sink.BroadcastSettingsRefreshed(snapshotModel, "", snapshotMode, nil)
+	a.applySessionRefresh(resp, normalizeCursorModelID, &a.permissionMode, "mode", func(model, mode string) {
+		a.sink.BroadcastSettingsRefreshed(model, "", mode, nil)
+	})
 }
 
 var cursorCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -184,14 +184,15 @@ func (a *CursorCLIAgent) refreshCursorFromSession(resp json.RawMessage) {
 	if mode != "" {
 		a.permissionMode = mode
 	}
+	snapshotModel, snapshotMode := a.model, a.permissionMode
 	a.mu.Unlock()
 	slog.Info("acp agent settings refreshed from session",
 		"provider", a.providerName,
 		"agent_id", a.agentID,
-		"model", a.model,
-		"mode", a.permissionMode,
+		"model", snapshotModel,
+		"mode", snapshotMode,
 	)
-	a.sink.BroadcastSettingsRefreshed(a.model, "", a.permissionMode, nil)
+	a.sink.BroadcastSettingsRefreshed(snapshotModel, "", snapshotMode, nil)
 }
 
 var cursorCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/util/version"
@@ -62,6 +63,7 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.extraMethod = a.handleExtraMethod
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndMode
+	a.refreshFromSession = a.refreshCursorFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -169,6 +171,27 @@ func (a *CursorCLIAgent) reapplyModelAndMode() {
 	a.mu.Unlock()
 	acpApplySetting(a.providerName, a.agentID, "model", model, a.setCursorModel)
 	acpApplySetting(a.providerName, a.agentID, "mode", mode, a.setPermissionMode)
+}
+
+// refreshCursorFromSession parses the session response and updates model
+// (with Cursor-specific normalization) and permission mode.
+func (a *CursorCLIAgent) refreshCursorFromSession(resp json.RawMessage) {
+	model, mode := parseSessionModelAndMode(resp)
+	a.mu.Lock()
+	if model != "" {
+		a.model = normalizeCursorModelID(model)
+	}
+	if mode != "" {
+		a.permissionMode = mode
+	}
+	a.mu.Unlock()
+	slog.Info("acp agent settings refreshed from session",
+		"provider", a.providerName,
+		"agent_id", a.agentID,
+		"model", a.model,
+		"mode", a.permissionMode,
+	)
+	a.sink.BroadcastSettingsRefreshed(a.model, "", a.permissionMode, nil)
 }
 
 var cursorCLIAvailableModels = []*leapmuxv1.AvailableModel{

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,81 +15,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type cursorRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []cursorRecordedRequest) {
-	t.Helper()
-	return newCursorAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newCursorAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CursorCLIAgent, func() []cursorRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-
-	agent := &CursorCLIAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []cursorRecordedRequest
+func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *CursorCLIAgent { return &CursorCLIAgent{} },
+		func(a *CursorCLIAgent) *acpBase { return &a.acpBase },
 	)
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, cursorRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if req.ID != 0 {
-				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					body := json.RawMessage(`{}`)
-					if respond != nil {
-						body = respond(req.Method)
-					}
-					ch.(chan json.RawMessage) <- body
-				}
-			}
-		}
-	}()
+}
 
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []cursorRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]cursorRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newCursorAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CursorCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *CursorCLIAgent { return &CursorCLIAgent{} },
+		func(a *CursorCLIAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func installFakeCursorCLI(t *testing.T, scenario string) {

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -63,6 +63,7 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.extraSessionUpdate = a.handleExtraSessionUpdate
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPermissionMode
+	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,80 +16,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type geminiRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newGeminiAgentForRPC(t *testing.T) (*GeminiCLIAgent, func() []geminiRecordedRequest) {
-	t.Helper()
-	return newGeminiAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newGeminiAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*GeminiCLIAgent, func() []geminiRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-
-	agent := &GeminiCLIAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []geminiRecordedRequest
+func newGeminiAgentForRPC(t *testing.T) (*GeminiCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *GeminiCLIAgent { return &GeminiCLIAgent{} },
+		func(a *GeminiCLIAgent) *acpBase { return &a.acpBase },
 	)
+}
 
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, geminiRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-				body := json.RawMessage(`{}`)
-				if respond != nil {
-					body = respond(req.Method)
-				}
-				ch.(chan json.RawMessage) <- body
-			}
-		}
-	}()
-
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []geminiRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]geminiRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newGeminiAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*GeminiCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *GeminiCLIAgent { return &GeminiCLIAgent{} },
+		func(a *GeminiCLIAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func installFakeGeminiCLI(t *testing.T, scenario string) {
@@ -323,7 +261,7 @@ func TestGeminiAvailableOptionGroupsFallsBack(t *testing.T) {
 // newGeminiAgentWithGate creates a Gemini agent where each prompt response is
 // held until the returned gate channel is sent to. This allows tests to
 // observe queueing behavior by controlling when turns complete.
-func newGeminiAgentWithGate(t *testing.T) (*GeminiCLIAgent, func() []geminiRecordedRequest, chan struct{}) {
+func newGeminiAgentWithGate(t *testing.T) (*GeminiCLIAgent, func() []recordedRequest, chan struct{}) {
 	t.Helper()
 
 	gate := make(chan struct{}, 8)

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -59,6 +59,7 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPermissionMode
+	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -24,6 +24,11 @@ type gooseRecordedRequest struct {
 
 func newGooseAgentForRPC(t *testing.T) (*GooseCLIAgent, func() []gooseRecordedRequest) {
 	t.Helper()
+	return newGooseAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+}
+
+func newGooseAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*GooseCLIAgent, func() []gooseRecordedRequest) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	readPipe, writePipe, err := os.Pipe()
@@ -64,7 +69,11 @@ func newGooseAgentForRPC(t *testing.T) (*GooseCLIAgent, func() []gooseRecordedRe
 			mu.Unlock()
 			if req.ID != 0 {
 				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+					body := json.RawMessage(`{}`)
+					if respond != nil {
+						body = respond(req.Method)
+					}
+					ch.(chan json.RawMessage) <- body
 				}
 			}
 		}

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/leapmux/leapmux/internal/util/testutil"
@@ -17,81 +16,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type gooseRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newGooseAgentForRPC(t *testing.T) (*GooseCLIAgent, func() []gooseRecordedRequest) {
-	t.Helper()
-	return newGooseAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newGooseAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*GooseCLIAgent, func() []gooseRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-
-	agent := &GooseCLIAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []gooseRecordedRequest
+func newGooseAgentForRPC(t *testing.T) (*GooseCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *GooseCLIAgent { return &GooseCLIAgent{} },
+		func(a *GooseCLIAgent) *acpBase { return &a.acpBase },
 	)
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, gooseRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if req.ID != 0 {
-				if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-					body := json.RawMessage(`{}`)
-					if respond != nil {
-						body = respond(req.Method)
-					}
-					ch.(chan json.RawMessage) <- body
-				}
-			}
-		}
-	}()
+}
 
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []gooseRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]gooseRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newGooseAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*GooseCLIAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *GooseCLIAgent { return &GooseCLIAgent{} },
+		func(a *GooseCLIAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func installFakeGooseCLI(t *testing.T, scenario string) {

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -57,6 +57,7 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 	}
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPrimaryAgent
+	a.refreshFromSession = a.refreshModelAndPrimaryAgentFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -1,11 +1,7 @@
 package agent
 
 import (
-	"bufio"
-	"context"
 	"encoding/json"
-	"os"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,79 +10,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type kiloRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newKiloAgentForRPC(t *testing.T) (*KiloAgent, func() []kiloRecordedRequest) {
-	t.Helper()
-	return newKiloAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newKiloAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*KiloAgent, func() []kiloRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-
-	agent := &KiloAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []kiloRecordedRequest
+func newKiloAgentForRPC(t *testing.T) (*KiloAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *KiloAgent { return &KiloAgent{} },
+		func(a *KiloAgent) *acpBase { return &a.acpBase },
 	)
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, kiloRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-				body := json.RawMessage(`{}`)
-				if respond != nil {
-					body = respond(req.Method)
-				}
-				ch.(chan json.RawMessage) <- body
-			}
-		}
-	}()
+}
 
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []kiloRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]kiloRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newKiloAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*KiloAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *KiloAgent { return &KiloAgent{} },
+		func(a *KiloAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func TestKiloBuildSessionRequest_NewSession(t *testing.T) {

--- a/backend/internal/worker/agent/kilo_test.go
+++ b/backend/internal/worker/agent/kilo_test.go
@@ -21,12 +21,15 @@ type kiloRecordedRequest struct {
 
 func newKiloAgentForRPC(t *testing.T) (*KiloAgent, func() []kiloRecordedRequest) {
 	t.Helper()
+	return newKiloAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+}
+
+func newKiloAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*KiloAgent, func() []kiloRecordedRequest) {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	readPipe, writePipe, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
+	require.NoError(t, err)
 
 	agent := &KiloAgent{
 		acpBase: acpBase{
@@ -62,7 +65,11 @@ func newKiloAgentForRPC(t *testing.T) (*KiloAgent, func() []kiloRecordedRequest)
 			requests = append(requests, kiloRecordedRequest{Method: req.Method, Params: req.Params})
 			mu.Unlock()
 			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-				ch.(chan json.RawMessage) <- json.RawMessage(`{}`)
+				body := json.RawMessage(`{}`)
+				if respond != nil {
+					body = respond(req.Method)
+				}
+				ch.(chan json.RawMessage) <- body
 			}
 		}
 	}()

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -69,6 +69,7 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 	}
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPrimaryAgent
+	a.refreshFromSession = a.refreshModelAndPrimaryAgentFromSession
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/agent/opencode_test.go
+++ b/backend/internal/worker/agent/opencode_test.go
@@ -1,11 +1,7 @@
 package agent
 
 import (
-	"bufio"
-	"context"
 	"encoding/json"
-	"os"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,81 +10,19 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-type openCodeRecordedRequest struct {
-	Method string
-	Params map[string]interface{}
-}
-
-func newOpenCodeAgentForRPC(t *testing.T) (*OpenCodeAgent, func() []openCodeRecordedRequest) {
-	t.Helper()
-	return newOpenCodeAgentForRPCWithResponder(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-}
-
-func newOpenCodeAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*OpenCodeAgent, func() []openCodeRecordedRequest) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	readPipe, writePipe, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-
-	agent := &OpenCodeAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
-			}},
-			sessionID: "session-1",
-		},
-	}
-	close(agent.stderrDone)
-
-	var (
-		mu       sync.Mutex
-		requests []openCodeRecordedRequest
+func newOpenCodeAgentForRPC(t *testing.T) (*OpenCodeAgent, func() []recordedRequest) {
+	return newACPAgentForRPC(t,
+		func() *OpenCodeAgent { return &OpenCodeAgent{} },
+		func(a *OpenCodeAgent) *acpBase { return &a.acpBase },
 	)
-	go func() {
-		scanner := bufio.NewScanner(readPipe)
-		for scanner.Scan() {
-			var req struct {
-				ID     int64                  `json:"id"`
-				Method string                 `json:"method"`
-				Params map[string]interface{} `json:"params"`
-			}
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, openCodeRecordedRequest{Method: req.Method, Params: req.Params})
-			mu.Unlock()
-			if ch, ok := agent.pendingReqs.Load(req.ID); ok {
-				body := json.RawMessage(`{}`)
-				if respond != nil {
-					body = respond(req.Method)
-				}
-				ch.(chan json.RawMessage) <- body
-			}
-		}
-	}()
+}
 
-	t.Cleanup(func() {
-		cancel()
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-
-	return agent, func() []openCodeRecordedRequest {
-		mu.Lock()
-		defer mu.Unlock()
-		out := make([]openCodeRecordedRequest, len(requests))
-		copy(out, requests)
-		return out
-	}
+func newOpenCodeAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*OpenCodeAgent, func() []recordedRequest) {
+	return newACPAgentForRPCWithResponder(t,
+		func() *OpenCodeAgent { return &OpenCodeAgent{} },
+		func(a *OpenCodeAgent) *acpBase { return &a.acpBase },
+		respond,
+	)
 }
 
 func TestBuildSessionRequest_NewSession(t *testing.T) {

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -54,6 +54,7 @@ type OutputSink interface {
 	BroadcastControlCancel(requestID string)
 	UpdateSessionID(sessionID string)
 	UpdatePermissionMode(mode string)
+	BroadcastSettingsRefreshed(model, effort, permissionMode string, extraSettings map[string]string)
 	BroadcastStatusActive(sessionID string)
 	BroadcastSessionInfo(info map[string]interface{})
 	BroadcastNotification(content map[string]interface{})

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -6,23 +6,32 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
+// testSinkSettingsRefreshed records the args of a BroadcastSettingsRefreshed call.
+type testSinkSettingsRefreshed struct {
+	Model          string
+	Effort         string
+	PermissionMode string
+	ExtraSettings  map[string]string
+}
+
 // testSink is a test implementation of OutputSink that records calls.
 type testSink struct {
-	mu               sync.Mutex
-	messages         []testSinkMessage
-	notifications    []testSinkMessage
-	streamChunks     []testSinkStreamChunk
-	streamEnds       []string
-	sessionIDs       []string
-	permissionModes  []string
-	sessionInfos     []map[string]interface{}
-	spanTypes        map[string]string
-	openSpans        []testSinkSpanOpen
-	closedSpans      []string
-	resetSpanCount   int
-	autoSchedules    []AutoContinueSchedule
-	autoCancels      []AutoContinueReason
-	planModeToolUses sync.Map
+	mu                sync.Mutex
+	messages          []testSinkMessage
+	notifications     []testSinkMessage
+	streamChunks      []testSinkStreamChunk
+	streamEnds        []string
+	sessionIDs        []string
+	permissionModes   []string
+	settingsRefreshes []testSinkSettingsRefreshed
+	sessionInfos      []map[string]interface{}
+	spanTypes         map[string]string
+	openSpans         []testSinkSpanOpen
+	closedSpans       []string
+	resetSpanCount    int
+	autoSchedules     []AutoContinueSchedule
+	autoCancels       []AutoContinueReason
+	planModeToolUses  sync.Map
 }
 
 type testSinkMessage struct {
@@ -121,6 +130,17 @@ func (s *testSink) UpdatePermissionMode(mode string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.permissionModes = append(s.permissionModes, mode)
+}
+func (s *testSink) BroadcastSettingsRefreshed(model, effort, permissionMode string, extraSettings map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make(map[string]string, len(extraSettings))
+	for k, v := range extraSettings {
+		cp[k] = v
+	}
+	s.settingsRefreshes = append(s.settingsRefreshes, testSinkSettingsRefreshed{
+		Model: model, Effort: effort, PermissionMode: permissionMode, ExtraSettings: cp,
+	})
 }
 func (s *testSink) BroadcastStatusActive(string) {}
 func (s *testSink) BroadcastSessionInfo(info map[string]interface{}) {
@@ -229,6 +249,18 @@ func (s *testSink) LastSessionID() string {
 	return s.sessionIDs[len(s.sessionIDs)-1]
 }
 
+func (s *testSink) SettingsRefreshCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.settingsRefreshes)
+}
+
+func (s *testSink) LastSettingsRefresh() testSinkSettingsRefreshed {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.settingsRefreshes[len(s.settingsRefreshes)-1]
+}
+
 func (s *testSink) PermissionMode() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -313,26 +345,27 @@ type noopSink struct{}
 func (noopSink) PersistMessage(leapmuxv1.MessageRole, []byte, SpanInfo) error {
 	return nil
 }
-func (noopSink) PersistNotification(leapmuxv1.MessageRole, []byte) error         { return nil }
-func (noopSink) OpenSpan(string, string)                                         {}
-func (noopSink) CloseSpan(string)                                                {}
-func (noopSink) ResetSpans()                                                     {}
-func (noopSink) SetSpanType(string, string)                                      {}
-func (noopSink) GetSpanType(string) string                                       { return "" }
-func (noopSink) PeekNextSpanColor() int32                                        { return 0 }
-func (noopSink) BroadcastStreamChunk([]byte, string, string)                     {}
-func (noopSink) BroadcastStreamEnd(string)                                       {}
-func (noopSink) PersistControlRequest(string, []byte)                            {}
-func (noopSink) DeleteControlRequest(string)                                     {}
-func (noopSink) BroadcastControlRequest(string, []byte)                          {}
-func (noopSink) BroadcastControlCancel(string)                                   {}
-func (noopSink) UpdateSessionID(string)                                          {}
-func (noopSink) UpdatePermissionMode(string)                                     {}
-func (noopSink) BroadcastStatusActive(string)                                    {}
-func (noopSink) BroadcastSessionInfo(map[string]interface{})                     {}
-func (noopSink) BroadcastNotification(map[string]interface{})                    {}
-func (noopSink) StorePlanModeToolUse(string, string)                             {}
-func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)              { return "", false }
-func (noopSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string) {}
-func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                       {}
-func (noopSink) CancelAutoContinue(AutoContinueReason)                           {}
+func (noopSink) PersistNotification(leapmuxv1.MessageRole, []byte) error              { return nil }
+func (noopSink) OpenSpan(string, string)                                              {}
+func (noopSink) CloseSpan(string)                                                     {}
+func (noopSink) ResetSpans()                                                          {}
+func (noopSink) SetSpanType(string, string)                                           {}
+func (noopSink) GetSpanType(string) string                                            { return "" }
+func (noopSink) PeekNextSpanColor() int32                                             { return 0 }
+func (noopSink) BroadcastStreamChunk([]byte, string, string)                          {}
+func (noopSink) BroadcastStreamEnd(string)                                            {}
+func (noopSink) PersistControlRequest(string, []byte)                                 {}
+func (noopSink) DeleteControlRequest(string)                                          {}
+func (noopSink) BroadcastControlRequest(string, []byte)                               {}
+func (noopSink) BroadcastControlCancel(string)                                        {}
+func (noopSink) UpdateSessionID(string)                                               {}
+func (noopSink) UpdatePermissionMode(string)                                          {}
+func (noopSink) BroadcastSettingsRefreshed(string, string, string, map[string]string) {}
+func (noopSink) BroadcastStatusActive(string)                                         {}
+func (noopSink) BroadcastSessionInfo(map[string]interface{})                          {}
+func (noopSink) BroadcastNotification(map[string]interface{})                         {}
+func (noopSink) StorePlanModeToolUse(string, string)                                  {}
+func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)                   { return "", false }
+func (noopSink) UpdatePlan(string, []byte, leapmuxv1.ContentCompression, string)      {}
+func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                            {}
+func (noopSink) CancelAutoContinue(AutoContinueReason)                                {}

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1064,17 +1064,9 @@ func (svc *Context) persistConfirmedAgentSettings(agentID string, provider leapm
 	})
 }
 
-// handleClearContext implements the /clear command. For providers that support
-// in-process context clearing (e.g. Claude Code), the running process is
-// reused. Otherwise, the agent is stopped and restarted with a fresh context.
+// handleClearContext implements the /clear command by restarting the agent
+// without resuming the previous session, giving it a fresh context window.
 func (svc *Context) handleClearContext(agentID string) {
-	// Try in-process clearing first (e.g. Claude Code sends /clear internally).
-	if _, ok := svc.Agents.ClearContext(agentID); ok {
-		svc.Output.ResetSpanTracker(agentID)
-		slog.Info("clear context: cleared in-process", "agent_id", agentID)
-		return
-	}
-
 	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
 	if err != nil {
 		slog.Error("clear context: failed to fetch agent", "agent_id", agentID, "error", err)

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1064,9 +1064,17 @@ func (svc *Context) persistConfirmedAgentSettings(agentID string, provider leapm
 	})
 }
 
-// handleClearContext implements the /clear command by restarting the agent
-// without resuming the previous session, giving it a fresh context window.
+// handleClearContext implements the /clear command. For providers that support
+// in-process context clearing (e.g. Claude Code), the running process is
+// reused. Otherwise, the agent is stopped and restarted with a fresh context.
 func (svc *Context) handleClearContext(agentID string) {
+	// Try in-process clearing first (e.g. Claude Code sends /clear internally).
+	if _, ok := svc.Agents.ClearContext(agentID); ok {
+		svc.Output.ResetSpanTracker(agentID)
+		slog.Info("clear context: cleared in-process", "agent_id", agentID)
+		return
+	}
+
 	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
 	if err != nil {
 		slog.Error("clear context: failed to fetch agent", "agent_id", agentID, "error", err)

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -284,7 +284,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		// Check for leapmux-level slash commands (e.g. /clear) that
 		// Claude Code does not handle natively.
-		isSlashClear := trimmed == "/clear" || trimmed == "/reset"
+		isSlashClear := trimmed == "/clear" || trimmed == "/reset" || trimmed == "/new"
 
 		userMsg := &leapmuxv1.AgentChatMessage{
 			Id:                 messageID,

--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -308,25 +309,46 @@ const mergeReadTimeout = 500 * time.Millisecond
 // readDirN reads at most n entries from a directory within mergeReadTimeout.
 // Returns an error if the directory cannot be opened or read in time.
 func readDirN(dirPath string, n int) ([]os.DirEntry, error) {
+	return readDirNWithTimeout(dirPath, n, mergeReadTimeout)
+}
+
+// readDirNWithTimeout is readDirN with a caller-supplied timeout, exposed
+// for tests.
+func readDirNWithTimeout(dirPath string, n int, timeout time.Duration) ([]os.DirEntry, error) {
 	type result struct {
 		entries []os.DirEntry
 		err     error
 	}
 	ch := make(chan result, 1)
+
+	// fd is populated once os.Open returns successfully. On timeout we close
+	// it to release the descriptor and, on platforms where a concurrent
+	// close unblocks a pending read, to let the goroutine exit promptly.
+	// If os.Open is still in flight when the timeout fires, the goroutine
+	// keeps running until the syscall returns — Go has no portable way to
+	// cancel an in-flight syscall — but it will close the fd itself before
+	// exiting, so nothing is permanently leaked.
+	var fd atomic.Pointer[os.File]
+
 	go func() {
 		f, err := os.Open(dirPath)
 		if err != nil {
 			ch <- result{nil, err}
 			return
 		}
+		fd.Store(f)
 		entries, err := f.ReadDir(n)
 		_ = f.Close()
 		ch <- result{entries, err}
 	}()
+
 	select {
 	case r := <-ch:
 		return r.entries, r.err
-	case <-time.After(mergeReadTimeout):
+	case <-time.After(timeout):
+		if f := fd.Load(); f != nil {
+			_ = f.Close()
+		}
 		return nil, fmt.Errorf("readDirN timed out for %s", dirPath)
 	}
 }

--- a/backend/internal/worker/service/file_timeout_test.go
+++ b/backend/internal/worker/service/file_timeout_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadDirNWithTimeout_OpenHang verifies the timeout fires and the call
+// returns promptly even when os.Open blocks indefinitely (e.g. a FIFO with
+// no writer, approximating a macOS TCC-protected directory that never
+// returns).
+func TestReadDirNWithTimeout_OpenHang(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "stuck")
+	require.NoError(t, syscall.Mkfifo(fifo, 0o644))
+
+	t.Cleanup(func() {
+		// Unblock the goroutine still stuck in os.Open so it can exit
+		// before the test process tears down.
+		go func() {
+			f, _ := os.OpenFile(fifo, os.O_WRONLY, 0)
+			if f != nil {
+				_ = f.Close()
+			}
+		}()
+	})
+
+	start := time.Now()
+	entries, err := readDirNWithTimeout(fifo, 10, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, entries)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Less(t, elapsed, 500*time.Millisecond, "readDirN blocked past its timeout")
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -634,6 +634,30 @@ func (s *agentOutputSink) UpdatePermissionMode(mode string) {
 	}
 }
 
+func (s *agentOutputSink) BroadcastSettingsRefreshed(model, effort, permissionMode string, extraSettings map[string]string) {
+	// Persist the refreshed settings to the DB.
+	_ = s.h.queries.UpdateAgentAllSettings(bgCtx(), db.UpdateAgentAllSettingsParams{
+		Model:          model,
+		Effort:         effort,
+		PermissionMode: permissionMode,
+		ExtraSettings:  marshalExtraSettings(extraSettings),
+		ID:             s.agentID,
+	})
+
+	// Broadcast a StatusChange so connected frontends see the new values.
+	dbAgent, err := s.h.queries.GetAgentByID(bgCtx(), s.agentID)
+	if err != nil {
+		slog.Error("failed to fetch agent for settings broadcast",
+			"agent_id", s.agentID, "error", err)
+		return
+	}
+	sc := s.buildStatusChange(dbAgent, leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE, dbAgent.AgentSessionID, permissionMode)
+	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
+		AgentId: s.agentID,
+		Event:   &leapmuxv1.AgentEvent_StatusChange{StatusChange: sc},
+	})
+}
+
 func (s *agentOutputSink) BroadcastStatusActive(sessionID string) {
 	existingAgent, err := s.h.queries.GetAgentByID(bgCtx(), s.agentID)
 	if err != nil {

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -1,5 +1,7 @@
+import type { TrailingDebounced } from '~/lib/debounce'
 import type { BuildInfo } from '~/lib/systemInfo'
 import { arrayBufferToBase64, base64ToArrayBuffer } from '~/lib/base64'
+import { trailingDebounce } from '~/lib/debounce'
 import { createLogger } from '~/lib/logger'
 
 export type PlatformMode = 'web' | 'tauri-desktop-solo' | 'tauri-desktop-distributed' | 'tauri-mobile-distributed'
@@ -332,7 +334,7 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
   let disposed = false
   let unlisten: (() => void) | undefined
   let last: boolean | undefined
-  let refresh: ReturnType<typeof trailingDebounce> | undefined
+  let refresh: TrailingDebounced | undefined
 
   const push = (next: boolean) => {
     if (disposed || next === last)
@@ -373,30 +375,6 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
     refresh?.cancel()
     unlisten?.()
   }
-}
-
-/**
- * Trailing-edge debounce with a `cancel()` method for dispose hooks.
- * Collapses rapid-fire events into a single trailing call after `ms`
- * quiet. Calling `.cancel()` drops any pending invocation.
- */
-function trailingDebounce(fn: () => void, ms: number): (() => void) & { cancel: () => void } {
-  let timer: ReturnType<typeof setTimeout> | null = null
-  const debounced = () => {
-    if (timer !== null)
-      clearTimeout(timer)
-    timer = setTimeout(() => {
-      timer = null
-      fn()
-    }, ms)
-  }
-  debounced.cancel = () => {
-    if (timer !== null) {
-      clearTimeout(timer)
-      timer = null
-    }
-  }
-  return debounced
 }
 
 export const platformBridge = {

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -264,22 +264,17 @@ export async function restoreWindowGeometry(width: number, height: number, maxim
     await appWindow.show()
 
     // Save window geometry on resize / maximize / unmaximize, debounced.
-    let saveTimer: ReturnType<typeof setTimeout> | null = null
-    const saveGeometry = () => {
-      if (saveTimer)
-        clearTimeout(saveTimer)
-      saveTimer = setTimeout(async () => {
-        try {
-          const isMax = await appWindow.isMaximized()
-          tauriInvoke('save_window_geometry', {
-            width: window.innerWidth,
-            height: window.innerHeight,
-            maximized: isMax,
-          }).catch(() => {})
-        }
-        catch { /* best-effort */ }
-      }, 500)
-    }
+    const saveGeometry = trailingDebounce(async () => {
+      try {
+        const isMax = await appWindow.isMaximized()
+        tauriInvoke('save_window_geometry', {
+          width: window.innerWidth,
+          height: window.innerHeight,
+          maximized: isMax,
+        }).catch(() => {})
+      }
+      catch { /* best-effort */ }
+    }, 500)
     window.addEventListener('resize', saveGeometry)
   }
   catch (err) {
@@ -337,9 +332,10 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
   let disposed = false
   let unlisten: (() => void) | undefined
   let last: boolean | undefined
+  let refresh: ReturnType<typeof trailingDebounce> | undefined
 
   const push = (next: boolean) => {
-    if (next === last)
+    if (disposed || next === last)
       return
     last = next
     onChange(next)
@@ -357,27 +353,50 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
     if (disposed)
       return
     try {
-      let debounce: ReturnType<typeof setTimeout> | null = null
-      unlisten = await win.onResized(() => {
-        if (debounce !== null)
-          clearTimeout(debounce)
-        debounce = setTimeout(async () => {
-          try {
-            push(await win.isMaximized())
-          }
-          catch { /* best-effort */ }
-        }, 150)
-      })
+      refresh = trailingDebounce(async () => {
+        try {
+          push(await win.isMaximized())
+        }
+        catch { /* best-effort */ }
+      }, 150)
+      unlisten = await win.onResized(refresh)
     }
     catch { /* best-effort */ }
-    if (disposed)
+    if (disposed) {
+      refresh?.cancel()
       unlisten?.()
+    }
   })()
 
   return () => {
     disposed = true
+    refresh?.cancel()
     unlisten?.()
   }
+}
+
+/**
+ * Trailing-edge debounce with a `cancel()` method for dispose hooks.
+ * Collapses rapid-fire events into a single trailing call after `ms`
+ * quiet. Calling `.cancel()` drops any pending invocation.
+ */
+function trailingDebounce(fn: () => void, ms: number): (() => void) & { cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const debounced = () => {
+    if (timer !== null)
+      clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      fn()
+    }, ms)
+  }
+  debounced.cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+  return debounced
 }
 
 export const platformBridge = {

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -357,11 +357,16 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
     if (disposed)
       return
     try {
-      unlisten = await win.onResized(async () => {
-        try {
-          push(await win.isMaximized())
-        }
-        catch { /* best-effort */ }
+      let debounce: ReturnType<typeof setTimeout> | null = null
+      unlisten = await win.onResized(() => {
+        if (debounce !== null)
+          clearTimeout(debounce)
+        debounce = setTimeout(async () => {
+          try {
+            push(await win.isMaximized())
+          }
+          catch { /* best-effort */ }
+        }, 150)
       })
     }
     catch { /* best-effort */ }

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -227,8 +227,8 @@ export const searchableSelectListbox = style({
   // Each item is 1lh tall + 6px vertical padding → calc(1lh + 6px) per item.
   // Font-size must match items so 1lh resolves to the correct item line-height.
   fontSize: 'var(--text-8)',
-  minHeight: 'calc((1lh + 6px) * 5)',
-  maxHeight: 'calc((1lh + 6px) * 5)',
+  minHeight: 'calc((1lh + 6px) * 7)',
+  maxHeight: 'calc((1lh + 6px) * 7)',
   overflowY: 'auto',
 })
 

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -175,8 +175,13 @@ export const settingsPanelColumnPrimary = style({
   flex: 1.2,
 })
 
+export const settingsPanelColumnSlightlyWider = style({
+  flex: 1.05,
+})
+
 export const settingsFieldset = style({
   paddingTop: 'var(--space-3)',
+  minWidth: 0,
 })
 
 export const settingsFieldsetFirst = style({
@@ -204,7 +209,6 @@ export const settingsRadioItem = style({
   'color': 'var(--foreground)',
   'cursor': 'pointer',
   'userSelect': 'none',
-  'whiteSpace': 'nowrap',
   ':hover': {
     backgroundColor: 'var(--card)',
   },

--- a/frontend/src/components/chat/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/MarkdownEditor.tsx
@@ -2,6 +2,7 @@ import type { Editor } from '@milkdown/core'
 import type { Ctx } from '@milkdown/ctx'
 import type { Component, JSX } from 'solid-js'
 import type { EnterKeyMode } from '~/lib/browserStorage'
+import type { TrailingDebounced } from '~/lib/debounce'
 import { editorViewCtx, serializerCtx } from '@milkdown/core'
 import { createCodeBlockCommand, toggleInlineCodeCommand } from '@milkdown/preset-commonmark'
 import { TextSelection } from '@milkdown/prose/state'
@@ -213,7 +214,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     }
   }
 
-  const draftSaveTimer: { current: ReturnType<typeof setTimeout> | undefined } = { current: undefined }
+  const draftSaveDebounce: { current: TrailingDebounced | undefined } = { current: undefined }
   // Track the last valid draft key so onCleanup can save the draft even when
   // reactive getters (props.agentId) return null during unmount.
   let latestDraftKey: string | undefined
@@ -262,7 +263,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       setMarkdown,
       onContentChange: hasContent => props.onContentChange?.(hasContent),
       getDraftKey,
-      draftSaveTimer,
+      draftSaveDebounce,
       getEditorInstance: () => editorInstance,
     })
 
@@ -355,7 +356,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   })
 
   onCleanup(() => {
-    clearTimeout(draftSaveTimer.current)
+    draftSaveDebounce.current?.cancel()
     // Save draft for the current agent/control-request before cleanup.
     // Prefer the cached latestDraftKey over getDraftKey(): during disposal
     // reactive getters (props.agentId) may already reflect the NEW agent

--- a/frontend/src/components/chat/editorSetup.ts
+++ b/frontend/src/components/chat/editorSetup.ts
@@ -1,5 +1,6 @@
 import type { Ctx } from '@milkdown/ctx'
 import type { Setter } from 'solid-js'
+import type { TrailingDebounced } from '~/lib/debounce'
 import type { PluginRefs } from '~/lib/editor/keyboardPlugins'
 import type { ToolbarStateSetters } from '~/lib/editor/toolbarState'
 import { defaultValueCtx, Editor, editorViewCtx, editorViewOptionsCtx, rootCtx } from '@milkdown/core'
@@ -18,6 +19,7 @@ import {
   strongInputRule as milkdownStrongInputRule,
 } from '@milkdown/preset-commonmark'
 import { gfm, strikethroughInputRule as milkdownStrikethroughInputRule } from '@milkdown/preset-gfm'
+import { trailingDebounce } from '~/lib/debounce'
 import { saveDraft } from '~/lib/editor/draftPersistence'
 import { createLinkBoundaryPlugin, createListItemEnterPlugin, createMarkdownPastePlugin, createSelectionWrapPlugin } from '~/lib/editor/inputPlugins'
 import { createBulletListAfterHardBreakInputRule, createCodeBlockInputRule, createEmphasisStarInputRule, createEmphasisUnderscoreInputRule, createHrInputRule, createInlineCodeInputRule, createLinkInputRule, createOrderedListAfterHardBreakInputRule, createStrikethroughInputRule, createStrongInputRule } from '~/lib/editor/inputRules'
@@ -60,8 +62,8 @@ export interface EditorSetupOptions {
   onContentChange?: (hasContent: boolean) => void
   /** Returns the current draft key, or undefined if drafts are disabled. */
   getDraftKey: () => string | undefined
-  /** Mutable ref holding the current draft-save timeout ID. */
-  draftSaveTimer: { current: ReturnType<typeof setTimeout> | undefined }
+  /** Mutable ref holding the debounced draft-save handle (cancellable on cleanup). */
+  draftSaveDebounce: { current: TrailingDebounced | undefined }
   /** Getter for the current editor instance (used inside the listener for cursor saving). */
   getEditorInstance: () => Editor | undefined
 }
@@ -120,25 +122,33 @@ export function buildEditor(opts: EditorSetupOptions): Promise<Editor> {
           autocapitalize: 'off',
         },
       }))
+      let pendingMd = ''
+      let pendingDraftKey = ''
+      opts.draftSaveDebounce.current = trailingDebounce(() => {
+        let cursor = -1
+        try {
+          opts.getEditorInstance()?.action((c: Ctx) => {
+            cursor = c.get(editorViewCtx).state.selection.from
+          })
+        }
+        catch { /* ignore */ }
+        saveDraft(pendingDraftKey, pendingMd.trim(), cursor)
+      }, 500)
       ctx.get(listenerCtx).markdownUpdated((_ctx, md) => {
         if (typeof md !== 'string')
           return
         opts.setMarkdown(md)
         opts.onContentChange?.(md.trim().length > 0)
-        // Debounced draft save
         const draftKey = opts.getDraftKey()
         if (draftKey) {
-          clearTimeout(opts.draftSaveTimer.current)
-          opts.draftSaveTimer.current = setTimeout(() => {
-            let cursor = -1
-            try {
-              opts.getEditorInstance()?.action((c: Ctx) => {
-                cursor = c.get(editorViewCtx).state.selection.from
-              })
-            }
-            catch { /* ignore */ }
-            saveDraft(draftKey, md.trim(), cursor)
-          }, 500)
+          pendingMd = md
+          pendingDraftKey = draftKey
+          opts.draftSaveDebounce.current?.()
+        }
+        else {
+          // Drafts disabled (or key cleared): drop any pending save so it
+          // doesn't fire with a stale draft key.
+          opts.draftSaveDebounce.current?.cancel()
         }
       })
     })

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -186,7 +186,7 @@ function classifyClaudeCodeMessage(
 const DEFAULT_CLAUDE_MODEL = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_MODEL || 'opus[1m]'
 const DEFAULT_CLAUDE_EFFORT = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_EFFORT || 'high'
 
-/** Claude Code settings panel (model, effort, permission mode, output style, fast mode, thinking). */
+/** Claude Code settings panel (two-column: left = thinking/effort/model, right = fast mode/output style/permission mode). */
 function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element {
   const menuId = createUniqueId()
   const currentModel = () => props.model || DEFAULT_CLAUDE_MODEL
@@ -205,85 +205,98 @@ function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element
   const fastModeItems = () => optionGroupItems(props.availableOptionGroups, FAST_MODE_KEY)
   const thinkingItems = () => optionGroupItems(props.availableOptionGroups, ALWAYS_THINKING_KEY)
 
+  // Identify the first visible group in each column so settingsFieldsetFirst
+  // is applied only to it.
+  const leftFirstGroup = () => thinkingItems().length > 0 ? 'thinking' : 'effort'
+  const rightFirstGroup = () => fastModeItems().length > 0 ? 'fast' : outputStyleItems().length > 0 ? 'output' : 'mode'
+  const firstLeftClass = (id: string) => leftFirstGroup() === id ? styles.settingsFieldsetFirst : undefined
+  const firstRightClass = (id: string) => rightFirstGroup() === id ? styles.settingsFieldsetFirst : undefined
+
   return (
-    <>
-      <Show when={props.availableModels && props.availableModels.length > 0}>
-        <Show when={hasEffort()}>
+    <div class={styles.settingsPanelColumns}>
+      <div class={[styles.settingsPanelColumn, styles.settingsPanelColumnSlightlyWider].join(' ')}>
+        <Show when={thinkingItems().length > 0}>
           <RadioGroup
-            label="Effort"
-            items={efforts()}
-            testIdPrefix="effort"
-            name={`${menuId}-effort`}
-            current={currentEffort()}
-            onChange={v => props.onEffortChange?.(v)}
-            fieldsetClass={styles.settingsFieldsetFirst}
+            label={optionGroup(props.availableOptionGroups, ALWAYS_THINKING_KEY)?.label || 'Extended Thinking'}
+            items={thinkingItems()}
+            testIdPrefix="thinking"
+            name={`${menuId}-thinking`}
+            current={currentThinking()}
+            onChange={v => props.onOptionGroupChange?.(ALWAYS_THINKING_KEY, v)}
+            fieldsetClass={firstLeftClass('thinking')}
           />
         </Show>
-        <ModelSelect
-          items={models()}
-          testIdPrefix="model"
-          name={`${menuId}-model`}
-          current={currentModel()}
-          fieldsetClass={!hasEffort() ? styles.settingsFieldsetFirst : undefined}
-          onChange={(v) => {
-            props.onModelChange?.(v)
-            // If switching away from opus and effort is max, downgrade to high
-            if (!v.startsWith('opus') && currentEffort() === 'max') {
-              props.onEffortChange?.('high')
-            }
-          }}
-        />
-      </Show>
-      <RadioGroup
-        label={modeGroup()?.label || 'Permission Mode'}
-        items={modeItems()}
-        testIdPrefix="permission-mode"
-        name={`${menuId}-mode`}
-        current={currentMode()}
-        onChange={v => props.onPermissionModeChange?.(v as PermissionMode)}
-      />
-      <Show when={outputStyleItems().length > 0}>
-        <RadioGroup
-          label={optionGroup(props.availableOptionGroups, OUTPUT_STYLE_KEY)?.label || 'Output Style'}
-          items={outputStyleItems()}
-          testIdPrefix="output-style"
-          name={`${menuId}-output-style`}
-          current={currentOutputStyle()}
-          onChange={v => props.onOptionGroupChange?.(OUTPUT_STYLE_KEY, v)}
-        />
-      </Show>
-      <Show when={fastModeItems().length > 0}>
-        <RadioGroup
-          label={optionGroup(props.availableOptionGroups, FAST_MODE_KEY)?.label || 'Fast Mode'}
-          items={fastModeItems()}
-          testIdPrefix="fast-mode"
-          name={`${menuId}-fast-mode`}
-          current={currentFastMode()}
-          onChange={v => props.onOptionGroupChange?.(FAST_MODE_KEY, v)}
-        />
-      </Show>
-      <Show when={thinkingItems().length > 0}>
-        <RadioGroup
-          label={optionGroup(props.availableOptionGroups, ALWAYS_THINKING_KEY)?.label || 'Extended Thinking'}
-          items={thinkingItems()}
-          testIdPrefix="thinking"
-          name={`${menuId}-thinking`}
-          current={currentThinking()}
-          onChange={v => props.onOptionGroupChange?.(ALWAYS_THINKING_KEY, v)}
-        />
-      </Show>
-    </>
+        <Show when={props.availableModels && props.availableModels.length > 0}>
+          <Show when={hasEffort()}>
+            <RadioGroup
+              label="Effort"
+              items={efforts()}
+              testIdPrefix="effort"
+              name={`${menuId}-effort`}
+              current={currentEffort()}
+              onChange={v => props.onEffortChange?.(v)}
+              fieldsetClass={firstLeftClass('effort')}
+            />
+          </Show>
+          <ModelSelect
+            items={models()}
+            testIdPrefix="model"
+            name={`${menuId}-model`}
+            current={currentModel()}
+            onChange={(v) => {
+              props.onModelChange?.(v)
+              // If switching away from opus and effort is max, downgrade to high
+              if (!v.startsWith('opus') && currentEffort() === 'max') {
+                props.onEffortChange?.('high')
+              }
+            }}
+          />
+        </Show>
+      </div>
+      <div class={styles.settingsPanelColumn}>
+        <Show when={fastModeItems().length > 0}>
+          <RadioGroup
+            label={optionGroup(props.availableOptionGroups, FAST_MODE_KEY)?.label || 'Fast Mode'}
+            items={fastModeItems()}
+            testIdPrefix="fast-mode"
+            name={`${menuId}-fast-mode`}
+            current={currentFastMode()}
+            onChange={v => props.onOptionGroupChange?.(FAST_MODE_KEY, v)}
+            fieldsetClass={firstRightClass('fast')}
+          />
+        </Show>
+        <Show when={outputStyleItems().length > 0}>
+          <RadioGroup
+            label={optionGroup(props.availableOptionGroups, OUTPUT_STYLE_KEY)?.label || 'Output Style'}
+            items={outputStyleItems()}
+            testIdPrefix="output-style"
+            name={`${menuId}-output-style`}
+            current={currentOutputStyle()}
+            onChange={v => props.onOptionGroupChange?.(OUTPUT_STYLE_KEY, v)}
+            fieldsetClass={firstRightClass('output')}
+          />
+        </Show>
+        <div>
+          <RadioGroup
+            label={modeGroup()?.label || 'Permission Mode'}
+            items={modeItems()}
+            testIdPrefix="permission-mode"
+            name={`${menuId}-mode`}
+            current={currentMode()}
+            onChange={v => props.onPermissionModeChange?.(v as PermissionMode)}
+            fieldsetClass={firstRightClass('mode')}
+          />
+        </div>
+      </div>
+    </div>
   )
 }
 
-/** Claude Code trigger label (model, effort icon, permission mode, output style, fast mode, thinking). */
+/** Claude Code trigger label (model, effort icon, permission mode). */
 function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element {
   const currentModel = () => props.model || DEFAULT_CLAUDE_MODEL
   const currentEffort = () => props.effort || DEFAULT_CLAUDE_EFFORT
   const currentMode = () => props.permissionMode || 'default'
-  const currentOutputStyle = () => props.extraSettings?.[OUTPUT_STYLE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, OUTPUT_STYLE_KEY) || 'default'
-  const currentFastMode = () => props.extraSettings?.[FAST_MODE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, FAST_MODE_KEY) || 'off'
-  const currentThinking = () => props.extraSettings?.[ALWAYS_THINKING_KEY] || optionGroupDefaultValue(props.availableOptionGroups, ALWAYS_THINKING_KEY) || 'on'
 
   const displayName = () => modelDisplayName(props.availableModels, currentModel())
 
@@ -299,7 +312,6 @@ function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element 
 
   const hasEffort = () => hasEfforts(props.availableModels, currentModel())
   const mode = () => optionLabel(props.availableOptionGroups, PERMISSION_MODE_KEY, currentMode())
-  const outputStyleLabel = () => optionLabel(props.availableOptionGroups, OUTPUT_STYLE_KEY, currentOutputStyle())
 
   return (
     <>
@@ -308,9 +320,6 @@ function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element 
         <Show when={hasEffort()}>{effortIcon()}</Show>
       </Show>
       {mode()}
-      <Show when={currentOutputStyle() !== 'default'}>{outputStyleLabel()}</Show>
-      <Show when={currentFastMode() === 'on'}>Fast</Show>
-      <Show when={currentThinking() === 'off'}>No Thinking</Show>
     </>
   )
 }

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -276,17 +276,15 @@ function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element
             fieldsetClass={firstRightClass('output')}
           />
         </Show>
-        <div>
-          <RadioGroup
-            label={modeGroup()?.label || 'Permission Mode'}
-            items={modeItems()}
-            testIdPrefix="permission-mode"
-            name={`${menuId}-mode`}
-            current={currentMode()}
-            onChange={v => props.onPermissionModeChange?.(v as PermissionMode)}
-            fieldsetClass={firstRightClass('mode')}
-          />
-        </div>
+        <RadioGroup
+          label={modeGroup()?.label || 'Permission Mode'}
+          items={modeItems()}
+          testIdPrefix="permission-mode"
+          name={`${menuId}-mode`}
+          current={currentMode()}
+          onChange={v => props.onPermissionModeChange?.(v as PermissionMode)}
+          fieldsetClass={firstRightClass('mode')}
+        />
       </div>
     </div>
   )

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -15,7 +15,7 @@ import { getToolName } from '~/utils/controlResponse'
 import * as styles from '../ChatView.css'
 import { ClaudeCodeControlActions, ClaudeCodeControlContent } from '../controls/ClaudeCodeControlRequest'
 import { isNotificationThreadWrapper, isObject } from '../messageUtils'
-import { effortItems, hasEfforts, modelDisplayName, modelItems, ModelSelect, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../settingsShared'
+import { ALWAYS_THINKING_KEY, effortItems, FAST_MODE_KEY, hasEfforts, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupDefaultValue, optionGroupItems, optionLabel, OUTPUT_STYLE_KEY, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../settingsShared'
 import { renderClaudeMessage } from './claudeRenderers'
 import { registerProvider } from './registry'
 
@@ -186,18 +186,24 @@ function classifyClaudeCodeMessage(
 const DEFAULT_CLAUDE_MODEL = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_MODEL || 'opus[1m]'
 const DEFAULT_CLAUDE_EFFORT = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_EFFORT || 'high'
 
-/** Claude Code settings panel (model, effort, permission mode). */
+/** Claude Code settings panel (model, effort, permission mode, output style, fast mode, thinking). */
 function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element {
   const menuId = createUniqueId()
   const currentModel = () => props.model || DEFAULT_CLAUDE_MODEL
   const currentEffort = () => props.effort || DEFAULT_CLAUDE_EFFORT
   const currentMode = () => props.permissionMode || 'default'
+  const currentOutputStyle = () => props.extraSettings?.[OUTPUT_STYLE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, OUTPUT_STYLE_KEY) || 'default'
+  const currentFastMode = () => props.extraSettings?.[FAST_MODE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, FAST_MODE_KEY) || 'off'
+  const currentThinking = () => props.extraSettings?.[ALWAYS_THINKING_KEY] || optionGroupDefaultValue(props.availableOptionGroups, ALWAYS_THINKING_KEY) || 'on'
 
   const models = () => modelItems(props.availableModels)
   const efforts = () => effortItems(props.availableModels, currentModel())
   const hasEffort = () => efforts().length > 0
   const modeGroup = () => permissionModeGroup(props.availableOptionGroups)
   const modeItems = () => permissionModeItems(props.availableOptionGroups)
+  const outputStyleItems = () => optionGroupItems(props.availableOptionGroups, OUTPUT_STYLE_KEY)
+  const fastModeItems = () => optionGroupItems(props.availableOptionGroups, FAST_MODE_KEY)
+  const thinkingItems = () => optionGroupItems(props.availableOptionGroups, ALWAYS_THINKING_KEY)
 
   return (
     <>
@@ -236,15 +242,48 @@ function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element
         current={currentMode()}
         onChange={v => props.onPermissionModeChange?.(v as PermissionMode)}
       />
+      <Show when={outputStyleItems().length > 0}>
+        <RadioGroup
+          label={optionGroup(props.availableOptionGroups, OUTPUT_STYLE_KEY)?.label || 'Output Style'}
+          items={outputStyleItems()}
+          testIdPrefix="output-style"
+          name={`${menuId}-output-style`}
+          current={currentOutputStyle()}
+          onChange={v => props.onOptionGroupChange?.(OUTPUT_STYLE_KEY, v)}
+        />
+      </Show>
+      <Show when={fastModeItems().length > 0}>
+        <RadioGroup
+          label={optionGroup(props.availableOptionGroups, FAST_MODE_KEY)?.label || 'Fast Mode'}
+          items={fastModeItems()}
+          testIdPrefix="fast-mode"
+          name={`${menuId}-fast-mode`}
+          current={currentFastMode()}
+          onChange={v => props.onOptionGroupChange?.(FAST_MODE_KEY, v)}
+        />
+      </Show>
+      <Show when={thinkingItems().length > 0}>
+        <RadioGroup
+          label={optionGroup(props.availableOptionGroups, ALWAYS_THINKING_KEY)?.label || 'Extended Thinking'}
+          items={thinkingItems()}
+          testIdPrefix="thinking"
+          name={`${menuId}-thinking`}
+          current={currentThinking()}
+          onChange={v => props.onOptionGroupChange?.(ALWAYS_THINKING_KEY, v)}
+        />
+      </Show>
     </>
   )
 }
 
-/** Claude Code trigger label (model, effort icon, permission mode). */
+/** Claude Code trigger label (model, effort icon, permission mode, output style, fast mode, thinking). */
 function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element {
   const currentModel = () => props.model || DEFAULT_CLAUDE_MODEL
   const currentEffort = () => props.effort || DEFAULT_CLAUDE_EFFORT
   const currentMode = () => props.permissionMode || 'default'
+  const currentOutputStyle = () => props.extraSettings?.[OUTPUT_STYLE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, OUTPUT_STYLE_KEY) || 'default'
+  const currentFastMode = () => props.extraSettings?.[FAST_MODE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, FAST_MODE_KEY) || 'off'
+  const currentThinking = () => props.extraSettings?.[ALWAYS_THINKING_KEY] || optionGroupDefaultValue(props.availableOptionGroups, ALWAYS_THINKING_KEY) || 'on'
 
   const displayName = () => modelDisplayName(props.availableModels, currentModel())
 
@@ -260,6 +299,7 @@ function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element 
 
   const hasEffort = () => hasEfforts(props.availableModels, currentModel())
   const mode = () => optionLabel(props.availableOptionGroups, PERMISSION_MODE_KEY, currentMode())
+  const outputStyleLabel = () => optionLabel(props.availableOptionGroups, OUTPUT_STYLE_KEY, currentOutputStyle())
 
   return (
     <>
@@ -268,6 +308,9 @@ function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element 
         <Show when={hasEffort()}>{effortIcon()}</Show>
       </Show>
       {mode()}
+      <Show when={currentOutputStyle() !== 'default'}>{outputStyleLabel()}</Show>
+      <Show when={currentFastMode() === 'on'}>Fast</Show>
+      <Show when={currentThinking() === 'off'}>No Thinking</Show>
     </>
   )
 }

--- a/frontend/src/components/chat/providers/codex.tsx
+++ b/frontend/src/components/chat/providers/codex.tsx
@@ -267,7 +267,7 @@ function CodexSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element {
         </div>
         <button
           class="outline small"
-          style={{ "margin-bottom": "var(--space-2)" }}
+          style={{ 'margin-bottom': 'var(--space-2)' }}
           data-testid="codex-bypass-permissions"
           disabled={currentNetwork() === 'enabled' && currentSandbox() === 'danger-full-access' && currentMode() === 'never'}
           onClick={() => {

--- a/frontend/src/components/chat/providers/codex.tsx
+++ b/frontend/src/components/chat/providers/codex.tsx
@@ -265,6 +265,19 @@ function CodexSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element {
             fieldsetClass={firstRightClass('mode')}
           />
         </div>
+        <button
+          class="outline small"
+          style={{ "margin-bottom": "var(--space-2)" }}
+          data-testid="codex-bypass-permissions"
+          disabled={currentNetwork() === 'enabled' && currentSandbox() === 'danger-full-access' && currentMode() === 'never'}
+          onClick={() => {
+            props.onOptionGroupChange?.(CODEX_EXTRA_NETWORK_ACCESS, 'enabled')
+            props.onOptionGroupChange?.(CODEX_EXTRA_SANDBOX_POLICY, 'danger-full-access')
+            props.onPermissionModeChange?.('never' as PermissionMode)
+          }}
+        >
+          Bypass permissions
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/chat/settingsShared.tsx
+++ b/frontend/src/components/chat/settingsShared.tsx
@@ -9,6 +9,11 @@ import * as styles from './ChatView.css'
 /** Option group key for the permission mode setting, shared across providers. */
 export const PERMISSION_MODE_KEY = 'permissionMode' as const
 
+/** Option group keys for Claude Code-specific settings. */
+export const OUTPUT_STYLE_KEY = 'outputStyle' as const
+export const FAST_MODE_KEY = 'fastMode' as const
+export const ALWAYS_THINKING_KEY = 'alwaysThinkingEnabled' as const
+
 /** Shared item type used by RadioGroup and settings helpers. */
 export interface SettingsItem {
   label: string

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -780,8 +780,7 @@ export const AppShell: ParentComponent = (props) => {
     // Tell the worker to reassign the tab's workspace, then persist
     // both workspaces to the hub. The RPC must complete before persist
     // so that a subsequent listAgents returns the agent under the new
-    // workspace. Persist without debounce — cross-workspace moves are
-    // discrete actions that must survive an immediate page refresh.
+    // workspace.
     const rpcDone = (workerId && tab.type !== TabType.FILE)
       ? moveTabWorkspace(workerId, {
           tabType: tab.type,
@@ -821,7 +820,7 @@ export const AppShell: ParentComponent = (props) => {
         }
         catch { /* ignore — will be picked up on next restore */ }
       }
-      persistMultiLayout(true)
+      persistMultiLayout()
     }).catch((err: unknown) => {
       // Worker RPC failed — revert the optimistic UI update.
       // Move the tab back to the source workspace.

--- a/frontend/src/components/shell/DesktopLayout.tsx
+++ b/frontend/src/components/shell/DesktopLayout.tsx
@@ -7,6 +7,7 @@ import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { ChatDropZone } from '~/components/chat/ChatDropZone'
 import { Icon } from '~/components/common/Icon'
 import { useShortcutContext } from '~/hooks/useShortcutContext'
+import { trailingDebounce } from '~/lib/debounce'
 import { getShortcutHint } from '~/lib/shortcuts/display'
 import * as styles from './AppShell.css'
 import { SectionDragProvider } from './SectionDragContext'
@@ -159,12 +160,9 @@ export const DesktopLayout: Component<DesktopLayoutProps> = (props) => {
     }
     sessionStorage.setItem(`leapmux:sidebar:${id}`, JSON.stringify(state))
   }
-  let sidebarSaveTimer: ReturnType<typeof setTimeout> | null = null
-  const saveSidebarState = () => {
-    if (sidebarSaveTimer)
-      clearTimeout(sidebarSaveTimer)
-    sidebarSaveTimer = setTimeout(doSaveSidebarState, 300)
-  }
+  // trailingDebounce reads signals at fire time; the lint can't see through it.
+  // eslint-disable-next-line solid/reactivity
+  const saveSidebarState = trailingDebounce(doSaveSidebarState, 300)
 
   // --- Collapse / Expand ---
   const collapseLeft = () => {
@@ -302,10 +300,7 @@ export const DesktopLayout: Component<DesktopLayoutProps> = (props) => {
     window.removeEventListener('resize', handleViewportResize)
     if (resizeRafId !== null)
       cancelAnimationFrame(resizeRafId)
-    if (sidebarSaveTimer) {
-      clearTimeout(sidebarSaveTimer)
-      doSaveSidebarState()
-    }
+    saveSidebarState.flush()
   })
 
   // Computed widths for CSS.

--- a/frontend/src/components/shell/WindowControlIcons.tsx
+++ b/frontend/src/components/shell/WindowControlIcons.tsx
@@ -2,7 +2,6 @@ import type { LucideProps } from 'lucide-solid'
 import { SvgIconFrame } from '~/components/common/SvgIconFrame'
 
 export function WindowMinimizeIcon(props: LucideProps) {
-  // Underbar resting near the baseline.
   return (
     <SvgIconFrame {...props}>
       <line x1="5" y1="18" x2="19" y2="18" />
@@ -11,7 +10,6 @@ export function WindowMinimizeIcon(props: LucideProps) {
 }
 
 export function WindowMaximizeIcon(props: LucideProps) {
-  // Big outline square, vertically centred-ish within the glyph area.
   return (
     <SvgIconFrame {...props}>
       <rect x="5" y="5" width="14" height="14" />
@@ -20,7 +18,6 @@ export function WindowMaximizeIcon(props: LucideProps) {
 }
 
 export function WindowRestoreIcon(props: LucideProps) {
-  // Small outline square centred in the glyph area.
   return (
     <SvgIconFrame {...props}>
       <rect x="7" y="8" width="10" height="10" />
@@ -29,7 +26,6 @@ export function WindowRestoreIcon(props: LucideProps) {
 }
 
 export function WindowCloseIcon(props: LucideProps) {
-  // Diagonal cross.
   return (
     <SvgIconFrame {...props}>
       <line x1="5" y1="5" x2="19" y2="19" />

--- a/frontend/src/components/shell/useTabPersistence.ts
+++ b/frontend/src/components/shell/useTabPersistence.ts
@@ -6,6 +6,7 @@ import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry
 import { createEffect, onCleanup } from 'solid-js'
 import { workspaceClient } from '~/api/clients'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { trailingDebounce } from '~/lib/debounce'
 import { floatingWindowsToProto } from '~/stores/floatingWindow.store'
 import { toProto } from '~/stores/layout.store'
 
@@ -31,11 +32,7 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
   } = opts
 
   // Debounced layout + tab persistence
-  let layoutSaveTimer: ReturnType<typeof setTimeout> | null = null
-  let layoutSaveDirty = false
-
   function doLayoutSave() {
-    layoutSaveDirty = false
     const ws = activeWorkspace()
     if (!ws || workspaceLoading())
       return
@@ -62,12 +59,7 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
     }).catch(() => {})
   }
 
-  const persistLayout = () => {
-    layoutSaveDirty = true
-    if (layoutSaveTimer)
-      clearTimeout(layoutSaveTimer)
-    layoutSaveTimer = setTimeout(doLayoutSave, 500)
-  }
+  const persistLayout = trailingDebounce(doLayoutSave, 500)
 
   // Persist active tab to sessionStorage
   createEffect(() => {
@@ -141,11 +133,7 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
   // Multi-workspace layout persistence: saves layout + tabs for all
   // workspaces that have cached snapshots in the registry, plus the
   // active workspace.
-  let multiSaveTimer: ReturnType<typeof setTimeout> | null = null
-  let multiSaveDirty = false
-
   function doMultiSave() {
-    multiSaveDirty = false
     const orgId = getOrgId()
     if (!orgId || workspaceLoading())
       return
@@ -217,40 +205,14 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
     }).catch(() => {})
   }
 
-  const persistMultiLayout = (immediate?: boolean) => {
-    if (immediate) {
-      if (multiSaveTimer) {
-        clearTimeout(multiSaveTimer)
-        multiSaveTimer = null
-      }
-      multiSaveDirty = false
-      doMultiSave()
-      return
-    }
-    multiSaveDirty = true
-    if (multiSaveTimer)
-      clearTimeout(multiSaveTimer)
-    multiSaveTimer = setTimeout(doMultiSave, 500)
-  }
+  // Cross-workspace moves are discrete actions that always persist
+  // synchronously — the debounce path is intentionally absent.
+  const persistMultiLayout = doMultiSave
 
-  // Flush any pending saves on page unload so cross-workspace moves
-  // aren't lost if the user refreshes before the debounce fires.
-  const flushOnUnload = () => {
-    if (multiSaveDirty) {
-      if (multiSaveTimer) {
-        clearTimeout(multiSaveTimer)
-        multiSaveTimer = null
-      }
-      doMultiSave()
-    }
-    if (layoutSaveDirty) {
-      if (layoutSaveTimer) {
-        clearTimeout(layoutSaveTimer)
-        layoutSaveTimer = null
-      }
-      doLayoutSave()
-    }
-  }
+  // Flush any pending layout save on page unload so the active workspace's
+  // in-flight changes aren't lost if the user refreshes before the debounce
+  // fires.
+  const flushOnUnload = () => persistLayout.flush()
   window.addEventListener('beforeunload', flushOnUnload)
   onCleanup(() => window.removeEventListener('beforeunload', flushOnUnload))
 

--- a/frontend/src/lib/debounce.test.ts
+++ b/frontend/src/lib/debounce.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { trailingDebounce } from './debounce'
+
+describe('trailingDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires once after the quiet period', () => {
+    const fn = vi.fn()
+    const debounced = trailingDebounce(fn, 100)
+    debounced()
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(99)
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces rapid-fire calls into a single trailing invocation', () => {
+    const fn = vi.fn()
+    const debounced = trailingDebounce(fn, 100)
+    debounced()
+    vi.advanceTimersByTime(50)
+    debounced()
+    vi.advanceTimersByTime(50)
+    debounced()
+    vi.advanceTimersByTime(99)
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts a fresh quiet period after firing', () => {
+    const fn = vi.fn()
+    const debounced = trailingDebounce(fn, 100)
+    debounced()
+    vi.advanceTimersByTime(100)
+    expect(fn).toHaveBeenCalledTimes(1)
+    debounced()
+    vi.advanceTimersByTime(100)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  describe('cancel()', () => {
+    it('drops a pending invocation', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced()
+      debounced.cancel()
+      vi.advanceTimersByTime(200)
+      expect(fn).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when nothing is pending', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      expect(() => debounced.cancel()).not.toThrow()
+      expect(fn).not.toHaveBeenCalled()
+    })
+
+    it('does not affect subsequent calls', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced()
+      debounced.cancel()
+      debounced()
+      vi.advanceTimersByTime(100)
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('flush()', () => {
+    it('fires the pending invocation immediately', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced()
+      debounced.flush()
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels the pending timer so it does not fire again', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced()
+      debounced.flush()
+      vi.advanceTimersByTime(200)
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op when nothing is pending', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced.flush()
+      expect(fn).not.toHaveBeenCalled()
+    })
+
+    it('allows new calls to schedule after a flush', () => {
+      const fn = vi.fn()
+      const debounced = trailingDebounce(fn, 100)
+      debounced()
+      debounced.flush()
+      debounced()
+      vi.advanceTimersByTime(100)
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/frontend/src/lib/debounce.ts
+++ b/frontend/src/lib/debounce.ts
@@ -1,0 +1,37 @@
+/** A trailing-edge-debounced function with cancel/flush controls. */
+export type TrailingDebounced = (() => void) & {
+  cancel: () => void
+  flush: () => void
+}
+
+/**
+ * Trailing-edge debounce. Coalesces rapid-fire calls into a single
+ * trailing invocation after `ms` of quiet. Use `.cancel()` to drop a
+ * pending invocation (e.g. on dispose) and `.flush()` to fire it now
+ * (e.g. on unload).
+ */
+export function trailingDebounce(fn: () => void, ms: number): TrailingDebounced {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const debounced = () => {
+    if (timer !== null)
+      clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      fn()
+    }, ms)
+  }
+  debounced.cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+  debounced.flush = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+      fn()
+    }
+  }
+  return debounced
+}

--- a/frontend/src/styles/global.css.ts
+++ b/frontend/src/styles/global.css.ts
@@ -222,3 +222,8 @@ globalStyle('*::-webkit-scrollbar-thumb:hover', {
 globalStyle('*::-webkit-scrollbar-corner', {
   background: 'transparent',
 })
+
+// Prevent radio/checkbox inputs from shrinking inside flex containers.
+globalStyle('input[type="radio"], input[type="checkbox"]', {
+  flexShrink: 0,
+})


### PR DESCRIPTION
## Motivation

Agent settings (model, effort, permission mode) were applied fire-and-forget: 
LeapMux sent an update request but never confirmed what the agent actually
adopted. This meant the UI could show stale values if the agent rejected or
adjusted a setting server-side, and agent-specific capabilities like Claude
Code's output-style variants were not surfaced in the settings panel at all.
Additionally, when context was cleared via ACP the per-provider state
(model, mode, primary agent) was not re-read from the new session
response, leaving internal caches out of sync.

## Modifications

**Claude Code agent (`claude.go`, `claude_livesettings_test.go`)**
- Added `outputStyle`, `availableOutputStyles`, `fastMode`, and
  `alwaysThinking` fields to `ClaudeCodeAgent`.
- Added extra-settings key constants `ExtraKeyOutputStyle`,
  `ExtraKeyFastMode`, `ExtraKeyAlwaysThinking`.
- Implemented `UpdateSettings()`: sends an `apply_flag_settings` control
  request and follows it with `refreshSettingsFromAgent()` (a
  `get_settings` round-trip that rehydrates all internal state). Returns
  `false` when `apply_flag_settings` is unsupported.
- `buildStartupFlagSettings()` re-applies persisted extra settings at
  agent startup.
- `AvailableOptionGroups()` now returns dynamic groups for output style
  (when the agent reports choices), fast mode, and extended thinking.

**ACP providers (`acp_common.go`, provider files)**
- Added `refreshFromSession` callback to `acpBase`, called by
  `ClearContext()` after `reapplySettings`, so each provider can sync
  state from the new session's initialize response.
- Extracted `parseSessionModelAndMode()` and three specialised refresh
  templates: `refreshModelAndPermissionModeFromSession` (Copilot, Gemini,
  Goose), `refreshModelAndPrimaryAgentFromSession` (Kilo, OpenCode), and
  Cursor's own `refreshCursorFromSession` (with model-ID normalization).

**Codex agent (`codex.go`, `codex_settings_test.go`)**
- `UpdateSettings()` now calls `refreshSettingsFromAgent()` which issues
  a `config/read` RPC and rehydrates model, effort, approval policy,
  sandbox mode, and service tier.
- New `jsonString()` helper handles nullable and complex JSON fields
  without panicking.
- Bug fix: Codex previously did not reconcile effective settings after
  applying changes, and would crash on null/complex JSON values from
  `config/read`.

**Output sink (`agent/provider.go`, `service/output.go`)**
- New `BroadcastSettingsRefreshed(model, effort, permissionMode,
  extraSettings)` method on `OutputSink`. The service implementation
  persists all four fields to the DB and broadcasts a `StatusChange`
  event so connected frontends immediately reflect the refreshed values.
- `noopSink` and `testSink` implementations updated accordingly.

**Service layer (`file.go`, `file_timeout_test.go`, `agent.go`)**
- Refactored `readDirN` to `readDirNWithTimeout` with a caller-supplied
  timeout. Uses `atomic.Pointer[os.File]` to close the open descriptor
  from the timeout path, preventing fd and goroutine leaks on
  macOS TCC-protected directories.
- Added `/new` as an accepted alias alongside `/clear` and `/reset` in
  the leapmux-level slash-command detector.

**Frontend (`debounce.ts`, `debounce.test.ts`, and UI files)**
- New `trailingDebounce(fn, ms)` utility with `.cancel()` / `.flush()`
  methods, with a dedicated test file. Migrated window geometry, draft
  save, sidebar state, layout persistence, and editor save off ad-hoc
  `setTimeout` calls.
- `ClaudeCodeSettingsPanel` reorganized into a two-column layout: left
  column holds extended thinking / effort / model; right column holds
  fast mode / output style / permission mode.
- New shared key constants `OUTPUT_STYLE_KEY`, `FAST_MODE_KEY`,
  `ALWAYS_THINKING_KEY` in `settingsShared.tsx`; new
  `optionGroupDefaultValue()` helper.
- Codex settings panel gains a "Bypass permissions" button that sets
  network access to enabled, sandbox to full access, and approval policy
  to never in one click.
- `persistMultiLayout()` is now synchronous; `persistLayout.flush()` is
  called on unload instead of the old ad-hoc cleanup.
- Bug fixes: `flex-shrink: 0` on radio/checkbox inputs prevents collapse
  in flex containers; `observeWindowMaximized` checks a `disposed` flag
  before dispatching resize events to prevent stale callbacks.

**Test infrastructure (`acp_refresh_test.go`, `acp_test_helpers.go`,
`sink_test.go`)**
- Generic `newACPAgentForRPC[T]` / `newACPAgentForRPCWithResponder[T]`
  helpers replace six duplicated per-provider peer scaffolds.
- New `acp_refresh_test.go`: six session-refresh cases, one per ACP
  provider.
- New `codex_settings_test.go`: four cases covering `config/read`
  parsing, null-field handling, granular approval policies, and
  end-to-end `UpdateSettings`.

## Result

After applying settings, LeapMux now reads back what the agent actually
has in effect and persists those values to the database, then pushes a
`StatusChange` event so every connected frontend updates immediately —
no more stale model, effort, or permission-mode indicators after a
settings change.

Claude Code agents expose their available output styles, fast mode, and
extended-thinking toggle dynamically in the settings panel as soon as
the agent reports them.

Codex agents no longer crash when `config/read` returns null or
structured JSON fields, and the settings panel now shows a one-click
"Bypass permissions" shortcut.

Directory reads on macOS TCC-protected paths no longer leak file
descriptors or goroutines when the open call stalls.