### PR TITLE
feat(terminal): Resume from byte-offset watermark on resubscribe

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -887,7 +887,13 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		// Filter terminals by access control and register watchers. Same
 		// batched-lookup rationale as the agent loop above.
-		requestedTerminalIDs := r.GetTerminalIds()
+		requestedTerminals := r.GetTerminals()
+		requestedTerminalIDs := make([]string, 0, len(requestedTerminals))
+		afterOffsetByID := make(map[string]int64, len(requestedTerminals))
+		for _, entry := range requestedTerminals {
+			requestedTerminalIDs = append(requestedTerminalIDs, entry.GetTerminalId())
+			afterOffsetByID[entry.GetTerminalId()] = entry.GetAfterOffset()
+		}
 		termRowsByID := make(map[string]db.Terminal, len(requestedTerminalIDs))
 		if len(requestedTerminalIDs) > 0 {
 			rows, err := svc.Queries.ListTerminalsByIDs(bgCtx(), requestedTerminalIDs)
@@ -1044,17 +1050,26 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			})
 		}
 
-		// Send initial screen snapshot for each verified terminal.
+		// Send the minimum screen bytes each verified terminal needs to
+		// catch up to the current PTY state. The frontend's after_offset
+		// tells us how far it has already processed; SnapshotSince
+		// returns an incremental delta when the offset is inside the
+		// retained ring, or a full-state snapshot (with is_snapshot=true)
+		// when the subscriber has fallen behind or is cold-subscribing.
+		// Caller is-caught-up returns (nil, _, false) and no event is sent.
 		for i, termID := range verifiedTerminalIDs {
-			if screen := svc.Terminals.ScreenSnapshot(termID); len(screen) > 0 {
+			afterOffset := afterOffsetByID[termID]
+			data, endOffset, isSnapshot := svc.Terminals.ScreenSnapshotSince(termID, afterOffset)
+			if len(data) > 0 {
 				broadcastWatchEvent(sender, &leapmuxv1.WatchEventsResponse{
 					Event: &leapmuxv1.WatchEventsResponse_TerminalEvent{
 						TerminalEvent: &leapmuxv1.TerminalEvent{
 							TerminalId: termID,
 							Event: &leapmuxv1.TerminalEvent_Data{
 								Data: &leapmuxv1.TerminalData{
-									Data:       screen,
-									IsSnapshot: true,
+									Data:       data,
+									IsSnapshot: isSnapshot,
+									EndOffset:  endOffset,
 								},
 							},
 						},

--- a/backend/internal/worker/service/close_during_startup_test.go
+++ b/backend/internal/worker/service/close_during_startup_test.go
@@ -222,7 +222,7 @@ func TestCloseTerminal_DuringStartup_SuppressesReadyAndCleansUp(t *testing.T) {
 			require.True(t, localBranchExists(t, repoDir, branchName))
 
 			dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
-				TerminalIds: []string{opts.ID},
+				Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: opts.ID}},
 			}, wWatch)
 
 			wClose := &testResponseWriter{channelID: "test-ch"}

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -124,6 +124,33 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 	return svc, d, w
 }
 
+// startTestTerminal spawns a live PTY via svc.Terminals, persists a
+// matching DB row so access-control lookups succeed, and registers the
+// full cleanup chain. Returns the working directory assigned to the
+// terminal so tests can use it for follow-up assertions. Used by tests
+// that need a running terminal attached to an accessible workspace.
+func startTestTerminal(t *testing.T, svc *Context, ctx context.Context, id, workspaceID string) string {
+	t.Helper()
+	workingDir := t.TempDir()
+
+	require.NoError(t, svc.Terminals.StartTerminal(ctx, terminal.Options{
+		ID: id, WorkspaceID: workspaceID,
+		Shell: testutil.TestShell(), WorkingDir: workingDir,
+		Cols: 80, Rows: 24,
+	}, func([]byte, int64) {}, nil))
+	t.Cleanup(func() {
+		svc.Terminals.StopTerminal(id)
+		testutil.AssertEventually(t, func() bool { return svc.Terminals.IsExited(id) }, "exit")
+		svc.Terminals.RemoveTerminal(id)
+	})
+
+	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+		ID: id, WorkspaceID: workspaceID, WorkingDir: workingDir, HomeDir: "/tmp",
+		Cols: 80, Rows: 24, Screen: []byte{},
+	}))
+	return workingDir
+}
+
 // drainAllInFlight joins any runAgentStartup / runTerminalStartup
 // goroutines spawned during the test and waits for any in-flight close
 // handlers tracked on svc.Cleanup. Call via `defer` immediately after
@@ -318,7 +345,7 @@ func TestWatchEvents_ClosedTerminal_NotWatched(t *testing.T) {
 	}))
 
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
-		TerminalIds: []string{"term-closed"},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "term-closed"}},
 	}, w)
 
 	// Closed terminal should produce a single stream error (NOT_FOUND).
@@ -347,7 +374,7 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 		ShellStartDir: "",
 		Cols:          80,
 		Rows:          24,
-	}, func([]byte) {}, nil))
+	}, func([]byte, int64) {}, nil))
 
 	require.True(t, svc.Terminals.UpdateTitle("term-1", "user@host: ~/dir"))
 
@@ -368,7 +395,8 @@ func TestShutdown_PersistsTerminalScreenSnapshots(t *testing.T) {
 	// Wait until the echo output appears in the screen buffer; otherwise
 	// Shutdown can race ahead of the shell processing the input.
 	testutil.AssertEventually(t, func() bool {
-		return bytes.Contains(svc.Terminals.ScreenSnapshot("term-1"), []byte("shutdown_test"))
+		screen, _, _ := svc.Terminals.ScreenSnapshotSince("term-1", 0)
+		return bytes.Contains(screen, []byte("shutdown_test"))
 	}, "expected terminal screen to contain 'shutdown_test'")
 
 	// Call Shutdown — should persist screen to DB.

--- a/backend/internal/worker/service/list_by_ids_test.go
+++ b/backend/internal/worker/service/list_by_ids_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -235,6 +236,73 @@ func TestListTerminals_ClosedTabsFiltered(t *testing.T) {
 	var resp leapmuxv1.ListTerminalsResponse
 	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
 	assert.Empty(t, resp.GetTerminals(), "closed terminal should not be returned")
+}
+
+// TestListTerminals_ScreenEndOffset_DBOnly: terminals that exist only in
+// the DB (no live PTY — worker restarted or shell exited) must report
+// screen_end_offset = len(screen). The frontend seeds its WatchEvents
+// after_offset from this, and the invariant means a cold subscribe
+// against a dead terminal resolves to "caught up" with no replay.
+func TestListTerminals_ScreenEndOffset_DBOnly(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-A")
+
+	screen := []byte("some persisted screen content")
+	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+		ID: "t-db", WorkspaceID: "ws-A", WorkingDir: "/tmp", HomeDir: "/tmp",
+		Cols: 80, Rows: 24, Screen: screen,
+	}))
+
+	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
+		TabIds: []string{"t-db"},
+	}, w)
+
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListTerminalsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetTerminals(), 1)
+	ti := resp.GetTerminals()[0]
+	assert.Equal(t, screen, ti.GetScreen())
+	assert.Equal(t, int64(len(screen)), ti.GetScreenEndOffset(),
+		"DB-only terminals: screen_end_offset must equal len(screen)")
+}
+
+// TestListTerminals_ScreenEndOffset_LiveTerminal: terminals with a live
+// PTY in the Manager must report screen_end_offset = cumulative bytes
+// written, which equals len(screen) until the ring wraps but can diverge
+// afterwards. Sanity-check: the returned offset matches Manager.ScreenSnapshot
+// (Manager is the authoritative source).
+func TestListTerminals_ScreenEndOffset_LiveTerminal(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-A")
+	startTestTerminal(t, svc, ctx, "t-live", "ws-A")
+
+	// Drive some output so the screen buffer is non-empty.
+	require.NoError(t, svc.Terminals.SendInput("t-live", []byte("echo live_offset_test"+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		screen, _, _ := svc.Terminals.ScreenSnapshotSince("t-live", 0)
+		return len(screen) > 0
+	}, "expected live output")
+
+	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
+		TabIds: []string{"t-live"},
+	}, w)
+
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListTerminalsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetTerminals(), 1)
+	ti := resp.GetTerminals()[0]
+
+	// The authoritative offset is whatever the Manager's ScreenBuffer
+	// holds at the time ListTerminals ran. Read the current value and
+	// assert the response matches — both should equal len(screen) before
+	// the ring wraps, and both should drift in lockstep after.
+	_, managerOffset, _ := svc.Terminals.ScreenSnapshotSince("t-live", 0)
+	assert.Equal(t, managerOffset, ti.GetScreenEndOffset(),
+		"live terminal: screen_end_offset must match the Manager's offset")
+	assert.Equal(t, int64(len(ti.GetScreen())), ti.GetScreenEndOffset(),
+		"before ring wrap: screen_end_offset equals len(screen)")
 }
 
 func TestListTerminals_InaccessibleWorkspaceDenied(t *testing.T) {

--- a/backend/internal/worker/service/list_by_ids_test.go
+++ b/backend/internal/worker/service/list_by_ids_test.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/util/testutil"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -268,21 +267,22 @@ func TestListTerminals_ScreenEndOffset_DBOnly(t *testing.T) {
 }
 
 // TestListTerminals_ScreenEndOffset_LiveTerminal: terminals with a live
-// PTY in the Manager must report screen_end_offset = cumulative bytes
-// written, which equals len(screen) until the ring wraps but can diverge
-// afterwards. Sanity-check: the returned offset matches Manager.ScreenSnapshot
-// (Manager is the authoritative source).
+// PTY in the Manager must report screen_end_offset sourced from the
+// Manager (cumulative bytes written), not from len(db_row.screen) which
+// is empty until Shutdown persists. Proves the path by injecting a
+// unique marker via AppendOutput and confirming the response carries
+// it — the DB row for this terminal has Screen=[]byte{}, so a
+// non-empty response can only have come from the Manager. Driving the
+// shell with SendInput was previously racy: PTY output continues
+// streaming asynchronously, so ti.ScreenEndOffset and a subsequent
+// ScreenSnapshotSince read at different moments diverged.
 func TestListTerminals_ScreenEndOffset_LiveTerminal(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-A")
 	startTestTerminal(t, svc, ctx, "t-live", "ws-A")
 
-	// Drive some output so the screen buffer is non-empty.
-	require.NoError(t, svc.Terminals.SendInput("t-live", []byte("echo live_offset_test"+testutil.TestShellEnter())))
-	testutil.AssertEventually(t, func() bool {
-		screen, _, _ := svc.Terminals.ScreenSnapshotSince("t-live", 0)
-		return len(screen) > 0
-	}, "expected live output")
+	marker := []byte("live_offset_test_marker")
+	require.True(t, svc.Terminals.AppendOutput("t-live", marker))
 
 	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
 		TabIds: []string{"t-live"},
@@ -294,13 +294,13 @@ func TestListTerminals_ScreenEndOffset_LiveTerminal(t *testing.T) {
 	require.Len(t, resp.GetTerminals(), 1)
 	ti := resp.GetTerminals()[0]
 
-	// The authoritative offset is whatever the Manager's ScreenBuffer
-	// holds at the time ListTerminals ran. Read the current value and
-	// assert the response matches — both should equal len(screen) before
-	// the ring wraps, and both should drift in lockstep after.
-	_, managerOffset, _ := svc.Terminals.ScreenSnapshotSince("t-live", 0)
-	assert.Equal(t, managerOffset, ti.GetScreenEndOffset(),
-		"live terminal: screen_end_offset must match the Manager's offset")
+	// Screen and ScreenEndOffset are sampled atomically inside
+	// buildEntryLocked (single Terminal.ScreenSnapshot call), so the
+	// len(screen) == offset invariant holds regardless of concurrent
+	// shell output. The marker presence confirms we got the Manager's
+	// buffer, not the DB row's empty Screen.
+	assert.Contains(t, string(ti.GetScreen()), string(marker),
+		"live terminal must return Manager's screen (DB row has Screen=[]byte{})")
 	assert.Equal(t, int64(len(ti.GetScreen())), ti.GetScreenEndOffset(),
 		"before ring wrap: screen_end_offset equals len(screen)")
 }

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -180,7 +180,7 @@ func TestOpenTerminal_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 
 	wWatch := &testResponseWriter{channelID: "test-ch"}
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
-		TerminalIds: []string{terminalID},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: terminalID}},
 	}, wWatch)
 
 	// Catch-up replay fires synchronously during the WatchEvents handler,

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -241,8 +241,7 @@ func appendTerminalDisconnectNotice(screen []byte) []byte {
 }
 
 func (svc *Context) appendTerminalDisconnectNotice(terminalID string) {
-	screen := svc.Terminals.ScreenSnapshot(terminalID)
-	if bytes.HasSuffix(screen, terminalDisconnectNotice) {
+	if svc.Terminals.ScreenHasSuffix(terminalID, terminalDisconnectNotice) {
 		return
 	}
 	_ = svc.Terminals.AppendOutput(terminalID, terminalDisconnectNotice)

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -55,6 +55,12 @@ type startupEntry struct {
 	// takePendingResize after StartTerminal and applies the result.
 	pendingResize    [2]uint16
 	hasPendingResize bool
+	// resizeSignal notifies waitForPendingResize that a resize has been
+	// stashed. Buffered size 1 with non-blocking send so repeated
+	// setPendingResize calls don't block and a late wait still sees the
+	// most-recent signal — takePendingResize under the lock is the
+	// authoritative read.
+	resizeSignal chan struct{}
 }
 
 // startupCore is the shared state-machine for tracking a set of in-flight
@@ -84,7 +90,7 @@ func newStartupCore() startupCore {
 func (r *startupCore) begin(id string, cancel context.CancelFunc) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.entries[id] = &startupEntry{cancel: cancel}
+	r.entries[id] = &startupEntry{cancel: cancel, resizeSignal: make(chan struct{}, 1)}
 	r.wg.Add(1)
 }
 
@@ -184,6 +190,15 @@ func (r *startupCore) setPendingResize(id string, cols, rows uint16) bool {
 	}
 	entry.pendingResize = [2]uint16{cols, rows}
 	entry.hasPendingResize = true
+	// Non-blocking send keeps the lock-hold trivially short. Signal goes
+	// to the entry's own channel, so even if this entry is cleared and
+	// recreated later the new channel starts fresh.
+	if entry.resizeSignal != nil {
+		select {
+		case entry.resizeSignal <- struct{}{}:
+		default:
+		}
+	}
 	return true
 }
 
@@ -202,15 +217,58 @@ func (r *startupCore) takePendingResize(id string) (cols, rows uint16, ok bool) 
 	return cols, rows, true
 }
 
