### PR TITLE
Add native Windows support with named-pipe IPC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Enforce LF line endings for all text files, in both the index and the
+# working tree, on every platform. Overrides core.autocrlf/core.eol.
+* text=auto eol=lf
+
+# Explicit binary markers so autodetection doesn't surprise us. text=auto
+# already skips these, but being explicit is safer when adding new files.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.eot binary

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ frontend/src/spinners/
 
 # Desktop
 /desktop/go/leapmux-desktop
+/desktop/go/leapmux-desktop.exe
 /desktop/go/bin/
 /desktop/rust/gen/
 /desktop/rust/icons/
@@ -51,6 +52,7 @@ frontend/src/spinners/
 # IDE
 .idea/
 .vscode/
+.claude/settings.local.json
 
 # OS
 .DS_Store

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,7 @@ vars:
   COMMIT_TIME:
     sh: echo "${COMMIT_TIME:-$(git log -1 --format=%cI 2>/dev/null)}"
   BUILD_TIME:
-    sh: echo "${BUILD_TIME:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+    sh: echo "${BUILD_TIME:-{{dateInZone `2006-01-02T15:04:05Z` now `UTC`}}}"
   VERSION_LDFLAGS: >-
     -X github.com/leapmux/leapmux/util/version.Value={{.VERSION}}
     -X github.com/leapmux/leapmux/util/version.CommitHash={{.COMMIT_HASH}}
@@ -93,19 +93,20 @@ tasks:
   generate-spinners:
     desc: Download spinner verb JSON files from awesome-claude-spinners
     vars:
-      CACHE_DIR: '{{.HOME}}/.cache/awesome-claude-spinners'
+      CACHE_DIR:
+        sh: echo "${HOME:-$USERPROFILE}/.cache/awesome-claude-spinners"
     generates:
       - frontend/src/spinners/**/*
     status:
       - test -d frontend/src/spinners
     cmds:
       - |
-        if [ ! -d "{{.CACHE_DIR}}" ] || [ -n "$(find "{{.CACHE_DIR}}" -maxdepth 0 -mtime +30 2>/dev/null)" ]; then
-          rm -rf "{{.CACHE_DIR}}"
+        if [ ! -d "{{.CACHE_DIR}}" ]; then
           git clone --depth 1 https://github.com/AlexPl292/awesome-claude-spinners "{{.CACHE_DIR}}"
         fi
+      - rm -rf frontend/src/spinners
       - mkdir -p frontend/src/spinners
-      - rsync -a --delete "{{.CACHE_DIR}}/spinners/" frontend/src/spinners/
+      - cp -r "{{.CACHE_DIR}}/spinners/." frontend/src/spinners/
 
   # --- Preparation ---
 
@@ -165,9 +166,10 @@ tasks:
       - task: generate-proto
       - task: generate-sqlc
       - task: build-frontend
+      - rm -rf backend/internal/hub/generated/frontend/public
       - mkdir -p backend/internal/hub/generated/frontend/public
-      - rsync -a backend/internal/hub/frontend.embed backend/internal/hub/generated/frontend/embed.go
-      - rsync -a --delete frontend/.output/public/ backend/internal/hub/generated/frontend/public/
+      - cp backend/internal/hub/frontend.embed backend/internal/hub/generated/frontend/embed.go
+      - cp -r frontend/.output/public/. backend/internal/hub/generated/frontend/public/
 
   prepare-desktop:
     desc: Prepare desktop for builds
@@ -238,10 +240,10 @@ tasks:
       - backend/**/*.go
       - backend/internal/hub/generated/frontend/public/**/*
     generates:
-      - leapmux
+      - leapmux{{if eq OS "windows"}}.exe{{end}}
     cmds:
       - task: prepare-backend
-      - cd backend && go build -ldflags "{{.VERSION_LDFLAGS}}" -o ../leapmux ./cmd/leapmux
+      - cd backend && go build -ldflags "{{.VERSION_LDFLAGS}}" -o ../leapmux{{if eq OS "windows"}}.exe{{end}} ./cmd/leapmux
 
   build-backend-docker:
     desc: Build backend for Docker images
@@ -372,19 +374,41 @@ tasks:
       - desktop/rust/Cargo.*
       - desktop/rust/capabilities/**/*
       - desktop/rust/tauri.conf.json
+      - desktop/rust/tauri.windows.conf.json
       - desktop/rust/icons/icon.ico
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
     generates:
-      - LeapMux*.exe
-      - LeapMux*.msi
+      - LeapMuxDesktop*.exe
+      - LeapMuxDesktop*.msi
+      - leapmux-desktop-service-*.exe
     cmds:
       - task: prepare-desktop
       - task: build-desktop-sidecar
-      - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
-      - cp -f desktop/rust/target/release/bundle/nsis/LeapMux*.exe .
-      - cp -f desktop/rust/target/release/bundle/msi/LeapMux*.msi .
+      - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION | replace "-dev" ""}}"}'
+      - cp -f desktop/rust/target/release/LeapMuxDesktop.exe .
+      - cp -f desktop/go/bin/leapmux-desktop-service-*.exe .
+      # Tauri's NSIS and WiX bundlers name the installer after productName
+      # ("LeapMux Desktop" — with a space), regardless of our mainBinaryName
+      # override. Copy with a space-stripping rename so we ship spaceless
+      # filenames. The WiX bundler additionally appends "_en-US"; strip that
+      # too. Destination is a bare filename so it resolves to cwd = repo
+      # root without triggering mvdan/sh's `./`-path quirk.
+      - |
+        for src in desktop/rust/target/release/bundle/nsis/LeapMux*-setup.exe; do
+          [ -e "$src" ] || continue
+          name="${src##*/}"
+          cp -f "$src" "${name// /}"
+        done
+      - |
+        for src in desktop/rust/target/release/bundle/msi/LeapMux*_en-US.msi; do
+          [ -e "$src" ] || continue
+          name="${src##*/}"
+          dest="${name// /}"
+          dest="${dest/_en-US/}"
+          cp -f "$src" "$dest"
+        done
 
   # --- Testing ---
 
@@ -556,7 +580,9 @@ tasks:
       - |
         TARGET="{{if eq OS "darwin"}}{{if eq ARCH "arm64"}}aarch64{{else}}x86_64{{end}}-apple-darwin{{else if eq OS "linux"}}{{if eq ARCH "arm64"}}aarch64{{else}}x86_64{{end}}-unknown-linux-gnu{{else}}x86_64-pc-windows-msvc{{end}}"
         BIN="./bin/leapmux-desktop-service-${TARGET}{{if eq OS "windows"}}.exe{{end}}"
-        cd desktop/go && go build -ldflags "{{.VERSION_LDFLAGS}}" -o "${BIN}" .
+        # -H=windowsgui links the sidecar for the Windows GUI subsystem so
+        # spawning it from the Tauri shell doesn't pop up a console window.
+        cd desktop/go && go build -ldflags "{{.VERSION_LDFLAGS}}{{if eq OS "windows"}} -H=windowsgui{{end}}" -o "${BIN}" .
 
   # --- Docker ---
 
@@ -665,8 +691,8 @@ tasks:
   clean-backend:
     desc: Remove backend build artifacts
     cmds:
-      - rm -f  leapmux
-      - rm -f  backend/leapmux
+      - rm -f  leapmux leapmux.exe
+      - rm -f  backend/leapmux backend/leapmux.exe
       - rm -rf backend/generated/
       - rm -rf backend/*/generated/
       - rm -rf backend/*/*/generated/
@@ -682,8 +708,9 @@ tasks:
       - rm -f  leapmux-desktop-service-*
       - rm -f  leapmux-desktop*.deb
       - rm -f  leapmux-desktop*.AppImage
+      - rm -f  LeapMux*.exe
       - rm -f  LeapMux*.msi
-      - rm -f  desktop/go/leapmux-desktop
+      - rm -f  desktop/go/leapmux-desktop desktop/go/leapmux-desktop.exe
       - rm -rf desktop/go/bin/
       - rm -rf desktop/rust/gen/
       - rm -rf desktop/rust/icons/

--- a/backend/cmd/leapmux/solo.go
+++ b/backend/cmd/leapmux/solo.go
@@ -2,275 +2,71 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
+	"net/http"
 	"os/signal"
-	"path/filepath"
-	"sync"
 	"syscall"
-	"time"
 
-	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
-	"github.com/leapmux/leapmux/internal/logging"
-	noiseutil "github.com/leapmux/leapmux/internal/noise"
-	workerconfig "github.com/leapmux/leapmux/internal/worker/config"
+	"github.com/leapmux/leapmux/solo"
 	"github.com/leapmux/leapmux/util/version"
-	"github.com/leapmux/leapmux/worker"
 )
 
