### PR TITLE
fix(chat): Show startup banner when auto-starting agent after restart

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1336,6 +1336,18 @@ func (svc *Context) broadcastAgentActive(dbAgent *db.Agent, gitStatus *leapmuxv1
 	})
 }
 
+// broadcastAgentInactive fans out an INACTIVE AgentStatusChange. Used to
+// clear a transient STARTING spinner when an auto-start attempt
+// (ensureAgentRunning) fails — the failure surfaces to the user as a
+// per-message delivery_error rather than a permanent STARTUP_FAILED, so
+// the agent stays retryable on the next send.
+func (svc *Context) broadcastAgentInactive(dbAgent *db.Agent) {
+	svc.Watchers.BroadcastAgentEvent(dbAgent.ID, &leapmuxv1.AgentEvent{
+		AgentId: dbAgent.ID,
+		Event:   &leapmuxv1.AgentEvent_StatusChange{StatusChange: buildAgentInactiveStatus(dbAgent, nil)},
+	})
+}
+
 // runAgentPhase0 broadcasts the per-mode label and executes the git-mode
 // mutation. Returns the result (with rollback metadata populated iff a
 // mutation partially succeeded before failing) and any error.
@@ -1561,8 +1573,15 @@ func (svc *Context) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	model := modelOrDefault(dbAgent.Model, dbAgent.AgentProvider)
 	extraSettings := loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider)
 
+	// Broadcast STARTING so the chat startup banner appears beneath any
+	// just-typed messages while the cold subprocess spins up. Symmetric
+	// with handleClearContext and runAgentStartup; without this, the
+	// auto-start path (cold subprocess after worker/desktop restart) is
+	// silent — the bubble pulses but no progress affordance is shown.
+	svc.broadcastAgentStarting(&dbAgent, "Starting "+agent.DisplayName(dbAgent.AgentProvider)+"…", nil)
+
 	sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
