### PR TITLE
feat(terminal): Restore sticky xterm modes on snapshot replay

### DIFF
--- a/backend/internal/worker/service/list_by_ids_test.go
+++ b/backend/internal/worker/service/list_by_ids_test.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/util/testutil"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -316,18 +315,7 @@ func TestListTerminals_AltScreenRecoveryAfterRingWrap(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-A")
 	startTestTerminal(t, svc, ctx, "t-altrefresh", "ws-A")
-
-	require.True(t, svc.Terminals.AppendOutput("t-altrefresh", []byte("\x1b[?1049h")))
-	big := make([]byte, 150*1024)
-	for i := range big {
-		big[i] = 'b'
-	}
-	require.True(t, svc.Terminals.AppendOutput("t-altrefresh", big))
-
-	testutil.AssertEventually(t, func() bool {
-		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-altrefresh", 0)
-		return off >= int64(len(big))
-	}, "alt-screen + filler arrived")
+	fillerLen := injectAltScreenAndFlushPastRing(t, svc, "t-altrefresh")
 
 	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
 		TabIds: []string{"t-altrefresh"},
@@ -346,7 +334,7 @@ func TestListTerminals_AltScreenRecoveryAfterRingWrap(t *testing.T) {
 	// The frontend uses this offset to seed its WatchEvents resume
 	// cursor; counting prefix bytes would skip real PTY output the next
 	// time the backend computes a delta.
-	assert.Equal(t, int64(len("\x1b[?1049h")+len(big)), ti.GetScreenEndOffset(),
+	assert.Equal(t, int64(len("\x1b[?1049h")+fillerLen), ti.GetScreenEndOffset(),
 		"screen_end_offset reflects total PTY bytes, not screen-payload length (which includes the synthesized prefix)")
 }
 

--- a/backend/internal/worker/service/list_by_ids_test.go
+++ b/backend/internal/worker/service/list_by_ids_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -303,6 +304,50 @@ func TestListTerminals_ScreenEndOffset_LiveTerminal(t *testing.T) {
 		"live terminal must return Manager's screen (DB row has Screen=[]byte{})")
 	assert.Equal(t, int64(len(ti.GetScreen())), ti.GetScreenEndOffset(),
 		"before ring wrap: screen_end_offset equals len(screen)")
+}
+
+// TestListTerminals_AltScreenRecoveryAfterRingWrap: page-refresh is the
+// most common path that hits the alt-screen rendering bug. The frontend
+// seeds xterm from TerminalInfo.screen with isSnapshot=true (resets
+// xterm before writing), so the bytes here MUST start with the
+// mode-restore prefix when the alt-screen toggle has fallen out of the
+// retained ring.
+func TestListTerminals_AltScreenRecoveryAfterRingWrap(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-A")
+	startTestTerminal(t, svc, ctx, "t-altrefresh", "ws-A")
+
+	require.True(t, svc.Terminals.AppendOutput("t-altrefresh", []byte("\x1b[?1049h")))
+	big := make([]byte, 150*1024)
+	for i := range big {
+		big[i] = 'b'
+	}
+	require.True(t, svc.Terminals.AppendOutput("t-altrefresh", big))
+
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-altrefresh", 0)
+		return off >= int64(len(big))
+	}, "alt-screen + filler arrived")
+
+	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
+		TabIds: []string{"t-altrefresh"},
+	}, w)
+
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListTerminalsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetTerminals(), 1)
+	ti := resp.GetTerminals()[0]
+	require.GreaterOrEqual(t, len(ti.GetScreen()), len("\x1b[?1049h"))
+	assert.Equal(t, []byte("\x1b[?1049h"), ti.GetScreen()[:len("\x1b[?1049h")],
+		"ListTerminals must return the alt-screen restore prefix; without it, page-refresh leaves vim/less rendering as garbage")
+
+	// screen_end_offset must NOT include the synthesized prefix bytes.
+	// The frontend uses this offset to seed its WatchEvents resume
+	// cursor; counting prefix bytes would skip real PTY output the next
+	// time the backend computes a delta.
+	assert.Equal(t, int64(len("\x1b[?1049h")+len(big)), ti.GetScreenEndOffset(),
+		"screen_end_offset reflects total PTY bytes, not screen-payload length (which includes the synthesized prefix)")
 }
 
 func TestListTerminals_InaccessibleWorkspaceDenied(t *testing.T) {

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -178,9 +178,9 @@ func TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap(t *testing.T) {
 // injectAltScreenAndFlushPastRing writes the alt-screen toggle followed
 // by enough plain bytes to overwrite the retained ring, then waits for
 // the manager's offset to confirm the bytes have landed. Returns the
-// filler length so callers can compute the expected end_offset. Used by
-// every test that asserts the modeTracker prefix appears on a snapshot
-// taken AFTER the toggle has fallen out of the ring.
+// filler length so callers can compute the expected end_offset. Shared
+// by service-layer tests that assert the modeTracker prefix appears on
+// a snapshot taken AFTER the toggle has fallen out of the ring.
 func injectAltScreenAndFlushPastRing(t *testing.T, svc *Context, terminalID string) int {
 	t.Helper()
 	require.True(t, svc.Terminals.AppendOutput(terminalID, []byte("\x1b[?1049h")))

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -133,6 +134,58 @@ func TestWatchEvents_Terminal_IncrementalDeltaAfterResubscribe(t *testing.T) {
 		"delta must contain the bytes the absent client missed")
 	assert.NotContains(t, string(delta.GetData()), string(firstMarker),
 		"delta must NOT re-send bytes the client already has")
+}
+
+// TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap: the bug this
+// whole feature exists to fix. A subscriber that joins (or rejoins)
+// after the ring has wrapped past an alt-screen toggle must receive a
+// snapshot whose first bytes re-establish alt screen. Without the
+// prefix, xterm.reset() drops to main screen and replays bytes that
+// assume alt screen — vim/less/htop render as garbage until the
+// program repaints.
+func TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, "ws-1")
+	startTestTerminal(t, svc, ctx, "t-altrecover", "ws-1")
+
+	// Inject the alt-screen toggle, then push >100 KB so the toggle
+	// falls out of the retained ring.
+	require.True(t, svc.Terminals.AppendOutput("t-altrecover", []byte("\x1b[?1049h")))
+	big := make([]byte, 150*1024)
+	for i := range big {
+		big[i] = 'a'
+	}
+	require.True(t, svc.Terminals.AppendOutput("t-altrecover", big))
+
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-altrecover", 0)
+		return off >= int64(len(big))
+	}, "alt-screen + filler arrived")
+
+	w := &testResponseWriter{channelID: "test-ch"}
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "t-altrecover", AfterOffset: 0}},
+	}, w)
+
+	var snap *leapmuxv1.TerminalData
+	testutil.AssertEventually(t, func() bool {
+		for _, data := range collectTerminalData(t, w, "t-altrecover") {
+			snap = data
+			return true
+		}
+		return false
+	}, "cold subscribe delivered the snapshot")
+	require.NotNil(t, snap)
+	require.True(t, snap.GetIsSnapshot(),
+		"fell-behind cold subscribe must be a snapshot so the frontend resets first")
+	assert.True(t, bytes.HasPrefix(snap.GetData(), []byte("\x1b[?1049h")),
+		"snapshot must lead with the alt-screen restore — without it, vim/less render garbage after the frontend's terminal.reset()")
+
+	// The tracker prefix is synthesized; it must NOT inflate end_offset
+	// beyond the actual byte counter the client uses to resume.
+	currentTotal := int64(len("\x1b[?1049h") + len(big))
+	assert.GreaterOrEqual(t, snap.GetEndOffset(), currentTotal,
+		"end_offset reflects total bytes written, not prefix length")
 }
 
 // TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap: when the backend's

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -147,20 +147,7 @@ func TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap(t *testing.T) {
 	ctx := context.Background()
 	svc, d, _ := setupTestService(t, "ws-1")
 	startTestTerminal(t, svc, ctx, "t-altrecover", "ws-1")
-
-	// Inject the alt-screen toggle, then push >100 KB so the toggle
-	// falls out of the retained ring.
-	require.True(t, svc.Terminals.AppendOutput("t-altrecover", []byte("\x1b[?1049h")))
-	big := make([]byte, 150*1024)
-	for i := range big {
-		big[i] = 'a'
-	}
-	require.True(t, svc.Terminals.AppendOutput("t-altrecover", big))
-
-	testutil.AssertEventually(t, func() bool {
-		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-altrecover", 0)
-		return off >= int64(len(big))
-	}, "alt-screen + filler arrived")
+	fillerLen := injectAltScreenAndFlushPastRing(t, svc, "t-altrecover")
 
 	w := &testResponseWriter{channelID: "test-ch"}
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
@@ -183,9 +170,32 @@ func TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap(t *testing.T) {
 
 	// The tracker prefix is synthesized; it must NOT inflate end_offset
 	// beyond the actual byte counter the client uses to resume.
-	currentTotal := int64(len("\x1b[?1049h") + len(big))
+	currentTotal := int64(len("\x1b[?1049h") + fillerLen)
 	assert.GreaterOrEqual(t, snap.GetEndOffset(), currentTotal,
 		"end_offset reflects total bytes written, not prefix length")
+}
+
+// injectAltScreenAndFlushPastRing writes the alt-screen toggle followed
+// by enough plain bytes to overwrite the retained ring, then waits for
+// the manager's offset to confirm the bytes have landed. Returns the
+// filler length so callers can compute the expected end_offset. Used by
+// every test that asserts the modeTracker prefix appears on a snapshot
+// taken AFTER the toggle has fallen out of the ring.
+func injectAltScreenAndFlushPastRing(t *testing.T, svc *Context, terminalID string) int {
+	t.Helper()
+	require.True(t, svc.Terminals.AppendOutput(terminalID, []byte("\x1b[?1049h")))
+	// 110 KB > screenBufferSize (100 KB), so the toggle is guaranteed
+	// out of the ring after this single write completes.
+	filler := make([]byte, 110*1024)
+	for i := range filler {
+		filler[i] = 'a'
+	}
+	require.True(t, svc.Terminals.AppendOutput(terminalID, filler))
+	testutil.AssertEventually(t, func() bool {
+		_, off, _ := svc.Terminals.ScreenSnapshotSince(terminalID, 0)
+		return off >= int64(len(filler))
+	}, "alt-screen + filler arrived")
+	return len(filler)
 }
 
 // TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap: when the backend's

--- a/backend/internal/worker/terminal/mode_tracker.go
+++ b/backend/internal/worker/terminal/mode_tracker.go
@@ -97,10 +97,13 @@ func (t *modeTracker) feed(data []byte) {
 				continue
 			}
 			if t.paramLen >= paramBufCap {
-				// Overflow: abort. Drop bytes until a final byte (or a
-				// fresh `\x1b`, handled above) ends the sequence. The
-				// final byte itself must not dispatch — track via
-				// paramLen sentinel + skipping the dispatch branch.
+				// Param buffer full — bail to ground state. Subsequent
+				// bytes (including the would-be final byte that ends
+				// this CSI) are read as plain text and ignored until a
+				// fresh `\x1b` starts a new escape. Dropping the entire
+				// sequence is the safe choice: a truncated DEC param
+				// list cannot be partially applied without risking
+				// silently flipping the wrong mode.
 				t.parseState = stateGround
 				continue
 			}

--- a/backend/internal/worker/terminal/mode_tracker.go
+++ b/backend/internal/worker/terminal/mode_tracker.go
@@ -217,35 +217,29 @@ func (t *modeTracker) applyMode(code int, set bool) {
 	case 2004:
 		t.bracketedPaste = set
 	case 1000:
-		if set {
-			t.mouseTrack = mouseTrackX10
-		} else if t.mouseTrack == mouseTrackX10 {
-			t.mouseTrack = mouseTrackOff
-		}
+		setOrClearSlot(&t.mouseTrack, mouseTrackX10, mouseTrackOff, set)
 	case 1002:
-		if set {
-			t.mouseTrack = mouseTrackBtnEvent
-		} else if t.mouseTrack == mouseTrackBtnEvent {
-			t.mouseTrack = mouseTrackOff
-		}
+		setOrClearSlot(&t.mouseTrack, mouseTrackBtnEvent, mouseTrackOff, set)
 	case 1003:
-		if set {
-			t.mouseTrack = mouseTrackAnyEvent
-		} else if t.mouseTrack == mouseTrackAnyEvent {
-			t.mouseTrack = mouseTrackOff
-		}
+		setOrClearSlot(&t.mouseTrack, mouseTrackAnyEvent, mouseTrackOff, set)
 	case 1006:
-		if set {
-			t.mouseEncoding = mouseEncSGR
-		} else if t.mouseEncoding == mouseEncSGR {
-			t.mouseEncoding = mouseEncOff
-		}
+		setOrClearSlot(&t.mouseEncoding, mouseEncSGR, mouseEncOff, set)
 	case 1015:
-		if set {
-			t.mouseEncoding = mouseEncURXVT
-		} else if t.mouseEncoding == mouseEncURXVT {
-			t.mouseEncoding = mouseEncOff
-		}
+		setOrClearSlot(&t.mouseEncoding, mouseEncURXVT, mouseEncOff, set)
+	}
+}
+
+// setOrClearSlot updates a single-slot mode (where multiple DEC codes
+// compete for the same field, last-write-wins): on `set==true` the slot
+// becomes `on`; on `set==false` it falls back to `off` only if the slot
+// was holding `on` — so resetting an inactive variant is a no-op and
+// can't accidentally clear a different variant of the same family.
+func setOrClearSlot[T comparable](slot *T, on, off T, set bool) {
+	switch {
+	case set:
+		*slot = on
+	case *slot == on:
+		*slot = off
 	}
 }
 

