### PR TITLE
feat(close): Make agent/terminal tab closure asynchronous

### DIFF
--- a/backend/internal/util/phasetrace/phasetrace.go
+++ b/backend/internal/util/phasetrace/phasetrace.go
@@ -1,0 +1,48 @@
+// Package phasetrace provides env-var-gated structured timing traces
+// used by perf e2e tests to reconstruct phase timelines from stderr.
+// Production logs are unaffected: when the gating env var is not set
+// to "1", every call is a single-bool-check no-op.
+//
+// Each domain constructs one Tracer with a fixed marker + message and
+// exposes a typed wrapper (e.g. agent.TraceStartupPhase,
+// service.traceTabClosePhase) so call sites don't pass marker strings
+// directly.
+package phasetrace
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Tracer emits structured timing log lines when its gate env var is
+// "1". The marker is written as the first key-value pair on every
+// line so grep-based log parsers can filter on it cheaply.
+type Tracer struct {
+	enabled bool
+	marker  string
+	message string
+}
+
+// New returns a Tracer gated on os.Getenv(envVar) == "1". The env var
+// is read once at construction time; toggling it at runtime has no
+// effect. marker is the value written as the "marker" key on every
+// emitted line; message is the slog record's top-level message.
+func New(envVar, marker, message string) *Tracer {
+	return &Tracer{
+		enabled: os.Getenv(envVar) == "1",
+		marker:  marker,
+		message: message,
+	}
+}
+
+// Log emits a slog.Info record with marker=<marker> prepended to the
+// caller-supplied key-value pairs. No-op when the tracer is disabled.
+func (t *Tracer) Log(kvs ...any) {
+	if !t.enabled {
+		return
+	}
+	args := make([]any, 0, 2+len(kvs))
+	args = append(args, "marker", t.marker)
+	args = append(args, kvs...)
+	slog.Info(t.message, args...)
+}

--- a/backend/internal/worker/agent/startuptrace.go
+++ b/backend/internal/worker/agent/startuptrace.go
@@ -1,25 +1,20 @@
 package agent
 
-import (
-	"log/slog"
-	"os"
+import "github.com/leapmux/leapmux/internal/util/phasetrace"
+
+// startupTracer emits structured timing log lines tagged with
+// marker=agent_startup_timing when LEAPMUX_TRACE_AGENT_STARTUP=1, so
+// that tests (e.g. the agent-startup-timing e2e) can parse the phase
+// timeline from stderr. Off by default — production logs are unaffected.
+var startupTracer = phasetrace.New(
+	"LEAPMUX_TRACE_AGENT_STARTUP",
+	"agent_startup_timing",
+	"agent startup timing",
 )
 
-// startupTraceEnabled is set at process start from the
-// LEAPMUX_TRACE_AGENT_STARTUP env var. When enabled, TraceStartupPhase
-// emits a slog.Info line tagged with marker=agent_startup_timing so that
-// tests (e.g. the agent-startup-timing e2e) can parse the phase timeline
-// from stderr. Off by default — production logs are unaffected.
-var startupTraceEnabled = os.Getenv("LEAPMUX_TRACE_AGENT_STARTUP") == "1"
-
-// TraceStartupPhase emits a structured timing log line for the given agent
-// startup phase. No-op unless LEAPMUX_TRACE_AGENT_STARTUP=1.
-//
-// Time is taken from the log handler at write time; the receiving test
-// correlates lines by agent_id and the phase name.
+// TraceStartupPhase emits a timing log line for the given agent
+// startup phase. Time is taken from the log handler at write time;
+// the receiving test correlates lines by agent_id and the phase name.
 func TraceStartupPhase(agentID, phase string) {
-	if !startupTraceEnabled {
-		return
-	}
-	slog.Info("agent startup timing", "marker", "agent_startup_timing", "agent_id", agentID, "phase", phase)
+	startupTracer.Log("agent_id", agentID, "phase", phase)
 }

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -164,25 +164,25 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		// Cancel any in-flight startup so the goroutine aborts the
-		// subprocess handshake cleanly.
-		svc.AgentStartup.cancelAndClear(agentID)
-
-		// Stop the agent process.
-		svc.Agents.StopAgent(agentID)
-
-		// Clean up per-agent output handler state.
-		svc.Output.CleanupAgent(agentID)
-
-		// Mark the agent as closed in the database.
-		if err := svc.Queries.CloseAgent(bgCtx(), agentID); err != nil {
-			slog.Error("failed to close agent in DB", "agent_id", agentID, "error", err)
-			sendInternalError(sender, "failed to close agent")
-			return
-		}
-
-		svc.unregisterTabAndCleanup(leapmuxv1.TabType_TAB_TYPE_AGENT, agentID)
-		sendProtoResponse(sender, &leapmuxv1.CloseAgentResponse{})
+		// The frontend fires this RPC as fire-and-forget after removing
+		// the tab from the UI. closeTabCommon tracks the handler on
+		// svc.Cleanup so a concurrent Shutdown can drain it, then runs
+		// the shared close-tab flow (stop → DB close → unregister →
+		// optional worktree remove). The AgentStartup goroutine's
+		// trailing rollback work is tracked separately by
+		// AgentStartup.WaitForInFlight and drained in Shutdown.
+		result := svc.closeTabCommon(
+			leapmuxv1.TabType_TAB_TYPE_AGENT,
+			agentID,
+			r.GetWorktreeAction(),
+			func() {
+				svc.AgentStartup.cancelAndClear(agentID)
+				svc.Agents.StopAgent(agentID)
+				svc.Output.CleanupAgent(agentID)
+			},
+			func() error { return svc.Queries.CloseAgent(bgCtx(), agentID) },
+		)
+		sendProtoResponse(sender, &leapmuxv1.CloseAgentResponse{Result: result})
 	})
 
 	d.Register("SendAgentMessage", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {

--- a/backend/internal/worker/service/close_during_startup_test.go
+++ b/backend/internal/worker/service/close_during_startup_test.go
@@ -41,7 +41,7 @@ import (
 func TestCloseAgent_DuringStartup_SuppressesActiveAndCleansUp(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Subscribe before OpenAgent so an accidental ACTIVE broadcast would
@@ -136,7 +136,7 @@ func TestCloseAgent_DuringStartup_RollsBackCreatedWorktree(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var closeOnce sync.Once
@@ -210,7 +210,7 @@ func TestCloseTerminal_DuringStartup_SuppressesReadyAndCleansUp(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	wWatch := &testResponseWriter{channelID: "test-ch"}
 

--- a/backend/internal/worker/service/close_tab.go
+++ b/backend/internal/worker/service/close_tab.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"database/sql"
+	"errors"
+	"log/slog"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// closeTabCommon runs the shared tab-close flow for the CloseAgent and
+// CloseTerminal handlers. The handler is tracked on svc.Cleanup so a
+// concurrent Shutdown drains it. On WorktreeAction_REMOVE, the worktree
+// is resolved BEFORE the tab→worktree association is dropped — otherwise
+// we'd lose the link needed to decide whether the worktree can be
+// deleted. If a partial failure occurs (DB soft-delete, worktree remove)
+// the returned result populates failure_message / failure_detail /
+// worktree_path / worktree_id so the UI can toast a warning. The
+// returned *CloseTabResult is never nil.
+func (svc *Context) closeTabCommon(
+	tabType leapmuxv1.TabType,
+	tabID string,
+	action leapmuxv1.WorktreeAction,
+	stopProcess func(),
+	closeDB func() error,
+) *leapmuxv1.CloseTabResult {
+	svc.Cleanup.Add(1)
+	defer svc.Cleanup.Done()
+
+	stopProcess()
+
+	// When REMOVE is requested, look up the worktree BEFORE the
+	// tab-worktree association is dropped, so we still see the link.
+	// The actual removal is gated on CountWorktreeTabs == 0 after
+	// unregister, which protects sibling tabs sharing the worktree.
+	var wtForRemoval *db.Worktree
+	if action == leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE {
+		wt, err := svc.Queries.GetWorktreeForTab(bgCtx(), db.GetWorktreeForTabParams{
+			TabType: tabType,
+			TabID:   tabID,
+		})
+		switch {
+		case err == nil:
+			wtForRemoval = &wt
+		case errors.Is(err, sql.ErrNoRows):
+			// Tab has no worktree association — REMOVE degrades to KEEP.
+		default:
+			// A real DB error degrades REMOVE to KEEP; log it so the
+			// degradation is observable rather than silent.
+			slog.Warn("failed to look up worktree for tab close", "tab_type", tabType, "tab_id", tabID, "error", err)
+		}
+	}
+
+	result := &leapmuxv1.CloseTabResult{}
+	if err := closeDB(); err != nil {
+		slog.Error("failed to close tab in DB", "tab_type", tabType, "tab_id", tabID, "error", err)
+		result.FailureMessage = dbCloseFailureMessage(tabType)
+		result.FailureDetail = err.Error()
+		return result
+	}
+
+	// When we resolved a worktree for REMOVE, guard the association
+	// delete by worktree_id via removeTabFromWorktree. Otherwise (KEEP,
+	// or REMOVE that degraded to no-worktree) fall through to the cheap
+	// single-query unregisterTab.
+	if wtForRemoval == nil {
+		svc.unregisterTab(tabType, tabID)
+		return result
+	}
+
+	svc.removeTabFromWorktree(tabType, tabID, wtForRemoval.ID)
+	remaining, countErr := svc.Queries.CountWorktreeTabs(bgCtx(), wtForRemoval.ID)
+	if countErr != nil {
+		slog.Warn("failed to count worktree tabs after close", "worktree_id", wtForRemoval.ID, "error", countErr)
+		return result
+	}
+	if remaining == 0 {
+		if err := svc.removeWorktreeFromDisk(*wtForRemoval, true); err != nil {
+			result.FailureMessage = "Failed to remove worktree"
+			result.FailureDetail = err.Error()
+			result.WorktreePath = wtForRemoval.WorktreePath
+			result.WorktreeId = wtForRemoval.ID
+		}
+	}
+	return result
+}
+
+func dbCloseFailureMessage(tabType leapmuxv1.TabType) string {
+	switch tabType {
+	case leapmuxv1.TabType_TAB_TYPE_AGENT:
+		return "Failed to close agent"
+	case leapmuxv1.TabType_TAB_TYPE_TERMINAL:
+		return "Failed to close terminal"
+	default:
+		return "Failed to close tab"
+	}
+}

--- a/backend/internal/worker/service/close_tab.go
+++ b/backend/internal/worker/service/close_tab.go
@@ -75,13 +75,14 @@ func (svc *Context) closeTabCommon(
 		slog.Warn("failed to count worktree tabs after close", "worktree_id", wtForRemoval.ID, "error", countErr)
 		return result
 	}
-	if remaining == 0 {
-		if err := svc.removeWorktreeFromDisk(*wtForRemoval, true); err != nil {
-			result.FailureMessage = "Failed to remove worktree"
-			result.FailureDetail = err.Error()
-			result.WorktreePath = wtForRemoval.WorktreePath
-			result.WorktreeId = wtForRemoval.ID
-		}
+	if remaining != 0 {
+		return result
+	}
+	if err := svc.removeWorktreeFromDisk(*wtForRemoval, true); err != nil {
+		result.FailureMessage = "Failed to remove worktree"
+		result.FailureDetail = err.Error()
+		result.WorktreePath = wtForRemoval.WorktreePath
+		result.WorktreeId = wtForRemoval.ID
 	}
 	return result
 }

--- a/backend/internal/worker/service/close_tab_test.go
+++ b/backend/internal/worker/service/close_tab_test.go
@@ -1,0 +1,537 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// --- Fixture ---------------------------------------------------------
+//
+// closeTabFixture bundles the setup common to the "happy path" close
+// tests: a service with one workspace, a real git repo + worktree on a
+// fresh branch, a registered agent or terminal, and a tab→worktree
+// association. The fixture registers drainAllInFlight via t.Cleanup *after*
+// its own t.TempDir() calls, so LIFO cleanup ordering drains in-flight
+// handlers before any fixture-owned disk is removed.
+
+type closeTabFixture struct {
+	svc   *Context
+	d     *channel.Dispatcher
+	w     *testResponseWriter
+	wtDir string
+	wtID  string
+	tabID string
+}
+
+func setupCloseTabFixture(t *testing.T, tabType leapmuxv1.TabType, scenario string) closeTabFixture {
+	t.Helper()
+	svc, d, w := setupTestService(t, "ws-1")
+
+	// The fixture only adds a worktree on a fresh branch named after
+	// the scenario, so a shared base repo is safe and saves ~4 git
+	// execs per call vs. initRepo.
+	repoDir := sharedCloseTabRepo(t)
+	wtDir := filepath.Join(t.TempDir(), scenario+"-wt")
+	run(t, repoDir, "git", "worktree", "add", "-b", scenario, wtDir)
+
+	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
+	require.NoError(t, err)
+
+	tabID := scenario + "-tab"
+	switch tabType {
+	case leapmuxv1.TabType_TAB_TYPE_AGENT:
+		createAgentForPath(t, svc, tabID, wtDir)
+	case leapmuxv1.TabType_TAB_TYPE_TERMINAL:
+		require.NoError(t, svc.Queries.UpsertTerminal(context.Background(), db.UpsertTerminalParams{
+			ID:          tabID,
+			WorkspaceID: "ws-1",
+			WorkingDir:  wtDir,
+			Screen:      []byte{},
+		}))
+	default:
+		t.Fatalf("unsupported tab type: %v", tabType)
+	}
+	svc.registerTabForWorktree(wtID, tabType, tabID)
+
+	t.Cleanup(func() { drainAllInFlight(svc) })
+
+	return closeTabFixture{svc: svc, d: d, w: w, wtDir: wtDir, wtID: wtID, tabID: tabID}
+}
+
+// --- CloseAgent -------------------------------------------------------
+
+func TestCloseAgent_WithWorktreeActionRemove_RemovesWorktreeSync(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_AGENT, "close-remove")
+
+	dispatch(fx.d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        fx.tabID,
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors, "unexpected RPC errors: %+v", fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+	var resp leapmuxv1.CloseAgentResponse
+	require.NoError(t, proto.Unmarshal(fx.w.responses[0].GetPayload(), &resp))
+	assert.Empty(t, resp.GetResult().GetFailureMessage(), "expected success, got failure: %s / %s", resp.GetResult().GetFailureMessage(), resp.GetResult().GetFailureDetail())
+
+	// Worktree directory gone.
+	_, statErr := os.Stat(fx.wtDir)
+	assert.True(t, os.IsNotExist(statErr), "expected worktree dir removed, stat err: %v", statErr)
+
+	// DB row soft-deleted.
+	row, err := fx.svc.Queries.GetWorktreeByID(context.Background(), fx.wtID)
+	require.NoError(t, err)
+	assert.True(t, row.DeletedAt.Valid, "expected DB row to be soft-deleted")
+}
+
+func TestCloseAgent_WithWorktreeActionKeep_PreservesWorktree(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_AGENT, "close-keep")
+
+	dispatch(fx.d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        fx.tabID,
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_KEEP,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+
+	// Worktree dir survives.
+	_, statErr := os.Stat(fx.wtDir)
+	assert.NoError(t, statErr, "expected worktree dir preserved")
+
+	// DB row still present and NOT soft-deleted.
+	row, err := fx.svc.Queries.GetWorktreeByID(context.Background(), fx.wtID)
+	require.NoError(t, err)
+	assert.False(t, row.DeletedAt.Valid, "worktree DB row should not be soft-deleted under KEEP")
+
+	// Tab association dropped.
+	count, err := fx.svc.Queries.CountWorktreeTabs(context.Background(), fx.wtID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestCloseAgent_WithWorktreeActionUnspecified_PreservesWorktree(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_AGENT, "close-default")
+
+	// No worktree_action set = UNSPECIFIED — should behave like KEEP.
+	dispatch(fx.d, "CloseAgent", &leapmuxv1.CloseAgentRequest{AgentId: fx.tabID}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+
+	_, statErr := os.Stat(fx.wtDir)
+	assert.NoError(t, statErr, "expected worktree dir preserved by default")
+}
+
+func TestCloseAgent_NoWorktree_Succeeds(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	// Agent without any worktree association.
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID:          "agent-noworktree",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+	}))
+
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        "agent-noworktree",
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.CloseAgentResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	assert.Empty(t, resp.GetResult().GetFailureMessage())
+}
+
+func TestCloseAgent_WorktreeRemove_OtherTabsStillOpen_PreservesWorktree(t *testing.T) {
+	// This test extends the fixture with a second agent on the same
+	// worktree; the fixture normally registers only fx.tabID. That
+	// sibling is what gates the worktree against removal even though
+	// the close request asks for REMOVE.
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_AGENT, "close-shared")
+	const siblingID = "close-shared-sibling"
+	createAgentForPath(t, fx.svc, siblingID, fx.wtDir)
+	fx.svc.registerTabForWorktree(fx.wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, siblingID)
+
+	dispatch(fx.d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        fx.tabID,
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+
+	// Other tab still references the worktree — it must survive.
+	_, statErr := os.Stat(fx.wtDir)
+	assert.NoError(t, statErr, "worktree must survive while other tabs reference it")
+
+	count, err := fx.svc.Queries.CountWorktreeTabs(context.Background(), fx.wtID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "exactly one tab should remain linked")
+}
+
+func TestCloseAgent_WorktreeRemoveFailure_ReturnsFailureMessage(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	// Create a worktree DB row pointing at a path that is NOT a git
+	// worktree. This makes `git worktree remove` fail; since the path
+	// still exists, removeWorktreeFromDisk must return an error.
+	repoDir := initRepo(t)
+	bogusPath := filepath.Join(t.TempDir(), "not-a-worktree")
+	require.NoError(t, os.MkdirAll(bogusPath, 0o755))
+	wtID := "wt-bogus"
+	require.NoError(t, svc.Queries.CreateWorktree(context.Background(), db.CreateWorktreeParams{
+		ID:           wtID,
+		WorktreePath: bogusPath,
+		RepoRoot:     repoDir,
+		BranchName:   "",
+	}))
+
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID:          "agent-fail",
+		WorkspaceID: "ws-1",
+		WorkingDir:  bogusPath,
+		HomeDir:     bogusPath,
+	}))
+	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-fail")
+
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        "agent-fail",
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.CloseAgentResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	assert.NotEmpty(t, resp.GetResult().GetFailureMessage(), "expected failure message for unremovable worktree")
+	assert.Contains(t, resp.GetResult().GetFailureDetail(), bogusPath, "detail should include worktree path")
+	assert.Equal(t, bogusPath, resp.GetResult().GetWorktreePath())
+	assert.Equal(t, wtID, resp.GetResult().GetWorktreeId())
+
+	// Disk orphan remains.
+	_, statErr := os.Stat(bogusPath)
+	assert.NoError(t, statErr, "disk path should still exist when removal failed")
+
+	// Per the plan, the DB row is still soft-deleted (a stale row is
+	// less harmful than a live row pointing at an unremovable path).
+	row, err := svc.Queries.GetWorktreeByID(context.Background(), wtID)
+	require.NoError(t, err)
+	assert.True(t, row.DeletedAt.Valid, "DB row should be soft-deleted even on disk-remove failure")
+}
+
+func TestCloseAgent_WorktreeRemove_DiskAlreadyGone_StillDeletesDBRow(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_AGENT, "close-gone")
+
+	// Simulate the user manually deleting the worktree directory before
+	// closing the tab. git worktree-remove will fail, but os.Stat tells
+	// us the path is already gone, so the handler treats it as success.
+	require.NoError(t, os.RemoveAll(fx.wtDir))
+
+	dispatch(fx.d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId:        fx.tabID,
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+	var resp leapmuxv1.CloseAgentResponse
+	require.NoError(t, proto.Unmarshal(fx.w.responses[0].GetPayload(), &resp))
+	assert.Empty(t, resp.GetResult().GetFailureMessage(), "path already gone should count as success")
+
+	row, err := fx.svc.Queries.GetWorktreeByID(context.Background(), fx.wtID)
+	require.NoError(t, err)
+	assert.True(t, row.DeletedAt.Valid, "DB row should be soft-deleted")
+}
+
+func TestCloseAgent_AlreadyClosed_Idempotent(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID:          "agent-idem",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+	}))
+
+	// First close.
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{AgentId: "agent-idem"}, w)
+	require.Empty(t, w.errors)
+
+	// Second close — requireAccessibleAgent should reject because the
+	// agent is now closed. That's acceptable; the key property is the
+	// handler does not wedge the Cleanup wait-group.
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{AgentId: "agent-idem"}, w)
+	// Accept either a benign error or a success response.
+	// What we actually require: Cleanup wait-group is not stuck.
+	done := make(chan struct{})
+	go func() {
+		svc.Cleanup.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Cleanup.Wait did not return after double close")
+	}
+}
+
+// --- CloseTerminal mirrors --------------------------------------------
+
+func TestCloseTerminal_WithWorktreeActionRemove_RemovesWorktreeSync(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_TERMINAL, "t-close-remove")
+
+	dispatch(fx.d, "CloseTerminal", &leapmuxv1.CloseTerminalRequest{
+		TerminalId:     fx.tabID,
+		WorkspaceId:    "ws-1",
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	require.Len(t, fx.w.responses, 1)
+	var resp leapmuxv1.CloseTerminalResponse
+	require.NoError(t, proto.Unmarshal(fx.w.responses[0].GetPayload(), &resp))
+	assert.Empty(t, resp.GetResult().GetFailureMessage())
+
+	_, statErr := os.Stat(fx.wtDir)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestCloseTerminal_WithWorktreeActionUnspecified_PreservesWorktree(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_TERMINAL, "t-close-default")
+
+	// No worktree_action = UNSPECIFIED, treated as KEEP.
+	dispatch(fx.d, "CloseTerminal", &leapmuxv1.CloseTerminalRequest{
+		TerminalId:  fx.tabID,
+		WorkspaceId: "ws-1",
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	_, statErr := os.Stat(fx.wtDir)
+	assert.NoError(t, statErr, "expected worktree dir preserved by default")
+}
+
+func TestCloseTerminal_NoWorktree_Succeeds(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	require.NoError(t, svc.Queries.UpsertTerminal(context.Background(), db.UpsertTerminalParams{
+		ID:          "term-noworktree",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		Screen:      []byte{},
+	}))
+
+	dispatch(d, "CloseTerminal", &leapmuxv1.CloseTerminalRequest{
+		TerminalId:     "term-noworktree",
+		WorkspaceId:    "ws-1",
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_REMOVE,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.CloseTerminalResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	assert.Empty(t, resp.GetResult().GetFailureMessage())
+}
+
+func TestCloseTerminal_WithWorktreeActionKeep_PreservesWorktree(t *testing.T) {
+	fx := setupCloseTabFixture(t, leapmuxv1.TabType_TAB_TYPE_TERMINAL, "t-close-keep")
+
+	dispatch(fx.d, "CloseTerminal", &leapmuxv1.CloseTerminalRequest{
+		TerminalId:     fx.tabID,
+		WorkspaceId:    "ws-1",
+		WorktreeAction: leapmuxv1.WorktreeAction_WORKTREE_ACTION_KEEP,
+	}, fx.w)
+
+	require.Empty(t, fx.w.errors)
+	_, statErr := os.Stat(fx.wtDir)
+	assert.NoError(t, statErr)
+}
+
+// --- removeWorktreeFromDisk direct coverage ---------------------------
+
+func TestRemoveWorktreeFromDisk_Success_ReturnsNil(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	repoDir := initRepo(t)
+	wtDir := filepath.Join(t.TempDir(), "rwtfd-ok")
+	run(t, repoDir, "git", "worktree", "add", "-b", "rwtfd-ok", wtDir)
+
+	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
+	require.NoError(t, err)
+	wt, err := svc.Queries.GetWorktreeByID(context.Background(), wtID)
+	require.NoError(t, err)
+
+	err = svc.removeWorktreeFromDisk(wt, true)
+	assert.NoError(t, err)
+	_, statErr := os.Stat(wtDir)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveWorktreeFromDisk_GitFailure_PathIntact_ReturnsError(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	repoDir := initRepo(t)
+	bogusPath := filepath.Join(t.TempDir(), "rwtfd-fail")
+	require.NoError(t, os.MkdirAll(bogusPath, 0o755))
+
+	wt := db.Worktree{
+		ID:           "wt-bogus",
+		WorktreePath: bogusPath,
+		RepoRoot:     repoDir,
+	}
+	require.NoError(t, svc.Queries.CreateWorktree(context.Background(), db.CreateWorktreeParams{
+		ID:           wt.ID,
+		WorktreePath: wt.WorktreePath,
+		RepoRoot:     wt.RepoRoot,
+	}))
+
+	err := svc.removeWorktreeFromDisk(wt, true)
+	assert.Error(t, err, "git-remove failure with path intact should return error")
+	assert.Contains(t, err.Error(), bogusPath)
+
+	// Disk path still present.
+	_, statErr := os.Stat(bogusPath)
+	assert.NoError(t, statErr)
+
+	// DB row still soft-deleted.
+	row, err := svc.Queries.GetWorktreeByID(context.Background(), wt.ID)
+	require.NoError(t, err)
+	assert.True(t, row.DeletedAt.Valid, "DB row soft-deleted even on failure")
+}
+
+func TestRemoveWorktreeFromDisk_PathMissing_ReturnsNil(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	repoDir := initRepo(t)
+	wtDir := filepath.Join(t.TempDir(), "rwtfd-missing")
+	// Never create the directory — it's missing from the start.
+
+	wt := db.Worktree{
+		ID:           "wt-missing",
+		WorktreePath: wtDir,
+		RepoRoot:     repoDir,
+	}
+	require.NoError(t, svc.Queries.CreateWorktree(context.Background(), db.CreateWorktreeParams{
+		ID:           wt.ID,
+		WorktreePath: wt.WorktreePath,
+		RepoRoot:     wt.RepoRoot,
+	}))
+
+	err := svc.removeWorktreeFromDisk(wt, true)
+	assert.NoError(t, err, "missing path should count as success")
+
+	row, err := svc.Queries.GetWorktreeByID(context.Background(), wt.ID)
+	require.NoError(t, err)
+	assert.True(t, row.DeletedAt.Valid, "DB row soft-deleted")
+}
+
+func TestForceRemoveWorktree_GitFailure_PathIntact_ReturnsInternalError(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	repoDir := initRepo(t)
+	bogusPath := filepath.Join(t.TempDir(), "force-fail")
+	require.NoError(t, os.MkdirAll(bogusPath, 0o755))
+	wtID := "wt-force-bogus"
+	require.NoError(t, svc.Queries.CreateWorktree(context.Background(), db.CreateWorktreeParams{
+		ID:           wtID,
+		WorktreePath: bogusPath,
+		RepoRoot:     repoDir,
+	}))
+
+	dispatch(d, "ForceRemoveWorktree", &leapmuxv1.ForceRemoveWorktreeRequest{WorktreeId: wtID}, w)
+
+	require.Len(t, w.errors, 1, "expected an RPC error; responses=%+v", w.responses)
+	assert.Contains(t, strings.ToLower(w.errors[0].message), "git worktree remove")
+}
+
+// --- Shutdown waiting -------------------------------------------------
+
+func TestShutdown_WaitsForInFlightClose(t *testing.T) {
+	svc, d, w := setupTestService(t, "ws-1")
+	// Intentionally do NOT defer drainAllInFlight — this test invokes
+	// Shutdown explicitly, which performs the same wait.
+
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID:          "agent-slow",
+		WorkspaceID: "ws-1",
+		WorkingDir:  t.TempDir(),
+		HomeDir:     t.TempDir(),
+	}))
+
+	// Manually Add(1) to the cleanup wait-group to simulate an
+	// in-flight close still doing work while Shutdown races it.
+	svc.Cleanup.Add(1)
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		svc.Shutdown()
+		close(shutdownDone)
+	}()
+
+	// Shutdown must not complete while a handler is still in flight.
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned while close was still in flight")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	svc.Cleanup.Done()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown did not return after cleanup finished")
+	}
+
+	// Smoke: dispatcher still functional post-shutdown isn't required.
+	_ = d
+	_ = w
+}
+
+func TestShutdown_WaitsForCloseAfterHandlerPanic(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+
+	// Simulate a handler that panics: Add(1) has been called, and the
+	// deferred Done() MUST still fire.
+	func() {
+		defer func() { _ = recover() }()
+		svc.Cleanup.Add(1)
+		defer svc.Cleanup.Done()
+		panic("simulated handler panic")
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		svc.Shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown hung after a handler panic")
+	}
+}

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -124,17 +124,19 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 	return svc, d, w
 }
 
