### PR TITLE
fix: Stabilize terminal restore, worker shutdown, and E2E tests

### DIFF
--- a/backend/cmd/leapmux/worker.go
+++ b/backend/cmd/leapmux/worker.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -42,8 +43,12 @@ func runWorker(args []string) error {
 		return fmt.Errorf("validate config: %w", err)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+	// Use a manually-cancelled context (rather than signal.NotifyContext)
+	// so SIGTERM/SIGINT can run svcCtx.Shutdown() *before* the bidi stream
+	// is torn down. Otherwise the disconnect-notice broadcasts emitted by
+	// Shutdown race a closed connection and never reach watchers.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Check if we already have credentials from a previous registration.
 	state, err := cfg.LoadState()
@@ -153,9 +158,32 @@ func runWorker(args []string) error {
 	svcCtx.Send = client.Send
 	svcCtx.Channels = channelMgr
 	svcCtx.Init()
-	// Shutdown must run before client.Stop() so terminal screen snapshots
-	// are persisted while in-memory state is still available.
-	defer svcCtx.Shutdown()
+	// svcCtx.Shutdown persists terminal screen snapshots and broadcasts the
+	// "Connection to the terminal was lost" notice to live watchers. Wrap it
+	// in sync.Once so all exit paths (signal, OnDeregister, defer fallback)
+	// converge on a single invocation that runs *before* the bidi stream is
+	// torn down — otherwise the broadcast races a closed connection.
+	var shutdownOnce sync.Once
+	runShutdown := func() {
+		shutdownOnce.Do(func() {
+			slog.Info("draining worker state for graceful shutdown")
+			svcCtx.Shutdown()
+		})
+	}
+	defer runShutdown()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			slog.Info("shutdown signal received")
+			runShutdown()
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 
 	dispatcher := channel.NewDispatcher()
 	service.RegisterAll(dispatcher, svcCtx)
@@ -173,7 +201,8 @@ func runWorker(args []string) error {
 	client.OnDeregister = func() {
 		slog.Info("worker deregistered by hub, clearing state and shutting down")
 		_ = cfg.ClearState()
-		stop()
+		runShutdown()
+		cancel()
 	}
 
 	client.ConnectWithReconnect(ctx, state.AuthToken)

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -299,7 +299,9 @@ func registerTerminalHandlers(d *channel.Dispatcher, svc *Context) {
 	})
 
 	// UpdateTerminalTitle updates a terminal's title in both the in-memory
-	// manager and the database. The frontend debounces calls at 10s intervals.
+	// manager and the database. The frontend throttles calls at 500ms
+	// intervals (kept short so a title set right before shell exit reaches
+	// the worker before the close handler persists meta to DB).
 	d.Register("UpdateTerminalTitle", func(userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
 		var r leapmuxv1.UpdateTerminalTitleRequest
 		if err := unmarshalRequest(req, &r); err != nil {

--- a/frontend/src/components/chat/EditorToolbar.tsx
+++ b/frontend/src/components/chat/EditorToolbar.tsx
@@ -477,6 +477,7 @@ export const EditorToolbar: Component<EditorToolbarProps> = (props) => {
           <button
             type="button"
             class="ghost small"
+            data-testid="enter-mode-toggle"
             onClick={() => {
               props.toggleEnterMode()
               props.setEnterTooltipOpen(true)

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -182,7 +182,11 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
     }
   }
 
-  // Debounce backend title updates: at most once per 10 seconds per terminal.
+  // Throttle backend title updates: at most once per 500 ms per terminal.
+  // Kept short so a title set right before a shell exit (Ctrl+D) reaches
+  // the worker before the close handler persists meta to DB; otherwise
+  // the post-restart restore would show the stale pre-update title.
+  const TITLE_THROTTLE_MS = 500
   const titleTimers = new Map<string, ReturnType<typeof setTimeout>>()
   const titleLastSent = new Map<string, number>()
 
@@ -210,7 +214,7 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
 
     const last = titleLastSent.get(terminalId) ?? 0
     const elapsed = Date.now() - last
-    const delay = Math.max(0, 10_000 - elapsed)
+    const delay = Math.max(0, TITLE_THROTTLE_MS - elapsed)
     if (delay === 0) {
       sendTitleToBackend(terminalId, title)
     }

--- a/frontend/src/components/shell/useWorkspaceRestore.ts
+++ b/frontend/src/components/shell/useWorkspaceRestore.ts
@@ -416,14 +416,17 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
     if (!activeId)
       return
 
-    // A tab needs hydration when its worker-side data hasn't been fetched
-    // yet (status undefined) or when it was marked disconnected after a
-    // temporary worker outage.
+    // A tab needs hydration when its worker-side data is missing: status
+    // undefined, marked DISCONNECTED after a worker outage, or a status
+    // event arrived without the accompanying ListTerminals payload.
+    // `cols` is the discriminator (not `title`) because shells that
+    // don't emit OSC titles would otherwise loop forever.
     const missingByWorker = new Map<string, string[]>()
     for (const tab of tabStore.state.tabs) {
       if (tab.type !== TabType.TERMINAL || !tab.workerId)
         continue
-      if (tab.status !== undefined && tab.status !== TerminalStatus.DISCONNECTED)
+      const hasWorkerSideData = tab.cols !== undefined
+      if (tab.status !== undefined && tab.status !== TerminalStatus.DISCONNECTED && hasWorkerSideData)
         continue
       const ids = missingByWorker.get(tab.workerId) ?? []
       ids.push(tab.id)

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -130,21 +130,34 @@ const TerminalContainer: Component<{
     // the tab store) rather than screen.length — once the backend's ring
     // has wrapped they differ, and the offset is what the backend uses
     // to compute the catch-up delta on resubscribe.
-    if (props.screen && props.screen.length > 0) {
+    //
+    // The screen may also arrive *after* mount when ListTerminals is
+    // queued behind a worker reconnect, so a reactive effect applies it
+    // the first time it becomes non-empty. `applied` latches per
+    // instance so subsequent reactive prop changes don't re-apply the
+    // same snapshot on top of live data.
+    let applied = false
+    createEffect(() => {
+      if (applied)
+        return
+      const screen = props.screen
+      if (!screen || screen.length === 0)
+        return
+      applied = true
       const termId = props.terminalId
       const reportReady = props.onContentReady
       applyTerminalData(
         instance,
-        props.screen,
+        screen,
         true,
-        props.lastOffset ?? props.screen.length,
+        props.lastOffset ?? screen.length,
         0,
         () => {
-          if (bufferHasVisibleContent(instance!.terminal))
+          if (bufferHasVisibleContent(instance.terminal))
             reportReady(termId)
         },
       )
-    }
+    })
 
     // ResizeObserver on this terminal's container element.
     // Only send resize to worker when dimensions actually change to avoid

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -472,6 +472,7 @@ const TreeNode: Component<{
         class={styles.node}
         classList={{ [styles.nodeSelected]: isSelected() }}
         style={{ 'padding-left': indent() }}
+        data-testid="tree-row"
         onClick={toggle}
       >
         <Show

--- a/frontend/src/components/workers/WorkerSectionContent.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.tsx
@@ -73,6 +73,7 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
               <>
                 <div
                   class={listStyles.item}
+                  data-testid="worker-row"
                   onClick={() => toggleExpanded(worker.id)}
                 >
                   <ChevronRight
@@ -80,7 +81,7 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
                     class={`${shared.chevron} ${isExpanded(worker.id) ? shared.chevronExpanded : ''}`}
                   />
                   <Tooltip text={workerName()} showWhen="clipped">
-                    <span class={listStyles.itemTitle}>
+                    <span class={listStyles.itemTitle} data-testid="worker-name">
                       {workerName()}
                     </span>
                   </Tooltip>

--- a/frontend/tests/e2e/09-worker-management.spec.ts
+++ b/frontend/tests/e2e/09-worker-management.spec.ts
@@ -12,7 +12,7 @@ test.describe('Worker Management', () => {
       await workersSection.locator('> [role="button"]').click()
 
     // Should contain the worker named "Local" (dev mode sets LEAPMUX_WORKER_NAME=Local)
-    await expect(workersSection.getByText('Local')).toBeVisible()
+    await expect(workersSection.getByTestId('worker-name').filter({ hasText: 'Local' })).toBeVisible()
   })
 
   test('should show green status dot for online worker', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/14a-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/14a-workspace-archive.spec.ts
@@ -206,7 +206,7 @@ test.describe('Workspace Archive', () => {
 
       // Verify mention button IS visible before archive (via context menu)
       await packageJsonNode.hover()
-      const treeRow = packageJsonNode.locator('..')
+      const treeRow = page.locator('[data-testid="tree-row"]').filter({ hasText: 'package.json' })
       const contextButton = treeRow.locator('[data-testid="tree-context-button"]')
       await expect(contextButton).toBeVisible()
       await contextButton.click()

--- a/frontend/tests/e2e/20-markdown-editor-input.spec.ts
+++ b/frontend/tests/e2e/20-markdown-editor-input.spec.ts
@@ -1015,7 +1015,7 @@ test.describe('Enter Sends Message', () => {
 
   test('Enter sends message after toggling to Enter mode', async ({ page, authenticatedWorkspace }) => {
     // Toggle from default Cmd+Enter mode to Enter-sends mode
-    await page.locator('button:has-text("Enter sends")').click()
+    await page.getByTestId('enter-mode-toggle').click()
 
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
@@ -1038,8 +1038,8 @@ test.describe('Enter Sends Message', () => {
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
-    // The toggle button always contains "Enter sends" text in both modes
-    const enterModeBtn = page.locator('button:has-text("Enter sends")')
+    // The toggle button label flips between modes ("Ctrl+⏎ sends" ↔ "Enter sends")
+    const enterModeBtn = page.getByTestId('enter-mode-toggle')
     await expect(enterModeBtn).toBeVisible()
 
     // Click to toggle from default Cmd+Enter mode to Enter-sends mode
@@ -1055,7 +1055,7 @@ test.describe('Enter Sends Message', () => {
     expect(textAfterFirstSend?.trim()).toBe('')
 
     // Click the same button again to toggle back to Cmd+Enter mode
-    await page.locator('button:has-text("Enter sends")').click()
+    await page.getByTestId('enter-mode-toggle').click()
 
     // Type text and verify Enter creates a newline (doesn't send)
     await editor.click()

--- a/frontend/tests/e2e/25-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/25-chat-message-rendering.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { assistantBubbles, firstAssistantBubble } from './helpers/ui'
+import { assistantBubbles, firstAssistantBubble, waitForAgentIdle } from './helpers/ui'
 
 async function sendAndWaitForReply(page: Page, message: string) {
   const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
@@ -9,8 +9,12 @@ async function sendAndWaitForReply(page: Page, message: string) {
   await page.keyboard.type(message)
   await page.keyboard.press('Meta+Enter')
 
-  // Wait for at least one assistant bubble to appear
+  // Wait for the turn to fully settle before asserting on bubbles. Tests
+  // that hover over earlier messages otherwise race the streaming
+  // auto-scroll, which slides the user bubble out from under the cursor
+  // mid-transition and looks like a flaky :hover drop.
   await expect(firstAssistantBubble(page)).toBeVisible()
+  await waitForAgentIdle(page)
 }
 
 test.describe('Chat Message Rendering', () => {

--- a/frontend/tests/e2e/25-tunnel-ui.spec.ts
+++ b/frontend/tests/e2e/25-tunnel-ui.spec.ts
@@ -77,7 +77,7 @@ async function openWorkerMenu(page: import('@playwright/test').Page) {
   if (!isOpen)
     await workersSection.locator('> [role="button"]').click()
 
-  await expect(workersSection.getByText('Local')).toBeVisible()
+  await expect(workersSection.getByTestId('worker-name').filter({ hasText: 'Local' })).toBeVisible()
 
   const menuButton = workersSection.locator('[aria-expanded]').first()
   await menuButton.click()

--- a/frontend/tests/unit/components/TerminalView.test.tsx
+++ b/frontend/tests/unit/components/TerminalView.test.tsx
@@ -1,6 +1,7 @@
 import type { TerminalInstance } from '~/lib/terminal'
 import { render, waitFor } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
+import { createStore } from 'solid-js/store'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
@@ -246,5 +247,112 @@ describe('terminalView', () => {
 
     pageScroll(-1)
     expect(instance.terminal.scrollPages).toHaveBeenCalledWith(-1)
+  })
+
+  // Regression: the saved screen snapshot can arrive *after* the
+  // TerminalContainer has mounted, e.g. when ListTerminals is queued
+  // behind a worker reconnect on a full-restart restore. The component
+  // must apply the snapshot reactively when `screen` becomes non-empty,
+  // not just inside onMount, or the restored xterm stays blank.
+  //
+  // Uses a Solid store (mirroring tabStore.updateTab in production) so
+  // the terminal object reference stays stable across the screen update
+  // — `<For>` would otherwise unmount + remount on a replaced array
+  // entry and re-trigger onMount, masking the regression.
+  it('applies the screen snapshot when it becomes available after mount', async () => {
+    const instance = makeMockTerminalInstance()
+    mockCreateTerminalInstance.mockReturnValue(instance)
+
+    const initialPayload = new TextEncoder().encode('restored screen')
+    const [terminals, setTerminals] = createStore<Array<{
+      id: string
+      workspaceId: string
+      screen?: Uint8Array
+    }>>([{
+      id: 'term-late-screen',
+      workspaceId: 'ws-1',
+      // screen is undefined initially — ListTerminals hasn't returned yet.
+      screen: undefined,
+    }])
+
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={terminals}
+          activeTerminalId="term-late-screen"
+          visible
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onTitleChange={vi.fn()}
+          onBell={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+
+    // Mount happens with an undefined screen — nothing is written yet.
+    await waitFor(() => {
+      expect(instance.terminal.open).toHaveBeenCalled()
+    })
+    expect(instance.terminal.write).not.toHaveBeenCalled()
+
+    // ListTerminals returns later. tabStore.updateTab mutates the existing
+    // tab's screen field in place — the For loop does NOT re-mount.
+    setTerminals(0, 'screen', initialPayload)
+
+    await waitFor(() => {
+      expect(instance.terminal.write).toHaveBeenCalled()
+    })
+    // The first write should carry the restored payload bytes.
+    const writtenArg = (instance.terminal.write as any).mock.calls[0][0]
+    expect(writtenArg).toBe(initialPayload)
+  })
+
+  // Counterpart: re-applying the snapshot every time props change would
+  // double-paint the restored state on top of any subsequent live data.
+  // The instance-level latch must keep the post-mount effect a one-shot.
+  it('does not re-apply the snapshot when an unrelated prop changes', async () => {
+    const instance = makeMockTerminalInstance()
+    mockCreateTerminalInstance.mockReturnValue(instance)
+
+    const screen = new TextEncoder().encode('once')
+    const [terminals, setTerminals] = createStore<Array<{
+      id: string
+      workspaceId: string
+      screen: Uint8Array
+      title?: string
+    }>>([{
+      id: 'term-no-double-write',
+      workspaceId: 'ws-1',
+      screen,
+      title: 'Initial',
+    }])
+
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={terminals}
+          activeTerminalId="term-no-double-write"
+          visible
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onTitleChange={vi.fn()}
+          onBell={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+
+    await waitFor(() => {
+      expect(instance.terminal.write).toHaveBeenCalledTimes(1)
+    })
+
+    // Bump an unrelated field — screen reference is unchanged.
+    setTerminals(0, 'title', 'Updated')
+
+    // Flush any pending reactive re-runs (microtask + animation frame).
+    await Promise.resolve()
+    await new Promise(r => requestAnimationFrame(() => r(undefined)))
+    expect(instance.terminal.write).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/tests/unit/components/useWorkspaceRestore.test.ts
+++ b/frontend/tests/unit/components/useWorkspaceRestore.test.ts
@@ -2,6 +2,8 @@ import { createRoot, createSignal } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorkspaceRestore } from '~/components/shell/useWorkspaceRestore'
 import { EXPANDED_WORKSPACES_KEY } from '~/components/workspace/expandedWorkspaces'
+import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
+import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createAgentStore } from '~/stores/agent.store'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
 import { createChatStore } from '~/stores/chat.store'
@@ -14,6 +16,7 @@ import { createWorkspaceStoreRegistry } from '~/stores/workspaceStoreRegistry'
 // the synchronous fan-out that happens inside the restore effect.
 const mockListTabsForWorkspace = vi.fn(() => new Promise<never>(() => {}))
 const mockGetLayout = vi.fn(() => new Promise<never>(() => {}))
+const mockListTerminals = vi.fn<(workerId: string, req: { tabIds: string[] }) => Promise<{ terminals: unknown[] }>>(() => new Promise<never>(() => {}))
 
 vi.mock('~/api/listTabsBatcher', () => ({
   listTabsForWorkspace: (...args: unknown[]) => mockListTabsForWorkspace(...args as []),
@@ -27,7 +30,7 @@ vi.mock('~/api/clients', () => ({
 
 vi.mock('~/api/workerRpc', () => ({
   listAgents: vi.fn(() => new Promise<never>(() => {})),
-  listTerminals: vi.fn(() => new Promise<never>(() => {})),
+  listTerminals: (workerId: string, req: { tabIds: string[] }) => mockListTerminals(workerId, req),
 }))
 
 function makeBaseOpts() {
@@ -55,6 +58,8 @@ beforeEach(() => {
   sessionStorage.clear()
   mockListTabsForWorkspace.mockClear()
   mockGetLayout.mockClear()
+  mockListTerminals.mockClear()
+  mockListTerminals.mockImplementation(() => new Promise<never>(() => {}))
 })
 
 afterEach(() => {
@@ -162,6 +167,154 @@ describe('useWorkspaceRestore sibling pre-fetch', () => {
 
     expect(mockListTabsForWorkspace).toHaveBeenCalledTimes(1)
     expect(onExpandWorkspace).not.toHaveBeenCalled()
+
+    dispose()
+  })
+})
+
+describe('useWorkspaceRestore terminal hydration retry', () => {
+  // Regression: after a full hub+worker restart, the WatchEvents catch-up
+  // can deliver a TerminalStatusChange (READY) before ListTerminals
+  // succeeds, leaving tab.status set but the worker-side payload (cols,
+  // title, screen, etc.) still missing. The retry must keep firing until
+  // worker-side fields land — skipping on status alone strands the tab
+  // without dimensions or screen forever.
+  it('re-hydrates a terminal tab whose status is set but worker payload is missing', async () => {
+    const opts = makeBaseOpts()
+    // Seed an existing workspace snapshot so the effect skips the
+    // network restore path and goes straight into the retry pass.
+    opts.registry.set('active-ws', {
+      workspaceId: 'active-ws',
+      tabs: [{
+        type: TabType.TERMINAL,
+        id: 'term-1',
+        workerId: 'worker-1',
+        // Worker-side StatusChange event has set status but cols is
+        // still undefined because ListTerminals hasn't returned yet.
+        status: TerminalStatus.READY,
+      }],
+      activeTabKey: null,
+      layout: { root: { type: 'leaf', id: 'default' }, focusedTileId: null },
+      agents: [],
+      restored: true,
+      tabsLoaded: true,
+    })
+
+    const [activeId, setActiveId] = createSignal<string | null>(null)
+    const [orgId, setOrgId] = createSignal<string | undefined>(undefined)
+
+    const dispose = createRoot((dispose) => {
+      useWorkspaceRestore({
+        ...opts,
+        getActiveWorkspaceId: activeId,
+        getOrgId: orgId,
+      })
+      setActiveId('active-ws')
+      setOrgId('org-1')
+      return dispose
+    })
+
+    await flushEffects()
+
+    expect(mockListTerminals).toHaveBeenCalledTimes(1)
+    expect(mockListTerminals).toHaveBeenCalledWith('worker-1', { tabIds: ['term-1'] })
+
+    dispose()
+  })
+
+  // Counterpart: once the worker payload has populated cols, the tab is
+  // fully hydrated and the retry must stay quiet — no thundering herd of
+  // ListTerminals calls. `title` is intentionally left undefined to
+  // confirm the discriminator is `cols`, not `title` (shells that don't
+  // emit OSC titles would otherwise loop forever).
+  it('does not re-hydrate a terminal tab that already has worker payload', async () => {
+    const opts = makeBaseOpts()
+    opts.registry.set('active-ws', {
+      workspaceId: 'active-ws',
+      tabs: [{
+        type: TabType.TERMINAL,
+        id: 'term-1',
+        workerId: 'worker-1',
+        status: TerminalStatus.READY,
+        cols: 80,
+        rows: 24,
+      }],
+      activeTabKey: null,
+      layout: { root: { type: 'leaf', id: 'default' }, focusedTileId: null },
+      agents: [],
+      restored: true,
+      tabsLoaded: true,
+    })
+
+    const [activeId, setActiveId] = createSignal<string | null>(null)
+    const [orgId, setOrgId] = createSignal<string | undefined>(undefined)
+
+    const dispose = createRoot((dispose) => {
+      useWorkspaceRestore({
+        ...opts,
+        getActiveWorkspaceId: activeId,
+        getOrgId: orgId,
+      })
+      setActiveId('active-ws')
+      setOrgId('org-1')
+      return dispose
+    })
+
+    await flushEffects()
+
+    expect(mockListTerminals).not.toHaveBeenCalled()
+
+    dispose()
+  })
+
+  // Mixed fixture: two tabs on the same worker, one fully hydrated and
+  // one missing its payload. Proves the filter is per-tab (not
+  // per-workspace) and that the RPC carries only the un-hydrated id.
+  it('passes only un-hydrated tab ids to listTerminals', async () => {
+    const opts = makeBaseOpts()
+    opts.registry.set('active-ws', {
+      workspaceId: 'active-ws',
+      tabs: [
+        {
+          type: TabType.TERMINAL,
+          id: 'term-hydrated',
+          workerId: 'worker-1',
+          status: TerminalStatus.READY,
+          cols: 80,
+          rows: 24,
+        },
+        {
+          type: TabType.TERMINAL,
+          id: 'term-missing',
+          workerId: 'worker-1',
+          status: TerminalStatus.READY,
+        },
+      ],
+      activeTabKey: null,
+      layout: { root: { type: 'leaf', id: 'default' }, focusedTileId: null },
+      agents: [],
+      restored: true,
+      tabsLoaded: true,
+    })
+
+    const [activeId, setActiveId] = createSignal<string | null>(null)
+    const [orgId, setOrgId] = createSignal<string | undefined>(undefined)
+
+    const dispose = createRoot((dispose) => {
+      useWorkspaceRestore({
+        ...opts,
+        getActiveWorkspaceId: activeId,
+        getOrgId: orgId,
+      })
+      setActiveId('active-ws')
+      setOrgId('org-1')
+      return dispose
+    })
+
+    await flushEffects()
+
+    expect(mockListTerminals).toHaveBeenCalledTimes(1)
+    expect(mockListTerminals).toHaveBeenCalledWith('worker-1', { tabIds: ['term-missing'] })
 
     dispose()
   })


### PR DESCRIPTION
## Motivation

Several interrelated bugs were causing terminal state to be lost or incorrectly restored after hub and worker restarts, and E2E tests were flaky due to brittle selectors and race conditions.

1. A race condition in worker graceful shutdown caused disconnect-notice broadcasts to fail: the bidirectional stream was torn down before `svcCtx.Shutdown()` completed, so watchers never received the disconnect notice.
2. Terminal titles were throttled at 10-second intervals, meaning a title set just before shell exit would not be flushed to the worker before the close handler wrote metadata to the database, causing stale titles to be restored on reconnect.
3. Terminal screen snapshot hydration ran at mount time, but the snapshot often arrives after mount (queued behind a reconnect message), so the initial screen content was silently dropped.
4. The workspace restore hook used `title` as the discriminator for detecting missing worker-side data. Shells that never emit OSC title sequences would trigger an infinite retry loop.
5. E2E tests used text-based selectors (`getByText`, `button:has-text`) that broke when UI text or styling changed, and a streaming auto-scroll race caused flaky hover-state assertions.

## Modifications

- Replaced `signal.NotifyContext` with manual context management and a goroutine signal handler in `backend/cmd/leapmux/worker.go` so `svcCtx.Shutdown()` runs before the bidi stream closes. Wrapped all shutdown paths in `sync.Once` to prevent duplicate invocations.
- Changed terminal title flush throttle from 10 s to 500 ms in `frontend/src/components/shell/useTerminalOperations.ts`.
- Converted `TerminalView.tsx` to apply the initial screen snapshot via a reactive effect that triggers when the snapshot arrives, rather than unconditionally on mount, with a per-instance latch to prevent double-painting.
- Updated `useWorkspaceRestore.ts` to use `cols` (not `title`) as the discriminator for missing worker-side data, and to distinguish DISCONNECTED status from genuinely absent data.
- Added `data-testid` attributes to `EditorToolbar.tsx`, `DirectoryTree.tsx`, and `WorkerSectionContent.tsx` to give E2E tests stable anchors.
- Added `waitForAgentIdle()` in the `sendAndWaitForReply()` E2E helper to eliminate the auto-scroll/hover race.
- Updated E2E tests in `09-worker-management`, `14a-workspace-archive`, `20-markdown-editor-input`, `25-chat-message-rendering`, and `25-tunnel-ui` to use `data-testid` selectors.
- Added 108-line unit test suite for `TerminalView` covering deferred hydration and one-shot latch behavior.
- Added 155-line unit test expansion for `useWorkspaceRestore` covering the retry mechanism when worker-side payload (cols, rows, screen) arrives after status-change events.

## Result

- Workers now broadcast disconnect notices reliably to all watchers on graceful shutdown.
- Terminal titles and screen content are correctly restored after hub and worker restarts, including for shells that do not emit OSC title sequences.
- Workspace restore no longer loops infinitely for non-OSC-title shells.
- Previously flaky E2E tests pass consistently.