--- a/backend/internal/worker/terminal/mode_tracker.go
+++ b/backend/internal/worker/terminal/mode_tracker.go
@@ -1,0 +1,339 @@
+package terminal
+
+// modeTracker observes PTY output bytes and keeps a minimal model of
+// sticky xterm state. It is NOT a terminal emulator — it tracks only
+// the modes listed below. Unknown escape sequences are skipped without
+// disturbing tracked state.
+//
+// Tracked modes (each yields a fragment of snapshotPrefix when set):
+//
+//   - Alt screen — DEC private modes 47, 1047, 1049 (smcup/rmcup),
+//     emitted as 1049.
+//   - Cursor visibility — DEC private mode 25 (DECTCEM).
+//   - Autowrap — DEC private mode 7 (DECAWM); default is ON, only
+//     emitted when a program disabled it.
+//   - Application cursor keys — DEC private mode 1 (DECCKM).
+//   - Bracketed paste — DEC private mode 2004.
+//   - Mouse tracking — DEC private modes 1000, 1002, 1003 (one slot,
+//     last-write-wins).
+//   - Mouse encoding — DEC private modes 1006, 1015 (independent slot,
+//     last-write-wins).
+//   - Window title — OSC 0/2 last-write-wins string, capped at oscBufCap.
+//
+// All methods must be called under the enclosing ScreenBuffer's mutex.
+type modeTracker struct {
+	altScreen      bool
+	cursorHidden   bool
+	autoWrapOff    bool // default ON: store negation so zero-value matches xterm.
+	appCursorKeys  bool
+	bracketedPaste bool
+	mouseTrack     mouseTrackMode
+	mouseEncoding  mouseEncodingMode
+	title          []byte // last OSC 0/2 title; nil when never set.
+
+	parseState parseState
+	paramBuf   [paramBufCap]byte
+	paramLen   int
+	oscBuf     [oscBufCap]byte
+	oscLen     int
+	oscOverrun bool // true once oscLen hit cap; drop the OSC, keep parsing terminator.
+}
+
+type parseState uint8
+
+const (
+	stateGround parseState = iota
+	stateEsc
+	stateCSI
+	stateOSC
+	stateOSCEsc
+)
+
+type mouseTrackMode uint8
+
+const (
+	mouseTrackOff mouseTrackMode = iota
+	mouseTrackX10
+	mouseTrackBtnEvent
+	mouseTrackAnyEvent
+)
+
+type mouseEncodingMode uint8
+
+const (
+	mouseEncOff mouseEncodingMode = iota
+	mouseEncSGR
+	mouseEncURXVT
+)
+
+const (
+	paramBufCap = 64  // CSI parameter cap; overflow aborts the sequence.
+	oscBufCap   = 256 // OSC body cap; overflow drops the OSC body silently.
+)
+
+// feed processes a chunk of PTY output. Allocation-free when the chunk
+// contains no escape sequences (the >99% case for shell output). Partial
+// sequences at the tail are buffered in parseState/paramBuf/oscBuf and
+// completed on the next call.
+func (t *modeTracker) feed(data []byte) {
+	for _, b := range data {
+		switch t.parseState {
+		case stateGround:
+			if b == 0x1b {
+				t.parseState = stateEsc
+			}
+		case stateEsc:
+			t.handleEscIntro(b)
+		case stateCSI:
+			// `\x1b` mid-CSI starts a fresh escape: abort the current
+			// sequence (paramBuf is wiped on the next stateCSI entry).
+			if b == 0x1b {
+				t.parseState = stateEsc
+				continue
+			}
+			if b >= 0x40 && b <= 0x7e {
+				t.dispatchCSI(b)
+				t.parseState = stateGround
+				continue
+			}
+			if t.paramLen >= paramBufCap {
+				// Overflow: abort. Drop bytes until a final byte (or a
+				// fresh `\x1b`, handled above) ends the sequence. The
+				// final byte itself must not dispatch — track via
+				// paramLen sentinel + skipping the dispatch branch.
+				t.parseState = stateGround
+				continue
+			}
+			t.paramBuf[t.paramLen] = b
+			t.paramLen++
+		case stateOSC:
+			switch b {
+			case 0x07: // BEL terminator.
+				t.dispatchOSC()
+				t.parseState = stateGround
+			case 0x1b:
+				t.parseState = stateOSCEsc
+			default:
+				if t.oscLen < oscBufCap {
+					t.oscBuf[t.oscLen] = b
+					t.oscLen++
+				} else {
+					t.oscOverrun = true
+				}
+			}
+		case stateOSCEsc:
+			if b == '\\' {
+				// ST terminator (\x1b\\) — finalize the OSC.
+				t.dispatchOSC()
+				t.parseState = stateGround
+				continue
+			}
+			// The `\x1b` mid-OSC was the start of a new escape, not ST.
+			// Abandon the OSC body and re-enter stateEsc handling with
+			// this byte as the escape's second byte.
+			t.oscLen = 0
+			t.oscOverrun = false
+			t.handleEscIntro(b)
+		}
+	}
+}
+
+// handleEscIntro processes the second byte of an escape sequence (the
+// byte after `\x1b`). Shared by stateEsc and the OSC-aborted recovery
+// path so a `\x1b[?1049h` immediately following an unterminated OSC
+// still parses.
+func (t *modeTracker) handleEscIntro(b byte) {
+	switch b {
+	case '[':
+		t.paramLen = 0
+		t.parseState = stateCSI
+	case ']':
+		t.oscLen = 0
+		t.oscOverrun = false
+		t.parseState = stateOSC
+	case 0x1b:
+		// Back-to-back ESC: stay in stateEsc so the next byte is read
+		// as a fresh intro.
+		t.parseState = stateEsc
+	default:
+		// Charset designators (`(`, `)`), save/restore cursor (`7`/`8`),
+		// single-byte escapes — all out of scope.
+		t.parseState = stateGround
+	}
+}
+
+// dispatchCSI handles a complete CSI sequence whose final byte is `final`.
+// The parameter buffer is `t.paramBuf[:t.paramLen]`. We only act on `h`
+// (set) and `l` (reset) of DEC private modes (params start with `?`).
+func (t *modeTracker) dispatchCSI(final byte) {
+	if final != 'h' && final != 'l' {
+		return
+	}
+	params := t.paramBuf[:t.paramLen]
+	if len(params) == 0 || params[0] != '?' {
+		return
+	}
+	set := final == 'h'
+	// Walk `;`-separated decimal numbers after the leading `?`. The
+	// loop bound is `i <= len(params)` so the iteration past the end
+	// flushes the trailing number — a real param has no `;` after it.
+	n := 0
+	hasDigit := false
+	for i := 1; i <= len(params); i++ {
+		if i == len(params) || params[i] == ';' {
+			if hasDigit {
+				t.applyMode(n, set)
+			}
+			n = 0
+			hasDigit = false
+			continue
+		}
+		c := params[i]
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+			hasDigit = true
+		} else {
+			// Non-digit, non-`;` inside DEC params (e.g. another `?`).
+			// Treat as separator: flush current and reset.
+			if hasDigit {
+				t.applyMode(n, set)
+			}
+			n = 0
+			hasDigit = false
+		}
+	}
+}
+
+func (t *modeTracker) applyMode(code int, set bool) {
+	switch code {
+	case 1:
+		t.appCursorKeys = set
+	case 7:
+		t.autoWrapOff = !set
+	case 25:
+		t.cursorHidden = !set
+	case 47, 1047, 1049:
+		t.altScreen = set
+	case 2004:
+		t.bracketedPaste = set
+	case 1000:
+		if set {
+			t.mouseTrack = mouseTrackX10
+		} else if t.mouseTrack == mouseTrackX10 {
+			t.mouseTrack = mouseTrackOff
+		}
+	case 1002:
+		if set {
+			t.mouseTrack = mouseTrackBtnEvent
+		} else if t.mouseTrack == mouseTrackBtnEvent {
+			t.mouseTrack = mouseTrackOff
+		}
+	case 1003:
+		if set {
+			t.mouseTrack = mouseTrackAnyEvent
+		} else if t.mouseTrack == mouseTrackAnyEvent {
+			t.mouseTrack = mouseTrackOff
+		}
+	case 1006:
+		if set {
+			t.mouseEncoding = mouseEncSGR
+		} else if t.mouseEncoding == mouseEncSGR {
+			t.mouseEncoding = mouseEncOff
+		}
+	case 1015:
+		if set {
+			t.mouseEncoding = mouseEncURXVT
+		} else if t.mouseEncoding == mouseEncURXVT {
+			t.mouseEncoding = mouseEncOff
+		}
+	}
+}
+
+// dispatchOSC handles a complete OSC body sitting in t.oscBuf[:t.oscLen].
+// We only care about Ps == 0 or 2 (window title). Bodies that overflowed
+// the cap are dropped (oscOverrun==true).
+func (t *modeTracker) dispatchOSC() {
+	defer func() {
+		t.oscLen = 0
+		t.oscOverrun = false
+	}()
+	if t.oscOverrun {
+		return
+	}
+	body := t.oscBuf[:t.oscLen]
+	// Body shape: `<Ps>;<text>`. We accept "0" or "2" as Ps.
+	if len(body) < 2 || body[1] != ';' {
+		return
+	}
+	if body[0] != '0' && body[0] != '2' {
+		return
+	}
+	text := body[2:]
+	// Clone — we're aliasing a fixed-size array.
+	t.title = append(t.title[:0], text...)
+}
+
+// snapshotPrefix returns the escape sequences that reproduce the
+// tracker's current state when prepended to a byte replay starting from
+// a fresh xterm. Returns nil when every mode is at its default (the
+// caller can skip an extra append). Always returns a freshly allocated
+// slice; never aliases internal state.
+func (t *modeTracker) snapshotPrefix() []byte {
+	// Worst-case length budget: each mode emission is short (≤ ~10
+	// bytes) and there are ~7 of them, plus the title (≤ oscBufCap+5).
+	// Pre-size on the high end to avoid reallocations; trim by returning
+	// the slice as-is.
+	if t.isDefault() {
+		return nil
+	}
+	out := make([]byte, 0, 64+len(t.title))
+
+	if t.altScreen {
+		out = append(out, "\x1b[?1049h"...)
+	}
+	if t.cursorHidden {
+		out = append(out, "\x1b[?25l"...)
+	}
+	if t.autoWrapOff {
+		out = append(out, "\x1b[?7l"...)
+	}
+	if t.appCursorKeys {
+		out = append(out, "\x1b[?1h"...)
+	}
+	if t.bracketedPaste {
+		out = append(out, "\x1b[?2004h"...)
+	}
+	switch t.mouseTrack {
+	case mouseTrackX10:
+		out = append(out, "\x1b[?1000h"...)
+	case mouseTrackBtnEvent:
+		out = append(out, "\x1b[?1002h"...)
+	case mouseTrackAnyEvent:
+		out = append(out, "\x1b[?1003h"...)
+	}
+	switch t.mouseEncoding {
+	case mouseEncSGR:
+		out = append(out, "\x1b[?1006h"...)
+	case mouseEncURXVT:
+		out = append(out, "\x1b[?1015h"...)
+	}
+	if t.title != nil {
+		out = append(out, "\x1b]0;"...)
+		out = append(out, t.title...)
+		out = append(out, 0x07)
+	}
+	return out
+}
+
+// isDefault reports whether every tracked field equals its zero/default
+// value. Used to short-circuit snapshotPrefix to a nil return.
+func (t *modeTracker) isDefault() bool {
+	return !t.altScreen &&
+		!t.cursorHidden &&
+		!t.autoWrapOff &&
+		!t.appCursorKeys &&
+		!t.bracketedPaste &&
+		t.mouseTrack == mouseTrackOff &&
+		t.mouseEncoding == mouseEncOff &&
+		t.title == nil
+}

