### PR TITLE
fix(desktop): Detect Zed editor via `zeditor` before falling back to bare `zed`

### DIFF
--- a/desktop/go/editors_linux.go
+++ b/desktop/go/editors_linux.go
@@ -62,9 +62,16 @@ func defaultEditorSpecs() []EditorSpec {
 		{
 			ID:          "zed",
 			DisplayName: "Zed",
+			// `zed` on PATH is the ZFS Event Daemon on systems with
+			// zfs-utils (Arch) or zfsutils-linux (Debian/Ubuntu) — unrelated
+			// to the editor. Distros that hit that collision (Arch's
+			// `extra/zed`, NixOS's `zed-editor`) ship the editor's CLI as
+			// `zeditor`; the Flatpak wrapper `dev.zed.Zed` is similarly
+			// unambiguous. Probe those first; fall through to `zed` last.
 			detect: tryAll(
-				tryLookPath("zed"),
+				tryLookPath("zeditor"),
 				tryPath(flatpakBin+"/dev.zed.Zed"),
+				tryLookPath("zed"),
 			),
 		},
 

--- a/desktop/go/editors_linux_test.go
+++ b/desktop/go/editors_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLinuxSpecs_GatesMatchPlatform(t *testing.T) {
@@ -16,4 +17,70 @@ func TestLinuxSpecs_GatesMatchPlatform(t *testing.T) {
 	}
 	assert.False(t, ids["xcode"], "Xcode must not appear on Linux")
 	assert.False(t, ids["notepad-plus-plus"], "Notepad++ must not appear on Linux")
+}
+
+// findLinuxSpec returns the EditorSpec with the given id from the live Linux
+// registry, or fails the test if no such spec exists.
+func findLinuxSpec(t *testing.T, id string) EditorSpec {
+	t.Helper()
+	for _, s := range defaultEditorSpecs() {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("spec %q not found in defaultEditorSpecs()", id)
+	return EditorSpec{}
+}
+
+// On Arch (and NixOS), the official Zed package ships its CLI as `zeditor`
+// because `zed` was already taken. Detection must find it.
+func TestLinuxZed_DetectsZededitorBinary(t *testing.T) {
+	t.Parallel()
+	p := newFakeProber()
+	p.addLookPath("zeditor", "/usr/bin/zeditor")
+
+	got := findLinuxSpec(t, "zed").detect(p)
+	require.NotNil(t, got, "Zed must be detected when only `zeditor` is on PATH")
+	assert.Equal(t, execKindBinary, got.kind)
+	assert.Equal(t, "/usr/bin/zeditor", got.path)
+}
+
+// On Arch, /usr/bin/zed belongs to zfs-utils (the ZFS Event Daemon), not the
+// editor. If both names are on PATH we MUST pick `zeditor` to avoid invoking
+// the wrong binary against the user's workspace.
+func TestLinuxZed_PrefersZededitorOverZed(t *testing.T) {
+	t.Parallel()
+	p := newFakeProber()
+	p.addLookPath("zed", "/usr/bin/zed")
+	p.addLookPath("zeditor", "/usr/bin/zeditor")
+
+	got := findLinuxSpec(t, "zed").detect(p)
+	require.NotNil(t, got)
+	assert.Equal(t, "/usr/bin/zeditor", got.path,
+		"zeditor is unambiguous; `zed` collides with zfs-utils and must not win")
+}
+
+// Distros without the rename (e.g. users who installed Zed via
+// zed.dev/install.sh on a non-ZFS box) only have `zed` on PATH, and that
+// `zed` really is the editor. Detection must still resolve.
+func TestLinuxZed_FallsBackToZedWhenAlone(t *testing.T) {
+	t.Parallel()
+	p := newFakeProber()
+	p.addLookPath("zed", "/home/u/.local/bin/zed")
+
+	got := findLinuxSpec(t, "zed").detect(p)
+	require.NotNil(t, got)
+	assert.Equal(t, "/home/u/.local/bin/zed", got.path)
+}
+
+// Flatpak install: only the dev.zed.Zed wrapper exists.
+func TestLinuxZed_DetectsFlatpakWrapper(t *testing.T) {
+	t.Parallel()
+	p := newFakeProber()
+	p.addPath("/var/lib/flatpak/exports/bin/dev.zed.Zed")
+
+	got := findLinuxSpec(t, "zed").detect(p)
+	require.NotNil(t, got)
+	assert.Equal(t, execKindBinary, got.kind)
+	assert.Equal(t, "/var/lib/flatpak/exports/bin/dev.zed.Zed", got.path)
 }


### PR DESCRIPTION
## Motivation

The desktop "Open in Editor" feature did not detect the Zed editor on Arch Linux. Arch's official `extra/zed` package ships the CLI as `zeditor` because the bare name `zed` is already claimed by `zfs-utils` (the ZFS Event Daemon, completely unrelated to the editor). NixOS's `zed-editor` derivation applies the same rename. The previous detection chain probed `tryLookPath("zed")` first, so on these distros the editor was reported as missing and never appeared in the menu.

The same name collision creates a second, more dangerous failure mode: on any system with `zfs-utils` (Arch) or `zfsutils-linux` (Debian/Ubuntu) installed but no Zed editor, `zed` on PATH resolves to the ZFS Event Daemon. Clicking "Open in Zed" would have invoked the daemon against the user's workspace path.

## Modifications

- Reordered the Zed editor detection chain in `desktop/go/editors_linux.go` so unambiguous identifiers come first: `zeditor` (Arch's `extra/zed`, NixOS's `zed-editor`), then the Flatpak wrapper `dev.zed.Zed`, and finally bare `zed` as a last resort for users who installed via `zed.dev/install.sh` on a non-ZFS box. The launcher already invokes the absolute path the prober resolves, so no launch-side changes were needed.
- Added a `findLinuxSpec()` test helper and four `TestLinuxZed_*` cases in `desktop/go/editors_linux_test.go` covering the four scenarios: `zeditor`-only, both names present (must prefer `zeditor`), `zed`-only fallback, and Flatpak-wrapper-only.

## Result

On Arch and NixOS, Zed is now detected and listed in "Open in Editor" regardless of whether `zfs-utils` is also installed. On systems with ZFS userland, the ZFS Event Daemon is no longer mistaken for the editor as long as either the editor's `zeditor` CLI or the Flatpak wrapper is present.
