### PR TITLE
Fix lost broadcasts and stale control_requests surviving agent restart

### DIFF
--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -44,6 +44,17 @@ func NewManager(onExit ExitHandler) *Manager {
 	}
 }
 
+// SetOnExit replaces the exit handler. The runner uses this to wire a
+// service-aware handler (which has access to OutputHandler / DB queries)
+// after the service.Context is constructed. The handler is read inside
+// the per-agent Wait goroutine under m.mu so a concurrent swap is
+// observed atomically by every in-flight exit.
+func (m *Manager) SetOnExit(onExit ExitHandler) {
+	m.mu.Lock()
+	m.onExit = onExit
+	m.mu.Unlock()
+}
+
 // LockAgent acquires a per-agent mutex that serializes multi-step lifecycle
 // operations (typically stop-then-start) against concurrent callers. Without
 // this, a second restart can slip in between the first's stop and start and
@@ -159,8 +170,11 @@ func (m *Manager) startAgentWith(ctx context.Context, opts Options, sink OutputS
 			)
 		}
 
-		if m.onExit != nil {
-			m.onExit(opts.AgentID, exitCode, err)
+		m.mu.RLock()
+		onExit := m.onExit
+		m.mu.RUnlock()
+		if onExit != nil {
+			onExit(opts.AgentID, exitCode, err)
 		}
 	}()
 

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os/exec"
 	"testing"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/testutil"