-	confirmedSettings, err := svc.Agents.StartAgent(bgCtx(), agent.Options{
+	confirmedSettings, err := svc.startAgent(bgCtx(), agent.Options{
 		AgentID:         agentID,
 		Model:           model,
 		Effort:          dbAgent.Effort,
@@ -1579,6 +1598,12 @@ func (svc *Context) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	}, sink)
 	if err != nil {
 		slog.Error("ensureAgentRunning: failed to start agent", "agent_id", agentID, "error", err)
+		// Revert the STARTING broadcast so the spinner clears. Caller
+		// surfaces the failure as a per-message delivery_error; we don't
+		// broadcast STARTUP_FAILED here because that would make the
+		// agent permanently unusable until the user opens a new one,
+		// while the existing design keeps it retryable on the next send.
+		svc.broadcastAgentInactive(&dbAgent)
 		return err
 	}
 	if _, err := svc.persistConfirmedAgentSettings(agentID, dbAgent.AgentProvider, model, dbAgent.Effort, dbAgent.PermissionMode, extraSettings, confirmedSettings); err != nil {

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1202,7 +1202,7 @@ func (svc *Context) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	gitStatus := gitutil.GetGitStatus(ctx, agentOpts.WorkingDir)
 
 	// Phase 2: spawn the subprocess and run the init handshake.
-	phase2Msg := "Starting " + agent.DisplayName(agentOpts.AgentProvider) + "…"
+	phase2Msg := agentStartupLabel("Starting", agentOpts.AgentProvider)
 	svc.AgentStartup.setMessage(agentID, phase2Msg)
 	svc.broadcastAgentStarting(&dbAgent, phase2Msg, gitStatus)
 	agent.TraceStartupPhase(agentID, "before_start_agent")
@@ -1303,11 +1303,20 @@ func (svc *Context) buildAgentActiveStatus(dbAgent *db.Agent, gitStatus *leapmux
 }
 
 // buildAgentInactiveStatus builds an INACTIVE AgentStatusChange. Used by
-// WatchEvents replay when the agent is neither running nor starting up
-// and has no persisted startup_error (deriveAgentStatus would return
-// STARTUP_FAILED otherwise).
+// WatchEvents replay (when the agent is neither running nor starting up
+// and has no persisted startup_error, where deriveAgentStatus would
+// otherwise return STARTUP_FAILED) and by broadcastAgentInactive to
+// revert a transient STARTING after an auto-start failure.
 func buildAgentInactiveStatus(dbAgent *db.Agent, gitStatus *leapmuxv1.AgentGitStatus) *leapmuxv1.AgentStatusChange {
 	return baseAgentStatusChange(dbAgent, leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE, gitStatus)
+}
+
+// agentStartupLabel renders the user-visible "<verb> <provider>…" phase
+// label shown beneath the chat startup banner during cold-start and
+// restart of an agent subprocess. Verb is typically "Starting" or
+// "Restarting".
+func agentStartupLabel(verb string, provider leapmuxv1.AgentProvider) string {
+	return verb + " " + agent.DisplayName(provider) + "…"
 }
 
 // broadcastAgentStarting fans out a STARTING AgentStatusChange to all
@@ -1446,7 +1455,7 @@ func (svc *Context) handleClearContext(agentID string) {
 	// after a worker restart that killed the process) shows no progress
 	// affordance until context_cleared lands — by which point the indicator
 	// is suppressed again because the chat history ends in a turn boundary.
-	startingMsg := "Restarting " + agent.DisplayName(dbAgent.AgentProvider) + "…"
+	startingMsg := agentStartupLabel("Restarting", dbAgent.AgentProvider)
 	svc.broadcastAgentStarting(&dbAgent, startingMsg, nil)
 
 	// Stop the running agent and wait for it to fully exit so that
@@ -1578,7 +1587,7 @@ func (svc *Context) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	// with handleClearContext and runAgentStartup; without this, the
 	// auto-start path (cold subprocess after worker/desktop restart) is
 	// silent — the bubble pulses but no progress affordance is shown.
-	svc.broadcastAgentStarting(&dbAgent, "Starting "+agent.DisplayName(dbAgent.AgentProvider)+"…", nil)
+	svc.broadcastAgentStarting(&dbAgent, agentStartupLabel("Starting", dbAgent.AgentProvider), nil)
 
 	sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
 	confirmedSettings, err := svc.startAgent(bgCtx(), agent.Options{

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning verifies
+// that when SendAgentMessage triggers ensureAgentRunning on an INACTIVE agent
+// (e.g. after a worker/desktop restart that killed the subprocess), the
+// auto-start path broadcasts a STARTING AgentStatusChange. Without this, the
+// chat startup banner stays hidden during the restart window even though a
+// just-typed message is queued behind the still-cold subprocess — the bubble
+// pulses but no progress affordance is shown beneath it.
+func TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	// Mock a successful auto-start so the happy path is exercised without
+	// spawning a real subprocess.
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return &leapmuxv1.AgentSettings{}, nil
+	}
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	sender := channel.NewSender(w)
+	svc.Watchers.WatchAgent("agent-1", &EventWatcher{
+		ChannelID: w.channelID,
+		Sender:    sender,
+	})
+
+	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
+		AgentId: "agent-1",
+		Content: "hello",
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	sawStarting := false
+	var startingMessage string
+	for _, stream := range w.streams {
+		ev := decodeWatchAgentEvent(t, stream)
+		sc := ev.GetStatusChange()
+		if sc == nil {
+			continue
+		}
+		if sc.GetStatus() == leapmuxv1.AgentStatus_AGENT_STATUS_STARTING {
+			sawStarting = true
+			startingMessage = sc.GetStartupMessage()
+			break
+		}
+	}
+
+	assert.True(t, sawStarting,
+		"expected STARTING status change while ensureAgentRunning auto-starts the cold subprocess, so the chat startup banner can render beneath the queued user message")
+	assert.NotEmpty(t, startingMessage,
+		"the STARTING broadcast must carry a phase label so the banner renders something readable (e.g. \"Starting Claude Code…\")")
+}
+
+// TestSendAgentMessage_AutoStartFailureRevertsToInactive verifies that when
+// ensureAgentRunning's startAgent call fails, the broadcast sequence ends in
+// INACTIVE — not STARTING (which would leave the banner spinning forever) and
+// not STARTUP_FAILED (which would mark the agent permanently unusable; the
+// existing design intentionally keeps it retryable on the next send by
+// surfacing the failure as a per-message delivery_error instead).
+func TestSendAgentMessage_AutoStartFailureRevertsToInactive(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return nil, assert.AnError
+	}
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	sender := channel.NewSender(w)
+	svc.Watchers.WatchAgent("agent-1", &EventWatcher{
+		ChannelID: w.channelID,
+		Sender:    sender,
+	})
+
+	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
+		AgentId: "agent-1",
+		Content: "hello",
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	startingIdx := -1
+	inactiveIdx := -1
+	startupFailedIdx := -1
+	for i, stream := range w.streams {
+		ev := decodeWatchAgentEvent(t, stream)
+		sc := ev.GetStatusChange()
+		if sc == nil {
+			continue
+		}
+		switch sc.GetStatus() {
+		case leapmuxv1.AgentStatus_AGENT_STATUS_STARTING:
+			if startingIdx == -1 {
+				startingIdx = i
+			}
+		case leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE:
+			if inactiveIdx == -1 {
+				inactiveIdx = i
+			}
+		case leapmuxv1.AgentStatus_AGENT_STATUS_STARTUP_FAILED:
+			if startupFailedIdx == -1 {
+				startupFailedIdx = i
+			}
+		}
+	}
+
+	require.NotEqual(t, -1, startingIdx, "expected a STARTING broadcast at the start of ensureAgentRunning")
+	require.NotEqual(t, -1, inactiveIdx, "expected an INACTIVE broadcast after auto-start failure so the startup banner clears")
+	assert.Less(t, startingIdx, inactiveIdx, "INACTIVE must follow STARTING so the spinner clears after the failed attempt")
+	assert.Equal(t, -1, startupFailedIdx,
+		"auto-start failure on the SendAgentMessage path must NOT mark the agent STARTUP_FAILED — the message gets a delivery_error and the agent stays retryable on the next send")
+}


### PR DESCRIPTION
## Motivation
After a worker or desktop restart, queued messages were delivered via the auto-start path in `ensureAgentRunning`. This path spawned a cold subprocess without broadcasting a STARTING status first, so the chat UI showed no progress affordance — just a pulsing message bubble with no explanation. Users had no indication that an agent was starting up beneath their queued message.

## Modifications
- `ensureAgentRunning` now broadcasts a STARTING status with a startup banner ("Starting \<Provider\>…") before spawning a cold subprocess on the auto-start path, matching the behavior of the manual-start path.
- When auto-start fails, `ensureAgentRunning` broadcasts INACTIVE (rather than STARTUP_FAILED) to clear the transient spinner and leave the agent retryable on the next send via a per-message `delivery_error`.
- Extracted `agentStartupLabel(verb, provider)` helper to consolidate the "\<verb\> \<provider\>…" formatting shared by cold-start and restart paths.
- Switched `svc.Agents.StartAgent` to `svc.startAgent` (the test-mockable wrapper) so the new broadcast sequences can be exercised in unit tests.
- Added `agent_auto_start_test.go` with two tests covering the happy-path (STARTING broadcast appears) and failure-path (STARTING → INACTIVE broadcast sequence).

## Result
After a worker or desktop restart, sending a message while the agent is stopped now shows the startup banner and STARTING spinner in the chat UI immediately, giving users visible progress feedback instead of a silent pulsing bubble. If startup fails, the spinner clears and the agent remains retryable on the next send.
