### PR TITLE
Enable terminal and agent support on Windows via ConPTY

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,9 @@ jobs:
           echo "BUN_VERSION=$(yq '.bun-version' versions.yaml)" >> $GITHUB_ENV
           echo "NODE_VERSION=$(yq '.node-version' versions.yaml)" >> $GITHUB_ENV
           echo "GOLANG_VERSION=$(yq '.golang-version' versions.yaml)" >> $GITHUB_ENV
+          echo "RUST_VERSION=$(yq '.rust-version' versions.yaml)" >> $GITHUB_ENV
           echo "TASK_VERSION=$(yq '.task-version' versions.yaml)" >> $GITHUB_ENV
+          echo "CACHE_WEEK=$(date -u +%G-W%V)" >> $GITHUB_ENV
 
       - name: Setup MSVC dev environment
         # Puts link.exe, cl.exe, and the Windows SDK on PATH so Tauri's
@@ -193,7 +195,30 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: |
+            backend/go.sum
+            desktop/go/go.sum
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/rust/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      - name: Cache Tauri downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/tauri
+          key: tauri-${{ runner.os }}-${{ env.CACHE_WEEK }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -267,6 +292,10 @@ jobs:
             ./spautil/... \
             ./tunnel/... \
             ./worker/...
+
+      - name: Build desktop app
+        shell: bash
+        run: task build-desktop
 
   docker:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,9 +144,6 @@ jobs:
 
   ci-windows:
     runs-on: windows-latest
-    # windows-latest runner behaviour is still being validated; failures
-    # are reported but not merge-blocking.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install yq
+        # windows-latest does not ship mikefarah/yq; without it the
+        # `Read tool versions` step below silently produces empty values
+        # because bash command substitution swallows the missing-binary
+        # failure inside `echo "FOO=$(yq ...)"`.
+        run: choco install yq -y --no-progress
+
       - name: Read tool versions
         shell: bash
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,12 @@ jobs:
         # `Read tool versions` step below silently produces empty values
         # because bash command substitution swallows the missing-binary
         # failure inside `echo "FOO=$(yq ...)"`.
-        run: choco install yq -y --no-progress
+        run: >-
+          winget install --id mikefarah.yq -e
+          --silent
+          --accept-package-agreements
+          --accept-source-agreements
+          --disable-interactivity
 
       - name: Read tool versions
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,9 +293,9 @@ jobs:
             ./tunnel/... \
             ./worker/...
 
-      - name: Build desktop app
+      - name: Build all modules
         shell: bash
-        run: task build-desktop
+        run: task build
 
   docker:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,13 +153,65 @@ jobs:
       - name: Read tool versions
         shell: bash
         run: |
+          echo "BUF_VERSION=$(yq '.buf-version' versions.yaml)" >> $GITHUB_ENV
+          echo "SQLC_VERSION=$(yq '.sqlc-version' versions.yaml)" >> $GITHUB_ENV
+          echo "BUN_VERSION=$(yq '.bun-version' versions.yaml)" >> $GITHUB_ENV
+          echo "NODE_VERSION=$(yq '.node-version' versions.yaml)" >> $GITHUB_ENV
           echo "GOLANG_VERSION=$(yq '.golang-version' versions.yaml)" >> $GITHUB_ENV
+          echo "TASK_VERSION=$(yq '.task-version' versions.yaml)" >> $GITHUB_ENV
+
+      - name: Setup MSVC dev environment
+        # Puts link.exe, cl.exe, and the Windows SDK on PATH so Tauri's
+        # Rust build (and any CGO packages) can link against MSVC.
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: backend/go.sum
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          version: ${{ env.BUF_VERSION }}
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: ${{ env.TASK_VERSION }}
+
+      - name: Cache Go tool binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin
+          key: go-tools-${{ runner.os }}-sqlc${{ env.SQLC_VERSION }}
+
+      - name: Install tools
+        shell: bash
+        run: |
+          test -x "$(go env GOPATH)/bin/sqlc" || test -x "$(go env GOPATH)/bin/sqlc.exe" || go install github.com/sqlc-dev/sqlc/cmd/sqlc@v${{ env.SQLC_VERSION }}
+
+      - name: Prepare backend (generate proto + sqlc, build frontend embed)
+        shell: bash
+        run: task prepare-backend
 
       - name: Backend tests (Windows-relevant packages)
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,61 @@ jobs:
       - name: Test
         run: task test
 
+  ci-windows:
+    runs-on: windows-latest
+    # windows-latest runner behaviour is still being validated; failures
+    # are reported but not merge-blocking.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read tool versions
+        shell: bash
+        run: |
+          echo "GOLANG_VERSION=$(yq '.golang-version' versions.yaml)" >> $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+          cache-dependency-path: backend/go.sum
+
+      - name: Backend tests (Windows-relevant packages)
+        shell: bash
+        working-directory: backend
+        run: |
+          # Excludes hub/store/{cockroachdb,mysql,postgres,tidb,yugabytedb}
+          # which require Docker (testcontainers) and are not part of the
+          # Windows worker/desktop runtime.
+          go test -tags integration -timeout 10m \
+            ./cmd/... \
+            ./channelwire/... \
+            ./hub/... \
+            ./internal/config/... \
+            ./internal/hub/auth/... \
+            ./internal/hub/bootstrap/... \
+            ./internal/hub/channelmgr/... \
+            ./internal/hub/cleanup/... \
+            ./internal/hub/config/... \
+            ./internal/hub/keystore/... \
+            ./internal/hub/layout/... \
+            ./internal/hub/oauth/... \
+            ./internal/hub/password/... \
+            ./internal/hub/service/... \
+            ./internal/hub/store/sqlite/... \
+            ./internal/hub/store/sqlutil/... \
+            ./internal/hub/workermgr/... \
+            ./internal/logging/... \
+            ./internal/metrics/... \
+            ./internal/noise/... \
+            ./internal/util/... \
+            ./internal/worker/... \
+            ./locallisten/... \
+            ./solo/... \
+            ./spautil/... \
+            ./tunnel/... \
+            ./worker/...
+
   docker:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,8 @@ jobs:
         # because bash command substitution swallows the missing-binary
         # failure inside `echo "FOO=$(yq ...)"`.
         run: >-
-          winget install --id mikefarah.yq -e
+          winget install --id MikeFarah.yq -e
+          --source winget
           --silent
           --accept-package-agreements
           --accept-source-agreements

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,7 +294,13 @@ jobs:
             ./worker/...
 
       - name: Build all modules
-        shell: bash
+        # Run under pwsh rather than bash: Git Bash prepends /usr/bin to
+        # PATH, and /usr/bin/link.exe (a Unix hard-link utility shipped
+        # with Git for Windows) shadows MSVC's link.exe, causing the
+        # Rust/Tauri build to fail with "/usr/bin/link: extra operand".
+        # Task has its own portable shell, so the Taskfile commands still
+        # work from pwsh.
+        shell: pwsh
         run: task build
 
   docker:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,13 +155,19 @@ jobs:
         # `Read tool versions` step below silently produces empty values
         # because bash command substitution swallows the missing-binary
         # failure inside `echo "FOO=$(yq ...)"`.
-        run: >-
-          winget install --id MikeFarah.yq -e
-          --source winget
-          --silent
-          --accept-package-agreements
-          --accept-source-agreements
-          --disable-interactivity
+        shell: pwsh
+        run: |
+          winget install --id MikeFarah.yq -e `
+            --source winget `
+            --silent `
+            --accept-package-agreements `
+            --accept-source-agreements `
+            --disable-interactivity
+          # winget drops a yq.exe shim into %LOCALAPPDATA%\Microsoft\WinGet\Links,
+          # but its PATH update only applies to new shells — the subsequent CI
+          # steps inherit the job's original PATH, so yq wouldn't be found.
+          # Surface the Links dir explicitly via GITHUB_PATH.
+          "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
       - name: Read tool versions
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,6 +237,13 @@ jobs:
         with:
           version: ${{ env.BUF_VERSION }}
 
+      - name: Setup protoc
+        # Tauri/Rust's prost-build invokes protoc directly; the Linux job
+        # gets it from `apt install protobuf-compiler`.
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,10 @@ jobs:
           test -x "$(go env GOPATH)/bin/sqlc" || test -x "$(go env GOPATH)/bin/sqlc.exe" || go install github.com/sqlc-dev/sqlc/cmd/sqlc@v${{ env.SQLC_VERSION }}
 
       - name: Prepare backend (generate proto + sqlc, build frontend embed)
-        shell: bash
+        # Use pwsh so Git Bash's /usr/bin isn't prepended to PATH; see the
+        # "Build all modules" step for details. Task has a portable shell,
+        # so the Taskfile commands still execute correctly.
+        shell: pwsh
         run: task prepare-backend
 
       - name: Backend tests (Windows-relevant packages)
@@ -298,8 +301,6 @@ jobs:
         # PATH, and /usr/bin/link.exe (a Unix hard-link utility shipped
         # with Git for Windows) shadows MSVC's link.exe, causing the
         # Rust/Tauri build to fail with "/usr/bin/link: extra operand".
-        # Task has its own portable shell, so the Taskfile commands still
-        # work from pwsh.
         shell: pwsh
         run: task build
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -392,22 +392,26 @@ tasks:
       # Tauri's NSIS and WiX bundlers name the installer after productName
       # ("LeapMux Desktop" — with a space), regardless of our mainBinaryName
       # override. Copy with a space-stripping rename so we ship spaceless
-      # filenames. The WiX bundler additionally appends "_en-US"; strip that
-      # too. Destination is a bare filename so it resolves to cwd = repo
-      # root without triggering mvdan/sh's `./`-path quirk.
+      # filenames. The WiX bundler additionally appends "_en-US"; strip
+      # that too. We cd into the bundle dir first so the glob expands to
+      # bare filenames: on Windows, mvdan/sh expands globs with directory
+      # segments to native backslash paths, and the resulting behavior of
+      # `${##*/}` varies with the parent shell (bash vs PowerShell).
       - |
-        for src in desktop/rust/target/release/bundle/nsis/LeapMux*-setup.exe; do
+        repo_root="$(pwd)"
+        cd desktop/rust/target/release/bundle/nsis
+        for src in LeapMux*-setup.exe; do
           [ -e "$src" ] || continue
-          name="${src##*/}"
-          cp -f "$src" "${name// /}"
+          cp -f "$src" "$repo_root/${src// /}"
         done
       - |
-        for src in desktop/rust/target/release/bundle/msi/LeapMux*_en-US.msi; do
+        repo_root="$(pwd)"
+        cd desktop/rust/target/release/bundle/msi
+        for src in LeapMux*_en-US.msi; do
           [ -e "$src" ] || continue
-          name="${src##*/}"
-          dest="${name// /}"
+          dest="${src// /}"
           dest="${dest/_en-US/}"
-          cp -f "$src" "$dest"
+          cp -f "$src" "$repo_root/$dest"
         done
 
   # --- Testing ---

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,11 +4,12 @@ go 1.26.1
 
 require (
 	connectrpc.com/connect v1.19.1
+	github.com/Microsoft/go-winio v0.6.2
+	github.com/aymanbagabas/go-pty v0.2.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cloudflare/circl v1.6.3
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.18.0
-	github.com/creack/pty v1.1.24
 	github.com/docker/go-connections v0.7.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.9.3
@@ -32,6 +33,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.48.2
@@ -41,7 +43,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
@@ -51,6 +52,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
@@ -98,6 +100,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/u-root/u-root v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
@@ -112,7 +115,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -10,6 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
+github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -196,6 +198,10 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90 h1:zTk5683I9K62wtZ6eUa6vu6IWwVHXPnoKK5n2unAwv0=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90/go.mod h1:lYt+LVfZBBwDZ3+PHk4k/c/TnKOkjJXiJO73E32Mmpc=
+github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
+github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/backend/internal/util/pathutil/pathutil.go
+++ b/backend/internal/util/pathutil/pathutil.go
@@ -19,6 +19,22 @@ func SamePath(a, b string) bool {
 	return ca == cb
 }
 
+// HasPathPrefix reports whether path is equal to or nested inside prefix,
+// matching the host's filesystem case rules (case-insensitive on Windows,
+// byte-exact on POSIX). Both inputs are cleaned; a trailing separator is
+// appended to prefix so `/foo` does not match `/foobar`.
+func HasPathPrefix(path, prefix string) bool {
+	cp := filepath.Clean(path) + string(filepath.Separator)
+	pp := filepath.Clean(prefix) + string(filepath.Separator)
+	if len(cp) < len(pp) {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(cp[:len(pp)], pp)
+	}
+	return cp[:len(pp)] == pp
+}
+
 // Canonicalize returns filepath.EvalSymlinks(p) if it succeeds, otherwise p
 // unchanged. Use this when you want a best-effort canonical path but don't
 // want to fail the caller when resolution isn't possible.

--- a/backend/internal/util/pathutil/pathutil_other.go
+++ b/backend/internal/util/pathutil/pathutil_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package pathutil
+
+import "path/filepath"
+
+// NormalizeNative returns filepath.Clean(p). On POSIX hosts there is no
+// separator or drive-path translation to do — `/c/foo` is a legitimate
+// directory, not an MSYS drive reference.
+func NormalizeNative(p string) string {
+	if p == "" {
+		return p
+	}
+	return filepath.Clean(p)
+}

--- a/backend/internal/util/pathutil/pathutil_test.go
+++ b/backend/internal/util/pathutil/pathutil_test.go
@@ -30,3 +30,54 @@ func TestSamePath_CaseSensitivity(t *testing.T) {
 		assert.False(t, got, "POSIX should compare paths case-sensitively")
 	}
 }
+
+func TestHasPathPrefix(t *testing.T) {
+	// Nested and equal paths match.
+	assert.True(t, HasPathPrefix("/home/user/plans/a.md", "/home/user/plans"))
+	assert.True(t, HasPathPrefix("/home/user/plans", "/home/user/plans"))
+	// Sibling with shared prefix does not match.
+	assert.False(t, HasPathPrefix("/home/user/plansx", "/home/user/plans"))
+	// Outside the prefix.
+	assert.False(t, HasPathPrefix("/home/user/other", "/home/user/plans"))
+
+	// Case sensitivity matches platform filesystem semantics.
+	got := HasPathPrefix("/Home/User/Plans/a.md", "/home/user/plans")
+	if runtime.GOOS == "windows" {
+		assert.True(t, got)
+	} else {
+		assert.False(t, got)
+	}
+}
+
+func TestNormalizeNative_WindowsForwardSlashes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific separator normalization")
+	}
+	assert.Equal(t, `C:\Users\foo`, NormalizeNative("C:/Users/foo"))
+	assert.Equal(t, `C:\Users\foo\bar`, NormalizeNative("C:/Users/foo/bar"))
+}
+
+func TestNormalizeNative_WindowsMsysDriveLetter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("MSYS path translation only applies on Windows")
+	}
+	// Git-Bash / MSYS style → native.
+	assert.Equal(t, `C:\Users\foo`, NormalizeNative("/c/Users/foo"))
+	assert.Equal(t, `C:\Users\foo`, NormalizeNative("/C/Users/foo"))
+	assert.Equal(t, `C:\`, NormalizeNative("/c/"))
+	// Bare drive (no trailing slash) still normalizes.
+	assert.Equal(t, `C:\`, NormalizeNative("/c"))
+}
+
+func TestNormalizeNative_PosixUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX paths on POSIX hosts")
+	}
+	// On POSIX, /c/foo is a legitimate path — do NOT rewrite it.
+	assert.Equal(t, "/c/foo", NormalizeNative("/c/foo"))
+	assert.Equal(t, "/home/user", NormalizeNative("/home/user/"))
+}
+
+func TestNormalizeNative_Empty(t *testing.T) {
+	assert.Equal(t, "", NormalizeNative(""))
+}

--- a/backend/internal/util/pathutil/pathutil_windows.go
+++ b/backend/internal/util/pathutil/pathutil_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// NormalizeNative returns p with backslash separators and converts MSYS /
+// Git-Bash-style drive paths (`/c/foo`, `/C/foo`) to `C:\foo` so paths from
+// git / bash tooling compare equal to paths from native Go APIs. Callers
+// that want symlink resolution too should feed the result into Canonicalize.
+func NormalizeNative(p string) string {
+	if p == "" {
+		return p
+	}
+	if len(p) >= 2 && p[0] == '/' {
+		c := p[1]
+		isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if isLetter && (len(p) == 2 || p[2] == '/' || p[2] == '\\') {
+			// Bare "/c" means drive root; make it "/c/" so Clean produces
+			// "C:\" rather than the drive-relative "C:.".
+			rest := p[2:]
+			if rest == "" {
+				rest = "/"
+			}
+			p = strings.ToUpper(string(c)) + ":" + rest
+		}
+	}
+	return filepath.Clean(p)
+}

--- a/backend/internal/util/testutil/shell.go
+++ b/backend/internal/util/testutil/shell.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"os"
+	"runtime"
+)
+
+// TestShell returns a shell binary suitable for spawning a real PTY in
+// tests. On Windows it prefers %COMSPEC% (typically cmd.exe) so the test
+// works on both classic Windows and stripped-down container images. On
+// Unix it returns /bin/sh, which is part of the POSIX baseline.
+func TestShell() string {
+	if runtime.GOOS == "windows" {
+		if shell := os.Getenv("COMSPEC"); shell != "" {
+			return shell
+		}
+		return "cmd.exe"
+	}
+	return "/bin/sh"
+}
+
+// TestShellEnter returns the line terminator that the test shell needs to
+// commit a command. cmd.exe via ConPTY only treats CR (\r) as Enter, while
+// POSIX shells accept LF (\n).
+func TestShellEnter() string {
+	if runtime.GOOS == "windows" {
+		return "\r"
+	}
+	return "\n"
+}

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -72,7 +72,6 @@ type jsonrpcBase struct {
 type acpBase struct {
 	jsonrpcBase
 	sink                   OutputSink
-	providerName           string                  // e.g. "copilot", "gemini", "opencode" — used in log messages
 	extraSessionUpdate     acpSessionUpdateHandler // optional provider-specific session update handler
 	extraMethod            acpMethodHandler        // optional provider-specific request/notification handler
 	reapplySettings        func()                  // called by ClearContext after session/new to re-apply model, mode, etc.

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -86,9 +85,9 @@ type providerRegistration struct {
 	start         startFunc
 	defaultModels []*leapmuxv1.AvailableModel
 	optionGroups  []*leapmuxv1.AvailableOptionGroup
-	envModelKey   string // e.g. "LEAPMUX_CLAUDE_DEFAULT_MODEL"
-	envEffortKey  string // e.g. "LEAPMUX_CLAUDE_DEFAULT_EFFORT"
-	binaryName    string // e.g. "claude", "codex"
+	envModelKey   string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_MODEL"
+	envEffortKey  string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_EFFORT"
+	binaryNames   []string // preferred first; e.g. {"codex", "codex-x86_64-pc-windows-msvc"}
 }
 
 // providerRegistry maps each AgentProvider to its registration.
@@ -97,13 +96,14 @@ var providerRegistry = map[leapmuxv1.AgentProvider]providerRegistration{}
 
 // registerProvider registers a provider's factory function, default model list,
 // option groups, and environment variable keys for overriding defaults.
+// binaryNames lists the executable names to probe (first entry is preferred).
 func registerProvider(
 	provider leapmuxv1.AgentProvider,
 	start startFunc,
 	defaultModels []*leapmuxv1.AvailableModel,
 	optionGroups []*leapmuxv1.AvailableOptionGroup,
 	envModelKey, envEffortKey string,
-	binaryName string,
+	binaryNames ...string,
 ) {
 	providerRegistry[provider] = providerRegistration{
 		start:         start,
@@ -111,7 +111,7 @@ func registerProvider(
 		optionGroups:  optionGroups,
 		envModelKey:   envModelKey,
 		envEffortKey:  envEffortKey,
-		binaryName:    binaryName,
+		binaryNames:   binaryNames,
 	}
 }
 
@@ -196,12 +196,12 @@ func filterEnv(environ []string, keys ...string) []string {
 func ListAvailableProviders(ctx context.Context, shellPath string, useLoginShell bool) []leapmuxv1.AgentProvider {
 	type check struct {
 		provider leapmuxv1.AgentProvider
-		binary   string
+		binaries []string
 	}
 	var checks []check
 	for provider, reg := range providerRegistry {
-		if reg.binaryName != "" {
-			checks = append(checks, check{provider, reg.binaryName})
+		if len(reg.binaryNames) > 0 {
+			checks = append(checks, check{provider, reg.binaryNames})
 		}
 	}
 
@@ -209,10 +209,15 @@ func ListAvailableProviders(ctx context.Context, shellPath string, useLoginShell
 	var wg sync.WaitGroup
 	for i, c := range checks {
 		wg.Add(1)
-		go func(idx int, binary string) {
+		go func(idx int, binaries []string) {
 			defer wg.Done()
-			found[idx] = checkBinaryAvailable(ctx, shellPath, useLoginShell, binary)
-		}(i, c.binary)
+			for _, b := range binaries {
+				if checkBinaryAvailable(ctx, shellPath, useLoginShell, b) {
+					found[idx] = true
+					return
+				}
+			}
+		}(i, c.binaries)
 	}
 	wg.Wait()
 
@@ -230,8 +235,51 @@ func ListAvailableProviders(ctx context.Context, shellPath string, useLoginShell
 	return result
 }
 
+// resolveBinaryName returns the first binary from candidates that is
+// available in the user's shell environment. If none are found, the first
+// candidate is returned so that invocation produces a meaningful
+// "command not found" error rather than silently picking an alias.
+func resolveBinaryName(ctx context.Context, shellPath string, loginShell bool, candidates []string) string {
+	for _, c := range candidates {
+		if checkBinaryAvailable(ctx, shellPath, loginShell, c) {
+			return c
+		}
+	}
+	return candidates[0]
+}
+
+// binaryAvailabilityCache memoizes the result of a login-shell binary probe.
+// Each probe spawns a (possibly login) shell that sources user profiles —
+// commonly hundreds of milliseconds — so repeat calls from
+// ListAvailableProviders and resolveBinaryName share results for the
+// worker's lifetime. Installed binaries don't appear or disappear within
+// a session, so no TTL is needed.
+var (
+	binaryAvailabilityCache   sync.Map // binaryAvailabilityKey -> bool
+	binaryAvailabilitySingles sync.Map // binaryAvailabilityKey -> *sync.Once
+)
+
+type binaryAvailabilityKey struct {
+	shellPath  string
+	loginShell bool
+	binaryName string
+}
+
 func checkBinaryAvailable(ctx context.Context, shellPath string, loginShell bool, binaryName string) bool {
-	shellName := filepath.Base(shellPath)
+	key := binaryAvailabilityKey{shellPath, loginShell, binaryName}
+	if v, ok := binaryAvailabilityCache.Load(key); ok {
+		return v.(bool)
+	}
+	onceAny, _ := binaryAvailabilitySingles.LoadOrStore(key, &sync.Once{})
+	onceAny.(*sync.Once).Do(func() {
+		binaryAvailabilityCache.Store(key, probeBinary(ctx, shellPath, loginShell, binaryName))
+	})
+	v, _ := binaryAvailabilityCache.Load(key)
+	return v.(bool)
+}
+
+func probeBinary(ctx context.Context, shellPath string, loginShell bool, binaryName string) bool {
+	shellName := terminal.ShellBaseName(shellPath)
 
 	var inner, flag string
 	switch {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -153,6 +153,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	a := &ClaudeCodeAgent{
 		processBase: processBase{
 			agentID:            opts.AgentID,
+			providerName:       "claude",
 			cmd:                cmd,
 			stdin:              stdin,
 			ctx:                ctx,
@@ -174,9 +175,8 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		alwaysThinking:         AlwaysThinkingOn,
 	}
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start claude: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	// Drain stderr in a background goroutine.

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -12,6 +13,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
+	"github.com/leapmux/leapmux/internal/util/pathutil"
 )
 
 // contextUsageSnapshot tracks token usage for debounced broadcasting.
@@ -198,8 +200,8 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 			}
 			filePath := input.FilePath
 			if filePath != "" && a.homeDir != "" {
-				planDir := a.homeDir + "/.claude/plans/"
-				if strings.HasPrefix(filePath, planDir) {
+				planDir := filepath.Join(a.homeDir, ".claude", "plans")
+				if pathutil.HasPathPrefix(filePath, planDir) {
 					planFileProcessed = true
 
 					var planContentStr string

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +29,14 @@ type outputTestSink struct {
 
 	modeMu          sync.Mutex
 	permissionModes []string
+
+	planMu    sync.Mutex
+	planCalls []planUpdateCall
+}
+
+type planUpdateCall struct {
+	FilePath string
+	Title    string
 }
 
 func (s *outputTestSink) OpenSpan(spanID, parentSpanID string) {
@@ -63,6 +73,18 @@ func (s *outputTestSink) PermissionModes() []string {
 	s.modeMu.Lock()
 	defer s.modeMu.Unlock()
 	return append([]string(nil), s.permissionModes...)
+}
+
+func (s *outputTestSink) UpdatePlan(filePath string, _ []byte, _ leapmuxv1.ContentCompression, title string) {
+	s.planMu.Lock()
+	defer s.planMu.Unlock()
+	s.planCalls = append(s.planCalls, planUpdateCall{FilePath: filePath, Title: title})
+}
+
+func (s *outputTestSink) PlanCalls() []planUpdateCall {
+	s.planMu.Lock()
+	defer s.planMu.Unlock()
+	return append([]planUpdateCall(nil), s.planCalls...)
 }
 
 // newTestAgent creates a minimal ClaudeCodeAgent for unit-testing HandleOutput.
@@ -197,6 +219,74 @@ func TestHandleOutput_AssistantNoToolUse(t *testing.T) {
 	// No spans opened.
 	assert.Empty(t, sink.OpenedSpans())
 	assert.Equal(t, 0, agent.turnToolUses)
+}
+
+// testHomeDir returns a platform-appropriate home directory path for tests
+// that exercise OS-native path handling.
+func testHomeDir() string {
+	if filepath.Separator == '/' {
+		return "/home/user"
+	}
+	return filepath.Join("C:", "Users", "user")
+}
+
+func TestHandleOutput_PlanFileDetected_UsesPlatformPathSeparators(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	agent.homeDir = testHomeDir()
+	planPath := filepath.Join(agent.homeDir, ".claude", "plans", "my-plan.md")
+
+	input, err := json.Marshal(map[string]string{
+		"file_path": planPath,
+		"content":   "# My Plan\n\nHere is the body.",
+	})
+	require.NoError(t, err)
+
+	content := []byte(fmt.Sprintf(`{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [
+				{"type": "tool_use", "id": "tu-plan", "name": "Write", "input": %s}
+			]
+		}
+	}`, input))
+
+	agent.HandleOutput(content)
+
+	calls := sink.PlanCalls()
+	require.Len(t, calls, 1, "UpdatePlan should fire for a Write to ~/.claude/plans/")
+	assert.Equal(t, planPath, calls[0].FilePath)
+	assert.Equal(t, "My Plan", calls[0].Title)
+}
+
+func TestHandleOutput_PlanFileIgnored_WhenPathIsOutsidePlansDir(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	agent.homeDir = testHomeDir()
+	otherPath := filepath.Join(agent.homeDir, ".claude", "other", "note.md")
+
+	input, err := json.Marshal(map[string]string{
+		"file_path": otherPath,
+		"content":   "not a plan",
+	})
+	require.NoError(t, err)
+
+	content := []byte(fmt.Sprintf(`{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [
+				{"type": "tool_use", "id": "tu-other", "name": "Write", "input": %s}
+			]
+		}
+	}`, input))
+
+	agent.HandleOutput(content)
+
+	assert.Empty(t, sink.PlanCalls())
 }
 
 func TestClaudeRateLimitEvent_SchedulesResumeWhenBlocked(t *testing.T) {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1148,7 +1148,7 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	assert.False(t, foundClaudeCode, "CLAUDECODE=1 should NOT be in env without login shell")
 
 	// With login shell - verify the env is set on the command.
-	shellCmd, _, _ := buildShellWrappedCommand(ctx, "/bin/sh", true, "claude", []string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "test"}, t.TempDir())
+	shellCmd, _, _ := buildShellWrappedCommand(ctx, testutil.TestShell(), true, "claude", []string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "test"}, t.TempDir())
 	shellCmd.Env = filterEnv(shellCmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
 	shellCmd.Env = append(shellCmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1", "CLAUDECODE=1")
 

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -93,8 +93,9 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Provider, e
 
 	// Codex doesn't have third-party provider detection or model/effort
 	// conditional args, so we pass empty modelEffortArgs for a simple command.
+	binary := resolveBinaryName(ctx, opts.Shell, opts.LoginShell, codexBinaryCandidates)
 	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "codex", []string{"CODEX_CI"}, []string{"app-server"}, nil, opts.WorkingDir,
+		ctx, opts.Shell, opts.LoginShell, binary, []string{"CODEX_CI"}, []string{"app-server"}, nil, opts.WorkingDir,
 	)
 
 	cmd.Env = filterEnv(cmd.Environ(), "CODEX_CI", "CODEX_THREAD_ID")
@@ -111,6 +112,7 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Provider, e
 	a := &CodexAgent{
 		jsonrpcBase: jsonrpcBase{processBase: processBase{
 			agentID:            opts.AgentID,
+			providerName:       "codex",
 			cmd:                cmd,
 			stdin:              stdin,
 			ctx:                ctx,
@@ -128,9 +130,8 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Provider, e
 		sink:       sink,
 	}
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start codex: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	// Drain stderr in background.
@@ -778,6 +779,11 @@ var codexDefaultModels = []*leapmuxv1.AvailableModel{
 	{Id: "gpt-5.1-codex-mini", DisplayName: "GPT-5.1 Codex Mini", Description: "Optimized for Codex; cheaper, faster, but less capable", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
 }
 
+// codexBinaryCandidates lists the executable names to probe for Codex, in
+// preference order. The second entry is the full Rust host triple produced
+// by `cargo install` on Windows when a shorter `codex` shim is absent.
+var codexBinaryCandidates = []string{"codex", "codex-x86_64-pc-windows-msvc"}
+
 func init() {
 	registerProvider(
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
@@ -831,7 +837,7 @@ func init() {
 		},
 		"LEAPMUX_CODEX_DEFAULT_MODEL",
 		"LEAPMUX_CODEX_DEFAULT_EFFORT",
-		"codex",
+		codexBinaryCandidates...,
 	)
 }
 

--- a/backend/internal/worker/agent/codex_test.go
+++ b/backend/internal/worker/agent/codex_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +38,7 @@ func TestCodex_LoginShellEnvUsesCodexMarkers(t *testing.T) {
 	assert.False(t, foundCodexCI, "CODEX_CI=1 should NOT be in env without login shell")
 	assert.False(t, foundThreadID, "CODEX_THREAD_ID should be filtered from env")
 
-	shellCmd, _, _ := buildShellWrappedCommand(ctx, "/bin/sh", true, "codex", []string{"CODEX_CI"}, []string{"app-server"}, nil, t.TempDir())
+	shellCmd, _, _ := buildShellWrappedCommand(ctx, testutil.TestShell(), true, "codex", []string{"CODEX_CI"}, []string{"app-server"}, nil, t.TempDir())
 	shellCmd.Env = filterEnv(shellCmd.Environ(), "CODEX_CI", "CODEX_THREAD_ID")
 	shellCmd.Env = append(shellCmd.Env, "LEAPMUX_WORKER=1", "CODEX_CI=1")
 

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -39,6 +39,7 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "copilot",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -50,9 +51,8 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "copilot",
-			model:        opts.Model,
+			sink:  sink,
+			model: opts.Model,
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
@@ -60,9 +60,8 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Provid
 	a.reapplySettings = a.reapplyModelAndPermissionMode
 	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start copilot: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/copilot_output_test.go
+++ b/backend/internal/worker/agent/copilot_output_test.go
@@ -10,11 +10,11 @@ func newCopilotAgentWithSink(sink OutputSink) *CopilotCLIAgent {
 	a := &CopilotCLIAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID: "test-agent",
+				agentID:      "test-agent",
+				providerName: "copilot",
 			}},
-			sink:         sink,
-			providerName: "copilot",
-			sessionID:    "test-session",
+			sink:      sink,
+			sessionID: "test-session",
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -116,7 +116,7 @@ func TestStartCopilotCLI_NewSessionHandshake(t *testing.T) {
 	provider, err := StartCopilotCLI(context.Background(), Options{
 		AgentID:       "copilot-new",
 		WorkingDir:    t.TempDir(),
-		Shell:         "/bin/sh",
+		Shell:         testutil.TestShell(),
 		LoginShell:    false,
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 	}, &testSink{})
@@ -144,7 +144,7 @@ func TestStartCopilotCLI_LoadSessionUsesResumeID(t *testing.T) {
 		AgentID:         "copilot-load",
 		WorkingDir:      t.TempDir(),
 		ResumeSessionID: "copilot-resume",
-		Shell:           "/bin/sh",
+		Shell:           testutil.TestShell(),
 		LoginShell:      false,
 		AgentProvider:   leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 	}, &testSink{})

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -42,6 +42,7 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "cursor",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -53,9 +54,8 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "cursor",
-			model:        normalizeCursorModelID(opts.Model),
+			sink:  sink,
+			model: normalizeCursorModelID(opts.Model),
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
@@ -64,9 +64,8 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.reapplySettings = a.reapplyModelAndMode
 	a.refreshFromSession = a.refreshCursorFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start agent (cursor): %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/cursor_output_test.go
+++ b/backend/internal/worker/agent/cursor_output_test.go
@@ -14,11 +14,11 @@ func newCursorAgentWithSink(sink OutputSink) *CursorCLIAgent {
 	a := &CursorCLIAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID: "test-agent",
+				agentID:      "test-agent",
+				providerName: "cursor",
 			}},
-			sink:         sink,
-			providerName: "cursor",
-			sessionID:    "test-session",
+			sink:      sink,
+			sessionID: "test-session",
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
@@ -104,16 +104,16 @@ func TestHandleCursorOutput_UpdateTodosAcknowledgesRequest(t *testing.T) {
 	agent := &CursorCLIAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:     "test-agent",
-				stdin:       writePipe,
-				ctx:         ctx,
-				cancel:      cancel,
-				processDone: make(chan struct{}),
-				stderrDone:  make(chan struct{}),
+				agentID:      "test-agent",
+				providerName: "cursor",
+				stdin:        writePipe,
+				ctx:          ctx,
+				cancel:       cancel,
+				processDone:  make(chan struct{}),
+				stderrDone:   make(chan struct{}),
 			}},
-			sink:         &testSink{},
-			providerName: "cursor",
-			sessionID:    "test-session",
+			sink:      &testSink{},
+			sessionID: "test-session",
 		},
 	}
 	agent.extraMethod = agent.handleExtraMethod

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
 func newCursorAgentForRPC(t *testing.T) (*CursorCLIAgent, func() []recordedRequest) {
@@ -95,7 +96,7 @@ func TestStartCursorCLI_NewSessionHandshake(t *testing.T) {
 	provider, err := StartCursorCLI(context.Background(), Options{
 		AgentID:       "cursor-new",
 		WorkingDir:    t.TempDir(),
-		Shell:         "/bin/sh",
+		Shell:         testutil.TestShell(),
 		LoginShell:    false,
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
 	}, &testSink{})
@@ -123,7 +124,7 @@ func TestStartCursorCLI_LoadSessionUsesResumeID(t *testing.T) {
 		AgentID:         "cursor-load",
 		WorkingDir:      t.TempDir(),
 		ResumeSessionID: "cursor-resume",
-		Shell:           "/bin/sh",
+		Shell:           testutil.TestShell(),
 		LoginShell:      false,
 		AgentProvider:   leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
 	}, &testSink{})

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -44,6 +44,7 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "gemini",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -55,9 +56,8 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "gemini",
-			model:        opts.Model,
+			sink:  sink,
+			model: opts.Model,
 		},
 	}
 	a.extraSessionUpdate = a.handleExtraSessionUpdate
@@ -65,9 +65,8 @@ func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Provide
 	a.reapplySettings = a.reapplyModelAndPermissionMode
 	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start gemini: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/gemini_output_test.go
+++ b/backend/internal/worker/agent/gemini_output_test.go
@@ -12,11 +12,11 @@ func newGeminiAgentWithSink(sink OutputSink) *GeminiCLIAgent {
 	a := &GeminiCLIAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID: "test-agent",
+				agentID:      "test-agent",
+				providerName: "gemini",
 			}},
-			sink:         sink,
-			providerName: "gemini",
-			sessionID:    "test-session",
+			sink:      sink,
+			sessionID: "test-session",
 		},
 	}
 	a.extraSessionUpdate = a.handleExtraSessionUpdate

--- a/backend/internal/worker/agent/gemini_test.go
+++ b/backend/internal/worker/agent/gemini_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
 func newGeminiAgentForRPC(t *testing.T) (*GeminiCLIAgent, func() []recordedRequest) {
@@ -116,7 +117,7 @@ func TestStartGeminiCLI_NewSessionHandshake(t *testing.T) {
 	provider, err := StartGeminiCLI(context.Background(), Options{
 		AgentID:       "gemini-new",
 		WorkingDir:    t.TempDir(),
-		Shell:         "/bin/sh",
+		Shell:         testutil.TestShell(),
 		LoginShell:    false,
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GEMINI_CLI,
 	}, &testSink{})
@@ -145,7 +146,7 @@ func TestStartGeminiCLI_NewSessionAppliesRequestedModelAndMode(t *testing.T) {
 	provider, err := StartGeminiCLI(context.Background(), Options{
 		AgentID:        "gemini-settings",
 		WorkingDir:     t.TempDir(),
-		Shell:          "/bin/sh",
+		Shell:          testutil.TestShell(),
 		LoginShell:     false,
 		Model:          "gemini-2.5-flash",
 		PermissionMode: GeminiCLIModePlan,
@@ -170,7 +171,7 @@ func TestStartGeminiCLI_LoadSessionUsesResumeID(t *testing.T) {
 		AgentID:         "gemini-load",
 		WorkingDir:      t.TempDir(),
 		ResumeSessionID: "session-resume",
-		Shell:           "/bin/sh",
+		Shell:           testutil.TestShell(),
 		LoginShell:      false,
 		AgentProvider:   leapmuxv1.AgentProvider_AGENT_PROVIDER_GEMINI_CLI,
 	}, &testSink{})

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -40,6 +40,7 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "goose",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -51,9 +52,8 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "goose",
-			model:        opts.Model,
+			sink:  sink,
+			model: opts.Model,
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
@@ -61,9 +61,8 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Provider
 	a.reapplySettings = a.reapplyModelAndPermissionMode
 	a.refreshFromSession = a.refreshModelAndPermissionModeFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start goose: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -96,7 +96,7 @@ func TestStartGooseCLI_NewSessionHandshake(t *testing.T) {
 	provider, err := StartGooseCLI(context.Background(), Options{
 		AgentID:       "goose-new",
 		WorkingDir:    t.TempDir(),
-		Shell:         "/bin/sh",
+		Shell:         testutil.TestShell(),
 		LoginShell:    false,
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
 	}, &testSink{})
@@ -130,7 +130,7 @@ func TestStartGooseCLI_LoadSessionUsesResumeID(t *testing.T) {
 		AgentID:         "goose-load",
 		WorkingDir:      t.TempDir(),
 		ResumeSessionID: "goose-resume",
-		Shell:           "/bin/sh",
+		Shell:           testutil.TestShell(),
 		LoginShell:      false,
 		AgentProvider:   leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
 	}, &testSink{})

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -39,6 +39,7 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "kilo",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -50,18 +51,16 @@ func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Provider, er
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "kilo",
-			model:        opts.Model,
+			sink:  sink,
+			model: opts.Model,
 		},
 	}
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPrimaryAgent
 	a.refreshFromSession = a.refreshModelAndPrimaryAgentFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start kilo: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/kilo_output_test.go
+++ b/backend/internal/worker/agent/kilo_output_test.go
@@ -13,11 +13,11 @@ func newKiloAgentWithSink(sink OutputSink) *KiloAgent {
 	return &KiloAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID: "test-agent",
+				agentID:      "test-agent",
+				providerName: "kilo",
 			}},
-			sink:         sink,
-			providerName: "kilo",
-			sessionID:    "test-session",
+			sink:      sink,
+			sessionID: "test-session",
 		},
 	}
 }

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -21,7 +21,15 @@ type Manager struct {
 	agents             map[string]Provider                          // agentID -> Provider
 	cachedModels       map[string][]*leapmuxv1.AvailableModel       // agentID -> last known models
 	cachedOptionGroups map[string][]*leapmuxv1.AvailableOptionGroup // agentID -> last known option groups
+	lifecycleLocks     map[string]*lifecycleEntry                   // agentID -> refcounted mutex
 	onExit             ExitHandler
+}
+
+// lifecycleEntry is a per-agent mutex whose refcount is guarded by Manager.mu.
+// Entries are evicted when no caller holds or is waiting for the lock.
+type lifecycleEntry struct {
+	mu       sync.Mutex
+	refcount int
 }
 
 // NewManager creates a new agent Manager.
@@ -31,8 +39,48 @@ func NewManager(onExit ExitHandler) *Manager {
 		agents:             make(map[string]Provider),
 		cachedModels:       make(map[string][]*leapmuxv1.AvailableModel),
 		cachedOptionGroups: make(map[string][]*leapmuxv1.AvailableOptionGroup),
+		lifecycleLocks:     make(map[string]*lifecycleEntry),
 		onExit:             onExit,
 	}
+}
+
+// LockAgent acquires a per-agent mutex that serializes multi-step lifecycle
+// operations (typically stop-then-start) against concurrent callers. Without
+// this, a second restart can slip in between the first's stop and start and
+// race the "agent already running" check in StartAgent. The returned function
+// releases the lock — callers should defer it.
+func (m *Manager) LockAgent(agentID string) func() {
+	m.mu.Lock()
+	entry, ok := m.lifecycleLocks[agentID]
+	if !ok {
+		entry = &lifecycleEntry{}
+		m.lifecycleLocks[agentID] = entry
+	}
+	entry.refcount++
+	m.mu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+		m.mu.Lock()
+		entry.refcount--
+		if entry.refcount == 0 {
+			delete(m.lifecycleLocks, agentID)
+		}
+		m.mu.Unlock()
+	}
+}
+
+// RestartAgent atomically stops any running agent for opts.AgentID, waits
+// for it to fully exit, then starts a new one. Concurrent restarts for the
+// same agent ID are serialized via LockAgent. Callers that need to interleave
+// work between stop and start should use LockAgent directly.
+func (m *Manager) RestartAgent(ctx context.Context, opts Options, sink OutputSink) (*leapmuxv1.AgentSettings, error) {
+	unlock := m.LockAgent(opts.AgentID)
+	defer unlock()
+
+	m.stopAndWait(opts.AgentID, false)
+	return m.StartAgent(ctx, opts, sink)
 }
 
 // startFunc is the function signature for starting an agent process.

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -153,6 +153,48 @@ func TestManager_StopAndWaitAgent_NotRunning(t *testing.T) {
 	assert.False(t, m.StopAndWaitAgent("nonexistent"), "expected false for non-running agent")
 }
 
+func TestManager_LockAgent_ComposesStopAndStart(t *testing.T) {
+	m := NewManager(nil)
+	ctx := context.Background()
+
+	_, err := m.startAgentWith(ctx, Options{AgentID: "r1", Model: "test", WorkingDir: t.TempDir()}, noopSink{}, startMockAgent)
+	require.NoError(t, err)
+
+	unlock := m.LockAgent("r1")
+	m.stopAndWait("r1", false)
+	_, err = m.startAgentWith(ctx, Options{AgentID: "r1", Model: "test", WorkingDir: t.TempDir()}, noopSink{}, startMockAgent)
+	unlock()
+	require.NoError(t, err, "restart composed under LockAgent should succeed")
+	assert.True(t, m.HasAgent("r1"))
+	m.StopAgent("r1")
+}
+
+func TestManager_LockAgent_SerializesConcurrentRestarts(t *testing.T) {
+	m := NewManager(nil)
+	ctx := context.Background()
+
+	_, err := m.startAgentWith(ctx, Options{AgentID: "race", Model: "test", WorkingDir: t.TempDir()}, noopSink{}, startMockAgent)
+	require.NoError(t, err)
+
+	restart := func() error {
+		unlock := m.LockAgent("race")
+		defer unlock()
+		m.stopAndWait("race", false)
+		_, err := m.startAgentWith(ctx, Options{AgentID: "race", Model: "test", WorkingDir: t.TempDir()}, noopSink{}, startMockAgent)
+		return err
+	}
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- restart() }()
+	go func() { errCh <- restart() }()
+
+	// Both must succeed: the lock serializes them so neither trips the
+	// "agent already running" guard.
+	assert.NoError(t, <-errCh)
+	assert.NoError(t, <-errCh)
+	m.StopAgent("race")
+}
+
 func TestManager_StopUnknownAgent(t *testing.T) {
 	m := NewManager(nil)
 	// Should not panic.

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -51,6 +51,7 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:            opts.AgentID,
+				providerName:       "opencode",
 				cmd:                cmd,
 				stdin:              stdin,
 				ctx:                ctx,
@@ -62,18 +63,16 @@ func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Provider
 				preambleMeta:       make(map[string]string),
 				apiTimeout:         opts.apiTimeout(),
 			}},
-			sink:         sink,
-			providerName: "opencode",
-			model:        opts.Model,
+			sink:  sink,
+			model: opts.Model,
 		},
 	}
 	a.promptFunc = a.doSendPrompt
 	a.reapplySettings = a.reapplyModelAndPrimaryAgent
 	a.refreshFromSession = a.refreshModelAndPrimaryAgentFromSession
 
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("start opencode: %w", err)
+	if err := a.startCmd(cmd, cancel); err != nil {
+		return nil, err
 	}
 
 	initParams, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/worker/agent/opencode_output_test.go
+++ b/backend/internal/worker/agent/opencode_output_test.go
@@ -13,11 +13,11 @@ func newOpenCodeAgentWithSink(sink OutputSink) *OpenCodeAgent {
 	return &OpenCodeAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID: "test-agent",
+				agentID:      "test-agent",
+				providerName: "opencode",
 			}},
-			sink:         sink,
-			providerName: "opencode",
-			sessionID:    "test-session",
+			sink:      sink,
+			sessionID: "test-session",
 		},
 	}
 }

--- a/backend/internal/worker/agent/process.go
+++ b/backend/internal/worker/agent/process.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 // maxStderrSize is the maximum amount of stderr to buffer.
@@ -23,8 +25,9 @@ const maxStderrSize = 1 << 20 // 1MB
 // ClaudeCodeAgent embeds it directly; ACP agents (GeminiCLIAgent, OpenCodeAgent)
 // and CodexAgent embed it via jsonrpcBase which adds JSON-RPC request plumbing.
 type processBase struct {
-	agentID string
-	stdin   io.WriteCloser
+	agentID      string
+	providerName string // e.g. "claude", "codex", "copilot" — used in log and error messages
+	stdin        io.WriteCloser
 
 	cmd         *exec.Cmd
 	ctx         context.Context
@@ -38,6 +41,12 @@ type processBase struct {
 
 	mu      sync.Mutex
 	stopped bool
+
+	// jobObject, when non-nil, is the Windows kill-on-close job group that
+	// holds the shell wrapper and every descendant it spawns. Terminating or
+	// closing it reaps the whole tree — the Windows analogue of Unix's
+	// process-group signalling.
+	jobObject *procutil.JobObject
 
 	discardOutput atomic.Bool
 
@@ -73,8 +82,10 @@ func (p *processBase) SendRawInput(data []byte) error {
 }
 
 // Stop terminates the process gracefully. It closes stdin and gives the
-// process a short grace period before cancelling the context (which sends
-// SIGTERM, then SIGKILL after WaitDelay).
+// process a short grace period to exit on its own. If the grace period
+// elapses, the process tree is torn down: on Windows via the job object
+// (kills orphaned grandchildren too), then via context cancellation as a
+// fallback (SIGTERM + WaitDelay).
 func (p *processBase) Stop() {
 	p.mu.Lock()
 	if p.stopped {
@@ -90,6 +101,9 @@ func (p *processBase) Stop() {
 	case <-p.processDone:
 		return
 	case <-time.After(3 * time.Second):
+		if err := p.jobObject.Terminate(); err != nil {
+			slog.Debug("job object terminate failed", "agent_id", p.agentID, "error", err)
+		}
 		p.cancel()
 	}
 
@@ -230,6 +244,33 @@ func (p *processBase) PreambleOutput() string {
 	return strings.Join(p.preambleOutput, "\n")
 }
 
+// attachJobObject assigns a freshly-started command to a Windows kill-on-close
+// job object so that force-killing later reaps the whole process tree. Must
+// be called immediately after cmd.Start. Non-Windows is a no-op; a job
+// creation failure is logged but not fatal — the agent still works, we just
+// lose the tree-kill guarantee for that session.
+func (p *processBase) attachJobObject(cmd *exec.Cmd) {
+	job, err := procutil.AssignCmd(cmd)
+	if err != nil {
+		slog.Warn("attach job object failed", "agent_id", p.agentID, "error", err)
+		return
+	}
+	p.jobObject = job
+}
+
+// startCmd runs cmd.Start and, on success, attaches the process to a Windows
+// kill-on-close job object so later force-kills reap the whole tree.
+// On failure, cancel is invoked and the error is wrapped as "start <providerName>".
+// Callers must populate p.agentID and p.providerName before calling.
+func (p *processBase) startCmd(cmd *exec.Cmd, cancel func()) error {
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return fmt.Errorf("start %s: %w", p.providerName, err)
+	}
+	p.attachJobObject(cmd)
+	return nil
+}
+
 // setupProcessPipes configures the command's cancel/wait behavior and opens
 // stdin, stdout, and stderr pipes. On error it calls cancel() and returns.
 func setupProcessPipes(cmd *exec.Cmd, cancel func()) (stdin io.WriteCloser, stdout, stderr io.ReadCloser, err error) {
@@ -331,6 +372,9 @@ func (p *processBase) readOutput(scanner *bufio.Scanner, intercept outputInterce
 	}
 
 	p.waitErr = p.cmd.Wait()
+	if err := p.jobObject.Close(); err != nil {
+		slog.Debug("job object close failed", "agent_id", p.agentID, "error", err)
+	}
 	close(p.processDone)
 }
 

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/leapmux/leapmux/internal/worker/terminal"
@@ -35,7 +34,7 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 	if len(modelEffortArgs) > 0 {
 		metaPrefix = "__LEAPMUX_META_" + id + "__ "
 	}
-	shellName := filepath.Base(shellPath)
+	shellName := terminal.ShellBaseName(shellPath)
 
 	var cmdArgs []string
 	switch {

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -158,8 +158,8 @@ func TestBuildShellWrappedCommand_Nu_NonInteractive(t *testing.T) {
 	assert.Equal(t, "-c", cmd.Args[1])
 }
 
-func TestBuildShellWrappedCommand_Pwsh_Interactive(t *testing.T) {
-	for _, shell := range []string{"/usr/bin/pwsh", "/usr/bin/powershell", "/usr/bin/pwsh-preview", "/usr/bin/powershell-preview"} {
+func TestBuildShellWrappedCommand_PwshCore_Interactive(t *testing.T) {
+	for _, shell := range []string{"/usr/bin/pwsh", "/usr/bin/pwsh-preview"} {
 		t.Run(shell, func(t *testing.T) {
 			cmd, delimiter, _ := buildShellWrappedCommand(
 				context.Background(), shell, true, "claude",
@@ -174,6 +174,30 @@ func TestBuildShellWrappedCommand_Pwsh_Interactive(t *testing.T) {
 			assert.Contains(t, cmd.Args[3], "& claude")
 			assert.NotContains(t, cmd.Args[3], "exec")
 			assert.Contains(t, cmd.Args[3], "CLAUDE_CODE_USE_BEDROCK")
+		})
+	}
+}
+
+// Windows PowerShell 5.1 (powershell.exe) does not understand -Login; its
+// CLI parser treats unknown leading switches as command names, raising
+// "ObjectNotFound: (-Login:String), CommandNotFoundException". Interactive
+// invocations must therefore omit -Login for powershell(-preview) and
+// invoke -Command directly.
+func TestBuildShellWrappedCommand_WindowsPowerShell_Interactive(t *testing.T) {
+	for _, shell := range []string{"/usr/bin/powershell", "/usr/bin/powershell-preview"} {
+		t.Run(shell, func(t *testing.T) {
+			cmd, delimiter, _ := buildShellWrappedCommand(
+				context.Background(), shell, true, "claude",
+				[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+			)
+			assert.Equal(t, shell, cmd.Path)
+			require.Len(t, cmd.Args, 3) // powershell -Command <cmd>
+			assert.Equal(t, "-Command", cmd.Args[1])
+			assert.NotContains(t, cmd.Args, "-Login")
+			assert.Contains(t, cmd.Args[2], "Write-Output '"+delimiter+"'")
+			assert.Contains(t, cmd.Args[2], "Remove-Item Env:CLAUDECODE")
+			assert.Contains(t, cmd.Args[2], "& claude")
+			assert.Contains(t, cmd.Args[2], "CLAUDE_CODE_USE_BEDROCK")
 		})
 	}
 }

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -651,8 +651,6 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			})
 
 			if !updated {
-				svc.Agents.StopAndWaitAgent(agentID)
-
 				resumeSessionID := svc.resolveResumeSessionID(agentID, dbAgent.AgentSessionID, dbAgent.Resumed)
 
 				agentOpts := agent.Options{
@@ -673,7 +671,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 				sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
 
-				confirmedSettings, err := svc.Agents.StartAgent(bgCtx(), agentOpts, sink)
+				confirmedSettings, err := svc.Agents.RestartAgent(bgCtx(), agentOpts, sink)
 				if err != nil {
 					slog.Error("failed to restart agent with new settings",
 						"agent_id", agentID, "error", err)
@@ -1088,6 +1086,9 @@ func (svc *Context) persistConfirmedAgentSettings(agentID string, provider leapm
 // handleClearContext implements the /clear command by restarting the agent
 // without resuming the previous session, giving it a fresh context window.
 func (svc *Context) handleClearContext(agentID string) {
+	unlock := svc.Agents.LockAgent(agentID)
+	defer unlock()
+
 	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
 	if err != nil {
 		slog.Error("clear context: failed to fetch agent", "agent_id", agentID, "error", err)
@@ -1109,7 +1110,7 @@ func (svc *Context) handleClearContext(agentID string) {
 	model := modelOrDefault(dbAgent.Model, dbAgent.AgentProvider)
 	extraSettings := loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider)
 	sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
-	confirmedSettings, err := svc.Agents.StartAgent(bgCtx(), agent.Options{
+	confirmedSettings, err := svc.startAgent(bgCtx(), agent.Options{
 		AgentID:        agentID,
 		Model:          model,
 		Effort:         dbAgent.Effort,
@@ -1133,14 +1134,16 @@ func (svc *Context) handleClearContext(agentID string) {
 			"type":  "agent_error",
 			"error": "Failed to restart agent after clearing context: " + err.Error(),
 		})
-	} else {
-		if err := svc.persistConfirmedAgentSettings(agentID, dbAgent.AgentProvider, model, dbAgent.Effort, dbAgent.PermissionMode, extraSettings, confirmedSettings); err != nil {
-			slog.Warn("clear context: failed to persist confirmed settings", "agent_id", agentID, "error", err)
-		}
-		slog.Info("clear context: agent restarted successfully", "agent_id", agentID)
+		return
 	}
+	if err := svc.persistConfirmedAgentSettings(agentID, dbAgent.AgentProvider, model, dbAgent.Effort, dbAgent.PermissionMode, extraSettings, confirmedSettings); err != nil {
+		slog.Warn("clear context: failed to persist confirmed settings", "agent_id", agentID, "error", err)
+	}
+	slog.Info("clear context: agent restarted successfully", "agent_id", agentID)
 
-	// Broadcast a context_cleared notification.
+	// Only broadcast context_cleared once the new agent is up; on failure
+	// the agent_error notification above stands on its own so clients do
+	// not see a "cleared" UI state for an agent that is actually down.
 	svc.Output.BroadcastNotification(agentID, dbAgent.AgentProvider, map[string]interface{}{
 		"type": "context_cleared",
 	})
@@ -1946,10 +1949,11 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 // initiatePlanExecutionRestart performs a full stop-and-restart to clear
 // context for providers that don't support in-place clearing (e.g. Claude Code).
 func (svc *Context) initiatePlanExecutionRestart(agentID, targetMode string, dbAgent db.Agent, planMsg string) {
-	// Discard remaining output and stop the agent. DiscardOutput prevents
-	// persisting spurious errors (e.g. "stream closed") emitted during
-	// shutdown. Waits for the process to fully exit so StartAgent below
-	// doesn't fail with "agent already running".
+	unlock := svc.Agents.LockAgent(agentID)
+	defer unlock()
+
+	// DiscardOutput before stop so shutdown noise ("stream closed") does not
+	// land in the persisted chat history.
 	svc.Agents.DiscardOutputAndStopAgent(agentID)
 
 	// Clear span tracking state from the previous session.

--- a/backend/internal/worker/service/agent_clear_test.go
+++ b/backend/internal/worker/service/agent_clear_test.go
@@ -11,6 +11,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -74,13 +75,19 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 	svc, d, w := setupTestService(t, "ws-1")
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
+	// Mock a successful restart so we can validate the happy-path ordering
+	// without spawning a real agent process. context_cleared is only
+	// broadcast when the new agent starts successfully.
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return &leapmuxv1.AgentSettings{}, nil
+	}
+
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
-		ID:          "agent-1",
-		WorkspaceID: "ws-1",
-		WorkingDir:  t.TempDir(),
-		HomeDir:     t.TempDir(),
-		// Leave AgentProvider unspecified so restart fails immediately and
-		// deterministically without spawning a real agent process.
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
 	sender := channel.NewSender(w)
@@ -124,6 +131,51 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 	require.NotEqual(t, -1, userIdx, "expected a streamed user message")
 	require.NotEqual(t, -1, contextClearedIdx, "expected a streamed context_cleared notification")
 	assert.Less(t, userIdx, contextClearedIdx, "the /clear user message must be streamed before context_cleared")
+}
+
+func TestSendAgentMessage_SlashClearRestartFailureSkipsContextCleared(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:          "agent-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+		// Unspecified provider → StartAgent returns an error, exercising
+		// the failure branch of handleClearContext.
+	}))
+
+	sender := channel.NewSender(w)
+	svc.Watchers.WatchAgent("agent-1", &EventWatcher{
+		ChannelID: w.channelID,
+		Sender:    sender,
+	})
+
+	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
+		AgentId: "agent-1",
+		Content: "/clear",
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	sawAgentError := false
+	sawContextCleared := false
+	for _, stream := range w.streams {
+		msg := decodeWatchAgentMessage(t, stream)
+		for _, typ := range decodeMessageTypes(t, msg) {
+			switch typ {
+			case "agent_error":
+				sawAgentError = true
+			case "context_cleared":
+				sawContextCleared = true
+			}
+		}
+	}
+
+	assert.True(t, sawAgentError, "expected an agent_error notification when restart fails")
+	assert.False(t, sawContextCleared, "context_cleared must not be broadcast when the restart fails — clients would otherwise think the agent is ready")
 }
 
 func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testing.T) {

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -316,9 +316,6 @@ func TestWatchEvents_ClosedTerminal_NotWatched(t *testing.T) {
 }
 
 func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("terminal tests require /bin/sh and creack/pty, which are not available on Windows")
-	}
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
 	workingDir := t.TempDir()
@@ -327,7 +324,7 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 	require.NoError(t, svc.Terminals.StartTerminal(terminal.Options{
 		ID:            "term-1",
 		WorkspaceID:   "ws-1",
-		Shell:         "/bin/sh",
+		Shell:         testutil.TestShell(),
 		WorkingDir:    workingDir,
 		ShellStartDir: "",
 		Cols:          80,
@@ -348,13 +345,13 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 	}))
 
 	// Send a command so the terminal has screen content.
-	require.NoError(t, svc.Terminals.SendInput("term-1", []byte("echo shutdown_test\n")))
+	require.NoError(t, svc.Terminals.SendInput("term-1", []byte("echo shutdown_test"+testutil.TestShellEnter())))
 
-	// Wait for the terminal to have screen data.
+	// Wait until the echo output appears in the screen buffer; otherwise
+	// Shutdown can race ahead of the shell processing the input.
 	testutil.AssertEventually(t, func() bool {
-		screen := svc.Terminals.ScreenSnapshot("term-1")
-		return len(screen) > 0
-	}, "expected terminal to have screen data")
+		return bytes.Contains(svc.Terminals.ScreenSnapshot("term-1"), []byte("shutdown_test"))
+	}, "expected terminal screen to contain 'shutdown_test'")
 
 	// Call Shutdown — should persist screen to DB.
 	svc.Shutdown()
@@ -373,16 +370,13 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 }
 
 func TestOpenTerminal_ExitPersistsDisconnectNotice(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("terminal tests require /bin/sh and creack/pty, which are not available on Windows")
-	}
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	workingDir := t.TempDir()
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId: "ws-1",
-		Shell:       "/bin/sh",
+		Shell:       testutil.TestShell(),
 		WorkingDir:  workingDir,
 		Cols:        80,
 		Rows:        24,
@@ -395,9 +389,10 @@ func TestOpenTerminal_ExitPersistsDisconnectNotice(t *testing.T) {
 	require.NotEmpty(t, terminalID)
 
 	w2 := &testResponseWriter{channelID: "test-ch"}
+	enter := testutil.TestShellEnter()
 	dispatch(d, "SendInput", &leapmuxv1.SendInputRequest{
 		TerminalId: terminalID,
-		Data:       []byte("echo exit_notice_test\nexit\n"),
+		Data:       []byte("echo exit_notice_test" + enter + "exit" + enter),
 	}, w2)
 	require.Empty(t, w2.errors)
 

--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -80,13 +80,16 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 
 		ctx := bgCtx()
 
-		// Resolve repo root.
+		// Resolve repo root. `git rev-parse --show-toplevel` emits posix
+		// separators on Windows (e.g. `C:/foo/bar`), and when git is invoked
+		// from Git-Bash/MSYS it can produce `/c/foo/bar`; both mismatch
+		// native paths like agent.workingDir on the frontend, so normalize.
 		repoRoot, err := gitOutput(ctx, dirPath, "rev-parse", "--show-toplevel")
 		if err != nil {
 			sendInternalError(sender, "not a git repository")
 			return
 		}
-		repoRoot = strings.TrimSpace(repoRoot)
+		repoRoot = pathutil.NormalizeNative(strings.TrimSpace(repoRoot))
 
 		files, err := getGitFileStatusEntries(ctx, repoRoot)
 		if err != nil {

--- a/backend/internal/worker/service/open_rollback_test.go
+++ b/backend/internal/worker/service/open_rollback_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
@@ -110,7 +111,7 @@ func TestOpenTerminal_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
 		WorkingDir:     repoDir,
 		CreateWorktree: true,
 		WorktreeBranch: branchName,
-		Shell:          "/bin/sh",
+		Shell:          testutil.TestShell(),
 	}, w)
 
 	require.Len(t, w.errors, 1)
@@ -136,7 +137,7 @@ func TestOpenTerminal_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
 		WorkspaceId:  "ws-1",
 		WorkingDir:   repoDir,
 		CreateBranch: branchName,
-		Shell:        "/bin/sh",
+		Shell:        testutil.TestShell(),
 	}, w)
 
 	require.Len(t, w.errors, 1)
@@ -233,7 +234,7 @@ func TestOpenTerminal_DoesNotRollBackSwitchBranchOnStartFailure(t *testing.T) {
 		WorkspaceId:    "ws-1",
 		WorkingDir:     repoDir,
 		CheckoutBranch: "feature/existing",
-		Shell:          "/bin/sh",
+		Shell:          testutil.TestShell(),
 	}, w)
 
 	require.Len(t, w.errors, 1)

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -5,25 +5,25 @@ import (
 	"strings"
 )
 
-var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?(?:\.exe)?$`)
+var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
 