-// drainStartups joins any runAgentStartup / runTerminalStartup goroutines
-// spawned during the test. Call via `defer` immediately after
+// drainAllInFlight joins any runAgentStartup / runTerminalStartup
+// goroutines spawned during the test and waits for any in-flight close
+// handlers tracked on svc.Cleanup. Call via `defer` immediately after
 // setupTestService so it fires ahead of t.Cleanup-registered TempDir
 // removal (test-body t.TempDir cleanups run first in LIFO order, and a
 // `defer` runs even earlier — before any t.Cleanup). Without this, the
-// goroutine's trailing DB writes, git rollback, or broadcast work can
-// race the cleanup, surfacing as "sql: database is closed" warnings or
-// "directory not empty" TempDir removal failures.
-func drainStartups(svc *Context) {
+// background goroutines' trailing DB writes, git rollback, or broadcast
+// work can race the cleanup, surfacing as "sql: database is closed"
+// warnings or "directory not empty" TempDir removal failures.
+func drainAllInFlight(svc *Context) {
 	svc.AgentStartup.WaitForInFlight()
 	svc.TerminalStartup.WaitForInFlight()
+	svc.Cleanup.Wait()
 }
 
 // dispatch is a helper that marshals a request proto and dispatches it.

--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -9,13 +9,14 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
-	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/pathutil"
 	"github.com/leapmux/leapmux/internal/util/validate"
 	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
+	"golang.org/x/sync/errgroup"
 )
 
 // registerGitHandlers registers handlers for git operations on the local filesystem.
@@ -270,12 +271,21 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
+		// Track on Cleanup so a concurrent Shutdown waits for the
+		// errgroup in inspectLastTabClose to finish instead of tearing
+		// down the DB mid-query.
+		svc.Cleanup.Add(1)
+		defer svc.Cleanup.Done()
+
+		traceTabClosePhase("inspect", r.GetTabId(), "handler_begin")
 		resp, err := svc.inspectLastTabClose(bgCtx(), r.GetTabType(), r.GetTabId())
 		if err != nil {
 			slog.Error("inspect last tab close failed", "tab_type", r.GetTabType(), "tab_id", r.GetTabId(), "error", err)
+			traceTabClosePhase("inspect", r.GetTabId(), "handler_error")
 			sendInternalError(sender, err.Error())
 			return
 		}
+		traceTabClosePhase("inspect", r.GetTabId(), "handler_end")
 		sendProtoResponse(sender, resp)
 	})
 
