### PR TITLE
Add xhigh effort, auto-permission mode, and fix access-control race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ frontend/src/spinners/
 .idea/
 .vscode/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # OS
 .DS_Store

--- a/backend/internal/hub/service/channel_service.go
+++ b/backend/internal/hub/service/channel_service.go
@@ -279,19 +279,28 @@ func (s *ChannelService) PrepareWorkspaceAccess(
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("worker is offline"))
 	}
 
+	// Send a ChannelAccessUpdate to each matching channel and wait for the
+	// worker to ack before returning. Without the ack the caller races the
+	// worker's AddAccessibleWorkspaceID handler — the next inner RPC on the
+	// channel (e.g. OpenAgent / ListAgents) can arrive first and fail the
+	// requireAccessibleWorkspace check at worker/service/service.go:369.
 	for _, chID := range channelIDs {
 		if s.channelMgr.GetWorkerID(chID) != workerID {
 			continue
 		}
-		if err := conn.Send(&leapmuxv1.ConnectResponse{
+		resp, err := s.pending.SendAndWait(ctx, conn, &leapmuxv1.ConnectResponse{
 			Payload: &leapmuxv1.ConnectResponse_ChannelAccessUpdate{
 				ChannelAccessUpdate: &leapmuxv1.ChannelAccessUpdate{
 					ChannelId:   chID,
 					WorkspaceId: workspaceID,
 				},
 			},
-		}); err != nil {
+		})
+		if err != nil {
 			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("failed to update worker: %w", err))
+		}
+		if resp.GetChannelAccessUpdateAck() == nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unexpected response from worker for channel access update"))
 		}
 	}
 

--- a/backend/internal/hub/service/channel_service.go
+++ b/backend/internal/hub/service/channel_service.go
@@ -283,7 +283,7 @@ func (s *ChannelService) PrepareWorkspaceAccess(
 	// worker to ack before returning. Without the ack the caller races the
 	// worker's AddAccessibleWorkspaceID handler — the next inner RPC on the
 	// channel (e.g. OpenAgent / ListAgents) can arrive first and fail the
-	// requireAccessibleWorkspace check at worker/service/service.go:369.
+	// worker-side requireAccessibleWorkspace check.
 	for _, chID := range channelIDs {
 		if s.channelMgr.GetWorkerID(chID) != workerID {
 			continue

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -35,6 +35,7 @@ type channelTestEnv struct {
 	store           store.Store
 	workerMgr       *workermgr.Manager
 	channelMgr      *channelmgr.Manager
+	pending         *workermgr.PendingRequests
 }
 
 func setupChannelTestServer(t *testing.T) *channelTestEnv {
@@ -84,6 +85,26 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 		store:           st,
 		workerMgr:       wMgr,
 		channelMgr:      cMgr,
+		pending:         pendingReqs,
+	}
+}
+
+// autoAckChannelAccessUpdate returns a SendFn that records each sent message
+// on out and, for ChannelAccessUpdate payloads, synthesizes the matching
+// ChannelAccessUpdateAck so PrepareWorkspaceAccess (which uses SendAndWait)
+// doesn't block waiting for a worker that isn't present in this unit test.
+func (e *channelTestEnv) autoAckChannelAccessUpdate(out chan<- *leapmuxv1.ConnectResponse) func(*leapmuxv1.ConnectResponse) error {
+	return func(msg *leapmuxv1.ConnectResponse) error {
+		out <- msg
+		if msg.GetChannelAccessUpdate() != nil && msg.GetRequestId() != "" {
+			e.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				RequestId: msg.GetRequestId(),
+				Payload: &leapmuxv1.ConnectRequest_ChannelAccessUpdateAck{
+					ChannelAccessUpdateAck: &leapmuxv1.ChannelAccessUpdateAck{},
+				},
+			})
+		}
+		return nil
 	}
 }
 
@@ -527,14 +548,12 @@ func TestPrepareWorkspaceAccess_Success(t *testing.T) {
 
 	workerID := env.createWorkerWithKey(t, token, []byte("key"))
 
-	// Simulate worker online with a mock connection that captures sent messages.
+	// Simulate worker online with a mock connection that captures sent
+	// messages and auto-acks ChannelAccessUpdate.
 	sentMsgs := make(chan *leapmuxv1.ConnectResponse, 10)
 	conn := &workermgr.Conn{
 		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentMsgs <- msg
-			return nil
-		},
+		SendFn:   env.autoAckChannelAccessUpdate(sentMsgs),
 	}
 	env.workerMgr.Register(conn)
 
@@ -553,15 +572,80 @@ func TestPrepareWorkspaceAccess_Success(t *testing.T) {
 		}, token))
 	require.NoError(t, err)
 
-	// Verify a ChannelAccessUpdate was sent to the worker.
+	// Verify a ChannelAccessUpdate was sent to the worker with a non-empty
+	// request_id so the worker can ack it (used by SendAndWait to avoid a
+	// race with the worker's async AddAccessibleWorkspaceID handler).
 	select {
 	case msg := <-sentMsgs:
 		update := msg.GetChannelAccessUpdate()
 		require.NotNil(t, update)
 		assert.Equal(t, channelID, update.GetChannelId())
 		assert.Equal(t, wsID, update.GetWorkspaceId())
+		assert.NotEmpty(t, msg.GetRequestId(), "ChannelAccessUpdate must carry a request_id for ack correlation")
 	default:
 		t.Fatal("expected a ChannelAccessUpdate to be sent to worker")
+	}
+}
+
+// TestPrepareWorkspaceAccess_AckTimeout verifies that when the worker fails
+// to reply with ChannelAccessUpdateAck within the context deadline, the hub
+// returns CodeUnavailable instead of succeeding (which would race the
+// worker's async access-set update and trip requireAccessibleWorkspace).
+func TestPrepareWorkspaceAccess_AckTimeout(t *testing.T) {
+	env := setupChannelTestServer(t)
+	ctx := context.Background()
+	token := env.adminToken(t)
+
+	adminUser, err := env.store.Users().GetByUsername(ctx, "admin")
+	require.NoError(t, err)
+
+	workerID := env.createWorkerWithKey(t, token, []byte("key"))
+
+	// Worker is online but NEVER acks — simulates a buggy or crashed
+	// worker that received the frame but didn't (or couldn't) process it.
+	sentMsgs := make(chan *leapmuxv1.ConnectResponse, 10)
+	conn := &workermgr.Conn{
+		WorkerID: workerID,
+		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+			sentMsgs <- msg
+			return nil
+		},
+	}
+	env.workerMgr.Register(conn)
+
+	channelID := id.Generate()
+	env.channelMgr.Register(channelID, workerID, adminUser.ID, nil)
+
+	wsID := env.createWorkspace(t, adminUser.ID, adminUser.OrgID)
+
+	// Short deadline so the test doesn't wait the default 10s timeout.
+	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	_, err = env.channelClient.PrepareWorkspaceAccess(shortCtx, authedReq(
+		&leapmuxv1.PrepareWorkspaceAccessRequest{
+			WorkerId:    workerID,
+			WorkspaceId: wsID,
+		}, token))
+	require.Error(t, err)
+	// Either code is correct: the handler returns CodeUnavailable when its
+	// SendAndWait observes the context deadline, but because both the
+	// client-side transport and the server handler share the same short
+	// deadline, the connect transport can see the client context cancel
+	// first and surface CodeDeadlineExceeded before the handler's error
+	// response arrives. Both outcomes are "ack did not arrive", which is
+	// what this test is verifying.
+	code := connect.CodeOf(err)
+	assert.Truef(t,
+		code == connect.CodeUnavailable || code == connect.CodeDeadlineExceeded,
+		"want CodeUnavailable or CodeDeadlineExceeded, got %v (%v)", code, err)
+
+	// The hub should still have attempted to send the update before waiting.
+	select {
+	case msg := <-sentMsgs:
+		require.NotNil(t, msg.GetChannelAccessUpdate())
+	default:
+		t.Fatal("expected ChannelAccessUpdate to be sent before waiting for ack")
 	}
 }
 
@@ -576,24 +660,19 @@ func TestPrepareWorkspaceAccess_OnlySendsToMatchingWorker(t *testing.T) {
 	worker1ID := env.createWorkerWithKey(t, token, []byte("key1"))
 	worker2ID := env.createWorkerWithKey(t, token, []byte("key2"))
 
-	// Register both workers online.
+	// Register both workers online, each with auto-ack for
+	// ChannelAccessUpdate so SendAndWait doesn't hang.
 	sent1 := make(chan *leapmuxv1.ConnectResponse, 10)
 	conn1 := &workermgr.Conn{
 		WorkerID: worker1ID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sent1 <- msg
-			return nil
-		},
+		SendFn:   env.autoAckChannelAccessUpdate(sent1),
 	}
 	env.workerMgr.Register(conn1)
 
 	sent2 := make(chan *leapmuxv1.ConnectResponse, 10)
 	conn2 := &workermgr.Conn{
 		WorkerID: worker2ID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sent2 <- msg
-			return nil
-		},
+		SendFn:   env.autoAckChannelAccessUpdate(sent2),
 	}
 	env.workerMgr.Register(conn2)
 
@@ -683,14 +762,11 @@ func TestPrepareWorkspaceAccess_SharedWorkspaceAccess(t *testing.T) {
 
 	workerID := env.createWorkerWithKey(t, adminToken, []byte("key"))
 
-	// Simulate worker online.
+	// Simulate worker online with auto-ack for ChannelAccessUpdate.
 	sentMsgs := make(chan *leapmuxv1.ConnectResponse, 10)
 	conn := &workermgr.Conn{
 		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentMsgs <- msg
-			return nil
-		},
+		SendFn:   env.autoAckChannelAccessUpdate(sentMsgs),
 	}
 	env.workerMgr.Register(conn)
 

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -139,10 +139,17 @@ func DefaultModel(provider leapmuxv1.AgentProvider) string {
 	return ""
 }
 
-// DefaultEffort returns the default effort ID for a provider, checking the
-// provider's environment variable first, then falling back to the default
-// effort of the default model.
+// DefaultEffort returns the default effort ID for a provider's default
+// model. See DefaultEffortForModel for the general lookup.
 func DefaultEffort(provider leapmuxv1.AgentProvider) string {
+	return DefaultEffortForModel(provider, "")
+}
+
+// DefaultEffortForModel returns the default effort ID for the given model
+// within a provider. It checks the provider's environment variable first,
+// then the model's DefaultEffort from the registry. If modelID is empty
+// or unknown, it falls back to the default model's DefaultEffort.
+func DefaultEffortForModel(provider leapmuxv1.AgentProvider, modelID string) string {
 	reg, ok := providerRegistry[provider]
 	if !ok {
 		return ""
@@ -152,10 +159,22 @@ func DefaultEffort(provider leapmuxv1.AgentProvider) string {
 			return env
 		}
 	}
-	defaultModelID := DefaultModel(provider)
+	if modelID == "" {
+		modelID = DefaultModel(provider)
+	}
 	for _, m := range reg.defaultModels {
-		if m.Id == defaultModelID && m.DefaultEffort != "" {
+		if m.Id == modelID && m.DefaultEffort != "" {
 			return m.DefaultEffort
+		}
+	}
+	// Fall back to the default model's DefaultEffort if the specified
+	// model is unknown or has no default (e.g. legacy records).
+	defaultID := DefaultModel(provider)
+	if defaultID != modelID {
+		for _, m := range reg.defaultModels {
+			if m.Id == defaultID && m.DefaultEffort != "" {
+				return m.DefaultEffort
+			}
 		}
 	}
 	return ""

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -139,12 +139,6 @@ func DefaultModel(provider leapmuxv1.AgentProvider) string {
 	return ""
 }
 
-// DefaultEffort returns the default effort ID for a provider's default
-// model. See DefaultEffortForModel for the general lookup.
-func DefaultEffort(provider leapmuxv1.AgentProvider) string {
-	return DefaultEffortForModel(provider, "")
-}
-
 // DefaultEffortForModel returns the default effort ID for the given model
 // within a provider. It checks the provider's environment variable first,
 // then the model's DefaultEffort from the registry. If modelID is empty
@@ -159,25 +153,20 @@ func DefaultEffortForModel(provider leapmuxv1.AgentProvider, modelID string) str
 			return env
 		}
 	}
-	if modelID == "" {
-		modelID = DefaultModel(provider)
-	}
-	for _, m := range reg.defaultModels {
-		if m.Id == modelID && m.DefaultEffort != "" {
-			return m.DefaultEffort
-		}
-	}
-	// Fall back to the default model's DefaultEffort if the specified
-	// model is unknown or has no default (e.g. legacy records).
-	defaultID := DefaultModel(provider)
-	if defaultID != modelID {
+	lookup := func(id string) string {
 		for _, m := range reg.defaultModels {
-			if m.Id == defaultID && m.DefaultEffort != "" {
+			if m.Id == id && m.DefaultEffort != "" {
 				return m.DefaultEffort
 			}
 		}
+		return ""
 	}
-	return ""
+	if modelID != "" {
+		if e := lookup(modelID); e != "" {
+			return e
+		}
+	}
+	return lookup(DefaultModel(provider))
 }
 
 // filterEnv returns a copy of environ with entries matching any of the

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -165,7 +165,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		sink:                   sink,
 		thirdPartyFromSettings: thirdPartyFromSettings,
 		pendingControl:         make(map[string]chan<- claudeCodeControlResult),
-		alwaysThinking:         AlwaysThinkingOn, // default; Claude Code's get_settings confirms at startup
+		alwaysThinking:         AlwaysThinkingOn, // Claude Code default; refreshSettingsFromAgent confirms after apply_flag_settings
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -212,13 +212,8 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.fastMode = "off"
 	}
 
-	// Probe auto-mode availability before locking in the real mode. The
-	// probe leaves the agent briefly in auto mode on success, but the
-	// subsequent set_permission_mode below restores the intended mode.
-	// Admin-disabled / plan-gated / unsupported-model sessions return an
-	// error matching autoModeUnavailableErrorPrefix; any other failure is
-	// treated as unavailable (conservative default) so the UI does not
-	// offer a mode the agent cannot enter.
+	// Probe auto-mode availability. The subsequent set_permission_mode
+	// below overrides any mode the probe may have left active.
 	a.autoModeAvailable = a.probeAutoMode(ctx, timeout)
 
 	// Send set_permission_mode to configure the agent's permission mode.

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -580,7 +580,7 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 // for apply_flag_settings. "on" → true, anything else → nil (which resets
 // the flag to its default).
 func flagSettingOnOff(v string) interface{} {
-	if v == FastModeOn {
+	if v == "on" {
 		return true
 	}
 	return nil
@@ -738,12 +738,12 @@ func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, reques
 		resp, err := setMode(PermissionModeAuto)
 		switch {
 		case err == nil:
-			a.autoModeAvailable = true
+			a.setAutoModeAvailable(true)
 			return resp, nil
 		case isAutoModeUnavailableError(err):
 			slog.Warn("requested auto permission mode is unavailable; falling back to default",
 				"agent_id", a.agentID)
-			a.autoModeAvailable = false
+			a.setAutoModeAvailable(false)
 			return setMode(PermissionModeDefault)
 		default:
 			return claudeCodeControlResult{}, err
@@ -755,11 +755,19 @@ func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, reques
 			slog.Warn("auto-mode probe failed (transient); treating as unavailable",
 				"agent_id", a.agentID, "error", err)
 		}
-		a.autoModeAvailable = false
+		a.setAutoModeAvailable(false)
 	} else {
-		a.autoModeAvailable = true
+		a.setAutoModeAvailable(true)
 	}
 	return setMode(requested)
+}
+
+// setAutoModeAvailable stores the auto-mode probe result under a.mu so
+// concurrent readers (e.g. AvailableOptionGroups) observe a consistent value.
+func (a *ClaudeCodeAgent) setAutoModeAvailable(v bool) {
+	a.mu.Lock()
+	a.autoModeAvailable = v
+	a.mu.Unlock()
 }
 
 // isAutoModeUnavailableError reports whether err is the Claude Code

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -89,7 +89,7 @@ type ClaudeCodeAgent struct {
 	availableOutputStyles []string
 	fastMode              string // "on" / "off"
 	alwaysThinking        string // "on" / "off"
-	autoModeAvailable     bool   // set by probeAutoMode() at startup
+	autoModeAvailable     bool
 }
 
 // StartClaudeCode spawns a new Claude Code process and begins reading its output.
@@ -171,7 +171,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		sink:                   sink,
 		thirdPartyFromSettings: thirdPartyFromSettings,
 		pendingControl:         make(map[string]chan<- claudeCodeControlResult),
-		alwaysThinking:         AlwaysThinkingOn, // Claude Code default; refreshSettingsFromAgent confirms after apply_flag_settings
+		alwaysThinking:         AlwaysThinkingOn,
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -385,9 +385,13 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 	model := a.model
 	a.mu.Unlock()
 
-	staticPermMode := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
-	groups := []*leapmuxv1.AvailableOptionGroup{
-		filterPermissionModeGroup(staticPermMode, autoAvail),
+	var groups []*leapmuxv1.AvailableOptionGroup
+	for _, g := range AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE) {
+		if g.GetKey() == OptionGroupKeyPermissionMode {
+			groups = append(groups, filterPermissionModeGroup(g, autoAvail))
+			continue
+		}
+		groups = append(groups, g)
 	}
 
 	if len(availStyles) > 0 {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -22,7 +22,14 @@ const (
 	PermissionModePlan              = "plan"
 	PermissionModeAcceptEdits       = "acceptEdits"
 	PermissionModeBypassPermissions = "bypassPermissions"
+	PermissionModeDontAsk           = "dontAsk"
+	PermissionModeAuto              = "auto"
 )
+
+// autoModeUnavailableErrorPrefix is the prefix of the error message Claude
+// Code returns when set_permission_mode:auto is rejected (regardless of
+// reason: admin settings, plan circuit-breaker, or unsupported model).
+const autoModeUnavailableErrorPrefix = "Cannot set permission mode to auto"
 
 // claudeCodeControlResult holds the outcome of a pending control request.
 type claudeCodeControlResult struct {
@@ -40,6 +47,16 @@ const (
 	ExtraKeyOutputStyle    = "outputStyle"
 	ExtraKeyFastMode       = "fastMode"
 	ExtraKeyAlwaysThinking = "alwaysThinkingEnabled"
+)
+
+// Extended Thinking option IDs. Claude Code only exposes a single
+// alwaysThinkingEnabled boolean — it picks thinking.type:"adaptive" vs
+// "enabled" per-model — so there is nothing to store beyond on/off. The
+// UI label for the "on" option is set per-model in AvailableOptionGroups
+// ("Adaptive" for Opus/Sonnet, "On" for Haiku).
+const (
+	AlwaysThinkingOn  = "on"
+	AlwaysThinkingOff = "off"
 )
 
 // ClaudeCodeAgent manages a single Claude Code process.
@@ -66,6 +83,7 @@ type ClaudeCodeAgent struct {
 	availableOutputStyles []string
 	fastMode              string // "on" / "off"
 	alwaysThinking        string // "on" / "off"
+	autoModeAvailable     bool   // set by probeAutoMode() at startup
 }
 
 // StartClaudeCode spawns a new Claude Code process and begins reading its output.
@@ -92,6 +110,9 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		"--dangerously-skip-permissions",
 		"--permission-prompt-tool", "stdio",
 		"--setting-sources", "user,project,local",
+		// Emit summarized thinking text in thinking blocks; without this,
+		// thinking blocks arrive with an empty `thinking` field.
+		"--thinking-display", "summarized",
 	}
 
 	if opts.ResumeSessionID != "" {
@@ -144,7 +165,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		sink:                   sink,
 		thirdPartyFromSettings: thirdPartyFromSettings,
 		pendingControl:         make(map[string]chan<- claudeCodeControlResult),
-		alwaysThinking:         "on", // default
+		alwaysThinking:         AlwaysThinkingOn, // default; Claude Code's get_settings confirms at startup
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -191,10 +212,24 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.fastMode = "off"
 	}
 
+	// Probe auto-mode availability before locking in the real mode. The
+	// probe leaves the agent briefly in auto mode on success, but the
+	// subsequent set_permission_mode below restores the intended mode.
+	// Admin-disabled / plan-gated / unsupported-model sessions return an
+	// error matching autoModeUnavailableErrorPrefix; any other failure is
+	// treated as unavailable (conservative default) so the UI does not
+	// offer a mode the agent cannot enter.
+	a.autoModeAvailable = a.probeAutoMode(ctx, timeout)
+
 	// Send set_permission_mode to configure the agent's permission mode.
 	// This serves as both a health check and permission mode sync (restores
 	// mode after worker restart).
 	mode := StringOrDefault(opts.PermissionMode, PermissionModeDefault)
+	if mode == PermissionModeAuto && !a.autoModeAvailable {
+		slog.Warn("requested auto permission mode is unavailable; falling back to default",
+			"agent_id", a.agentID)
+		mode = PermissionModeDefault
+	}
 	resp, err := a.sendControlAndWait(ctx,
 		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, mode), timeout)
 	if err != nil {
@@ -230,7 +265,7 @@ func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[
 		fs[ExtraKeyFastMode] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != a.alwaysThinking {
-		fs[ExtraKeyAlwaysThinking] = flagSettingOffOn(v)
+		fs[ExtraKeyAlwaysThinking] = flagSettingThinking(v)
 	}
 	return fs
 }
@@ -358,10 +393,13 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 	a.mu.Lock()
 	outputStyle, fastMode, thinking := a.outputStyle, a.fastMode, a.alwaysThinking
 	availStyles := a.availableOutputStyles
+	autoAvail := a.autoModeAvailable
+	model := a.model
 	a.mu.Unlock()
 
+	staticPermMode := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 	groups := []*leapmuxv1.AvailableOptionGroup{
-		AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0], // permission mode
+		filterPermissionModeGroup(staticPermMode, autoAvail),
 	}
 
 	if len(availStyles) > 0 {
@@ -389,16 +427,41 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		},
 	})
 
