### PR TITLE
feat(chat): Add Ctrl+J/Cmd+J keyboard shortcut to send chat messages

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -19,6 +19,7 @@ import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { EDITOR_MIN_HEIGHT } from '~/lib/editor/editorMinHeight'
 import { formatResetTimestamp, getResetsAt } from '~/lib/rateLimitUtils'
 import { registerEditorRef, unregisterEditorRef } from '~/stores/editorRef.store'
+import { registerPanelSend, unregisterPanelSend } from '~/stores/focusedChatSend.store'
 import { spinner } from '~/styles/animations.css'
 import { iconSize } from '~/styles/tokens'
 import { useAgentInfoCard } from './AgentInfoCard'
@@ -136,6 +137,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         unregisterEditorRef(registeredAgentId)
         registeredAgentId = null
       }
+      if (panelRef)
+        unregisterPanelSend(panelRef)
     })
   })
   createEffect(on(() => props.agentId, (agentId, prevAgentId) => {
@@ -205,6 +208,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
       ref={panelRef}
       class={styles.editorPanelWrapper}
       data-testid="agent-editor-panel"
+      data-chat-panel
     >
       <div
         class={`${styles.editorResizeHandle} ${isDragging() ? styles.editorResizeHandleActive : ''}`}
@@ -256,6 +260,8 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
             sendRef: (fn) => {
               triggerSend = fn
               props.triggerSendRef?.(fn)
+              if (panelRef)
+                registerPanelSend(panelRef, fn)
             },
             focusRef: (fn) => {
               editorFocusFn = fn

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
@@ -503,6 +503,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         class={styles.editorWrapper}
         ref={editorRef}
         data-testid="chat-editor"
+        data-chat-input
         style={editorWrapperStyle()}
       />
       <CodeLanguagePopover

--- a/frontend/src/hooks/useShortcuts.test.tsx
+++ b/frontend/src/hooks/useShortcuts.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Dialog } from '~/components/common/Dialog'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { executeCommand, getCommand, resetCommands } from '~/lib/shortcuts/commands'
+import { evaluateWhen } from '~/lib/shortcuts/context'
+import { registerPanelSend, unregisterPanelSend } from '~/stores/focusedChatSend.store'
 import { useShortcuts } from './useShortcuts'
 
 const refreshFileTree = vi.fn()
@@ -283,6 +285,83 @@ describe('useShortcuts', () => {
       expect(props.termOps.handleOpenTerminal).not.toHaveBeenCalled()
       expect(props.setShowNewTerminalDialog).not.toHaveBeenCalled()
       expect(props.setShowNewWorkspace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('chat.sendMessage', () => {
+    afterEach(() => {
+      document.body.innerHTML = ''
+    })
+
+    it('invokes the registered send fn for the panel containing focused element', () => {
+      const props = makeProps()
+
+      render(() => {
+        useShortcuts(props as any)
+        return null
+      })
+
+      const panel = document.createElement('div')
+      panel.setAttribute('data-chat-panel', '')
+      const input = document.createElement('input')
+      panel.appendChild(input)
+      document.body.appendChild(panel)
+
+      const send = vi.fn()
+      registerPanelSend(panel, send)
+      input.focus()
+
+      executeCommand('chat.sendMessage')
+      expect(send).toHaveBeenCalledOnce()
+
+      unregisterPanelSend(panel)
+    })
+
+    it('is a no-op when focus is not inside a chat panel', () => {
+      const props = makeProps()
+
+      render(() => {
+        useShortcuts(props as any)
+        return null
+      })
+
+      const send = vi.fn()
+      const panel = document.createElement('div')
+      panel.setAttribute('data-chat-panel', '')
+      document.body.appendChild(panel)
+      registerPanelSend(panel, send)
+
+      const outside = document.createElement('input')
+      document.body.appendChild(outside)
+      outside.focus()
+
+      executeCommand('chat.sendMessage')
+      expect(send).not.toHaveBeenCalled()
+
+      unregisterPanelSend(panel)
+    })
+
+    it('chatInputFocused is true only when focus is inside [data-chat-input]', () => {
+      const props = makeProps()
+
+      render(() => {
+        useShortcuts(props as any)
+        return null
+      })
+
+      const editor = document.createElement('div')
+      editor.setAttribute('data-chat-input', '')
+      const inside = document.createElement('input')
+      editor.appendChild(inside)
+
+      const outside = document.createElement('input')
+      document.body.append(editor, outside)
+
+      inside.focus()
+      expect(evaluateWhen('chatInputFocused')).toBe(true)
+
+      outside.focus()
+      expect(evaluateWhen('chatInputFocused')).toBe(false)
     })
   })
 

--- a/frontend/src/hooks/useShortcuts.ts
+++ b/frontend/src/hooks/useShortcuts.ts
@@ -19,6 +19,7 @@ import { DEFAULT_KEYBINDINGS } from '~/lib/shortcuts/defaults'
 import { activateBindings, mergeKeybindings, unbindAll } from '~/lib/shortcuts/keybindings'
 import { getPlatform } from '~/lib/shortcuts/platform'
 import { getPrimaryBindingForCommand, tinykeysToTauriAccelerator } from '~/lib/shortcuts/tauriAccelerator'
+import { getFocusedChatSend } from '~/stores/focusedChatSend.store'
 import { tabKey } from '~/stores/tab.store'
 
 interface UseShortcutsProps {
@@ -215,6 +216,10 @@ export function useShortcuts(props: UseShortcutsProps): void {
   cmd('app.scrollActiveTabPageUp', 'Scroll Active Tab Up One Page', () => scrollActiveTabPage(-1), 'View')
   cmd('app.scrollActiveTabPageDown', 'Scroll Active Tab Down One Page', () => scrollActiveTabPage(1), 'View')
 
+  cmd('chat.sendMessage', 'Send Message', () => {
+    getFocusedChatSend()?.()
+  }, 'Chat')
+
   // Terminal cursor navigation
   cmd('terminal.lineStart', 'Go to Line Start', () => writeToFocusedTerminal('\x01'), 'Terminal')
   cmd('terminal.lineEnd', 'Go to Line End', () => writeToFocusedTerminal('\x05'), 'Terminal')
@@ -239,6 +244,11 @@ export function useShortcuts(props: UseShortcutsProps): void {
   registerLazyContext('editorFocused', () => {
     const el = document.activeElement
     return !!el?.closest('.ProseMirror')
+  })
+
+  registerLazyContext('chatInputFocused', () => {
+    const el = document.activeElement
+    return !!el?.closest('[data-chat-input]')
   })
 
   registerLazyContext('terminalFocused', () => {
@@ -294,6 +304,7 @@ export function useShortcuts(props: UseShortcutsProps): void {
     observer?.disconnect()
     unregisterLazyContext('inputFocused')
     unregisterLazyContext('editorFocused')
+    unregisterLazyContext('chatInputFocused')
     unregisterLazyContext('terminalFocused')
   })
 }

--- a/frontend/src/lib/shortcuts/defaults.ts
+++ b/frontend/src/lib/shortcuts/defaults.ts
@@ -72,4 +72,7 @@ export const DEFAULT_KEYBINDINGS: readonly Keybinding[] = [
   // Desktop-only
   { key: '$mod+q', command: 'app.quit', when: 'isDesktop' },
   { key: '$mod+Shift+e', command: 'app.openInExternalEditor', when: '!dialogOpen && isDesktop' },
+
+  // Chat input
+  { key: '$mod+j', command: 'chat.sendMessage', when: 'chatInputFocused' },
 ]

--- a/frontend/src/lib/shortcuts/keybindings.test.ts
+++ b/frontend/src/lib/shortcuts/keybindings.test.ts
@@ -235,3 +235,46 @@ describe('activateBindings (Mac Option dead-key)', () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('activateBindings (IME composition)', () => {
+  afterEach(() => {
+    unbindAll()
+    resetCommands()
+  })
+
+  it('does not invoke the handler while an IME composition is active', () => {
+    const handler = vi.fn()
+    resetCommands()
+    registerCommand({ id: 'test.composing', title: 'Test', handler })
+
+    activateBindings([{ key: '$mod+j', command: 'test.composing' }])
+
+    // Simulate a keydown that fires during CJK composition (e.g. Korean
+    // double-consonant input on macOS where event.isComposing is true).
+    const event = new KeyboardEvent('keydown', {
+      key: 'j',
+      code: 'KeyJ',
+      ctrlKey: true,
+    })
+    Object.defineProperty(event, 'isComposing', { get: () => true })
+    window.dispatchEvent(event)
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('still invokes the handler when isComposing is false', () => {
+    const handler = vi.fn()
+    resetCommands()
+    registerCommand({ id: 'test.notComposing', title: 'Test', handler })
+
+    activateBindings([{ key: '$mod+j', command: 'test.notComposing' }])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'j',
+      code: 'KeyJ',
+      ctrlKey: true,
+    }))
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/shortcuts/keybindings.ts
+++ b/frontend/src/lib/shortcuts/keybindings.ts
@@ -170,6 +170,10 @@ export function activateBindings(bindings: readonly Keybinding[]): void {
 
   for (const group of groups) {
     keyMap[toTinykeysKey(group.key)] = (e: KeyboardEvent) => {
+      // Skip dispatch while an IME composition is active so CJK input is not
+      // hijacked by modifier shortcuts that share keys with composition commits.
+      if (e.isComposing)
+        return
       const commandId = resolve(group.bindings, group.key)
       if (commandId) {
         e.preventDefault()

--- a/frontend/src/stores/focusedChatSend.store.test.ts
+++ b/frontend/src/stores/focusedChatSend.store.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getFocusedChatSend, registerPanelSend, unregisterPanelSend } from './focusedChatSend.store'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('focusedChatSend store', () => {
+  it('returns the send fn for the panel containing the focused element', () => {
+    const panel = document.createElement('div')
+    panel.setAttribute('data-chat-panel', '')
+    const input = document.createElement('input')
+    panel.appendChild(input)
+    document.body.appendChild(panel)
+
+    const send = vi.fn()
+    registerPanelSend(panel, send)
+    input.focus()
+
+    const resolved = getFocusedChatSend()
+    expect(resolved).toBe(send)
+  })
+
+  it('returns undefined when focus is outside any chat panel', () => {
+    const panel = document.createElement('div')
+    panel.setAttribute('data-chat-panel', '')
+    document.body.appendChild(panel)
+    registerPanelSend(panel, vi.fn())
+
+    const outside = document.createElement('input')
+    document.body.appendChild(outside)
+    outside.focus()
+
+    expect(getFocusedChatSend()).toBeUndefined()
+  })
+
+  it('resolves the panel that actually contains the focused element when multiple are registered', () => {
+    const panelA = document.createElement('div')
+    panelA.setAttribute('data-chat-panel', '')
+    const inputA = document.createElement('input')
+    panelA.appendChild(inputA)
+
+    const panelB = document.createElement('div')
+    panelB.setAttribute('data-chat-panel', '')
+    const inputB = document.createElement('input')
+    panelB.appendChild(inputB)
+
+    document.body.append(panelA, panelB)
+
+    const sendA = vi.fn()
+    const sendB = vi.fn()
+    registerPanelSend(panelA, sendA)
+    registerPanelSend(panelB, sendB)
+
+    inputB.focus()
+    expect(getFocusedChatSend()).toBe(sendB)
+
+    inputA.focus()
+    expect(getFocusedChatSend()).toBe(sendA)
+  })
+
+  it('returns undefined after unregister', () => {
+    const panel = document.createElement('div')
+    panel.setAttribute('data-chat-panel', '')
+    const input = document.createElement('input')
+    panel.appendChild(input)
+    document.body.appendChild(panel)
+
+    registerPanelSend(panel, vi.fn())
+    input.focus()
+    unregisterPanelSend(panel)
+
+    expect(getFocusedChatSend()).toBeUndefined()
+  })
+})

--- a/frontend/src/stores/focusedChatSend.store.ts
+++ b/frontend/src/stores/focusedChatSend.store.ts
@@ -1,0 +1,26 @@
+/**
+ * Per-panel registry of "send the current message" functions, used by the
+ * `chat.sendMessage` shortcut to invoke the send function of the chat panel
+ * that currently contains keyboard focus.
+ *
+ * The registry is keyed by the panel's root DOM element rather than agent ID
+ * so the focused-panel lookup falls out of `document.activeElement.closest()`
+ * without leaking an agent ID into the DOM. The `WeakMap` lets entries be
+ * collected automatically when the panel element is detached.
+ */
+
+const sendByPanel = new WeakMap<Element, () => void>()
+
+export function registerPanelSend(panel: Element, send: () => void): void {
+  sendByPanel.set(panel, send)
+}
+
+export function unregisterPanelSend(panel: Element): void {
+  sendByPanel.delete(panel)
+}
+
+/** Resolve the send function for the panel containing `document.activeElement`. */
+export function getFocusedChatSend(): (() => void) | undefined {
+  const panel = document.activeElement?.closest('[data-chat-panel]')
+  return panel ? sendByPanel.get(panel) : undefined
+}


### PR DESCRIPTION
## Motivation

Previously, sending a chat message was only possible via Enter or Cmd+Enter, hard-coded in a ProseMirror plugin and controlled by `preferences.enterKeyMode`. There was no rebindable command exposed through the shortcut system, making it impossible for users to trigger send from a keyboard shortcut that does not interfere with normal text editing. This PR introduces a proper `chat.sendMessage` command bound to Ctrl+J (Cmd+J on Mac) as a globally rebindable shortcut.

Additionally, there was no guard against IME composition events, meaning CJK users could have modifier-key shortcuts accidentally triggered while composing text via an input method editor.

## Modifications

- Added a new `chat.sendMessage` command under the "Chat" category, bound to `Ctrl+J` / `Cmd+J`, active only when the `chatInputFocused` lazy context is satisfied.
- Introduced `chatInputFocused` as a new lazy context that evaluates at dispatch time by checking whether `document.activeElement` is inside a `[data-chat-input]` element.
- Created `focusedChatSend.store.ts`: a WeakMap-based registry keyed on chat panel DOM elements that stores send callbacks. `getFocusedChatSend()` resolves the correct callback by walking up from `document.activeElement` to the nearest `[data-chat-panel]` element, avoiding any leakage of agent IDs into the DOM.
- Updated `AgentEditorPanel` to register and unregister its send function with the store, and added a `data-chat-panel` attribute to its wrapper element.
- Updated `MarkdownEditor` to carry a `data-chat-input` attribute for focus detection.
- Added an IME composition guard in the keybinding dispatcher that skips all modifier shortcuts while a composition session is active, protecting CJK users across all shortcuts, not only `chat.sendMessage`.

## Result

Users can now press Ctrl+J (Cmd+J on Mac) while focused in any chat input to send a message, as an alternative to Enter / Cmd+Enter. The shortcut is rebindable through the standard shortcut system. CJK users composing text via IME no longer risk accidentally triggering modifier-key shortcuts mid-composition.
