### PR TITLE
feat(desktop): Add minimal titlebar chrome for non-workspace routes

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -7,6 +7,7 @@ import { channelManager } from '~/api/workerRpc'
 import { showInfoToast } from '~/components/common/Toast'
 import { LauncherView } from '~/components/desktop/LauncherView'
 import { AboutDialog } from '~/components/shell/AboutDialog'
+import { DesktopMinimalChrome, DesktopRouteChrome } from '~/components/shell/DesktopChrome'
 import { UserMenuDialogs } from '~/components/shell/UserMenu'
 import { setShowAboutDialog, setShowPreferencesDialog, showAboutDialog } from '~/components/shell/UserMenuState'
 import { AuthProvider } from '~/context/AuthContext'
@@ -231,7 +232,12 @@ export default function App() {
               <AuthProvider>
                 <PreferencesProvider>
                   <PreferencesApplier>
-                    <Router root={props => <Suspense>{props.children}</Suspense>}>
+                    <Router root={props => (
+                      <Suspense>
+                        <DesktopRouteChrome>{props.children}</DesktopRouteChrome>
+                      </Suspense>
+                    )}
+                    >
                       <FileRoutes />
                     </Router>
                   </PreferencesApplier>
@@ -241,7 +247,9 @@ export default function App() {
             </DesktopFadeIn>
           </Match>
           <Match when={desktopState() === 'launcher'}>
-            <LauncherView onConnected={() => setDesktopState('connected')} />
+            <DesktopMinimalChrome>
+              <LauncherView onConnected={() => setDesktopState('connected')} />
+            </DesktopMinimalChrome>
           </Match>
         </Switch>
         <Show when={showAboutDialog()}>

--- a/frontend/src/components/desktop/LauncherView.css.ts
+++ b/frontend/src/components/desktop/LauncherView.css.ts
@@ -1,15 +1,21 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
+import { headerHeightPx } from '~/styles/tokens'
+
+const titlebarCenterOffset = `${headerHeightPx / 2}px`
+const opticalCenterOffset = `calc(${titlebarCenterOffset} + 8px)`
 
 export const container = style({
   '--container-gap': '2rem',
+  'boxSizing': 'border-box',
   'display': 'flex',
   'flexDirection': 'column',
   'alignItems': 'center',
   'justifyContent': 'center',
-  'minHeight': '100vh',
+  'minHeight': '100%',
   'maxWidth': '720px',
   'margin': '0 auto',
-  'padding': '2rem',
+  'paddingBlock': `calc(2rem - ${opticalCenterOffset}) calc(2rem + ${opticalCenterOffset})`,
+  'paddingInline': '2rem',
   'gap': 'var(--container-gap)',
   'transition': 'opacity 0.3s ease',
 } as any)
@@ -149,6 +155,10 @@ export const connectBtn = style({
   fontWeight: 500,
   cursor: 'pointer',
   transition: 'opacity 0.15s',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 'var(--space-2)',
   selectors: {
     '&:hover:not(:disabled)': {
       opacity: 0.9,
@@ -158,19 +168,6 @@ export const connectBtn = style({
       cursor: 'not-allowed',
     },
   },
-})
-
-const spin = keyframes({
-  to: { transform: 'rotate(360deg)' },
-})
-
-export const spinner = style({
-  width: '24px',
-  height: '24px',
-  border: '3px solid var(--border)',
-  borderTopColor: 'var(--primary)',
-  borderRadius: '50%',
-  animation: `${spin} 0.6s linear infinite`,
 })
 
 export const errorText = style({

--- a/frontend/src/components/desktop/LauncherView.tsx
+++ b/frontend/src/components/desktop/LauncherView.tsx
@@ -1,8 +1,11 @@
 import type { Component } from 'solid-js'
+import LoaderCircle from 'lucide-solid/icons/loader-circle'
 import { createSignal, onCleanup, onMount } from 'solid-js'
 import { getRuntimeState, platformBridge, restoreWindowGeometry } from '~/api/platformBridge'
+import { Icon } from '~/components/common/Icon'
 import { createLogger } from '~/lib/logger'
 import { formatVersionLine } from '~/lib/systemInfo'
+import { spinner } from '~/styles/animations.css'
 import * as styles from './LauncherView.css'
 
 const log = createLogger('launcher')
@@ -262,9 +265,9 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
           disabled={!canConnect() || loading()}
           onClick={connect}
         >
+          {loading() && <Icon icon={LoaderCircle} size="sm" class={spinner} />}
           Connect
         </button>
-        {loading() && <div class={styles.spinner} />}
         {/* Collapsible error message */}
         <div class={`${styles.collapsible} ${error() ? styles.collapsibleVisible : ''}`} style={{ 'margin-top': 0 }}>
           <div class={styles.collapsibleInner}>

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -30,6 +30,7 @@ import { useChatAutoFocus } from '~/hooks/useChatAutoFocus'
 import { useIsMobile } from '~/hooks/useIsMobile'
 import { useShortcuts } from '~/hooks/useShortcuts'
 import { useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
+import { hasWorkspaceDesktopChrome } from '~/lib/desktopChrome'
 import { createIdentityCache } from '~/lib/identityCache'
 import { createInflightCache } from '~/lib/inflightCache'
 import { createLogger } from '~/lib/logger'
@@ -242,12 +243,7 @@ export const AppShell: ParentComponent = (props) => {
     }
   })
 
-  // Detect if we're on a workspace route
-  const isWorkspaceRoute = createMemo(() => {
-    const path = location.pathname
-    const orgPrefix = `/o/${params.orgSlug}`
-    return path === orgPrefix || path === `${orgPrefix}/` || path.startsWith(`${orgPrefix}/workspace/`)
-  })
+  const isWorkspaceRoute = createMemo(() => hasWorkspaceDesktopChrome(location.pathname))
 
   // True when the URL has a workspace ID but it doesn't exist in the loaded list
   const workspaceNotFound = createMemo(() => {

--- a/frontend/src/components/shell/CustomTitlebar.css.ts
+++ b/frontend/src/components/shell/CustomTitlebar.css.ts
@@ -49,11 +49,19 @@ export const titlebarLayout = style({
   flexDirection: 'column',
   height: '100%',
   width: '100%',
+  minHeight: 0,
 })
 
 export const titlebarContent = style({
   flex: 1,
+  minHeight: 0,
   overflow: 'hidden',
+})
+
+export const minimalTitlebarContent = style({
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
 })
 
 // Optical-balance nudge: Lucide's Menu glyph (three horizontal lines) renders

--- a/frontend/src/components/shell/CustomTitlebar.test.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.test.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { openWebInspector, quitApp, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
+import { openWebInspector, quitApp, windowClose, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
 import { CustomTitlebar } from './CustomTitlebar'
 
 // Hoisted so the vi.mock factories below can close over them — vi.mock
@@ -19,13 +19,9 @@ vi.mock('~/lib/shortcuts/platform', () => ({
   isMac: () => false,
 }))
 
-vi.mock('~/lib/systemInfo', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/lib/systemInfo')>()
-  return {
-    ...actual,
-    isDesktopApp: () => true,
-  }
-})
+vi.mock('~/lib/systemInfo', () => ({
+  isDesktopApp: () => true,
+}))
 
 vi.mock('~/api/platformBridge', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~/api/platformBridge')>()
@@ -63,6 +59,9 @@ vi.mock('~/api/platformBridge', async (importOriginal) => {
 })
 
 vi.mock('~/components/shell/UserMenuItems', () => ({
+  AppAboutMenuItem: () => (
+    <button role="menuitem" onClick={() => setShowAboutDialog(true)}>About LeapMux Desktop...</button>
+  ),
   UserMenuItems: () => (
     <>
       <button role="menuitem">Profile...</button>
@@ -90,6 +89,11 @@ beforeAll(() => {
   }
 })
 
+beforeEach(() => {
+  vi.clearAllMocks()
+  initialMaximized.value = false
+})
+
 function renderTitlebar(activeWorkingDir?: () => string | undefined) {
   return render(() => (
     <CustomTitlebar
@@ -102,11 +106,31 @@ function renderTitlebar(activeWorkingDir?: () => string | undefined) {
   ))
 }
 
-describe('customTitlebar hamburger menu', () => {
-  beforeEach(() => {
-    initialMaximized.value = false
-  })
+function renderMinimalTitlebar() {
+  return render(() => (
+    <CustomTitlebar variant="minimal" />
+  ))
+}
 
+function getMenuItemLabels(container: HTMLElement) {
+  const popover = container.querySelector('[data-testid="app-menu"]')
+  expect(popover).not.toBeNull()
+  const items = popover!.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]')
+  return Array.from(items, el => el.textContent?.trim() ?? '')
+}
+
+function clickMenuItem(labelPrefix: string, renderFn = renderTitlebar) {
+  const { container } = renderFn()
+  const popover = container.querySelector('[data-testid="app-menu"]')!
+  const items = Array.from(popover.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]'))
+  const match = items.find(el => (el.textContent ?? '').trim().startsWith(labelPrefix))
+  if (!match)
+    throw new Error(`menuitem not found for "${labelPrefix}"`)
+  fireEvent.click(match)
+  return container
+}
+
+describe('customTitlebar hamburger menu', () => {
   it('renders the hamburger trigger on Linux desktop', () => {
     renderTitlebar()
     expect(screen.getByTestId('app-menu-trigger')).toBeInTheDocument()
@@ -114,10 +138,7 @@ describe('customTitlebar hamburger menu', () => {
 
   it('dropdown exposes merged account and app items', () => {
     const { container } = renderTitlebar()
-    const popover = container.querySelector('[data-testid="app-menu"]')
-    expect(popover).not.toBeNull()
-    const items = popover!.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]')
-    const labels = Array.from(items, el => el.textContent?.trim() ?? '')
+    const labels = getMenuItemLabels(container)
     expect(labels).toEqual([
       'Profile...',
       'About LeapMux Desktop...',
@@ -130,16 +151,6 @@ describe('customTitlebar hamburger menu', () => {
       expect.stringMatching(/^Quit/),
     ])
   })
-
-  function clickMenuItem(labelPrefix: string) {
-    const { container } = renderTitlebar()
-    const popover = container.querySelector('[data-testid="app-menu"]')!
-    const items = Array.from(popover.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]'))
-    const match = items.find(el => (el.textContent ?? '').trim().startsWith(labelPrefix))
-    if (!match)
-      throw new Error(`menuitem not found for "${labelPrefix}"`)
-    fireEvent.click(match)
-  }
 
   it('quit invokes quitApp', () => {
     clickMenuItem('Quit')
@@ -170,9 +181,7 @@ describe('customTitlebar hamburger menu', () => {
   it('menu item reads "Restore" when the window is maximized', () => {
     initialMaximized.value = true
     const { container } = renderTitlebar()
-    const popover = container.querySelector('[data-testid="app-menu"]')!
-    const items = Array.from(popover.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]'))
-    const labels = items.map(el => (el.textContent ?? '').trim())
+    const labels = getMenuItemLabels(container)
     expect(labels).toContain('Restore')
     expect(labels).not.toContain('Maximize')
   })
@@ -183,6 +192,61 @@ describe('customTitlebar hamburger menu', () => {
     // The Linux window-controls cluster exposes the maximize/restore button via aria-label.
     expect(screen.getByLabelText('Restore')).toBeInTheDocument()
     expect(screen.queryByLabelText('Maximize')).toBeNull()
+  })
+})
+
+describe('customTitlebar minimal variant', () => {
+  it('renders the minimal app and window menu', () => {
+    const { container } = renderMinimalTitlebar()
+    expect(screen.getByTestId('app-menu-trigger')).toBeInTheDocument()
+    expect(getMenuItemLabels(container)).toEqual([
+      'About LeapMux Desktop...',
+      'Minimize',
+      'Maximize',
+      'Open Web Inspector',
+      expect.stringMatching(/^Quit/),
+    ])
+  })
+
+  it('omits workspace and account actions', () => {
+    const { container } = renderMinimalTitlebar()
+    const text = container.textContent ?? ''
+    expect(text).not.toContain('Switch mode')
+    expect(text).not.toContain('Preferences')
+    expect(text).not.toContain('Profile')
+    expect(text).not.toContain('Log out')
+    expect(container.querySelector('[data-testid="open-in-editor"]')).toBeNull()
+    expect(container.querySelector('button[aria-label^="Toggle left sidebar"]')).toBeNull()
+    expect(container.querySelector('button[aria-label^="Toggle right sidebar"]')).toBeNull()
+  })
+
+  it('about sets the about-dialog signal', () => {
+    clickMenuItem('About LeapMux Desktop', renderMinimalTitlebar)
+    expect(setShowAboutDialog).toHaveBeenCalledWith(true)
+  })
+
+  it('window menu actions invoke desktop APIs', () => {
+    clickMenuItem('Minimize', renderMinimalTitlebar)
+    expect(windowMinimize).toHaveBeenCalledTimes(1)
+
+    clickMenuItem('Maximize', renderMinimalTitlebar)
+    expect(windowToggleMaximize).toHaveBeenCalledTimes(1)
+
+    clickMenuItem('Open Web Inspector', renderMinimalTitlebar)
+    expect(openWebInspector).toHaveBeenCalledTimes(1)
+
+    clickMenuItem('Quit', renderMinimalTitlebar)
+    expect(quitApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('right-side window controls include minimize, maximize, and close', () => {
+    renderMinimalTitlebar()
+    fireEvent.click(screen.getByLabelText('Minimize'))
+    expect(windowMinimize).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByLabelText('Maximize'))
+    expect(windowToggleMaximize).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(windowClose).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/src/components/shell/CustomTitlebar.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.tsx
@@ -9,11 +9,10 @@ import { IconButton } from '~/components/common/IconButton'
 import { getShortcutHintsText, shortcutHint } from '~/lib/shortcuts/display'
 import { getPlatform } from '~/lib/shortcuts/platform'
 import { isDesktopApp } from '~/lib/systemInfo'
-import { menuSectionHeader } from '~/styles/shared.css'
 import * as styles from './CustomTitlebar.css'
 import { OpenInEditorButton } from './OpenInEditorButton'
 import { PanelLeftFilled, PanelRightFilled } from './SidebarIcons'
-import { UserMenuItems } from './UserMenuItems'
+import { AppAboutMenuItem, UserMenuItems } from './UserMenuItems'
 import { WindowCloseIcon, WindowMaximizeIcon, WindowMinimizeIcon, WindowRestoreIcon } from './WindowControlIcons'
 
 const platform = getPlatform()
@@ -24,7 +23,8 @@ const showCustomWindowControls = desktop && (platform === 'linux' || platform ==
 const MAC_TRAFFIC_LIGHT_INSET_PX = 78
 const macPadding = desktop && platform === 'mac' ? `${MAC_TRAFFIC_LIGHT_INSET_PX}px` : undefined
 
-interface CustomTitlebarProps {
+interface WorkspaceCustomTitlebarProps {
+  variant?: 'workspace'
   onToggleLeftSidebar: () => void
   onToggleRightSidebar: () => void
   leftSidebarVisible: boolean
@@ -32,6 +32,33 @@ interface CustomTitlebarProps {
   /** Working directory of the active tab, or undefined when nothing is active. */
   activeWorkingDir?: () => string | undefined
 }
+
+interface MinimalCustomTitlebarProps {
+  variant: 'minimal'
+}
+
+type CustomTitlebarProps = WorkspaceCustomTitlebarProps | MinimalCustomTitlebarProps
+
+const WorkspaceActions: Component<WorkspaceCustomTitlebarProps> = props => (
+  <>
+    <OpenInEditorButton workingDir={() => props.activeWorkingDir?.()} />
+
+    <IconButton
+      icon={props.leftSidebarVisible ? PanelLeftFilled : PanelLeft}
+      iconSize="lg"
+      size="md"
+      title={shortcutHint('Toggle left sidebar', 'app.toggleLeftSidebar')}
+      onClick={() => props.onToggleLeftSidebar()}
+    />
+    <IconButton
+      icon={props.rightSidebarVisible ? PanelRightFilled : PanelRight}
+      iconSize="lg"
+      size="md"
+      title={shortcutHint('Toggle right sidebar', 'app.toggleRightSidebar')}
+      onClick={() => props.onToggleRightSidebar()}
+    />
+  </>
+)
 
 export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
   const [isMaximized, setIsMaximized] = createSignal(false)
@@ -60,10 +87,11 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
         )}
         data-testid="app-menu"
       >
-        <UserMenuItems />
+        <Show when={props.variant !== 'minimal'} fallback={<AppAboutMenuItem />}>
+          <UserMenuItems />
+        </Show>
         <Show when={desktop}>
           <hr />
-          <li class={menuSectionHeader}>Window</li>
           <button role="menuitem" onClick={() => void windowMinimize()}>
             <DropdownMenuItemContent label="Minimize" />
           </button>
@@ -81,22 +109,9 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
       <div class={styles.dragRegion} data-tauri-drag-region />
       <div class={styles.titleText}>LeapMux Desktop</div>
 
-      <OpenInEditorButton workingDir={() => props.activeWorkingDir?.()} />
-
-      <IconButton
-        icon={props.leftSidebarVisible ? PanelLeftFilled : PanelLeft}
-        iconSize="lg"
-        size="md"
-        title={shortcutHint('Toggle left sidebar', 'app.toggleLeftSidebar')}
-        onClick={() => props.onToggleLeftSidebar()}
-      />
-      <IconButton
-        icon={props.rightSidebarVisible ? PanelRightFilled : PanelRight}
-        iconSize="lg"
-        size="md"
-        title={shortcutHint('Toggle right sidebar', 'app.toggleRightSidebar')}
-        onClick={() => props.onToggleRightSidebar()}
-      />
+      <Show when={props.variant !== 'minimal'}>
+        <WorkspaceActions {...(props as WorkspaceCustomTitlebarProps)} />
+      </Show>
 
       <Show when={showCustomWindowControls}>
         <div class={styles.windowControls}>

--- a/frontend/src/components/shell/DesktopChrome.tsx
+++ b/frontend/src/components/shell/DesktopChrome.tsx
@@ -1,0 +1,32 @@
+import type { ParentComponent } from 'solid-js'
+import { useLocation } from '@solidjs/router'
+import { Show } from 'solid-js'
+import { isTauriApp } from '~/api/platformBridge'
+import { hasWorkspaceDesktopChrome } from '~/lib/desktopChrome'
+import { CustomTitlebar } from './CustomTitlebar'
+import * as styles from './CustomTitlebar.css'
+
+export const DesktopMinimalChrome: ParentComponent = props => (
+  <div class={styles.titlebarLayout}>
+    <CustomTitlebar variant="minimal" />
+    <div class={styles.minimalTitlebarContent}>
+      {props.children}
+    </div>
+  </div>
+)
+
+export const DesktopRouteChrome: ParentComponent = (props) => {
+  const location = useLocation()
+  const shouldRenderMinimalChrome = () => isTauriApp() && !hasWorkspaceDesktopChrome(location.pathname)
+
+  return (
+    <Show
+      when={shouldRenderMinimalChrome()}
+      fallback={props.children}
+    >
+      <DesktopMinimalChrome>
+        {props.children}
+      </DesktopMinimalChrome>
+    </Show>
+  )
+}

--- a/frontend/src/components/shell/UserMenuItems.tsx
+++ b/frontend/src/components/shell/UserMenuItems.tsx
@@ -15,6 +15,12 @@ import {
   setShowProfileDialog,
 } from './UserMenuState'
 
+export const AppAboutMenuItem: Component = () => (
+  <button role="menuitem" onClick={() => setShowAboutDialog(true)}>
+    {isDesktopApp() ? 'About LeapMux Desktop...' : 'About...'}
+  </button>
+)
+
 export const UserMenuItems: Component = () => {
   const auth = useAuth()
   const org = useOrg()
@@ -52,15 +58,12 @@ export const UserMenuItems: Component = () => {
 
   return (
     <>
-      <li class={menuSectionHeader}>App</li>
       <Show when={!isSoloMode()}>
         <button role="menuitem" onClick={() => setShowProfileDialog(true)}>
           Profile...
         </button>
       </Show>
-      <button role="menuitem" onClick={() => setShowAboutDialog(true)}>
-        {isDesktopApp() ? 'About LeapMux Desktop...' : 'About...'}
-      </button>
+      <AppAboutMenuItem />
       <button role="menuitem" onClick={() => setShowPreferencesDialog(true)}>
         <DropdownMenuItemContent label="Preferences..." shortcut={getShortcutHintsText('app.openPreferences')} />
       </button>
@@ -92,7 +95,6 @@ export const UserMenuItems: Component = () => {
 
       <Show when={isDesktopApp()}>
         <hr />
-        <li class={menuSectionHeader}>Desktop</li>
         <button role="menuitem" onClick={handleSwitchMode}>
           Switch mode...
         </button>

--- a/frontend/src/lib/desktopChrome.test.ts
+++ b/frontend/src/lib/desktopChrome.test.ts
@@ -1,0 +1,20 @@
+/// <reference types="vitest/globals" />
+import { describe, expect, it } from 'vitest'
+import { hasWorkspaceDesktopChrome } from './desktopChrome'
+
+describe('hasWorkspaceDesktopChrome', () => {
+  it('returns true for workspace chrome routes', () => {
+    expect(hasWorkspaceDesktopChrome('/o/acme')).toBe(true)
+    expect(hasWorkspaceDesktopChrome('/o/acme/')).toBe(true)
+    expect(hasWorkspaceDesktopChrome('/o/acme/workspace/ws1')).toBe(true)
+  })
+
+  it('returns false for non-workspace routes', () => {
+    expect(hasWorkspaceDesktopChrome('/login')).toBe(false)
+    expect(hasWorkspaceDesktopChrome('/setup')).toBe(false)
+    expect(hasWorkspaceDesktopChrome('/register/token')).toBe(false)
+    expect(hasWorkspaceDesktopChrome('/oauth/complete-signup')).toBe(false)
+    expect(hasWorkspaceDesktopChrome('/o/acme/org')).toBe(false)
+    expect(hasWorkspaceDesktopChrome('/unknown')).toBe(false)
+  })
+})

--- a/frontend/src/lib/desktopChrome.ts
+++ b/frontend/src/lib/desktopChrome.ts
@@ -1,0 +1,3 @@
+export function hasWorkspaceDesktopChrome(pathname: string): boolean {
+  return /^\/o\/[^/]+(?:\/(?:workspace\/.*)?)?$/.test(pathname)
+}


### PR DESCRIPTION
## Motivation

The desktop app previously showed no titlebar chrome on non-workspace routes (login, setup, launcher), leaving users without window controls or any app menu on those screens. The launcher view also had layout issues where content was not properly centered due to ignoring the titlebar height, and used `100vh` which does not account for the titlebar offset.

## Modifications

- Added a new `DesktopChrome` component module (`DesktopMinimalChrome`, `DesktopRouteChrome`) that conditionally renders a minimal titlebar on non-workspace routes in the Tauri desktop app.
- Extracted route detection into a `hasWorkspaceDesktopChrome(pathname: string)` utility with dedicated tests (`frontend/src/lib/desktopChrome.ts`, `frontend/src/lib/desktopChrome.test.ts`).
- Extended `CustomTitlebar` with a `variant` prop (`"workspace" | "minimal"`) so the minimal variant shows only window controls and the About menu, omitting workspace-specific actions and all menu section headers ("App", "Window", "Desktop").
- Extracted `AppAboutMenuItem` from `UserMenuItems.tsx` so it can be reused in the minimal menu.
- Fixed `LauncherView` layout: replaced `100vh` with relative sizing and added an optical-centering padding offset (half the titlebar height plus 8px) using design tokens.
- Replaced the custom spinner keyframes/style in `LauncherView` with the shared `spinner` style from `~/styles/animations.css`, rendered via the common `Icon` component using `lucide-solid`'s `LoaderCircle`, and moved the indicator inside the Connect button.
- Updated `AppShell` and `app.tsx` to use the new `DesktopRouteChrome` wrapper for route-aware chrome rendering.

## Result

Non-workspace screens (login, setup, launcher) now display a minimal titlebar with window controls and an About menu on desktop, matching expected native app behavior. The launcher view is correctly centered regardless of the titlebar's presence, and the overall chrome code is simpler and easier to extend for future routes.