+	enabledName := "On"
+	if modelSupportsAdaptiveThinking(model) {
+		enabledName = "Adaptive"
+	}
 	groups = append(groups, &leapmuxv1.AvailableOptionGroup{
 		Key:   ExtraKeyAlwaysThinking,
 		Label: "Extended Thinking",
 		Options: []*leapmuxv1.AvailableOption{
-			{Id: "on", Name: "On", IsDefault: thinking != "off"},
-			{Id: "off", Name: "Off", IsDefault: thinking == "off"},
+			{Id: AlwaysThinkingOn, Name: enabledName, IsDefault: thinking != AlwaysThinkingOff},
+			{Id: AlwaysThinkingOff, Name: "Off", IsDefault: thinking == AlwaysThinkingOff},
 		},
 	})
 
 	return groups
+}
+
+// filterPermissionModeGroup returns a copy of the permission-mode option
+// group with modes unavailable to this agent instance removed. Currently
+// only filters "auto" when auto mode was rejected by the probe at startup.
+func filterPermissionModeGroup(group *leapmuxv1.AvailableOptionGroup, autoAvail bool) *leapmuxv1.AvailableOptionGroup {
+	if autoAvail {
+		return group
+	}
+	opts := make([]*leapmuxv1.AvailableOption, 0, len(group.GetOptions()))
+	for _, o := range group.GetOptions() {
+		if o.GetId() == PermissionModeAuto {
+			continue
+		}
+		opts = append(opts, o)
+	}
+	return &leapmuxv1.AvailableOptionGroup{
+		Key:     group.GetKey(),
+		Label:   group.GetLabel(),
+		Options: opts,
+	}
 }
 
 // UpdateSettings applies settings changes via the apply_flag_settings control
@@ -431,7 +494,7 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		flagSettings[ExtraKeyFastMode] = flagSettingOnOff(v)
 	}
 	if v := extra[ExtraKeyAlwaysThinking]; v != "" && v != curThinking {
-		flagSettings[ExtraKeyAlwaysThinking] = flagSettingOffOn(v)
+		flagSettings[ExtraKeyAlwaysThinking] = flagSettingThinking(v)
 	}
 
 	if len(flagSettings) == 0 {
@@ -481,7 +544,7 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 
 	a.mu.Lock()
 	if settings.Applied.Model != "" {
-		a.model = settings.Applied.Model
+		a.model = normalizeClaudeCodeModel(settings.Applied.Model)
 	}
 	if settings.Applied.Effort != nil {
 		a.effort = *settings.Applied.Effort
@@ -498,9 +561,9 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 	}
 	if settings.Effective.AlwaysThinkingEnabled != nil {
 		if *settings.Effective.AlwaysThinkingEnabled {
-			a.alwaysThinking = "on"
+			a.alwaysThinking = AlwaysThinkingOn
 		} else {
-			a.alwaysThinking = "off"
+			a.alwaysThinking = AlwaysThinkingOff
 		}
 	}
 	model, effort, mode := a.model, a.effort, a.confirmedPermissionMode
@@ -533,37 +596,100 @@ func flagSettingOnOff(v string) interface{} {
 	return nil
 }
 
-// flagSettingOffOn maps an "off"/"on" string to a boolean flag setting value
-// for apply_flag_settings. "off" → false, anything else → nil (which resets
-// the flag to its default).
-func flagSettingOffOn(v string) interface{} {
-	if v == "off" {
+// flagSettingThinking maps an "on"/"off" string to the alwaysThinkingEnabled
+// flag value for apply_flag_settings. "off" → false (thinking disabled).
+// Anything else returns nil, which removes the key from flagSettings and
+// lets Claude Code fall back to its default-on behavior — internally picking
+// type:"adaptive" or type:"enabled" per its own model gate.
+func flagSettingThinking(v string) interface{} {
+	if v == AlwaysThinkingOff {
 		return false
 	}
 	return nil
 }
 
-// claudeCodeEfforts shared across models (except haiku gets none, and only opus gets max).
-var claudeCodeEffortAll = []*leapmuxv1.AvailableEffort{
+// normalizeClaudeCodeModel collapses the fully-qualified model ID that
+// Claude Code's get_settings "applied.model" field returns (e.g.
+// "claude-opus-4-7", "claude-haiku-4-5-20251001", "claude-sonnet-4-6[1m]")
+// back to the short alias leapmux uses (opus, opus[1m], sonnet,
+// sonnet[1m], haiku). Short aliases pass through unchanged.
+//
+// Rules:
+//   - Strip an optional "claude-" prefix.
+//   - Preserve a trailing "[...]" bracket suffix (the 1M-context marker).
+//   - Keep only the leading alphabetic token (opus/sonnet/haiku), dropping
+//     version numbers (e.g. "-4-7") and date suffixes (e.g. "-20251001").
+func normalizeClaudeCodeModel(model string) string {
+	if model == "" {
+		return ""
+	}
+	core := strings.TrimPrefix(model, "claude-")
+	var suffix string
+	if i := strings.IndexByte(core, '['); i >= 0 {
+		suffix = core[i:]
+		core = core[:i]
+	}
+	end := 0
+	for end < len(core) {
+		c := core[end]
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+			break
+		}
+		end++
+	}
+	alias := core[:end]
+	if alias == "" {
+		// Unrecognized shape — return the original input unchanged so the
+		// caller can still display it.
+		return model
+	}
+	return alias + suffix
+}
+
+// modelSupportsAdaptiveThinking reports whether Claude Code emits
+// thinking.type:"adaptive" for this model (Opus and Sonnet) versus
+// thinking.type:"enabled" with a budget (Haiku). Unknown model strings
+// default to true to match Claude Code's first-party fallback. This is
+// used purely to pick the "Adaptive" vs "On" display label in
+// AvailableOptionGroups — the wire payload (alwaysThinkingEnabled) is
+// identical either way.
+//
+// Expects the short alias (e.g. "opus", "haiku"). `a.model` is kept
+// normalized after every refreshSettingsFromAgent call, so internal
+// callers can pass it directly without re-normalizing.
+func modelSupportsAdaptiveThinking(model string) bool {
+	return !strings.HasPrefix(model, "haiku")
+}
+
+// Claude Code effort levels are model-dependent. Keep each slice ordered
+// strongest → weakest so the RadioGroup renders in the same order.
+
+// claudeEffortXHighMax is used by models that support both xhigh and max
+// (currently Opus 4.7).
+var claudeEffortXHighMax = []*leapmuxv1.AvailableEffort{
 	{Id: "auto", Name: "Auto", Description: "Let Claude decide the appropriate effort"},
-	{Id: "max", Name: "Max", Description: "Deepest reasoning; uses extended thinking"},
+	{Id: "max", Name: "Max", Description: "Deepest reasoning; no constraints on token spend"},
+	{Id: "xhigh", Name: "X-High", Description: "Extended capability for long-horizon agentic tasks"},
 	{Id: "high", Name: "High", Description: "Thorough reasoning for complex tasks"},
 	{Id: "medium", Name: "Medium", Description: "Balanced speed and reasoning depth"},
 	{Id: "low", Name: "Low", Description: "Faster responses with lighter reasoning"},
 }
 
-var claudeCodeEffortNoMax = []*leapmuxv1.AvailableEffort{
+// claudeEffortMax is used by models that support max but not xhigh
+// (currently Sonnet 4.6, older Opus).
+var claudeEffortMax = []*leapmuxv1.AvailableEffort{
 	{Id: "auto", Name: "Auto", Description: "Let Claude decide the appropriate effort"},
+	{Id: "max", Name: "Max", Description: "Deepest reasoning; no constraints on token spend"},
 	{Id: "high", Name: "High", Description: "Thorough reasoning for complex tasks"},
 	{Id: "medium", Name: "Medium", Description: "Balanced speed and reasoning depth"},
 	{Id: "low", Name: "Low", Description: "Faster responses with lighter reasoning"},
 }
 
 var claudeCodeAvailableModels = []*leapmuxv1.AvailableModel{
-	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: "high", SupportedEfforts: claudeCodeEffortAll, ContextWindow: 200_000},
-	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: "high", SupportedEfforts: claudeCodeEffortAll, ContextWindow: 1_000_000},
-	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeCodeEffortNoMax, ContextWindow: 200_000},
-	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeCodeEffortNoMax, ContextWindow: 1_000_000},
+	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: "xhigh", SupportedEfforts: claudeEffortXHighMax, ContextWindow: 200_000},
+	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: "xhigh", SupportedEfforts: claudeEffortXHighMax, ContextWindow: 1_000_000},
+	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 200_000},
+	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 1_000_000},
 	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", DefaultEffort: "high", ContextWindow: 200_000},
 }
 
@@ -599,6 +725,36 @@ func (a *ClaudeCodeAgent) sendControlAndWait(ctx context.Context, requestBody st
 		a.unregisterPendingControl(requestID)
 		return claudeCodeControlResult{}, fmt.Errorf("timeout waiting for agent to respond")
 	}
