### PR TITLE
fix(terminal): Default xterm renderer to canvas on Linux/WebKitGTK

### DIFF
--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1926,16 +1926,13 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
 }
 
 fn main() {
-    // Work around known WebKitGTK issues on Linux:
+    // Work around known WebKitGTK DMA-BUF renderer issues on Linux:
     // - DMA-BUF renderer fails with "Failed to create GBM buffer"
-    // - Hardware compositing can trigger Wayland protocol errors
-    //   (tauri-apps/tauri#8541)
-    // Disabling both avoids GPU buffer management issues while
+    // Disabling DMA-BUF avoids GPU buffer management issues while
     // keeping native Wayland support.
     #[cfg(target_os = "linux")]
     {
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 
         // Pin GStreamer's registry cache to a stable per-user file so
         // the plugin scan survives across launches and doesn't collide

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 export type EnterKeyMode = 'enter-sends' | 'cmd-enter-sends'
+export type TerminalRendererPreference = 'auto' | 'webgl' | 'canvas'
 
 /**
  * Browser-level preferences stored as a single JSON object.
@@ -28,6 +29,7 @@ export interface BrowserPreferences {
   expandAgentThoughts?: boolean
   showHiddenMessages?: boolean
   enterKeyMode?: EnterKeyMode
+  terminalRenderer?: TerminalRendererPreference
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { copySelectionToClipboard, createTerminalInstance, resolveTerminalThemeMode } from './terminal'
+import { KEY_BROWSER_PREFS } from './browserStorage'
+import { copySelectionToClipboard, createTerminalInstance, getTerminalRendererPreference, resolveTerminalRendererPreference, resolveTerminalThemeMode } from './terminal'
 
 // xterm.js requires a DOM element for open(), but we can still test
 // the suppressInput mechanism without rendering.
@@ -88,6 +89,66 @@ describe('resolveTerminalThemeMode', () => {
   it('falls back to OS prefers-color-scheme when both prefs defer to system', () => {
     expect(resolveTerminalThemeMode('match-ui', 'system', true)).toBe('dark')
     expect(resolveTerminalThemeMode('match-ui', 'system', false)).toBe('light')
+  })
+})
+
+describe('getTerminalRendererPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+    })
+  })
+
+  it('defaults to auto', () => {
+    expect(getTerminalRendererPreference()).toBe('auto')
+  })
+
+  it('accepts the canvas experiment override', () => {
+    localStorage.setItem(KEY_BROWSER_PREFS, JSON.stringify({ terminalRenderer: 'canvas' }))
+
+    expect(getTerminalRendererPreference()).toBe('canvas')
+  })
+
+  it('ignores unknown values', () => {
+    localStorage.setItem(KEY_BROWSER_PREFS, JSON.stringify({ terminalRenderer: 'invalid' }))
+
+    expect(getTerminalRendererPreference()).toBe('auto')
+  })
+
+  it('defaults auto to WebGL outside Linux desktop Tauri', () => {
+    expect(resolveTerminalRendererPreference('auto')).toBe('webgl')
+  })
+
+  it('defaults auto to canvas on Linux desktop Tauri', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15',
+    })
+
+    expect(resolveTerminalRendererPreference('auto')).toBe('canvas')
+  })
+
+  it('allows WebGL override on Linux desktop Tauri', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15',
+    })
+
+    expect(resolveTerminalRendererPreference('webgl')).toBe('webgl')
   })
 })
 

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -1,13 +1,17 @@
 import type { ITheme } from '@xterm/xterm'
+import type { BrowserPreferences, TerminalRendererPreference } from './browserStorage'
 import type { ThemePreference } from '~/app'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import { loadBrowserPrefs } from './browserStorage'
+import { createLogger } from './logger'
 
 const DEFAULT_MONO_FONT_FAMILY = '"Hack NF", Hack, "SF Mono", Consolas, monospace'
+const log = createLogger('terminal')
 
 export type TerminalThemePreference = 'light' | 'dark' | 'match-ui'
+type ResolvedTerminalRenderer = 'webgl' | 'canvas'
 
 export interface TerminalFontOptions {
   fontFamily?: string
@@ -77,11 +81,37 @@ export const lightTerminalTheme: ITheme = {
 }
 
 /** Get the stored terminal theme preference from localStorage. */
-export function getTerminalThemePreference(): TerminalThemePreference {
-  const stored = loadBrowserPrefs().terminalTheme
+export function getTerminalThemePreference(prefs: BrowserPreferences = loadBrowserPrefs()): TerminalThemePreference {
+  const stored = prefs.terminalTheme
   if (stored === 'light' || stored === 'dark' || stored === 'match-ui')
     return stored
   return 'match-ui'
+}
+
+/** Get the stored terminal renderer preference from localStorage. */
+export function getTerminalRendererPreference(prefs: BrowserPreferences = loadBrowserPrefs()): TerminalRendererPreference {
+  const stored = prefs.terminalRenderer
+  if (stored === 'auto' || stored === 'webgl' || stored === 'canvas')
+    return stored
+  return 'auto'
+}
+
+/** Resolve the renderer preference, defaulting Linux desktop Tauri away from WebGL. */
+export function resolveTerminalRendererPreference(
+  pref: TerminalRendererPreference,
+): ResolvedTerminalRenderer {
+  if (pref === 'canvas' || pref === 'webgl')
+    return pref
+  return isLinuxDesktopTauri() ? 'canvas' : 'webgl'
+}
+
+function isLinuxDesktopTauri(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined')
+    return false
+  if (typeof window.__TAURI_INTERNALS__ === 'undefined')
+    return false
+  // Android UA also contains "Linux", so exclude mobile explicitly.
+  return /\bLinux\b/i.test(navigator.userAgent) && !/android|mobile/i.test(navigator.userAgent)
 }
 
 /**
@@ -178,9 +208,10 @@ export function bufferHasVisibleContent(terminal: Terminal): boolean {
 }
 
 export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: ITheme }): TerminalInstance {
+  const prefs = loadBrowserPrefs()
   const theme = opts?.theme ?? resolveTerminalTheme(
-    getTerminalThemePreference(),
-    (loadBrowserPrefs().theme as ThemePreference) || 'system',
+    getTerminalThemePreference(prefs),
+    (prefs.theme as ThemePreference) || 'system',
     typeof window !== 'undefined'
     && window.matchMedia('(prefers-color-scheme: dark)').matches,
   )
@@ -199,15 +230,23 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   const fitAddon = new FitAddon()
   terminal.loadAddon(fitAddon)
 
-  try {
-    const webglAddon = new WebglAddon()
-    terminal.loadAddon(webglAddon)
-    webglAddon.onContextLoss(() => {
-      webglAddon.dispose()
-    })
+  const preference = getTerminalRendererPreference(prefs)
+  if (resolveTerminalRendererPreference(preference) === 'canvas') {
+    log.debug('terminal_renderer', { renderer: 'canvas', preference })
   }
-  catch {
-    // WebGL not supported, fall back to canvas renderer
+  else {
+    try {
+      const webglAddon = new WebglAddon()
+      terminal.loadAddon(webglAddon)
+      webglAddon.onContextLoss(() => {
+        log.warn('terminal_renderer_webgl_context_lost')
+        webglAddon.dispose()
+      })
+      log.debug('terminal_renderer', { renderer: 'webgl', preference })
+    }
+    catch (error) {
+      log.warn('terminal_renderer', { renderer: 'canvas', preference, reason: 'webgl_unavailable', error })
+    }
   }
 
   // Web fonts (e.g. Hack NF) are declared with font-display: swap and load


### PR DESCRIPTION
## Motivation

WebGL terminal rendering on WebKitGTK (Linux desktop Tauri) produces sporadic frame jank and visible rendering delays. The canvas renderer does not have this problem, so make it the default on Linux desktop while keeping WebGL on every other platform and allowing an explicit override.

## Modifications

- Add a `terminalRenderer` field (`'auto' | 'webgl' | 'canvas'`) to `BrowserPreferences` in `browserStorage.ts`, letting users override the automatic renderer selection.
- Add `TerminalRendererPreference` type, `getTerminalRendererPreference()`, and `resolveTerminalRendererPreference()` to `terminal.ts`. Resolution order: explicit user preference wins; otherwise `'auto'` picks canvas on Linux desktop Tauri and WebGL elsewhere.
- Drop `WEBKIT_DISABLE_COMPOSITING_MODE=1` from the Tauri main process. The comment had cited it as a workaround for a Wayland protocol error (tauri-apps/tauri#8541); removing it re-enables hardware compositing in the WebView. DMA-BUF stays disabled — that is a separate GBM-buffer issue.
- Log the chosen renderer and selection reason on each terminal creation; WebGL context-loss and init-failure paths are now explicitly logged instead of silently swallowed.
- Hoist `loadBrowserPrefs()` in `createTerminalInstance` so localStorage is read once per terminal creation instead of three times. The two preference getters now accept an optional pre-loaded `BrowserPreferences`.
- Add 6 unit tests covering `getTerminalRendererPreference()` and `resolveTerminalRendererPreference()`, including the Linux desktop Tauri auto-default behavior.

## Result

Terminal rendering on Linux desktop no longer exhibits sporadic frame jank from WebGL on WebKitGTK. Users who prefer WebGL can opt back in via the `terminalRenderer` preference. On all other platforms behavior is unchanged.