--- a/backend/internal/worker/terminal/mode_tracker_corpus_test.go
+++ b/backend/internal/worker/terminal/mode_tracker_corpus_test.go
@@ -1,0 +1,179 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Corpus tests run hand-crafted but realistic PTY byte traces through
+// the tracker and assert it converges to the expected end-state. They
+// catch regressions that the per-mode unit tests would miss (e.g. an
+// edit that only breaks one byte order, or only when interleaved with
+// OSC traffic). Synthesized inline rather than captured from `script`
+// because real captures vary per OS / terminal size / font and would
+// make the tests environment-dependent.
+
+// modeTrackerSnapshot is the small projection of internal tracker state
+// the corpus tests assert against. Avoids exposing every field publicly
+// while letting tests compare a literal struct value.
+type modeTrackerSnapshot struct {
+	altScreen      bool
+	cursorHidden   bool
+	autoWrapOff    bool
+	appCursorKeys  bool
+	bracketedPaste bool
+	mouseTrack     mouseTrackMode
+	mouseEncoding  mouseEncodingMode
+	title          string
+}
+
+func snap(t *modeTracker) modeTrackerSnapshot {
+	var title string
+	if t.title != nil {
+		title = string(t.title)
+	}
+	return modeTrackerSnapshot{
+		altScreen:      t.altScreen,
+		cursorHidden:   t.cursorHidden,
+		autoWrapOff:    t.autoWrapOff,
+		appCursorKeys:  t.appCursorKeys,
+		bracketedPaste: t.bracketedPaste,
+		mouseTrack:     t.mouseTrack,
+		mouseEncoding:  t.mouseEncoding,
+		title:          title,
+	}
+}
+
+// TestCorpus_VimOpenEditQuit simulates a typical vim session:
+// enters alt screen, hides cursor, sets app cursor keys, paints
+// content, then exits all modes when the user `:q`s. The tracker
+// must converge back to default state — otherwise reconnecting after
+// vim quits would prefix the snapshot with stale alt-screen bytes.
+func TestCorpus_VimOpenEditQuit(t *testing.T) {
+	tr := &modeTracker{}
+
+	// Enter: vim sets alt screen + hides cursor + app cursor keys.
+	feedString(tr, "\x1b[?1049h\x1b[?25l\x1b[?1h")
+	// Body: any number of SGR + cursor positioning + text — all opaque
+	// to the tracker. SGRs in particular must not perturb state.
+	for i := 0; i < 50; i++ {
+		feedString(tr, "\x1b[1;1H\x1b[K\x1b[33m~\x1b[39m\r\n")
+	}
+	feedString(tr, "\x1b[2;5HHello, vim!\x1b[H")
+	// Exit: reverse every mode the entry set.
+	feedString(tr, "\x1b[?1l\x1b[?25h\x1b[?1049l")
+
+	assert.Equal(t, modeTrackerSnapshot{}, snap(tr),
+		"vim open+quit must leave the tracker at default state")
+	assert.Nil(t, tr.snapshotPrefix())
+}
+
+// TestCorpus_LessScroll simulates `less` paging through a file:
+// enters alt screen, paints lines, then exits. less also disables
+// autowrap during paint so output doesn't soft-wrap into the next row.
+func TestCorpus_LessScroll(t *testing.T) {
+	tr := &modeTracker{}
+
+	feedString(tr, "\x1b[?1049h\x1b[?7l\x1b[H")
+	for line := 0; line < 24; line++ {
+		feedString(tr, "this is line "+strings.Repeat("x", 60)+"\r\n")
+	}
+	feedString(tr, ":")
+	// User quits.
+	feedString(tr, "\x1b[?7h\x1b[?1049l")
+
+	assert.Equal(t, modeTrackerSnapshot{}, snap(tr))
+	assert.Nil(t, tr.snapshotPrefix())
+}
+
+// TestCorpus_HtopTick simulates htop running in alt screen for a few
+// refresh cycles. htop typically enables mouse tracking + SGR encoding
+// and stays in alt screen until the user quits — i.e. a snapshot
+// captured mid-run must restore alt screen + mouse modes.
+func TestCorpus_HtopTick(t *testing.T) {
+	tr := &modeTracker{}
+
+	// Setup.
+	feedString(tr, "\x1b[?1049h\x1b[?25l\x1b[?1006h\x1b[?1002h")
+	// Five ticks of repaint (cursor moves + SGR + text — all opaque).
+	for tick := 0; tick < 5; tick++ {
+		feedString(tr, "\x1b[1;1H\x1b[K\x1b[1;32mPID\x1b[m   USER  CPU%\r\n")
+		for row := 2; row <= 20; row++ {
+			feedString(tr, "\x1b["+itoa(row)+";1H\x1b[K"+strings.Repeat("data ", 12))
+		}
+	}
+
+	got := snap(tr)
+	assert.True(t, got.altScreen)
+	assert.True(t, got.cursorHidden)
+	assert.Equal(t, mouseTrackBtnEvent, got.mouseTrack)
+	assert.Equal(t, mouseEncSGR, got.mouseEncoding)
+
+	prefix := string(tr.snapshotPrefix())
+	assert.Contains(t, prefix, "\x1b[?1049h")
+	assert.Contains(t, prefix, "\x1b[?25l")
+	assert.Contains(t, prefix, "\x1b[?1002h")
+	assert.Contains(t, prefix, "\x1b[?1006h")
+}
+
+// TestCorpus_BashPromptCommand simulates a bash session whose
+// $PROMPT_COMMAND emits OSC 0 on every prompt redraw — frequent enough
+// that a careless OSC parser would either leak titles into the body or
+// hang on the BEL terminator. The tracker must end with the most recent
+// title only.
+func TestCorpus_BashPromptCommand(t *testing.T) {
+	tr := &modeTracker{}
+
+	dirs := []string{"/", "/home", "/home/me", "/home/me/work", "/home/me/work/leapmux"}
+	for _, d := range dirs {
+		feedString(tr, "\x1b]0;me@host:"+d+"\x07")
+		feedString(tr, "$ ls\r\nfile1 file2\r\n")
+	}
+
+	assert.Equal(t, "me@host:/home/me/work/leapmux", string(tr.title),
+		"title must reflect the LAST OSC 0 emitted, not an earlier one")
+	assert.False(t, tr.altScreen, "no alt-screen toggles in this corpus")
+}
+
+// TestCorpus_TmuxNested simulates tmux: the outer tmux enters alt
+// screen via legacy code 1047 (some tmux configs prefer it for
+// compatibility with old tic databases), then the inner shell uses the
+// modern 1049. The tracker must collapse all three aliases — 47, 1047,
+// 1049 — to a single altScreen bit and emit the canonical 1049 on
+// snapshot regardless of which alias the program used.
+func TestCorpus_TmuxNested(t *testing.T) {
+	tr := &modeTracker{}
+
+	feedString(tr, "\x1b[?1047h") // outer enters alt screen via 1047.
+	// Some content.
+	feedString(tr, "\x1b[Htmux\r\n")
+	// Outer exits via 47 (rare but valid).
+	feedString(tr, "\x1b[?47l")
+
+	assert.False(t, tr.altScreen, "alt-screen aliases must all flip the same bit")
+	assert.Nil(t, tr.snapshotPrefix())
+
+	// Inner now enters alt screen via 1049.
+	feedString(tr, "\x1b[?1049h")
+	assert.True(t, tr.altScreen)
+	assert.Equal(t, []byte("\x1b[?1049h"), tr.snapshotPrefix(),
+		"emission must always normalize to 1049 regardless of which alias was used")
+}
+
+// itoa is a tiny inline integer→ASCII helper so the corpus tests don't
+// pull in strconv just for cursor-position numerals.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [4]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/backend/internal/worker/terminal/mode_tracker_corpus_test.go
+++ b/backend/internal/worker/terminal/mode_tracker_corpus_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -101,7 +102,7 @@ func TestCorpus_HtopTick(t *testing.T) {
 	for tick := 0; tick < 5; tick++ {
 		feedString(tr, "\x1b[1;1H\x1b[K\x1b[1;32mPID\x1b[m   USER  CPU%\r\n")
 		for row := 2; row <= 20; row++ {
-			feedString(tr, "\x1b["+itoa(row)+";1H\x1b[K"+strings.Repeat("data ", 12))
+			feedString(tr, "\x1b["+strconv.Itoa(row)+";1H\x1b[K"+strings.Repeat("data ", 12))
 		}
 	}
 
@@ -160,20 +161,4 @@ func TestCorpus_TmuxNested(t *testing.T) {
 	assert.True(t, tr.altScreen)
 	assert.Equal(t, []byte("\x1b[?1049h"), tr.snapshotPrefix(),
 		"emission must always normalize to 1049 regardless of which alias was used")
-}
-
-// itoa is a tiny inline integer→ASCII helper so the corpus tests don't
-// pull in strconv just for cursor-position numerals.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b [4]byte
-	i := len(b)
-	for n > 0 {
-		i--
-		b[i] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(b[i:])
 }

--- a/backend/internal/worker/terminal/mode_tracker_test.go
+++ b/backend/internal/worker/terminal/mode_tracker_test.go
@@ -288,3 +288,19 @@ func TestModeTracker_NoAllocOnPlainText(t *testing.T) {
 	allocs := testing.AllocsPerRun(10, func() { tr.feed(plain) })
 	assert.Zero(t, allocs, "plain-text feed must not allocate")
 }
+
+// TestModeTracker_NoAllocOnTypicalShellOutput exercises a chunk shaped
+// like real shell output — OSC 0 title + SGR-coloured prompt + plain
+// text + CRLF — to catch regressions the plain-text test would miss
+// (e.g. a stray `[]byte(...)` conversion inside dispatchCSI, or an
+// OSC body path that stopped reusing t.title's backing array). The
+// initial feed is a warmup so the title slice reaches its steady-state
+// capacity; from there, repeated feeds of the same chunk must allocate
+// nothing.
+func TestModeTracker_NoAllocOnTypicalShellOutput(t *testing.T) {
+	tr := &modeTracker{}
+	chunk := []byte("\x1b]0;me@host\x07\x1b[1;32muser@host\x1b[m:~$ ls\r\n")
+	tr.feed(chunk)
+	allocs := testing.AllocsPerRun(10, func() { tr.feed(chunk) })
+	assert.Zero(t, allocs, "steady-state mixed-CSI+OSC feed must not allocate")
+}

--- a/backend/internal/worker/terminal/mode_tracker_test.go
+++ b/backend/internal/worker/terminal/mode_tracker_test.go
@@ -1,0 +1,290 @@
+package terminal
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// feedString is a small helper so tests can write expressive strings
+// rather than `[]byte("\x1b[?1049h")` repeatedly.
+func feedString(t *modeTracker, s string) {
+	t.feed([]byte(s))
+}
+
+// TestModeTracker_PerModeSetReset is the table that covers every tracked
+// DEC private mode end-to-end: the canonical set sequence flips the
+// field, the canonical reset sequence flips it back, and snapshotPrefix
+// reflects the current state.
+func TestModeTracker_PerModeSetReset(t *testing.T) {
+	cases := []struct {
+		name           string
+		setSeq         string
+		resetSeq       string
+		expectInPrefix string
+	}{
+		{"alt screen 1049", "\x1b[?1049h", "\x1b[?1049l", "\x1b[?1049h"},
+		{"cursor visibility", "\x1b[?25l", "\x1b[?25h", "\x1b[?25l"},
+		{"autowrap off", "\x1b[?7l", "\x1b[?7h", "\x1b[?7l"},
+		{"app cursor keys", "\x1b[?1h", "\x1b[?1l", "\x1b[?1h"},
+		{"bracketed paste", "\x1b[?2004h", "\x1b[?2004l", "\x1b[?2004h"},
+		{"mouse track 1000", "\x1b[?1000h", "\x1b[?1000l", "\x1b[?1000h"},
+		{"mouse track 1002", "\x1b[?1002h", "\x1b[?1002l", "\x1b[?1002h"},
+		{"mouse track 1003", "\x1b[?1003h", "\x1b[?1003l", "\x1b[?1003h"},
+		{"mouse encoding 1006", "\x1b[?1006h", "\x1b[?1006l", "\x1b[?1006h"},
+		{"mouse encoding 1015", "\x1b[?1015h", "\x1b[?1015l", "\x1b[?1015h"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/set then reset → empty prefix", func(t *testing.T) {
+			tr := &modeTracker{}
+			feedString(tr, tc.setSeq)
+			assert.Contains(t, string(tr.snapshotPrefix()), tc.expectInPrefix,
+				"set sequence must produce the corresponding prefix bytes")
+			feedString(tr, tc.resetSeq)
+			assert.Nil(t, tr.snapshotPrefix(),
+				"reset sequence must return prefix to nil")
+		})
+	}
+}
+
+// TestModeTracker_AltScreenAliases covers the legacy private modes 47
+// and 1047 — semantically equivalent to 1049 for our purposes. Programs
+// that predate 1049 (some tmux configs, older curses) emit the older
+// codes; emission must always normalize to 1049 so xterm gets the most
+// complete restore (1049 == save cursor + alt screen).
+func TestModeTracker_AltScreenAliases(t *testing.T) {
+	for _, seq := range []string{"\x1b[?47h", "\x1b[?1047h", "\x1b[?1049h"} {
+		tr := &modeTracker{}
+		feedString(tr, seq)
+		assert.Equal(t, []byte("\x1b[?1049h"), tr.snapshotPrefix(),
+			"%q must drive altScreen and emit 1049 on snapshot", seq)
+	}
+}
+
+// TestModeTracker_MultiParamCSI: a single CSI with several `;`-separated
+// parameters must update each field independently. xterm accepts this
+// form even though most programs split into separate sequences.
+func TestModeTracker_MultiParamCSI(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[?25;7l") // hide cursor + autowrap off in one go.
+	prefix := string(tr.snapshotPrefix())
+	assert.Contains(t, prefix, "\x1b[?25l")
+	assert.Contains(t, prefix, "\x1b[?7l")
+}
+
+// TestModeTracker_PartialAcrossFeeds: a sequence chopped at every byte
+// boundary must produce the same end-state as the unsplit feed. This is
+// the invariant that makes the tracker safe to call from inside Write —
+// PTY chunks split at arbitrary boundaries.
+func TestModeTracker_PartialAcrossFeeds(t *testing.T) {
+	full := "\x1b[?1049h"
+	for split := 1; split < len(full); split++ {
+		tr := &modeTracker{}
+		feedString(tr, full[:split])
+		feedString(tr, full[split:])
+		assert.Equal(t, []byte("\x1b[?1049h"), tr.snapshotPrefix(),
+			"split at %d should still set altScreen", split)
+	}
+}
+
+// TestModeTracker_UnknownFinalByte: SGR (`m`), erase (`2J`), status
+// query (`5n`) and other CSIs that aren't `h`/`l` must leave state
+// untouched. This is the cheap-out that keeps SGR explicitly out of
+// scope.
+func TestModeTracker_UnknownFinalByte(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[31m\x1b[2J\x1b[5n\x1b[H")
+	assert.Nil(t, tr.snapshotPrefix(),
+		"non-h/l CSIs and non-DEC params must not change tracker state")
+}
+
+// TestModeTracker_MixedPrintableAndCSI: printable text bracketing a CSI
+// must not pollute state. Verifies that ground-state bytes are truly
+// no-ops, not accidentally mutating the tracker.
+func TestModeTracker_MixedPrintableAndCSI(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "hello\x1b[?25lworld")
+	assert.Equal(t, []byte("\x1b[?25l"), tr.snapshotPrefix())
+}
+
+// TestModeTracker_SetThenResetReturnsDefault is the second-most-important
+// correctness property after "set survives ring rotation". Programs
+// frequently enter alt screen, do work, then exit alt screen before
+// returning control to the shell. After that, snapshotPrefix MUST be
+// nil so we don't strand reconnecting clients in alt screen.
+func TestModeTracker_SetThenResetReturnsDefault(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[?1049h\x1b[?25l\x1b[?2004h")
+	require.NotNil(t, tr.snapshotPrefix())
+	feedString(tr, "\x1b[?1049l\x1b[?25h\x1b[?2004l")
+	assert.Nil(t, tr.snapshotPrefix(),
+		"every set sequence reversed → prefix must be nil")
+}
+
+// TestModeTracker_FreshIsDefault: the zero value of modeTracker matches
+// xterm's default state. No allocation, no prefix, no surprises.
+func TestModeTracker_FreshIsDefault(t *testing.T) {
+	tr := &modeTracker{}
+	assert.Nil(t, tr.snapshotPrefix())
+}
+
+// TestModeTracker_EmissionOrdering verifies the documented prefix
+// ordering: alt-screen first (so subsequent mode changes land on the
+// right buffer), then cursor, autowrap, app-cursor-keys, bracketed
+// paste, mouse track, mouse encoding, then title.
+func TestModeTracker_EmissionOrdering(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[?2004h\x1b[?25l\x1b[?1049h\x1b[?1006h\x1b[?1002h\x1b[?7l\x1b[?1h\x1b]0;hello\x07")
+	prefix := string(tr.snapshotPrefix())
+	indices := []int{
+		strings.Index(prefix, "\x1b[?1049h"),
+		strings.Index(prefix, "\x1b[?25l"),
+		strings.Index(prefix, "\x1b[?7l"),
+		strings.Index(prefix, "\x1b[?1h"),
+		strings.Index(prefix, "\x1b[?2004h"),
+		strings.Index(prefix, "\x1b[?1002h"),
+		strings.Index(prefix, "\x1b[?1006h"),
+		strings.Index(prefix, "\x1b]0;hello\x07"),
+	}
+	for i, idx := range indices {
+		require.NotEqual(t, -1, idx, "fragment %d must be present", i)
+	}
+	for i := 1; i < len(indices); i++ {
+		assert.Less(t, indices[i-1], indices[i],
+			"fragments must appear in documented order; broken at index %d", i)
+	}
+}
+
+// TestModeTracker_ParamBufOverflow: a malicious or malformed CSI with a
+// huge parameter run must NOT corrupt state, must NOT allocate without
+// bound, and must leave the parser in a recoverable state for the next
+// real sequence.
+func TestModeTracker_ParamBufOverflow(t *testing.T) {
+	tr := &modeTracker{}
+	// 200 bytes of "1;" is way past the 64-byte cap.
+	overflow := "\x1b[" + strings.Repeat("1;", 200) + "h"
+	feedString(tr, overflow)
+	assert.Nil(t, tr.snapshotPrefix(),
+		"overflowed CSI must not change any tracked field")
+
+	// And the parser must recover for the next valid sequence.
+	feedString(tr, "\x1b[?1049h")
+	assert.Equal(t, []byte("\x1b[?1049h"), tr.snapshotPrefix())
+}
+
+// TestModeTracker_MouseEncodingOrthogonal: 1006/1015 (encoding) and
+// 1000/1002/1003 (tracking) live in independent slots. Resetting one
+// must not reset the other. Real programs (e.g. neovim) toggle these
+// separately on focus events.
+func TestModeTracker_MouseEncodingOrthogonal(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[?1006h\x1b[?1002h")
+	prefix := string(tr.snapshotPrefix())
+	assert.Contains(t, prefix, "\x1b[?1002h")
+	assert.Contains(t, prefix, "\x1b[?1006h")
+
+	feedString(tr, "\x1b[?1006l")
+	prefix = string(tr.snapshotPrefix())
+	assert.Contains(t, prefix, "\x1b[?1002h",
+		"resetting encoding must not clear tracking mode")
+	assert.NotContains(t, prefix, "\x1b[?1006h",
+		"encoding mode must reset to off")
+}
+
+// TestModeTracker_OSC_BEL: OSC 0 with BEL terminator captures the
+// title and round-trips through snapshotPrefix.
+func TestModeTracker_OSC_BEL(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]0;hello\x07")
+	prefix := tr.snapshotPrefix()
+	assert.Equal(t, []byte("\x1b]0;hello\x07"), prefix,
+		"OSC 0 with BEL must produce the same OSC 0 with BEL on snapshot")
+}
+
+// TestModeTracker_OSC_ST: OSC 2 with ST (\x1b\\) terminator. Less
+// common than BEL but spec-compliant; some terminals emit it.
+func TestModeTracker_OSC_ST(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]2;world\x1b\\")
+	prefix := tr.snapshotPrefix()
+	assert.Equal(t, []byte("\x1b]0;world\x07"), prefix,
+		"OSC 2 must drive the same title slot as OSC 0; emission normalizes to OSC 0+BEL")
+}
+
+// TestModeTracker_OSC_BodyOverflow: an OSC body longer than oscBufCap
+// must be dropped silently. Previous title (or nil) must persist.
+func TestModeTracker_OSC_BodyOverflow(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]0;previous\x07")
+	require.Equal(t, []byte("\x1b]0;previous\x07"), tr.snapshotPrefix())
+
+	// 300 bytes of body — well past oscBufCap=256.
+	overflow := "\x1b]0;" + strings.Repeat("X", 300) + "\x07"
+	feedString(tr, overflow)
+	assert.Equal(t, []byte("\x1b]0;previous\x07"), tr.snapshotPrefix(),
+		"overflowed OSC body must leave the previous title intact")
+}
+
+// TestModeTracker_OSC_AbortedByNewEscape: an OSC interrupted by a fresh
+// `\x1b[...` escape must abandon the OSC and parse the new sequence.
+// Without this, a malformed program could silently disable mode tracking
+// for everything that follows.
+func TestModeTracker_OSC_AbortedByNewEscape(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]0;partial\x1b[?1049h")
+	prefix := tr.snapshotPrefix()
+	assert.Contains(t, string(prefix), "\x1b[?1049h",
+		"the trailing CSI must be parsed even after an aborted OSC")
+	assert.NotContains(t, string(prefix), "partial",
+		"the abandoned OSC must not become a title")
+}
+
+// TestModeTracker_TitleEmissionAfterModes verifies the title appears at
+// the very end of the prefix so it doesn't get clobbered by mode
+// resets that some terminals emit on cursor visibility changes.
+func TestModeTracker_TitleEmissionAfterModes(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]0;myshell\x07\x1b[?25l\x1b[?1049h")
+	prefix := tr.snapshotPrefix()
+	titleAt := bytes.Index(prefix, []byte("\x1b]0;"))
+	altAt := bytes.Index(prefix, []byte("\x1b[?1049h"))
+	require.NotEqual(t, -1, titleAt)
+	require.NotEqual(t, -1, altAt)
+	assert.Less(t, altAt, titleAt, "title must come after every mode fragment")
+}
+
+// TestModeTracker_OSC_OtherPsIgnored: only Ps==0 and Ps==2 affect the
+// title. OSC 1 (icon name only, in xterm semantics) and unknown Ps
+// codes must be ignored — emission should not pick them up.
+func TestModeTracker_OSC_OtherPsIgnored(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b]1;icon\x07\x1b]7;cwd\x07")
+	assert.Nil(t, tr.snapshotPrefix(),
+		"OSC 1 (icon) and OSC 7 (cwd) must not become a window title")
+}
+
+// TestModeTracker_CSIInterruptedByEscape: a CSI cut short by a fresh
+// `\x1b` is aborted in favor of the new escape. This matches xterm's
+// "ESC always cancels" rule and ensures we don't accumulate stale params
+// across a malformed sequence.
+func TestModeTracker_CSIInterruptedByEscape(t *testing.T) {
+	tr := &modeTracker{}
+	feedString(tr, "\x1b[?25\x1b[?1049h") // first CSI lacks final byte.
+	prefix := tr.snapshotPrefix()
+	assert.Equal(t, []byte("\x1b[?1049h"), prefix,
+		"interrupted CSI must not commit, and the new CSI must parse cleanly")
+}
+
+// TestModeTracker_NoAllocOnPlainText is a smoke test for the hot-path
+// invariant: feeding ASCII text must not allocate. The tracker sits on
+// every PTY chunk; a single allocation here would cost us roughly one
+// per shell prompt across the worker.
+func TestModeTracker_NoAllocOnPlainText(t *testing.T) {
+	tr := &modeTracker{}
+	plain := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 100)
+	allocs := testing.AllocsPerRun(10, func() { tr.feed(plain) })
+	assert.Zero(t, allocs, "plain-text feed must not allocate")
+}

--- a/backend/internal/worker/terminal/screenbuffer_test.go
+++ b/backend/internal/worker/terminal/screenbuffer_test.go
@@ -372,6 +372,19 @@ func TestScreenBuffer_Snapshot_DefaultStateNoPrefix(t *testing.T) {
 		"default-state Snapshot must return body bytes only")
 }
 
+// ringOverflowFiller returns plain-ASCII bytes sized just past the
+// retained ring, so writing them is guaranteed to overwrite anything
+// emitted earlier (including a leading mode toggle). 110% of the ring
+// is enough margin to stay correct even if screenBufferSize grows
+// modestly without making test runs gratuitously large.
+func ringOverflowFiller() []byte {
+	out := make([]byte, screenBufferSize+screenBufferSize/10)
+	for i := range out {
+		out[i] = 'x'
+	}
+	return out
+}
+
 // TestScreenBuffer_ConcurrentWriteAndSnapshot: Write and SnapshotSince
 // must not data-race under -race. No assertion on content — the goal is
 // just to exercise the locks. The race detector surfaces violations as

--- a/backend/internal/worker/terminal/screenbuffer_test.go
+++ b/backend/internal/worker/terminal/screenbuffer_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bytes"
 	"sync"
 	"testing"
 
@@ -273,6 +274,116 @@ func TestScreenBuffer_HasSuffix(t *testing.T) {
 	assert.True(t, sb.HasSuffix([]byte("ABC\nEND")),
 		"suffix that straddles the ring wrap must still match")
 	assert.False(t, sb.HasSuffix([]byte("WRONG")))
+}
+
+// TestScreenBuffer_SnapshotSince_FallenBehindIncludesModePrefix: when
+// the subscriber has fallen out of the retained window, the snapshot
+// reply must start with the mode-restore prefix synthesized from the
+// tracker's state. This is the whole reason the tracker exists: a TUI
+// that entered alt screen via bytes that have since been overwritten
+// in the ring still gets a working post-reset render.
+func TestScreenBuffer_SnapshotSince_FallenBehindIncludesModePrefix(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("\x1b[?1049h")) // enter alt screen.
+
+	// Push enough bytes that the alt-screen toggle falls out of the ring.
+	chunk := bytes.Repeat([]byte{'x'}, 8*1024)
+	for i := 0; i < 20; i++ { // 160 KB total, ring overwrites by 60 KB.
+		sb.Write(chunk)
+	}
+
+	data, _, isSnap := sb.SnapshotSince(0)
+	require.True(t, isSnap, "fallen-behind subscriber must get a snapshot")
+	require.True(t, bytes.HasPrefix(data, []byte("\x1b[?1049h")),
+		"snapshot must lead with the mode-restore prefix; got first 16 bytes: %q",
+		string(data[:min(16, len(data))]))
+}
+
+// TestScreenBuffer_SnapshotSince_InWindowHasNoPrefix: a subscriber
+// resuming inside the retained window already received the mode bytes
+// during the live stream, so the incremental delta must NOT add another
+// prefix. Doing so would cause xterm to re-toggle modes and confuse the
+// running program.
+func TestScreenBuffer_SnapshotSince_InWindowHasNoPrefix(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("\x1b[?1049h"))
+	mid := sb.TotalBytes()
+	sb.Write([]byte("more output"))
+
+	data, _, isSnap := sb.SnapshotSince(mid)
+	assert.False(t, isSnap, "in-window resume must not be flagged as snapshot")
+	assert.Equal(t, []byte("more output"), data,
+		"in-window delta must contain only the post-offset bytes — no prefix")
+}
+
+// TestScreenBuffer_SnapshotSince_PrefixDoesNotInflateOffset: the
+// returned endOffset must equal sb.total even when a prefix was added.
+// The prefix is synthesized; counting it would advance the resume
+// cursor past bytes the client never saw and break delta math on the
+// next subscribe.
+func TestScreenBuffer_SnapshotSince_PrefixDoesNotInflateOffset(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("\x1b[?1049h"))
+	chunk := bytes.Repeat([]byte{'y'}, 8*1024)
+	for i := 0; i < 20; i++ {
+		sb.Write(chunk)
+	}
+	expectedTotal := sb.TotalBytes()
+
+	_, end, isSnap := sb.SnapshotSince(0)
+	require.True(t, isSnap)
+	assert.Equal(t, expectedTotal, end,
+		"snapshot endOffset must equal total bytes written, not total+len(prefix)")
+}
+
+// TestScreenBuffer_SnapshotSince_DefaultStateNoPrefix: a tracker at
+// default state (no escape sequences observed, or every set has been
+// reset) must produce a snapshot with no prefix at all. Otherwise we
+// emit unnecessary bytes on every resubscribe.
+func TestScreenBuffer_SnapshotSince_DefaultStateNoPrefix(t *testing.T) {
+	sb := NewScreenBuffer()
+	chunk := bytes.Repeat([]byte{'z'}, 8*1024)
+	for i := 0; i < 20; i++ {
+		sb.Write(chunk)
+	}
+
+	data, _, isSnap := sb.SnapshotSince(0)
+	require.True(t, isSnap)
+	assert.False(t, bytes.HasPrefix(data, []byte("\x1b[")),
+		"plain text ring must not produce a CSI prefix")
+}
+
+// TestScreenBuffer_Snapshot_PrefixesPersistedScreenPath: Snapshot() is
+// the path used by Manager.SnapshotTerminal (DB persistence on shutdown
+// / exit) and Manager.buildEntryLocked (ListTerminals). Worker restarts
+// reload these bytes and the frontend writes them after terminal.reset()
+// — so they MUST carry the mode prefix or alt-screen state is lost
+// across restarts.
+func TestScreenBuffer_Snapshot_PrefixesPersistedScreenPath(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("\x1b[?1049h"))
+	chunk := bytes.Repeat([]byte{'p'}, 8*1024)
+	for i := 0; i < 20; i++ {
+		sb.Write(chunk)
+	}
+
+	data, end := sb.Snapshot()
+	assert.True(t, bytes.HasPrefix(data, []byte("\x1b[?1049h")),
+		"persisted-screen path must include the mode-restore prefix")
+	assert.Equal(t, sb.TotalBytes(), end,
+		"Snapshot() endOffset must not include synthesized prefix bytes")
+}
+
+// TestScreenBuffer_Snapshot_DefaultStateNoPrefix: the persisted-screen
+// path must also short-circuit when the tracker is at default state,
+// matching SnapshotSince's behavior.
+func TestScreenBuffer_Snapshot_DefaultStateNoPrefix(t *testing.T) {
+	sb := NewScreenBuffer()
+	sb.Write([]byte("plain shell output\r\n$ "))
+
+	data, _ := sb.Snapshot()
+	assert.Equal(t, []byte("plain shell output\r\n$ "), data,
+		"default-state Snapshot must return body bytes only")
 }
 
 // TestScreenBuffer_ConcurrentWriteAndSnapshot: Write and SnapshotSince

--- a/backend/internal/worker/terminal/screenbuffer_test.go
+++ b/backend/internal/worker/terminal/screenbuffer_test.go
@@ -285,12 +285,7 @@ func TestScreenBuffer_HasSuffix(t *testing.T) {
 func TestScreenBuffer_SnapshotSince_FallenBehindIncludesModePrefix(t *testing.T) {
 	sb := NewScreenBuffer()
 	sb.Write([]byte("\x1b[?1049h")) // enter alt screen.
-
-	// Push enough bytes that the alt-screen toggle falls out of the ring.
-	chunk := bytes.Repeat([]byte{'x'}, 8*1024)
-	for i := 0; i < 20; i++ { // 160 KB total, ring overwrites by 60 KB.
-		sb.Write(chunk)
-	}
+	sb.Write(ringOverflowFiller())
 
 	data, _, isSnap := sb.SnapshotSince(0)
 	require.True(t, isSnap, "fallen-behind subscriber must get a snapshot")
@@ -324,10 +319,7 @@ func TestScreenBuffer_SnapshotSince_InWindowHasNoPrefix(t *testing.T) {
 func TestScreenBuffer_SnapshotSince_PrefixDoesNotInflateOffset(t *testing.T) {
 	sb := NewScreenBuffer()
 	sb.Write([]byte("\x1b[?1049h"))
-	chunk := bytes.Repeat([]byte{'y'}, 8*1024)
-	for i := 0; i < 20; i++ {
-		sb.Write(chunk)
-	}
+	sb.Write(ringOverflowFiller())
 	expectedTotal := sb.TotalBytes()
 
 	_, end, isSnap := sb.SnapshotSince(0)
@@ -342,10 +334,7 @@ func TestScreenBuffer_SnapshotSince_PrefixDoesNotInflateOffset(t *testing.T) {
 // emit unnecessary bytes on every resubscribe.
 func TestScreenBuffer_SnapshotSince_DefaultStateNoPrefix(t *testing.T) {
 	sb := NewScreenBuffer()
-	chunk := bytes.Repeat([]byte{'z'}, 8*1024)
-	for i := 0; i < 20; i++ {
-		sb.Write(chunk)
-	}
+	sb.Write(ringOverflowFiller())
 
 	data, _, isSnap := sb.SnapshotSince(0)
 	require.True(t, isSnap)
@@ -362,10 +351,7 @@ func TestScreenBuffer_SnapshotSince_DefaultStateNoPrefix(t *testing.T) {
 func TestScreenBuffer_Snapshot_PrefixesPersistedScreenPath(t *testing.T) {
 	sb := NewScreenBuffer()
 	sb.Write([]byte("\x1b[?1049h"))
-	chunk := bytes.Repeat([]byte{'p'}, 8*1024)
-	for i := 0; i < 20; i++ {
-		sb.Write(chunk)
-	}
+	sb.Write(ringOverflowFiller())
 
 	data, end := sb.Snapshot()
 	assert.True(t, bytes.HasPrefix(data, []byte("\x1b[?1049h")),

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -22,25 +22,30 @@ const screenBufferSize = 100 * 1024 // 100KB ring buffer for screen restore
 // It also tracks a cumulative byte counter so callers can resume from a
 // known offset instead of re-reading the full buffer on every subscribe.
 //
-// Retention limit: the ring holds the most recent screenBufferSize bytes
-// of PTY output. Any terminal state established by escape sequences
-// emitted before that window — alt-screen toggles, cursor-visibility
-// changes, scrolling regions, character-set designations, SGR colors,
-// saved cursor position, cell content positioned by earlier writes — is
-// unrecoverable by byte-stream replay alone. A subscriber whose
-// after_offset has fallen out of the window receives a full snapshot
-// that reproduces the retained bytes correctly, but a TUI running
-// *before* that window (vim in alt screen, say) may render with missing
-// cells or misaligned cursor until the program repaints. This is the
-// ceiling of any byte-replay approach; reconstructing state beyond the
-// ring requires a parsed cell grid (tmux-style terminal emulation),
-// which is deliberately out of scope for this worker.
+// Snapshot replies (the bytes a fallen-behind or page-refreshing
+// subscriber needs to reset its xterm and replay) are prefixed with the
+// output of an internal modeTracker that observes a small set of sticky
+// xterm modes — alt-screen toggle, cursor visibility, autowrap, app
+// cursor keys, bracketed paste, mouse tracking/encoding, window title.
+// Programs that entered alt screen well before the retained window
+// still render correctly after a reconnect because the prefix
+// re-establishes the mode before the body bytes replay.
+//
+// What's still out of reach by byte-replay alone (and why the tracker
+// stops where it does): SGR colors / bold / italic, scrolling regions
+// (DECSTBM), saved cursor (DECSC/DECRC), character-set designations,
+// origin mode (DECOM), and the cell content of bytes that fell out of
+// the retained window. SGR self-heals on the next color change. The
+// cell content beyond the ring is irrecoverable in any byte-replay
+// design — only a parsed cell grid (tmux-style emulation) can
+// reconstruct it, which is deliberately out of scope.
 type ScreenBuffer struct {
-	mu    sync.Mutex
-	buf   []byte
-	pos   int
-	full  bool
-	total int64 // Total bytes ever written (monotonic within a PTY session).
+	mu      sync.Mutex
+	buf     []byte
+	pos     int
+	full    bool
+	total   int64 // Total bytes ever written (monotonic within a PTY session).
+	tracker modeTracker
 }
 
 // NewScreenBuffer creates a new screen buffer.
@@ -55,6 +60,12 @@ func (sb *ScreenBuffer) Write(data []byte) int64 {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 
+	// Observe the bytes for sticky-mode tracking before the ring copy.
+	// Order is irrelevant for correctness (feed is a pure function of
+	// data), but feeding first reads naturally and keeps the tracker
+	// state consistent with what a fresh xterm receiving these same
+	// bytes would hold.
+	sb.tracker.feed(data)
 	sb.total += int64(len(data))
 	// Writes larger than the ring would overwrite themselves; only the
 	// final len(buf) bytes can survive, so skip ahead to them.
@@ -85,12 +96,28 @@ func (sb *ScreenBuffer) TotalBytes() int64 {
 }
 
 // Snapshot returns a copy of every retained byte in chronological order
-// and the cumulative offset at the end of that copy. Convenience for
-// callers that want the full buffer regardless of the ring's base offset.
+// (prefixed with the mode tracker's snapshotPrefix so xterm reset+replay
+// still lands the program in the right mode), and the cumulative offset
+// at the end of the body bytes. The prefix is synthesized — it does NOT
+// count toward the offset.
 func (sb *ScreenBuffer) Snapshot() ([]byte, int64) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
-	return sb.tailBytesLocked(sb.retainedLocked()), sb.total
+	body := sb.tailBytesLocked(sb.retainedLocked())
+	return prependPrefix(sb.tracker.snapshotPrefix(), body), sb.total
+}
+
+// prependPrefix concatenates prefix and body. Returns body unchanged
+// when prefix is nil so the common case (default tracker state) avoids
+// the extra alloc + copy.
+func prependPrefix(prefix, body []byte) []byte {
+	if len(prefix) == 0 {
+		return body
+	}
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix...)
+	out = append(out, body...)
+	return out
 }
 
 // HasSuffix reports whether the retained bytes end with needle. Used by
@@ -179,8 +206,11 @@ func (sb *ScreenBuffer) SnapshotSince(afterOffset int64) (data []byte, endOffset
 
 	// Cold subscribe, negative offset, stale offset > total, or caller
 	// has fallen behind the retained window: send everything we have
-	// with the snapshot flag.
-	return sb.tailBytesLocked(sb.retainedLocked()), total, true
+	// with the snapshot flag, prefixed with the tracker's mode-restore
+	// bytes so a TUI in alt screen still renders correctly after the
+	// xterm reset+replay.
+	body := sb.tailBytesLocked(sb.retainedLocked())
+	return prependPrefix(sb.tracker.snapshotPrefix(), body), total, true
 }
 
 // OutputHandler is called for each chunk of output from the PTY. The

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -403,6 +403,83 @@ func TestManager_AppendOutput_AdvancesOffset(t *testing.T) {
 	assert.False(t, isSnap)
 }
 
+// TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind: the manager
+// wrapper must propagate the mode-restore prefix produced inside the
+// ScreenBuffer when a subscriber has fallen out of the retained ring.
+// Tests the seam between Manager and Terminal — easy to break by
+// swapping the ScreenSnapshotSince implementation.
+func TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind(t *testing.T) {
+	m := NewManager()
+	err := m.StartTerminal(context.Background(), Options{
+		ID:         "tm-prefix",
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+		Cols:       80,
+		Rows:       24,
+	}, func(data []byte, _ int64) {}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		m.StopTerminal("tm-prefix")
+		testutil.AssertEventually(t, func() bool { return m.IsExited("tm-prefix") }, "exit")
+		m.RemoveTerminal("tm-prefix")
+	})
+
+	// Inject the alt-screen toggle, then push enough bytes to overwrite
+	// the ring. AppendOutput goes through the same write path so the
+	// tracker observes the toggle.
+	require.True(t, m.AppendOutput("tm-prefix", []byte("\x1b[?1049h")))
+	filler := make([]byte, 8*1024)
+	for i := range filler {
+		filler[i] = 'q'
+	}
+	for i := 0; i < 20; i++ {
+		require.True(t, m.AppendOutput("tm-prefix", filler))
+	}
+
+	data, _, isSnap := m.ScreenSnapshotSince("tm-prefix", 0)
+	require.True(t, isSnap, "fallen-behind subscriber must get a snapshot")
+	require.GreaterOrEqual(t, len(data), len("\x1b[?1049h"))
+	assert.Equal(t, []byte("\x1b[?1049h"), data[:len("\x1b[?1049h")],
+		"manager.ScreenSnapshotSince must propagate the alt-screen restore prefix")
+}
+
+// TestManager_ScreenSnapshot_PrefixesPersistedScreen: ScreenSnapshot is
+// the entry point for the DB-persistence and ListTerminals paths. The
+// prefix MUST appear here too, otherwise alt-screen state is lost
+// across worker restarts even when the bug-fix landed for resubscribe.
+func TestManager_ScreenSnapshot_PrefixesPersistedScreen(t *testing.T) {
+	m := NewManager()
+	err := m.StartTerminal(context.Background(), Options{
+		ID:          "tm-snapshot",
+		WorkspaceID: "ws-snapshot",
+		Shell:       testutil.TestShell(),
+		WorkingDir:  t.TempDir(),
+		Cols:        80,
+		Rows:        24,
+	}, func(data []byte, _ int64) {}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		m.StopTerminal("tm-snapshot")
+		testutil.AssertEventually(t, func() bool { return m.IsExited("tm-snapshot") }, "exit")
+		m.RemoveTerminal("tm-snapshot")
+	})
+
+	require.True(t, m.AppendOutput("tm-snapshot", []byte("\x1b[?1049h")))
+	filler := make([]byte, 8*1024)
+	for i := range filler {
+		filler[i] = 'r'
+	}
+	for i := 0; i < 20; i++ {
+		require.True(t, m.AppendOutput("tm-snapshot", filler))
+	}
+
+	snap, ok := m.SnapshotTerminal("tm-snapshot")
+	require.True(t, ok)
+	require.GreaterOrEqual(t, len(snap.Screen), len("\x1b[?1049h"))
+	assert.Equal(t, []byte("\x1b[?1049h"), snap.Screen[:len("\x1b[?1049h")],
+		"SnapshotTerminal must include the mode-restore prefix so DB-persisted screens survive worker restarts")
+}
+
 func TestManager_IsExited_UnknownTerminal(t *testing.T) {
 	m := NewManager()
 	assert.False(t, m.IsExited("nonexistent"), "expected IsExited = false for unknown terminal")

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -409,7 +409,7 @@ func TestManager_AppendOutput_AdvancesOffset(t *testing.T) {
 // Tests the seam between Manager and Terminal — easy to break by
 // swapping the ScreenSnapshotSince implementation.
 func TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind(t *testing.T) {
-	m := newTestManagerWithTerminal(t, "tm-prefix", Options{
+	m := newTestManagerWithTerminal(t, Options{
 		ID:         "tm-prefix",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
@@ -430,7 +430,7 @@ func TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind(t *testing.T) {
 // prefix MUST appear here too, otherwise alt-screen state is lost
 // across worker restarts even when the bug-fix landed for resubscribe.
 func TestManager_ScreenSnapshot_PrefixesPersistedScreen(t *testing.T) {
-	m := newTestManagerWithTerminal(t, "tm-snapshot", Options{
+	m := newTestManagerWithTerminal(t, Options{
 		ID:          "tm-snapshot",
 		WorkspaceID: "ws-snapshot",
 		Shell:       testutil.TestShell(),
@@ -450,11 +450,10 @@ func TestManager_ScreenSnapshot_PrefixesPersistedScreen(t *testing.T) {
 // newTestManagerWithTerminal starts a Manager + one terminal and wires
 // up the standard cleanup so callers don't repeat the StartTerminal +
 // t.Cleanup boilerplate. The Options are passed through verbatim (so
-// callers can vary WorkspaceID / Cols / Rows) and the terminal id is
-// expected to match Options.ID — splitting the parameter is purely for
-// the cleanup closure.
-func newTestManagerWithTerminal(t *testing.T, id string, opts Options) *Manager {
+// callers can vary WorkspaceID / Cols / Rows).
+func newTestManagerWithTerminal(t *testing.T, opts Options) *Manager {
 	t.Helper()
+	id := opts.ID
 	m := NewManager()
 	err := m.StartTerminal(context.Background(), opts, func(data []byte, _ int64) {}, nil)
 	require.NoError(t, err)
@@ -475,19 +474,6 @@ func pushAltScreenPastRing(t *testing.T, m *Manager, id string) {
 	t.Helper()
 	require.True(t, m.AppendOutput(id, []byte("\x1b[?1049h")))
 	require.True(t, m.AppendOutput(id, ringOverflowFiller()))
-}
-
-// ringOverflowFiller returns plain-ASCII bytes sized just past the
-// retained ring, so writing them is guaranteed to overwrite anything
-// emitted earlier (including a leading mode toggle). 110% of the ring
-// is enough margin to stay correct even if screenBufferSize grows
-// modestly without making test runs gratuitously large.
-func ringOverflowFiller() []byte {
-	out := make([]byte, screenBufferSize+screenBufferSize/10)
-	for i := range out {
-		out[i] = 'x'
-	}
-	return out
 }
 
 func TestManager_IsExited_UnknownTerminal(t *testing.T) {

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -409,32 +409,14 @@ func TestManager_AppendOutput_AdvancesOffset(t *testing.T) {
 // Tests the seam between Manager and Terminal — easy to break by
 // swapping the ScreenSnapshotSince implementation.
 func TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind(t *testing.T) {
-	m := NewManager()
-	err := m.StartTerminal(context.Background(), Options{
+	m := newTestManagerWithTerminal(t, "tm-prefix", Options{
 		ID:         "tm-prefix",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte, _ int64) {}, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		m.StopTerminal("tm-prefix")
-		testutil.AssertEventually(t, func() bool { return m.IsExited("tm-prefix") }, "exit")
-		m.RemoveTerminal("tm-prefix")
 	})
-
-	// Inject the alt-screen toggle, then push enough bytes to overwrite
-	// the ring. AppendOutput goes through the same write path so the
-	// tracker observes the toggle.
-	require.True(t, m.AppendOutput("tm-prefix", []byte("\x1b[?1049h")))
-	filler := make([]byte, 8*1024)
-	for i := range filler {
-		filler[i] = 'q'
-	}
-	for i := 0; i < 20; i++ {
-		require.True(t, m.AppendOutput("tm-prefix", filler))
-	}
+	pushAltScreenPastRing(t, m, "tm-prefix")
 
 	data, _, isSnap := m.ScreenSnapshotSince("tm-prefix", 0)
 	require.True(t, isSnap, "fallen-behind subscriber must get a snapshot")
@@ -448,36 +430,64 @@ func TestManager_ScreenSnapshotSince_ModePrefixOnFallenBehind(t *testing.T) {
 // prefix MUST appear here too, otherwise alt-screen state is lost
 // across worker restarts even when the bug-fix landed for resubscribe.
 func TestManager_ScreenSnapshot_PrefixesPersistedScreen(t *testing.T) {
-	m := NewManager()
-	err := m.StartTerminal(context.Background(), Options{
+	m := newTestManagerWithTerminal(t, "tm-snapshot", Options{
 		ID:          "tm-snapshot",
 		WorkspaceID: "ws-snapshot",
 		Shell:       testutil.TestShell(),
 		WorkingDir:  t.TempDir(),
 		Cols:        80,
 		Rows:        24,
-	}, func(data []byte, _ int64) {}, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		m.StopTerminal("tm-snapshot")
-		testutil.AssertEventually(t, func() bool { return m.IsExited("tm-snapshot") }, "exit")
-		m.RemoveTerminal("tm-snapshot")
 	})
-
-	require.True(t, m.AppendOutput("tm-snapshot", []byte("\x1b[?1049h")))
-	filler := make([]byte, 8*1024)
-	for i := range filler {
-		filler[i] = 'r'
-	}
-	for i := 0; i < 20; i++ {
-		require.True(t, m.AppendOutput("tm-snapshot", filler))
-	}
+	pushAltScreenPastRing(t, m, "tm-snapshot")
 
 	snap, ok := m.SnapshotTerminal("tm-snapshot")
 	require.True(t, ok)
 	require.GreaterOrEqual(t, len(snap.Screen), len("\x1b[?1049h"))
 	assert.Equal(t, []byte("\x1b[?1049h"), snap.Screen[:len("\x1b[?1049h")],
 		"SnapshotTerminal must include the mode-restore prefix so DB-persisted screens survive worker restarts")
+}
+
+// newTestManagerWithTerminal starts a Manager + one terminal and wires
+// up the standard cleanup so callers don't repeat the StartTerminal +
+// t.Cleanup boilerplate. The Options are passed through verbatim (so
+// callers can vary WorkspaceID / Cols / Rows) and the terminal id is
+// expected to match Options.ID — splitting the parameter is purely for
+// the cleanup closure.
+func newTestManagerWithTerminal(t *testing.T, id string, opts Options) *Manager {
+	t.Helper()
+	m := NewManager()
+	err := m.StartTerminal(context.Background(), opts, func(data []byte, _ int64) {}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		m.StopTerminal(id)
+		testutil.AssertEventually(t, func() bool { return m.IsExited(id) }, "exit")
+		m.RemoveTerminal(id)
+	})
+	return m
+}
+
+// pushAltScreenPastRing injects the alt-screen toggle and then enough
+// filler bytes to overwrite the retained ring, so a subsequent snapshot
+// must reach for the modeTracker prefix to recover alt-screen state.
+// AppendOutput goes through the same Write path as live PTY output, so
+// the tracker observes the toggle exactly as it would in production.
+func pushAltScreenPastRing(t *testing.T, m *Manager, id string) {
+	t.Helper()
+	require.True(t, m.AppendOutput(id, []byte("\x1b[?1049h")))
+	require.True(t, m.AppendOutput(id, ringOverflowFiller()))
+}
+
+// ringOverflowFiller returns plain-ASCII bytes sized just past the
+// retained ring, so writing them is guaranteed to overwrite anything
+// emitted earlier (including a leading mode toggle). 110% of the ring
+// is enough margin to stay correct even if screenBufferSize grows
+// modestly without making test runs gratuitously large.
+func ringOverflowFiller() []byte {
+	out := make([]byte, screenBufferSize+screenBufferSize/10)
+	for i := range out {
+		out[i] = 'x'
+	}
+	return out
 }
 
 func TestManager_IsExited_UnknownTerminal(t *testing.T) {

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -49,6 +49,10 @@ if (typeof window !== 'undefined') {
   ;(window as any).__getActiveTerminalRows = () => {
     return (lastActiveTerminalId ? instances.get(lastActiveTerminalId)?.terminal.rows : 0) ?? 0
   }
+  ;(window as any).__getActiveTerminalBufferType = () => {
+    const instance = lastActiveTerminalId ? instances.get(lastActiveTerminalId) : undefined
+    return instance?.terminal.buffer.active.type ?? 'normal'
+  }
 }
 
 /** Per-terminal container that calls terminal.open() exactly once. */

--- a/frontend/tests/e2e/04-terminal.spec.ts
+++ b/frontend/tests/e2e/04-terminal.spec.ts
@@ -96,6 +96,46 @@ test.describe('Terminal', () => {
     await waitForTerminalText(page, 'TERM2MARKER', 30_000)
   })
 
+  test('should keep xterm in alt-screen after page refresh once the ring has wrapped', async ({ page, authenticatedWorkspace }) => {
+    // Reproduces the rendering bug the modeTracker fix exists for:
+    // toggling alt-screen, then emitting >100 KB of output so the
+    // toggle falls out of the worker's retained ring, then refreshing
+    // the page. The frontend hydrates xterm via terminal.reset() +
+    // write(snapshot). Without the tracker prefix, xterm comes up in
+    // main screen and renders the alt-screen body bytes as garbage.
+
+    const saved = waitForLayoutSave(page)
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await saved
+
+    // Toggle alt-screen, paint a sentinel, then push ~150 KB of
+    // filler. `yes ... | head -c N` is portable across macOS and Linux
+    // and emits printable bytes (no null pollution in xterm).
+    await typeInTerminal(page, 'printf \'\\033[?1049h\'; yes leapmux-altscreen-filler | head -c 150000; printf \'DONE_FILLING\\n\'')
+    await waitForTerminalText(page, 'DONE_FILLING', 30_000)
+
+    // Sanity: the terminal is currently in alt screen. If this fails,
+    // the test setup is wrong and the post-refresh assertion below
+    // would be meaningless.
+    const before = await page.evaluate(() => (window as any).__getActiveTerminalBufferType?.() ?? 'normal')
+    expect(before).toBe('alternate')
+
+    await page.reload()
+    await expect(page.locator('[data-testid="tab"][data-tab-type="terminal"]')).toBeVisible()
+    await page.locator('[data-testid="tab"][data-tab-type="terminal"]').click()
+    await expect(page.locator('.xterm')).toBeVisible()
+
+    // The sentinel itself is gone — it fell out of the ring along with
+    // the alt-screen toggle. What we CAN verify is the buffer type:
+    // the tracker's snapshotPrefix must have set xterm back into
+    // alt-screen mode before replay.
+    await expect(async () => {
+      const bufType = await page.evaluate(() => (window as any).__getActiveTerminalBufferType?.() ?? 'normal')
+      expect(bufType).toBe('alternate')
+    }).toPass({ timeout: 30_000 })
+  })
+
   test('should restore terminal screen content after page refresh', async ({ page, authenticatedWorkspace }) => {
     // Start listening for the layout save before opening the terminal
     const saved = waitForLayoutSave(page)

--- a/frontend/tests/e2e/04-terminal.spec.ts
+++ b/frontend/tests/e2e/04-terminal.spec.ts
@@ -115,11 +115,13 @@ test.describe('Terminal', () => {
     await typeInTerminal(page, 'printf \'\\033[?1049h\'; yes leapmux-altscreen-filler | head -c 150000; printf \'DONE_FILLING\\n\'')
     await waitForTerminalText(page, 'DONE_FILLING', 30_000)
 
+    const getBufferType = () =>
+      page.evaluate(() => (window as any).__getActiveTerminalBufferType?.() ?? 'normal')
+
     // Sanity: the terminal is currently in alt screen. If this fails,
     // the test setup is wrong and the post-refresh assertion below
     // would be meaningless.
-    const before = await page.evaluate(() => (window as any).__getActiveTerminalBufferType?.() ?? 'normal')
-    expect(before).toBe('alternate')
+    expect(await getBufferType()).toBe('alternate')
 
     await page.reload()
     await expect(page.locator('[data-testid="tab"][data-tab-type="terminal"]')).toBeVisible()
@@ -131,8 +133,7 @@ test.describe('Terminal', () => {
     // the tracker's snapshotPrefix must have set xterm back into
     // alt-screen mode before replay.
     await expect(async () => {
-      const bufType = await page.evaluate(() => (window as any).__getActiveTerminalBufferType?.() ?? 'normal')
-      expect(bufType).toBe('alternate')
+      expect(await getBufferType()).toBe('alternate')
     }).toPass({ timeout: 30_000 })
   })
 


### PR DESCRIPTION
## Motivation

When a terminal client reconnects or refreshes the page, the backend
replays the retained ring buffer so xterm can restore its state. This
works correctly as long as the mode-setting escape sequences (e.g.,
alt-screen enter, cursor hide, bracketed paste) are still inside that
100 KB ring. Once enough PTY output has been written to push those
sequences out of the ring, reconnecting clients land in the wrong
rendering state — most visibly, a program running in alt-screen mode
appears broken because the alt-screen was never entered on the fresh
xterm instance.

## Modifications

- Added `modeTracker` (`backend/internal/worker/terminal/mode_tracker.go`),
  a minimal escape-sequence parser that observes PTY output and maintains
  live state for 8 sticky xterm modes: alt-screen (DEC 47/1047/1049),
  cursor visibility (DECTCEM), autowrap (DECAWM), application cursor keys
  (DECCKM), bracketed paste, mouse tracking, mouse encoding, and window
  title (OSC 0/2).
- `ScreenBuffer.Snapshot()` and `SnapshotSince()` now prepend a
  synthesized mode-restore escape sequence prefix to the body bytes
  before returning. The prefix is generated on-the-fly and does not
  advance the byte-offset counter, preserving the delta-math used by
  the resume-from-watermark path.
- The tracker is explicitly scoped to only sticky modes lost to ring-buffer
  rotation. It does not track SGR colors, scrolling regions, cursor
  position, or cell content — those either self-heal or require full
  terminal emulation.
- Feed calls on plain text (the vast majority of PTY output) allocate
  nothing. Parser state is held in fixed-size arrays; overflows and
  malformed sequences bail and recover cleanly.
- Added `TestListTerminals_AltScreenRecoveryAfterRingWrap` and
  `TestWatchEvents_Terminal_AltScreenRecoveryAfterRingWrap` in the service
  layer to verify the synthesized prefix appears on the page-refresh and
  cold-subscribe paths respectively, and that `screen_end_offset` reflects
  total PTY bytes rather than payload length.
- Added `window.__getActiveTerminalBufferType()` debug hook in
  `TerminalView.tsx` (returns `'normal'` or `'alternate'`), consistent
  with the existing `__getActiveTerminalText` / `__getActiveTerminalRows`
  hooks, for use by tests.
- Added Playwright E2E test that enters alt-screen, writes ~150 KB of
  filler to push the toggle out of the ring, refreshes the page, and
  asserts the terminal comes back up in the alternate buffer.

## Result

Clients that reconnect or refresh the page after a program has entered
alt-screen mode (or hidden the cursor, enabled bracketed paste, etc.)
now see the terminal in the correct mode, regardless of how much PTY
output has been written since those modes were set. For example, running
`vim` or `htop` and then refreshing the browser tab no longer leaves the
terminal in a broken rendering state.