+}
+
+// probeAutoMode sends a set_permission_mode:auto control request to detect
+// whether auto mode is available for this session. It does not leave auto
+// mode active — the caller must set the real mode afterward.
+//
+// Returns true if auto mode is accepted. Returns false if the agent rejects
+// it with the "Cannot set permission mode to auto" prefix, which covers all
+// unavailability reasons (managed settings, plan circuit-breaker, or
+// unsupported model). Other errors are treated conservatively as
+// unavailable and logged.
+func (a *ClaudeCodeAgent) probeAutoMode(ctx context.Context, timeout time.Duration) bool {
+	_, err := a.sendControlAndWait(ctx,
+		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, PermissionModeAuto), timeout)
+	if err == nil {
+		return true
+	}
+	if isAutoModeUnavailableError(err) {
+		return false
+	}
+	slog.Warn("auto-mode probe failed (transient)",
+		"agent_id", a.agentID, "error", err)
+	return false
+}
+
+// isAutoModeUnavailableError reports whether err is the Claude Code
+// control_response rejection for set_permission_mode:auto (admin-disabled,
+// plan-gated, or unsupported-model).
+func isAutoModeUnavailableError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), autoModeUnavailableErrorPrefix)
 }
 
 func (a *ClaudeCodeAgent) registerPendingControl(requestID string, ch chan<- claudeCodeControlResult) {
@@ -687,18 +843,36 @@ func generateRequestID() string {
 }
 
 // buildModelEffortArgs constructs the --model and --effort CLI arguments for
-// Claude Code. Haiku does not support effort, and max effort is only
-// supported for opus models (falls back to high for others).
+// Claude Code. Haiku does not support --effort at all. Other models each
+// expose a subset of effort levels via claudeCodeAvailableModels; any effort
+// not in the subset is downgraded to "high" as a universal safe fallback.
 func buildModelEffortArgs(model, effort string) []string {
 	args := []string{"--model", model}
-	if effort != "" && model != "haiku" {
-		// Max effort is only supported for opus models; fall back to high.
-		if effort == "max" && !strings.HasPrefix(model, "opus") {
-			effort = "high"
-		}
-		args = append(args, "--effort", effort)
+	if effort == "" || model == "haiku" {
+		return args
 	}
-	return args
+	if !effortSupported(model, effort) {
+		effort = "high"
+	}
+	return append(args, "--effort", effort)
+}
+
+// effortSupported reports whether the given effort ID is in the known
+// SupportedEfforts list for the given model. Unknown models are trusted
+// (returns true) so new aliases work without a code change.
+func effortSupported(modelID, effort string) bool {
+	for _, m := range claudeCodeAvailableModels {
+		if m.Id != modelID {
+			continue
+		}
+		for _, e := range m.SupportedEfforts {
+			if e.Id == effort {
+				return true
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func init() {
@@ -712,10 +886,37 @@ func init() {
 			Key:   OptionGroupKeyPermissionMode,
 			Label: "Permission Mode",
 			Options: []*leapmuxv1.AvailableOption{
-				{Id: PermissionModeDefault, Name: "Default", IsDefault: true},
-				{Id: PermissionModePlan, Name: "Plan Mode"},
-				{Id: PermissionModeAcceptEdits, Name: "Accept Edits"},
-				{Id: PermissionModeBypassPermissions, Name: "Bypass Permissions"},
+				{
+					Id:          PermissionModeDefault,
+					Name:        "Default",
+					Description: "Standard behavior, prompts for dangerous operations.",
+					IsDefault:   true,
+				},
+				{
+					Id:          PermissionModePlan,
+					Name:        "Plan Mode",
+					Description: "Planning mode, no actual tool execution.",
+				},
+				{
+					Id:          PermissionModeAcceptEdits,
+					Name:        "Accept Edits",
+					Description: "Auto-accept file edit operations.",
+				},
+				{
+					Id:          PermissionModeBypassPermissions,
+					Name:        "Bypass Permissions",
+					Description: "Bypass all permission checks (requires allowDangerouslySkipPermissions).",
+				},
+				{
+					Id:          PermissionModeDontAsk,
+					Name:        "Don't Ask",
+					Description: "Don't prompt for permissions, deny if not pre-approved.",
+				},
+				{
+					Id:          PermissionModeAuto,
+					Name:        "Auto Mode",
+					Description: "Uses an AI classifier to auto-approve safe tool calls and falls back to prompting for risky ones.",
+				},
 			},
 		}},
 		"LEAPMUX_CLAUDE_DEFAULT_MODEL",

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -59,6 +59,12 @@ const (
 	AlwaysThinkingOff = "off"
 )
 
+// Fast Mode option IDs.
+const (
+	FastModeOn  = "on"
+	FastModeOff = "off"
+)
+
 // ClaudeCodeAgent manages a single Claude Code process.
 type ClaudeCodeAgent struct {
 	processBase // shared process lifecycle (Stop, Wait, Stderr, etc.)
@@ -207,26 +213,19 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	}
 	a.availableOutputStyles = initResp.AvailableOutputStyles
 	if initResp.FastModeState == "on" || initResp.FastModeState == "cooldown" {
-		a.fastMode = "on"
+		a.fastMode = FastModeOn
 	} else {
-		a.fastMode = "off"
+		a.fastMode = FastModeOff
 	}
 
-	// Probe auto-mode availability. The subsequent set_permission_mode
-	// below overrides any mode the probe may have left active.
-	a.autoModeAvailable = a.probeAutoMode(ctx, timeout)
-
-	// Send set_permission_mode to configure the agent's permission mode.
-	// This serves as both a health check and permission mode sync (restores
-	// mode after worker restart).
+	// Configure the agent's permission mode. This also doubles as a probe
+	// for auto-mode availability so the UI never offers auto to a session
+	// that cannot enter it (admin-disabled, plan-gated, or unsupported
+	// model). When the user requested auto we merge probe and apply into a
+	// single set_permission_mode call; otherwise we probe auto separately
+	// and then apply the requested mode.
 	mode := StringOrDefault(opts.PermissionMode, PermissionModeDefault)
-	if mode == PermissionModeAuto && !a.autoModeAvailable {
-		slog.Warn("requested auto permission mode is unavailable; falling back to default",
-			"agent_id", a.agentID)
-		mode = PermissionModeDefault
-	}
-	resp, err := a.sendControlAndWait(ctx,
-		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, mode), timeout)
+	resp, err := a.applyStartupPermissionMode(ctx, &mode, timeout)
 	if err != nil {
 		cleanup()
 		return nil, a.formatStartupError("set_permission_mode", err)
@@ -375,7 +374,7 @@ func (a *ClaudeCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
 // can_change_model_and_effort=false metadata), which tells the frontend
 // to hide model and effort settings.
 func (a *ClaudeCodeAgent) AvailableModels() []*leapmuxv1.AvailableModel {
-	if a.thirdPartyFromSettings || a.preambleMeta["can_change_model_and_effort"] == "false" {
+	if a.thirdPartyFromSettings || a.preambleMetaValue("can_change_model_and_effort") == "false" {
 		return nil
 	}
 	return claudeCodeAvailableModels
@@ -417,8 +416,8 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 		Key:   ExtraKeyFastMode,
 		Label: "Fast Mode",
 		Options: []*leapmuxv1.AvailableOption{
-			{Id: "on", Name: "On", IsDefault: fastMode == "on"},
-			{Id: "off", Name: "Off", IsDefault: fastMode != "on"},
+			{Id: FastModeOn, Name: "On", IsDefault: fastMode == FastModeOn},
+			{Id: FastModeOff, Name: "Off", IsDefault: fastMode != FastModeOn},
 		},
 	})
 
@@ -549,9 +548,9 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 	}
 	if settings.Effective.FastMode != nil {
 		if *settings.Effective.FastMode {
-			a.fastMode = "on"
+			a.fastMode = FastModeOn
 		} else {
-			a.fastMode = "off"
+			a.fastMode = FastModeOff
 		}
 	}
 	if settings.Effective.AlwaysThinkingEnabled != nil {
@@ -585,7 +584,7 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 // for apply_flag_settings. "on" → true, anything else → nil (which resets
 // the flag to its default).
 func flagSettingOnOff(v string) interface{} {
-	if v == "on" {
+	if v == FastModeOn {
 		return true
 	}
 	return nil
@@ -722,27 +721,52 @@ func (a *ClaudeCodeAgent) sendControlAndWait(ctx context.Context, requestBody st
 	}
 }
 
-// probeAutoMode sends a set_permission_mode:auto control request to detect
-// whether auto mode is available for this session. It does not leave auto
-// mode active — the caller must set the real mode afterward.
+// applyStartupPermissionMode sets the agent's permission mode during startup
+// while also detecting whether auto mode is available for this session. It
+// updates a.autoModeAvailable as a side effect.
 //
-// Returns true if auto mode is accepted. Returns false if the agent rejects
-// it with the "Cannot set permission mode to auto" prefix, which covers all
-// unavailability reasons (managed settings, plan circuit-breaker, or
-// unsupported model). Other errors are treated conservatively as
-// unavailable and logged.
-func (a *ClaudeCodeAgent) probeAutoMode(ctx context.Context, timeout time.Duration) bool {
-	_, err := a.sendControlAndWait(ctx,
-		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, PermissionModeAuto), timeout)
-	if err == nil {
-		return true
+// When the requested mode is auto, a single set_permission_mode call serves
+// both purposes: success means auto is available and active; a response
+// matching autoModeUnavailableErrorPrefix means auto is unavailable and the
+// mode is rewritten to default and re-sent. Any other error is fatal.
+//
+// When the requested mode is non-auto, we probe auto first (leaving the
+// session briefly in auto on success) and then apply the requested mode,
+// which restores the intended state. Transient probe errors are treated as
+// unavailable so the UI does not offer a mode the agent cannot enter.
+func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, mode *string, timeout time.Duration) (claudeCodeControlResult, error) {
+	setMode := func(m string) (claudeCodeControlResult, error) {
+		return a.sendControlAndWait(ctx,
+			fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, m), timeout)
 	}
-	if isAutoModeUnavailableError(err) {
-		return false
+
+	if *mode == PermissionModeAuto {
+		resp, err := setMode(PermissionModeAuto)
+		switch {
+		case err == nil:
+			a.autoModeAvailable = true
+			return resp, nil
+		case isAutoModeUnavailableError(err):
+			slog.Warn("requested auto permission mode is unavailable; falling back to default",
+				"agent_id", a.agentID)
+			a.autoModeAvailable = false
+			*mode = PermissionModeDefault
+			return setMode(PermissionModeDefault)
+		default:
+			return claudeCodeControlResult{}, err
+		}
 	}
-	slog.Warn("auto-mode probe failed (transient)",
-		"agent_id", a.agentID, "error", err)
-	return false
+
+	if _, err := setMode(PermissionModeAuto); err != nil {
+		if !isAutoModeUnavailableError(err) {
+			slog.Warn("auto-mode probe failed (transient); treating as unavailable",
+				"agent_id", a.agentID, "error", err)
+		}
+		a.autoModeAvailable = false
+	} else {
+		a.autoModeAvailable = true
+	}
+	return setMode(*mode)
 }
 
 // isAutoModeUnavailableError reports whether err is the Claude Code

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -218,14 +218,8 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.fastMode = FastModeOff
 	}
 
-	// Configure the agent's permission mode. This also doubles as a probe
-	// for auto-mode availability so the UI never offers auto to a session
-	// that cannot enter it (admin-disabled, plan-gated, or unsupported
-	// model). When the user requested auto we merge probe and apply into a
-	// single set_permission_mode call; otherwise we probe auto separately
-	// and then apply the requested mode.
-	mode := StringOrDefault(opts.PermissionMode, PermissionModeDefault)
-	resp, err := a.applyStartupPermissionMode(ctx, &mode, timeout)
+	// Configure the permission mode and detect auto-mode availability for the UI.
+	resp, err := a.applyStartupPermissionMode(ctx, StringOrDefault(opts.PermissionMode, PermissionModeDefault), timeout)
 	if err != nil {
 		cleanup()
 		return nil, a.formatStartupError("set_permission_mode", err)
@@ -722,25 +716,23 @@ func (a *ClaudeCodeAgent) sendControlAndWait(ctx context.Context, requestBody st
 }
 
 // applyStartupPermissionMode sets the agent's permission mode during startup
-// while also detecting whether auto mode is available for this session. It
-// updates a.autoModeAvailable as a side effect.
+// while also detecting whether auto mode is available for this session.
+// a.autoModeAvailable is updated as a side effect; the returned result
+// reflects the mode actually applied (which may be default if the requested
+// auto mode was rejected with autoModeUnavailableErrorPrefix).
 //
-// When the requested mode is auto, a single set_permission_mode call serves
-// both purposes: success means auto is available and active; a response
-// matching autoModeUnavailableErrorPrefix means auto is unavailable and the
-// mode is rewritten to default and re-sent. Any other error is fatal.
-//
-// When the requested mode is non-auto, we probe auto first (leaving the
-// session briefly in auto on success) and then apply the requested mode,
-// which restores the intended state. Transient probe errors are treated as
-// unavailable so the UI does not offer a mode the agent cannot enter.
-func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, mode *string, timeout time.Duration) (claudeCodeControlResult, error) {
+// When requested == auto a single set_permission_mode call serves both
+// purposes; otherwise auto is probed first (leaving the session briefly in
+// auto on success) before the requested mode is applied to restore the
+// intended state. Transient probe errors are treated as unavailable so the
+// UI does not offer a mode the agent cannot enter.
+func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, requested string, timeout time.Duration) (claudeCodeControlResult, error) {
 	setMode := func(m string) (claudeCodeControlResult, error) {
 		return a.sendControlAndWait(ctx,
 			fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, m), timeout)
 	}
 
-	if *mode == PermissionModeAuto {
+	if requested == PermissionModeAuto {
 		resp, err := setMode(PermissionModeAuto)
 		switch {
 		case err == nil:
@@ -750,7 +742,6 @@ func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, mode *
 			slog.Warn("requested auto permission mode is unavailable; falling back to default",
 				"agent_id", a.agentID)
 			a.autoModeAvailable = false
-			*mode = PermissionModeDefault
 			return setMode(PermissionModeDefault)
 		default:
 			return claudeCodeControlResult{}, err
@@ -766,7 +757,7 @@ func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, mode *
 	} else {
 		a.autoModeAvailable = true
 	}
-	return setMode(*mode)
+	return setMode(requested)
 }
 
 // isAutoModeUnavailableError reports whether err is the Claude Code

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -218,7 +218,6 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.fastMode = FastModeOff
 	}
 
-	// Configure the permission mode and detect auto-mode availability for the UI.
 	resp, err := a.applyStartupPermissionMode(ctx, StringOrDefault(opts.PermissionMode, PermissionModeDefault), timeout)
 	if err != nil {
 		cleanup()
@@ -435,9 +434,8 @@ func (a *ClaudeCodeAgent) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGr
 	return groups
 }
 
-// filterPermissionModeGroup returns a copy of the permission-mode option
-// group with modes unavailable to this agent instance removed. Currently
-// only filters "auto" when auto mode was rejected by the probe at startup.
+// filterPermissionModeGroup hides "auto" when the startup probe rejected it,
+// so the UI can't offer a mode this Claude Code instance can't enter.
 func filterPermissionModeGroup(group *leapmuxv1.AvailableOptionGroup, autoAvail bool) *leapmuxv1.AvailableOptionGroup {
 	if autoAvail {
 		return group

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -212,7 +212,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.outputStyle = initResp.OutputStyle
 	}
 	a.availableOutputStyles = initResp.AvailableOutputStyles
-	if initResp.FastModeState == "on" || initResp.FastModeState == "cooldown" {
+	if initResp.FastModeState == FastModeOn || initResp.FastModeState == "cooldown" {
 		a.fastMode = FastModeOn
 	} else {
 		a.fastMode = FastModeOff
@@ -580,7 +580,7 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 // for apply_flag_settings. "on" → true, anything else → nil (which resets
 // the flag to its default).
 func flagSettingOnOff(v string) interface{} {
-	if v == "on" {
+	if v == FastModeOn {
 		return true
 	}
 	return nil

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -107,7 +107,7 @@ func TestAvailableOptionGroups_FastModeDefaultsToOff(t *testing.T) {
 
 func TestAvailableOptionGroups_AlwaysIncludesThinking(t *testing.T) {
 	a := &ClaudeCodeAgent{
-		alwaysThinking: "off",
+		alwaysThinking: AlwaysThinkingOff,
 	}
 	groups := a.AvailableOptionGroups()
 
@@ -120,12 +120,115 @@ func TestAvailableOptionGroups_AlwaysIncludesThinking(t *testing.T) {
 	}
 	require.NotNil(t, thinkingGroup, "thinking group should always be present")
 	for _, opt := range thinkingGroup.Options {
-		if opt.Id == "off" {
+		if opt.Id == AlwaysThinkingOff {
 			assert.True(t, opt.IsDefault)
 		} else {
 			assert.False(t, opt.IsDefault)
 		}
 	}
+}
+
+// TestAvailableOptionGroups_ThinkingLabelsByModel verifies that the
+// enabled thinking option re-labels to match Claude Code's per-model
+// thinking-type gate: "Adaptive" for Opus/Sonnet and unknown models
+// (first-party fallback), "On" for Haiku (legacy type:"enabled"). The
+// option ID stays "on" for all models; only the display name changes.
+func TestAvailableOptionGroups_ThinkingLabelsByModel(t *testing.T) {
+	cases := []struct {
+		model     string
+		wantName  string
+		current   string // initial a.alwaysThinking
+		wantOnDef bool   // whether the "on" option is IsDefault
+	}{
+		{"opus", "Adaptive", AlwaysThinkingOn, true},
+		{"opus[1m]", "Adaptive", AlwaysThinkingOn, true},
+		{"sonnet", "Adaptive", AlwaysThinkingOn, true},
+		{"sonnet[1m]", "Adaptive", AlwaysThinkingOff, false},
+		{"haiku", "On", AlwaysThinkingOn, true},
+		{"haiku", "On", AlwaysThinkingOff, false},
+		{"", "Adaptive", AlwaysThinkingOn, true},
+		{"unknown-future-model", "Adaptive", AlwaysThinkingOn, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model+"/"+tc.current, func(t *testing.T) {
+			a := &ClaudeCodeAgent{model: tc.model, alwaysThinking: tc.current}
+			groups := a.AvailableOptionGroups()
+
+			var g *leapmuxv1.AvailableOptionGroup
+			for _, gr := range groups {
+				if gr.Key == ExtraKeyAlwaysThinking {
+					g = gr
+					break
+				}
+			}
+			require.NotNil(t, g)
+			require.Len(t, g.Options, 2, "thinking group has exactly two options (enabled + off)")
+
+			enabled := g.Options[0]
+			off := g.Options[1]
+			assert.Equal(t, AlwaysThinkingOn, enabled.Id, "enabled option ID is always 'on'")
+			assert.Equal(t, tc.wantName, enabled.Name, "enabled option name varies by model")
+			assert.Equal(t, tc.wantOnDef, enabled.IsDefault, "'on' IsDefault")
+			assert.Equal(t, AlwaysThinkingOff, off.Id)
+			assert.Equal(t, "Off", off.Name)
+			assert.Equal(t, !tc.wantOnDef, off.IsDefault, "'off' IsDefault")
+		})
+	}
+}
+
+func TestModelSupportsAdaptiveThinking(t *testing.T) {
+	// Expects the short alias. Fully-qualified IDs should be normalized
+	// via normalizeClaudeCodeModel before calling.
+	cases := map[string]bool{
+		"opus":                 true,
+		"opus[1m]":             true,
+		"sonnet":               true,
+		"sonnet[1m]":           true,
+		"haiku":                false,
+		"":                     true, // unknown → default-on
+		"unknown-future-model": true,
+	}
+	for model, want := range cases {
+		t.Run(model, func(t *testing.T) {
+			assert.Equal(t, want, modelSupportsAdaptiveThinking(model))
+		})
+	}
+}
+
+func TestNormalizeClaudeCodeModel(t *testing.T) {
+	cases := map[string]string{
+		// Short aliases pass through.
+		"opus":       "opus",
+		"opus[1m]":   "opus[1m]",
+		"sonnet":     "sonnet",
+		"sonnet[1m]": "sonnet[1m]",
+		"haiku":      "haiku",
+		// Fully-qualified IDs Claude Code returns from get_settings.
+		"claude-opus-4-7":            "opus",
+		"claude-opus-4-7[1m]":        "opus[1m]",
+		"claude-opus-4-6":            "opus",
+		"claude-opus-4-6[1m]":        "opus[1m]",
+		"claude-sonnet-4-6":          "sonnet",
+		"claude-sonnet-4-6[1m]":      "sonnet[1m]",
+		"claude-haiku-4-5-20251001":  "haiku",
+		"claude-haiku-4-5":           "haiku",
+		"claude-sonnet-4-5-20240101": "sonnet",
+		// Degenerate input.
+		"":              "",
+		"unknown-thing": "unknown",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, normalizeClaudeCodeModel(in))
+		})
+	}
+}
+
+func TestFlagSettingThinking(t *testing.T) {
+	assert.Equal(t, false, flagSettingThinking(AlwaysThinkingOff))
+	assert.Nil(t, flagSettingThinking(AlwaysThinkingOn), "on → nil (lets Claude Code default-on kick in)")
+	assert.Nil(t, flagSettingThinking(""), "empty → nil")
+	assert.Nil(t, flagSettingThinking("anything-else"), "unknown → nil")
 }
 
 // --- Unit tests for CurrentSettings ---
@@ -274,21 +377,24 @@ func TestUpdateSettings_FastModeOff(t *testing.T) {
 	assert.Equal(t, "off", a.fastMode)
 }
 
+// TestUpdateSettings_AlwaysThinkingOn verifies that flipping from "off"
+// to "on" sends alwaysThinkingEnabled:null (nil, "use default") and that
+// the get_settings round-trip confirms the enabled state.
 func TestUpdateSettings_AlwaysThinkingOn(t *testing.T) {
 	a := newTestAgentWithControlProtocol(t)
 	defer stopTestAgent(a)
 
-	a.alwaysThinking = "off"
+	a.alwaysThinking = AlwaysThinkingOff
 
 	result := a.UpdateSettings(&leapmuxv1.AgentSettings{
 		Model:  a.model,
 		Effort: a.effort,
 		ExtraSettings: map[string]string{
-			ExtraKeyAlwaysThinking: "on",
+			ExtraKeyAlwaysThinking: AlwaysThinkingOn,
 		},
 	})
 	assert.True(t, result)
-	assert.Equal(t, "on", a.alwaysThinking)
+	assert.Equal(t, AlwaysThinkingOn, a.alwaysThinking)
 }
 
 func TestUpdateSettings_ApplyFlagSettingsFails(t *testing.T) {
@@ -555,7 +661,7 @@ func newTestAgentWithControlProtocol(t *testing.T) *ClaudeCodeAgent {
 		outputStyle:           "default",
 		availableOutputStyles: []string{"default", "Explanatory", "Learning"},
 		fastMode:              "off",
-		alwaysThinking:        "on",
+		alwaysThinking:        AlwaysThinkingOn,
 		workingDir:            t.TempDir(),
 		sink:                  noopSink{},
 		pendingControl:        make(map[string]chan<- claudeCodeControlResult),

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -128,11 +127,9 @@ func TestAvailableOptionGroups_AlwaysIncludesThinking(t *testing.T) {
 	}
 }
 
-// TestAvailableOptionGroups_ThinkingLabelsByModel verifies that the
-// enabled thinking option re-labels to match Claude Code's per-model
-// thinking-type gate: "Adaptive" for Opus/Sonnet and unknown models
-// (first-party fallback), "On" for Haiku (legacy type:"enabled"). The
-// option ID stays "on" for all models; only the display name changes.
+// The enabled option's display name tracks Claude Code's per-model
+// thinking-type gate: "Adaptive" for first-party models, "On" for Haiku
+// (legacy type:"enabled"). The option ID stays "on" for all models.
 func TestAvailableOptionGroups_ThinkingLabelsByModel(t *testing.T) {
 	cases := []struct {
 		model     string
@@ -377,9 +374,6 @@ func TestUpdateSettings_FastModeOff(t *testing.T) {
 	assert.Equal(t, "off", a.fastMode)
 }
 
-// TestUpdateSettings_AlwaysThinkingOn verifies that flipping from "off"
-// to "on" sends alwaysThinkingEnabled:null (nil, "use default") and that
-// the get_settings round-trip confirms the enabled state.
 func TestUpdateSettings_AlwaysThinkingOn(t *testing.T) {
 	a := newTestAgentWithControlProtocol(t)
 	defer stopTestAgent(a)
@@ -631,49 +625,21 @@ func TestHelperProcessWithControlProtocol(t *testing.T) {
 // defaults set for testing UpdateSettings.
 func newTestAgentWithControlProtocol(t *testing.T) *ClaudeCodeAgent {
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcessWithControlProtocol", "--")
-	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_CONTROL=1")
-	cmd.Dir = t.TempDir()
-
-	stdin, err := cmd.StdinPipe()
-	require.NoError(t, err)
-
-	stdout, err := cmd.StdoutPipe()
-	require.NoError(t, err)
-
-	cmd.Stderr = nil
-
-	a := &ClaudeCodeAgent{
-		processBase: processBase{
-			agentID:     "test-ctrl",
-			cmd:         cmd,
-			stdin:       stdin,
-			ctx:         ctx,
-			cancel:      cancel,
-			processDone: make(chan struct{}),
-			stderrDone:  make(chan struct{}),
-			apiTimeout:  5 * time.Second,
+	a, err := spawnMockClaudeAgent(context.Background(), "TestHelperProcessWithControlProtocol",
+		[]string{"GO_WANT_HELPER_PROCESS_CONTROL=1"},
+		Options{
+			AgentID:    "test-ctrl",
+			Model:      "opus[1m]",
+			WorkingDir: t.TempDir(),
+			APITimeout: 5 * time.Second,
 		},
-		model:                 "opus[1m]",
-		effort:                "high",
-		outputStyle:           "default",
-		availableOutputStyles: []string{"default", "Explanatory", "Learning"},
-		fastMode:              "off",
-		alwaysThinking:        AlwaysThinkingOn,
-		workingDir:            t.TempDir(),
-		sink:                  noopSink{},
-		pendingControl:        make(map[string]chan<- claudeCodeControlResult),
-	}
-	close(a.stderrDone)
-
-	require.NoError(t, cmd.Start())
-
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-	go a.readOutputLoop(scanner)
-
+		noopSink{})
+	require.NoError(t, err)
+	a.effort = "high"
+	a.outputStyle = "default"
+	a.availableOutputStyles = []string{"default", "Explanatory", "Learning"}
+	a.fastMode = "off"
+	a.alwaysThinking = AlwaysThinkingOn
 	return a
 }
 

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -638,7 +638,7 @@ func newTestAgentWithControlProtocol(t *testing.T) *ClaudeCodeAgent {
 	a.effort = "high"
 	a.outputStyle = "default"
 	a.availableOutputStyles = []string{"default", "Explanatory", "Learning"}
-	a.fastMode = "off"
+	a.fastMode = FastModeOff
 	a.alwaysThinking = AlwaysThinkingOn
 	return a
 }

--- a/backend/internal/worker/agent/claude_mockhelpers_test.go
+++ b/backend/internal/worker/agent/claude_mockhelpers_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// spawnMockClaudeAgent spawns os.Args[0] with -test.run=testRun as a mock
+// Claude process, wires its stdin/stdout into a ClaudeCodeAgent, and starts
+// the output reader. extraEnv is appended to os.Environ(). Callers populate
+// any additional agent fields on the returned instance before use.
+func spawnMockClaudeAgent(ctx context.Context, testRun string, extraEnv []string, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run="+testRun, "--")
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Dir = opts.WorkingDir
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	cmd.Stderr = nil
+
+	a := &ClaudeCodeAgent{
+		processBase: processBase{
+			agentID:     opts.AgentID,
+			cmd:         cmd,
+			stdin:       stdin,
+			ctx:         ctx,
+			cancel:      cancel,
+			processDone: make(chan struct{}),
+			stderrDone:  make(chan struct{}),
+			apiTimeout:  opts.apiTimeout(),
+		},
+		model:          opts.Model,
+		workingDir:     opts.WorkingDir,
+		sink:           sink,
+		pendingControl: make(map[string]chan<- claudeCodeControlResult),
+	}
+	close(a.stderrDone)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutputLoop(scanner)
+
+	return a, nil
+}

--- a/backend/internal/worker/agent/claude_mockhelpers_test.go
+++ b/backend/internal/worker/agent/claude_mockhelpers_test.go
@@ -14,5 +14,5 @@ func spawnMockClaudeAgent(ctx context.Context, testRun string, extraEnv []string
 	ctx, cancel := context.WithCancel(ctx)
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run="+testRun, "--")
 	cmd.Env = append(os.Environ(), extraEnv...)
-	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink, "")
+	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink)
 }

--- a/backend/internal/worker/agent/claude_mockhelpers_test.go
+++ b/backend/internal/worker/agent/claude_mockhelpers_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"os"
 	"os/exec"
@@ -13,49 +12,7 @@ import (
 // any additional agent fields on the returned instance before use.
 func spawnMockClaudeAgent(ctx context.Context, testRun string, extraEnv []string, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
 	ctx, cancel := context.WithCancel(ctx)
-
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run="+testRun, "--")
 	cmd.Env = append(os.Environ(), extraEnv...)
-	cmd.Dir = opts.WorkingDir
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-	cmd.Stderr = nil
-
-	a := &ClaudeCodeAgent{
-		processBase: processBase{
-			agentID:     opts.AgentID,
-			cmd:         cmd,
-			stdin:       stdin,
-			ctx:         ctx,
-			cancel:      cancel,
-			processDone: make(chan struct{}),
-			stderrDone:  make(chan struct{}),
-			apiTimeout:  opts.apiTimeout(),
-		},
-		model:          opts.Model,
-		workingDir:     opts.WorkingDir,
-		sink:           sink,
-		pendingControl: make(map[string]chan<- claudeCodeControlResult),
-	}
-	close(a.stderrDone)
-
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-	go a.readOutputLoop(scanner)
-
-	return a, nil
+	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink, "")
 }

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1198,12 +1198,8 @@ func TestProbeAutoMode_TransientError(t *testing.T) {
 		"probe should conservatively return false on non-matching errors")
 }
 
-// TestStartupHandshake_ProbeBeforeMode replicates the post-init control-
-// request sequence from StartClaudeCode and verifies the probe is issued
-// before the user's real-mode request. This mirrors the pattern used by
-// TestAgent_TimeoutDetected's startUnresponsive helper, which also
-// replicates (rather than invokes) StartClaudeCode to exercise individual
-// handshake steps.
+// TestStartupHandshake_ProbeBeforeMode verifies the auto-mode probe is
+// issued before the user's real set_permission_mode request.
 func TestStartupHandshake_ProbeBeforeMode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1183,12 +1183,10 @@ func TestApplyStartupPermissionMode_AutoAccepted(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModeAuto
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
 	require.NoError(t, err)
 
 	assert.True(t, agent.autoModeAvailable)
-	assert.Equal(t, PermissionModeAuto, mode, "requested mode should be preserved on acceptance")
 	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
 		"accepted auto must complete in one set_permission_mode call")
 }
@@ -1208,13 +1206,11 @@ func TestApplyStartupPermissionMode_AutoRejectedFallsBack(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModeAuto
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
 	require.NoError(t, err)
 
 	assert.False(t, agent.autoModeAvailable,
 		"auto must be marked unavailable after a rejection with the auto-unavailable prefix")
-	assert.Equal(t, PermissionModeDefault, mode, "mode should be rewritten to default on fallback")
 	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath),
 		"fallback path must issue auto then default")
 }
@@ -1233,8 +1229,7 @@ func TestApplyStartupPermissionMode_AutoTransientErrorPropagates(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModeAuto
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
 	require.Error(t, err, "transient errors should not be treated as unavailability")
 	assert.NotContains(t, err.Error(), autoModeUnavailableErrorPrefix)
 	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
@@ -1254,8 +1249,7 @@ func TestApplyStartupPermissionMode_NonAutoProbesAutoAvailable(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModeDefault
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeDefault, 2*time.Second)
 	require.NoError(t, err)
 
 	assert.True(t, agent.autoModeAvailable, "probe should confirm auto availability")
@@ -1278,8 +1272,7 @@ func TestApplyStartupPermissionMode_NonAutoProbeRejected(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModePlan
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModePlan, 2*time.Second)
 	require.NoError(t, err)
 
 	assert.False(t, agent.autoModeAvailable, "probe rejection must hide auto from the UI")
@@ -1302,8 +1295,7 @@ func TestApplyStartupPermissionMode_NonAutoProbeTransient(t *testing.T) {
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	mode := PermissionModeDefault
-	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeDefault, 2*time.Second)
 	require.NoError(t, err, "transient probe error must not fail startup")
 
 	assert.False(t, agent.autoModeAvailable, "transient probe failure must conservatively hide auto")

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -133,109 +133,19 @@ func TestHelperProcessControlResponder(t *testing.T) {
 // as LEAPMUX_TEST_CONTROL_SCRIPT; logPath (optional) as
 // LEAPMUX_TEST_CONTROL_LOG.
 func mockStartWithResponder(ctx context.Context, opts Options, sink OutputSink, script, logPath string) (*ClaudeCodeAgent, error) {
-	ctx, cancel := context.WithCancel(ctx)
-
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcessControlResponder", "--")
-	env := append(os.Environ(),
+	env := []string{
 		"GO_WANT_HELPER_PROCESS_RESPONDER=1",
-		"LEAPMUX_TEST_CONTROL_SCRIPT="+script,
-	)
+		"LEAPMUX_TEST_CONTROL_SCRIPT=" + script,
+	}
 	if logPath != "" {
 		env = append(env, "LEAPMUX_TEST_CONTROL_LOG="+logPath)
 	}
-	cmd.Env = env
-	cmd.Dir = opts.WorkingDir
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-	cmd.Stderr = nil
-
-	a := &ClaudeCodeAgent{
-		processBase: processBase{
-			agentID:     opts.AgentID,
-			cmd:         cmd,
-			stdin:       stdin,
-			ctx:         ctx,
-			cancel:      cancel,
-			processDone: make(chan struct{}),
-			stderrDone:  make(chan struct{}),
-		},
-		model:          opts.Model,
-		workingDir:     opts.WorkingDir,
-		sink:           sink,
-		pendingControl: make(map[string]chan<- claudeCodeControlResult),
-	}
-	close(a.stderrDone)
-
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-	go a.readOutputLoop(scanner)
-
-	return a, nil
+	return spawnMockClaudeAgent(ctx, "TestHelperProcessControlResponder", env, opts, sink)
 }
 
 // mockStart spawns a test helper process instead of the real claude binary.
 func mockStart(ctx context.Context, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
-	ctx, cancel := context.WithCancel(ctx)
-
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess", "--")
-	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
-	cmd.Dir = opts.WorkingDir
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	cmd.Stderr = nil
-
-	a := &ClaudeCodeAgent{
-		processBase: processBase{
-			agentID:     opts.AgentID,
-			cmd:         cmd,
-			stdin:       stdin,
-			ctx:         ctx,
-			cancel:      cancel,
-			processDone: make(chan struct{}),
-			stderrDone:  make(chan struct{}),
-		},
-		model:          opts.Model,
-		workingDir:     opts.WorkingDir,
-		sink:           sink,
-		pendingControl: make(map[string]chan<- claudeCodeControlResult),
-	}
-	close(a.stderrDone)
-
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-	go a.readOutputLoop(scanner)
-
-	return a, nil
+	return spawnMockClaudeAgent(ctx, "TestHelperProcess", []string{"GO_WANT_HELPER_PROCESS=1"}, opts, sink)
 }
 
 func TestAgent_StartAndStop(t *testing.T) {
@@ -347,53 +257,8 @@ func TestHelperProcessWithInit(t *testing.T) {
 // mockStartWithInit spawns a test helper process that outputs an init line
 // with a session_id, simulating real Claude Code behavior.
 func mockStartWithInit(ctx context.Context, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
-	ctx, cancel := context.WithCancel(ctx)
-
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcessWithInit", "--")
-	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_WITH_INIT=1")
-	cmd.Dir = opts.WorkingDir
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	cmd.Stderr = nil
-
-	a := &ClaudeCodeAgent{
-		processBase: processBase{
-			agentID:     opts.AgentID,
-			cmd:         cmd,
-			stdin:       stdin,
-			ctx:         ctx,
-			cancel:      cancel,
-			processDone: make(chan struct{}),
-			stderrDone:  make(chan struct{}),
-		},
-		model:          opts.Model,
-		workingDir:     opts.WorkingDir,
-		sink:           sink,
-		pendingControl: make(map[string]chan<- claudeCodeControlResult),
-	}
-	close(a.stderrDone)
-
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-	go a.readOutputLoop(scanner)
-
-	return a, nil
+	return spawnMockClaudeAgent(ctx, "TestHelperProcessWithInit",
+		[]string{"GO_WANT_HELPER_PROCESS_WITH_INIT=1"}, opts, sink)
 }
 
 // TestAgent_InitMessageFlowsThrough verifies that the init message with
@@ -1170,136 +1035,92 @@ func readHandshakeModes(t *testing.T, logPath string) []string {
 	return modes
 }
 
-// Auto startup succeeds in a single round trip when Claude Code accepts it
-// — probe and apply are merged into one set_permission_mode call.
-func TestApplyStartupPermissionMode_AutoAccepted(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+func TestApplyStartupPermissionMode(t *testing.T) {
+	cases := []struct {
+		name          string
+		agentID       string
+		script        string
+		requested     string
+		wantAuto      bool
+		wantModes     []string
+		wantErrSubstr string // non-empty means the call must fail; checks err contains it
+	}{
+		{
+			name:      "AutoAccepted",
+			agentID:   "handshake-auto-ok",
+			script:    "success",
+			requested: PermissionModeAuto,
+			wantAuto:  true,
+			wantModes: []string{PermissionModeAuto},
+		},
+		{
+			name:      "AutoRejectedFallsBack",
+			agentID:   "handshake-auto-reject",
+			script:    "error:Cannot set permission mode to auto: auto mode disabled by settings|success",
+			requested: PermissionModeAuto,
+			wantAuto:  false,
+			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+		},
+		{
+			name:          "AutoTransientErrorPropagates",
+			agentID:       "handshake-auto-transient",
+			script:        "error:some unrelated runtime error",
+			requested:     PermissionModeAuto,
+			wantAuto:      false,
+			wantModes:     []string{PermissionModeAuto},
+			wantErrSubstr: "some unrelated runtime error",
+		},
+		{
+			name:      "NonAutoProbesAutoAvailable",
+			agentID:   "handshake-probe-ok",
+			script:    "success|success",
+			requested: PermissionModeDefault,
+			wantAuto:  true,
+			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+		},
+		{
+			name:      "NonAutoProbeRejected",
+			agentID:   "handshake-probe-reject",
+			script:    "error:Cannot set permission mode to auto: auto mode disabled by settings|success",
+			requested: PermissionModePlan,
+			wantAuto:  false,
+			wantModes: []string{PermissionModeAuto, PermissionModePlan},
+		},
+		{
+			name:      "NonAutoProbeTransient",
+			agentID:   "handshake-probe-transient",
+			script:    "error:some unrelated runtime error|success",
+			requested: PermissionModeDefault,
+			wantAuto:  false,
+			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+		},
+	}
 
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-auto-ok", WorkingDir: t.TempDir()},
-		noopSink{}, "success", logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
 
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
-	require.NoError(t, err)
+			logPath := filepath.Join(t.TempDir(), "control.log")
+			agent, err := mockStartWithResponder(ctx,
+				Options{AgentID: tc.agentID, WorkingDir: t.TempDir()},
+				noopSink{}, tc.script, logPath)
+			require.NoError(t, err, "mockStartWithResponder")
+			defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	assert.True(t, agent.autoModeAvailable)
-	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
-		"accepted auto must complete in one set_permission_mode call")
-}
+			_, err = agent.applyStartupPermissionMode(ctx, tc.requested, 2*time.Second)
+			if tc.wantErrSubstr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				assert.NotContains(t, err.Error(), autoModeUnavailableErrorPrefix)
+			}
 
-// Auto startup falls back to default when Claude Code rejects it with the
-// auto-unavailable prefix.
-func TestApplyStartupPermissionMode_AutoRejectedFallsBack(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-auto-reject", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:Cannot set permission mode to auto: auto mode disabled by settings|success",
-		logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
-	require.NoError(t, err)
-
-	assert.False(t, agent.autoModeAvailable,
-		"auto must be marked unavailable after a rejection with the auto-unavailable prefix")
-	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath),
-		"fallback path must issue auto then default")
-}
-
-// A non-auto-unavailable error surfaces as a startup failure without retry.
-func TestApplyStartupPermissionMode_AutoTransientErrorPropagates(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-auto-transient", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:some unrelated runtime error",
-		logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeAuto, 2*time.Second)
-	require.Error(t, err, "transient errors should not be treated as unavailability")
-	assert.NotContains(t, err.Error(), autoModeUnavailableErrorPrefix)
-	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
-		"transient error must not trigger a retry")
-}
-
-// Non-auto startup probes auto first so the UI reflects actual availability,
-// then applies the requested mode.
-func TestApplyStartupPermissionMode_NonAutoProbesAutoAvailable(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-probe-ok", WorkingDir: t.TempDir()},
-		noopSink{}, "success|success", logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeDefault, 2*time.Second)
-	require.NoError(t, err)
-
-	assert.True(t, agent.autoModeAvailable, "probe should confirm auto availability")
-	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath),
-		"non-auto startup must probe auto, then apply the requested mode")
-}
-
-// A rejected probe marks auto unavailable; the requested mode is still
-// applied so the session proceeds.
-func TestApplyStartupPermissionMode_NonAutoProbeRejected(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-probe-reject", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:Cannot set permission mode to auto: auto mode disabled by settings|success",
-		logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModePlan, 2*time.Second)
-	require.NoError(t, err)
-
-	assert.False(t, agent.autoModeAvailable, "probe rejection must hide auto from the UI")
-	assert.Equal(t, []string{PermissionModeAuto, PermissionModePlan}, readHandshakeModes(t, logPath),
-		"requested mode must be applied after the probe")
-}
-
-// A transient probe error is conservatively treated as unavailable and
-// doesn't block startup; the requested mode is still applied.
-func TestApplyStartupPermissionMode_NonAutoProbeTransient(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	logPath := filepath.Join(t.TempDir(), "control.log")
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "handshake-probe-transient", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:some unrelated runtime error|success",
-		logPath)
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	_, err = agent.applyStartupPermissionMode(ctx, PermissionModeDefault, 2*time.Second)
-	require.NoError(t, err, "transient probe error must not fail startup")
-
-	assert.False(t, agent.autoModeAvailable, "transient probe failure must conservatively hide auto")
-	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath))
+			assert.Equal(t, tc.wantAuto, agent.autoModeAvailable)
+			assert.Equal(t, tc.wantModes, readHandshakeModes(t, logPath))
+		})
+	}
 }
 
 func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