+// waitForPendingResize is takePendingResize with a bounded wait. Used
+// before the shell is spawned so the PTY can be sized correctly on the
+// first call to cmd.Start — otherwise the shell paints its first prompt
+// at the placeholder 80x24 and zsh's SIGWINCH handler leaves a
+// PROMPT_SP '%' in the buffer when the resize lands a moment later.
+// Returns false if the entry is cleared/failed or the timeout elapses
+// without a stashed resize.
+func (r *startupCore) waitForPendingResize(id string, timeout time.Duration) (cols, rows uint16, ok bool) {
+	r.mu.Lock()
+	entry, found := r.entries[id]
+	if !found || entry.failed {
+		r.mu.Unlock()
+		return 0, 0, false
+	}
+	if entry.hasPendingResize {
+		cols = entry.pendingResize[0]
+		rows = entry.pendingResize[1]
+		entry.hasPendingResize = false
+		r.mu.Unlock()
+		return cols, rows, true
+	}
+	ch := entry.resizeSignal
+	r.mu.Unlock()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+	}
+	return r.takePendingResize(id)
+}
+
 // clearPendingResize drops any stashed dims for id. Called from the
 // ResizeTerminal handler when the PTY is already in the Manager so the
 // direct Resize call has already been applied; leaving a stale stash in
 // place would cause runTerminalStartup to overwrite the newer size.
+// Also drains the buffered resizeSignal so a later waitForPendingResize
+// on the same entry can't wake on a stash that no longer exists.
 func (r *startupCore) clearPendingResize(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if entry, ok := r.entries[id]; ok {
-		entry.hasPendingResize = false
+	entry, ok := r.entries[id]
+	if !ok {
+		return
+	}
+	entry.hasPendingResize = false
+	if entry.resizeSignal != nil {
+		select {
+		case <-entry.resizeSignal:
+		default:
+		}
 	}
 }
 

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// beginForTest records an entry and returns a cleanup that pairs with
+// finish() to keep WaitForInFlight happy. Tests use this to exercise
+// the startupCore primitives without the full startup-goroutine
+// machinery.
+func beginForTest(t *testing.T, r *startupCore, id string) {
+	t.Helper()
+	r.begin(id, func() {})
+	t.Cleanup(func() {
+		r.cancelAndClear(id)
+		r.finish()
+	})
+}
+
+// TestStartupCore_ClearPendingResize_DrainsSignal pins the contract
+// that clearPendingResize empties the buffered resizeSignal along with
+// the hasPendingResize bool. Without the drain, a later
+// waitForPendingResize on the same entry would wake immediately on the
+// stale signal — behavior is still functionally safe because
+// takePendingResize re-checks under lock, but the spurious wake
+// short-circuits the timeout that callers rely on as the "no resize
+// arrived" signal.
+func TestStartupCore_ClearPendingResize_DrainsSignal(t *testing.T) {
+	r := newStartupCore()
+	id := "term-clear-drain"
+	beginForTest(t, &r, id)
+
+	require.True(t, r.setPendingResize(id, 120, 40))
+
+	// Capture the chan reference before clearing so we can inspect its
+	// buffer independently of later takePendingResize calls.
+	r.mu.Lock()
+	ch := r.entries[id].resizeSignal
+	r.mu.Unlock()
+	require.NotNil(t, ch)
+	require.Equal(t, 1, len(ch), "setPendingResize should have buffered a signal")
+
+	r.clearPendingResize(id)
+	assert.Equal(t, 0, len(ch),
+		"clearPendingResize must drain the buffered signal so a later waiter can't wake on it")
+
+	// A wait after clear should block for roughly the full timeout,
+	// not wake immediately on a stale signal.
+	start := time.Now()
+	_, _, ok := r.waitForPendingResize(id, 50*time.Millisecond)
+	assert.False(t, ok, "no resize stashed, should time out")
+	assert.GreaterOrEqual(t, time.Since(start), 40*time.Millisecond,
+		"wait should block for roughly the full timeout, not wake on a drained signal")
+}
+
+// TestStartupCore_WaitForPendingResize_WakesOnSignal covers the normal
+// path: a setPendingResize that arrives while a waiter is parked wakes
+// it immediately via the chan signal.
+func TestStartupCore_WaitForPendingResize_WakesOnSignal(t *testing.T) {
+	r := newStartupCore()
+	id := "term-wake"
+	beginForTest(t, &r, id)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		r.setPendingResize(id, 90, 30)
+	}()
+
+	start := time.Now()
+	cols, rows, ok := r.waitForPendingResize(id, 500*time.Millisecond)
+	elapsed := time.Since(start)
+	require.True(t, ok)
+	assert.Equal(t, uint16(90), cols)
+	assert.Equal(t, uint16(30), rows)
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"chan signal should wake the waiter in ms, not hit the timeout")
+}
+
+// TestStartupCore_WaitForPendingResize_AlreadyStashed covers the fast
+// path where dims were already stashed before the wait starts — returns
+// synchronously without touching the chan.
+func TestStartupCore_WaitForPendingResize_AlreadyStashed(t *testing.T) {
+	r := newStartupCore()
+	id := "term-prestashed"
+	beginForTest(t, &r, id)
+
+	require.True(t, r.setPendingResize(id, 100, 50))
+	cols, rows, ok := r.waitForPendingResize(id, 500*time.Millisecond)
+	require.True(t, ok)
+	assert.Equal(t, uint16(100), cols)
+	assert.Equal(t, uint16(50), rows)
+}

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/id"
@@ -14,6 +15,12 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
 )
+
+// pendingResizeWaitCap bounds how long runTerminalStartup blocks waiting
+// for the frontend's first ResizeTerminal before spawning the shell. A
+// typical wait returns in a few tens of ms; the cap is a safety valve
+// for a wedged or unusually slow frontend.
+const pendingResizeWaitCap = 500 * time.Millisecond
 
 // terminalStartingLabel returns the "Starting <shell>…" label used for the
 // sync prologue broadcast and the phase-1 re-broadcast once git status is
@@ -75,7 +82,7 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 
 		terminalID := id.Generate()
 
-		outputFn := func(data []byte) {
+		outputFn := func(data []byte, endOffset int64) {
 			if svc.WakeLock != nil {
 				svc.WakeLock.RecordActivity()
 			}
@@ -83,7 +90,8 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 				TerminalId: terminalID,
 				Event: &leapmuxv1.TerminalEvent_Data{
 					Data: &leapmuxv1.TerminalData{
-						Data: data,
+						Data:      data,
+						EndOffset: endOffset,
 					},
 				},
 			})
@@ -362,15 +370,16 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 			}
 			seen[e.ID] = true
 			ti := &leapmuxv1.TerminalInfo{
-				TerminalId:    e.ID,
-				Cols:          e.Meta.Cols,
-				Rows:          e.Meta.Rows,
-				Screen:        e.Screen,
-				Exited:        e.Exited,
-				WorkingDir:    e.Meta.WorkingDir,
-				ShellStartDir: e.Meta.ShellStartDir,
-				Title:         e.Meta.Title,
-				Status:        leapmuxv1.TerminalStatus_TERMINAL_STATUS_READY,
+				TerminalId:      e.ID,
+				Cols:            e.Meta.Cols,
+				Rows:            e.Meta.Rows,
+				Screen:          e.Screen,
+				ScreenEndOffset: e.ScreenEndOffset,
+				Exited:          e.Exited,
+				WorkingDir:      e.Meta.WorkingDir,
+				ShellStartDir:   e.Meta.ShellStartDir,
+				Title:           e.Meta.Title,
+				Status:          leapmuxv1.TerminalStatus_TERMINAL_STATUS_READY,
 			}
 			if sup, errStr, msg, ok := svc.TerminalStartup.status(e.ID); ok {
 				ti.Status = sup
@@ -393,18 +402,25 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 					continue
 				}
 				status, startupError, startupMessage := svc.deriveTerminalStatus(&ts)
+				// DB-persisted screen is just the bytes; the backend has no
+				// live ring for this terminal (PTY exited or worker
+				// restarted), so the "end offset" equals the screen
+				// length. The client's after_offset will be the same
+				// value, and WatchEvents will return nothing for a dead
+				// terminal — correct, since there are no new bytes.
 				ti := &leapmuxv1.TerminalInfo{
-					TerminalId:     ts.ID,
-					Cols:           uint32(ts.Cols),
-					Rows:           uint32(ts.Rows),
-					Screen:         ts.Screen,
-					Exited:         !svc.Terminals.HasTerminal(ts.ID),
-					WorkingDir:     ts.WorkingDir,
-					ShellStartDir:  ts.ShellStartDir,
-					Title:          ts.Title,
-					Status:         status,
-					StartupError:   startupError,
-					StartupMessage: startupMessage,
+					TerminalId:      ts.ID,
+					Cols:            uint32(ts.Cols),
+					Rows:            uint32(ts.Rows),
+					Screen:          ts.Screen,
+					ScreenEndOffset: int64(len(ts.Screen)),
+					Exited:          !svc.Terminals.HasTerminal(ts.ID),
+					WorkingDir:      ts.WorkingDir,
+					ShellStartDir:   ts.ShellStartDir,
+					Title:           ts.Title,
+					Status:          status,
+					StartupError:    startupError,
+					StartupMessage:  startupMessage,
 				}
 				terminals = append(terminals, ti)
 				gitDirs = append(gitDirs, gitutil.ResolveGitDir(ts.ShellStartDir, ts.WorkingDir))