@@ -38,6 +39,34 @@ func (s *stubProvider) UpdateSettings(*leapmuxv1.AgentSettings) bool            
 // startMockAgent wraps mockStart to satisfy the startFunc signature.
 func startMockAgent(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	return mockStart(ctx, opts, sink)
+}
+
+func TestManager_SetOnExit_FiresOnStop(t *testing.T) {
+	m := NewManager(func(string, int, error) {
+		// Original handler: should be replaced by SetOnExit below.
+		t.Error("original onExit should not be called after SetOnExit")
+	})
+
+	exited := make(chan string, 1)
+	m.SetOnExit(func(agentID string, _ int, _ error) {
+		exited <- agentID
+	})
+
+	_, err := m.startAgentWith(context.Background(), Options{
+		AgentID:    "s-exit",
+		Model:      "test",
+		WorkingDir: t.TempDir(),
+	}, noopSink{}, startMockAgent)
+	require.NoError(t, err)
+
+	m.StopAgent("s-exit")
+
+	select {
+	case got := <-exited:
+		assert.Equal(t, "s-exit", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit handler did not fire after stop")
+	}
 }
 
 func TestManager_StartAndStop(t *testing.T) {

--- a/backend/internal/worker/db/queries/control_requests.sql
+++ b/backend/internal/worker/db/queries/control_requests.sql
@@ -5,8 +5,8 @@ ON CONFLICT (agent_id, request_id) DO UPDATE SET payload = excluded.payload;
 -- name: DeleteControlRequest :exec
 DELETE FROM control_requests WHERE agent_id = ? AND request_id = ?;
 
--- name: DeleteControlRequestsByAgentID :exec
-DELETE FROM control_requests WHERE agent_id = ?;
+-- name: DeleteControlRequestsByAgentID :many
+DELETE FROM control_requests WHERE agent_id = ? RETURNING request_id;
 
 -- name: ListControlRequestsByAgentID :many
 SELECT * FROM control_requests WHERE agent_id = ? ORDER BY created_at ASC;

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -178,7 +178,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			func() {
 				svc.AgentStartup.cancelAndClear(agentID)
 				svc.Agents.StopAgent(agentID)
-				svc.Output.CleanupAgent(agentID)
+				svc.Output.ClearAgentRuntimeState(agentID)
 			},
 			func() error { return svc.Queries.CloseAgent(bgCtx(), agentID) },
 		)
@@ -1441,6 +1441,8 @@ func (svc *Context) handleClearContext(agentID string) {
 	// StartAgent below doesn't fail with "agent already running".
 	svc.Agents.StopAndWaitAgent(agentID)
 
+	svc.Output.ClearAgentRuntimeState(agentID)
+
 	// Clear span tracking state from the previous session.
 	svc.Output.ResetSpanTracker(agentID)
 
@@ -2313,6 +2315,8 @@ func (svc *Context) initiatePlanExecutionRestart(agentID, targetMode string, dbA
 	// land in the persisted chat history.
 	svc.Agents.DiscardOutputAndStopAgent(agentID)
 
+	svc.Output.ClearAgentRuntimeState(agentID)
+
 	// Clear span tracking state from the previous session.
 	svc.Output.ResetSpanTracker(agentID)
 
@@ -2325,11 +2329,13 @@ func (svc *Context) initiatePlanExecutionRestart(agentID, targetMode string, dbA
 		"plan_file_path": dbAgent.PlanFilePath,
 	})
 
-	// Restart agent with plan content.
+	// Restart agent with plan content. Use svc.startAgent — the
+	// test-injectable wrapper that forwards to svc.Agents.StartAgent in
+	// production — so unit tests can stub the restart out.
 	model := modelOrDefault(dbAgent.Model, dbAgent.AgentProvider)
 	extraSettings := loadExtraSettings(dbAgent.ExtraSettings, dbAgent.AgentProvider)
 	sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
-	confirmedSettings, err := svc.Agents.StartAgent(bgCtx(), agent.Options{
+	confirmedSettings, err := svc.startAgent(bgCtx(), agent.Options{
 		AgentID:        agentID,
 		Model:          model,
 		Effort:         dbAgent.Effort,

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -605,6 +605,37 @@ func (h *OutputHandler) CleanupAgent(agentID string) {
 	h.cleanupAutoContinue(agentID)
 }
 
+// broadcastControlCancel fans out a single AgentControlCancelRequest to
+// any registered watchers. Shared by ClearAgentRuntimeState and the
+// per-agent sink so the envelope shape lives in one place.
+func (h *OutputHandler) broadcastControlCancel(agentID, requestID string) {
+	h.watcher.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
+		AgentId: agentID,
+		Event: &leapmuxv1.AgentEvent_ControlCancel{
+			ControlCancel: &leapmuxv1.AgentControlCancelRequest{
+				AgentId:   agentID,
+				RequestId: requestID,
+			},
+		},
+	})
+}
+
+// ClearAgentRuntimeState removes every piece of state tied to a dying
+// agent process: pending control_requests in the DB plus the in-memory
+// trackers cleared by CleanupAgent. A controlCancel is broadcast for
+// each deleted row so live tabs drop the prompt without waiting for the
+// reconnect-and-replay path.
+func (h *OutputHandler) ClearAgentRuntimeState(agentID string) {
+	deletedIDs, err := h.queries.DeleteControlRequestsByAgentID(bgCtx(), agentID)
+	if err != nil {
+		slog.Error("clear runtime state: delete control requests", "agent_id", agentID, "error", err)
+	}
+	for _, requestID := range deletedIDs {
+		h.broadcastControlCancel(agentID, requestID)
+	}
+	h.CleanupAgent(agentID)
+}
+
 // spanTracker returns the per-agent SpanTracker, creating one if needed.
 func (h *OutputHandler) spanTracker(agentID string) *SpanTracker {
 	if v, ok := h.spanTrackers.Load(agentID); ok {
@@ -757,15 +788,7 @@ func (s *agentOutputSink) BroadcastControlRequest(requestID string, payload []by
 }
 
 func (s *agentOutputSink) BroadcastControlCancel(requestID string) {
-	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
-		AgentId: s.agentID,
-		Event: &leapmuxv1.AgentEvent_ControlCancel{
-			ControlCancel: &leapmuxv1.AgentControlCancelRequest{
-				AgentId:   s.agentID,
-				RequestId: requestID,
-			},
-		},
-	})
+	s.h.broadcastControlCancel(s.agentID, requestID)
 }
 
 func (s *agentOutputSink) UpdateSessionID(sessionID string) {

--- a/backend/internal/worker/service/output_cleanup_callsites_test.go
+++ b/backend/internal/worker/service/output_cleanup_callsites_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// These tests pin the contract that every agent-process stop path drives
+// OutputHandler.ClearAgentRuntimeState — the helper is unit-tested
+// elsewhere; here we prove each call site actually reaches it. A
+// regression that drops one of those calls would let stale
+// control_requests survive the process restart and reappear on the next
+// WatchEvents subscribe.
+
+// seedPendingControlRequest creates a DB row + registers a watcher and
+// returns the request ID, ready for assertions on cleanup behavior.
+func seedPendingControlRequest(t *testing.T, ctx context.Context, svc *Context, w *testResponseWriter, agentID, workspaceID string) string {
+	t.Helper()
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            agentID,
+		WorkspaceID:   workspaceID,
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	requestID := "req-" + agentID
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   agentID,
+		RequestID: requestID,
+		Payload:   []byte(`{"jsonrpc":"2.0","id":1,"method":"tool/permission"}`),
+	}))
+
+	svc.Watchers.WatchAgent(agentID, &EventWatcher{
+		ChannelID: w.channelID,
+		Sender:    channel.NewSender(w),
+	})
+	return requestID
+}
+
+func assertControlRequestsCleared(t *testing.T, ctx context.Context, svc *Context, w *testResponseWriter, agentID, expectedRequestID string) {
+	t.Helper()
+
+	rows, err := svc.Queries.ListControlRequestsByAgentID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "control_requests rows should be deleted")
+
+	cancels := collectBroadcastCancelIDs(t, w)
+	assert.Contains(t, cancels, expectedRequestID, "expected a controlCancel broadcast for the cleared request")
+}
+
+// TestCloseAgent_ClearsPendingControlRequests proves the CloseAgent RPC
+// stop-callback drives ClearAgentRuntimeState. A regression dropping the
+// call from agent.go's CloseAgent handler would leave stale rows that
+// the next WatchEvents replay would re-emit as unanswerable prompts.
+func TestCloseAgent_ClearsPendingControlRequests(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	requestID := seedPendingControlRequest(t, ctx, svc, w, "agent-close", "ws-1")
+
+	dispatch(d, "CloseAgent", &leapmuxv1.CloseAgentRequest{
+		AgentId: "agent-close",
+	}, w)
+
+	require.Empty(t, w.errors, "unexpected RPC errors: %+v", w.errors)
+	assertControlRequestsCleared(t, ctx, svc, w, "agent-close", requestID)
+}
+
+// TestInitiatePlanExecutionRestart_ClearsPendingControlRequests proves
+// the plan-approval restart path drives ClearAgentRuntimeState before
+// the new subprocess starts. The new process has its own request_id
+// namespace, so any stale row would be unanswerable by it.
+func TestInitiatePlanExecutionRestart_ClearsPendingControlRequests(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	// Mock a successful restart so the test exercises only the cleanup
+	// path, not a real Claude Code subprocess.
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return &leapmuxv1.AgentSettings{}, nil
+	}
+
+	requestID := seedPendingControlRequest(t, ctx, svc, w, "agent-plan", "ws-1")
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-plan")
+	require.NoError(t, err)
+
+	svc.initiatePlanExecutionRestart("agent-plan", agent.PermissionModeDefault, dbAgent, "Execute the plan.")
+
+	assertControlRequestsCleared(t, ctx, svc, w, "agent-plan", requestID)
+}
+
+// TestHandleClearContext_ClearsPendingControlRequests proves the /clear
+// command drives ClearAgentRuntimeState before restarting the agent
+// with a fresh context.
+func TestHandleClearContext_ClearsPendingControlRequests(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
+		return &leapmuxv1.AgentSettings{}, nil
+	}
+
+	requestID := seedPendingControlRequest(t, ctx, svc, w, "agent-clear", "ws-1")
+
+	svc.handleClearContext("agent-clear")
+
+	assertControlRequestsCleared(t, ctx, svc, w, "agent-clear", requestID)
+}
+
+// TestSubprocessCrash_FiresClearAgentRuntimeState wires the runner-style
+// onExit handler and proves a subprocess exit (graceful or otherwise)
+// drives the cleanup. This is the only place outside an explicit RPC
+// where stale rows could survive into the next session, so the chain
+// {Manager.startAgentWith Wait goroutine → onExit → ClearAgentRuntimeState}
+// is the sole guard.
+func TestSubprocessCrash_FiresClearAgentRuntimeState(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, "ws-1")
+	defer drainAllInFlight(svc)
+
+	// Mirror runner.go's wiring: every subprocess exit should run the
+	// service-aware cleanup against svc.Output.
+	cleared := make(chan string, 1)
+	svc.Agents.SetOnExit(func(agentID string, _ int, _ error) {
+		svc.Output.ClearAgentRuntimeState(agentID)
+		cleared <- agentID
+	})
+
+	requestID := seedPendingControlRequest(t, ctx, svc, w, "agent-crash", "ws-1")
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-crash",
+		Model:      "test",
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-crash", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+
+	svc.Agents.StopAgent("agent-crash")
+
+	select {
+	case got := <-cleared:
+		assert.Equal(t, "agent-crash", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("onExit handler never fired after subprocess stop")
+	}
+
+	assertControlRequestsCleared(t, ctx, svc, w, "agent-crash", requestID)
+}