@@ -1345,9 +1166,6 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	assert.True(t, foundClaudeCode, "CLAUDECODE=1 should be in shell-wrapped env")
 }
 
-// TestClaudeCodeAvailableModels_EffortsMatchDocs pins the per-model effort
-// lists and defaults to the documented Claude Code rules so accidental edits
-// to the tables get caught at test time.
 func TestClaudeCodeAvailableModels_EffortsMatchDocs(t *testing.T) {
 	byID := map[string]*leapmuxv1.AvailableModel{}
 	for _, m := range claudeCodeAvailableModels {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1019,7 +1019,7 @@ func TestAgent_PreambleMetaParsing(t *testing.T) {
 	}, "expected output after preamble")
 
 	// Verify metadata was parsed.
-	assert.Equal(t, "false", a.preambleMeta["can_change_model_and_effort"])
+	assert.Equal(t, "false", a.preambleMetaValue("can_change_model_and_effort"))
 
 	// Verify preamble output does NOT contain the metadata line.
 	preamble := a.PreambleOutput()
@@ -1152,92 +1152,162 @@ func TestClaudeCodeAgent_AvailableOptionGroupsFiltersAutoWhenUnavailable(t *test
 	assert.True(t, found, "auto should appear when autoModeAvailable is true")
 }
 
-func TestProbeAutoMode_Available(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "probe-ok", WorkingDir: t.TempDir()},
-		noopSink{}, "success", "")
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	assert.True(t, agent.probeAutoMode(ctx, 2*time.Second),
-		"probe should return true when the agent accepts set_permission_mode:auto")
+func readHandshakeModes(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err, "read control log")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	modes := make([]string, 0, len(lines))
+	for _, line := range lines {
+		var body struct {
+			Subtype string `json:"subtype"`
+			Mode    string `json:"mode"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &body))
+		require.Equal(t, "set_permission_mode", body.Subtype)
+		modes = append(modes, body.Mode)
+	}
+	return modes
 }
 
-func TestProbeAutoMode_DisabledBySettings(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "probe-disabled", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:Cannot set permission mode to auto: auto mode disabled by settings",
-		"")
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	assert.False(t, agent.probeAutoMode(ctx, 2*time.Second),
-		"probe should return false when the agent rejects with the auto-unavailable prefix")
-}
-
-func TestProbeAutoMode_TransientError(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "probe-transient", WorkingDir: t.TempDir()},
-		noopSink{},
-		"error:some unrelated runtime error",
-		"")
-	require.NoError(t, err, "mockStartWithResponder")
-	defer func() { agent.Stop(); _ = agent.Wait() }()
-
-	assert.False(t, agent.probeAutoMode(ctx, 2*time.Second),
-		"probe should conservatively return false on non-matching errors")
-}
-
-// TestStartupHandshake_ProbeBeforeMode verifies the auto-mode probe is
-// issued before the user's real set_permission_mode request.
-func TestStartupHandshake_ProbeBeforeMode(t *testing.T) {
+// Auto startup succeeds in a single round trip when Claude Code accepts it
+// — probe and apply are merged into one set_permission_mode call.
+func TestApplyStartupPermissionMode_AutoAccepted(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	logPath := filepath.Join(t.TempDir(), "control.log")
 	agent, err := mockStartWithResponder(ctx,
-		Options{AgentID: "ord", WorkingDir: t.TempDir()},
-		noopSink{},
-		"success|success", logPath)
+		Options{AgentID: "handshake-auto-ok", WorkingDir: t.TempDir()},
+		noopSink{}, "success", logPath)
 	require.NoError(t, err, "mockStartWithResponder")
 	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	// Step 1: probe auto-mode availability (mirrors claude.go:213).
-	agent.autoModeAvailable = agent.probeAutoMode(ctx, 2*time.Second)
-	require.True(t, agent.autoModeAvailable, "probe should succeed in this scripted scenario")
+	mode := PermissionModeAuto
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.NoError(t, err)
 
-	// Step 2: set the user's requested mode (mirrors claude.go:224-225).
-	_, err = agent.sendControlAndWait(ctx,
-		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, PermissionModeDefault),
-		2*time.Second)
-	require.NoError(t, err, "real-mode set_permission_mode should succeed")
+	assert.True(t, agent.autoModeAvailable)
+	assert.Equal(t, PermissionModeAuto, mode, "requested mode should be preserved on acceptance")
+	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
+		"accepted auto must complete in one set_permission_mode call")
+}
 
-	data, err := os.ReadFile(logPath)
-	require.NoError(t, err, "read control log")
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	require.Len(t, lines, 2, "expected exactly two control_request bodies recorded")
+// Auto startup falls back to default when Claude Code rejects it with the
+// auto-unavailable prefix.
+func TestApplyStartupPermissionMode_AutoRejectedFallsBack(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	var first, second struct {
-		Subtype string `json:"subtype"`
-		Mode    string `json:"mode"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
-	require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "handshake-auto-reject", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:Cannot set permission mode to auto: auto mode disabled by settings|success",
+		logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
 
-	assert.Equal(t, "set_permission_mode", first.Subtype, "first request should be set_permission_mode")
-	assert.Equal(t, PermissionModeAuto, first.Mode, "probe must send mode=auto first")
-	assert.Equal(t, "set_permission_mode", second.Subtype, "second request should be set_permission_mode")
-	assert.Equal(t, PermissionModeDefault, second.Mode, "user's real mode must be sent after the probe")
+	mode := PermissionModeAuto
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.NoError(t, err)
+
+	assert.False(t, agent.autoModeAvailable,
+		"auto must be marked unavailable after a rejection with the auto-unavailable prefix")
+	assert.Equal(t, PermissionModeDefault, mode, "mode should be rewritten to default on fallback")
+	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath),
+		"fallback path must issue auto then default")
+}
+
+// A non-auto-unavailable error surfaces as a startup failure without retry.
+func TestApplyStartupPermissionMode_AutoTransientErrorPropagates(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "handshake-auto-transient", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:some unrelated runtime error",
+		logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	mode := PermissionModeAuto
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.Error(t, err, "transient errors should not be treated as unavailability")
+	assert.NotContains(t, err.Error(), autoModeUnavailableErrorPrefix)
+	assert.Equal(t, []string{PermissionModeAuto}, readHandshakeModes(t, logPath),
+		"transient error must not trigger a retry")
+}
+
+// Non-auto startup probes auto first so the UI reflects actual availability,
+// then applies the requested mode.
+func TestApplyStartupPermissionMode_NonAutoProbesAutoAvailable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "handshake-probe-ok", WorkingDir: t.TempDir()},
+		noopSink{}, "success|success", logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	mode := PermissionModeDefault
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.NoError(t, err)
+
+	assert.True(t, agent.autoModeAvailable, "probe should confirm auto availability")
+	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath),
+		"non-auto startup must probe auto, then apply the requested mode")
+}
+
+// A rejected probe marks auto unavailable; the requested mode is still
+// applied so the session proceeds.
+func TestApplyStartupPermissionMode_NonAutoProbeRejected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "handshake-probe-reject", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:Cannot set permission mode to auto: auto mode disabled by settings|success",
+		logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	mode := PermissionModePlan
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.NoError(t, err)
+
+	assert.False(t, agent.autoModeAvailable, "probe rejection must hide auto from the UI")
+	assert.Equal(t, []string{PermissionModeAuto, PermissionModePlan}, readHandshakeModes(t, logPath),
+		"requested mode must be applied after the probe")
+}
+
+// A transient probe error is conservatively treated as unavailable and
+// doesn't block startup; the requested mode is still applied.
+func TestApplyStartupPermissionMode_NonAutoProbeTransient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "handshake-probe-transient", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:some unrelated runtime error|success",
+		logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	mode := PermissionModeDefault
+	_, err = agent.applyStartupPermissionMode(ctx, &mode, 2*time.Second)
+	require.NoError(t, err, "transient probe error must not fail startup")
+
+	assert.False(t, agent.autoModeAvailable, "transient probe failure must conservatively hide auto")
+	assert.Equal(t, []string{PermissionModeAuto, PermissionModeDefault}, readHandshakeModes(t, logPath))
 }
 
 func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -39,6 +39,154 @@ func TestHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+// TestHelperProcessControlResponder is a test helper that acts as a