@@ -469,6 +485,16 @@ func (svc *Context) runTerminalStartup(ctx context.Context, opts terminal.Option
 	svc.TerminalStartup.setMessage(terminalID, shellMsg)
 	svc.broadcastTerminalStarting(terminalID, shellMsg, gs)
 
+	// Wait for the frontend's first ResizeTerminal to arrive so the shell
+	// is spawned at the final size rather than being SIGWINCH'd to it
+	// after StartTerminal returns — some shells emit artifacts on a
+	// mid-startup resize. If the cap elapses, the post-spawn apply below
+	// still lands the dims on the running PTY.
+	if cols, rows, ok := svc.TerminalStartup.waitForPendingResize(terminalID, pendingResizeWaitCap); ok {
+		opts.Cols = cols
+		opts.Rows = rows
+	}
+
 	startErr := svc.startTerminal(ctx, opts, outputFn, exitFn)
 
 	// Re-read the row so we can detect whether CloseTerminal landed
@@ -491,11 +517,10 @@ func (svc *Context) runTerminalStartup(ctx context.Context, opts terminal.Option
 		return
 	}
 
-	// Apply any ResizeTerminal that arrived during the PTY-spawn window.
-	// The PTY was created with the placeholder cols/rows from the
-	// OpenTerminal request; the frontend's first fit() fires long before
-	// the Manager holds the terminal, so its RPC is stashed in the
-	// startup registry and drained here.
+	// Apply any ResizeTerminal that arrived after the pre-spawn wait
+	// above (e.g. the frontend's fit() was unusually slow, or a second
+	// resize has since landed). The PTY is already the correct size for
+	// the pre-wait case; this handler covers the rare late-arriving dims.
 	if cols, rows, ok := svc.TerminalStartup.takePendingResize(terminalID); ok {
 		if err := svc.Terminals.Resize(terminalID, cols, rows); err != nil {
 			slog.Warn("apply pending resize after startup", "terminal_id", terminalID, "error", err)

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -90,29 +90,26 @@ func TestWatchEvents_Terminal_ResubscribeWithCurrentOffset_NoDuplicate(t *testin
 // subscribes, captures the offset, more output arrives, client
 // resubscribes. The second subscribe's catch-up must contain EXACTLY
 // the newly-written bytes (is_snapshot=false), not the whole buffer.
+//
+// Uses AppendOutput for deterministic bytes: SendInput + AssertEventually
+// was racy because AssertEventually fires on the first byte the shell
+// emits, leaving firstOffset mid-echo. AppendOutput writes synchronously
+// under the ring mutex, so the marker is fully committed before we read
+// the offset. Concurrent shell prompt bytes are fine — they're nameless
+// and can't collide with the markers we assert on.
 func TestWatchEvents_Terminal_IncrementalDeltaAfterResubscribe(t *testing.T) {
 	ctx := context.Background()
 	svc, d, _ := setupTestService(t, "ws-1")
 	startTestTerminal(t, svc, ctx, "t-delta", "ws-1")
 
-	// Drive some initial output.
-	require.NoError(t, svc.Terminals.SendInput("t-delta", []byte("echo first_chunk"+testutil.TestShellEnter())))
-	testutil.AssertEventually(t, func() bool {
-		screen, _, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
-		return len(screen) > 0
-	}, "first chunk")
+	firstMarker := []byte("FIRST_CHUNK_MARKER_BYTES\r\n")
+	require.True(t, svc.Terminals.AppendOutput("t-delta", firstMarker))
 
-	// Capture the current offset — this is what a frontend would have
-	// after the first subscribe.
 	_, firstOffset, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
-	require.Greater(t, firstOffset, int64(0))
+	require.GreaterOrEqual(t, firstOffset, int64(len(firstMarker)))
 
-	// Drive more output the "absent" client will miss.
-	require.NoError(t, svc.Terminals.SendInput("t-delta", []byte("echo second_chunk"+testutil.TestShellEnter())))
-	testutil.AssertEventually(t, func() bool {
-		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
-		return off > firstOffset
-	}, "second chunk")
+	secondMarker := []byte("SECOND_CHUNK_MARKER_BYTES\r\n")
+	require.True(t, svc.Terminals.AppendOutput("t-delta", secondMarker))
 
 	// Resubscribe at firstOffset. Must receive an incremental delta with
 	// is_snapshot=false containing only the new bytes.
@@ -132,9 +129,9 @@ func TestWatchEvents_Terminal_IncrementalDeltaAfterResubscribe(t *testing.T) {
 	require.NotNil(t, delta)
 	assert.False(t, delta.GetIsSnapshot(),
 		"in-window resume must NOT be flagged as snapshot — frontend would reset unnecessarily")
-	assert.Contains(t, string(delta.GetData()), "second_chunk",
+	assert.Contains(t, string(delta.GetData()), string(secondMarker),
 		"delta must contain the bytes the absent client missed")
-	assert.NotContains(t, string(delta.GetData()), "first_chunk",
+	assert.NotContains(t, string(delta.GetData()), string(firstMarker),
 		"delta must NOT re-send bytes the client already has")
 }
 

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
+)
+
+// collectTerminalData drains all TerminalData events (snapshot or
+// incremental) addressed to terminalID from w's stream buffer.
+func collectTerminalData(t *testing.T, w *testResponseWriter, terminalID string) []*leapmuxv1.TerminalData {
+	t.Helper()
+	var out []*leapmuxv1.TerminalData
+	for _, s := range w.streamsSnapshot() {
+		var resp leapmuxv1.WatchEventsResponse
+		if err := proto.Unmarshal(s.GetPayload(), &resp); err != nil {
+			continue
+		}
+		te := resp.GetTerminalEvent()
+		if te == nil || te.GetTerminalId() != terminalID {
+			continue
+		}
+		if d := te.GetData(); d != nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// TestWatchEvents_Terminal_ResubscribeWithCurrentOffset_NoDuplicate:
+// a resubscribe with after_offset == the terminal's current cumulative
+// offset produces NO TerminalData event. The backend has nothing new
+// to send, so the client's xterm must not receive any replay — seeing
+// one would mean the backend is re-sending bytes the client already
+// has, which manifests as duplicated prompt output in the live UI.
+func TestWatchEvents_Terminal_ResubscribeWithCurrentOffset_NoDuplicate(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, "ws-1")
+	startTestTerminal(t, svc, ctx, "t-resub", "ws-1")
+
+	require.NoError(t, svc.Terminals.SendInput("t-resub", []byte("echo resubscribe_test"+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-resub", 0)
+		return off > 0
+	}, "initial shell output")
+
+	// First subscribe: after_offset=0 delivers a cold-catch-up event with
+	// the current screen contents.
+	w1 := &testResponseWriter{channelID: "test-ch"}
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "t-resub", AfterOffset: 0}},
+	}, w1)
+
+	var initialOffset int64
+	testutil.AssertEventually(t, func() bool {
+		for _, data := range collectTerminalData(t, w1, "t-resub") {
+			if data.GetEndOffset() > 0 {
+				initialOffset = data.GetEndOffset()
+				return true
+			}
+		}
+		return false
+	}, "first subscribe delivered the current screen")
+	require.Greater(t, initialOffset, int64(0))
+
+	// Second subscribe with after_offset at the current head. The backend
+	// must not send any TerminalData.
+	w2 := &testResponseWriter{channelID: "test-ch"}
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "t-resub", AfterOffset: initialOffset}},
+	}, w2)
+
+	// Give the handler a moment; if it was going to emit data it'd be in
+	// the stream buffer synchronously (the catch-up loop runs in the RPC
+	// call path, not a background goroutine).
+	time.Sleep(50 * time.Millisecond)
+	datas := collectTerminalData(t, w2, "t-resub")
+	assert.Empty(t, datas,
+		"resubscribe with after_offset=current must not replay bytes — the client already has them")
+}
+
+// TestWatchEvents_Terminal_IncrementalDeltaAfterResubscribe: client
+// subscribes, captures the offset, more output arrives, client
+// resubscribes. The second subscribe's catch-up must contain EXACTLY
+// the newly-written bytes (is_snapshot=false), not the whole buffer.
+func TestWatchEvents_Terminal_IncrementalDeltaAfterResubscribe(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, "ws-1")
+	startTestTerminal(t, svc, ctx, "t-delta", "ws-1")
+
+	// Drive some initial output.
+	require.NoError(t, svc.Terminals.SendInput("t-delta", []byte("echo first_chunk"+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		screen, _, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
+		return len(screen) > 0
+	}, "first chunk")
+
+	// Capture the current offset — this is what a frontend would have
+	// after the first subscribe.
+	_, firstOffset, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
+	require.Greater(t, firstOffset, int64(0))
+
+	// Drive more output the "absent" client will miss.
+	require.NoError(t, svc.Terminals.SendInput("t-delta", []byte("echo second_chunk"+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-delta", 0)
+		return off > firstOffset
+	}, "second chunk")
+
+	// Resubscribe at firstOffset. Must receive an incremental delta with
+	// is_snapshot=false containing only the new bytes.
+	w2 := &testResponseWriter{channelID: "test-ch"}
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "t-delta", AfterOffset: firstOffset}},
+	}, w2)
+
+	var delta *leapmuxv1.TerminalData
+	testutil.AssertEventually(t, func() bool {
+		for _, data := range collectTerminalData(t, w2, "t-delta") {
+			delta = data
+			return true
+		}
+		return false
+	}, "resubscribe delivered a catch-up event")
+	require.NotNil(t, delta)
+	assert.False(t, delta.GetIsSnapshot(),
+		"in-window resume must NOT be flagged as snapshot — frontend would reset unnecessarily")
+	assert.Contains(t, string(delta.GetData()), "second_chunk",
+		"delta must contain the bytes the absent client missed")
+	assert.NotContains(t, string(delta.GetData()), "first_chunk",
+		"delta must NOT re-send bytes the client already has")
+}
+
+// TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap: when the backend's
+// ring has wrapped, a cold subscriber (after_offset=0) receives a full
+// screen snapshot with is_snapshot=true so the client resets its xterm
+// rather than appending to possibly-stale state. Guards the fallen-behind
+// branch of SnapshotSince in the WatchEvents handler.
+func TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, "ws-1")
+	startTestTerminal(t, svc, ctx, "t-wrap", "ws-1")
+
+	// Inject >100KB synthetic output directly so we don't have to wait on
+	// the shell to produce it. AppendOutput goes through the same write
+	// path as PTY output.
+	big := make([]byte, 150*1024)
+	for i := range big {
+		big[i] = 'x'
+	}
+	require.True(t, svc.Terminals.AppendOutput("t-wrap", big))
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-wrap", 0)
+		return off >= int64(len(big))
+	}, "appended bytes arrived")
+
+	// Cold subscribe — after_offset=0 is now well below the retained
+	// window.
+	w := &testResponseWriter{channelID: "test-ch"}
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "t-wrap", AfterOffset: 0}},
+	}, w)
+
+	var snap *leapmuxv1.TerminalData
+	testutil.AssertEventually(t, func() bool {
+		for _, data := range collectTerminalData(t, w, "t-wrap") {
+			snap = data
+			return true
+		}
+		return false
+	}, "cold subscribe delivered a catch-up event")
+	require.NotNil(t, snap)
+	assert.True(t, snap.GetIsSnapshot(),
+		"fell-behind-ring cold subscribe must be flagged as snapshot so the frontend resets")
+	// Delta size is bounded by the 100KB ring, even though the PTY has
+	// emitted ~150KB.
+	assert.LessOrEqual(t, len(snap.GetData()), 100*1024)
+	assert.Greater(t, snap.GetEndOffset(), int64(100*1024),
+		"end_offset reflects the cumulative counter, which is > ring size once the ring has wrapped")
+}

--- a/backend/internal/worker/terminal/manager.go
+++ b/backend/internal/worker/terminal/manager.go
@@ -203,16 +203,32 @@ func (m *Manager) UpdateTitle(terminalID, title string) bool {
 	return true
 }
 
-// ScreenSnapshot returns the screen buffer snapshot for a terminal.
-func (m *Manager) ScreenSnapshot(terminalID string) []byte {
+// ScreenSnapshotSince returns the bytes a subscriber needs to advance
+// from afterOffset to the current head of the terminal's screen buffer,
+// for the watch-event catch-up path. Returns (nil, 0, false) if the
+// terminal is unknown. See Terminal.ScreenSnapshotSince for the
+// isSnapshot contract.
+func (m *Manager) ScreenSnapshotSince(terminalID string, afterOffset int64) (data []byte, endOffset int64, isSnapshot bool) {
 	m.mu.RLock()
 	t, ok := m.terminals[terminalID]
 	m.mu.RUnlock()
 
 	if !ok {
-		return nil
+		return nil, 0, false
 	}
-	return t.ScreenSnapshot()
+	return t.ScreenSnapshotSince(afterOffset)
+}
+
+// ScreenHasSuffix reports whether the live terminal's retained screen
+// ends with needle. Returns false if the terminal is unknown.
+func (m *Manager) ScreenHasSuffix(terminalID string, needle []byte) bool {
+	m.mu.RLock()
+	t, ok := m.terminals[terminalID]
+	m.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	return t.ScreenHasSuffix(needle)
 }
 
 // AppendOutput injects synthetic output into the tracked terminal's screen
@@ -240,7 +256,7 @@ func (m *Manager) SnapshotTerminal(terminalID string) (snap TerminalSnapshot, ok
 	if !exists {
 		return TerminalSnapshot{}, false
 	}
-	screen := t.ScreenSnapshot()
+	screen, _ := t.ScreenSnapshot()
 	if len(screen) == 0 {
 		return TerminalSnapshot{}, false
 	}
@@ -278,7 +294,27 @@ type TerminalEntry struct {
 	ID     string
 	Meta   TerminalMeta
 	Screen []byte
-	Exited bool
+	// ScreenEndOffset is the cumulative PTY byte offset at the end of
+	// Screen. Equal to len(Screen) before the ring wraps and strictly
+	// greater once old bytes have fallen off. Subscribers use this to
+	// seed their WatchEvents after_offset so resubscribes pick up
+	// exactly where the snapshot left off instead of replaying Screen.
+	ScreenEndOffset int64
+	Exited          bool
+}
+
+// buildEntryLocked assembles a TerminalEntry for id, attaching the live
+// screen snapshot and offset when a PTY is present. Caller must hold
+// m.mu (read or write).
+func (m *Manager) buildEntryLocked(id string, meta TerminalMeta) TerminalEntry {
+	entry := TerminalEntry{ID: id, Meta: meta}
+	if t, ok := m.terminals[id]; ok {
+		entry.Screen, entry.ScreenEndOffset = t.ScreenSnapshot()
+		entry.Exited = t.IsExited()
+	} else {
+		entry.Exited = true
+	}
+	return entry
 }
 
 // ListByWorkspace returns all terminals belonging to the given workspace.
@@ -291,17 +327,7 @@ func (m *Manager) ListByWorkspace(workspaceID string) []TerminalEntry {
 		if meta.WorkspaceID != workspaceID {
 			continue
 		}
-		entry := TerminalEntry{
-			ID:   id,
-			Meta: meta,
-		}
-		if t, ok := m.terminals[id]; ok {
-			entry.Screen = t.ScreenSnapshot()
-			entry.Exited = t.IsExited()
-		} else {
-			entry.Exited = true
-		}
-		result = append(result, entry)
+		result = append(result, m.buildEntryLocked(id, meta))
 	}
 	return result
 }
@@ -317,17 +343,7 @@ func (m *Manager) ListByIDs(ids []string) []TerminalEntry {
 		if !ok {
 			continue
 		}
-		entry := TerminalEntry{
-			ID:   id,
-			Meta: meta,
-		}
-		if t, ok := m.terminals[id]; ok {
-			entry.Screen = t.ScreenSnapshot()
-			entry.Exited = t.IsExited()
-		} else {
-			entry.Exited = true
-		}
-		result = append(result, entry)
+		result = append(result, m.buildEntryLocked(id, meta))
 	}
 	return result
 }