-// soloState persists the auto-registered worker credentials.
-type soloState struct {
-	WorkerID         string `json:"worker_id"`
-	AuthToken        string `json:"auth_token"`
-	RegisteredBy     string `json:"registered_by,omitempty"`
-	PublicKey        string `json:"public_key,omitempty"`
-	PrivateKey       string `json:"private_key,omitempty"`
-	MlkemPublicKey   string `json:"mlkem_public_key,omitempty"`
-	MlkemPrivateKey  string `json:"mlkem_private_key,omitempty"`
-	SlhdsaPublicKey  string `json:"slhdsa_public_key,omitempty"`
-	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"`
-}
-
 func runSolo(args []string, soloMode bool) error {
-	modeName := "solo"
-	if !soloMode {
-		modeName = "dev"
+	for _, a := range args {
+		if a == "-version" || a == "--version" {
+			fmt.Println(version.Value)
+			return nil
+		}
 	}
 
+	modeName := "solo"
 	defaultAddr := "127.0.0.1:4327"
 	if !soloMode {
+		modeName = "dev"
 		defaultAddr = ":4327"
 	}
+	configDir := "~/.config/leapmux/" + modeName
+	configFile := configDir + "/" + modeName + ".yaml"
 
-	defaultConfigDir := "~/.config/leapmux/" + modeName
-	defaultConfigFile := defaultConfigDir + "/" + modeName + ".yaml"
-
-	hubCfg, showVersion, err := hubconfig.LoadWithOptions(args, hubconfig.LoadOptions{
-		DefaultAddr:       defaultAddr,
-		DefaultConfigDir:  defaultConfigDir,
-		DefaultConfigFile: defaultConfigFile,
-		FlagSetName:       "leapmux",
-		CLIFlags:          []string{"addr", "data-dir", "dev-frontend", "storage-sqlite-max-conns", "max-message-size", "max-incomplete-chunked", "api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds", "log-level"},
-		ExtraFlags: []hubconfig.ExtraFlagDef{
-			{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
-		},
-		SoloMode: soloMode,
-	})
-	if err != nil {
-		return err
+	cliFlags := []string{
+		"addr", "data-dir", "dev-frontend",
+		"storage-sqlite-max-conns", "max-message-size", "max-incomplete-chunked",
+		"api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds",
+		"log-level",
 	}
-	hubCfg.DevMode = !soloMode
-
-	if showVersion {
-		fmt.Println(version.Value)
-		return nil
-	}
-
-	level, err := logging.ParseLevel(hubCfg.LogLevel)
-	if err != nil {
-		return fmt.Errorf("invalid log level: %w", err)
-	}
-	logging.SetLevel(level)
-
-	logging.PrintBanner(modeName, logging.VersionInfo{Version: version.Value, CommitHash: version.CommitHash, CommitTime: version.CommitTime, BuildTime: version.BuildTime})
-	logging.PrintAccessURL(hubCfg.Addr)
-
-	// Split the data dir into hub and worker subdirectories.
-	dataDir := hubCfg.DataDir
-	hubCfg.DataDir = filepath.Join(dataDir, "hub")
-	workerDataDir := filepath.Join(dataDir, "worker")
-
-	// Ensure top-level data directory exists.
-	if err := os.MkdirAll(dataDir, 0o750); err != nil {
-		return fmt.Errorf("create data dir: %w", err)
-	}
-
-	// Start the Hub server.
-	server, err := hub.NewServer(hubCfg)
-	if err != nil {
-		return fmt.Errorf("create hub server: %w", err)
+	extraFlags := []hubconfig.ExtraFlagDef{
+		{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Run Hub in background.
-	var wg sync.WaitGroup
-	hubErrCh := make(chan error, 1)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		hubErrCh <- server.Serve(ctx)
-	}()
-
-	// Wait briefly for Hub to start listening on the Unix socket.
-	socketPath := server.SocketPath()
-	if err := waitForSocket(ctx, socketPath); err != nil {
-		stop()
-		wg.Wait()
-		return fmt.Errorf("wait for hub socket: %w", err)
-	}
-
-	// Auto-register worker via direct DB access (no network round-trip).
-	statePath := filepath.Join(workerDataDir, "state.json")
-	state, err := loadOrCreateWorkerState(ctx, server, statePath, workerDataDir)
+	inst, err := solo.Start(ctx, solo.Config{
+		Addr:       defaultAddr,
+		ConfigDir:  configDir,
+		ConfigFile: configFile,
+		Args:       args,
+		CLIFlags:   cliFlags,
+		ExtraFlags: extraFlags,
+		DevMode:    !soloMode,
+	})
 	if err != nil {
-		stop()
-		wg.Wait()
-		return fmt.Errorf("auto-register worker: %w", err)
-	}
-
-	// Ensure the worker has a composite keypair for E2EE channels.
-	if state.PublicKey == "" || state.PrivateKey == "" || state.MlkemPublicKey == "" || state.MlkemPrivateKey == "" || state.SlhdsaPublicKey == "" || state.SlhdsaPrivateKey == "" {
-		ck, kpErr := noiseutil.GenerateCompositeKeypair()
-		if kpErr != nil {
-			stop()
-			wg.Wait()
-			return fmt.Errorf("generate composite keypair: %w", kpErr)
-		}
-		slhdsaPub, _ := ck.SlhdsaPublicKeyBytes()
-		slhdsaPriv, _ := ck.SlhdsaPrivateKey.MarshalBinary()
-		state.PublicKey = base64.StdEncoding.EncodeToString(ck.X25519Public)
-		state.PrivateKey = base64.StdEncoding.EncodeToString(ck.X25519Private)
-		state.MlkemPublicKey = base64.StdEncoding.EncodeToString(ck.MlkemPublicKeyBytes())
-		state.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
-		state.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
-		state.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
-		stateData, err := json.MarshalIndent(state, "", "  ")
-		if err != nil {
-			slog.Warn("failed to marshal state", "error", err)
-		} else if writeErr := os.WriteFile(statePath, stateData, 0o600); writeErr != nil {
-			slog.Warn("failed to save keypair", "error", writeErr)
-		}
-	}
-
-	compositeKey, ckErr := noiseutil.RestoreCompositeKeypair(
-		mustDecode64(state.PublicKey),
-		mustDecode64(state.PrivateKey),
-		mustDecode64(state.MlkemPrivateKey),
-		mustDecode64(state.SlhdsaPublicKey),
-		mustDecode64(state.SlhdsaPrivateKey),
-	)
-	if ckErr != nil {
-		stop()
-		wg.Wait()
-		return fmt.Errorf("restore composite keypair: %w", ckErr)
-	}
-
-	slog.Info(modeName+" worker registered",
-		"worker_id", state.WorkerID,
-		"socket", socketPath,
-	)
-
-	// Run Worker in background, connecting via the Hub's Unix domain socket.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := worker.Run(ctx, worker.RunConfig{
-			HubURL:               "unix:" + socketPath,
-			DataDir:              workerDataDir,
-			AuthToken:            state.AuthToken,
-			CompositeKey:         compositeKey,
-			WorkerID:             state.WorkerID,
-			DBMaxConns:           hubCfg.Storage.SQLite.MaxConns,
-			DBCacheSize:          hubCfg.Storage.SQLite.CacheSize,
-			DBMmapSize:           hubCfg.Storage.SQLite.MmapSize,
-			MaxMessageSize:       hubCfg.MaxMessageSize,
-			MaxIncompleteChunked: hubCfg.MaxIncompleteChunked,
-			AgentStartupTimeout:  hubCfg.AgentStartupTimeout(),
-			APITimeout:           hubCfg.APITimeout(),
-			EncryptionMode:       workerconfig.ParseEncryptionMode(hubCfg.Extras["encryption_mode"]),
-			RegisteredBy:         state.RegisteredBy,
-		}); err != nil {
-			slog.Error("worker error", "error", err)
-		}
-	}()
-
-	slog.Info("leapmux "+modeName+" listening", "addr", hubCfg.Addr)
-
-	// Wait for Hub error or context cancellation.
-	select {
-	case err := <-hubErrCh:
-		stop()
-		wg.Wait()
 		return err
+	}
+	defer inst.Stop()
+
+	// Exit when the user signals or the Hub errors out.
+	hubExited := make(chan error, 1)
+	go func() { hubExited <- inst.Wait() }()
+	select {
 	case <-ctx.Done():
-		wg.Wait()
+		return nil
+	case err := <-hubExited:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
 		return nil
 	}
-}
-
-// waitForSocket polls until the Unix socket exists (max ~5 seconds).
-func waitForSocket(ctx context.Context, path string) error {
-	for i := 0; i < 50; i++ {
-		if _, err := os.Stat(path); err == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-	return fmt.Errorf("socket %s not created in time", path)
-}
-
-// loadOrCreateWorkerState loads saved credentials or creates a new worker
-// record directly in the Hub's database (avoiding the registration flow).
-func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath, workerDataDir string) (*soloState, error) {
-	if err := os.MkdirAll(workerDataDir, 0o750); err != nil {
-		return nil, fmt.Errorf("create worker data dir: %w", err)
-	}
-
-	// Try loading existing state.
-	data, err := os.ReadFile(statePath)
-	if err == nil {
-		var s soloState
-		if json.Unmarshal(data, &s) == nil && s.WorkerID != "" && s.AuthToken != "" {
-			// Verify the worker still exists in the DB.
-			if dbErr := server.GetWorkerByID(ctx, s.WorkerID); dbErr == nil {
-				return &s, nil
-			}
-			slog.Warn("saved worker not found in DB, re-registering")
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("read state: %w", err)
-	}
-
-	// Find the admin user (created by bootstrap).
-	userID, _, err := server.GetAdminUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	creds, err := server.RegisterWorker(ctx, userID)
-	if err != nil {
-		return nil, err
-	}
-
-	state := &soloState{
-		WorkerID:     creds.WorkerID,
-		AuthToken:    creds.AuthToken,
-		RegisteredBy: userID,
-	}
-
-	stateData, err := json.MarshalIndent(state, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal state: %w", err)
-	}
-	if err := os.WriteFile(statePath, stateData, 0o600); err != nil {
-		return nil, fmt.Errorf("write state: %w", err)
-	}
-
-	return state, nil
-}
-
-func mustDecode64(s string) []byte {
-	b, _ := base64.StdEncoding.DecodeString(s)
-	return b
 }

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -5,11 +5,9 @@ package hub
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"connectrpc.com/connect"
@@ -29,6 +27,7 @@ import (
 	"github.com/leapmux/leapmux/internal/logging"
 	"github.com/leapmux/leapmux/internal/metrics"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/locallisten"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -236,11 +235,6 @@ func (s *Server) Store() store.Store {
 	return s.store
 }
 
-// SocketPath returns the Unix domain socket path for this server.
-func (s *Server) SocketPath() string {
-	return s.cfg.SocketPath()
-}
-
 // WorkerCredentials holds the credentials for a registered worker.
 type WorkerCredentials struct {
 	WorkerID  string
@@ -287,32 +281,27 @@ func (s *Server) GetAdminUser(ctx context.Context) (userID, orgID string, err er
 	return user.ID, user.OrgID, nil
 }
 
-// Serve starts the Hub server on TCP and Unix socket listeners.
+// Serve starts the Hub server on TCP and local IPC listeners.
 // It blocks until ctx is cancelled, then performs graceful shutdown.
 func (s *Server) Serve(ctx context.Context) error {
-	sockPath := s.cfg.SocketPath()
-	if err := removeStaleSocket(sockPath); err != nil {
-		_ = s.store.Close()
-		return fmt.Errorf("remove stale socket: %w", err)
-	}
-
 	tcpLn := s.tcpLn
 
-	unixLn, err := net.Listen("unix", sockPath)
+	listenURL, err := s.cfg.LocalListenURL()
 	if err != nil {
 		if tcpLn != nil {
 			_ = tcpLn.Close()
 		}
 		_ = s.store.Close()
-		return fmt.Errorf("listen unix: %w", err)
+		return fmt.Errorf("resolve local-listen URL: %w", err)
 	}
-	if err := os.Chmod(sockPath, 0o600); err != nil {
+
+	localLn, err := locallisten.Listen(listenURL)
+	if err != nil {
 		if tcpLn != nil {
 			_ = tcpLn.Close()
 		}
-		_ = unixLn.Close()
 		_ = s.store.Close()
-		return fmt.Errorf("chmod socket: %w", err)
+		return fmt.Errorf("listen local: %w", err)
 	}
 
 	// Start background OAuth token refresh.
@@ -341,7 +330,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		close(shutdownDone)
 	}()
 
-	listenerCount := 1 // unix listener always present
+	listenerCount := 1 // local listener always present
 	if tcpLn != nil {
 		listenerCount = 2
 	}
@@ -350,12 +339,12 @@ func (s *Server) Serve(ctx context.Context) error {
 	if tcpLn != nil {
 		go func() { errCh <- s.server.Serve(tcpLn) }()
 	}
-	go func() { errCh <- s.server.Serve(unixLn) }()
+	go func() { errCh <- s.server.Serve(localLn) }()
 
 	if tcpLn != nil {
-		slog.Info("hub listening", "addr", s.cfg.Addr, "socket", sockPath)
+		slog.Info("hub listening", "addr", s.cfg.Addr, "local", listenURL)
 	} else {
-		slog.Info("hub listening", "socket", sockPath)
+		slog.Info("hub listening", "local", listenURL)
 	}
 
 	if err := <-errCh; err != http.ErrServerClosed {
@@ -370,25 +359,8 @@ func (s *Server) Serve(ctx context.Context) error {
 	// 4. Wait for the shutdown goroutine to complete.
 	<-shutdownDone
 
-	// 5. Clean up socket.
-	_ = os.Remove(sockPath)
-
-	// 6. Close store.
+	// 5. Close store. The local listener cleans up its own endpoint (unix
+	// socket file unlinks itself on Close; named pipes auto-release).
 	_ = s.store.Close()
 	return nil
-}
-
-// removeStaleSocket removes a leftover socket file from a previous crash.
-func removeStaleSocket(path string) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if info.Mode().Type() == fs.ModeSocket {
-		return os.Remove(path)
-	}
-	return fmt.Errorf("%s exists but is not a socket", path)
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -190,8 +190,11 @@ func TestResolveDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("absolute data dir used as-is", func(t *testing.T) {
-		result := ResolveDataDir("/absolute/data", "/some/config.yaml", "/default/config/dir")
-		assert.Equal(t, "/absolute/data", result)
+		// Pick a path that's absolute on whatever OS we're running on so the
+		// "return as-is" branch of ResolveDataDir is actually exercised.
+		absDir := t.TempDir() // always absolute
+		result := ResolveDataDir(absDir, "/some/config.yaml", "/default/config/dir")
+		assert.Equal(t, absDir, result)
 	})
 
 	t.Run("relative data dir resolved against config file directory", func(t *testing.T) {

--- a/backend/internal/hub/config/config.go
+++ b/backend/internal/hub/config/config.go
@@ -12,6 +12,7 @@ import (
 	internalconfig "github.com/leapmux/leapmux/internal/config"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/locallisten"
 )
 
 const (
@@ -31,6 +32,7 @@ const (
 // Config holds the hub's runtime configuration.
 type Config struct {
 	Addr                         string        `koanf:"addr"`
+	LocalListen                  string        `koanf:"local_listen"`
 	DataDir                      string        `koanf:"data_dir"`
 	DevFrontend                  string        `koanf:"dev_frontend"`
 	MaxMessageSize               int           `koanf:"max_message_size"`
@@ -235,6 +237,7 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 
 	allFlags := []flagDef{
 		{"addr", "addr", "listen address", ptrconv.Ptr(addr), nil, nil},
+		{"local-listen", "local_listen", "local IPC listen URL (unix:<path> or npipe:<name>); platform default used if empty", ptrconv.Ptr(""), nil, nil},
 		{"data-dir", "data_dir", "data directory", ptrconv.Ptr("."), nil, nil},
 		{"dev-frontend", "dev_frontend", "Vite dev server URL for reverse proxy (dev mode only)", ptrconv.Ptr(""), nil, nil},
 		{"max-message-size", "max_message_size", "maximum reassembled channel message size in bytes (default 16 MiB)", nil, ptrconv.Ptr(0), nil},
@@ -334,6 +337,14 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 	var cfg Config
 	if err := k.Unmarshal("", &cfg); err != nil {
 		return nil, false, fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	// Validate --local-listen early: malformed values should surface at
+	// startup with a clear error rather than failing later inside Serve.
+	if cfg.LocalListen != "" {
+		if _, _, err := locallisten.Parse(cfg.LocalListen); err != nil {
+			return nil, false, fmt.Errorf("invalid local_listen: %w", err)
+		}
 	}
 
 	// Resolve relative data_dir against config file directory.
@@ -440,7 +451,13 @@ func (c *Config) BaseURL() string {
 	return scheme + "://" + host
 }
 
-// SocketPath returns the path to the Unix domain socket.
-func (c *Config) SocketPath() string {
-	return filepath.Join(c.DataDir, "hub.sock")
+// LocalListenURL returns the local IPC listen URL the hub should bind.
+// If the user set --local-listen explicitly, that value is returned verbatim.
+// Otherwise a per-platform default is used: unix:<data-dir>/hub.sock on Unix,
+// npipe:leapmux-hub-<SID> on Windows.
+func (c *Config) LocalListenURL() (string, error) {
+	if c.LocalListen != "" {
+		return c.LocalListen, nil
+	}
+	return defaultLocalListen(c.DataDir)
 }

--- a/backend/internal/hub/config/config_test.go
+++ b/backend/internal/hub/config/config_test.go
@@ -96,8 +96,9 @@ log_level: "debug"
 		tmpDir := t.TempDir()
 		dataDir := filepath.Join(tmpDir, "mydata")
 		configPath := filepath.Join(tmpDir, "hub.yaml")
-		yamlContent := `data_dir: "` + dataDir + `"
-`
+		// YAML single quotes are literal — no backslash escape processing,
+		// which matters on Windows where dataDir looks like `C:\Users\...`.
+		yamlContent := "data_dir: '" + dataDir + "'\n"
 		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o644))
 
 		cfg, _, err := Load([]string{"-config", configPath})
@@ -244,8 +245,7 @@ func TestValidate(t *testing.T) {
 
 func TestPaths(t *testing.T) {
 	cfg := &Config{DataDir: "/test/dir"}
-	assert.Equal(t, "/test/dir/hub.db", cfg.SQLiteDBPath(), "defaults to DataDir/hub.db")
-	assert.Equal(t, "/test/dir/hub.sock", cfg.SocketPath())
+	assert.Equal(t, filepath.Join("/test/dir", "hub.db"), cfg.SQLiteDBPath(), "defaults to DataDir/hub.db")
 
 	cfg.Storage.SQLite.Path = "/custom/path.db"
 	assert.Equal(t, "/custom/path.db", cfg.SQLiteDBPath(), "uses explicit SQLite path")

--- a/backend/internal/hub/config/default_listen_unix.go
+++ b/backend/internal/hub/config/default_listen_unix.go
@@ -1,0 +1,11 @@
+//go:build unix
+
+package config
+
+import "path/filepath"
+
+// defaultLocalListen returns the default local-listen URL on Unix:
+// "hub.sock" inside the configured data directory.
+func defaultLocalListen(dataDir string) (string, error) {
+	return "unix:" + filepath.Join(dataDir, "hub.sock"), nil
+}

--- a/backend/internal/hub/config/default_listen_windows.go
+++ b/backend/internal/hub/config/default_listen_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"os/user"
+)
+
+// defaultLocalListen returns a per-user npipe URL; the SID in the name
+// prevents cross-user collisions on a shared host.
+func defaultLocalListen(_ string) (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("resolve current user for local-listen default: %w", err)
+	}
+	if u.Uid == "" {
+		return "", fmt.Errorf("current user has empty SID; cannot derive local-listen default")
+	}
+	return "npipe:leapmux-hub-" + u.Uid, nil
+}

--- a/backend/internal/hub/config/local_listen_test.go
+++ b/backend/internal/hub/config/local_listen_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/locallisten"
+)
+
+// TestLocalListen_DefaultPerPlatform verifies the default-path computation.
+// The per-platform helpers live in default_listen_{unix,windows}.go — this
+// test is platform-agnostic but its expectation branches on runtime.GOOS.
+func TestLocalListen_DefaultPerPlatform(t *testing.T) {
+	cfg := &Config{DataDir: "/data/leapmux/hub"}
+	got, err := cfg.LocalListenURL()
+	require.NoError(t, err)
+	switch runtime.GOOS {
+	case "windows":
+		assert.True(t, strings.HasPrefix(got, "npipe:leapmux-hub"),
+			"expected Windows default to start with npipe:leapmux-hub, got %q", got)
+	default:
+		assert.Equal(t, "unix:/data/leapmux/hub/hub.sock", got)
+	}
+}
+
+func TestLocalListen_ExplicitUnix(t *testing.T) {
+	cfg := &Config{LocalListen: "unix:/srv/custom.sock", DataDir: "/ignored"}
+	got, err := cfg.LocalListenURL()
+	require.NoError(t, err)
+	assert.Equal(t, "unix:/srv/custom.sock", got)
+}
+
+func TestLocalListen_ExplicitNpipe(t *testing.T) {
+	cfg := &Config{LocalListen: "npipe:custom-hub", DataDir: "/ignored"}
+	got, err := cfg.LocalListenURL()
+	require.NoError(t, err)
+	assert.Equal(t, "npipe:custom-hub", got)
+}
+
+func TestLoad_LocalListenFlagRoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"unix", "unix:/srv/leapmux/hub.sock", "unix:/srv/leapmux/hub.sock"},
+		{"npipe short", "npipe:custom-hub", "npipe:custom-hub"},
+		{"npipe full NT", `npipe:\\.\pipe\custom-hub`, `npipe:\\.\pipe\custom-hub`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, _, err := Load([]string{"-local-listen", tc.arg})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.LocalListen)
+			got, err := cfg.LocalListenURL()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestLoad_LocalListenEmptyFallsBackToDefault(t *testing.T) {
+	cfg, _, err := Load(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", cfg.LocalListen, "flag not set should not back-fill the field")
+	// LocalListenURL() resolves to the per-platform default.
+	got, err := cfg.LocalListenURL()
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}
+
+func TestLoad_LocalListenEnvVarRoundTrips(t *testing.T) {
+	t.Setenv(locallisten.EnvLocalListen, "unix:/from/env.sock")
+	cfg, _, err := Load(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "unix:/from/env.sock", cfg.LocalListen)
+}
+
+// TestLoad_LocalListenMalformedRejected confirms that a bad --local-listen
+// value is surfaced at Load time rather than deferred to the listener.
+// Covers: unknown scheme, missing target after the scheme colon, plain
+// strings with no scheme at all.
+func TestLoad_LocalListenMalformedRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{"unknown scheme", "gopher://example:70/bogus"},
+		{"tcp scheme", "tcp://127.0.0.1:4327"},
+		{"missing target unix", "unix:"},
+		{"missing target npipe", "npipe:"},
+		{"bare string no scheme", "just-a-name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Load([]string{"-local-listen", tc.arg})
+			require.Error(t, err, "Load should reject %q", tc.arg)
+			assert.Contains(t, err.Error(), "invalid local_listen",
+				"error should surface the field name so users can find the flag")
+		})
+	}
+}

--- a/backend/internal/hub/keystore/keystore_test.go
+++ b/backend/internal/hub/keystore/keystore_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,10 +180,15 @@ func TestAutoGenerateKeyFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), ks.ActiveVersion())
 
-	// Verify file permissions.
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	// Verify file permissions. Skipped on Windows: NTFS uses ACLs, not Unix
+	// mode bits, so os.FileInfo.Mode only reports a coarse approximation
+	// (typically 0o666). Per-user security on Windows is enforced via the
+	// inherited ACL of %LOCALAPPDATA%, not via chmod.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }
 
 func TestLoadFromBase64File(t *testing.T) {

--- a/backend/internal/worker/agent/acp_refresh_test.go
+++ b/backend/internal/worker/agent/acp_refresh_test.go
@@ -1,3 +1,7 @@
+//go:build unix
+
+// Depends on helpers in claude_test.go / goose_test.go that spawn /bin/sh.
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/config"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 // Control response behavior values (shared protocol between frontend and backend).
@@ -249,5 +250,6 @@ func checkBinaryAvailable(ctx context.Context, shellPath string, loginShell bool
 
 	cmd := exec.CommandContext(ctx, shellPath, args...)
 	cmd.Dir = os.TempDir()
+	procutil.HideConsoleWindow(cmd)
 	return cmd.Run() == nil
 }

--- a/backend/internal/worker/agent/attachment_test.go
+++ b/backend/internal/worker/agent/attachment_test.go
@@ -1,3 +1,7 @@
+//go:build unix
+
+// Depends on helpers in claude_test.go / goose_test.go that spawn /bin/sh.
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/codex_test.go
+++ b/backend/internal/worker/agent/codex_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -1,3 +1,7 @@
+//go:build unix
+
+// Depends on helpers in claude_test.go / goose_test.go that spawn /bin/sh.
+
 package agent
 
 import (

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/leapmux/leapmux/internal/worker/terminal"
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 // buildShellWrappedCommand constructs an exec.Cmd that launches a binary
@@ -46,7 +47,7 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 			cmdArgs = []string{"-Command", inner}
 		}
 	case shellName == "tcsh" || shellName == "csh":
-		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
+		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
 		if interactive {
 			cmdArgs = []string{"-ic", inner} // tcsh: -l must be the only flag
 		} else {
@@ -61,7 +62,7 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 		}
 	default:
 		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
-		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs, true)
+		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
 		if interactive {
 			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-c", inner)
 		} else {
@@ -71,22 +72,18 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 
 	cmd := exec.CommandContext(ctx, shellPath, cmdArgs...)
 	cmd.Dir = workingDir
+	procutil.HideConsoleWindow(cmd)
 	return cmd, delimiter, metaPrefix
 }
 
 // buildPosixCommand builds the inner command string for POSIX-like shells.
-// If useExec is true, the command uses exec to replace the shell process.
-// When modelEffortArgs is non-empty, a conditional is emitted to check for
-// third-party provider env vars at runtime.
-func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, metaPrefix string, baseArgs, modelEffortArgs []string, useExec bool) string {
+// The command is always prefixed with `exec` so the shell process is
+// replaced. When modelEffortArgs is non-empty, a conditional is emitted to
+// check for third-party provider env vars at runtime.
+func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
 	quotedBase := make([]string, len(baseArgs))
 	for i, arg := range baseArgs {
 		quotedBase[i] = posixQuote(arg)
-	}
-
-	execPrefix := ""
-	if useExec {
-		execPrefix = "exec "
 	}
 
 	baseArgsStr := strings.Join(quotedBase, " ")
@@ -94,8 +91,8 @@ func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, meta
 
 	// Simple path: no model/effort args (third-party detected from settings).
 	if len(modelEffortArgs) == 0 {
-		return fmt.Sprintf("%secho '%s' && %s%s %s",
-			clearEnvPrefix, delimiter, execPrefix, binaryName, baseArgsStr)
+		return fmt.Sprintf("%secho '%s' && exec %s %s",
+			clearEnvPrefix, delimiter, binaryName, baseArgsStr)
 	}
 
 	// Conditional path: check env vars at runtime.
@@ -109,14 +106,14 @@ func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, meta
 		"%s"+
 			"if "+posixEnvCondition()+"; then "+
 			"echo '%scan_change_model_and_effort=false' && "+
-			"echo '%s' && %s%s %s; "+
+			"echo '%s' && exec %s %s; "+
 			"else "+
 			"echo '%scan_change_model_and_effort=true' && "+
-			"echo '%s' && %s%s %s %s; "+
+			"echo '%s' && exec %s %s %s; "+
 			"fi",
 		clearEnvPrefix,
-		metaPrefix, delimiter, execPrefix, binaryName, baseArgsStr,
-		metaPrefix, delimiter, execPrefix, binaryName, baseArgsStr, meArgsStr,
+		metaPrefix, delimiter, binaryName, baseArgsStr,
+		metaPrefix, delimiter, binaryName, baseArgsStr, meArgsStr,
 	)
 }
 

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -235,7 +235,7 @@ func TestBuildShellWrappedCommand_NoModelEffort_Pwsh(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_ModelEffortInElseBranch(t *testing.T) {
-	inner := buildPosixCommand("claude", []string{"CLAUDECODE"}, "__DELIM__", "__META__ ", []string{"--output-format", "stream-json"}, []string{"--model", "opus", "--effort", "high"}, true)
+	inner := buildPosixCommand("claude", []string{"CLAUDECODE"}, "__DELIM__", "__META__ ", []string{"--output-format", "stream-json"}, []string{"--model", "opus", "--effort", "high"})
 
 	// The else branch should contain model/effort args
 	parts := strings.SplitN(inner, "else", 2)

--- a/backend/internal/worker/config/config.go
+++ b/backend/internal/worker/config/config.go
@@ -153,7 +153,7 @@ func Load(args []string) (*Config, bool, error) {
 	// Define CLI flags.
 	fs := flag.NewFlagSet("worker", flag.ContinueOnError)
 	fs.String("config", defaultConfigFile, "path to config file")
-	fs.String("hub", defaultHubURL, "Hub server URL or unix:<socket-path>")
+	fs.String("hub", defaultHubURL, "Hub server URL (http[s]://..., unix:<socket-path>, or npipe:<pipe-name>)")
 	fs.String("name", "", "worker display name (default: hostname)")
 	fs.String("data-dir", ".", "data directory")
 	fs.Int("db-max-conns", sqlitedb.DefaultMaxConns, "maximum number of open database connections")

--- a/backend/internal/worker/config/config_test.go
+++ b/backend/internal/worker/config/config_test.go
@@ -91,8 +91,11 @@ log_level: "warn"
 		tmpDir := t.TempDir()
 		dataDir := filepath.Join(tmpDir, "mydata")
 		configPath := filepath.Join(tmpDir, "worker.yaml")
-		yamlContent := `data_dir: "` + dataDir + `"
-`
+		// Use YAML single quotes: they're literal and don't interpret
+		// backslash escapes, which matters on Windows where dataDir is
+		// something like `C:\Users\...` and `\U` triggers a YAML error in
+		// double-quoted strings.
+		yamlContent := "data_dir: '" + dataDir + "'\n"
 		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o644))
 
 		cfg, _, err := Load([]string{"-config", configPath})
@@ -141,6 +144,6 @@ func TestValidate(t *testing.T) {
 
 func TestPaths(t *testing.T) {
 	cfg := &Config{DataDir: "/test/dir"}
-	assert.Equal(t, "/test/dir/worker.db", cfg.DBPath())
-	assert.Equal(t, "/test/dir/state.json", cfg.StatePath())
+	assert.Equal(t, filepath.Join("/test/dir", "worker.db"), cfg.DBPath())
+	assert.Equal(t, filepath.Join("/test/dir", "state.json"), cfg.StatePath())
 }

--- a/backend/internal/worker/config/hub_url_scheme_test.go
+++ b/backend/internal/worker/config/hub_url_scheme_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoad_HubFlagAcceptsAllTransportSchemes verifies the --hub CLI flag
+// round-trips every URL shape supported by backend/internal/worker/hub.New.
+// Load itself performs no scheme validation — dispatch happens later in the
+// transport layer — so these tests enforce that the flag value is preserved
+// verbatim for every expected scheme.
+func TestLoad_HubFlagAcceptsAllTransportSchemes(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{"http", "http://localhost:4327"},
+		{"https", "https://hub.example:443"},
+		{"unix", "unix:/tmp/leapmux/hub.sock"},
+		{"npipe short", "npipe:leapmux-hub"},
+		{"npipe full NT", `npipe:\\.\pipe\leapmux-hub`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, _, err := Load([]string{"-hub", tc.arg})
+			require.NoError(t, err)
+			assert.Equal(t, tc.arg, cfg.HubURL)
+		})
+	}
+}
+
+func TestLoad_HubFlagDefaultRemainsHTTP(t *testing.T) {
+	cfg, _, err := Load(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:4327", cfg.HubURL,
+		"default HubURL should be preserved for backwards compatibility")
+}

--- a/backend/internal/worker/filebrowser/browser_test.go
+++ b/backend/internal/worker/filebrowser/browser_test.go
@@ -1,3 +1,12 @@
+//go:build unix
+
+// filebrowser's ListDirectory / ReadFile / StatFile call
+// validate.SanitizePath, which only accepts POSIX-style absolute paths
+// (starting with `/`). Windows absolute paths (`C:\...`) are rejected, so
+// these integration tests are inherently Unix-only. Until file browsing
+// grows explicit Windows-path support, the Windows path is exercised via
+// the desktop end-to-end tests instead.
+
 package filebrowser
 
 import (

--- a/backend/internal/worker/gitutil/gitutil.go
+++ b/backend/internal/worker/gitutil/gitutil.go
@@ -11,15 +11,18 @@ import (
 	"unicode"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 var errNotGitRepo = errors.New("not a git repository")
 
-// NewGitCmd creates an exec.Cmd for git with terminal interaction disabled.
+// NewGitCmd creates an exec.Cmd for git with terminal interaction disabled
+// and no console window on Windows.
 func NewGitCmd(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	cmd.Stdin = nil
+	procutil.HideConsoleWindow(cmd)
 	return cmd
 }
 

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
+	"golang.org/x/net/http2"
 
 	"connectrpc.com/connect"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -22,7 +24,7 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
-	"golang.org/x/net/http2"
+	"github.com/leapmux/leapmux/locallisten"
 )
 
 // Client manages the connection to the Hub.
@@ -65,26 +67,12 @@ type Client struct {
 
 // New creates a new Hub client with integrated lifecycle management.
 // It creates agent and terminal managers internally.
-// If hubURL starts with "unix:", it creates a Unix domain socket transport automatically.
+// hubURL may be:
+//   - http[s]://host:port — a remote Hub reached over TCP
+//   - unix:<socket-path>  — a local Hub reached over a Unix domain socket
+//   - npipe:<pipe-name>   — a local Hub reached over a Windows named pipe
 func New(hubURL string) *Client {
-	if strings.HasPrefix(hubURL, "unix:") {
-		socketPath := strings.TrimPrefix(hubURL, "unix:")
-		return NewWithHTTPClient(newUnixSocketClient(socketPath), hubURL)
-	}
-	return NewWithHTTPClient(newH2CClient(), hubURL)
-}
-
-// NewWithHTTPClient creates a new Hub client that uses the provided HTTP client
-// for ConnectRPC communication. This allows callers to provide a custom transport
-// (e.g. one that dials via Unix domain socket).
-func NewWithHTTPClient(httpClient *http.Client, hubURL string) *Client {
-	// When connecting via Unix domain socket, hubURL is "unix:<path>".
-	// ConnectRPC needs a valid HTTP base URL, so use http://localhost instead.
-	connectURL := hubURL
-	if strings.HasPrefix(hubURL, "unix:") {
-		connectURL = "http://localhost"
-	}
-
+	httpClient, connectURL := clientForHubURL(hubURL)
 	c := &Client{
 		connector: leapmuxv1connect.NewWorkerConnectorServiceClient(
 			httpClient,
@@ -94,7 +82,6 @@ func NewWithHTTPClient(httpClient *http.Client, hubURL string) *Client {
 		hubURL:    hubURL,
 		terminals: terminal.NewManager(),
 	}
-
 	c.agents = agent.NewManager(func(agentID string, exitCode int, err error) {
 		if err != nil {
 			slog.Info("agent exited with error", "agent_id", agentID, "exit_code", exitCode, "error", err)
@@ -102,8 +89,26 @@ func NewWithHTTPClient(httpClient *http.Client, hubURL string) *Client {
 			slog.Info("agent exited", "agent_id", agentID, "exit_code", exitCode)
 		}
 	})
-
 	return c
+}
+
+// clientForHubURL picks the HTTP client and ConnectRPC URL for hubURL.
+// Local-IPC schemes (unix:/npipe:) get a dialer-backed h2c client and a
+// placeholder "http://localhost" route (the transport dials the real
+// endpoint); remote URLs pass through to a plain h2c client.
+func clientForHubURL(hubURL string) (*http.Client, string) {
+	if locallisten.IsLocal(hubURL) {
+		dial, _ := locallisten.Dialer(hubURL) // IsLocal guarantees success.
+		return &http.Client{Transport: locallisten.NewLocalH2CTransport(dial)}, "http://localhost"
+	}
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, addr)
+		},
+	}
+	return &http.Client{Transport: transport}, hubURL
 }
 
 // Stop gracefully stops all managers.
@@ -130,33 +135,6 @@ func (c *Client) AgentManager() *agent.Manager {
 // TerminalManager returns the terminal manager.
 func (c *Client) TerminalManager() *terminal.Manager {
 	return c.terminals
-}
-
-// newH2CClient creates an HTTP client that supports HTTP/2 cleartext (h2c),
-// which is required for gRPC bidirectional streaming over plain HTTP.
-func newH2CClient() *http.Client {
-	return &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, network, addr)
-			},
-		},
-	}
-}
-
-// newUnixSocketClient creates an h2c HTTP client that dials via a Unix domain socket.
-func newUnixSocketClient(socketPath string) *http.Client {
-	return &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, "unix", socketPath)
-			},
-		},
-	}
 }
 
 // Send sends a message to the Hub via the bidi stream.