+// control-protocol mock. For each control_request line on stdin it emits a
+// canned control_response determined by the LEAPMUX_TEST_CONTROL_SCRIPT env
+// var, a "|"-separated list where each entry is:
+//
+//	success           — emit a success control_response
+//	error:<text>      — emit an error control_response with the given text
+//	skip              — ignore the request (simulate a timeout / no reply)
+//
+// Each incoming control_request body is appended to
+// LEAPMUX_TEST_CONTROL_LOG (if set) as one JSON line, in the order
+// received. Non-control lines on stdin are ignored.
+func TestHelperProcessControlResponder(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_RESPONDER") != "1" {
+		return
+	}
+
+	scriptRaw := os.Getenv("LEAPMUX_TEST_CONTROL_SCRIPT")
+	var script []string
+	if scriptRaw != "" {
+		script = strings.Split(scriptRaw, "|")
+	}
+
+	var logFile *os.File
+	if p := os.Getenv("LEAPMUX_TEST_CONTROL_LOG"); p != "" {
+		f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			logFile = f
+			defer func() { _ = f.Close() }()
+		}
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	idx := 0
+	for scanner.Scan() {
+		var env struct {
+			Type      string          `json:"type"`
+			RequestID string          `json:"request_id"`
+			Request   json.RawMessage `json:"request"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &env); err != nil {
+			continue
+		}
+		if env.Type != "control_request" {
+			continue
+		}
+		if logFile != nil {
+			_, _ = logFile.Write(env.Request)
+			_, _ = logFile.WriteString("\n")
+			_ = logFile.Sync()
+		}
+
+		var action string
+		if idx < len(script) {
+			action = script[idx]
+		}
+		idx++
+
+		switch {
+		case action == "success":
+			resp := map[string]any{
+				"type": "control_response",
+				"response": map[string]any{
+					"subtype":    "success",
+					"request_id": env.RequestID,
+					"response":   map[string]any{},
+				},
+			}
+			b, _ := json.Marshal(resp)
+			fmt.Println(string(b))
+		case strings.HasPrefix(action, "error:"):
+			resp := map[string]any{
+				"type": "control_response",
+				"response": map[string]any{
+					"subtype":    "error",
+					"request_id": env.RequestID,
+					"error":      strings.TrimPrefix(action, "error:"),
+				},
+			}
+			b, _ := json.Marshal(resp)
+			fmt.Println(string(b))
+		case action == "skip":
+			// no response — the waiter will time out.
+		}
+	}
+	os.Exit(0)
+}
+
+// mockStartWithResponder spawns TestHelperProcessControlResponder as the
+// child process and wires it up as a ClaudeCodeAgent. script is forwarded
+// as LEAPMUX_TEST_CONTROL_SCRIPT; logPath (optional) as
+// LEAPMUX_TEST_CONTROL_LOG.
+func mockStartWithResponder(ctx context.Context, opts Options, sink OutputSink, script, logPath string) (*ClaudeCodeAgent, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcessControlResponder", "--")
+	env := append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS_RESPONDER=1",
+		"LEAPMUX_TEST_CONTROL_SCRIPT="+script,
+	)
+	if logPath != "" {
+		env = append(env, "LEAPMUX_TEST_CONTROL_LOG="+logPath)
+	}
+	cmd.Env = env
+	cmd.Dir = opts.WorkingDir
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	cmd.Stderr = nil
+
+	a := &ClaudeCodeAgent{
+		processBase: processBase{
+			agentID:     opts.AgentID,
+			cmd:         cmd,
+			stdin:       stdin,
+			ctx:         ctx,
+			cancel:      cancel,
+			processDone: make(chan struct{}),
+			stderrDone:  make(chan struct{}),
+		},
+		model:          opts.Model,
+		workingDir:     opts.WorkingDir,
+		sink:           sink,
+		pendingControl: make(map[string]chan<- claudeCodeControlResult),
+	}
+	close(a.stderrDone)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	go a.readOutputLoop(scanner)
+
+	return a, nil
+}
+
 // mockStart spawns a test helper process instead of the real claude binary.
 func mockStart(ctx context.Context, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
 	ctx, cancel := context.WithCancel(ctx)
@@ -882,6 +1030,220 @@ func TestAgent_PreambleMetaParsing(t *testing.T) {
 	_ = a.Wait()
 }
 
+func TestClaudeCodePermissionModeOptions_AllDescriptionsPopulated(t *testing.T) {
+	groups := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	require.NotEmpty(t, groups, "expected at least the permission-mode group")
+
+	var permGroup *leapmuxv1.AvailableOptionGroup
+	for _, g := range groups {
+		if g.GetKey() == OptionGroupKeyPermissionMode {
+			permGroup = g
+			break
+		}
+	}
+	require.NotNil(t, permGroup, "permission-mode option group not found")
+
+	wantIDs := []string{
+		PermissionModeDefault,
+		PermissionModePlan,
+		PermissionModeAcceptEdits,
+		PermissionModeBypassPermissions,
+		PermissionModeDontAsk,
+		PermissionModeAuto,
+	}
+	options := permGroup.GetOptions()
+	require.Len(t, options, len(wantIDs), "expected 6 permission modes")
+
+	gotIDs := make([]string, 0, len(options))
+	defaultCount := 0
+	for _, o := range options {
+		gotIDs = append(gotIDs, o.GetId())
+		assert.NotEmptyf(t, o.GetName(), "mode %q: Name must be set", o.GetId())
+		assert.NotEmptyf(t, o.GetDescription(), "mode %q: Description must be set (used as tooltip)", o.GetId())
+		if o.GetIsDefault() {
+			defaultCount++
+		}
+	}
+	assert.Equal(t, wantIDs, gotIDs, "unexpected mode ids or order")
+	assert.Equal(t, 1, defaultCount, "exactly one option should be marked IsDefault")
+}
+
+func TestFilterPermissionModeGroup_AutoAvailable(t *testing.T) {
+	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
+
+	got := filterPermissionModeGroup(staticGroup, true)
+
+	assert.Same(t, staticGroup, got, "when auto is available, the static group should be returned unchanged")
+	assert.Len(t, got.GetOptions(), 6)
+}
+
+func TestFilterPermissionModeGroup_AutoUnavailable(t *testing.T) {
+	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
+
+	got := filterPermissionModeGroup(staticGroup, false)
+
+	require.NotSame(t, staticGroup, got, "filtered result must be a fresh copy")
+	assert.Equal(t, staticGroup.GetKey(), got.GetKey())
+	assert.Equal(t, staticGroup.GetLabel(), got.GetLabel())
+
+	ids := make([]string, 0, len(got.GetOptions()))
+	for _, o := range got.GetOptions() {
+		ids = append(ids, o.GetId())
+		assert.NotEmptyf(t, o.GetDescription(), "mode %q: Description must be preserved after filtering", o.GetId())
+	}
+	assert.NotContains(t, ids, PermissionModeAuto, "auto must be filtered out")
+	assert.ElementsMatch(t, []string{
+		PermissionModeDefault,
+		PermissionModePlan,
+		PermissionModeAcceptEdits,
+		PermissionModeBypassPermissions,
+		PermissionModeDontAsk,
+	}, ids, "remaining modes should include dontAsk and all non-auto modes")
+}
+
+func TestIsAutoModeUnavailableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"bare prefix", fmt.Errorf("Cannot set permission mode to auto"), true},
+		{"settings reason", fmt.Errorf("Cannot set permission mode to auto: auto mode disabled by settings"), true},
+		{"circuit-breaker reason", fmt.Errorf("Cannot set permission mode to auto: auto mode is unavailable for your plan"), true},
+		{"model reason", fmt.Errorf("Cannot set permission mode to auto: auto mode unavailable for this model"), true},
+		{"wrapped error", fmt.Errorf("set_permission_mode failed: %w", fmt.Errorf("Cannot set permission mode to auto: auto mode disabled by settings")), true},
+		{"unrelated error", fmt.Errorf("timeout waiting for agent to respond"), false},
+		{"other mode rejection", fmt.Errorf("Cannot set permission mode to plan"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAutoModeUnavailableError(tc.err))
+		})
+	}
+}
+
+func TestClaudeCodeAgent_AvailableOptionGroupsFiltersAutoWhenUnavailable(t *testing.T) {
+	agent := &ClaudeCodeAgent{
+		processBase:       processBase{agentID: "t"},
+		pendingControl:    make(map[string]chan<- claudeCodeControlResult),
+		autoModeAvailable: false,
+	}
+
+	groups := agent.AvailableOptionGroups()
+	require.NotEmpty(t, groups, "expected at least the permission-mode group")
+
+	permGroup := groups[0]
+	assert.Equal(t, OptionGroupKeyPermissionMode, permGroup.GetKey())
+	for _, o := range permGroup.GetOptions() {
+		assert.NotEqual(t, PermissionModeAuto, o.GetId(), "auto must not appear when autoModeAvailable is false")
+	}
+
+	agent.autoModeAvailable = true
+	groups = agent.AvailableOptionGroups()
+	permGroup = groups[0]
+	found := false
+	for _, o := range permGroup.GetOptions() {
+		if o.GetId() == PermissionModeAuto {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "auto should appear when autoModeAvailable is true")
+}
+
+func TestProbeAutoMode_Available(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "probe-ok", WorkingDir: t.TempDir()},
+		noopSink{}, "success", "")
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	assert.True(t, agent.probeAutoMode(ctx, 2*time.Second),
+		"probe should return true when the agent accepts set_permission_mode:auto")
+}
+
+func TestProbeAutoMode_DisabledBySettings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "probe-disabled", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:Cannot set permission mode to auto: auto mode disabled by settings",
+		"")
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	assert.False(t, agent.probeAutoMode(ctx, 2*time.Second),
+		"probe should return false when the agent rejects with the auto-unavailable prefix")
+}
+
+func TestProbeAutoMode_TransientError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "probe-transient", WorkingDir: t.TempDir()},
+		noopSink{},
+		"error:some unrelated runtime error",
+		"")
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	assert.False(t, agent.probeAutoMode(ctx, 2*time.Second),
+		"probe should conservatively return false on non-matching errors")
+}
+
+// TestStartupHandshake_ProbeBeforeMode replicates the post-init control-
+// request sequence from StartClaudeCode and verifies the probe is issued
+// before the user's real-mode request. This mirrors the pattern used by
+// TestAgent_TimeoutDetected's startUnresponsive helper, which also
+// replicates (rather than invokes) StartClaudeCode to exercise individual
+// handshake steps.
+func TestStartupHandshake_ProbeBeforeMode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logPath := filepath.Join(t.TempDir(), "control.log")
+	agent, err := mockStartWithResponder(ctx,
+		Options{AgentID: "ord", WorkingDir: t.TempDir()},
+		noopSink{},
+		"success|success", logPath)
+	require.NoError(t, err, "mockStartWithResponder")
+	defer func() { agent.Stop(); _ = agent.Wait() }()
+
+	// Step 1: probe auto-mode availability (mirrors claude.go:213).
+	agent.autoModeAvailable = agent.probeAutoMode(ctx, 2*time.Second)
+	require.True(t, agent.autoModeAvailable, "probe should succeed in this scripted scenario")
+
+	// Step 2: set the user's requested mode (mirrors claude.go:224-225).
+	_, err = agent.sendControlAndWait(ctx,
+		fmt.Sprintf(`{"subtype":"set_permission_mode","mode":"%s"}`, PermissionModeDefault),
+		2*time.Second)
+	require.NoError(t, err, "real-mode set_permission_mode should succeed")
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err, "read control log")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 2, "expected exactly two control_request bodies recorded")
+
+	var first, second struct {
+		Subtype string `json:"subtype"`
+		Mode    string `json:"mode"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+
+	assert.Equal(t, "set_permission_mode", first.Subtype, "first request should be set_permission_mode")
+	assert.Equal(t, PermissionModeAuto, first.Mode, "probe must send mode=auto first")
+	assert.Equal(t, "set_permission_mode", second.Subtype, "second request should be set_permission_mode")
+	assert.Equal(t, PermissionModeDefault, second.Mode, "user's real mode must be sent after the probe")
+}
+
 func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	// Verify that LEAPMUX_WORKER=1 is always present for Claude Code and that
 	// CLAUDECODE=1 is injected only for login shells.
@@ -923,4 +1285,43 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	}
 	assert.True(t, foundWorker, "LEAPMUX_WORKER=1 should be in shell-wrapped env")
 	assert.True(t, foundClaudeCode, "CLAUDECODE=1 should be in shell-wrapped env")
+}
+
+// TestClaudeCodeAvailableModels_EffortsMatchDocs pins the per-model effort
+// lists and defaults to the documented Claude Code rules so accidental edits
+// to the tables get caught at test time.
+func TestClaudeCodeAvailableModels_EffortsMatchDocs(t *testing.T) {
+	byID := map[string]*leapmuxv1.AvailableModel{}
+	for _, m := range claudeCodeAvailableModels {
+		byID[m.Id] = m
+	}
+
+	effortIDs := func(m *leapmuxv1.AvailableModel) []string {
+		ids := make([]string, 0, len(m.SupportedEfforts))
+		for _, e := range m.SupportedEfforts {
+			ids = append(ids, e.Id)
+		}
+		return ids
+	}
+
+	opusEfforts := []string{"auto", "max", "xhigh", "high", "medium", "low"}
+	sonnetEfforts := []string{"auto", "max", "high", "medium", "low"}
+
+	for _, id := range []string{"opus", "opus[1m]"} {
+		m := byID[id]
+		require.NotNil(t, m, "model %q missing", id)
+		assert.Equal(t, opusEfforts, effortIDs(m), "opus effort list for %q", id)
+		assert.Equal(t, "xhigh", m.DefaultEffort, "opus default effort for %q", id)
+	}
+
+	for _, id := range []string{"sonnet", "sonnet[1m]"} {
+		m := byID[id]
+		require.NotNil(t, m, "model %q missing", id)
+		assert.Equal(t, sonnetEfforts, effortIDs(m), "sonnet effort list for %q", id)
+		assert.Equal(t, "high", m.DefaultEffort, "sonnet default effort for %q", id)
+	}
+
+	haiku := byID["haiku"]
+	require.NotNil(t, haiku)
+	assert.Empty(t, haiku.SupportedEfforts, "haiku has no effort UI")
 }

--- a/backend/internal/worker/agent/process.go
+++ b/backend/internal/worker/agent/process.go
@@ -177,6 +177,10 @@ func (p *processBase) formatStartupError(phase string, err error) error {
 // agent's JSONL stream. Metadata lines (key=value pairs prefixed with
 // preambleMetaPrefix) are parsed and stored; other preamble lines are captured
 // for diagnostics. This is a no-op if preambleDelimiter is empty.
+//
+// Writes to preambleMeta and preambleOutput are guarded by p.mu so concurrent
+// readers (e.g. AvailableModels called from the hub goroutine) observe
+// consistent state.
 func (p *processBase) skipPreamble(scanner *bufio.Scanner) {
 	if p.preambleDelimiter == "" {
 		return
@@ -193,19 +197,33 @@ func (p *processBase) skipPreamble(scanner *bufio.Scanner) {
 		if len(metaPrefixBytes) > 0 && bytes.HasPrefix(trimmed, metaPrefixBytes) {
 			kv := string(trimmed[len(metaPrefixBytes):])
 			if eqIdx := strings.IndexByte(kv, '='); eqIdx >= 0 {
+				p.mu.Lock()
 				p.preambleMeta[kv[:eqIdx]] = kv[eqIdx+1:]
+				p.mu.Unlock()
 			}
 			continue
 		}
+		p.mu.Lock()
 		if len(p.preambleOutput) < maxPreambleLines {
 			p.preambleOutput = append(p.preambleOutput, string(line))
 		}
+		p.mu.Unlock()
 	}
+}
+
+// preambleMetaValue returns the parsed preamble metadata value for key, or
+// the empty string if absent. Safe to call concurrently with skipPreamble.
+func (p *processBase) preambleMetaValue(key string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.preambleMeta[key]
 }
 
 // PreambleOutput returns the captured stdout preamble lines (before the
 // delimiter) when running under a login shell wrapper.
 func (p *processBase) PreambleOutput() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if len(p.preambleOutput) == 0 {
 		return ""
 	}

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -298,15 +298,39 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			expected: []string{"--model", "opus[1m]", "--effort", "max"},
 		},
 		{
-			name:     "sonnet with max effort falls back to high",
+			name:     "sonnet with max effort unchanged",
 			model:    "sonnet",
 			effort:   "max",
+			expected: []string{"--model", "sonnet", "--effort", "max"},
+		},
+		{
+			name:     "sonnet[1m] with max effort unchanged",
+			model:    "sonnet[1m]",
+			effort:   "max",
+			expected: []string{"--model", "sonnet[1m]", "--effort", "max"},
+		},
+		{
+			name:     "opus with xhigh effort",
+			model:    "opus",
+			effort:   "xhigh",
+			expected: []string{"--model", "opus", "--effort", "xhigh"},
+		},
+		{
+			name:     "opus[1m] with xhigh effort",
+			model:    "opus[1m]",
+			effort:   "xhigh",
+			expected: []string{"--model", "opus[1m]", "--effort", "xhigh"},
+		},
+		{
+			name:     "sonnet with xhigh effort falls back to high",
+			model:    "sonnet",
+			effort:   "xhigh",
 			expected: []string{"--model", "sonnet", "--effort", "high"},
 		},
 		{
-			name:     "sonnet[1m] with max effort falls back to high",
+			name:     "sonnet[1m] with xhigh effort falls back to high",
 			model:    "sonnet[1m]",
-			effort:   "max",
+			effort:   "xhigh",
 			expected: []string{"--model", "sonnet[1m]", "--effort", "high"},
 		},
 		{
@@ -328,6 +352,12 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			expected: []string{"--model", "haiku"},
 		},
 		{
+			name:     "haiku omits xhigh effort",
+			model:    "haiku",
+			effort:   "xhigh",
+			expected: []string{"--model", "haiku"},
+		},
+		{
 			name:     "empty effort omitted",
 			model:    "sonnet",
 			effort:   "",
@@ -338,6 +368,12 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			model:    "sonnet",
 			effort:   "auto",
 			expected: []string{"--model", "sonnet", "--effort", "auto"},
+		},
+		{
+			name:     "unknown model passes effort through",
+			model:    "claude-future-preview",
+			effort:   "xhigh",
+			expected: []string{"--model", "claude-future-preview", "--effort", "xhigh"},
 		},
 	}
 	for _, tt := range tests {

--- a/backend/internal/worker/agent/testing.go
+++ b/backend/internal/worker/agent/testing.go
@@ -27,14 +27,14 @@ func mockStartForTest(ctx context.Context, opts Options, sink OutputSink) (Provi
 	ctx, cancel := context.WithCancel(ctx)
 	cmd := exec.CommandContext(ctx, "cat")
 	cmd.Env = os.Environ()
-	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink, opts.HomeDir)
+	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink)
 }
 
 // wireClaudeMockAgent takes a cmd pre-bound to ctx via exec.CommandContext
 // and builds a ClaudeCodeAgent around it: wires stdin/stdout, starts the
 // process, and spawns the output reader loop. Callers pass the matching
 // cancel so cmd.Start failures can release the context.