--- a/backend/internal/worker/terminal/screenbuffer_test.go
+++ b/backend/internal/worker/terminal/screenbuffer_test.go
@@ -1,0 +1,311 @@
+package terminal
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScreenBuffer_SnapshotSince_CaughtUp: a subscriber whose after_offset
+// equals the buffer's total-written counter gets an empty response with
+// no snapshot flag — there's nothing for the client to apply.
+func TestScreenBuffer_SnapshotSince_CaughtUp(t *testing.T) {
+	sb := NewScreenBuffer()
+	end := sb.Write([]byte("hello"))
+
+	data, offset, isSnap := sb.SnapshotSince(end)
+	assert.Nil(t, data)
+	assert.Equal(t, end, offset)
+	assert.False(t, isSnap)
+}
+
+// TestScreenBuffer_SnapshotSince_ColdSubscribeWithinWindow: after_offset=0
+// on a buffer whose ring has NOT wrapped returns the full retained bytes
+// as an incremental delta, NOT a snapshot. The snapshot flag exists to
+// tell a frontend to reset pre-existing state; a cold subscriber has no
+// state to reset, and a frontend that happens to hold the first N bytes
+// legitimately is resuming in-window. The distinction only matters once
+// the ring has wrapped (see BehindRing test).
+func TestScreenBuffer_SnapshotSince_ColdSubscribeWithinWindow(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("hello"))
+	sb.Write([]byte(" world"))
+
+	data, offset, isSnap := sb.SnapshotSince(0)
+	assert.Equal(t, []byte("hello world"), data)
+	assert.Equal(t, int64(11), offset)
+	assert.False(t, isSnap,
+		"offset 0 while the ring still holds byte 0 is valid in-window resume")
+}
+
+// TestScreenBuffer_SnapshotSince_IncrementalDelta: after_offset inside the
+// retained window must return only the bytes since afterOffset, not the
+// whole buffer, and must NOT set the snapshot flag.
+func TestScreenBuffer_SnapshotSince_IncrementalDelta(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("hello"))
+	midOffset := int64(5)
+	sb.Write([]byte(" world"))
+	sb.Write([]byte("!"))
+
+	data, offset, isSnap := sb.SnapshotSince(midOffset)
+	assert.Equal(t, []byte(" world!"), data,
+		"subscriber at offset 5 should receive exactly the post-offset bytes")
+	assert.Equal(t, int64(12), offset)
+	assert.False(t, isSnap, "in-window resume must be incremental, not a snapshot")
+}
+
+// TestScreenBuffer_SnapshotSince_StaleOffset: after_offset larger than the
+// current total (PTY recreated beneath the client) must be treated the
+// same as a cold subscribe — return the whole buffer as a snapshot so the
+// client drops its stale state.
+func TestScreenBuffer_SnapshotSince_StaleOffset(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("fresh"))
+
+	data, offset, isSnap := sb.SnapshotSince(9999)
+	assert.Equal(t, []byte("fresh"), data)
+	assert.Equal(t, int64(5), offset)
+	assert.True(t, isSnap)
+}
+
+// TestScreenBuffer_SnapshotSince_BehindRing: after_offset that has fallen
+// out of the 100KB retained window returns the full retained buffer with
+// the snapshot flag set — the client cannot be resumed incrementally.
+func TestScreenBuffer_SnapshotSince_BehindRing(t *testing.T) {
+	sb := NewScreenBuffer()
+	// Fill well past the ring capacity so the early offsets drop out.
+	chunk := make([]byte, 8*1024)
+	for i := range chunk {
+		chunk[i] = 'x'
+	}
+	for i := 0; i < 20; i++ { // 160KB total, 60KB overwritten
+		sb.Write(chunk)
+	}
+	total := sb.TotalBytes()
+	require.Equal(t, int64(20*8*1024), total)
+
+	// Offset 0 is now well outside the retained window.
+	data, offset, isSnap := sb.SnapshotSince(0)
+	assert.Len(t, data, screenBufferSize,
+		"fell-behind subscriber should receive the full retained ring")
+	assert.Equal(t, total, offset)
+	assert.True(t, isSnap, "fell-behind resume must be flagged as snapshot")
+}
+
+// TestScreenBuffer_SnapshotSince_EmptyBuffer: fresh buffer with no writes
+// returns nothing regardless of the requested offset — no snapshot flag
+// because there's nothing to replace either.
+func TestScreenBuffer_SnapshotSince_EmptyBuffer(t *testing.T) {
+	sb := NewScreenBuffer()
+
+	data, offset, isSnap := sb.SnapshotSince(0)
+	assert.Empty(t, data)
+	assert.Zero(t, offset)
+	assert.False(t, isSnap)
+}
+
+// TestScreenBuffer_Write_ReturnsEndOffset: Write must return the
+// cumulative total-bytes *after* the write so callers can forward it to
+// watchers as the resume cursor without a separate TotalBytes call.
+func TestScreenBuffer_Write_ReturnsEndOffset(t *testing.T) {
+	sb := NewScreenBuffer()
+	assert.Equal(t, int64(5), sb.Write([]byte("hello")))
+	assert.Equal(t, int64(11), sb.Write([]byte(" world")))
+	assert.Equal(t, int64(11), sb.TotalBytes())
+}
+
+// TestScreenBuffer_SnapshotSince_BoundaryAtWindowStart: afterOffset
+// exactly at the retention-window start must be in-window (incremental).
+// Off-by-one here would either duplicate the first retained byte or
+// misclassify a valid offset as fallen-behind.
+func TestScreenBuffer_SnapshotSince_BoundaryAtWindowStart(t *testing.T) {
+	sb := NewScreenBuffer()
+	// Fill past capacity so the ring has wrapped exactly once and the
+	// retained window is [screenBufferSize, 2*screenBufferSize).
+	chunk := make([]byte, screenBufferSize)
+	for i := range chunk {
+		chunk[i] = 'a'
+	}
+	sb.Write(chunk)
+	sb.Write(chunk)
+	total := sb.TotalBytes()
+	windowStart := total - screenBufferSize
+
+	// At windowStart exactly: must be in-window.
+	data, end, isSnap := sb.SnapshotSince(windowStart)
+	assert.Equal(t, total, end)
+	assert.False(t, isSnap,
+		"offset equal to windowStart is still in the retained ring")
+	assert.Len(t, data, screenBufferSize,
+		"missing bytes from windowStart to total should equal ring size")
+
+	// One byte before windowStart: fallen out of the window.
+	_, _, isSnap = sb.SnapshotSince(windowStart - 1)
+	assert.True(t, isSnap,
+		"offset one byte below windowStart must be flagged as snapshot")
+}
+
+// TestScreenBuffer_SnapshotSince_BoundaryAtTotalMinusOne: asking for the
+// last byte must return exactly one byte, not nothing and not the whole
+// tail. Keeps the delta math honest when consumers are nearly caught up.
+func TestScreenBuffer_SnapshotSince_BoundaryAtTotalMinusOne(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("hello"))
+
+	data, end, isSnap := sb.SnapshotSince(4)
+	assert.Equal(t, []byte("o"), data)
+	assert.Equal(t, int64(5), end)
+	assert.False(t, isSnap)
+}
+
+// TestScreenBuffer_SnapshotSince_NegativeOffset: a negative afterOffset
+// (malformed client state) must be treated defensively as a stale/cold
+// subscribe and receive a full snapshot — never a partial delta computed
+// from a negative windowStart comparison.
+func TestScreenBuffer_SnapshotSince_NegativeOffset(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("hello"))
+
+	data, end, isSnap := sb.SnapshotSince(-1)
+	assert.Equal(t, []byte("hello"), data)
+	assert.Equal(t, int64(5), end)
+	assert.True(t, isSnap,
+		"negative offsets must be treated as stale — full snapshot")
+}
+
+// TestScreenBuffer_SnapshotSince_WrapsAtExactBoundary: when a write
+// exactly fills the ring (pos==len(buf), full transitions false→true),
+// SnapshotSince(0) must still return all bytes as an in-window resume —
+// not a snapshot, because byte 0 is still the retention window's start.
+func TestScreenBuffer_SnapshotSince_WrapsAtExactBoundary(t *testing.T) {
+	sb := NewScreenBuffer()
+	chunk := make([]byte, screenBufferSize)
+	for i := range chunk {
+		chunk[i] = 'z'
+	}
+	sb.Write(chunk)
+
+	require.Equal(t, int64(screenBufferSize), sb.TotalBytes())
+	data, end, isSnap := sb.SnapshotSince(0)
+	assert.Len(t, data, screenBufferSize)
+	assert.Equal(t, int64(screenBufferSize), end)
+	assert.False(t, isSnap,
+		"ring exactly full: byte 0 is at windowStart, still in-window")
+}
+
+// TestScreenBuffer_SnapshotSince_MultiWrap: after the ring has wrapped
+// several times, windowStart tracks total - retained correctly. Stale
+// offsets from early wraps return snapshots; offsets inside the current
+// window return incremental deltas.
+func TestScreenBuffer_SnapshotSince_MultiWrap(t *testing.T) {
+	sb := NewScreenBuffer()
+	chunk := make([]byte, screenBufferSize/2)
+	for i := range chunk {
+		chunk[i] = 'w'
+	}
+	// 5 writes of half-ring = 2.5x the ring capacity: wraps twice.
+	for i := 0; i < 5; i++ {
+		sb.Write(chunk)
+	}
+	total := sb.TotalBytes()
+	require.Equal(t, int64(5*len(chunk)), total)
+	windowStart := total - screenBufferSize
+
+	// Offset inside the window — incremental.
+	inWindow := windowStart + int64(len(chunk))
+	_, _, isSnap := sb.SnapshotSince(inWindow)
+	assert.False(t, isSnap)
+
+	// Offset from the first wrap — should be out of the current window.
+	_, _, isSnap = sb.SnapshotSince(int64(len(chunk)))
+	assert.True(t, isSnap,
+		"offsets from early wraps must now be outside the retained ring")
+}
+
+// TestScreenBuffer_Write_LargerThanRing: a single Write larger than the
+// ring must still advance the total counter by len(data). The returned
+// bytes are the *last* len(buf) bytes of the write.
+func TestScreenBuffer_Write_LargerThanRing(t *testing.T) {
+	sb := NewScreenBuffer()
+	big := make([]byte, 2*screenBufferSize)
+	for i := range big {
+		big[i] = byte(i & 0xff)
+	}
+	end := sb.Write(big)
+	assert.Equal(t, int64(2*screenBufferSize), end)
+	assert.Equal(t, int64(2*screenBufferSize), sb.TotalBytes())
+
+	// Full buffer equals the last ring-size bytes of the input.
+	data, _, _ := sb.SnapshotSince(0)
+	require.Len(t, data, screenBufferSize)
+	assert.Equal(t, big[screenBufferSize:], data)
+}
+
+// TestScreenBuffer_HasSuffix covers the three regimes the
+// disconnect-notice path relies on: empty-buffer no-match, no-wrap
+// match, and post-wrap match where the suffix straddles the ring
+// boundary. Empty-needle is true by convention (mirrors bytes.HasSuffix).
+func TestScreenBuffer_HasSuffix(t *testing.T) {
+	// Empty needle on an empty buffer.
+	sb := NewScreenBuffer()
+	assert.True(t, sb.HasSuffix(nil))
+	assert.False(t, sb.HasSuffix([]byte("anything")))
+
+	// No-wrap: write less than capacity, check suffix.
+	sb.Write([]byte("prefix-NOTICE"))
+	assert.True(t, sb.HasSuffix([]byte("NOTICE")))
+	assert.False(t, sb.HasSuffix([]byte("prefix")))
+	assert.False(t, sb.HasSuffix([]byte("some-longer-string-than-was-written")))
+
+	// Post-wrap: fill past the ring, then write a marker so it straddles.
+	sb = NewScreenBuffer()
+	filler := make([]byte, screenBufferSize-3)
+	for i := range filler {
+		filler[i] = 'x'
+	}
+	sb.Write(filler)
+	sb.Write([]byte("AB"))     // ring now has 'x'*n-3 + "AB", pos just before wrap
+	sb.Write([]byte("C\nEND")) // writes wrap across the boundary
+	assert.True(t, sb.HasSuffix([]byte("END")))
+	assert.True(t, sb.HasSuffix([]byte("ABC\nEND")),
+		"suffix that straddles the ring wrap must still match")
+	assert.False(t, sb.HasSuffix([]byte("WRONG")))
+}
+
+// TestScreenBuffer_ConcurrentWriteAndSnapshot: Write and SnapshotSince
+// must not data-race under -race. No assertion on content — the goal is
+// just to exercise the locks. The race detector surfaces violations as
+// test failures.
+func TestScreenBuffer_ConcurrentWriteAndSnapshot(t *testing.T) {
+	sb := NewScreenBuffer()
+	chunk := []byte("chunk of output")
+
+	var wg sync.WaitGroup
+	// One writer producing a steady stream.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			sb.Write(chunk)
+		}
+	}()
+	// Several concurrent readers at varying offsets.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				_, _, _ = sb.SnapshotSince(int64(i))
+				_, _ = sb.Snapshot()
+				_ = sb.TotalBytes()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Final offset must equal the total bytes the writer emitted.
+	assert.Equal(t, int64(500*len(chunk)), sb.TotalBytes())
+}

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -18,11 +19,28 @@ import (
 const screenBufferSize = 100 * 1024 // 100KB ring buffer for screen restore
 
 // ScreenBuffer is a thread-safe ring buffer that stores recent PTY output.
+// It also tracks a cumulative byte counter so callers can resume from a
+// known offset instead of re-reading the full buffer on every subscribe.
+//
+// Retention limit: the ring holds the most recent screenBufferSize bytes
+// of PTY output. Any terminal state established by escape sequences
+// emitted before that window — alt-screen toggles, cursor-visibility
+// changes, scrolling regions, character-set designations, SGR colors,
+// saved cursor position, cell content positioned by earlier writes — is
+// unrecoverable by byte-stream replay alone. A subscriber whose
+// after_offset has fallen out of the window receives a full snapshot
+// that reproduces the retained bytes correctly, but a TUI running
+// *before* that window (vim in alt screen, say) may render with missing
+// cells or misaligned cursor until the program repaints. This is the
+// ceiling of any byte-replay approach; reconstructing state beyond the
+// ring requires a parsed cell grid (tmux-style terminal emulation),
+// which is deliberately out of scope for this worker.
 type ScreenBuffer struct {
-	mu   sync.Mutex
-	buf  []byte
-	pos  int
-	full bool
+	mu    sync.Mutex
+	buf   []byte
+	pos   int
+	full  bool
+	total int64 // Total bytes ever written (monotonic within a PTY session).
 }
 
 // NewScreenBuffer creates a new screen buffer.
@@ -30,11 +48,22 @@ func NewScreenBuffer() *ScreenBuffer {
 	return &ScreenBuffer{buf: make([]byte, screenBufferSize)}
 }
 
-// Write appends data to the ring buffer.
-func (sb *ScreenBuffer) Write(data []byte) {
+// Write appends data to the ring buffer and returns the cumulative byte
+// offset at the end of the write. Callers forward that offset to watchers
+// so they can persist it as their resume cursor.
+func (sb *ScreenBuffer) Write(data []byte) int64 {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 
+	sb.total += int64(len(data))
+	// Writes larger than the ring would overwrite themselves; only the
+	// final len(buf) bytes can survive, so skip ahead to them.
+	if len(data) >= len(sb.buf) {
+		copy(sb.buf, data[len(data)-len(sb.buf):])
+		sb.pos = 0
+		sb.full = true
+		return sb.total
+	}
 	for len(data) > 0 {
 		n := copy(sb.buf[sb.pos:], data)
 		data = data[n:]
@@ -44,27 +73,120 @@ func (sb *ScreenBuffer) Write(data []byte) {
 			sb.full = true
 		}
 	}
+	return sb.total
 }
 
-// Snapshot returns a copy of the buffered data in chronological order.
-func (sb *ScreenBuffer) Snapshot() []byte {
+// TotalBytes returns the cumulative byte count ever written to this buffer.
+// Monotonic within a single PTY session; a new Terminal starts at 0.
+func (sb *ScreenBuffer) TotalBytes() int64 {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
+	return sb.total
+}
 
-	if !sb.full {
-		out := make([]byte, sb.pos)
-		copy(out, sb.buf[:sb.pos])
-		return out
+// Snapshot returns a copy of every retained byte in chronological order
+// and the cumulative offset at the end of that copy. Convenience for
+// callers that want the full buffer regardless of the ring's base offset.
+func (sb *ScreenBuffer) Snapshot() ([]byte, int64) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.tailBytesLocked(sb.retainedLocked()), sb.total
+}
+
+// HasSuffix reports whether the retained bytes end with needle. Used by
+// the disconnect-notice path to check idempotency without allocating a
+// copy of the full buffer.
+func (sb *ScreenBuffer) HasSuffix(needle []byte) bool {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	if len(needle) == 0 {
+		return true
 	}
+	head, wrap := sb.tailLocked(len(needle))
+	if len(head)+len(wrap) < len(needle) {
+		return false
+	}
+	return bytes.Equal(head, needle[:len(head)]) &&
+		bytes.Equal(wrap, needle[len(head):])
+}
 
-	out := make([]byte, len(sb.buf))
-	n := copy(out, sb.buf[sb.pos:])
-	copy(out[n:], sb.buf[:sb.pos])
+// retainedLocked reports the number of bytes currently in the ring: pos
+// before the first wrap, the full buffer length after. Caller must hold
+// sb.mu.
+func (sb *ScreenBuffer) retainedLocked() int {
+	if sb.full {
+		return len(sb.buf)
+	}
+	return sb.pos
+}
+
+// tailLocked returns the trailing n retained bytes as two ring segments
+// — head then wrap in chronological order, head+wrap == last n bytes.
+// If fewer than n bytes are retained, returns what's available. Caller
+// must hold sb.mu.
+func (sb *ScreenBuffer) tailLocked(n int) (head, wrap []byte) {
+	if retained := sb.retainedLocked(); n > retained {
+		n = retained
+	}
+	start := sb.pos - n
+	if start >= 0 {
+		return nil, sb.buf[start:sb.pos]
+	}
+	headLen := -start
+	return sb.buf[len(sb.buf)-headLen:], sb.buf[:sb.pos]
+}
+
+// tailBytesLocked returns the trailing n retained bytes as a freshly
+// allocated, flattened slice. Zero-length when n <= 0 or the buffer is
+// empty. Caller must hold sb.mu.
+func (sb *ScreenBuffer) tailBytesLocked(n int) []byte {
+	head, wrap := sb.tailLocked(n)
+	out := make([]byte, len(head)+len(wrap))
+	copy(out, head)
+	copy(out[len(head):], wrap)
 	return out
 }
 
-// OutputHandler is called for each chunk of output from the PTY.
-type OutputHandler func(data []byte)
+// SnapshotSince returns the bytes the caller needs in order to advance
+// from afterOffset to the current head, the cumulative offset at the end
+// of those bytes, and whether the returned bytes should be treated as a
+// full-state replacement (caller must reset its terminal buffer before
+// writing) rather than an incremental append.
+//
+//   - afterOffset == total: caller is caught up. Returns (nil, total, false).
+//   - afterOffset within the retained window: returns the incremental
+//     delta since afterOffset. isSnapshot is false.
+//   - afterOffset has fallen out of the retained window, is negative, or
+//     is larger than total (PTY recreated beneath a stale client):
+//     returns the full retained buffer with isSnapshot=true so the caller
+//     drops any stale state.
+func (sb *ScreenBuffer) SnapshotSince(afterOffset int64) (data []byte, endOffset int64, isSnapshot bool) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	total := sb.total
+	if afterOffset == total {
+		return nil, total, false
+	}
+	// Retained window is [total-retained, total).
+	windowStart := total - int64(sb.retainedLocked())
+
+	// Incremental catch-up: afterOffset is inside the retained window,
+	// so copy only the missing suffix directly from the ring.
+	if afterOffset >= windowStart && afterOffset < total {
+		return sb.tailBytesLocked(int(total - afterOffset)), total, false
+	}
+
+	// Cold subscribe, negative offset, stale offset > total, or caller
+	// has fallen behind the retained window: send everything we have
+	// with the snapshot flag.
+	return sb.tailBytesLocked(sb.retainedLocked()), total, true
+}
+
+// OutputHandler is called for each chunk of output from the PTY. The
+// endOffset is the cumulative byte counter *after* this chunk; callers
+// forward it to watchers as the resume cursor for this event.
+type OutputHandler func(data []byte, endOffset int64)
 
 // Terminal manages a single PTY session.
 type Terminal struct {
@@ -72,7 +194,10 @@ type Terminal struct {
 	cmd       *pty.Cmd
 	ptmx      pty.Pty
 	jobObject *procutil.JobObject
-	outputFn  OutputHandler
+	// outputFn is the internal dispatch for both live PTY reads and
+	// AppendOutput. It writes into screenBuf and forwards the resulting
+	// cumulative offset to the user-provided OutputHandler.
+	outputFn  func(data []byte)
 	screenBuf *ScreenBuffer
 	mu        sync.Mutex
 	stopped   bool
@@ -154,8 +279,8 @@ func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Terminal
 
 	screenBuf := NewScreenBuffer()
 	wrappedOutput := func(data []byte) {
-		screenBuf.Write(data)
-		outputFn(data)
+		endOffset := screenBuf.Write(data)
+		outputFn(data, endOffset)
 	}
 
 	t := &Terminal{
@@ -254,14 +379,33 @@ func (t *Terminal) ID() string {
 	return t.id
 }
 
-// ScreenSnapshot returns the recent PTY output for screen restore.
-func (t *Terminal) ScreenSnapshot() []byte {
+// ScreenSnapshot returns the full retained PTY output and the cumulative
+// byte offset at its end.
+func (t *Terminal) ScreenSnapshot() ([]byte, int64) {
 	return t.screenBuf.Snapshot()
+}
+
+// ScreenSnapshotSince returns the bytes a subscriber needs to advance
+// from afterOffset to the current head of the screen buffer, the
+// cumulative offset at the end of those bytes, and whether the returned
+// bytes are a full-state replacement (subscriber must reset its
+// terminal) rather than an append. See ScreenBuffer.SnapshotSince for
+// the detailed contract.
+func (t *Terminal) ScreenSnapshotSince(afterOffset int64) (data []byte, endOffset int64, isSnapshot bool) {
+	return t.screenBuf.SnapshotSince(afterOffset)
+}
+
+// ScreenHasSuffix reports whether the retained screen buffer ends with
+// needle. Avoids the allocation of ScreenSnapshot for callers that only
+// need to check a trailing marker.
+func (t *Terminal) ScreenHasSuffix(needle []byte) bool {
+	return t.screenBuf.HasSuffix(needle)
 }
 
 // AppendOutput injects synthetic output into the terminal stream and screen
 // buffer without writing to the PTY. This is used for system notices that
-// should be restorable like normal terminal output.
+// should be restorable like normal terminal output. Runs through the same
+// wrappedOutput path as live PTY data so the cumulative offset advances.
 func (t *Terminal) AppendOutput(data []byte) {
 	if len(data) == 0 {
 		return

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -26,7 +26,7 @@ func TestTerminal_StartAndStop(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte) {
+	}, func(data []byte, _ int64) {
 		mu.Lock()
 		output = append(output, data...)
 		mu.Unlock()
@@ -59,7 +59,7 @@ func TestTerminal_Resize(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func([]byte) {})
+	}, func([]byte, int64) {})
 	require.NoError(t, err, "Start")
 	defer func() {
 		term.Stop()
@@ -74,7 +74,7 @@ func TestTerminal_SendInputAfterStop(t *testing.T) {
 		ID:         "test-stopped",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {})
+	}, func([]byte, int64) {})
 	require.NoError(t, err, "Start")
 
 	term.Stop()
@@ -88,7 +88,7 @@ func TestTerminal_IsExited(t *testing.T) {
 		ID:         "test-exited",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {})
+	}, func([]byte, int64) {})
 	require.NoError(t, err, "Start")
 
 	assert.False(t, term.IsExited(), "expected IsExited = false before stop")
@@ -106,7 +106,7 @@ func TestManager_StartAndRemove(t *testing.T) {
 		ID:         "tm-1",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {}, nil)
+	}, func([]byte, int64) {}, nil)
 	require.NoError(t, err, "StartTerminal")
 
 	assert.True(t, m.HasTerminal("tm-1"), "expected HasTerminal = true")
@@ -116,7 +116,7 @@ func TestManager_StartAndRemove(t *testing.T) {
 		ID:         "tm-1",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {}, nil)
+	}, func([]byte, int64) {}, nil)
 	assert.Error(t, err, "expected error for duplicate terminal")
 
 	// StopTerminal keeps it in the map (exited but not removed).
