### PR TITLE
Document default login credentials in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,17 @@ Each `dev` target generates code and builds prerequisites, then launches `mprocs
 | `task dev-solo` | Go backend (`leapmux` solo) + Bun frontend dev server | Localhost-only, no login, single-user |
 | `task dev-desktop` | Bun frontend dev server + Tauri desktop app | Desktop app development (builds sidecar first) |
 
+### Default login
+
+`task dev` requires login and bootstraps a default admin user on first launch:
+
+- **Username:** `admin`
+- **Password:** `admin123`
+
+After signing in, open the user menu (top left) → **Profile…** → **Password**, enter the current and new passwords, and click **Change Password**.
+
+`task dev-solo` runs in solo mode and does not require login. `task dev-desktop` is no-login only inside the native Tauri window.
+
 ## Development
 
 ### Building


### PR DESCRIPTION
 ## Motivation

The Quick Start launches `task dev` which requires login, but the README never states the bootstrapped admin credentials. Finding `admin` / `admin123` currently requires reading
`backend/internal/hub/bootstrap/bootstrap.go`.

## Modifications

Add a "Default login" subsection to Quick Start covering:

- Default dev credentials (`admin` / `admin123`)
- Password change via the **Profile… → Password** dialog in the web UI
- Login behavior for `task dev-solo` (no login) and `task dev-desktop` (no-login only inside the native Tauri window)

## Result

New users can complete Quick Start without reading source code to discover the initial login.