-// IsPwsh returns true if the shell name matches PowerShell variants
-// (pwsh, powershell, pwsh-preview, powershell-preview, plus the ".exe"
-// suffix forms surfaced when paths are split on Windows).
+// IsPwsh returns true if name is one of the PowerShell kind-names
+// (pwsh, powershell, pwsh-preview, powershell-preview). The input must be
+// already normalized — feed paths through ShellBaseName first.
 func IsPwsh(name string) bool {
 	return pwshPattern.MatchString(name)
 }
 
-// baseName extracts the trailing component of a file path, treating both
-// "/" and "\" as separators regardless of the runtime OS. This is needed
-// because filepath.Base is platform-dependent: on Unix it does not split
-// on "\", so a Windows-style path like `C:\...\pwsh.exe` is returned as-is
-// and downstream shell-kind detection fails.
-func baseName(p string) string {
+// ShellBaseName returns the canonical kind-name of a shell path: lowercased,
+// `.exe`-stripped, splitting on both "/" and "\" regardless of host OS so
+// Windows paths compare correctly on Unix builds (where filepath.Base would
+// leave `C:\...\pwsh.exe` intact).
+func ShellBaseName(p string) string {
+	base := p
 	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
-		return p[i+1:]
+		base = p[i+1:]
 	}
-	return p
+	return strings.TrimSuffix(strings.ToLower(base), ".exe")
 }
 
 // LoginShellArgs returns the flags needed to start the given shell as an