@@ -140,7 +140,7 @@ func TestManager_ExitedTerminalRejectsInput(t *testing.T) {
 		ID:         "tm-exit",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {}, nil)
+	}, func([]byte, int64) {}, nil)
 	require.NoError(t, err, "StartTerminal")
 
 	// Stop and wait for exit.
@@ -168,7 +168,7 @@ func TestManager_ExitNotification(t *testing.T) {
 		ID:         "tm-notify",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte) {}, func(id string, code int) {
+	}, func([]byte, int64) {}, func(id string, code int) {
 		gotID = id
 		gotCode = code
 		close(exitCh)
@@ -198,7 +198,7 @@ func TestManager_StopAll(t *testing.T) {
 			ID:         id,
 			Shell:      testutil.TestShell(),
 			WorkingDir: t.TempDir(),
-		}, func([]byte) {}, nil)
+		}, func([]byte, int64) {}, nil)
 		require.NoError(t, err, "StartTerminal(%s)", id)
 	}
 
@@ -241,7 +241,7 @@ func TestManager_Resize_SameDimensions(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func([]byte) {}, nil)
+	}, func([]byte, int64) {}, nil)
 	require.NoError(t, err)
 	defer m.StopAll()
 
@@ -255,7 +255,7 @@ func TestManager_Resize_SameDimensions(t *testing.T) {
 	assert.NoError(t, m.Resize("tm-resize-noop", 120, 40))
 }
 