@@ -413,12 +391,9 @@ func (c *Client) connectWithReconnect(ctx context.Context, authToken string, con
 
 // isCodeUnauthenticated checks if an error is a ConnectRPC Unauthenticated error.
 func isCodeUnauthenticated(err error) bool {
-	if err == nil {
-		return false
-	}
-	if connectErr, ok := err.(*connect.Error); ok {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
 		return connectErr.Code() == connect.CodeUnauthenticated
 	}
-	// The error may be wrapped - check for the string pattern as fallback.
-	return strings.Contains(err.Error(), "unauthenticated")
+	return false
 }

--- a/backend/internal/worker/hub/client_test.go
+++ b/backend/internal/worker/hub/client_test.go
@@ -3,16 +3,84 @@ package hub
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNew_DispatchesOnURLScheme verifies the scheme-dispatch branches in
+// New() construct a non-nil *Client for every supported URL shape.
+// Transport-level round-trip tests live alongside each scheme.
+func TestNew_DispatchesOnURLScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"http", "http://localhost:4327"},
+		{"https", "https://hub.example:443"},
+		{"unix", "unix:/tmp/hub.sock"},
+		{"npipe short", "npipe:leapmux-hub-test"},
+		{"npipe full NT", `npipe:\\.\pipe\leapmux-hub-test`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := New(tc.url)
+			require.NotNil(t, client, "New(%q) returned nil", tc.url)
+			assert.Equal(t, tc.url, client.hubURL, "hubURL preserved verbatim")
+		})
+	}
+}
+
+// Regression guards: a scheme-dispatch bug silently routes local URLs to
+// the plain h2c dialer, which then resolves them as DNS host:port. Each
+// test asserts the resulting error is NOT from the TCP/DNS path.
+func TestHTTPClientForHubURL_NpipeDispatches(t *testing.T) {
+	assertDialNotRoutedToTCP(t, "npipe:leapmux-hub-nonexistent")
+}
+
+func TestHTTPClientForHubURL_UnixDispatches(t *testing.T) {
+	assertDialNotRoutedToTCP(t, "unix:/nonexistent/leapmux.sock")
+}
+
+func TestHTTPClientForHubURL_HTTPFallsBackToH2C(t *testing.T) {
+	httpClient, connectURL := clientForHubURL("http://127.0.0.1:1")
+	require.NotNil(t, httpClient)
+	assert.Equal(t, "http://127.0.0.1:1", connectURL, "remote URL should pass through verbatim")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://127.0.0.1:1/probe", nil)
+	require.NoError(t, err)
+
+	_, err = httpClient.Do(req)
+	require.Error(t, err)
+}
+
+func assertDialNotRoutedToTCP(t *testing.T, url string) {
+	t.Helper()
+	httpClient, connectURL := clientForHubURL(url)
+	require.NotNil(t, httpClient)
+	assert.Equal(t, "http://localhost", connectURL, "%s should route through localhost placeholder", url)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost/probe", nil)
+	require.NoError(t, err)
+
+	_, err = httpClient.Do(req)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.NotContains(t, msg, "no such host", "%s dispatched through DNS", url)
+	assert.NotContains(t, msg, "dial tcp", "%s dispatched to TCP dialer", url)
+}
 
 func TestResolveWorkingDir_HomeDir(t *testing.T) {
 	home, err := os.UserHomeDir()
@@ -232,4 +300,27 @@ func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 		gap := timestamps[i].Sub(timestamps[i-1])
 		assert.LessOrEqual(t, gap, bo.MaxInterval+tolerance, "gap[%d]=%v exceeds MaxInterval=%v", i, gap, bo.MaxInterval)
 	}
+}
+
+func TestIsCodeUnauthenticated(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.False(t, isCodeUnauthenticated(nil))
+	})
+	t.Run("direct connect.Error unauthenticated", func(t *testing.T) {
+		err := connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("bad token"))
+		assert.True(t, isCodeUnauthenticated(err))
+	})
+	t.Run("wrapped connect.Error unauthenticated", func(t *testing.T) {
+		inner := connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("bad token"))
+		err := fmt.Errorf("connect to hub: %w", inner)
+		assert.True(t, isCodeUnauthenticated(err), "errors.As should unwrap")
+	})
+	t.Run("other connect code", func(t *testing.T) {
+		err := connect.NewError(connect.CodeUnavailable, fmt.Errorf("server down"))
+		assert.False(t, isCodeUnauthenticated(err))
+	})
+	t.Run("non-connect error containing the word unauthenticated", func(t *testing.T) {
+		err := fmt.Errorf("some other unauthenticated failure")
+		assert.False(t, isCodeUnauthenticated(err), "string match must not leak through")
+	})
 }

--- a/backend/internal/worker/hub/registration.go
+++ b/backend/internal/worker/hub/registration.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -14,6 +12,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/logging"
+	"github.com/leapmux/leapmux/locallisten"
 )
 
 // RegistrationResult contains the credentials obtained after registration approval.
