### PR TITLE
Replace PeekNextSpanColor with ReserveSpanColor and shuffled-deck algorithm

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -812,7 +812,7 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 		return
 	}
 
-	spanColor := b.sink.PeekNextSpanColor()
+	spanColor := b.sink.ReserveSpanColor(tc.ToolCallID, "")
 	if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{
 		SpanID: tc.ToolCallID, SpanType: spanType, SpanColor: spanColor,
 	}); err != nil {

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -318,11 +318,11 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		content = a.enrichResultWithToolUses(content)
 	}
 
-	// Pre-peek the span color for tool_use messages (assistant with a spanID)
+	// Reserve the span color for tool_use messages (assistant with a spanID)
 	// so it is available at persist time, before the span is actually opened.
 	var spanColor int32
 	if msgType == "assistant" && spanID != "" {
-		spanColor = a.sink.PeekNextSpanColor()
+		spanColor = a.sink.ReserveSpanColor(spanID, parentSpanID)
 	}
 
 	// Persist as a standalone message with hierarchy metadata.

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -238,8 +238,8 @@ func (a *CodexAgent) handleItemStarted(params json.RawMessage) {
 			slog.Error("codex persist compacting notification", "agent_id", a.agentID, "error", err)
 		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
-		// Pre-peek the span color before persisting so it is recorded with the message.
-		spanColor := a.sink.PeekNextSpanColor()
+		// Reserve the span color before persisting so it is recorded with the message.
+		spanColor := a.sink.ReserveSpanColor(itemID, parentSpanID)
 		// Persist first at parent depth, then open span so the
 		// completed message is indented under the started message.
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
@@ -250,7 +250,7 @@ func (a *CodexAgent) handleItemStarted(params json.RawMessage) {
 		a.sink.SetSpanType(itemID, itemType)
 		a.sink.OpenSpan(itemID, parentSpanID)
 	case "collabAgentToolCall":
-		spanColor := a.sink.PeekNextSpanColor()
+		spanColor := a.sink.ReserveSpanColor(itemID, parentSpanID)
 		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
 		}); err != nil {

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -45,7 +45,7 @@ type OutputSink interface {
 	ResetSpans()
 	SetSpanType(spanID, spanType string)
 	GetSpanType(spanID string) string
-	PeekNextSpanColor() int32
+	ReserveSpanColor(spanID, parentSpanID string) int32
 	BroadcastStreamChunk(content []byte, spanID string, method string)
 	BroadcastStreamEnd(spanID string)
 	PersistControlRequest(requestID string, payload []byte)

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -99,7 +99,7 @@ func (s *testSink) GetSpanType(spanID string) string {
 	return s.spanTypes[spanID]
 }
 
-func (s *testSink) PeekNextSpanColor() int32 { return 0 }
+func (s *testSink) ReserveSpanColor(spanID, parentSpanID string) int32 { return 0 }
 
 func (s *testSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
 	s.mu.Lock()
@@ -351,7 +351,7 @@ func (noopSink) CloseSpan(string)                                               
 func (noopSink) ResetSpans()                                                          {}
 func (noopSink) SetSpanType(string, string)                                           {}
 func (noopSink) GetSpanType(string) string                                            { return "" }
-func (noopSink) PeekNextSpanColor() int32                                             { return 0 }
+func (noopSink) ReserveSpanColor(string, string) int32                                { return 0 }
 func (noopSink) BroadcastStreamChunk([]byte, string, string)                          {}
 func (noopSink) BroadcastStreamEnd(string)                                            {}
 func (noopSink) PersistControlRequest(string, []byte)                                 {}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"slices"
 	"sort"
 	"sync"
@@ -54,26 +55,95 @@ type SpanLine struct {
 // Color indices are 1-based and wrap around within [1, spanPaletteSize].
 const spanPaletteSize = 8
 
+// pendingSpan holds the color reserved for a span by ReserveSpanColor that
+// hasn't yet been committed by OpenSpan. Treated as "in use" by chooseColor
+// so a back-to-back reservation cannot pick the same color.
+type pendingSpan struct {
+	spanID string
+	color  int
+}
+
 // SpanTracker manages hierarchical span state for an agent's message threading.
 type SpanTracker struct {
 	mu        sync.Mutex
 	spans     []ActiveSpan
 	spanTypes map[string]string // spanID → span type (tool name / item type)
 	parentMap map[string]string // spanID → parentSpanID (persists after close for ancestry lookups)
-	nextColor int
+	pending   *pendingSpan      // color reserved by ReserveSpanColor; consumed by matching OpenSpan.
+	rng       *rand.Rand        // lazy-initialized random source for color choice; tests inject directly.
+	deck      []int             // shuffled draw pile for primary-rule color selection; refilled when empty.
 }
 
-// OpenSpan registers a new subagent span.
-func (t *SpanTracker) OpenSpan(spanID, parentSpanID string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+// randIntn returns a random integer in [0, n) from the tracker's RNG, lazy
+// initializing it on first use. Must be called with t.mu held.
+func (t *SpanTracker) randIntn(n int) int {
+	t.ensureRNG()
+	return t.rng.IntN(n)
+}
 
-	// Record parentage (persists after close for ancestry lookups).
-	if t.parentMap == nil {
-		t.parentMap = make(map[string]string)
+func (t *SpanTracker) ensureRNG() {
+	if t.rng == nil {
+		t.rng = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 	}
-	t.parentMap[spanID] = parentSpanID
+}
 
+// refillDeck repopulates the draw pile with a freshly shuffled palette.
+// Must be called with t.mu held.
+func (t *SpanTracker) refillDeck() {
+	t.ensureRNG()
+	if cap(t.deck) < spanPaletteSize {
+		t.deck = make([]int, spanPaletteSize)
+	} else {
+		t.deck = t.deck[:spanPaletteSize]
+	}
+	for i := 0; i < spanPaletteSize; i++ {
+		t.deck[i] = i + 1
+	}
+	t.rng.Shuffle(len(t.deck), func(i, j int) {
+		t.deck[i], t.deck[j] = t.deck[j], t.deck[i]
+	})
+}
+
+// drawFromDeck returns the first color in the deck that is not blocked,
+// popping it from the pile. If no remaining card is eligible, the deck is
+// refilled and the search retried — guaranteeing every "round" of 8 picks
+// without external blocking constraints visits all 8 palette colors before
+// any repeats. Caller is expected to ensure at least one of
+// {1..spanPaletteSize} is not blocked; if every color is blocked anyway,
+// returns a uniformly random palette color so output keeps flowing.
+// Must be called with t.mu held.
+func (t *SpanTracker) drawFromDeck(blocked map[int]bool) int {
+	if len(t.deck) == 0 {
+		t.refillDeck()
+	}
+	for i, c := range t.deck {
+		if !blocked[c] {
+			t.deck = slices.Delete(t.deck, i, i+1)
+			return c
+		}
+	}
+	// Every remaining card is blocked. Refill once: with a fresh shuffled
+	// deck of all 8 cards, an unblocked color will be found unless the
+	// caller has every palette color blocked.
+	t.refillDeck()
+	for i, c := range t.deck {
+		if !blocked[c] {
+			t.deck = slices.Delete(t.deck, i, i+1)
+			return c
+		}
+	}
+	// Defensive: caller is supposed to fall back to chooseColor's saturated
+	// branch when every color is in use. If we end up here anyway, pick a
+	// random palette color so output keeps flowing rather than crashing.
+	slog.Warn("span color deck exhausted with all colors blocked; using random fallback")
+	return 1 + t.randIntn(spanPaletteSize)
+}
+
+// resolveColumn computes the column index a new span with the given parent
+// would receive if opened now. Mirrors the logic in OpenSpan so that
+// ReserveSpanColor can pre-compute adjacency at peek time without committing
+// any state. Must be called with t.mu held.
+func (t *SpanTracker) resolveColumn(parentSpanID string) int {
 	// Single pass: find parent column, build used-column set, and track the
 	// rightmost active column for minCol computation below.
 	parentCol := -1
@@ -106,18 +176,112 @@ func (t *SpanTracker) OpenSpan(spanID, parentSpanID string) {
 	}
 
 	// Find first free column starting from minCol.
-	column := -1
 	for i := minCol; ; i++ {
 		if !used[i] {
-			column = i
+			return i
+		}
+	}
+}
+
+// chooseColor picks a color for a new span using the two-tier rule:
+//
+//  1. Primary: draw the next eligible color from a shuffled deck of the
+//     full palette, skipping any deck card currently in use by an active
+//     span or pending reservation. The deck is refilled (reshuffled) when
+//     emptied, so any 8-pick window with no blocking constraints visits
+//     every palette color exactly once before any repeats.
+//  2. Fallback (only when every palette color is in use): pick uniformly
+//     at random from colors that are not the parent's, not the
+//     column-immediately-left active span's, and not the
+//     column-immediately-right active span's.
+//
+// Must be called with t.mu held.
+func (t *SpanTracker) chooseColor(parentSpanID string, newColumn int) int {
+	inUse := make(map[int]bool, len(t.spans)+1)
+	allInUse := true
+	for _, s := range t.spans {
+		inUse[s.ColorIndex] = true
+	}
+	if t.pending != nil {
+		inUse[t.pending.color] = true
+	}
+	for c := 1; c <= spanPaletteSize; c++ {
+		if !inUse[c] {
+			allInUse = false
 			break
 		}
 	}
+	if !allInUse {
+		return t.drawFromDeck(inUse)
+	}
 
-	t.nextColor = t.nextColor%spanPaletteSize + 1
+	// Saturated palette: relax exclusion to parent + adjacents only.
+	parentColor := 0
+	leftCol := -1
+	leftColor := 0
+	rightCol := -1
+	rightColor := 0
+	for _, s := range t.spans {
+		if s.SpanID == parentSpanID {
+			parentColor = s.ColorIndex
+		}
+		if s.Column < newColumn && s.Column > leftCol {
+			leftCol = s.Column
+			leftColor = s.ColorIndex
+		}
+		if s.Column > newColumn && (rightCol == -1 || s.Column < rightCol) {
+			rightCol = s.Column
+			rightColor = s.ColorIndex
+		}
+	}
+
+	excluded := make(map[int]bool, 3)
+	if parentColor != 0 {
+		excluded[parentColor] = true
+	}
+	if leftColor != 0 {
+		excluded[leftColor] = true
+	}
+	if rightColor != 0 {
+		excluded[rightColor] = true
+	}
+
+	candidates := make([]int, 0, spanPaletteSize)
+	for c := 1; c <= spanPaletteSize; c++ {
+		if !excluded[c] {
+			candidates = append(candidates, c)
+		}
+	}
+	// At most 3 exclusions vs 8 colors, so candidates is always non-empty.
+	return candidates[t.randIntn(len(candidates))]
+}
+
+// OpenSpan registers a new subagent span.
+func (t *SpanTracker) OpenSpan(spanID, parentSpanID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Record parentage (persists after close for ancestry lookups).
+	if t.parentMap == nil {
+		t.parentMap = make(map[string]string)
+	}
+	t.parentMap[spanID] = parentSpanID
+
+	column := t.resolveColumn(parentSpanID)
+
+	// Honor a pending reservation for this exact span so the persisted
+	// span_color matches the rendered span color.
+	var color int
+	if t.pending != nil && t.pending.spanID == spanID {
+		color = t.pending.color
+		t.pending = nil
+	} else {
+		color = t.chooseColor(parentSpanID, column)
+	}
+
 	t.spans = append(t.spans, ActiveSpan{
 		SpanID:     spanID,
-		ColorIndex: t.nextColor,
+		ColorIndex: color,
 		Column:     column,
 	})
 }
@@ -155,7 +319,8 @@ func (t *SpanTracker) Reset() {
 	defer t.mu.Unlock()
 
 	t.spans = nil
-	t.nextColor = 0
+	t.pending = nil
+	t.deck = t.deck[:0]
 	clear(t.spanTypes)
 	clear(t.parentMap)
 }
@@ -170,6 +335,11 @@ func (t *SpanTracker) CloseSpan(spanID string) {
 	})
 	if t.spanTypes != nil {
 		delete(t.spanTypes, spanID)
+	}
+	// Defensive: if a reservation for this exact span was never consumed by
+	// OpenSpan, drop it so the color goes back to Free.
+	if t.pending != nil && t.pending.spanID == spanID {
+		t.pending = nil
 	}
 	if len(t.spans) == 0 {
 		clear(t.parentMap)
@@ -199,13 +369,25 @@ func (t *SpanTracker) GetSpanType(spanID string) string {
 	return t.spanTypes[spanID]
 }
 
-// PeekNextColor returns the color index that will be assigned to the next
-// span opened via OpenSpan. Safe to call only when output processing is
-// sequential per agent (which it is for both Claude and Codex handlers).
-func (t *SpanTracker) PeekNextColor() int32 {
+// ReserveSpanColor commits to the color that the next OpenSpan(spanID,
+// parentSpanID) call will receive, so the caller can persist the color into
+// a message before the span itself opens. The reservation is held on the
+// tracker's pending slot and consumed when OpenSpan is called for the same
+// spanID. Subsequent calls with the same spanID are idempotent and return
+// the cached color; calls with a different spanID overwrite the slot.
+//
+// Safe to call only when output processing is sequential per agent (which
+// it is for all Claude/Codex/ACP handlers).
+func (t *SpanTracker) ReserveSpanColor(spanID, parentSpanID string) int32 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return int32(t.nextColor%spanPaletteSize + 1)
+	if t.pending != nil && t.pending.spanID == spanID {
+		return int32(t.pending.color)
+	}
+	column := t.resolveColumn(parentSpanID)
+	color := t.chooseColor(parentSpanID, column)
+	t.pending = &pendingSpan{spanID: spanID, color: color}
+	return int32(color)
 }
 
 // Snapshot returns the depth and span lines for a given parentSpanID in a single
@@ -479,8 +661,8 @@ func (s *agentOutputSink) GetSpanType(spanID string) string {
 	return s.tracker.GetSpanType(spanID)
 }
 
-func (s *agentOutputSink) PeekNextSpanColor() int32 {
-	return s.tracker.PeekNextColor()
+func (s *agentOutputSink) ReserveSpanColor(spanID, parentSpanID string) int32 {
+	return s.tracker.ReserveSpanColor(spanID, parentSpanID)
 }
 
 func (s *agentOutputSink) BroadcastStreamChunk(content []byte, spanID string, method string) {

--- a/backend/internal/worker/service/span_tracker_test.go
+++ b/backend/internal/worker/service/span_tracker_test.go
@@ -3,11 +3,34 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newTrackerWithSeed builds a SpanTracker with a deterministic RNG so tests
+// that depend on randomized branches are reproducible.
+func newTrackerWithSeed(seed uint64) *SpanTracker {
+	return &SpanTracker{rng: rand.New(rand.NewPCG(seed, seed^0x9E3779B97F4A7C15))}
+}
+
+// snapshotColor returns the color a given active span has by inspecting the
+// tracker's serialized span lines.
+func snapshotColor(t *testing.T, tracker *SpanTracker, spanID string) int {
+	t.Helper()
+	_, lines, _ := tracker.Snapshot("", "", false)
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	for _, l := range parsed {
+		if l != nil && l.SpanID == spanID {
+			return l.Color
+		}
+	}
+	t.Fatalf("span %q not found in snapshot", spanID)
+	return 0
+}
 
 func TestSpanTracker_OpenClose(t *testing.T) {
 	tracker := &SpanTracker{}
@@ -29,7 +52,8 @@ func TestSpanTracker_OpenClose(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
 	require.Len(t, parsed, 1)
 	assert.Equal(t, "span-1", parsed[0].SpanID)
-	assert.Equal(t, 1, parsed[0].Color)
+	assert.GreaterOrEqual(t, parsed[0].Color, 1)
+	assert.LessOrEqual(t, parsed[0].Color, spanPaletteSize)
 
 	// Close the span.
 	tracker.CloseSpan("span-1")
@@ -54,8 +78,11 @@ func TestSpanTracker_NestedSpans(t *testing.T) {
 	require.Len(t, parsed, 2)
 	assert.Equal(t, "span-1", parsed[0].SpanID)
 	assert.Equal(t, "span-2", parsed[1].SpanID)
-	assert.Equal(t, 1, parsed[0].Color)
-	assert.Equal(t, 2, parsed[1].Color)
+	for _, l := range parsed {
+		assert.GreaterOrEqual(t, l.Color, 1)
+		assert.LessOrEqual(t, l.Color, spanPaletteSize)
+	}
+	assert.NotEqual(t, parsed[0].Color, parsed[1].Color, "parent and nested child should not share a color when palette has free slots")
 }
 
 func TestSpanTracker_ColumnReuse(t *testing.T) {
@@ -111,9 +138,13 @@ func TestSpanTracker_ParallelSpans(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
 	require.Len(t, parsed, 3)
 
-	assert.Equal(t, 1, parsed[0].Color)
-	assert.Equal(t, 2, parsed[1].Color)
-	assert.Equal(t, 3, parsed[2].Color)
+	seen := make(map[int]bool, 3)
+	for _, l := range parsed {
+		assert.GreaterOrEqual(t, l.Color, 1)
+		assert.LessOrEqual(t, l.Color, spanPaletteSize)
+		seen[l.Color] = true
+	}
+	assert.Len(t, seen, 3, "three concurrently active spans must have three distinct colors")
 }
 
 func TestSpanTracker_CloseNonexistent(t *testing.T) {
@@ -130,7 +161,7 @@ func TestSpanTracker_DepthForMainScope(t *testing.T) {
 	assert.Equal(t, int32(0), depth)
 }
 
-func TestSpanTracker_ColorIncrements(t *testing.T) {
+func TestSpanTracker_ColorAfterClose(t *testing.T) {
 	tracker := &SpanTracker{}
 
 	tracker.OpenSpan("span-1", "")
@@ -141,63 +172,70 @@ func TestSpanTracker_ColorIncrements(t *testing.T) {
 	var parsed []*SpanLine
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
 	require.Len(t, parsed, 1)
-	assert.Equal(t, 2, parsed[0].Color)
+	assert.GreaterOrEqual(t, parsed[0].Color, 1)
+	assert.LessOrEqual(t, parsed[0].Color, spanPaletteSize)
 }
 
-func TestSpanTracker_PeekNextColor(t *testing.T) {
+func TestSpanTracker_ReserveSpanColor(t *testing.T) {
 	tracker := &SpanTracker{}
 
-	// First peek returns 1.
-	assert.Equal(t, int32(1), tracker.PeekNextColor())
+	// Reserving for span-1 returns a color in palette range.
+	c1 := tracker.ReserveSpanColor("span-1", "")
+	assert.GreaterOrEqual(t, c1, int32(1))
+	assert.LessOrEqual(t, c1, int32(spanPaletteSize))
 
-	// Opening a span consumes color 1; next peek returns 2.
+	// Reserving again with the same span ID is idempotent.
+	assert.Equal(t, c1, tracker.ReserveSpanColor("span-1", ""))
+
+	// OpenSpan consumes the reservation; the active span has the reserved color.
 	tracker.OpenSpan("span-1", "")
-	assert.Equal(t, int32(2), tracker.PeekNextColor())
+	assert.Equal(t, int(c1), snapshotColor(t, tracker, "span-1"))
 
-	// Close and reopen — peek still advances.
-	tracker.CloseSpan("span-1")
-	assert.Equal(t, int32(2), tracker.PeekNextColor())
-	tracker.OpenSpan("span-2", "")
-	assert.Equal(t, int32(3), tracker.PeekNextColor())
+	// Reserving for span-2 while span-1 is active must avoid span-1's color.
+	c2 := tracker.ReserveSpanColor("span-2", "")
+	assert.GreaterOrEqual(t, c2, int32(1))
+	assert.LessOrEqual(t, c2, int32(spanPaletteSize))
+	assert.NotEqual(t, c1, c2, "second reservation must avoid the active span's color")
 }
 
-func TestSpanTracker_ColorWrapsAroundPalette(t *testing.T) {
+func TestSpanTracker_PaletteSaturation(t *testing.T) {
 	tracker := &SpanTracker{}
 
-	// Open and close spanPaletteSize spans to exhaust the palette.
+	// Open the full palette of root-level spans simultaneously.
 	for i := 0; i < spanPaletteSize; i++ {
 		tracker.OpenSpan(fmt.Sprintf("s%d", i), "")
-		tracker.CloseSpan(fmt.Sprintf("s%d", i))
 	}
 
-	// Next span wraps back to color 1.
-	tracker.OpenSpan("wrap", "")
-	_, lines, _ := tracker.Snapshot("wrap", "", false)
+	_, lines, _ := tracker.Snapshot("", "", false)
 	var parsed []*SpanLine
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
-	require.Len(t, parsed, 1)
-	assert.Equal(t, 1, parsed[0].Color)
+	require.Len(t, parsed, spanPaletteSize)
 
-	// PeekNextColor also wraps.
-	assert.Equal(t, int32(2), tracker.PeekNextColor())
+	seen := make(map[int]bool, spanPaletteSize)
+	for _, l := range parsed {
+		assert.GreaterOrEqual(t, l.Color, 1)
+		assert.LessOrEqual(t, l.Color, spanPaletteSize)
+		seen[l.Color] = true
+	}
+	assert.Len(t, seen, spanPaletteSize, "saturating the palette must use every color exactly once")
 }
 
 func TestSpanTracker_RenderingHints(t *testing.T) {
 	tracker := &SpanTracker{}
 
-	// Two parallel spans: A (col 0, color 1) and B (col 1, color 2).
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "")
+	colorA := snapshotColor(t, tracker, "span-A")
 
 	// Snapshot for a message connecting to span-A (col 0).
-	// Col 0 = connector, col 1 = active_passthrough with passthrough_color = 1.
+	// Col 0 = connector, col 1 = active_passthrough with passthrough_color = colorA.
 	_, lines, _ := tracker.Snapshot("", "span-A", false)
 	var parsed []*SpanLine
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
 	require.Len(t, parsed, 2)
 	assert.Equal(t, SpanLineConnector, parsed[0].Type)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[1].Type)
-	assert.Equal(t, 1, parsed[1].PassthroughColor)
+	assert.Equal(t, colorA, parsed[1].PassthroughColor)
 
 	// Snapshot for a message connecting to span-B (col 1).
 	// Col 0 = active (no passthrough needed), col 1 = connector.
@@ -221,6 +259,7 @@ func TestSpanTracker_ConnectorEnd(t *testing.T) {
 	// Two parallel spans: A (col 0) and B (col 1).
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "")
+	colorA := snapshotColor(t, tracker, "span-A")
 
 	// Closing snapshot for span-A: col 0 = connector_end (└), col 1 = active_passthrough.
 	_, lines, _ := tracker.Snapshot("", "span-A", true)
@@ -229,7 +268,7 @@ func TestSpanTracker_ConnectorEnd(t *testing.T) {
 	require.Len(t, parsed, 2)
 	assert.Equal(t, SpanLineConnectorEnd, parsed[0].Type)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[1].Type)
-	assert.Equal(t, 1, parsed[1].PassthroughColor)
+	assert.Equal(t, colorA, parsed[1].PassthroughColor)
 
 	// Closing snapshot for span-B: col 0 = active, col 1 = connector_end (└).
 	_, lines, _ = tracker.Snapshot("", "span-B", true)
@@ -269,6 +308,7 @@ func TestSpanTracker_PassthroughWithNullSlot(t *testing.T) {
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "")
 	tracker.OpenSpan("span-C", "")
+	colorA := snapshotColor(t, tracker, "span-A")
 	tracker.CloseSpan("span-B")
 
 	// Connect to span-A: col 0 = connector, col 1 = passthrough (null slot),
@@ -280,9 +320,9 @@ func TestSpanTracker_PassthroughWithNullSlot(t *testing.T) {
 	assert.Equal(t, SpanLineConnector, parsed[0].Type)
 	require.NotNil(t, parsed[1])
 	assert.Equal(t, SpanLinePassthrough, parsed[1].Type)
-	assert.Equal(t, 1, parsed[1].PassthroughColor)
+	assert.Equal(t, colorA, parsed[1].PassthroughColor)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[2].Type)
-	assert.Equal(t, 1, parsed[2].PassthroughColor)
+	assert.Equal(t, colorA, parsed[2].PassthroughColor)
 }
 
 func TestSpanTracker_SpanLinesNullSlots(t *testing.T) {
@@ -481,17 +521,18 @@ func TestSpanTracker_MultipleChildrenDepth(t *testing.T) {
 func TestSpanTracker_SnapshotConnectorColor(t *testing.T) {
 	tracker := &SpanTracker{}
 
-	// A (color 1) and B (color 2).
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "")
+	colorA := snapshotColor(t, tracker, "span-A")
+	colorB := snapshotColor(t, tracker, "span-B")
 
-	// Connector to A should return color 1.
+	// Connector to A should return A's color.
 	_, _, connColor := tracker.Snapshot("", "span-A", false)
-	assert.Equal(t, int32(1), connColor)
+	assert.Equal(t, int32(colorA), connColor)
 
-	// Connector to B should return color 2.
+	// Connector to B should return B's color.
 	_, _, connColor = tracker.Snapshot("", "span-B", false)
-	assert.Equal(t, int32(2), connColor)
+	assert.Equal(t, int32(colorB), connColor)
 
 	// No connector returns 0.
 	_, _, connColor = tracker.Snapshot("", "", false)
@@ -508,6 +549,7 @@ func TestSpanTracker_ConnectorOnNestedChild(t *testing.T) {
 	// A (col 0) → B (col 1). Connect to B while A is active.
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "span-A")
+	colorB := snapshotColor(t, tracker, "span-B")
 
 	// Connector to B: A = active, B = connector.
 	_, lines, connColor := tracker.Snapshot("span-A", "span-B", false)
@@ -516,7 +558,7 @@ func TestSpanTracker_ConnectorOnNestedChild(t *testing.T) {
 	require.Len(t, parsed, 2)
 	assert.Equal(t, SpanLineActive, parsed[0].Type)
 	assert.Equal(t, SpanLineConnector, parsed[1].Type)
-	assert.Equal(t, int32(2), connColor)
+	assert.Equal(t, int32(colorB), connColor)
 
 	// Closing connector to B: A = active, B = connector_end.
 	_, lines, _ = tracker.Snapshot("span-A", "span-B", true)
@@ -533,6 +575,8 @@ func TestSpanTracker_ConnectorWithDepthAndPassthrough(t *testing.T) {
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "span-A")
 	tracker.OpenSpan("span-C", "span-B")
+	colorA := snapshotColor(t, tracker, "span-A")
+	colorB := snapshotColor(t, tracker, "span-B")
 
 	_, lines, _ := tracker.Snapshot("", "span-A", false)
 	var parsed []*SpanLine
@@ -540,9 +584,9 @@ func TestSpanTracker_ConnectorWithDepthAndPassthrough(t *testing.T) {
 	require.Len(t, parsed, 3)
 	assert.Equal(t, SpanLineConnector, parsed[0].Type)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[1].Type)
-	assert.Equal(t, 1, parsed[1].PassthroughColor)
+	assert.Equal(t, colorA, parsed[1].PassthroughColor)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[2].Type)
-	assert.Equal(t, 1, parsed[2].PassthroughColor)
+	assert.Equal(t, colorA, parsed[2].PassthroughColor)
 
 	// Connect to B: A = active, B = connector, C = active_passthrough.
 	_, lines, _ = tracker.Snapshot("span-A", "span-B", false)
@@ -551,7 +595,7 @@ func TestSpanTracker_ConnectorWithDepthAndPassthrough(t *testing.T) {
 	assert.Equal(t, SpanLineActive, parsed[0].Type)
 	assert.Equal(t, SpanLineConnector, parsed[1].Type)
 	assert.Equal(t, SpanLineActivePassthrough, parsed[2].Type)
-	assert.Equal(t, 2, parsed[2].PassthroughColor)
+	assert.Equal(t, colorB, parsed[2].PassthroughColor)
 }
 
 func TestSpanTracker_SpanType(t *testing.T) {
@@ -698,8 +742,10 @@ func TestSpanTracker_Reset(t *testing.T) {
 	assert.Equal(t, "", tracker.GetSpanType("span-A"))
 	assert.Equal(t, "", tracker.GetSpanType("span-B"))
 
-	// Color counter resets — next span gets color 1 again.
-	assert.Equal(t, int32(1), tracker.PeekNextColor())
+	// Reservation slot is cleared — a new reserve returns a valid color.
+	c := tracker.ReserveSpanColor("span-X", "")
+	assert.GreaterOrEqual(t, c, int32(1))
+	assert.LessOrEqual(t, c, int32(spanPaletteSize))
 
 	// Tracker is fully reusable after reset.
 	tracker.OpenSpan("span-X", "")
@@ -710,5 +756,196 @@ func TestSpanTracker_Reset(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
 	require.Len(t, parsed, 1)
 	assert.Equal(t, "span-X", parsed[0].SpanID)
-	assert.Equal(t, 1, parsed[0].Color)
+	assert.Equal(t, int(c), parsed[0].Color, "OpenSpan must consume the reserved color")
+}
+
+func TestSpanTracker_ResetClearsPending(t *testing.T) {
+	tracker := &SpanTracker{}
+
+	tracker.ReserveSpanColor("a", "")
+	require.NotNil(t, tracker.pending, "reservation populates pending")
+
+	tracker.Reset()
+	assert.Nil(t, tracker.pending, "Reset must clear pending")
+}
+
+func TestSpanTracker_ResetClearsDeck(t *testing.T) {
+	tracker := newTrackerWithSeed(1)
+
+	// Drain the deck partway by opening and closing a few spans.
+	for i := 0; i < 3; i++ {
+		spanID := fmt.Sprintf("s%d", i)
+		tracker.OpenSpan(spanID, "")
+		tracker.CloseSpan(spanID)
+	}
+	require.NotEmpty(t, tracker.deck, "deck should hold remaining cards mid-round")
+
+	tracker.Reset()
+	assert.Empty(t, tracker.deck, "Reset must drop the in-progress deck so the next turn starts with a fresh shuffle")
+}
+
+func TestSpanTracker_ColorAvoidsActiveColors(t *testing.T) {
+	tracker := newTrackerWithSeed(1)
+
+	// Open spanPaletteSize-1 spans so exactly one color remains free.
+	for i := 0; i < spanPaletteSize-1; i++ {
+		tracker.OpenSpan(fmt.Sprintf("s%d", i), "")
+	}
+
+	// Determine which color is currently free.
+	used := make(map[int]bool)
+	for i := 0; i < spanPaletteSize-1; i++ {
+		used[snapshotColor(t, tracker, fmt.Sprintf("s%d", i))] = true
+	}
+	freeColor := -1
+	for c := 1; c <= spanPaletteSize; c++ {
+		if !used[c] {
+			freeColor = c
+			break
+		}
+	}
+	require.NotEqual(t, -1, freeColor, "exactly one color should be free")
+
+	// The next span MUST get that unique free color.
+	tracker.OpenSpan("last", "")
+	assert.Equal(t, freeColor, snapshotColor(t, tracker, "last"))
+}
+
+func TestSpanTracker_ColorAvoidsParentWhenAvailable(t *testing.T) {
+	for seed := uint64(1); seed <= 20; seed++ {
+		tracker := newTrackerWithSeed(seed)
+		tracker.OpenSpan("parent", "")
+		tracker.OpenSpan("child", "parent")
+
+		parentColor := snapshotColor(t, tracker, "parent")
+		childColor := snapshotColor(t, tracker, "child")
+		assert.NotEqual(t, parentColor, childColor, "child must not share color with parent (seed=%d)", seed)
+	}
+}
+
+func TestSpanTracker_ExhaustedPaletteAvoidsParentAndAdjacent(t *testing.T) {
+	for seed := uint64(1); seed <= 20; seed++ {
+		tracker := newTrackerWithSeed(seed)
+
+		// Open 8 root-level spans; this saturates the palette.
+		for i := 0; i < spanPaletteSize; i++ {
+			tracker.OpenSpan(fmt.Sprintf("s%d", i), "")
+		}
+
+		// Open a 9th span as a child of s3 (col 3). Its column lands at 8
+		// (rightmost), so the only column-adjacent active span is s7 at col 7.
+		tracker.OpenSpan("ninth", "s3")
+		ninthColor := snapshotColor(t, tracker, "ninth")
+		parentColor := snapshotColor(t, tracker, "s3")
+		leftColor := snapshotColor(t, tracker, "s7")
+
+		assert.GreaterOrEqual(t, ninthColor, 1, "color in palette range (seed=%d)", seed)
+		assert.LessOrEqual(t, ninthColor, spanPaletteSize, "color in palette range (seed=%d)", seed)
+		assert.NotEqual(t, parentColor, ninthColor, "saturated branch must avoid parent color (seed=%d)", seed)
+		assert.NotEqual(t, leftColor, ninthColor, "saturated branch must avoid left-adjacent color (seed=%d)", seed)
+	}
+}
+
+func TestSpanTracker_ReserveMatchesOpenSpan(t *testing.T) {
+	tracker := newTrackerWithSeed(42)
+
+	cases := []struct {
+		spanID, parentSpanID string
+	}{
+		{"a", ""},
+		{"b", "a"},
+		{"c", "a"},
+		{"d", "b"},
+	}
+
+	for _, tc := range cases {
+		reserved := tracker.ReserveSpanColor(tc.spanID, tc.parentSpanID)
+		tracker.OpenSpan(tc.spanID, tc.parentSpanID)
+		actual := snapshotColor(t, tracker, tc.spanID)
+		assert.Equal(t, int(reserved), actual, "spanID=%q: OpenSpan must use the reserved color", tc.spanID)
+	}
+}
+
+func TestSpanTracker_ReserveIsIdempotentForSameSpanID(t *testing.T) {
+	tracker := newTrackerWithSeed(7)
+
+	first := tracker.ReserveSpanColor("a", "")
+	second := tracker.ReserveSpanColor("a", "")
+	assert.Equal(t, first, second, "repeated reserve for same spanID must return the same color")
+
+	// Reservation for a different ID computes independently.
+	other := tracker.ReserveSpanColor("b", "")
+	assert.GreaterOrEqual(t, other, int32(1))
+	assert.LessOrEqual(t, other, int32(spanPaletteSize))
+}
+
+func TestSpanTracker_DistributionUsesAllColors(t *testing.T) {
+	tracker := newTrackerWithSeed(99)
+	seen := make(map[int]bool, spanPaletteSize)
+
+	for i := 0; i < 200; i++ {
+		spanID := fmt.Sprintf("s%d", i)
+		tracker.OpenSpan(spanID, "")
+		seen[snapshotColor(t, tracker, spanID)] = true
+		tracker.CloseSpan(spanID)
+	}
+
+	assert.Len(t, seen, spanPaletteSize, "200 root-level openings must observe every palette color at least once")
+}
+
+func TestSpanTracker_ShuffleVisitsAllColorsInWindowOf8(t *testing.T) {
+	// With shuffle-deck selection, any 8 sequential single-span openings
+	// (no concurrent spans constraining the deck) must use all 8 palette
+	// colors before any repeats. Repeat across many seeds and across
+	// multiple back-to-back windows on the same tracker.
+	for seed := uint64(1); seed <= 25; seed++ {
+		tracker := newTrackerWithSeed(seed)
+		for window := 0; window < 3; window++ {
+			seen := make(map[int]bool, spanPaletteSize)
+			for i := 0; i < spanPaletteSize; i++ {
+				spanID := fmt.Sprintf("w%d-s%d", window, i)
+				tracker.OpenSpan(spanID, "")
+				seen[snapshotColor(t, tracker, spanID)] = true
+				tracker.CloseSpan(spanID)
+			}
+			assert.Lenf(t, seen, spanPaletteSize,
+				"seed=%d window=%d: 8 sequential opens must visit all 8 palette colors", seed, window)
+		}
+	}
+}
+
+func TestSpanTracker_PendingCountsAsInUseForNextReserve(t *testing.T) {
+	tracker := newTrackerWithSeed(3)
+
+	first := tracker.ReserveSpanColor("a", "")
+	second := tracker.ReserveSpanColor("b", "")
+
+	assert.NotEqual(t, first, second, "pending color from a previous reserve must count as in use")
+	assert.GreaterOrEqual(t, second, int32(1))
+	assert.LessOrEqual(t, second, int32(spanPaletteSize))
+}
+
+func TestSpanTracker_PendingClearedOnReserveDifferentSpan(t *testing.T) {
+	tracker := newTrackerWithSeed(5)
+
+	tracker.ReserveSpanColor("a", "")
+	bColor := tracker.ReserveSpanColor("b", "")
+
+	// pending now refers to b; opening a recomputes a fresh color.
+	tracker.OpenSpan("a", "")
+	aColor := snapshotColor(t, tracker, "a")
+
+	assert.GreaterOrEqual(t, aColor, 1)
+	assert.LessOrEqual(t, aColor, spanPaletteSize)
+	assert.NotEqual(t, int(bColor), aColor, "a's recomputed color must avoid b's pending color (it counts as in use)")
+}
+
+func TestSpanTracker_CloseClearsPendingForSameSpan(t *testing.T) {
+	tracker := newTrackerWithSeed(11)
+
+	tracker.ReserveSpanColor("a", "")
+	require.NotNil(t, tracker.pending)
+
+	tracker.CloseSpan("a")
+	assert.Nil(t, tracker.pending, "CloseSpan for the pending span must clear pending")
 }


### PR DESCRIPTION
## Motivation
Span color assignment previously used a simple monotonic counter
(1→2→3→...→8→1). Because the counter advanced globally and did not
account for which colors were already in use, simultaneously active spans
frequently received the same color, making it hard to visually distinguish
concurrent subagent threads in the UI.

Additionally, `PeekNextSpanColor()` only previewed the next color without
committing it, so the color written into a persisted message could diverge
from the color actually assigned when the span opened.

## Modifications
- Replaced the monotonic color counter with a shuffled-deck algorithm:
  a deck of all 8 color indices is drawn sequentially and refilled +
  reshuffled when exhausted, guaranteeing all 8 colors are used before
  any repeat within an 8-span window.
- Added two-tier color selection: the primary rule draws from the deck
  while avoiding colors currently held by active spans or pending
  reservations; the fallback (triggered when all 8 colors are in use)
  picks randomly while excluding only the parent, left-adjacent, and
  right-adjacent spans' colors.
- (Breaking) `OutputSink.PeekNextSpanColor() int32` is removed. Use
  `ReserveSpanColor(spanID, parentSpanID string) int32` instead. The new
  method pre-commits a color before the span opens and is idempotent for
  the same `spanID`, so callers can call it multiple times safely.
- `SpanTracker.PeekNextColor()` is removed; replaced by
  `ReserveSpanColor()`.
- Updated all three agent handlers (ACP, Claude, Codex) to call
  `ReserveSpanColor(spanID, parentSpanID)` so that messages carry the
  correct, committed color.
- Added 13 new test functions covering deck shuffling, palette saturation
  fallback, color-avoidance rules, pending-reservation mechanics, and
  distribution properties across 200+ span creations.

## Result
Simultaneously active spans are now assigned distinct colors across the
full 8-color palette before any color is reused, eliminating the visual
collisions that made concurrent subagent threads indistinguishable. When
more than 8 spans are active at once, the fallback heuristic still avoids
the parent and immediately adjacent columns, minimizing confusion. The
color stored in a persisted message is now guaranteed to match the color
used when the span is rendered.