-func wireClaudeMockAgent(ctx context.Context, cancel context.CancelFunc, cmd *exec.Cmd, opts Options, sink OutputSink, homeDir string) (*ClaudeCodeAgent, error) {
+func wireClaudeMockAgent(ctx context.Context, cancel context.CancelFunc, cmd *exec.Cmd, opts Options, sink OutputSink) (*ClaudeCodeAgent, error) {
 	cmd.Dir = opts.WorkingDir
 
 	stdin, err := cmd.StdinPipe()
@@ -62,7 +62,7 @@ func wireClaudeMockAgent(ctx context.Context, cancel context.CancelFunc, cmd *ex
 		},
 		model:          opts.Model,
 		workingDir:     opts.WorkingDir,
-		homeDir:        homeDir,
+		homeDir:        opts.HomeDir,
 		sink:           sink,
 		pendingControl: make(map[string]chan<- claudeCodeControlResult),
 	}

--- a/backend/internal/worker/agent/testing.go
+++ b/backend/internal/worker/agent/testing.go
@@ -19,28 +19,34 @@ func (m *Manager) MockStartAgent(ctx context.Context, opts Options, sink OutputS
 	return m.startAgentWith(ctx, opts, sink, mockStartForTest)
 }
 
-// mockStartForTest spawns a test helper process (simple cat) instead of the
-// real claude binary. Unlike the internal mockStart used in agent_test.go,
-// this does not depend on TestHelperProcess and uses a plain "cat" command.
+// mockStartForTest spawns a plain "cat" process and wires it up as a
+// ClaudeCodeAgent. Unlike the in-package spawnMockClaudeAgent (which runs
+// TestHelperProcess to simulate the Claude Code protocol), this helper is
+// for external consumers that only need a running agent in the manager.
 func mockStartForTest(ctx context.Context, opts Options, sink OutputSink) (Provider, error) {
 	ctx, cancel := context.WithCancel(ctx)
-
 	cmd := exec.CommandContext(ctx, "cat")
-	cmd.Dir = opts.WorkingDir
 	cmd.Env = os.Environ()
+	return wireClaudeMockAgent(ctx, cancel, cmd, opts, sink, opts.HomeDir)
+}
+
+// wireClaudeMockAgent takes a cmd pre-bound to ctx via exec.CommandContext
+// and builds a ClaudeCodeAgent around it: wires stdin/stdout, starts the
+// process, and spawns the output reader loop. Callers pass the matching
+// cancel so cmd.Start failures can release the context.
+func wireClaudeMockAgent(ctx context.Context, cancel context.CancelFunc, cmd *exec.Cmd, opts Options, sink OutputSink, homeDir string) (*ClaudeCodeAgent, error) {
+	cmd.Dir = opts.WorkingDir
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		cancel()
 		return nil, err
 	}
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
 		return nil, err
 	}
-
 	cmd.Stderr = nil
 
 	a := &ClaudeCodeAgent{
@@ -52,14 +58,15 @@ func mockStartForTest(ctx context.Context, opts Options, sink OutputSink) (Provi
 			cancel:      cancel,
 			stderrDone:  make(chan struct{}),
 			processDone: make(chan struct{}),
+			apiTimeout:  opts.apiTimeout(),
 		},
 		model:          opts.Model,
 		workingDir:     opts.WorkingDir,
-		homeDir:        opts.HomeDir,
+		homeDir:        homeDir,
 		sink:           sink,
 		pendingControl: make(map[string]chan<- claudeCodeControlResult),
 	}
-	close(a.stderrDone) // no stderr pipe in mock
+	close(a.stderrDone)
 
 	if err := cmd.Start(); err != nil {
 		cancel()

--- a/backend/internal/worker/hub/channel_handlers.go
+++ b/backend/internal/worker/hub/channel_handlers.go
@@ -46,11 +46,30 @@ func (c *Client) handleChannelClose(notification *leapmuxv1.ChannelCloseNotifica
 	c.channelMgr.HandleClose(notification.GetChannelId())
 }
 
-func (c *Client) handleChannelAccessUpdate(update *leapmuxv1.ChannelAccessUpdate) {
+func (c *Client) handleChannelAccessUpdate(requestID string, update *leapmuxv1.ChannelAccessUpdate) {
 	if c.channelMgr == nil {
 		slog.Warn("channel access update received but no channel manager configured")
 		return
 	}
 
 	c.channelMgr.AddAccessibleWorkspaceID(update.GetChannelId(), update.GetWorkspaceId())
+
+	// Ack synchronously so the hub-side PrepareWorkspaceAccess caller can
+	// observe that the accessible set is updated before it issues the next
+	// inner RPC. Without this ack the worker's hardened access checks race
+	// the frontend's follow-up RPC.
+	if requestID == "" {
+		return
+	}
+	if err := c.Send(&leapmuxv1.ConnectRequest{
+		RequestId: requestID,
+		Payload: &leapmuxv1.ConnectRequest_ChannelAccessUpdateAck{
+			ChannelAccessUpdateAck: &leapmuxv1.ChannelAccessUpdateAck{},
+		},
+	}); err != nil {
+		slog.Warn("failed to send channel access update ack",
+			"channel_id", update.GetChannelId(),
+			"workspace_id", update.GetWorkspaceId(),
+			"error", err)
+	}
 }

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -252,7 +252,7 @@ func (c *Client) handleMessage(msg *leapmuxv1.ConnectResponse) {
 		c.handleChannelClose(payload.ChannelClose)
 
 	case *leapmuxv1.ConnectResponse_ChannelAccessUpdate:
-		c.handleChannelAccessUpdate(payload.ChannelAccessUpdate)
+		c.handleChannelAccessUpdate(msg.GetRequestId(), payload.ChannelAccessUpdate)
 
 	default:
 		slog.Warn("unhandled hub message", "request_id", msg.GetRequestId(), "payload_type", fmt.Sprintf("%T", msg.GetPayload()))

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -88,6 +88,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			agentProvider = leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
 		}
 		model := modelOrDefault(r.GetModel(), agentProvider)
+		effort := effortOrDefault(r.GetEffort(), model, agentProvider)
 		extraSettings := resolveCodexExtras(mergeExtraSettings(nil, r.GetExtraSettings()), agentProvider)
 
 		// Track whether this agent was created via session resume.
@@ -102,7 +103,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			Title:         r.GetTitle(),
 			Model:         model,
 			SystemPrompt:  r.GetSystemPrompt(),
-			Effort:        r.GetEffort(),
+			Effort:        effort,
 			ExtraSettings: marshalExtraSettings(extraSettings),
 			AgentProvider: agentProvider,
 			Resumed:       resumed,
@@ -116,7 +117,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		agentOpts := agent.Options{
 			AgentID:         agentID,
 			Model:           model,
-			Effort:          r.GetEffort(),
+			Effort:          effort,
 			WorkingDir:      workingDir,
 			ResumeSessionID: r.GetAgentSessionId(),
 			ExtraSettings:   extraSettings,
@@ -709,7 +710,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			}
 		}
 		if dbAgent.Effort != newEffort {
-			oldID := effortOrDefault(dbAgent.Effort, dbAgent.AgentProvider)
+			oldID := effortOrDefault(dbAgent.Effort, dbAgent.Model, dbAgent.AgentProvider)
 			changes["effort"] = map[string]string{
 				"old": oldID, "new": newEffort,
 				"oldLabel": effortLabel(oldID), "newLabel": effortLabel(newEffort),

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,8 +25,14 @@ import (
 )
 
 // testResponseWriter captures responses and stream messages sent by handlers.
+//
+// Some handlers (e.g. tunnel reads) emit stream messages from background
+// goroutines, so writes are guarded by mu. Tests that read fields while a
+// background goroutine may still be writing should call streamsSnapshot
+// instead of accessing the slice directly.
 type testResponseWriter struct {
 	channelID string
+	mu        sync.Mutex
 	responses []*leapmuxv1.InnerRpcResponse
 	errors    []testError
 	streams   []*leapmuxv1.InnerStreamMessage
@@ -37,21 +44,45 @@ type testError struct {
 }
 
 func (w *testResponseWriter) SendResponse(r *leapmuxv1.InnerRpcResponse) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.responses = append(w.responses, r)
 	return nil
 }
 
 func (w *testResponseWriter) SendError(code int32, msg string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.errors = append(w.errors, testError{code, msg})
 	return nil
 }
 
 func (w *testResponseWriter) SendStream(m *leapmuxv1.InnerStreamMessage) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.streams = append(w.streams, m)
 	return nil
 }
 
 func (w *testResponseWriter) ChannelID() string { return w.channelID }
+
+// streamsSnapshot returns a copy of streams under the lock so callers can
+// iterate without racing concurrent SendStream writes from handler
+// goroutines. The lock also establishes happens-before with the writer so
+// proto payload bytes produced in another goroutine are safe to unmarshal.
+func (w *testResponseWriter) streamsSnapshot() []*leapmuxv1.InnerStreamMessage {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]*leapmuxv1.InnerStreamMessage(nil), w.streams...)
+}
+
+// streamCount returns len(streams) under the lock, for AssertEventually
+// conditions that wait for handler goroutines to produce output.
+func (w *testResponseWriter) streamCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.streams)
+}
 
 // setupTestService creates a minimal service.Context with an in-memory DB
 // and a channel manager that grants access to the given workspace IDs.

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -76,14 +76,6 @@ func (w *testResponseWriter) streamsSnapshot() []*leapmuxv1.InnerStreamMessage {
 	return append([]*leapmuxv1.InnerStreamMessage(nil), w.streams...)
 }
 
-// streamCount returns len(streams) under the lock, for AssertEventually
-// conditions that wait for handler goroutines to produce output.
-func (w *testResponseWriter) streamCount() int {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return len(w.streams)
-}
-
 // setupTestService creates a minimal service.Context with an in-memory DB
 // and a channel manager that grants access to the given workspace IDs.
 func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.Dispatcher, *testResponseWriter) {

--- a/backend/internal/worker/service/open_default_effort_test.go
+++ b/backend/internal/worker/service/open_default_effort_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+)
+
+// TestOpenAgent_DefaultsEffortFromModel verifies that when the OpenAgent
+// request omits the effort, the backend fills it in from the resolved
+// model's DefaultEffort (e.g. Claude Code's default Opus[1m] → "xhigh")
+// rather than leaving it empty and letting the agent binary pick its
+// own default.
+func TestOpenAgent_DefaultsEffortFromModel(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	var captured agent.Options
+	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		captured = opts
+		return &leapmuxv1.AgentSettings{}, nil
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkspaceId:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}, w)
+
+	require.Empty(t, w.errors, "OpenAgent should succeed")
+	require.Len(t, w.responses, 1)
+
+	assert.Equal(t, "xhigh", captured.Effort,
+		"agent.Options.Effort should default to the resolved model's DefaultEffort")
+
+	var resp leapmuxv1.OpenAgentResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.NotNil(t, resp.GetAgent())
+	assert.Equal(t, "xhigh", resp.GetAgent().GetEffort(),
+		"response agent.effort should reflect the resolved default effort")
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, resp.GetAgent().GetId())
+	require.NoError(t, err)
+	assert.Equal(t, "xhigh", dbAgent.Effort,
+		"persisted agent.effort should default to the resolved model's DefaultEffort")
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -589,16 +589,18 @@ func (s *agentOutputSink) buildStatusChange(
 	sessionID, permissionMode string,
 ) *leapmuxv1.AgentStatusChange {
 	return &leapmuxv1.AgentStatusChange{
-		AgentId:        s.agentID,
-		Status:         status,
-		AgentSessionId: sessionID,
-		WorkerOnline:   true,
-		PermissionMode: permissionMode,
-		Model:          modelOrDefault(dbAgent.Model, dbAgent.AgentProvider),
-		Effort:         dbAgent.Effort,
-		GitStatus:      gitutil.GetGitStatus(dbAgent.WorkingDir),
-		AgentProvider:  s.agentProvider,
-		ExtraSettings:  loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider),
+		AgentId:               s.agentID,
+		Status:                status,
+		AgentSessionId:        sessionID,
+		WorkerOnline:          true,
+		PermissionMode:        permissionMode,
+		Model:                 modelOrDefault(dbAgent.Model, dbAgent.AgentProvider),
+		Effort:                dbAgent.Effort,
+		GitStatus:             gitutil.GetGitStatus(dbAgent.WorkingDir),
+		AgentProvider:         s.agentProvider,
+		ExtraSettings:         loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider),
+		AvailableModels:       s.h.agents.AvailableModels(s.agentID, dbAgent.AgentProvider),
+		AvailableOptionGroups: s.h.agents.AvailableOptionGroups(s.agentID, dbAgent.AgentProvider),
 	}
 }
 

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -240,13 +240,14 @@ func modelOrDefault(model string, provider leapmuxv1.AgentProvider) string {
 	return agent.DefaultModel(provider)
 }
 
-// effortOrDefault returns the effort if non-empty, otherwise the
-// provider's default effort from the agent registry.
-func effortOrDefault(effort string, provider leapmuxv1.AgentProvider) string {
+// effortOrDefault returns the effort if non-empty, otherwise the default
+// effort for the given model (falling back to the provider's default model
+// if the given model has no configured default).
+func effortOrDefault(effort, model string, provider leapmuxv1.AgentProvider) string {
 	if effort != "" {
 		return effort
 	}
-	return agent.DefaultEffort(provider)
+	return agent.DefaultEffortForModel(provider, model)
 }
 
 // settingsDisplayLabels returns lookup functions for model and effort display

--- a/backend/internal/worker/service/tunnel_test.go
+++ b/backend/internal/worker/service/tunnel_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -187,25 +186,32 @@ func TestTunnelTargetEOF(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &openResp))
 
 	// Wait for stream messages (data + EOF).
-	time.Sleep(200 * time.Millisecond)
+	testutil.AssertEventually(t, func() bool {
+		data, hasEOF := collectTunnelEvents(w.streamsSnapshot())
+		return len(data) > 0 && hasEOF
+	}, "expected both data and EOF stream messages")
 