@@ -31,13 +31,16 @@ func baseName(p string) string {
 // append to.
 //
 //   - pwsh/powershell: ["-Login"]
+//   - cmd.exe:         []  — cmd has no login concept and rejects POSIX flags
 //   - tcsh/csh:        ["-l"]  — tcsh requires -l as the only flag
 //   - all others:      ["-i", "-l"]
 func LoginShellArgs(shellPath string) []string {
-	name := baseName(shellPath)
+	name := ShellBaseName(shellPath)
 	switch {
 	case IsPwsh(name):
 		return []string{"-Login"}
+	case name == "cmd":
+		return nil
 	case name == "tcsh" || name == "csh":
 		return []string{"-l"}
 	default:

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -5,7 +5,13 @@ import (
 	"strings"
 )
 
-var pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
+var (
+	pwshPattern = regexp.MustCompile(`^(?:pwsh|powershell)(?:-preview)?$`)
+	// pwshCorePattern matches only PowerShell Core (pwsh 6+), excluding
+	// Windows PowerShell 5.1 (powershell.exe). Used to gate the -Login
+	// switch, which Core introduced and 5.1 does not understand.
+	pwshCorePattern = regexp.MustCompile(`^pwsh(?:-preview)?$`)
+)
 
 // IsPwsh returns true if name is one of the PowerShell kind-names
 // (pwsh, powershell, pwsh-preview, powershell-preview). The input must be
@@ -30,15 +36,20 @@ func ShellBaseName(p string) string {
 // interactive login shell (no -c command). The returned slice is safe to
 // append to.
 //
-//   - pwsh/powershell: ["-Login"]
-//   - cmd.exe:         []  — cmd has no login concept and rejects POSIX flags
-//   - tcsh/csh:        ["-l"]  — tcsh requires -l as the only flag
-//   - all others:      ["-i", "-l"]
+//   - pwsh/pwsh-preview:        ["-Login"]  — PowerShell Core 6+
+//   - powershell(-preview):     nil  — Windows PowerShell 5.1 has no -Login
+//     and parses the unknown switch as a command name, raising
+//     "ObjectNotFound: (-Login:String), CommandNotFoundException".
+//   - cmd.exe:                  nil  — no login concept; rejects POSIX flags
+//   - tcsh/csh:                 ["-l"]  — tcsh requires -l as the only flag
+//   - all others:               ["-i", "-l"]
 func LoginShellArgs(shellPath string) []string {
 	name := ShellBaseName(shellPath)
 	switch {
-	case IsPwsh(name):
+	case pwshCorePattern.MatchString(name):
 		return []string{"-Login"}
+	case IsPwsh(name):
+		return nil
 	case name == "cmd":
 		return nil
 	case name == "tcsh" || name == "csh":

--- a/backend/internal/worker/terminal/login_shell_test.go
+++ b/backend/internal/worker/terminal/login_shell_test.go
@@ -24,6 +24,10 @@ func TestLoginShellArgs(t *testing.T) {
 		{"pwsh-preview", "/usr/bin/pwsh-preview", []string{"-Login"}},
 		{"pwsh.exe", `C:\Program Files\PowerShell\7\pwsh.exe`, []string{"-Login"}},
 		{"powershell.exe", `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, []string{"-Login"}},
+		{"cmd.exe", `C:\Windows\System32\cmd.exe`, nil},
+		{"cmd.exe upper", `C:\Windows\System32\CMD.EXE`, nil},
+		{"cmd bare", "cmd", nil},
+		{"powershell.exe upper", `C:\Windows\System32\WindowsPowerShell\v1.0\POWERSHELL.EXE`, []string{"-Login"}},
 		{"unknown", "/usr/bin/xonsh", []string{"-i", "-l"}},
 	}
 	for _, tt := range tests {
@@ -34,23 +38,15 @@ func TestLoginShellArgs(t *testing.T) {
 }
 
 func TestIsPwsh(t *testing.T) {
-	// Positive cases — Unix name forms
 	assert.True(t, IsPwsh("pwsh"))
 	assert.True(t, IsPwsh("powershell"))
 	assert.True(t, IsPwsh("pwsh-preview"))
 	assert.True(t, IsPwsh("powershell-preview"))
 
-	// Positive cases — Windows ".exe" suffix forms produced by filepath.Base
-	assert.True(t, IsPwsh("pwsh.exe"))
-	assert.True(t, IsPwsh("powershell.exe"))
-	assert.True(t, IsPwsh("pwsh-preview.exe"))
-	assert.True(t, IsPwsh("powershell-preview.exe"))
-
-	// Negative cases
 	assert.False(t, IsPwsh("bash"))
-	assert.False(t, IsPwsh("bash.exe"))
 	assert.False(t, IsPwsh("zsh"))
 	assert.False(t, IsPwsh("fish"))
 	assert.False(t, IsPwsh("pwsh-extra-stuff"))
-	assert.False(t, IsPwsh("pwshxexe")) // no dot -> must not match
+	// IsPwsh expects normalized input — callers must strip .exe via ShellBaseName.
+	assert.False(t, IsPwsh("pwsh.exe"))
 }

--- a/backend/internal/worker/terminal/login_shell_test.go
+++ b/backend/internal/worker/terminal/login_shell_test.go
@@ -20,14 +20,15 @@ func TestLoginShellArgs(t *testing.T) {
 		{"tcsh", "/bin/tcsh", []string{"-l"}},
 		{"csh", "/bin/csh", []string{"-l"}},
 		{"pwsh", "/usr/bin/pwsh", []string{"-Login"}},
-		{"powershell", "/usr/bin/powershell", []string{"-Login"}},
+		{"powershell", "/usr/bin/powershell", nil},
 		{"pwsh-preview", "/usr/bin/pwsh-preview", []string{"-Login"}},
+		{"powershell-preview", "/usr/bin/powershell-preview", nil},
 		{"pwsh.exe", `C:\Program Files\PowerShell\7\pwsh.exe`, []string{"-Login"}},
-		{"powershell.exe", `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, []string{"-Login"}},
+		{"powershell.exe", `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, nil},
 		{"cmd.exe", `C:\Windows\System32\cmd.exe`, nil},
 		{"cmd.exe upper", `C:\Windows\System32\CMD.EXE`, nil},
 		{"cmd bare", "cmd", nil},
-		{"powershell.exe upper", `C:\Windows\System32\WindowsPowerShell\v1.0\POWERSHELL.EXE`, []string{"-Login"}},
+		{"powershell.exe upper", `C:\Windows\System32\WindowsPowerShell\v1.0\POWERSHELL.EXE`, nil},
 		{"unknown", "/usr/bin/xonsh", []string{"-i", "-l"}},
 	}
 	for _, tt := range tests {
@@ -35,6 +36,23 @@ func TestLoginShellArgs(t *testing.T) {
 			assert.Equal(t, tt.want, LoginShellArgs(tt.shellPath))
 		})
 	}
+}
+
+// TestLoginShellArgs_WindowsPowerShellNoLogin pins the fix for a Windows
+// regression where opening a terminal whose default shell resolved to
+// powershell.exe (Windows PowerShell 5.1) printed:
+//
+//	-Login : The term '-Login' is not recognized as the name of a cmdlet…
+//	+ CategoryInfo : ObjectNotFound: (-Login:String) [], CommandNotFoundException
+//
+// 5.1's CLI parser falls back to treating an unrecognized leading token as
+// a command, so passing -Login made it try to *run* a command named
+// "-Login". Only pwsh (PowerShell Core 6+) understands the switch.
+func TestLoginShellArgs_WindowsPowerShellNoLogin(t *testing.T) {
+	assert.Nil(t, LoginShellArgs(`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`))
+	assert.Nil(t, LoginShellArgs("powershell"))
+	assert.Equal(t, []string{"-Login"}, LoginShellArgs(`C:\Program Files\PowerShell\7\pwsh.exe`))
+	assert.Equal(t, []string{"-Login"}, LoginShellArgs("pwsh"))
 }
 
 func TestIsPwsh(t *testing.T) {

--- a/backend/internal/worker/terminal/shells.go
+++ b/backend/internal/worker/terminal/shells.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 )
 
@@ -26,7 +25,7 @@ func computeShells() (shells []string, defaultShell string) {
 	}
 
 	knownShells := []string{"sh", "bash", "zsh", "fish", "pwsh", "powershell"}
-	defaultBase := strings.ToLower(strings.TrimSuffix(filepath.Base(defaultShell), ".exe"))
+	defaultBase := ShellBaseName(defaultShell)
 	for _, name := range knownShells {
 		if name == defaultBase {
 			continue

--- a/backend/internal/worker/terminal/shells_unix_test.go
+++ b/backend/internal/worker/terminal/shells_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveDefaultShell_Unix_PrefersLeapmuxEnv(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", "/bin/test-leapmux-shell")
+	t.Setenv("SHELL", "/bin/other-shell")
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.Equal(t, "/bin/test-leapmux-shell", shell)
+}
+
+func TestResolveDefaultShell_Unix_LeapmuxEnvBareName(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", "sh")
+	t.Setenv("SHELL", "/bin/other-shell")
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.NotEmpty(t, shell, "bare name should be resolved")
+	assert.True(t, strings.HasPrefix(shell, "/"), "resolved path should be absolute")
+	assert.True(t, strings.HasSuffix(shell, "/sh"), "resolved path should end with /sh")
+}
+
+func TestResolveDefaultShell_Unix_UsesEnvWhenSet(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
+	t.Setenv("SHELL", "/bin/test-shell")
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.Equal(t, "/bin/test-shell", shell, "ResolveDefaultShell should prefer $SHELL")
+}
+
+func TestResolveShellEnv_Unix_AbsolutePath(t *testing.T) {
+	t.Setenv("TEST_SHELL_ENV", "/usr/bin/zsh")
+	assert.Equal(t, "/usr/bin/zsh", resolveShellEnv("TEST_SHELL_ENV"))
+}
+
+func TestResolveShellEnv_Unix_BareNameResolved(t *testing.T) {
+	t.Setenv("TEST_SHELL_ENV", "sh")
+	result := resolveShellEnv("TEST_SHELL_ENV")
+	assert.NotEmpty(t, result)
+	assert.True(t, filepath.IsAbs(result))
+}

--- a/backend/internal/worker/terminal/shells_windows_test.go
+++ b/backend/internal/worker/terminal/shells_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package terminal
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Windows mirrors of the shell-env tests. On Windows, "absolute" paths
+// require a drive letter, and exec.LookPath honours PATHEXT (so a bare
+// "cmd" resolves to ...\cmd.exe).
+
+func TestResolveDefaultShell_Windows_PrefersLeapmuxEnv(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", `C:\test-leapmux-shell.exe`)
+	t.Setenv("SHELL", `C:\other-shell.exe`)
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.Equal(t, `C:\test-leapmux-shell.exe`, shell)
+}
+
+func TestResolveDefaultShell_Windows_LeapmuxEnvBareName(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", "cmd")
+	t.Setenv("SHELL", `C:\other-shell.exe`)
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.NotEmpty(t, shell, "bare name should be resolved")
+	assert.True(t, filepath.IsAbs(shell), "resolved path should be absolute, got %q", shell)
+	assert.True(t, strings.HasSuffix(strings.ToLower(shell), `\cmd.exe`), "resolved path should end with \\cmd.exe, got %q", shell)
+}
+
+func TestResolveDefaultShell_Windows_UsesEnvWhenSet(t *testing.T) {
+	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
+	t.Setenv("SHELL", `C:\test-shell.exe`)
+	resetShellCache()
+	shell := ResolveDefaultShell()
+	assert.Equal(t, `C:\test-shell.exe`, shell, "ResolveDefaultShell should prefer $SHELL")
+}
+
+func TestResolveShellEnv_Windows_AbsolutePath(t *testing.T) {
+	t.Setenv("TEST_SHELL_ENV", `C:\Windows\System32\cmd.exe`)
+	assert.Equal(t, `C:\Windows\System32\cmd.exe`, resolveShellEnv("TEST_SHELL_ENV"))
+}
+
+func TestResolveShellEnv_Windows_BareNameResolved(t *testing.T) {
+	t.Setenv("TEST_SHELL_ENV", "cmd")
+	result := resolveShellEnv("TEST_SHELL_ENV")
+	assert.NotEmpty(t, result)
+	assert.True(t, filepath.IsAbs(result), "expected absolute path, got %q", result)
+	assert.True(t, strings.HasSuffix(strings.ToLower(result), `\cmd.exe`), "expected to end with \\cmd.exe, got %q", result)
+}

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/creack/pty"
+	pty "github.com/aymanbagabas/go-pty"
 
 	"github.com/leapmux/leapmux/util/procutil"
 )
@@ -68,8 +68,9 @@ type OutputHandler func(data []byte)
 // Terminal manages a single PTY session.
 type Terminal struct {
 	id        string
-	cmd       *exec.Cmd
-	ptmx      *os.File
+	cmd       *pty.Cmd
+	ptmx      pty.Pty
+	jobObject *procutil.JobObject
 	outputFn  OutputHandler
 	screenBuf *ScreenBuffer
 	mu        sync.Mutex
@@ -97,27 +98,48 @@ func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 	}
 
 	args := LoginShellArgs(shell)
-	cmd := exec.Command(shell, args...)
+
+	ptmx, err := pty.New()
+	if err != nil {
+		return nil, fmt.Errorf("new pty: %w", err)
+	}
+
+	cmd := ptmx.Command(shell, args...)
 	cmd.Dir = opts.WorkingDir
 	cmd.Env = append(os.Environ(),
 		"TERM=xterm-256color",
 	)
-	procutil.HideConsoleWindow(cmd)
+	// No procutil.HideConsoleWindow here: on Windows, CREATE_NO_WINDOW is
+	// incompatible with ConPTY — the pseudo console already serves as the
+	// child's console, and the flag would leave it with none.
 
-	winSize := &pty.Winsize{
-		Cols: opts.Cols,
-		Rows: opts.Rows,
+	cols, rows := opts.Cols, opts.Rows
+	if cols == 0 {
+		cols = 80
 	}
-	if winSize.Cols == 0 {
-		winSize.Cols = 80
+	if rows == 0 {
+		rows = 24
 	}
-	if winSize.Rows == 0 {
-		winSize.Rows = 24
+	if err := ptmx.Resize(int(cols), int(rows)); err != nil {
+		_ = ptmx.Close()
+		return nil, fmt.Errorf("resize pty: %w", err)
 	}
 
-	ptmx, err := pty.StartWithSize(cmd, winSize)
-	if err != nil {
+	if err := cmd.Start(); err != nil {
+		_ = ptmx.Close()
 		return nil, fmt.Errorf("start pty: %w", err)
+	}
+
+	// Put the shell and its descendants into a kill group so closing the
+	// tab reaps the whole tree, not just the direct shell. Failure is
+	// non-fatal: the terminal still works, it just loses the tree-kill
+	// guarantee for this session.
+	jobObject, err := procutil.AssignPID(cmd.Process.Pid)
+	if err != nil {
+		slog.Warn("terminal attach job object failed",
+			"terminal_id", opts.ID,
+			"error", err,
+		)
 	}
 
 	screenBuf := NewScreenBuffer()
@@ -130,6 +152,7 @@ func Start(opts Options, outputFn OutputHandler) (*Terminal, error) {
 		id:        opts.ID,
 		cmd:       cmd,
 		ptmx:      ptmx,
+		jobObject: jobObject,
 		outputFn:  wrappedOutput,
 		screenBuf: screenBuf,
 		exitCh:    make(chan struct{}),
@@ -170,13 +193,13 @@ func (t *Terminal) Resize(cols, rows uint16) error {
 		return fmt.Errorf("terminal is stopped")
 	}
 
-	return pty.Setsize(t.ptmx, &pty.Winsize{
-		Cols: cols,
-		Rows: rows,
-	})
+	return t.ptmx.Resize(int(cols), int(rows))
 }
 
-// Stop terminates the terminal session.
+// Stop terminates the terminal session and every process spawned beneath
+// the shell. Closing the PTY master triggers the kernel's normal hang-up
+// flow; Terminate then reaps anything still alive in the shell's kill
+// group (JobObject on Windows, process-group SIGHUP+SIGKILL on Unix).
 func (t *Terminal) Stop() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -187,7 +210,15 @@ func (t *Terminal) Stop() {
 	t.stopped = true
 
 	_ = t.ptmx.Close()
-	if t.cmd.Process != nil {
+	if err := t.jobObject.Terminate(); err != nil {
+		slog.Debug("terminal job object terminate failed",
+			"terminal_id", t.id,
+			"error", err,
+		)
+	}
+	if t.jobObject == nil && t.cmd.Process != nil {
+		// Fallback when AssignPID failed at startup; better than leaking
+		// the direct shell process even if we lose the tree guarantee.
 		_ = t.cmd.Process.Kill()
 	}
 }
@@ -257,6 +288,12 @@ func (t *Terminal) waitForExit() {
 		} else {
 			t.exitCode = -1
 		}
+	}
+	if closeErr := t.jobObject.Close(); closeErr != nil {
+		slog.Debug("terminal job object close failed",
+			"terminal_id", t.id,
+			"error", closeErr,
+		)
 	}
 	close(t.exitCh)
 

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -3,7 +3,6 @@ package terminal
 import (
 	"context"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -17,25 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// skipIfNoPTY skips tests that spawn a real PTY. creack/pty returns
-// "unsupported" on Windows — the production worker falls back to ConPTY
-// where available, but the test harness uses /bin/sh directly which isn't
-// reachable from Windows anyway.
-func skipIfNoPTY(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("PTY tests require /bin/sh and creack/pty, which are not available on Windows")
-	}
-}
-
 func TestTerminal_StartAndStop(t *testing.T) {
-	skipIfNoPTY(t)
 	var mu sync.Mutex
 	var output []byte
 
 	term, err := Start(Options{
 		ID:         "test-1",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
@@ -47,7 +34,7 @@ func TestTerminal_StartAndStop(t *testing.T) {
 	require.NoError(t, err, "Start")
 
 	// Send a command.
-	require.NoError(t, term.SendInput([]byte("echo hello\n")), "SendInput")
+	require.NoError(t, term.SendInput([]byte("echo hello"+testutil.TestShellEnter())), "SendInput")
 
 	// Wait for output.
 	testutil.AssertEventually(t, func() bool {
@@ -66,10 +53,9 @@ func TestTerminal_StartAndStop(t *testing.T) {
 }
 
 func TestTerminal_Resize(t *testing.T) {
-	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-resize",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
@@ -84,10 +70,9 @@ func TestTerminal_Resize(t *testing.T) {
 }
 
 func TestTerminal_SendInputAfterStop(t *testing.T) {
-	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-stopped",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {})
 	require.NoError(t, err, "Start")
@@ -95,14 +80,13 @@ func TestTerminal_SendInputAfterStop(t *testing.T) {
 	term.Stop()
 	term.Wait()
 
-	assert.Error(t, term.SendInput([]byte("echo fail\n")), "expected error sending input after stop")
+	assert.Error(t, term.SendInput([]byte("echo fail"+testutil.TestShellEnter())), "expected error sending input after stop")
 }
 
 func TestTerminal_IsExited(t *testing.T) {
-	skipIfNoPTY(t)
 	term, err := Start(Options{
 		ID:         "test-exited",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {})
 	require.NoError(t, err, "Start")
@@ -116,12 +100,11 @@ func TestTerminal_IsExited(t *testing.T) {
 }
 
 func TestManager_StartAndRemove(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 
 	err := m.StartTerminal(Options{
 		ID:         "tm-1",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {}, nil)
 	require.NoError(t, err, "StartTerminal")
@@ -131,7 +114,7 @@ func TestManager_StartAndRemove(t *testing.T) {
 	// Duplicate should fail.
 	err = m.StartTerminal(Options{
 		ID:         "tm-1",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {}, nil)
 	assert.Error(t, err, "expected error for duplicate terminal")
@@ -151,12 +134,11 @@ func TestManager_StartAndRemove(t *testing.T) {
 }
 
 func TestManager_ExitedTerminalRejectsInput(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 
 	err := m.StartTerminal(Options{
 		ID:         "tm-exit",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {}, nil)
 	require.NoError(t, err, "StartTerminal")
@@ -177,7 +159,6 @@ func TestManager_ExitedTerminalRejectsInput(t *testing.T) {
 }
 
 func TestManager_ExitNotification(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 	exitCh := make(chan struct{})
 	var gotID string
@@ -185,7 +166,7 @@ func TestManager_ExitNotification(t *testing.T) {
 
 	err := m.StartTerminal(Options{
 		ID:         "tm-notify",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 	}, func([]byte) {}, func(id string, code int) {
 		gotID = id
@@ -210,13 +191,12 @@ func TestManager_ExitNotification(t *testing.T) {
 }
 
 func TestManager_StopAll(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 
 	for _, id := range []string{"a", "b"} {
 		err := m.StartTerminal(Options{
 			ID:         id,
-			Shell:      "/bin/sh",
+			Shell:      testutil.TestShell(),
 			WorkingDir: t.TempDir(),
 		}, func([]byte) {}, nil)
 		require.NoError(t, err, "StartTerminal(%s)", id)
@@ -254,11 +234,10 @@ func TestManager_Resize_UnknownTerminal(t *testing.T) {
 }
 
 func TestManager_Resize_SameDimensions(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 	err := m.StartTerminal(Options{
 		ID:         "tm-resize-noop",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
@@ -277,14 +256,13 @@ func TestManager_Resize_SameDimensions(t *testing.T) {
 }
 
 func TestManager_ScreenSnapshot(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 	var mu sync.Mutex
 	var output []byte
 
 	err := m.StartTerminal(Options{
 		ID:         "tm-snap",
-		Shell:      "/bin/sh",
+		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
@@ -296,7 +274,7 @@ func TestManager_ScreenSnapshot(t *testing.T) {
 	require.NoError(t, err, "StartTerminal")
 
 	// Send a command to produce output.
-	require.NoError(t, m.SendInput("tm-snap", []byte("echo snapshot_test\n")), "SendInput")
+	require.NoError(t, m.SendInput("tm-snap", []byte("echo snapshot_test"+testutil.TestShellEnter())), "SendInput")
 
 	// Wait for the output to arrive.
 	testutil.AssertEventually(t, func() bool {
@@ -344,7 +322,6 @@ func newTestDB(t *testing.T) *db.Queries {
 }
 
 func TestSnapshotTerminal(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 	var mu sync.Mutex
 	var output []byte
@@ -355,7 +332,7 @@ func TestSnapshotTerminal(t *testing.T) {
 	err := m.StartTerminal(Options{
 		ID:          termID,
 		WorkspaceID: wsID,
-		Shell:       "/bin/sh",
+		Shell:       testutil.TestShell(),
 		WorkingDir:  t.TempDir(),
 		Cols:        80,
 		Rows:        24,
@@ -366,7 +343,7 @@ func TestSnapshotTerminal(t *testing.T) {
 	}, nil)
 	require.NoError(t, err, "StartTerminal")
 
-	require.NoError(t, m.SendInput(termID, []byte("echo snapshot_single\n")), "SendInput")
+	require.NoError(t, m.SendInput(termID, []byte("echo snapshot_single"+testutil.TestShellEnter())), "SendInput")
 	testutil.AssertEventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -425,7 +402,6 @@ func TestUpsertAndGetTerminal(t *testing.T) {
 }
 
 func TestUpdateTitle(t *testing.T) {
-	skipIfNoPTY(t)
 	m := NewManager()
 	wsID := "ws-title"
 
@@ -433,7 +409,7 @@ func TestUpdateTitle(t *testing.T) {
 	err := m.StartTerminal(Options{
 		ID:          termID,
 		WorkspaceID: wsID,
-		Shell:       "/bin/sh",
+		Shell:       testutil.TestShell(),
 		WorkingDir:  t.TempDir(),
 		Cols:        80,
 		Rows:        24,
@@ -555,47 +531,12 @@ func TestDetectDefaultShell(t *testing.T) {
 	assert.True(t, filepath.IsAbs(shell), "detectDefaultShell should return an absolute path, got %q", shell)
 }
 
-func TestResolveDefaultShell_PrefersLeapmuxEnv(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
-	}
-	t.Setenv("LEAPMUX_DEFAULT_SHELL", "/bin/test-leapmux-shell")
-	t.Setenv("SHELL", "/bin/other-shell")
-	resetShellCache()
-	shell := ResolveDefaultShell()
-	assert.Equal(t, "/bin/test-leapmux-shell", shell)
-}
-
-func TestResolveDefaultShell_LeapmuxEnvBareName(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
-	}
-	t.Setenv("LEAPMUX_DEFAULT_SHELL", "sh")
-	t.Setenv("SHELL", "/bin/other-shell")
-	resetShellCache()
-	shell := ResolveDefaultShell()
-	assert.NotEmpty(t, shell, "bare name should be resolved")
-	assert.True(t, strings.HasPrefix(shell, "/"), "resolved path should be absolute")
-	assert.True(t, strings.HasSuffix(shell, "/sh"), "resolved path should end with /sh")
-}
-
 func TestResolveDefaultShell_LeapmuxEnvInvalidBareName(t *testing.T) {
 	t.Setenv("LEAPMUX_DEFAULT_SHELL", "nonexistent-shell-xyz")
 	t.Setenv("SHELL", "/bin/fallback-shell")
 	resetShellCache()
 	shell := ResolveDefaultShell()
 	assert.Equal(t, "/bin/fallback-shell", shell, "should fall back to $SHELL when LEAPMUX_DEFAULT_SHELL is unresolvable")
-}
-
-func TestResolveDefaultShell_UsesEnvWhenSet(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-shell-path test: Windows shell resolution is covered separately")
-	}
-	t.Setenv("LEAPMUX_DEFAULT_SHELL", "")
-	t.Setenv("SHELL", "/bin/test-shell")
-	resetShellCache()
-	shell := ResolveDefaultShell()
-	assert.Equal(t, "/bin/test-shell", shell, "ResolveDefaultShell should prefer $SHELL")
 }
 
 func TestResolveDefaultShell_FallsBackWhenEnvUnset(t *testing.T) {
@@ -610,21 +551,6 @@ func TestResolveDefaultShell_FallsBackWhenEnvUnset(t *testing.T) {
 func TestResolveShellEnv_Empty(t *testing.T) {
 	t.Setenv("TEST_SHELL_ENV", "")
 	assert.Equal(t, "", resolveShellEnv("TEST_SHELL_ENV"))
-}
-
-func TestResolveShellEnv_AbsolutePath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-shell-path test: /usr/bin/zsh is not an absolute path on Windows")
-	}
-	t.Setenv("TEST_SHELL_ENV", "/usr/bin/zsh")
-	assert.Equal(t, "/usr/bin/zsh", resolveShellEnv("TEST_SHELL_ENV"))
-}
-
-func TestResolveShellEnv_BareNameResolved(t *testing.T) {
-	t.Setenv("TEST_SHELL_ENV", "sh")
-	result := resolveShellEnv("TEST_SHELL_ENV")
-	assert.NotEmpty(t, result)
-	assert.True(t, filepath.IsAbs(result))
 }
 
 func TestResolveShellEnv_BareNameNotFound(t *testing.T) {

--- a/backend/util/procutil/procutil_other.go
+++ b/backend/util/procutil/procutil_other.go
@@ -3,8 +3,68 @@
 // Package procutil contains small helpers for configuring child processes.
 package procutil
 
-import "os/exec"
+import (
+	"os/exec"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// sighupGrace is how long Terminate waits between SIGHUP and SIGKILL to let
+// an interactive shell propagate SIGHUP to its job process groups.
+const sighupGrace = 200 * time.Millisecond
 
 // HideConsoleWindow suppresses the child's console window on Windows;
 // no-op on Unix.
 func HideConsoleWindow(*exec.Cmd) {}
+
+// JobObject is a process-tree kill group. On Unix it wraps a process group
+// leader PID: Terminate sends SIGHUP (letting an interactive shell propagate
+// to its jobs), waits briefly, then SIGKILLs the group. Methods are safe on
+// a nil receiver and idempotent.
+type JobObject struct {
+	pgid atomic.Int32 // 0 once Terminate/Close has consumed it
+}
+
+// AssignCmd is a no-op on Unix. Callers that need tree-kill semantics for an
+// arbitrary child process should start it with Setpgid and use AssignPID.
+// Retained as a no-op so agent startup paths keep the pre-existing Unix
+// behavior of relying on SIGTERM propagation.
+func AssignCmd(*exec.Cmd) (*JobObject, error) { return nil, nil }
+
+// AssignPID records pid as the leader of a process group to be torn down on
+// Terminate/Close. The caller is responsible for ensuring pid was started
+// such that it is its own process group leader (e.g. with SysProcAttr.Setsid
+// or Setpgid). go-pty's pty.Cmd sets Setsid on Unix, so PTY-spawned shells
+// satisfy this contract.
+func AssignPID(pid int) (*JobObject, error) {
+	j := &JobObject{}
+	j.pgid.Store(int32(pid))
+	return j, nil
+}
+
+// Terminate kills every process in the group. Sends SIGHUP first — interactive
+// shells handle SIGHUP by forwarding it to their own jobs (which run in
+// distinct process groups) — then SIGKILLs the leader's group after a short
+// grace period. Safe on nil receiver; idempotent.
+func (j *JobObject) Terminate() error {
+	if j == nil {
+		return nil
+	}
+	pgid := j.pgid.Swap(0)
+	if pgid == 0 {
+		return nil
+	}
+	_ = syscall.Kill(-int(pgid), syscall.SIGHUP)
+	time.Sleep(sighupGrace)
+	if err := syscall.Kill(-int(pgid), syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}
+
+// Close is equivalent to Terminate on Unix since there is no separate
+// handle to release. Safe on nil receiver; idempotent.
+func (j *JobObject) Close() error {
+	return j.Terminate()
+}

--- a/backend/util/procutil/procutil_windows.go
+++ b/backend/util/procutil/procutil_windows.go
@@ -4,18 +4,126 @@
 package procutil
 
 import (
+	"fmt"
 	"os/exec"
+	"sync/atomic"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // Win32 CREATE_NO_WINDOW — suppress the child's console allocation.
 const createNoWindow = 0x08000000
 
 // HideConsoleWindow suppresses the child's console window on Windows.
+//
+// Note: do NOT apply this to a process attached to a ConPTY — CREATE_NO_WINDOW
+// prevents the pseudo console from becoming the child's console, leaving the
+// process with no console at all and hanging stdio.
 func HideConsoleWindow(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}
+
+// JobObject wraps a Win32 job object configured with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Assigning a process to the job puts
+// the process and its descendants under a single kill group: closing the
+// handle (or calling Terminate) terminates the whole tree, which is the
+// only reliable way to avoid orphaned grandchildren on Windows since
+// there is no equivalent of Unix's process-group signalling.
+type JobObject struct {
+	handle atomic.Uintptr // windows.Handle; zero once Close has released it
+}
+
+// AssignCmd creates a kill-on-close job object and assigns cmd.Process to it.
+// Must be called after cmd.Start has succeeded. A nil *JobObject is returned
+// only when creation itself failed; callers may still invoke Terminate/Close
+// on a nil receiver safely.
+func AssignCmd(cmd *exec.Cmd) (*JobObject, error) {
+	return AssignPID(cmd.Process.Pid)
+}
+
+// AssignPID creates a kill-on-close job object and assigns the process with
+// the given PID to it. Equivalent to AssignCmd but usable when the caller
+// holds only the PID (e.g. go-pty's pty.Cmd doesn't expose *exec.Cmd).
+func AssignPID(pid int) (*JobObject, error) {
+	h, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("CreateJobObject: %w", err)
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		h,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, fmt.Errorf("SetInformationJobObject: %w", err)
+	}
+
+	procHandle, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, fmt.Errorf("OpenProcess: %w", err)
+	}
+	defer windows.CloseHandle(procHandle)
+
+	if err := windows.AssignProcessToJobObject(h, procHandle); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, fmt.Errorf("AssignProcessToJobObject: %w", err)
+	}
+
+	j := &JobObject{}
+	j.handle.Store(uintptr(h))
+	return j, nil
+}
+
+// Terminate kills every process currently in the job and releases the
+// handle. Consumes the handle atomically so a concurrent Close cannot
+// invalidate it mid-call; subsequent Terminate/Close are no-ops. Safe on
+// nil receiver.
+func (j *JobObject) Terminate() error {
+	if j == nil {
+		return nil
+	}
+	raw := j.handle.Swap(0)
+	if raw == 0 {
+		return nil
+	}
+	h := windows.Handle(raw)
+	termErr := windows.TerminateJobObject(h, 1)
+	closeErr := windows.CloseHandle(h)
+	if termErr != nil {
+		return termErr
+	}
+	return closeErr
+}
+
+// Close releases the kernel handle. Because the job was created with
+// KILL_ON_JOB_CLOSE, the kernel tears down any surviving processes when the
+// last handle is closed. Safe on nil receiver and idempotent; a no-op if
+// Terminate has already run.
+func (j *JobObject) Close() error {
+	if j == nil {
+		return nil
+	}
+	raw := j.handle.Swap(0)
+	if raw == 0 {
+		return nil
+	}
+	return windows.CloseHandle(windows.Handle(raw))
 }

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -336,7 +336,7 @@ export const infoLabel = style({
 export const infoValue = style({
   fontSize: 'var(--text-8)',
   color: 'var(--foreground)',
-  fontFamily: 'monospace',
+  fontFamily: 'var(--font-mono)',
   wordBreak: 'break-all',
 })
 

--- a/frontend/src/components/common/Dialog.test.tsx
+++ b/frontend/src/components/common/Dialog.test.tsx
@@ -93,7 +93,8 @@ describe('dialog', () => {
     const dialog = container.querySelector('dialog')!
     // Mock bounding rect so the click coordinates fall outside.
     dialog.getBoundingClientRect = () => ({ top: 100, left: 100, right: 500, bottom: 500, width: 400, height: 400, x: 100, y: 100, toJSON: () => {} })
-    // Simulate a click on the backdrop (target is dialog, coordinates outside content).
+    // Simulate a full press+release on the backdrop (target is dialog, coordinates outside content).
+    dialog.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }))
     dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 10, clientY: 10 }))
     expect(onClose).toHaveBeenCalled()
   })
@@ -107,7 +108,45 @@ describe('dialog', () => {
     ))
 
     const dialog = container.querySelector('dialog')!
-    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    dialog.getBoundingClientRect = () => ({ top: 100, left: 100, right: 500, bottom: 500, width: 400, height: 400, x: 100, y: 100, toJSON: () => {} })
+    dialog.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }))
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 10, clientY: 10 }))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when a drag started inside the dialog ends on the backdrop', () => {
+    const onClose = vi.fn()
+    const { container } = render(() => (
+      <Dialog title="Test" onClose={onClose}>
+        <p>Content</p>
+      </Dialog>
+    ))
+
+    const dialog = container.querySelector('dialog')!
+    dialog.getBoundingClientRect = () => ({ top: 100, left: 100, right: 500, bottom: 500, width: 400, height: 400, x: 100, y: 100, toJSON: () => {} })
+    const content = container.querySelector('p')!
+    // Press starts inside the dialog content (e.g. beginning of a text selection).
+    content.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 300, clientY: 300 }))
+    // Release ends on the backdrop — target is the dialog itself, coords outside content.
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 10, clientY: 10 }))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when a drag started on the backdrop ends inside the dialog', () => {
+    const onClose = vi.fn()
+    const { container } = render(() => (
+      <Dialog title="Test" onClose={onClose}>
+        <p>Content</p>
+      </Dialog>
+    ))
+
+    const dialog = container.querySelector('dialog')!
+    dialog.getBoundingClientRect = () => ({ top: 100, left: 100, right: 500, bottom: 500, width: 400, height: 400, x: 100, y: 100, toJSON: () => {} })
+    // Press starts on the backdrop.
+    dialog.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }))
+    // Release ends on the dialog content — click target is the content element.
+    const content = container.querySelector('p')!
+    content.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 300, clientY: 300 }))
     expect(onClose).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -18,6 +18,12 @@ interface DialogProps {
 export const Dialog: Component<DialogProps> = (props) => {
   let dialogRef!: HTMLDialogElement
   let unmounting = false
+  let pointerDownOnBackdrop = false
+
+  const isOutsideDialogRect = (clientX: number, clientY: number) => {
+    const rect = dialogRef.getBoundingClientRect()
+    return clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom
+  }
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -68,14 +74,21 @@ export const Dialog: Component<DialogProps> = (props) => {
       data-testid={props['data-testid']}
       data-busy={props.busy ? '' : undefined}
       aria-label={props.title}
+      onPointerDown={(e) => {
+        // Only treat this as a backdrop press if the pointer went down directly
+        // on the dialog element in the ::backdrop area. Presses that start
+        // inside the dialog content (e.g. the start of a text selection drag)
+        // must not be treated as backdrop interactions, even if the release
+        // lands on the backdrop.
+        pointerDownOnBackdrop = e.target === dialogRef && isOutsideDialogRect(e.clientX, e.clientY)
+      }}
       onClick={(e) => {
-        // Close on backdrop click: check if the click landed outside
-        // the dialog's bounding rect (i.e. on the ::backdrop).
-        if (e.target === dialogRef && !props.busy) {
-          const rect = dialogRef.getBoundingClientRect()
-          if (e.clientX < rect.left || e.clientX > rect.right || e.clientY < rect.top || e.clientY > rect.bottom) {
-            dialogRef.close()
-          }
+        // Close on backdrop click: require both press and release to land on
+        // the backdrop, so drags that end on the backdrop don't dismiss.
+        const startedOnBackdrop = pointerDownOnBackdrop
+        pointerDownOnBackdrop = false
+        if (startedOnBackdrop && e.target === dialogRef && !props.busy && isOutsideDialogRect(e.clientX, e.clientY)) {
+          dialogRef.close()
         }
       }}
       onClose={() => {

--- a/frontend/src/lib/shortcuts/defaults.ts
+++ b/frontend/src/lib/shortcuts/defaults.ts
@@ -23,6 +23,15 @@ export const DEFAULT_KEYBINDINGS: readonly Keybinding[] = [
   { key: '$mod+7', command: 'app.switchToTab7' },
   { key: '$mod+8', command: 'app.switchToTab8' },
   { key: '$mod+9', command: 'app.switchToTab9' },
+  { key: 'Alt+1', command: 'app.switchToTab1' },
+  { key: 'Alt+2', command: 'app.switchToTab2' },
+  { key: 'Alt+3', command: 'app.switchToTab3' },
+  { key: 'Alt+4', command: 'app.switchToTab4' },
+  { key: 'Alt+5', command: 'app.switchToTab5' },
+  { key: 'Alt+6', command: 'app.switchToTab6' },
+  { key: 'Alt+7', command: 'app.switchToTab7' },
+  { key: 'Alt+8', command: 'app.switchToTab8' },
+  { key: 'Alt+9', command: 'app.switchToTab9' },
 
   // Tab navigation
   { key: '$mod+BracketLeft', command: 'app.previousTab' },


### PR DESCRIPTION
## Motivation

LeapMux currently runs only on macOS and Linux. This PR adds first-class Windows support by wiring in ConPTY-based terminal sessions, Windows-compatible process lifecycle management, and platform-aware path and shell handling throughout the backend. It also introduces a Windows CI job that blocks merges, so regressions are caught automatically going forward.

## Modifications

- Replaced `creack/pty` with `github.com/aymanbagabas/go-pty` to get ConPTY support on Windows; the old library is now a transitive dependency only.
- Added `procutil.JobObject` abstraction: uses Win32 kill-on-close job objects on Windows and SIGHUP/SIGKILL process-group teardown on Unix, eliminating orphaned process trees on both platforms.
- Distinguished PowerShell Core (`pwsh` 6+, accepts `-Login`) from Windows PowerShell 5.1 (`powershell.exe`, rejects `-Login`) in `LoginShellArgs()`; `cmd.exe` is also handled explicitly.
- Introduced `pathutil.HasPathPrefix()` (case-insensitive on Windows, case-sensitive on POSIX) and `pathutil.NormalizeNative()` (converts MSYS/Git-Bash paths like `/c/foo/bar` to `C:\foo\bar` on Windows) for correct cross-platform path comparisons.
- Added `terminal.ShellBaseName()` that lowercases, strips `.exe`, and splits on both slash types, replacing fragile `filepath.Base()` calls throughout agent code.
- Changed agent provider registration from a single `binaryName string` to `binaryCandidates []string`; `resolveBinaryName()` probes each candidate in the login shell and caches results via `binaryAvailabilityCache` sync.Maps to avoid repeated expensive shell probes.
- Attached child processes to a job object in new `startCmd()` helper; added `LockAgent()` and `RestartAgent()` to `Manager` to serialize concurrent stop/start operations and fix a race in `/clear` context-reset notifications.
- Added `testutil.TestShell()` / `TestShellEnter()` helpers that abstract `cmd.exe`/`COMSPEC` vs `/bin/sh` and `\r\n` vs `\n` so existing tests run unmodified on Windows.
- Added a `ci-windows` workflow job on `windows-latest` that installs the full toolchain (MSVC, Rust, Go, Bun, buf, protoc, Task) and runs targeted Go tests; it now blocks merges alongside the existing Linux job.
- Worked around `mvdan/sh` backslash path-expansion on Windows in Taskfile installer bundling by `cd`-ing into bundle directories before glob expansion.
- Fixed Dialog backdrop dismissal: track pointer-down position and only close when both press and release land on the backdrop, preventing accidental dismissal from drag operations.
- Added Alt+1-9 keyboard shortcuts as Windows-friendly alternatives to Cmd/Ctrl+1-9 for tab switching.
- Changed hardcoded `monospace` to `var(--font-mono)` in `ChatView.css.ts`.

## Result

LeapMux can now be built and run on Windows. Terminal sessions use ConPTY, agent binaries (including MSVC-suffixed Codex variants) are discovered and cached correctly, and process trees are reliably cleaned up on exit. The new Windows CI job ensures ongoing compatibility. Users on Windows no longer encounter PowerShell 5.1 startup failures, orphaned subprocesses, or incorrect path-prefix comparisons against MSYS-style git paths.
