### PR TITLE
feat(hub): Replace hardcoded admin/admin123 with first-admin setup flow

### DIFF
--- a/backend/cmd/leapmux/admin_user.go
+++ b/backend/cmd/leapmux/admin_user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/leapmux/leapmux/internal/util/validate"
 )
@@ -141,6 +142,10 @@ func runUserCreate(args []string) error {
 		slug, err := validate.SanitizeSlug("username", *username)
 		if err != nil {
 			return err
+		}
+
+		if usernames.IsReservedSystem(slug) {
+			return fmt.Errorf("%q is a reserved username", slug)
 		}
 
 		if err := validate.ValidatePassword(pwValue); err != nil {

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/storeopen"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
 	"github.com/leapmux/leapmux/internal/logging"
 	"github.com/leapmux/leapmux/internal/metrics"
@@ -105,10 +106,26 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	}
 	slog.Info("encryption keystore loaded", "active_version", ks.ActiveVersion(), "versions", len(ks.Versions()))
 
-	if err := bootstrap.Run(context.Background(), st, cfg.SoloMode, cfg.DevMode); err != nil {
+	if err := bootstrap.Run(context.Background(), st, cfg.SoloMode); err != nil {
 		_ = st.Close()
 		closeTCP()
 		return nil, fmt.Errorf("bootstrap: %w", err)
+	}
+
+	// In solo mode, bootstrap just created the solo user; load it once so
+	// the auth interceptor and channel relay can synthesize auth without
+	// repeating the lookup. A failure here indicates a broken bootstrap or
+	// a DB fault — fail startup rather than letting every subsequent request
+	// fail with an opaque 500.
+	var soloUser *auth.UserInfo
+	if cfg.SoloMode {
+		u, loadErr := auth.LoadSoloUser(context.Background(), st)
+		if loadErr != nil {
+			_ = st.Close()
+			closeTCP()
+			return nil, fmt.Errorf("load solo user: %w", loadErr)
+		}
+		soloUser = u
 	}
 
 	shutdownCh := make(chan struct{})
@@ -124,7 +141,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	cMgr := channelmgr.New(cMgrOpts...)
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
 
-	authInterceptor, sessionCache := auth.NewInterceptor(st, cfg.SoloMode, cfg.SecureCookies, cfg.EmailVerificationRequired)
+	authInterceptor, sessionCache := auth.NewInterceptor(st, soloUser, cfg.SecureCookies, cfg.EmailVerificationRequired)
 	connectOpts := connect.WithInterceptors(
 		auth.NewShutdownInterceptor(shutdownCh),
 		metrics.NewInterceptor(),
@@ -153,18 +170,6 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	mux.Handle(channelPath, channelHandler)
 
 	// WebSocket endpoint for encrypted channel relay (Frontend <-> Worker).
-	var soloUser *auth.UserInfo
-	if cfg.SoloMode {
-		username := bootstrap.Username(cfg.SoloMode)
-		if u, lookupErr := st.Users().GetByUsername(context.Background(), username); lookupErr == nil {
-			soloUser = &auth.UserInfo{
-				ID:       u.ID,
-				OrgID:    u.OrgID,
-				Username: u.Username,
-				IsAdmin:  u.IsAdmin,
-			}
-		}
-	}
 	channelRelay := service.NewChannelRelayHandler(st, wMgr, cMgr, soloUser, cfg.SecureCookies)
 	mux.Handle("/ws/channel", channelRelay)
 
@@ -271,12 +276,23 @@ func (s *Server) GetWorkerByID(ctx context.Context, workerID string) error {
 	return err
 }
 
-// GetAdminUser returns the admin user's ID and org ID.
+// GetAdminUser returns the ID and org ID of the user to attribute
+// auto-registered local workers to. In solo mode this is the bootstrapped
+// solo user. In dev/hub mode this is the first admin user registered via the
+// /setup flow; the caller gets store.ErrNotFound when no admin exists yet and
+// is expected to retry once one does.
 func (s *Server) GetAdminUser(ctx context.Context) (userID, orgID string, err error) {
-	username := bootstrap.Username(s.cfg.SoloMode)
-	user, err := s.store.Users().GetByUsername(ctx, username)
+	if s.cfg.SoloMode {
+		user, err := s.store.Users().GetByUsername(ctx, usernames.Solo)
+		if err != nil {
+			return "", "", fmt.Errorf("get solo user: %w", err)
+		}
+		return user.ID, user.OrgID, nil
+	}
+
+	user, err := s.store.Users().GetFirstAdmin(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("get admin user: %w", err)
+		return "", "", fmt.Errorf("get first admin: %w", err)
 	}
 	return user.ID, user.OrgID, nil
 }

--- a/backend/internal/hub/auth/auth.go
+++ b/backend/internal/hub/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	pwdhash "github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
@@ -50,6 +51,22 @@ func MustGetUser(ctx context.Context) (*UserInfo, error) {
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("not authenticated"))
 	}
 	return u, nil
+}
+
+// LoadSoloUser looks up the bootstrapped solo user and maps it into a
+// UserInfo suitable for synthetic authentication in solo mode. Returns
+// store.ErrNotFound if the solo user has not been created yet.
+func LoadSoloUser(ctx context.Context, st store.Store) (*UserInfo, error) {
+	user, err := st.Users().GetByUsername(ctx, usernames.Solo)
+	if err != nil {
+		return nil, err
+	}
+	return &UserInfo{
+		ID:       user.ID,
+		OrgID:    user.OrgID,
+		Username: user.Username,
+		IsAdmin:  user.IsAdmin,
+	}, nil
 }
 
 // Login validates credentials and creates a new session token.

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -94,14 +94,32 @@ func (c *SessionCache) Evict(sessionID string) {
 	if c == nil {
 		return
 	}
-	if v, ok := c.sessions.Load(sessionID); ok {
-		cached := v.(cachedSession)
-		if idx, ok := c.userSessions.Load(cached.user.ID); ok {
-			idx.(*sync.Map).Delete(sessionID)
-		}
+	if v, ok := c.sessions.LoadAndDelete(sessionID); ok {
+		unindexSession(c.userSessions, v.(cachedSession).user.ID, sessionID)
 	}
 	c.touch.Delete(sessionID)
-	c.sessions.Delete(sessionID)
+}
+
+// unindexSession removes sessionID from the user's inner sessions map, and
+// deletes the outer userSessions entry if the inner map becomes empty.
+func unindexSession(userSessions *sync.Map, userID, sessionID string) {
+	idx, ok := userSessions.Load(userID)
+	if !ok {
+		return
+	}
+	inner := idx.(*sync.Map)
+	inner.Delete(sessionID)
+	if isSyncMapEmpty(inner) {
+		userSessions.Delete(userID)
+	}
+}
+
+// isSyncMapEmpty reports whether m has no entries. sync.Map has no Len(), so
+// we probe with Range and break on the first element.
+func isSyncMapEmpty(m *sync.Map) bool {
+	empty := true
+	m.Range(func(_, _ any) bool { empty = false; return false })
+	return empty
 }
 
 // EvictByUserID removes all cached sessions for a user. Call this after
@@ -273,16 +291,7 @@ func (a *authInterceptor) sweepCaches(stop <-chan struct{}) {
 				cached := value.(cachedSession)
 				if now.Sub(cached.cachedAt) > sessionCacheTTL {
 					a.sessionCache.Delete(key)
-					if idx, ok := a.userSessions.Load(cached.user.ID); ok {
-						inner := idx.(*sync.Map)
-						inner.Delete(key)
-						// Remove the outer entry if the inner map is now empty.
-						empty := true
-						inner.Range(func(_, _ any) bool { empty = false; return false })
-						if empty {
-							a.userSessions.Delete(cached.user.ID)
-						}
-					}
+					unindexSession(&a.userSessions, cached.user.ID, key.(string))
 				}
 				return true
 			})

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/leapmux/leapmux/internal/hub/bootstrap"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 )
 
@@ -50,7 +50,6 @@ type cachedSession struct {
 // on both unary and streaming RPCs.
 type authInterceptor struct {
 	store                     store.Store
-	soloMode                  bool
 	secureCookie              bool
 	emailVerificationRequired bool
 	soloUser                  *UserInfo
@@ -61,23 +60,18 @@ type authInterceptor struct {
 
 // NewInterceptor creates a ConnectRPC interceptor that validates session cookies
 // and attaches user info to the context. Public procedures (login, worker
-// registration) are exempt from auth checks. In solo mode, all requests are
-// automatically authenticated as the admin user.
+// registration) are exempt from auth checks. Pass a non-nil soloUser to enable
+// solo mode, in which all requests are automatically authenticated as that
+// user; pass nil for normal multi-user auth.
 //
 // The returned SessionCache can be used to evict entries from the in-memory
 // touch throttle (e.g., on logout).
-func NewInterceptor(st store.Store, soloMode bool, secureCookie bool, emailVerificationRequired bool) (connect.Interceptor, *SessionCache) {
-	a := &authInterceptor{store: st, soloMode: soloMode, secureCookie: secureCookie, emailVerificationRequired: emailVerificationRequired}
-	if soloMode {
-		user, err := st.Users().GetByUsername(context.Background(), bootstrap.Username(soloMode))
-		if err == nil {
-			a.soloUser = &UserInfo{
-				ID:       user.ID,
-				OrgID:    user.OrgID,
-				Username: user.Username,
-				IsAdmin:  user.IsAdmin,
-			}
-		}
+func NewInterceptor(st store.Store, soloUser *UserInfo, secureCookie bool, emailVerificationRequired bool) (connect.Interceptor, *SessionCache) {
+	a := &authInterceptor{
+		store:                     st,
+		secureCookie:              secureCookie,
+		emailVerificationRequired: emailVerificationRequired,
+		soloUser:                  soloUser,
 	}
 	sc := &SessionCache{touch: &a.lastTouch, sessions: &a.sessionCache, userSessions: &a.userSessions, stop: make(chan struct{})}
 	go a.sweepCaches(sc.stop)
@@ -167,16 +161,13 @@ func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 // requests are checked for email verification when required.
 func (a *authInterceptor) authenticate(ctx context.Context, procedure, cookieHeader string) (context.Context, error) {
 	if publicProcedures[procedure] {
-		if a.soloMode && a.soloUser != nil {
+		if a.soloUser != nil {
 			ctx = WithUser(ctx, a.soloUser)
 		}
 		return ctx, nil
 	}
 
-	if a.soloMode {
-		if a.soloUser == nil {
-			return ctx, connect.NewError(connect.CodeInternal, fmt.Errorf("solo mode admin user not found"))
-		}
+	if a.soloUser != nil {
 		return WithUser(ctx, a.soloUser), nil
 	}
 

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -31,7 +31,7 @@ func setupInterceptorTestServer(t *testing.T) leapmuxv1connect.AuthServiceClient
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, nil, nil)
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -97,11 +97,14 @@ func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 
 	// Bootstrap in solo mode creates a user named "solo".
-	err := bootstrap.Run(context.Background(), st, true, false)
+	err := bootstrap.Run(context.Background(), st, true)
+	require.NoError(t, err)
+
+	soloUser, err := auth.LoadSoloUser(context.Background(), st)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, true, false, false)
+	interceptor, _ := auth.NewInterceptor(st, soloUser, false, false)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{SoloMode: true}, nil, nil)
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -156,7 +159,7 @@ func setupInterceptorTestServerWithCache(t *testing.T) (leapmuxv1connect.AuthSer
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, false, false, false)
+	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, sc, nil)

--- a/backend/internal/hub/bootstrap/bootstrap.go
+++ b/backend/internal/hub/bootstrap/bootstrap.go
@@ -6,30 +6,18 @@ import (
 	"log/slog"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
-const (
-	defaultPassword = "admin123"
-)
-
-// Username returns the default username for solo mode.
-func Username(soloMode bool) string {
-	if soloMode {
-		return "solo"
-	}
-	return "admin"
-}
-
-// Run creates the personal org and default admin user when the database
-// is empty. In hub mode (soloMode=false, devMode=false) this is a no-op
-// because the first admin user is created interactively via the /setup page.
-// In solo or dev mode, it bootstraps a default user for convenience.
-func Run(ctx context.Context, st store.Store, soloMode, devMode bool) error {
-	if !soloMode && !devMode {
-		slog.Info("bootstrap: skipped (hub mode uses interactive setup)")
+// Run creates the personal org and passwordless solo user when the database
+// is empty and soloMode is true. In hub or dev mode this is a no-op — the
+// first admin is registered interactively via the /setup page, which invokes
+// the SignUp RPC's setup-mode branch.
+func Run(ctx context.Context, st store.Store, soloMode bool) error {
+	if !soloMode {
+		slog.Info("bootstrap: skipped (hub/dev mode uses interactive setup)")
 		return nil
 	}
 
@@ -42,41 +30,26 @@ func Run(ctx context.Context, st store.Store, soloMode, devMode bool) error {
 		return nil
 	}
 
-	username := Username(soloMode)
-
-	var passwordHash string
-	displayName := "Admin"
-	if soloMode {
-		displayName = "Solo"
-	} else {
-		hash, err := password.Hash(defaultPassword)
-		if err != nil {
-			return fmt.Errorf("hash password: %w", err)
-		}
-		passwordHash = hash
-	}
-
 	orgID := id.Generate()
 	userID := id.Generate()
 
 	if err := st.RunInTransaction(ctx, func(tx store.Store) error {
 		if err := tx.Orgs().Create(ctx, store.CreateOrgParams{
 			ID:         orgID,
-			Name:       username,
+			Name:       usernames.Solo,
 			IsPersonal: true,
 		}); err != nil {
 			return fmt.Errorf("create personal org: %w", store.NewConflictError(err, store.ConflictEntityOrg))
 		}
 
 		if err := tx.Users().Create(ctx, store.CreateUserParams{
-			ID:           userID,
-			OrgID:        orgID,
-			Username:     username,
-			PasswordHash: passwordHash,
-			DisplayName:  displayName,
-			Email:        "",
-			PasswordSet:  true,
-			IsAdmin:      true,
+			ID:          userID,
+			OrgID:       orgID,
+			Username:    usernames.Solo,
+			DisplayName: "Solo",
+			Email:       "",
+			PasswordSet: true,
+			IsAdmin:     true,
 		}); err != nil {
 			return fmt.Errorf("create user: %w", store.NewConflictError(err, store.ConflictEntityUser))
 		}
@@ -97,7 +70,7 @@ func Run(ctx context.Context, st store.Store, soloMode, devMode bool) error {
 	slog.Info("bootstrap: created personal org and user",
 		"org_id", orgID,
 		"user_id", userID,
-		"username", username,
+		"username", usernames.Solo,
 	)
 
 	return nil

--- a/backend/internal/hub/bootstrap/bootstrap_test.go
+++ b/backend/internal/hub/bootstrap/bootstrap_test.go
@@ -8,21 +8,22 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/hub/bootstrap"
-	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 )
 
 func setupStore(t *testing.T) store.Store {
 	return hubtestutil.OpenTestStore(t)
 }
 
-func TestRun_SkipsHubMode(t *testing.T) {
+// TestRun_SkipsNonSolo asserts that hub/dev mode is a no-op — the first admin
+// user must be registered via the /setup flow, not auto-created.
+func TestRun_SkipsNonSolo(t *testing.T) {
 	st := setupStore(t)
 	ctx := context.Background()
 
-	// Hub mode (soloMode=false, devMode=false) should not create any orgs or users.
-	err := bootstrap.Run(ctx, st, false, false)
+	err := bootstrap.Run(ctx, st, false)
 	require.NoError(t, err)
 
 	hasOrgs, err := st.Orgs().HasAny(ctx)
@@ -38,52 +39,29 @@ func TestRun_SoloMode(t *testing.T) {
 	st := setupStore(t)
 	ctx := context.Background()
 
-	err := bootstrap.Run(ctx, st, true, false)
+	err := bootstrap.Run(ctx, st, true)
 	require.NoError(t, err)
 
-	org, err := st.Orgs().GetByName(ctx, "solo")
+	org, err := st.Orgs().GetByName(ctx, usernames.Solo)
 	require.NoError(t, err)
-	assert.Equal(t, "solo", org.Name)
+	assert.Equal(t, usernames.Solo, org.Name)
 
-	user, err := st.Users().GetByUsername(ctx, "solo")
+	user, err := st.Users().GetByUsername(ctx, usernames.Solo)
 	require.NoError(t, err)
-	assert.Equal(t, "solo", user.Username)
+	assert.Equal(t, usernames.Solo, user.Username)
 	assert.Equal(t, org.ID, user.OrgID)
 	assert.True(t, user.IsAdmin)
 	assert.Empty(t, user.PasswordHash)
-}
-
-func TestRun_DevMode(t *testing.T) {
-	st := setupStore(t)
-	ctx := context.Background()
-
-	err := bootstrap.Run(ctx, st, false, true)
-	require.NoError(t, err)
-
-	org, err := st.Orgs().GetByName(ctx, "admin")
-	require.NoError(t, err)
-	assert.Equal(t, "admin", org.Name)
-
-	user, err := st.Users().GetByUsername(ctx, "admin")
-	require.NoError(t, err)
-	assert.Equal(t, "admin", user.Username)
-	assert.Equal(t, org.ID, user.OrgID)
-	assert.True(t, user.IsAdmin)
-
-	// Dev mode should have a valid password hash.
-	match, err := password.Verify(user.PasswordHash, "admin123")
-	assert.NoError(t, err)
-	assert.True(t, match)
 }
 
 func TestRun_Idempotent(t *testing.T) {
 	st := setupStore(t)
 	ctx := context.Background()
 
-	err := bootstrap.Run(ctx, st, true, false)
+	err := bootstrap.Run(ctx, st, true)
 	require.NoError(t, err)
 
-	err = bootstrap.Run(ctx, st, true, false)
+	err = bootstrap.Run(ctx, st, true)
 	require.NoError(t, err)
 
 	orgs, err := st.Orgs().ListAll(ctx, store.ListAllOrgsParams{Limit: 100})

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/keystore"
 	pwdhash "github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/validate"
 	"github.com/leapmux/leapmux/util/version"
 )
@@ -144,6 +145,16 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 	username, err := validate.SanitizeSlug("username", req.Msg.GetUsername())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	// `solo` is rejected in every mode: if a non-solo data-dir ever gets opened
+	// in solo mode, the interceptor auto-authenticates every request as that
+	// user. `admin` is allowed in setup mode so the first operator can
+	// legitimately claim it; in public signup it's squat-protected.
+	if usernames.IsReservedSystem(username) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%q is a reserved username", username))
+	}
+	if !isSetupMode && usernames.IsReservedPublic(username) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%q is a reserved username", username))
 	}
 	displayName, err := validate.SanitizeDisplayName(req.Msg.GetDisplayName(), username)
 	if err != nil {
@@ -305,7 +316,7 @@ func (s *AuthService) GetSystemInfo(ctx context.Context, req *connect.Request[le
 	providers, _ := s.store.OAuthProviders().ListEnabled(ctx)
 
 	var setupRequired bool
-	if !s.cfg.SoloMode && !s.cfg.DevMode {
+	if !s.cfg.SoloMode {
 		hasUser, err := s.checkHasAnyUser(ctx)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("check users: %w", err))
@@ -397,6 +408,11 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	username, err := validate.SanitizeSlug("username", req.Msg.GetUsername())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	// OAuth completion is always treated as public signup — the first-admin
+	// flow lives at /setup, so both reserved rules apply.
+	if usernames.IsReservedForPublicSignup(username) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%q is a reserved username", username))
 	}
 
 	if err := checkUsernameAvailable(ctx, s.store, username); err != nil {

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -31,7 +31,7 @@ func setupAuthTestServerBase(t *testing.T, cfg *config.Config) (leapmuxv1connect
 	st := hubtestutil.OpenTestStore(t)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, false, false, false)
+	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, sc, nil)
@@ -200,7 +200,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 
 	// Set up a UserService client using the same queries and auth interceptor.
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	userSvc := service.NewUserService(st, testConfig(), nil)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -403,7 +403,7 @@ func setupVerificationGatingTestServer(t *testing.T, emailVerificationRequired b
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, emailVerificationRequired)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, emailVerificationRequired)
 	opts := connect.WithInterceptors(interceptor)
 
 	cfg := testConfig()
@@ -550,7 +550,7 @@ func setupAuthTestServerWithKeystore(t *testing.T, cfg *config.Config) (leapmuxv
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, nil, nil)
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
@@ -854,8 +854,10 @@ func TestSetupSignUp_RejectedInSoloMode(t *testing.T) {
 	err = st.Migrator().Migrate(context.Background())
 	require.NoError(t, err)
 
+	// No solo user is seeded — the test asserts that AuthService rejects setup
+	// signup in solo mode at the service layer, independent of the interceptor.
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, true, false, false)
+	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, sc, nil)
@@ -964,4 +966,71 @@ func TestSetupSignUp_ValidatesInputs(t *testing.T) {
 			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 		})
 	}
+}
+
+func TestGetSystemInfo_DevModeReportsSetupRequired(t *testing.T) {
+	cfg := testConfig()
+	cfg.DevMode = true
+
+	client, _ := setupEmptyAuthTestServer(t, cfg)
+
+	resp, err := client.GetSystemInfo(context.Background(), connect.NewRequest(&leapmuxv1.GetSystemInfoRequest{}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetSetupRequired(), "dev mode with empty DB should require setup")
+}
+
+func TestSignUp_RejectsSoloAlways(t *testing.T) {
+	t.Run("setup mode", func(t *testing.T) {
+		client, _ := setupEmptyAuthTestServer(t, testConfig())
+
+		for _, input := range []string{"solo", "SOLO", "  solo  "} {
+			_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+				Username:    input,
+				Password:    "strongpass1",
+				DisplayName: "First",
+			}))
+			require.Errorf(t, err, "setup mode must reject %q", input)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		}
+	})
+
+	t.Run("public signup", func(t *testing.T) {
+		client, _ := setupAuthTestServer(t, testConfigWithSignup())
+
+		for _, input := range []string{"solo", "SOLO"} {
+			_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+				Username:    input,
+				Password:    "strongpass1",
+				DisplayName: "Someone",
+			}))
+			require.Errorf(t, err, "public signup must reject %q", input)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		}
+	})
+}
+
+func TestSignUp_AllowsAdminInSetupMode(t *testing.T) {
+	client, _ := setupEmptyAuthTestServer(t, testConfig())
+
+	resp, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "admin",
+		Password:    "strongpass1",
+		DisplayName: "First Admin",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "admin", resp.Msg.GetUser().GetUsername())
+	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
+}
+
+func TestSignUp_RejectsAdminInPublicSignup(t *testing.T) {
+	// A seeded user exists, so isSetupMode=false and the public reservation applies.
+	client, _ := setupAuthTestServer(t, testConfigWithSignup())
+
+	_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "admin",
+		Password:    "strongpass1",
+		DisplayName: "Squatter",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -56,7 +56,7 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(service.NewAuthService(st, cfg, nil, nil), opts)

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -312,7 +312,7 @@ func setupOAuthTestServerWithAuthService(t *testing.T) (
 	oauthHandler.RegisterRoutes(mux)
 
 	// Register AuthService ConnectRPC routes.
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, nil, ks)
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
@@ -546,6 +546,40 @@ func TestCompleteOAuthSignup_InvalidUsername(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestCompleteOAuthSignup_RejectsSoloAlways(t *testing.T) {
+	_, client, st, ks, _ := setupOAuthTestServerWithAuthService(t)
+	providerID := createTestProvider(t, st, ks)
+	signupToken := id.Generate()
+
+	insertPendingSignup(t, st, ks, providerID, signupToken, "new@example.com", "New", "sub-new", time.Now().Add(5*time.Minute).UTC())
+
+	_, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "solo",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestCompleteOAuthSignup_RejectsAdminInPublicSignup(t *testing.T) {
+	// setupOAuthTestServerWithAuthService seeds the admin fixture, so this is
+	// a non-setup-mode OAuth signup and the public reservation applies.
+	_, client, st, ks, _ := setupOAuthTestServerWithAuthService(t)
+
+	providerID := createTestProvider(t, st, ks)
+	signupToken := id.Generate()
+	insertPendingSignup(t, st, ks, providerID, signupToken, "new@example.com", "New", "sub-new", time.Now().Add(5*time.Minute).UTC())
+
+	_, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "admin",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "reserved")
 }
 
 func TestCompleteOAuthSignup_TokenConsumedOnSuccess(t *testing.T) {

--- a/backend/internal/hub/service/org_service_test.go
+++ b/backend/internal/hub/service/org_service_test.go
@@ -46,7 +46,7 @@ func setupOrgTestServer(t *testing.T) *orgTestEnv {
 	cfg := testConfig()
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 
 	orgSvc := service.NewOrgService(st, false)

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -43,7 +43,7 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	sectionSvc := service.NewSectionService(st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(path, handler)

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -45,7 +45,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	userSvc := service.NewUserService(st, testConfig(), nil)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
@@ -102,7 +102,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	userSvc := service.NewUserService(st, testConfig(), nil)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
@@ -460,7 +460,7 @@ func setupVerificationUserTestServer(t *testing.T) (leapmuxv1connect.UserService
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, true)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, true)
 	opts := connect.WithInterceptors(interceptor)
 
 	cfg := testConfig()

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -50,7 +50,7 @@ func setupWorkspaceTest(t *testing.T) *workspaceTestEnv {
 	workspaceSvc := service.NewWorkspaceService(st, false)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, false, false, false)
+	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewWorkspaceServiceHandler(workspaceSvc, opts)
 	mux.Handle(path, handler)

--- a/backend/internal/hub/store/mysql/db/queries/users.sql
+++ b/backend/internal/hub/store/mysql/db/queries/users.sql
@@ -11,6 +11,9 @@ SELECT * FROM users WHERE id = ?;
 -- name: GetUserByUsername :one
 SELECT * FROM users WHERE username = ? AND deleted_at IS NULL;
 
+-- name: GetFirstAdmin :one
+SELECT * FROM users WHERE is_admin = TRUE AND deleted_at IS NULL ORDER BY created_at LIMIT 1;
+
 -- name: ExistsByUsername :one
 SELECT EXISTS(SELECT 1 FROM users WHERE username = ? AND deleted_at IS NULL) AS exists_flag;
 

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -89,6 +89,15 @@ func (s *userStore) GetByEmail(ctx context.Context, email string) (*store.User, 
 	return &out, nil
 }
 
+func (s *userStore) GetFirstAdmin(ctx context.Context) (*store.User, error) {
+	u, err := s.conn.q.GetFirstAdmin(ctx)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBUser(u)
+	return &out, nil
+}
+
 func (s *userStore) ExistsByUsername(ctx context.Context, username string) (bool, error) {
 	exists, err := s.conn.q.ExistsByUsername(ctx, store.NormalizeUsername(username))
 	if err != nil {

--- a/backend/internal/hub/store/postgres/db/queries/users.sql
+++ b/backend/internal/hub/store/postgres/db/queries/users.sql
@@ -11,6 +11,9 @@ SELECT * FROM users WHERE id = $1;
 -- name: GetUserByUsername :one
 SELECT * FROM users WHERE username = $1 AND deleted_at IS NULL;
 
+-- name: GetFirstAdmin :one
+SELECT * FROM users WHERE is_admin = TRUE AND deleted_at IS NULL ORDER BY created_at LIMIT 1;
+
 -- name: ExistsByUsername :one
 SELECT EXISTS(SELECT 1 FROM users WHERE username = $1 AND deleted_at IS NULL);
 

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -88,6 +88,15 @@ func (s *userStore) GetByEmail(ctx context.Context, email string) (*store.User, 
 	return &out, nil
 }
 
+func (s *userStore) GetFirstAdmin(ctx context.Context) (*store.User, error) {
+	u, err := s.conn.q.GetFirstAdmin(ctx)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBUser(u)
+	return &out, nil
+}
+
 func (s *userStore) ExistsByUsername(ctx context.Context, username string) (bool, error) {
 	exists, err := s.conn.q.ExistsByUsername(ctx, store.NormalizeUsername(username))
 	if err != nil {

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -11,6 +11,9 @@ SELECT * FROM users WHERE id = ?;
 -- name: GetUserByUsername :one
 SELECT * FROM users WHERE username = ? AND deleted_at IS NULL;
 
+-- name: GetFirstAdmin :one
+SELECT * FROM users WHERE is_admin = 1 AND deleted_at IS NULL ORDER BY created_at LIMIT 1;
+
 -- name: ExistsByUsername :one
 SELECT EXISTS(SELECT 1 FROM users WHERE username = ? AND deleted_at IS NULL);
 

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -89,6 +89,15 @@ func (s *userStore) GetByEmail(ctx context.Context, email string) (*store.User, 
 	return &out, nil
 }
 
+func (s *userStore) GetFirstAdmin(ctx context.Context) (*store.User, error) {
+	u, err := s.conn.q.GetFirstAdmin(ctx)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBUser(u)
+	return &out, nil
+}
+
 func (s *userStore) ExistsByUsername(ctx context.Context, username string) (bool, error) {
 	v, err := s.conn.q.ExistsByUsername(ctx, store.NormalizeUsername(username))
 	if err != nil {

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -80,6 +80,7 @@ type UserStore interface {
 	GetByIDIncludeDeleted(ctx context.Context, id string) (*User, error)
 	GetByUsername(ctx context.Context, username string) (*User, error)
 	GetByEmail(ctx context.Context, email string) (*User, error)
+	GetFirstAdmin(ctx context.Context) (*User, error)
 	ExistsByUsername(ctx context.Context, username string) (bool, error)
 	ExistsByEmail(ctx context.Context, email, excludeUserID string) (bool, error)
 	GetByPendingEmailToken(ctx context.Context, token string) (*User, error)

--- a/backend/internal/hub/store/storetest/test_users.go
+++ b/backend/internal/hub/store/storetest/test_users.go
@@ -72,6 +72,50 @@ func (s *Suite) testUsers(t *testing.T) {
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
+	t.Run("get first admin", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "admin-org", true)
+
+		// No users: ErrNotFound.
+		_, err := st.Users().GetFirstAdmin(ctx)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+
+		// Non-admin user only: still ErrNotFound.
+		SeedUser(t, st, orgID, "regular")
+		_, err = st.Users().GetFirstAdmin(ctx)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+
+		// Sleep between creates so created_at ordering is deterministic
+		// (some backends only have millisecond precision).
+		time.Sleep(5 * time.Millisecond)
+		older := SeedUser(t, st, orgID, "older-admin")
+		require.NoError(t, st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			ID:      older.ID,
+			IsAdmin: true,
+		}))
+		time.Sleep(5 * time.Millisecond)
+		newer := SeedUser(t, st, orgID, "newer-admin")
+		require.NoError(t, st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			ID:      newer.ID,
+			IsAdmin: true,
+		}))
+
+		// With two admins, returns the one with the oldest created_at.
+		found, err := st.Users().GetFirstAdmin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, older.ID, found.ID)
+
+		// Soft-deleted admins are ignored.
+		require.NoError(t, st.Users().Delete(ctx, older.ID))
+		found, err = st.Users().GetFirstAdmin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, newer.ID, found.ID)
+
+		require.NoError(t, st.Users().Delete(ctx, newer.ID))
+		_, err = st.Users().GetFirstAdmin(ctx)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
 	t.Run("has any", func(t *testing.T) {
 		st := s.NewStore(t)
 

--- a/backend/internal/hub/testutil/admin.go
+++ b/backend/internal/hub/testutil/admin.go
@@ -4,14 +4,18 @@ package testutil
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
-	"github.com/leapmux/leapmux/internal/hub/bootstrap"
+	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/hub/usernames"
+	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 )
 
@@ -25,11 +29,67 @@ func OpenTestStore(t *testing.T) store.Store {
 	return st
 }
 
-// CreateTestAdmin bootstraps a default admin user ("admin"/"admin123") with
-// a personal org and OWNER membership, using dev-mode bootstrap.
+// TestAdminUsername and TestAdminPassword are the credentials created by
+// CreateTestAdmin. Exported so service and e2e tests that log in as the
+// fixture don't hardcode the strings in multiple places.
+const (
+	TestAdminUsername = usernames.Admin
+	TestAdminPassword = "admin123"
+)
+
+// Argon2id is intentionally slow. Hash the fixture password once per process
+// so tests that seed the admin user don't each pay ~200ms.
+var (
+	testAdminHashOnce sync.Once
+	testAdminHash     string
+	testAdminHashErr  error
+)
+
+func cachedTestAdminHash() (string, error) {
+	testAdminHashOnce.Do(func() {
+		testAdminHash, testAdminHashErr = password.Hash(TestAdminPassword)
+	})
+	return testAdminHash, testAdminHashErr
+}
+
+// CreateTestAdmin creates the default admin fixture directly via the store,
+// bypassing the SignUp RPC (and therefore its reserved-username check).
 func CreateTestAdmin(t *testing.T, st store.Store) {
 	t.Helper()
-	require.NoError(t, bootstrap.Run(context.Background(), st, false, true))
+	ctx := context.Background()
+
+	hash, err := cachedTestAdminHash()
+	require.NoError(t, err)
+
+	orgID := id.Generate()
+	userID := id.Generate()
+
+	require.NoError(t, st.RunInTransaction(ctx, func(tx store.Store) error {
+		if err := tx.Orgs().Create(ctx, store.CreateOrgParams{
+			ID:         orgID,
+			Name:       TestAdminUsername,
+			IsPersonal: true,
+		}); err != nil {
+			return err
+		}
+		if err := tx.Users().Create(ctx, store.CreateUserParams{
+			ID:           userID,
+			OrgID:        orgID,
+			Username:     TestAdminUsername,
+			PasswordHash: hash,
+			DisplayName:  "Admin",
+			Email:        "",
+			PasswordSet:  true,
+			IsAdmin:      true,
+		}); err != nil {
+			return err
+		}
+		return tx.OrgMembers().Create(ctx, store.CreateOrgMemberParams{
+			OrgID:  orgID,
+			UserID: userID,
+			Role:   leapmuxv1.OrgMemberRole_ORG_MEMBER_ROLE_OWNER,
+		})
+	}))
 }
 
 // SessionFromCookie extracts the session ID from a Set-Cookie header value.

--- a/backend/internal/hub/usernames/reserved.go
+++ b/backend/internal/hub/usernames/reserved.go
@@ -1,0 +1,48 @@
+// Package usernames defines the reserved-username constants and predicates
+// shared across Hub packages (bootstrap, auth, service, cmd/leapmux). It
+// sits below service/auth/bootstrap in the import graph so all of them can
+// reference a single source of truth. Named in the plural to avoid shadowing
+// common `username` variables in callers.
+package usernames
+
+import "strings"
+
+// Solo is the reserved username for the single passwordless user auto-created
+// and auto-authenticated in solo mode.
+const Solo = "solo"
+
+// Admin is the conventional username for the first administrator. Reserved in
+// anonymous public signup but allowed in the /setup flow and admin-initiated
+// creation paths.
+const Admin = "admin"
+
+func normalize(u string) string {
+	return strings.ToLower(strings.TrimSpace(u))
+}
+
+// IsReservedSystem reports whether a username is reserved in every creation
+// path (public signup, setup signup, OAuth signup, CLI user-create). Covers
+// Solo: a user by that name in a non-solo database would be auto-authenticated
+// for every request if the same data-dir were later opened in solo mode (see
+// auth/interceptor.go).
+func IsReservedSystem(u string) bool {
+	return normalize(u) == Solo
+}
+
+// IsReservedPublic reports whether a username is reserved for anonymous,
+// post-setup signup paths (public SignUp, public OAuth completion). Covers
+// Admin. Setup-mode signup and the admin CLI accept the name because they do
+// not call this predicate.
+func IsReservedPublic(u string) bool {
+	return normalize(u) == Admin
+}
+
+// IsReservedForPublicSignup reports whether a username is reserved in any
+// anonymous signup context — both the system rule and the public rule apply.
+// Use this in paths that have no setup-mode exemption (e.g. OAuth completion,
+// post-setup SignUp). Equivalent to IsReservedSystem(u) || IsReservedPublic(u)
+// but normalizes the input once.
+func IsReservedForPublicSignup(u string) bool {
+	n := normalize(u)
+	return n == Solo || n == Admin
+}

--- a/backend/internal/hub/usernames/reserved_test.go
+++ b/backend/internal/hub/usernames/reserved_test.go
@@ -1,0 +1,36 @@
+package usernames_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leapmux/leapmux/internal/hub/usernames"
+)
+
+func TestIsReservedSystem(t *testing.T) {
+	for _, in := range []string{"solo", "SOLO", "  solo  ", "Solo"} {
+		assert.True(t, usernames.IsReservedSystem(in), "expected reserved: %q", in)
+	}
+	for _, in := range []string{"admin", "owner", "alice", ""} {
+		assert.False(t, usernames.IsReservedSystem(in), "expected allowed: %q", in)
+	}
+}
+
+func TestIsReservedPublic(t *testing.T) {
+	for _, in := range []string{"admin", "ADMIN", "  admin  ", "Admin"} {
+		assert.True(t, usernames.IsReservedPublic(in), "expected reserved: %q", in)
+	}
+	for _, in := range []string{"solo", "owner", "alice", ""} {
+		assert.False(t, usernames.IsReservedPublic(in), "expected allowed: %q", in)
+	}
+}
+
+func TestIsReservedForPublicSignup(t *testing.T) {
+	for _, in := range []string{"solo", "SOLO", "admin", "ADMIN", "  admin  ", "Solo"} {
+		assert.True(t, usernames.IsReservedForPublicSignup(in), "expected reserved: %q", in)
+	}
+	for _, in := range []string{"owner", "alice", ""} {
+		assert.False(t, usernames.IsReservedForPublicSignup(in), "expected allowed: %q", in)
+	}
+}

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -13,9 +13,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/logging"
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	workerconfig "github.com/leapmux/leapmux/internal/worker/config"
@@ -23,6 +25,11 @@ import (
 	"github.com/leapmux/leapmux/util/version"
 	"github.com/leapmux/leapmux/worker"
 )
+
+// workerSetupPollInterval is how often dev mode re-checks whether the first
+// admin user has completed the /setup flow so the auto-registered local
+// worker can come online.
+const workerSetupPollInterval = 2 * time.Second
 
 // Config configures the solo launcher.
 type Config struct {
@@ -215,83 +222,25 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		return nil, errors.New("hub serve exited before listener became ready")
 	}
 
-	// Auto-register worker.
+	// In dev mode the first admin may not exist yet; defer worker bringup
+	// until /setup completes.
 	statePath := filepath.Join(workerDataDir, "state.json")
-	state, err := loadOrCreateWorkerState(soloCtx, server, statePath, workerDataDir)
-	if err != nil {
+	setupWorker := func(ctx context.Context) error {
+		return bringUpLocalWorker(ctx, &inst.wg, server, statePath, workerDataDir, hubCfg, listenURL, modeName)
+	}
+	err = setupWorker(soloCtx)
+	switch {
+	case err == nil:
+		// Worker is up.
+	case errors.Is(err, store.ErrNotFound) && cfg.DevMode:
+		slog.Info("dev mode: deferring worker auto-registration until first admin signs up via /setup")
+		inst.wg.Add(1)
+		go pollForDeferredWorkerSetup(soloCtx, &inst.wg, setupWorker)
+	default:
 		cancel()
 		inst.wg.Wait()
 		return nil, fmt.Errorf("auto-register worker: %w", err)
 	}
-
-	// Ensure composite keypair for E2EE.
-	if state.PublicKey == "" || state.PrivateKey == "" ||
-		state.MlkemPublicKey == "" || state.MlkemPrivateKey == "" ||
-		state.SlhdsaPublicKey == "" || state.SlhdsaPrivateKey == "" {
-		ck, kpErr := noiseutil.GenerateCompositeKeypair()
-		if kpErr != nil {
-			cancel()
-			inst.wg.Wait()
-			return nil, fmt.Errorf("generate composite keypair: %w", kpErr)
-		}
-		slhdsaPub, _ := ck.SlhdsaPublicKeyBytes()
-		slhdsaPriv, _ := ck.SlhdsaPrivateKey.MarshalBinary()
-		state.PublicKey = base64.StdEncoding.EncodeToString(ck.X25519Public)
-		state.PrivateKey = base64.StdEncoding.EncodeToString(ck.X25519Private)
-		state.MlkemPublicKey = base64.StdEncoding.EncodeToString(ck.MlkemPublicKeyBytes())
-		state.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
-		state.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
-		state.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
-		stateData, err := json.MarshalIndent(state, "", "  ")
-		if err != nil {
-			slog.Warn("failed to marshal state", "error", err)
-		} else if writeErr := os.WriteFile(statePath, stateData, 0o600); writeErr != nil {
-			slog.Warn("failed to save keypair", "error", writeErr)
-		}
-	}
-
-	compositeKey, ckErr := noiseutil.RestoreCompositeKeypair(
-		mustDecode64(state.PublicKey),
-		mustDecode64(state.PrivateKey),
-		mustDecode64(state.MlkemPrivateKey),
-		mustDecode64(state.SlhdsaPublicKey),
-		mustDecode64(state.SlhdsaPrivateKey),
-	)
-	if ckErr != nil {
-		cancel()
-		inst.wg.Wait()
-		return nil, fmt.Errorf("restore composite keypair: %w", ckErr)
-	}
-
-	slog.Info(modeName+" worker registered",
-		"worker_id", state.WorkerID,
-		"local", listenURL,
-	)
-
-	// Start Worker.
-	inst.wg.Add(1)
-	go func() {
-		defer inst.wg.Done()
-		if wErr := worker.Run(soloCtx, worker.RunConfig{
-			HubURL:               listenURL,
-			DataDir:              workerDataDir,
-			AuthToken:            state.AuthToken,
-			CompositeKey:         compositeKey,
-			WorkerID:             state.WorkerID,
-			DBMaxConns:           hubCfg.Storage.SQLite.MaxConns,
-			DBCacheSize:          hubCfg.Storage.SQLite.CacheSize,
-			DBMmapSize:           hubCfg.Storage.SQLite.MmapSize,
-			MaxMessageSize:       hubCfg.MaxMessageSize,
-			MaxIncompleteChunked: hubCfg.MaxIncompleteChunked,
-			AgentStartupTimeout:  hubCfg.AgentStartupTimeout(),
-			APITimeout:           hubCfg.APITimeout(),
-			EncryptionMode:       workerconfig.ParseEncryptionMode(hubCfg.Extras["encryption_mode"]),
-			UseLoginShell:        parseBool(hubCfg.Extras["use_login_shell"], true),
-			RegisteredBy:         state.RegisteredBy,
-		}); wErr != nil {
-			slog.Error("worker error", "error", wErr)
-		}
-	}()
 
 	slog.Info("leapmux "+modeName+" listening", "addr", hubCfg.Addr)
 
@@ -322,6 +271,117 @@ type soloState struct {
 	MlkemPrivateKey  string `json:"mlkem_private_key,omitempty"`
 	SlhdsaPublicKey  string `json:"slhdsa_public_key,omitempty"`
 	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"`
+}
+
+// pollForDeferredWorkerSetup retries setupWorker on a ticker until it succeeds,
+// the context is cancelled, or a non-ErrNotFound error occurs. Must be invoked
+// as `go pollForDeferredWorkerSetup(...)` with wg.Add(1) already called — this
+// function calls wg.Done on exit.
+func pollForDeferredWorkerSetup(ctx context.Context, wg *sync.WaitGroup, setupWorker func(context.Context) error) {
+	defer wg.Done()
+	ticker := time.NewTicker(workerSetupPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		err := setupWorker(ctx)
+		if err == nil {
+			return
+		}
+		if errors.Is(err, store.ErrNotFound) {
+			continue
+		}
+		slog.Error("deferred worker setup failed", "error", err)
+		return
+	}
+}
+
+// bringUpLocalWorker loads (or creates, then persists) the local worker's
+// registration state, ensures the composite E2EE keypair is present, and
+// launches the worker goroutine under wg. It returns store.ErrNotFound if no
+// admin user exists yet; the caller is expected to retry after the first
+// /setup signup completes.
+func bringUpLocalWorker(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	server *hub.Server,
+	statePath, workerDataDir string,
+	hubCfg *hubconfig.Config,
+	listenURL, modeName string,
+) error {
+	state, err := loadOrCreateWorkerState(ctx, server, statePath, workerDataDir)
+	if err != nil {
+		return err
+	}
+
+	// Ensure composite keypair for E2EE.
+	if state.PublicKey == "" || state.PrivateKey == "" ||
+		state.MlkemPublicKey == "" || state.MlkemPrivateKey == "" ||
+		state.SlhdsaPublicKey == "" || state.SlhdsaPrivateKey == "" {
+		ck, kpErr := noiseutil.GenerateCompositeKeypair()
+		if kpErr != nil {
+			return fmt.Errorf("generate composite keypair: %w", kpErr)
+		}
+		slhdsaPub, _ := ck.SlhdsaPublicKeyBytes()
+		slhdsaPriv, _ := ck.SlhdsaPrivateKey.MarshalBinary()
+		state.PublicKey = base64.StdEncoding.EncodeToString(ck.X25519Public)
+		state.PrivateKey = base64.StdEncoding.EncodeToString(ck.X25519Private)
+		state.MlkemPublicKey = base64.StdEncoding.EncodeToString(ck.MlkemPublicKeyBytes())
+		state.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
+		state.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
+		state.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
+		stateData, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			slog.Warn("failed to marshal state", "error", err)
+		} else if writeErr := os.WriteFile(statePath, stateData, 0o600); writeErr != nil {
+			slog.Warn("failed to save keypair", "error", writeErr)
+		}
+	}
+
+	compositeKey, ckErr := noiseutil.RestoreCompositeKeypair(
+		mustDecode64(state.PublicKey),
+		mustDecode64(state.PrivateKey),
+		mustDecode64(state.MlkemPrivateKey),
+		mustDecode64(state.SlhdsaPublicKey),
+		mustDecode64(state.SlhdsaPrivateKey),
+	)
+	if ckErr != nil {
+		return fmt.Errorf("restore composite keypair: %w", ckErr)
+	}
+
+	slog.Info(modeName+" worker registered",
+		"worker_id", state.WorkerID,
+		"local", listenURL,
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if wErr := worker.Run(ctx, worker.RunConfig{
+			HubURL:               listenURL,
+			DataDir:              workerDataDir,
+			AuthToken:            state.AuthToken,
+			CompositeKey:         compositeKey,
+			WorkerID:             state.WorkerID,
+			DBMaxConns:           hubCfg.Storage.SQLite.MaxConns,
+			DBCacheSize:          hubCfg.Storage.SQLite.CacheSize,
+			DBMmapSize:           hubCfg.Storage.SQLite.MmapSize,
+			MaxMessageSize:       hubCfg.MaxMessageSize,
+			MaxIncompleteChunked: hubCfg.MaxIncompleteChunked,
+			AgentStartupTimeout:  hubCfg.AgentStartupTimeout(),
+			APITimeout:           hubCfg.APITimeout(),
+			EncryptionMode:       workerconfig.ParseEncryptionMode(hubCfg.Extras["encryption_mode"]),
+			UseLoginShell:        parseBool(hubCfg.Extras["use_login_shell"], true),
+			RegisteredBy:         state.RegisteredBy,
+		}); wErr != nil {
+			slog.Error("worker error", "error", wErr)
+		}
+	}()
+
+	return nil
 }
 
 func loadOrCreateWorkerState(ctx context.Context, server *hub.Server, statePath, workerDataDir string) (*soloState, error) {

--- a/frontend/src/components/common/SetupPage.tsx
+++ b/frontend/src/components/common/SetupPage.tsx
@@ -30,6 +30,7 @@ export const SetupPage: Component = () => {
             submitLabel="Create account"
             submittingLabel="Creating account..."
             errorPrefix="Setup failed"
+            allowAdminUsername
             header={<p>Create the first administrator account to get started.</p>}
             onSuccess={(resp, slug) => {
               loadSystemInfo(true)

--- a/frontend/src/components/common/SignupForm.tsx
+++ b/frontend/src/components/common/SignupForm.tsx
@@ -4,7 +4,7 @@ import type { SignUpResponse } from '~/generated/leapmux/v1/auth_pb'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
-import { sanitizeDisplayName, sanitizeSlug, validateEmail } from '~/lib/validate'
+import { sanitizeDisplayName, sanitizeSlug, validateEmail, validateReservedUsername } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
 import { errorText } from '~/styles/shared.css'
 import { Icon } from './Icon'
@@ -16,6 +16,11 @@ interface SignupFormProps {
   submittingLabel: string
   errorPrefix?: string
   header?: JSX.Element
+  /**
+   * When true, the username field accepts `admin`. Used by the first-admin
+   * setup flow. Defaults to false for public signup paths.
+   */
+  allowAdminUsername?: boolean
   onSuccess: (resp: SignUpResponse, username: string) => void
 }
 
@@ -37,6 +42,11 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
     const [slug, slugErr] = sanitizeSlug('Username', username())
     if (slugErr) {
       setError(slugErr)
+      return
+    }
+    const reservedErr = validateReservedUsername(slug, props.allowAdminUsername ?? false)
+    if (reservedErr) {
+      setError(reservedErr)
       return
     }
     const { value: sanitizedDisplayName, error: dnErr } = sanitizeDisplayName(displayName(), slug)

--- a/frontend/src/lib/validate.test.ts
+++ b/frontend/src/lib/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { sanitizeName, validateEmail, validatePassword } from './validate'
+import { sanitizeName, validateEmail, validatePassword, validateReservedUsername } from './validate'
 
 describe('sanitizeName', () => {
   it('returns sanitized value for valid names', () => {
@@ -133,5 +133,26 @@ describe('validatePassword', () => {
 
   it('rejects password exceeding 128 characters', () => {
     expect(validatePassword('a'.repeat(129))).not.toBeNull()
+  })
+})
+
+describe('validateReservedUsername', () => {
+  it('rejects "solo" in every context', () => {
+    expect(validateReservedUsername('solo', false)).not.toBeNull()
+    expect(validateReservedUsername('solo', true)).not.toBeNull()
+    expect(validateReservedUsername('SOLO', true)).not.toBeNull()
+    expect(validateReservedUsername('  solo  ', true)).not.toBeNull()
+  })
+
+  it('rejects "admin" only when allowAdmin is false', () => {
+    expect(validateReservedUsername('admin', false)).not.toBeNull()
+    expect(validateReservedUsername('ADMIN', false)).not.toBeNull()
+    expect(validateReservedUsername('admin', true)).toBeNull()
+  })
+
+  it('accepts ordinary usernames in both contexts', () => {
+    expect(validateReservedUsername('alice', false)).toBeNull()
+    expect(validateReservedUsername('alice', true)).toBeNull()
+    expect(validateReservedUsername('admin-dev', false)).toBeNull()
   })
 })

--- a/frontend/src/lib/validate.ts
+++ b/frontend/src/lib/validate.ts
@@ -155,3 +155,31 @@ export function sanitizeSlug(fieldName: string, value: string): [string, string 
   }
   return [slug, null]
 }
+
+/**
+ * Usernames reserved across every creation path (public signup, setup,
+ * OAuth signup, admin CLI). Mirrors backend `usernames.IsReservedSystem`.
+ */
+const SYSTEM_RESERVED_USERNAMES: ReadonlySet<string> = new Set(['solo'])
+
+/**
+ * Usernames reserved only for anonymous post-setup signup. Mirrors backend
+ * `usernames.IsReservedPublic`.
+ */
+const PUBLIC_RESERVED_USERNAMES: ReadonlySet<string> = new Set(['admin'])
+
+/**
+ * Returns an error message if the username is reserved for the given context,
+ * or null otherwise. Pass `allowAdmin=true` for first-admin setup forms; use
+ * the default (`false`) for public signup and OAuth-completion paths.
+ */
+export function validateReservedUsername(slug: string, allowAdmin: boolean): string | null {
+  const normalized = slug.trim().toLowerCase()
+  if (SYSTEM_RESERVED_USERNAMES.has(normalized)) {
+    return `"${normalized}" is a reserved username`
+  }
+  if (!allowAdmin && PUBLIC_RESERVED_USERNAMES.has(normalized)) {
+    return `"${normalized}" is a reserved username`
+  }
+  return null
+}

--- a/frontend/src/routes/oauth/complete-signup.tsx
+++ b/frontend/src/routes/oauth/complete-signup.tsx
@@ -8,7 +8,7 @@ import { Icon } from '~/components/common/Icon'
 import * as styles from '~/components/common/LoginPage.css'
 import { UsernameField } from '~/components/common/UsernameField'
 import { useAuth } from '~/context/AuthContext'
-import { sanitizeDisplayName, sanitizeSlug } from '~/lib/validate'
+import { sanitizeDisplayName, sanitizeSlug, validateReservedUsername } from '~/lib/validate'
 import { spinner } from '~/styles/animations.css'
 import { cardNarrow, errorText } from '~/styles/shared.css'
 
@@ -53,6 +53,13 @@ const OAuthCompleteSignupPage: Component = () => {
     const [slug, slugErr] = sanitizeSlug('Username', username())
     if (slugErr) {
       setError(slugErr)
+      return
+    }
+    // OAuth completion is a post-authentication flow; always treat it as
+    // public signup (admin is reserved, setup uses the /setup page instead).
+    const reservedErr = validateReservedUsername(slug, false)
+    if (reservedErr) {
+      setError(reservedErr)
       return
     }
     const { value: sanitizedDisplayName, error: dnErr } = sanitizeDisplayName(displayName(), slug)

--- a/frontend/tests/e2e/06-signup.spec.ts
+++ b/frontend/tests/e2e/06-signup.spec.ts
@@ -11,9 +11,15 @@ test.describe('Sign Up', () => {
     await expect(page).toHaveURL(new RegExp(`/o/${username}`))
   })
 
-  test('should show error for duplicate username', async ({ page }) => {
+  test('should show error for reserved username', async ({ page }) => {
     await signUpViaUI(page, 'admin', 'password123')
-    // Should show an error (username taken)
+    // Public signup rejects "admin" before the server is even hit.
+    await expect(page.getByText(/reserved username/i)).toBeVisible()
+  })
+
+  test('should show error for duplicate username', async ({ page }) => {
+    // newuser is seeded by the worker-scoped fixture.
+    await signUpViaUI(page, 'newuser', 'password123')
     await expect(page.getByText('username already taken')).toBeVisible()
   })
 

--- a/frontend/tests/e2e/37-first-admin-setup.spec.ts
+++ b/frontend/tests/e2e/37-first-admin-setup.spec.ts
@@ -1,0 +1,67 @@
+import type { UnseededDevServerHandle } from './helpers/devServer'
+import { test as base, expect } from '@playwright/test'
+import { getCurrentUser } from './helpers/api'
+import { startUnseededDevServer, stopDevServer } from './helpers/devServer'
+
+/**
+ * Uses a standalone unseeded dev server (no pre-registered admin) so we can
+ * exercise the /setup flow. Scoped per test so each test sees a fresh
+ * setup-mode instance; the shared fixtures from fixtures.ts can't be used
+ * because that fixture signs up `admin` automatically.
+ */
+// Playwright fixtures declare their dependencies by destructuring the first
+// parameter; this fixture has no dependencies, hence the empty pattern.
+// eslint-disable-next-line no-empty-pattern
+async function setupServer({}: object, use: (server: UnseededDevServerHandle) => Promise<void>): Promise<void> {
+  const server = await startUnseededDevServer({ dataDirPrefix: 'leapmux-e2e-setup' })
+  try {
+    await use(server)
+  }
+  finally {
+    await stopDevServer(server)
+  }
+}
+
+const test = base.extend<{ server: UnseededDevServerHandle }>({
+  server: setupServer,
+  baseURL: async ({ server }, use) => {
+    await use(server.hubUrl)
+  },
+})
+
+test.describe('First-admin setup', () => {
+  test('root path redirects to /setup on a fresh instance', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/setup$/)
+    await expect(page.getByRole('heading', { name: /Welcome to LeapMux/i })).toBeVisible()
+  })
+
+  test('setup rejects reserved username "solo"', async ({ page }) => {
+    await page.goto('/setup')
+    await page.getByLabel('Username').fill('solo')
+    await page.getByLabel('Display Name').fill('Solo')
+    await page.getByLabel('New Password').fill('strongpass1')
+    await page.getByLabel('Confirm Password').fill('strongpass1')
+    await page.getByRole('button', { name: 'Create account' }).click()
+    await expect(page.getByText(/reserved username/i)).toBeVisible()
+    await expect(page).toHaveURL(/\/setup$/)
+  })
+
+  test('setup accepts username "admin" and marks the user as admin', async ({ page, server, context }) => {
+    await page.goto('/setup')
+    await page.getByLabel('Username').fill('admin')
+    await page.getByLabel('Display Name').fill('Admin')
+    await page.getByLabel('New Password').fill('strongpass1')
+    await page.getByLabel('Confirm Password').fill('strongpass1')
+    await page.getByRole('button', { name: 'Create account' }).click()
+    await expect(page).toHaveURL(/\/o\/admin$/)
+
+    // Verify the backend recorded this user as an admin.
+    const cookies = await context.cookies()
+    const session = cookies.find(c => c.name === 'leapmux-session')
+    expect(session?.value).toBeTruthy()
+    const user = await getCurrentUser(server.hubUrl, `leapmux-session=${session!.value}`)
+    expect(user.isAdmin).toBe(true)
+    expect(user.username).toBe('admin')
+  })
+})

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -11,9 +11,11 @@ import {
   deleteWorkspaceViaAPI,
   getAdminOrgId,
   getWorkerId,
-  loginViaAPI,
   openAgentViaAPI,
   signUpViaAPI,
+  TEST_ADMIN_DISPLAY_NAME,
+  TEST_ADMIN_PASSWORD,
+  TEST_ADMIN_USERNAME,
 } from './helpers/api'
 import { findFreePort, getGlobalState, waitForServer } from './helpers/server'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
@@ -72,8 +74,10 @@ export const test = base.extend<
     await waitForServer(hubUrl)
     console.log(`[e2e] Dev instance ready on port ${port}`)
 
-    // Login as admin (bootstrap creates admin/admin123 in dev mode)
-    const adminToken = await loginViaAPI(hubUrl, 'admin', 'admin123')
+    // Register the first admin via setup mode. The /setup flow allows `admin`
+    // as a username only when no users exist yet; after this, `admin` is
+    // reserved for public signup.
+    const adminToken = await signUpViaAPI(hubUrl, TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD, TEST_ADMIN_DISPLAY_NAME)
     const adminOrgId = await getAdminOrgId(hubUrl, adminToken)
     const workerId = await getWorkerId(hubUrl, adminToken)
 

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -33,6 +33,14 @@ async function getTestChannel(hubUrl: string, cookie: string): Promise<ChannelMa
 
 export { getTestChannel }
 
+// ---- Test admin fixture credentials ----
+// The first-admin user seeded by e2e fixtures via /setup mode. Mirrors the
+// backend's testutil.TestAdminUsername / TestAdminPassword.
+
+export const TEST_ADMIN_USERNAME = 'admin'
+export const TEST_ADMIN_PASSWORD = 'admin123'
+export const TEST_ADMIN_DISPLAY_NAME = 'Admin'
+
 // ---- Cookie helpers ----
 
 const SESSION_COOKIE_NAME = 'leapmux-session'
@@ -83,20 +91,37 @@ export async function loginViaAPI(hubUrl: string, username: string, password: st
   return extractSessionCookie(res.headers.get('set-cookie'))
 }
 
+export interface ApiUser {
+  id: string
+  username: string
+  displayName: string
+  isAdmin: boolean
+  email: string
+  orgId: string
+  orgName: string
+}
+
 /**
- * Get the current user's ID via the Connect API.
+ * Get the full current-user payload via the Connect API.
  */
-export async function getUserId(hubUrl: string, cookie: string): Promise<string> {
+export async function getCurrentUser(hubUrl: string, cookie: string): Promise<ApiUser> {
   const res = await fetch(`${hubUrl}/leapmux.v1.AuthService/GetCurrentUser`, {
     method: 'POST',
     headers: authedHeaders(cookie),
     body: JSON.stringify({}),
   })
   if (!res.ok) {
-    throw new Error(`getUserId failed: ${res.status}`)
+    throw new Error(`getCurrentUser failed: ${res.status}`)
   }
-  const data = await res.json() as { user: { id: string } }
-  return data.user.id
+  const data = await res.json() as { user: ApiUser }
+  return data.user
+}
+
+/**
+ * Get the current user's ID via the Connect API.
+ */
+export async function getUserId(hubUrl: string, cookie: string): Promise<string> {
+  return (await getCurrentUser(hubUrl, cookie)).id
 }
 
 /**

--- a/frontend/tests/e2e/helpers/devServer.ts
+++ b/frontend/tests/e2e/helpers/devServer.ts
@@ -11,7 +11,14 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
-import { getAdminOrgId, getWorkerId, loginViaAPI } from './api'
+import {
+  getAdminOrgId,
+  getWorkerId,
+  signUpViaAPI,
+  TEST_ADMIN_DISPLAY_NAME,
+  TEST_ADMIN_PASSWORD,
+  TEST_ADMIN_USERNAME,
+} from './api'
 import { findFreePort, getGlobalState, waitForServer } from './server'
 
 export interface DevServerHandle {
@@ -19,6 +26,12 @@ export interface DevServerHandle {
   adminToken: string
   adminOrgId: string
   workerId: string
+  proc: ChildProcess
+  dataDir: string
+}
+
+export interface UnseededDevServerHandle {
+  hubUrl: string
   proc: ChildProcess
   dataDir: string
 }
@@ -33,6 +46,19 @@ export interface StartDevServerOptions {
 }
 
 export async function startDevServer(opts: StartDevServerOptions = {}): Promise<DevServerHandle> {
+  const unseeded = await startUnseededDevServer(opts)
+  // Register the first admin via setup mode (dev mode no longer auto-bootstraps).
+  const adminToken = await signUpViaAPI(unseeded.hubUrl, TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD, TEST_ADMIN_DISPLAY_NAME)
+  const adminOrgId = await getAdminOrgId(unseeded.hubUrl, adminToken)
+  const workerId = await getWorkerId(unseeded.hubUrl, adminToken)
+  return { ...unseeded, adminToken, adminOrgId, workerId }
+}
+
+/**
+ * Like startDevServer, but does not register the initial admin. Use this for
+ * specs that need to exercise the /setup flow directly.
+ */
+export async function startUnseededDevServer(opts: StartDevServerOptions = {}): Promise<UnseededDevServerHandle> {
   const { binaryPath } = getGlobalState()
   const dataDir = mkdtempSync(join(tmpdir(), `${opts.dataDirPrefix ?? 'leapmux-e2e-'}-`))
   const port = await findFreePort()
@@ -53,13 +79,10 @@ export async function startDevServer(opts: StartDevServerOptions = {}): Promise<
   }
 
   await waitForServer(hubUrl)
-  const adminToken = await loginViaAPI(hubUrl, 'admin', 'admin123')
-  const adminOrgId = await getAdminOrgId(hubUrl, adminToken)
-  const workerId = await getWorkerId(hubUrl, adminToken)
-  return { hubUrl, adminToken, adminOrgId, workerId, proc, dataDir }
+  return { hubUrl, proc, dataDir }
 }
 
-export async function stopDevServer(handle: DevServerHandle, extraPaths: string[] = []): Promise<void> {
+export async function stopDevServer(handle: DevServerHandle | UnseededDevServerHandle, extraPaths: string[] = []): Promise<void> {
   handle.proc.kill('SIGTERM')
   await new Promise(r => setTimeout(r, 1000))
   try {

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -16,6 +16,9 @@ import {
   loginViaAPI,
   openAgentViaAPI,
   signUpViaAPI,
+  TEST_ADMIN_DISPLAY_NAME,
+  TEST_ADMIN_PASSWORD,
+  TEST_ADMIN_USERNAME,
 } from './helpers/api'
 import { findFreePort, getGlobalState, waitForServer } from './helpers/server'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
@@ -214,7 +217,7 @@ export async function restartHub(serverInfo: SeparateServerInfo) {
   // Verify the hub is fully operational by testing login
   for (let i = 0; i < 10; i++) {
     try {
-      await loginViaAPI(serverInfo.hubUrl, 'admin', 'admin123')
+      await loginViaAPI(serverInfo.hubUrl, TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD)
       break
     }
     catch {
@@ -275,7 +278,7 @@ export const processTest = base.extend<
     console.log(`[e2e] Hub ready on port ${hubPort}`)
 
     // Create admin via setup mode (first signup becomes admin)
-    const adminToken = await signUpViaAPI(hubUrl, 'admin', 'admin123', 'Admin')
+    const adminToken = await signUpViaAPI(hubUrl, TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD, TEST_ADMIN_DISPLAY_NAME)
     const adminOrgId = await getAdminOrgId(hubUrl, adminToken)
 
     // Start worker in its own process group so stray signals from the test


### PR DESCRIPTION
## Motivation

Dev-mode instances shipped with a hardcoded `admin`/`admin123` account that was auto-created at bootstrap. Anyone who knew the default credentials could access any dev or freshly-deployed instance, making it a security footgun in practice. The fix is to remove the auto-created account entirely and replace it with an interactive `/setup` page where the first operator claims the admin identity explicitly.

## Modifications

- Added `usernames` package with `Solo` and `Admin` constants and three predicate functions (`IsReservedSystem`, `IsReservedPublic`, `IsReservedForPublicSignup`) to centralize reserved-username rules across bootstrap, auth, service, and CLI layers.
- Removed `devMode` parameter from `bootstrap.Run()` and deleted `bootstrap.Username()` (callers use `usernames.Solo` instead). Dev and hub modes no longer auto-create an admin user at startup.
- Changed `auth.NewInterceptor` signature: the `soloMode bool` parameter is replaced by `soloUser *UserInfo`. Callers must now call `auth.LoadSoloUser()` at startup and pass the result in explicitly.
- `AuthService.SignUp` now rejects the `solo` username in all modes and the `admin` username outside of setup mode. `CompleteOAuthSignup` applies the same public-signup rules.
- Added `UserStore.GetFirstAdmin(ctx) (*User, error)` across mysql, postgres, and sqlite backends (returns `ErrNotFound` when no admin exists yet).
- `hub.Server` eager-loads the solo user at startup via `auth.LoadSoloUser()`. New `Server.GetAdminUser(ctx)` is backed by `GetFirstAdmin`. `GetSystemInfo` now returns `setupRequired=true` until the first admin exists, directing the frontend to `/setup`.
- `solo.go` refactored: worker bring-up extracted to `bringUpLocalWorker()`; new `pollForDeferredWorkerSetup()` retries on a 2-second ticker in dev mode until an admin account exists, then registers the worker with that admin's user ID.
- CLI `admin_user.go` now rejects reserved system usernames when creating users via command line.
- Extracted `unindexSession` / `isSyncMapEmpty` helpers in the auth interceptor so the session-cache sweep and `SessionCache.Evict` share index-maintenance logic; incidentally fixes a latent leak where Evict left empty outer `userSessions` entries behind.
- Frontend `SignupForm` gains an `allowAdminUsername` prop; `/setup` passes it as `true` so the first operator can legitimately claim the `admin` name while public signup keeps the stricter validation.
- Added `validateReservedUsername()` in the frontend validation library (mirrors backend predicates) with unit tests.
- E2E infra: `startDevServer()` now seeds the admin fixture via `signUpViaAPI()` against the `/setup` endpoint. New `startUnseededDevServer()` variant for specs that exercise `/setup` directly. `TEST_ADMIN_USERNAME`, `TEST_ADMIN_PASSWORD`, `TEST_ADMIN_DISPLAY_NAME` are exported as named constants.
- New e2e suite `37-first-admin-setup.spec.ts` covers: rejecting `solo` in public signup, rejecting `admin` in public signup, accepting `admin` in setup mode, and rejecting signup attempts once setup is already complete.

**Breaking internal APIs:** `bootstrap.Run()` drops its `devMode` parameter; `bootstrap.Username()` is removed (use `usernames.Solo`); `auth.NewInterceptor` takes `soloUser *UserInfo` instead of `soloMode bool`.

## Result

Dev and production instances no longer have a hardcoded `admin`/`admin123` account. On first launch, the frontend shows a `/setup` page where the operator chooses their own username and password. The `solo` username is always reserved for the internal solo-mode user and cannot be registered by anyone. Subsequent signup attempts for `admin` through the public signup path are rejected, preventing account squatting before the operator completes setup. In dev mode, workers wait for the first admin account to exist before registering, so the full flow works even when setup has not been completed yet.