-func TestManager_ScreenSnapshot(t *testing.T) {
+func TestManager_ScreenSnapshotSince(t *testing.T) {
 	m := NewManager()
 	var mu sync.Mutex
 	var output []byte
@@ -266,7 +266,7 @@ func TestManager_ScreenSnapshot(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte) {
+	}, func(data []byte, _ int64) {
 		mu.Lock()
 		output = append(output, data...)
 		mu.Unlock()
@@ -283,10 +283,12 @@ func TestManager_ScreenSnapshot(t *testing.T) {
 		return strings.Contains(string(output), "snapshot_test")
 	}, "expected output to contain 'snapshot_test'")
 
-	// Verify ScreenSnapshot returns non-empty data.
-	snap := m.ScreenSnapshot("tm-snap")
+	// Verify a cold subscribe (afterOffset=0) returns the retained
+	// bytes and a matching offset.
+	snap, offset, _ := m.ScreenSnapshotSince("tm-snap", 0)
 	assert.NotEmpty(t, snap, "expected non-empty screen snapshot")
 	assert.Contains(t, string(snap), "snapshot_test", "snapshot should contain the echoed text")
+	assert.Equal(t, int64(len(snap)), offset, "first snapshot's offset should equal its length before the ring wraps")
 
 	m.StopTerminal("tm-snap")
 	testutil.AssertEventually(t, func() bool {
@@ -295,10 +297,110 @@ func TestManager_ScreenSnapshot(t *testing.T) {
 	m.RemoveTerminal("tm-snap")
 }
 
-func TestManager_ScreenSnapshot_UnknownTerminal(t *testing.T) {
+func TestManager_ScreenSnapshotSince_UnknownTerminal(t *testing.T) {
 	m := NewManager()
-	snap := m.ScreenSnapshot("nonexistent")
+	snap, offset, isSnap := m.ScreenSnapshotSince("nonexistent", 0)
 	assert.Nil(t, snap, "expected nil snapshot for unknown terminal")
+	assert.Zero(t, offset, "expected zero offset for unknown terminal")
+	assert.False(t, isSnap)
+}
+
+// TestManager_SnapshotAfterExit: after the shell exits, the Terminal
+// stays in the Manager until RemoveTerminal is called, so snapshots must
+// continue to return the final screen state + offset. The disconnect
+// notice is appended to the buffer on exit (via appendTerminalDisconnectNotice
+// in the service layer), and subscribers that reconnect need those bytes.
+func TestManager_SnapshotAfterExit(t *testing.T) {
+	m := NewManager()
+	var mu sync.Mutex
+	var output []byte
+	err := m.StartTerminal(context.Background(), Options{
+		ID:         "tm-exit",
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+		Cols:       80,
+		Rows:       24,
+	}, func(data []byte, _ int64) {
+		mu.Lock()
+		output = append(output, data...)
+		mu.Unlock()
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, m.SendInput("tm-exit", []byte("echo before_exit"+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return strings.Contains(string(output), "before_exit")
+	}, "expected output before exit")
+
+	m.StopTerminal("tm-exit")
+	testutil.AssertEventually(t, func() bool {
+		return m.IsExited("tm-exit")
+	}, "expected terminal to exit")
+
+	// Snapshot must still work between exit and RemoveTerminal; this is
+	// the window where a reconnecting client asks for the final screen.
+	snap, offset, _ := m.ScreenSnapshotSince("tm-exit", 0)
+	assert.NotEmpty(t, snap, "post-exit snapshot must be retained until RemoveTerminal")
+	assert.Contains(t, string(snap), "before_exit")
+	assert.Equal(t, int64(len(snap)), offset)
+
+	// SnapshotSince(offset) must also return empty (caught up) even after exit.
+	data, endOffset, isSnap := m.ScreenSnapshotSince("tm-exit", offset)
+	assert.Empty(t, data)
+	assert.Equal(t, offset, endOffset)
+	assert.False(t, isSnap)
+
+	m.RemoveTerminal("tm-exit")
+
+	// After removal, the entry is gone and snapshots return zero-value.
+	gone, goneOffset, _ := m.ScreenSnapshotSince("tm-exit", 0)
+	assert.Nil(t, gone)
+	assert.Zero(t, goneOffset)
+}
+
+// TestManager_AppendOutput_AdvancesOffset: synthetic output injected via
+// AppendOutput (used for the "terminal disconnected" notice when the
+// shell exits) must advance the cumulative byte counter so subscribers
+// deltaing past the exit see the notice in their incremental catch-up.
+func TestManager_AppendOutput_AdvancesOffset(t *testing.T) {
+	m := NewManager()
+	err := m.StartTerminal(context.Background(), Options{
+		ID:         "tm-append",
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+		Cols:       80,
+		Rows:       24,
+	}, func(data []byte, _ int64) {}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		m.StopTerminal("tm-append")
+		testutil.AssertEventually(t, func() bool { return m.IsExited("tm-append") }, "exit")
+		m.RemoveTerminal("tm-append")
+	})
+
+	// Wait for the shell's initial prompt bytes so we have a stable baseline.
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := m.ScreenSnapshotSince("tm-append", 0)
+		return off > 0
+	}, "initial shell output")
+	_, baseline, _ := m.ScreenSnapshotSince("tm-append", 0)
+
+	notice := []byte("\r\n[terminal disconnected]\r\n")
+	require.True(t, m.AppendOutput("tm-append", notice))
+
+	_, afterAppend, _ := m.ScreenSnapshotSince("tm-append", 0)
+	assert.Equal(t, baseline+int64(len(notice)), afterAppend,
+		"AppendOutput must advance the cumulative byte counter by len(data)")
+
+	// A subscriber at `baseline` must receive exactly the appended bytes
+	// as an incremental delta — the catch-up contract for the disconnect
+	// notice.
+	data, endOffset, isSnap := m.ScreenSnapshotSince("tm-append", baseline)
+	assert.Equal(t, notice, data)
+	assert.Equal(t, afterAppend, endOffset)
+	assert.False(t, isSnap)
 }
 
 func TestManager_IsExited_UnknownTerminal(t *testing.T) {
@@ -336,7 +438,7 @@ func TestSnapshotTerminal(t *testing.T) {
 		WorkingDir:  t.TempDir(),
 		Cols:        80,
 		Rows:        24,
-	}, func(data []byte) {
+	}, func(data []byte, _ int64) {
 		mu.Lock()
 		output = append(output, data...)
 		mu.Unlock()
@@ -413,7 +515,7 @@ func TestUpdateTitle(t *testing.T) {
 		WorkingDir:  t.TempDir(),
 		Cols:        80,
 		Rows:        24,
-	}, func([]byte) {}, nil)
+	}, func([]byte, int64) {}, nil)
 	require.NoError(t, err)
 
 	// Initially empty title via ListByWorkspace.

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -198,10 +198,8 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       agentOps.handleCloseAgent(tab.id, worktreeAction)
     }
     else {
-      const instance = getTerminalInstance(tab.id)
-      if (instance) {
-        instance.dispose()
-      }
+      // Instance disposal is owned by TerminalView's reactive effect,
+      // which fires when removeTab evicts the tab from the store.
       termOps.handleTerminalClose(tab.id, worktreeAction)
     }
     removeEmptyFloatingWindow(tab.tileId)

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -238,8 +238,8 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
       // Do NOT gate on status === READY: the ResizeObserver's first fit()
       // fires well before the backend broadcasts READY, and that first
       // fit is often the only resize event the layout produces. The
-      // backend stashes resizes received during STARTING and applies
-      // them when the PTY is registered (see resize_during_startup_test).
+      // backend waits briefly for this during startup so the PTY can be
+      // spawned at the final size rather than SIGWINCHed to it.
       if (!ws || !tab)
         return
       await workerRpc.resizeTerminal(tab.workerId ?? '', { orgId: props.org.orgId(), workspaceId: ws.id, terminalId, cols, rows })

--- a/frontend/src/components/terminal/TerminalView.css.ts
+++ b/frontend/src/components/terminal/TerminalView.css.ts
@@ -3,8 +3,12 @@ import { globalStyle, style } from '@vanilla-extract/css'
 export const terminalInner = style({
   flex: 1,
   overflow: 'hidden',
-  display: 'flex',
-  flexDirection: 'column',
+  // Positioning context for the absolutely-positioned terminal wrappers
+  // below. All terminals share this single stacking slot; only the active
+  // one is visible. Keeping inactive wrappers in layout (rather than
+  // display:none) preserves their xterm.js dimensions so switching tabs
+  // doesn't trigger a rewrap/refit/SIGWINCH cycle.
+  position: 'relative',
 })
 
 export const container = style({
@@ -15,11 +19,21 @@ export const container = style({
 })
 
 export const terminalWrapper = style({
-  flex: 1,
+  position: 'absolute',
+  inset: 0,
   overflow: 'hidden',
   backgroundColor: 'var(--background)',
   fontVariantLigatures: 'none',
-  position: 'relative',
+})
+
+/**
+ * Applied to inactive terminal wrappers. `visibility: hidden` keeps the
+ * element in layout (so its dimensions stay valid for xterm.js / FitAddon)
+ * while hiding it visually and suppressing pointer events.
+ */
+export const terminalWrapperHidden = style({
+  visibility: 'hidden',
+  pointerEvents: 'none',
 })
 
 /** Container that xterm.open() attaches to. Fills the wrapper. */
@@ -54,8 +68,10 @@ export const startupOverlay = style({
  * active terminal id.
  */
 export const startupErrorPane = style({
-  flex: 1,
+  position: 'absolute',
+  inset: 0,
   overflow: 'hidden',
+  display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -7,7 +7,7 @@ import { StartupErrorBody, StartupSpinner } from '~/components/common/StartupPan
 import { usePreferences } from '~/context/PreferencesContext'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { isMac } from '~/lib/shortcuts/platform'
-import { bufferHasVisibleContent, createTerminalInstance, resolveTerminalTheme, resolveTerminalThemeMode } from '~/lib/terminal'
+import { applyTerminalData, bufferHasVisibleContent, createTerminalInstance, resolveTerminalTheme, resolveTerminalThemeMode } from '~/lib/terminal'
 import * as styles from './TerminalView.css'
 import '@xterm/xterm/css/xterm.css'
 
@@ -57,6 +57,7 @@ const TerminalContainer: Component<{
   active: boolean
   visible: boolean
   screen?: Uint8Array
+  lastOffset?: number
   cols?: number
   rows?: number
   fontFamily: string
@@ -120,20 +121,25 @@ const TerminalContainer: Component<{
 
     instance.terminal.open(ref)
 
-    // Write screen snapshot if available (restore on refresh).
-    // Suppress onData during replay to prevent xterm.js query responses
-    // (DECRPM, DA, DECRQSS, OSC) from being forwarded to the PTY,
-    // where the shell's echo would display them as visible text.
+    // Write screen snapshot if available (restore on refresh). Seed the
+    // resume cursor from lastOffset (from the backend, carried through
+    // the tab store) rather than screen.length — once the backend's ring
+    // has wrapped they differ, and the offset is what the backend uses
+    // to compute the catch-up delta on resubscribe.
     if (props.screen && props.screen.length > 0) {
       const termId = props.terminalId
       const reportReady = props.onContentReady
-      instance.suppressInput = true
-      instance.terminal.write(props.screen, () => {
-        instance!.suppressInput = false
-        if (bufferHasVisibleContent(instance!.terminal))
-          reportReady(termId)
-      })
-      instance.screenRestored = true
+      applyTerminalData(
+        instance,
+        props.screen,
+        true,
+        props.lastOffset ?? props.screen.length,
+        0,
+        () => {
+          if (bufferHasVisibleContent(instance!.terminal))
+            reportReady(termId)
+        },
+      )
     }
 
     // ResizeObserver on this terminal's container element.
@@ -178,8 +184,9 @@ const TerminalContainer: Component<{
   return (
     <div
       class={styles.terminalWrapper}
+      classList={{ [styles.terminalWrapperHidden]: !props.active }}
       data-terminal-id={props.terminalId}
-      style={{ display: props.active ? undefined : 'none' }}
+      data-active={props.active ? 'true' : 'false'}
     >
       <div ref={ref} class={styles.xtermHost} />
       <Show when={!props.contentReady}>
@@ -231,6 +238,22 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
     props.writeRef?.(write)
   })
 
+  // Dispose per-terminal instances as tabs are closed. The `instances`
+  // map deliberately outlives TerminalContainer mount/unmount (status
+  // transitions like STARTING → STARTUP_FAILED → READY swap between the
+  // container and the error pane while keeping the xterm alive), so this
+  // is the authoritative place to release WebGL contexts and listener
+  // refs for removed terminals.
+  createEffect(() => {
+    const liveIds = new Set(props.terminals.map(t => t.id))
+    for (const id of [...instances.keys()]) {
+      if (!liveIds.has(id)) {
+        instances.get(id)?.dispose()
+        instances.delete(id)
+      }
+    }
+  })
+
   // Clean up instances when component unmounts
   onCleanup(() => {
     for (const [, instance] of instances) {
@@ -254,6 +277,7 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
                   active={terminal.id === props.activeTerminalId}
                   visible={props.visible}
                   screen={terminal.screen}
+                  lastOffset={terminal.lastOffset}
                   cols={terminal.cols}
                   rows={terminal.rows}
                   fontFamily={preferences.monoFontFamily()}
@@ -272,8 +296,8 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
               <Match when={terminal.status === TerminalStatus.STARTUP_FAILED}>
                 <div
                   class={styles.startupErrorPane}
+                  classList={{ [styles.terminalWrapperHidden]: terminal.id !== props.activeTerminalId }}
                   data-testid="terminal-startup-error"
-                  style={{ display: terminal.id === props.activeTerminalId ? 'flex' : 'none' }}
                 >
                   <StartupErrorBody
                     title="Terminal failed to start"

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -17,7 +17,7 @@ import { ChannelError } from '~/lib/channel'
 import { createLogger } from '~/lib/logger'
 import { extractAgentRenamed, extractAssistantUsage, extractCodexTokenUsage, extractPlanFilePath, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 import { emitSettingsChanged } from '~/lib/settingsChangedEvent'
-import { bufferHasVisibleContent } from '~/lib/terminal'
+import { applyTerminalData, bufferHasVisibleContent } from '~/lib/terminal'
 import { MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
 import { gitTabFieldsDiffer, tabKey, toGitTabFields } from '~/stores/tab.store'
 
@@ -521,22 +521,16 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             if (checkContent && bufferHasVisibleContent(instance.terminal))
               tabStore.markTerminalContentReady(terminalId)
           }
-          if (termEvent.event.value.isSnapshot) {
-            // Initial screen snapshot from WatchEvents. Only apply if the
-            // screen hasn't already been restored (e.g. from the
-            // listTerminals snapshot written during component mount).
-            if (!instance.screenRestored) {
-              instance.suppressInput = true
-              instance.terminal.write(termEvent.event.value.data, () => {
-                instance!.suppressInput = false
-                onParsed()
-              })
-              instance.screenRestored = true
-            }
-          }
-          else {
-            instance.terminal.write(termEvent.event.value.data, onParsed)
-          }
+          const { data, isSnapshot, endOffset } = termEvent.event.value
+          const newOffset = applyTerminalData(
+            instance,
+            data,
+            isSnapshot,
+            Number(endOffset),
+            tab?.lastOffset ?? 0,
+            onParsed,
+          )
+          tabStore.setTerminalLastOffset(terminalId, newOffset)
         }
         break
       }
@@ -656,10 +650,18 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         if (!workerId)
           return
 
+        // Seed after_offset from the tab's resume cursor; 0 means a
+        // cold subscribe (the tab was hydrated without a screen or the
+        // cursor hasn't advanced yet).
+        const terminals = terminalIds.map(id => ({
+          terminalId: id,
+          afterOffset: BigInt(untrack(() => tabStore.getTerminalTab(id)?.lastOffset ?? 0)),
+        }))
+
         // Open the E2EE channel stream to the Worker.
         const handle = await watchEventsViaChannel(workerId, {
           agents,
-          terminalIds,
+          terminals,
         })
 
         // Now that the new stream listener is registered, clean up

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -18,8 +18,6 @@ export interface TerminalFontOptions {
 export interface TerminalInstance {
   terminal: Terminal
   fitAddon: FitAddon
-  /** True after a screen snapshot has been written (prevents duplicate writes). */
-  screenRestored: boolean
   /** When true, onData responses are suppressed (e.g. during snapshot replay). */
   suppressInput: boolean
   /** Send raw input data to the PTY backing this terminal. */
@@ -109,6 +107,43 @@ export function resolveTerminalTheme(pref: TerminalThemePreference): ITheme {
 }
 
 /**
+ * Apply a TerminalData event (or an initial snapshot from ListTerminals)
+ * to an xterm instance. Returns the new resume cursor — callers store
+ * this as the tab's `lastOffset` and echo it on the next resubscribe.
+ *
+ * - isSnapshot=true: backend is replacing the terminal's visible state
+ *   (client's after_offset was stale or outside the retained ring). The
+ *   xterm buffer is reset before the payload is written so the new bytes
+ *   don't append to stale content. The returned cursor is `endOffset`
+ *   unconditionally — even if smaller than `currentOffset`, since the
+ *   buffer now exactly reflects those `endOffset` bytes.
+ * - isSnapshot=false: payload is a strict incremental delta since
+ *   `currentOffset`; written without resetting. The returned cursor is
+ *   `max(currentOffset, endOffset)` so out-of-order duplicates can't
+ *   rewind it.
+ */
+export function applyTerminalData(
+  instance: TerminalInstance,
+  data: Uint8Array,
+  isSnapshot: boolean,
+  endOffset: number,
+  currentOffset: number,
+  onParsed?: () => void,
+): number {
+  if (isSnapshot) {
+    instance.terminal.reset()
+    instance.suppressInput = true
+    instance.terminal.write(data, () => {
+      instance.suppressInput = false
+      onParsed?.()
+    })
+    return endOffset
+  }
+  instance.terminal.write(data, onParsed)
+  return endOffset > currentOffset ? endOffset : currentOffset
+}
+
+/**
  * Returns true when any line in the active buffer contains at least one
  * non-whitespace character (after trimming trailing spaces, which xterm
  * pads unused cells with). Used to decide when to drop the "Starting
@@ -156,7 +191,6 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   return {
     terminal,
     fitAddon,
-    screenRestored: false,
     suppressInput: false,
     dispose() {
       terminal.dispose()

--- a/frontend/src/stores/tab.store.ts
+++ b/frontend/src/stores/tab.store.ts
@@ -44,6 +44,16 @@ export interface Tab {
   shellStartDir?: string
   /** Last-known screen snapshot for fast visual restore. */
   screen?: Uint8Array
+  /**
+   * Cumulative PTY byte offset this tab has already applied to its
+   * xterm. Seeded at hydration from the backend's screen_end_offset
+   * (the offset at the end of `screen`, which equals `screen.length`
+   * before the ring wraps and is larger once bytes fall off), then
+   * advanced monotonically as TerminalData events arrive. Echoed back
+   * to the backend as WatchTerminalEntry.after_offset on resubscribe
+   * so the handler skips bytes we already have.
+   */
+  lastOffset?: number
   cols?: number
   rows?: number
   /** Error string from TerminalStatusChange when status is STARTUP_FAILED. */
@@ -86,6 +96,7 @@ export function protoToTerminalTabFields(workerId: string, term: ProtoTerminal):
     workingDir: term.workingDir || undefined,
     shellStartDir: term.shellStartDir || undefined,
     screen: term.screen.length > 0 ? term.screen : undefined,
+    lastOffset: term.screen.length > 0 ? Number(term.screenEndOffset) : undefined,
     cols: term.cols || undefined,
     rows: term.rows || undefined,
     gitBranch: term.gitBranch || undefined,
@@ -525,6 +536,21 @@ export function createTabStore() {
         t => t.type === TabType.TERMINAL && t.id === id && !t.contentReady,
         'contentReady',
         true,
+      )
+    },
+
+    /**
+     * Advance a terminal tab's resume cursor. Callers pass the offset
+     * returned by `applyTerminalData`, which has already applied its
+     * snapshot-vs-incremental return rule. Predicate skips no-op writes
+     * so same-value updates don't fire reactive notifications.
+     */
+    setTerminalLastOffset(id: string, offset: number) {
+      setState(
+        'tabs',
+        t => t.type === TabType.TERMINAL && t.id === id && t.lastOffset !== offset,
+        'lastOffset',
+        offset,
       )
     },
 

--- a/frontend/tests/e2e/04-terminal.spec.ts
+++ b/frontend/tests/e2e/04-terminal.spec.ts
@@ -12,7 +12,7 @@ async function getTerminalText(page: Page): Promise<string> {
     // Fallback: DOM-based reading
     const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
     for (const container of containers) {
-      if (container.style.display !== 'none') {
+      if (container.dataset.active === 'true') {
         const rows = container.querySelector('.xterm-rows')
         if (rows)
           return rows.textContent ?? ''
@@ -36,7 +36,7 @@ async function typeInTerminal(page: Page, command: string) {
   await page.evaluate(() => {
     const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
     for (const container of containers) {
-      if (container.style.display !== 'none') {
+      if (container.dataset.active === 'true') {
         const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
         if (textarea) {
           textarea.focus()
@@ -167,7 +167,7 @@ test.describe('Terminal', () => {
     await page.evaluate(() => {
       const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
       for (const container of containers) {
-        if (container.style.display !== 'none') {
+        if (container.dataset.active === 'true') {
           const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
           if (textarea) {
             textarea.focus()

--- a/frontend/tests/e2e/24-full-restart.spec.ts
+++ b/frontend/tests/e2e/24-full-restart.spec.ts
@@ -142,7 +142,7 @@ test.describe('Full Hub+Worker Restart', () => {
     await page.evaluate(() => {
       const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
       for (const container of containers) {
-        if (container.style.display !== 'none') {
+        if (container.dataset.active === 'true') {
           const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
           if (textarea) {
             textarea.focus()
@@ -194,7 +194,7 @@ test.describe('Full Hub+Worker Restart', () => {
     await page.evaluate(() => {
       const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
       for (const container of containers) {
-        if (container.style.display !== 'none') {
+        if (container.dataset.active === 'true') {
           const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
           if (textarea) {
             textarea.focus()
@@ -209,7 +209,7 @@ test.describe('Full Hub+Worker Restart', () => {
     await page.evaluate(() => {
       const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
       for (const container of containers) {
-        if (container.style.display !== 'none') {
+        if (container.dataset.active === 'true') {
           const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
           if (textarea) {
             textarea.focus()

--- a/frontend/tests/e2e/24-terminal-disconnect.spec.ts
+++ b/frontend/tests/e2e/24-terminal-disconnect.spec.ts
@@ -11,7 +11,7 @@ async function getTerminalText(page: Page): Promise<string> {
     }
     const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
     for (const container of containers) {
-      if (container.style.display !== 'none') {
+      if (container.dataset.active === 'true') {
         const rows = container.querySelector('.xterm-rows')
         if (rows)
           return rows.textContent ?? ''

--- a/frontend/tests/unit/components/TerminalView.test.tsx
+++ b/frontend/tests/unit/components/TerminalView.test.tsx
@@ -1,5 +1,6 @@
 import type { TerminalInstance } from '~/lib/terminal'
 import { render, waitFor } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
@@ -14,7 +15,7 @@ vi.mock('~/lib/terminal', async () => {
   }
 })
 
-const { TerminalView } = await import('~/components/terminal/TerminalView')
+const { TerminalView, getTerminalInstance } = await import('~/components/terminal/TerminalView')
 
 beforeAll(() => {
   globalThis.ResizeObserver ??= class {
@@ -35,6 +36,7 @@ function makeMockTerminalInstance(): TerminalInstance {
       bellHandler = cb
     }),
     open: vi.fn(),
+    reset: vi.fn(),
     write: vi.fn((data: string | Uint8Array, cb?: () => void) => {
       const text = typeof data === 'string' ? data : new TextDecoder().decode(data)
       if (text.includes('\x07')) {
@@ -59,7 +61,6 @@ function makeMockTerminalInstance(): TerminalInstance {
   return {
     terminal,
     fitAddon: { fit: vi.fn() } as any,
-    screenRestored: false,
     suppressInput: false,
     dispose: vi.fn(),
   }
@@ -161,6 +162,58 @@ describe('terminalView', () => {
 
     await findByTestId('terminal-startup-overlay')
     await findByText('Starting terminal…')
+  })
+
+  // Closing a single tab must dispose exactly that terminal's xterm
+  // instance (releasing its WebGL context, scrollback, and listener
+  // refs) and leave other tabs' instances intact. The disposal is
+  // driven by TerminalView's tabs-diff effect, not by the full-unmount
+  // onCleanup — a workspace switch is a separate path.
+  it('disposes a terminal instance when its tab is closed', async () => {
+    const instanceA = makeMockTerminalInstance()
+    const instanceB = makeMockTerminalInstance()
+    // createTerminalInstance is called once per new terminal; return in
+    // the order TerminalContainer mounts them.
+    mockCreateTerminalInstance
+      .mockReturnValueOnce(instanceA)
+      .mockReturnValueOnce(instanceB)
+
+    const baseTab = { workspaceId: 'ws-1', screen: new Uint8Array() }
+    const [terminals, setTerminals] = createSignal([
+      { id: 'dispose-test-A', ...baseTab },
+      { id: 'dispose-test-B', ...baseTab },
+    ])
+
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={terminals()}
+          activeTerminalId="dispose-test-A"
+          visible
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onTitleChange={vi.fn()}
+          onBell={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+
+    await waitFor(() => {
+      expect(getTerminalInstance('dispose-test-A')).toBe(instanceA)
+      expect(getTerminalInstance('dispose-test-B')).toBe(instanceB)
+    })
+
+    // Close tab A by removing it from the list.
+    setTerminals([{ id: 'dispose-test-B', ...baseTab }])
+
+    await waitFor(() => {
+      expect(getTerminalInstance('dispose-test-A')).toBeUndefined()
+    })
+    expect(instanceA.dispose).toHaveBeenCalledTimes(1)
+    // B stays live — only the closed tab's instance should be disposed.
+    expect(getTerminalInstance('dispose-test-B')).toBe(instanceB)
+    expect(instanceB.dispose).not.toHaveBeenCalled()
   })
 
   it('scrolls the active terminal by one page', async () => {

--- a/frontend/tests/unit/hooks/applyTerminalData.test.ts
+++ b/frontend/tests/unit/hooks/applyTerminalData.test.ts
@@ -1,0 +1,129 @@
+import type { TerminalInstance } from '~/lib/terminal'
+import { describe, expect, it, vi } from 'vitest'
+import { applyTerminalData } from '~/lib/terminal'
+
+// A bare minimum stub that exercises the two xterm.Terminal methods
+// applyTerminalData touches (write, reset), records the call order, and
+// preserves the onParsed callback semantics so onParsed side effects can
+// be asserted. Intentionally NOT a real xterm — the contract we care
+// about is "reset before write on snapshot, write only on incremental".
+function makeStubInstance(): TerminalInstance & { _log: string[] } {
+  const log: string[] = []
+  return {
+    terminal: {
+      reset: vi.fn(() => { log.push('reset') }),
+      write: vi.fn((data: Uint8Array, cb?: () => void) => {
+        log.push(`write:${new TextDecoder().decode(data)}`)
+        cb?.()
+      }),
+    } as any,
+    fitAddon: { fit: vi.fn() } as any,
+    suppressInput: false,
+    dispose: vi.fn(),
+    _log: log,
+  }
+}
+
+describe('applyTerminalData', () => {
+  it('is_snapshot=true: resets xterm before writing the payload', () => {
+    const inst = makeStubInstance()
+    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0)
+
+    // The reset MUST come before the write. An implementation that
+    // writes first and then resets would still pass "both were called"
+    // but leave the buffer empty; asserting order pins the invariant.
+    expect(inst._log).toEqual(['reset', 'write:snap'])
+  })
+
+  it('is_snapshot=false: writes without resetting (incremental catch-up)', () => {
+    const inst = makeStubInstance()
+    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0)
+
+    expect(inst._log).toEqual(['write:delta'])
+    expect(inst.terminal.reset).not.toHaveBeenCalled()
+  })
+
+  it('snapshot after incremental: wipes the previous state before writing the new payload', () => {
+    // When an incremental event is followed by a snapshot (backend
+    // decided the client had fallen behind), the snapshot's reset()
+    // must fire before the write — otherwise the xterm ends up holding
+    // "abc" + "xyz" instead of just "xyz".
+    const inst = makeStubInstance()
+    applyTerminalData(inst, new TextEncoder().encode('abc'), false, 3, 0)
+    applyTerminalData(inst, new TextEncoder().encode('xyz'), true, 3, 3)
+
+    expect(inst._log).toEqual(['write:abc', 'reset', 'write:xyz'])
+  })
+
+  it('returns endOffset on incremental writes when greater than current', () => {
+    const inst = makeStubInstance()
+    expect(applyTerminalData(inst, new TextEncoder().encode('a'), false, 1, 0)).toBe(1)
+    expect(applyTerminalData(inst, new TextEncoder().encode('bc'), false, 3, 1)).toBe(3)
+  })
+
+  it('returns endOffset on snapshot writes', () => {
+    const inst = makeStubInstance()
+    expect(applyTerminalData(inst, new TextEncoder().encode('reset'), true, 100, 42)).toBe(100)
+  })
+
+  it('does not decrease the cursor on an incremental event with a smaller end_offset', () => {
+    // Defensive: single-channel delivery should be ordered, but the
+    // max-guard means out-of-order or duplicate increments can't rewind
+    // the resume cursor and trigger spurious snapshot replays on the
+    // next resubscribe.
+    const inst = makeStubInstance()
+    expect(applyTerminalData(inst, new TextEncoder().encode('late'), false, 50, 100)).toBe(100)
+  })
+
+  it('snapshot returns endOffset even when smaller than current', () => {
+    // A snapshot resets xterm to match exactly `endOffset`; keeping a
+    // larger stale cursor would tell the backend on resubscribe that we
+    // have bytes we don't, silently skipping bytes on the next catch-up.
+    const inst = makeStubInstance()
+    expect(applyTerminalData(inst, new TextEncoder().encode('snap'), true, 50, 100)).toBe(50)
+  })
+
+  it('sets and clears suppressInput around snapshot writes', () => {
+    // suppressInput silences xterm's automatic replies to DA/DSR/DECRQSS
+    // queries inside the replayed bytes. It must be true while writing
+    // the snapshot and released in the write callback so live user input
+    // afterwards is delivered normally.
+    const inst = makeStubInstance()
+    let suppressedDuringWrite = false
+    ;(inst.terminal.write as any).mockImplementation((_data: Uint8Array, cb?: () => void) => {
+      suppressedDuringWrite = inst.suppressInput
+      cb?.()
+    })
+
+    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0)
+
+    expect(suppressedDuringWrite).toBe(true)
+    expect(inst.suppressInput).toBe(false)
+  })
+
+  it('does not touch suppressInput on incremental writes', () => {
+    // Incremental data is live PTY output; xterm's replies to escape
+    // sequences in it ARE legitimate user-visible behavior and must
+    // reach the PTY (e.g. cursor position reports).
+    const inst = makeStubInstance()
+    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0)
+
+    expect(inst.suppressInput).toBe(false)
+  })
+
+  it('invokes onParsed after snapshot write completes', () => {
+    const inst = makeStubInstance()
+    const onParsed = vi.fn()
+
+    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0, onParsed)
+    expect(onParsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onParsed on incremental writes', () => {
+    const inst = makeStubInstance()
+    const onParsed = vi.fn()
+
+    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0, onParsed)
+    expect(onParsed).toHaveBeenCalledTimes(1)
+  })
+})

--- a/proto/leapmux/v1/terminal.proto
+++ b/proto/leapmux/v1/terminal.proto
@@ -108,11 +108,26 @@ message TerminalInfo {
   string startup_error = 12;    // Populated when status=TERMINAL_STATUS_STARTUP_FAILED
   string startup_message = 13;  // Populated when status=TERMINAL_STATUS_STARTING (e.g. "Starting zsh…")
   string git_toplevel = 14;     // Working-tree root of the enclosing git repo, if any
+  // Cumulative PTY byte offset at the end of `screen`. Equal to `screen`
+  // length before the ring wraps, and greater once old bytes start
+  // falling off the retained window. Client seeds its WatchEvents
+  // `after_offset` from this so a resubscribe picks up exactly where
+  // the snapshot left off instead of replaying `screen`.
+  int64 screen_end_offset = 15;
 }
 
 message TerminalData {
   bytes data = 1;
-  bool is_snapshot = 2; // True for initial screen buffer snapshots; frontend should reset buffer before writing.
+  // True when `data` replaces the entire screen state — the client must
+  // reset its terminal buffer before writing. Set when the subscribing
+  // client's after_offset is behind the backend's retention window, or
+  // on a cold subscribe. Live-data chunks set this to false.
+  bool is_snapshot = 2;
+  // Cumulative byte offset at the end of `data`. Monotonically
+  // increases within a single PTY session and resets when the PTY is
+  // recreated. Clients persist the highest value they have observed
+  // and echo it back as WatchTerminalEntry.after_offset on resubscribe.
+  int64 end_offset = 3;
 }
 
 message TerminalClosed {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -257,12 +257,25 @@ message MoveTabWorkspaceResponse {}
 
 message WatchEventsRequest {
   repeated WatchAgentEntry agents = 1;
-  repeated string terminal_ids = 2;
+  repeated WatchTerminalEntry terminals = 2;
 }
 
 message WatchAgentEntry {
   string agent_id = 1;
   int64 after_seq = 2; // Resume from this sequence number (0 = from beginning, -1 = live only)
+}
+
+message WatchTerminalEntry {
+  string terminal_id = 1;
+  // Cumulative byte offset the client has already processed for this
+  // terminal's output stream. Backend replays bytes with offset >
+  // after_offset. A fresh subscription (or a client that has lost its
+  // state) sends 0; the backend responds with a full snapshot marked
+  // is_snapshot=true. A resubscribe with an up-to-date offset yields an
+  // empty catch-up (no TerminalData event). An offset that has fallen
+  // out of the backend's retention window, or is larger than the
+  // backend's counter (PTY recreated), is treated the same as 0.
+  int64 after_offset = 2;
 }
 
 message WatchEventsResponse {


### PR DESCRIPTION
## Motivation

When the frontend resubscribes to terminal events (after a WebSocket reconnect, tab switch, or workspace reconnect), the backend had no way to know which bytes the client had already received. Every resubscribe triggered a full-screen snapshot replay, causing the shell prompt to be re-rendered by xterm and producing duplicate prompts or stray `PROMPT_SP '%'` artifacts. A separate but related problem caused the same artifact during initial shell startup: the shell was spawned at the placeholder 80x24 size, then hit with a SIGWINCH when the frontend reported the actual terminal dimensions, resulting in zsh printing `%` at startup.

Additionally, switching tabs caused inactive terminal containers to collapse via `display: none`, which zeroed their dimensions and triggered a refit/SIGWINCH cycle on every switch.

## Modifications

**Protocol**
- Added `TerminalInfo.screen_end_offset: int64` (field 15) and `TerminalData.end_offset: int64` (field 3) to `terminal.proto`.
- Replaced `WatchEventsRequest.terminal_ids: repeated string` with `terminals: repeated WatchTerminalEntry { terminal_id, after_offset }` in `workspace.proto`. Clients now declare their resume cursor per terminal on every (re)subscribe.

**Backend - core PTY ring (`backend/internal/worker/terminal`)**
- Added a monotonically increasing `total` byte counter to `ScreenBuffer`; `Write()` now returns the cumulative end offset.
- Introduced `ScreenSnapshotSince(afterOffset)` on `ScreenBuffer`, `Terminal`, and `Manager`. Returns `(data, isFullSnapshot)`: empty for a caught-up subscriber, an incremental delta for an in-window offset, or a full snapshot for a stale/out-of-window offset.
- Added `ScreenHasSuffix()` to `ScreenBuffer`/`Manager` for allocation-free suffix checks.
- Changed `OutputHandler` signature from `func(data []byte)` to `func(data []byte, endOffset int64)`.
- Added `ScreenEndOffset` to `TerminalEntry`; extracted `buildEntryLocked()` helper to reduce duplication.
- Fixed oversized-write handling in the ring buffer.

**Backend - service layer (`backend/internal/worker/service`)**
- `WatchEvents` terminal handler now reads `after_offset` per terminal and calls `ScreenSnapshotSince()` to send only the bytes the client is missing.
- Added `waitForPendingResize()` that blocks up to 500 ms for the frontend's first `ResizeTerminal` RPC before spawning the shell, so the PTY is created at the correct size.
- Added a buffered `resizeSignal` channel per `startupEntry`; `clearPendingResize()` drains it to discard stale signals on reused terminal IDs.
- `appendTerminalDisconnectNotice` now uses `ScreenHasSuffix` instead of allocating a full snapshot copy.

**Frontend**
- Added `lastOffset` to the tab store, seeded from `screen_end_offset` at hydration and advanced by each live `TerminalData` event.
- Extracted `applyTerminalData(instance, data, isSnapshot, endOffset, currentOffset, onParsed?)` in `~/lib/terminal`, centralizing xterm reset on snapshot, input suppression during replay, and monotonic-max offset tracking. Used from both `TerminalView` mount path and `useWorkspaceConnection` live-event path.
- Changed `TerminalView` layout from flex to absolute-positioned stacked wrappers; inactive terminals use `visibility: hidden` instead of `display: none` so dimensions are preserved across tab switches.
- Moved xterm instance disposal from `useTabOperations` close-click handler into a reactive `createEffect` in `TerminalView` that diffs the tabs list against the instances map, eliminating a double-dispose.
- `watchEventsViaChannel` now accepts `terminals: [{terminalId, afterOffset}]` instead of a flat `terminalIds` array.
- Removed the now-redundant `screenRestored` flag from `TerminalInstance`.

**Tests**
- New `screenbuffer_test.go`: 311-line coverage of ring-wrap, boundary conditions, offset arithmetic, `SnapshotSince` regimes, and `HasSuffix`.
- New `startupstate_test.go`: validates `clearPendingResize` drains buffered signals and `waitForPendingResize` handles pre-stashed and late-arriving dimensions.
- New `watch_events_terminal_test.go`: end-to-end coverage of snapshot vs. incremental delivery, caught-up subscriber, ring-wrap cold-subscribe.
- New `applyTerminalData.test.ts`: 11 unit tests for the extracted helper.
- `TerminalView` unit test: verifies single-tab close disposes exactly that instance without leaking others; exports `getTerminalInstance` for inspection.
- E2E selectors updated: active terminal lookup changed from `container.style.display !== 'none'` to `container.dataset.active === 'true'`.

## Result

Reconnecting to a workspace (WebSocket drop, page reload, or worker restart) no longer replays bytes the client already rendered. The frontend sends its current byte offset on every resubscribe and receives only the incremental delta, or a full snapshot if the ring has wrapped past that offset.

Shells no longer print a stray `%` (zsh `PROMPT_SP`) at startup because the PTY is now spawned at the correct terminal size rather than the placeholder 80x24.

Switching between terminal tabs no longer triggers SIGWINCH, rewrap, or refit because inactive containers stay in the layout with `visibility: hidden` instead of collapsing to zero size with `display: none`.