@@ -291,20 +301,6 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 		sendProtoResponse(sender, &leapmuxv1.PushBranchForCloseResponse{})
-	})
-
-	d.Register("ScheduleWorktreeDeletion", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
-		var r leapmuxv1.ScheduleWorktreeDeletionRequest
-		if err := unmarshalRequest(req, &r); err != nil {
-			sendInvalidArgument(sender, "invalid request")
-			return
-		}
-
-		if err := svc.scheduleWorktreeDeletion(bgCtx(), r.GetWorktreeId()); err != nil {
-			sendInternalError(sender, err.Error())
-			return
-		}
-		sendProtoResponse(sender, &leapmuxv1.ScheduleWorktreeDeletionResponse{})
 	})
 
 	d.Register("CheckWorktreeStatus", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
@@ -352,24 +348,11 @@ func registerGitHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		// Remove worktree from disk.
-		if err := gitCommand(ctx, wt.RepoRoot, "worktree", "remove", "--force", wt.WorktreePath); err != nil {
-			slog.Warn("failed to remove worktree from disk", "path", wt.WorktreePath, "error", err)
-			// Continue anyway; the worktree may already be gone.
-		}
-
-		// Try to delete the branch.
-		if wt.BranchName != "" {
-			if err := gitCommand(ctx, wt.RepoRoot, "branch", "-D", wt.BranchName); err != nil {
-				slog.Debug("failed to delete branch", "branch", wt.BranchName, "error", err)
-				// Non-fatal: branch may have been merged or already deleted.
-			}
-		}
-
-		// Delete from DB.
-		if err := svc.Queries.DeleteWorktree(ctx, wt.ID); err != nil {
-			slog.Error("failed to delete worktree from DB", "id", wt.ID, "error", err)
-			sendInternalError(sender, "failed to delete worktree record")
+		// Remove worktree from disk + branch + DB row. Reports an error
+		// when the git worktree-remove failed AND the directory is still
+		// on disk, so the caller knows manual cleanup is needed.
+		if err := svc.removeWorktreeFromDisk(wt, true); err != nil {
+			sendInternalError(sender, err.Error())
 			return
 		}
 
@@ -425,13 +408,68 @@ func (t *tabGitContext) commitDir() string {
 }
 
 func (svc *Context) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.TabType, tabID string) (*leapmuxv1.InspectLastTabCloseResponse, error) {
-	tabCtx, err := svc.loadTabGitContext(ctx, tabType, tabID)
-	if err != nil {
-		// If the tab's working directory is not (or no longer) a git repository,
-		// there is nothing to prompt about — allow the tab to close normally.
-		return &leapmuxv1.InspectLastTabCloseResponse{
-			Target: leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE,
-		}, nil
+	trace := func(phase string) { traceTabClosePhase("inspect", tabID, phase) }
+
+	// Fast path: the only reason to run the expensive git subprocesses
+	// (diffStatsForPath, pushStatusForPath) is to populate the dialog.
+	// If the tab count already tells us no dialog will be shown, we can
+	// answer from DB alone and skip every git call below.
+	//
+	// - Worktree tab with siblings (CountWorktreeTabs > 1) → no prompt.
+	//   Answer entirely from the worktree DB row; don't touch git.
+	// - Non-worktree tab with other tabs on the same branch (otherTabs
+	//   > 0) → no prompt. We still need the branch name to do the
+	//   sibling count, so loadTabGitContext still runs; but diff/push
+	//   are skipped.
+	//
+	// When shouldPrompt is false, the frontend ignores diff_* / push_*
+	// fields, so leaving them zero is safe.
+	var tabCtx *tabGitContext
+	if wt, err := svc.Queries.GetWorktreeForTab(ctx, db.GetWorktreeForTabParams{
+		TabType: tabType,
+		TabID:   tabID,
+	}); err == nil {
+		count, countErr := svc.Queries.CountWorktreeTabs(ctx, wt.ID)
+		trace("worktree_count_done")
+		if countErr == nil && count > 1 {
+			trace("fast_path_taken")
+			return &leapmuxv1.InspectLastTabCloseResponse{
+				Target:       leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_WORKTREE,
+				ShouldPrompt: false,
+				RepoRoot:     wt.RepoRoot,
+				WorktreePath: wt.WorktreePath,
+				WorktreeId:   wt.ID,
+				BranchName:   wt.BranchName,
+			}, nil
+		}
+		// The worktree DB row already carries RepoRoot / BranchName /
+		// WorktreePath, so we can skip getTabWorkingDir (DB),
+		// queryGitPathInfo (rev-parse), branchOrShortSHA (possibly
+		// another rev-parse), and GetWorktreeByPath (DB) — all work
+		// that loadTabGitContext would otherwise repeat on the
+		// dialog-latency path.
+		tabCtx = &tabGitContext{
+			workingDir:   wt.WorktreePath,
+			repoRoot:     wt.RepoRoot,
+			branchName:   wt.BranchName,
+			worktreeRoot: wt.WorktreePath,
+			worktreeID:   wt.ID,
+			isWorktree:   true,
+		}
+		trace("git_ctx_synth")
+	}
+
+	if tabCtx == nil {
+		loaded, err := svc.loadTabGitContext(ctx, tabType, tabID)
+		trace("git_ctx_done")
+		if err != nil {
+			// If the tab's working directory is not (or no longer) a git repository,
+			// there is nothing to prompt about — allow the tab to close normally.
+			return &leapmuxv1.InspectLastTabCloseResponse{
+				Target: leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE,
+			}, nil
+		}
+		tabCtx = loaded
 	}
 
 	resp := &leapmuxv1.InspectLastTabCloseResponse{
@@ -440,20 +478,57 @@ func (svc *Context) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 		BranchName: tabCtx.branchName,
 	}
 
-	statsPath := tabCtx.commitDir()
-	added, deleted, untracked, hasChanges, err := diffStatsForPath(ctx, statsPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect diff stats: %w", err)
+	// Non-worktree fast path: if there are sibling tabs on the same
+	// branch, we'll never prompt regardless of git state — skip diff
+	// and push.
+	if !tabCtx.isWorktree {
+		hasOther, err := svc.hasOtherNonWorktreeTabOnBranch(ctx, tabType, tabID, tabCtx.repoRoot, tabCtx.branchName)
+		trace("branch_count_done")
+		if err != nil {
+			return nil, err
+		}
+		if hasOther {
+			trace("fast_path_taken")
+			return resp, nil
+		}
 	}
+
+	// diffStatsForPath and pushStatusForPath are independent git
+	// subprocesses on the same working directory; run them concurrently
+	// so the dialog-latency path pays the max of the two, not the sum.
+	statsPath := tabCtx.commitDir()
+	var (
+		added, deleted, untracked int32
+		hasChanges                bool
+		push                      pushStatus
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		a, d, u, hc, err := diffStatsForPath(gctx, statsPath)
+		if err != nil {
+			return fmt.Errorf("failed to inspect diff stats: %w", err)
+		}
+		added, deleted, untracked, hasChanges = a, d, u, hc
+		return nil
+	})
+	g.Go(func() error {
+		ps, err := pushStatusForPath(gctx, statsPath, tabCtx.branchName)
+		if err != nil {
+			return fmt.Errorf("failed to inspect push status: %w", err)
+		}
+		push = ps
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	// Single emission covers both parallel calls completing — their
+	// individual timestamps are no longer meaningful once they race.
+	trace("diff_and_push_done")
 	resp.DiffAdded = added
 	resp.DiffDeleted = deleted
 	resp.DiffUntracked = untracked
 	resp.HasUncommittedChanges = hasChanges
-
-	push, err := pushStatusForPath(ctx, tabCtx.commitDir(), tabCtx.branchName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect push status: %w", err)
-	}
 	resp.UnpushedCommitCount = push.Unpushed
 	resp.UpstreamExists = push.UpstreamExists
 	resp.RemoteBranchMissing = push.RemoteMissing
@@ -461,22 +536,20 @@ func (svc *Context) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 	resp.CanPush = push.CanPush(tabCtx.branchName)
 
 	if tabCtx.isWorktree {
-		tabCount, err := svc.Queries.CountWorktreeTabs(ctx, tabCtx.worktreeID)
-		if err != nil {
-			return nil, err
-		}
+		// If we reached here, the worktree fast path didn't apply
+		// (GetWorktreeForTab miss or count <= 1). The last-tab case is
+		// the only reason we still need worktree details in the
+		// response.
 		resp.Target = leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_WORKTREE
-		resp.ShouldPrompt = tabCount <= 1
+		resp.ShouldPrompt = true
 		resp.WorktreePath = tabCtx.worktreeRoot
 		resp.WorktreeId = tabCtx.worktreeID
 		return resp, nil
 	}
 
-	otherTabs, err := svc.countOtherNonWorktreeTabsOnBranch(ctx, tabType, tabID, tabCtx.repoRoot, tabCtx.branchName)
-	if err != nil {
-		return nil, err
-	}
-	if otherTabs == 0 && (hasChanges || push.Unpushed > 0 || push.RemoteMissing) {
+	// Non-worktree, last tab on branch: prompt only if the branch has
+	// state the user might lose.
+	if hasChanges || push.Unpushed > 0 || push.RemoteMissing {
 		resp.Target = leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_BRANCH
 		resp.ShouldPrompt = true
 	}
@@ -531,41 +604,6 @@ func (svc *Context) pushBranchForClose(ctx context.Context, tabType leapmuxv1.Ta
 		}
 		return fmt.Errorf("git push failed: %w", err)
 	}
-	return nil
-}
-
-func (svc *Context) scheduleWorktreeDeletion(ctx context.Context, worktreeID string) error {
-	wt, err := svc.Queries.GetWorktreeByID(ctx, worktreeID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return errors.New("worktree not found")
-		}
-		return err
-	}
-
-	count, err := svc.Queries.CountWorktreeTabs(ctx, wt.ID)
-	if err != nil {
-		return err
-	}
-	if count > 1 {
-		return errors.New("cannot delete worktree while tabs are still open")
-	}
-
-	go func() {
-		for i := 0; i < 50; i++ {
-			remaining, err := svc.Queries.CountWorktreeTabs(bgCtx(), wt.ID)
-			if err != nil {
-				slog.Warn("scheduled worktree deletion count failed", "worktree_id", wt.ID, "error", err)
-				return
-			}
-			if remaining == 0 {
-				svc.removeWorktreeFromDisk(wt, true)
-				return
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		slog.Warn("scheduled worktree deletion timed out waiting for tabs to close", "worktree_id", wt.ID)
-	}()
 	return nil
 }
 
@@ -630,46 +668,40 @@ func (svc *Context) getTabWorkingDir(ctx context.Context, tabType leapmuxv1.TabT
 	}
 }
 
-func (svc *Context) countOtherNonWorktreeTabsOnBranch(ctx context.Context, tabType leapmuxv1.TabType, tabID, repoRoot, branchName string) (int, error) {
+func (svc *Context) hasOtherNonWorktreeTabOnBranch(ctx context.Context, tabType leapmuxv1.TabType, tabID, repoRoot, branchName string) (bool, error) {
 	// Two terminals in the same repo share a workingDir; cache so each unique
 	// dir costs one rev-parse.
 	infoCache := map[string]*gitPathInfo{}
 
-	countMatching := func(query string, skipType leapmuxv1.TabType) (int, error) {
+	scan := func(query string, skipType leapmuxv1.TabType) (bool, error) {
 		rows, err := svc.DB.QueryContext(ctx, query)
 		if err != nil {
-			return 0, err
+			return false, err
 		}
 		defer func() {
 			if closeErr := rows.Close(); closeErr != nil {
 				slog.Warn("failed to close row iterator", "error", closeErr)
 			}
 		}()
-		n := 0
 		for rows.Next() {
 			var id, workingDir string
 			if err := rows.Scan(&id, &workingDir); err != nil {
-				return 0, err
+				return false, err
 			}
 			if tabType == skipType && id == tabID {
 				continue
 			}
 			if matches, err := tabMatchesBranch(ctx, workingDir, repoRoot, branchName, infoCache); err == nil && matches {
-				n++
+				return true, nil
 			}
 		}
-		return n, nil
+		return false, nil
 	}
 
-	agents, err := countMatching(`SELECT id, working_dir FROM agents WHERE closed_at IS NULL`, leapmuxv1.TabType_TAB_TYPE_AGENT)
-	if err != nil {
-		return 0, err
+	if hit, err := scan(`SELECT id, working_dir FROM agents WHERE closed_at IS NULL`, leapmuxv1.TabType_TAB_TYPE_AGENT); err != nil || hit {
+		return hit, err
 	}
-	terminals, err := countMatching(`SELECT id, working_dir FROM terminals WHERE closed_at IS NULL`, leapmuxv1.TabType_TAB_TYPE_TERMINAL)
-	if err != nil {
-		return 0, err
-	}
-	return agents + terminals, nil
+	return scan(`SELECT id, working_dir FROM terminals WHERE closed_at IS NULL`, leapmuxv1.TabType_TAB_TYPE_TERMINAL)
 }
 
 // tabMatchesBranch reports whether a tab's workingDir resolves to repoRoot
@@ -786,9 +818,9 @@ func remoteRefExists(ctx context.Context, dir, remoteName, branchName string) bo
 //   - git diff --numstat --staged -z (staged diff stats)
 //
 // Returns nil for non-git directories.
-func getGitFileStatusEntries(_ context.Context, repoRoot string) ([]*leapmuxv1.GitFileStatusEntry, error) {
+func getGitFileStatusEntries(ctx context.Context, repoRoot string) ([]*leapmuxv1.GitFileStatusEntry, error) {
 	// 1. Get file status via porcelain v2.
-	cmd := gitutil.NewGitCmd(context.Background(), "-C", repoRoot, "status", "--porcelain=v2", "-z")
+	cmd := gitutil.NewGitCmd(ctx, "-C", repoRoot, "status", "--porcelain=v2", "-z")
 	statusOut, err := cmd.Output()
 	if err != nil {
 		return nil, nil // Not a git repo or git unavailable.
@@ -806,13 +838,13 @@ func getGitFileStatusEntries(_ context.Context, repoRoot string) ([]*leapmuxv1.G
 	}
 
 	// 2. Get unstaged diff stats.
-	cmd2 := gitutil.NewGitCmd(context.Background(), "-C", repoRoot, "diff", "--numstat", "-z")
+	cmd2 := gitutil.NewGitCmd(ctx, "-C", repoRoot, "diff", "--numstat", "-z")
 	if numstatOut, err := cmd2.Output(); err == nil {
 		applyNumstat(numstatOut, fileMap, false)
 	}
 
 	// 3. Get staged diff stats.
-	cmd3 := gitutil.NewGitCmd(context.Background(), "-C", repoRoot, "diff", "--numstat", "--staged", "-z")
+	cmd3 := gitutil.NewGitCmd(ctx, "-C", repoRoot, "diff", "--numstat", "--staged", "-z")
 	if numstatOut, err := cmd3.Output(); err == nil {
 		applyNumstat(numstatOut, fileMap, true)
 	}

--- a/backend/internal/worker/service/git_mode_test.go
+++ b/backend/internal/worker/service/git_mode_test.go
@@ -234,7 +234,7 @@ func osSymlink(target, link string) error { return os.Symlink(target, link) }
 
 func TestOpenAgent_CreateWorktree_EndToEnd(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return &leapmuxv1.AgentSettings{}, nil
@@ -272,7 +272,7 @@ func TestOpenAgent_CreateWorktree_EndToEnd(t *testing.T) {
 
 func TestOpenAgent_CreateBranch_EndToEnd(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return &leapmuxv1.AgentSettings{}, nil

--- a/backend/internal/worker/service/git_test.go
+++ b/backend/internal/worker/service/git_test.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,18 +23,65 @@ import (
 func initRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	cmds := [][]string{
-		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "config", "user.email", "test@test.com"},
-		{"git", "-C", dir, "config", "user.name", "Test"},
-		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
-	}
-	for _, args := range cmds {
-		cmd := exec.Command(args[0], args[1:]...)
-		require.NoError(t, cmd.Run(), "command failed: %v", args)
+	if err := gitInitRepo(dir); err != nil {
+		t.Fatalf("init repo: %v", err)
 	}
 	return dir
 }
+
+// gitInitRepo runs `git init` + user config + an empty initial commit in
+// the given directory. Returns the first failure, or nil.
+func gitInitRepo(dir string) error {
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		{"commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git %v: %w", args, err)
+		}
+	}
+	return nil
+}
+
+// sharedCloseTabRepo returns a package-scoped git repo with a single
+// initial commit, created on first use. Tests that only add a worktree
+// on a unique branch can reuse it rather than paying ~4 git execs per
+// call to initRepo. The repo is created under os.MkdirTemp and cleaned
+// up by TestMain when the test binary exits.
+//
+// Safe to use when every caller passes a unique branch name to
+// `git worktree add -b <branch>` — branch refs and `.git/worktrees/`
+// entries are scoped per worktree path, so serialized callers don't
+// collide. Do NOT use for tests that mutate the base repo (commits,
+// branch deletes, tag creation, etc.) — those still need initRepo.
+func sharedCloseTabRepo(t *testing.T) string {
+	t.Helper()
+	sharedCloseTabRepoOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "leapmux-close-tab-shared-repo-*")
+		if err != nil {
+			sharedCloseTabRepoErr = err
+			return
+		}
+		if err := gitInitRepo(dir); err != nil {
+			sharedCloseTabRepoErr = err
+			return
+		}
+		sharedCloseTabRepoDir = dir
+	})
+	if sharedCloseTabRepoErr != nil {
+		t.Fatalf("shared repo init: %v", sharedCloseTabRepoErr)
+	}
+	return sharedCloseTabRepoDir
+}
+
+var (
+	sharedCloseTabRepoOnce sync.Once
+	sharedCloseTabRepoDir  string
+	sharedCloseTabRepoErr  error
+)
 
 // run executes a command in the given directory.
 func run(t *testing.T, dir string, name string, args ...string) {
@@ -40,6 +89,14 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	require.NoError(t, cmd.Run(), "command failed: %s %v", name, args)
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedCloseTabRepoDir != "" {
+		_ = os.RemoveAll(sharedCloseTabRepoDir)
+	}
+	os.Exit(code)
 }
 
 func TestGetGitFileStatusEntries_UntrackedFile(t *testing.T) {
@@ -443,6 +500,66 @@ func TestInspectLastTabClose_BranchMissingRemotePrompts(t *testing.T) {
 	assert.True(t, resp.GetCanPush())
 }
 
+// Fast path: a worktree with more than one tab must not prompt, and
+// must not pay for diffStatsForPath / pushStatusForPath. We can't
+// observe the skipped subprocesses directly from a test, but we can
+// assert that the diff_* and push_* fields are left zero — those are
+// only populated when the full inspect path runs.
+func TestInspectLastTabClose_WorktreeMultiTabFastPath(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+	repoDir := initRepo(t)
+	wtDir := filepath.Join(t.TempDir(), "multi-tab-wt")
+	run(t, repoDir, "git", "worktree", "add", "-b", "multi-tab", wtDir)
+
+	// Make the worktree dirty and unpushed — the slow path would surface
+	// hasUncommittedChanges=true. The fast path must skip the diff/push
+	// calls and leave those fields zero.
+	require.NoError(t, os.WriteFile(filepath.Join(wtDir, "dirty.txt"), []byte("dirty\n"), 0o644))
+
+	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
+	require.NoError(t, err)
+	createAgentForPath(t, svc, "agent-mt-1", wtDir)
+	createAgentForPath(t, svc, "agent-mt-2", wtDir)
+	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-mt-1")
+	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-mt-2")
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-mt-1")
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_WORKTREE, resp.GetTarget())
+	assert.False(t, resp.GetShouldPrompt(), "multi-tab worktree must not prompt")
+	// Fast-path-specific: diff/push fields must NOT have been populated.
+	assert.False(t, resp.GetHasUncommittedChanges(), "fast path skips diff stats")
+	assert.Equal(t, int32(0), resp.GetDiffAdded())
+	assert.Equal(t, int32(0), resp.GetDiffUntracked())
+	assert.Equal(t, int32(0), resp.GetUnpushedCommitCount())
+	// Worktree identity fields must come from the DB row, though.
+	assert.Equal(t, wtID, resp.GetWorktreeId())
+	expectedWtPath, err := filepath.EvalSymlinks(wtDir)
+	require.NoError(t, err)
+	assert.True(t, pathutil.SamePath(expectedWtPath, resp.GetWorktreePath()),
+		"expected same path; got expected=%q actual=%q", expectedWtPath, resp.GetWorktreePath())
+	assert.Equal(t, "multi-tab", resp.GetBranchName())
+}
+
+// Fast path: a non-worktree tab with other non-worktree tabs on the
+// same branch must not prompt, and must not pay for diff/push.
+func TestInspectLastTabClose_BranchMultiTabFastPath(t *testing.T) {
+	svc, _, _ := setupTestService(t, "ws-1")
+	repoDir := initRepo(t)
+	// Dirty the branch — the slow path would set hasUncommittedChanges=true.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644))
+	createAgentForPath(t, svc, "agent-branch-mt-1", repoDir)
+	createAgentForPath(t, svc, "agent-branch-mt-2", repoDir)
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-branch-mt-1")
+	require.NoError(t, err)
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE, resp.GetTarget())
+	assert.False(t, resp.GetShouldPrompt())
+	assert.False(t, resp.GetHasUncommittedChanges(), "fast path skips diff stats")
+	assert.Equal(t, int32(0), resp.GetDiffAdded())
+	assert.Equal(t, int32(0), resp.GetUnpushedCommitCount())
+}
+
 func TestPushBranchForClose_CreatesWIPCommitAndPushes(t *testing.T) {
 	svc, _, _ := setupTestService(t, "ws-1")
 	bareDir := filepath.Join(t.TempDir(), "push-dirty.git")
@@ -491,42 +608,4 @@ func TestPushBranchForClose_RecreatesUpstream(t *testing.T) {
 	upstream, err := gitOutput(context.Background(), repoDir, "rev-parse", "--abbrev-ref", "recreate-upstream@{upstream}")
 	require.NoError(t, err)
 	assert.Equal(t, "origin/recreate-upstream", strings.TrimSpace(upstream))
-}
-
-func TestScheduleWorktreeDeletion_ExternalTrackedWorktreeDeletes(t *testing.T) {
-	svc, _, _ := setupTestService(t, "ws-1")
-	repoDir := initRepo(t)
-	wtDir := filepath.Join(t.TempDir(), "external-tracked")
-	run(t, repoDir, "git", "worktree", "add", "-b", "external-tracked", wtDir)
-
-	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
-	require.NoError(t, err)
-
-	err = svc.scheduleWorktreeDeletion(context.Background(), wtID)
-	require.NoError(t, err)
-	waitForPathToDisappear(t, wtDir)
-
-	// removeWorktreeFromDisk deletes the branch after removing the worktree
-	// directory, so the directory can be gone before `git branch -D` runs.
-	// Poll for the branch deletion rather than asserting immediately.
-	require.Eventually(t, func() bool {
-		_, err := gitOutput(context.Background(), repoDir, "rev-parse", "--verify", "refs/heads/external-tracked")
-		return err != nil
-	}, 5*time.Second, 100*time.Millisecond)
-}
-
-func TestScheduleWorktreeDeletion_RejectsMultipleOpenTabs(t *testing.T) {
-	svc, _, _ := setupTestService(t, "ws-1")
-	repoDir := initRepo(t)
-	wtDir := filepath.Join(t.TempDir(), "reject-open-tabs")
-	run(t, repoDir, "git", "worktree", "add", "-b", "reject-open-tabs", wtDir)
-
-	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
-	require.NoError(t, err)
-	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, "a-1")
-	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_TERMINAL, "t-1")
-
-	err = svc.scheduleWorktreeDeletion(context.Background(), wtID)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "tabs are still open")
 }

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -25,7 +25,7 @@ import (
 // within ~200 ms — the whole point of the OpenAgent split.
 func TestOpenAgent_SyncPrologueReturnsFast(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	released := make(chan struct{})
@@ -64,7 +64,7 @@ func TestOpenAgent_SyncPrologueReturnsFast(t *testing.T) {
 // emits ACTIVE once startAgent eventually returns.
 func TestOpenAgent_DelayedStartupBroadcastsActive(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	releaseAfter := 150 * time.Millisecond
@@ -117,7 +117,7 @@ func TestOpenAgent_DelayedStartupBroadcastsActive(t *testing.T) {
 // the RPC returns without forking `git status`.
 func TestOpenAgent_ResponseHasNilGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	blocked := make(chan struct{})
@@ -155,7 +155,7 @@ func TestOpenAgent_ResponseHasNilGitStatus(t *testing.T) {
 // catch-up replay can surface it to the just-arriving subscriber.
 func TestOpenTerminal_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	// Block the PTY spawn indefinitely so the terminal stays in STARTING
 	// long enough for the WatchEvents catch-up replay to read the
 	// registry.
@@ -213,7 +213,7 @@ func TestOpenTerminal_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 // label was computed from r.GetShell() before resolution.
 func TestOpenTerminal_ResolvesDefaultShellForStartupMessage(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	blocked := make(chan struct{})
 	svc.startTerminalFn = func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
 		<-blocked
@@ -246,7 +246,7 @@ func TestOpenTerminal_ResolvesDefaultShellForStartupMessage(t *testing.T) {
 // spawn) falls back to the generic "Starting terminal…" label.
 func TestListTerminals_SurfacesRegistryStartupMessage(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	blocked := make(chan struct{})
 	svc.startTerminalFn = func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
 		<-blocked
@@ -285,7 +285,7 @@ func TestListTerminals_SurfacesRegistryStartupMessage(t *testing.T) {
 // phase label via catch-up replay, not an empty string.
 func TestOpenAgent_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	// Block startAgent so the goroutine settles after setting phase 2
 	// ("Starting Claude Code…") and waits there — the registry entry
@@ -352,7 +352,7 @@ func TestOpenAgent_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 // mapping directly, race-free.
 func TestOpenAgent_ActiveBroadcastCarriesGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Block startAgent briefly so the test can subscribe before ACTIVE lands.
@@ -480,7 +480,7 @@ func TestBuildTerminalStatusChange(t *testing.T) {
 // can render branch info alongside the error.
 func TestOpenAgent_StartupFailurePhaseCarriesGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(_ context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced startup failure")
@@ -528,7 +528,7 @@ func TestOpenAgent_StartupFailurePhaseCarriesGitStatus(t *testing.T) {
 func TestOpenAgent_StartupFailureBroadcastsFailureAndRollsBack(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var startCalls sync.WaitGroup
@@ -599,7 +599,7 @@ func TestExecuteCreateWorktree_FailureIsRecoverable(t *testing.T) {
 // "Rolling back worktree …" then STARTUP_FAILED with the injected error.
 func TestOpenAgent_BroadcastsRollbackLabelOnStartFailure(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")

--- a/backend/internal/worker/service/open_rollback_test.go
+++ b/backend/internal/worker/service/open_rollback_test.go
@@ -44,7 +44,7 @@ func TestOpenAgent_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
@@ -83,7 +83,7 @@ func TestOpenAgent_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
 	branchName := "feature/agent-branch"
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
@@ -112,7 +112,7 @@ func TestOpenAgent_RollsBackCreatedBranchToDetachedHEADOnStartFailure(t *testing
 	branchName := "feature/detached-rollback"
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
@@ -142,7 +142,7 @@ func TestOpenTerminal_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.startTerminalFn = func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
 		return errors.New("forced start failure")
 	}
@@ -174,7 +174,7 @@ func TestOpenTerminal_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
 	branchName := "feature/terminal-branch"
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.startTerminalFn = func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
 		return errors.New("forced start failure")
 	}
@@ -230,7 +230,7 @@ func TestOpenAgent_NoWorktreeMutationOnCreateRecordFailure(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
 		return errors.New("forced create failure")
@@ -261,7 +261,7 @@ func TestOpenAgent_NoBranchMutationOnCreateRecordFailure(t *testing.T) {
 	branchName := "feature/agent-create-branch"
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
 		return errors.New("forced create failure")
@@ -285,7 +285,7 @@ func TestOpenTerminal_DoesNotRollBackSwitchBranchOnStartFailure(t *testing.T) {
 	run(t, repoDir, "git", "checkout", "-")
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	svc.startTerminalFn = func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error {
 		return errors.New("forced start failure")
 	}

--- a/backend/internal/worker/service/open_validate_test.go
+++ b/backend/internal/worker/service/open_validate_test.go
@@ -55,7 +55,7 @@ func countTerminalRows(t *testing.T, svc *Context) int {
 func TestOpenAgent_Validate_BranchNameSyntax(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
@@ -72,7 +72,7 @@ func TestOpenAgent_Validate_BranchNameSyntax(t *testing.T) {
 func TestOpenAgent_Validate_WorkingDirNotGitRepo(t *testing.T) {
 	notARepo := t.TempDir()
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
@@ -91,7 +91,7 @@ func TestOpenAgent_Validate_BranchAlreadyExists(t *testing.T) {
 	run(t, repoDir, "git", "checkout", "-b", "feature/taken")
 	run(t, repoDir, "git", "checkout", "-")
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
@@ -108,7 +108,7 @@ func TestOpenAgent_Validate_BranchAlreadyExists(t *testing.T) {
 func TestOpenAgent_Validate_BaseBranchMissing(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:        "ws-1",
@@ -130,7 +130,7 @@ func TestOpenAgent_Validate_WorktreePathAlreadyPresent(t *testing.T) {
 	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
 		WorkingDir:     repoDir,
@@ -146,7 +146,7 @@ func TestOpenAgent_Validate_WorktreePathAlreadyPresent(t *testing.T) {
 func TestOpenAgent_Validate_CheckoutBranchMissing(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
@@ -164,7 +164,7 @@ func TestOpenAgent_Validate_CreateBranchAlreadyExists(t *testing.T) {
 	run(t, repoDir, "git", "checkout", "-b", "feature/taken")
 	run(t, repoDir, "git", "checkout", "-")
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:  "ws-1",
@@ -183,7 +183,7 @@ func TestOpenAgent_Validate_UseWorktreePathUnknown(t *testing.T) {
 	require.NoError(t, os.MkdirAll(bogusPath, 0o755))
 
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:     "ws-1",
 		WorkingDir:      repoDir,
@@ -200,7 +200,7 @@ func TestOpenAgent_Validate_UseWorktreePathUnknown(t *testing.T) {
 func TestOpenAgent_Validate_TitleTooLong(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	longTitle := strings.Repeat("a", 256) // exceeds the 128-char cap
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
@@ -217,7 +217,7 @@ func TestOpenAgent_Validate_TitleTooLong(t *testing.T) {
 func TestOpenAgent_Validate_TitleStripsControlChars(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId: "ws-1",
@@ -242,7 +242,7 @@ func TestOpenAgent_Validate_TitleStripsControlChars(t *testing.T) {
 func TestOpenAgent_Validate_SessionIDRejectsControlChar(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
 		WorkspaceId:    "ws-1",
@@ -259,7 +259,7 @@ func TestOpenAgent_Validate_SessionIDRejectsControlChar(t *testing.T) {
 func TestOpenTerminal_Validate_BranchNameSyntax(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId:    "ws-1",
@@ -276,7 +276,7 @@ func TestOpenTerminal_Validate_BranchNameSyntax(t *testing.T) {
 func TestOpenTerminal_Validate_WorkingDirNotGitRepo(t *testing.T) {
 	notARepo := t.TempDir()
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId:    "ws-1",
@@ -295,7 +295,7 @@ func TestOpenTerminal_Validate_BranchAlreadyExists(t *testing.T) {
 	run(t, repoDir, "git", "checkout", "-b", "feature/taken")
 	run(t, repoDir, "git", "checkout", "-")
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId:    "ws-1",
@@ -315,7 +315,7 @@ func TestOpenTerminal_Validate_WorktreePathAlreadyPresent(t *testing.T) {
 	worktreePath := expectedWorktreePath(repoDir, branchName)
 	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId:    "ws-1",
@@ -332,7 +332,7 @@ func TestOpenTerminal_Validate_WorktreePathAlreadyPresent(t *testing.T) {
 func TestOpenTerminal_Validate_CheckoutBranchMissing(t *testing.T) {
 	repoDir := initRepo(t)
 	svc, d, w := setupTestService(t, "ws-1")
-	defer drainStartups(svc)
+	defer drainAllInFlight(svc)
 
 	dispatch(d, "OpenTerminal", &leapmuxv1.OpenTerminalRequest{
 		WorkspaceId:    "ws-1",

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -62,6 +63,12 @@ type Context struct {
 	// being ready. See startupstate.go.
 	AgentStartup    *startupRegistry[leapmuxv1.AgentStatus]
 	TerminalStartup *startupRegistry[leapmuxv1.TerminalStatus]
+
+	// Cleanup tracks in-flight close handlers so Shutdown() can wait for
+	// them to finish before DB/data-dir teardown. Close handlers must
+	// Add(1) at entry and defer Done() so Wait() in Shutdown observes
+	// them even if a handler panics.
+	Cleanup sync.WaitGroup
 }
 
 // agentStartupTimeout returns the configured agent startup timeout,
@@ -161,14 +168,18 @@ func (svc *Context) Init() {
 // Shutdown persists in-memory terminal state to the database so it
 // survives a worker restart. Call this before stopping the terminal
 // manager (which clears in-memory state). Callers must have already
-// stopped dispatching new OpenAgent/OpenTerminal requests; otherwise
-// WaitForInFlight can race with a fresh begin().
+// stopped dispatching new OpenAgent/OpenTerminal/CloseAgent/CloseTerminal
+// requests; otherwise the Wait calls below can race with a fresh Add.
 func (svc *Context) Shutdown() {
 	// Drain any goroutines spawned by OpenAgent/OpenTerminal so their
 	// trailing DB writes and filesystem work land before the caller
 	// closes the DB or removes data directories.
 	svc.AgentStartup.WaitForInFlight()
 	svc.TerminalStartup.WaitForInFlight()
+	// Also drain in-flight close handlers. The frontend fires close RPCs
+	// as fire-and-forget, so a close can still be running on the
+	// dispatcher goroutine while the worker receives a deregister/SIGTERM.
+	svc.Cleanup.Wait()
 
 	for _, tid := range svc.Terminals.ListTerminalIDs() {
 		svc.appendTerminalDisconnectNotice(tid)

--- a/backend/internal/worker/service/tabclosetrace.go
+++ b/backend/internal/worker/service/tabclosetrace.go
@@ -1,0 +1,20 @@
+package service
+
+import "github.com/leapmux/leapmux/internal/util/phasetrace"
+
+// tabCloseTracer emits structured timing log lines tagged with
+// marker=tab_close_timing when LEAPMUX_TRACE_TAB_CLOSE=1, so that tests
+// (e.g. the tab-close-timing e2e) can parse the phase timeline from
+// stderr. Off by default — production logs are unaffected.
+var tabCloseTracer = phasetrace.New(
+	"LEAPMUX_TRACE_TAB_CLOSE",
+	"tab_close_timing",
+	"tab close timing",
+)
+
+// traceTabClosePhase emits a timing log line for the given inspect /
+// close tab phase. Time is taken from the log handler at write time;
+// the receiving test correlates lines by tab_id and the phase name.
+func traceTabClosePhase(op, tabID, phase string) {
+	tabCloseTracer.Log("op", op, "tab_id", tabID, "phase", phase)
+}

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -197,16 +197,24 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
-		// Clear any in-flight startup entry.
-		svc.TerminalStartup.cancelAndClear(terminalID)
-
-		svc.Terminals.RemoveTerminal(terminalID)
-
-		// Soft-delete the terminal record.
-		_ = svc.Queries.CloseTerminal(bgCtx(), terminalID)
-
-		svc.unregisterTabAndCleanup(leapmuxv1.TabType_TAB_TYPE_TERMINAL, terminalID)
-		sendProtoResponse(sender, &leapmuxv1.CloseTerminalResponse{})
+		// The frontend fires this RPC as fire-and-forget after removing
+		// the tab from the UI. closeTabCommon tracks the handler on
+		// svc.Cleanup so a concurrent Shutdown can drain it, then runs
+		// the shared close-tab flow (stop → DB close → unregister →
+		// optional worktree remove). The TerminalStartup goroutine's
+		// trailing rollback work is tracked separately by
+		// TerminalStartup.WaitForInFlight and drained in Shutdown.
+		result := svc.closeTabCommon(
+			leapmuxv1.TabType_TAB_TYPE_TERMINAL,
+			terminalID,
+			r.GetWorktreeAction(),
+			func() {
+				svc.TerminalStartup.cancelAndClear(terminalID)
+				svc.Terminals.RemoveTerminal(terminalID)
+			},
+			func() error { return svc.Queries.CloseTerminal(bgCtx(), terminalID) },
+		)
+		sendProtoResponse(sender, &leapmuxv1.CloseTerminalResponse{Result: result})
 	})
 
 	// SendInput sends input data to a terminal.

--- a/backend/internal/worker/service/workspace_cleanup.go
+++ b/backend/internal/worker/service/workspace_cleanup.go
@@ -48,7 +48,7 @@ func handleCleanupWorkspace(svc *Context) channel.HandlerFunc {
 			svc.Output.CleanupAgent(row)
 			_ = svc.Queries.CloseAgent(bgCtx(), row)
 
-			svc.unregisterTabAndCleanup(leapmuxv1.TabType_TAB_TYPE_AGENT, row)
+			svc.unregisterTab(leapmuxv1.TabType_TAB_TYPE_AGENT, row)
 		}
 
 		// 2. Close all agents (including already-closed ones) for consistency.
@@ -64,11 +64,8 @@ func handleCleanupWorkspace(svc *Context) channel.HandlerFunc {
 				"workspace_id", workspaceID, "error", err)
 		}
 		for _, ts := range terminals {
-			if svc.Terminals.HasTerminal(ts.ID) {
-				svc.Terminals.RemoveTerminal(ts.ID)
-			}
-
-			svc.unregisterTabAndCleanup(leapmuxv1.TabType_TAB_TYPE_TERMINAL, ts.ID)
+			svc.Terminals.RemoveTerminal(ts.ID)
+			svc.unregisterTab(leapmuxv1.TabType_TAB_TYPE_TERMINAL, ts.ID)
 		}
 
 		// 4. Soft-delete active terminals for the workspace.

--- a/backend/internal/worker/service/worktree.go
+++ b/backend/internal/worker/service/worktree.go
@@ -507,18 +507,26 @@ func (svc *Context) ensureTrackedWorktree(ctx context.Context, worktreePath stri
 	return wtID, nil
 }
 
-// removeWorktreeFromDisk force-removes a worktree and deletes its branch when
-// it is no longer used by any remaining worktree.
-func (svc *Context) removeWorktreeFromDisk(wt db.Worktree, force bool) {
+// removeWorktreeFromDisk force-removes a worktree from disk, deletes its
+// branch if no other worktree still uses it, and soft-deletes the DB row.
+//
+// The DB row is always soft-deleted so a stale entry does not block future
+// reuse of the working directory. Returns a non-nil error when the git
+// worktree-remove command failed AND the path is still on disk — callers
+// surface this so the user can clean up manually. Branch deletion
+// failures are logged but never bubbled (a retained branch is
+// recoverable; a lost DB row is not).
+func (svc *Context) removeWorktreeFromDisk(wt db.Worktree, force bool) error {
 	ctx := bgCtx()
 	args := []string{"worktree", "remove"}
 	if force {
 		args = append(args, "--force")
 	}
 	args = append(args, wt.WorktreePath)
-	if err := gitCommand(ctx, wt.RepoRoot, args...); err != nil {
+	removeErr := gitCommand(ctx, wt.RepoRoot, args...)
+	if removeErr != nil {
 		slog.Warn("failed to remove worktree",
-			"worktree_path", wt.WorktreePath, "force", force, "error", err)
+			"worktree_path", wt.WorktreePath, "force", force, "error", removeErr)
 	}
 	if wt.BranchName != "" {
 		if inUse, err := gitutil.IsBranchInUse(wt.RepoRoot, wt.BranchName); err == nil && !inUse {
@@ -534,6 +542,16 @@ func (svc *Context) removeWorktreeFromDisk(wt db.Worktree, force bool) {
 		slog.Warn("failed to delete worktree record",
 			"worktree_id", wt.ID, "error", err)
 	}
+	if removeErr == nil {
+		return nil
+	}
+	// git worktree-remove failed. If the path is gone anyway (user
+	// pre-deleted it, or git cleaned up partially), treat as success —
+	// nothing for the user to clean up.
+	if _, statErr := os.Stat(wt.WorktreePath); os.IsNotExist(statErr) {
+		return nil
+	}
+	return fmt.Errorf("git worktree remove %q: %w", wt.WorktreePath, removeErr)
 }
 
 func currentCheckoutTarget(ctx context.Context, workingDir string) (*rollbackBranch, error) {
@@ -615,28 +633,37 @@ func (svc *Context) rollbackCreatedBranch(r rollbackBranch) {
 	}
 }
 
-// unregisterTabAndCleanup removes a tab's worktree association but does not
-// delete the worktree. Deletion now requires an explicit schedule RPC.
-func (svc *Context) unregisterTabAndCleanup(tabType leapmuxv1.TabType, tabID string) {
-	ctx := bgCtx()
-
-	// Find the worktree for this tab.
-	wt, err := svc.Queries.GetWorktreeForTab(ctx, db.GetWorktreeForTabParams{
+// unregisterTab drops a tab's worktree association row. Worktree
+// deletion itself is driven by the close handler when the caller
+// passed WorktreeAction_REMOVE and no other tabs remain.
+//
+// The REMOVE-close path in closeTabCommon still uses removeTabFromWorktree
+// so it can guard the delete by worktree_id (defense-in-depth against a
+// stale association). Other callers don't have the worktree in hand and
+// would pay for a GetWorktreeForTab round-trip; the bare (tab_type, tab_id)
+// delete is enough, because (tab_type, tab_id) is unique in practice.
+func (svc *Context) unregisterTab(tabType leapmuxv1.TabType, tabID string) {
+	if err := svc.Queries.DeleteWorktreeTabsByTabID(bgCtx(), db.DeleteWorktreeTabsByTabIDParams{
 		TabType: tabType,
 		TabID:   tabID,
-	})
-	if err != nil {
-		return
+	}); err != nil {
+		slog.Warn("failed to remove worktree tab",
+			"tab_type", tabType, "tab_id", tabID, "error", err)
 	}
+}
 
-	// Remove the tab association.
-	if err := svc.Queries.RemoveWorktreeTab(ctx, db.RemoveWorktreeTabParams{
-		WorktreeID: wt.ID,
+// removeTabFromWorktree drops the tab→worktree association row for a
+// caller that already holds the worktree row. Used by the REMOVE-close
+// path to avoid a second GetWorktreeForTab lookup AND to guard the
+// delete by worktree_id against a stale association.
+func (svc *Context) removeTabFromWorktree(tabType leapmuxv1.TabType, tabID, worktreeID string) {
+	if err := svc.Queries.RemoveWorktreeTab(bgCtx(), db.RemoveWorktreeTabParams{
+		WorktreeID: worktreeID,
 		TabType:    tabType,
 		TabID:      tabID,
 	}); err != nil {
 		slog.Warn("failed to remove worktree tab",
-			"worktree_id", wt.ID, "tab_id", tabID, "error", err)
+			"worktree_id", worktreeID, "tab_id", tabID, "error", err)
 	}
 }
 

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -38,7 +38,6 @@ import type {
   ListGitWorktreesResponse,
   PushBranchForCloseResponse,
   ReadGitFileResponse,
-  ScheduleWorktreeDeletionResponse,
 } from '~/generated/leapmux/v1/git_pb'
 import type {
   CloseTerminalResponse,
@@ -116,8 +115,6 @@ import {
   PushBranchForCloseResponseSchema,
   ReadGitFileRequestSchema,
   ReadGitFileResponseSchema,
-  ScheduleWorktreeDeletionRequestSchema,
-  ScheduleWorktreeDeletionResponseSchema,
 } from '~/generated/leapmux/v1/git_pb'
 import {
   CloseTerminalRequestSchema,
@@ -505,10 +502,6 @@ export function inspectLastTabClose(workerId: string, req: MessageInitShape<type
 
 export function pushBranchForClose(workerId: string, req: MessageInitShape<typeof PushBranchForCloseRequestSchema>): Promise<PushBranchForCloseResponse> {
   return callWorker(workerId, 'PushBranchForClose', PushBranchForCloseRequestSchema, PushBranchForCloseResponseSchema, req)
-}
-
-export function scheduleWorktreeDeletion(workerId: string, req: MessageInitShape<typeof ScheduleWorktreeDeletionRequestSchema>): Promise<ScheduleWorktreeDeletionResponse> {
-  return callWorker(workerId, 'ScheduleWorktreeDeletion', ScheduleWorktreeDeletionRequestSchema, ScheduleWorktreeDeletionResponseSchema, req)
 }
 
 export function forceRemoveWorktree(workerId: string, req: MessageInitShape<typeof ForceRemoveWorktreeRequestSchema>): Promise<ForceRemoveWorktreeResponse> {

--- a/frontend/src/components/shell/closeFailureToast.ts
+++ b/frontend/src/components/shell/closeFailureToast.ts
@@ -1,0 +1,12 @@
+import type { CloseTabResult } from '~/generated/leapmux/v1/common_pb'
+import { showWarnToast } from '~/components/common/Toast'
+
+// toastCloseFailure surfaces a partial tab-close failure. No-op on
+// success (empty failureMessage or missing result). The backend always
+// pairs failureMessage with a failureDetail (err.Error()), but we guard
+// against empty detail defensively.
+export function toastCloseFailure(result: CloseTabResult | undefined): void {
+  if (!result || !result.failureMessage)
+    return
+  showWarnToast(result.failureDetail ? `${result.failureMessage}: ${result.failureDetail}` : result.failureMessage)
+}

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -15,7 +15,9 @@ import { CODEX_EXTRA_COLLABORATION_MODE, DEFAULT_CODEX_COLLABORATION_MODE } from
 import { getProviderPlugin } from '~/components/chat/providers/registry'
 import { optionGroupDefaultValue, optionGroupLabel } from '~/components/chat/settingsShared'
 import { showWarnToast } from '~/components/common/Toast'
+import { toastCloseFailure } from '~/components/shell/closeFailureToast'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { base64ToUint8Array } from '~/lib/base64'
 import { createLogger } from '~/lib/logger'
@@ -390,25 +392,36 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Close an agent
-  const handleCloseAgent = async (agentId: string) => {
-    try {
-      const workerId = getAgentWorkerId(agentId)
-      props.controlStore.clearAgent(agentId)
-      clearAttachments(agentId)
-      if (workerId) {
-        await workerRpc.closeAgent(workerId, { agentId })
-      }
-      props.agentStore.removeAgent(agentId)
-      props.tabStore.removeTab(TabType.AGENT, agentId)
-      // Unregister tab from hub.
-      const ws = props.activeWorkspace()
-      if (ws) {
-        workspaceClient.removeTab({ workspaceId: ws.id, tabType: TabType.AGENT, tabId: agentId }).catch(() => {})
-      }
+  // Close an agent.
+  //
+  // All store mutations run synchronously so the UI updates the moment
+  // the caller returns. The worker close RPC and Hub unregister are
+  // fire-and-forget; failures are surfaced via toast without blocking
+  // the UI or rolling back the local state — the tab is already gone.
+  const handleCloseAgent = (agentId: string, worktreeAction: WorktreeAction = WorktreeAction.KEEP) => {
+    const workerId = getAgentWorkerId(agentId)
+
+    // Synchronous local cleanup: the tab disappears immediately.
+    props.controlStore.clearAgent(agentId)
+    clearAttachments(agentId)
+    props.agentStore.removeAgent(agentId)
+    props.tabStore.removeTab(TabType.AGENT, agentId)
+
+    // Background: kill the subprocess, DB-close the agent, optionally
+    // remove the worktree. Partial failures come back as a non-empty
+    // failure_message on the response.
+    if (workerId) {
+      workerRpc.closeAgent(workerId, { agentId, worktreeAction })
+        .then(resp => toastCloseFailure(resp.result))
+        .catch((err) => {
+          showWarnToast('Failed to close agent', err)
+        })
     }
-    catch (err) {
-      showWarnToast('Failed to close agent', err)
+
+    // Unregister tab from hub (runs in parallel with the worker close).
+    const ws = props.activeWorkspace()
+    if (ws) {
+      workspaceClient.removeTab({ workspaceId: ws.id, tabType: TabType.AGENT, tabId: agentId }).catch(() => {})
     }
   }
 

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -10,6 +10,7 @@ import { batch, createEffect, createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { showInfoToast, showWarnToast } from '~/components/common/Toast'
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { basename } from '~/lib/paths'
 import { MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
@@ -160,6 +161,12 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       return
     addClosingTabKey(key)
 
+    // Decide phase: the tab stays visible (with a spinner) while we
+    // await the worker's last-tab inspection and, if needed, the user's
+    // dialog choice. This is the only phase that awaits; the commit
+    // phase below mutates stores synchronously and fires the worker
+    // close + hub unregister RPCs as fire-and-forget.
+    let worktreeAction: WorktreeAction = WorktreeAction.KEEP
     try {
       const tabType = tab.type === TabType.AGENT ? TabType.AGENT : TabType.TERMINAL
       const workerId = tab.workerId ?? ''
@@ -170,28 +177,34 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
           return
         }
         if (choice === 'schedule-delete') {
-          await workerRpc.scheduleWorktreeDeletion(workerId, { worktreeId: status.worktreeId })
-          showInfoToast('Worktree deletion scheduled')
+          worktreeAction = WorktreeAction.REMOVE
+          showInfoToast('Worktree will be removed')
         }
       }
-      if (tab.type === TabType.AGENT) {
-        await agentOps.handleCloseAgent(tab.id)
-      }
-      else {
-        const instance = getTerminalInstance(tab.id)
-        if (instance) {
-          instance.dispose()
-        }
-        await termOps.handleTerminalClose(tab.id)
-      }
-      removeEmptyFloatingWindow(tab.tileId)
     }
     catch (err) {
       showWarnToast('Failed to prepare tab close', err)
+      return
     }
     finally {
       removeClosingTabKey(key)
     }
+
+    // Commit phase: synchronous UI mutations first so the tab
+    // disappears immediately, then fire-and-forget worker cleanup and
+    // hub unregister. handleCloseAgent/handleTerminalClose own both
+    // halves (sync + fire-and-forget).
+    if (tab.type === TabType.AGENT) {
+      agentOps.handleCloseAgent(tab.id, worktreeAction)
+    }
+    else {
+      const instance = getTerminalInstance(tab.id)
+      if (instance) {
+        instance.dispose()
+      }
+      termOps.handleTerminalClose(tab.id, worktreeAction)
+    }
+    removeEmptyFloatingWindow(tab.tileId)
   }
 
   let fileTabCounter = 0

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -7,6 +7,8 @@ import { createEffect, createSignal, on } from 'solid-js'
 import { workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
+import { toastCloseFailure } from '~/components/shell/closeFailureToast'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { tabKey } from '~/stores/tab.store'
@@ -241,23 +243,35 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
     }
   }
 
-  const handleTerminalClose = async (terminalId: string) => {
+  // Close a terminal.
+  //
+  // Symmetric to handleCloseAgent: store mutations run synchronously;
+  // the worker close RPC and Hub unregister are fire-and-forget with
+  // failure surfaced via toast.
+  const handleTerminalClose = (terminalId: string, worktreeAction: WorktreeAction = WorktreeAction.KEEP) => {
+    const workerId = props.tabStore.getTerminalTab(terminalId)?.workerId ?? ''
     const ws = props.activeWorkspace()
-    try {
-      if (!ws)
-        return
-      const workerId = props.tabStore.getTerminalTab(terminalId)?.workerId ?? ''
-      await workerRpc.closeTerminal(workerId, { orgId: props.org.orgId(), workspaceId: ws.id, terminalId })
+
+    // Synchronous: tab disappears immediately.
+    props.tabStore.removeTab(TabType.TERMINAL, terminalId)
+
+    // Background: PTY close, DB close, optional worktree removal.
+    if (workerId && ws) {
+      workerRpc.closeTerminal(workerId, {
+        orgId: props.org.orgId(),
+        workspaceId: ws.id,
+        terminalId,
+        worktreeAction,
+      })
+        .then(resp => toastCloseFailure(resp.result))
+        .catch((err) => {
+          showWarnToast('Failed to close terminal', err)
+        })
     }
-    catch {
-      // Ignore errors (e.g. terminal already exited or not tracked by worker)
-    }
-    finally {
-      props.tabStore.removeTab(TabType.TERMINAL, terminalId)
-      // Unregister tab from hub.
-      if (ws) {
-        workspaceClient.removeTab({ workspaceId: ws.id, tabType: TabType.TERMINAL, tabId: terminalId }).catch(() => {})
-      }
+
+    // Hub unregister (parallel with worker close).
+    if (ws) {
+      workspaceClient.removeTab({ workspaceId: ws.id, tabType: TabType.TERMINAL, tabId: terminalId }).catch(() => {})
     }
   }
 

--- a/frontend/tests/e2e/121-claude-agent-open-timing.spec.ts
+++ b/frontend/tests/e2e/121-claude-agent-open-timing.spec.ts
@@ -3,111 +3,35 @@
  * Measures the end-to-end latency of opening a new Claude Code agent tab
  * and produces a phase-by-phase timeline breakdown.
  *
- * Why its own fixture: we need
- *   (a) `LEAPMUX_TRACE_AGENT_STARTUP=1` so the worker emits phase markers
- *   (b) the backend stderr captured (the shared fixture drains it)
- * so we reimplement the small bits of fixtures.ts that we need.
+ * Backend stderr capture + JSON parse and the ASCII timeline renderer
+ * live in ./helpers/timingFixture.ts; this file supplies the spec-
+ * specific env (LEAPMUX_TRACE_AGENT_STARTUP) and the per-iteration DOM
+ * observation logic.
  */
-import type { Buffer } from 'node:buffer'
-import type { DevServerHandle } from './helpers/devServer'
+import type { LogLine, PhaseMark, TimingServer } from './helpers/timingFixture'
+
 import { expect, test } from '@playwright/test'
 import {
   createWorkspaceViaAPI,
   deleteWorkspaceViaAPI,
   openAgentViaAPI,
 } from './helpers/api'
-import { startDevServer, stopDevServer } from './helpers/devServer'
+import { stopDevServer } from './helpers/devServer'
+import { extractWorkerMarks, installRpcListeners, renderTimeline, startTimingServer } from './helpers/timingFixture'
 import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
-
-// ──────────────────────────────────────────────
-// Phase enum & helpers
-// ──────────────────────────────────────────────
-
-interface PhaseMark { name: string, tMs: number }
-
-/**
- * Parse a single JSON log line. Returns null on non-JSON or parse error.
- * slog's JSONHandler emits one JSON object per line on stderr when not
- * attached to a TTY (which is how child_process pipes work).
- */
-function parseJsonLine(line: string): Record<string, unknown> | null {
-  const trimmed = line.trim()
-  if (!trimmed.startsWith('{'))
-    return null
-  try {
-    return JSON.parse(trimmed) as Record<string, unknown>
-  }
-  catch {
-    return null
-  }
-}
 
 /**
  * Return the agent_id of the first handler_begin marker logged after
  * the given log offset. Used by the timing test to identify the agent
  * opened by a specific click in a multi-iteration loop.
  */
-function findNewAgentId(logLines: Array<{ json: Record<string, unknown> | null }>, offset: number): string | null {
+function findNewAgentId(logLines: LogLine[], offset: number): string | null {
   for (let i = offset; i < logLines.length; i++) {
     const j = logLines[i]?.json
     if (j && j.marker === 'agent_startup_timing' && j.phase === 'handler_begin' && typeof j.agent_id === 'string')
       return j.agent_id
   }
   return null
-}
-
-// ──────────────────────────────────────────────
-// Local fixture: dev server with stderr capture + timing env var
-// ──────────────────────────────────────────────
-
-interface TimingServer extends DevServerHandle {
-  /** All backend log lines emitted since server start, parsed if JSON. */
-  logLines: Array<{ raw: string, json: Record<string, unknown> | null, rxAt: number }>
-}
-
-async function startTimingServer(): Promise<TimingServer> {
-  const logLines: TimingServer['logLines'] = []
-  const handleChunk = (chunk: Buffer) => {
-    const text = chunk.toString('utf8')
-    const now = performance.now()
-    for (const line of text.split(/\r?\n/)) {
-      if (!line)
-        continue
-      logLines.push({ raw: line, json: parseJsonLine(line), rxAt: now })
-    }
-  }
-  const handle = await startDevServer({
-    dataDirPrefix: 'leapmux-timing-e2e',
-    env: {
-      LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
-      LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
-      LEAPMUX_WORKER_NAME: 'Local',
-      LEAPMUX_TRACE_AGENT_STARTUP: '1',
-    },
-    onStdio: handleChunk,
-  })
-  return { ...handle, logLines }
-}
-
-// ──────────────────────────────────────────────
-// Timeline formatter
-// ──────────────────────────────────────────────
-
-function renderTimeline(marks: PhaseMark[]): string {
-  if (marks.length === 0)
-    return '(no marks captured)'
-  const t0 = marks[0]!.tMs
-  const nameWidth = Math.max(...marks.map(m => m.name.length))
-  const lines: string[] = []
-  lines.push(`${'phase'.padEnd(nameWidth)}  abs (ms)     Δ (ms)`)
-  lines.push(`${'-'.repeat(nameWidth)}  --------   --------`)
-  for (let i = 0; i < marks.length; i++) {
-    const m = marks[i]!
-    const abs = m.tMs - t0
-    const delta = i === 0 ? 0 : m.tMs - marks[i - 1]!.tMs
-    lines.push(`${m.name.padEnd(nameWidth)}  ${abs.toFixed(1).padStart(8)}   ${delta.toFixed(1).padStart(8)}`)
-  }
-  return lines.join('\n')
 }
 
 // ──────────────────────────────────────────────
@@ -121,7 +45,15 @@ test.describe('Claude Code agent open timing', () => {
   let srv: TimingServer
 
   test.beforeAll(async () => {
-    srv = await startTimingServer()
+    srv = await startTimingServer({
+      dataDirPrefix: 'leapmux-timing-e2e',
+      env: {
+        LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
+        LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
+        LEAPMUX_WORKER_NAME: 'Local',
+        LEAPMUX_TRACE_AGENT_STARTUP: '1',
+      },
+    })
   })
 
   test.afterAll(async () => {
@@ -154,19 +86,7 @@ test.describe('Claude Code agent open timing', () => {
     await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
     await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
 
-    await page.evaluate(() => {
-      interface RpcMark { type: 'rpc-send' | 'rpc-recv', method: string, at: number, ok?: boolean }
-      const w = window as unknown as { __rpcMarks?: RpcMark[] }
-      w.__rpcMarks = []
-      window.addEventListener('leapmux:rpc-send', (ev) => {
-        const d = (ev as CustomEvent<{ method: string, at: number }>).detail
-        w.__rpcMarks!.push({ type: 'rpc-send', method: d.method, at: d.at })
-      })
-      window.addEventListener('leapmux:rpc-recv', (ev) => {
-        const d = (ev as CustomEvent<{ method: string, at: number, ok: boolean }>).detail
-        w.__rpcMarks!.push({ type: 'rpc-recv', method: d.method, at: d.at, ok: d.ok })
-      })
-    })
+    await installRpcListeners(page)
 
     const runs: PhaseMark[][] = []
 
@@ -262,17 +182,17 @@ test.describe('Claude Code agent open timing', () => {
       const openSend = rpcMarks.find(m => m.type === 'rpc-send' && m.method === 'OpenAgent')
       const openRecv = rpcMarks.find(m => m.type === 'rpc-recv' && m.method === 'OpenAgent')
 
-      const newLogs = srv.logLines.slice(logsBefore)
-      const timingRows = newLogs
-        .map(l => l.json)
-        .filter((j): j is Record<string, unknown> => !!j && j.marker === 'agent_startup_timing')
-      const backendPhases = timingRows
-        .filter(r => r.agent_id === iterAgentId)
-        .map(r => ({ phase: String(r.phase), wallMs: new Date(String(r.time ?? '')).getTime() }))
-      const backendMarks: PhaseMark[] = backendPhases.map(p => ({
-        name: `worker:${p.phase}`,
-        tMs: tClickMs + (p.wallMs - clockAnchorWallMs),
-      }))
+      const backendMarks = extractWorkerMarks(
+        srv.logLines,
+        logsBefore,
+        { perf: tClickMs, wall: clockAnchorWallMs },
+        {
+          marker: 'agent_startup_timing',
+          idField: 'agent_id',
+          idValue: iterAgentId,
+          name: row => `worker:${String(row.phase)}`,
+        },
+      )
 
       const marks: PhaseMark[] = []
       marks.push({ name: 'ui:click', tMs: tClickMs })
@@ -302,7 +222,7 @@ test.describe('Claude Code agent open timing', () => {
 
       // Sanity: every expected backend phase present on iter 0.
       if (iter === 0) {
-        const seen = new Set(backendPhases.map(p => p.phase))
+        const seen = new Set(backendMarks.map(m => m.name.replace(/^worker:/, '')))
         for (const expected of [
           'handler_begin',
           'gitmode_validated',

--- a/frontend/tests/e2e/122-tab-close-timing.spec.ts
+++ b/frontend/tests/e2e/122-tab-close-timing.spec.ts
@@ -1,0 +1,411 @@
+/* eslint-disable no-console */
+/**
+ * Measures the end-to-end latency of closing an agent tab and produces a
+ * phase-by-phase timeline breakdown. Complements
+ * `121-claude-agent-open-timing.spec.ts`.
+ *
+ * Instrumentation:
+ *   - Browser: `leapmux:rpc-send` / `leapmux:rpc-recv` CustomEvents
+ *     from `src/api/workerRpc.ts` (gated on `LEAPMUX_DEV`, enabled by
+ *     the e2e runner) plus a MutationObserver for tab / dialog
+ *     timestamps.
+ *   - Worker: `LEAPMUX_TRACE_TAB_CLOSE=1` makes
+ *     `backend/internal/worker/service/tabclosetrace.go` emit
+ *     `marker=tab_close_timing` slog lines for the inspect RPC's inner
+ *     phases (git_ctx_done, diff_and_push_done,
+ *     worktree_count_done / branch_count_done, handler_end). We combine
+ *     them with browser marks using a wall-clock anchor captured
+ *     immediately before the click.
+ *
+ * Three scenarios:
+ *   1. Two worktree tabs on the same worktree, close one. No prompt
+ *      because `CountWorktreeTabs > 1`. This is the topology the user
+ *      reported as "~1 second slow".
+ *   2. Worktree last tab, dialog → Close anyway (KEEP).
+ *   3. Worktree last tab, dialog → Delete (REMOVE).
+ *
+ * Point at a real repository by setting
+ * `LEAPMUX_CLOSE_TIMING_REPO_DIR=/path/to/your/repo`. Without it, each
+ * scenario creates a tiny synthetic repo under the test's dataDir.
+ */
+import type { Page, TestInfo } from '@playwright/test'
+import type { ClockAnchor, LogLine, PhaseMark, RpcMark, TimingServer } from './helpers/timingFixture'
+import { existsSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { expect, test } from '@playwright/test'
+import { deleteWorkspaceViaAPI } from './helpers/api'
+import { stopDevServer } from './helpers/devServer'
+import { extractWorkerMarks, installRpcListeners, renderTimeline, startTimingServer } from './helpers/timingFixture'
+import { loginViaToken, waitForWorkspaceReady } from './helpers/ui'
+import {
+  createGitRepo,
+  createWorkspaceWithWorktreeViaAPI,
+  waitForPathDeleted,
+} from './helpers/worktree'
+
+// ─── Browser instrumentation ──────────────────────────────────────────
+
+interface TimingWindow {
+  __rpcMarks?: RpcMark[]
+  __tabRemovedAt?: number | null
+  __dialogVisibleAt?: number | null
+  __dialogRemovedAt?: number | null
+  __observer?: MutationObserver
+  __tabBaseline?: number
+}
+
+async function installObservers(page: Page): Promise<void> {
+  await installRpcListeners(page)
+  await page.evaluate(() => {
+    const w = window as unknown as TimingWindow
+    w.__tabRemovedAt = null
+    w.__dialogVisibleAt = null
+    w.__dialogRemovedAt = null
+    w.__tabBaseline = document.querySelectorAll('[data-testid="tab"][data-tab-type="agent"]').length
+    w.__observer?.disconnect()
+    w.__observer = new MutationObserver(() => {
+      if (w.__tabRemovedAt == null) {
+        const tabs = document.querySelectorAll('[data-testid="tab"][data-tab-type="agent"]').length
+        if (tabs < (w.__tabBaseline ?? 0))
+          w.__tabRemovedAt = performance.now()
+      }
+      if (w.__dialogVisibleAt == null) {
+        const dialog = document.querySelector('dialog[open]')
+        if (dialog && dialog.textContent?.includes('Close Last Tab'))
+          w.__dialogVisibleAt = performance.now()
+      }
+      if (w.__dialogVisibleAt != null && w.__dialogRemovedAt == null) {
+        const dialog = document.querySelector('dialog[open]')
+        if (!dialog || !dialog.textContent?.includes('Close Last Tab'))
+          w.__dialogRemovedAt = performance.now()
+      }
+    })
+    w.__observer.observe(document.body, { childList: true, subtree: true })
+  })
+}
+
+interface RawMarks {
+  rpcMarks: RpcMark[]
+  tabRemovedAt: number | null
+  dialogVisibleAt: number | null
+  dialogRemovedAt: number | null
+}
+
+async function snapshotMarks(page: Page): Promise<RawMarks> {
+  return page.evaluate(() => {
+    const w = window as unknown as TimingWindow
+    return {
+      rpcMarks: w.__rpcMarks ?? [],
+      tabRemovedAt: w.__tabRemovedAt ?? null,
+      dialogVisibleAt: w.__dialogVisibleAt ?? null,
+      dialogRemovedAt: w.__dialogRemovedAt ?? null,
+    }
+  })
+}
+
+// ─── Combine browser + worker marks ───────────────────────────────────
+
+function extractCloseWorkerMarks(logLines: LogLine[], logOffset: number, tabID: string, anchor: ClockAnchor): PhaseMark[] {
+  return extractWorkerMarks(logLines, logOffset, anchor, {
+    marker: 'tab_close_timing',
+    idField: 'tab_id',
+    idValue: tabID,
+    name: row => `worker:${String(row.op ?? 'inspect')}:${String(row.phase)}`,
+  })
+}
+
+function buildTimeline(
+  tClickMs: number,
+  raw: RawMarks,
+  workerMarks: PhaseMark[],
+  extra: PhaseMark[] = [],
+): PhaseMark[] {
+  const marks: PhaseMark[] = [{ name: 'ui:click', tMs: tClickMs }]
+  const inspectSend = raw.rpcMarks.find(m => m.type === 'rpc-send' && m.method === 'InspectLastTabClose')
+  const inspectRecv = raw.rpcMarks.find(m => m.type === 'rpc-recv' && m.method === 'InspectLastTabClose')
+  const closeSend = raw.rpcMarks.find(m => m.type === 'rpc-send' && (m.method === 'CloseAgent' || m.method === 'CloseTerminal'))
+  const closeRecv = raw.rpcMarks.find(m => m.type === 'rpc-recv' && (m.method === 'CloseAgent' || m.method === 'CloseTerminal'))
+  if (inspectSend)
+    marks.push({ name: `ui:rpc-send ${inspectSend.method}`, tMs: inspectSend.at })
+  marks.push(...workerMarks)
+  if (inspectRecv)
+    marks.push({ name: `ui:rpc-recv ${inspectRecv.method}`, tMs: inspectRecv.at })
+  if (raw.dialogVisibleAt != null)
+    marks.push({ name: 'ui:dialog-visible', tMs: raw.dialogVisibleAt })
+  if (raw.dialogRemovedAt != null)
+    marks.push({ name: 'ui:dialog-closed', tMs: raw.dialogRemovedAt })
+  if (raw.tabRemovedAt != null)
+    marks.push({ name: 'ui:tab-dom-removed', tMs: raw.tabRemovedAt })
+  if (closeSend)
+    marks.push({ name: `ui:rpc-send ${closeSend.method}`, tMs: closeSend.at })
+  if (closeRecv)
+    marks.push({ name: `ui:rpc-recv ${closeRecv.method}`, tMs: closeRecv.at })
+  marks.push(...extra)
+  marks.sort((a, b) => a.tMs - b.tMs)
+  return marks
+}
+
+// Identify the agent_id of the just-closed tab from the backend logs so
+// we can match the correct tab_close_timing entries. The inspect
+// handler_begin line carries tab_id as the agent id.
+function findClosedTabID(logLines: LogLine[], logOffset: number): string | null {
+  for (let i = logOffset; i < logLines.length; i++) {
+    const j = logLines[i]?.json
+    if (j && j.marker === 'tab_close_timing' && j.phase === 'handler_begin' && typeof j.tab_id === 'string')
+      return j.tab_id
+  }
+  return null
+}
+
+// Await the close RPC round-trip and the backend handler_begin marker,
+// then assemble the browser+worker timeline, render it, log it, and
+// attach it to the Playwright report. Returns the snapshot of browser
+// marks so the caller can make scenario-specific assertions (e.g. on
+// dialogVisibleAt / tabRemovedAt).
+async function captureCloseTimeline(
+  page: Page,
+  srv: TimingServer,
+  logsBefore: number,
+  anchor: ClockAnchor,
+  testInfo: TestInfo,
+  scenarioLabel: string,
+  attachName: string,
+  extra: PhaseMark[] = [],
+): Promise<RawMarks> {
+  await expect.poll(async () => {
+    const r = await snapshotMarks(page)
+    return r.rpcMarks.some(m => m.type === 'rpc-recv' && (m.method === 'CloseAgent' || m.method === 'CloseTerminal'))
+  }, { timeout: 10_000 }).toBeTruthy()
+  await expect.poll(() => findClosedTabID(srv.logLines, logsBefore) !== null, { timeout: 10_000 }).toBeTruthy()
+  const closedTabID = findClosedTabID(srv.logLines, logsBefore)!
+
+  const raw = await snapshotMarks(page)
+  const workerMarks = extractCloseWorkerMarks(srv.logLines, logsBefore, closedTabID, anchor)
+  const marks = buildTimeline(anchor.perf, raw, workerMarks, extra)
+  const report = renderTimeline(marks)
+  const border = '─'.repeat(scenarioLabel.length + 6)
+  console.log(`\n──── ${scenarioLabel} ────\n${report}\n${border}\n`)
+  await testInfo.attach(attachName, { body: report, contentType: 'text/plain' })
+  return raw
+}
+
+// ─── The repo the scenarios operate on ────────────────────────────────
+
+interface RepoCtx {
+  /** Absolute path of the repo root (HEAD branch is whatever git init gives). */
+  repoDir: string
+  /** Whether the repo is owned by the test (safe to clean up via worktree rm). */
+  synthetic: boolean
+}
+
+function getRepoCtx(dataDir: string, scenarioName: string): RepoCtx {
+  const override = process.env.LEAPMUX_CLOSE_TIMING_REPO_DIR
+  if (override) {
+    return { repoDir: override, synthetic: false }
+  }
+  return { repoDir: createGitRepo(dataDir, scenarioName), synthetic: true }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+test.describe('Tab close timing', () => {
+  test.describe.configure({ retries: 0 })
+
+  let srv: TimingServer
+
+  test.beforeAll(async () => {
+    srv = await startTimingServer({
+      dataDirPrefix: 'leapmux-close-timing-e2e',
+      env: {
+        LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
+        LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
+        LEAPMUX_WORKER_NAME: 'Local',
+        LEAPMUX_TRACE_TAB_CLOSE: '1',
+      },
+    })
+  })
+
+  test.afterAll(async () => {
+    if (srv)
+      await stopDevServer(srv)
+  })
+
+  test('scenario 1 — two worktree tabs on the same worktree, close one', async ({ browser }, testInfo) => {
+    const { hubUrl, adminToken, workerId, adminOrgId, dataDir } = srv
+    const ctx = getRepoCtx(dataDir, 'close-timing-scn1')
+
+    // createWorkspaceWithWorktreeViaAPI opens agent 1 with createWorktree=true
+    // on branch "scn1-branch". After the page loads, clicking "+ New Agent"
+    // opens a second agent. The workspace's currentDir is the worktree, so
+    // the new agent reuses the same worktree — ensureTrackedWorktree finds
+    // the existing row and registers tab 2 against the same worktree_id.
+    // Closing either tab leaves tabCount=1 for the worktree, so inspect
+    // returns shouldPrompt=false.
+    const workspaceId = await createWorkspaceWithWorktreeViaAPI(
+      hubUrl,
+      adminToken,
+      workerId,
+      'close-timing-scn1',
+      adminOrgId,
+      ctx.repoDir,
+      'scn1-branch',
+    )
+
+    const context = await browser.newContext({ baseURL: hubUrl })
+    const page = await context.newPage()
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
+      await page.locator('[data-testid^="new-agent-button"]').first().click()
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(2)
+
+      await installObservers(page)
+
+      const anchor = await page.evaluate(() => ({ perf: performance.now(), wall: Date.now() }))
+      const logsBefore = srv.logLines.length
+      await page.locator('[data-testid="tab"][data-tab-type="agent"]').first().locator('[data-testid="tab-close"]').dispatchEvent('click')
+
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
+      const raw = await captureCloseTimeline(
+        page,
+        srv,
+        logsBefore,
+        anchor,
+        testInfo,
+        'scenario 1: two-worktree-tabs, close one',
+        'close-timing-scenario-1',
+      )
+
+      expect(raw.dialogVisibleAt, 'no dialog expected when worktree has >1 tab').toBeNull()
+      expect(raw.tabRemovedAt, 'tab DOM should have been removed').not.toBeNull()
+      expect(raw.tabRemovedAt! - anchor.perf).toBeLessThan(3000)
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      await context.close()
+    }
+  })
+
+  test('scenario 2 — worktree close with "Close anyway" (KEEP)', async ({ browser }, testInfo) => {
+    const { hubUrl, adminToken, workerId, adminOrgId, dataDir } = srv
+    const ctx = getRepoCtx(dataDir, 'close-timing-scn2')
+
+    const workspaceId = await createWorkspaceWithWorktreeViaAPI(
+      hubUrl,
+      adminToken,
+      workerId,
+      'close-timing-scn2',
+      adminOrgId,
+      ctx.repoDir,
+      'scn2-branch',
+    )
+
+    const context = await browser.newContext({ baseURL: hubUrl })
+    const page = await context.newPage()
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
+
+      await installObservers(page)
+
+      const anchor = await page.evaluate(() => ({ perf: performance.now(), wall: Date.now() }))
+      const logsBefore = srv.logLines.length
+      await page.locator('[data-testid="tab"][data-tab-type="agent"]')
+        .locator('[data-testid="tab-close"]')
+        .dispatchEvent('click')
+
+      await expect(page.getByRole('heading', { name: 'Close Last Tab' })).toBeVisible()
+      const tDialogClickMs = await page.evaluate(() => performance.now())
+      await page.getByRole('button', { name: 'Close anyway' }).click()
+      await page.getByRole('button', { name: 'Confirm?' }).click()
+
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(0)
+      const raw = await captureCloseTimeline(
+        page,
+        srv,
+        logsBefore,
+        anchor,
+        testInfo,
+        'scenario 2: worktree close-anyway (KEEP)',
+        'close-timing-scenario-2',
+        [{ name: 'ui:dialog-user-click', tMs: tDialogClickMs }],
+      )
+
+      expect(raw.dialogVisibleAt).not.toBeNull()
+      expect(raw.tabRemovedAt).not.toBeNull()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      await context.close()
+    }
+  })
+
+  test('scenario 3 — worktree close with "Delete" (REMOVE)', async ({ browser }, testInfo) => {
+    const { hubUrl, adminToken, workerId, adminOrgId, dataDir } = srv
+    const ctx = getRepoCtx(dataDir, 'close-timing-scn3')
+    const worktreeDir = ctx.synthetic
+      ? join(realpathSync(dataDir), 'close-timing-scn3-worktrees', 'scn3-branch')
+      : null
+
+    const workspaceId = await createWorkspaceWithWorktreeViaAPI(
+      hubUrl,
+      adminToken,
+      workerId,
+      'close-timing-scn3',
+      adminOrgId,
+      ctx.repoDir,
+      'scn3-branch',
+    )
+    if (worktreeDir) {
+      await expect.poll(() => existsSync(worktreeDir), { timeout: 15_000, intervals: [100] }).toBe(true)
+    }
+
+    const context = await browser.newContext({ baseURL: hubUrl })
+    const page = await context.newPage()
+    try {
+      await loginViaToken(page, adminToken)
+      await page.goto(`/o/admin/workspace/${workspaceId}`)
+      await waitForWorkspaceReady(page)
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
+
+      await installObservers(page)
+
+      const anchor = await page.evaluate(() => ({ perf: performance.now(), wall: Date.now() }))
+      const logsBefore = srv.logLines.length
+      await page.locator('[data-testid="tab"][data-tab-type="agent"]')
+        .locator('[data-testid="tab-close"]')
+        .dispatchEvent('click')
+
+      await expect(page.getByRole('heading', { name: 'Close Last Tab' })).toBeVisible()
+      const tDialogClickMs = await page.evaluate(() => performance.now())
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await page.getByRole('button', { name: 'Confirm?' }).click()
+
+      await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(0)
+      const raw = await captureCloseTimeline(
+        page,
+        srv,
+        logsBefore,
+        anchor,
+        testInfo,
+        'scenario 3: worktree delete (REMOVE)',
+        'close-timing-scenario-3',
+        [{ name: 'ui:dialog-user-click', tMs: tDialogClickMs }],
+      )
+
+      expect(raw.dialogVisibleAt).not.toBeNull()
+      expect(raw.tabRemovedAt).not.toBeNull()
+      if (worktreeDir)
+        await waitForPathDeleted(worktreeDir, 10_000)
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+      await context.close()
+    }
+  })
+})

--- a/frontend/tests/e2e/55b-worktree-lifecycle.spec.ts
+++ b/frontend/tests/e2e/55b-worktree-lifecycle.spec.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { WorktreeAction } from '../../src/generated/leapmux/v1/common_pb'
 import {
   OpenTerminalRequestSchema,
   OpenTerminalResponseSchema,
@@ -18,7 +19,6 @@ import {
   inspectLastTabCloseViaAPI,
   openNewWorkspaceDialog,
   pushBranchForCloseViaAPI,
-  scheduleWorktreeDeletionViaAPI,
   setWorkingDir,
   waitForAgentsViaAPI,
   waitForOrgPageReady,
@@ -100,8 +100,7 @@ test.describe('Worktree Lifecycle', () => {
     const inspect = await inspectLastTabCloseViaAPI(hubUrl, adminToken, workerId, TabType.AGENT, agents[0].id)
     expect(inspect.shouldPrompt).toBe(true)
     expect(inspect.worktreePath).toContain('test-repo-autoclean-worktrees/autoclean-branch')
-    await scheduleWorktreeDeletionViaAPI(hubUrl, adminToken, workerId, inspect.worktreeId)
-    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id, WorktreeAction.REMOVE)
 
     await waitForPathDeleted(worktreeDir)
     await waitForPathDeleted(join(repoDir, '.git', 'refs', 'heads', 'autoclean-branch'))
@@ -147,8 +146,7 @@ test.describe('Worktree Lifecycle', () => {
     const agents = await waitForAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId, adminOrgId)
     const inspect = await inspectLastTabCloseViaAPI(hubUrl, adminToken, workerId, TabType.AGENT, agents[0].id)
     expect(inspect.shouldPrompt).toBe(true)
-    await scheduleWorktreeDeletionViaAPI(hubUrl, adminToken, workerId, inspect.worktreeId)
-    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id, WorktreeAction.REMOVE)
 
     await waitForPathDeleted(worktreeDir)
     await waitForPathDeleted(join(repoDir, '.git', 'refs', 'heads', 'shared-branch'))
@@ -183,8 +181,7 @@ test.describe('Worktree Lifecycle', () => {
     expect(inspect.shouldPrompt).toBe(true)
     expect(inspect.branchName).toBe('manual-branch')
 
-    await scheduleWorktreeDeletionViaAPI(hubUrl, adminToken, workerId, inspect.worktreeId)
-    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id, WorktreeAction.REMOVE)
 
     await waitForPathDeleted(manualWorktreeDir)
     expect(branchExists(repoDir, 'manual-branch')).toBe(false)

--- a/frontend/tests/e2e/55c-worktree-git-modes.spec.ts
+++ b/frontend/tests/e2e/55c-worktree-git-modes.spec.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { existsSync, realpathSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { WorktreeAction } from '../../src/generated/leapmux/v1/common_pb'
 import { TabType } from '../../src/generated/leapmux/v1/workspace_pb'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
@@ -12,7 +13,6 @@ import {
   createWorkspaceWithWorktreeViaAPI,
   inspectLastTabCloseViaAPI,
   openNewWorkspaceDialog,
-  scheduleWorktreeDeletionViaAPI,
   setWorkingDir,
   waitForAgentsViaAPI,
   waitForOrgPageReady,
@@ -298,15 +298,13 @@ test.describe('Worktree Git Modes', () => {
     const agents = await waitForAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId, adminOrgId)
     const firstAgent = agents.find(a => a.id !== secondAgentId)!
     expect(firstAgent).toBeTruthy()
-    const resp = await closeAgentViaAPI(hubUrl, adminToken, workerId, firstAgent.id)
-    expect(resp.worktreeCleanupPending).toBeFalsy()
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, firstAgent.id)
     expect(existsSync(worktreeDir)).toBe(true)
 
-    // Schedule deletion for the last tab, then close the second agent — worktree should be deleted.
+    // Close the last tab with WORKTREE_ACTION_REMOVE — worktree should be deleted.
     const inspect2 = await inspectLastTabCloseViaAPI(hubUrl, adminToken, workerId, TabType.AGENT, secondAgentId)
-    await scheduleWorktreeDeletionViaAPI(hubUrl, adminToken, workerId, inspect2.worktreeId)
-    const resp2 = await closeAgentViaAPI(hubUrl, adminToken, workerId, secondAgentId)
-    expect(resp2.worktreeCleanupPending).toBeFalsy()
+    expect(inspect2.shouldPrompt).toBe(true)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, secondAgentId, WorktreeAction.REMOVE)
     await waitForPathDeleted(worktreeDir)
   })
 
@@ -330,10 +328,9 @@ test.describe('Worktree Git Modes', () => {
 
     // Close the agent.
     const agents = await waitForAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId, adminOrgId)
-    const resp = await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
 
     // Unmanaged worktree should NOT be cleaned up.
-    expect(resp.worktreeCleanupPending).toBeFalsy()
     expect(existsSync(worktreeDir)).toBe(true)
     expect(branchExists(repoDir, 'ext-branch')).toBe(true)
   })
@@ -411,15 +408,13 @@ test.describe('Worktree Git Modes', () => {
     const agents = await waitForAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId, adminOrgId)
     const firstAgent = agents.find(a => a.id !== secondAgentId)!
     expect(firstAgent).toBeTruthy()
-    const resp = await closeAgentViaAPI(hubUrl, adminToken, workerId, firstAgent.id)
-    expect(resp.worktreeCleanupPending).toBeFalsy()
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, firstAgent.id)
     expect(existsSync(worktreeDir)).toBe(true)
 
-    // Schedule deletion for the last tab, then close the second agent — worktree should be deleted.
+    // Close the last tab with WORKTREE_ACTION_REMOVE — worktree should be deleted.
     const inspect2 = await inspectLastTabCloseViaAPI(hubUrl, adminToken, workerId, TabType.AGENT, secondAgentId)
-    await scheduleWorktreeDeletionViaAPI(hubUrl, adminToken, workerId, inspect2.worktreeId)
-    const resp2 = await closeAgentViaAPI(hubUrl, adminToken, workerId, secondAgentId)
-    expect(resp2.worktreeCleanupPending).toBeFalsy()
+    expect(inspect2.shouldPrompt).toBe(true)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, secondAgentId, WorktreeAction.REMOVE)
     await waitForPathDeleted(worktreeDir)
   })
 
@@ -441,10 +436,9 @@ test.describe('Worktree Git Modes', () => {
 
     // Close the agent.
     const agents = await waitForAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId, adminOrgId)
-    const resp = await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
+    await closeAgentViaAPI(hubUrl, adminToken, workerId, agents[0].id)
 
     // No cleanup — unmanaged worktree should still exist.
-    expect(resp.worktreeCleanupPending).toBeFalsy()
     expect(existsSync(worktreeDir)).toBe(true)
     expect(branchExists(repoDir, 'ext-branch')).toBe(true)
   })

--- a/frontend/tests/e2e/helpers/timingFixture.ts
+++ b/frontend/tests/e2e/helpers/timingFixture.ts
@@ -1,0 +1,211 @@
+/**
+ * Shared infrastructure for perf-timing e2e specs (e.g.
+ * 121-claude-agent-open-timing, 122-tab-close-timing). Each spec uses
+ * its own dev-server fixture so it can pass `LEAPMUX_TRACE_*` env vars
+ * and capture backend stderr for slog phase markers. This module
+ * consolidates the log-line buffer, JSON-line parsing, browser-side
+ * RPC mark wiring, and the ASCII-table timeline renderer.
+ *
+ * The spec-specific bits (which phase names to expect, which markers
+ * to filter, what DOM events to observe with MutationObserver) stay in
+ * each spec file.
+ */
+import type { Page } from '@playwright/test'
+import type { Buffer } from 'node:buffer'
+import type { DevServerHandle } from './devServer'
+import { startDevServer } from './devServer'
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+export interface LogLine {
+  raw: string
+  json: Record<string, unknown> | null
+  rxAt: number
+}
+
+export interface PhaseMark {
+  name: string
+  tMs: number
+}
+
+export interface RpcMark {
+  type: 'rpc-send' | 'rpc-recv'
+  method: string
+  at: number
+  ok?: boolean
+}
+
+export interface TimingServer extends DevServerHandle {
+  /** All backend log lines emitted since server start, parsed if JSON. */
+  logLines: LogLine[]
+}
+
+// ──────────────────────────────────────────────
+// Dev server with stderr capture
+// ──────────────────────────────────────────────
+
+/**
+ * Parse a single JSON log line. Returns null on non-JSON or parse error.
+ * slog's JSONHandler emits one JSON object per line on stderr when not
+ * attached to a TTY (which is how child_process pipes work).
+ */
+function parseJsonLine(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('{'))
+    return null
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>
+  }
+  catch {
+    return null
+  }
+}
+
+export interface TimingServerOptions {
+  /** Prefix for the mkdtemp name (helps when debugging leftover dirs). */
+  dataDirPrefix: string
+  /**
+   * Extra env vars layered on top of process.env. Pass the
+   * spec-specific LEAPMUX_TRACE_* gate here.
+   */
+  env: Record<string, string>
+}
+
+/**
+ * Spin up `leapmux dev` with stderr captured into `logLines`. Each log
+ * line is parsed as JSON when possible; the raw text is preserved for
+ * grep-style lookups.
+ */
+export async function startTimingServer(opts: TimingServerOptions): Promise<TimingServer> {
+  const logLines: LogLine[] = []
+  const handleChunk = (chunk: Buffer) => {
+    const text = chunk.toString('utf8')
+    const now = performance.now()
+    for (const line of text.split(/\r?\n/)) {
+      if (!line)
+        continue
+      logLines.push({ raw: line, json: parseJsonLine(line), rxAt: now })
+    }
+  }
+  const handle = await startDevServer({
+    dataDirPrefix: opts.dataDirPrefix,
+    env: opts.env,
+    onStdio: handleChunk,
+  })
+  return { ...handle, logLines }
+}
+
+// ──────────────────────────────────────────────
+// Browser-side RPC mark wiring
+// ──────────────────────────────────────────────
+
+/**
+ * Install leapmux:rpc-send / leapmux:rpc-recv listeners and initialize
+ * `window.__rpcMarks` as an empty array. The listeners are only added
+ * once per page — calling this helper again resets the array but does
+ * not re-register, so iteration loops can zero the buffer between
+ * samples without piling up duplicate listeners.
+ *
+ * Callers read `window.__rpcMarks` directly (keeps the read pattern
+ * obvious at the call site; there's no single shared "snapshot" shape
+ * since each spec combines marks with its own DOM state).
+ */
+export async function installRpcListeners(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    interface RpcWindow {
+      __rpcMarks?: Array<{ type: 'rpc-send' | 'rpc-recv', method: string, at: number, ok?: boolean }>
+      __rpcListenersInstalled?: boolean
+    }
+    const w = window as unknown as RpcWindow
+    w.__rpcMarks = []
+    if (w.__rpcListenersInstalled)
+      return
+    w.__rpcListenersInstalled = true
+    window.addEventListener('leapmux:rpc-send', (ev) => {
+      const d = (ev as CustomEvent<{ method: string, at: number }>).detail
+      w.__rpcMarks!.push({ type: 'rpc-send', method: d.method, at: d.at })
+    })
+    window.addEventListener('leapmux:rpc-recv', (ev) => {
+      const d = (ev as CustomEvent<{ method: string, at: number, ok: boolean }>).detail
+      w.__rpcMarks!.push({ type: 'rpc-recv', method: d.method, at: d.at, ok: d.ok })
+    })
+  })
+}
+
+// ──────────────────────────────────────────────
+// Worker phase extraction
+// ──────────────────────────────────────────────
+
+export interface ClockAnchor {
+  /** performance.now() captured in the browser at click time. */
+  perf: number
+  /** Date.now() captured alongside `perf`, used to translate slog's wall timestamps. */
+  wall: number
+}
+
+export interface ExtractWorkerMarksOptions {
+  /** slog marker to filter on, e.g. 'agent_startup_timing'. */
+  marker: string
+  /** Log row field holding the entity id, e.g. 'agent_id' or 'tab_id'. */
+  idField: string
+  /** Only include rows whose `idField` equals this value. */
+  idValue: string
+  /** Formatter for the returned mark name; receives the raw JSON row. */
+  name: (row: Record<string, unknown>) => string
+}
+
+/**
+ * Scan stderr log lines for backend phase markers and convert their
+ * wall-clock timestamps into the browser's performance.now clock via
+ * the given anchor. Shared by perf specs so they need only specify
+ * their marker + id field.
+ */
+export function extractWorkerMarks(
+  logLines: LogLine[],
+  logOffset: number,
+  anchor: ClockAnchor,
+  opts: ExtractWorkerMarksOptions,
+): PhaseMark[] {
+  const out: PhaseMark[] = []
+  for (let i = logOffset; i < logLines.length; i++) {
+    const j = logLines[i]?.json
+    if (!j || j.marker !== opts.marker || j[opts.idField] !== opts.idValue)
+      continue
+    const timeStr = String(j.time ?? '')
+    if (!timeStr)
+      continue
+    const wallMs = new Date(timeStr).getTime()
+    out.push({
+      name: opts.name(j),
+      tMs: anchor.perf + (wallMs - anchor.wall),
+    })
+  }
+  return out
+}
+
+// ──────────────────────────────────────────────
+// Timeline formatter
+// ──────────────────────────────────────────────
+
+/**
+ * Render a sorted mark list as an ASCII table with absolute and delta
+ * milliseconds per phase. Input must already be sorted by tMs.
+ */
+export function renderTimeline(marks: PhaseMark[]): string {
+  if (marks.length === 0)
+    return '(no marks captured)'
+  const t0 = marks[0]!.tMs
+  const nameWidth = Math.max(...marks.map(m => m.name.length))
+  const lines: string[] = []
+  lines.push(`${'phase'.padEnd(nameWidth)}  abs (ms)     Δ (ms)`)
+  lines.push(`${'-'.repeat(nameWidth)}  --------   --------`)
+  for (let i = 0; i < marks.length; i++) {
+    const m = marks[i]!
+    const abs = m.tMs - t0
+    const delta = i === 0 ? 0 : m.tMs - marks[i - 1]!.tMs
+    lines.push(`${m.name.padEnd(nameWidth)}  ${abs.toFixed(1).padStart(8)}   ${delta.toFixed(1).padStart(8)}`)
+  }
+  return lines.join('\n')
+}

--- a/frontend/tests/e2e/helpers/worktree.ts
+++ b/frontend/tests/e2e/helpers/worktree.ts
@@ -8,6 +8,7 @@ import {
   ListAgentsRequestSchema,
   ListAgentsResponseSchema,
 } from '../../../src/generated/leapmux/v1/agent_pb'
+import { WorktreeAction } from '../../../src/generated/leapmux/v1/common_pb'
 import {
   ForceRemoveWorktreeRequestSchema,
   ForceRemoveWorktreeResponseSchema,
@@ -17,8 +18,6 @@ import {
   KeepWorktreeResponseSchema,
   PushBranchForCloseRequestSchema,
   PushBranchForCloseResponseSchema,
-  ScheduleWorktreeDeletionRequestSchema,
-  ScheduleWorktreeDeletionResponseSchema,
 } from '../../../src/generated/leapmux/v1/git_pb'
 import {
   CloseTerminalRequestSchema,
@@ -121,8 +120,8 @@ export async function createWorkspaceWithWorktreeViaAPI(
 }
 
 /**
- * Close a terminal via E2EE channel.
- * Returns the response including worktree cleanup info.
+ * Close a terminal via E2EE channel. Pass `worktreeAction` to atomically
+ * remove the worktree after the PTY/DB cleanup (REMOVE) or keep it (KEEP).
  */
 export async function closeTerminalViaAPI(
   hubUrl: string,
@@ -131,44 +130,51 @@ export async function closeTerminalViaAPI(
   workspaceId: string,
   orgId: string,
   terminalId: string,
-): Promise<{ worktreeCleanupPending: boolean, worktreePath: string, worktreeId: string }> {
+  worktreeAction: WorktreeAction = WorktreeAction.KEEP,
+): Promise<{ worktreePath: string, worktreeId: string, failureMessage: string, failureDetail: string }> {
   const channel = await getTestChannel(hubUrl, token)
   const resp = await channel.callWorker(
     workerId,
     'CloseTerminal',
     CloseTerminalRequestSchema,
     CloseTerminalResponseSchema,
-    { workspaceId, orgId, terminalId },
+    { workspaceId, orgId, terminalId, worktreeAction },
   )
+  const result = resp.result
   return {
-    worktreeCleanupPending: resp.worktreeCleanupPending,
-    worktreePath: resp.worktreePath,
-    worktreeId: resp.worktreeId,
+    worktreePath: result?.worktreePath ?? '',
+    worktreeId: result?.worktreeId ?? '',
+    failureMessage: result?.failureMessage ?? '',
+    failureDetail: result?.failureDetail ?? '',
   }
 }
 
 /**
- * Close an agent via E2EE channel.
- * Returns the response including worktree cleanup info.
+ * Close an agent via E2EE channel. Pass `worktreeAction` to atomically
+ * remove the worktree after the process/DB cleanup (REMOVE) or keep it
+ * (KEEP).
  */
 export async function closeAgentViaAPI(
   hubUrl: string,
   token: string,
   workerId: string,
   agentId: string,
-): Promise<{ worktreeCleanupPending: boolean, worktreePath: string, worktreeId: string }> {
+  worktreeAction: WorktreeAction = WorktreeAction.KEEP,
+): Promise<{ worktreePath: string, worktreeId: string, failureMessage: string, failureDetail: string }> {
   const channel = await getTestChannel(hubUrl, token)
   const resp = await channel.callWorker(
     workerId,
     'CloseAgent',
     CloseAgentRequestSchema,
     CloseAgentResponseSchema,
-    { agentId },
+    { agentId, worktreeAction },
   )
+  const result = resp.result
   return {
-    worktreeCleanupPending: resp.worktreeCleanupPending,
-    worktreePath: resp.worktreePath,
-    worktreeId: resp.worktreeId,
+    worktreePath: result?.worktreePath ?? '',
+    worktreeId: result?.worktreeId ?? '',
+    failureMessage: result?.failureMessage ?? '',
+    failureDetail: result?.failureDetail ?? '',
   }
 }
 
@@ -306,25 +312,6 @@ export async function inspectLastTabCloseViaAPI(
     unpushedCommitCount: resp.unpushedCommitCount,
     remoteBranchMissing: resp.remoteBranchMissing,
   }
-}
-
-/**
- * Schedule worktree deletion via E2EE channel.
- */
-export async function scheduleWorktreeDeletionViaAPI(
-  hubUrl: string,
-  token: string,
-  workerId: string,
-  worktreeId: string,
-): Promise<void> {
-  const channel = await getTestChannel(hubUrl, token)
-  await channel.callWorker(
-    workerId,
-    'ScheduleWorktreeDeletion',
-    ScheduleWorktreeDeletionRequestSchema,
-    ScheduleWorktreeDeletionResponseSchema,
-    { worktreeId },
-  )
 }
 
 /**

--- a/frontend/tests/unit/components/useAgentOperations.test.ts
+++ b/frontend/tests/unit/components/useAgentOperations.test.ts
@@ -6,6 +6,7 @@ import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAgentOperations } from '~/components/shell/useAgentOperations'
 import { AgentInfoSchema, AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createAgentStore } from '~/stores/agent.store'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
@@ -13,7 +14,7 @@ import { createControlStore } from '~/stores/control.store'
 import { createLayoutStore } from '~/stores/layout.store'
 import { createTabStore } from '~/stores/tab.store'
 
-const mockCloseAgent = vi.fn<(workerId: string, req: { agentId: string }) => Promise<CloseAgentResponse>>()
+const mockCloseAgent = vi.fn<(workerId: string, req: { agentId: string, worktreeAction?: WorktreeAction }) => Promise<CloseAgentResponse>>()
 const mockOpenAgent = vi.fn()
 const mockSendAgentRawMessage = vi.fn()
 const mockSendAgentMessage = vi.fn()
@@ -22,7 +23,7 @@ const mockListAvailableProviders = vi.fn().mockResolvedValue({ providers: [] })
 const mockShowWarnToast = vi.fn()
 
 vi.mock('~/api/workerRpc', () => ({
-  closeAgent: (...args: unknown[]) => mockCloseAgent(...args as [string, { agentId: string }]),
+  closeAgent: (...args: unknown[]) => mockCloseAgent(...args as [string, { agentId: string, worktreeAction?: WorktreeAction }]),
   openAgent: (...args: unknown[]) => mockOpenAgent(...args),
   sendAgentMessage: (...args: unknown[]) => mockSendAgentMessage(...args),
   sendAgentRawMessage: (...args: unknown[]) => mockSendAgentRawMessage(...args),
@@ -417,7 +418,7 @@ describe('useAgentOperations', () => {
   })
 
   describe('handleCloseAgent', () => {
-    it('should call closeAgent RPC when workerId is available', async () => {
+    it('removes agent/tab synchronously BEFORE the close RPC resolves', async () => {
       await createRoot(async (dispose) => {
         try {
           const { agentStore, tabStore, ops } = setup()
@@ -425,12 +426,16 @@ describe('useAgentOperations', () => {
           agentStore.addAgent(agent)
           tabStore.addTab({ type: TabType.AGENT, id: 'a-1', title: 'Agent 1', tileId: 'tile-1', workerId: 'w-1', workingDir: '/tmp' })
 
-          mockCloseAgent.mockResolvedValueOnce({ worktreeCleanupPending: false, worktreeId: '' } as CloseAgentResponse)
+          // Never-resolving RPC to prove the UI mutation is synchronous.
+          mockCloseAgent.mockReturnValueOnce(new Promise(() => {}))
 
-          await ops.handleCloseAgent('a-1')
+          ops.handleCloseAgent('a-1')
 
-          expect(mockCloseAgent).toHaveBeenCalledWith('w-1', { agentId: 'a-1' })
+          // Store mutations happened synchronously.
           expect(agentStore.state.agents.find(a => a.id === 'a-1')).toBeUndefined()
+          expect(tabStore.state.tabs.find(t => t.id === 'a-1')).toBeUndefined()
+          // RPC was dispatched with KEEP as the default worktree action.
+          expect(mockCloseAgent).toHaveBeenCalledWith('w-1', { agentId: 'a-1', worktreeAction: WorktreeAction.KEEP })
         }
         finally {
           dispose()
@@ -438,18 +443,98 @@ describe('useAgentOperations', () => {
       })
     })
 
-    it('should skip RPC and still remove tab when workerId is missing', async () => {
+    it('passes through the worktreeAction argument', async () => {
       await createRoot(async (dispose) => {
         try {
           const { agentStore, tabStore, ops } = setup()
-          // Agent with no workerId (e.g. worker gone after restart)
+          const agent = create(AgentInfoSchema, { id: 'a-remove', workerId: 'w-1' })
+          agentStore.addAgent(agent)
+          tabStore.addTab({ type: TabType.AGENT, id: 'a-remove', title: 'Agent Remove', tileId: 'tile-1', workerId: 'w-1', workingDir: '/tmp' })
+
+          mockCloseAgent.mockResolvedValueOnce({
+            result: {
+              worktreePath: '',
+              worktreeId: '',
+              failureMessage: '',
+              failureDetail: '',
+            },
+          } as CloseAgentResponse)
+
+          ops.handleCloseAgent('a-remove', WorktreeAction.REMOVE)
+          await flushMicrotasks()
+
+          expect(mockCloseAgent).toHaveBeenCalledWith('w-1', { agentId: 'a-remove', worktreeAction: WorktreeAction.REMOVE })
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('surfaces failure_message + failure_detail via toast when the RPC reports a partial failure', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { agentStore, tabStore, ops } = setup()
+          const agent = create(AgentInfoSchema, { id: 'a-fail', workerId: 'w-1' })
+          agentStore.addAgent(agent)
+          tabStore.addTab({ type: TabType.AGENT, id: 'a-fail', title: 'Agent Fail', tileId: 'tile-1', workerId: 'w-1', workingDir: '/tmp' })
+
+          mockCloseAgent.mockResolvedValueOnce({
+            result: {
+              worktreeId: 'wt-1',
+              worktreePath: '/some/wt',
+              failureMessage: 'Failed to remove worktree',
+              failureDetail: 'git worktree remove /some/wt: exit 128',
+            },
+          } as CloseAgentResponse)
+
+          ops.handleCloseAgent('a-fail', WorktreeAction.REMOVE)
+          await flushMicrotasks()
+
+          expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to remove worktree: git worktree remove /some/wt: exit 128')
+          // Tab was removed synchronously — failure doesn't roll back UI.
+          expect(tabStore.state.tabs.find(t => t.id === 'a-fail')).toBeUndefined()
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('surfaces a generic toast when the RPC rejects', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { agentStore, tabStore, ops } = setup()
+          const agent = create(AgentInfoSchema, { id: 'a-reject', workerId: 'w-1' })
+          agentStore.addAgent(agent)
+          tabStore.addTab({ type: TabType.AGENT, id: 'a-reject', title: 'Agent Reject', tileId: 'tile-1', workerId: 'w-1', workingDir: '/tmp' })
+
+          const err = new Error('network down')
+          mockCloseAgent.mockRejectedValueOnce(err)
+
+          ops.handleCloseAgent('a-reject')
+          await flushMicrotasks()
+
+          expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to close agent', err)
+          expect(tabStore.state.tabs.find(t => t.id === 'a-reject')).toBeUndefined()
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('skips RPC and still removes tab when workerId is missing', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { agentStore, tabStore, ops } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-2', workerId: '' })
           agentStore.addAgent(agent)
           tabStore.addTab({ type: TabType.AGENT, id: 'a-2', title: 'Agent 2', tileId: 'tile-1', workerId: '', workingDir: '' })
 
           mockCloseAgent.mockClear()
 
-          await ops.handleCloseAgent('a-2')
+          ops.handleCloseAgent('a-2')
 
           expect(mockCloseAgent).not.toHaveBeenCalled()
           expect(agentStore.state.agents.find(a => a.id === 'a-2')).toBeUndefined()
@@ -461,14 +546,14 @@ describe('useAgentOperations', () => {
       })
     })
 
-    it('should skip RPC when agent is not found in store', async () => {
+    it('skips RPC when agent is not found in store', async () => {
       await createRoot(async (dispose) => {
         try {
           const { ops } = setup()
 
           mockCloseAgent.mockClear()
 
-          await ops.handleCloseAgent('nonexistent')
+          ops.handleCloseAgent('nonexistent')
 
           expect(mockCloseAgent).not.toHaveBeenCalled()
         }

--- a/frontend/tests/unit/components/useTabOperations.test.ts
+++ b/frontend/tests/unit/components/useTabOperations.test.ts
@@ -1,6 +1,7 @@
 import { createRoot } from 'solid-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useTabOperations } from '~/components/shell/useTabOperations'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createAgentStore } from '~/stores/agent.store'
 import { createChatStore, MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
@@ -8,16 +9,17 @@ import { createLayoutStore } from '~/stores/layout.store'
 import { createTabStore } from '~/stores/tab.store'
 
 const mockInspectLastTabClose = vi.fn()
-const mockScheduleWorktreeDeletion = vi.fn()
+const mockPushBranchForClose = vi.fn()
 const mockShowWarnToast = vi.fn()
+const mockShowInfoToast = vi.fn()
 
 vi.mock('~/api/workerRpc', () => ({
   inspectLastTabClose: (...args: unknown[]) => mockInspectLastTabClose(...args),
-  scheduleWorktreeDeletion: (...args: unknown[]) => mockScheduleWorktreeDeletion(...args),
+  pushBranchForClose: (...args: unknown[]) => mockPushBranchForClose(...args),
 }))
 
 vi.mock('~/components/common/Toast', () => ({
-  showInfoToast: vi.fn(),
+  showInfoToast: (...args: unknown[]) => mockShowInfoToast(...args),
   showWarnToast: (...args: unknown[]) => mockShowWarnToast(...args),
 }))
 
@@ -44,11 +46,13 @@ function setup() {
   layoutStore.setLayout({ type: 'leaf', id: tileId })
   layoutStore.setFocusedTile(tileId)
 
-  tabStore.addTab({ type: TabType.AGENT, id: 'agent-a', tileId })
-  tabStore.addTab({ type: TabType.AGENT, id: 'agent-b', tileId }, { activate: false })
+  tabStore.addTab({ type: TabType.AGENT, id: 'agent-a', tileId, workerId: 'w-1' })
+  tabStore.addTab({ type: TabType.AGENT, id: 'agent-b', tileId, workerId: 'w-1' }, { activate: false })
   tabStore.setActiveTabForTile(tileId, TabType.AGENT, 'agent-a')
   agentStore.setActiveAgent('agent-a')
 
+  // handleCloseAgent / handleTerminalClose are now synchronous (void-returning)
+  // fire-and-forget handlers. Use plain vi.fn() with no resolved value.
   const handleCloseAgent = vi.fn()
   const handleTerminalClose = vi.fn()
 
@@ -76,41 +80,79 @@ function setup() {
 describe('useTabOperations', () => {
   afterEach(() => {
     mockInspectLastTabClose.mockReset()
-    mockScheduleWorktreeDeletion.mockReset()
+    mockPushBranchForClose.mockReset()
     mockShowWarnToast.mockReset()
+    mockShowInfoToast.mockReset()
   })
 
-  it.each([
-    { tabType: TabType.AGENT, tabId: 'agent-a', label: 'agent', handlerKey: 'handleCloseAgent' as const },
-    { tabType: TabType.TERMINAL, tabId: 'term-a', label: 'terminal', handlerKey: 'handleTerminalClose' as const },
-  ])('marks a $label tab as closing while persisted close is in flight', async ({ tabType, tabId, handlerKey }) => {
+  it('marks a tab as closing during decide phase, then clears once inspect resolves', async () => {
     await createRoot(async (dispose) => {
       try {
-        const result = setup()
-        const { tabStore, ops } = result
-        if (tabType === TabType.TERMINAL) {
-          tabStore.addTab({ type: TabType.TERMINAL, id: tabId, tileId: 'tile-1', workerId: 'w-1' }, { activate: false })
-        }
-        const tab = tabStore.state.tabs.find(t => t.id === tabId)!
-        const key = `${tabType}:${tabId}`
+        const { tabStore, ops, handleCloseAgent } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        const key = `${TabType.AGENT}:agent-a`
+
         let resolveInspect!: (value: { shouldPrompt: boolean }) => void
-        let resolveClose!: () => void
         mockInspectLastTabClose.mockImplementationOnce(() => new Promise((resolve) => {
           resolveInspect = resolve as typeof resolveInspect
-        }))
-        result[handlerKey].mockImplementationOnce(() => new Promise<void>((resolve) => {
-          resolveClose = resolve
         }))
 
         const closePromise = ops.handleTabClose(tab)
         expect(ops.closingTabKeys().has(key)).toBe(true)
+        expect(handleCloseAgent).not.toHaveBeenCalled()
 
         resolveInspect({ shouldPrompt: false })
-        await Promise.resolve()
-        expect(ops.closingTabKeys().has(key)).toBe(true)
-
-        resolveClose()
         await closePromise
+
+        // Decide phase done: spinner cleared, commit phase already ran.
+        expect(ops.closingTabKeys().has(key)).toBe(false)
+        expect(handleCloseAgent).toHaveBeenCalledTimes(1)
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
+  it('no-prompt path: tab is removed from the store synchronously with KEEP action', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleCloseAgent } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        mockInspectLastTabClose.mockResolvedValueOnce({ shouldPrompt: false })
+
+        await ops.handleTabClose(tab)
+
+        expect(handleCloseAgent).toHaveBeenCalledWith('agent-a', WorktreeAction.KEEP)
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
+  it('dialog cancel path: tab stays, handler not invoked, spinner cleared', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleCloseAgent, handleTerminalClose } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        const key = `${TabType.AGENT}:agent-a`
+        mockInspectLastTabClose.mockResolvedValueOnce({ shouldPrompt: true })
+
+        // Simulate the dialog resolving cancel as soon as it's opened.
+        const closePromise = ops.handleTabClose(tab)
+        // Wait for the handler to reach setLastTabConfirm and open the
+        // dialog; the signal holds the resolve fn.
+        await Promise.resolve()
+        await Promise.resolve()
+        const dlg = ops.lastTabConfirm()
+        expect(dlg).not.toBeNull()
+        dlg!.resolve('cancel')
+        await closePromise
+
+        expect(tabStore.state.tabs.some(t => t.id === 'agent-a')).toBe(true)
+        expect(handleCloseAgent).not.toHaveBeenCalled()
+        expect(handleTerminalClose).not.toHaveBeenCalled()
         expect(ops.closingTabKeys().has(key)).toBe(false)
       }
       finally {
@@ -119,10 +161,53 @@ describe('useTabOperations', () => {
     })
   })
 
-  it('clears the closing state if preparing the persisted close fails', async () => {
+  it('dialog close-anyway path: commit runs with KEEP', async () => {
     await createRoot(async (dispose) => {
       try {
-        const { tabStore, ops } = setup()
+        const { tabStore, ops, handleCloseAgent } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        mockInspectLastTabClose.mockResolvedValueOnce({ shouldPrompt: true })
+
+        const closePromise = ops.handleTabClose(tab)
+        await Promise.resolve()
+        await Promise.resolve()
+        ops.lastTabConfirm()!.resolve('close-anyway')
+        await closePromise
+
+        expect(handleCloseAgent).toHaveBeenCalledWith('agent-a', WorktreeAction.KEEP)
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
+  it('dialog schedule-delete path: commit runs with REMOVE', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleCloseAgent } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        mockInspectLastTabClose.mockResolvedValueOnce({ shouldPrompt: true })
+
+        const closePromise = ops.handleTabClose(tab)
+        await Promise.resolve()
+        await Promise.resolve()
+        ops.lastTabConfirm()!.resolve('schedule-delete')
+        await closePromise
+
+        expect(handleCloseAgent).toHaveBeenCalledWith('agent-a', WorktreeAction.REMOVE)
+        expect(mockShowInfoToast).toHaveBeenCalledWith('Worktree will be removed')
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
+  it('inspect error: toast shown, handler not invoked, spinner cleared', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleCloseAgent } = setup()
         const agentTab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
         const err = new Error('boom')
         mockInspectLastTabClose.mockRejectedValueOnce(err)
@@ -131,6 +216,35 @@ describe('useTabOperations', () => {
 
         expect(ops.closingTabKeys().has(`${TabType.AGENT}:agent-a`)).toBe(false)
         expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to prepare tab close', err)
+        expect(handleCloseAgent).not.toHaveBeenCalled()
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
+  it('rapid double-close dedupes during decide phase', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleCloseAgent } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+
+        let resolveInspect!: (value: { shouldPrompt: boolean }) => void
+        mockInspectLastTabClose.mockImplementationOnce(() => new Promise((resolve) => {
+          resolveInspect = resolve as typeof resolveInspect
+        }))
+
+        const p1 = ops.handleTabClose(tab)
+        const p2 = ops.handleTabClose(tab)
+
+        // Only one inspect should have been dispatched.
+        expect(mockInspectLastTabClose).toHaveBeenCalledTimes(1)
+
+        resolveInspect({ shouldPrompt: false })
+        await Promise.all([p1, p2])
+
+        expect(handleCloseAgent).toHaveBeenCalledTimes(1)
       }
       finally {
         dispose()

--- a/frontend/tests/unit/components/useTerminalOperations.test.ts
+++ b/frontend/tests/unit/components/useTerminalOperations.test.ts
@@ -1,18 +1,23 @@
+import type { CloseTerminalResponse } from '~/generated/leapmux/v1/terminal_pb'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 
 import { createRoot } from 'solid-js'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useTerminalOperations } from '~/components/shell/useTerminalOperations'
+import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createLayoutStore } from '~/stores/layout.store'
 import { createTabStore } from '~/stores/tab.store'
+
+const mockCloseTerminal = vi.fn<(workerId: string, req: { terminalId: string, worktreeAction?: WorktreeAction }) => Promise<CloseTerminalResponse>>()
+const mockShowWarnToast = vi.fn()
 
 vi.mock('~/api/workerRpc', () => ({
   createTerminal: vi.fn(),
   createTerminalWithShell: vi.fn(),
   sendTerminalInput: vi.fn(),
   resizeTerminal: vi.fn(),
-  closeTerminal: vi.fn(),
+  closeTerminal: (...args: unknown[]) => mockCloseTerminal(...args as [string, { terminalId: string, worktreeAction?: WorktreeAction }]),
   updateTerminalTitle: vi.fn(),
   listAvailableShells: vi.fn().mockResolvedValue({ shells: [], defaultShell: '' }),
 }))
@@ -25,7 +30,7 @@ vi.mock('~/api/clients', () => ({
 }))
 
 vi.mock('~/components/common/Toast', () => ({
-  showWarnToast: vi.fn(),
+  showWarnToast: (...args: unknown[]) => mockShowWarnToast(...args),
 }))
 
 function setup() {
@@ -47,7 +52,17 @@ function setup() {
   return { tabStore, ops }
 }
 
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe('useTerminalOperations', () => {
+  afterEach(() => {
+    mockCloseTerminal.mockReset()
+    mockShowWarnToast.mockReset()
+  })
+
   it('does not notify the active terminal tab on bell', () => {
     createRoot((dispose) => {
       const { tabStore, ops } = setup()
@@ -57,6 +72,103 @@ describe('useTerminalOperations', () => {
 
       expect(tabStore.state.tabs[0].hasNotification).not.toBe(true)
       dispose()
+    })
+  })
+
+  describe('handleTerminalClose', () => {
+    it('removes the terminal tab synchronously and fires closeTerminal with KEEP by default', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { tabStore, ops } = setup()
+          tabStore.addTab({ type: TabType.TERMINAL, id: 'term-close', tileId: 'tile-1', workerId: 'w-1' })
+
+          mockCloseTerminal.mockReturnValueOnce(new Promise(() => {}))
+
+          ops.handleTerminalClose('term-close')
+
+          expect(tabStore.state.tabs.find(t => t.id === 'term-close')).toBeUndefined()
+          expect(mockCloseTerminal).toHaveBeenCalledWith('w-1', expect.objectContaining({
+            terminalId: 'term-close',
+            worktreeAction: WorktreeAction.KEEP,
+          }))
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('passes through the worktreeAction argument', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { tabStore, ops } = setup()
+          tabStore.addTab({ type: TabType.TERMINAL, id: 'term-remove', tileId: 'tile-1', workerId: 'w-1' })
+
+          mockCloseTerminal.mockResolvedValueOnce({
+            result: {
+              worktreeId: '',
+              failureMessage: '',
+            },
+          } as CloseTerminalResponse)
+
+          ops.handleTerminalClose('term-remove', WorktreeAction.REMOVE)
+          await flushMicrotasks()
+
+          expect(mockCloseTerminal).toHaveBeenCalledWith('w-1', expect.objectContaining({
+            terminalId: 'term-remove',
+            worktreeAction: WorktreeAction.REMOVE,
+          }))
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('toasts a failure_message on partial failure', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { tabStore, ops } = setup()
+          tabStore.addTab({ type: TabType.TERMINAL, id: 'term-fail', tileId: 'tile-1', workerId: 'w-1' })
+
+          mockCloseTerminal.mockResolvedValueOnce({
+            result: {
+              worktreeId: 'wt-1',
+              worktreePath: '/some/wt',
+              failureMessage: 'Failed to remove worktree',
+              failureDetail: 'git worktree remove exit 128',
+            },
+          } as CloseTerminalResponse)
+
+          ops.handleTerminalClose('term-fail', WorktreeAction.REMOVE)
+          await flushMicrotasks()
+
+          expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to remove worktree: git worktree remove exit 128')
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('toasts a generic failure on RPC reject', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { tabStore, ops } = setup()
+          tabStore.addTab({ type: TabType.TERMINAL, id: 'term-reject', tileId: 'tile-1', workerId: 'w-1' })
+
+          const err = new Error('offline')
+          mockCloseTerminal.mockRejectedValueOnce(err)
+
+          ops.handleTerminalClose('term-reject')
+          await flushMicrotasks()
+
+          expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to close terminal', err)
+        }
+        finally {
+          dispose()
+        }
+      })
     })
   })
 })

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -73,10 +73,10 @@ message CloseAgentRequest {
   WorktreeAction worktree_action = 2;
 }
 
+// CloseAgentResponse reports the outcome of CloseAgent. See CloseTabResult
+// for why partial failures are returned in-band rather than as RPC errors.
 message CloseAgentResponse {
-  bool worktree_cleanup_pending = 1;  // True if worktree is dirty and needs confirmation
-  string worktree_path = 2;           // Path of the dirty worktree
-  string worktree_id = 3;             // ID for ForceRemoveWorktree/KeepWorktree
+  CloseTabResult result = 1;
 }
 
 message ListAgentsRequest {

--- a/proto/leapmux/v1/common.proto
+++ b/proto/leapmux/v1/common.proto
@@ -29,6 +29,26 @@ enum WorktreeAction {
   WORKTREE_ACTION_REMOVE = 2;       // User chose Remove
 }
 
+// CloseTabResult carries the outcome shared by CloseAgentResponse and
+// CloseTerminalResponse.
+//
+// Partial failures (DB close failed, worktree directory couldn't be
+// removed) are returned as success-plus-failure-fields rather than as
+// an RPC error. This is intentional: the close RPCs are fire-and-forget
+// dispatches issued *after* the frontend has already committed the UI
+// tab removal synchronously, so there is nothing to "roll back" if the
+// backend hits a hiccup. Structured failure fields let the UI surface a
+// warn toast (with the worktree path, if relevant) while still honoring
+// the already-visible close. An RPC error would collapse the structured
+// info into a single string and imply the close didn't happen, neither
+// of which matches the async-close contract.
+message CloseTabResult {
+  string worktree_path = 1;   // Populated on worktree-remove failure so the user can clean up manually
+  string worktree_id = 2;     // Populated on worktree-remove failure alongside worktree_path
+  string failure_message = 3; // Short human title of a partial failure (empty = success)
+  string failure_detail = 4;  // Longer context (path, stderr, stack) for the failure
+}
+
 // --- Per-file git status ---
 
 // GitFileStatusCode describes the status of a file in the index or working tree.

--- a/proto/leapmux/v1/git.proto
+++ b/proto/leapmux/v1/git.proto
@@ -70,12 +70,6 @@ message PushBranchForCloseRequest {
 
 message PushBranchForCloseResponse {}
 
-message ScheduleWorktreeDeletionRequest {
-  string worktree_id = 1;
-}
-
-message ScheduleWorktreeDeletionResponse {}
-
 message CheckWorktreeStatusResponse {
   bool has_worktree = 1;             // True if this tab is associated with a managed worktree
   bool is_last_tab = 2;             // True if this is the last tab referencing the worktree

--- a/proto/leapmux/v1/terminal.proto
+++ b/proto/leapmux/v1/terminal.proto
@@ -50,10 +50,11 @@ message CloseTerminalRequest {
   WorktreeAction worktree_action = 4;
 }
 
+// CloseTerminalResponse reports the outcome of CloseTerminal. See
+// CloseTabResult for why partial failures are returned in-band rather
+// than as RPC errors.
 message CloseTerminalResponse {
-  bool worktree_cleanup_pending = 1;  // True if worktree is dirty and needs confirmation
-  string worktree_path = 2;           // Path of the dirty worktree
-  string worktree_id = 3;             // ID for ForceRemoveWorktree/KeepWorktree
+  CloseTabResult result = 1;
 }
 
 message SendInputRequest {


### PR DESCRIPTION
## Motivation

Tab closure previously blocked the UI: the RPC call to the backend had to complete before the tab disappeared from the screen. For tabs with worktrees, this wait was especially noticeable because the close path ran git diff and push-status checks serially before the process even stopped. The result was a perceptible lag between clicking the close button and the tab going away.

Additionally, the worktree deletion path was fragmented: the "last tab" inspection ran git subprocesses even when no dialog would ever be shown (e.g., when sibling tabs share the same worktree), and the actual disk removal was triggered via a separate `scheduleWorktreeDeletion` RPC call after the close RPC returned.

## Modifications

**Backend**

- Added `closeTabCommon()` in a new `close_tab.go` file that consolidates the shared close flow for `CloseAgent` and `CloseTerminal`: stop process → DB delete → unregister tab → optional worktree removal. Both handlers now call this function on a `sync.WaitGroup` (`svc.Cleanup`) and return immediately; `Shutdown` drains the wait group before tearing down the database.
- Extracted `removeWorktreeFromDisk()` from `CheckWorktreeStatus` and the old `ScheduleWorktreeDeletion` handler. Force-removes the path, deletes branches, and soft-deletes the DB row. Returns an error only when the git command fails and the path still exists, so the UI knows manual cleanup is needed.
- Added fast-path detection in `inspectLastTabClose` to skip expensive git subprocesses (diff stats, push status) when no dialog will be shown (worktree with siblings, or non-worktree tab with siblings on the same branch). Remaining diff and push queries now run concurrently via `errgroup`.
- Split tab unregistration into `unregisterTab()` (tab-only) and `removeTabFromWorktree()` (guarded by `worktree_id`, used on the REMOVE path) to reduce coupling.
- Added a `phasetrace` package: env-var-gated structured timing logs emitted as marker strings consumed by e2e timing specs. No-op in production when the env var is unset.
- (Breaking) `ScheduleWorktreeDeletion` RPC removed. `WorktreeAction` is now passed inline to `CloseAgent` / `CloseTerminal`.
- (Breaking) `CloseAgentResponse` and `CloseTerminalResponse` now return a single `CloseTabResult` (in `common.proto`) carrying `failure_message`, `failure_detail`, `worktree_path`, and `worktree_id` for partial-failure reporting.

**Frontend**

- `handleCloseAgent` and `handleTerminalClose` now mutate stores synchronously (tab disappears at once), then fire the worker close RPC and hub `removeTab` as fire-and-forget. Both functions are now `void`-returning.
- `handleTabClose` in `useTabOperations` is split into two explicit phases: a *decide* phase (tab stays visible with a spinner while `inspectLastTabClose` and an optional dialog run) and a *commit* phase (synchronous store mutations followed by fire-and-forget RPCs). `worktreeAction` is passed directly into the close RPC, replacing the separate `scheduleWorktreeDeletion` call.
- Added `closeFailureToast.ts` to surface partial close failures (e.g., worktree removal failed) via a warn toast without rolling back the already-committed UI state.
- Removed `scheduleWorktreeDeletion` from `workerRpc.ts`.

**Tests**

- New `frontend/tests/e2e/helpers/timingFixture.ts` extracts shared timing infrastructure (dev-server startup, JSON log parsing, RPC listeners, ASCII timeline rendering) so both timing specs share one module. Spec 121 slimmed by ~113 lines.
- New `frontend/tests/e2e/122-tab-close-timing.spec.ts` measures end-to-end close latency for three scenarios: sibling on same worktree, last tab with dialog KEEP, and last tab with dialog REMOVE.
- Expanded unit test coverage in `useAgentOperations`, `useTabOperations`, and `useTerminalOperations` for the async-close flow: partial-failure toasting, KEEP vs REMOVE action, dialog cancel / close-anyway / schedule-delete paths, and verification that store mutations are synchronous.
- Updated `worktree.ts` e2e helper and related specs to pass `worktreeAction` through `closeAgentViaAPI` / `closeTerminalViaAPI` instead of calling the now-removed `scheduleWorktreeDeletionViaAPI`.

## Result

Clicking the close button on an agent or terminal tab now removes it from the UI immediately. Backend cleanup (process shutdown, DB deletion, optional worktree removal) runs in the background without making the user wait.

If worktree removal fails after the tab is already gone, a warning toast appears with the worktree path and error detail so the user knows manual cleanup is needed — without any confusing rollback of UI state.