--- a/backend/internal/worker/service/output_cleanup_test.go
+++ b/backend/internal/worker/service/output_cleanup_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// TestClearAgentRuntimeState_DeletesPendingAndBroadcastsCancels covers the
+// crash / stop cleanup contract: every pending control_request row for the
+// agent must be deleted from the DB, and a controlCancel must be broadcast
+// for each one so any still-connected tabs drop the prompt without waiting
+// for a reconnect-and-replay round trip.
+func TestClearAgentRuntimeState_DeletesPendingAndBroadcastsCancels(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, "ws-1")
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	// Two pending requests so we can verify both get cancelled.
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1", Payload: []byte(`{"a":1}`),
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-2", Payload: []byte(`{"b":2}`),
+	}))
+
+	// Register a watcher so broadcasts have somewhere to go.
+	watcher := &EventWatcher{ChannelID: "test-ch", Sender: channel.NewSender(w)}
+	svc.Watchers.WatchAgent("agent-1", watcher)
+
+	svc.Output.ClearAgentRuntimeState("agent-1")
+
+	// DB rows are gone.
+	remaining, err := svc.Queries.ListControlRequestsByAgentID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "expected all control_requests rows to be deleted")
+
+	// One controlCancel broadcast per previously pending row.
+	cancels := collectBroadcastCancelIDs(t, w)
+	assert.ElementsMatch(t, []string{"req-1", "req-2"}, cancels)
+}
+
+// TestClearAgentRuntimeState_NoPendingIsNoOp ensures the helper is safe to
+// call on agents with nothing to clean up — the common case for stop paths
+// that fire on every CloseAgent / restart regardless of whether a prompt
+// was open.
+func TestClearAgentRuntimeState_NoPendingIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, "ws-1")
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-empty",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	watcher := &EventWatcher{ChannelID: "test-ch", Sender: channel.NewSender(w)}
+	svc.Watchers.WatchAgent("agent-empty", watcher)
+
+	svc.Output.ClearAgentRuntimeState("agent-empty")
+
+	cancels := collectBroadcastCancelIDs(t, w)
+	assert.Empty(t, cancels, "expected no broadcasts when nothing was pending")
+}
+
+// collectBroadcastCancelIDs decodes every stream payload captured by the
+// test writer and returns the request IDs of any AgentControlCancel events
+// that were broadcast.
+func collectBroadcastCancelIDs(t *testing.T, w *testResponseWriter) []string {
+	t.Helper()
+	var ids []string
+	for _, msg := range w.streamsSnapshot() {
+		var resp leapmuxv1.WatchEventsResponse
+		if err := proto.Unmarshal(msg.GetPayload(), &resp); err != nil {
+			continue
+		}
+		ae, ok := resp.GetEvent().(*leapmuxv1.WatchEventsResponse_AgentEvent)
+		if !ok {
+			continue
+		}
+		cc, ok := ae.AgentEvent.GetEvent().(*leapmuxv1.AgentEvent_ControlCancel)
+		if !ok {
+			continue
+		}
+		ids = append(ids, cc.ControlCancel.GetRequestId())
+	}
+	return ids
+}

--- a/backend/internal/worker/service/watcher.go
+++ b/backend/internal/worker/service/watcher.go
@@ -143,12 +143,49 @@ func (m *WatcherManager) broadcastToWatchers(registry map[string][]*EventWatcher
 		return
 	}
 