@@ -28,17 +27,10 @@ type RegistrationResult struct {
 // 2. Print the approval URL for the user.
 // 3. Poll until the registration is approved or expires.
 //
-// If hubURL starts with "unix:", it creates a Unix domain socket transport automatically.
+// A hubURL with a local-IPC scheme (locallisten.SchemeUnix or SchemeNpipe)
+// is dispatched to the matching transport automatically.
 func Register(ctx context.Context, hubURL, version string, publicKey, mlkemPublicKey, slhdsaPublicKey []byte) (*RegistrationResult, error) {
-	var httpClient *http.Client
-	connectURL := hubURL
-	if strings.HasPrefix(hubURL, "unix:") {
-		socketPath := strings.TrimPrefix(hubURL, "unix:")
-		httpClient = newUnixSocketClient(socketPath)
-		connectURL = "http://localhost"
-	} else {
-		httpClient = newH2CClient()
-	}
+	httpClient, connectURL := clientForHubURL(hubURL)
 	client := leapmuxv1connect.NewWorkerConnectorServiceClient(
 		httpClient,
 		connectURL,
@@ -50,7 +42,8 @@ func Register(ctx context.Context, hubURL, version string, publicKey, mlkemPubli
 func registerWithClient(
 	ctx context.Context,
 	client leapmuxv1connect.WorkerConnectorServiceClient,
-	hubURL, version string,
+	hubURL string,
+	version string,
 	publicKey, mlkemPublicKey, slhdsaPublicKey []byte,
 	bo backoff.BackOff,
 ) (*RegistrationResult, error) {
@@ -87,9 +80,10 @@ func registerWithClient(
 	regToken := reqResp.Msg.GetRegistrationToken()
 	regPath := reqResp.Msg.GetRegistrationUrl()
 
-	if strings.HasPrefix(hubURL, "unix:") {
-		// Unix socket — can't construct a browser-navigable URL.
-		// Show the relative path and let the user navigate via the Hub's web UI.
+	if locallisten.IsLocal(hubURL) {
+		// Local IPC (unix socket or named pipe) — can't construct a
+		// browser-navigable URL. Show the relative path and let the user
+		// navigate via the Hub's web UI.
 		slog.Info("registration requested — approve via Hub web UI",
 			"path", regPath,
 			"token", regToken,

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -292,6 +293,9 @@ func TestWatchEvents_ClosedTerminal_NotWatched(t *testing.T) {
 }
 
 func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("terminal tests require /bin/sh and creack/pty, which are not available on Windows")
+	}
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
 	workingDir := t.TempDir()
@@ -346,6 +350,9 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 }
 
 func TestOpenTerminal_ExitPersistsDisconnectNotice(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("terminal tests require /bin/sh and creack/pty, which are not available on Windows")
+	}
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	workingDir := t.TempDir()

--- a/backend/internal/worker/service/git_test.go
+++ b/backend/internal/worker/service/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -306,6 +307,9 @@ func TestResolveMainRepoRoot_Subdirectory(t *testing.T) {
 }
 
 func TestResolveMainRepoRoot_LinkedWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("resolveMainRepoRoot needs Windows-path awareness")
+	}
 	dir := initRepo(t)
 	resolved, err := filepath.EvalSymlinks(dir)
 	require.NoError(t, err)
@@ -321,6 +325,9 @@ func TestResolveMainRepoRoot_LinkedWorktree(t *testing.T) {
 }
 
 func TestResolveMainRepoRoot_NestedWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("resolveMainRepoRoot needs Windows-path awareness")
+	}
 	dir := initRepo(t)
 	resolved, err := filepath.EvalSymlinks(dir)
 	require.NoError(t, err)
@@ -370,6 +377,9 @@ func waitForPathToDisappear(t *testing.T, path string) {
 }
 
 func TestInspectLastTabClose_WorktreeLastTabPromptsEvenWhenClean(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree path handling needs Windows-path awareness")
+	}
 	svc, _, _ := setupTestService(t, "ws-1")
 	repoDir := initRepo(t)
 	wtDir := filepath.Join(t.TempDir(), "inspect-clean-wt")
@@ -488,6 +498,9 @@ func TestPushBranchForClose_RecreatesUpstream(t *testing.T) {
 }
 
 func TestScheduleWorktreeDeletion_ExternalTrackedWorktreeDeletes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree path handling needs Windows-path awareness")
+	}
 	svc, _, _ := setupTestService(t, "ws-1")
 	repoDir := initRepo(t)
 	wtDir := filepath.Join(t.TempDir(), "external-tracked")

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -5,10 +5,11 @@ import (
 	"regexp"
 )
 
-var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
+var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?(?:\.exe)?$`)
 
 // IsPwsh returns true if the shell name matches PowerShell variants
-// (pwsh, powershell, pwsh-preview, powershell-preview).
+// (pwsh, powershell, pwsh-preview, powershell-preview, plus the ".exe"
+// suffix forms surfaced by filepath.Base on Windows).
 func IsPwsh(name string) bool {
 	return pwshPattern.MatchString(name)
 }

--- a/backend/internal/worker/terminal/login_shell_test.go
+++ b/backend/internal/worker/terminal/login_shell_test.go
@@ -22,6 +22,8 @@ func TestLoginShellArgs(t *testing.T) {
 		{"pwsh", "/usr/bin/pwsh", []string{"-Login"}},
 		{"powershell", "/usr/bin/powershell", []string{"-Login"}},
 		{"pwsh-preview", "/usr/bin/pwsh-preview", []string{"-Login"}},
+		{"pwsh.exe", `C:\Program Files\PowerShell\7\pwsh.exe`, []string{"-Login"}},
+		{"powershell.exe", `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, []string{"-Login"}},
 		{"unknown", "/usr/bin/xonsh", []string{"-i", "-l"}},
 	}
 	for _, tt := range tests {
@@ -32,15 +34,23 @@ func TestLoginShellArgs(t *testing.T) {
 }
 
 func TestIsPwsh(t *testing.T) {
-	// Positive cases
+	// Positive cases — Unix name forms
 	assert.True(t, IsPwsh("pwsh"))
 	assert.True(t, IsPwsh("powershell"))
 	assert.True(t, IsPwsh("pwsh-preview"))
 	assert.True(t, IsPwsh("powershell-preview"))
 
+	// Positive cases — Windows ".exe" suffix forms produced by filepath.Base
+	assert.True(t, IsPwsh("pwsh.exe"))
+	assert.True(t, IsPwsh("powershell.exe"))
+	assert.True(t, IsPwsh("pwsh-preview.exe"))
+	assert.True(t, IsPwsh("powershell-preview.exe"))
+
 	// Negative cases
 	assert.False(t, IsPwsh("bash"))
+	assert.False(t, IsPwsh("bash.exe"))
 	assert.False(t, IsPwsh("zsh"))
 	assert.False(t, IsPwsh("fish"))
 	assert.False(t, IsPwsh("pwsh-extra-stuff"))
+	assert.False(t, IsPwsh("pwshxexe")) // no dot -> must not match
 }

--- a/backend/internal/worker/terminal/shells.go
+++ b/backend/internal/worker/terminal/shells.go
@@ -5,38 +5,41 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
-var shellCache struct {
-	once         sync.Once
-	shells       []string
-	defaultShell string
+// resolveShells is swapped out by tests to invalidate the cache between
+// cases that mutate environment variables.
+var resolveShells = newShellsResolver()
+
+func newShellsResolver() func() (shells []string, defaultShell string) {
+	return sync.OnceValues(computeShells)
 }
 
-func initShellCache() {
-	shellCache.defaultShell = resolveDefaultShellOnce()
-
+func computeShells() (shells []string, defaultShell string) {
+	defaultShell = resolveDefaultShellOnce()
 	// Place the default shell first so it appears at the top of
 	// the UI dropdown.
-	if shellCache.defaultShell != "" {
-		shellCache.shells = append(shellCache.shells, shellCache.defaultShell)
+	if defaultShell != "" {
+		shells = append(shells, defaultShell)
 	}
 
-	knownShells := []string{"sh", "bash", "zsh", "fish"}
+	knownShells := []string{"sh", "bash", "zsh", "fish", "pwsh", "powershell"}
+	defaultBase := strings.ToLower(strings.TrimSuffix(filepath.Base(defaultShell), ".exe"))
 	for _, name := range knownShells {
+		if name == defaultBase {
+			continue
+		}
 		path, err := exec.LookPath(name)
 		if err != nil {
 			continue
 		}
-		// Skip if it duplicates the default shell already at [0].
-		if path == shellCache.defaultShell {
-			continue
-		}
-		shellCache.shells = append(shellCache.shells, path)
+		shells = append(shells, path)
 	}
 
-	slog.Info("available shells resolved", "shells", shellCache.shells, "default", shellCache.defaultShell)
+	slog.Info("available shells resolved", "shells", shells, "default", defaultShell)
+	return shells, defaultShell
 }
 
 // ResolveDefaultShell returns the user's default shell.  It checks the
@@ -45,8 +48,8 @@ func initShellCache() {
 // environment variable, and finally falls back to platform-specific detection
 // (e.g. dscl on macOS, /etc/passwd on Linux).
 func ResolveDefaultShell() string {
-	shellCache.once.Do(initShellCache)
-	return shellCache.defaultShell
+	_, def := resolveShells()
+	return def
 }
 
 func resolveDefaultShellOnce() string {
@@ -91,7 +94,5 @@ func resolveShellEnv(name string) string {
 // as separate entries even if the underlying binary is the same, because
 // invoking as "sh" activates POSIX mode.
 func ListAvailableShells() (shells []string, defaultShell string) {
-	shellCache.once.Do(initShellCache)
-
-	return shellCache.shells, shellCache.defaultShell
+	return resolveShells()
 }

--- a/backend/internal/worker/terminal/shells_other.go
+++ b/backend/internal/worker/terminal/shells_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package terminal
 

--- a/backend/internal/worker/terminal/shells_windows.go
+++ b/backend/internal/worker/terminal/shells_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package terminal
+
+import "os/exec"
+
+func detectDefaultShell() string {
+	for _, name := range []string{"pwsh", "powershell"} {
+		if path, err := exec.LookPath(name); err == nil {
+			return path
+		}
+	}
+	// Every supported Windows release ships this path.
+	return `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+}

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9,6 +10,8 @@ import (
 	"sync"
 
 	"github.com/creack/pty"
+
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 const screenBufferSize = 100 * 1024 // 100KB ring buffer for screen restore
@@ -99,6 +102,7 @@ func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 	cmd.Env = append(os.Environ(),
 		"TERM=xterm-256color",
 	)
+	procutil.HideConsoleWindow(cmd)
 
 	winSize := &pty.Winsize{
 		Cols: opts.Cols,
@@ -234,7 +238,7 @@ func (t *Terminal) readOutput() {
 			t.outputFn(data)
 		}
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				slog.Debug("terminal read error",
 					"terminal_id", t.id,
 					"error", err,

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -16,7 +17,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// skipIfNoPTY skips tests that spawn a real PTY. creack/pty returns
+// "unsupported" on Windows — the production worker falls back to ConPTY
+// where available, but the test harness uses /bin/sh directly which isn't
+// reachable from Windows anyway.
+func skipIfNoPTY(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY tests require /bin/sh and creack/pty, which are not available on Windows")
+	}
+}
+
 func TestTerminal_StartAndStop(t *testing.T) {
+	skipIfNoPTY(t)
 	var mu sync.Mutex
 	var output []byte
 
@@ -53,6 +66,7 @@ func TestTerminal_StartAndStop(t *testing.T) {
 }
 
 func TestTerminal_Resize(t *testing.T) {
+	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-resize",
 		Shell:      "/bin/sh",
@@ -70,6 +84,7 @@ func TestTerminal_Resize(t *testing.T) {
 }
 
 func TestTerminal_SendInputAfterStop(t *testing.T) {
+	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-stopped",
 		Shell:      "/bin/sh",
@@ -84,6 +99,7 @@ func TestTerminal_SendInputAfterStop(t *testing.T) {
 }
 
 func TestTerminal_IsExited(t *testing.T) {
+	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-exited",
 		Shell:      "/bin/sh",
@@ -100,6 +116,7 @@ func TestTerminal_IsExited(t *testing.T) {
 }
 
 func TestManager_StartAndRemove(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 
 	err := m.StartTerminal(Options{
@@ -134,6 +151,7 @@ func TestManager_StartAndRemove(t *testing.T) {
 }
 
 func TestManager_ExitedTerminalRejectsInput(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 
 	err := m.StartTerminal(Options{
@@ -159,6 +177,7 @@ func TestManager_ExitedTerminalRejectsInput(t *testing.T) {
 }
 
 func TestManager_ExitNotification(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 	exitCh := make(chan struct{})
 	var gotID string
@@ -191,6 +210,7 @@ func TestManager_ExitNotification(t *testing.T) {
 }
 
 func TestManager_StopAll(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 
 	for _, id := range []string{"a", "b"} {
@@ -234,6 +254,7 @@ func TestManager_Resize_UnknownTerminal(t *testing.T) {
 }
 
 func TestManager_Resize_SameDimensions(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 	err := m.StartTerminal(Options{
 		ID:         "tm-resize-noop",
@@ -256,6 +277,7 @@ func TestManager_Resize_SameDimensions(t *testing.T) {
 }
 
 func TestManager_ScreenSnapshot(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 	var mu sync.Mutex
 	var output []byte
@@ -322,6 +344,7 @@ func newTestDB(t *testing.T) *db.Queries {
 }
 
 func TestSnapshotTerminal(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 	var mu sync.Mutex
 	var output []byte
@@ -402,6 +425,7 @@ func TestUpsertAndGetTerminal(t *testing.T) {
 }
 
 func TestUpdateTitle(t *testing.T) {
+	skipIfNoPTY(t)
 	m := NewManager()
 	wsID := "ws-title"
 
@@ -468,11 +492,10 @@ func TestUpsertTerminalTitle(t *testing.T) {
 	assert.Equal(t, "My Shell", row.Title)
 }
 
-// resetShellCache resets the sync.Once so ListAvailableShells recomputes.
+// resetShellCache swaps in a fresh sync.OnceValues so ListAvailableShells
+// recomputes after env-var mutations.
 func resetShellCache() {
-	shellCache.once = sync.Once{}
-	shellCache.shells = nil
-	shellCache.defaultShell = ""
+	resolveShells = newShellsResolver()
 }
 
 func TestListAvailableShells_ReturnsAtLeastOne(t *testing.T) {
@@ -529,10 +552,13 @@ func TestListAvailableShells_Cached(t *testing.T) {
 func TestDetectDefaultShell(t *testing.T) {
 	shell := detectDefaultShell()
 	assert.NotEmpty(t, shell, "detectDefaultShell should return a non-empty string")
-	assert.True(t, strings.HasPrefix(shell, "/"), "detectDefaultShell should return an absolute path")
+	assert.True(t, filepath.IsAbs(shell), "detectDefaultShell should return an absolute path, got %q", shell)
 }
 
 func TestResolveDefaultShell_PrefersLeapmuxEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
+	}
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "/bin/test-leapmux-shell")
 	t.Setenv("SHELL", "/bin/other-shell")
 	resetShellCache()
@@ -541,6 +567,9 @@ func TestResolveDefaultShell_PrefersLeapmuxEnv(t *testing.T) {
 }
 
 func TestResolveDefaultShell_LeapmuxEnvBareName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
+	}
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "sh")
 	t.Setenv("SHELL", "/bin/other-shell")
 	resetShellCache()
@@ -559,6 +588,9 @@ func TestResolveDefaultShell_LeapmuxEnvInvalidBareName(t *testing.T) {
 }
 
 func TestResolveDefaultShell_UsesEnvWhenSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
+	}
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
 	t.Setenv("SHELL", "/bin/test-shell")
 	resetShellCache()
@@ -572,7 +604,7 @@ func TestResolveDefaultShell_FallsBackWhenEnvUnset(t *testing.T) {
 	resetShellCache()
 	shell := ResolveDefaultShell()
 	assert.NotEmpty(t, shell, "ResolveDefaultShell should return a shell even without $SHELL")
-	assert.True(t, strings.HasPrefix(shell, "/"), "ResolveDefaultShell should return an absolute path")
+	assert.True(t, filepath.IsAbs(shell), "ResolveDefaultShell should return an absolute path, got %q", shell)
 }
 
 func TestResolveShellEnv_Empty(t *testing.T) {
@@ -581,6 +613,9 @@ func TestResolveShellEnv_Empty(t *testing.T) {
 }
 
 func TestResolveShellEnv_AbsolutePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-shell-path test: /usr/bin/zsh is not an absolute path on Windows")
+	}
 	t.Setenv("TEST_SHELL_ENV", "/usr/bin/zsh")
 	assert.Equal(t, "/usr/bin/zsh", resolveShellEnv("TEST_SHELL_ENV"))
 }

--- a/backend/locallisten/locallisten.go
+++ b/backend/locallisten/locallisten.go
@@ -1,0 +1,153 @@
+// Package locallisten hides the difference between Unix domain sockets and
+// Windows named pipes behind a small URL-based API. A local-listen URL has
+// the form "unix:<path>" or "npipe:<name>"; callers pass the string through
+// without caring which platform they're on, and per-scheme implementations
+// below do the right thing or return a clear ErrUnsupportedScheme error.
+package locallisten
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// Scheme identifies a local IPC transport.
+type Scheme string
+
+// Known schemes.
+const (
+	SchemeUnix  Scheme = "unix"
+	SchemeNpipe Scheme = "npipe"
+)
+
+// ErrUnsupportedScheme is returned when the URL's scheme is unknown or not
+// implemented on the current platform (e.g. npipe on Unix or unix on Windows).
+var ErrUnsupportedScheme = errors.New("unsupported local-listen scheme")
+
+// ErrMissingTarget is returned when the URL has a known scheme but the
+// trailing path/name is empty (e.g. "unix:", "npipe:").
+var ErrMissingTarget = errors.New("missing target after scheme")
+
+// EnvLocalListen is the env-var form of the hub's --local-listen flag.
+const EnvLocalListen = "LEAPMUX_HUB_LOCAL_LISTEN"
+
+// Parse splits a local-listen URL into its scheme and target components.
+// Accepted forms: "unix:<path>", "npipe:<name>", "npipe:<full-nt-path>".
+// The target is returned verbatim.
+func Parse(url string) (Scheme, string, error) {
+	if url == "" {
+		return "", "", fmt.Errorf("%w: empty url", ErrUnsupportedScheme)
+	}
+	for _, scheme := range []Scheme{SchemeUnix, SchemeNpipe} {
+		prefix := string(scheme) + ":"
+		if target, ok := strings.CutPrefix(url, prefix); ok {
+			if target == "" {
+				return "", "", fmt.Errorf("%w: %s", ErrMissingTarget, prefix)
+			}
+			return scheme, target, nil
+		}
+	}
+	return "", "", fmt.Errorf("%w: %q (expected unix:<path> or npipe:<name>)", ErrUnsupportedScheme, url)
+}
+
+// IsLocal reports whether url uses a local-IPC scheme (unix: or npipe:).
+func IsLocal(url string) bool {
+	_, _, err := Parse(url)
+	return err == nil
+}
+
+// Dialer returns a function that opens a fresh connection to the endpoint
+// encoded by url. Schemes the current platform can't implement return a
+// dialer that always fails with ErrUnsupportedScheme.
+func Dialer(url string) (func(ctx context.Context) (net.Conn, error), error) {
+	scheme, target, err := Parse(url)
+	if err != nil {
+		return nil, err
+	}
+	switch scheme {
+	case SchemeUnix:
+		return unixDialer(target), nil
+	case SchemeNpipe:
+		return npipeDialer(target), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedScheme, scheme)
+	}
+}
+
+// NewLocalH2CTransport wraps a pre-bound local-IPC dialer (unix:/npipe:) in
+// an HTTP/2-cleartext transport suitable for gRPC bidi streaming.
+func NewLocalH2CTransport(dial func(ctx context.Context) (net.Conn, error)) *http2.Transport {
+	return &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
+			return dial(ctx)
+		},
+	}
+}
+
+// HTTPDialContext adapts a pre-bound dialer to net/http's DialContext
+// signature. The network/addr args are ignored.
+func HTTPDialContext(dial func(ctx context.Context) (net.Conn, error)) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return dial(ctx)
+	}
+}
+
+// Listen opens a listener for the URL. Unsupported schemes return
+// ErrUnsupportedScheme wrapped with a descriptive message.
+func Listen(url string) (net.Listener, error) {
+	scheme, target, err := Parse(url)
+	if err != nil {
+		return nil, err
+	}
+	switch scheme {
+	case SchemeUnix:
+		return listenUnix(target)
+	case SchemeNpipe:
+		return listenNpipe(target)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedScheme, scheme)
+	}
+}
+
+// WaitReady polls until a client can dial the listener at url, or ctx is
+// cancelled.
+func WaitReady(ctx context.Context, url string) error {
+	dial, err := Dialer(url)
+	if err != nil {
+		return err
+	}
+	const (
+		overallTimeout = 5 * time.Second
+		backoff        = 100 * time.Millisecond
+		probeTimeout   = 100 * time.Millisecond
+	)
+	waitCtx, cancel := context.WithTimeout(ctx, overallTimeout)
+	defer cancel()
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	for {
+		probeCtx, probeCancel := context.WithTimeout(waitCtx, probeTimeout)
+		conn, err := dial(probeCtx)
+		probeCancel()
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("%s not ready after %s", url, overallTimeout)
+		case <-timer.C:
+			timer.Reset(backoff)
+		}
+	}
+}

--- a/backend/locallisten/locallisten_test.go
+++ b/backend/locallisten/locallisten_test.go
@@ -1,0 +1,83 @@
+package locallisten
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParse_UnixScheme(t *testing.T) {
+	scheme, target, err := Parse("unix:/tmp/leapmux/hub.sock")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scheme != SchemeUnix {
+		t.Errorf("scheme = %q, want %q", scheme, SchemeUnix)
+	}
+	if target != "/tmp/leapmux/hub.sock" {
+		t.Errorf("target = %q, want %q", target, "/tmp/leapmux/hub.sock")
+	}
+}
+
+func TestParse_NpipeSchemeShortForm(t *testing.T) {
+	scheme, target, err := Parse("npipe:leapmux-hub-S-1-5-21")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scheme != SchemeNpipe {
+		t.Errorf("scheme = %q, want %q", scheme, SchemeNpipe)
+	}
+	if target != "leapmux-hub-S-1-5-21" {
+		t.Errorf("target = %q", target)
+	}
+}
+
+func TestParse_NpipeSchemeFullNTPath(t *testing.T) {
+	// Users sometimes paste the NT pipe path from Windows tooling; preserving
+	// backslashes means the Listen path accepts it as-is.
+	scheme, target, err := Parse(`npipe:\\.\pipe\leapmux-hub`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scheme != SchemeNpipe {
+		t.Errorf("scheme = %q", scheme)
+	}
+	if target != `\\.\pipe\leapmux-hub` {
+		t.Errorf("target = %q", target)
+	}
+}
+
+func TestParse_RejectsEmpty(t *testing.T) {
+	_, _, err := Parse("")
+	if !errors.Is(err, ErrUnsupportedScheme) {
+		t.Fatalf("got %v, want ErrUnsupportedScheme", err)
+	}
+}
+
+func TestParse_RejectsMissingTarget(t *testing.T) {
+	for _, url := range []string{"unix:", "npipe:"} {
+		_, _, err := Parse(url)
+		if !errors.Is(err, ErrMissingTarget) {
+			t.Errorf("%s: got %v, want ErrMissingTarget", url, err)
+		}
+		// A supported scheme with empty target is NOT an unsupported-scheme
+		// error; the sentinels must be distinct.
+		if errors.Is(err, ErrUnsupportedScheme) {
+			t.Errorf("%s: error %v should not match ErrUnsupportedScheme", url, err)
+		}
+	}
+}
+
+func TestParse_RejectsUnknownSchemes(t *testing.T) {
+	cases := []string{
+		"http://localhost:8080",
+		"tcp://host:1",
+		"/plain/path",
+		"leapmux-hub",
+	}
+	for _, url := range cases {
+		_, _, err := Parse(url)
+		if !errors.Is(err, ErrUnsupportedScheme) {
+			t.Errorf("%s: got %v, want ErrUnsupportedScheme", url, err)
+		}
+	}
+}

--- a/backend/locallisten/locallisten_unix.go
+++ b/backend/locallisten/locallisten_unix.go
@@ -1,0 +1,73 @@
+//go:build unix
+
+package locallisten
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+)
+
+func listenUnix(path string) (net.Listener, error) {
+	if err := removeStaleSocket(path); err != nil {
+		return nil, fmt.Errorf("unix listen: %w", err)
+	}
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("unix listen %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("unix listen: chmod %s: %w", path, err)
+	}
+	return &unixListener{Listener: listener, path: path}, nil
+}
+
+// unixListener unlinks the socket file when the listener closes.
+type unixListener struct {
+	net.Listener
+	path string
+}
+
+func (l *unixListener) Close() error {
+	err := l.Listener.Close()
+	_ = os.Remove(l.path)
+	return err
+}
+
+func listenNpipe(name string) (net.Listener, error) {
+	return nil, fmt.Errorf("%w: npipe listener requires Windows", ErrUnsupportedScheme)
+}
+
+// removeStaleSocket unlinks a leftover socket file, refusing to touch
+// a non-socket path so user data can't be clobbered.
+func removeStaleSocket(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode().Type() == fs.ModeSocket {
+		return os.Remove(path)
+	}
+	return fmt.Errorf("%s exists but is not a socket", path)
+}
+
+func unixDialer(path string) func(ctx context.Context) (net.Conn, error) {
+	return func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "unix", path)
+	}
+}
+
+func npipeDialer(string) func(ctx context.Context) (net.Conn, error) {
+	return func(context.Context) (net.Conn, error) {
+		return nil, fmt.Errorf("%w: npipe transport requires Windows", ErrUnsupportedScheme)
+	}
+}

--- a/backend/locallisten/locallisten_unix_test.go
+++ b/backend/locallisten/locallisten_unix_test.go
@@ -27,7 +27,7 @@ func TestListen_UnixBindsAcceptsAndRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestListen_UnixBindsAcceptsAndRoundTrips(t *testing.T) {
 			acceptErr <- err
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		buf := make([]byte, 5)
 		if _, err := io.ReadFull(conn, buf); err != nil {
 			acceptErr <- err
@@ -58,7 +58,7 @@ func TestListen_UnixBindsAcceptsAndRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	if _, err := conn.Write([]byte("hello")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestWaitReady_UnixSucceedsOnceListening(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -166,7 +166,7 @@ func TestWaitReady_UnixSucceedsAfterDelayedListen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	select {
 	case err := <-readyCh:
@@ -184,7 +184,7 @@ func TestDialer_UnixReachesListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	accepted := make(chan struct{}, 1)
 	go func() {

--- a/backend/locallisten/locallisten_unix_test.go
+++ b/backend/locallisten/locallisten_unix_test.go
@@ -1,0 +1,232 @@
+//go:build unix
+
+package locallisten
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// uniqueUnixPathShort returns a per-test socket path whose full length stays
+// well under the AF_UNIX sun_path limit. t.TempDir handles cleanup.
+func uniqueUnixPathShort(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "s.sock")
+}
+
+func TestListen_UnixBindsAcceptsAndRoundTrips(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("socket mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	accepted := make(chan []byte, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- buf
+	}()
+
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case got := <-accepted:
+		if string(got) != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	case err := <-acceptErr:
+		t.Fatalf("accept: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for accept")
+	}
+}
+
+func TestListen_UnixClosesUnlinks(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket still present after Close: err=%v", err)
+	}
+}
+
+func TestListen_UnixRemovesStaleSocket(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+
+	// Create a stale socket: bind and close, leaving the file on disk
+	// (net.Listener.Close on unix does not unlink).
+	pre, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("pre-listen: %v", err)
+	}
+	if err := pre.Close(); err != nil {
+		t.Fatalf("pre-close: %v", err)
+	}
+
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen over stale socket: %v", err)
+	}
+	_ = ln.Close()
+}
+
+func TestListen_UnixRejectsNonSocketFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-socket")
+	if err := os.WriteFile(path, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, err := Listen("unix:" + path)
+	if err == nil {
+		t.Fatal("expected error when target exists but is not a socket")
+	}
+}
+
+func TestListen_NpipeRejectedOnUnix(t *testing.T) {
+	_, err := Listen("npipe:should-not-work")
+	if !errors.Is(err, ErrUnsupportedScheme) {
+		t.Fatalf("got %v, want ErrUnsupportedScheme", err)
+	}
+}
+
+func TestWaitReady_UnixSucceedsOnceListening(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := WaitReady(ctx, "unix:"+path); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+}
+
+func TestWaitReady_UnixTimesOut(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := WaitReady(ctx, "unix:"+path)
+	if err == nil {
+		t.Fatal("expected error when no listener exists")
+	}
+}
+
+func TestWaitReady_UnixSucceedsAfterDelayedListen(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	readyCh := make(chan error, 1)
+	go func() {
+		readyCh <- WaitReady(ctx, "unix:"+path)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("WaitReady: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitReady did not return after Listen succeeded")
+	}
+}
+
+func TestDialer_UnixReachesListener(t *testing.T) {
+	path := uniqueUnixPathShort(t)
+	ln, err := Listen("unix:" + path)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			_ = conn.Close()
+			accepted <- struct{}{}
+		}
+	}()
+
+	dial, err := Dialer("unix:" + path)
+	if err != nil {
+		t.Fatalf("Dialer: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("unix listener never accepted a connection")
+	}
+}
+
+func TestDialer_NpipeFailsWithSchemeError(t *testing.T) {
+	dial, err := Dialer("npipe:some-pipe")
+	if err != nil {
+		t.Fatalf("Dialer: %v", err)
+	}
+	_, err = dial(context.Background())
+	if err == nil {
+		t.Fatal("expected dial error on non-Windows platforms")
+	}
+	if !errors.Is(err, ErrUnsupportedScheme) {
+		t.Errorf("error %v does not wrap ErrUnsupportedScheme", err)
+	}
+	if !strings.Contains(err.Error(), "npipe") {
+		t.Errorf("error %v does not mention npipe", err)
+	}
+}

--- a/backend/locallisten/locallisten_windows.go
+++ b/backend/locallisten/locallisten_windows.go
@@ -1,0 +1,82 @@
+//go:build windows
+
+package locallisten
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os/user"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+)
+
+const pipePrefix = `\\.\pipe\`
+
+func listenNpipe(name string) (net.Listener, error) {
+	pipePath := fullPipePath(name)
+	sddl, err := userOnlySDDL()
+	if err != nil {
+		return nil, fmt.Errorf("npipe listen: build security descriptor: %w", err)
+	}
+	listener, err := winio.ListenPipe(pipePath, &winio.PipeConfig{
+		SecurityDescriptor: sddl,
+		InputBufferSize:    65536,
+		OutputBufferSize:   65536,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("npipe listen %s: %w", pipePath, err)
+	}
+	return &npipeListener{Listener: listener}, nil
+}
+
+// npipeListener wraps winio.Listener so callers can uniformly check for
+// "listener closed" via errors.Is(err, net.ErrClosed) regardless of the
+// underlying transport.
+type npipeListener struct {
+	net.Listener
+}
+
+func (l *npipeListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if errors.Is(err, winio.ErrPipeListenerClosed) {
+		return nil, fmt.Errorf("%w: %w", net.ErrClosed, err)
+	}
+	return conn, err
+}
+
+func listenUnix(string) (net.Listener, error) {
+	return nil, fmt.Errorf("%w: unix listener not supported on Windows", ErrUnsupportedScheme)
+}
+
+// fullPipePath accepts both "my-pipe" and a pre-qualified "\\.\pipe\my-pipe".
+func fullPipePath(name string) string {
+	if strings.HasPrefix(name, pipePrefix) {
+		return name
+	}
+	return pipePrefix + name
+}
+
+// userOnlySDDL returns an SDDL granting Generic All only to the current user's SID.
+func userOnlySDDL() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("O:%sG:%sD:(A;;GA;;;%s)", u.Uid, u.Uid, u.Uid), nil
+}
+
+func unixDialer(string) func(ctx context.Context) (net.Conn, error) {
+	return func(context.Context) (net.Conn, error) {
+		return nil, fmt.Errorf("%w: unix transport not supported on Windows", ErrUnsupportedScheme)
+	}
+}
+
+func npipeDialer(name string) func(ctx context.Context) (net.Conn, error) {
+	fullPath := fullPipePath(name)
+	return func(ctx context.Context) (net.Conn, error) {
+		return winio.DialPipeContext(ctx, fullPath)
+	}
+}

--- a/backend/locallisten/locallisten_windows_test.go
+++ b/backend/locallisten/locallisten_windows_test.go
@@ -1,0 +1,276 @@
+//go:build windows
+
+package locallisten
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/user"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+var pipeTestCounter atomic.Uint64
+
+func uniqueTestPipeName(t *testing.T) string {
+	t.Helper()
+	n := pipeTestCounter.Add(1)
+	return fmt.Sprintf("leapmux-locallisten-test-%d-%d-%d", os.Getpid(), time.Now().UnixNano(), n)
+}
+
+// runAcceptLoop starts a background goroutine that accepts connections on ln
+// until ln.Close is called. Each accepted connection is closed immediately,
+// matching what production code needs from a pipe "ready" check (the pipe is
+// reachable, not that an RPC session runs). Returns a done channel the test
+// can wait on to ensure the goroutine exited.
+func runAcceptLoop(t *testing.T, ln net.Listener) chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return done
+}
+
+func TestListen_NpipeBindsAcceptsAndRoundTrips(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ln, err := Listen("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan []byte, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- buf
+	}()
+
+	conn, err := winio.DialPipe(`\\.\pipe\`+name, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case got := <-accepted:
+		if string(got) != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	case err := <-acceptErr:
+		t.Fatalf("accept: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for accept")
+	}
+}
+
+func TestListen_NpipeAcceptsFullNTPath(t *testing.T) {
+	// Parse preserves backslashes; this test confirms Listen accepts the
+	// fully-qualified NT pipe path in addition to the short name form.
+	name := uniqueTestPipeName(t)
+	fullPath := `\\.\pipe\` + name
+	ln, err := Listen("npipe:" + fullPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	_ = ln.Close()
+}
+
+// TestUserOnlySDDL_HasCurrentUserSID unit-tests the SDDL we construct before
+// handing it to winio. We deliberately avoid probing the live pipe's security
+// descriptor (GetNamedSecurityInfo on a pipe path requires an active instance
+// and races with the winio accept loop); validating the generated SDDL
+// string against the current user's SID catches the bug class that matters —
+// a malformed or empty descriptor making the pipe world-accessible.
+func TestUserOnlySDDL_HasCurrentUserSID(t *testing.T) {
+	sddl, err := userOnlySDDL()
+	if err != nil {
+		t.Fatalf("userOnlySDDL: %v", err)
+	}
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	if !strings.Contains(sddl, u.Uid) {
+		t.Errorf("SDDL %q missing current user SID %s", sddl, u.Uid)
+	}
+
+	// Round-trip through Windows' SDDL parser and confirm the resulting
+	// owner SID matches the current user. This guarantees the string is
+	// syntactically valid and semantically what we intend.
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		t.Fatalf("SecurityDescriptorFromString: %v", err)
+	}
+	owner, _, err := sd.Owner()
+	if err != nil {
+		t.Fatalf("Owner: %v", err)
+	}
+	if owner.String() != u.Uid {
+		t.Errorf("SDDL owner = %s, want %s", owner.String(), u.Uid)
+	}
+}
+
+func TestListen_UnixRejectedOnWindows(t *testing.T) {
+	_, err := Listen("unix:C:\\ProgramData\\leapmux\\hub.sock")
+	if !errors.Is(err, ErrUnsupportedScheme) {
+		t.Fatalf("got %v, want ErrUnsupportedScheme", err)
+	}
+}
+
+func TestWaitReady_NpipeSucceedsOnceAccepting(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ln, err := Listen("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	acceptDone := runAcceptLoop(t, ln)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := WaitReady(ctx, "npipe:"+name); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	_ = ln.Close()
+	<-acceptDone
+}
+
+func TestWaitReady_NpipeTimesOut(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := WaitReady(ctx, "npipe:"+name)
+	if err == nil {
+		t.Fatal("expected error when no listener exists")
+	}
+}
+
+func TestWaitReady_NpipeSucceedsAfterDelayedListen(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	readyCh := make(chan error, 1)
+	go func() {
+		readyCh <- WaitReady(ctx, "npipe:"+name)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	ln, err := Listen("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	acceptDone := runAcceptLoop(t, ln)
+
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("WaitReady: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitReady did not return after Listen succeeded")
+	}
+	_ = ln.Close()
+	<-acceptDone
+}
+
+func TestDialer_NpipeReachesListener(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ln, err := Listen("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	acceptDone := runAcceptLoop(t, ln)
+
+	dial, err := Dialer("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Dialer: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.Close()
+
+	_ = ln.Close()
+	<-acceptDone
+}
+
+func TestDialer_NpipeAcceptsFullNTPath(t *testing.T) {
+	name := uniqueTestPipeName(t)
+	ln, err := Listen("npipe:" + name)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	acceptDone := runAcceptLoop(t, ln)
+
+	dial, err := Dialer("npipe:" + fullPipePath(name))
+	if err != nil {
+		t.Fatalf("Dialer: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("dial with full NT path: %v", err)
+	}
+	_ = conn.Close()
+
+	_ = ln.Close()
+	<-acceptDone
+}
+
+// TestNpipeListener_AcceptTranslatesClose verifies that closing the pipe
+// listener surfaces an error satisfying errors.Is(net.ErrClosed) — so shared
+// accept loops can check a single sentinel rather than winio.ErrPipeListenerClosed.
+func TestNpipeListener_AcceptTranslatesClose(t *testing.T) {
+	ln, err := Listen("npipe:" + uniqueTestPipeName(t))
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	_ = ln.Close()
+
+	_, acceptErr := ln.Accept()
+	if acceptErr == nil {
+		t.Fatal("expected Accept on closed listener to return an error")
+	}
+	if !errors.Is(acceptErr, net.ErrClosed) {
+		t.Errorf("Accept error %v does not wrap net.ErrClosed", acceptErr)
+	}
+	if !errors.Is(acceptErr, winio.ErrPipeListenerClosed) {
+		t.Errorf("Accept error %v should still wrap winio.ErrPipeListenerClosed for debugging", acceptErr)
+	}
+}

--- a/backend/locallisten/locallistentest/locallistentest.go
+++ b/backend/locallisten/locallistentest/locallistentest.go
@@ -1,0 +1,49 @@
+// Package locallistentest supplies test helpers for packages that exercise
+// the locallisten transport. Kept in its own package so production code
+// doesn't pull in testing.T dependencies.
+package locallistentest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// SandboxHome redirects home-directory lookups to a fresh temp directory for
+// the duration of the test. Sets both HOME and USERPROFILE so os.UserHomeDir
+// returns the sandbox on every platform. Returns the sandbox path.
+func SandboxHome(t *testing.T) string {
+	t.Helper()
+	home, err := os.MkdirTemp("", "leapmux-sandbox-home-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	home = filepath.Clean(home)
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	return home
+}
+
+var counter atomic.Uint64
+
+// UniqueListenURL returns a per-test local-listen URL that won't collide
+// with concurrent tests in the same process. Prefix is embedded in the
+// name so failures point at the test package.
+//
+// On Unix returns unix:<t.TempDir>/<prefix>.sock (t.TempDir handles
+// cleanup); on Windows returns npipe:<prefix>-<pid>-<nanos>-<counter>.
+func UniqueListenURL(t *testing.T, prefix string) string {
+	t.Helper()
+	n := counter.Add(1)
+	if runtime.GOOS == "windows" {
+		return fmt.Sprintf("npipe:%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), n)
+	}
+	return "unix:" + filepath.Join(t.TempDir(), prefix+".sock")
+}

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -13,13 +13,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/logging"
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	workerconfig "github.com/leapmux/leapmux/internal/worker/config"
+	"github.com/leapmux/leapmux/locallisten"
 	"github.com/leapmux/leapmux/util/version"
 	"github.com/leapmux/leapmux/worker"
 )
@@ -36,6 +36,9 @@ type Config struct {
 	Args []string
 	// CLIFlags restricts which flags are registered (nil = all hub flags).
 	CLIFlags []string
+	// ExtraFlags registers additional koanf-backed flags; nil uses the
+	// desktop-oriented default (encryption-mode, use-login-shell).
+	ExtraFlags []hubconfig.ExtraFlagDef
 	// DevMode runs in dev mode (binds to all interfaces, logs "dev" banner).
 	DevMode bool
 	// SkipBanner suppresses the ASCII art banner and access URL.
@@ -48,20 +51,33 @@ type Config struct {
 
 // Instance represents a running solo Hub+Worker pair.
 type Instance struct {
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-	addr   string
-	server *hub.Server
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	listenURL string
+	server    *hub.Server
+	hubErr    error         // set before hubDone is closed
+	hubDone   chan struct{} // closed when the Hub goroutine exits
 }
 
-// Addr returns the listen address of the running instance.
-func (i *Instance) Addr() string {
-	return i.addr
+// LocalListenURL returns the URL at which the Hub is accepting local IPC
+// connections (unix:<path> on Unix, npipe:<name> on Windows). Callers that
+// need to dial the Hub from within the same process tree (e.g. the desktop
+// proxy) should use this rather than reconstructing a path.
+func (i *Instance) LocalListenURL() string {
+	return i.listenURL
 }
 
 // Server returns the underlying Hub server instance.
 func (i *Instance) Server() *hub.Server {
 	return i.server
+}
+
+// Wait blocks until the Hub exits (either via Stop or because it failed
+// on its own) and returns its terminal error. Returns nil on clean
+// shutdown or http.ErrServerClosed. Safe to call multiple times.
+func (i *Instance) Wait() error {
+	<-i.hubDone
+	return i.hubErr
 }
 
 // Stop gracefully shuts down the Hub and Worker.
@@ -102,17 +118,22 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		cliFlags = []string{"addr", "data-dir", "dev-frontend", "storage-sqlite-max-conns", "storage-sqlite-cache-size", "storage-sqlite-mmap-size", "max-message-size", "max-incomplete-chunked", "api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds", "log-level", "use-login-shell"}
 	}
 
+	extraFlags := cfg.ExtraFlags
+	if extraFlags == nil {
+		extraFlags = []hubconfig.ExtraFlagDef{
+			{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
+			{Name: "use-login-shell", KoanfKey: "use_login_shell", Usage: "wrap claude invocation in user's login shell", StrDefault: "true"},
+		}
+	}
+
 	hubCfg, _, err := hubconfig.LoadWithOptions(cfg.Args, hubconfig.LoadOptions{
 		DefaultAddr:       defaultAddr,
 		DefaultConfigDir:  configDir,
 		DefaultConfigFile: configFile,
 		FlagSetName:       "leapmux",
 		CLIFlags:          cliFlags,
-		ExtraFlags: []hubconfig.ExtraFlagDef{
-			{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
-			{Name: "use-login-shell", KoanfKey: "use_login_shell", Usage: "wrap claude invocation in user's login shell", StrDefault: "true"},
-		},
-		SoloMode: !cfg.DevMode,
+		ExtraFlags:        extraFlags,
+		SoloMode:          !cfg.DevMode,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("load hub config: %w", err)
@@ -150,22 +171,31 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 
 	soloCtx, cancel := context.WithCancel(ctx)
 
-	inst := &Instance{cancel: cancel, addr: hubCfg.Addr, server: server}
+	listenURL, err := hubCfg.LocalListenURL()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("resolve local-listen URL: %w", err)
+	}
+	inst := &Instance{
+		cancel:    cancel,
+		listenURL: listenURL,
+		server:    server,
+		hubDone:   make(chan struct{}),
+	}
 
-	// Start Hub.
-	hubErrCh := make(chan error, 1)
+	// Start Hub. hubErr/hubDone publish the terminal error to Wait callers.
 	inst.wg.Add(1)
 	go func() {
 		defer inst.wg.Done()
-		hubErrCh <- server.Serve(soloCtx)
+		inst.hubErr = server.Serve(soloCtx)
+		close(inst.hubDone)
 	}()
 
-	// Wait for Hub's Unix socket.
-	socketPath := server.SocketPath()
-	if err := waitForSocket(soloCtx, socketPath); err != nil {
+	// Wait for Hub's local listener (unix socket or named pipe).
+	if err := locallisten.WaitReady(soloCtx, listenURL); err != nil {
 		cancel()
 		inst.wg.Wait()
-		return nil, fmt.Errorf("wait for hub socket: %w", err)
+		return nil, fmt.Errorf("wait for hub local listener: %w", err)
 	}
 
 	// Auto-register worker.
@@ -218,7 +248,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 
 	slog.Info(modeName+" worker registered",
 		"worker_id", state.WorkerID,
-		"socket", socketPath,
+		"local", listenURL,
 	)
 
 	// Start Worker.
@@ -226,7 +256,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	go func() {
 		defer inst.wg.Done()
 		if wErr := worker.Run(soloCtx, worker.RunConfig{
-			HubURL:               "unix:" + socketPath,
+			HubURL:               listenURL,
 			DataDir:              workerDataDir,
 			AuthToken:            state.AuthToken,
 			CompositeKey:         compositeKey,
@@ -248,12 +278,13 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 
 	slog.Info("leapmux "+modeName+" listening", "addr", hubCfg.Addr)
 
-	// Monitor Hub in background.
+	// If the Hub exits unexpectedly, cancel soloCtx so the worker tears down
+	// promptly instead of looping against a dead endpoint.
 	go func() {
 		select {
-		case err := <-hubErrCh:
-			if err != nil {
-				slog.Error("hub error", "error", err)
+		case <-inst.hubDone:
+			if inst.hubErr != nil {
+				slog.Error("hub error", "error", inst.hubErr)
 			}
 			cancel()
 		case <-soloCtx.Done():
@@ -274,20 +305,6 @@ type soloState struct {
 	MlkemPrivateKey  string `json:"mlkem_private_key,omitempty"`
 	SlhdsaPublicKey  string `json:"slhdsa_public_key,omitempty"`
 	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"`
-}
-
-func waitForSocket(ctx context.Context, path string) error {
-	for range 50 {
-		if _, err := os.Stat(path); err == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-	return fmt.Errorf("socket %s not created in time", path)
 }
 
 func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath, workerDataDir string) (*soloState, error) {

--- a/backend/solo/solo_integration_test.go
+++ b/backend/solo/solo_integration_test.go
@@ -1,0 +1,112 @@
+package solo_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/locallisten"
+	"github.com/leapmux/leapmux/locallisten/locallistentest"
+	"github.com/leapmux/leapmux/solo"
+)
+
+func uniqueListenURL(t *testing.T) string {
+	return locallistentest.UniqueListenURL(t, "leapmux-solo-test")
+}
+
+// startForTest runs solo.Start with NoTCP + a unique local listen URL + an
+// isolated home so the hub + worker don't touch shared state. Returns the
+// started Instance; teardown is wired through t.Cleanup.
+func startForTest(t *testing.T, localListen string, extraCfg solo.Config) *solo.Instance {
+	t.Helper()
+
+	locallistentest.SandboxHome(t)
+
+	if localListen == "" {
+		localListen = uniqueListenURL(t)
+	}
+	t.Setenv(locallisten.EnvLocalListen, localListen)
+
+	cfg := extraCfg
+	cfg.SkipBanner = true
+	cfg.NoTCP = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	inst, err := solo.Start(ctx, cfg)
+	require.NoError(t, err, "solo.Start")
+	t.Cleanup(inst.Stop)
+	return inst
+}
+
+// TestSoloStart_RespectsExplicitLocalListen confirms the hub actually binds
+// the URL the caller requested (and not the platform default).
+func TestSoloStart_RespectsExplicitLocalListen(t *testing.T) {
+	explicit := uniqueListenURL(t)
+	inst := startForTest(t, explicit, solo.Config{})
+
+	assert.Equal(t, explicit, inst.LocalListenURL(),
+		"Instance.LocalListenURL should echo the configured URL")
+
+	// Dial the reported URL to prove something is actually listening.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, locallisten.WaitReady(ctx, inst.LocalListenURL()),
+		"hub listener should be dial-able at the returned URL")
+}
+
+// TestSoloStart_DefaultLocalListen confirms solo.Start uses the per-platform
+// default when the caller doesn't override it, and the derived URL is
+// reachable. Inlined setup here because the shared helper auto-injects
+// a unique LocalListen to keep other tests isolated.
+func TestSoloStart_DefaultLocalListen(t *testing.T) {
+	locallistentest.SandboxHome(t)
+	t.Setenv(locallisten.EnvLocalListen, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	inst, err := solo.Start(ctx, solo.Config{
+		SkipBanner: true,
+		NoTCP:      true,
+	})
+	require.NoError(t, err, "solo.Start with default local-listen")
+	t.Cleanup(inst.Stop)
+
+	url := inst.LocalListenURL()
+	require.NotEmpty(t, url, "LocalListenURL must resolve to a non-empty default")
+	switch runtime.GOOS {
+	case "windows":
+		assert.Contains(t, url, "npipe:leapmux-hub")
+	default:
+		assert.Contains(t, url, "unix:")
+		assert.Contains(t, url, "hub.sock")
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer waitCancel()
+	require.NoError(t, locallisten.WaitReady(waitCtx, url),
+		"default hub listener should be dial-able")
+}
+
+// TestSoloStart_InvalidLocalListenErrors confirms an unparseable URL surfaces
+// as a startup error without leaking resources.
+func TestSoloStart_InvalidLocalListenErrors(t *testing.T) {
+	locallistentest.SandboxHome(t)
+	t.Setenv(locallisten.EnvLocalListen, "gopher://example:70/bogus")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := solo.Start(ctx, solo.Config{
+		SkipBanner: true,
+		NoTCP:      true,
+	})
+	require.Error(t, err, "solo.Start should reject an unparseable LocalListen")
+	assert.Contains(t, err.Error(), "local_listen",
+		"error should surface the offending flag name")
+}

--- a/backend/tunnel/channel_integration_test.go
+++ b/backend/tunnel/channel_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -21,13 +22,19 @@ import (
 	leapmuxv1connect "github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/channelmgr"
 	"github.com/leapmux/leapmux/internal/util/testutil"
+	"github.com/leapmux/leapmux/locallisten"
+	"github.com/leapmux/leapmux/locallisten/locallistentest"
 	"github.com/leapmux/leapmux/solo"
 	"github.com/leapmux/leapmux/tunnel"
 )
 
+func uniqueTestListenURL(t *testing.T) string {
+	return locallistentest.UniqueListenURL(t, "leapmux-test")
+}
+
 // startTestSolo starts a solo Hub+Worker instance for integration testing.
-// Returns the hub URL, socket path, admin token, admin user ID, and worker ID.
-func startTestSolo(t *testing.T) (hubURL, socketPath, userID, workerID string) {
+// Returns the hub URL, local-listen URL, admin user ID, and worker ID.
+func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID string) {
 	t.Helper()
 
 	// Use a short path under /tmp to stay within the 104-byte macOS Unix
@@ -45,6 +52,8 @@ func startTestSolo(t *testing.T) (hubURL, socketPath, userID, workerID string) {
 	addr := ln.Addr().String()
 	_ = ln.Close()
 
+	t.Setenv(locallisten.EnvLocalListen, uniqueTestListenURL(t))
+
 	inst, err := solo.Start(ctx, solo.Config{
 		Addr:       addr,
 		ConfigDir:  dataDir,
@@ -55,7 +64,7 @@ func startTestSolo(t *testing.T) (hubURL, socketPath, userID, workerID string) {
 	t.Cleanup(inst.Stop)
 
 	hubURL = "http://" + addr
-	socketPath = inst.Server().SocketPath()
+	localListenURL = inst.LocalListenURL()
 
 	// Wait for Hub to be ready.
 	require.NoError(t, waitForHTTP(hubURL, 30*time.Second))
@@ -109,7 +118,7 @@ func startTestSolo(t *testing.T) (hubURL, socketPath, userID, workerID string) {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	return hubURL, socketPath, userID, wID
+	return hubURL, localListenURL, userID, wID
 }
 
 func waitForHTTP(url string, timeout time.Duration) error {
@@ -445,8 +454,11 @@ func TestRegistration_AutoApproveViaUnixSocket_E2E(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-socket-specific auto-approve path")
+	}
 
-	hubURL, socketPath, _, _ := startTestSolo(t)
+	hubURL, localListenURL, _, _ := startTestSolo(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -458,8 +470,16 @@ func TestRegistration_AutoApproveViaUnixSocket_E2E(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = ws.CloseNow() }()
 
+	scheme, _, err := locallisten.Parse(localListenURL)
+	require.NoError(t, err)
+	require.Equal(t, locallisten.SchemeUnix, scheme, "test gated to unix-only above")
+
 	// Register a new worker via Unix socket — should be auto-approved.
-	unixClient := newUnixHTTPClient(socketPath)
+	dial, err := locallisten.Dialer(localListenURL)
+	require.NoError(t, err)
+	unixClient := &http.Client{
+		Transport: &http.Transport{DialContext: locallisten.HTTPDialContext(dial)},
+	}
 	connClient := leapmuxv1connect.NewWorkerConnectorServiceClient(unixClient, "http://localhost")
 
 	regResp, err := connClient.RequestRegistration(ctx, connect.NewRequest(
@@ -494,16 +514,6 @@ func TestRegistration_AutoApproveViaUnixSocket_E2E(t *testing.T) {
 	}
 
 	assert.Contains(t, frame.GetEvents(), leapmuxv1.HubControlEvent_HUB_CONTROL_EVENT_WORKERS_CHANGED)
-}
-
-func newUnixHTTPClient(socketPath string) *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
-		},
-	}
 }
 
 func TestChannelMultipleRPCs(t *testing.T) {

--- a/backend/util/procutil/procutil_other.go
+++ b/backend/util/procutil/procutil_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+// Package procutil contains small helpers for configuring child processes.
+package procutil
+
+import "os/exec"
+
+// HideConsoleWindow suppresses the child's console window on Windows;
+// no-op on Unix.
+func HideConsoleWindow(*exec.Cmd) {}

--- a/backend/util/procutil/procutil_windows.go
+++ b/backend/util/procutil/procutil_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+// Package procutil contains small helpers for configuring child processes.
+package procutil
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Win32 CREATE_NO_WINDOW — suppress the child's console allocation.
+const createNoWindow = 0x08000000
+
+// HideConsoleWindow suppresses the child's console window on Windows.
+func HideConsoleWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}

--- a/backend/worker/runner.go
+++ b/backend/worker/runner.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,10 +23,10 @@ import (
 
 // RunConfig holds configuration for running the worker as a library.
 type RunConfig struct {
-	HubURL               string                      // Hub server URL (e.g. "http://localhost:4327") or "unix:<socket-path>"
+	HubURL               string                      // Hub server URL: http[s]://host:port, unix:<socket-path>, or npipe:<name>
+
 	DataDir              string                      // Directory for persistent state
 	AuthToken            string                      // Pre-provisioned auth token (skip registration)
-	HTTPClient           *http.Client                // Custom HTTP client (e.g. for Unix socket transport)
 	CompositeKey         *noiseutil.CompositeKeypair // Worker's composite keypair for E2EE channels
 	WorkerID             string                      // Worker ID (from registration)
 	Name                 string                      // Worker display name (from LEAPMUX_WORKER_NAME, defaults to hostname)
@@ -45,7 +44,6 @@ type RunConfig struct {
 
 // Run starts the worker and blocks until ctx is cancelled.
 // If AuthToken is set, registration is skipped and the worker connects directly.
-// If HTTPClient is set, it is used for ConnectRPC communication instead of the default.
 func Run(ctx context.Context, cfg RunConfig) error {
 	// Open the Worker-local database for persistent state.
 	dbPath := filepath.Join(cfg.DataDir, "worker.db")
@@ -67,12 +65,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		return fmt.Errorf("migrate worker db: %w", err)
 	}
 
-	var client *hub.Client
-	if cfg.HTTPClient != nil {
-		client = hub.NewWithHTTPClient(cfg.HTTPClient, cfg.HubURL)
-	} else {
-		client = hub.New(cfg.HubURL)
-	}
+	client := hub.New(cfg.HubURL)
 	defer client.Stop()
 
 	// Set up E2EE channel manager if composite key is provided.

--- a/backend/worker/runner.go
+++ b/backend/worker/runner.go
@@ -23,7 +23,7 @@ import (
 
 // RunConfig holds configuration for running the worker as a library.
 type RunConfig struct {
-	HubURL               string                      // Hub server URL: http[s]://host:port, unix:<socket-path>, or npipe:<name>
+	HubURL string // Hub server URL: http[s]://host:port, unix:<socket-path>, or npipe:<name>
 
 	DataDir              string                      // Directory for persistent state
 	AuthToken            string                      // Pre-provisioned auth token (skip registration)

--- a/desktop/go/app.go
+++ b/desktop/go/app.go
@@ -12,6 +12,7 @@ import (
 	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
 	"github.com/leapmux/leapmux/solo"
 	tunnelpkg "github.com/leapmux/leapmux/tunnel"
+	"github.com/leapmux/leapmux/util/procutil"
 	"github.com/leapmux/leapmux/util/version"
 )
 
@@ -148,7 +149,9 @@ func (a *App) Restart() error {
 	if err != nil {
 		return err
 	}
-	return exec.Command(exe).Start()
+	cmd := exec.Command(exe)
+	procutil.HideConsoleWindow(cmd)
+	return cmd.Start()
 }
 
 func (a *App) SwitchMode() error {
@@ -169,13 +172,15 @@ func (a *App) ConnectSolo() error {
 		return err
 	}
 
-	socketPath := a.solo.Server().SocketPath()
-	if err := a.waitForSoloReady(a.ctx, socketPath); err != nil {
+	// solo.Start already blocked until the Hub's local listener was reachable,
+	// so no extra polling is needed before building the proxy.
+	proxy, err := newLocalProxy(a.solo.LocalListenURL())
+	if err != nil {
 		a.stopSolo()
-		return fmt.Errorf("waiting for LeapMux to start: %w", err)
+		return fmt.Errorf("build local proxy: %w", err)
 	}
-
-	a.proxy = newUnixSocketProxy(socketPath)
+	a.proxy = proxy
+	a.applyProxyToTunnels()
 	a.config.Mode = "solo"
 	a.config.HubURL = ""
 	if err := SaveConfig(a.config); err != nil {
@@ -200,6 +205,7 @@ func (a *App) ConnectDistributed(hubURL string) error {
 	}
 
 	a.proxy = newHTTPProxy(hubURL)
+	a.applyProxyToTunnels()
 	a.hubURL = hubURL
 	a.config.Mode = "distributed"
 	a.config.HubURL = hubURL
@@ -220,11 +226,19 @@ func (a *App) CreateTunnel(config TunnelConfig) (*TunnelInfo, error) {
 	}
 
 	config.HubURL = a.proxy.baseURL
+	return a.tunnels.CreateTunnel(a.ctx, config)
+}
+
+// applyProxyToTunnels wires the current proxy's HTTP clients into the tunnel
+// manager so subsequent CreateTunnel calls dial through them.
+func (a *App) applyProxyToTunnels() {
+	if a.proxy == nil {
+		return
+	}
 	a.tunnels.SetChannelOptions(&tunnelpkg.OpenChannelOptions{
 		HTTPClient:          a.proxy.client,
 		WebSocketHTTPClient: a.proxy.wsClient,
 	})
-	return a.tunnels.CreateTunnel(a.ctx, config)
 }
 
 func (a *App) DeleteTunnel(tunnelID string) error {

--- a/desktop/go/channel_relay_test.go
+++ b/desktop/go/channel_relay_test.go
@@ -1,24 +1,29 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+	"github.com/leapmux/leapmux/locallisten"
+	"github.com/leapmux/leapmux/locallisten/locallistentest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// setUniqueSoloLocalListen scopes the hub's local-listen URL per-test so
+// multiple tests running in the same process don't collide on the
+// per-platform default endpoint (the Windows default embeds the current
+// user's SID, which is identical across tests as the same user).
+func setUniqueSoloLocalListen(t *testing.T) {
+	t.Helper()
+	t.Setenv(locallisten.EnvLocalListen, locallistentest.UniqueListenURL(t, "leapmux-desktop-test"))
+}
+
 func TestApp_OpenChannelRelay_Solo(t *testing.T) {
-	home, err := os.MkdirTemp("/tmp", "leapmux-home-")
-	if err != nil {
-		t.Fatalf("MkdirTemp() failed: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-	t.Setenv("HOME", filepath.Clean(home))
+	setUniqueSoloLocalListen(t)
+	locallistentest.SandboxHome(t)
 
 	app := NewApp("")
 	defer app.Shutdown()
@@ -37,10 +42,8 @@ func TestApp_OpenChannelRelay_Solo(t *testing.T) {
 }
 
 func TestApp_SidecarLogEvents_EmittedAfterSoloStart(t *testing.T) {
-	home, err := os.MkdirTemp("/tmp", "leapmux-home-")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-	t.Setenv("HOME", filepath.Clean(home))
+	setUniqueSoloLocalListen(t)
+	locallistentest.SandboxHome(t)
 
 	var mu sync.Mutex
 	var events []*desktoppb.SidecarLogEvent
@@ -87,10 +90,8 @@ func TestApp_SidecarLogEvents_EmittedAfterSoloStart(t *testing.T) {
 // Churning would tear down the hub's relay binding and (combined with the
 // race in UnregisterUnboundByUser) wipe channels the new page just opened.
 func TestApp_OpenChannelRelay_ReusesAliveRelay(t *testing.T) {
-	home, err := os.MkdirTemp("/tmp", "leapmux-home-")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-	t.Setenv("HOME", filepath.Clean(home))
+	setUniqueSoloLocalListen(t)
+	locallistentest.SandboxHome(t)
 
 	var mu sync.Mutex
 	var connectCount, disconnectCount int

--- a/desktop/go/go.mod
+++ b/desktop/go/go.mod
@@ -3,6 +3,7 @@ module github.com/leapmux/leapmux-desktop
 go 1.26.1
 
 require (
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/coder/websocket v1.8.14
 	github.com/google/uuid v1.6.0
 	github.com/leapmux/leapmux v0.0.0-20260417013050-e9c57827d9d2

--- a/desktop/go/go.sum
+++ b/desktop/go/go.sum
@@ -43,8 +43,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
-github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
+github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
+github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/desktop/go/main.go
+++ b/desktop/go/main.go
@@ -5,19 +5,32 @@ import (
 	"os"
 )
 
+// Cross-language contract with desktop/rust/src/main.rs:
+//
+//   envDevEndpoint — when set, the sidecar listens on this endpoint (unix
+//     socket path on Unix, named-pipe name on Windows) instead of using
+//     stdio. The Rust shell uses this path in debug builds to reconnect
+//     to an already-running sidecar across reloads.
+//   envBinaryHash — hash the Rust shell computed from the sidecar binary;
+//     the sidecar reports it back so the shell can detect stale processes.
+const (
+	envDevEndpoint = "LEAPMUX_DESKTOP_DEV_ENDPOINT"
+	envBinaryHash  = "LEAPMUX_DESKTOP_BINARY_HASH"
+)
+
 func main() {
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})
 	slog.SetDefault(slog.New(handler))
 
-	if socketPath := os.Getenv("LEAPMUX_DESKTOP_DEV_SOCKET"); socketPath != "" {
-		if err := RunSocketServer(socketPath, os.Getenv("LEAPMUX_DESKTOP_BINARY_HASH")); err != nil {
+	if endpoint := os.Getenv(envDevEndpoint); endpoint != "" {
+		if err := RunSocketServer(endpoint, os.Getenv(envBinaryHash)); err != nil {
 			slog.Error("desktop sidecar exited", "error", err)
 			os.Exit(1)
 		}
 		return
 	}
 
-	app := NewApp(os.Getenv("LEAPMUX_DESKTOP_BINARY_HASH"))
+	app := NewApp(os.Getenv(envBinaryHash))
 	defer app.Shutdown()
 
 	session := NewRPCSession(app, os.Stdin, os.Stdout, func() {

--- a/desktop/go/main.go
+++ b/desktop/go/main.go
@@ -7,12 +7,12 @@ import (
 
 // Cross-language contract with desktop/rust/src/main.rs:
 //
-//   envDevEndpoint — when set, the sidecar listens on this endpoint (unix
-//     socket path on Unix, named-pipe name on Windows) instead of using
-//     stdio. The Rust shell uses this path in debug builds to reconnect
-//     to an already-running sidecar across reloads.
-//   envBinaryHash — hash the Rust shell computed from the sidecar binary;
-//     the sidecar reports it back so the shell can detect stale processes.
+//	envDevEndpoint — when set, the sidecar listens on this endpoint (unix
+//	  socket path on Unix, named-pipe name on Windows) instead of using
+//	  stdio. The Rust shell uses this path in debug builds to reconnect
+//	  to an already-running sidecar across reloads.
+//	envBinaryHash — hash the Rust shell computed from the sidecar binary;
+//	  the sidecar reports it back so the shell can detect stale processes.
 const (
 	envDevEndpoint = "LEAPMUX_DESKTOP_DEV_ENDPOINT"
 	envBinaryHash  = "LEAPMUX_DESKTOP_BINARY_HASH"

--- a/desktop/go/pipe_closed_other.go
+++ b/desktop/go/pipe_closed_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func isPipeClosed(error) bool { return false }

--- a/desktop/go/pipe_closed_windows.go
+++ b/desktop/go/pipe_closed_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func isPipeClosed(err error) bool {
+	return errors.Is(err, winio.ErrFileClosed)
+}

--- a/desktop/go/pipe_closed_windows_test.go
+++ b/desktop/go/pipe_closed_windows_test.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func TestIsBenignSessionReadError_WrapsWinioErrFileClosed(t *testing.T) {
+	err := fmt.Errorf("read frame: %w", winio.ErrFileClosed)
+	if !isBenignSessionReadError(err) {
+		t.Fatal("expected wrapped winio.ErrFileClosed to be benign")
+	}
+}

--- a/desktop/go/proxy.go
+++ b/desktop/go/proxy.go
@@ -2,17 +2,14 @@ package main
 
 import (
 	"bytes"
-	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"strings"
 
-	"golang.org/x/net/http2"
+	"github.com/leapmux/leapmux/locallisten"
 )
 
 // ProxyResponse is the response metadata returned from ProxyHTTP.
@@ -29,33 +26,30 @@ type HubProxy struct {
 	baseURL  string
 }
 
-// newUnixSocketProxy creates a proxy that connects to the Hub via Unix socket.
-func newUnixSocketProxy(socketPath string) *HubProxy {
+// newLocalProxy returns a proxy that dials whichever local IPC transport
+// the supplied URL names. `unix:<path>` uses the kernel's AF_UNIX listener;
+// `npipe:<name>` uses a Windows named pipe via go-winio. Any other scheme
+// is rejected.
+func newLocalProxy(listenURL string) (*HubProxy, error) {
+	dial, err := locallisten.Dialer(listenURL)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported local proxy URL %q: %w", listenURL, err)
+	}
 	jar, _ := cookiejar.New(nil)
-
 	return &HubProxy{
 		client: &http.Client{
-			Jar: jar,
-			Transport: &http2.Transport{
-				AllowHTTP: true,
-				DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", socketPath)
-				},
-			},
+			Jar:       jar,
+			Transport: locallisten.NewLocalH2CTransport(dial),
 		},
 		// WebSocket upgrade requires HTTP/1.1, not h2c.
 		wsClient: &http.Client{
 			Jar: jar,
 			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "unix", socketPath)
-				},
+				DialContext: locallisten.HTTPDialContext(dial),
 			},
 		},
 		baseURL: "http://localhost",
-	}
+	}, nil
 }
 
 // newHTTPProxy creates a proxy that connects to a remote Hub via HTTP(S).
@@ -108,11 +102,14 @@ func (a *App) ProxyHTTP(method, path string, headers map[string]string, body []b
 	// Build response headers. For Set-Cookie, join all values so the
 	// frontend can see them (map[string]string loses multi-values).
 	respHeaders := make(map[string]string, len(resp.Header))
-	for k := range resp.Header {
-		if strings.EqualFold(k, "Set-Cookie") {
-			respHeaders[k] = strings.Join(resp.Header.Values(k), ", ")
+	for k, v := range resp.Header {
+		if len(v) == 0 {
+			continue
+		}
+		if k == "Set-Cookie" {
+			respHeaders[k] = strings.Join(v, ", ")
 		} else {
-			respHeaders[k] = resp.Header.Get(k)
+			respHeaders[k] = v[0]
 		}
 	}
 

--- a/desktop/go/rpc.go
+++ b/desktop/go/rpc.go
@@ -47,6 +47,9 @@ func (s *RPCSession) Run() error {
 		if req == nil {
 			continue
 		}
+		// Unbounded per-request goroutine is intentional: the peer is the
+		// trusted Tauri shell (one session at a time, enforced by socket.go),
+		// not an untrusted network client.
 		go s.handleRequest(req)
 	}
 }
@@ -61,6 +64,11 @@ func isBenignSessionReadError(err error) bool {
 	if errors.Is(err, net.ErrClosed) {
 		return true
 	}
+	if isPipeClosed(err) {
+		return true
+	}
+	// Fallback for errors that don't implement Unwrap (net/net.OpError
+	// occasionally wraps the bare "use of closed network connection" string).
 	return strings.Contains(err.Error(), "use of closed network connection")
 }
 

--- a/desktop/go/socket.go
+++ b/desktop/go/socket.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/leapmux/leapmux/locallisten"
+)
+
+// sidecarIdleTimeout is the duration of quiet between sessions after which
+// the sidecar shuts itself down. A variable (not const) so tests can shorten it.
+var sidecarIdleTimeout = 15 * time.Second
+
+// RunSocketServer listens on endpoint (a raw Unix socket path or Windows pipe
+// name; the scheme is prepended automatically) and serves one RPC session at
+// a time. Shuts the sidecar down when no client has been attached for
+// sidecarIdleTimeout.
+func RunSocketServer(endpoint string, binaryHash string) error {
+	listenURL, err := prepareEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	listener, err := locallisten.Listen(listenURL)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", listenURL, err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	app := NewApp(binaryHash)
+	defer app.Shutdown()
+
+	go func() {
+		<-app.ctx.Done()
+		_ = listener.Close()
+	}()
+
+	// Single-owner idle timer: the goroutine that reads from timer.C also
+	// drives Stop/Reset via busyStart/busyEnd, so the accept loop never
+	// races the timer. The timer is stopped for the full duration of a
+	// session and re-armed only when the session ends, so long-lived
+	// connections don't trip the idle deadline.
+	busyStart := make(chan struct{}, 1)
+	busyEnd := make(chan struct{}, 1)
+	go func() {
+		timer := time.NewTimer(sidecarIdleTimeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-busyStart:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				select {
+				case <-busyEnd:
+					timer.Reset(sidecarIdleTimeout)
+				case <-app.ctx.Done():
+					return
+				}
+			case <-timer.C:
+				slog.Info("desktop sidecar idle timeout reached; shutting down")
+				app.Shutdown()
+				return
+			case <-app.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	signal := func(ch chan<- struct{}) {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if app.ctx.Err() != nil {
+				return nil
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+
+		signal(busyStart)
+
+		session := NewRPCSession(app, conn, conn, func() {
+			app.Shutdown()
+			_ = conn.Close()
+		})
+		runErr := session.Run()
+		_ = conn.Close()
+		if runErr != nil {
+			return runErr
+		}
+
+		signal(busyEnd)
+	}
+}

--- a/desktop/go/socket_unix.go
+++ b/desktop/go/socket_unix.go
@@ -3,85 +3,13 @@
 package main
 
 import (
-	"errors"
-	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
-	"time"
 )
 
-const sidecarIdleTimeout = 15 * time.Second
-
-func RunSocketServer(socketPath string, binaryHash string) error {
+func prepareEndpoint(socketPath string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
-		return err
+		return "", err
 	}
-	_ = os.Remove(socketPath)
-
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = listener.Close()
-		_ = os.Remove(socketPath)
-	}()
-	_ = os.Chmod(socketPath, 0o600)
-
-	app := NewApp(binaryHash)
-	defer app.Shutdown()
-
-	go func() {
-		<-app.ctx.Done()
-		_ = listener.Close()
-	}()
-
-	idleTimer := time.NewTimer(sidecarIdleTimeout)
-	defer idleTimer.Stop()
-
-	go func() {
-		for {
-			select {
-			case <-idleTimer.C:
-				slog.Info("desktop sidecar idle timeout reached; shutting down")
-				app.Shutdown()
-				return
-			case <-app.ctx.Done():
-				return
-			}
-		}
-	}()
-
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			if app.ctx.Err() != nil {
-				return nil
-			}
-			if errors.Is(err, net.ErrClosed) {
-				return nil
-			}
-			return err
-		}
-
-		if !idleTimer.Stop() {
-			select {
-			case <-idleTimer.C:
-			default:
-			}
-		}
-
-		session := NewRPCSession(app, conn, conn, func() {
-			app.Shutdown()
-			_ = conn.Close()
-		})
-		runErr := session.Run()
-		_ = conn.Close()
-		if runErr != nil {
-			return runErr
-		}
-
-		idleTimer.Reset(sidecarIdleTimeout)
-	}
+	return "unix:" + socketPath, nil
 }

--- a/desktop/go/socket_windows.go
+++ b/desktop/go/socket_windows.go
@@ -2,10 +2,6 @@
 
 package main
 
-import "fmt"
-
-func RunSocketServer(socketPath string, binaryHash string) error {
-	_ = socketPath
-	_ = binaryHash
-	return fmt.Errorf("dev socket mode is not implemented on windows")
+func prepareEndpoint(pipePath string) (string, error) {
+	return "npipe:" + pipePath, nil
 }

--- a/desktop/go/socket_windows_test.go
+++ b/desktop/go/socket_windows_test.go
@@ -1,0 +1,219 @@
+//go:build windows
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+var testPipeCounter atomic.Uint64
+
+func uniqueTestPipePath(t *testing.T) string {
+	n := testPipeCounter.Add(1)
+	return fmt.Sprintf(`\\.\pipe\leapmux-test-%d-%d-%d`, os.Getpid(), time.Now().UnixNano(), n)
+}
+
+// TestRunSocketServerErrorsOnInvalidPipePath ensures an invalid pipe path
+// returns a wrapped error instead of panicking.
+func TestRunSocketServerErrorsOnInvalidPipePath(t *testing.T) {
+	err := RunSocketServer("", "test-hash")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listen ")
+}
+
+// runServerInBackground starts RunSocketServer on a goroutine and returns a
+// channel that yields the terminal error (nil on clean exit). It waits briefly
+// for the listener to be ready by polling DialPipe.
+func runServerInBackground(t *testing.T, pipePath, binaryHash string) <-chan error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunSocketServer(pipePath, binaryHash)
+	}()
+
+	// Wait for the pipe to appear. The listener is up after the first
+	// successful DialPipe.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		probe, err := winio.DialPipe(pipePath, nil)
+		if err == nil {
+			_ = probe.Close()
+			return done
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("pipe %s never became reachable", pipePath)
+	return done
+}
+
+// TestRunSocketServerHandshake exercises the full server-side flow: connect,
+// send a GetSidecarInfo request via the real frame encoder, and verify the
+// RPC session responds with the protocol version and binary hash we passed in.
+func TestRunSocketServerHandshake(t *testing.T) {
+	pipePath := uniqueTestPipePath(t)
+	const binaryHash = "test-binary-hash-abc"
+
+	done := runServerInBackground(t, pipePath, binaryHash)
+
+	conn, err := winio.DialPipe(pipePath, nil)
+	require.NoError(t, err, "DialPipe")
+	reader := bufio.NewReader(conn)
+
+	request := &desktoppb.Frame{
+		Message: &desktoppb.Frame_Request{
+			Request: &desktoppb.Request{
+				Id: 1,
+				Method: &desktoppb.Request_GetSidecarInfo{
+					GetSidecarInfo: &desktoppb.GetSidecarInfoRequest{},
+				},
+			},
+		},
+	}
+	require.NoError(t, WriteFrame(conn, request), "WriteFrame")
+
+	got, err := ReadFrame(reader)
+	require.NoError(t, err, "ReadFrame")
+	resp := got.GetResponse()
+	require.NotNil(t, resp, "expected Response frame")
+	assert.Equal(t, uint64(1), resp.Id)
+	assert.Empty(t, resp.Error)
+
+	info := resp.GetSidecarInfo()
+	require.NotNil(t, info, "expected SidecarInfo result")
+	assert.Equal(t, "1", info.ProtocolVersion)
+	assert.Equal(t, binaryHash, info.BinaryHash)
+	assert.Equal(t, int64(os.Getpid()), info.Pid)
+
+	// Initiate a graceful shutdown so the server goroutine exits cleanly
+	// instead of leaking until the idle timeout fires.
+	shutdown := &desktoppb.Frame{
+		Message: &desktoppb.Frame_Request{
+			Request: &desktoppb.Request{
+				Id:     2,
+				Method: &desktoppb.Request_Shutdown{Shutdown: &desktoppb.ShutdownRequest{}},
+			},
+		},
+	}
+	require.NoError(t, WriteFrame(conn, shutdown), "WriteFrame shutdown")
+	// The server responds before tearing the connection down; drain it so
+	// the session loop observes EOF cleanly.
+	_, _ = ReadFrame(reader)
+	_ = conn.Close()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "RunSocketServer exited with error")
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not exit after shutdown RPC")
+	}
+}
+
+// TestRunSocketServerRejectsConcurrentSessions confirms only one session runs
+// at a time: while the first client is still connected, a second dial should
+// block until the first session returns (winio's default pipe config allows
+// exactly one instance as we configured).
+func TestRunSocketServerSerializesSessions(t *testing.T) {
+	pipePath := uniqueTestPipePath(t)
+	done := runServerInBackground(t, pipePath, "hash")
+
+	first, err := winio.DialPipe(pipePath, nil)
+	require.NoError(t, err, "first DialPipe")
+
+	// Second dial should fail fast or block until first closes.
+	secondCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		timeout := 500 * time.Millisecond
+		c, err := winio.DialPipe(pipePath, &timeout)
+		if err == nil {
+			_ = c.Close()
+		}
+		secondCh <- err
+	}()
+
+	select {
+	case err := <-secondCh:
+		// Some winio versions fail fast with ERROR_PIPE_BUSY / deadline exceeded
+		// when the pipe has only one instance. Either behavior is acceptable
+		// as long as it doesn't silently let both clients through.
+		assert.Error(t, err, "second dial should not succeed while first is open")
+	case <-time.After(2 * time.Second):
+		t.Fatal("second dial neither succeeded nor returned an error in time")
+	}
+	wg.Wait()
+
+	// Clean up: shutdown the first session.
+	shutdown := &desktoppb.Frame{
+		Message: &desktoppb.Frame_Request{
+			Request: &desktoppb.Request{
+				Id:     1,
+				Method: &desktoppb.Request_Shutdown{Shutdown: &desktoppb.ShutdownRequest{}},
+			},
+		},
+	}
+	_ = WriteFrame(first, shutdown)
+	_, _ = ReadFrame(bufio.NewReader(first))
+	_ = first.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not exit after first session shut down")
+	}
+}
+
+// TestRunSocketServerLongSessionSurvivesIdleTimeout is a regression guard:
+// while a client is connected, the idle timer must stay stopped — otherwise
+// a long-lived RPC session gets killed mid-flight at idleTimeout.
+func TestRunSocketServerLongSessionSurvivesIdleTimeout(t *testing.T) {
+	orig := sidecarIdleTimeout
+	sidecarIdleTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { sidecarIdleTimeout = orig })
+
+	pipePath := uniqueTestPipePath(t)
+	done := runServerInBackground(t, pipePath, "hash")
+
+	conn, err := winio.DialPipe(pipePath, nil)
+	require.NoError(t, err, "DialPipe")
+
+	// Hold the connection idle for ~4× the timeout. If the idle timer fires
+	// mid-session, the server closes the connection and exits; we'd observe
+	// the server goroutine returning early.
+	select {
+	case err := <-done:
+		t.Fatalf("server exited while client was connected: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	shutdown := &desktoppb.Frame{
+		Message: &desktoppb.Frame_Request{
+			Request: &desktoppb.Request{
+				Id:     1,
+				Method: &desktoppb.Request_Shutdown{Shutdown: &desktoppb.ShutdownRequest{}},
+			},
+		},
+	}
+	require.NoError(t, WriteFrame(conn, shutdown))
+	_, _ = ReadFrame(bufio.NewReader(conn))
+	_ = conn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not exit after shutdown RPC")
+	}
+}

--- a/desktop/go/solo.go
+++ b/desktop/go/solo.go
@@ -42,4 +42,3 @@ func (a *App) stopSolo() {
 		a.prevLogHandler = nil
 	}
 }
-

--- a/desktop/go/solo.go
+++ b/desktop/go/solo.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
-	"os"
-	"time"
 
 	"github.com/leapmux/leapmux/solo"
 )
@@ -47,23 +43,3 @@ func (a *App) stopSolo() {
 	}
 }
 
-// waitForSoloReady polls for the Unix socket file until it exists.
-func (a *App) waitForSoloReady(ctx context.Context, socketPath string) error {
-	const (
-		pollInterval = 100 * time.Millisecond
-		timeout      = 30 * time.Second
-	)
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(socketPath); err == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(pollInterval):
-		}
-	}
-	return fmt.Errorf("LeapMux did not become ready within %s", timeout)
-}

--- a/desktop/rust/Cargo.lock
+++ b/desktop/rust/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tokio",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/desktop/rust/Cargo.toml
+++ b/desktop/rust/Cargo.toml
@@ -17,3 +17,14 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+] }

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -44,13 +44,21 @@ const SHOW_PREFERENCES_MENU_ID: &str = "show-preferences";
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
 const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024; // 16 MB
 const SIDECAR_PROTOCOL_VERSION: &str = "1";
-const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(unix)]
-const DEV_SIDECAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+// CONNECT_TIMEOUT is the outer loop budget for "endpoint reachable +
+// handshake succeeds"; HANDSHAKE_TIMEOUT bounds a single attempt. Keep
+// CONNECT meaningfully larger so the loop can retry after a wedged probe.
+const DEV_SIDECAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+const DEV_SIDECAR_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+const SIDECAR_INITIAL_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+// Cross-language env-var contract; see desktop/go/main.go for semantics.
+const ENV_DEV_ENDPOINT: &str = "LEAPMUX_DESKTOP_DEV_ENDPOINT";
+const ENV_BINARY_HASH: &str = "LEAPMUX_DESKTOP_BINARY_HASH";
 
 #[derive(Serialize)]
 struct SidecarMetadata {
-    socket_path: String,
+    endpoint: String,
     pid: u32,
     binary_hash: String,
     protocol_version: String,
@@ -264,11 +272,78 @@ fn start_sidecar_reader_thread(
 }
 
 fn bootstrap_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     if cfg!(debug_assertions) {
-        return bootstrap_dev_socket_sidecar(sidecar_path);
+        return bootstrap_dev_sidecar(sidecar_path);
     }
     spawn_stdio_sidecar(sidecar_path)
+}
+
+// bootstrap_dev_sidecar tries to reuse a live dev sidecar at the well-known
+// endpoint (unix socket on Unix, named pipe on Windows) and falls back to
+// spawning a fresh one when the endpoint is stale, incompatible, or missing.
+#[cfg(any(unix, windows))]
+fn bootstrap_dev_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
+    #[cfg(unix)]
+    let endpoint = dev_sidecar_endpoint();
+    #[cfg(windows)]
+    let endpoint = dev_sidecar_endpoint()?;
+    let metadata_path = dev_sidecar_metadata_path();
+    let binary_hash = hash_sidecar_binary(sidecar_path)?;
+
+    if let Ok(Some((reader, writer, info))) = try_connect_dev_sidecar(&endpoint) {
+        if info.protocol_version == SIDECAR_PROTOCOL_VERSION && info.binary_hash == binary_hash {
+            write_sidecar_metadata(&metadata_path, &endpoint, info.pid as u32, &binary_hash)?;
+            return Ok(SidecarBootstrap {
+                child: None,
+                reader,
+                writer,
+            });
+        }
+        request_sidecar_shutdown(&endpoint, info.pid as u32)?;
+    }
+    cleanup_dev_sidecar_artifacts(&endpoint, &metadata_path);
+
+    let mut command = Command::new(sidecar_path);
+    command
+        .env(ENV_DEV_ENDPOINT, &endpoint)
+        .env(ENV_BINARY_HASH, &binary_hash)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let child = command
+        .spawn()
+        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
+
+    let start = Instant::now();
+    loop {
+        match try_connect_dev_sidecar(&endpoint) {
+            Ok(Some((reader, writer, info))) => {
+                if info.protocol_version != SIDECAR_PROTOCOL_VERSION {
+                    return Err(format!(
+                        "unexpected sidecar protocol version: {}",
+                        info.protocol_version,
+                    ));
+                }
+                if info.binary_hash != binary_hash {
+                    return Err("spawned sidecar reported an unexpected binary hash".to_string());
+                }
+                write_sidecar_metadata(&metadata_path, &endpoint, info.pid as u32, &binary_hash)?;
+                return Ok(SidecarBootstrap {
+                    child: Some(child),
+                    reader,
+                    writer,
+                });
+            }
+            Ok(None) => {}
+            Err(err) => return Err(err),
+        }
+
+        if start.elapsed() > DEV_SIDECAR_CONNECT_TIMEOUT {
+            return Err("timed out waiting for desktop sidecar endpoint".to_string());
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
 fn spawn_stdio_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
@@ -310,74 +385,6 @@ fn start_sidecar_stderr_thread(stderr: impl Read + Send + 'static) {
     });
 }
 
-#[cfg(unix)]
-fn bootstrap_dev_socket_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
-    let socket_path = dev_sidecar_socket_path();
-    let metadata_path = dev_sidecar_metadata_path();
-    let binary_hash = hash_sidecar_binary(sidecar_path)?;
-
-    if let Ok(Some((reader, writer, info))) = try_connect_dev_sidecar(&socket_path) {
-        if info.protocol_version == SIDECAR_PROTOCOL_VERSION && info.binary_hash == binary_hash {
-            write_sidecar_metadata(&metadata_path, &socket_path, info.pid as u32, &binary_hash)?;
-            return Ok(SidecarBootstrap {
-                child: None,
-                reader,
-                writer,
-            });
-        }
-        request_sidecar_shutdown(&socket_path, info.pid as u32)?;
-        cleanup_dev_sidecar_artifacts(&socket_path, &metadata_path);
-    } else {
-        cleanup_dev_sidecar_artifacts(&socket_path, &metadata_path);
-    }
-
-    let mut command = Command::new(sidecar_path);
-    command
-        .env("LEAPMUX_DESKTOP_DEV_SOCKET", &socket_path)
-        .env("LEAPMUX_DESKTOP_BINARY_HASH", &binary_hash)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit());
-    let child = command
-        .spawn()
-        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
-    let start = Instant::now();
-    loop {
-        match try_connect_dev_sidecar(&socket_path) {
-            Ok(Some((reader, writer, info))) => {
-                if info.protocol_version != SIDECAR_PROTOCOL_VERSION {
-                    return Err(format!(
-                        "unexpected sidecar protocol version: {}",
-                        info.protocol_version,
-                    ));
-                }
-                if info.binary_hash != binary_hash {
-                    return Err("spawned sidecar reported an unexpected binary hash".to_string());
-                }
-                write_sidecar_metadata(
-                    &metadata_path,
-                    &socket_path,
-                    info.pid as u32,
-                    &binary_hash,
-                )?;
-                return Ok(SidecarBootstrap {
-                    child: Some(child),
-                    reader,
-                    writer,
-                });
-            }
-            Ok(None) => {}
-            Err(err) => return Err(err),
-        }
-
-        if start.elapsed() > DEV_SIDECAR_CONNECT_TIMEOUT {
-            return Err("timed out waiting for desktop sidecar socket".to_string());
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-}
-
-#[cfg(unix)]
 type DevSidecarConnection = (
     Box<dyn Read + Send>,
     Box<dyn Write + Send>,
@@ -385,10 +392,12 @@ type DevSidecarConnection = (
 );
 
 #[cfg(unix)]
-fn try_connect_dev_sidecar(
-    socket_path: &Path,
-) -> Result<Option<DevSidecarConnection>, String> {
-    match connect_and_handshake_dev_sidecar(socket_path)? {
+type SidecarStream = UnixStream;
+#[cfg(windows)]
+type SidecarStream = PipeHandle;
+
+fn try_connect_dev_sidecar(endpoint: &str) -> Result<Option<DevSidecarConnection>, String> {
+    match connect_and_handshake_dev_sidecar(endpoint)? {
         Some((reader, writer, info)) => Ok(Some((
             Box::new(reader),
             Box::new(BufWriter::new(writer)),
@@ -398,11 +407,51 @@ fn try_connect_dev_sidecar(
     }
 }
 
+fn connect_and_handshake_dev_sidecar(
+    endpoint: &str,
+) -> Result<Option<(SidecarStream, SidecarStream, proto::SidecarInfo)>, String> {
+    let (mut reader, mut writer) = match connect_sidecar_endpoint(endpoint)? {
+        Some(pair) => pair,
+        None => return Ok(None),
+    };
+    // Unix streams carry per-op timeouts from connect; Windows named pipes
+    // don't, so arm a watchdog that cancels the handshake's synchronous I/O.
+    #[cfg(windows)]
+    let _watchdog = HandshakeWatchdog::arm(DEV_SIDECAR_HANDSHAKE_TIMEOUT)?;
+    let info = fetch_sidecar_info(&mut reader, &mut writer)?;
+    finalize_sidecar_streams(&reader, &writer)?;
+    Ok(Some((reader, writer, info)))
+}
+
+fn request_sidecar_shutdown(endpoint: &str, pid: u32) -> Result<(), String> {
+    if let Ok(Some((mut reader, mut writer))) = connect_sidecar_endpoint(endpoint) {
+        let frame = proto::Frame {
+            message: Some(proto::frame::Message::Request(proto::Request {
+                id: 1,
+                method: Some(proto::request::Method::Shutdown(proto::ShutdownRequest {})),
+            })),
+        };
+        let _ = write_frame(&mut writer, &frame);
+        let _ = read_frame(&mut reader);
+    }
+
+    let deadline = Instant::now() + DEV_SIDECAR_SHUTDOWN_TIMEOUT;
+    while Instant::now() < deadline {
+        if is_sidecar_gone(endpoint) {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    force_kill_sidecar(pid)?;
+    Ok(())
+}
+
 #[cfg(unix)]
-fn connect_sidecar_socket(
-    socket_path: &Path,
-) -> Result<Option<(UnixStream, UnixStream)>, String> {
-    let stream = match UnixStream::connect(socket_path) {
+fn connect_sidecar_endpoint(
+    endpoint: &str,
+) -> Result<Option<(SidecarStream, SidecarStream)>, String> {
+    let stream = match UnixStream::connect(endpoint) {
         Ok(stream) => stream,
         Err(err)
             if err.kind() == io::ErrorKind::NotFound
@@ -417,39 +466,33 @@ fn connect_sidecar_socket(
         .map_err(|err| format!("clone sidecar socket: {err}"))?;
     let writer = stream;
     writer
-        .set_write_timeout(Some(DEV_SIDECAR_CONNECT_TIMEOUT))
+        .set_write_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
         .map_err(|err| format!("set sidecar socket write timeout: {err}"))?;
-    let reader = reader;
     reader
-        .set_read_timeout(Some(DEV_SIDECAR_CONNECT_TIMEOUT))
+        .set_read_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
         .map_err(|err| format!("set sidecar socket read timeout: {err}"))?;
     Ok(Some((reader, writer)))
 }
 
+// Handshake timeouts must be cleared before streams are handed to the
+// long-lived reader thread; otherwise reads fail with EAGAIN after a few
+// seconds of idle and tear the connection down.
 #[cfg(unix)]
-fn connect_and_handshake_dev_sidecar(
-    socket_path: &Path,
-) -> Result<Option<(UnixStream, UnixStream, proto::SidecarInfo)>, String> {
-    let (mut reader, mut writer) = match connect_sidecar_socket(socket_path)? {
-        Some(pair) => pair,
-        None => return Ok(None),
-    };
-    let info = fetch_sidecar_info(&mut reader, &mut writer)?;
-    // The handshake timeouts guarded against a wedged sidecar replying
-    // to GetSidecarInfo. The reader/writer are about to be handed to a
-    // long-lived thread that must block indefinitely on idle — leaving
-    // the timeout in place causes reads to surface EAGAIN (os error 35)
-    // after ~2s of inactivity and tears the connection down.
+fn finalize_sidecar_streams(reader: &SidecarStream, writer: &SidecarStream) -> Result<(), String> {
     reader
         .set_read_timeout(None)
         .map_err(|err| format!("clear sidecar socket read timeout: {err}"))?;
     writer
         .set_write_timeout(None)
         .map_err(|err| format!("clear sidecar socket write timeout: {err}"))?;
-    Ok(Some((reader, writer, info)))
+    Ok(())
 }
 
 #[cfg(unix)]
+fn is_sidecar_gone(endpoint: &str) -> bool {
+    !Path::new(endpoint).exists()
+}
+
 fn fetch_sidecar_info(
     reader: &mut impl Read,
     writer: &mut impl Write,
@@ -478,31 +521,6 @@ fn fetch_sidecar_info(
 }
 
 #[cfg(unix)]
-fn request_sidecar_shutdown(socket_path: &Path, pid: u32) -> Result<(), String> {
-    if let Ok(Some((mut reader, mut writer))) = connect_sidecar_socket(socket_path) {
-        let frame = proto::Frame {
-            message: Some(proto::frame::Message::Request(proto::Request {
-                id: 1,
-                method: Some(proto::request::Method::Shutdown(proto::ShutdownRequest {})),
-            })),
-        };
-        let _ = write_frame(&mut writer, &frame);
-        let _ = read_frame(&mut reader);
-    }
-
-    let deadline = Instant::now() + DEV_SIDECAR_SHUTDOWN_TIMEOUT;
-    while Instant::now() < deadline {
-        if !socket_path.exists() {
-            return Ok(());
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    force_kill_sidecar(pid)?;
-    Ok(())
-}
-
-#[cfg(unix)]
 fn force_kill_sidecar(pid: u32) -> Result<(), String> {
     let status = Command::new("kill")
         .args(["-TERM", &pid.to_string()])
@@ -521,40 +539,62 @@ fn force_kill_sidecar(pid: u32) -> Result<(), String> {
 }
 
 #[cfg(unix)]
-fn cleanup_dev_sidecar_artifacts(socket_path: &Path, metadata_path: &Path) {
-    let _ = fs::remove_file(socket_path);
+fn cleanup_dev_sidecar_artifacts(endpoint: &str, metadata_path: &Path) {
+    let _ = fs::remove_file(endpoint);
     let _ = fs::remove_file(metadata_path);
 }
 
-#[cfg(unix)]
 fn write_sidecar_metadata(
     metadata_path: &Path,
-    socket_path: &Path,
+    endpoint: &str,
     pid: u32,
     binary_hash: &str,
 ) -> Result<(), String> {
     let metadata = SidecarMetadata {
-        socket_path: socket_path.display().to_string(),
+        endpoint: endpoint.to_string(),
         pid,
         binary_hash: binary_hash.to_string(),
         protocol_version: SIDECAR_PROTOCOL_VERSION.to_string(),
     };
     if let Some(parent) = metadata_path.parent() {
         fs::create_dir_all(parent).map_err(|err| format!("create sidecar metadata dir: {err}"))?;
-        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
-            .map_err(|err| format!("set sidecar metadata dir permissions: {err}"))?;
+        restrict_dir_permissions(parent)?;
     }
     let data = serde_json::to_vec_pretty(&metadata)
         .map_err(|err| format!("serialize sidecar metadata: {err}"))?;
     fs::write(metadata_path, data).map_err(|err| format!("write sidecar metadata: {err}"))?;
-    fs::set_permissions(metadata_path, fs::Permissions::from_mode(0o600))
-        .map_err(|err| format!("set sidecar metadata permissions: {err}"))?;
+    restrict_file_permissions(metadata_path)?;
     Ok(())
 }
 
 #[cfg(unix)]
-fn dev_sidecar_socket_path() -> PathBuf {
-    dev_sidecar_runtime_dir().join(format!("{}-sidecar.sock", sidecar_identity()))
+fn restrict_dir_permissions(path: &Path) -> Result<(), String> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|err| format!("set sidecar metadata dir permissions: {err}"))
+}
+
+#[cfg(unix)]
+fn restrict_file_permissions(path: &Path) -> Result<(), String> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|err| format!("set sidecar metadata permissions: {err}"))
+}
+
+#[cfg(windows)]
+fn restrict_dir_permissions(_: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn restrict_file_permissions(_: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn dev_sidecar_endpoint() -> String {
+    dev_sidecar_runtime_dir()
+        .join(format!("{}-sidecar.sock", sidecar_identity()))
+        .display()
+        .to_string()
 }
 
 #[cfg(unix)]
@@ -569,12 +609,18 @@ fn dev_sidecar_runtime_dir() -> PathBuf {
 
 #[cfg(unix)]
 fn sidecar_identity() -> String {
-    std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
-        .unwrap_or_else(|_| "default".to_string())
-        .chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-        .collect()
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<String> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .unwrap_or_else(|_| "default".to_string())
+                .chars()
+                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+                .collect()
+        })
+        .clone()
 }
 
 fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
@@ -594,6 +640,340 @@ fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
     }
     let digest = hasher.finalize();
     Ok(digest.iter().map(|b| format!("{:02x}", b)).collect())
+}
+
+// --- Windows named-pipe dev-mode sidecar reconnect ---
+
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+#[cfg(windows)]
+use windows_sys::Win32::{
+    Foundation::{
+        CloseHandle, DuplicateHandle, GetLastError, LocalFree, DUPLICATE_SAME_ACCESS,
+        ERROR_FILE_NOT_FOUND, ERROR_PIPE_BUSY, HANDLE, HLOCAL, INVALID_HANDLE_VALUE,
+    },
+    Security::{
+        Authorization::ConvertSidToStringSidW, GetTokenInformation, TokenUser, TOKEN_QUERY,
+        TOKEN_USER,
+    },
+    Storage::FileSystem::{
+        CreateFileW, ReadFile, WriteFile, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ,
+        FILE_GENERIC_WRITE, OPEN_EXISTING,
+    },
+    System::{
+        Pipes::WaitNamedPipeW,
+        Threading::{
+            GetCurrentProcess, GetCurrentThread, OpenProcess, OpenProcessToken, TerminateProcess,
+            PROCESS_TERMINATE,
+        },
+        IO::CancelSynchronousIo,
+    },
+};
+
+#[cfg(windows)]
+fn finalize_sidecar_streams(_: &SidecarStream, _: &SidecarStream) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn is_sidecar_gone(pipe_name: &str) -> bool {
+    matches!(connect_sidecar_endpoint(pipe_name), Ok(None))
+}
+
+#[cfg(windows)]
+fn connect_sidecar_endpoint(
+    pipe_name: &str,
+) -> Result<Option<(SidecarStream, SidecarStream)>, String> {
+    const MAX_BUSY_RETRIES: u32 = 3;
+    let wide = wide_cstring(pipe_name);
+    for _ in 0..=MAX_BUSY_RETRIES {
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                0,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            let err = unsafe { GetLastError() };
+            if err == ERROR_FILE_NOT_FOUND {
+                return Ok(None);
+            }
+            if err == ERROR_PIPE_BUSY {
+                let waited = unsafe { WaitNamedPipeW(wide.as_ptr(), 5_000) };
+                if waited == 0 {
+                    // Still busy or pipe closed between retries; let the caller
+                    // decide whether to keep trying.
+                    return Ok(None);
+                }
+                continue;
+            }
+            return Err(format!("open named pipe {pipe_name}: error {err}"));
+        }
+
+        let dup = match duplicate_handle(handle) {
+            Ok(dup) => dup,
+            Err(err) => {
+                unsafe {
+                    CloseHandle(handle);
+                }
+                return Err(format!("duplicate pipe handle: error {err}"));
+            }
+        };
+        return Ok(Some((PipeHandle(handle), PipeHandle(dup))));
+    }
+    Ok(None)
+}
+
+#[cfg(windows)]
+fn force_kill_sidecar(pid: u32) -> Result<(), String> {
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if handle.is_null() {
+            return Err(format!(
+                "open sidecar process {pid}: error {}",
+                GetLastError()
+            ));
+        }
+        let ok = TerminateProcess(handle, 1);
+        let err = if ok == 0 { GetLastError() } else { 0 };
+        CloseHandle(handle);
+        if ok == 0 {
+            return Err(format!("terminate sidecar process {pid}: error {err}"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn cleanup_dev_sidecar_artifacts(_endpoint: &str, metadata_path: &Path) {
+    // Named pipes release themselves when the server closes the listener;
+    // only the metadata file persists on disk.
+    let _ = fs::remove_file(metadata_path);
+}
+
+#[cfg(windows)]
+fn dev_sidecar_endpoint() -> Result<String, String> {
+    Ok(format!(
+        "\\\\.\\pipe\\leapmux-desktop-{}-sidecar",
+        sidecar_identity()?
+    ))
+}
+
+#[cfg(windows)]
+fn dev_sidecar_metadata_path() -> PathBuf {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    base.join("leapmux-desktop").join("sidecar.json")
+}
+
+#[cfg(windows)]
+fn sidecar_identity() -> Result<String, String> {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<Result<String, String>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            current_user_sid().map(|raw| {
+                raw.chars()
+                    .map(|c| {
+                        if c.is_ascii_alphanumeric() || c == '-' {
+                            c
+                        } else {
+                            '_'
+                        }
+                    })
+                    .collect()
+            })
+        })
+        .clone()
+}
+
+#[cfg(windows)]
+fn current_user_sid() -> Result<String, String> {
+    unsafe {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err(format!("open process token: error {}", GetLastError()));
+        }
+        let mut needed: u32 = 0;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+        let mut buffer = vec![0u8; needed as usize];
+        let ok = GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr() as *mut _,
+            needed,
+            &mut needed,
+        );
+        let token_err = if ok == 0 { GetLastError() } else { 0 };
+        CloseHandle(token);
+        if ok == 0 {
+            return Err(format!("get token user info: error {token_err}"));
+        }
+        let user_info = &*(buffer.as_ptr() as *const TOKEN_USER);
+        let mut sid_string_ptr: *mut u16 = std::ptr::null_mut();
+        if ConvertSidToStringSidW(user_info.User.Sid, &mut sid_string_ptr) == 0 {
+            return Err(format!("convert sid to string: error {}", GetLastError()));
+        }
+        let mut len = 0;
+        while *sid_string_ptr.add(len) != 0 {
+            len += 1;
+        }
+        let slice = std::slice::from_raw_parts(sid_string_ptr, len);
+        let sid = String::from_utf16_lossy(slice);
+        LocalFree(sid_string_ptr as HLOCAL);
+        Ok(sid)
+    }
+}
+
+#[cfg(windows)]
+fn duplicate_handle(source: HANDLE) -> Result<HANDLE, u32> {
+    unsafe {
+        let mut dup: HANDLE = std::ptr::null_mut();
+        let proc = GetCurrentProcess();
+        if DuplicateHandle(proc, source, proc, &mut dup, 0, 0, DUPLICATE_SAME_ACCESS) == 0 {
+            return Err(GetLastError());
+        }
+        Ok(dup)
+    }
+}
+
+#[cfg(windows)]
+fn wide_cstring(s: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+// Invariant: .0 is an owned, non-aliased HANDLE — Drop closes it, so
+// constructors (only reachable within this module) must ensure exclusive
+// ownership. Aliased handles would cause double-close and break Send.
+#[cfg(windows)]
+struct PipeHandle(HANDLE);
+
+#[cfg(windows)]
+impl Drop for PipeHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+// Safe given the ownership invariant on PipeHandle.0 above.
+#[cfg(windows)]
+unsafe impl Send for PipeHandle {}
+
+#[cfg(windows)]
+impl Read for PipeHandle {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        const ERROR_BROKEN_PIPE: u32 = 109;
+        const ERROR_PIPE_NOT_CONNECTED: u32 = 233;
+        let mut read: u32 = 0;
+        let ok = unsafe {
+            ReadFile(
+                self.0,
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as u32,
+                &mut read,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            let err = unsafe { GetLastError() };
+            if err == ERROR_BROKEN_PIPE || err == ERROR_PIPE_NOT_CONNECTED {
+                return Ok(0);
+            }
+            return Err(io::Error::from_raw_os_error(err as i32));
+        }
+        Ok(read as usize)
+    }
+}
+
+#[cfg(windows)]
+impl Write for PipeHandle {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut written: u32 = 0;
+        let ok = unsafe {
+            WriteFile(
+                self.0,
+                buf.as_ptr() as *const _,
+                buf.len() as u32,
+                &mut written,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe { GetLastError() } as i32));
+        }
+        Ok(written as usize)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+// ThreadHandle wraps a duplicated thread HANDLE and closes it on drop. The
+// raw HANDLE is !Send; this newtype asserts the invariant that callers hand
+// ownership to exactly one thread.
+#[cfg(windows)]
+struct ThreadHandle(HANDLE);
+
+#[cfg(windows)]
+impl Drop for ThreadHandle {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+// Safe: HANDLE is a kernel-object reference; ownership has been duplicated
+// explicitly via DuplicateHandle and is not shared elsewhere.
+#[cfg(windows)]
+unsafe impl Send for ThreadHandle {}
+
+// HandshakeWatchdog bounds a blocking I/O sequence on the arming thread with
+// a deadline. On drop (or deadline), the watchdog thread exits; if the
+// deadline elapses before drop, it calls CancelSynchronousIo on the arming
+// thread so the in-flight ReadFile/WriteFile returns with an error.
+#[cfg(windows)]
+struct HandshakeWatchdog {
+    done_tx: std::sync::mpsc::Sender<()>,
+}
+
+#[cfg(windows)]
+impl HandshakeWatchdog {
+    fn arm(timeout: Duration) -> Result<Self, String> {
+        let target = duplicate_current_thread_handle()?;
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        thread::spawn(move || {
+            if done_rx.recv_timeout(timeout).is_err() {
+                unsafe { CancelSynchronousIo(target.0) };
+            }
+            drop(target);
+        });
+        Ok(HandshakeWatchdog { done_tx })
+    }
+}
+
+#[cfg(windows)]
+impl Drop for HandshakeWatchdog {
+    fn drop(&mut self) {
+        let _ = self.done_tx.send(());
+    }
+}
+
+#[cfg(windows)]
+fn duplicate_current_thread_handle() -> Result<ThreadHandle, String> {
+    duplicate_handle(unsafe { GetCurrentThread() })
+        .map(ThreadHandle)
+        .map_err(|err| format!("duplicate current thread handle: error {err}"))
 }
 
 impl DesktopShell {
@@ -628,7 +1008,21 @@ impl DesktopShell {
             }),
         };
 
-        tauri::async_runtime::block_on(shell.refresh_state_from_sidecar())?;
+        // Bound the initial sidecar handshake so a wedged child can't hang
+        // the Tauri setup thread indefinitely.
+        tauri::async_runtime::block_on(async {
+            tokio::time::timeout(
+                SIDECAR_INITIAL_HANDSHAKE_TIMEOUT,
+                shell.refresh_state_from_sidecar(),
+            )
+            .await
+            .map_err(|_| {
+                format!(
+                    "initial sidecar handshake timed out after {:?}",
+                    SIDECAR_INITIAL_HANDSHAKE_TIMEOUT
+                )
+            })?
+        })?;
         Ok(shell)
     }
 
@@ -1474,6 +1868,7 @@ fn main() {
             } else if event.id() == OPEN_WEB_INSPECTOR_MENU_ID {
                 open_main_web_inspector(app);
             }
+            #[cfg(not(target_os = "macos"))]
             let _ = (app, event);
         })
         .on_window_event(|window, event| {
@@ -1491,10 +1886,12 @@ fn main() {
             }
         })
         .setup(|app| {
-            // On Linux, titleBarStyle "Overlay" is ignored, so remove
-            // native decorations entirely — the frontend renders its own
-            // titlebar with custom window controls.
-            #[cfg(target_os = "linux")]
+            // titleBarStyle "Overlay" is a macOS-only option. On Linux and
+            // Windows the native decorations are left in place by default,
+            // which causes the OS title bar to render alongside our custom
+            // one. Drop the native decorations so the frontend can draw its
+            // own drag region and window controls end-to-end.
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             if let Some(w) = app.get_webview_window("main") {
                 let _ = w.set_decorations(false);
             }
@@ -1561,16 +1958,28 @@ fn main() {
         });
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::io;
-    use std::os::unix::net::UnixListener;
     use std::sync::atomic::AtomicU64;
     use std::time::SystemTime;
 
+    #[cfg(unix)]
+    use std::os::unix::net::UnixListener;
+
+    #[cfg(windows)]
+    use windows_sys::Win32::Storage::FileSystem::PIPE_ACCESS_DUPLEX;
+    #[cfg(windows)]
+    use windows_sys::Win32::System::Pipes::{
+        ConnectNamedPipe, CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+    };
+
     static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+    // ---- Unix-specific helpers and tests ----
+
+    #[cfg(unix)]
     fn unique_test_socket_path() -> PathBuf {
         let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
         let nanos = SystemTime::now()
@@ -1581,6 +1990,7 @@ mod tests {
         std::env::temp_dir().join(format!("leapmux-test-{pid}-{nanos}-{counter}.sock"))
     }
 
+    #[cfg(unix)]
     fn spawn_fake_sidecar(socket_path: PathBuf) -> thread::JoinHandle<()> {
         let listener = UnixListener::bind(&socket_path).expect("bind fake sidecar");
         thread::spawn(move || {
@@ -1608,6 +2018,7 @@ mod tests {
         })
     }
 
+    #[cfg(unix)]
     #[test]
     fn connect_and_handshake_clears_stream_timeouts() {
         let socket_path = unique_test_socket_path();
@@ -1618,10 +2029,10 @@ mod tests {
             .expect("server present");
 
         assert_eq!(info.protocol_version, SIDECAR_PROTOCOL_VERSION);
-        // Without the fix these return `Some(DEV_SIDECAR_CONNECT_TIMEOUT)`,
+        // Without the fix these return `Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT)`,
         // which causes the long-lived reader thread to see EAGAIN
-        // ("Resource temporarily unavailable (os error 35)") after ~2s of
-        // idle and tear the sidecar connection down.
+        // ("Resource temporarily unavailable (os error 35)") after the
+        // handshake timeout of idle and tear the sidecar connection down.
         assert_eq!(reader.read_timeout().expect("read_timeout"), None);
         assert_eq!(writer.write_timeout().expect("write_timeout"), None);
 
@@ -1629,6 +2040,218 @@ mod tests {
         drop(writer);
         server.join().expect("fake sidecar thread");
         let _ = fs::remove_file(&socket_path);
+    }
+
+    // ---- Windows-specific helpers and tests ----
+
+    #[cfg(windows)]
+    fn unique_test_pipe_name() -> String {
+        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let nanos = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let pid = std::process::id();
+        format!("\\\\.\\pipe\\leapmux-test-{pid}-{nanos}-{counter}")
+    }
+
+    #[cfg(windows)]
+    fn spawn_fake_sidecar_pipe(pipe_name: String) -> thread::JoinHandle<()> {
+        // Create the pipe synchronously so the client can connect as soon as
+        // this function returns, regardless of when the accept thread runs.
+        let wide = wide_cstring(&pipe_name);
+        let handle = unsafe {
+            CreateNamedPipeW(
+                wide.as_ptr(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                1,
+                65536,
+                65536,
+                0,
+                std::ptr::null(),
+            )
+        };
+        assert!(
+            handle != INVALID_HANDLE_VALUE,
+            "CreateNamedPipeW failed: error {}",
+            unsafe { GetLastError() },
+        );
+        let server = PipeHandle(handle);
+        thread::spawn(move || {
+            let mut stream = server;
+            let connected = unsafe { ConnectNamedPipe(stream.0, std::ptr::null_mut()) };
+            if connected == 0 {
+                let err = unsafe { GetLastError() };
+                const ERROR_PIPE_CONNECTED: u32 = 535;
+                assert_eq!(
+                    err, ERROR_PIPE_CONNECTED,
+                    "ConnectNamedPipe failed: error {err}"
+                );
+            }
+            let _ = read_frame(&mut stream).expect("read handshake request");
+            let response = proto::Frame {
+                message: Some(proto::frame::Message::Response(proto::Response {
+                    id: 1,
+                    error: String::new(),
+                    result: Some(proto::response::Result::SidecarInfo(proto::SidecarInfo {
+                        protocol_version: SIDECAR_PROTOCOL_VERSION.to_string(),
+                        binary_hash: "test-hash".to_string(),
+                        pid: std::process::id() as i64,
+                        shell_mode: 0,
+                        connected: false,
+                        hub_url: String::new(),
+                    })),
+                })),
+            };
+            write_frame(&mut stream, &response).expect("write handshake response");
+            let _ = stream.read(&mut [0u8; 1]);
+        })
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn connect_and_handshake_pipe_returns_sidecar_info() {
+        let pipe_name = unique_test_pipe_name();
+        let server = spawn_fake_sidecar_pipe(pipe_name.clone());
+
+        let (reader, writer, info) = connect_and_handshake_dev_sidecar(&pipe_name)
+            .expect("handshake ok")
+            .expect("server present");
+
+        assert_eq!(info.protocol_version, SIDECAR_PROTOCOL_VERSION);
+        assert_eq!(info.binary_hash, "test-hash");
+        assert_eq!(info.pid as u32, std::process::id());
+
+        drop(reader);
+        drop(writer);
+        server.join().expect("fake sidecar thread");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn connect_returns_none_when_pipe_absent() {
+        let pipe_name = unique_test_pipe_name();
+        let result = connect_sidecar_endpoint(&pipe_name).expect("no error");
+        assert!(
+            result.is_none(),
+            "expected None for nonexistent pipe, got Some"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn handshake_watchdog_cancels_wedged_read() {
+        // Spawn a server that accepts the connection but never writes back.
+        // With the watchdog armed, the ReadFile should return an error after
+        // the deadline instead of blocking indefinitely.
+        let pipe_name = unique_test_pipe_name();
+        let wide = wide_cstring(&pipe_name);
+        let server_handle = unsafe {
+            CreateNamedPipeW(
+                wide.as_ptr(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                1,
+                65536,
+                65536,
+                0,
+                std::ptr::null(),
+            )
+        };
+        assert!(server_handle != INVALID_HANDLE_VALUE);
+        let server = PipeHandle(server_handle);
+        let server_thread = thread::spawn(move || {
+            let _stream = server;
+            unsafe { ConnectNamedPipe(_stream.0, std::ptr::null_mut()) };
+            thread::sleep(Duration::from_secs(3));
+        });
+
+        let (mut reader, _writer) = connect_sidecar_endpoint(&pipe_name)
+            .expect("connect ok")
+            .expect("server reachable");
+
+        let start = Instant::now();
+        let _watchdog = HandshakeWatchdog::arm(Duration::from_millis(200)).expect("arm");
+        let mut buf = [0u8; 16];
+        let err = reader.read(&mut buf).expect_err("read should fail");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "read should have been cancelled, elapsed {:?}",
+            elapsed
+        );
+        const ERROR_OPERATION_ABORTED: i32 = 995;
+        assert_eq!(
+            err.raw_os_error(),
+            Some(ERROR_OPERATION_ABORTED),
+            "unexpected error: {err}"
+        );
+
+        drop(_watchdog);
+        let _ = server_thread.join();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sidecar_identity_returns_valid_sid_form() {
+        let sid = sidecar_identity().expect("sidecar_identity");
+        assert!(
+            sid.starts_with("S-1-"),
+            "expected SID to start with S-1-, got: {sid}"
+        );
+        assert!(
+            sid.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "sanitized SID must contain only alphanumerics and hyphens, got: {sid}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dev_sidecar_endpoint_has_expected_shape() {
+        let name = dev_sidecar_endpoint().expect("endpoint");
+        assert!(
+            name.starts_with("\\\\.\\pipe\\leapmux-desktop-"),
+            "unexpected prefix in pipe name: {name}"
+        );
+        assert!(
+            name.ends_with("-sidecar"),
+            "unexpected suffix in pipe name: {name}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dev_sidecar_metadata_path_ends_with_sidecar_json() {
+        let path = dev_sidecar_metadata_path();
+        let suffix = PathBuf::from("leapmux-desktop").join("sidecar.json");
+        assert!(
+            path.ends_with(&suffix),
+            "expected path to end with {}, got: {}",
+            suffix.display(),
+            path.display()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_sidecar_metadata_roundtrips_json() {
+        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!("leapmux-test-metadata-{counter}.json"));
+        let _ = fs::remove_file(&path);
+
+        write_sidecar_metadata(&path, "\\\\.\\pipe\\test", 4242, "hash-abc")
+            .expect("write metadata");
+        let data = fs::read_to_string(&path).expect("read metadata");
+        assert!(data.contains("\\\\\\\\.\\\\pipe\\\\test"));
+        assert!(data.contains("\"pid\": 4242"));
+        assert!(data.contains("\"binary_hash\": \"hash-abc\""));
+        assert!(data.contains(&format!(
+            "\"protocol_version\": \"{SIDECAR_PROTOCOL_VERSION}\""
+        )));
+
+        let _ = fs::remove_file(&path);
     }
 
     #[derive(Clone, Default)]

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1602,6 +1602,9 @@ async fn switch_mode(
     Ok(())
 }
 
+// restart_app is macOS-only: only the Full Disk Access flow needs the app
+// to relaunch itself, and FDA is macOS-only.
+#[cfg(target_os = "macos")]
 #[tauri::command]
 async fn restart_app(
     shell: State<'_, Arc<DesktopShell>>,
@@ -1609,7 +1612,24 @@ async fn restart_app(
 ) -> Result<(), String> {
     let current_exe =
         std::env::current_exe().map_err(|err| format!("resolve current exe: {err}"))?;
-    Command::new(current_exe)
+    let app_bundle = current_exe
+        .ancestors()
+        .find(|p| p.extension().is_some_and(|e| e == "app"))
+        .unwrap_or(&current_exe)
+        .to_path_buf();
+
+    // The single-instance plugin kills any second instance that starts while
+    // the primary is still alive, so the relaunch helper polls for the parent
+    // PID to disappear before invoking the new instance via LaunchServices.
+    let parent_pid = std::process::id();
+    Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!(
+            "while kill -0 {pid} 2>/dev/null; do sleep 0.1; done; \
+             exec /usr/bin/open -n {bundle:?}",
+            pid = parent_pid,
+            bundle = app_bundle,
+        ))
         .spawn()
         .map_err(|err| format!("restart app: {err}"))?;
     shell.app_handle.exit(0);
@@ -1935,6 +1955,7 @@ fn main() {
             delete_tunnel,
             list_tunnels,
             switch_mode,
+            #[cfg(target_os = "macos")]
             restart_app,
             save_window_geometry,
             quit_app,
@@ -2024,7 +2045,8 @@ mod tests {
         let socket_path = unique_test_socket_path();
         let server = spawn_fake_sidecar(socket_path.clone());
 
-        let (reader, writer, info) = connect_and_handshake_dev_sidecar(&socket_path)
+        let endpoint = socket_path.to_str().expect("socket path is utf-8");
+        let (reader, writer, info) = connect_and_handshake_dev_sidecar(endpoint)
             .expect("handshake ok")
             .expect("server present");
 

--- a/desktop/rust/tauri.windows.conf.json
+++ b/desktop/rust/tauri.windows.conf.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "mainBinaryName": "LeapMuxDesktop"
+}

--- a/frontend/src/components/shell/CustomTitlebar.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.tsx
@@ -18,11 +18,11 @@ import { WindowCloseIcon, WindowMaximizeIcon, WindowMinimizeIcon, WindowRestoreI
 
 const platform = getPlatform()
 const desktop = isDesktopApp()
-const isLinuxDesktop = desktop && platform === 'linux'
+// Linux and Windows run with `decorations: false`, so the app renders its own
+// min/max/close buttons. macOS keeps native traffic lights.
+const showCustomWindowControls = desktop && (platform === 'linux' || platform === 'windows')
 const MAC_TRAFFIC_LIGHT_INSET_PX = 78
-const WINDOWS_CAPTION_BUTTON_INSET_PX = 138
 const macPadding = desktop && platform === 'mac' ? `${MAC_TRAFFIC_LIGHT_INSET_PX}px` : undefined
-const windowsPadding = desktop && platform === 'windows' ? `${WINDOWS_CAPTION_BUTTON_INSET_PX}px` : undefined
 
 const hamburgerPlacement = platform === 'mac'
   ? { placement: 'auto' as const, xOffset: MAC_TRAFFIC_LIGHT_INSET_PX, yOffset: headerHeightPx }
@@ -46,7 +46,6 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
       class={styles.titlebar}
       style={{
         'padding-left': macPadding,
-        'padding-right': windowsPadding,
       }}
     >
       <DropdownMenu
@@ -99,7 +98,7 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
         onClick={() => props.onToggleRightSidebar()}
       />
 
-      <Show when={isLinuxDesktop}>
+      <Show when={showCustomWindowControls}>
         <div class={styles.windowControls}>
           <IconButton
             icon={WindowMinimizeIcon}


### PR DESCRIPTION
## Motivation

LeapMux previously ran only on macOS and Linux. Windows users had no supported path, and several internal assumptions (Unix domain sockets, PTY-based terminals, file permissions, process console windows) actively blocked a port. This PR adds full native Windows support across the desktop app, backend hub/worker, and Go sidecar, while keeping the existing Unix behaviour unchanged.

## Modifications

**New `locallisten` package** (`backend/locallisten/`)

A platform-agnostic IPC abstraction unifies Unix domain sockets (`unix:<path>`) and Windows named pipes (`npipe:<name>`) behind a single URL-based API. Platform-specific defaults are resolved at startup: Windows uses per-user named pipes keyed to the current user's SID (`npipe:leapmux-hub-<SID>`) for collision-free multi-user support; Unix keeps the existing `unix:<data_dir>/hub.sock` path. Public API: `Parse`, `Dialer`, `Listen`, `WaitReady`, `IsLocal`, `NewLocalH2CTransport`, `HTTPDialContext`.

**Backend solo/hub/worker refactor**

- 275+ lines of Hub + Worker orchestration moved from `backend/cmd/leapmux/solo.go` into a reusable `backend/solo/` package exposing `Start(ctx, Config) (*Instance, error)`.
- Hub and Worker no longer hardcode socket paths; they resolve `LocalListenURL()` per platform.
- `hub.Server.SocketPath()` removed in favour of `Instance.LocalListenURL()`.
- `worker.RunConfig.HTTPClient` removed; `hub.New()` auto-detects transport from the URL scheme.
- New `clientForHubURL()` in the worker centralises `unix:` / `npipe:` / `http[s]:` scheme dispatch.

**Windows-specific backend additions**

- `procutil.HideConsoleWindow(*exec.Cmd)` suppresses spurious console windows spawned by child processes on Windows; called from the shell, agent, git, and terminal modules.
- `shells_windows.go` detects `pwsh`/`powershell` in PATH, falling back to the built-in `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`.
- `IsPwsh()` extended to recognise `.exe`-suffixed binary names.
- Unix-only tests (PTY, file-permission checks, Unix-socket auto-approve) gated with `//go:build unix` tags.

**Desktop Go sidecar**

- New `socket.go` introduces `prepareEndpoint()` platform hooks; Unix prepends `unix:`, Windows prepends `npipe:`.
- Full Windows named-pipe support via `go-winio` (replacing the prior `"not implemented on windows"` stub). A 219-line Windows test suite covers handshake, session serialization, and idle-timeout correctness.
- Unified proxy: `newLocalProxy(listenURL)` accepts both `unix:` and `npipe:` URLs via the `locallisten` dialer and H2C transport.
- Solo init no longer polls: it relies on `solo.Start()` blocking until the Hub's local listener is reachable.
- Idle-timer race fixed: the socket server stops the idle timer during active sessions, preventing mid-flight RPC closure.
- `isPipeClosed(error)` added with Windows (`winio.ErrFileClosed`) and Unix no-op variants.

**Desktop Rust app**

- `bootstrap_dev_sidecar()` replaces the Unix-only `bootstrap_dev_socket_sidecar()`, supporting both Unix sockets and Windows named pipes (`\\.\pipe\leapmux-desktop-{SID}-sidecar`).
- `PipeHandle` added: a safe HANDLE wrapper implementing `Read`/`Write` traits via Win32 API bindings.
- Handshake timeout architecture split into `DEV_SIDECAR_HANDSHAKE_TIMEOUT` (30 s per attempt) and `DEV_SIDECAR_CONNECT_TIMEOUT` (60 s outer budget). `HandshakeWatchdog` uses `CancelSynchronousIo` on Windows to unblock wedged reads.
- Sidecar metadata field renamed `socket_path` -> `endpoint`; new env vars `LEAPMUX_DESKTOP_DEV_ENDPOINT` and `LEAPMUX_DESKTOP_BINARY_HASH`.
- `restart_app` gated to macOS only (FDA-specific behaviour).
- Custom titlebar extended from Linux-only to Linux + Windows via `showCustomWindowControls`.
- Windows native decorations removed to allow the custom titlebar to render.

**Build and tooling**

- Taskfile updated for `.exe` suffixes on Windows, GUI-subsystem linker flag (`-H=windowsgui`) for the sidecar, and Tauri space-padded installer filename handling.
- `.gitattributes` added to enforce LF line endings and mark binary files.
- `.exe` patterns excluded from `.gitignore`.
- `rsync`/`date` CLI calls replaced with Task built-in template functions for cross-platform compatibility.

**Follow-up bug fix**

- Avoid single-instance race in macOS FDA restart: spawn/exit was racing `tauri-plugin-single-instance`. Restart flow now resolves the `.app` bundle and relaunches via `/usr/bin/open -n` after the parent is reaped.

## Result

LeapMux now runs natively on Windows. Users get the same Hub + Worker + sidecar experience as on macOS and Linux, with IPC handled transparently via named pipes. No configuration changes are required; the correct transport is chosen automatically at startup based on the host OS.
