### PR TITLE
refactor: Rename MessageRole to MessageSource across the stack

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -176,7 +176,7 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 		if extra != nil && extra(header.SessionUpdate, update) {
 			return
 		}
-		if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{}); err != nil {
+		if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{}); err != nil {
 			slog.Error("persist unknown acp sessionUpdate", "agent_id", b.agentID, "type", header.SessionUpdate, "error", err)
 		}
 	}
@@ -714,7 +714,7 @@ func (b *acpBase) persistTextMessage(sessionUpdate, text string) {
 		slog.Warn("marshal acp text content", "agent_id", b.agentID, "error", err)
 		return
 	}
-	if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msgContent, SpanInfo{}); err != nil {
+	if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msgContent, SpanInfo{}); err != nil {
 		slog.Error("persist acp text", "agent_id", b.agentID, "session_update", sessionUpdate, "error", err)
 	}
 }
@@ -731,7 +731,7 @@ func (b *acpBase) persistPromptResponse(
 	if enrich != nil {
 		resp = enrich(resp)
 	}
-	if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, resp, SpanInfo{}); err != nil {
+	if err := b.sink.PersistTurnEnd(resp, SpanInfo{}); err != nil {
 		slog.Error("persist acp prompt result", "agent_id", b.agentID, "error", err)
 	}
 	b.sink.ResetSpans()
@@ -782,7 +782,7 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 	// Tool calls that arrive already terminal (completed/failed/cancelled)
 	// are persisted as closing spans immediately — no open/close cycle.
 	if tc.Status == "completed" || tc.Status == "failed" || tc.Status == "cancelled" {
-		if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{
+		if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
 			SpanID: tc.ToolCallID, SpanType: spanType, Closing: true,
 		}); err != nil {
 			slog.Error("persist terminal acp tool_call", "agent_id", b.agentID, "kind", tc.Kind, "status", tc.Status, "error", err)
@@ -791,7 +791,7 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 	}
 
 	spanColor := b.sink.ReserveSpanColor(tc.ToolCallID, "")
-	if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{
+	if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
 		SpanID: tc.ToolCallID, SpanType: spanType, SpanColor: spanColor,
 	}); err != nil {
 		slog.Error("persist acp tool_call", "agent_id", b.agentID, "kind", tc.Kind, "error", err)
@@ -840,7 +840,7 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 		if spanType == "" {
 			spanType = acpUpdateToolCall
 		}
-		if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{
+		if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
 			SpanID: tcu.ToolCallID, SpanType: spanType, Closing: true,
 		}); err != nil {
 			slog.Error("persist acp tool_call_update", "agent_id", b.agentID, "status", tcu.Status, "error", err)
@@ -1368,7 +1368,7 @@ func hasACPOption(options []*leapmuxv1.AvailableOption, id string) bool {
 }
 
 func (b *acpBase) handlePlan(update json.RawMessage) {
-	if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, update, SpanInfo{}); err != nil {
+	if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{}); err != nil {
 		slog.Error("persist acp plan", "agent_id", b.agentID, "error", err)
 	}
 }