+	// Collect dead channel IDs so we can drop them after the send loop. A
+	// SendStream error means the underlying channel-RPC stream cannot
+	// deliver bytes (transport gone, correlation ID closed, peer dropped),
+	// so further broadcasts to this watcher would be lost silently. Drop
+	// the registration; the channel layer's eventual transport-level error
+	// will surface to the frontend as onError/onEnd, which trips the
+	// reconnect loop in useWorkspaceConnection.ts and replays from DB.
+	var deadChannelIDs []string
 	for _, w := range watchers {
 		if err := w.Sender.SendStream(&leapmuxv1.InnerStreamMessage{
 			Payload: payload,
 		}); err != nil {
-			slog.Warn("broadcastToWatchers: SendStream failed",
+			slog.Warn("broadcastToWatchers: SendStream failed; dropping watcher",
 				"entity_id", entityID, "channel_id", w.ChannelID, "error", err)
+			deadChannelIDs = append(deadChannelIDs, w.ChannelID)
 		}
+	}
+
+	if len(deadChannelIDs) > 0 {
+		m.removeWatchersFromRegistry(registry, entityID, deadChannelIDs)
+	}
+}
+
+// removeWatchersFromRegistry drops every watcher whose channel ID is in
+// channelIDs from registry[entityID]. One lock acquisition + one filter
+// pass regardless of how many watchers failed simultaneously.
+func (m *WatcherManager) removeWatchersFromRegistry(registry map[string][]*EventWatcher, entityID string, channelIDs []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	dead := make(map[string]bool, len(channelIDs))
+	for _, id := range channelIDs {
+		dead[id] = true
+	}
+	watchers := registry[entityID]
+	filtered := watchers[:0]
+	for _, w := range watchers {
+		if !dead[w.ChannelID] {
+			filtered = append(filtered, w)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(registry, entityID)
+	} else {
+		registry[entityID] = filtered
 	}
 }

--- a/backend/internal/worker/service/watcher_test.go
+++ b/backend/internal/worker/service/watcher_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -14,12 +15,20 @@ import (
 type mockResponseWriter struct {
 	channelID   string
 	streamCount atomic.Int64
+	// sendErr, when non-nil, is returned from SendStream to simulate a
+	// dead transport for invalidation tests. Stored as a pointer so tests
+	// can clear it mid-run with sendErr.Store(nil) — atomic.Value would
+	// panic on a nil store.
+	sendErr atomic.Pointer[error]
 }
 
 func (m *mockResponseWriter) SendResponse(_ *leapmuxv1.InnerRpcResponse) error { return nil }
 func (m *mockResponseWriter) SendError(_ int32, _ string) error                { return nil }
 func (m *mockResponseWriter) SendStream(_ *leapmuxv1.InnerStreamMessage) error {
 	m.streamCount.Add(1)
+	if errPtr := m.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
 	return nil
 }
 func (m *mockResponseWriter) ChannelID() string { return m.channelID }
@@ -28,6 +37,15 @@ func newTestWatcher(channelID string) (*EventWatcher, *mockResponseWriter) {
 	mock := &mockResponseWriter{channelID: channelID}
 	sender := channel.NewSender(mock)
 	return &EventWatcher{ChannelID: channelID, Sender: sender}, mock
+}
+
+// failSends arms the mock to return err from SendStream. Pass nil to clear.
+func (m *mockResponseWriter) failSends(err error) {
+	if err == nil {
+		m.sendErr.Store(nil)
+		return
+	}
+	m.sendErr.Store(&err)
 }
 
 func TestBroadcastTerminalEvent_DeduplicatesWithinPerTerminal(t *testing.T) {
@@ -183,6 +201,179 @@ func TestUnwatchAll_RemovesFromAllLists(t *testing.T) {
 	})
 
 	assert.Equal(t, int64(0), mock.streamCount.Load(), "expected 0 broadcasts after UnwatchAll")
+}
+
+func TestBroadcast_DropsWatcherOnSendError(t *testing.T) {
+	m := NewWatcherManager()
+	w, mock := newTestWatcher("ch-dead")
+	mock.failSends(errors.New("transport gone"))
+
+	m.WatchAgent("agent-1", w)
+
+	// First broadcast hits the dead sender once.
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+	assert.Equal(t, int64(1), mock.streamCount.Load(), "expected 1 send attempt before invalidation")
+
+	// Watcher should have been dropped.
+	m.mu.RLock()
+	got := len(m.agents["agent-1"])
+	m.mu.RUnlock()
+	assert.Equal(t, 0, got, "expected watcher to be removed after SendStream error")
+
+	// Subsequent broadcasts must skip the dead watcher.
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+	assert.Equal(t, int64(1), mock.streamCount.Load(), "expected no further sends after invalidation")
+}
+
+func TestBroadcast_TerminalDropsWatcherOnSendError(t *testing.T) {
+	m := NewWatcherManager()
+	w, mock := newTestWatcher("ch-dead")
+	mock.failSends(errors.New("transport gone"))
+
+	m.WatchTerminal("term-1", w)
+
+	m.BroadcastTerminalEvent("term-1", &leapmuxv1.TerminalEvent{
+		TerminalId: "term-1",
+		Event:      &leapmuxv1.TerminalEvent_Data{Data: &leapmuxv1.TerminalData{Data: []byte("a")}},
+	})
+	assert.Equal(t, int64(1), mock.streamCount.Load())
+
+	m.mu.RLock()
+	got := len(m.terminals["term-1"])
+	m.mu.RUnlock()
+	assert.Equal(t, 0, got, "expected terminal watcher to be removed after SendStream error")
+
+	m.BroadcastTerminalEvent("term-1", &leapmuxv1.TerminalEvent{
+		TerminalId: "term-1",
+		Event:      &leapmuxv1.TerminalEvent_Data{Data: &leapmuxv1.TerminalData{Data: []byte("b")}},
+	})
+	assert.Equal(t, int64(1), mock.streamCount.Load(), "expected no further sends after invalidation")
+}
+
+func TestBroadcast_DropsOnlyDeadWatcher(t *testing.T) {
+	m := NewWatcherManager()
+	wDead, mockDead := newTestWatcher("ch-dead")
+	mockDead.failSends(errors.New("transport gone"))
+	wLive, mockLive := newTestWatcher("ch-live")
+
+	m.WatchAgent("agent-1", wDead)
+	m.WatchAgent("agent-1", wLive)
+
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+	assert.Equal(t, int64(1), mockDead.streamCount.Load())
+	assert.Equal(t, int64(1), mockLive.streamCount.Load())
+
+	m.mu.RLock()
+	remaining := len(m.agents["agent-1"])
+	m.mu.RUnlock()
+	assert.Equal(t, 1, remaining, "live watcher should remain registered")
+
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+	assert.Equal(t, int64(1), mockDead.streamCount.Load(), "dead watcher should not receive further events")
+	assert.Equal(t, int64(2), mockLive.streamCount.Load(), "live watcher should receive subsequent events")
+}
+
+// TestWatcher_ReSubscribeAfterInvalidate pins that a channel that lost
+// its watcher to a SendStream failure can re-register on the same
+// agent and receive subsequent broadcasts. Without this the registry
+// slot would stay stuck closed and reconnect would silently keep
+// missing events.
+func TestWatcher_ReSubscribeAfterInvalidate(t *testing.T) {
+	m := NewWatcherManager()
+
+	// First registration: send fails, watcher gets dropped.
+	wDead, mockDead := newTestWatcher("ch-1")
+	mockDead.failSends(errors.New("transport gone"))
+	m.WatchAgent("agent-1", wDead)
+
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+
+	m.mu.RLock()
+	got := len(m.agents["agent-1"])
+	m.mu.RUnlock()
+	assert.Equal(t, 0, got, "precondition: dead watcher should be dropped")
+
+	// Re-subscribe on the same channel ID with a fresh sender.
+	wAlive, mockAlive := newTestWatcher("ch-1")
+	m.WatchAgent("agent-1", wAlive)
+
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+
+	assert.Equal(t, int64(1), mockAlive.streamCount.Load(), "re-subscribed watcher should receive broadcasts")
+}
+
+// TestWatcher_InvalidateScopedToEntity pins the chosen semantic that a
+// SendStream failure invalidates the watcher only for the failing
+// entity, leaving the same channel's other-entity registrations intact
+// AND functional. A future "drop the whole channel on first failure"
+// change would surface here as a test failure rather than a behavior
+// shift.
+func TestWatcher_InvalidateScopedToEntity(t *testing.T) {
+	m := NewWatcherManager()
+	w, mock := newTestWatcher("ch-multi")
+	mock.failSends(errors.New("transport gone"))
+
+	m.WatchAgent("agent-1", w)
+	m.WatchAgent("agent-2", w)
+
+	// First send to agent-1 fails — should drop the agent-1 registration
+	// but leave agent-2's intact (same channel, same sender).
+	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
+		AgentId: "agent-1",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-1",
+		}},
+	})
+
+	m.mu.RLock()
+	agent1Count := len(m.agents["agent-1"])
+	agent2Count := len(m.agents["agent-2"])
+	m.mu.RUnlock()
+	assert.Equal(t, 0, agent1Count, "agent-1 watcher should be dropped after its send failed")
+	assert.Equal(t, 1, agent2Count, "agent-2 watcher should remain registered")
+
+	// With the transient error cleared, agent-2 broadcasts must reach
+	// the surviving watcher — proving the registration isn't merely
+	// present but still functional.
+	mock.failSends(nil)
+	beforeAgent2 := mock.streamCount.Load()
+	m.BroadcastAgentEvent("agent-2", &leapmuxv1.AgentEvent{
+		AgentId: "agent-2",
+		Event: &leapmuxv1.AgentEvent_StatusChange{StatusChange: &leapmuxv1.AgentStatusChange{
+			AgentId: "agent-2",
+		}},
+	})
+	assert.Equal(t, beforeAgent2+1, mock.streamCount.Load(), "agent-2 broadcast should reach the surviving watcher")
 }
 
 func TestUnwatchAll_PreservesOtherChannels(t *testing.T) {

--- a/backend/worker/runner.go
+++ b/backend/worker/runner.go
@@ -108,6 +108,13 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		svcCtx.Send = client.Send
 		svcCtx.Channels = channelMgr
 		svcCtx.Init()
+
+		// Drop pending control_requests on every subprocess exit (graceful
+		// stop, crash, worker tear-down) so request_ids bound to the
+		// exited subprocess don't reappear stale on resume.
+		client.AgentManager().SetOnExit(func(agentID string, _ int, _ error) {
+			svcCtx.Output.ClearAgentRuntimeState(agentID)
+		})
 		// Shutdown must run before client.Stop() so terminal screen snapshots
 		// are persisted while in-memory state is still available.
 		defer svcCtx.Shutdown()

--- a/frontend/src/api/streamBuffer.test.ts
+++ b/frontend/src/api/streamBuffer.test.ts
@@ -1,0 +1,137 @@
+import type { StreamSource } from './streamBuffer'
+import { describe, expect, it } from 'vitest'
+import { bufferStreamHandle } from './streamBuffer'
+
+// fakeSource lets the test fire onMessage / onEnd / onError on demand.
+function fakeSource<T>(): {
+  source: StreamSource<T>
+  fireMessage: (msg: T) => void
+  fireEnd: () => void
+  fireError: (err: Error) => void
+} {
+  let messageCb: ((msg: T) => void) | null = null
+  let endCb: (() => void) | null = null
+  let errorCb: ((err: Error) => void) | null = null
+  return {
+    source: {
+      onMessage(cb) { messageCb = cb },
+      onEnd(cb) { endCb = cb },
+      onError(cb) { errorCb = cb },
+    },
+    fireMessage(msg) { messageCb?.(msg) },
+    fireEnd() { endCb?.() },
+    fireError(err) { errorCb?.(err) },
+  }
+}
+
+describe('bufferStreamHandle', () => {
+  it('flushes pre-registration messages once onEvent is called', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n * 2)
+
+    fake.fireMessage(1)
+    fake.fireMessage(2)
+    fake.fireMessage(3)
+
+    const received: number[] = []
+    handle.onEvent(n => received.push(n))
+
+    expect(received).toEqual([2, 4, 6])
+  })
+
+  it('delivers messages directly once onEvent is wired', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n * 2)
+
+    const received: number[] = []
+    handle.onEvent(n => received.push(n))
+
+    fake.fireMessage(10)
+    expect(received).toEqual([20])
+  })
+
+  it('flushes a pre-registration end signal exactly once', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n)
+
+    fake.fireEnd()
+
+    let endCount = 0
+    handle.onEnd(() => {
+      endCount++
+    })
+    expect(endCount).toBe(1)
+
+    // Re-registering should not re-fire the buffered end.
+    handle.onEnd(() => {
+      endCount++
+    })
+    expect(endCount).toBe(1)
+  })
+
+  it('flushes a pre-registration error', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n)
+
+    const err = new Error('transport gone')
+    fake.fireError(err)
+
+    let received: Error | null = null
+    handle.onError((e) => {
+      received = e
+    })
+    expect(received).toBe(err)
+  })
+
+  it('routes a decode error to onError (buffered)', () => {
+    const fake = fakeSource<string>()
+    const decodeErr = new Error('bad payload')
+    const handle = bufferStreamHandle<string, string>(fake.source, () => {
+      throw decodeErr
+    })
+
+    fake.fireMessage('garbage')
+
+    let received: Error | null = null
+    handle.onError((e) => {
+      received = e
+    })
+    expect(received).toBe(decodeErr)
+  })
+
+  it('only flushes events once', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n)
+
+    fake.fireMessage(1)
+    fake.fireMessage(2)
+
+    const first: number[] = []
+    handle.onEvent(n => first.push(n))
+    expect(first).toEqual([1, 2])
+
+    // Re-registering must not re-flush the same buffered events.
+    const second: number[] = []
+    handle.onEvent(n => second.push(n))
+    expect(second).toEqual([])
+
+    // New events go to the latest callback.
+    fake.fireMessage(3)
+    expect(first).toEqual([1, 2])
+    expect(second).toEqual([3])
+  })
+
+  it('preserves message ordering in the buffer', () => {
+    const fake = fakeSource<number>()
+    const handle = bufferStreamHandle<number, number>(fake.source, n => n)
+
+    fake.fireMessage(1)
+    fake.fireMessage(2)
+    fake.fireMessage(3)
+    fake.fireMessage(4)
+
+    const received: number[] = []
+    handle.onEvent(n => received.push(n))
+    expect(received).toEqual([1, 2, 3, 4])
+  })
+})