-	// Check stream messages.
-	hasData := false
-	hasEOF := false
-	for _, s := range w.streams {
+	data, hasEOF := collectTunnelEvents(w.streamsSnapshot())
+	assert.Equal(t, "hello", string(data), "expected data stream message")
+	assert.True(t, hasEOF, "expected EOF stream message")
+}
+
+// collectTunnelEvents decodes stream payloads and returns the concatenated
+// data bytes plus whether any event signalled EOF.
+func collectTunnelEvents(streams []*leapmuxv1.InnerStreamMessage) (data []byte, hasEOF bool) {
+	for _, s := range streams {
 		var event leapmuxv1.TunnelConnEvent
-		if proto.Unmarshal(s.GetPayload(), &event) == nil {
-			if len(event.GetData()) > 0 {
-				hasData = true
-				assert.Equal(t, "hello", string(event.GetData()))
-			}
-			if event.GetEof() {
-				hasEOF = true
-			}
+		if proto.Unmarshal(s.GetPayload(), &event) != nil {
+			continue
+		}
+		if len(event.GetData()) > 0 {
+			data = append(data, event.GetData()...)
+		}
+		if event.GetEof() {
+			hasEOF = true
 		}
 	}
-	assert.True(t, hasData, "expected data stream message")
-	assert.True(t, hasEOF, "expected EOF stream message")
+	return
 }
 
 func TestTunnelConcurrentConnections(t *testing.T) {
@@ -278,16 +284,12 @@ func TestTunnelEchoIntegration(t *testing.T) {
 	require.Len(t, w2.errors, 0)
 
 	// Wait for echo response via stream.
-	time.Sleep(200 * time.Millisecond)
+	testutil.AssertEventually(t, func() bool {
+		echoed, _ := collectTunnelEvents(w.streamsSnapshot())
+		return len(echoed) >= len("echo test")
+	}, "expected echoed data via stream")
 
-	// The echo data should appear in stream messages.
-	var echoed []byte
-	for _, s := range w.streams {
-		var event leapmuxv1.TunnelConnEvent
-		if proto.Unmarshal(s.GetPayload(), &event) == nil {
-			echoed = append(echoed, event.GetData()...)
-		}
-	}
+	echoed, _ := collectTunnelEvents(w.streamsSnapshot())
 	assert.Equal(t, "echo test", string(echoed), "expected echoed data")
 
 	// Clean up.
@@ -358,18 +360,15 @@ func TestTunnelLargeDataTransfer(t *testing.T) {
 		require.Len(t, w2.errors, 0, "send chunk at offset %d failed", sent)
 	}
 
-	// Wait for echo data.
-	time.Sleep(500 * time.Millisecond)
-
-	// Verify we received data back via stream.
-	var totalReceived int
-	for _, s := range w.streams {
-		var event leapmuxv1.TunnelConnEvent
-		if proto.Unmarshal(s.GetPayload(), &event) == nil {
-			totalReceived += len(event.GetData())
-		}
+	// Wait for the full echo to come back via stream.
+	totalReceived := func() int {
+		echoed, _ := collectTunnelEvents(w.streamsSnapshot())
+		return len(echoed)
 	}
-	assert.Equal(t, totalSize, totalReceived, "expected all data echoed back")
+	testutil.AssertEventually(t, func() bool {
+		return totalReceived() >= totalSize
+	}, "expected all echoed data via stream")
+	assert.Equal(t, totalSize, totalReceived(), "expected all data echoed back")
 
 	w3 := &testResponseWriter{channelID: "test-ch"}
 	dispatch(d, "CloseTunnelConn", &leapmuxv1.CloseTunnelConnRequest{ConnId: connID}, w3)
@@ -456,22 +455,12 @@ func TestTunnelHalfClose_TargetClosesFirst(t *testing.T) {
 	require.Len(t, w2.errors, 0)
 
 	// Wait for echo + EOF.
-	time.Sleep(300 * time.Millisecond)
+	testutil.AssertEventually(t, func() bool {
+		data, hasEOF := collectTunnelEvents(w.streamsSnapshot())
+		return len(data) > 0 && hasEOF
+	}, "expected echo data followed by EOF")
 
-	hasData := false
-	hasEOF := false
-	for _, s := range w.streams {
-		var event leapmuxv1.TunnelConnEvent
-		if proto.Unmarshal(s.GetPayload(), &event) == nil {
-			if len(event.GetData()) > 0 {
-				hasData = true
-				assert.Equal(t, "half-close-test", string(event.GetData()))
-			}
-			if event.GetEof() {
-				hasEOF = true
-			}
-		}
-	}
-	assert.True(t, hasData, "expected echo data")
+	data, hasEOF := collectTunnelEvents(w.streamsSnapshot())
+	assert.Equal(t, "half-close-test", string(data), "expected echo data")
 	assert.True(t, hasEOF, "expected EOF after target closes")
 }

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -1,17 +1,29 @@
 package terminal
 
 import (
-	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?(?:\.exe)?$`)
 
 // IsPwsh returns true if the shell name matches PowerShell variants
 // (pwsh, powershell, pwsh-preview, powershell-preview, plus the ".exe"
-// suffix forms surfaced by filepath.Base on Windows).
+// suffix forms surfaced when paths are split on Windows).
 func IsPwsh(name string) bool {
 	return pwshPattern.MatchString(name)
+}
+
+// baseName extracts the trailing component of a file path, treating both
+// "/" and "\" as separators regardless of the runtime OS. This is needed
+// because filepath.Base is platform-dependent: on Unix it does not split
+// on "\", so a Windows-style path like `C:\...\pwsh.exe` is returned as-is
+// and downstream shell-kind detection fails.
+func baseName(p string) string {
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
 }
 
 // LoginShellArgs returns the flags needed to start the given shell as an
@@ -22,7 +34,7 @@ func IsPwsh(name string) bool {
 //   - tcsh/csh:        ["-l"]  — tcsh requires -l as the only flag
 //   - all others:      ["-i", "-l"]
 func LoginShellArgs(shellPath string) []string {
-	name := filepath.Base(shellPath)
+	name := baseName(shellPath)
 	switch {
 	case IsPwsh(name):
 		return []string{"-Login"}

--- a/backend/locallisten/locallisten_unix_test.go
+++ b/backend/locallisten/locallisten_unix_test.go
@@ -15,10 +15,21 @@ import (
 )
 
 // uniqueUnixPathShort returns a per-test socket path whose full length stays
-// well under the AF_UNIX sun_path limit. t.TempDir handles cleanup.
+// well under the AF_UNIX sun_path limit (104 bytes on macOS).
+//
+// We avoid t.TempDir() because its path embeds the full test name plus a
+// sequence counter; on macOS that yields paths like
+// /var/folders/.../<TestName>/001/ which can push past the limit once a
+// filename is appended. Instead we mint a short temp dir with prefix "lm"
+// and register cleanup ourselves.
 func uniqueUnixPathShort(t *testing.T) string {
 	t.Helper()
-	return filepath.Join(t.TempDir(), "s.sock")
+	dir, err := os.MkdirTemp("", "lm")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
 }
 
 func TestListen_UnixBindsAcceptsAndRoundTrips(t *testing.T) {

--- a/backend/locallisten/locallistentest/locallistentest.go
+++ b/backend/locallisten/locallistentest/locallistentest.go
@@ -16,9 +16,13 @@ import (
 // SandboxHome redirects home-directory lookups to a fresh temp directory for
 // the duration of the test. Sets both HOME and USERPROFILE so os.UserHomeDir
 // returns the sandbox on every platform. Returns the sandbox path.
+//
+// The prefix is kept short ("lm") so that downstream Unix socket paths built
+// from this home (e.g. <home>/.config/leapmux/solo/hub/hub.sock) stay within
+// the 104-byte AF_UNIX sun_path limit on macOS.
 func SandboxHome(t *testing.T) string {
 	t.Helper()
-	home, err := os.MkdirTemp("", "leapmux-sandbox-home-")
+	home, err := os.MkdirTemp("", "lm")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
@@ -34,16 +38,27 @@ func SandboxHome(t *testing.T) string {
 var counter atomic.Uint64
 
 // UniqueListenURL returns a per-test local-listen URL that won't collide
-// with concurrent tests in the same process. Prefix is embedded in the
-// name so failures point at the test package.
+// with concurrent tests in the same process.
 //
-// On Unix returns unix:<t.TempDir>/<prefix>.sock (t.TempDir handles
-// cleanup); on Windows returns npipe:<prefix>-<pid>-<nanos>-<counter>.
+// On Unix it returns unix:<short-temp-dir>/s.sock. We avoid t.TempDir()
+// because its path embeds the full test name plus a sequence counter; on
+// macOS that routinely exceeds the 104-byte AF_UNIX sun_path limit once
+// the caller's prefix and ".sock" are appended, and net.Listen fails with
+// "bind: invalid argument". Cleanup is wired through t.Cleanup.
+//
+// On Windows it returns npipe:<prefix>-<pid>-<nanos>-<counter>; named
+// pipe names have no equivalent length constraint, so the caller-supplied
+// prefix is preserved to make failures easier to attribute.
 func UniqueListenURL(t *testing.T, prefix string) string {
 	t.Helper()
 	n := counter.Add(1)
 	if runtime.GOOS == "windows" {
 		return fmt.Sprintf("npipe:%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), n)
 	}
-	return "unix:" + filepath.Join(t.TempDir(), prefix+".sock")
+	dir, err := os.MkdirTemp("", "lm")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return "unix:" + filepath.Join(dir, "s.sock")
 }

--- a/backend/locallisten/locallistentest/locallistentest.go
+++ b/backend/locallisten/locallistentest/locallistentest.go
@@ -13,21 +13,27 @@ import (
 	"time"
 )
 
-// SandboxHome redirects home-directory lookups to a fresh temp directory for
-// the duration of the test. Sets both HOME and USERPROFILE so os.UserHomeDir
-// returns the sandbox on every platform. Returns the sandbox path.
-//
-// The prefix is kept short ("lm") so that downstream Unix socket paths built
-// from this home (e.g. <home>/.config/leapmux/solo/hub/hub.sock) stay within
-// the 104-byte AF_UNIX sun_path limit on macOS.
-func SandboxHome(t *testing.T) string {
+// shortTempDir mints a fresh temp dir with the minimal prefix "lm" and
+// registers cleanup. The short prefix matters because downstream Unix
+// socket paths built under this dir (e.g. <dir>/.../hub.sock) must stay
+// within the 104-byte AF_UNIX sun_path limit on macOS; t.TempDir() embeds
+// the full test name and routinely exceeds that limit.
+func shortTempDir(t *testing.T) string {
 	t.Helper()
-	home, err := os.MkdirTemp("", "lm")
+	dir, err := os.MkdirTemp("", "lm")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
-	home = filepath.Clean(home)
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// SandboxHome redirects home-directory lookups to a fresh temp directory for
+// the duration of the test. Sets both HOME and USERPROFILE so os.UserHomeDir
+// returns the sandbox on every platform. Returns the sandbox path.
+func SandboxHome(t *testing.T) string {
+	t.Helper()
+	home := filepath.Clean(shortTempDir(t))
 	t.Setenv("HOME", home)
 	if runtime.GOOS == "windows" {
 		t.Setenv("USERPROFILE", home)
@@ -40,25 +46,15 @@ var counter atomic.Uint64
 // UniqueListenURL returns a per-test local-listen URL that won't collide
 // with concurrent tests in the same process.
 //
-// On Unix it returns unix:<short-temp-dir>/s.sock. We avoid t.TempDir()
-// because its path embeds the full test name plus a sequence counter; on
-// macOS that routinely exceeds the 104-byte AF_UNIX sun_path limit once
-// the caller's prefix and ".sock" are appended, and net.Listen fails with
-// "bind: invalid argument". Cleanup is wired through t.Cleanup.
-//
-// On Windows it returns npipe:<prefix>-<pid>-<nanos>-<counter>; named
-// pipe names have no equivalent length constraint, so the caller-supplied
-// prefix is preserved to make failures easier to attribute.
+// On Unix it returns unix:<short-temp-dir>/s.sock. On Windows it returns
+// npipe:<prefix>-<pid>-<nanos>-<counter>; named pipe names have no length
+// constraint, so the caller-supplied prefix is preserved to make failures
+// easier to attribute.
 func UniqueListenURL(t *testing.T, prefix string) string {
 	t.Helper()
 	n := counter.Add(1)
 	if runtime.GOOS == "windows" {
 		return fmt.Sprintf("npipe:%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), n)
 	}
-	dir, err := os.MkdirTemp("", "lm")
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return "unix:" + filepath.Join(dir, "s.sock")
+	return "unix:" + filepath.Join(shortTempDir(t), "s.sock")
 }

--- a/backend/locallisten/locallistentest/locallistentest_test.go
+++ b/backend/locallisten/locallistentest/locallistentest_test.go
@@ -1,0 +1,42 @@
+package locallistentest
+
+import (
+	"net"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestUniqueListenURL_BindsSuccessfully is a regression test for a bug where
+// UniqueListenURL returned a path rooted at t.TempDir() that exceeded the
+// 104-byte AF_UNIX sun_path limit on macOS (t.TempDir() embeds the full test
+// name + a sequence counter, which combined with the caller's prefix and the
+// ".sock" suffix overflows the limit). Callers of this helper must always
+// receive a URL they can actually bind.
+func TestUniqueListenURL_BindsSuccessfully(t *testing.T) {
+	// Use a realistically long prefix to match real callers like the
+	// "leapmux-solo-test" suite. The helper must still produce a bind-able
+	// URL on every supported platform.
+	url := UniqueListenURL(t, "leapmux-unique-url-probe")
+
+	if runtime.GOOS == "windows" {
+		if !strings.HasPrefix(url, "npipe:") {
+			t.Fatalf("windows: want npipe:<name>, got %q", url)
+		}
+		// Named pipes don't have a strict path-length limit relevant here;
+		// skip the bind probe (no test server required).
+		return
+	}
+
+	const prefix = "unix:"
+	if !strings.HasPrefix(url, prefix) {
+		t.Fatalf("unix: want unix:<path>, got %q", url)
+	}
+	path := url[len(prefix):]
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("bind %s (len=%d): %v", path, len(path), err)
+	}
+	_ = ln.Close()
+}

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -191,11 +191,28 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		close(inst.hubDone)
 	}()
 
-	// Wait for Hub's local listener (unix socket or named pipe).
-	if err := locallisten.WaitReady(soloCtx, listenURL); err != nil {
+	// Wait for Hub's local listener (unix socket or named pipe). Race
+	// against inst.hubDone so that if Serve returns before the listener
+	// is ready, we surface the underlying Serve error (e.g. "bind:
+	// invalid argument") instead of the generic "not ready" timeout.
+	readyCh := make(chan error, 1)
+	go func() { readyCh <- locallisten.WaitReady(soloCtx, listenURL) }()
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			cancel()
+			inst.wg.Wait()
+			if inst.hubErr != nil && !errors.Is(inst.hubErr, context.Canceled) {
+				return nil, fmt.Errorf("hub serve: %w", inst.hubErr)
+			}
+			return nil, fmt.Errorf("wait for hub local listener: %w", err)
+		}
+	case <-inst.hubDone:
 		cancel()
-		inst.wg.Wait()
-		return nil, fmt.Errorf("wait for hub local listener: %w", err)
+		if inst.hubErr != nil {
+			return nil, fmt.Errorf("hub serve: %w", inst.hubErr)
+		}
+		return nil, errors.New("hub serve exited before listener became ready")
 	}
 
 	// Auto-register worker.

--- a/backend/solo/solo_integration_test.go
+++ b/backend/solo/solo_integration_test.go
@@ -110,3 +110,40 @@ func TestSoloStart_InvalidLocalListenErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "local_listen",
 		"error should surface the offending flag name")
 }
+
+// TestSoloStart_SurfacesHubServeError confirms that when the hub's Serve
+// goroutine fails before the listener is ready (e.g. a well-formed URL that
+// points at an unwritable location), solo.Start returns the underlying error
+// immediately instead of blocking on the 5-second WaitReady timeout.
+//
+// Regression test for a bug where any Serve-time failure was masked as
+// "wait for hub local listener: ... not ready after 5s", making diagnosis
+// unnecessarily hard.
+func TestSoloStart_SurfacesHubServeError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket-specific reproduction")
+	}
+	locallistentest.SandboxHome(t)
+	// Well-formed URL, but the parent directory does not exist, so
+	// net.Listen("unix", ...) fails with ENOENT.
+	t.Setenv(locallisten.EnvLocalListen, "unix:/nonexistent-parent-dir-for-solo-test/hub.sock")
+
+	// Use a short deadline: if the fix regresses, we'd fall back to the
+	// 5s WaitReady timeout and this test would flake-fail, making the
+	// regression obvious.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := solo.Start(ctx, solo.Config{
+		SkipBanner: true,
+		NoTCP:      true,
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "solo.Start should surface the bind failure")
+	assert.Contains(t, err.Error(), "hub serve",
+		"error should attribute the failure to hub Serve, not the WaitReady timeout")
+	assert.Less(t, elapsed, 5*time.Second,
+		"should not wait the full WaitReady timeout once Serve has already failed")
+}

--- a/frontend/src/components/chat/providers/claude.test.ts
+++ b/frontend/src/components/chat/providers/claude.test.ts
@@ -78,4 +78,30 @@ describe('claude classify', () => {
     }
     expect(plugin.classify(input(parent))).toEqual({ kind: 'tool_result' })
   })
+
+  it('classifies assistant thinking with visible text', () => {
+    const parent = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Let me consider...', signature: 'sig' },
+        ],
+      },
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'assistant_thinking' })
+  })
+
+  it('hides assistant thinking with empty text', () => {
+    const parent = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: 'sig' },
+        ],
+      },
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
+  })
 })

--- a/frontend/src/components/chat/providers/claude.test.ts
+++ b/frontend/src/components/chat/providers/claude.test.ts
@@ -92,6 +92,16 @@ describe('claude classify', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'assistant_thinking' })
   })
 
+  it('hides task_updated system messages', () => {
+    const parent = {
+      type: 'system',
+      subtype: 'task_updated',
+      task_id: 'bi3vq0jmx',
+      patch: { is_backgrounded: true },
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
+  })
+
   it('hides assistant thinking with empty text', () => {
     const parent = {
       type: 'assistant',

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -140,10 +140,9 @@ function classifyClaudeCodeMessage(
         if (contentArr.some(c => isObject(c) && c.type === 'text'))
           return { kind: 'assistant_text' }
         if (contentArr.some(c => isObject(c) && c.type === 'thinking')) {
-          // Defense-in-depth: hide thinking blocks that arrive without any
-          // visible text. The agent is launched with --thinking-display
-          // summarized so this should be rare, but the model can still
-          // emit a signature-only block in edge cases.
+          // Signature-only thinking blocks (no visible text) can slip past
+          // --thinking-display summarized; hide them so the UI doesn't
+          // render an empty row.
           const hasText = contentArr.some(c =>
             isObject(c) && c.type === 'thinking'
             && typeof c.thinking === 'string' && c.thinking.length > 0)

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -51,7 +51,7 @@ function buildInterruptRequest(): string {
 const CLAUDE_EXTRA_TYPES = new Set(['plan_execution'])
 function isClaudeNotifThread(wrapper: { messages: unknown[] } | null): wrapper is { messages: unknown[] } {
   return isNotificationThreadWrapper(wrapper, CLAUDE_EXTRA_TYPES, (t, st) =>
-    t === 'system' && st !== 'init' && st !== 'task_notification')
+    t === 'system' && st !== 'init' && st !== 'task_notification' && st !== 'task_updated')
 }
 
 /** Claude Code message classification. */
@@ -93,7 +93,7 @@ function classifyClaudeCodeMessage(
       return { kind: 'hidden' }
     if (subtype === 'status' && parentObject.status !== 'compacting')
       return { kind: 'hidden' }
-    if (subtype === 'task_notification')
+    if (subtype === 'task_notification' || subtype === 'task_updated')
       return { kind: 'hidden' }
     return { kind: 'notification' }
   }

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -5,6 +5,7 @@ import type { PermissionMode } from '~/utils/controlResponse'
 import ChevronsDown from 'lucide-solid/icons/chevrons-down'
 import ChevronsUp from 'lucide-solid/icons/chevrons-up'
 import Dot from 'lucide-solid/icons/dot'
+import Flame from 'lucide-solid/icons/flame'
 import Sparkles from 'lucide-solid/icons/sparkles'
 import Zap from 'lucide-solid/icons/zap'
 import { createUniqueId, Show } from 'solid-js'
@@ -138,8 +139,18 @@ function classifyClaudeCodeMessage(
         }
         if (contentArr.some(c => isObject(c) && c.type === 'text'))
           return { kind: 'assistant_text' }
-        if (contentArr.some(c => isObject(c) && c.type === 'thinking'))
+        if (contentArr.some(c => isObject(c) && c.type === 'thinking')) {
+          // Defense-in-depth: hide thinking blocks that arrive without any
+          // visible text. The agent is launched with --thinking-display
+          // summarized so this should be rare, but the model can still
+          // emit a signature-only block in edge cases.
+          const hasText = contentArr.some(c =>
+            isObject(c) && c.type === 'thinking'
+            && typeof c.thinking === 'string' && c.thinking.length > 0)
+          if (!hasText)
+            return { kind: 'hidden' }
           return { kind: 'assistant_thinking' }
+        }
       }
     }
     return { kind: 'unknown' }
@@ -194,7 +205,7 @@ function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element
   const currentMode = () => props.permissionMode || 'default'
   const currentOutputStyle = () => props.extraSettings?.[OUTPUT_STYLE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, OUTPUT_STYLE_KEY) || 'default'
   const currentFastMode = () => props.extraSettings?.[FAST_MODE_KEY] || optionGroupDefaultValue(props.availableOptionGroups, FAST_MODE_KEY) || 'off'
-  const currentThinking = () => props.extraSettings?.[ALWAYS_THINKING_KEY] || optionGroupDefaultValue(props.availableOptionGroups, ALWAYS_THINKING_KEY) || 'on'
+  const currentThinking = () => props.extraSettings?.[ALWAYS_THINKING_KEY] || optionGroupDefaultValue(props.availableOptionGroups, ALWAYS_THINKING_KEY)
 
   const models = () => modelItems(props.availableModels)
   const efforts = () => effortItems(props.availableModels, currentModel())
@@ -245,9 +256,14 @@ function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element
             current={currentModel()}
             onChange={(v) => {
               props.onModelChange?.(v)
-              // If switching away from opus and effort is max, downgrade to high
-              if (!v.startsWith('opus') && currentEffort() === 'max') {
-                props.onEffortChange?.('high')
+              // If the new model doesn't support the current effort, fall
+              // back to its default so the UI doesn't show a selection that
+              // the backend will silently downgrade.
+              const next = props.availableModels?.find(m => m.id === v)
+              if (next && currentEffort()) {
+                const ok = next.supportedEfforts.some(e => e.id === currentEffort())
+                if (!ok)
+                  props.onEffortChange?.(next.defaultEffort || 'high')
               }
             }}
           />
@@ -303,6 +319,7 @@ function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element 
       case 'auto': return <Icon icon={Sparkles} size="xs" />
       case 'low': return <Icon icon={ChevronsDown} size="xs" />
       case 'high': return <Icon icon={ChevronsUp} size="xs" />
+      case 'xhigh': return <Icon icon={Flame} size="xs" />
       case 'max': return <Icon icon={Zap} size="xs" />
       default: return <Icon icon={Dot} size="xs" />
     }

--- a/frontend/src/components/chat/providers/claude.tsx
+++ b/frontend/src/components/chat/providers/claude.tsx
@@ -49,9 +49,11 @@ function buildInterruptRequest(): string {
 
 /** Extra notification types for Claude Code (plan_execution, system subtypes). */
 const CLAUDE_EXTRA_TYPES = new Set(['plan_execution'])
+/** System message subtypes that should never surface in the UI. */
+const HIDDEN_SYSTEM_SUBTYPES = new Set(['init', 'task_notification', 'task_updated'])
 function isClaudeNotifThread(wrapper: { messages: unknown[] } | null): wrapper is { messages: unknown[] } {
   return isNotificationThreadWrapper(wrapper, CLAUDE_EXTRA_TYPES, (t, st) =>
-    t === 'system' && st !== 'init' && st !== 'task_notification' && st !== 'task_updated')
+    t === 'system' && !HIDDEN_SYSTEM_SUBTYPES.has(st ?? ''))
 }
 
 /** Claude Code message classification. */
@@ -89,11 +91,9 @@ function classifyClaudeCodeMessage(
   if (type === 'system') {
     if (input.parentSpanId && (subtype === 'task_started' || subtype === 'task_progress'))
       return { kind: 'hidden' }
-    if (subtype === 'init')
+    if (HIDDEN_SYSTEM_SUBTYPES.has(subtype ?? ''))
       return { kind: 'hidden' }
     if (subtype === 'status' && parentObject.status !== 'compacting')
-      return { kind: 'hidden' }
-    if (subtype === 'task_notification' || subtype === 'task_updated')
       return { kind: 'hidden' }
     return { kind: 'notification' }
   }

--- a/frontend/src/components/chat/settingsShared.tsx
+++ b/frontend/src/components/chat/settingsShared.tsx
@@ -14,6 +14,14 @@ export const OUTPUT_STYLE_KEY = 'outputStyle' as const
 export const FAST_MODE_KEY = 'fastMode' as const
 export const ALWAYS_THINKING_KEY = 'alwaysThinkingEnabled' as const
 
+/**
+ * Extended Thinking option IDs. The backend picks the display name per
+ * model ("Adaptive" for Opus/Sonnet, "On" for Haiku); the ID is always
+ * "on" because Claude Code decides thinking.type internally.
+ */
+export const ALWAYS_THINKING_ON = 'on' as const
+export const ALWAYS_THINKING_OFF = 'off' as const
+
 /** Shared item type used by RadioGroup and settings helpers. */
 export interface SettingsItem {
   label: string

--- a/frontend/src/components/chat/settingsShared.tsx
+++ b/frontend/src/components/chat/settingsShared.tsx
@@ -14,14 +14,6 @@ export const OUTPUT_STYLE_KEY = 'outputStyle' as const
 export const FAST_MODE_KEY = 'fastMode' as const
 export const ALWAYS_THINKING_KEY = 'alwaysThinkingEnabled' as const
 
-/**
- * Extended Thinking option IDs. The backend picks the display name per
- * model ("Adaptive" for Opus/Sonnet, "On" for Haiku); the ID is always
- * "on" because Claude Code decides thinking.type internally.
- */
-export const ALWAYS_THINKING_ON = 'on' as const
-export const ALWAYS_THINKING_OFF = 'off' as const
-
 /** Shared item type used by RadioGroup and settings helpers. */
 export interface SettingsItem {
   label: string

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -308,6 +308,15 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
                 ...(sc.model ? { model: sc.model } : {}),
                 ...(sc.effort ? { effort: sc.effort } : {}),
               }),
+          // Agent-reported catalogs. Empty arrays mean "unchanged" — the
+          // status change events cover non-setting transitions too, and we
+          // don't want those to clobber the previously-fetched groups.
+          ...(sc.availableModels && sc.availableModels.length > 0
+            ? { availableModels: sc.availableModels }
+            : {}),
+          ...(sc.availableOptionGroups && sc.availableOptionGroups.length > 0
+            ? { availableOptionGroups: sc.availableOptionGroups }
+            : {}),
           gitStatus: sc.gitStatus,
         })
         if (sc.gitStatus) {

--- a/frontend/tests/e2e/31-agent-settings.spec.ts
+++ b/frontend/tests/e2e/31-agent-settings.spec.ts
@@ -40,8 +40,26 @@ test.describe('Agent Settings', () => {
     await expect(trigger).toContainText('Bypass Permissions')
     await waitForSettingsIdle(page)
 
-    // Switch back to Default
+    // Switch to Don't Ask (always available — not plan/admin-gated)
     await openSettingsMenu(page)
+    await page.locator('[data-testid="permission-mode-dontAsk"]').click()
+    await expect(trigger).toContainText('Don\'t Ask')
+    await waitForSettingsIdle(page)
+
+    // Switch to Auto Mode if the backend's startup probe surfaced it.
+    // Auto mode depends on plan / model / admin-managed settings
+    // (see permission-modes docs); if the probe rejected it, the radio
+    // is filtered out server-side and this block becomes a no-op.
+    await openSettingsMenu(page)
+    const autoOption = page.locator('[data-testid="permission-mode-auto"]')
+    if (await autoOption.isVisible()) {
+      await autoOption.click()
+      await expect(trigger).toContainText('Auto Mode')
+      await waitForSettingsIdle(page)
+      await openSettingsMenu(page)
+    }
+
+    // Switch back to Default
     await page.locator('[data-testid="permission-mode-default"]').click()
     await expect(trigger).toContainText('Default')
   })
@@ -60,11 +78,13 @@ test.describe('Agent Settings', () => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
-    // Switch to Sonnet[1m] — model name contains brackets that must be
+    // Switch to Opus[1m] — model name contains brackets that must be
     // properly escaped in the shell command when spawning Claude Code.
+    // We use Opus[1m] (not Sonnet[1m]) because the e2e account doesn't have
+    // extra-usage billing enabled for Sonnet's 1M context tier.
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet\\[1m\\]"]').click()
-    await expect(trigger).toContainText('Sonnet (1M context)')
+    await page.locator('[data-testid="model-opus\\[1m\\]"]').click()
+    await expect(trigger).toContainText('Opus (1M context)')
     await waitForSettingsIdle(page)
 
     // Verify agent restarted successfully by sending a message
@@ -115,6 +135,104 @@ test.describe('Agent Settings', () => {
 
     await openSettingsMenu(page)
     await expect(page.locator('[data-testid="effort-high"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+
+  test('xhigh effort is opus-only', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Default (Sonnet): xhigh must not be offered, max must be offered.
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-xhigh"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="effort-max"]')).toBeVisible()
+
+    // Switch to Opus — xhigh and max both appear.
+    await page.locator('[data-testid="model-opus"]').click()
+    await expect(trigger).toContainText('Opus')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-xhigh"]')).toBeVisible()
+    await expect(page.locator('[data-testid="effort-max"]')).toBeVisible()
+
+    // Switch back to Sonnet — xhigh disappears, max stays.
+    await page.locator('[data-testid="model-sonnet"]').click()
+    await expect(trigger).toContainText('Sonnet')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-xhigh"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="effort-max"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+
+  test('Extended Thinking label reflects model', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    const onOpt = page.locator('[data-testid="thinking-on"]')
+    const offOpt = page.locator('[data-testid="thinking-off"]')
+
+    // Default (Sonnet — set via LEAPMUX_CLAUDE_DEFAULT_MODEL) supports
+    // adaptive thinking, so the enabled option is labeled "Adaptive".
+    // The option ID is always "on"; only the display name varies.
+    await openSettingsMenu(page)
+    await expect(onOpt).toBeVisible()
+    await expect(onOpt).toContainText('Adaptive')
+    await expect(offOpt).toBeVisible()
+    await expect(offOpt).toContainText('Off')
+
+    // Toggle Off + back on to verify the radio wires through.
+    await offOpt.click()
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="thinking-off"] input[type="radio"]')).toBeChecked()
+    await onOpt.click()
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="thinking-on"] input[type="radio"]')).toBeChecked()
+
+    // Switch to Haiku — no adaptive support, so the enabled option
+    // relabels to "On". AgentStatusChange carries fresh option groups, so
+    // this happens without a page reload.
+    await page.locator('[data-testid="model-haiku"]').click()
+    await expect(trigger).toContainText('Haiku')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(onOpt).toContainText('On')
+    await expect(onOpt).not.toContainText('Adaptive')
+
+    // Switch back to Opus — adaptive support returns.
+    await page.locator('[data-testid="model-opus"]').click()
+    await expect(trigger).toContainText('Opus')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(onOpt).toContainText('Adaptive')
+    await page.keyboard.press('Escape')
+  })
+
+  test('xhigh downgrades when switching from opus to sonnet', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Switch to Opus first, then pick xhigh.
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="model-opus"]').click()
+    await expect(trigger).toContainText('Opus')
+    await waitForSettingsIdle(page)
+
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="effort-xhigh"]').click()
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-xhigh"] input[type="radio"]')).toBeChecked()
+
+    // Switching to Sonnet must auto-downgrade xhigh to the model's default
+    // (high) since Sonnet doesn't support xhigh.
+    await page.locator('[data-testid="model-sonnet"]').click()
+    await expect(trigger).toContainText('Sonnet')
+    await waitForSettingsIdle(page)
+
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-xhigh"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="effort-high"] input[type="radio"]')).toBeChecked()
     await page.keyboard.press('Escape')
   })
 
@@ -271,13 +389,15 @@ test.describe('Agent Settings', () => {
     await expect(page.locator('[data-testid="model-opus"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="model-opus\\[1m\\]"]')).not.toHaveAttribute('data-disabled', '')
 
-    // Verify effort items are enabled when idle (max is only shown for opus)
+    // Verify effort items are enabled when idle
     await expect(page.locator('[data-testid="effort-auto"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-low"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-medium"]')).not.toHaveAttribute('data-disabled', '')
     await expect(page.locator('[data-testid="effort-high"]')).not.toHaveAttribute('data-disabled', '')
-    // Max effort is hidden for non-opus models (default is Sonnet)
-    await expect(page.locator('[data-testid="effort-max"]')).not.toBeVisible()
+    // Sonnet (default) supports max; xhigh is Opus-only
+    await expect(page.locator('[data-testid="effort-max"]')).toBeVisible()
+    await expect(page.locator('[data-testid="effort-max"]')).not.toHaveAttribute('data-disabled', '')
+    await expect(page.locator('[data-testid="effort-xhigh"]')).not.toBeVisible()
 
     // Verify permission mode items are enabled when idle
     await expect(page.locator('[data-testid="permission-mode-default"]')).not.toHaveAttribute('data-disabled', '')

--- a/frontend/tests/e2e/31a-1m-context-model.spec.ts
+++ b/frontend/tests/e2e/31a-1m-context-model.spec.ts
@@ -1,20 +1,23 @@
 import { expect, test } from './fixtures'
 import { lastAssistantBubble, openSettingsMenu, waitForSettingsIdle } from './helpers/ui'
 
-const MODEL_CHANGE_PATTERN = /Model.*Sonnet.*Sonnet.*1M/
+// The e2e account can't bill Sonnet's 1M-context tier, so this suite uses
+// Opus[1m] instead. The underlying coverage — bracketed model IDs and the
+// settings-change notification — is the same.
+const MODEL_CHANGE_PATTERN = /Model.*Sonnet.*Opus.*1M/
 
 test.describe('1m-context model', () => {
-  test('switch to sonnet[1m] and exchange messages', async ({ authenticatedWorkspace, page }) => {
+  test('switch to opus[1m] and exchange messages', async ({ authenticatedWorkspace, page }) => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     await expect(trigger).toBeVisible()
 
     // Default model should be Sonnet
     await expect(trigger).toContainText('Sonnet')
 
-    // Switch to Sonnet[1m]
+    // Switch to Opus[1m]
     await openSettingsMenu(page)
-    await page.locator('[data-testid="model-sonnet\\[1m\\]"]').click()
-    await expect(trigger).toContainText('Sonnet (1M context)')
+    await page.locator('[data-testid="model-opus\\[1m\\]"]').click()
+    await expect(trigger).toContainText('Opus (1M context)')
 
     // Verify the settings change notification appears in chat
     await expect(page.getByText(MODEL_CHANGE_PATTERN)).toBeVisible()
@@ -40,7 +43,7 @@ test.describe('1m-context model', () => {
     const lastAssistant2 = lastAssistantBubble(page)
     await expect(lastAssistant2).toContainText('6', { timeout: 30000 })
 
-    // Verify the model is still shown as Sonnet[1m] after exchanging messages
-    await expect(trigger).toContainText('Sonnet (1M context)')
+    // Verify the model is still shown as Opus[1m] after exchanging messages
+    await expect(trigger).toContainText('Opus (1M context)')
   })
 })

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -248,6 +248,24 @@ export async function openAgentViaAPI(
 ): Promise<string> {
   const { OpenAgentRequestSchema, OpenAgentResponseSchema } = await import('../../../src/generated/leapmux/v1/agent_pb')
   const channel = await getTestChannel(hubUrl, cookie)
+
+  // Notify the worker that the test channel has access to this workspace
+  // BEFORE issuing any workspace-scoped RPC. getTestChannel caches a
+  // ChannelManager across tests, so on the 2nd+ test the channel's
+  // AccessibleWorkspaceIds set was frozen at handshake time and does not
+  // include the workspace created in this test. The worker's hardened
+  // requireAccessibleWorkspace check would reject OpenAgent until the
+  // ChannelAccessUpdate lands. Calling PrepareWorkspaceAccess first — which
+  // now blocks on the worker's ack — guarantees the set is up-to-date.
+  const prepResp = await fetch(`${hubUrl}/leapmux.v1.ChannelService/PrepareWorkspaceAccess`, {
+    method: 'POST',
+    headers: authedHeaders(cookie),
+    body: JSON.stringify({ workerId, workspaceId }),
+  })
+  if (!prepResp.ok) {
+    throw new Error(`openAgentViaAPI: PrepareWorkspaceAccess failed: ${prepResp.status}`)
+  }
+
   const resp = await channel.callWorker(
     workerId,
     'OpenAgent',
@@ -277,16 +295,6 @@ export async function openAgentViaAPI(
       workspaceId,
       tab: { tabType: 'TAB_TYPE_AGENT', tabId: resp.agent.id, workerId },
     }),
-  })
-
-  // Notify the worker that the test channel now has access to this workspace.
-  // OpenChannel only includes workspaces that existed at handshake time; any
-  // workspace created after that is invisible to ListAgents until the worker
-  // receives a PrepareWorkspaceAccess (ChannelAccessUpdate) notification.
-  await fetch(`${hubUrl}/leapmux.v1.ChannelService/PrepareWorkspaceAccess`, {
-    method: 'POST',
-    headers: authedHeaders(cookie),
-    body: JSON.stringify({ workerId, workspaceId }),
   })
 
   return resp.agent.id

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -217,6 +217,8 @@ message AgentStatusChange {
   reserved 9; // was supports_model_effort
   AgentProvider agent_provider = 10; // Provider for this agent
   map<string, string> extra_settings = 11; // Provider-specific persisted settings
+  repeated AvailableModel available_models = 12; // Models reported by the agent process (empty = don't update)
+  repeated AvailableOptionGroup available_option_groups = 13; // Option groups reported by the agent (empty = don't update)
 }
 
 // AgentGitStatus holds git repository status for an agent's working directory.

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -150,6 +150,8 @@ message ConnectRequest {
     ChannelMessage channel_message_resp = 5;
     // Health
     Heartbeat heartbeat = 6;
+    // Access control
+    ChannelAccessUpdateAck channel_access_update_ack = 7;
   }
 }
 
@@ -185,11 +187,18 @@ message ConnectResponse {
 
 // ChannelAccessUpdate is sent by the Hub to a Worker when a new workspace
 // becomes accessible to a channel (e.g. after the user creates a workspace).
-// The Worker adds the workspace ID to the channel's accessible set.
+// The Worker adds the workspace ID to the channel's accessible set and
+// replies with ChannelAccessUpdateAck using the request's request_id so the
+// Hub can wait for the update to land before responding to the caller.
 message ChannelAccessUpdate {
   string channel_id = 1;
   string workspace_id = 2;
 }
+
+// ChannelAccessUpdateAck confirms the Worker has added the workspace ID to
+// the channel's accessible set. The matching request_id is carried on the
+// ConnectRequest envelope.
+message ChannelAccessUpdateAck {}
 
 // --- Notification messages (used in bidi stream) ---
 


### PR DESCRIPTION
## Motivation

Several related capability and correctness gaps needed to be addressed together:

1. Claude Opus supports a higher-effort tier ("xhigh") that was not exposed in the UI or backend, leaving Opus users without access to its maximum capability level.
2. Claude Code's "auto" permission mode (and its "don't ask" variant) was not surfaced at all. Whether auto-mode is actually available depends on admin settings, plan gating, and model support — none of which was being probed or communicated to the UI.
3. The extended-thinking label ("On") was model-agnostic, even though Opus and Sonnet display it as "Adaptive" in Claude Code itself.
4. A race condition existed in workspace access control: `PrepareWorkspaceAccess` returned before the worker had applied the new access set, so a subsequent RPC could arrive at the worker before it knew the channel was permitted.
5. Several test-reliability issues existed: `time.Sleep()` polling in tunnel tests, non-thread-safe `testResponseWriter`, and Unix socket paths exceeding macOS's 104-byte `AF_UNIX` limit when test names were used as temp-dir prefixes.

## Modifications

**Effort levels**
- Added `xhigh` effort tier, exclusive to Opus, with a flame icon in the UI.
- Separated effort capability lists per model (`claudeEffortXHighMax` for Opus, `claudeEffortMax` for Sonnet).
- Changed Opus default effort from `high` to `xhigh`.
- Renamed `DefaultEffort(provider)` to `DefaultEffortForModel(provider, modelID)` so defaults are model-aware throughout the stack.
- `effortOrDefault()` in the worker service now passes the resolved model ID.
- Model switching in the UI auto-downgrades unsupported efforts to the new model's default (e.g., switching from Opus to Sonnet downgrades `xhigh` → `high`).

**Auto permission mode**
- Added `PermissionModeAuto` and `PermissionModeDontAsk` constants.
- `applyStartupPermissionMode()` probes whether auto-mode is available at agent startup and filters it from the UI option group when it is unavailable.

**Model-aware thinking labels**
- Introduced `AlwaysThinkingOn`/`AlwaysThinkingOff` constants.
- `flagSettingThinking()` replaces `flagSettingOffOn()` with inverted semantics.
- UI renders "Adaptive" for Opus/Sonnet and "On" for Haiku.
- Added `--thinking-display summarized` CLI flag for enhanced thinking block output.
- Removed hardcoded default 'on' for thinking mode; server-side option-group defaults are used instead.
- Signature-only thinking blocks (empty text) are now hidden rather than rendered as empty rows.

**Dynamic option groups from agent**
- Added `available_models` and `available_option_groups` fields to `AgentStatusChange` proto message.
- UI captures fresh model/effort catalogs and option groups from agent status-change events so labels stay accurate as agent state evolves.

**Channel access-control race fix**
- Added a synchronous `ChannelAccessUpdateAck` acknowledgment protocol: hub now waits for the worker to confirm it has applied the access update before returning from `PrepareWorkspaceAccess`.
- Test API helper updated so `PrepareWorkspaceAccess` runs before `OpenAgent` and blocks until the worker acknowledges.
- New proto message type added to `worker.proto` for the ack.

**Thread safety**
- Added mutex protection around preamble metadata reads and writes in the Claude agent; introduced `preambleMetaValue()` accessor.
- `testResponseWriter` in worker-hub tests is now guarded by a mutex.

**Test infrastructure and reliability**
- Replaced `time.Sleep()` polling in tunnel tests with `testutil.AssertEventually()`.
- Extracted common mock-process setup into `wireClaudeMockAgent()`, `spawnMockClaudeAgent()`, and `TestHelperProcessControlResponder`.
- Shortened temp-dir prefixes to `"lm"` to stay within the 104-byte `AF_UNIX` `sun_path` limit on macOS.
- Added `testutil` helper `locallistentest.go` and a corresponding test file.
- Switched 1M-context e2e test from Sonnet to Opus due to billing constraints.

**Other**
- `normalizeClaudeCodeModel()` collapses fully-qualified Claude Code model IDs to short aliases.
- `baseName()` splits on both `/` and `\` for correct PowerShell detection on Windows paths.
- `task_updated` added to hidden system message subtypes in the frontend.
- Solo startup now races listener readiness against Hub goroutine completion to surface bind errors immediately.
- Added `.gitignore` entry for new generated or transient paths.

## Result

- Opus users can now select the `xhigh` effort tier and it is set as their default automatically.
- The "auto" permission mode appears in the UI only when it is actually supported by the current plan, admin configuration, and model — users are no longer shown an option that silently fails.
- The extended-thinking toggle label correctly reads "Adaptive" for Opus/Sonnet and "On" for Haiku, matching Claude Code's own terminology.
- Switching models no longer leaves an incompatible effort level selected; the UI downgrades to the new model's default when necessary.
- The workspace access race is eliminated: RPCs issued immediately after `PrepareWorkspaceAccess` returns are guaranteed to be authorized on the worker side.
- Unix socket tests no longer fail on macOS due to path-length overflow.
- Tunnel tests are deterministic instead of relying on fixed sleeps.