@@ -1406,7 +1406,7 @@ func (b *acpBase) handleACPOutput(line *parsedLine, extraSessionUpdate acpSessio
 		if extraMethod != nil && extraMethod(line) {
 			return
 		}
-		if err := b.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, line.Raw, SpanInfo{}); err != nil {
+		if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw, SpanInfo{}); err != nil {
 			slog.Error("acp persist notification", "agent_id", b.agentID, "method", line.Method, "error", err)
 		}
 	}

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -38,8 +38,14 @@ type AutoContinueSchedule struct {
 // OutputSink provides generic primitives for persisting and broadcasting
 // agent output. Implemented by the service layer and injected into providers.
 type OutputSink interface {
-	PersistMessage(role leapmuxv1.MessageRole, content []byte, span SpanInfo) error
-	PersistNotification(role leapmuxv1.MessageRole, content []byte) error
+	PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error
+	PersistNotification(source leapmuxv1.MessageSource, content []byte) error
+	// PersistTurnEnd persists the agent's turn-end divider envelope and
+	// fires the sink-level git-status auto-broadcast. Each provider's
+	// terminal envelope (Claude type:"result", Codex turn/completed,
+	// ACP prompt response, Pi agent_end) routes here so that turn-end-
+	// specific side effects are explicit at the call site.
+	PersistTurnEnd(content []byte, span SpanInfo) error
 	OpenSpan(spanID string, parentSpanID string)
 	CloseSpan(spanID string)
 	ResetSpans()

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -827,7 +827,7 @@ func (a *ClaudeCodeAgent) unregisterPendingControl(requestID string) {
 // channel and returns true (the line should be consumed, not forwarded).
 func (a *ClaudeCodeAgent) handlePendingControlResponse(line *parsedLine) bool {
 	// Quick check using the pre-parsed Type field.
-	if line.Type != "control_response" {
+	if line.Type != claudeMsgTypeControlResponse {
 		return false
 	}
 

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -16,6 +16,21 @@ import (
 	"github.com/leapmux/leapmux/internal/util/pathutil"
 )
 
+// Claude Code wire-format envelope types. Top-level `type` field on each
+// NDJSON line emitted by the Claude Code SDK. Centralized here so the
+// dispatch switches and downstream branches share a single source of
+// truth and a typo turns into a compile error rather than a silent
+// fall-through.
+const (
+	claudeMsgTypeAssistant            = "assistant"
+	claudeMsgTypeUser                 = "user"
+	claudeMsgTypeSystem               = "system"
+	claudeMsgTypeResult               = "result"
+	claudeMsgTypeControlRequest       = "control_request"
+	claudeMsgTypeControlCancelRequest = "control_cancel_request"
+	claudeMsgTypeControlResponse      = "control_response"
+)
+
 // contextUsageSnapshot tracks token usage for debounced broadcasting.
 type contextUsageSnapshot struct {
 	mu                       sync.Mutex
@@ -48,25 +63,13 @@ func (a *ClaudeCodeAgent) handleClaudeOutput(content []byte, msgType string) {
 		msgType = envelope.Type
 	}
 
-	var role leapmuxv1.MessageRole
-	switch msgType {
-	case "user":
-		role = leapmuxv1.MessageRole_MESSAGE_ROLE_USER
-	case "assistant":
-		role = leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT
-	case "system":
-		role = leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM
-	case "result":
-		role = leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END
-	}
-
 	slog.Debug("HandleOutput", "agent_id", a.agentID, "type", msgType, "len", len(content))
 
 	switch msgType {
-	case "assistant", "system", "result":
-		a.handlePersistableMessage(content, msgType, role)
+	case claudeMsgTypeAssistant, claudeMsgTypeSystem, claudeMsgTypeResult:
+		a.handlePersistableMessage(content, msgType)
 
-	case "user":
+	case claudeMsgTypeUser:
 		if isSimpleUserTextEcho(content) {
 			// Reset tool use counter at the start of each user turn.
 			// Only reset for user text echoes, not tool_result messages,
@@ -75,24 +78,24 @@ func (a *ClaudeCodeAgent) handleClaudeOutput(content []byte, msgType string) {
 			a.turnToolUses = 0
 			a.mu.Unlock()
 		} else {
-			a.handlePersistableMessage(content, msgType, role)
+			a.handlePersistableMessage(content, msgType)
 		}
 
 	case NotificationTypeContextCleared, NotificationTypeInterrupted, NotificationTypePlanExecution:
 		if msgType == NotificationTypeInterrupted {
 			a.sink.ResetSpans()
 		}
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, content); err != nil {
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, content); err != nil {
 			slog.Error("persist agent notification", "agent_id", a.agentID, "type", msgType, "error", err)
 		}
 
-	case "control_request":
+	case claudeMsgTypeControlRequest:
 		a.claudeCodeHandleControlRequest(content)
 
-	case "control_cancel_request":
+	case claudeMsgTypeControlCancelRequest:
 		a.claudeCodeHandleControlCancel(content)
 
-	case "control_response":
+	case claudeMsgTypeControlResponse:
 		a.claudeCodeHandleControlResponse(content)
 
 	case NotificationTypeRateLimitEvent:
@@ -237,11 +240,22 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 }
 
 // handlePersistableMessage handles assistant, system, user, and result messages.
-func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType string, role leapmuxv1.MessageRole) {
-	if msgType == "system" {
+//
+// Source for persistence is derived from msgType: USER for the `user`
+// envelope (which on the Claude wire includes both human input and
+// tool_result echoes under role:"user"); AGENT for assistant text,
+// system notifications, and the terminal `result` envelope. `result`
+// routes through PersistTurnEnd so its source value is unused.
+func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType string) {
+	source := leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT
+	if msgType == claudeMsgTypeUser {
+		source = leapmuxv1.MessageSource_MESSAGE_SOURCE_USER
+	}
+
+	if msgType == claudeMsgTypeSystem {
 		a.claudeCodeHandleSystemInit(content)
 
-		if isNotificationThreadable(content, role) {
+		if isNotificationThreadable(content, source) {
 			if statusVal, ok := extractStatusValue(content); ok {
 				prev := a.lastAgentStatus
 				a.lastAgentStatus = statusVal
@@ -249,12 +263,13 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 					return
 				}
 			}
-			// Persist the raw `system` message verbatim (role is already
-			// SYSTEM here). Includes `compacting` status, api_retry, and
-			// other notification-threaded subtypes — the renderer extracts
-			// `subtype`/`status` from the raw envelope so future fields
-			// like `tokensBefore`/`durationMs` don't get discarded.
-			if err := a.sink.PersistNotification(role, content); err != nil {
+			// Persist the raw `system` message verbatim (source is AGENT
+			// here — system notifications are agent-emitted). Includes
+			// `compacting` status, api_retry, and other notification-
+			// threaded subtypes — the renderer extracts `subtype`/`status`
+			// from the raw envelope so future fields like `tokensBefore`/
+			// `durationMs` don't get discarded.
+			if err := a.sink.PersistNotification(source, content); err != nil {
 				slog.Error("persist notification-threaded system message", "agent_id", a.agentID, "error", err)
 			}
 			return
@@ -271,7 +286,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// Extract agent context metadata from top-level assistant and result
 	// messages. Subagent messages (with parent_tool_use_id) have their own
 	// smaller context and would make the bar show a misleadingly low value.
-	if (msgType == "assistant" || msgType == "result") && env.ParentToolUseID == "" {
+	if (msgType == claudeMsgTypeAssistant || msgType == claudeMsgTypeResult) && env.ParentToolUseID == "" {
 		a.extractAndBroadcastUsage(&env, msgType)
 	}
 
@@ -285,14 +300,14 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// and tool name, for tool_result messages use the tool_use_id reference
 	// and look up the tool name from the span tracker.
 	var spanID, spanType string
-	if msgType == "assistant" {
+	if msgType == claudeMsgTypeAssistant {
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_use" && block.ID != "" {
 				spanID, spanType = block.ID, block.Name
 				break
 			}
 		}
-	} else if role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER {
+	} else if msgType == claudeMsgTypeUser {
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_result" && block.ToolUseID != "" {
 				spanID = block.ToolUseID
@@ -305,19 +320,19 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	}
 
 	// Detect plan mode from tool_result messages.
-	if role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER {
+	if msgType == claudeMsgTypeUser {
 		a.detectPlanModeFromToolResult(&env)
 	}
 
 	// Enrich result messages with num_tool_uses.
-	if msgType == "result" {
+	if msgType == claudeMsgTypeResult {
 		content = a.enrichResultWithToolUses(content)
 	}
 
 	// Reserve the span color for tool_use messages (assistant with a spanID)
 	// so it is available at persist time, before the span is actually opened.
 	var spanColor int32
-	if msgType == "assistant" && spanID != "" {
+	if msgType == claudeMsgTypeAssistant && spanID != "" {
 		spanColor = a.sink.ReserveSpanColor(spanID, parentSpanID)
 	}
 
@@ -325,15 +340,24 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// This MUST happen before processAssistantBlocks (which opens spans)
 	// so the assistant message stays at the parent depth.
 	// closing is true when this is a tool_result that will close its span.
-	closing := role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER && spanID != ""
-	if err := a.sink.PersistMessage(role, content, SpanInfo{
+	closing := msgType == claudeMsgTypeUser && spanID != ""
+	spanInfo := SpanInfo{
 		ParentSpanID: parentSpanID,
 		SpanID:       spanID,
 		SpanType:     spanType,
 		SpanColor:    spanColor,
 		Closing:      closing,
-	}); err != nil {
-		slog.Error("persist agent message", "agent_id", a.agentID, "error", err)
+	}
+	var persistErr error
+	if msgType == claudeMsgTypeResult {
+		// Terminal turn-end envelope — routes through PersistTurnEnd so
+		// the sink fires the git-status auto-broadcast explicitly.
+		persistErr = a.sink.PersistTurnEnd(content, spanInfo)
+	} else {
+		persistErr = a.sink.PersistMessage(source, content, spanInfo)
+	}
+	if persistErr != nil {
+		slog.Error("persist agent message", "agent_id", a.agentID, "error", persistErr)
 	}
 
 	if spanType != "" {
@@ -344,13 +368,13 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// plan file tracking, tool use counting, and span management.
 	// Runs after persist so spans open AFTER the tool_use message,
 	// keeping it at parent depth while its tool_result is indented.
-	if msgType == "assistant" {
+	if msgType == claudeMsgTypeAssistant {
 		a.processAssistantBlocks(&env)
 	}
 
 	// A single user message may contain multiple tool_result blocks
 	// (parallel tool calls), so close all of them.
-	if role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER {
+	if msgType == claudeMsgTypeUser {
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_result" && block.ToolUseID != "" {
 				a.sink.CloseSpan(block.ToolUseID)
@@ -358,7 +382,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		}
 	}
 
-	if msgType == "result" {
+	if msgType == claudeMsgTypeResult {
 		// Auto-continue on retryable Claude result errors; reset on normal results.
 		if env.IsError && isRetryableClaudeResultError(env.Result) {
 			a.sink.ScheduleAutoContinue(AutoContinueSchedule{
@@ -495,12 +519,12 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 		"rate_limits": map[string]any{rlInfo.RateLimitType: tier},
 	})
 
-	// Persist the raw `rate_limit_event` envelope verbatim as SYSTEM. The
-	// frontend's extractRateLimitInfo / notification renderer reads
-	// `rate_limit_info` from this raw Claude-native shape (camelCase) —
-	// the persisted side stays in the SDK's format so notification
-	// rendering remains a passthrough.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, content); err != nil {
+	// Persist the raw `rate_limit_event` envelope verbatim as an
+	// agent-emitted notification. The frontend's extractRateLimitInfo /
+	// notification renderer reads `rate_limit_info` from this raw
+	// Claude-native shape (camelCase) — the persisted side stays in
+	// the SDK's format so notification rendering remains a passthrough.
+	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("persist rate_limit notification", "agent_id", a.agentID, "error", err)
 	}
 
@@ -528,7 +552,7 @@ func (a *ClaudeCodeAgent) extractAndBroadcastUsage(env *messageEnvelope, msgType
 
 	snapshot := a.getOrCreateUsageSnapshot()
 
-	if msgType == "assistant" && env.Message.Usage != nil {
+	if msgType == claudeMsgTypeAssistant && env.Message.Usage != nil {
 		u := env.Message.Usage
 		snapshot.mu.Lock()
 		snapshot.InputTokens = u.InputTokens
@@ -538,7 +562,7 @@ func (a *ClaudeCodeAgent) extractAndBroadcastUsage(env *messageEnvelope, msgType
 		snapshot.mu.Unlock()
 	}
 
-	if msgType == "result" && env.ModelUsage != nil {
+	if msgType == claudeMsgTypeResult && env.ModelUsage != nil {
 		// Find the context window for the primary model in the usage map.
 		// Top-level result messages include cumulative session-level usage
 		// that always contains the primary model's entry. Subagent results
@@ -557,7 +581,7 @@ func (a *ClaudeCodeAgent) extractAndBroadcastUsage(env *messageEnvelope, msgType
 		snapshot.CacheCreationInputTokens > 0 || snapshot.CacheReadInputTokens > 0
 	if hasUsage {
 		now := time.Now()
-		shouldBroadcast := msgType == "result" ||
+		shouldBroadcast := msgType == claudeMsgTypeResult ||
 			now.Sub(snapshot.LastBroadcast) >= 10*time.Second
 		if shouldBroadcast {
 			snapshot.LastBroadcast = now
@@ -733,14 +757,19 @@ func extractToolUseResultMessage(raw json.RawMessage) string {
 
 // --- Notification threading helpers ---
 
-func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
-	switch role {
-	case leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX:
+// isNotificationThreadable decides whether a notification envelope can
+// participate in thread consolidation. Only invoked on the
+// PersistNotification path, so the AGENT branch always means
+// "agent-emitted system notification" — never assistant text or tool
+// content (those go through PersistMessage / PersistTurnEnd).
+func isNotificationThreadable(content []byte, source leapmuxv1.MessageSource) bool {
+	switch source {
+	case leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX:
 		var msg struct {
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(content, &msg); err != nil {
-			slog.Warn("notification threadable unmarshal failed", "role", "leapmux", "error", err)
+			slog.Warn("notification threadable unmarshal failed", "source", "leapmux", "error", err)
 			return false
 		}
 		switch msg.Type {
@@ -753,7 +782,7 @@ func isNotificationThreadable(content []byte, role leapmuxv1.MessageRole) bool {
 			return true
 		}
 		return false
-	case leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM:
+	case leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT:
 		return ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE).Classify(content).Consolidatable()
 	default:
 		return false
@@ -800,7 +829,7 @@ func isSimpleUserTextEcho(content []byte) bool {
 		slog.Warn("user text echo unmarshal failed", "error", err)
 		return false
 	}
-	if msg.Type != "user" {
+	if msg.Type != claudeMsgTypeUser {
 		return false
 	}
 	trimmed := bytes.TrimSpace(msg.Message.Content)

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -118,7 +118,7 @@ func TestHandleOutput_AssistantToolUse(t *testing.T) {
 	require.Len(t, msgs, 1)
 
 	msg := msgs[0]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	assert.Equal(t, "parent-123", msg.ParentSpanID)
 	assert.Equal(t, "tu-001", msg.SpanID)
 	assert.Equal(t, "Read", msg.SpanType)
@@ -182,7 +182,7 @@ func TestHandleOutput_UserToolResult(t *testing.T) {
 	require.Len(t, msgs, 1)
 
 	msg := msgs[0]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, msg.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, msg.Source)
 	assert.Equal(t, "parent-123", msg.ParentSpanID)
 	assert.Equal(t, "tu-001", msg.SpanID)
 	assert.Equal(t, "Read", msg.SpanType)
@@ -300,12 +300,12 @@ func TestClaudeRateLimitEvent_SchedulesResumeWhenBlocked(t *testing.T) {
 	assert.Equal(t, time.Unix(1893456000, 0).UTC(), schedule.DueAt)
 	assert.JSONEq(t, `{"rateLimitType":"five_hour","status":"exceeded","resetsAt":1893456000}`, string(schedule.SourcePayload))
 
-	// Persists raw rate_limit_event verbatim as SYSTEM (no longer
+	// Persists raw rate_limit_event verbatim as AGENT (no longer
 	// synthesizes a stripped-down {type:"rate_limit",rate_limit_info}).
 	require.Equal(t, 1, sink.NotificationCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"Claude-emitted rate_limit_event must persist as SYSTEM")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"Claude-emitted rate_limit_event must persist as AGENT")
 	assert.JSONEq(t, rawEvent, string(last.Content),
 		"raw envelope must be preserved verbatim so future fields flow through")
 }

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -343,18 +343,18 @@ func TestAgent_ToolUseCountSurvivesToolResult(t *testing.T) {
 	testutil.AssertEventually(t, func() bool {
 		msgs := sink.Messages()
 		for _, m := range msgs {
-			if m.Role == leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END {
+			if m.TurnEnd {
 				return true
 			}
 		}
 		return false
 	}, "expected result message to be persisted")
 
-	// Find the result message and verify num_tool_uses.
+	// Find the result message (recorded by PersistTurnEnd) and verify num_tool_uses.
 	msgs := sink.Messages()
 	var resultContent []byte
 	for _, m := range msgs {
-		if m.Role == leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END {
+		if m.TurnEnd {
 			resultContent = m.Content
 		}
 	}

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -16,8 +16,8 @@ var codexRetryableDisconnectPattern = regexp.MustCompile(`^stream disconnected b
 // codexSystemMetadataMethods are Codex-emitted JSON-RPC notifications that
 // carry agent/system metadata (lifecycle, MCP startup, skills invalidation,
 // remote-control status). They share one handler — persist verbatim as
-// SYSTEM. Methods with extra side effects (rate-limit, token-usage
-// broadcasts) keep dedicated cases below.
+// agent-emitted notifications. Methods with extra side effects
+// (rate-limit, token-usage broadcasts) keep dedicated cases below.
 var codexSystemMetadataMethods = map[string]struct{}{
 	"thread/compacted":                {},
 	"thread/name/updated":             {},
@@ -32,7 +32,7 @@ func handleCodexOutput(a *CodexAgent, line *parsedLine) {
 	slog.Debug("codex HandleOutput", "agent_id", a.agentID, "method", line.Method, "len", len(line.Raw))
 
 	if _, ok := codexSystemMetadataMethods[line.Method]; ok {
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, line.Raw); err != nil {
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
 			slog.Error("codex persist system metadata", "agent_id", a.agentID, "method", line.Method, "error", err)
 		}
 		return
@@ -98,7 +98,7 @@ func handleCodexOutput(a *CodexAgent, line *parsedLine) {
 
 	default:
 		// Persist unknown notifications so the frontend can decide how to render them.
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, line.Raw, SpanInfo{}); err != nil {
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw, SpanInfo{}); err != nil {
 			slog.Error("codex persist notification", "agent_id", a.agentID, "method", line.Method, "error", err)
 		}
 	}
@@ -240,11 +240,11 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		// No-op for started — wait for completed to persist.
 	case "contextCompaction":
 		// Persist the raw `item/started` JSON-RPC notification verbatim as
-		// SYSTEM. Preserves both `method:"item/started"` (so the
+		// AGENT. Preserves both `method:"item/started"` (so the
 		// notification consolidator and frontend classifier route by
 		// method) and Codex-specific fields under `params.item.*` that a
 		// synthesized `{type:"compacting"}` would discard.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, raw); err != nil {
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("codex persist compacting notification", "agent_id", a.agentID, "error", err)
 		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
@@ -252,7 +252,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		spanColor := a.sink.ReserveSpanColor(itemID, parentSpanID)
 		// Persist first at parent depth, then open span so the
 		// completed message is indented under the started message.
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
 		}); err != nil {
 			slog.Error("codex persist item/started", "agent_id", a.agentID, "type", itemType, "error", err)
@@ -261,7 +261,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		a.sink.OpenSpan(itemID, parentSpanID)
 	case "collabAgentToolCall":
 		spanColor := a.sink.ReserveSpanColor(itemID, parentSpanID)
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
 		}); err != nil {
 			slog.Error("codex persist collabAgentToolCall/started", "agent_id", a.agentID, "error", err)
@@ -289,7 +289,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 
 	switch itemType {
 	case "agentMessage":
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist agentMessage", "agent_id", a.agentID, "error", err)
@@ -314,7 +314,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 			a.turnPlanText = planItem.Text
 			a.mu.Unlock()
 		}
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist plan", "agent_id", a.agentID, "error", err)
@@ -324,7 +324,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		a.turnToolUses++
 		a.mu.Unlock()
 		// Persist inside the span (at child depth), then close it.
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType, Closing: true,
 		}); err != nil {
 			slog.Error("codex persist item/completed", "agent_id", a.agentID, "type", itemType, "error", err)
@@ -335,14 +335,14 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		a.sink.CloseSpan(itemID)
 	case "collabAgentToolCall":
 		closingParentSpanID := a.closingCollabParentSpanID(collab, parentSpanID, true)
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, ConnectorSpanID: closingParentSpanID, SpanID: itemID, SpanType: itemType, Closing: closingParentSpanID != "",
 		}); err != nil {
 			slog.Error("codex persist collabAgentToolCall/completed", "agent_id", a.agentID, "error", err)
 		}
 		a.handleCollabAgentSpan(collab, itemID, parentSpanID, true)
 	case "reasoning":
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist reasoning", "agent_id", a.agentID, "error", err)
@@ -352,7 +352,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		// No-op: completion is represented by thread/compacted, which is emitted as
 		// a LEAPMUX notification-thread boundary instead of an assistant message.
 	default:
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, params, SpanInfo{
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			ParentSpanID: parentSpanID, SpanID: itemID, SpanType: itemType,
 		}); err != nil {
 			slog.Error("codex persist unknown item", "agent_id", a.agentID, "type", itemType, "error", err)
@@ -408,7 +408,7 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	}
 
 	// Persist as a result divider.
-	if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, params, SpanInfo{}); err != nil {
+	if err := a.sink.PersistTurnEnd(params, SpanInfo{}); err != nil {
 		slog.Error("codex persist turn/completed", "agent_id", a.agentID, "error", err)
 	}
 
@@ -485,8 +485,8 @@ func (a *CodexAgent) handleTokenUsageUpdated(content []byte, params json.RawMess
 	}
 
 	// Persist the raw Codex notification so reconnect/catch-up can rehydrate
-	// context usage from history. Codex-emitted metadata → SYSTEM role.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, content); err != nil {
+	// context usage from history. Codex-emitted metadata → AGENT source.
+	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("codex persist tokenUsage", "agent_id", a.agentID, "error", err)
 	}
 
@@ -559,8 +559,8 @@ func (a *CodexAgent) handleErrorNotification(params json.RawMessage) {
 // The raw content is persisted as-is via PersistNotification, and converted
 // rate limit info is broadcast via BroadcastSessionInfo for the live popover.
 func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMessage) {
-	// Persist the raw Codex notification — agent-emitted metadata, SYSTEM role.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, content); err != nil {
+	// Persist the raw Codex notification — agent-emitted metadata, AGENT source.
+	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("codex persist rateLimits", "agent_id", a.agentID, "error", err)
 	}
 

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -16,8 +16,8 @@ type startupStatusGuardSink struct {
 	t *testing.T
 }
 
-func (s *startupStatusGuardSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, span SpanInfo) error {
-	s.t.Fatalf("startup status notification must not be persisted as a regular message: role=%v content=%s", role, string(content))
+func (s *startupStatusGuardSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
+	s.t.Fatalf("startup status notification must not be persisted as a regular message: source=%v content=%s", source, string(content))
 	return nil
 }
 
@@ -162,7 +162,7 @@ func TestHandleCodexOutput_PlanDelta(t *testing.T) {
 	assert.Equal(t, 0, sink.MessageCount())
 }
 
-func TestHandleCodexOutput_ContextCompactionStartPersistsRawAsSystem(t *testing.T) {
+func TestHandleCodexOutput_ContextCompactionStartPersistsRawAsAgent(t *testing.T) {
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 
@@ -172,13 +172,13 @@ func TestHandleCodexOutput_ContextCompactionStartPersistsRawAsSystem(t *testing.
 	require.Equal(t, 1, sink.NotificationCount())
 	require.Equal(t, 0, sink.MessageCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"contextCompaction must persist as SYSTEM (Codex-emitted, not LeapMux-synthesized)")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"contextCompaction must persist as AGENT (Codex-emitted, not LeapMux-synthesized)")
 	assert.JSONEq(t, input, string(last.Content),
 		"raw JSON-RPC envelope must be preserved verbatim — synthesized {type:\"compacting\"} discarded item.id and threadId")
 }
 
-func TestHandleCodexOutput_McpStartupStatusPersistsAsSystem(t *testing.T) {
+func TestHandleCodexOutput_McpStartupStatusPersistsAsAgent(t *testing.T) {
 	sink := &startupStatusGuardSink{t: t}
 	agent := newCodexAgentWithSink(sink)
 
@@ -188,12 +188,12 @@ func TestHandleCodexOutput_McpStartupStatusPersistsAsSystem(t *testing.T) {
 	require.Equal(t, 1, sink.NotificationCount())
 	require.Equal(t, 0, sink.MessageCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"Codex-emitted MCP startup-status updates must persist as SYSTEM (not LEAPMUX)")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"Codex-emitted MCP startup-status updates must persist as AGENT (not LEAPMUX)")
 	assert.JSONEq(t, input, string(last.Content), "raw JSON-RPC envelope must be preserved verbatim")
 }
 
-func TestHandleCodexOutput_ThreadNameUpdatedPersistsRawAsSystem(t *testing.T) {
+func TestHandleCodexOutput_ThreadNameUpdatedPersistsRawAsAgent(t *testing.T) {
 	sink := &recordingControlSink{}
 	agent := newCodexAgentWithSink(sink)
 
@@ -203,15 +203,15 @@ func TestHandleCodexOutput_ThreadNameUpdatedPersistsRawAsSystem(t *testing.T) {
 	require.Equal(t, 1, sink.NotificationCount(),
 		"thread/name/updated must persist for reconnect rehydration")
 	require.Equal(t, 0, sink.MessageCount(),
-		"thread/name/updated must NOT fall through to the default ASSISTANT branch")
+		"thread/name/updated must NOT fall through to the default AGENT branch")
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"Codex-emitted lifecycle metadata must persist as SYSTEM")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"Codex-emitted lifecycle metadata must persist as AGENT")
 	assert.JSONEq(t, input, string(last.Content),
 		"raw envelope must be preserved so future renderers can read every field")
 }
 
-func TestHandleCodexOutput_MetadataNotificationsPersistRawAsSystem(t *testing.T) {
+func TestHandleCodexOutput_MetadataNotificationsPersistRawAsAgent(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		input string
@@ -233,10 +233,10 @@ func TestHandleCodexOutput_MetadataNotificationsPersistRawAsSystem(t *testing.T)
 
 			require.Equal(t, 1, sink.NotificationCount())
 			require.Equal(t, 0, sink.MessageCount(),
-				"Codex metadata notifications must not fall through to the default ASSISTANT branch")
+				"Codex metadata notifications must not fall through to the default AGENT branch")
 			last := sink.LastNotification()
-			assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-				"Codex-emitted metadata must persist as SYSTEM")
+			assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+				"Codex-emitted metadata must persist as AGENT")
 			assert.JSONEq(t, tc.input, string(last.Content),
 				"raw JSON-RPC envelope must be preserved verbatim")
 		})
@@ -255,10 +255,10 @@ func TestHandleCodexOutput_RateLimitExceededSchedulesResume(t *testing.T) {
 	require.Equal(t, AutoContinueReasonRateLimit, schedule.Reason)
 	require.True(t, schedule.DueAt.Equal(time.Unix(1893456000, 0).UTC()))
 
-	// Raw notification persisted as SYSTEM (agent-emitted metadata).
+	// Raw notification persisted as AGENT (agent-emitted metadata).
 	require.Equal(t, 1, sink.NotificationCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source)
 	assert.JSONEq(t, input, string(last.Content))
 }
 
@@ -540,7 +540,7 @@ func TestHandleCodexOutput_WaitCompletedClosesParentSpawnOnlyAfterLastReceiverFi
 	require.Equal(t, "call-1", closedSpans[0])
 }
 
-func TestHandleCodexOutput_ThreadCompactedPersistsRawAsSystem(t *testing.T) {
+func TestHandleCodexOutput_ThreadCompactedPersistsRawAsAgent(t *testing.T) {
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 
@@ -550,8 +550,8 @@ func TestHandleCodexOutput_ThreadCompactedPersistsRawAsSystem(t *testing.T) {
 	require.Equal(t, 1, sink.NotificationCount())
 	require.Equal(t, 0, sink.MessageCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"thread/compacted must persist as SYSTEM (Codex-emitted)")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"thread/compacted must persist as AGENT (Codex-emitted)")
 	assert.JSONEq(t, input, string(last.Content),
 		"raw JSON-RPC envelope must be preserved verbatim — frontend keys off `method:\"thread/compacted\"`")
 }
@@ -736,8 +736,8 @@ func TestHandleCodexOutput_TokenUsageUpdatedBroadcastsContextUsage(t *testing.T)
 
 	require.Equal(t, 1, sink.NotificationCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"Codex-emitted thread/tokenUsage/updated must persist as SYSTEM")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"Codex-emitted thread/tokenUsage/updated must persist as AGENT")
 	assert.JSONEq(t, input, string(last.Content),
 		"raw envelope must be preserved so reconnect/catch-up sees full token usage detail")
 	require.Equal(t, 1, sink.SessionInfoCount())

--- a/backend/internal/worker/agent/gemini_output_test.go
+++ b/backend/internal/worker/agent/gemini_output_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,7 +100,7 @@ func TestGeminiHandlePromptResponsePersistsTurn(t *testing.T) {
 	})
 
 	require.Equal(t, 3, sink.MessageCount())
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, sink.Messages()[2].Role)
+	require.True(t, sink.Messages()[2].TurnEnd, "prompt response must route through PersistTurnEnd")
 	require.Equal(t, 1, sink.SessionInfoCount())
 }
 

--- a/backend/internal/worker/agent/kilo_output_test.go
+++ b/backend/internal/worker/agent/kilo_output_test.go
@@ -67,7 +67,7 @@ func TestHandleKiloPromptResponse_PersistsThinkingText(t *testing.T) {
 	require.Equal(t, 3, sink.MessageCount())
 
 	thinkingMsg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, thinkingMsg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, thinkingMsg.Source)
 	var thinkingParsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(thinkingMsg.Content, &thinkingParsed))
 	require.Equal(t, "agent_thought_chunk", thinkingParsed["sessionUpdate"])
@@ -80,7 +80,7 @@ func TestHandleKiloPromptResponse_PersistsThinkingText(t *testing.T) {
 	require.Equal(t, "agent_message_chunk", assistantParsed["sessionUpdate"])
 
 	resultMsg := sink.Messages()[2]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, resultMsg.Role)
+	require.True(t, resultMsg.TurnEnd, "prompt response must route through PersistTurnEnd")
 
 	agent.mu.Lock()
 	require.Equal(t, "", agent.turnThinkingText.String())
@@ -97,7 +97,7 @@ func TestHandleKiloOutput_ToolCallOpensSpan(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	require.Equal(t, "tc-1", msg.SpanID)
 	require.Equal(t, "execute", msg.SpanType)
 
@@ -153,7 +153,7 @@ func TestHandleKiloOutput_Plan(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	var plan struct {
 		SessionUpdate string `json:"sessionUpdate"`
 		Entries       []struct {

--- a/backend/internal/worker/agent/notification_types.go
+++ b/backend/internal/worker/agent/notification_types.go
@@ -2,7 +2,7 @@ package agent
 
 // LeapMux notification-type vocabulary. The platform persists each of
 // these as the inner `type` field on a notification envelope (LEAPMUX
-// role for worker-synthesized events; SYSTEM role for agent-emitted
+// source for worker-synthesized events; AGENT source for agent-emitted
 // metadata that flows through the same renderer). Centralizing the
 // strings turns rename mistakes into compile errors and gives the
 // dispatch switches a single source of truth.

--- a/backend/internal/worker/agent/opencode_output_test.go
+++ b/backend/internal/worker/agent/opencode_output_test.go
@@ -71,7 +71,7 @@ func TestHandlePromptResponse_PersistsThinkingText(t *testing.T) {
 
 	// First message: thinking text.
 	thinkingMsg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, thinkingMsg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, thinkingMsg.Source)
 	var thinkingParsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(thinkingMsg.Content, &thinkingParsed))
 	require.Equal(t, "agent_thought_chunk", thinkingParsed["sessionUpdate"])
@@ -86,7 +86,7 @@ func TestHandlePromptResponse_PersistsThinkingText(t *testing.T) {
 
 	// Third message: result divider.
 	resultMsg := sink.Messages()[2]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, resultMsg.Role)
+	require.True(t, resultMsg.TurnEnd, "prompt response must route through PersistTurnEnd")
 
 	// Accumulated text should be reset.
 	agent.mu.Lock()
@@ -104,7 +104,7 @@ func TestHandleOpenCodeOutput_ToolCallOpensSpan(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	require.Equal(t, "tc-1", msg.SpanID)
 	require.Equal(t, "execute", msg.SpanType)
 
@@ -215,7 +215,7 @@ func TestHandleOpenCodeOutput_Plan(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	// Verify the content contains the plan entries.
 	var plan struct {
 		SessionUpdate string `json:"sessionUpdate"`
@@ -362,7 +362,7 @@ func TestHandlePromptResponse_WrappedFormat(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, msg.Role)
+	require.True(t, msg.TurnEnd, "wrapped prompt response must route through PersistTurnEnd")
 
 	// The persisted content should have stopReason at the top level.
 	var parsed map[string]interface{}

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -99,9 +99,9 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 	case PiEventCompactionStart, PiEventCompactionEnd,
 		PiEventAutoRetryStart, PiEventAutoRetryEnd,
 		PiEventExtensionError:
-		// Pi-emitted lifecycle / extension events — SYSTEM role per the
+		// Pi-emitted lifecycle / extension events — AGENT source per the
 		// proto rule (LEAPMUX is reserved for worker-synthesized envelopes).
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, line.Raw); err != nil {
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
 			slog.Error("pi persist notification", "agent_id", a.agentID, "type", line.Type, "error", err)
 		}
 	case PiEventExtensionUIRequest:
@@ -112,7 +112,7 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 		slog.Warn("pi orphan response line", "agent_id", a.agentID, "len", len(line.Raw))
 	default:
 		// Persist unknown event types so the user can still see them.
-		if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, line.Raw, SpanInfo{}); err != nil {
+		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw, SpanInfo{}); err != nil {
 			slog.Error("pi persist unknown event", "agent_id", a.agentID, "type", line.Type, "error", err)
 		}
 	}
@@ -153,7 +153,7 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 
 func (a *PiAgent) handlePiMessageEnd(raw []byte) {
 	augmented := a.augmentPiMessageEnd(raw)
-	if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, augmented, SpanInfo{}); err != nil {
+	if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, augmented, SpanInfo{}); err != nil {
 		slog.Error("pi persist message_end", "agent_id", a.agentID, "error", err)
 	}
 }
@@ -192,7 +192,7 @@ func (a *PiAgent) handlePiToolExecutionStart(raw []byte) {
 	}
 
 	spanColor := a.sink.ReserveSpanColor(env.ToolCallID, "")
-	if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, raw, SpanInfo{
+	if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
 		SpanID:    env.ToolCallID,
 		SpanType:  env.ToolName,
 		SpanColor: spanColor,
@@ -266,7 +266,7 @@ func (a *PiAgent) handlePiToolExecutionEnd(raw []byte) {
 	a.mu.Unlock()
 	a.clearCumulativeDelta(env.ToolCallID)
 
-	if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, raw, SpanInfo{
+	if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
 		SpanID:   env.ToolCallID,
 		SpanType: env.ToolName,
 		Closing:  true,
@@ -313,10 +313,10 @@ func (a *PiAgent) handlePiExtensionUIRequest(raw []byte) {
 
 	switch head.Method {
 	case PiExtensionMethodNotify:
-		// Persist the raw extension_ui_request envelope as SYSTEM. The
+		// Persist the raw extension_ui_request envelope as AGENT. The
 		// frontend's Pi notification renderer derives level/message from
 		// `notifyType`/`message` on the raw payload — no synthesis needed.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, raw); err != nil {
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("pi persist notify", "agent_id", a.agentID, "error", err)
 		}
 	case PiExtensionMethodSetStatus:
@@ -349,8 +349,8 @@ func (a *PiAgent) handlePiExtensionUIRequest(raw []byte) {
 		})
 	default:
 		// Unknown extension UI method — record so the user can see it.
-		// Pi-emitted, so SYSTEM role.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, raw); err != nil {
+		// Pi-emitted, so AGENT source.
+		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("pi persist unknown extension_ui_request",
 				"agent_id", a.agentID, "method", head.Method, "error", err)
 		}

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -51,7 +51,7 @@ func TestHandlePiOutput_AgentEnd_PersistsResultDividerAndResets(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, msg.Role)
+	assert.True(t, msg.TurnEnd, "agent_end must route through PersistTurnEnd")
 
 	assert.Equal(t, 1, sink.ResetSpanCount(), "agent_end should reset spans")
 	require.Equal(t, 1, sink.SessionInfoCount())
@@ -116,7 +116,7 @@ func TestHandlePiOutput_MessageEnd_PersistsAssistantMessage(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 	assert.JSONEq(t, string(raw), string(msg.Content))
 }
 
@@ -131,7 +131,7 @@ func TestHandlePiOutput_MessageEnd_AugmentsUsageAndBroadcastsSessionInfo(t *test
 
 	require.Equal(t, 1, sink.MessageCount())
 	msg := sink.Messages()[0]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, msg.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
 
 	var persisted map[string]any
 	require.NoError(t, json.Unmarshal(msg.Content, &persisted))
@@ -168,7 +168,7 @@ func TestHandlePiOutput_AgentEnd_AugmentsWithLatestUsageSnapshot(t *testing.T) {
 	msgs := sink.Messages()
 	require.Equal(t, 2, len(msgs))
 	result := msgs[1]
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, result.Role)
+	assert.True(t, result.TurnEnd, "agent_end must route through PersistTurnEnd")
 
 	var persisted map[string]any
 	require.NoError(t, json.Unmarshal(result.Content, &persisted))
@@ -285,7 +285,7 @@ func TestHandlePiOutput_QueueUpdate_BroadcastsDepth(t *testing.T) {
 	assert.Equal(t, 1, info["pi_follow_up_depth"])
 }
 
-func TestHandlePiOutput_CompactionEvents_PersistAsSystemNotification(t *testing.T) {
+func TestHandlePiOutput_CompactionEvents_PersistAsAgentNotification(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
 
@@ -298,12 +298,12 @@ func TestHandlePiOutput_CompactionEvents_PersistAsSystemNotification(t *testing.
 
 	require.Equal(t, 2, sink.NotificationCount())
 	for _, n := range sink.PersistedNotifications() {
-		assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, n.Role,
-			"Pi-emitted lifecycle events must persist as SYSTEM (LEAPMUX is reserved for worker-synthesized envelopes)")
+		assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, n.Source,
+			"Pi-emitted lifecycle events must persist as AGENT (LEAPMUX is reserved for worker-synthesized envelopes)")
 	}
 }
 
-func TestHandlePiOutput_AutoRetryEvents_PersistAsSystemNotification(t *testing.T) {
+func TestHandlePiOutput_AutoRetryEvents_PersistAsAgentNotification(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
 
@@ -316,11 +316,11 @@ func TestHandlePiOutput_AutoRetryEvents_PersistAsSystemNotification(t *testing.T
 
 	require.Equal(t, 2, sink.NotificationCount())
 	for _, n := range sink.PersistedNotifications() {
-		assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, n.Role)
+		assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, n.Source)
 	}
 }
 
-func TestHandlePiOutput_ExtensionError_PersistAsSystemNotification(t *testing.T) {
+func TestHandlePiOutput_ExtensionError_PersistAsAgentNotification(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
 
@@ -329,7 +329,7 @@ func TestHandlePiOutput_ExtensionError_PersistAsSystemNotification(t *testing.T)
 	)))
 
 	require.Equal(t, 1, sink.NotificationCount())
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, sink.LastNotification().Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, sink.LastNotification().Source)
 }
 
 func TestHandlePiOutput_ExtensionUIRequest_DialogPersistsControlRequest(t *testing.T) {
@@ -392,7 +392,7 @@ func TestHandlePiOutput_ExtensionUIRequest_DialogWithoutIDIsDropped(t *testing.T
 	assert.Empty(t, sink.BroadcastControls())
 }
 
-func TestHandlePiOutput_ExtensionUIRequest_NotifyPersistsRawAsSystem(t *testing.T) {
+func TestHandlePiOutput_ExtensionUIRequest_NotifyPersistsRawAsAgent(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
 
@@ -402,8 +402,8 @@ func TestHandlePiOutput_ExtensionUIRequest_NotifyPersistsRawAsSystem(t *testing.
 	// Single raw passthrough — no synthesized agent_notify wrapper.
 	require.Equal(t, 1, sink.NotificationCount(), "single raw extension_ui_request notification persisted")
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role,
-		"Pi-emitted notify must persist as SYSTEM (the agent is the source)")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source,
+		"Pi-emitted notify must persist as AGENT (the agent is the source)")
 	assert.JSONEq(t, rawLine, string(last.Content),
 		"raw envelope must be preserved verbatim so renderers can read every method-specific field")
 
@@ -425,7 +425,7 @@ func TestHandlePiOutput_ExtensionUIRequest_NotifyMissingNotifyTypePreservesRaw(t
 
 	require.Equal(t, 1, sink.NotificationCount())
 	last := sink.LastNotification()
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, last.Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, last.Source)
 	// notifyType absent in the raw — renderer is responsible for defaulting to "info".
 	assert.NotContains(t, string(last.Content), `"notifyType"`)
 	assert.Empty(t, sink.Notifications(), "no synthesized agent_notify on the side channel")
@@ -538,12 +538,12 @@ func TestHandlePiOutput_ResponseLineWithoutPendingID_LoggedNotPersisted(t *testi
 	assert.Equal(t, 0, sink.NotificationCount())
 }
 
-func TestHandlePiOutput_UnknownEventType_PersistedAsAssistant(t *testing.T) {
+func TestHandlePiOutput_UnknownEventType_PersistedAsAgent(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"future_event","stuff":1}`)))
 
 	require.Equal(t, 1, sink.MessageCount())
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, sink.Messages()[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, sink.Messages()[0].Source)
 }

--- a/backend/internal/worker/agent/pi_usage.go
+++ b/backend/internal/worker/agent/pi_usage.go
@@ -5,8 +5,6 @@ import (
 	"log/slog"
 	"maps"
 	"time"
-
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 const piSessionStatsMaxWait = 2 * time.Second
@@ -319,7 +317,7 @@ func (a *PiAgent) augmentPiMessageEnd(raw []byte) []byte {
 
 func (a *PiAgent) persistPiAgentEnd(raw []byte, snap piUsageSnapshot) {
 	augmented := piAugmentRawWithSnapshot(raw, snap)
-	if err := a.sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END, augmented, SpanInfo{}); err != nil {
+	if err := a.sink.PersistTurnEnd(augmented, SpanInfo{}); err != nil {
 		slog.Error("pi persist agent_end", "agent_id", a.agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/agent/provider_test.go
+++ b/backend/internal/worker/agent/provider_test.go
@@ -54,7 +54,7 @@ func TestProviderFor_CodexClassification(t *testing.T) {
 		"item/started for a contextCompaction item is the in-progress compacting indicator")
 
 	assert.False(t, plugin.Classify(commandExecutionStart).Consolidatable(),
-		"item/started for non-contextCompaction items must NOT be classified as a notification — those go through PersistMessage as ASSISTANT spans")
+		"item/started for non-contextCompaction items must NOT be classified as a notification — those go through PersistMessage as AGENT spans")
 }
 
 func TestProviderFor_ClaudeClassification(t *testing.T) {
@@ -83,19 +83,19 @@ func TestProviderFor_ClaudeClassification(t *testing.T) {
 	)
 }
 
-func TestIsNotificationThreadable_ClaudeRateLimitEventViaSystem(t *testing.T) {
-	// rate_limit_event arrives as SYSTEM after Phase 4.4. The plugin
-	// classifies it as provider-scoped, so isNotificationThreadable returns
-	// true and it threads with surrounding notifications.
-	assert.True(t, isNotificationThreadable([]byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"exceeded"}}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+func TestIsNotificationThreadable_ClaudeRateLimitEventAsAgent(t *testing.T) {
+	// rate_limit_event arrives as AGENT. The plugin classifies it as
+	// provider-scoped, so isNotificationThreadable returns true and it
+	// threads with surrounding notifications.
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"exceeded"}}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
 }
 
-func TestIsNotificationThreadable_ClaudeStatusCompactingViaSystem(t *testing.T) {
-	// After Phase 4.1 the worker persists the raw `system` message as
-	// SYSTEM (not the synthesized `{type:"compacting"}` envelope), and
+func TestIsNotificationThreadable_ClaudeStatusCompactingAsAgent(t *testing.T) {
+	// The worker persists the raw `system` message as AGENT (not a
+	// synthesized `{type:"compacting"}` envelope), and
 	// isNotificationThreadable still returns true because the plugin
 	// classifies it as a Status notification.
-	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"compacting"}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"compacting"}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
 }
 
 func TestProviderFor_PiClassification(t *testing.T) {
@@ -211,7 +211,7 @@ func TestProviderFor_IsInterruptIsolatedPerProvider(t *testing.T) {
 }
 
 func TestIsNotificationThreadable_ClaudeSystemUsesPlugin(t *testing.T) {
-	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"idle"}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
-	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"api_retry","attempt":1}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
-	assert.False(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"other"}`), leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM))
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"idle"}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
+	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"api_retry","attempt":1}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
+	assert.False(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"other"}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
 }

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -36,13 +36,17 @@ type testSink struct {
 }
 
 type testSinkMessage struct {
-	Role            leapmuxv1.MessageRole
+	Source          leapmuxv1.MessageSource
 	Content         []byte
 	ParentSpanID    string
 	ConnectorSpanID string
 	SpanID          string
 	SpanType        string
 	Closing         bool
+	// TurnEnd is set on entries recorded by PersistTurnEnd so tests can
+	// distinguish the turn-end divider from regular AGENT messages
+	// without inspecting the inner content.
+	TurnEnd bool
 }
 
 type testSinkStreamChunk struct {
@@ -56,17 +60,33 @@ type testSinkSpanOpen struct {
 	ParentSpanID string
 }
 
-func (s *testSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, span SpanInfo) error {
+func (s *testSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messages = append(s.messages, testSinkMessage{Role: role, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing})
+	s.messages = append(s.messages, testSinkMessage{Source: source, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing})
 	return nil
 }
 
-func (s *testSink) PersistNotification(role leapmuxv1.MessageRole, content []byte) error {
+func (s *testSink) PersistTurnEnd(content []byte, span SpanInfo) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.notifications = append(s.notifications, testSinkMessage{Role: role, Content: append([]byte(nil), content...)})
+	s.messages = append(s.messages, testSinkMessage{
+		Source:          leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		Content:         append([]byte(nil), content...),
+		ParentSpanID:    span.ParentSpanID,
+		ConnectorSpanID: span.ConnectorSpanID,
+		SpanID:          span.SpanID,
+		SpanType:        span.SpanType,
+		Closing:         span.Closing,
+		TurnEnd:         true,
+	})
+	return nil
+}
+
+func (s *testSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifications = append(s.notifications, testSinkMessage{Source: source, Content: append([]byte(nil), content...)})
 	return nil
 }
 
@@ -363,10 +383,11 @@ func (s *testSink) LastAutoCancel() AutoContinueReason {
 // need to verify output.
 type noopSink struct{}
 
-func (noopSink) PersistMessage(leapmuxv1.MessageRole, []byte, SpanInfo) error {
+func (noopSink) PersistMessage(leapmuxv1.MessageSource, []byte, SpanInfo) error {
 	return nil
 }
-func (noopSink) PersistNotification(leapmuxv1.MessageRole, []byte) error          { return nil }
+func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                            { return nil }
+func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) error        { return nil }
 func (noopSink) OpenSpan(string, string)                                          {}
 func (noopSink) CloseSpan(string)                                                 {}
 func (noopSink) ResetSpans()                                                      {}

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -32,7 +32,7 @@ CREATE TABLE messages (
     id                  TEXT PRIMARY KEY,
     agent_id            TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
     seq                 INTEGER NOT NULL,
-    role                INTEGER NOT NULL,
+    source              INTEGER NOT NULL,
     content             BLOB NOT NULL,
     content_compression INTEGER NOT NULL,
     depth               INTEGER NOT NULL DEFAULT 0,

--- a/backend/internal/worker/db/queries/messages.sql
+++ b/backend/internal/worker/db/queries/messages.sql
@@ -1,10 +1,10 @@
 -- name: CreateMessage :one
-INSERT INTO messages (id, agent_id, seq, role, content, content_compression, depth, span_id, parent_span_id, span_type, span_lines, span_color, agent_provider, created_at)
+INSERT INTO messages (id, agent_id, seq, source, content, content_compression, depth, span_id, parent_span_id, span_type, span_lines, span_color, agent_provider, created_at)
 VALUES (
   sqlc.arg(id),
   sqlc.arg(agent_id),
   (SELECT COALESCE(MAX(m.seq), 0) + 1 FROM messages m WHERE m.agent_id = sqlc.arg(agent_id)),
-  sqlc.arg(role),
+  sqlc.arg(source),
   sqlc.arg(content),
   sqlc.arg(content_compression),
   sqlc.arg(depth),
@@ -59,7 +59,7 @@ RETURNING seq;
 SELECT * FROM messages WHERE agent_id = ? ORDER BY seq DESC LIMIT 1;
 
 -- name: HasUserMessages :one
-SELECT EXISTS(SELECT 1 FROM messages m JOIN agents a ON m.agent_id = a.id WHERE m.agent_id = ? AND m.role = 1 AND m.seq > a.session_start_seq) AS has_messages;
+SELECT EXISTS(SELECT 1 FROM messages m JOIN agents a ON m.agent_id = a.id WHERE m.agent_id = ? AND m.source = 1 AND m.seq > a.session_start_seq) AS has_messages;
 
 -- name: DeleteMessageByAgentAndID :exec
 DELETE FROM messages WHERE id = ? AND agent_id = ?;

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -287,7 +287,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		seq, err := svc.Queries.CreateMessage(bgCtx(), db.CreateMessageParams{
 			ID:                 messageID,
 			AgentID:            agentID,
-			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+			Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:            compressed,
 			ContentCompression: compressionType,
 			Depth:              0,
@@ -310,7 +310,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		userMsg := &leapmuxv1.AgentChatMessage{
 			Id:                 messageID,
-			Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+			Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:            compressed,
 			ContentCompression: compressionType,
 			Seq:                seq,
@@ -1673,7 +1673,7 @@ func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmux
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
 		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
 	}
 }
@@ -1877,7 +1877,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 	seq, err := svc.Queries.CreateMessage(bgCtx(), db.CreateMessageParams{
 		ID:                 messageID,
 		AgentID:            agentID,
-		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Depth:              0,
@@ -1915,7 +1915,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 
 	userMsg := &leapmuxv1.AgentChatMessage{
 		Id:                 messageID,
-		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Seq:                seq,
@@ -2213,7 +2213,7 @@ func (svc *Context) handleControlResponsePlanMode(agentID string, content []byte
 		displayJSON, marshalErr := json.Marshal(displayContent)
 		if marshalErr != nil {
 			slog.Warn("marshal control response notification", "agent_id", agentID, "error", marshalErr)
-		} else if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, displayJSON, agent.SpanInfo{}, nil); err != nil {
+		} else if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, displayJSON, agent.SpanInfo{}, nil); err != nil {
 			slog.Warn("failed to persist control response notification", "agent_id", agentID, "error", err)
 		}
 	}
@@ -2334,7 +2334,7 @@ func (svc *Context) initiatePlanExecution(agentID string, targetMode string) {
 		slog.Warn("plan exec: marshal plan execution message", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
+	if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
 		slog.Warn("plan exec: failed to persist plan execution message", "agent_id", agentID, "error", err)
 	}
 }
@@ -2440,7 +2440,7 @@ func broadcastWatchEvent(sender *channel.Sender, resp *leapmuxv1.WatchEventsResp
 func messageToProto(m *db.Message) *leapmuxv1.AgentChatMessage {
 	return &leapmuxv1.AgentChatMessage{
 		Id:                 m.ID,
-		Role:               leapmuxv1.MessageRole(m.Role),
+		Source:             m.Source,
 		Content:            m.Content,
 		Seq:                m.Seq,
 		DeliveryError:      m.DeliveryError,

--- a/backend/internal/worker/service/agent_clear_test.go
+++ b/backend/internal/worker/service/agent_clear_test.go
@@ -123,7 +123,7 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 	for i, stream := range w.streams {
 		ev := decodeWatchAgentEvent(t, stream)
 		if msg := ev.GetAgentMessage(); msg != nil {
-			if userIdx == -1 && msg.Role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER {
+			if userIdx == -1 && msg.Source == leapmuxv1.MessageSource_MESSAGE_SOURCE_USER {
 				userIdx = i
 			}
 			if contextClearedIdx == -1 {
@@ -191,7 +191,7 @@ func TestSendAgentMessage_SlashClearBroadcastsStartingDuringRestart(t *testing.T
 	for i, stream := range w.streams {
 		ev := decodeWatchAgentEvent(t, stream)
 		if msg := ev.GetAgentMessage(); msg != nil {
-			if userIdx == -1 && msg.Role == leapmuxv1.MessageRole_MESSAGE_ROLE_USER {
+			if userIdx == -1 && msg.Source == leapmuxv1.MessageSource_MESSAGE_SOURCE_USER {
 				userIdx = i
 			}
 			if contextClearedIdx == -1 {
@@ -311,7 +311,7 @@ func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testin
 	require.Len(t, w.streams, 1)
 
 	msg := decodeWatchAgentMessage(t, w.streams[0])
-	require.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, msg.Role)
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, msg.Source)
 	assert.Equal(t, "[Request interrupted by user]", decodeAgentChatMessageContent(t, msg)["content"])
 }
 

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -124,7 +124,7 @@ func TestResolveResumeSessionID_IgnoresPreClearMessages(t *testing.T) {
 	_, err := svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
 		ID:        "msg-1",
 		AgentID:   "agent-clear",
-		Role:      leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:    leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:   []byte(`{"content":"hello"}`),
 		CreatedAt: time.Now(),
 	})
@@ -156,7 +156,7 @@ func TestResolveResumeSessionID_IgnoresPreClearMessages(t *testing.T) {
 	_, err = svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
 		ID:        "msg-2",
 		AgentID:   "agent-clear",
-		Role:      leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:    leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:   []byte(`{"content":"world"}`),
 		CreatedAt: time.Now(),
 	})
@@ -199,7 +199,7 @@ func TestResolveResumeSessionID_NotAffectedByJustPersistedMessage(t *testing.T) 
 	_, err = svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
 		ID:        "msg-first",
 		AgentID:   "agent-idle",
-		Role:      leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:    leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:   []byte(`{"content":"hello"}`),
 		CreatedAt: time.Now(),
 	})

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -192,7 +192,7 @@ func TestListAgentMessages_ClosedAgent_ReturnsEmpty(t *testing.T) {
 	_, err := svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
 		ID:        "msg-1",
 		AgentID:   "agent-1",
-		Role:      leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:    leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:   []byte("hello"),
 		CreatedAt: time.Now(),
 	})
@@ -303,7 +303,7 @@ func TestWatchEvents_ClosedAgent_NotWatched(t *testing.T) {
 	_, err := svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
 		ID:        "msg-1",
 		AgentID:   "agent-closed",
-		Role:      leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
+		Source:    leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:   []byte("hello"),
 		CreatedAt: time.Now(),
 	})

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -86,7 +86,7 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Task: Inspect the renderer\nReason: Need parity with Claude Code", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
 }
 
@@ -145,7 +145,7 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Please add tests before exiting plan mode.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
 }
 
@@ -204,7 +204,7 @@ func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_USER, rows[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Task: Build\nEnv: Dev", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
 }
 

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -6,6 +6,7 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -503,14 +504,27 @@ func resolveConnectorSpanID(spanID, connectorSpanID, parentSpanID string, closin
 // --- Notification threading ---
 
 // notifThreadRef tracks the current notification thread for an agent.
+// `source` lets the cross-source guard short-circuit before the DB read —
+// adjacent USER↔AGENT↔LEAPMUX flips just open a new thread and never
+// touch sqlite or zstd.
 type notifThreadRef struct {
-	msgID string
-	seq   int64
+	msgID  string
+	seq    int64
+	source leapmuxv1.MessageSource
 }
+
+// notifThreadWrapperType is the constant value of the wrapper's `type`
+// discriminator. The frontend's content-shape probe keys on this string
+// alone, so it must never collide with any inner-envelope `type` value
+// produced by an agent provider.
+const notifThreadWrapperType = "notification_thread"
 
 // notifThreadWrapper is the content envelope stored in the DB for notification
 // thread messages. It consolidates multiple notifications into a single DB row.
+// The Type field is an explicit discriminator so consumers can identify the
+// wrapper from content shape alone, decoupled from the persisted source.
 type notifThreadWrapper struct {
+	Type     string            `json:"type"`
 	OldSeqs  []int64           `json:"old_seqs,omitempty"`
 	Messages []json.RawMessage `json:"messages"`
 }
@@ -518,12 +532,13 @@ type notifThreadWrapper struct {
 // wrapNotifContent wraps a single raw notification JSON into a notifThreadWrapper.
 func wrapNotifContent(rawJSON []byte) []byte {
 	w := notifThreadWrapper{
+		Type:     notifThreadWrapperType,
 		Messages: []json.RawMessage{rawJSON},
 	}
 	data, err := json.Marshal(w)
 	if err != nil {
 		slog.Warn("marshal notification wrapper", "error", err)
-		return []byte(`{"messages":[]}`)
+		return []byte(`{"type":"` + notifThreadWrapperType + `","messages":[]}`)
 	}
 	return data
 }
@@ -680,26 +695,27 @@ type agentOutputSink struct {
 
 // --- OutputSink interface implementation ---
 
-func (s *agentOutputSink) PersistMessage(role leapmuxv1.MessageRole, content []byte, span agent.SpanInfo) error {
-	if err := s.h.persistAndBroadcast(s.agentID, s.agentProvider, role, content, span, s.tracker); err != nil {
+func (s *agentOutputSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span agent.SpanInfo) error {
+	return s.h.persistAndBroadcast(s.agentID, s.agentProvider, source, content, span, s.tracker)
+}
+
+// PersistTurnEnd persists the universal turn-end divider envelope and
+// fires the git-status auto-broadcast. Each provider's terminal
+// envelope (Claude type:"result", Codex turn/completed, ACP prompt
+// response, Pi agent_end) routes here, so the side effect is explicit
+// at the call site. Runs BroadcastGitStatus on a goroutine so the
+// agent's stdout-read loop is not blocked by the git subprocesses plus
+// the DB lookup.
+func (s *agentOutputSink) PersistTurnEnd(content []byte, span agent.SpanInfo) error {
+	if err := s.h.persistAndBroadcast(s.agentID, s.agentProvider, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content, span, s.tracker); err != nil {
 		return err
 	}
-	// TURN_END role marks the universal turn-end signal across providers
-	// (Claude type:"result", Codex turn/completed, ACP prompt response,
-	// Pi agent_end). Refresh git status at every turn end so the user
-	// does not have to update it manually. Mid-turn notifications use
-	// PersistNotification, not PersistMessage, so they don't trigger
-	// here. Run on a goroutine so the agent's stdout-read loop is not
-	// blocked by the four git subprocesses BroadcastGitStatus shells out
-	// to plus the DB lookup.
-	if role == leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END {
-		go s.BroadcastGitStatus()
-	}
+	go s.BroadcastGitStatus()
 	return nil
 }
 
-func (s *agentOutputSink) PersistNotification(role leapmuxv1.MessageRole, content []byte) error {
-	return s.h.persistNotificationThreaded(s.agentID, s.agentProvider, s.plugin, role, content)
+func (s *agentOutputSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) error {
+	return s.h.persistNotificationThreaded(s.agentID, s.agentProvider, s.plugin, source, content)
 }
 
 func (s *agentOutputSink) OpenSpan(spanID, parentSpanID string) {
@@ -936,9 +952,8 @@ func (s *agentOutputSink) BroadcastStatusActive(sessionID string) {
 
 // BroadcastGitStatus emits a partial AgentStatusChange carrying only the
 // agent id and a freshly-computed git status. Auto-fired by
-// PersistMessage at every turn-end (TURN_END role) so the working-tree
-// view stays in sync without provider involvement; providers do not
-// call this directly.
+// PersistTurnEnd so the working-tree view stays in sync without
+// provider involvement; providers do not call this directly.
 //
 // The frontend's statusChange handler treats events whose Status is
 // UNSPECIFIED as partial updates and applies only the populated fields,
@@ -1056,7 +1071,7 @@ func (h *OutputHandler) clearNotifThread(agentID string) {
 
 // persistAndBroadcast persists a message and broadcasts it to watchers.
 // tracker may be nil, in which case it is resolved from the agentID.
-func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmuxv1.AgentProvider, role leapmuxv1.MessageRole, contentJSON []byte, span agent.SpanInfo, tracker *SpanTracker) error {
+func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmuxv1.AgentProvider, source leapmuxv1.MessageSource, contentJSON []byte, span agent.SpanInfo, tracker *SpanTracker) error {
 	if h.wakeLock != nil {
 		h.wakeLock.RecordActivity()
 	}
@@ -1080,7 +1095,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 	seq, err := h.queries.CreateMessage(bgCtx(), db.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Role:               role,
+		Source:             source,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Depth:              int64(depth),
@@ -1101,7 +1116,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 
 	h.broadcastMessage(agentID, &leapmuxv1.AgentChatMessage{
 		Id:                 msgID,
-		Role:               role,
+		Source:             source,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Seq:                seq,
@@ -1119,7 +1134,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 
 // persistNotificationThreaded persists a notification message, appending it
 // to the current notification thread if one exists.
-func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, role leapmuxv1.MessageRole, contentJSON []byte) error {
+func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, source leapmuxv1.MessageSource, contentJSON []byte) error {
 	if h.wakeLock != nil {
 		h.wakeLock.RecordActivity()
 	}
@@ -1129,16 +1144,43 @@ func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvide
 
 	if ref, ok := h.lastNotifThread.Load(agentID); ok {
 		threadRef := ref.(*notifThreadRef)
-		if err := h.appendToNotificationThread(agentID, agentProvider, plugin, threadRef, role, contentJSON); err == nil {
+		err := h.appendToNotificationThread(agentID, agentProvider, plugin, threadRef, source, contentJSON)
+		if err == nil {
 			return nil
+		}
+		// errSourceMismatch is the documented fall-through signal — start a
+		// fresh standalone thread silently. Any other error is a real failure
+		// (DB read/write, decompress, marshal); log it but still fall through
+		// so the notification reaches users via a new standalone row.
+		if !errors.Is(err, errSourceMismatch) {
+			slog.Error("append to notification thread failed; creating standalone", "agent_id", agentID, "error", err)
 		}
 	}
 
-	return h.createNotificationStandalone(agentID, agentProvider, role, contentJSON)
+	return h.createNotificationStandalone(agentID, agentProvider, source, contentJSON)
 }
 
+// errSourceMismatch is returned by appendToNotificationThread when the
+// existing thread's source does not match the incoming notification's.
+// It is a normal fall-through signal, not a failure — the caller starts
+// a fresh standalone thread.
+var errSourceMismatch = errors.New("notification thread source mismatch")
+
 // appendToNotificationThread appends a message to an existing notification thread.
-func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, threadRef *notifThreadRef, role leapmuxv1.MessageRole, contentJSON []byte) error {
+// Returns an error if the thread's source does not match the new
+// notification's source — adjacent cross-source notifications must
+// produce separate threads so that the persisted source remains a
+// truthful per-thread provenance signal. The caller treats the error
+// as a normal "fall through to a new standalone thread" signal, not as
+// a failure.
+func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, threadRef *notifThreadRef, source leapmuxv1.MessageSource, contentJSON []byte) error {
+	// Short-circuit cross-source flips before the DB hit — the in-memory
+	// threadRef carries the source that was persisted when the thread
+	// opened, so we don't need to fetch + decompress the row to learn it.
+	if threadRef.source != source {
+		return errSourceMismatch
+	}
+
 	parentRow, err := h.queries.GetMessageByAgentAndID(bgCtx(), db.GetMessageByAgentAndIDParams{
 		ID:      threadRef.msgID,
 		AgentID: agentID,
@@ -1194,7 +1236,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 
 	h.broadcastMessage(agentID, &leapmuxv1.AgentChatMessage{
 		Id:                 parentRow.ID,
-		Role:               parentRow.Role,
+		Source:             parentRow.Source,
 		Content:            mergedCompressed,
 		ContentCompression: mergedCompType,
 		Seq:                newSeq,
@@ -1206,7 +1248,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 }
 
 // createNotificationStandalone creates a new standalone notification message.
-func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvider leapmuxv1.AgentProvider, role leapmuxv1.MessageRole, contentJSON []byte) error {
+func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvider leapmuxv1.AgentProvider, source leapmuxv1.MessageSource, contentJSON []byte) error {
 	msgID := id.Generate()
 	wrapped := wrapNotifContent(contentJSON)
 	compressed, compressionType := msgcodec.Compress(wrapped)
@@ -1215,7 +1257,7 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 	seq, err := h.queries.CreateMessage(bgCtx(), db.CreateMessageParams{
 		ID:                 msgID,
 		AgentID:            agentID,
-		Role:               role,
+		Source:             source,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Depth:              0,
@@ -1231,13 +1273,14 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 	}
 
 	h.lastNotifThread.Store(agentID, &notifThreadRef{
-		msgID: msgID,
-		seq:   seq,
+		msgID:  msgID,
+		seq:    seq,
+		source: source,
 	})
 
 	h.broadcastMessage(agentID, &leapmuxv1.AgentChatMessage{
 		Id:                 msgID,
-		Role:               role,
+		Source:             source,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Seq:                seq,
@@ -1271,7 +1314,7 @@ func (h *OutputHandler) broadcastAgentSessionInfo(agentID string, info map[strin
 	compressed, compressionType := msgcodec.Compress(contentJSON)
 	h.broadcastMessage(agentID, &leapmuxv1.AgentChatMessage{
 		Id:                 id.Generate(),
-		Role:               leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX,
+		Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX,
 		Content:            compressed,
 		ContentCompression: compressionType,
 		Seq:                -1, // Ephemeral sentinel
@@ -1285,7 +1328,7 @@ func (h *OutputHandler) PersistLeapMuxNotification(agentID string, agentProvider
 		slog.Warn("marshal notification content", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := h.persistNotificationThreaded(agentID, agentProvider, agent.ProviderFor(agentProvider), leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, contentJSON); err != nil {
+	if err := h.persistNotificationThreaded(agentID, agentProvider, agent.ProviderFor(agentProvider), leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, contentJSON); err != nil {
 		slog.Warn("failed to persist notification", "agent_id", agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/service/output_git_status_test.go
+++ b/backend/internal/worker/service/output_git_status_test.go
@@ -132,17 +132,17 @@ func TestBroadcastGitStatus_RepeatedCallsBroadcastEachTime(t *testing.T) {
 		"BroadcastGitStatus must broadcast each call; debouncing belongs higher in the stack if needed")
 }
 
-// TestPersistMessage_TurnEnd_AutoBroadcastsGitStatus locks in the
-// turn-end contract: every provider's TURN_END-role persist (Codex
-// turn/completed, Claude type:"result", ACP prompt response, Pi
-// agent_end) auto-fires BroadcastGitStatus so providers don't have to.
-// The auto-fire runs on a goroutine to keep the agent's stdout-read
-// loop free of the git-subprocess + DB latency, so the test polls.
-func TestPersistMessage_TurnEnd_AutoBroadcastsGitStatus(t *testing.T) {
+// TestPersistTurnEnd_AutoBroadcastsGitStatus locks in the turn-end
+// contract: every provider's terminal envelope (Codex turn/completed,
+// Claude type:"result", ACP prompt response, Pi agent_end) routes
+// through PersistTurnEnd, which auto-fires BroadcastGitStatus so
+// providers don't have to. The auto-fire runs on a goroutine to keep
+// the agent's stdout-read loop free of the git-subprocess + DB
+// latency, so the test polls.
+func TestPersistTurnEnd_AutoBroadcastsGitStatus(t *testing.T) {
 	sink, mock := newGitStatusFixture(t)
 
-	require.NoError(t, sink.PersistMessage(
-		leapmuxv1.MessageRole_MESSAGE_ROLE_TURN_END,
+	require.NoError(t, sink.PersistTurnEnd(
 		[]byte(`{"type":"result","subtype":"success"}`),
 		agent.SpanInfo{},
 	))
@@ -150,29 +150,30 @@ func TestPersistMessage_TurnEnd_AutoBroadcastsGitStatus(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return mock.lastStatus() != nil
 	}, time.Second, 10*time.Millisecond,
-		"TURN_END persist should auto-fire BroadcastGitStatus on a goroutine")
+		"PersistTurnEnd should auto-fire BroadcastGitStatus on a goroutine")
 	sc := mock.lastStatus()
 	assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_UNSPECIFIED, sc.GetStatus(),
 		"auto-fired git-status broadcast must use the partial-update shape")
 }
 
-// TestPersistMessage_NonTurnEnd_DoesNotBroadcastGitStatus confirms the
-// auto-fire is gated on TURN_END only — assistant/system/user persists
-// must not pay the git-status cost on every message.
-func TestPersistMessage_NonTurnEnd_DoesNotBroadcastGitStatus(t *testing.T) {
+// TestPersistMessage_DoesNotBroadcastGitStatus confirms the
+// auto-fire lives on PersistTurnEnd only — regular AGENT/USER
+// PersistMessage calls must not pay the git-status cost on every
+// message.
+func TestPersistMessage_DoesNotBroadcastGitStatus(t *testing.T) {
 	sink, mock := newGitStatusFixture(t)
 
-	for _, role := range []leapmuxv1.MessageRole{
-		leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
-		leapmuxv1.MessageRole_MESSAGE_ROLE_USER,
-		leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM,
+	for _, source := range []leapmuxv1.MessageSource{
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX,
 	} {
-		require.NoError(t, sink.PersistMessage(role, []byte(`{}`), agent.SpanInfo{}))
+		require.NoError(t, sink.PersistMessage(source, []byte(`{}`), agent.SpanInfo{}))
 	}
 
 	// Give any spurious goroutine fire enough time to land. With the
 	// gate working correctly, no goroutine ever starts.
 	time.Sleep(50 * time.Millisecond)
 	sc := mock.lastStatus()
-	assert.Nil(t, sc, "non-TURN_END persists must not auto-broadcast git status")
+	assert.Nil(t, sc, "PersistMessage must not auto-broadcast git status")
 }

--- a/backend/internal/worker/service/output_thread_test.go
+++ b/backend/internal/worker/service/output_thread_test.go
@@ -63,8 +63,8 @@ func TestNotificationThreading_MergesOnlyAdjacentNotifications(t *testing.T) {
 	secondNotif, err := json.Marshal(map[string]any{"type": "interrupted"})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, firstNotif))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, secondNotif))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif))
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -72,6 +72,32 @@ func TestNotificationThreading_MergesOnlyAdjacentNotifications(t *testing.T) {
 	wrapper := decodeNotifWrapper(t, rows[0].Content, rows[0].ContentCompression)
 	require.Len(t, wrapper.Messages, 2)
 	assert.Equal(t, []string{"context_cleared", "interrupted"}, types(t, wrapper.Messages))
+}
+
+// TestNotificationThreading_CrossSourceProducesSeparateThreads verifies
+// that adjacent notifications with different sources do not consolidate
+// into one thread. An AGENT-source system notification followed by a
+// LEAPMUX-source platform notification must produce two separate
+// notification rows, each carrying a truthful per-thread source.
+func TestNotificationThreading_CrossSourceProducesSeparateThreads(t *testing.T) {
+	sink, listRows := setupNotifThreadTest(t, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	agentNotif, err := json.Marshal(map[string]any{"type": "system", "subtype": "status", "status": "compacting"})
+	require.NoError(t, err)
+	leapmuxNotif, err := json.Marshal(map[string]any{"type": "context_cleared"})
+	require.NoError(t, err)
+
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, agentNotif))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, leapmuxNotif))
+
+	rows := listRows()
+	require.Len(t, rows, 2, "cross-source adjacent notifications must not consolidate")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, rows[0].Source)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[1].Source)
+
+	firstWrapper := decodeNotifWrapper(t, rows[0].Content, rows[0].ContentCompression)
+	secondWrapper := decodeNotifWrapper(t, rows[1].Content, rows[1].ContentCompression)
+	require.Len(t, firstWrapper.Messages, 1)
+	require.Len(t, secondWrapper.Messages, 1)
 }
 
 func TestNotificationThreading_NonNotificationBreaksAdjacency(t *testing.T) {
@@ -88,9 +114,9 @@ func TestNotificationThreading_NonNotificationBreaksAdjacency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, firstNotif))
-	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageRole_MESSAGE_ROLE_ASSISTANT, assistantMsg, agent.SpanInfo{}))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, secondNotif))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif))
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, assistantMsg, agent.SpanInfo{}))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif))
 
 	rows := listRows()
 	require.Len(t, rows, 3)
@@ -115,9 +141,9 @@ func TestNotificationThreading_CodexStartupStatusConsolidatesInWrapper(t *testin
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, starting))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, ready))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_LEAPMUX, settingsChanged))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, starting))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, ready))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, settingsChanged))
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -132,7 +158,7 @@ func TestNotificationThreading_CodexStartupStatusConsolidatesInWrapper(t *testin
 	assert.Equal(t, "ready", params["status"])
 }
 
-func TestNotificationThreading_CodexMetadataNotificationsPersistAsSystemWrapper(t *testing.T) {
+func TestNotificationThreading_CodexMetadataNotificationsPersistAsAgentWrapper(t *testing.T) {
 	sink, listRows := setupNotifThreadTest(t, leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
 	skillsChanged := raw(t, codexMethod("skills/changed", map[string]interface{}{}))
 	remoteControlChanged := raw(t, codexMethod("remoteControl/status/changed", map[string]interface{}{
@@ -140,12 +166,12 @@ func TestNotificationThreading_CodexMetadataNotificationsPersistAsSystemWrapper(
 		"environmentId": nil,
 	}))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, skillsChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, remoteControlChanged))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged))
 
 	rows := listRows()
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, rows[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, rows[0].Source)
 
 	wrapper := decodeNotifWrapper(t, rows[0].Content, rows[0].ContentCompression)
 	require.Len(t, wrapper.Messages, 2)
@@ -162,14 +188,14 @@ func TestNotificationThreading_CodexMetadataNotificationsSurviveMixedThread(t *t
 	}))
 	ready := raw(t, codexStartupStatus("codex_apps", "ready", nil))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, starting))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, skillsChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, remoteControlChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, ready))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, starting))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, ready))
 
 	rows := listRows()
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, rows[0].Role)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, rows[0].Source)
 
 	wrapper := decodeNotifWrapper(t, rows[0].Content, rows[0].ContentCompression)
 	require.Len(t, wrapper.Messages, 3)
@@ -195,13 +221,13 @@ func TestNotificationThreading_RepeatedIdenticalProviderScopedSkipsWrite(t *test
 		"environmentId": nil,
 	}))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, payload))
+	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload))
 	rows := listRows()
 	require.Len(t, rows, 1)
 	seqAfterFirst := rows[0].Seq
 
 	for i := 0; i < 5; i++ {
-		require.NoError(t, sink.PersistNotification(leapmuxv1.MessageRole_MESSAGE_ROLE_SYSTEM, payload))
+		require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload))
 	}
 	rows = listRows()
 	require.Len(t, rows, 1)

--- a/backend/internal/worker/sqlc.yaml
+++ b/backend/internal/worker/sqlc.yaml
@@ -10,10 +10,10 @@ sql:
         emit_json_tags: true
         emit_empty_slices: true
         overrides:
-          - column: "messages.role"
+          - column: "messages.source"
             go_type:
               import: "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-              type: "MessageRole"
+              type: "MessageSource"
           - column: "messages.content_compression"
             go_type:
               import: "github.com/leapmux/leapmux/generated/proto/leapmux/v1"

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -13,7 +13,7 @@ import { createMemo, createResource, ErrorBoundary, onCleanup, onMount, Show } f
 import { render } from 'solid-js/web'
 import { IconButton } from '~/components/common/IconButton'
 import { usePreferences } from '~/context/PreferencesContext'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { useCopyButton } from '~/hooks/useCopyButton'
 import { prettifyJson } from '~/lib/jsonFormat'
 import { createLogger } from '~/lib/logger'
@@ -21,7 +21,7 @@ import { parseMessageContent } from '~/lib/messageParser'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { resolveStack } from '~/lib/resolveStack'
 import * as styles from './MessageBubble.css'
-import { buildClassificationInput, classifyMessage, messageBubbleClass, messageRowClass } from './messageClassification'
+import { classifyMessage, messageBubbleClass, messageRowClass, toClassificationInput } from './messageClassification'
 import { renderMessageContent } from './messageRenderers'
 import * as chatStyles from './messageStyles.css'
 import { MESSAGE_UI_KEY } from './messageUiKeys'
@@ -52,14 +52,17 @@ function renderErrorFallback(label: string) {
   }
 }
 
-function roleLabel(role: MessageRole): string {
-  switch (role) {
-    case MessageRole.USER: return 'user'
-    case MessageRole.ASSISTANT: return 'assistant'
-    case MessageRole.SYSTEM: return 'system'
-    case MessageRole.TURN_END: return 'result'
-    case MessageRole.LEAPMUX: return 'leapmux'
-    default: return 'system'
+function sourceLabel(source: MessageSource): string {
+  switch (source) {
+    case MessageSource.USER: return 'user'
+    case MessageSource.AGENT: return 'agent'
+    case MessageSource.LEAPMUX: return 'leapmux'
+    // Default fires only on MESSAGE_SOURCE_UNSPECIFIED (proto 0), which
+    // every persistence path sets to a real value. UNSPECIFIED on a
+    // persisted row represents a misconfigured agent-side persistence
+    // path, not a user-typed input or leapmux notification — fall back
+    // to 'agent'.
+    default: return 'agent'
   }
 }
 
@@ -107,7 +110,7 @@ export function classifyParsedMessage(
   classificationContext?: { hasCommandStream?: boolean, commandStreamLength?: number },
 ) {
   const parsed = parseMessageContent(message)
-  const category = classifyMessage(buildClassificationInput(parsed, message), classificationContext)
+  const category = classifyMessage(toClassificationInput(parsed, message), classificationContext)
   return { parsed, category }
 }
 
@@ -181,7 +184,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     const msg = props.message
     const envelope: Record<string, unknown> = {
       id: msg.id,
-      role: roleLabel(msg.role),
+      source: sourceLabel(msg.source),
       seq: Number(msg.seq),
       created_at: msg.createdAt,
     }
@@ -318,12 +321,12 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
 
   const { copied: markdownCopied, copy: copyMarkdown } = useCopyButton(() => extractQuotableText() ?? undefined)
 
-  const rowClass = () => messageRowClass(category().kind, props.message.role)
+  const rowClass = () => messageRowClass(category().kind, props.message.source)
   const isLocalPending = () => props.message.id.startsWith('local-')
-  const isPendingUserMessage = () => isLocalPending() && props.message.role === MessageRole.USER && !props.error
+  const isPendingUserMessage = () => isLocalPending() && props.message.source === MessageSource.USER && !props.error
   const bubbleClass = () => isPendingUserMessage()
     ? chatStyles.userMessagePending
-    : messageBubbleClass(category().kind, props.message.role)
+    : messageBubbleClass(category().kind, props.message.source)
 
   onMount(() => {
     if (!contentRef)
@@ -344,7 +347,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
         <div
           class={bubbleClass()}
           data-testid="message-bubble"
-          data-role={roleLabel(props.message.role)}
+          data-role={sourceLabel(props.message.source)}
         >
           <div ref={contentRef} data-testid="message-content">
             <ErrorBoundary fallback={renderErrorFallback('Failed to render message:')}>
@@ -355,7 +358,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
                   )
                 : category().kind === 'notification_thread'
                   ? renderNotificationThread((category() as { kind: 'notification_thread', messages: unknown[] }).messages, props.message.agentProvider)
-                  : renderMessageContent(parsed().parentObject ?? parsed().rawText, props.message.role, renderContext, category(), props.message.agentProvider)}
+                  : renderMessageContent(parsed().parentObject ?? parsed().rawText, renderContext, category(), props.message.agentProvider)}
             </ErrorBoundary>
           </div>
         </div>

--- a/frontend/src/components/chat/messageClassification.ts
+++ b/frontend/src/components/chat/messageClassification.ts
@@ -1,5 +1,8 @@
 import type { ClassificationContext, ClassificationInput } from './providers/registry'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { ParsedMessageContent } from '~/lib/messageParser'
+import { AgentProvider, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { parseMessageContent } from '~/lib/messageParser'
 import * as chatStyles from './messageStyles.css'
 import { providerFor } from './providers/registry'
 import './providers'
@@ -26,21 +29,20 @@ export type MessageCategory
     | { kind: 'compact_summary' }
     | { kind: 'unknown' }
 
-export function buildClassificationInput(
-  parsed: Pick<ClassificationInput, 'rawText' | 'topLevel' | 'parentObject' | 'wrapper'>,
-  message: {
-    role: MessageRole
-    agentProvider?: AgentProvider
-    spanId?: string
-    spanType?: string
-    parentSpanId?: string
-    seq?: bigint
-    createdAt?: string
-  },
+/**
+ * Build the input for `classifyMessage` from a parsed envelope and an
+ * `AgentChatMessage`. Keeps the common case
+ * (`classifyMessage(toClassificationInput(parsed, msg))`) terse.
+ */
+export function toClassificationInput(
+  parsed: ParsedMessageContent,
+  message: AgentChatMessage,
 ): ClassificationInput {
   return {
-    ...parsed,
-    messageRole: message.role,
+    rawText: parsed.rawText,
+    topLevel: parsed.topLevel,
+    parentObject: parsed.parentObject,
+    wrapper: parsed.wrapper,
     agentProvider: message.agentProvider,
     spanId: message.spanId,
     spanType: message.spanType,
@@ -68,14 +70,52 @@ export function classifyMessage(
   return { kind: 'unknown' }
 }
 
+// AgentChatMessage is immutable once persisted, so caching the
+// context-free classification by message reference avoids redispatching
+// through the provider plugin on every isAgentWorking scan. Skip when a
+// ClassificationContext is supplied (MessageBubble's per-render path)
+// because the classifier may consult context-dependent fields like the
+// command-stream length.
+//
+// Solid's createStore wraps stored objects in proxies, so the wire-side
+// ref passed at broadcast time and the proxy ref read by per-render
+// scans have different identities. The cache therefore primarily serves
+// the dominant cost — repeated isAgentWorking scans across visible
+// chats — and broadcast-time hits act as one-shot warm-ups whose
+// entries are GC'd once the wire ref goes out of scope.
+//
+// Cache safety caveat: today's consumers (isAgentWorking,
+// shouldClearStreamingText) treat 'hidden' and 'assistant_thinking'
+// equivalently, which is why the Codex reasoning classifier's
+// context-dependent split between those two kinds is currently
+// invisible to cache readers. A future caller that distinguishes them
+// MUST either pass through `classifyMessage` directly or extend this
+// cache key to include the relevant context bits.
+const classifyCache = new WeakMap<AgentChatMessage, MessageCategory>()
+
+/**
+ * Classify a persisted AgentChatMessage. Cached by message reference.
+ * `parseMessageContent` is itself WeakMap-cached on the same message
+ * ref, so the inner call costs a hash lookup when the caller has
+ * already parsed.
+ */
+export function classifyAgentMessage(message: AgentChatMessage): MessageCategory {
+  const cached = classifyCache.get(message)
+  if (cached)
+    return cached
+  const result = classifyMessage(toClassificationInput(parseMessageContent(message), message))
+  classifyCache.set(message, result)
+  return result
+}
+
 // ---------------------------------------------------------------------------
 // CSS helpers — derive layout classes from category
 // ---------------------------------------------------------------------------
 
-function roleStyle(role: MessageRole): string {
-  switch (role) {
-    case MessageRole.USER: return chatStyles.userMessage
-    case MessageRole.ASSISTANT: return chatStyles.assistantMessage
+function sourceStyle(source: MessageSource): string {
+  switch (source) {
+    case MessageSource.USER: return chatStyles.userMessage
+    case MessageSource.AGENT: return chatStyles.assistantMessage
     default: return chatStyles.systemMessage
   }
 }
@@ -92,17 +132,54 @@ const META_KINDS = new Set<MessageCategory['kind']>([
   'task_notification',
 ])
 
+/**
+ * Categories that must NOT clear the in-flight streaming text buffer
+ * when a persisted AGENT message arrives. Notification-thread rows are
+ * handled separately via `parsed.wrapper`.
+ */
+const NON_STREAM_CLEAR_KINDS = new Set<MessageCategory['kind']>([
+  'notification',
+  'notification_thread',
+  'task_notification',
+  'hidden',
+  'control_response',
+  'compact_summary',
+  'agent_prompt',
+  'plan_execution',
+])
+
+/**
+ * True when a persisted AGENT message should drop the in-flight
+ * streaming text buffer. Notification wrappers and meta categories
+ * leave the buffer alone — only assistant-side outputs (text,
+ * thinking, tool_use, tool_result) and turn-end dividers close it.
+ * `kind === 'unknown'` deliberately falls through to true so any
+ * unclassified AGENT shape conservatively closes the buffer rather
+ * than leaving stale streaming text glued to the next message.
+ */
+export function shouldClearStreamingText(
+  msg: { source: MessageSource },
+  parsed: ParsedMessageContent,
+  category: MessageCategory,
+): boolean {
+  if (msg.source !== MessageSource.AGENT)
+    return false
+  if (parsed.wrapper !== null)
+    return false
+  return !NON_STREAM_CLEAR_KINDS.has(category.kind)
+}
+
 /** Row class: determines horizontal alignment. */
-export function messageRowClass(kind: MessageCategory['kind'], role: MessageRole): string {
+export function messageRowClass(kind: MessageCategory['kind'], source: MessageSource): string {
   if (kind === 'notification' || kind === 'notification_thread')
     return chatStyles.messageRowCenter
-  if (!META_KINDS.has(kind) && role === MessageRole.USER)
+  if (!META_KINDS.has(kind) && source === MessageSource.USER)
     return chatStyles.messageRowEnd
   return chatStyles.messageRow
 }
 
 /** Bubble class: determines visual style of the message container. */
-export function messageBubbleClass(kind: MessageCategory['kind'], role: MessageRole): string {
+export function messageBubbleClass(kind: MessageCategory['kind'], source: MessageSource): string {
   if (kind === 'notification' || kind === 'notification_thread')
     return chatStyles.systemMessage
   if (kind === 'assistant_thinking')
@@ -111,5 +188,5 @@ export function messageBubbleClass(kind: MessageCategory['kind'], role: MessageR
     return chatStyles.planExecutionMessage
   if (META_KINDS.has(kind))
     return chatStyles.metaMessage
-  return roleStyle(role)
+  return sourceStyle(source)
 }

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -3,7 +3,7 @@ import type { RenderContext } from './messageRenderers'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, ContentCompression } from '~/generated/leapmux/v1/agent_pb'
 import { parseMessageContent } from '~/lib/messageParser'
 import { renderMessageContent } from './messageRenderers'
 import './providers'
@@ -34,7 +34,7 @@ function makeToolUseCategory(name: string, input: Record<string, unknown>): Mess
 function renderToolUseText(name: string, input: Record<string, unknown>, context?: RenderContext): string {
   const parsed = makeToolUseMessage(name, input)
   const category = makeToolUseCategory(name, input)
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -121,7 +121,7 @@ describe('write/edit tool_use messages never render the diff body', () => {
   it('does not render Write file content (no linked tool_result)', () => {
     const category = makeToolUseCategory('Write', writeInput)
     const { container } = render(() =>
-      renderMessageContent(makeToolUseMessage('Write', writeInput), MessageRole.ASSISTANT, undefined, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(makeToolUseMessage('Write', writeInput), undefined, category, AgentProvider.CLAUDE_CODE),
     )
     // The diff body lives on the tool_result; tool_use only shows the header.
     expect(container.textContent).not.toContain('package main')
@@ -142,7 +142,7 @@ describe('write/edit tool_use messages never render the diff body', () => {
     const context: RenderContext = { toolResultParsed }
     const category = makeToolUseCategory('Write', writeInput)
     const { container } = render(() =>
-      renderMessageContent(makeToolUseMessage('Write', writeInput), MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(makeToolUseMessage('Write', writeInput), context, category, AgentProvider.CLAUDE_CODE),
     )
     // Same outcome as the no-linked-result case: never renders content.
     expect(container.textContent).not.toContain('package main')
@@ -156,7 +156,7 @@ describe('write/edit tool_use messages never render the diff body', () => {
     }
     const category = makeToolUseCategory('Edit', editInput)
     const { container } = render(() =>
-      renderMessageContent(makeToolUseMessage('Edit', editInput), MessageRole.ASSISTANT, undefined, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(makeToolUseMessage('Edit', editInput), undefined, category, AgentProvider.CLAUDE_CODE),
     )
     expect(container.textContent).not.toContain('beforeMarkerXYZ')
     expect(container.textContent).not.toContain('afterMarkerXYZ')
@@ -182,7 +182,7 @@ function makeReadToolResult(resultContent: string, context?: Partial<RenderConte
     parsed,
     render: () => {
       const category: MessageCategory = { kind: 'tool_result' }
-      const result = renderMessageContent(parsed, MessageRole.USER, { spanType: 'Read', ...context }, category, AgentProvider.CLAUDE_CODE)
+      const result = renderMessageContent(parsed, { spanType: 'Read', ...context }, category, AgentProvider.CLAUDE_CODE)
       const { container } = render(() => result)
       return container
     },

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -3,7 +3,6 @@ import type { JSX } from 'solid-js'
 import type { MessageCategory } from './messageClassification'
 import type { MessageUiKey } from './messageUiKeys'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { CommandStreamSegment } from '~/stores/chat.store'
 import Brain from 'lucide-solid/icons/brain'
@@ -75,7 +74,7 @@ export interface RenderContext {
 
 export interface MessageContentRenderer {
   /** Try to render the parsed JSON content. Return null if this renderer doesn't handle it. */
-  render: (parsed: unknown, role: MessageRole, context?: RenderContext) => JSX.Element | null
+  render: (parsed: unknown, context?: RenderContext) => JSX.Element | null
 }
 
 /**
@@ -227,7 +226,6 @@ export function UserContentMessage(props: { parsed: unknown }): JSX.Element {
  */
 export function renderMessageContent(
   parsedOrRawJson: unknown,
-  role: MessageRole,
   context?: RenderContext,
   category?: MessageCategory,
   agentProvider?: AgentProvider,
@@ -239,7 +237,7 @@ export function renderMessageContent(
 
     const provider = agentProvider ?? AgentProvider.CLAUDE_CODE
     const plugin = providerFor(provider) ?? providerFor(AgentProvider.CLAUDE_CODE)
-    const result = plugin?.renderMessage?.(category ?? { kind: 'unknown' }, parsed, role, context) ?? null
+    const result = plugin?.renderMessage?.(category ?? { kind: 'unknown' }, parsed, context) ?? null
     if (result !== null)
       return result
   }

--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { updateSettingsLabelCache } from '~/lib/settingsLabelCache'
 import { renderNotificationThread } from './notificationRenderers'
 import { resultRenderer } from './providers/claude/notifications'
@@ -283,7 +282,7 @@ describe('renderNotificationThread: plan_updated', () => {
 
 /** Render a result message and return trimmed text content. */
 function renderResultText(parsed: Record<string, unknown>): string {
-  const result = resultRenderer.render(parsed, MessageRole.SYSTEM)
+  const result = resultRenderer.render(parsed)
   if (result === null)
     return ''
   const { container } = render(() => result)
@@ -292,7 +291,7 @@ function renderResultText(parsed: Record<string, unknown>): string {
 
 /** Check if the result is rendered with danger color (error style). */
 function isRenderedAsError(parsed: Record<string, unknown>): boolean {
-  const result = resultRenderer.render(parsed, MessageRole.SYSTEM)
+  const result = resultRenderer.render(parsed)
   if (result === null)
     return false
   const { container } = render(() => result)
@@ -302,7 +301,7 @@ function isRenderedAsError(parsed: Record<string, unknown>): boolean {
 
 describe('resultRenderer', () => {
   it('returns null for non-result messages', () => {
-    expect(resultRenderer.render({ type: 'other' }, MessageRole.SYSTEM)).toBeNull()
+    expect(resultRenderer.render({ type: 'other' })).toBeNull()
   })
 
   it('renders is_error=true as error', () => {

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -37,7 +37,7 @@ function displayValue(key: string, value: string): string {
 
 /** Handles settings change notifications: {"type":"settings_changed","changes":{...}} */
 export const settingsChangedRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== NOTIFICATION_TYPE.SettingsChanged)
       return null
     const changes = parsed.changes as Record<string, { old: string, new: string, label?: string, oldLabel?: string, newLabel?: string }>
@@ -63,7 +63,7 @@ export const settingsChangedRenderer: MessageContentRenderer = {
 
 /** Handles interrupt notifications: {"type":"interrupted"} */
 export const interruptedRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== NOTIFICATION_TYPE.Interrupted)
       return null
     return <div class={controlResponseMessage}>Interrupted</div>
@@ -75,7 +75,7 @@ export const interruptedRenderer: MessageContentRenderer = {
  * Claude `system` message: `{type:"system",subtype:"status",status:"compacting"}`.
  */
 export const compactingRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed))
       return null
     if (!(parsed.type === 'system' && parsed.subtype === 'status' && parsed.status === NOTIFICATION_TYPE.Compacting))
@@ -90,7 +90,7 @@ export const compactingRenderer: MessageContentRenderer = {
 }
 
 export const contextClearedRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== NOTIFICATION_TYPE.ContextCleared)
       return null
     return <div class={controlResponseMessage}>Context cleared</div>
@@ -99,7 +99,7 @@ export const contextClearedRenderer: MessageContentRenderer = {
 
 /** Handles agent error notifications: {"type":"agent_error","error":"..."} */
 export const agentErrorRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== NOTIFICATION_TYPE.AgentError)
       return null
     const error = pickString(parsed, 'error', 'Unknown error')
@@ -116,7 +116,7 @@ export const agentErrorRenderer: MessageContentRenderer = {
  * - Without:                       "Plan updated: <title>".
  */
 export const planUpdatedRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== NOTIFICATION_TYPE.PlanUpdated)
       return null
     const title = pickString(parsed, 'plan_title')
@@ -152,7 +152,7 @@ function formatApiRetryLabel(data: Record<string, unknown>): string {
 
 /** Handles api_retry notifications: {"type":"system","subtype":"api_retry","attempt":N,"max_retries":N,...} */
 export const apiRetryRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'api_retry')
       return null
     return <div class={controlResponseMessage}>{formatApiRetryLabel(parsed as Record<string, unknown>)}</div>
@@ -169,7 +169,7 @@ export const apiRetryRenderer: MessageContentRenderer = {
  *  - Codex raw JSON-RPC notification: `{method:"thread/compacted",params:{threadId,turnId}}`
  */
 export const compactBoundaryRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed))
       return null
     const isClaude = parsed.type === 'system' && parsed.subtype === 'compact_boundary'
@@ -192,7 +192,7 @@ export const compactBoundaryRenderer: MessageContentRenderer = {
 
 /** Handles microcompact_boundary messages: {"type":"system","subtype":"microcompact_boundary","microcompactMetadata":{"trigger":...,"preTokens":number,"tokensSaved":number,...}} */
 export const microcompactBoundaryRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'microcompact_boundary')
       return null
     const meta = pickFirstObject(parsed, ['microcompactMetadata', 'microcompact_metadata'])
@@ -209,7 +209,7 @@ export const microcompactBoundaryRenderer: MessageContentRenderer = {
 
 /** Handles system init messages: {"type":"system","subtype":"init","session_id":"..."} — hidden at MessageBubble level */
 export const systemInitRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'init')
       return null
     return <span />
@@ -218,7 +218,7 @@ export const systemInitRenderer: MessageContentRenderer = {
 
 /** Handles control response messages: {"isSynthetic":true,"controlResponse":{"action":"approved"|"rejected","comment":"..."}} */
 export const controlResponseRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || !isObject(parsed.controlResponse))
       return null
 

--- a/frontend/src/components/chat/providers/acp/renderers/plan.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/plan.tsx
@@ -1,11 +1,10 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { TodoListMessage } from '../../../todoListMessage'
 import { acpPlanFromEntries } from '../extractors/plan'
 
 /** Render an ACP plan (todo list). */
-export function acpPlanRenderer(toolUse: Record<string, unknown>, _role: MessageRole, context?: RenderContext): JSX.Element | null {
+export function acpPlanRenderer(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element | null {
   const entries = toolUse.entries as Array<{ priority?: string, status?: string, content: string }> | undefined
   const source = acpPlanFromEntries(entries)
   if (!source)

--- a/frontend/src/components/chat/providers/acp/renderers/thought.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/thought.tsx
@@ -1,11 +1,10 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { ThinkingMessage } from '../../../messageRenderers'
 import { extractAgentText } from './helpers'
 
 /** Render an ACP agent_thought_chunk as collapsible thinking (same style as Claude Code). */
-export function acpThoughtRenderer(parsed: unknown, _role: MessageRole, context?: RenderContext): JSX.Element | null {
+export function acpThoughtRenderer(parsed: unknown, context?: RenderContext): JSX.Element | null {
   const text = extractAgentText(parsed)
   if (!text)
     return null

--- a/frontend/src/components/chat/providers/acp/renderers/toolCall.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/toolCall.tsx
@@ -1,11 +1,10 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { ToolUseLayout } from '../../../toolRenderers'
 import { kindIcon, kindLabel } from './helpers'
 
 /** Render an ACP tool_call (pending status) — like Claude Code's tool_use header. */
-export function acpToolCallRenderer(toolUse: Record<string, unknown>, _role: MessageRole, context?: RenderContext): JSX.Element {
+export function acpToolCallRenderer(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
   const kind = toolUse.kind as string | undefined
   const title = (toolUse.title as string | undefined) || kind || 'Tool'
   const icon = kindIcon(kind)

--- a/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
@@ -6,7 +6,6 @@ import type { FileEditDiffSource } from '../../../results/fileEditDiff'
 import type { ReadFileResultSource } from '../../../results/readFileResult'
 import type { SearchResultSource } from '../../../results/searchResult'
 import type { WebFetchResultSource } from '../../../results/webFetchResult'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import CircleAlert from 'lucide-solid/icons/circle-alert'
 import { createMemo, Show } from 'solid-js'
 import { useCopyButton } from '~/hooks/useCopyButton'
@@ -219,6 +218,6 @@ function ToolCallUpdateMessage(props: {
 }
 
 /** Render an ACP tool_call_update (completed/failed) — combined tool_use + tool_result. */
-export function acpToolCallUpdateRenderer(toolUse: Record<string, unknown>, _role: MessageRole, context?: RenderContext): JSX.Element {
+export function acpToolCallUpdateRenderer(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element {
   return <ToolCallUpdateMessage toolUse={toolUse} context={context} />
 }

--- a/frontend/src/components/chat/providers/acp/rendering.tsx
+++ b/frontend/src/components/chat/providers/acp/rendering.tsx
@@ -6,7 +6,6 @@
 import type { JSX } from 'solid-js'
 import type { MessageCategory } from '../../messageClassification'
 import type { RenderContext } from '../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import type { ContentBlock } from '~/lib/contentBlocks'
 import { joinContentParagraphs } from '~/lib/contentBlocks'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
@@ -27,20 +26,20 @@ export const ACP_FILE_PATH_KEYS = ['filePath', 'path', 'file_path'] as const
 export const ACP_OLD_TEXT_KEYS = ['oldText', 'oldString', 'old_string'] as const
 export const ACP_NEW_TEXT_KEYS = ['newText', 'newString', 'new_string'] as const
 
-export function renderACPMessage(category: MessageCategory, parsed: unknown, role: MessageRole, context?: RenderContext): JSX.Element | null {
+export function renderACPMessage(category: MessageCategory, parsed: unknown, context?: RenderContext): JSX.Element | null {
   if (category.kind === 'assistant_text')
     return acpAgentMessageRenderer(parsed)
   if (category.kind === 'assistant_thinking')
-    return acpThoughtRenderer(parsed, role, context)
+    return acpThoughtRenderer(parsed, context)
   if (category.kind === 'result_divider')
     return acpResultDividerRenderer(parsed)
   if (category.kind === 'tool_use') {
     const cat = category as { toolName: string, toolUse: Record<string, unknown> }
     if (cat.toolName === ACP_SESSION_UPDATE.PLAN)
-      return acpPlanRenderer(cat.toolUse, role, context)
+      return acpPlanRenderer(cat.toolUse, context)
     if (cat.toolUse.sessionUpdate === ACP_SESSION_UPDATE.TOOL_CALL_UPDATE)
-      return acpToolCallUpdateRenderer(cat.toolUse, role, context)
-    return acpToolCallRenderer(cat.toolUse, role, context)
+      return acpToolCallUpdateRenderer(cat.toolUse, context)
+    return acpToolCallRenderer(cat.toolUse, context)
   }
   if (category.kind === 'user_content')
     return <UserContentMessage parsed={parsed} />

--- a/frontend/src/components/chat/providers/claude/extractors/grepGlob.test.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/grepGlob.test.ts
@@ -42,6 +42,42 @@ describe('parseRawGrepGlobResult', () => {
       content: '',
     })
   })
+
+  it('parses count-mode trailing summary "Found N total occurrences across M files."', () => {
+    // Claude's Grep `output_mode: "count"` raw text places per-file `path:count`
+    // lines first and the summary on the last line (separated by a blank line).
+    const raw = 'a/x.ts:5\na/y.ts:2\n\nFound 7 total occurrences across 2 files.'
+    expect(parseRawGrepGlobResult(raw, 'Grep')).toEqual({
+      numFiles: 2,
+      numLines: 0,
+      numMatches: 7,
+      mode: 'count',
+      filenames: [],
+      content: 'a/x.ts:5\na/y.ts:2',
+    })
+  })
+
+  it('parses count-mode trailing summary in singular form', () => {
+    const raw = 'a/x.ts:1\n\nFound 1 total occurrence across 1 file.'
+    expect(parseRawGrepGlobResult(raw, 'Grep')).toEqual({
+      numFiles: 1,
+      numLines: 0,
+      numMatches: 1,
+      mode: 'count',
+      filenames: [],
+      content: 'a/x.ts:1',
+    })
+  })
+
+  it('parses count-mode trailing summary with pagination suffix', () => {
+    const raw = 'a/x.ts:5\na/y.ts:2\n\nFound 7 total occurrences across 2 files. with pagination = limit: 2'
+    const parsed = parseRawGrepGlobResult(raw, 'Grep')
+    expect(parsed.mode).toBe('count')
+    expect(parsed.numFiles).toBe(2)
+    expect(parsed.numMatches).toBe(7)
+    expect(parsed.filenames).toEqual([])
+    expect(parsed.content).toBe('a/x.ts:5\na/y.ts:2')
+  })
 })
 
 describe('claudeGrepFromToolResult', () => {
@@ -75,6 +111,16 @@ describe('claudeGrepFromToolResult', () => {
     const source = claudeGrepFromToolResult(null, 'Found 1 file\n/a.ts')
     expect(source.numFiles).toBe(1)
     expect(source.filenames).toEqual(['/a.ts'])
+  })
+
+  it('threads count-mode mode/numMatches through the subagent fallback', () => {
+    const raw = 'a/x.ts:5\na/y.ts:2\n\nFound 7 total occurrences across 2 files.'
+    const source = claudeGrepFromToolResult(null, raw)
+    expect(source.mode).toBe('count')
+    expect(source.numMatches).toBe(7)
+    expect(source.numFiles).toBe(2)
+    expect(source.filenames).toEqual([])
+    expect(source.content).toBe('a/x.ts:5\na/y.ts:2')
   })
 })
 

--- a/frontend/src/components/chat/providers/claude/extractors/grepGlob.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/grepGlob.ts
@@ -13,13 +13,22 @@ const GREP_CONTENT_LINE_RE = /^\d+[:-]|^[^:]+:\d+[:-]/
 const RAW_RESULT_SUMMARY_RE = /^(?:Found (\d+) (?:files?|lines?(?:\s+and\s+\d+\s+files?)?)|(\d+) match(?:es)? in (\d+) files?|No (?:matches|files) found)$/
 
 /**
+ * Trailing summary line emitted by Grep `output_mode: "count"`. Per
+ * claude-code/src/tools/GrepTool/GrepTool.ts the suffix may include
+ * " with pagination = limit: N, offset: N", so we anchor on the prefix only.
+ */
+const RAW_COUNT_TRAILING_SUMMARY_RE = /^Found (\d+) total occurrences? across (\d+) files?\b/
+
+/**
  * Parse raw Grep/Glob result text (without tool_use_result).
- * Strips the leading summary line (if any) and returns structured data
- * matching what tool_use_result would provide.
+ * Strips the leading or trailing summary line (if any) and returns
+ * structured data matching what tool_use_result would provide.
  */
 export function parseRawGrepGlobResult(raw: string, toolName: string): {
   numFiles: number
   numLines: number
+  numMatches?: number
+  mode?: 'count'
   filenames: string[]
   content: string
 } {
@@ -27,9 +36,27 @@ export function parseRawGrepGlobResult(raw: string, toolName: string): {
   const firstLine = lines[0]?.trim() ?? ''
   const summaryMatch = firstLine.match(RAW_RESULT_SUMMARY_RE)
 
-  // Strip the summary line from the data lines.
-  const dataLines = summaryMatch ? lines.slice(1) : lines
-  const nonEmpty = dataLines.filter(l => l.trim())
+  // Strip the leading summary (if any), then look at non-empty data lines.
+  const afterLeading = summaryMatch ? lines.slice(1) : lines
+  const nonEmpty = afterLeading.filter(l => l.trim())
+
+  // Count-mode emits the summary on the *last* non-empty line. Detect and
+  // strip it before classifying the body.
+  const lastLine = nonEmpty[nonEmpty.length - 1]?.trim() ?? ''
+  const trailingMatch = lastLine.match(RAW_COUNT_TRAILING_SUMMARY_RE)
+  if (trailingMatch) {
+    const numMatches = Number.parseInt(trailingMatch[1]!, 10)
+    const numFiles = Number.parseInt(trailingMatch[2]!, 10)
+    const body = nonEmpty.slice(0, -1)
+    return {
+      numFiles,
+      numLines: 0,
+      numMatches,
+      mode: 'count',
+      filenames: [],
+      content: body.join('\n'),
+    }
+  }
 
   // For Grep content mode (lines contain "file:line:match" or "line_num:text"),
   // we check the first few lines to classify the output format.
@@ -116,12 +143,25 @@ export function claudeSearchFromToolResult(
   // Subagent: parse raw resultContent.
   const toolName = variant === 'grep' ? CLAUDE_TOOL.GREP : CLAUDE_TOOL.GLOB
   const raw = parseRawGrepGlobResult(resultContent, toolName)
+  if (variant === 'grep') {
+    return {
+      variant,
+      filenames: raw.filenames,
+      content: raw.content,
+      numFiles: raw.numFiles,
+      numLines: raw.numLines,
+      numMatches: raw.numMatches,
+      mode: raw.mode,
+      truncated: false,
+      fallbackContent: resultContent,
+    }
+  }
   return {
     variant,
     filenames: raw.filenames,
-    content: variant === 'grep' ? raw.content : '',
+    content: '',
     numFiles: raw.numFiles,
-    numLines: variant === 'grep' ? raw.numLines : 0,
+    numLines: 0,
     truncated: false,
     fallbackContent: resultContent,
   }

--- a/frontend/src/components/chat/providers/claude/messageRenderers.tsx
+++ b/frontend/src/components/chat/providers/claude/messageRenderers.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable solid/components-return-once -- render methods are not Solid components */
 import type { JSX } from 'solid-js'
 import type { MessageContentRenderer, RenderContext } from '../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import Bot from 'lucide-solid/icons/bot'
 import { joinContentParagraphs } from '~/lib/contentBlocks'
 import { isObject } from '~/lib/jsonPick'
@@ -11,7 +10,7 @@ import { getMessageContentArray } from './extractors/assistantContent'
 
 /** Handles assistant messages: {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}} */
 export const assistantTextRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     const content = getMessageContentArray(parsed)
     if (!content)
       return null
@@ -24,7 +23,7 @@ export const assistantTextRenderer: MessageContentRenderer = {
 
 /** Handles assistant thinking messages: {"type":"assistant","message":{"content":[{"type":"thinking","thinking":"..."}]}} */
 export const assistantThinkingRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
+  render(parsed, context) {
     const content = getMessageContentArray(parsed)
     if (!content)
       return null
@@ -37,7 +36,7 @@ export const assistantThinkingRenderer: MessageContentRenderer = {
 
 /** Handles plan execution messages: {"content":"...","planExecution":true} */
 export const planExecutionRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
+  render(parsed, context) {
     if (!isObject(parsed) || parsed.planExecution !== true)
       return null
     const content = parsed.content as string | undefined
@@ -49,7 +48,7 @@ export const planExecutionRenderer: MessageContentRenderer = {
 
 /** Renders task_started system messages as a minimal "Task started" line (thread child). */
 export const taskStartedRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'task_started')
       return null
 
@@ -65,7 +64,7 @@ export const taskStartedRenderer: MessageContentRenderer = {
  * as markdown.
  */
 export const userTextContentRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'user')
       return null
 
@@ -101,7 +100,7 @@ export const userTextContentRenderer: MessageContentRenderer = {
  * a `type` field (those are routed to other Claude-shaped renderers).
  */
 export const userContentRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || 'type' in parsed)
       return null
     return <UserContentMessage parsed={parsed} />
@@ -116,12 +115,11 @@ export const userContentRenderer: MessageContentRenderer = {
  */
 export function tryClaudeUnknownKindRenderers(
   parsed: unknown,
-  role: MessageRole,
   context: RenderContext | undefined,
 ): JSX.Element | null {
-  return userTextContentRenderer.render(parsed, role, context)
-    ?? assistantTextRenderer.render(parsed, role, context)
-    ?? assistantThinkingRenderer.render(parsed, role, context)
-    ?? userContentRenderer.render(parsed, role, context)
-    ?? taskStartedRenderer.render(parsed, role, context)
+  return userTextContentRenderer.render(parsed, context)
+    ?? assistantTextRenderer.render(parsed, context)
+    ?? assistantThinkingRenderer.render(parsed, context)
+    ?? userContentRenderer.render(parsed, context)
+    ?? taskStartedRenderer.render(parsed, context)
 }

--- a/frontend/src/components/chat/providers/claude/notifications.tsx
+++ b/frontend/src/components/chat/providers/claude/notifications.tsx
@@ -42,7 +42,7 @@ function cleanAPIErrorMessage(msg: string): string {
 
 /** Handles Claude rate limit notifications: {"type":"rate_limit_event","rate_limit_info":{...}} */
 export const rateLimitRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'rate_limit_event')
       return null
     const info = parsed.rate_limit_info
@@ -58,7 +58,7 @@ export const rateLimitRenderer: MessageContentRenderer = {
 
 /** Handles Claude result messages: {"type":"result","duration_ms":865,"num_turns":558,...} */
 export const resultRenderer: MessageContentRenderer = {
-  render(parsed, _role, _context) {
+  render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'result')
       return null
 

--- a/frontend/src/components/chat/providers/claude/renderMessage.tsx
+++ b/frontend/src/components/chat/providers/claude/renderMessage.tsx
@@ -2,7 +2,6 @@
 import type { JSX } from 'solid-js'
 import type { MessageCategory } from '../../messageClassification'
 import type { RenderContext } from '../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import MessageSquare from 'lucide-solid/icons/message-square'
 import { createMemo } from 'solid-js'
 import { joinContentParagraphs } from '~/lib/contentBlocks'
@@ -49,7 +48,6 @@ import { renderClaudeToolUse } from './toolUse'
 export function renderClaudeMessage(
   category: MessageCategory,
   parsed: unknown,
-  role: MessageRole,
   context?: RenderContext,
 ): JSX.Element | null {
   switch (category.kind) {
@@ -60,28 +58,28 @@ export function renderClaudeMessage(
     case 'agent_prompt':
       return renderClaudeAgentPrompt(parsed, context)
     case 'assistant_text':
-      return assistantTextRenderer.render(parsed, role, context)
+      return assistantTextRenderer.render(parsed, context)
     case 'assistant_thinking':
-      return assistantThinkingRenderer.render(parsed, role, context)
+      return assistantThinkingRenderer.render(parsed, context)
     case 'user_text':
-      return userTextContentRenderer.render(parsed, role, context)
+      return userTextContentRenderer.render(parsed, context)
     case 'user_content':
-      return userContentRenderer.render(parsed, role, context)
+      return userContentRenderer.render(parsed, context)
     case 'plan_execution':
-      return planExecutionRenderer.render(parsed, role, context)
+      return planExecutionRenderer.render(parsed, context)
     case 'task_notification':
-      return taskNotificationRenderer.render(parsed, role, context)
+      return taskNotificationRenderer.render(parsed, context)
     case 'notification':
-      return claudeNotificationRenderer(parsed, role, context)
+      return claudeNotificationRenderer(parsed, context)
     case 'result_divider':
-      return resultRenderer.render(parsed, role, context)
+      return resultRenderer.render(parsed, context)
     case 'control_response':
-      return controlResponseRenderer.render(parsed, role, context)
+      return controlResponseRenderer.render(parsed, context)
     case 'compact_summary':
     case 'hidden':
       return <span />
     case 'unknown':
-      return tryClaudeUnknownKindRenderers(parsed, role, context)
+      return tryClaudeUnknownKindRenderers(parsed, context)
     default:
       return null
   }
@@ -94,20 +92,19 @@ export function renderClaudeMessage(
  */
 function claudeNotificationRenderer(
   parsed: unknown,
-  role: MessageRole,
   context: RenderContext | undefined,
 ): JSX.Element | null {
-  return settingsChangedRenderer.render(parsed, role, context)
-    ?? interruptedRenderer.render(parsed, role, context)
-    ?? contextClearedRenderer.render(parsed, role, context)
-    ?? compactingRenderer.render(parsed, role, context)
-    ?? agentErrorRenderer.render(parsed, role, context)
-    ?? planUpdatedRenderer.render(parsed, role, context)
-    ?? rateLimitRenderer.render(parsed, role, context)
-    ?? apiRetryRenderer.render(parsed, role, context)
-    ?? compactBoundaryRenderer.render(parsed, role, context)
-    ?? microcompactBoundaryRenderer.render(parsed, role, context)
-    ?? systemInitRenderer.render(parsed, role, context)
+  return settingsChangedRenderer.render(parsed, context)
+    ?? interruptedRenderer.render(parsed, context)
+    ?? contextClearedRenderer.render(parsed, context)
+    ?? compactingRenderer.render(parsed, context)
+    ?? agentErrorRenderer.render(parsed, context)
+    ?? planUpdatedRenderer.render(parsed, context)
+    ?? rateLimitRenderer.render(parsed, context)
+    ?? apiRetryRenderer.render(parsed, context)
+    ?? compactBoundaryRenderer.render(parsed, context)
+    ?? microcompactBoundaryRenderer.render(parsed, context)
+    ?? systemInitRenderer.render(parsed, context)
 }
 
 /** Collapsed agent prompt view: MessageSquare icon + "Prompt" title + collapsed markdown body. */

--- a/frontend/src/components/chat/providers/codex/defineRenderer.test.ts
+++ b/frontend/src/components/chat/providers/codex/defineRenderer.test.ts
@@ -1,6 +1,6 @@
 import type { CodexItemType } from '~/types/toolMessages'
 import { describe, expect, it } from 'vitest'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+
 import { CODEX_RENDERERS, defineCodexRenderer } from './defineRenderer'
 
 // Tests use synthetic item-type strings (cast through CodexItemType) rather
@@ -19,15 +19,15 @@ describe('defineCodexRenderer', () => {
       },
     })
 
-    Renderer({ parsed: { item: { type: 'fooType' } }, role: MessageRole.ASSISTANT })
+    Renderer({ parsed: { item: { type: 'fooType' } } })
     expect(calls).toBe(1)
 
     // Wrong type — guard returns null without calling render.
-    Renderer({ parsed: { item: { type: 'otherType' } }, role: MessageRole.ASSISTANT })
+    Renderer({ parsed: { item: { type: 'otherType' } } })
     expect(calls).toBe(1)
 
     // No item — guard returns null.
-    Renderer({ parsed: {}, role: MessageRole.ASSISTANT })
+    Renderer({ parsed: {} })
     expect(calls).toBe(1)
   })
 
@@ -40,7 +40,7 @@ describe('defineCodexRenderer', () => {
         return null
       },
     })
-    Renderer({ parsed: { type: 'barType' }, role: MessageRole.ASSISTANT })
+    Renderer({ parsed: { type: 'barType' } })
     expect(calls).toBe(1)
   })
 
@@ -56,8 +56,8 @@ describe('defineCodexRenderer', () => {
     expect(CODEX_RENDERERS.has('typeA')).toBe(true)
     expect(CODEX_RENDERERS.has('typeB')).toBe(true)
 
-    CODEX_RENDERERS.get('typeA')!({ item: { type: 'typeA' }, role: MessageRole.ASSISTANT })
-    CODEX_RENDERERS.get('typeB')!({ item: { type: 'typeB' }, role: MessageRole.ASSISTANT })
+    CODEX_RENDERERS.get('typeA')!({ item: { type: 'typeA' } })
+    CODEX_RENDERERS.get('typeB')!({ item: { type: 'typeB' } })
     expect(calls).toBe(2)
   })
 
@@ -71,7 +71,7 @@ describe('defineCodexRenderer', () => {
       },
     })
     const Inner = CODEX_RENDERERS.get('captureType')!
-    Inner({ item: { type: 'captureType', extra: 42 }, role: MessageRole.ASSISTANT })
+    Inner({ item: { type: 'captureType', extra: 42 } })
     expect(received).toEqual({ type: 'captureType', extra: 42 })
   })
 })

--- a/frontend/src/components/chat/providers/codex/defineRenderer.tsx
+++ b/frontend/src/components/chat/providers/codex/defineRenderer.tsx
@@ -1,6 +1,5 @@
 import type { Component, JSX } from 'solid-js'
 import type { RenderContext } from '../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import type { CodexItemType } from '~/types/toolMessages'
 import { Show } from 'solid-js'
 import { extractItem } from './renderHelpers'
@@ -13,7 +12,6 @@ import { extractItem } from './renderHelpers'
  */
 export interface CodexItemRendererProps {
   item: Record<string, unknown>
-  role: MessageRole
   context?: RenderContext
 }
 
@@ -26,7 +24,6 @@ export type CodexItemRenderer = Component<CodexItemRendererProps>
  */
 export interface CodexMessageRendererProps {
   parsed: unknown
-  role: MessageRole
   context?: RenderContext
 }
 
@@ -81,7 +78,7 @@ export function defineCodexRenderer(spec: CodexRendererSpec): CodexMessageRender
     }
     return (
       <Show when={item()}>
-        {unwrapped => <Inner item={unwrapped()} role={props.role} context={props.context} />}
+        {unwrapped => <Inner item={unwrapped()} context={props.context} />}
       </Show>
     )
   }

--- a/frontend/src/components/chat/providers/codex/notifications.test.tsx
+++ b/frontend/src/components/chat/providers/codex/notifications.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 
 // Importing the registry side-effect-registers the Codex plugin so the thread
 // renderer can dispatch into `notificationThreadEntry`.
@@ -17,7 +17,7 @@ function renderText(messages: unknown[]): string {
 }
 
 function renderCodexStatusText(parsed: Record<string, unknown>): string {
-  const result = codexNotificationRenderer(parsed, MessageRole.SYSTEM)
+  const result = codexNotificationRenderer(parsed)
   if (result === null)
     return ''
   const { container } = render(() => result)
@@ -68,7 +68,7 @@ describe('codexNotificationRenderer: MCP startup status', () => {
   })
 
   it('returns null for non-Codex notification shapes', () => {
-    expect(codexNotificationRenderer({ type: 'context_cleared' }, MessageRole.SYSTEM)).toBeNull()
+    expect(codexNotificationRenderer({ type: 'context_cleared' })).toBeNull()
   })
 })
 

--- a/frontend/src/components/chat/providers/codex/notifications.tsx
+++ b/frontend/src/components/chat/providers/codex/notifications.tsx
@@ -1,7 +1,5 @@
 import type { JSX, JSXElement } from 'solid-js'
-import type { RenderContext } from '../../messageRenderers'
 import type { NotificationThreadEntry } from '../registry'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
 import { CODEX_RATE_LIMITS_METHOD, formatRateLimitMessage, iterCodexRateLimitTiers } from '~/lib/rateLimitUtils'
 import { CODEX_METHOD } from '~/types/toolMessages'
@@ -111,8 +109,6 @@ function renderRateLimits(parsed: Record<string, unknown>): JSXElement {
  */
 export function codexNotificationRenderer(
   parsed: unknown,
-  _role: MessageRole,
-  _context?: RenderContext,
 ): JSX.Element | null {
   if (!isObject(parsed))
     return null

--- a/frontend/src/components/chat/providers/codex/plugin.test.ts
+++ b/frontend/src/components/chat/providers/codex/plugin.test.ts
@@ -2,7 +2,7 @@ import type { AskQuestionState, Question } from '../../controls/types'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { sendCodexDecision, sendCodexUserInputResponse, toRpcId } from '../../controls/CodexControlRequest'
 import { providerFor } from '../registry'
 import { input, model, option, optionGroup } from '../testUtils'
@@ -427,7 +427,7 @@ describe('codex result divider', () => {
     const parsed = {
       turn: { id: 'turn-1', status: 'completed' },
     }
-    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed, MessageRole.TURN_END)
+    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed)
     expect(result).not.toBeNull()
   })
 })

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -4,7 +4,6 @@ import type { Question } from '../../controls/types'
 import type { MessageCategory } from '../../messageClassification'
 import type { RenderContext } from '../../messageRenderers'
 import type { ClassificationContext, ClassificationInput, Provider } from '../registry'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { PermissionMode } from '~/utils/controlResponse'
 import * as workerRpc from '~/api/workerRpc'
@@ -360,15 +359,15 @@ const codexPlugin: Provider = {
     return { kind: 'unknown' }
   },
 
-  renderMessage(category: MessageCategory, parsed: unknown, role: MessageRole, context?: RenderContext): JSX.Element | null {
+  renderMessage(category: MessageCategory, parsed: unknown, context?: RenderContext): JSX.Element | null {
     if (category.kind === 'assistant_text')
-      return <CodexAgentMessageRenderer parsed={parsed} role={role} context={context} />
+      return <CodexAgentMessageRenderer parsed={parsed} context={context} />
     if (category.kind === 'assistant_thinking')
-      return <CodexReasoningRenderer parsed={parsed} role={role} context={context} />
+      return <CodexReasoningRenderer parsed={parsed} context={context} />
     if (category.kind === 'result_divider')
-      return <CodexTurnCompletedRenderer parsed={parsed} role={role} context={context} />
+      return <CodexTurnCompletedRenderer parsed={parsed} context={context} />
     if (category.kind === 'notification') {
-      const codexResult = codexNotificationRenderer(parsed, role, context)
+      const codexResult = codexNotificationRenderer(parsed)
       if (codexResult !== null)
         return codexResult
       // Fall through to Claude-shaped notification renderers (settings_changed,
@@ -388,7 +387,7 @@ const codexPlugin: Provider = {
       // turnPlan dispatches off `parent.method` (not item.type), so it's
       // not in CODEX_RENDERERS — handle it explicitly.
       if (cat.toolName === CODEX_INTERNAL_TOOL.TURN_PLAN)
-        return <CodexTurnPlanRenderer parsed={cat.toolUse} role={role} context={context} />
+        return <CodexTurnPlanRenderer parsed={cat.toolUse} context={context} />
       // For mcp/dynamic tool calls the toolName comes from item.tool, not
       // item.type. Look up by the actual item type (after unwrapping the
       // optional `{item, threadId}` envelope) and fall back to the generic
@@ -397,8 +396,8 @@ const codexPlugin: Provider = {
       const itemType = item ? pickString(item, 'type', undefined) : undefined
       const Renderer = itemType ? CODEX_RENDERERS.get(itemType) : undefined
       if (Renderer && item)
-        return <Renderer item={item} role={role} context={context} />
-      return <CodexMcpToolCallRenderer parsed={cat.toolUse} role={role} context={context} />
+        return <Renderer item={item} context={context} />
+      return <CodexMcpToolCallRenderer parsed={cat.toolUse} context={context} />
     }
     return null
   },

--- a/frontend/src/components/chat/providers/commandRendering.test.tsx
+++ b/frontend/src/components/chat/providers/commandRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './codex'
 import './opencode'
@@ -20,7 +20,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -44,7 +44,7 @@ function renderCodexItem(item: Record<string, unknown>, context?: RenderContext)
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 
@@ -55,7 +55,7 @@ function renderOpenCodeUpdate(toolUse: Record<string, unknown>, context?: Render
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/editRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/editRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './testMocks'
 
@@ -39,7 +39,7 @@ function renderEditToolUse(input: Record<string, unknown>) {
     toolUse,
     content: msg.message.content as Array<Record<string, unknown>>,
   }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, undefined, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, undefined, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/globRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/globRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -46,7 +46,7 @@ function renderToolUseText(context?: RenderContext): string {
   const msg = makeGlobToolUse()
   const toolUse = (msg.message.content as Array<Record<string, unknown>>)[0]
   const category: MessageCategory = { kind: 'tool_use', toolName: 'Glob', toolUse, content: msg.message.content as Array<Record<string, unknown>> }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -59,7 +59,7 @@ function renderToolResultContainer(
 ): HTMLElement {
   const msg = makeGlobToolResult(resultContent, toolUseResult)
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(msg, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container
 }

--- a/frontend/src/components/chat/providers/grepRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/grepRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -46,7 +46,7 @@ function renderToolUseText(context?: RenderContext): string {
   const msg = makeGrepToolUse({ path: '/home/user/project/src' })
   const toolUse = (msg.message.content as Array<Record<string, unknown>>)[0]
   const category: MessageCategory = { kind: 'tool_use', toolName: 'Grep', toolUse, content: msg.message.content as Array<Record<string, unknown>> }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -59,7 +59,7 @@ function renderToolResultText(
 ): string {
   const msg = makeGrepToolResult(resultContent, toolUseResult)
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(msg, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }

--- a/frontend/src/components/chat/providers/mcpRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/mcpRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -57,7 +57,7 @@ describe('mcp tool_use rendering', () => {
     })
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.ASSISTANT, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, toolUseCategory, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, toolUseCategory, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''
@@ -81,7 +81,7 @@ describe('mcp tool_use rendering', () => {
     }
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.ASSISTANT, { spanType: 'mcp__github__search__repos' }, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'mcp__github__search__repos' }, category, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''
@@ -105,7 +105,7 @@ describe('mcp tool_use rendering', () => {
     }
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.ASSISTANT, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, category, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''
@@ -127,7 +127,7 @@ describe('mcp tool_use rendering', () => {
     }
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.ASSISTANT, { spanType: 'SomeNewTool' }, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'SomeNewTool' }, category, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''
@@ -149,7 +149,7 @@ describe('mcp tool_use rendering', () => {
     }
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.ASSISTANT, { spanType: 'Bash' }, category, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'Bash' }, category, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''
@@ -164,7 +164,7 @@ describe('mcp tool_result rendering', () => {
     const parsed = makeMcpToolResult('# Research Report\n\nThis is a comparison of Go OIDC libraries.')
 
     const { container } = render(() =>
-      renderMessageContent(parsed, MessageRole.USER, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, toolResultCategory, AgentProvider.CLAUDE_CODE),
+      renderMessageContent(parsed, { spanType: 'mcp__claude_ai_Tavily__tavily_research' }, toolResultCategory, AgentProvider.CLAUDE_CODE),
     )
 
     const text = container.textContent || ''

--- a/frontend/src/components/chat/providers/mcpToolCallRendering.test.tsx
+++ b/frontend/src/components/chat/providers/mcpToolCallRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './codex'
 import './testMocks'
@@ -19,7 +19,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -42,7 +42,7 @@ function renderCodexItem(item: Record<string, unknown>, context?: RenderContext)
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/opencode/plugin.test.ts
+++ b/frontend/src/components/chat/providers/opencode/plugin.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { sendOpenCodePermissionResponse, sendOpenCodeQuestionResponse } from '../../controls/OpenCodeControlRequest'
 import { acpResultDividerRenderer } from '../acp/renderers'
 import { providerFor } from '../registry'
@@ -267,7 +267,7 @@ describe('opencode result divider renderer', () => {
 
   it('is returned by plugin.renderMessage for result_divider', () => {
     const parsed = { stopReason: 'end_turn' }
-    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed, MessageRole.TURN_END)
+    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed)
     expect(result).not.toBeNull()
   })
 })
@@ -287,7 +287,7 @@ describe('opencode tool_call renderer', () => {
     }
     const category = plugin.classify(input(toolUse))
     expect(category.kind).toBe('tool_use')
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -299,7 +299,7 @@ describe('opencode tool_call renderer', () => {
       status: 'pending',
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 })
@@ -381,7 +381,7 @@ describe('opencode tool_call_update renderer', () => {
     }
     const category = plugin.classify(input(toolUse))
     expect(category.kind).toBe('tool_use')
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -397,7 +397,7 @@ describe('opencode tool_call_update renderer', () => {
       content: [],
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -426,7 +426,7 @@ describe('opencode tool_call_update renderer', () => {
       content: [{ type: 'content', content: { type: 'text', text: 'output' } }],
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -449,7 +449,7 @@ describe('opencode tool_call_update renderer', () => {
       content: [{ type: 'content', content: { type: 'text', text: 'Found 24 matches\n...' } }],
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -472,7 +472,7 @@ describe('opencode tool_call_update renderer', () => {
       content: [{ type: 'content', content: { type: 'text', text: '537: func foo() {\n538:   return\n539: }' } }],
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -487,7 +487,7 @@ describe('opencode tool_call_update renderer', () => {
       rawOutput: { output: 'everything ok', metadata: { exit: 0 } },
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 })

--- a/frontend/src/components/chat/providers/pi/plugin.test.ts
+++ b/frontend/src/components/chat/providers/pi/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { providerFor } from '../registry'
 import { input } from '../testUtils'
 
@@ -57,7 +57,6 @@ describe('pi classify', () => {
     const result = plugin.renderMessage!(
       { kind: 'result_divider' },
       { type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }] },
-      MessageRole.TURN_END,
     )
     expect(result).not.toBeNull()
   })

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -5,7 +5,6 @@ import type { RenderContext } from '../../messageRenderers'
 import type { FileEditDiffSource } from '../../results/fileEditDiff'
 import type { ClassificationInput, Provider, ToolResultMeta } from '../registry'
 import type { PiExtensionResponse } from './controlResponse'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
@@ -86,24 +85,23 @@ function formatPiDiffSources(sources: FileEditDiffSource[]): string | null {
 type PiRenderer = (
   category: MessageCategory,
   parsed: unknown,
-  role: MessageRole,
   context: RenderContext | undefined,
 ) => JSX.Element | null
 
 const PI_RENDERERS: Partial<Record<MessageCategory['kind'], PiRenderer>> = {
-  assistant_text: (_cat, parsed, role, context) =>
-    <PiAssistantMessage parsed={parsed} role={role} context={context} />,
-  assistant_thinking: (_cat, parsed, role, context) =>
-    <PiAssistantThinking parsed={parsed} role={role} context={context} />,
-  tool_use: (category, _parsed, role, context) => {
+  assistant_text: (_cat, parsed, context) =>
+    <PiAssistantMessage parsed={parsed} context={context} />,
+  assistant_thinking: (_cat, parsed, context) =>
+    <PiAssistantThinking parsed={parsed} context={context} />,
+  tool_use: (category, _parsed, context) => {
     const cat = category as { toolName: string, toolUse: Record<string, unknown> }
-    return <PiToolExecutionRenderer parsed={cat.toolUse} role={role} context={context} />
+    return <PiToolExecutionRenderer parsed={cat.toolUse} context={context} />
   },
-  tool_result: (_cat, parsed, role, context) =>
-    <PiToolResultRenderer parsed={parsed} role={role} context={context} />,
+  tool_result: (_cat, parsed, context) =>
+    <PiToolResultRenderer parsed={parsed} context={context} />,
   result_divider: (_cat, parsed) => renderPiResultDivider(parsed),
   user_content: (_cat, parsed) => <UserContentMessage parsed={parsed} />,
-  plan_execution: (_cat, parsed, _role, context) => {
+  plan_execution: (_cat, parsed, context) => {
     const obj = isObject(parsed) ? parsed : null
     const text = obj && typeof obj.content === 'string' ? obj.content : ''
     return text ? <PlanExecutionMessage text={text} context={context} /> : null
@@ -236,6 +234,9 @@ const piPlugin: Provider = {
       // the synthetic user_content row, and tool results render through the
       // tool_execution_* span. Hide these to avoid duplicates; only the
       // assistant's text/thinking message_end should reach the chat view.
+      // Pi's wire envelope carries the message author under `role` (Anthropic
+      // Messages API style), distinct from the proto-side MessageSource that
+      // describes who persisted the row. Read the wire field by name.
       const messageRole = pickString(pickObject(parent, 'message'), 'role')
       if (messageRole !== 'assistant')
         return { kind: 'hidden' }
@@ -272,8 +273,8 @@ const piPlugin: Provider = {
     return { kind: 'unknown' }
   },
 
-  renderMessage(category: MessageCategory, parsed: unknown, role: MessageRole, context?: RenderContext): JSX.Element | null {
-    return PI_RENDERERS[category.kind]?.(category, parsed, role, context) ?? null
+  renderMessage(category: MessageCategory, parsed: unknown, context?: RenderContext): JSX.Element | null {
+    return PI_RENDERERS[category.kind]?.(category, parsed, context) ?? null
   },
 
   toolResultMeta: piToolResultMeta,

--- a/frontend/src/components/chat/providers/pi/renderers/assistantMessage.tsx
+++ b/frontend/src/components/chat/providers/pi/renderers/assistantMessage.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { createMemo, Show } from 'solid-js'
 import { isObject } from '~/lib/jsonPick'
 import { MarkdownText, ThinkingMessage } from '../../../messageRenderers'
@@ -8,7 +7,6 @@ import { piContentText } from '../messageContent'
 
 interface Props {
   parsed: unknown
-  role: MessageRole
   context?: RenderContext
 }
 

--- a/frontend/src/components/chat/providers/pi/renderers/toolExecution.tsx
+++ b/frontend/src/components/chat/providers/pi/renderers/toolExecution.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable solid/no-innerhtml -- HTML produced via shiki, not arbitrary user input */
 import type { Component, JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import Eye from 'lucide-solid/icons/eye'
 import FileEdit from 'lucide-solid/icons/file-edit'
 import FilePlus from 'lucide-solid/icons/file-plus'
@@ -22,7 +21,6 @@ import { PI_TOOL } from '../protocol'
 
 interface RendererProps {
   parsed: unknown
-  role: MessageRole
   context?: RenderContext
 }
 

--- a/frontend/src/components/chat/providers/pi/renderers/toolResult.tsx
+++ b/frontend/src/components/chat/providers/pi/renderers/toolResult.tsx
@@ -1,7 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
 import type { FileEditDiffSource } from '../../../results/fileEditDiff'
-import type { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { createMemo, For, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
@@ -16,7 +15,6 @@ import { PI_TOOL } from '../protocol'
 
 interface RendererProps {
   parsed: unknown
-  role: MessageRole
   context?: RenderContext
 }
 

--- a/frontend/src/components/chat/providers/readRendering.test.tsx
+++ b/frontend/src/components/chat/providers/readRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './opencode'
 import './pi'
@@ -20,7 +20,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -42,7 +42,7 @@ function renderOpenCodeUpdate(toolUse: Record<string, unknown>, context?: Render
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 
@@ -69,7 +69,7 @@ function renderPiReadResult(content: string, startArgs: Record<string, unknown> 
     args: startArgs,
   }
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(payload, MessageRole.ASSISTANT, {
+  const result = renderMessageContent(payload, {
     spanType: 'read',
     toolUseParsed: parsed(start),
   }, category, AgentProvider.PI)

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -11,7 +11,7 @@ import type { Component, JSX } from 'solid-js'
 import type { ActionsProps, AskQuestionState, ContentProps, Question } from '../controls/types'
 import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
-import type { AgentInfo, AgentProvider, AvailableModel, AvailableOptionGroup, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentInfo, AgentProvider, AvailableModel, AvailableOptionGroup } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentSessionInfo } from '~/stores/agentSession.store'
 import type { PermissionMode } from '~/utils/controlResponse'
@@ -53,7 +53,6 @@ export interface AttachmentCapabilities {
 }
 
 export interface ClassificationInput extends ParsedMessageContent {
-  messageRole: MessageRole
   agentProvider?: AgentProvider
   spanId?: string
   spanType?: string
@@ -117,7 +116,6 @@ export interface Provider {
   renderMessage?: (
     category: MessageCategory,
     parsed: unknown,
-    role: MessageRole,
     context?: RenderContext,
   ) => JSX.Element | null
 

--- a/frontend/src/components/chat/providers/remoteTriggerRendering.test.tsx
+++ b/frontend/src/components/chat/providers/remoteTriggerRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { claudeToolResultMeta } from './claude/toolResult'
 import './testMocks'
 
@@ -51,7 +51,7 @@ function renderToolUseText(input: Record<string, unknown>): string {
     toolUse,
     content: msg.message.content as Array<Record<string, unknown>>,
   }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, undefined, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, undefined, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -65,7 +65,6 @@ function renderToolResultContainer(
   const category: MessageCategory = { kind: 'tool_result' }
   const result = renderMessageContent(
     msg,
-    MessageRole.USER,
     { spanType: 'RemoteTrigger', ...context },
     category,
     AgentProvider.CLAUDE_CODE,

--- a/frontend/src/components/chat/providers/searchRendering.test.tsx
+++ b/frontend/src/components/chat/providers/searchRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './opencode'
 import './testMocks'
@@ -19,7 +19,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -41,7 +41,7 @@ function renderOpenCodeUpdate(toolUse: Record<string, unknown>, context?: Render
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 
@@ -91,6 +91,53 @@ describe('claude Grep tool_result rendering', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('Found 1 file')
     expect(text).toContain('sub.ts')
+  })
+
+  it('renders structured count-mode summary as "N matches in M files"', () => {
+    // Mirrors the GrepTool count-mode tool_use_result shape.
+    const parsed = makeResult({
+      tool_name: 'Grep',
+      mode: 'count',
+      numFiles: 13,
+      numMatches: 57,
+      filenames: [],
+      content: 'a/x.ts:5\na/y.ts:2',
+    }, '')
+    const { container } = renderClaudeToolResult(parsed, { spanType: 'Grep' })
+    const text = container.textContent ?? ''
+    expect(text).toContain('57 matches in 13 files')
+    expect(text).not.toContain('Found 13 files')
+  })
+
+  it('renders raw count-mode subagent output as "N matches in M files"', () => {
+    const raw = [
+      'frontend/tests/e2e/024-message-delivery-error.spec.ts:5',
+      'frontend/tests/e2e/026-agent-resume.spec.ts:2',
+      'frontend/tests/e2e/044-agent-settings.spec.ts:3',
+      'frontend/tests/e2e/025-no-worker-settings.spec.ts:5',
+      'frontend/tests/e2e/023-full-restart.spec.ts:6',
+      'frontend/tests/e2e/036-dropdown-popover.spec.ts:3',
+      'frontend/tests/e2e/022-worker-restart-thinking-indicator.spec.ts:4',
+      'frontend/tests/e2e/041-chat-pagination.spec.ts:2',
+      'frontend/tests/e2e/040-chat-message-rendering.spec.ts:4',
+      'frontend/tests/e2e/100-codex-basic-chat.spec.ts:2',
+      'frontend/tests/e2e/037-quote-and-mention.spec.ts:13',
+      'frontend/tests/e2e/130-pi-basic-chat.spec.ts:2',
+      'frontend/tests/e2e/helpers/ui.ts:6',
+      '',
+      'Found 57 total occurrences across 13 files.',
+    ].join('\n')
+    const parsed = makeResult(undefined, raw)
+    const { container } = renderClaudeToolResult(parsed, { spanType: 'Grep' })
+    const text = container.textContent ?? ''
+    expect(text).toContain('57 matches in 13 files')
+    expect(text).not.toContain('Found 14 files')
+  })
+
+  it('renders raw "No matches found" payload as the empty-state summary', () => {
+    const parsed = makeResult(undefined, 'No matches found')
+    const { container } = renderClaudeToolResult(parsed, { spanType: 'Grep' })
+    expect(container.textContent ?? '').toContain('No matches found')
   })
 })
 

--- a/frontend/src/components/chat/providers/stubs/kilo.test.ts
+++ b/frontend/src/components/chat/providers/stubs/kilo.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { sendOpenCodePermissionResponse, sendOpenCodeQuestionResponse } from '../../controls/OpenCodeControlRequest'
 import { acpResultDividerRenderer } from '../acp/renderers'
 import { providerFor } from '../registry'
@@ -239,7 +239,7 @@ describe('kilo result divider renderer', () => {
 
   it('is returned by plugin.renderMessage for result_divider', () => {
     const parsed = { stopReason: 'end_turn' }
-    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed, MessageRole.TURN_END)
+    const result = plugin.renderMessage!({ kind: 'result_divider' }, parsed)
     expect(result).not.toBeNull()
   })
 })
@@ -259,7 +259,7 @@ describe('kilo tool_call renderer', () => {
     }
     const category = plugin.classify(input(toolUse))
     expect(category.kind).toBe('tool_use')
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -271,7 +271,7 @@ describe('kilo tool_call renderer', () => {
       status: 'pending',
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 })
@@ -353,7 +353,7 @@ describe('kilo tool_call_update renderer', () => {
     }
     const category = plugin.classify(input(toolUse))
     expect(category.kind).toBe('tool_use')
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 
@@ -369,7 +369,7 @@ describe('kilo tool_call_update renderer', () => {
       content: [],
     }
     const category = plugin.classify(input(toolUse))
-    const result = plugin.renderMessage!(category, toolUse, MessageRole.ASSISTANT)
+    const result = plugin.renderMessage!(category, toolUse)
     expect(result).not.toBeNull()
   })
 

--- a/frontend/src/components/chat/providers/taskOutputRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/taskOutputRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -28,7 +28,7 @@ function renderText(context?: RenderContext): string {
   const msg = makeTaskOutputMessage()
   const toolUse = (msg.message.content as Array<Record<string, unknown>>)[0]
   const category: MessageCategory = { kind: 'tool_use', toolName: 'TaskOutput', toolUse, content: msg.message.content as Array<Record<string, unknown>> }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }

--- a/frontend/src/components/chat/providers/taskStopRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/taskStopRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -43,7 +43,7 @@ function renderToolUseText(input?: Record<string, unknown>, context?: RenderCont
   const msg = makeTaskStopMessage(input)
   const toolUse = (msg.message.content as Array<Record<string, unknown>>)[0]
   const category: MessageCategory = { kind: 'tool_use', toolName: 'TaskStop', toolUse, content: msg.message.content as Array<Record<string, unknown>> }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -52,7 +52,7 @@ function renderToolUseText(input?: Record<string, unknown>, context?: RenderCont
 function renderToolResultText(resultContent: string, context?: RenderContext): string {
   const msg = makeTaskStopResult(resultContent)
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(msg, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }

--- a/frontend/src/components/chat/providers/testUtils.ts
+++ b/frontend/src/components/chat/providers/testUtils.ts
@@ -5,7 +5,6 @@ import {
   AvailableModelSchema,
   AvailableOptionGroupSchema,
   AvailableOptionSchema,
-  MessageRole,
 } from '~/generated/leapmux/v1/agent_pb'
 
 /** Build a ClassificationInput from a parent object and optional wrapper, for tests. */
@@ -18,7 +17,6 @@ export function input(
     topLevel: parent ?? null,
     parentObject: parent,
     wrapper: wrapper ?? null,
-    messageRole: MessageRole.SYSTEM,
   }
 }
 

--- a/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
+++ b/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './codex'
 import './opencode'
@@ -41,7 +41,7 @@ function makeClaudeToolUseCategory(name: string, input: Record<string, unknown>)
 function renderClaudeToolUse(name: string, input: Record<string, unknown>, context?: RenderContext) {
   const parsed = makeClaudeToolUseMessage(name, input)
   const category = makeClaudeToolUseCategory(name, input)
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -54,7 +54,7 @@ function renderCodexItem(item: Record<string, unknown>, context?: RenderContext)
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 
@@ -65,7 +65,7 @@ function renderCodexTurnPlan(parsed: Record<string, unknown>, context?: RenderCo
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.LEAPMUX, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 
@@ -76,7 +76,7 @@ function renderOpenCodePlan(toolUse: Record<string, unknown>, context?: RenderCo
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/toolIconConsistency.test.ts
+++ b/frontend/src/components/chat/providers/toolIconConsistency.test.ts
@@ -1,7 +1,6 @@
 import { render } from '@solidjs/testing-library'
 import Eye from 'lucide-solid/icons/eye'
 import { describe, expect, it } from 'vitest'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
 import { ACP_TOOL_KIND, CLAUDE_TOOL } from '~/types/toolMessages'
 import { kindIcon } from './acp/renderers/helpers'
 import { toolIconFor } from './claude/toolUse/icons'
@@ -15,7 +14,6 @@ describe('read tool icons', () => {
         toolName: 'read',
         args: { path: '/tmp/a.ts' },
       },
-      role: MessageRole.ASSISTANT,
     }))
 
     expect(container.querySelector('svg.lucide-eye')).not.toBeNull()

--- a/frontend/src/components/chat/providers/toolSearchRenderer.test.tsx
+++ b/frontend/src/components/chat/providers/toolSearchRenderer.test.tsx
@@ -1,7 +1,7 @@
 import type { MessageCategory } from '../messageClassification'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
@@ -46,7 +46,7 @@ function renderToolUseText(input?: Record<string, unknown>, context?: RenderCont
   const msg = makeToolSearchMessage(input)
   const toolUse = (msg.message.content as Array<Record<string, unknown>>)[0]
   const category: MessageCategory = { kind: 'tool_use', toolName: 'ToolSearch', toolUse, content: msg.message.content as Array<Record<string, unknown>> }
-  const result = renderMessageContent(msg, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container.textContent?.trim() ?? ''
 }
@@ -59,7 +59,7 @@ function renderToolResultContainer(
 ): HTMLElement {
   const msg = makeToolSearchResult(toolRefs, toolUseResult)
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(msg, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
   const { container } = render(() => result)
   return container
 }

--- a/frontend/src/components/chat/providers/webFetchRendering.test.tsx
+++ b/frontend/src/components/chat/providers/webFetchRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './opencode'
 import './testMocks'
@@ -19,7 +19,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -41,7 +41,7 @@ function renderOpenCodeUpdate(toolUse: Record<string, unknown>, context?: Render
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/webSearchRendering.test.tsx
+++ b/frontend/src/components/chat/providers/webSearchRendering.test.tsx
@@ -2,7 +2,7 @@ import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import './claude'
 import './codex'
 import './testMocks'
@@ -19,7 +19,7 @@ const { renderMessageContent } = await import('../messageRenderers')
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -43,7 +43,7 @@ function renderCodexItem(item: Record<string, unknown>, context?: RenderContext)
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/providers/writeEditRendering.test.tsx
+++ b/frontend/src/components/chat/providers/writeEditRendering.test.tsx
@@ -3,7 +3,7 @@ import type { RenderContext } from '../messageRenderers'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, ContentCompression } from '~/generated/leapmux/v1/agent_pb'
 import { parseMessageContent } from '~/lib/messageParser'
 import './claude'
 import './codex'
@@ -74,13 +74,13 @@ function makeClaudeToolResultMessage(
 function renderClaudeToolUse(name: string, input: Record<string, unknown>, context?: RenderContext) {
   const parsed = makeClaudeToolUseMessage(name, input)
   const category = makeClaudeToolUseCategory(name, input)
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
 function renderClaudeToolResult(parsed: Record<string, unknown>, context?: RenderContext) {
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(parsed, MessageRole.USER, context, category, AgentProvider.CLAUDE_CODE)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CLAUDE_CODE)
   return render(() => result)
 }
 
@@ -106,7 +106,7 @@ function makePiToolEnd(toolName: string, result: Record<string, unknown>, isErro
 function renderPiToolUse(toolName: string, args: Record<string, unknown>, context?: RenderContext) {
   const toolUse = makePiToolStart(toolName, args)
   const category: MessageCategory = { kind: 'tool_use', toolName, toolUse, content: [] }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.PI)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.PI)
   return render(() => result)
 }
 
@@ -114,7 +114,7 @@ function renderPiToolResult(toolName: string, resultPayload: Record<string, unkn
   const start = makePiToolStart(toolName, startArgs)
   const end = makePiToolEnd(toolName, resultPayload, isError)
   const category: MessageCategory = { kind: 'tool_result' }
-  const result = renderMessageContent(end, MessageRole.ASSISTANT, {
+  const result = renderMessageContent(end, {
     spanType: toolName,
     toolUseParsed: parseMessageContent(makeFakeMessage(start)),
   }, category, AgentProvider.PI)
@@ -418,7 +418,7 @@ function renderCodexFileChange(item: Record<string, unknown>, context?: RenderCo
     toolUse: parsed,
     content: [],
   }
-  const result = renderMessageContent(parsed, MessageRole.ASSISTANT, context, category, AgentProvider.CODEX)
+  const result = renderMessageContent(parsed, context, category, AgentProvider.CODEX)
   return render(() => result)
 }
 
@@ -489,7 +489,7 @@ function renderOpenCodeUpdate(toolUse: Record<string, unknown>, context?: Render
     toolUse,
     content: [],
   }
-  const result = renderMessageContent(toolUse, MessageRole.ASSISTANT, context, category, AgentProvider.OPENCODE)
+  const result = renderMessageContent(toolUse, context, category, AgentProvider.OPENCODE)
   return render(() => result)
 }
 

--- a/frontend/src/components/chat/results/searchResult.tsx
+++ b/frontend/src/components/chat/results/searchResult.tsx
@@ -63,18 +63,31 @@ export function FileListView(props: {
   )
 }
 
+function emptySummaryFor(source: SearchResultSource, marker: string): string {
+  // Empty result: route to a muted prompt summary only when we have positive
+  // evidence (no fallback text or the canonical marker for this variant).
+  // Unknown fallback text falls through to the pre-content body.
+  const fc = source.fallbackContent.trim()
+  if (!fc || fc === marker)
+    return marker
+  return ''
+}
+
 function summaryFor(source: SearchResultSource): string {
   if (source.variant === 'grep') {
+    // Count mode: total occurrences across N files, even when zero.
+    if (source.mode === 'count' && typeof source.numMatches === 'number')
+      return `${pluralize(source.numMatches, 'match', 'matches')} in ${pluralize(source.numFiles, 'file')}`
     if (source.numLines > 0 && source.numFiles > 0)
       return `${pluralize(source.numLines, 'match', 'matches')} in ${pluralize(source.numFiles, 'file')}`
     if (source.numFiles > 0)
       return `Found ${pluralize(source.numFiles, 'file')}`
-    return ''
+    return emptySummaryFor(source, 'No matches found')
   }
   if (source.variant === 'glob') {
     if (source.numFiles > 0)
       return `Found ${pluralize(source.numFiles, 'file')}`
-    return ''
+    return emptySummaryFor(source, 'No files found')
   }
   // ACP search
   if (typeof source.matches === 'number' && source.matches >= 0) {
@@ -83,14 +96,6 @@ function summaryFor(source: SearchResultSource): string {
     return `Found ${pluralize(source.matches, 'match', 'matches')}`
   }
   return ''
-}
-
-function emptyFallback(source: SearchResultSource): string {
-  if (source.variant === 'grep')
-    return source.fallbackContent || 'No matches found'
-  if (source.variant === 'glob')
-    return source.fallbackContent || 'No files found'
-  return source.fallbackContent || ''
 }
 
 export function SearchResultBody(props: {
@@ -116,9 +121,9 @@ export function SearchResultBody(props: {
   }
 
   const fallbackEl = () => {
-    if (props.source.variant === 'search' && summary())
+    if (summary())
       return <div class={toolResultPrompt}>{summary()}</div>
-    return <div class={toolResultContentPre}>{emptyFallback(props.source)}</div>
+    return <div class={toolResultContentPre}>{props.source.fallbackContent}</div>
   }
 
   return (

--- a/frontend/src/components/chat/taskRenderers.tsx
+++ b/frontend/src/components/chat/taskRenderers.tsx
@@ -10,7 +10,7 @@ import {
 
 /** Renders task_notification system messages as a tool-use-style block with Check icon. */
 export const taskNotificationRenderer: MessageContentRenderer = {
-  render(parsed, _role, context) {
+  render(parsed, context) {
     if (!isObject(parsed) || parsed.type !== 'system' || parsed.subtype !== 'task_notification')
       return null
 

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -22,7 +22,7 @@ import { agentProviderLabel } from '~/components/common/AgentProviderIcon'
 import { showWarnToast } from '~/components/common/Toast'
 import { FileViewer } from '~/components/fileviewer/FileViewer'
 import { TerminalView } from '~/components/terminal/TerminalView'
-import { AgentChatMessageSchema, AgentStatus, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, AgentStatus, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { uint8ArrayToBase64 } from '~/lib/base64'
@@ -532,7 +532,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
           const localId = `local-${crypto.randomUUID()}`
           const localMsg = create(AgentChatMessageSchema, {
             id: localId,
-            role: MessageRole.USER,
+            source: MessageSource.USER,
             content: new TextEncoder().encode(JSON.stringify(optimisticPayload)),
             contentCompression: ContentCompression.NONE,
             seq: 0n,

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -8,9 +8,10 @@ import type { createTabStore, Tab } from '~/stores/tab.store'
 import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry'
 import { batch, createEffect, createSignal, onCleanup, untrack } from 'solid-js'
 import { sendAgentMessage, watchEventsViaChannel } from '~/api/workerRpc'
+import { classifyAgentMessage, shouldClearStreamingText } from '~/components/chat/messageClassification'
 import { showWarnToast } from '~/components/common/Toast'
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
-import { AgentProvider, AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, AgentStatus, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { waitForStreamCompletion } from '~/hooks/streamCompletion'
@@ -152,7 +153,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         const msg = inner.value
 
         // Single decompress-and-parse pass shared across the metadata,
-        // span-cleanup, assistant-usage, and TURN_END branches below.
+        // span-cleanup, assistant-usage, and result-divider branches below.
         // parseMessageContent never throws — failures yield EMPTY_PARSED
         // (topLevel null), which causes each branch to no-op cleanly.
         const parsed = parseMessageContent(msg)
@@ -185,9 +186,9 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           break
         }
 
-        // Pull notification metadata out of any message regardless of role —
-        // Codex token-usage / rate-limit notifications now arrive as SYSTEM,
-        // while LeapMux-injected settings_changed / context_cleared remain
+        // Pull notification metadata out of any message regardless of source —
+        // Codex token-usage / rate-limit notifications arrive as AGENT, while
+        // LeapMux-injected settings_changed / context_cleared arrive as
         // LEAPMUX. Each branch is gated on the inner type/method so a Pi
         // assistant message doesn't pay for five sequential extractors that
         // can never match.
@@ -250,17 +251,22 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         ) {
           chatStore.trimOldMessages(agentId, MAX_BACKGROUND_CHAT_MESSAGES)
         }
-        // Any persisted assistant or result message ends the in-flight
-        // streaming text. The streamed deltas have either been promoted
-        // to a persisted text block (Codex agentMessage, Pi message_end,
-        // ACP text) or the agent has transitioned to a tool/span message
-        // that implicitly closes the prior text block — without clearing
-        // here, subsequent text deltas concatenate onto the previous
-        // block into one wall of text.
-        if (msg.role === MessageRole.ASSISTANT || msg.role === MessageRole.TURN_END)
+        // Classify once and reuse across the per-message gates below.
+        const category = classifyAgentMessage(msg)
+
+        // Any persisted assistant text, tool use/result, thinking block,
+        // or turn-end divider ends the in-flight streaming text. The
+        // streamed deltas have either been promoted to a persisted text
+        // block (Codex agentMessage, Pi message_end, ACP text) or the
+        // agent has transitioned to a tool/span message that implicitly
+        // closes the prior text block — without clearing here,
+        // subsequent text deltas concatenate onto the previous block
+        // into one wall of text. Notification-thread rows and meta
+        // categories never close the streaming buffer.
+        if (shouldClearStreamingText(msg, parsed, category))
           chatStore.clearStreamingText(agentId)
 
-        if (msg.spanId && (msg.spanType === 'commandExecution' || msg.spanType === 'fileChange' || msg.spanType === 'reasoning') && msg.role === MessageRole.ASSISTANT) {
+        if (msg.spanId && (msg.spanType === 'commandExecution' || msg.spanType === 'fileChange' || msg.spanType === 'reasoning') && msg.source === MessageSource.AGENT) {
           const item = parsed.parentObject?.item as Record<string, unknown> | undefined
           const isCompletedReasoning = item?.type === 'reasoning'
             && (((item.summary as unknown[] | undefined)?.length ?? 0) > 0 || ((item.content as unknown[] | undefined)?.length ?? 0) > 0)
@@ -272,8 +278,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           }
         }
 
-        // Extract context usage from assistant messages (rehydrates on reconnect).
-        if (msg.role === MessageRole.ASSISTANT) {
+        // Method-specific lifecycle handling and assistant-usage
+        // extraction. Gated on AGENT source rather than category because
+        // some lifecycle items (e.g. Codex `thread/started`) classify as
+        // `hidden` — a category-only gate would silently skip them.
+        if (msg.source === MessageSource.AGENT) {
           const method = parsed.parentObject?.method as string | undefined
           const item = parsed.parentObject?.item as Record<string, unknown> | undefined
           if (method === 'thread/started') {
@@ -282,7 +291,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             // empty state instead of a phantom thinking indicator.
             agentSessionStore.updateInfo(agentId, { codexTurnId: '' })
           }
-          // The general assistant-message clear above already drops the
+          // The general streaming-clear above already drops the
           // streamed text buffer. Plan items additionally clear the
           // streamingType session flag so the plan streaming UI dismisses.
           if (item?.type === 'plan') {
@@ -294,9 +303,12 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           }
         }
 
-        // Play turn-end sound when a TURN_END divider (with subtype) arrives.
+        // Play turn-end sound when a result divider (with subtype) arrives.
         // Also extract contextWindow and total_cost_usd (rehydrates on reconnect).
-        if (msg.role === MessageRole.TURN_END) {
+        // Each provider plugin classifies its terminal envelope (Claude
+        // type:"result", Codex turn/completed, ACP stopReason, Pi agent_end)
+        // as `result_divider`, so this gate is provider-agnostic.
+        if (category.kind === 'result_divider') {
           const modelId = agentStore.getById(agentId)?.model
           const meta = extractResultMetadata(parsed, modelId)
           if (meta) {

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { makeMessage, rawContent } from '../../tests/unit/helpers/messageFactory'
 import {
   extractAssistantUsage,
@@ -13,17 +13,18 @@ import {
   findLatestTodos,
   getInnerMessage,
   getInnerMessageType,
+  NOTIFICATION_THREAD_TYPE,
   parseMessageContent,
 } from './messageParser'
 
 /** Build a mock AgentChatMessage with the given JSON content (uncompressed). */
-function makeMsg(role: MessageRole, content: unknown, opts?: { seq?: bigint }) {
-  return makeMessage({ role, content: rawContent(content), seq: opts?.seq })
+function makeMsg(source: MessageSource, content: unknown, opts?: { seq?: bigint }) {
+  return makeMessage({ source, content: rawContent(content), seq: opts?.seq })
 }
 
-/** Wrap inner messages in a notification thread wrapper envelope (LEAPMUX only). */
-function wrap(...messages: unknown[]): { old_seqs: number[], messages: unknown[] } {
-  return { old_seqs: [], messages }
+/** Wrap inner messages in a notification-thread wrapper envelope. */
+function wrap(...messages: unknown[]): { type: typeof NOTIFICATION_THREAD_TYPE, old_seqs: number[], messages: unknown[] } {
+  return { type: NOTIFICATION_THREAD_TYPE, old_seqs: [], messages }
 }
 
 // ---------------------------------------------------------------------------
@@ -33,7 +34,7 @@ function wrap(...messages: unknown[]): { old_seqs: number[], messages: unknown[]
 describe('parseMessageContent', () => {
   it('parses LEAPMUX notification wrapper content', () => {
     const inner = { type: 'settings_changed', changes: {} }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(inner))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(inner))
     const result = parseMessageContent(msg)
 
     expect(result.wrapper).not.toBeNull()
@@ -41,9 +42,9 @@ describe('parseMessageContent', () => {
     expect(result.rawText).toBeTruthy()
   })
 
-  it('parses SYSTEM notification wrapper content (e.g. api_retry)', () => {
+  it('parses AGENT-source notification wrapper content (e.g. api_retry)', () => {
     const inner = { type: 'system', subtype: 'api_retry', attempt: 2, max_retries: 10 }
-    const msg = makeMsg(MessageRole.SYSTEM, wrap(inner))
+    const msg = makeMsg(MessageSource.AGENT, wrap(inner))
     const result = parseMessageContent(msg)
 
     expect(result.wrapper).not.toBeNull()
@@ -52,7 +53,7 @@ describe('parseMessageContent', () => {
   })
 
   it('handles empty LEAPMUX wrapper messages array', () => {
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap())
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap())
     const result = parseMessageContent(msg)
 
     expect(result.wrapper).not.toBeNull()
@@ -61,7 +62,7 @@ describe('parseMessageContent', () => {
 
   it('parses raw content for non-LEAPMUX messages', () => {
     const content = { type: 'assistant', message: { content: [] } }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = parseMessageContent(msg)
 
     expect(result.wrapper).toBeNull()
@@ -71,7 +72,7 @@ describe('parseMessageContent', () => {
 
   it('parses unwrapped LEAPMUX content (e.g. agent_session_info)', () => {
     const content = { type: 'agent_session_info', info: {} }
-    const msg = makeMsg(MessageRole.LEAPMUX, content)
+    const msg = makeMsg(MessageSource.LEAPMUX, content)
     const result = parseMessageContent(msg)
 
     expect(result.wrapper).toBeNull()
@@ -106,7 +107,7 @@ describe('parseMessageContent', () => {
 describe('getInnerMessage', () => {
   it('returns parentObject for LEAPMUX notification wrapper', () => {
     const inner = { type: 'settings_changed', changes: {} }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(inner))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(inner))
     const parsed = parseMessageContent(msg)
 
     expect(getInnerMessage(parsed)).toEqual(inner)
@@ -114,7 +115,7 @@ describe('getInnerMessage', () => {
 
   it('returns topLevel for raw content', () => {
     const content = { type: 'assistant', message: {} }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const parsed = parseMessageContent(msg)
 
     expect(getInnerMessage(parsed)).toEqual(content)
@@ -123,17 +124,17 @@ describe('getInnerMessage', () => {
 
 describe('getInnerMessageType', () => {
   it('returns type from raw content', () => {
-    const msg = makeMsg(MessageRole.ASSISTANT, { type: 'assistant' })
+    const msg = makeMsg(MessageSource.AGENT, { type: 'assistant' })
     expect(getInnerMessageType(parseMessageContent(msg))).toBe('assistant')
   })
 
   it('returns type from LEAPMUX content', () => {
-    const msg = makeMsg(MessageRole.LEAPMUX, { type: 'rate_limit' })
+    const msg = makeMsg(MessageSource.LEAPMUX, { type: 'rate_limit' })
     expect(getInnerMessageType(parseMessageContent(msg))).toBe('rate_limit')
   })
 
   it('returns undefined when no type', () => {
-    const msg = makeMsg(MessageRole.ASSISTANT, { message: {} })
+    const msg = makeMsg(MessageSource.AGENT, { message: {} })
     expect(getInnerMessageType(parseMessageContent(msg))).toBeUndefined()
   })
 })
@@ -163,7 +164,7 @@ describe('extractTodos', () => {
   }
 
   it('extracts todos from a valid TodoWrite message', () => {
-    const msg = makeMsg(MessageRole.ASSISTANT, todoContent)
+    const msg = makeMsg(MessageSource.AGENT, todoContent)
     const parsed = parseMessageContent(msg)
     const todos = extractTodos(msg, parsed)
 
@@ -174,8 +175,8 @@ describe('extractTodos', () => {
     ])
   })
 
-  it('returns null for non-ASSISTANT role', () => {
-    const msg = makeMsg(MessageRole.USER, todoContent)
+  it('returns null for non-AGENT source', () => {
+    const msg = makeMsg(MessageSource.USER, todoContent)
     const parsed = parseMessageContent(msg)
     expect(extractTodos(msg, parsed)).toBeNull()
   })
@@ -187,7 +188,7 @@ describe('extractTodos', () => {
         content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }],
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const parsed = parseMessageContent(msg)
     expect(extractTodos(msg, parsed)).toBeNull()
   })
@@ -197,7 +198,7 @@ describe('extractTodos', () => {
       type: 'assistant',
       message: { content: [{ type: 'text', text: 'Hello' }] },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const parsed = parseMessageContent(msg)
     expect(extractTodos(msg, parsed)).toBeNull()
   })
@@ -213,14 +214,14 @@ describe('extractTodos', () => {
         }],
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const parsed = parseMessageContent(msg)
     const todos = extractTodos(msg, parsed)
     expect(todos![0].status).toBe('pending')
   })
 
   it('extracts todos from a Codex turn/plan/updated message', () => {
-    const msg = makeMsg(MessageRole.ASSISTANT, {
+    const msg = makeMsg(MessageSource.AGENT, {
       method: 'turn/plan/updated',
       params: {
         threadId: 'thread-1',
@@ -250,7 +251,7 @@ describe('extractTodos', () => {
 
 describe('findLatestTodos', () => {
   const makeTodoMsg = (seq: bigint, tasks: Array<{ content: string, status: string, activeForm: string }>) =>
-    makeMsg(MessageRole.ASSISTANT, {
+    makeMsg(MessageSource.AGENT, {
       type: 'assistant',
       message: {
         content: [{
@@ -263,11 +264,11 @@ describe('findLatestTodos', () => {
 
   it('finds the latest TodoWrite scanning backward', () => {
     const messages = [
-      makeMsg(MessageRole.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
+      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
       makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
-      makeMsg(MessageRole.ASSISTANT, { type: 'assistant', message: { content: [{ type: 'text', text: 'response' }] } }, { seq: 3n }),
+      makeMsg(MessageSource.AGENT, { type: 'assistant', message: { content: [{ type: 'text', text: 'response' }] } }, { seq: 3n }),
       makeTodoMsg(4n, [{ content: 'New task', status: 'in_progress', activeForm: 'New' }]),
-      makeMsg(MessageRole.USER, { type: 'user', message: { content: 'bye' } }, { seq: 5n }),
+      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'bye' } }, { seq: 5n }),
     ]
     const todos = findLatestTodos(messages)
     expect(todos).toEqual([{ content: 'New task', status: 'in_progress', activeForm: 'New' }])
@@ -275,8 +276,8 @@ describe('findLatestTodos', () => {
 
   it('returns null when no TodoWrite exists', () => {
     const messages = [
-      makeMsg(MessageRole.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
-      makeMsg(MessageRole.ASSISTANT, { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }, { seq: 2n }),
+      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
+      makeMsg(MessageSource.AGENT, { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }, { seq: 2n }),
     ]
     expect(findLatestTodos(messages)).toBeNull()
   })
@@ -288,7 +289,7 @@ describe('findLatestTodos', () => {
   it('finds the latest Codex turn/plan/updated scanning backward', () => {
     const messages = [
       makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
-      makeMsg(MessageRole.ASSISTANT, {
+      makeMsg(MessageSource.AGENT, {
         method: 'turn/plan/updated',
         params: {
           threadId: 'thread-1',
@@ -320,7 +321,7 @@ describe('extractAssistantUsage', () => {
         },
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractAssistantUsage(parseMessageContent(msg))
 
     expect(result).toEqual({
@@ -339,14 +340,14 @@ describe('extractAssistantUsage', () => {
       total_cost_usd: 0.01,
       message: { usage: {} },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractAssistantUsage(parseMessageContent(msg))
     expect(result).toEqual({ totalCostUsd: 0.01 })
   })
 
   it('returns null when no usage field', () => {
     const content = { type: 'assistant', message: {} }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     expect(extractAssistantUsage(parseMessageContent(msg))).toBeNull()
   })
 
@@ -372,7 +373,7 @@ describe('extractAssistantUsage', () => {
         },
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractAssistantUsage(parseMessageContent(msg))
 
     expect(result).toEqual({
@@ -401,7 +402,7 @@ describe('extractAssistantUsage', () => {
         },
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractAssistantUsage(parseMessageContent(msg))
 
     expect(result).toEqual({
@@ -428,7 +429,7 @@ describe('extractAssistantUsage', () => {
         },
       },
     }
-    const msg = makeMsg(MessageRole.ASSISTANT, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     expect(extractAssistantUsage(parseMessageContent(msg))).toBeNull()
   })
 })
@@ -439,7 +440,7 @@ describe('extractAssistantUsage', () => {
 
 describe('extractCodexTokenUsage', () => {
   it('extracts context usage from persisted Codex token usage notifications', () => {
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap({
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap({
       method: 'thread/tokenUsage/updated',
       params: {
         threadId: 'thread-1',
@@ -475,7 +476,7 @@ describe('extractCodexTokenUsage', () => {
   })
 
   it('returns null for unrelated messages', () => {
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap({ method: 'turn/completed', params: {} }))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap({ method: 'turn/completed', params: {} }))
     expect(extractCodexTokenUsage(parseMessageContent(msg))).toBeNull()
   })
 })
@@ -494,7 +495,7 @@ describe('extractResultMetadata', () => {
         'claude-sonnet': { contextWindow: 200000 },
       },
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
 
     expect(result).toEqual({
@@ -518,7 +519,7 @@ describe('extractResultMetadata', () => {
       },
       messages: [],
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
 
     expect(result).toEqual({
@@ -543,7 +544,7 @@ describe('extractResultMetadata', () => {
         'claude-opus-4-6[1m]': { contextWindow: 1000000 },
       },
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg), 'opus[1m]')
 
     expect(result).toEqual({
@@ -561,7 +562,7 @@ describe('extractResultMetadata', () => {
         'claude-opus-4-6-20251001': { contextWindow: 200000 },
       },
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg), 'opus')
 
     expect(result).toEqual({
@@ -579,7 +580,7 @@ describe('extractResultMetadata', () => {
         'claude-opus-4-6[1m]': { contextWindow: 1000000 },
       },
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg), 'sonnet')
 
     expect(result).toEqual({
@@ -589,13 +590,13 @@ describe('extractResultMetadata', () => {
   })
 
   it('returns null for empty inner message', () => {
-    const msg = makeMsg(MessageRole.TURN_END, {})
+    const msg = makeMsg(MessageSource.AGENT, {})
     expect(extractResultMetadata(parseMessageContent(msg))).toBeNull()
   })
 
   it('extracts only subtype when no modelUsage or cost', () => {
     const content = { type: 'result', subtype: 'turn_end' }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     expect(extractResultMetadata(parseMessageContent(msg))).toEqual({ subtype: 'turn_end' })
   })
 
@@ -609,7 +610,7 @@ describe('extractResultMetadata', () => {
         'claude-sonnet': { contextWindow: 200000 },
       },
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     expect(extractResultMetadata(parseMessageContent(msg))).toBeNull()
   })
 
@@ -619,7 +620,7 @@ describe('extractResultMetadata', () => {
       subtype: 'turn_end',
       num_tool_uses: 5,
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
     expect(result).toEqual({ subtype: 'turn_end', numToolUses: 5 })
   })
@@ -630,7 +631,7 @@ describe('extractResultMetadata', () => {
       subtype: 'turn_end',
       num_tool_uses: 0,
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
     expect(result).toEqual({ subtype: 'turn_end', numToolUses: 0 })
   })
@@ -641,7 +642,7 @@ describe('extractResultMetadata', () => {
       turn: { status: 'completed', usage: { inputTokens: 100, outputTokens: 50 } },
       num_tool_uses: 3,
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
     expect(result).toEqual({ subtype: 'turn_completed', numToolUses: 3 })
   })
@@ -651,7 +652,7 @@ describe('extractResultMetadata', () => {
       turn: { status: 'completed', usage: { inputTokens: 100, outputTokens: 50 } },
       num_tool_uses: 0,
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
     expect(result).toEqual({ subtype: 'turn_completed', numToolUses: 0 })
   })
@@ -661,7 +662,7 @@ describe('extractResultMetadata', () => {
       turn: { status: 'failed' },
       num_tool_uses: 0,
     }
-    const msg = makeMsg(MessageRole.TURN_END, content)
+    const msg = makeMsg(MessageSource.AGENT, content)
     const result = extractResultMetadata(parseMessageContent(msg))
     expect(result).toEqual({ subtype: 'turn_completed', numToolUses: 0 })
   })
@@ -681,7 +682,7 @@ describe('extractRateLimitInfo', () => {
         utilization: 0.85,
       },
     }
-    const msg = makeMsg(MessageRole.SYSTEM, wrap(content))
+    const msg = makeMsg(MessageSource.AGENT, wrap(content))
     const result = extractRateLimitInfo(parseMessageContent(msg))
 
     expect(result).toEqual([{
@@ -695,20 +696,20 @@ describe('extractRateLimitInfo', () => {
       type: 'rate_limit_event',
       rate_limit_info: { status: 'exceeded' },
     }
-    const msg = makeMsg(MessageRole.SYSTEM, wrap(content))
+    const msg = makeMsg(MessageSource.AGENT, wrap(content))
     const result = extractRateLimitInfo(parseMessageContent(msg))
     expect(result[0].key).toBe('unknown')
   })
 
   it('returns empty array for non-rate_limit_event type', () => {
     const content = { type: 'settings_changed', rate_limit_info: {} }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractRateLimitInfo(parseMessageContent(msg))).toEqual([])
   })
 
   it('returns empty array when rate_limit_info is missing', () => {
     const content = { type: 'rate_limit_event' }
-    const msg = makeMsg(MessageRole.SYSTEM, wrap(content))
+    const msg = makeMsg(MessageSource.AGENT, wrap(content))
     expect(extractRateLimitInfo(parseMessageContent(msg))).toEqual([])
   })
 
@@ -719,7 +720,7 @@ describe('extractRateLimitInfo', () => {
       type: 'rate_limit',
       rate_limit_info: { rateLimitType: 'five_hour', status: 'exceeded' },
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractRateLimitInfo(parseMessageContent(msg))).toEqual([])
   })
 
@@ -733,7 +734,7 @@ describe('extractRateLimitInfo', () => {
         },
       },
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     const result = extractRateLimitInfo(parseMessageContent(msg))
     expect(result).toHaveLength(2)
     expect(result[0].key).toBe('five_hour')
@@ -749,7 +750,7 @@ describe('extractRateLimitInfo', () => {
       method: 'account/rateLimits/updated',
       params: { rateLimits: {} },
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractRateLimitInfo(parseMessageContent(msg))).toEqual([])
   })
 })
@@ -764,7 +765,7 @@ describe('extractSettingsChanges', () => {
       type: 'settings_changed',
       changes: { permissionMode: { old: 'default', new: 'plan' } },
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     const result = extractSettingsChanges(parseMessageContent(msg))
 
     expect(result).toEqual({ permissionMode: { old: 'default', new: 'plan' } })
@@ -772,13 +773,13 @@ describe('extractSettingsChanges', () => {
 
   it('returns null for non-settings_changed type', () => {
     const content = { type: 'rate_limit', changes: {} }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractSettingsChanges(parseMessageContent(msg))).toBeNull()
   })
 
   it('returns null when changes is missing', () => {
     const content = { type: 'settings_changed' }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractSettingsChanges(parseMessageContent(msg))).toBeNull()
   })
 })
@@ -794,7 +795,7 @@ describe('extractPlanUpdated', () => {
       plan_title: 'Add authentication',
       plan_file_path: '/plans/auth.md',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanUpdated(parseMessageContent(msg))).toEqual({
       planTitle: 'Add authentication',
       planFilePath: '/plans/auth.md',
@@ -809,7 +810,7 @@ describe('extractPlanUpdated', () => {
       plan_file_path: '/plans/auth.md',
       update_agent_title: true,
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     const got = extractPlanUpdated(parseMessageContent(msg))
     expect(got?.updateAgentTitle).toBe(true)
   })
@@ -817,7 +818,7 @@ describe('extractPlanUpdated', () => {
   it('returns the most recent plan_updated entry in a consolidated thread', () => {
     const earlier = { type: 'plan_updated', plan_title: 'old', plan_file_path: '/plans/old.md' }
     const later = { type: 'plan_updated', plan_title: 'new', plan_file_path: '/plans/new.md' }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(earlier, later))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(earlier, later))
     const got = extractPlanUpdated(parseMessageContent(msg))
     expect(got?.planTitle).toBe('new')
     expect(got?.planFilePath).toBe('/plans/new.md')
@@ -829,7 +830,7 @@ describe('extractPlanUpdated', () => {
       plan_title: 'Unwrapped',
       plan_file_path: '/plans/u.md',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, content)
+    const msg = makeMsg(MessageSource.LEAPMUX, content)
     const got = extractPlanUpdated(parseMessageContent(msg))
     expect(got?.planTitle).toBe('Unwrapped')
     expect(got?.planFilePath).toBe('/plans/u.md')
@@ -837,13 +838,13 @@ describe('extractPlanUpdated', () => {
 
   it('returns undefined for non-plan_updated messages', () => {
     const content = { type: 'settings_changed', plan_title: 'Not a plan update' }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanUpdated(parseMessageContent(msg))).toBeUndefined()
   })
 
   it('returns the payload even when fields are empty strings, leaving consumer to decide', () => {
     const content = { type: 'plan_updated', plan_title: '', plan_file_path: '' }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanUpdated(parseMessageContent(msg))).toEqual({
       planTitle: '',
       planFilePath: '',
@@ -858,7 +859,7 @@ describe('extractPlanUpdated', () => {
       plan_file_path: '/p.md',
       update_agent_title: 'truthy-but-not-true',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanUpdated(parseMessageContent(msg))?.updateAgentTitle).toBe(false)
   })
 })
@@ -873,7 +874,7 @@ describe('extractPlanFilePath', () => {
       type: 'plan_execution',
       plan_file_path: '/home/user/.claude/plans/plan.md',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanFilePath(parseMessageContent(msg))).toBe('/home/user/.claude/plans/plan.md')
   })
 
@@ -883,7 +884,7 @@ describe('extractPlanFilePath', () => {
       type: 'plan_execution',
       plan_file_path: '/path/to/plan.md',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(ccMsg, peMsg))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(ccMsg, peMsg))
     expect(extractPlanFilePath(parseMessageContent(msg))).toBe('/path/to/plan.md')
   })
 
@@ -892,7 +893,7 @@ describe('extractPlanFilePath', () => {
       type: 'plan_execution',
       plan_file_path: '/path/plan.md',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, content)
+    const msg = makeMsg(MessageSource.LEAPMUX, content)
     expect(extractPlanFilePath(parseMessageContent(msg))).toBe('/path/plan.md')
   })
 
@@ -901,13 +902,13 @@ describe('extractPlanFilePath', () => {
       type: 'plan_execution',
       plan_file_path: '',
     }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanFilePath(parseMessageContent(msg))).toBeUndefined()
   })
 
   it('returns undefined for non-plan_execution messages', () => {
     const content = { type: 'context_cleared' }
-    const msg = makeMsg(MessageRole.LEAPMUX, wrap(content))
+    const msg = makeMsg(MessageSource.LEAPMUX, wrap(content))
     expect(extractPlanFilePath(parseMessageContent(msg))).toBeUndefined()
   })
 })

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -1,11 +1,18 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ContextUsageInfo, RateLimitInfo } from '~/stores/agentSession.store'
 import type { TodoItem } from '~/stores/chat.store'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { decompressContentToString } from '~/lib/decompress'
 import { isObject, pickFirstNumber, pickNumber } from '~/lib/jsonPick'
 import { CODEX_RATE_LIMITS_METHOD, iterCodexRateLimitTiers } from '~/lib/rateLimitUtils'
 import { normalizeTodoStatus, rawTodosToItems } from '~/stores/chat.store'
+
+/**
+ * Content-type discriminator emitted by the backend's `wrapNotifContent`
+ * for every notification-thread row. Match this constant in lockstep with
+ * `notifThreadWrapperType` in `backend/internal/worker/service/output.go`.
+ */
+export const NOTIFICATION_THREAD_TYPE = 'notification_thread'
 
 /**
  * The result of parsing a compressed AgentChatMessage. Every field is
@@ -40,9 +47,10 @@ const parseCache = new WeakMap<AgentChatMessage, ParsedMessageContent>()
  * Decompress and parse an AgentChatMessage's content in a single pass.
  * Never throws -- returns safe defaults on any failure.
  *
- * Notification-threaded messages use a wrapper format:
- *   {"old_seqs": [...], "messages": [{...}, ...]}
- * Both LEAPMUX and SYSTEM role messages may use this format.
+ * Notification-threaded messages use the wrapper format:
+ *   {"type":"notification_thread","old_seqs":[...],"messages":[{...},...]}
+ * Detection is purely shape-based — `type === 'notification_thread'`
+ * uniquely identifies the wrapper, decoupled from the persisted source.
  * All other messages are stored as raw JSON (no wrapper).
  */
 export function parseMessageContent(message: AgentChatMessage): ParsedMessageContent {
@@ -62,10 +70,12 @@ function parseMessageContentImpl(message: AgentChatMessage): ParsedMessageConten
   try {
     const obj = JSON.parse(text)
 
-    // Notification-threaded messages use the wrapper format for consolidation.
-    // Both LEAPMUX and SYSTEM role messages may use this format (e.g. api_retry,
-    // compact_boundary, microcompact_boundary are stored with SYSTEM role).
-    if ((message.role === MessageRole.LEAPMUX || message.role === MessageRole.SYSTEM) && obj?.messages && Array.isArray(obj.messages)) {
+    // Notification-threaded messages are identified by their explicit
+    // `type: "notification_thread"` discriminator. The discriminator is
+    // emitted by the backend's wrapNotifContent for every notification
+    // thread row regardless of source (AGENT or LEAPMUX), so the parser
+    // does not need to look at message.source.
+    if (obj?.type === NOTIFICATION_THREAD_TYPE && Array.isArray(obj.messages)) {
       const wrapper = { old_seqs: obj.old_seqs ?? [], messages: obj.messages }
 
       if (obj.messages.length === 0)
@@ -145,7 +155,11 @@ export function codexPlanToTodos(plan: unknown[]): TodoItem[] {
 
 /** Extract TodoWrite todos from a parsed assistant message. Returns null if not applicable. */
 export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageContent): TodoItem[] | null {
-  if (message.role !== MessageRole.ASSISTANT)
+  // Source gate: a USER-side row may legitimately echo back an
+  // assistant-shape tool_use envelope (Claude tool_result chunks
+  // arrive with role:"user" on the wire). Treating those as todos
+  // would surface stale TodoWrite contents on the user side.
+  if (message.source !== MessageSource.AGENT)
     return null
   const parent = parsed.parentObject
   if (!parent)

--- a/frontend/src/lib/notificationTypes.ts
+++ b/frontend/src/lib/notificationTypes.ts
@@ -2,8 +2,8 @@
  * LeapMux notification-type vocabulary. Mirrors the backend constants in
  * `backend/internal/worker/agent/notification_types.go`. The platform
  * persists each of these as the inner `type` field on a notification
- * envelope (LEAPMUX role for worker-synthesized events, SYSTEM role for
- * agent-emitted metadata that flows through the same renderer).
+ * envelope (LEAPMUX source for worker-synthesized events, AGENT source
+ * for agent-emitted metadata that flows through the same renderer).
  *
  * Importing the constant from this module instead of inlining the wire
  * string turns rename mistakes into compile errors and gives the

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -2,7 +2,7 @@ import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import { createStore } from 'solid-js/store'
 import * as workerRpc from '~/api/workerRpc'
-import { ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { PREFIX_LOCAL_MESSAGES, safeGetJson, safeRemoveItem, safeSetJson } from '~/lib/browserStorage'
 import { extractTodos, findLatestTodos, parseMessageContent } from '~/lib/messageParser'
 
@@ -42,7 +42,7 @@ function removePersistedLocalMessage(agentId: string, messageId: string) {
 }
 
 function extractUserMessagePayload(message: AgentChatMessage): { content: string, attachments?: Array<{ filename?: string, mime_type?: string }> } | null {
-  if (message.role !== MessageRole.USER)
+  if (message.source !== MessageSource.USER)
     return null
   const parsed = parseMessageContent(message)
   const parent = parsed.parentObject
@@ -102,7 +102,7 @@ function hydrateLocalMessage(p: PersistedLocalMessage): AgentChatMessage {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage' as const,
     id: p.id,
-    role: MessageRole.USER,
+    source: MessageSource.USER,
     content: new TextEncoder().encode(contentJson),
     contentCompression: ContentCompression.NONE,
     seq: 0n,
@@ -383,13 +383,13 @@ export function createChatStore() {
         // Reconcile optimistic local user messages before updating the store,
         // so the localStorage side-effect stays outside the setState updater.
         let reconciledLocalId: string | undefined
-        if (message.role === MessageRole.USER) {
+        if (message.source === MessageSource.USER) {
           const incomingSignature = userMessageSignature(message)
           if (incomingSignature) {
             const current = state.messagesByAgent[agentId] ?? []
             const local = current.find(candidate =>
               candidate.id.startsWith('local-')
-              && candidate.role === MessageRole.USER
+              && candidate.source === MessageSource.USER
               && !candidate.deliveryError
               && userMessageSignature(candidate) === incomingSignature,
             )

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -1,8 +1,10 @@
 import type { AgentChatMessage, AgentInfo } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentSessionInfo } from '~/stores/agentSession.store'
+import { classifyAgentMessage } from '~/components/chat/messageClassification'
 import { allRegisteredProviders, providerFor } from '~/components/chat/providers/registry'
-import { AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
+import { isObject } from '~/lib/jsonPick'
 import { getInnerMessage, getInnerMessageType, parseMessageContent } from '~/lib/messageParser'
 import { NOTIFICATION_TYPE } from '~/lib/notificationTypes'
 // Side-effect import: ensures every provider has registered itself before
@@ -18,10 +20,10 @@ import '~/components/chat/providers'
  * extend this set via `Provider.nonProgressTypes` (e.g. Pi compaction /
  * auto-retry / extension events).
  *
- * `context_cleared` is intentionally absent: for LEAPMUX/SYSTEM it is a
- * turn boundary handled by `containsContextCleared`, and for
- * USER/ASSISTANT it must not be skipped at all (the payload carries
- * user/agent content).
+ * `context_cleared` is intentionally absent: when it appears inside a
+ * notification-thread wrapper it is a turn boundary handled by
+ * `containsContextCleared`; when it appears as a USER/AGENT plain payload
+ * it must not be skipped (the payload carries user/agent content).
  */
 const BASE_NON_PROGRESS_TYPES: ReadonlySet<string> = new Set<string>([
   NOTIFICATION_TYPE.SettingsChanged,
@@ -99,29 +101,32 @@ function isNonProgressInner(inner: Record<string, unknown> | null | undefined): 
 
 /**
  * True if `parsed` carries a `context_cleared` event at top level or anywhere
- * in its wrapper. Only LEAPMUX/SYSTEM-roled messages are platform-emitted
- * turn boundaries; USER/ASSISTANT payloads that happen to surface a
- * top-level `type: "context_cleared"` (e.g. literal user text, a Pi
+ * in its wrapper. Only notification-thread rows (the wrapper format) are
+ * platform-emitted turn boundaries; USER/AGENT plain payloads that happen to
+ * surface a top-level `type: "context_cleared"` (e.g. literal user text, a Pi
  * `default`-handler echo of an unknown event) carry user/agent content and
- * must not be interpreted as turn boundaries.
+ * must not be interpreted as turn boundaries. The wrapper presence is the
+ * right gate because the backend only ever produces the wrapper format from
+ * PersistNotification — never for plain user/agent messages.
  */
-function containsContextCleared(role: MessageRole, parsed: ParsedMessageContent): boolean {
-  if (role !== MessageRole.LEAPMUX && role !== MessageRole.SYSTEM)
+function containsContextCleared(parsed: ParsedMessageContent): boolean {
+  if (parsed.wrapper === null)
     return false
   if (getInnerMessageType(parsed) === NOTIFICATION_TYPE.ContextCleared)
     return true
-  if (parsed.wrapper) {
-    for (const m of parsed.wrapper.messages) {
-      if (typeof m === 'object' && m !== null && (m as Record<string, unknown>).type === NOTIFICATION_TYPE.ContextCleared)
-        return true
-    }
+  for (const m of parsed.wrapper.messages) {
+    if (isObject(m) && m.type === NOTIFICATION_TYPE.ContextCleared)
+      return true
   }
   return false
 }
 
 /**
  * Whether the agent is still working — the last meaningful (non-notification)
- * message is not a TURN_END divider.
+ * message is not a turn-end divider. Turn-end detection is delegated to each
+ * provider's plugin, which classifies its terminal envelope (Claude
+ * `type:"result"`, Codex `turn/completed`, ACP `stopReason`, Pi `agent_end`)
+ * as `result_divider`.
  */
 export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
   for (let i = msgs.length - 1; i >= 0; i--) {
@@ -130,13 +135,13 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     if (msg.deliveryError)
       continue
 
-    if (msg.role === MessageRole.TURN_END)
-      return false
-
     const parsed = parseMessageContent(msg)
-    // context_cleared in a LEAPMUX/SYSTEM notification means the agent
+    const category = classifyAgentMessage(msg)
+    if (category.kind === 'result_divider')
+      return false
+    // context_cleared in a notification-thread row means the agent
     // restarted with a fresh context and is now idle — stop scanning.
-    if (containsContextCleared(msg.role, parsed))
+    if (containsContextCleared(parsed))
       return false
     // Empty notification wrappers are what the consolidator emits when
     // every threaded message has been superseded — no progress signal.

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -41,8 +41,8 @@ export async function waitForControlBanner(page: Page) {
   return banner
 }
 
-/** CSS selector for assistant message bubbles. Exported for use in browser-context code (e.g. waitForFunction). */
-export const ASSISTANT_BUBBLE_SELECTOR = '[data-testid="message-bubble"][data-role="assistant"]'
+/** CSS selector for agent message bubbles. Exported for use in browser-context code (e.g. waitForFunction). */
+export const ASSISTANT_BUBBLE_SELECTOR = '[data-testid="message-bubble"][data-role="agent"]'
 
 /** Return a locator for all assistant message bubbles. */
 export function assistantBubbles(page: Page) {

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -5,7 +5,7 @@ import { createSignal } from 'solid-js'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { ChatView } from '~/components/chat/ChatView'
 import { PreferencesProvider } from '~/context/PreferencesContext'
-import { AgentProvider, AgentStatus, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 
 const A_TXT_RE = /a\.txt/
 const B_TXT_RE = /b\.txt/
@@ -82,7 +82,7 @@ function makeCodexCommandMessage(params: {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id: params.id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify({
       item: {
         type: 'commandExecution',
@@ -117,7 +117,7 @@ function makeCodexFileChangeMessage(params: {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id: params.id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify({
       item: {
         type: 'fileChange',
@@ -149,7 +149,7 @@ function makeCodexReasoningMessage(params: {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id: params.id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify({
       item: {
         type: 'reasoning',
@@ -178,7 +178,7 @@ function makeCodexTurnPlanMessage(params: {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id: params.id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify({
       method: 'turn/plan/updated',
       params: {
@@ -206,7 +206,7 @@ function makeCodexWebSearchMessage(params: {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id: params.id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify({
       item: {
         type: 'webSearch',
@@ -231,8 +231,9 @@ function makeCodexHiddenLifecycleMessage(id: string = 'codex-hidden'): AgentChat
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id,
-    role: MessageRole.LEAPMUX,
+    source: MessageSource.LEAPMUX,
     content: new TextEncoder().encode(JSON.stringify({
+      type: 'notification_thread',
       old_seqs: [],
       messages: [
         {
@@ -252,7 +253,7 @@ function makeClaudeEnterPlanModeResultMessage(id: string = 'claude-enter-plan-re
   return {
     $typeName: 'leapmux.v1.AgentChatMessage',
     id,
-    role: MessageRole.USER,
+    source: MessageSource.USER,
     content: new TextEncoder().encode(JSON.stringify({
       type: 'user',
       message: {

--- a/frontend/tests/unit/components/MessageBubble.test.tsx
+++ b/frontend/tests/unit/components/MessageBubble.test.tsx
@@ -4,7 +4,7 @@ import { MessageBubble } from '~/components/chat/MessageBubble'
 import * as chatStyles from '~/components/chat/messageStyles.css'
 import { toolBodyContent } from '~/components/chat/toolStyles.css'
 import { PreferencesProvider, usePreferences } from '~/context/PreferencesContext'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { makeMessage, rawContent, wrapContent } from '../helpers/messageFactory'
 
 // jsdom does not provide ResizeObserver or Worker
@@ -89,7 +89,7 @@ describe('askUserQuestion thread rendering', () => {
   it('shows question text for single-question tool_use', () => {
     const parent = askUserQuestionToolUse([{ header: 'Uncommitted' }])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -108,7 +108,7 @@ describe('askUserQuestion thread rendering', () => {
   it('shows question count for multi-question tool_use', () => {
     const parent = askUserQuestionToolUse([{ header: 'Auth' }, { header: 'Database' }])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -140,7 +140,7 @@ describe('thinking message toolbar buttons', () => {
       message: { content: [{ type: 'thinking', thinking: 'Let me think about this...' }] },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -161,7 +161,7 @@ describe('thinking message toolbar buttons', () => {
       message: { content: [{ type: 'thinking', thinking: thinkingText }] },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -185,7 +185,7 @@ describe('thinking message expansion preference', () => {
       message: { content: [{ type: 'thinking', thinking: thinkingText }] },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -225,7 +225,7 @@ describe('thinking message expansion preference', () => {
       message: { content: [{ type: 'thinking', thinking: thinkingText }] },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -268,7 +268,7 @@ describe('messageBubble rawJson', () => {
     }
     const msg = makeMsg({
       id: 'msg-meta-1',
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       seq: 3n,
       createdAt: '2025-01-15T10:00:00.000Z',
       deliveryError: 'worker offline',
@@ -283,7 +283,7 @@ describe('messageBubble rawJson', () => {
 
     const envelope = await copyRawJson()
     expect(envelope.id).toBe('msg-meta-1')
-    expect(envelope.role).toBe('assistant')
+    expect(envelope.source).toBe('agent')
     expect(envelope.seq).toBe(3)
     expect(envelope.created_at).toBe('2025-01-15T10:00:00.000Z')
     expect(envelope.delivery_error).toBe('worker offline')
@@ -299,7 +299,7 @@ describe('messageBubble rawJson', () => {
     }
     const msg = makeMsg({
       id: 'msg-no-opts',
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       deliveryError: '',
       content: rawContent(innerMsg),
     })
@@ -314,7 +314,7 @@ describe('messageBubble rawJson', () => {
     expect(envelope).not.toHaveProperty('delivery_error')
     // Required fields should still be present.
     expect(envelope.id).toBe('msg-no-opts')
-    expect(envelope.role).toBe('assistant')
+    expect(envelope.source).toBe('agent')
     expect(envelope).toHaveProperty('content')
   })
 
@@ -348,7 +348,7 @@ describe('messageBubble rawJson', () => {
       message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'file.txt' }] },
     }
     const msg = makeMsg({
-      role: MessageRole.LEAPMUX,
+      source: MessageSource.LEAPMUX,
       content: wrapContent([parentMsg, childMsg], [5, 8]),
     })
 
@@ -365,7 +365,7 @@ describe('messageBubble rawJson', () => {
 
   it('uses toolbar copy for hidden raw JSON instead of injecting an inline pre copy button', () => {
     const msg = makeMsg({
-      role: MessageRole.SYSTEM,
+      source: MessageSource.AGENT,
       content: rawContent({ type: 'system', subtype: 'init', cwd: '/repo' }),
     })
 
@@ -415,7 +415,7 @@ describe('todoWrite collapse/expand', () => {
       { content: 'Task C', status: 'pending', activeForm: 'Working on C' },
     ])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -435,7 +435,7 @@ describe('todoWrite collapse/expand', () => {
       { content: 'Task B', status: 'pending', activeForm: 'Working on B' },
     ])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -458,7 +458,7 @@ describe('todoWrite collapse/expand', () => {
       { content: 'Task C', status: 'pending', activeForm: 'Working on C' },
     ])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -480,7 +480,7 @@ describe('todoWrite collapse/expand', () => {
       { content: 'Task B', status: 'in_progress', activeForm: 'Running tests' },
     ])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -499,7 +499,7 @@ describe('todoWrite collapse/expand', () => {
       { content: 'Task A', status: 'pending', activeForm: 'Working on A' },
     ])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -541,7 +541,7 @@ describe('taskOutput rendering', () => {
   it('shows waiting state for standalone tool_use', () => {
     const parent = taskOutputToolUse()
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -558,7 +558,7 @@ describe('taskOutput rendering', () => {
   it('hides metadata when no child result', () => {
     const parent = taskOutputToolUse()
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -581,7 +581,7 @@ describe('askUserQuestion left border', () => {
   it('body has left border', () => {
     const parent = askUserQuestionToolUse([{ header: 'Auth' }])
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -614,7 +614,7 @@ describe('header-only renderers', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -641,7 +641,7 @@ describe('header-only renderers', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -668,7 +668,7 @@ describe('header-only renderers', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -702,7 +702,7 @@ describe('grep result summary', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -736,7 +736,7 @@ describe('glob result summary', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -769,7 +769,7 @@ describe('agent stats summary', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -801,7 +801,7 @@ describe('agent stats summary', () => {
       },
     }
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(innerMsg),
     })
 
@@ -820,7 +820,7 @@ describe('pending user bubble state', () => {
   it('stops pulsation when a local user message has a delivery error', () => {
     const msg = makeMsg({
       id: 'local-1',
-      role: MessageRole.USER,
+      source: MessageSource.USER,
       content: rawContent({ content: 'hello' }),
     })
 
@@ -836,7 +836,7 @@ describe('pending user bubble state', () => {
   it('keeps pulsation for a local user message without a delivery error', () => {
     const msg = makeMsg({
       id: 'local-2',
-      role: MessageRole.USER,
+      source: MessageSource.USER,
       content: rawContent({ content: 'hello' }),
     })
 
@@ -890,7 +890,7 @@ describe('edit/write tool_use rendering', () => {
   it('edit shows file path in header', () => {
     const parent = editToolUse('const a = 1', 'const a = 2')
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -907,7 +907,7 @@ describe('edit/write tool_use rendering', () => {
   it('write shows file path in header', () => {
     const parent = writeToolUse('export const hello = "world"')
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 
@@ -924,7 +924,7 @@ describe('edit/write tool_use rendering', () => {
   it('write with empty content renders without error', () => {
     const parent = writeToolUse('')
     const msg = makeMsg({
-      role: MessageRole.ASSISTANT,
+      source: MessageSource.AGENT,
       content: rawContent(parent),
     })
 

--- a/frontend/tests/unit/components/messageClassification.test.ts
+++ b/frontend/tests/unit/components/messageClassification.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { classifyMessage, messageBubbleClass, messageRowClass } from '~/components/chat/messageClassification'
 import * as chatStyles from '~/components/chat/messageStyles.css'
 import { input } from '~/components/chat/providers/testUtils'
-import { MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 
 // ---------------------------------------------------------------------------
 // Helper to build assistant message payloads
@@ -370,30 +370,30 @@ describe('classifyMessage', () => {
 
 describe('messageRowClass', () => {
   it('returns messageRowCenter for notification', () => {
-    expect(messageRowClass('notification', MessageRole.SYSTEM)).toBe(chatStyles.messageRowCenter)
+    expect(messageRowClass('notification', MessageSource.AGENT)).toBe(chatStyles.messageRowCenter)
   })
 
   it('returns messageRowCenter for notification_thread', () => {
-    expect(messageRowClass('notification_thread', MessageRole.SYSTEM)).toBe(chatStyles.messageRowCenter)
+    expect(messageRowClass('notification_thread', MessageSource.AGENT)).toBe(chatStyles.messageRowCenter)
   })
 
   it('returns messageRowEnd for non-meta user messages', () => {
-    expect(messageRowClass('user_text', MessageRole.USER)).toBe(chatStyles.messageRowEnd)
-    expect(messageRowClass('user_content', MessageRole.USER)).toBe(chatStyles.messageRowEnd)
+    expect(messageRowClass('user_text', MessageSource.USER)).toBe(chatStyles.messageRowEnd)
+    expect(messageRowClass('user_content', MessageSource.USER)).toBe(chatStyles.messageRowEnd)
   })
 
   it('returns messageRow for assistant_text', () => {
-    expect(messageRowClass('assistant_text', MessageRole.ASSISTANT)).toBe(chatStyles.messageRow)
+    expect(messageRowClass('assistant_text', MessageSource.AGENT)).toBe(chatStyles.messageRow)
   })
 
   it('returns messageRow for assistant_thinking', () => {
-    expect(messageRowClass('assistant_thinking', MessageRole.ASSISTANT)).toBe(chatStyles.messageRow)
+    expect(messageRowClass('assistant_thinking', MessageSource.AGENT)).toBe(chatStyles.messageRow)
   })
 
-  it('returns messageRow for meta kinds even with USER role', () => {
-    expect(messageRowClass('tool_use', MessageRole.USER)).toBe(chatStyles.messageRow)
-    expect(messageRowClass('tool_result', MessageRole.USER)).toBe(chatStyles.messageRow)
-    expect(messageRowClass('hidden', MessageRole.USER)).toBe(chatStyles.messageRow)
+  it('returns messageRow for meta kinds even with USER source', () => {
+    expect(messageRowClass('tool_use', MessageSource.USER)).toBe(chatStyles.messageRow)
+    expect(messageRowClass('tool_result', MessageSource.USER)).toBe(chatStyles.messageRow)
+    expect(messageRowClass('hidden', MessageSource.USER)).toBe(chatStyles.messageRow)
   })
 })
 
@@ -403,40 +403,40 @@ describe('messageRowClass', () => {
 
 describe('messageBubbleClass', () => {
   it('returns systemMessage for notification', () => {
-    expect(messageBubbleClass('notification', MessageRole.SYSTEM)).toBe(chatStyles.systemMessage)
+    expect(messageBubbleClass('notification', MessageSource.AGENT)).toBe(chatStyles.systemMessage)
   })
 
   it('returns systemMessage for notification_thread', () => {
-    expect(messageBubbleClass('notification_thread', MessageRole.SYSTEM)).toBe(chatStyles.systemMessage)
+    expect(messageBubbleClass('notification_thread', MessageSource.AGENT)).toBe(chatStyles.systemMessage)
   })
 
   it('returns thinkingMessage for assistant_thinking', () => {
-    expect(messageBubbleClass('assistant_thinking', MessageRole.ASSISTANT)).toBe(chatStyles.thinkingMessage)
+    expect(messageBubbleClass('assistant_thinking', MessageSource.AGENT)).toBe(chatStyles.thinkingMessage)
   })
 
   it('returns metaMessage for meta kinds', () => {
-    expect(messageBubbleClass('tool_use', MessageRole.ASSISTANT)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('tool_result', MessageRole.USER)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('hidden', MessageRole.SYSTEM)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('result_divider', MessageRole.SYSTEM)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('control_response', MessageRole.USER)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('compact_summary', MessageRole.SYSTEM)).toBe(chatStyles.metaMessage)
-    expect(messageBubbleClass('task_notification', MessageRole.SYSTEM)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('tool_use', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('tool_result', MessageSource.USER)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('hidden', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('result_divider', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('control_response', MessageSource.USER)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('compact_summary', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
+    expect(messageBubbleClass('task_notification', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
   })
 
-  it('returns assistantMessage for assistant_text with ASSISTANT role', () => {
-    expect(messageBubbleClass('assistant_text', MessageRole.ASSISTANT)).toBe(chatStyles.assistantMessage)
+  it('returns assistantMessage for assistant_text with AGENT source', () => {
+    expect(messageBubbleClass('assistant_text', MessageSource.AGENT)).toBe(chatStyles.assistantMessage)
   })
 
-  it('returns userMessage for user_text with USER role', () => {
-    expect(messageBubbleClass('user_text', MessageRole.USER)).toBe(chatStyles.userMessage)
+  it('returns userMessage for user_text with USER source', () => {
+    expect(messageBubbleClass('user_text', MessageSource.USER)).toBe(chatStyles.userMessage)
   })
 
-  it('returns userMessage for user_content with USER role', () => {
-    expect(messageBubbleClass('user_content', MessageRole.USER)).toBe(chatStyles.userMessage)
+  it('returns userMessage for user_content with USER source', () => {
+    expect(messageBubbleClass('user_content', MessageSource.USER)).toBe(chatStyles.userMessage)
   })
 
-  it('returns systemMessage for unknown kind with unrecognized role', () => {
-    expect(messageBubbleClass('unknown', MessageRole.SYSTEM)).toBe(chatStyles.systemMessage)
+  it('returns systemMessage for unknown kind with LEAPMUX source', () => {
+    expect(messageBubbleClass('unknown', MessageSource.LEAPMUX)).toBe(chatStyles.systemMessage)
   })
 })

--- a/frontend/tests/unit/components/useAgentOperations.test.ts
+++ b/frontend/tests/unit/components/useAgentOperations.test.ts
@@ -5,7 +5,7 @@ import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAgentOperations } from '~/components/shell/useAgentOperations'
-import { AgentInfoSchema, AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentInfoSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createAgentStore } from '~/stores/agent.store'
@@ -372,7 +372,7 @@ describe('useAgentOperations', () => {
           agentStore.addAgent(agent)
           chatStore.getMessages.mockReturnValue([{
             id: 'local-1',
-            role: MessageRole.USER,
+            source: MessageSource.USER,
             content: new TextEncoder().encode(JSON.stringify({ content: 'retry me' })),
             contentCompression: ContentCompression.NONE,
           }])
@@ -398,7 +398,7 @@ describe('useAgentOperations', () => {
           agentStore.addAgent(agent)
           chatStore.getMessages.mockReturnValue([{
             id: 'local-2',
-            role: MessageRole.USER,
+            source: MessageSource.USER,
             content: new TextEncoder().encode(JSON.stringify({ content: 'retry me' })),
             contentCompression: ContentCompression.NONE,
           }])

--- a/frontend/tests/unit/helpers/messageFactory.ts
+++ b/frontend/tests/unit/helpers/messageFactory.ts
@@ -1,20 +1,21 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
-import { AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { NOTIFICATION_THREAD_TYPE } from '~/lib/messageParser'
 
 /** Encode a JSON object as raw message content bytes (no wrapper). */
 export function rawContent(obj: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(obj))
 }
 
-/** Encode messages into a LEAPMUX notification wrapper envelope. */
+/** Encode messages into a notification-thread wrapper envelope. */
 export function wrapContent(messages: unknown[], oldSeqs: number[] = []): Uint8Array {
-  return rawContent({ old_seqs: oldSeqs, messages })
+  return rawContent({ type: NOTIFICATION_THREAD_TYPE, old_seqs: oldSeqs, messages })
 }
 
 /** Build a minimal AgentChatMessage for testing. */
 export function makeMessage(overrides: Partial<{
   id: string
-  role: MessageRole
+  source: MessageSource
   seq: bigint
   createdAt: string
   deliveryError: string
@@ -24,13 +25,14 @@ export function makeMessage(overrides: Partial<{
   depth: number
   spanId: string
   parentSpanId: string
+  spanType: string
   spanLines: string
   spanColor: number
 }>): AgentChatMessage {
   return {
     $typeName: 'leapmux.v1.AgentChatMessage' as const,
     id: overrides.id ?? 'msg-1',
-    role: overrides.role ?? MessageRole.ASSISTANT,
+    source: overrides.source ?? MessageSource.AGENT,
     seq: overrides.seq ?? 1n,
     createdAt: overrides.createdAt ?? '',
     deliveryError: overrides.deliveryError ?? '',
@@ -39,6 +41,7 @@ export function makeMessage(overrides: Partial<{
     depth: overrides.depth ?? 0,
     spanId: overrides.spanId ?? '',
     parentSpanId: overrides.parentSpanId ?? '',
+    spanType: overrides.spanType ?? '',
     spanLines: overrides.spanLines ?? '[]',
     agentProvider: overrides.agentProvider ?? AgentProvider.CLAUDE_CODE,
     spanColor: overrides.spanColor ?? -1,

--- a/frontend/tests/unit/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/tests/unit/hooks/useWorkspaceConnection.test.ts
@@ -1,6 +1,6 @@
 import { createRoot } from 'solid-js'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, AgentStatus, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { extractResultMetadata, parseMessageContent } from '~/lib/messageParser'
@@ -163,7 +163,7 @@ describe('background agent history trimming', () => {
   function makeUserMessage(id: string, seq: bigint) {
     return {
       id,
-      role: MessageRole.USER,
+      source: MessageSource.USER,
       content: new TextEncoder().encode('{"content":"test"}'),
       seq,
     } as Parameters<ReturnType<typeof createChatStore>['addMessage']>[1]
@@ -275,7 +275,7 @@ describe('codex result replay handling', () => {
 
       const msg = {
         id: 'm1',
-        role: MessageRole.TURN_END,
+        source: MessageSource.AGENT,
         content: new TextEncoder().encode(JSON.stringify({
           num_tool_uses: 2,
           threadId: 'thread-1',
@@ -310,15 +310,13 @@ describe('streaming text preservation', () => {
 
       const echoedUserMessage = {
         id: 'server-user-1',
-        role: MessageRole.USER,
+        source: MessageSource.USER,
         content: new TextEncoder().encode(JSON.stringify({ content: 'follow-up' })),
         contentCompression: ContentCompression.NONE,
         seq: 1n,
       } as Parameters<ReturnType<typeof createChatStore>['addMessage']>[1]
 
       chatStore.addMessage('agent-1', echoedUserMessage)
-      if (echoedUserMessage.role !== MessageRole.USER)
-        chatStore.clearStreamingText('agent-1')
 
       chatStore.setStreamingText('agent-1', `${chatStore.state.streamingText['agent-1'] ?? ''} world`)
 
@@ -338,7 +336,7 @@ describe('streaming text preservation', () => {
 
       const completedAssistantMessage = {
         id: 'assistant-1',
-        role: MessageRole.ASSISTANT,
+        source: MessageSource.AGENT,
         content: new TextEncoder().encode(JSON.stringify({
           item: {
             type: 'agentMessage',
@@ -374,7 +372,7 @@ describe('streaming text preservation', () => {
 
       const completedPlanMessage = {
         id: 'plan-1',
-        role: MessageRole.ASSISTANT,
+        source: MessageSource.AGENT,
         content: new TextEncoder().encode(JSON.stringify({
           item: {
             type: 'plan',

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -1,7 +1,7 @@
 import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { createChatStore } from '~/stores/chat.store'
 
 // Mock workerRpc for loadInitialMessages / loadOlderMessages / loadNewerMessages
@@ -13,7 +13,7 @@ vi.mock('~/api/workerRpc', () => ({
 function makeMessage(id: string, seq: bigint, deliveryError = '') {
   return create(AgentChatMessageSchema, {
     id,
-    role: MessageRole.USER,
+    source: MessageSource.USER,
     content: new TextEncoder().encode(`{"content":"test"}`),
     seq,
     deliveryError,
@@ -23,7 +23,7 @@ function makeMessage(id: string, seq: bigint, deliveryError = '') {
 function makeUserMessage(id: string, seq: bigint, content: string, deliveryError = '', agentProvider?: AgentProvider) {
   return create(AgentChatMessageSchema, {
     id,
-    role: MessageRole.USER,
+    source: MessageSource.USER,
     content: new TextEncoder().encode(JSON.stringify({ content })),
     contentCompression: ContentCompression.NONE,
     seq,
@@ -42,7 +42,7 @@ function makeUserMessageWithAttachments(
 ) {
   return create(AgentChatMessageSchema, {
     id,
-    role: MessageRole.USER,
+    source: MessageSource.USER,
     content: new TextEncoder().encode(JSON.stringify({ content, attachments })),
     contentCompression: ContentCompression.NONE,
     seq,
@@ -69,7 +69,7 @@ function makeTodoWriteMessage(
   }
   return create(AgentChatMessageSchema, {
     id,
-    role: MessageRole.ASSISTANT,
+    source: MessageSource.AGENT,
     content: new TextEncoder().encode(JSON.stringify(raw)),
     contentCompression: ContentCompression.NONE,
     seq,

--- a/frontend/tests/unit/utils/agentState.test.ts
+++ b/frontend/tests/unit/utils/agentState.test.ts
@@ -1,12 +1,12 @@
 import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
 import type { AgentSessionInfo } from '~/stores/agentSession.store'
 import { describe, expect, it } from 'vitest'
-import { AgentProvider, AgentStatus, MessageRole } from '~/generated/leapmux/v1/agent_pb'
+import { AgentProvider, AgentStatus, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { isAgentWorking, shouldShowThinkingIndicator } from '~/utils/agentState'
 import { makeMessage, rawContent, wrapContent } from '../helpers/messageFactory'
 
-function makeMsg(role: MessageRole, content?: Uint8Array, deliveryError?: string) {
-  return makeMessage({ role, content, deliveryError })
+function makeMsg(source: MessageSource, content?: Uint8Array, deliveryError?: string) {
+  return makeMessage({ source, content, deliveryError })
 }
 
 function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
@@ -38,123 +38,99 @@ describe('isAgentWorking', () => {
     expect(isAgentWorking([])).toBe(false)
   })
 
-  it('returns true when last message is USER role', () => {
+  it('returns true when last message is USER source', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.USER),
+      makeMsg(MessageSource.USER),
     ])).toBe(true)
   })
 
-  it('returns true when last message is ASSISTANT role', () => {
+  it('returns true when last message is AGENT source', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
+      makeMsg(MessageSource.AGENT),
     ])).toBe(true)
   })
 
-  it('returns false when last message is TURN_END', () => {
+  it('returns false when last message is a result divider', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.USER),
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.USER),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
     ])).toBe(false)
   })
 
-  it('returns false on TURN_END regardless of inner type (every TURN_END is a real turn end)', () => {
-    // No producer creates TURN_END messages with mid-turn types; the role
-    // alone is the contract. Spot-check with a non-result inner type.
+  it('skips LEAPMUX message and finds result divider underneath', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'interrupted' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
     ])).toBe(false)
   })
 
-  it('handles TURN_END with unparseable content as a turn end', () => {
-    const badContent = new TextEncoder().encode('not valid json')
+  it('skips LEAPMUX settings_changed and finds preceding AGENT', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.TURN_END, badContent),
-    ])).toBe(false)
-  })
-
-  it('handles TURN_END with empty content as a turn end', () => {
-    expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.TURN_END),
-    ])).toBe(false)
-  })
-
-  it('skips LEAPMUX message and finds TURN_END underneath', () => {
-    expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
-    ])).toBe(false)
-  })
-
-  it('skips LEAPMUX settings_changed and finds preceding ASSISTANT', () => {
-    expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
     ])).toBe(true)
   })
 
   it('treats LEAPMUX context_cleared as turn boundary (returns false)', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
   it('skips multiple trailing LEAPMUX messages', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
   it('returns false when all messages are LEAPMUX notifications', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'settings_changed' }])),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
   it('skips USER message with deliveryError (agent never received it)', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.USER, undefined, 'connection lost'),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.USER, undefined, 'connection lost'),
     ])).toBe(false)
   })
 
-  it('skips trailing deliveryError messages and finds preceding ASSISTANT', () => {
+  it('skips trailing deliveryError messages and finds preceding AGENT', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.USER, undefined, 'connection lost'),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.USER, undefined, 'connection lost'),
     ])).toBe(true)
   })
 
-  it('skips trailing LEAPMUX context_cleared and stops at preceding TURN_END', () => {
+  it('skips trailing LEAPMUX context_cleared and stops at preceding result divider', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
   it('treats LEAPMUX wrapper with [settings_changed, context_cleared] as turn boundary', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'settings_changed' }, { type: 'context_cleared' }])),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'settings_changed' }, { type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
   it('treats LEAPMUX wrapper with [context_cleared, settings_changed] as turn boundary', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([{ type: 'context_cleared' }, { type: 'settings_changed' }])),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([{ type: 'context_cleared' }, { type: 'settings_changed' }])),
     ])).toBe(false)
   })
 
   // ---------------------------------------------------------------------
-  // SYSTEM-role parity: agent-emitted metadata that migrated from LEAPMUX
-  // to SYSTEM must produce the same isAgentWorking outcome.
+  // AGENT-source parity: agent-emitted metadata persisted as AGENT must
+  // produce the same isAgentWorking outcome as the LEAPMUX equivalents.
   // ---------------------------------------------------------------------
 
   it.each([
@@ -167,10 +143,10 @@ describe('isAgentWorking', () => {
     { type: 'auto_retry_end' },
     { type: 'extension_error', error: 'oops' },
     { type: 'extension_ui_request', method: 'notify' },
-  ])('skips SYSTEM-roled non-progress event (%j) and finds preceding ASSISTANT', (payload) => {
+  ])('skips AGENT-source non-progress event (%j) and finds preceding AGENT', (payload) => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, rawContent(payload)),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.AGENT, rawContent(payload)),
     ])).toBe(true)
   })
 
@@ -187,64 +163,57 @@ describe('isAgentWorking', () => {
     { method: 'thread/compacted', params: {} },
     { method: 'mcpServer/startupStatus/updated', params: {} },
     { method: 'account/rateLimits/updated', params: {} },
-  ])('skips SYSTEM-roled Codex JSON-RPC notification (%j) and finds preceding ASSISTANT', (payload) => {
+  ])('skips AGENT-source Codex JSON-RPC notification (%j) and finds preceding AGENT', (payload) => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, rawContent(payload)),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.AGENT, rawContent(payload)),
     ])).toBe(true)
   })
 
-  it('skips Claude SYSTEM status message ({type:"system",subtype:"status"}) and finds preceding ASSISTANT', () => {
+  it('skips Claude system status message ({type:"system",subtype:"status"}) and finds preceding AGENT', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'system', subtype: 'status', status: 'compacting' })),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'status', status: 'compacting' })),
     ])).toBe(true)
   })
 
-  it('skips Claude SYSTEM api_retry message and finds preceding ASSISTANT', () => {
+  it('skips Claude system api_retry message and finds preceding AGENT', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'system', subtype: 'api_retry', attempt: 1 })),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'api_retry', attempt: 1 })),
     ])).toBe(true)
   })
 
-  it('does NOT skip Claude SYSTEM init (other system subtype is real progress)', () => {
+  it('does NOT skip Claude system init (other system subtype is real progress)', () => {
     // A bare assistant followed by a system init only — system init isn't a
     // notification subtype, so it counts as progress and the agent appears
     // to be working. Sanity check that the subtype filter isn't too broad.
     expect(isAgentWorking([
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'system', subtype: 'init', cwd: '/x' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'init', cwd: '/x' })),
     ])).toBe(true)
   })
 
-  it('treats SYSTEM context_cleared as turn boundary (returns false)', () => {
+  it('treats AGENT-source wrapper containing context_cleared as turn boundary', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'context_cleared' })),
+      makeMsg(MessageSource.AGENT),
+      makeMsg(MessageSource.AGENT, wrapContent([{ method: 'thread/tokenUsage/updated' }, { type: 'context_cleared' }])),
     ])).toBe(false)
   })
 
-  it('treats SYSTEM wrapper containing context_cleared as turn boundary', () => {
+  it('skips trailing AGENT-source rate-limit notifications and falls through to result divider', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT),
-      makeMsg(MessageRole.SYSTEM, wrapContent([{ method: 'thread/tokenUsage/updated' }, { type: 'context_cleared' }])),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'rate_limit_event', rate_limit_info: {} })),
+      makeMsg(MessageSource.AGENT, rawContent({ method: 'thread/tokenUsage/updated' })),
     ])).toBe(false)
   })
 
-  it('skips trailing SYSTEM rate-limit notifications and falls through to TURN_END', () => {
-    expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'rate_limit_event', rate_limit_info: {} })),
-      makeMsg(MessageRole.SYSTEM, rawContent({ method: 'thread/tokenUsage/updated' })),
-    ])).toBe(false)
-  })
-
-  it('returns true when last message is plain SYSTEM content (e.g. unknown notification)', () => {
-    // A SYSTEM message whose inner type/method isn't recognized as
+  it('returns true when last message is plain AGENT content (e.g. unknown notification)', () => {
+    // An AGENT message whose inner type/method isn't recognized as
     // non-progress is treated as activity — better to over-show the
     // thinking indicator than to miss a real-progress signal.
     expect(isAgentWorking([
-      makeMsg(MessageRole.SYSTEM, rawContent({ type: 'unknown_payload', some: 'data' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'unknown_payload', some: 'data' })),
     ])).toBe(true)
   })
 
@@ -256,27 +225,27 @@ describe('isAgentWorking', () => {
 
   it('treats LEAPMUX wrapper with empty messages array as non-progress', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.LEAPMUX, wrapContent([])),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([])),
     ])).toBe(false)
   })
 
-  it('treats SYSTEM wrapper with empty messages array as non-progress', () => {
+  it('treats AGENT-source wrapper with empty messages array as non-progress', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.TURN_END, rawContent({ type: 'result', subtype: 'turn_result' })),
-      makeMsg(MessageRole.SYSTEM, wrapContent([])),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
+      makeMsg(MessageSource.AGENT, wrapContent([])),
     ])).toBe(false)
   })
 
   it('returns false when the only message is an empty LEAPMUX wrapper', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.LEAPMUX, wrapContent([])),
+      makeMsg(MessageSource.LEAPMUX, wrapContent([])),
     ])).toBe(false)
   })
 
   // ---------------------------------------------------------------------
-  // context_cleared boundary scope: only LEAPMUX/SYSTEM-roled messages
-  // are emitted by the platform as turn boundaries. USER/ASSISTANT
+  // context_cleared boundary scope: only notification-thread wrapper rows
+  // are emitted by the platform as turn boundaries. USER/AGENT plain
   // payloads that happen to surface a top-level `type: "context_cleared"`
   // (e.g. a Pi `default`-handler echo of an unknown event) must NOT be
   // interpreted as a turn boundary — they carry user/agent content.
@@ -284,13 +253,13 @@ describe('isAgentWorking', () => {
 
   it('does not treat USER message containing type:"context_cleared" as a turn boundary', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.USER, rawContent({ type: 'context_cleared', content: 'literal user text' })),
+      makeMsg(MessageSource.USER, rawContent({ type: 'context_cleared', content: 'literal user text' })),
     ])).toBe(true)
   })
 
-  it('does not treat ASSISTANT message containing type:"context_cleared" as a turn boundary', () => {
+  it('does not treat AGENT message containing type:"context_cleared" as a turn boundary', () => {
     expect(isAgentWorking([
-      makeMsg(MessageRole.ASSISTANT, rawContent({ type: 'context_cleared' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'context_cleared' })),
     ])).toBe(true)
   })
 })
@@ -300,7 +269,7 @@ describe('shouldShowThinkingIndicator', () => {
     expect(shouldShowThinkingIndicator(
       makeAgent({ status: AgentStatus.INACTIVE }),
       {},
-      [makeMsg(MessageRole.USER)],
+      [makeMsg(MessageSource.USER)],
       '',
     )).toBe(false)
   })
@@ -309,7 +278,7 @@ describe('shouldShowThinkingIndicator', () => {
     expect(shouldShowThinkingIndicator(
       makeAgent(),
       {},
-      [makeMsg(MessageRole.USER)],
+      [makeMsg(MessageSource.USER)],
       '',
       1,
     )).toBe(false)
@@ -329,7 +298,7 @@ describe('shouldShowThinkingIndicator', () => {
     expect(shouldShowThinkingIndicator(
       makeAgent({ agentProvider: AgentProvider.CODEX }),
       sessionInfo,
-      [makeMsg(MessageRole.ASSISTANT)],
+      [makeMsg(MessageSource.AGENT)],
       '',
     )).toBe(false)
   })
@@ -348,7 +317,7 @@ describe('shouldShowThinkingIndicator', () => {
     expect(shouldShowThinkingIndicator(
       makeAgent({ agentProvider: AgentProvider.CLAUDE_CODE }),
       {},
-      [makeMsg(MessageRole.USER)],
+      [makeMsg(MessageSource.USER)],
       '',
     )).toBe(true)
   })

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -26,17 +26,41 @@ enum AgentStatus {
   AGENT_STATUS_STARTUP_FAILED = 4;  // Subprocess launch failed; see startup_error
 }
 
-// MessageRole identifies who produced a chat message.
-enum MessageRole {
-  MESSAGE_ROLE_UNSPECIFIED = 0;
-  MESSAGE_ROLE_USER = 1;
-  MESSAGE_ROLE_ASSISTANT = 2;
-  MESSAGE_ROLE_SYSTEM = 3;
-  // Turn-end divider. Persisted by every provider's terminal envelope
-  // (Claude type:"result", Codex turn/completed, ACP prompt response,
-  // Pi agent_end) and gates the sink-level git-status auto-broadcast.
-  MESSAGE_ROLE_TURN_END = 4;
-  MESSAGE_ROLE_LEAPMUX = 5;  // Platform notifications (settings changes, interrupts)
+// MessageSource identifies which side of the transcript a chat row
+// belongs to. This is a transcript-row classifier, not a strict
+// provenance / "who produced the bytes" classifier.
+enum MessageSource {
+  MESSAGE_SOURCE_UNSPECIFIED = 0;
+
+  // User-side transcript row. Includes:
+  //   - Human-typed input.
+  //   - Synthetic conversational prompts injected by LeapMux that are
+  //     forwarded to the agent's stdin (auto-continue, plan-execution
+  //     prompts).
+  //   - Display-only synthetic rows that mirror a user-side action
+  //     (control-response / approval feedback such as Claude permission
+  //     decisions or Pi extension_ui_response display text; agent
+  //     interrupt display rows that are persisted but not forwarded
+  //     to stdin).
+  //   - Provider transcripts that arrive with a `user` role on the
+  //     wire but represent agent-internal echoes (e.g. Claude tool
+  //     results returned to the agent under role:"user").
+  MESSAGE_SOURCE_USER = 1;
+
+  // Agent-side transcript row. Anything the agent process emits to
+  // its output stream — assistant text, tool calls, thinking blocks,
+  // system notifications (rate limits, compaction, status updates),
+  // and turn-end dividers. The fine-grained per-provider semantics
+  // (assistant vs. system notification vs. terminal envelope) are
+  // recovered by classifying the inner JSON envelope, not by source.
+  MESSAGE_SOURCE_AGENT = 2;
+
+  // LeapMux-synthesized non-conversational platform notification.
+  // These rows are produced by LeapMux itself (never by the agent or
+  // the user) and never reach the agent's stdin. Examples:
+  // settings_changed, plan_execution metadata, context_cleared
+  // markers, interrupt-event metadata.
+  MESSAGE_SOURCE_LEAPMUX = 3;
 }
 
 // ContentCompression identifies the compression algorithm used for message content.
@@ -183,7 +207,7 @@ message SendAgentRawMessageResponse {}
 // AgentChatMessage represents a complete message in the conversation.
 message AgentChatMessage {
   string id = 1;
-  MessageRole role = 2;
+  MessageSource source = 2;
   bytes content = 3; // JSON blob from Claude Code (may be compressed per content_compression)
   int64 seq = 4;
   string created_at = 5;


### PR DESCRIPTION
## Motivation

The existing `MessageRole` enum in the proto schema was named after the conversational role a message plays (USER, ASSISTANT, SYSTEM), but the actual stored value in the `messages` table served a different purpose: classifying which side of the transcript a row belongs to (the human, the agent process, or the LeapMux platform itself). This mismatch caused ambiguity — for example, Claude tool results arrive on the wire with role `"user"` but belong on the agent side of the transcript, and `MESSAGE_ROLE_TURN_END` was a lifecycle marker smuggled into a field that should only classify provenance.

Separately, notification-thread boundary detection was tied to `role === LEAPMUX || role === SYSTEM` at the frontend, and turn-end side effects (git-status broadcast) were inferred from a sentinel role value rather than an explicit code path, both of which were fragile.

## Modifications

- Renamed the `MessageRole` proto enum to `MessageSource` with three values: `MESSAGE_SOURCE_USER`, `MESSAGE_SOURCE_AGENT`, and `MESSAGE_SOURCE_LEAPMUX`. Expanded doc comments clarify the classifier semantics.
- Removed `MESSAGE_ROLE_TURN_END` from the enum entirely.
- Renamed the `messages.role` database column to `messages.source` in the schema migration, SQL queries, and `sqlc.yaml` overrides.
- Added `PersistTurnEnd()` as a dedicated `OutputSink` method. Turn-end side effects (auto-firing `BroadcastGitStatus()`) are now explicit at call sites rather than inferred from a sentinel role value.
- Updated all provider output implementations (Claude, Codex, Pi, ACP) and their tests to derive `MessageSource` from the envelope type and call `PersistTurnEnd()` at the correct point.
- Centralized Claude message-type string literals as named constants in `claude_output.go`.
- Removed the `role: MessageRole` parameter from all `MessageContentRenderer.render()` signatures; the field was unused in every implementation.
- Removed `messageRole` from `ClassificationInput` across all frontend providers and tests.
- Added `NOTIFICATION_THREAD_TYPE` constant and switched notification-thread boundary detection from role comparison (`role === LEAPMUX`) to explicit type-field check (`type === 'notification_thread'`), decoupling the parser from role assumptions. Backend now always emits the `type` discriminator in the wrapper JSON.
- Replaced `role === TURN_END` turn-end detection in `useWorkspaceConnection` with `classifyAgentMessage()` delegating to provider plugins via `kind: 'result_divider'`.
- Added `classifyAgentMessage()` with WeakMap caching in the frontend to avoid redundant classification passes during `isAgentWorking` scans.
- Extended `parseRawGrepGlobResult()` to handle Grep `output_mode: "count"` trailing summary lines, surfacing `numMatches` and `mode: 'count'` metadata for proper "N matches in M files" display.
- Centralized streaming-text buffer clearing into `shouldClearStreamingText()` with a `NON_STREAM_CLEAR_KINDS` set, removing duplicated clearing logic from `useWorkspaceConnection`.
- Fixed a bug where TODO extraction was gated on role rather than source, causing stale `TodoWrite` contents to surface from tool-result echoes on USER-source messages.

## Result

The transcript classifier field now accurately describes what it models: the side of the conversation a row belongs to, not a conversational role. Turn-end handling is an explicit code path rather than a convention encoded in an enum value, making it easier to reason about and extend. Notification-thread detection is robust to future source changes because it uses an explicit type discriminator. Grep count-mode output is now rendered with match counts instead of falling back to generic file counts.