--- a/frontend/src/api/streamBuffer.ts
+++ b/frontend/src/api/streamBuffer.ts
@@ -1,0 +1,98 @@
+// Buffer-then-flush adapter for an underlying stream listener — see
+// bufferStreamHandle below for the full rationale.
+
+export interface StreamSource<TMessage> {
+  onMessage: (cb: (msg: TMessage) => void) => void
+  onEnd: (cb: () => void) => void
+  onError: (cb: (err: Error) => void) => void
+}
+
+export interface BufferedStreamHandle<TEvent> {
+  onEvent: (cb: (event: TEvent) => void) => void
+  onEnd: (cb: () => void) => void
+  onError: (cb: (err: Error) => void) => void
+}
+
+/**
+ * Wrap a raw stream source with buffering plus a `decode` step that
+ * converts low-level messages into typed events. Any backend event
+ * arriving before the consumer wires its callbacks is captured and
+ * flushed on first registration, so events emitted exactly when a
+ * stream is being (re)established aren't silently dropped.
+ *
+ * Each flush is one-shot: re-registering a callback replaces the
+ * destination but does not re-deliver already-flushed events.
+ *
+ * If `decode` throws, the error is routed through onError (buffered if
+ * the consumer hasn't registered yet).
+ */
+export function bufferStreamHandle<TMessage, TEvent>(
+  source: StreamSource<TMessage>,
+  decode: (msg: TMessage) => TEvent,
+): BufferedStreamHandle<TEvent> {
+  let eventCb: ((event: TEvent) => void) | null = null
+  let endCb: (() => void) | null = null
+  let errorCb: ((err: Error) => void) | null = null
+
+  const pendingEvents: TEvent[] = []
+  let pendingEnd = false
+  let pendingError: Error | null = null
+
+  source.onMessage((msg) => {
+    let event: TEvent
+    try {
+      event = decode(msg)
+    }
+    catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      if (errorCb)
+        errorCb(e)
+      else
+        pendingError = e
+      return
+    }
+    if (eventCb)
+      eventCb(event)
+    else
+      pendingEvents.push(event)
+  })
+
+  source.onEnd(() => {
+    if (endCb)
+      endCb()
+    else
+      pendingEnd = true
+  })
+
+  source.onError((err) => {
+    if (errorCb)
+      errorCb(err)
+    else
+      pendingError = err
+  })
+
+  return {
+    onEvent(cb) {
+      eventCb = cb
+      if (pendingEvents.length > 0) {
+        const buffered = pendingEvents.splice(0, pendingEvents.length)
+        for (const event of buffered) cb(event)
+      }
+    },
+    onEnd(cb) {
+      endCb = cb
+      if (pendingEnd) {
+        pendingEnd = false
+        cb()
+      }
+    },
+    onError(cb) {
+      errorCb = cb
+      if (pendingError) {
+        const err = pendingError
+        pendingError = null
+        cb(err)
+      }
+    },
+  }
+}

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -60,6 +60,7 @@ import type { ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '~/lib/ch
 import { create, fromBinary, toBinary, toJsonString } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { getCapabilities, isTauriApp, platformBridge } from '~/api/platformBridge'
+import { bufferStreamHandle } from '~/api/streamBuffer'
 import { apiLoadingTimeoutMs, transport } from '~/api/transport'
 import {
   CloseAgentRequestSchema,
@@ -553,35 +554,18 @@ export async function watchEventsViaChannel(
 
   const streamHandle = channelManager.stream(channelId, 'WatchEvents', payload)
 
-  let eventCb: ((resp: WatchEventsResponse) => void) | null = null
-  let endCb: (() => void) | null = null
-  let errorCb: ((err: Error) => void) | null = null
-
-  streamHandle.onMessage((msg: InnerStreamMessage) => {
-    if (eventCb) {
-      try {
-        const resp = fromBinary(WatchEventsResponseSchema, msg.payload)
-        log.debug('WatchEvents stream message', { response: toJsonString(WatchEventsResponseSchema, resp) })
-        eventCb(resp)
-      }
-      catch (err) {
-        errorCb?.(err instanceof Error ? err : new Error(String(err)))
-      }
-    }
-  })
-
-  streamHandle.onEnd(() => {
-    endCb?.()
-  })
-
-  streamHandle.onError((err: Error) => {
-    errorCb?.(err)
+  // Buffer messages that arrive before the consumer wires its callbacks.
+  // See streamBuffer.ts for the full rationale.
+  const buffered = bufferStreamHandle<InnerStreamMessage, WatchEventsResponse>(streamHandle, (msg) => {
+    const resp = fromBinary(WatchEventsResponseSchema, msg.payload)
+    log.debug('WatchEvents stream message', { response: toJsonString(WatchEventsResponseSchema, resp) })
+    return resp
   })
 
   return {
-    onEvent: (cb) => { eventCb = cb },
-    onEnd: (cb) => { endCb = cb },
-    onError: (cb) => { errorCb = cb },
+    onEvent: buffered.onEvent,
+    onEnd: buffered.onEnd,
+    onError: buffered.onError,
     close: () => { channelManager.removeStreamListener(channelId, streamHandle.requestId) },
   }
 }

--- a/frontend/src/hooks/streamCompletion.test.ts
+++ b/frontend/src/hooks/streamCompletion.test.ts
@@ -1,0 +1,112 @@
+import type { StreamCompletionHandle } from './streamCompletion'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitForStreamCompletion } from './streamCompletion'
+
+// fakeHandle exposes manual triggers for end/error so tests can drive
+// each completion path without touching the real channel layer.
+function fakeHandle(): {
+  handle: StreamCompletionHandle
+  fireEnd: () => void
+  fireError: (err: Error) => void
+} {
+  let endCb: (() => void) | null = null
+  let errorCb: ((err: Error) => void) | null = null
+  return {
+    handle: {
+      onEnd(cb) {
+        endCb = cb
+      },
+      onError(cb) {
+        errorCb = cb
+      },
+    },
+    fireEnd() {
+      endCb?.()
+    },
+    fireError(err) {
+      errorCb?.(err)
+    },
+  }
+}
+
+describe('waitForStreamCompletion', () => {
+  let fake: ReturnType<typeof fakeHandle>
+  let ctrl: AbortController
+
+  beforeEach(() => {
+    fake = fakeHandle()
+    ctrl = new AbortController()
+  })
+
+  it('resolves when the stream ends after wait starts', async () => {
+    const promise = waitForStreamCompletion(fake.handle, ctrl.signal)
+    fake.fireEnd()
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('rejects when the stream errors after wait starts', async () => {
+    const promise = waitForStreamCompletion(fake.handle, ctrl.signal)
+    const err = new Error('transport gone')
+    fake.fireError(err)
+    await expect(promise).rejects.toBe(err)
+  })
+
+  it('resolves when the signal aborts after wait starts', async () => {
+    const promise = waitForStreamCompletion(fake.handle, ctrl.signal)
+    ctrl.abort()
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  // The synchronous-window race: end/error/abort can all fire during the
+  // synchronous setup window before the Promise body assigns
+  // resolveStream/rejectStream. The flag dance must let those signals
+  // be observed instead of leaving the consumer hung.
+
+  it('resolves immediately when end fires during synchronous setup', async () => {
+    // A handle that fires onEnd as soon as it's wired — simulates
+    // bufferStreamHandle flushing a buffered end on registration.
+    const handle: StreamCompletionHandle = {
+      onEnd(cb) {
+        cb()
+      },
+      onError() {},
+    }
+    await expect(waitForStreamCompletion(handle, ctrl.signal)).resolves.toBeUndefined()
+  })
+
+  it('rejects immediately when error fires during synchronous setup', async () => {
+    const err = new Error('flushed pre-registration error')
+    const handle: StreamCompletionHandle = {
+      onEnd() {},
+      onError(cb) {
+        cb(err)
+      },
+    }
+    await expect(waitForStreamCompletion(handle, ctrl.signal)).rejects.toBe(err)
+  })
+
+  // Load-bearing regression test: caught a real bug where
+  // `addEventListener('abort', ..., { once: true })` does NOT fire on an
+  // already-aborted signal in standard implementations, so without the
+  // entry-time `if (signal.aborted)` guard the helper hangs forever.
+  it('resolves when the signal is already aborted at entry', async () => {
+    ctrl.abort()
+    await expect(waitForStreamCompletion(fake.handle, ctrl.signal)).resolves.toBeUndefined()
+  })
+
+  it('removes the abort listener once end fires before abort', async () => {
+    const removeSpy = vi.spyOn(ctrl.signal, 'removeEventListener')
+    const promise = waitForStreamCompletion(fake.handle, ctrl.signal)
+    fake.fireEnd()
+    await promise
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+  })
+
+  it('removes the abort listener once error fires before abort', async () => {
+    const removeSpy = vi.spyOn(ctrl.signal, 'removeEventListener')
+    const promise = waitForStreamCompletion(fake.handle, ctrl.signal)
+    fake.fireError(new Error('boom'))
+    await expect(promise).rejects.toBeInstanceOf(Error)
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+  })
+})

--- a/frontend/src/hooks/streamCompletion.ts
+++ b/frontend/src/hooks/streamCompletion.ts
@@ -1,0 +1,63 @@
+// Returns a Promise that resolves when the handle ends or the signal
+// aborts, and rejects when the handle errors. The end / error / abort
+// callbacks are wired synchronously so a signal that fires — or a
+// buffered end/error that flushes — before the returned Promise is
+// awaited still terminates the wait. Without this captured-flag dance,
+// a synchronous abort fired between callback wiring and the await
+// would leave the consumer hung.
+
+export interface StreamCompletionHandle {
+  onEnd: (cb: () => void) => void
+  onError: (cb: (err: Error) => void) => void
+}
+
+export function waitForStreamCompletion(
+  handle: StreamCompletionHandle,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted)
+    return Promise.resolve()
+
+  let streamEnded = false
+  let streamAborted = false
+  let streamError: unknown = null
+  let resolveStream: (() => void) | undefined
+  let rejectStream: ((err: unknown) => void) | undefined
+
+  const onAbort = () => {
+    if (resolveStream)
+      resolveStream()
+    else
+      streamAborted = true
+  }
+  signal.addEventListener('abort', onAbort, { once: true })
+
+  handle.onEnd(() => {
+    signal.removeEventListener('abort', onAbort)
+    if (resolveStream)
+      resolveStream()
+    else
+      streamEnded = true
+  })
+
+  handle.onError((err) => {
+    signal.removeEventListener('abort', onAbort)
+    if (rejectStream)
+      rejectStream(err)
+    else
+      streamError = err
+  })
+
+  return new Promise<void>((resolve, reject) => {
+    if (streamError) {
+      reject(streamError)
+      return
+    }
+    if (streamEnded || streamAborted) {
+      resolve()
+      return
+    }
+    resolveStream = resolve
+    rejectStream = reject
+  })
+}

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -13,6 +13,7 @@ import { getTerminalInstance } from '~/components/terminal/TerminalView'
 import { AgentProvider, AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { waitForStreamCompletion } from '~/hooks/streamCompletion'
 import { ChannelError } from '~/lib/channel'
 import { createLogger } from '~/lib/logger'
 import { extractAssistantUsage, extractCodexTokenUsage, extractPlanFilePath, extractPlanUpdated, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessage, normalizeContextUsage, parseMessageContent } from '~/lib/messageParser'
@@ -729,42 +730,29 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           terminals,
         })
 
-        // Now that the new stream listener is registered, clean up
-        // the previous one. The server-side sender update (Bug 2 fix)
-        // ensures no more events will arrive on the old request ID
-        // once the server processes this new WatchEvents RPC.
+        // Wire the consumer callbacks before closing the previous handle.
+        // workerRpc.ts buffers any events that arrive before onEvent is
+        // wired; waitForStreamCompletion captures end / error / abort that
+        // fire during the synchronous setup window.
+        handle.onEvent((response) => {
+          backoff = 1000
+          switch (response.event.case) {
+            case 'agentEvent':
+              handleAgentEvent(response.event.value, catchUpPhases, signal)
+              break
+            case 'terminalEvent':
+              handleTerminalEvent(response.event.value)
+              break
+          }
+        })
+
+        // Now that callbacks are wired, clean up the previous stream.
+        // The server-side sender update ensures no more events arrive on
+        // the old request ID once the server processes this WatchEvents.
         previousHandle?.close()
         previousHandle = handle
 
-        // Wait for the stream to end or error using a promise.
-        await new Promise<void>((resolve, reject) => {
-          const onAbort = () => {
-            resolve()
-          }
-          signal.addEventListener('abort', onAbort, { once: true })
-
-          handle.onEvent((response) => {
-            backoff = 1000
-            switch (response.event.case) {
-              case 'agentEvent':
-                handleAgentEvent(response.event.value, catchUpPhases, signal)
-                break
-              case 'terminalEvent':
-                handleTerminalEvent(response.event.value)
-                break
-            }
-          })
-
-          handle.onEnd(() => {
-            signal.removeEventListener('abort', onAbort)
-            resolve()
-          })
-
-          handle.onError((err) => {
-            signal.removeEventListener('abort', onAbort)
-            reject(err)
-          })
-        })
+        await waitForStreamCompletion(handle, signal)
       }
       catch (err) {
         if (signal.aborted)


### PR DESCRIPTION
## Motivation

Two independent defects combined to cause the exit-plan-mode prompt to silently fail to render in Claude Code / Codex sessions:

1. **Stale control_requests after agent restart.** Pending `control_requests` rows were not cleaned up when an agent process stopped. On the next `WatchEvents` replay they re-emitted as prompts that no running subprocess could answer, leaving the UI waiting indefinitely. The workaround was opening a new agent tab to force a fresh re-subscribe-and-replay.

2. **Silent broadcast loss on half-open transports.** `WatcherManager.broadcastToWatchers` kept dead watchers in its set when their `SendStream` returned an error. Subsequent broadcasts were swallowed silently; the frontend never observed the failure and could not trigger its existing reconnect loop.

3. **Frontend event-delivery gap.** Events arriving on the underlying stream listener between `await watchEventsViaChannel(...)` returning and the caller wiring its `handle.onEvent(...)` callback were silently dropped. This meant the prompt could disappear even when the transport itself was healthy.

4. **AbortSignal already-aborted hang.** The reconnect loop's `addEventListener('abort', cb, { once: true })` does not fire when the signal is already aborted in standard implementations, so the loop could hang if the signal aborted during the synchronous setup window.

## Modifications

**Backend**

- Add `OutputHandler.ClearAgentRuntimeState(agentID)`: deletes pending `control_requests` rows from the DB in a single `DELETE ... RETURNING` round trip and broadcasts a `controlCancel` event to all connected tabs so they drop the prompt immediately without waiting for reconnect-and-replay.
- Wire `ClearAgentRuntimeState` into every agent-stop path: `CloseAgent` RPC, plan-execution restart, `/clear` context handler, and subprocess crash via the new `Manager.SetOnExit` hook.
- Add `Manager.SetOnExit(handler ExitHandler)` so the runner can attach a service-aware exit handler after `service.Context` is fully constructed, replacing the logging-only handler that was the only option at manager construction time.
- Drop a watcher from `WatcherManager` when its `SendStream` returns an error, using a single lock-and-filter pass. The channel layer's transport error then surfaces normally to the frontend, tripping the existing reconnect loop and triggering DB replay.
- Collapse the previous list-then-delete SQL pair for `DeleteControlRequestsByAgentID` into a single `:many` `DELETE ... RETURNING` query.

**Frontend**

- Add `bufferStreamHandle(source, decode)`: a one-shot adapter that captures messages, end signals, and errors arriving before the consumer wires its callbacks, then flushes them on first registration. `watchEventsViaChannel` now uses it, closing the event-delivery gap.
- Add `waitForStreamCompletion(handle, signal)`: returns a Promise that resolves on end / abort and rejects on error. All listener wiring is synchronous; an entry-time guard handles the already-aborted case that `addEventListener('abort', ..., { once: true })` misses. The reconnect loop in `useWorkspaceConnection` drops ~35 lines of manual Promise + listener + flag plumbing in favor of one call.

**Tests**

- New backend tests pin every `ClearAgentRuntimeState` call site, watcher-invalidation behavior (including re-subscribe after invalidate and per-entity scoping), and the `SetOnExit` swap.
- New frontend tests cover `bufferStreamHandle` buffering and flush semantics and the already-aborted signal regression for `waitForStreamCompletion`.

## Result

- The exit-plan-mode prompt renders correctly even when the `WatchEvents` stream is being re-established; events are no longer dropped in the buffer-and-wire gap.
- Pending control_requests are cleaned up on every agent process stop path, so a fresh agent subprocess never receives unanswerable prompts replayed from a previous run.
- Half-open transports are detected and evicted from the watcher set, allowing the frontend's reconnect loop to trigger as expected.
- The reconnect loop no longer hangs when the `AbortSignal` aborts during the synchronous setup window.
- The workaround of opening a new agent tab to force prompt re-delivery is no longer needed.
