### PR TITLE
Add SMTP mail delivery with proper TLS and disabled-state handling

### DIFF
--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -152,9 +152,32 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 
 	mux := http.NewServeMux()
 
-	mailSender := mail.NewStubSender()
+	// Mail sender: real SMTP when smtp_host is configured, otherwise the
+	// no-op disabledSender that returns ErrEmailDisabled. Validation in
+	// cfg.Validate() prevents email_verification_required=true paired
+	// with an empty smtp_host, so the disabled sender should not be
+	// reached during normal operation; it exists as a loud, matchable
+	// fallback rather than a silent no-op (which is what the previous
+	// StubSender used to do).
+	var mailSender mail.Sender
+	if cfg.SmtpHost != "" {
+		mailSender = mail.NewSMTPSender(mail.SMTPConfig{
+			Host:     cfg.SmtpHost,
+			Port:     cfg.SmtpPort,
+			Username: cfg.SmtpUsername,
+			Password: cfg.SmtpPassword,
+			From:     cfg.SmtpFromAddress,
+			TLSMode:  cfg.SmtpTLSMode,
+		})
+	} else {
+		mailSender = mail.NewDisabledSender()
+	}
+	// Renderer carries the hub's public URL once at construction so the
+	// signup / email-change / resend / worker-registration paths don't
+	// each have to thread cfg.BaseURL() through.
+	mailRenderer := mail.Renderer{HubURL: cfg.BaseURL()}
 
-	authSvc := service.NewAuthService(st, cfg, sessionCache, ks, mailSender)
+	authSvc := service.NewAuthService(st, cfg, sessionCache, ks, mailSender, mailRenderer)
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(authSvc, connectOpts)
 	mux.Handle(authPath, authHandler)
 
@@ -164,7 +187,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	connectorSvc := service.NewWorkerConnectorService(st, wMgr, cMgr, broadcaster, pendingReqs, notifierSvc, shutdownCh)
 	connectorPath, connectorHandler := leapmuxv1connect.NewWorkerConnectorServiceHandler(connectorSvc, connectOpts)
 	mux.Handle(connectorPath, connectorHandler)
-	mgmtSvc := service.NewWorkerManagementService(st, wMgr, broadcaster, notifierSvc, mailSender)
+	mgmtSvc := service.NewWorkerManagementService(st, wMgr, broadcaster, notifierSvc, mailSender, mailRenderer, cfg)
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(mgmtSvc, connectOpts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
@@ -184,7 +207,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	orgPath, orgHandler := leapmuxv1connect.NewOrgServiceHandler(orgSvc, connectOpts)
 	mux.Handle(orgPath, orgHandler)
 
-	userSvc := service.NewUserService(st, cfg, sessionCache, mailSender)
+	userSvc := service.NewUserService(st, cfg, sessionCache, mailSender, mailRenderer)
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, connectOpts)
 	mux.Handle(userPath, userHandler)
 

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -34,7 +34,7 @@ func setupInterceptorTestServer(t *testing.T) leapmuxv1connect.AuthServiceClient
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	interceptors := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)
 
@@ -107,7 +107,7 @@ func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, soloUser, false, false)
 	interceptors := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, &config.Config{SoloMode: true}, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, &config.Config{SoloMode: true}, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)
 
@@ -163,7 +163,7 @@ func setupInterceptorTestServerWithCache(t *testing.T) (leapmuxv1connect.AuthSer
 	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, &config.Config{}, sc, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, &config.Config{}, sc, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)
 

--- a/backend/internal/hub/auth/shutdown_test.go
+++ b/backend/internal/hub/auth/shutdown_test.go
@@ -29,7 +29,7 @@ func setupShutdownTestServer(t *testing.T, shutdownCh chan struct{}) leapmuxv1co
 	interceptors := connect.WithInterceptors(
 		auth.NewShutdownInterceptor(shutdownCh),
 	)
-	authSvc := service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)
 

--- a/backend/internal/hub/auth/timeout_test.go
+++ b/backend/internal/hub/auth/timeout_test.go
@@ -40,7 +40,7 @@ func setupTimeoutTestServer(t *testing.T, timeout time.Duration) (leapmuxv1conne
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
 
-	capture := &timeoutCapture{inner: service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender())}
+	capture := &timeoutCapture{inner: service.NewAuthService(st, &config.Config{}, nil, nil, mail.NewStubSender(), mail.Renderer{})}
 
 	mux := http.NewServeMux()
 	interceptors := connect.WithInterceptors(auth.NewTimeoutInterceptor(func() time.Duration { return timeout }))

--- a/backend/internal/hub/config/config.go
+++ b/backend/internal/hub/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 	"github.com/leapmux/leapmux/locallisten"
+	"github.com/leapmux/leapmux/util/validate"
 )
 
 const (
@@ -47,7 +49,7 @@ type Config struct {
 	SmtpUsername                 string        `koanf:"smtp_username"`
 	SmtpPassword                 string        `koanf:"smtp_password"`
 	SmtpFromAddress              string        `koanf:"smtp_from_address"`
-	SmtpUseTLS                   bool          `koanf:"smtp_use_tls"`
+	SmtpTLSMode                  string        `koanf:"smtp_tls_mode"` // See SmtpTLSMode* constants for valid values.
 	APITimeoutSeconds            int           `koanf:"api_timeout_seconds"`
 	AgentStartupTimeoutSeconds   int           `koanf:"agent_startup_timeout_seconds"`
 	WorktreeCreateTimeoutSeconds int           `koanf:"worktree_create_timeout_seconds"`
@@ -58,6 +60,25 @@ type Config struct {
 	DevMode                      bool              // Dev mode: non-solo but with auto-bootstrapped admin
 	Extras                       map[string]string // Extra flag values not in the hub Config struct
 }
+
+// SMTP TLS mode constants for SmtpTLSMode.
+//
+// SmtpTLSModeSTARTTLS is the default and most common production setting:
+// connect in plaintext, then upgrade to TLS via the STARTTLS extension
+// (typically port 587). SmtpTLSModeImplicit dials TLS directly (port 465,
+// the legacy "SMTPS" pattern). SmtpTLSModeNone is plaintext-only and
+// should normally only be used for trusted localhost relays — the
+// validation layer rejects it for non-localhost relays that require auth
+// because Go's smtp.PlainAuth refuses to send credentials over an
+// unencrypted, non-localhost connection.
+const (
+	SmtpTLSModeSTARTTLS = "starttls"
+	SmtpTLSModeImplicit = "implicit"
+	SmtpTLSModeNone     = "none"
+)
+
+// validSmtpTLSModes is the display string for valid smtp_tls_mode values.
+const validSmtpTLSModes = "starttls, implicit, none"
 
 // StorageType identifies a storage backend.
 type StorageType string
@@ -253,7 +274,7 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 		{"smtp-username", "smtp_username", "SMTP username", ptrconv.Ptr(""), nil, nil},
 		{"smtp-password", "smtp_password", "SMTP password", ptrconv.Ptr(""), nil, nil},
 		{"smtp-from-address", "smtp_from_address", "SMTP from address", ptrconv.Ptr(""), nil, nil},
-		{"smtp-use-tls", "smtp_use_tls", "use TLS for SMTP", nil, nil, ptrconv.Ptr(true)},
+		{"smtp-tls-mode", "smtp_tls_mode", "SMTP TLS mode (" + validSmtpTLSModes + ")", ptrconv.Ptr(SmtpTLSModeSTARTTLS), nil, nil},
 		{"api-timeout-seconds", "api_timeout_seconds", "general API timeout in seconds", nil, ptrconv.Ptr(DefaultAPITimeoutSeconds), nil},
 		{"agent-startup-timeout-seconds", "agent_startup_timeout_seconds", "agent startup timeout in seconds", nil, ptrconv.Ptr(DefaultAgentStartupTimeoutSeconds), nil},
 		{"worktree-create-timeout-seconds", "worktree_create_timeout_seconds", "worktree creation timeout in seconds", nil, ptrconv.Ptr(DefaultWorktreeCreateTimeoutSeconds), nil},
@@ -436,7 +457,63 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("unsupported storage.type: %q (valid: %s)", c.Storage.Type, validStorageTypes)
 	}
 
+	// SMTP / email configuration. Validation is layered:
+	//   1. Normalize: empty SmtpTLSMode → starttls (handles programmatically
+	//      built configs that bypass flag-parsing defaults).
+	//   2. Always: SmtpTLSMode must be a valid constant — even when SMTP is
+	//      disabled, so a typo in smtp_tls_mode never silently sticks.
+	//   3. SmtpHost set: requires from-address and a valid port. There is no
+	//      "half-configured SMTP" state.
+	//   4. Email verification required: requires SmtpHost (chains through #3).
+	//   5. tls_mode=none + auth + non-localhost is rejected — Go's
+	//      smtp.PlainAuth refuses to send credentials over an unencrypted
+	//      non-localhost connection, so this combo never works in practice.
+	if c.SmtpTLSMode == "" {
+		c.SmtpTLSMode = SmtpTLSModeSTARTTLS
+	}
+	switch c.SmtpTLSMode {
+	case SmtpTLSModeSTARTTLS, SmtpTLSModeImplicit, SmtpTLSModeNone:
+	default:
+		return fmt.Errorf("unsupported smtp_tls_mode: %q (valid: %s)", c.SmtpTLSMode, validSmtpTLSModes)
+	}
+	if c.SmtpHost != "" {
+		if c.SmtpFromAddress == "" {
+			return fmt.Errorf("smtp_from_address is required when smtp_host is set")
+		}
+		if err := validate.ValidateEmail(c.SmtpFromAddress); err != nil {
+			return fmt.Errorf("invalid smtp_from_address: %w", err)
+		}
+		if c.SmtpPort < 1 || c.SmtpPort > 65535 {
+			return fmt.Errorf("smtp_port must be in [1, 65535], got %d", c.SmtpPort)
+		}
+		if c.SmtpTLSMode == SmtpTLSModeNone && c.SmtpUsername != "" && !isLocalhost(c.SmtpHost) {
+			return fmt.Errorf("smtp_tls_mode=none with smtp_username set is rejected for non-localhost smtp_host=%q: "+
+				"Go's smtp.PlainAuth refuses to send credentials over an unencrypted non-localhost connection", c.SmtpHost)
+		}
+	}
+	if c.EmailVerificationRequired && c.SmtpHost == "" {
+		return fmt.Errorf("smtp_host is required when email_verification_required is true")
+	}
+
 	return nil
+}
+
+// isLocalhost reports whether host (a hostname or numeric IP, no port) is a
+// loopback address. Used to relax validation for SMTP relays running on the
+// same machine, where unencrypted credentialed AUTH is acceptable.
+//
+// We accept the literal name "localhost" (a hostname, not an IP — Go's
+// resolver and smtp.PlainAuth both treat it specially) plus anything that
+// parses as a loopback IP, which covers 127.0.0.0/8 and ::1 — matching
+// the criteria smtp.PlainAuth uses.
+func isLocalhost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(strings.Trim(host, "[]")); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // DefaultHubDataDir returns the default hub data directory with ~ expanded.

--- a/backend/internal/hub/config/config_test.go
+++ b/backend/internal/hub/config/config_test.go
@@ -371,6 +371,115 @@ func TestValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "solo mode")
 	})
+
+	t.Run("empty SmtpTLSMode is normalized to starttls", func(t *testing.T) {
+		cfg := &Config{Listen: ":4327", DataDir: t.TempDir()}
+		require.NoError(t, cfg.Validate())
+		assert.Equal(t, SmtpTLSModeSTARTTLS, cfg.SmtpTLSMode)
+	})
+
+	t.Run("invalid SmtpTLSMode is rejected even without SmtpHost", func(t *testing.T) {
+		// Validating unconditionally — not gated on SmtpHost — surfaces typos
+		// at startup instead of waiting until someone configures smtp_host.
+		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SmtpTLSMode: "bogus"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "smtp_tls_mode")
+		assert.Contains(t, err.Error(), validSmtpTLSModes)
+	})
+
+	t.Run("SMTP block rejection cases", func(t *testing.T) {
+		// Valid baseline; each subtest mutates a single field. Pulling
+		// the boilerplate up here is the point of the table — it forces
+		// each row to highlight only the field that triggers rejection.
+		base := func() *Config {
+			return &Config{
+				Listen:          ":4327",
+				DataDir:         t.TempDir(),
+				SmtpHost:        "smtp.example.com",
+				SmtpPort:        587,
+				SmtpFromAddress: "hub@example.test",
+				SmtpTLSMode:     SmtpTLSModeSTARTTLS,
+			}
+		}
+		cases := []struct {
+			name     string
+			mutate   func(*Config)
+			contains string
+		}{
+			{"missing from address", func(c *Config) { c.SmtpFromAddress = "" }, "smtp_from_address is required"},
+			{"malformed from address", func(c *Config) { c.SmtpFromAddress = "not-an-email" }, "invalid smtp_from_address"},
+			{"out-of-range port", func(c *Config) { c.SmtpPort = 0 }, "smtp_port"},
+			{"verification required without host", func(c *Config) {
+				*c = Config{Listen: ":4327", DataDir: t.TempDir(), EmailVerificationRequired: true}
+			}, "smtp_host is required"},
+			{"tls=none + auth on non-localhost", func(c *Config) {
+				c.SmtpTLSMode = SmtpTLSModeNone
+				c.SmtpPort = 25
+				c.SmtpUsername = "user"
+				c.SmtpPassword = "pw"
+			}, "smtp_tls_mode=none"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := base()
+				tc.mutate(cfg)
+				err := cfg.Validate()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.contains)
+			})
+		}
+	})
+
+	t.Run("tls_mode=none + auth + localhost is accepted", func(t *testing.T) {
+		// Trusted local relay: PlainAuth permits credentials on loopback even
+		// without TLS, so the validation rule must not over-reach.
+		// Includes 127.0.0.2 because Go treats the entire 127.0.0.0/8
+		// range as loopback — verifying we use IsLoopback rather than
+		// hard-coding the canonical addresses.
+		for _, host := range []string{"localhost", "LOCALHOST", "127.0.0.1", "127.0.0.2", "::1", "[::1]"} {
+			cfg := &Config{
+				Listen:          ":4327",
+				DataDir:         t.TempDir(),
+				SmtpHost:        host,
+				SmtpPort:        25,
+				SmtpUsername:    "user",
+				SmtpPassword:    "pw",
+				SmtpFromAddress: "hub@example.test",
+				SmtpTLSMode:     SmtpTLSModeNone,
+			}
+			require.NoError(t, cfg.Validate(), "host=%s", host)
+		}
+	})
+
+	t.Run("tls_mode=none + no auth on non-localhost is accepted", func(t *testing.T) {
+		// No credentials means PlainAuth's localhost-only restriction doesn't
+		// apply; an unauthenticated relay over plaintext is admin's choice.
+		cfg := &Config{
+			Listen:          ":4327",
+			DataDir:         t.TempDir(),
+			SmtpHost:        "relay.example.com",
+			SmtpPort:        25,
+			SmtpFromAddress: "hub@example.test",
+			SmtpTLSMode:     SmtpTLSModeNone,
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("valid SMTP block is accepted", func(t *testing.T) {
+		cfg := &Config{
+			Listen:                    ":4327",
+			DataDir:                   t.TempDir(),
+			SmtpHost:                  "smtp.example.com",
+			SmtpPort:                  587,
+			SmtpUsername:              "user",
+			SmtpPassword:              "pw",
+			SmtpFromAddress:           "hub@example.test",
+			SmtpTLSMode:               SmtpTLSModeSTARTTLS,
+			EmailVerificationRequired: true,
+		}
+		require.NoError(t, cfg.Validate())
+	})
 }
 
 func TestPaths(t *testing.T) {

--- a/backend/internal/hub/mail/disabled.go
+++ b/backend/internal/hub/mail/disabled.go
@@ -1,0 +1,33 @@
+package mail
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrEmailDisabled is returned by the no-op Sender that the hub wires up
+// when SMTP is not configured. Callers can match it via errors.Is to
+// distinguish "the hub has no mail backend at all" from a transient SMTP
+// failure. Validation in the config layer prevents email-using features
+// (verification, worker registration email) from being reachable when
+// SMTP is unconfigured, so this error should not surface during normal
+// operation; it exists as a loud, matchable signal in case any code path
+// slips past those gates.
+var ErrEmailDisabled = errors.New("hub email is not configured")
+
+// disabledSender is the production no-SMTP sender. It returns
+// ErrEmailDisabled from every Send. Unlike StubSender (TEST-ONLY), it
+// never silently succeeds — silent success here would mean verification
+// codes were "sent" while no mail server was wired up.
+type disabledSender struct{}
+
+// NewDisabledSender returns the production no-SMTP Sender. Use this
+// when the operator has not configured any SMTP host; the hub server
+// already does so at backend/hub/server.go.
+func NewDisabledSender() Sender { return disabledSender{} }
+
+// Send returns ErrEmailDisabled. The argument is ignored — there is no
+// transport to deliver it on.
+func (disabledSender) Send(_ context.Context, _ Message) error {
+	return ErrEmailDisabled
+}

--- a/backend/internal/hub/mail/disabled_test.go
+++ b/backend/internal/hub/mail/disabled_test.go
@@ -1,0 +1,30 @@
+package mail_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leapmux/leapmux/internal/hub/mail"
+)
+
+// TestDisabledSender_ReturnsSentinel locks in the no-silent-fallback
+// invariant: when SMTP is unconfigured, every Send returns
+// mail.ErrEmailDisabled (not nil, not some opaque wrapped error).
+// `errors.Is` matchability is part of the contract — future code that
+// wants to distinguish "hub email is off" from a transient relay
+// failure must be able to use it.
+func TestDisabledSender_ReturnsSentinel(t *testing.T) {
+	s := mail.NewDisabledSender()
+	err := s.Send(context.Background(), mail.Message{
+		To:      "alice@example.test",
+		Subject: "anything",
+		Body:    "anything\n",
+	})
+	if err == nil {
+		t.Fatal("Send returned nil; disabled sender must never silently succeed")
+	}
+	if !errors.Is(err, mail.ErrEmailDisabled) {
+		t.Errorf("err = %v, want errors.Is(_, ErrEmailDisabled)", err)
+	}
+}

--- a/backend/internal/hub/mail/smtp.go
+++ b/backend/internal/hub/mail/smtp.go
@@ -1,0 +1,299 @@
+package mail
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"mime"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/config"
+)
+
+// SMTPConfig configures an SMTPSender. Production callers fill the first
+// six fields from hub config; the last two are test-only injection
+// points that let smtp_test.go point the sender at an in-process fake
+// without touching the OS's TLS root pool or DNS.
+type SMTPConfig struct {
+	// Host is the SMTP relay's hostname (e.g. "smtp.example.com"). Used
+	// both for the network dial and for TLS ServerName / PlainAuth host
+	// pinning.
+	Host string
+	// Port is the SMTP TCP port. Conventional values: 25 (none), 465
+	// (implicit), 587 (starttls).
+	Port int
+	// Username, when non-empty, triggers SMTP AUTH PLAIN. An empty
+	// Username skips authentication — appropriate for trusted local
+	// relays.
+	Username string
+	// Password is the credential paired with Username.
+	Password string
+	// From is the envelope sender address. Must be a parseable
+	// net/mail.ParseAddress value; the bare local@domain form is used
+	// for SMTP MAIL FROM and the full canonical form for the From:
+	// header.
+	From string
+	// TLSMode selects between starttls / implicit / none. Use the
+	// SmtpTLSMode* constants from internal/hub/config.
+	TLSMode string
+
+	// TLSConfig, when non-nil, overrides the default TLS configuration.
+	// Tests use this to inject a self-signed-cert RootCAs pool. The
+	// SMTPSender always clones this value per Send, so callers can
+	// safely share a single config across goroutines.
+	TLSConfig *tls.Config
+	// Dialer, when non-nil, overrides the default
+	// (&net.Dialer{}).DialContext for the initial TCP connection. Tests
+	// use this to point at a loopback fake without depending on DNS or
+	// OS routing. The hook always produces a raw TCP connection — the
+	// SMTPSender wraps it in TLS as needed.
+	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// SMTPSender delivers Messages over real SMTP. Safe for concurrent use:
+// each Send opens a fresh connection.
+type SMTPSender struct {
+	cfg SMTPConfig
+}
+
+// NewSMTPSender returns a Sender that delivers via the configured SMTP
+// relay. The config is used as-is on each Send, so callers should fully
+// populate it before construction; mid-flight mutation is unsupported.
+func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
+	return &SMTPSender{cfg: cfg}
+}
+
+// Send delivers msg via SMTP. Returns nil on success.
+//
+// The flow:
+//  1. Reject CRLF in addresses and subject (header-injection defense).
+//  2. Parse From / To via net/mail.ParseAddress and remember both the
+//     bare envelope address (for MAIL FROM / RCPT TO) and the canonical
+//     header form (for the From: / To: headers).
+//  3. Clone the TLS config and default ServerName to cfg.Host so
+//     concurrent Send calls and tests can't accidentally disable
+//     hostname verification on a shared config.
+//  4. Dial. For implicit mode, wrap the raw connection with tls.Client
+//     and HandshakeContext(ctx); for STARTTLS, dial in the clear and
+//     issue STARTTLS after EHLO; for none, dial in the clear.
+//  5. Spawn a watchdog goroutine that closes the connection on
+//     ctx.Done(). A local done channel + defer close(done) ensures the
+//     goroutine exits even when ctx is context.Background() (whose
+//     Done() never fires) — without it, every Send would leak a
+//     goroutine.
+//  6. AUTH PLAIN if Username is set.
+//  7. Build RFC 5322 headers + body and write via Data(). The textproto
+//     DotWriter handles dot-stuffing AND \n→\r\n translation, so the
+//     body is written with plain LF line endings.
+func (s *SMTPSender) Send(ctx context.Context, msg Message) error {
+	cfg := s.cfg
+	if err := validateNoCRLF("To", msg.To); err != nil {
+		return err
+	}
+	if err := validateNoCRLF("Subject", msg.Subject); err != nil {
+		return err
+	}
+	if err := validateNoCRLF("From", cfg.From); err != nil {
+		return err
+	}
+
+	toAddr, err := mail.ParseAddress(msg.To)
+	if err != nil {
+		return fmt.Errorf("parse to address: %w", err)
+	}
+	fromAddr, err := mail.ParseAddress(cfg.From)
+	if err != nil {
+		return fmt.Errorf("parse from address: %w", err)
+	}
+
+	// Clone TLSConfig per Send; default ServerName when unset. Cloning
+	// shields concurrent Sends — and any test that injects a shared
+	// *tls.Config — from accidental mutation, and the ServerName
+	// default closes the door on hostname-verification misconfiguration.
+	var tlsCfg *tls.Config
+	if cfg.TLSConfig != nil {
+		tlsCfg = cfg.TLSConfig.Clone()
+	} else {
+		tlsCfg = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	if tlsCfg.ServerName == "" {
+		tlsCfg.ServerName = cfg.Host
+	}
+
+	dial := cfg.Dialer
+	if dial == nil {
+		dial = (&net.Dialer{}).DialContext
+	}
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	conn, err := dial(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("dial smtp: %w", err)
+	}
+	// Watchdog: close the connection on ctx cancellation so EHLO/AUTH/
+	// DATA — none of which are ctx-aware in stdlib — can be interrupted.
+	// done lets the watchdog exit on success even when ctx is Background
+	// (Done never fires, so without done the goroutine would leak).
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	// If ctx has a deadline, propagate it as an I/O deadline for the
+	// rest of the SMTP exchange. Stdlib's smtp.Client doesn't accept a
+	// context, but it does honor net.Conn deadlines.
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	switch cfg.TLSMode {
+	case config.SmtpTLSModeImplicit:
+		// Wrap-after-dial keeps the Dialer hook usable across all three
+		// TLS modes; tls.Dialer{NetDialer: …} only accepts *net.Dialer,
+		// not an arbitrary dial function.
+		tlsConn := tls.Client(conn, tlsCfg)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return fmt.Errorf("tls handshake: %w", err)
+		}
+		conn = tlsConn
+	case config.SmtpTLSModeSTARTTLS, config.SmtpTLSModeNone, "":
+		// Stay plaintext for now; STARTTLS upgrade happens after EHLO.
+	default:
+		_ = conn.Close()
+		return fmt.Errorf("unsupported smtp tls mode: %q", cfg.TLSMode)
+	}
+
+	c, err := smtp.NewClient(conn, cfg.Host)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("smtp greet: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if cfg.TLSMode == config.SmtpTLSModeSTARTTLS {
+		if ok, _ := c.Extension("STARTTLS"); !ok {
+			return errors.New("smtp: server did not advertise STARTTLS")
+		}
+		if err := c.StartTLS(tlsCfg); err != nil {
+			return fmt.Errorf("starttls: %w", err)
+		}
+	}
+
+	if cfg.Username != "" {
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+
+	// Envelope vs header forms: c.Mail / c.Rcpt expect a bare
+	// `local@domain`; the From: / To: headers want the full quoted form
+	// (which includes any display name). Reusing one variable for both
+	// would silently send malformed envelopes when callers add a
+	// display name to From.
+	if err := c.Mail(fromAddr.Address); err != nil {
+		return fmt.Errorf("smtp mail: %w", err)
+	}
+	if err := c.Rcpt(toAddr.Address); err != nil {
+		return fmt.Errorf("smtp rcpt: %w", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+	if err := writeMessage(w, fromAddr, toAddr, msg, cfg.Host); err != nil {
+		return fmt.Errorf("smtp write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp data close: %w", err)
+	}
+	if err := c.Quit(); err != nil {
+		return fmt.Errorf("smtp quit: %w", err)
+	}
+	return nil
+}
+
+// validateNoCRLF rejects any \r or \n in field. Header injection (e.g.
+// To = "victim@x\r\nBcc: leak@y") would otherwise let an attacker who
+// controls one header line inject arbitrary additional headers.
+func validateNoCRLF(name, value string) error {
+	if strings.ContainsAny(value, "\r\n") {
+		return fmt.Errorf("invalid %s: contains CR or LF", name)
+	}
+	return nil
+}
+
+// writeMessage emits an RFC 5322 message: headers, blank line, body.
+// The DotWriter passed in handles \n→\r\n translation and dot-stuffing,
+// so we write with plain LF line endings.
+func writeMessage(w interface {
+	Write([]byte) (int, error)
+}, from, to *mail.Address, msg Message, host string) error {
+	subject := msg.Subject
+	if !isASCII(subject) {
+		// Q-encode non-ASCII subjects per RFC 2047. The output is
+		// "=?utf-8?Q?…?=" or "=?utf-8?q?…?=" depending on stdlib
+		// implementation — both are valid encoded-word framings.
+		subject = mime.QEncoding.Encode("utf-8", subject)
+	}
+
+	headers := []string{
+		"From: " + from.String(),
+		"To: " + to.String(),
+		"Subject: " + subject,
+		"Date: " + time.Now().UTC().Format(time.RFC1123Z),
+		"Message-ID: " + newMessageID(host),
+		"MIME-Version: 1.0",
+		// We deliberately do NOT advertise format=flowed: that profile
+		// would only matter if we implemented flowed-text reflowing,
+		// and the byte-level output already preserves the RFC 3676
+		// signature delimiter on its own.
+		"Content-Type: text/plain; charset=UTF-8",
+		"Content-Transfer-Encoding: 8bit",
+	}
+	header := strings.Join(headers, "\n") + "\n\n"
+	if _, err := w.Write([]byte(header)); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(msg.Body)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// isASCII reports whether s contains only ASCII characters.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+// newMessageID returns a fresh RFC 5322 Message-ID. The local part is
+// 16 bytes of crypto/rand entropy hex-encoded; the domain is the SMTP
+// host so receiving MTAs see a recognizable origin.
+func newMessageID(host string) string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	if host == "" {
+		host = "leapmux.invalid"
+	}
+	return "<" + hex.EncodeToString(b[:]) + "@" + host + ">"
+}

--- a/backend/internal/hub/mail/smtp_test.go
+++ b/backend/internal/hub/mail/smtp_test.go
@@ -1,0 +1,564 @@
+package mail_test
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"mime"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/mail"
+)
+
+// fakeSMTPServer is a minimal in-process SMTP server for unit tests. It
+// handles 220/EHLO/STARTTLS/AUTH/MAIL/RCPT/DATA/QUIT well enough to
+// exercise our SMTPSender code path. It is NOT a production SMTP relay
+// and does not validate inputs beyond what the tests rely on.
+type fakeSMTPServer struct {
+	t *testing.T
+
+	listener net.Listener
+	tlsCfg   *tls.Config // server-side cert (used for STARTTLS or implicit-TLS listener)
+
+	advertiseSTARTTLS bool // when false, EHLO response omits STARTTLS
+	requireImplicit   bool // when true, the listener wraps every accepted conn in TLS
+
+	mu       sync.Mutex
+	received []*receivedMessage
+	authBlob string // last AUTH PLAIN payload (base64), empty if none
+	authUsed bool
+}
+
+type receivedMessage struct {
+	from string
+	to   []string
+	data string
+}
+
+func newFakeSMTPServer(t *testing.T) *fakeSMTPServer {
+	t.Helper()
+	tlsCfg, _ := newSelfSignedTLS(t, "127.0.0.1")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &fakeSMTPServer{
+		t:                 t,
+		listener:          ln,
+		tlsCfg:            tlsCfg,
+		advertiseSTARTTLS: true,
+	}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *fakeSMTPServer) addr() string { return s.listener.Addr().String() }
+
+func (s *fakeSMTPServer) lastMessage() *receivedMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.received) == 0 {
+		return nil
+	}
+	return s.received[len(s.received)-1]
+}
+
+func (s *fakeSMTPServer) lastAuthBlob() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authBlob
+}
+
+func (s *fakeSMTPServer) sawAuth() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authUsed
+}
+
+func (s *fakeSMTPServer) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		if s.requireImplicit {
+			tlsConn := tls.Server(conn, s.tlsCfg)
+			if err := tlsConn.Handshake(); err != nil {
+				_ = conn.Close()
+				continue
+			}
+			conn = tlsConn
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeSMTPServer) handle(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+	writeLine := func(line string) {
+		_, _ = w.WriteString(line + "\r\n")
+		_ = w.Flush()
+	}
+
+	writeLine("220 fake.example.test ESMTP")
+
+	var (
+		envFrom string
+		envTo   []string
+	)
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(strings.ToUpper(line), "EHLO"):
+			writeLine("250-fake.example.test")
+			writeLine("250-AUTH PLAIN")
+			if s.advertiseSTARTTLS {
+				writeLine("250-STARTTLS")
+			}
+			writeLine("250 8BITMIME")
+		case strings.EqualFold(line, "STARTTLS"):
+			writeLine("220 Ready to start TLS")
+			tlsConn := tls.Server(conn, s.tlsCfg)
+			if err := tlsConn.Handshake(); err != nil {
+				return
+			}
+			conn = tlsConn
+			r = bufio.NewReader(conn)
+			w = bufio.NewWriter(conn)
+			writeLine = func(line string) {
+				_, _ = w.WriteString(line + "\r\n")
+				_ = w.Flush()
+			}
+		case strings.HasPrefix(strings.ToUpper(line), "AUTH PLAIN"):
+			fields := strings.Fields(line)
+			s.mu.Lock()
+			s.authUsed = true
+			if len(fields) > 2 {
+				s.authBlob = fields[2]
+			}
+			s.mu.Unlock()
+			writeLine("235 Authentication successful")
+		case strings.HasPrefix(strings.ToUpper(line), "MAIL FROM:"):
+			envFrom = extractAngleAddr(line)
+			writeLine("250 OK")
+		case strings.HasPrefix(strings.ToUpper(line), "RCPT TO:"):
+			envTo = append(envTo, extractAngleAddr(line))
+			writeLine("250 OK")
+		case strings.EqualFold(line, "DATA"):
+			writeLine("354 End data with <CR><LF>.<CR><LF>")
+			var buf strings.Builder
+			for {
+				dataLine, err := r.ReadString('\n')
+				if err != nil {
+					return
+				}
+				if dataLine == ".\r\n" {
+					break
+				}
+				// Undo dot-stuffing.
+				if strings.HasPrefix(dataLine, "..") {
+					dataLine = dataLine[1:]
+				}
+				buf.WriteString(dataLine)
+			}
+			s.mu.Lock()
+			s.received = append(s.received, &receivedMessage{
+				from: envFrom,
+				to:   envTo,
+				data: buf.String(),
+			})
+			s.mu.Unlock()
+			writeLine("250 OK queued")
+			envFrom, envTo = "", nil
+		case strings.EqualFold(line, "QUIT"):
+			writeLine("221 Bye")
+			return
+		case strings.EqualFold(line, "RSET"):
+			envFrom, envTo = "", nil
+			writeLine("250 OK")
+		default:
+			writeLine("500 unknown command")
+		}
+	}
+}
+
+// extractAngleAddr pulls the bare email out of "MAIL FROM:<addr>" /
+// "RCPT TO:<addr>" lines. Returns "" if no angle-bracket address is
+// present, which the tests treat as a failure.
+func extractAngleAddr(s string) string {
+	lt := strings.IndexByte(s, '<')
+	gt := strings.LastIndexByte(s, '>')
+	if lt < 0 || gt < 0 || gt <= lt {
+		return ""
+	}
+	return s[lt+1 : gt]
+}
+
+// newSelfSignedTLS mints a single-use ECDSA self-signed certificate
+// covering the given hostnames/IPs. Returns the server-side
+// *tls.Config and a *x509.CertPool the client can trust.
+func newSelfSignedTLS(t *testing.T, hosts ...string) (*tls.Config, *x509.CertPool) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "leapmux-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+	pool := x509.NewCertPool()
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool.AddCert(parsed)
+	return &tls.Config{Certificates: []tls.Certificate{cert}}, pool
+}
+
+// dialerToHostPort returns an SMTPConfig.Dialer that ignores the addr
+// argument and always connects to the fake server's actual port. We
+// still set Host="127.0.0.1" so PlainAuth's localhost rule is happy and
+// TLS ServerName matches the cert SAN.
+func dialerToHostPort(target string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, _ string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, network, target)
+	}
+}
+
+func TestSMTPSender_None_PlaintextDelivery(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.advertiseSTARTTLS = false
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    25,
+		From:    "Hub <hub@example.test>",
+		TLSMode: "none",
+		Dialer:  dialerToHostPort(srv.addr()),
+	})
+	if err := sender.Send(context.Background(), mail.Message{
+		To:      "alice@example.test",
+		Subject: "[LeapMux] Verify your email address",
+		Body:    "hello\n-- \nfooter\n",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	got := srv.lastMessage()
+	if got == nil {
+		t.Fatal("server received no message")
+	}
+	if got.from != "hub@example.test" {
+		t.Errorf("envelope From = %q, want bare envelope address", got.from)
+	}
+	if len(got.to) != 1 || got.to[0] != "alice@example.test" {
+		t.Errorf("envelope To = %v, want [alice@example.test]", got.to)
+	}
+	if !strings.Contains(got.data, "From: \"Hub\" <hub@example.test>") {
+		t.Errorf("From: header missing display-name form: %q", got.data)
+	}
+	if !strings.Contains(got.data, "Subject: [LeapMux] Verify your email address") {
+		t.Errorf("Subject header missing: %q", got.data)
+	}
+	if !strings.Contains(got.data, "\nhello\r\n-- \r\nfooter\r\n") {
+		t.Errorf("body bytes do not match expected wire form (DotWriter LF→CRLF): %q", got.data)
+	}
+	if srv.sawAuth() {
+		t.Error("AUTH was used despite empty Username")
+	}
+}
+
+func TestSMTPSender_None_AuthPLAIN(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.advertiseSTARTTLS = false
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:     "127.0.0.1",
+		Port:     25,
+		Username: "alice",
+		Password: "s3cret",
+		From:     "hub@example.test",
+		TLSMode:  "none",
+		Dialer:   dialerToHostPort(srv.addr()),
+	})
+	if err := sender.Send(context.Background(), mail.Message{
+		To:      "bob@example.test",
+		Subject: "x",
+		Body:    "y\n",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !srv.sawAuth() {
+		t.Fatal("expected AUTH PLAIN, got none")
+	}
+	// RFC 4616: the SASL PLAIN payload is base64("\0" username "\0" password).
+	raw, err := base64.StdEncoding.DecodeString(srv.lastAuthBlob())
+	if err != nil {
+		t.Fatalf("decode auth blob: %v", err)
+	}
+	want := "\x00alice\x00s3cret"
+	if string(raw) != want {
+		t.Errorf("AUTH PLAIN payload = %q, want %q", string(raw), want)
+	}
+}
+
+func TestSMTPSender_STARTTLS_Upgrade(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	// Use the fake server's actual cert for client trust.
+	// (newSelfSignedTLS mints a fresh cert each call, so we can't reuse
+	// the result of an additional call here.)
+	clientPool := poolFromServerCfg(t, srv.tlsCfg)
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    587,
+		From:    "hub@example.test",
+		TLSMode: "starttls",
+		TLSConfig: &tls.Config{
+			RootCAs:    clientPool,
+			ServerName: "127.0.0.1",
+		},
+		Dialer: dialerToHostPort(srv.addr()),
+	})
+	if err := sender.Send(context.Background(), mail.Message{
+		To:      "alice@example.test",
+		Subject: "starttls",
+		Body:    "body\n",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := srv.lastMessage(); got == nil {
+		t.Fatal("no message received after STARTTLS upgrade")
+	}
+}
+
+func TestSMTPSender_STARTTLS_RequiredButMissing(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.advertiseSTARTTLS = false
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    587,
+		From:    "hub@example.test",
+		TLSMode: "starttls",
+		Dialer:  dialerToHostPort(srv.addr()),
+	})
+	err := sender.Send(context.Background(), mail.Message{
+		To: "alice@example.test", Subject: "x", Body: "y\n",
+	})
+	if err == nil || !strings.Contains(err.Error(), "STARTTLS") {
+		t.Fatalf("expected STARTTLS error, got %v", err)
+	}
+}
+
+func TestSMTPSender_Implicit_TLSDelivery(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.requireImplicit = true
+	clientPool := poolFromServerCfg(t, srv.tlsCfg)
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    465,
+		From:    "hub@example.test",
+		TLSMode: "implicit",
+		TLSConfig: &tls.Config{
+			RootCAs:    clientPool,
+			ServerName: "127.0.0.1",
+		},
+		Dialer: dialerToHostPort(srv.addr()),
+	})
+	if err := sender.Send(context.Background(), mail.Message{
+		To:      "alice@example.test",
+		Subject: "implicit",
+		Body:    "body\n",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := srv.lastMessage(); got == nil {
+		t.Fatal("no message received over implicit TLS")
+	}
+}
+
+func TestSMTPSender_RejectsHeaderInjection(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.advertiseSTARTTLS = false
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    25,
+		From:    "hub@example.test",
+		TLSMode: "none",
+		Dialer:  dialerToHostPort(srv.addr()),
+	})
+	cases := []struct {
+		name string
+		msg  mail.Message
+	}{
+		{
+			name: "CRLF in To",
+			msg:  mail.Message{To: "victim@x.test\r\nBcc: leak@y.test", Subject: "ok", Body: "b\n"},
+		},
+		{
+			name: "CRLF in Subject",
+			msg:  mail.Message{To: "victim@x.test", Subject: "ok\r\nBcc: leak", Body: "b\n"},
+		},
+		{
+			name: "LF only in To",
+			msg:  mail.Message{To: "victim@x.test\nBcc: leak@y.test", Subject: "ok", Body: "b\n"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sender.Send(context.Background(), tc.msg)
+			if err == nil || !strings.Contains(err.Error(), "CR or LF") {
+				t.Fatalf("expected header-injection rejection, got %v", err)
+			}
+		})
+	}
+	if got := srv.lastMessage(); got != nil {
+		t.Errorf("server should not have received any message; got %+v", got)
+	}
+}
+
+func TestSMTPSender_SubjectEncoding(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+	srv.advertiseSTARTTLS = false
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    25,
+		From:    "hub@example.test",
+		TLSMode: "none",
+		Dialer:  dialerToHostPort(srv.addr()),
+	})
+
+	t.Run("ASCII subject is not encoded", func(t *testing.T) {
+		if err := sender.Send(context.Background(), mail.Message{
+			To: "alice@example.test", Subject: "Plain ASCII", Body: "b\n",
+		}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		got := srv.lastMessage()
+		if !strings.Contains(got.data, "\r\nSubject: Plain ASCII\r\n") {
+			t.Errorf("ASCII subject must pass through unchanged: %q", got.data)
+		}
+	})
+
+	t.Run("non-ASCII subject is RFC 2047 encoded-word", func(t *testing.T) {
+		const original = "héllo wörld"
+		if err := sender.Send(context.Background(), mail.Message{
+			To: "alice@example.test", Subject: original, Body: "b\n",
+		}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		got := srv.lastMessage()
+		// Find the Subject header line.
+		var subjectLine string
+		for _, line := range strings.Split(got.data, "\r\n") {
+			if strings.HasPrefix(line, "Subject: ") {
+				subjectLine = strings.TrimPrefix(line, "Subject: ")
+				break
+			}
+		}
+		if subjectLine == "" {
+			t.Fatalf("no Subject header in body: %q", got.data)
+		}
+		// Assert encoded-word framing — the Q-vs-q letter case is
+		// implementation-defined by stdlib, so don't pin it.
+		if !strings.HasPrefix(strings.ToLower(subjectLine), "=?utf-8?") || !strings.HasSuffix(subjectLine, "?=") {
+			t.Errorf("expected RFC 2047 encoded-word framing, got %q", subjectLine)
+		}
+		// Round-trip via mime.WordDecoder: the decoded subject must
+		// match the original.
+		dec := &mime.WordDecoder{}
+		decoded, err := dec.DecodeHeader(subjectLine)
+		if err != nil {
+			t.Fatalf("decode subject: %v", err)
+		}
+		if decoded != original {
+			t.Errorf("round-trip mismatch: got %q, want %q", decoded, original)
+		}
+	})
+}
+
+func TestSMTPSender_ContextCancelledBeforeDial(t *testing.T) {
+	srv := newFakeSMTPServer(t)
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    25,
+		From:    "hub@example.test",
+		TLSMode: "none",
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Honor the context the sender hands us.
+			var d net.Dialer
+			return d.DialContext(ctx, network, srv.addr())
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := sender.Send(ctx, mail.Message{
+		To: "alice@example.test", Subject: "x", Body: "y\n",
+	})
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected wrapped context.Canceled, got %v", err)
+	}
+}
+
+// poolFromServerCfg lifts the leaf cert from a server-side *tls.Config
+// (where it lives as a tls.Certificate) into a *x509.CertPool the
+// client can trust. Avoids re-minting cert material per test.
+func poolFromServerCfg(t *testing.T, cfg *tls.Config) *x509.CertPool {
+	t.Helper()
+	if len(cfg.Certificates) == 0 || len(cfg.Certificates[0].Certificate) == 0 {
+		t.Fatal("server tls config has no certificates")
+	}
+	leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse server cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+	return pool
+}

--- a/backend/internal/hub/mail/stub.go
+++ b/backend/internal/hub/mail/stub.go
@@ -1,27 +1,24 @@
 package mail
 
-import (
-	"context"
-	"log/slog"
-)
+import "context"
 
-// StubSender is the default Sender. It logs every outgoing message at
-// info level, including the full body, so developers can copy
-// verification codes / registration commands straight from the hub's
-// stdout. A production backend will replace this.
+// StubSender is a TEST-ONLY Sender that silently accepts every Message
+// and returns nil. Use it in unit tests that need a non-nil Sender but
+// don't assert on body content.
+//
+// Production wiring picks between SMTPSender (when SMTP is configured)
+// and disabledSender (when it isn't); StubSender is not used in either
+// path. Do not log message bodies here — verification codes are
+// credentials, and logging them leaks them into log aggregation
+// pipelines.
 type StubSender struct{}
 
-// NewStubSender returns a Sender that logs messages instead of sending.
+// NewStubSender returns a TEST-ONLY Sender that silently succeeds.
 func NewStubSender() *StubSender { return &StubSender{} }
 
-// Send logs the message and returns nil. It never fails so callers can
-// rely on it during development without conditioning behavior on the
-// dispatch outcome.
-func (s *StubSender) Send(_ context.Context, msg Message) error {
-	slog.Info("[mail-stub] would send",
-		"to", msg.To,
-		"subject", msg.Subject,
-		"body", msg.Body,
-	)
+// Send silently accepts the message and returns nil. It never fails so
+// callers can rely on it during tests without conditioning behavior on
+// the dispatch outcome.
+func (s *StubSender) Send(_ context.Context, _ Message) error {
 	return nil
 }

--- a/backend/internal/hub/mail/templates.go
+++ b/backend/internal/hub/mail/templates.go
@@ -7,38 +7,129 @@ import (
 	"github.com/leapmux/leapmux/internal/util/verifycode"
 )
 
-// RenderVerificationEmail builds the verification email containing both a
-// short hand-typeable code and a one-click link. The same code backs both
-// — the link just deep-links to the frontend page that submits it.
-func RenderVerificationEmail(to, storedCode, link string) Message {
+// footerSeparator is the literal RFC 3676 §4.3 signature delimiter:
+// dash, dash, space, newline. The trailing space is intentional and
+// editors that trim trailing whitespace will silently break it — the
+// strict-byte tests in templates_test.go pin this exact sequence.
+const footerSeparator = "-- \n"
+
+// verifyEmailPath is the frontend route that consumes the verification
+// code from the deep-link in the verification email. Centralizing the
+// constant here keeps the renderer the single owner of "how a
+// verification link is built" — callers only know the code, not the URL
+// shape.
+const verifyEmailPath = "/verify-email?code="
+
+// Renderer builds the email Messages this package sends. It carries
+// the hub's public base URL once so render call sites only pass
+// per-message data (recipient, code, command). The zero value
+// Renderer{} is valid; tests that don't inspect URLs in the rendered
+// output use it directly.
+type Renderer struct {
+	// HubURL is the absolute base URL the hub exposes (cfg.BaseURL()).
+	// Used in two places: the absolute /verify-email link in the
+	// verification email body, and the auto-message footer in every
+	// email's body.
+	HubURL string
+}
+
+// footer renders the standard auto-message footer naming LeapMux and
+// the hub's public URL. Every email this package sends uses this
+// footer so recipients can identify the sender and know the mailbox is
+// unattended.
+func (r Renderer) footer() string {
+	return footerSeparator +
+		"This is an automated message from your LeapMux hub at " + r.HubURL + ".\n" +
+		"Please do not reply.\n"
+}
+
+// VerificationEmail builds the email that delivers a verification code
+// to confirm a new or changed email address.
+//
+// Sent when:
+//   - Password sign-up with email when EmailVerificationRequired=true.
+//   - OAuth sign-up when the provider's email is untrusted.
+//   - User requests an email change.
+//   - User requests a resend of a previously-issued code.
+//
+// Inputs: `to` is the recipient's email address; `storedCode` is the
+// raw 6-symbol verifycode (this method calls verifycode.Format to
+// render the user-facing XXX-XXX form, and reuses the formatted code
+// in the deep-link).
+//
+// Rendered body:
+//
+//	Use this code to verify your email address:
+//
+//	    {code}
+//
+//	Or click the link below:
+//
+//	    {link}
+//
+//	The code expires in 30 minutes.
+//
+//	-- ␠
+//	This is an automated message from your LeapMux hub at {hubURL}.
+//	Please do not reply.
+//
+// (The "␠" marker stands in for a literal trailing space on the "-- "
+// signature delimiter; see RFC 3676 §4.3.)
+func (r Renderer) VerificationEmail(to, storedCode string) Message {
 	display := verifycode.Format(storedCode)
+	link := r.HubURL + verifyEmailPath + display
 	var body strings.Builder
-	body.WriteString("Your verification code:\n\n    ")
+	body.WriteString("Use this code to verify your email address:\n\n    ")
 	body.WriteString(display)
-	body.WriteString("\n\n")
-	body.WriteString("Or click this link:\n    ")
+	body.WriteString("\n\nOr click the link below:\n\n    ")
 	body.WriteString(link)
-	body.WriteString("\n\nThis code expires in 30 minutes.\n")
+	body.WriteString("\n\nThe code expires in 30 minutes.\n\n")
+	body.WriteString(r.footer())
 	return Message{
 		To:      to,
-		Subject: "Verify your email",
+		Subject: "[LeapMux] Verify your email address",
 		Body:    body.String(),
 	}
 }
 
-// RenderRegistrationInstructions builds the email a user sends to
-// themselves when they want to set up a worker on another machine.
-// The body is the exact command line; the recipient pastes it into a
-// terminal on the worker host.
-func RenderRegistrationInstructions(to, command string) Message {
+// RegistrationInstructions builds the email a user sends to themselves
+// when they want to set up a worker on another machine.
+//
+// Sent when: the user clicks "Send email" in the worker registration
+// dialog (frontend → WorkerManagementService.EmailRegistrationInstructions).
+//
+// Inputs: `to` is the user's verified email address; `command` is the
+// full `leapmux worker --hub … --registration-key …` shell command.
+//
+// Rendered body:
+//
+//	Here's the worker registration command you asked LeapMux to send.
+//
+//	Run it on the machine where the worker should run:
+//
+//	    {command}
+//
+//	The registration key only works while the dialog stays open in
+//	your browser, so keep that tab open until the command finishes.
+//
+//	-- ␠
+//	This is an automated message from your LeapMux hub at {hubURL}.
+//	Please do not reply.
+//
+// (The "␠" marker stands in for a literal trailing space on the "-- "
+// signature delimiter; see RFC 3676 §4.3.)
+func (r Renderer) RegistrationInstructions(to, command string) Message {
 	body := fmt.Sprintf(
-		"Run the command below on the machine where the worker should run:\n\n    %s\n\n"+
-			"This registration key is only valid while the registration dialog stays open in your browser.\n",
+		"Here's the worker registration command you asked LeapMux to send.\n\n"+
+			"Run it on the machine where the worker should run:\n\n    %s\n\n"+
+			"The registration key only works while the dialog stays open in your browser, "+
+			"so keep that tab open until the command finishes.\n\n%s",
 		command,
+		r.footer(),
 	)
 	return Message{
 		To:      to,
-		Subject: "Worker registration command",
+		Subject: "[LeapMux] Your worker registration command",
 		Body:    body,
 	}
 }

--- a/backend/internal/hub/mail/templates_test.go
+++ b/backend/internal/hub/mail/templates_test.go
@@ -1,0 +1,154 @@
+package mail_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/leapmux/leapmux/internal/hub/mail"
+)
+
+// expectedVerificationBody and expectedRegistrationBody build the
+// strict-byte expected output of the two render methods. They are
+// constructed via string concatenation rather than a backtick raw-string
+// literal so that editor save-on-format hooks cannot strip the trailing
+// space on the "-- " (dash-dash-space) RFC 3676 §4.3 signature
+// delimiter. If you need to update the template wording, also update
+// these expectations.
+const verificationFooterTrailingSpace = "-- " // intentional trailing space
+
+func expectedVerificationBody(formattedCode, link, hubURL string) string {
+	var b strings.Builder
+	b.WriteString("Use this code to verify your email address:\n\n    ")
+	b.WriteString(formattedCode)
+	b.WriteString("\n\nOr click the link below:\n\n    ")
+	b.WriteString(link)
+	b.WriteString("\n\nThe code expires in 30 minutes.\n\n")
+	b.WriteString(verificationFooterTrailingSpace + "\n")
+	b.WriteString("This is an automated message from your LeapMux hub at " + hubURL + ".\n")
+	b.WriteString("Please do not reply.\n")
+	return b.String()
+}
+
+func expectedRegistrationBody(command, hubURL string) string {
+	var b strings.Builder
+	b.WriteString("Here's the worker registration command you asked LeapMux to send.\n\n")
+	b.WriteString("Run it on the machine where the worker should run:\n\n    ")
+	b.WriteString(command)
+	b.WriteString("\n\n")
+	b.WriteString("The registration key only works while the dialog stays open in your browser, ")
+	b.WriteString("so keep that tab open until the command finishes.\n\n")
+	b.WriteString(verificationFooterTrailingSpace + "\n")
+	b.WriteString("This is an automated message from your LeapMux hub at " + hubURL + ".\n")
+	b.WriteString("Please do not reply.\n")
+	return b.String()
+}
+
+// TestRenderer_VerificationEmail_Bytes is the exactness oracle for the
+// verification email's body. It pins every byte including the trailing
+// space on "-- ", the blank line before the link, and the {hubURL}
+// substitution in the footer.
+func TestRenderer_VerificationEmail_Bytes(t *testing.T) {
+	const storedCode = "ABC234"
+	const formatted = "ABC-234"
+	const hubURL = "https://hub.example.com"
+	link := hubURL + "/verify-email?code=" + formatted
+
+	r := mail.Renderer{HubURL: hubURL}
+	msg := r.VerificationEmail("alice@example.test", storedCode)
+
+	if msg.To != "alice@example.test" {
+		t.Errorf("To = %q, want %q", msg.To, "alice@example.test")
+	}
+	if msg.Subject != "[LeapMux] Verify your email address" {
+		t.Errorf("Subject = %q, want %q", msg.Subject, "[LeapMux] Verify your email address")
+	}
+
+	want := expectedVerificationBody(formatted, link, hubURL)
+	if msg.Body != want {
+		t.Errorf("Body bytes mismatch.\n got: %q\nwant: %q", msg.Body, want)
+	}
+	if !strings.Contains(msg.Body, "\n-- \n") {
+		t.Error("body must contain the literal RFC 3676 §4.3 signature delimiter \"\\n-- \\n\" (dash-dash-space-newline)")
+	}
+}
+
+// TestRenderer_RegistrationInstructions_Bytes pins the worker
+// registration email's body byte-for-byte.
+func TestRenderer_RegistrationInstructions_Bytes(t *testing.T) {
+	const command = "leapmux worker --hub https://hub.example.com --registration-key abc123"
+	const hubURL = "https://hub.example.com"
+
+	r := mail.Renderer{HubURL: hubURL}
+	msg := r.RegistrationInstructions("bob@example.test", command)
+
+	if msg.To != "bob@example.test" {
+		t.Errorf("To = %q, want %q", msg.To, "bob@example.test")
+	}
+	if msg.Subject != "[LeapMux] Your worker registration command" {
+		t.Errorf("Subject = %q, want %q", msg.Subject, "[LeapMux] Your worker registration command")
+	}
+
+	want := expectedRegistrationBody(command, hubURL)
+	if msg.Body != want {
+		t.Errorf("Body bytes mismatch.\n got: %q\nwant: %q", msg.Body, want)
+	}
+	if !strings.Contains(msg.Body, "\n-- \n") {
+		t.Error("body must contain the literal RFC 3676 §4.3 signature delimiter \"\\n-- \\n\" (dash-dash-space-newline)")
+	}
+}
+
+// printForExample renders the message for a testable Example. The
+// trailing space on the signature delimiter "-- " is rewritten as
+// "-- ␠" (open-box marker) so the // Output: block survives editor
+// trailing-whitespace stripping. The strict-byte tests above are the
+// real source of truth for wire bytes.
+func printForExample(msg mail.Message) string {
+	visible := strings.ReplaceAll(msg.Body, verificationFooterTrailingSpace+"\n", "-- ␠\n")
+	return msg.Subject + "\n\n" + visible
+}
+
+func ExampleRenderer_VerificationEmail() {
+	r := mail.Renderer{HubURL: "https://hub.example.com"}
+	msg := r.VerificationEmail("alice@example.test", "ABC234")
+	fmt.Print(printForExample(msg))
+	// Output:
+	// [LeapMux] Verify your email address
+	//
+	// Use this code to verify your email address:
+	//
+	//     ABC-234
+	//
+	// Or click the link below:
+	//
+	//     https://hub.example.com/verify-email?code=ABC-234
+	//
+	// The code expires in 30 minutes.
+	//
+	// -- ␠
+	// This is an automated message from your LeapMux hub at https://hub.example.com.
+	// Please do not reply.
+}
+
+func ExampleRenderer_RegistrationInstructions() {
+	r := mail.Renderer{HubURL: "https://hub.example.com"}
+	msg := r.RegistrationInstructions(
+		"bob@example.test",
+		"leapmux worker --hub https://hub.example.com --registration-key abc123",
+	)
+	fmt.Print(printForExample(msg))
+	// Output:
+	// [LeapMux] Your worker registration command
+	//
+	// Here's the worker registration command you asked LeapMux to send.
+	//
+	// Run it on the machine where the worker should run:
+	//
+	//     leapmux worker --hub https://hub.example.com --registration-key abc123
+	//
+	// The registration key only works while the dialog stays open in your browser, so keep that tab open until the command finishes.
+	//
+	// -- ␠
+	// This is an automated message from your LeapMux hub at https://hub.example.com.
+	// Please do not reply.
+}

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -29,12 +29,14 @@ type AuthService struct {
 	sessionCache *auth.SessionCache
 	keystore     *keystore.Keystore
 	mail         mail.Sender
+	renderer     mail.Renderer
 	hasAnyUser   atomic.Bool // one-way latch: once true, never re-queried
 }
 
-// NewAuthService creates a new AuthService.
-func NewAuthService(st store.Store, cfg *config.Config, sc *auth.SessionCache, ks *keystore.Keystore, sender mail.Sender) *AuthService {
-	return &AuthService{store: st, cfg: cfg, sessionCache: sc, keystore: ks, mail: sender}
+// NewAuthService creates a new AuthService. renderer carries the hub's
+// public URL used to build absolute deep-links in verification emails.
+func NewAuthService(st store.Store, cfg *config.Config, sc *auth.SessionCache, ks *keystore.Keystore, sender mail.Sender, renderer mail.Renderer) *AuthService {
+	return &AuthService{store: st, cfg: cfg, sessionCache: sc, keystore: ks, mail: sender, renderer: renderer}
 }
 
 // checkHasAnyUser returns true if at least one user exists. The result is
@@ -206,7 +208,7 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		// user: signup succeeds and the frontend surfaces a Resend prompt
 		// driven by verification_email_sent=false. The pending row stays
 		// in place so a future Resend can reuse the same address slot.
-		emailSent, err := issuePendingEmailVerification(ctx, s.store, s.mail, user.ID, email)
+		emailSent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, user.ID, email)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
@@ -351,6 +353,7 @@ func (s *AuthService) GetSystemInfo(ctx context.Context, req *connect.Request[le
 		Branch:        version.Branch,
 		OauthEnabled:  len(providers) > 0,
 		WorkerHubUrl:  workerHubURL,
+		EmailEnabled:  s.cfg.SmtpHost != "",
 	}), nil
 }
 
@@ -360,6 +363,11 @@ func (s *AuthService) GetOAuthProviders(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
+	// Sourced from cfg directly, not s.renderer.HubURL — the renderer is
+	// the email-templating seam; OAuth login URLs are an unrelated kind
+	// of absolute URL the OAuth flow needs the frontend to redirect to.
+	// They happen to resolve to the same value today, but they're
+	// conceptually different and should not be conflated.
 	baseURL := s.cfg.BaseURL()
 
 	var pbProviders []*leapmuxv1.OAuthProviderInfo
@@ -511,7 +519,7 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	// SMTP send failed but the row was written.
 	emailSent := false
 	if pendingEmail != "" {
-		sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, user.ID, pendingEmail)
+		sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, user.ID, pendingEmail)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -37,7 +37,7 @@ func setupAuthTestServerBase(t *testing.T, cfg *config.Config) (leapmuxv1connect
 	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(path, handler)
 
@@ -205,7 +205,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
-	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender())
+	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
 	server := httptest.NewServer(mux)
@@ -413,11 +413,11 @@ func setupVerificationGatingTestServer(t *testing.T, emailVerificationRequired b
 	cfg.SignupEnabled = true
 	cfg.EmailVerificationRequired = emailVerificationRequired
 
-	userSvc := service.NewUserService(st, cfg, nil, mail.NewStubSender())
+	userSvc := service.NewUserService(st, cfg, nil, mail.NewStubSender(), mail.Renderer{})
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(userPath, userHandler)
 
-	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(authPath, authHandler)
 
@@ -562,7 +562,7 @@ func setupAuthTestServerWithKeystore(t *testing.T, cfg *config.Config) (leapmuxv
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(path, handler)
 
@@ -819,7 +819,7 @@ func TestSetupSignUp_RejectedInSoloMode(t *testing.T) {
 	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(path, handler)
 
@@ -974,6 +974,30 @@ func TestGetSystemInfo_WorkerHubURL(t *testing.T) {
 		resp, err := client.GetSystemInfo(context.Background(), connect.NewRequest(&leapmuxv1.GetSystemInfoRequest{}))
 		require.NoError(t, err)
 		assert.Empty(t, resp.Msg.GetWorkerHubUrl())
+	})
+}
+
+// TestGetSystemInfo_EmailEnabled covers the email_enabled flag the
+// frontend reads to decide whether to render the "Send email" button on
+// the worker registration dialog. We mirror it directly off SmtpHost so
+// admins control it through the same SMTP block they configure for
+// verification emails.
+func TestGetSystemInfo_EmailEnabled(t *testing.T) {
+	t.Run("false when SmtpHost is empty", func(t *testing.T) {
+		client, _ := setupEmptyAuthTestServer(t, testConfig())
+		resp, err := client.GetSystemInfo(context.Background(), connect.NewRequest(&leapmuxv1.GetSystemInfoRequest{}))
+		require.NoError(t, err)
+		assert.False(t, resp.Msg.GetEmailEnabled())
+	})
+
+	t.Run("true when SmtpHost is set", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.SmtpHost = "smtp.example.test"
+		cfg.SmtpFromAddress = "hub@example.test"
+		client, _ := setupEmptyAuthTestServer(t, cfg)
+		resp, err := client.GetSystemInfo(context.Background(), connect.NewRequest(&leapmuxv1.GetSystemInfoRequest{}))
+		require.NoError(t, err)
+		assert.True(t, resp.Msg.GetEmailEnabled())
 	})
 }
 

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -60,7 +60,7 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
 
-	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender()), opts)
+	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender(), mail.Renderer{}), opts)
 	mux.Handle(authPath, authHandler)
 
 	connPath, connHandler := leapmuxv1connect.NewWorkerConnectorServiceHandler(
@@ -68,7 +68,7 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	mux.Handle(connPath, connHandler)
 
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(
-		service.NewWorkerManagementService(st, wMgr, nil, nil, mail.NewStubSender()), opts)
+		service.NewWorkerManagementService(st, wMgr, nil, nil, mail.NewStubSender(), mail.Renderer{}, cfg), opts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
 	channelSvc := service.NewChannelService(st, wMgr, cMgr, pendingReqs)

--- a/backend/internal/hub/service/create_user.go
+++ b/backend/internal/hub/service/create_user.go
@@ -248,7 +248,7 @@ func ClearCompetingPendingEmails(ctx context.Context, st store.Store, email, own
 // place so signup / OAuth-signup / Resend callers can let the user try
 // again via Resend. Email-change callers should use
 // issuePendingEmailVerificationOrRollback instead.
-func issuePendingEmailVerification(ctx context.Context, st store.Store, sender mail.Sender, userID, email string) (bool, error) {
+func issuePendingEmailVerification(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) (bool, error) {
 	if err := CheckEmailAvailable(ctx, st, email, userID); err != nil {
 		return false, err
 	}
@@ -263,8 +263,7 @@ func issuePendingEmailVerification(ctx context.Context, st store.Store, sender m
 		return false, fmt.Errorf("set pending email: %w", err)
 	}
 
-	link := "/verify-email?code=" + verifycode.Format(storedCode)
-	if err := sender.Send(ctx, mail.RenderVerificationEmail(email, storedCode, link)); err != nil {
+	if err := sender.Send(ctx, renderer.VerificationEmail(email, storedCode)); err != nil {
 		return false, nil
 	}
 	return true, nil
@@ -275,8 +274,8 @@ func issuePendingEmailVerification(ctx context.Context, st store.Store, sender m
 // pending_email row before returning the error so the user can retry
 // from a clean slate. Used by the email-change flow where the failure
 // is surfaced to the user inline.
-func issuePendingEmailVerificationOrRollback(ctx context.Context, st store.Store, sender mail.Sender, userID, email string) error {
-	sent, err := issuePendingEmailVerification(ctx, st, sender, userID, email)
+func issuePendingEmailVerificationOrRollback(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) error {
+	sent, err := issuePendingEmailVerification(ctx, st, sender, renderer, userID, email)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/hub/service/create_user_test.go
+++ b/backend/internal/hub/service/create_user_test.go
@@ -46,7 +46,7 @@ func TestSetPendingEmailWithToken_RejectsAlreadyVerifiedEmail(t *testing.T) {
 	userB := createSimpleUser(t, st, "user-b", "")
 
 	// User B tries to set pending_email to the already-verified address.
-	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, userB.ID, "taken@example.com")
+	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, mail.Renderer{HubURL: "https://hub.example.test"}, userB.ID, "taken@example.com")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already in use")
 
@@ -63,7 +63,7 @@ func TestSetPendingEmailWithToken_StoresPendingForUnclaimedEmail(t *testing.T) {
 
 	user := createSimpleUser(t, st, "user-a", "")
 
-	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, user.ID, "free@example.com")
+	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, mail.Renderer{HubURL: "https://hub.example.test"}, user.ID, "free@example.com")
 	require.NoError(t, err)
 
 	// The row stays pending until the user submits a code via UserService.VerifyEmail.

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -315,7 +315,7 @@ func setupOAuthTestServerWithAuthService(t *testing.T) (
 	// Register AuthService ConnectRPC routes.
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
 	opts := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, cfg, nil, ks, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, nil, ks, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(path, handler)
 

--- a/backend/internal/hub/service/org_service_test.go
+++ b/backend/internal/hub/service/org_service_test.go
@@ -54,7 +54,7 @@ func setupOrgTestServer(t *testing.T) *orgTestEnv {
 	orgPath, orgHandler := leapmuxv1connect.NewOrgServiceHandler(orgSvc, opts)
 	mux.Handle(orgPath, orgHandler)
 
-	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, nil, nil, mail.NewStubSender(), mail.Renderer{})
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(authPath, authHandler)
 

--- a/backend/internal/hub/service/test_helpers_test.go
+++ b/backend/internal/hub/service/test_helpers_test.go
@@ -37,3 +37,16 @@ func testConfigWithSignup() *config.Config {
 	cfg.SignupEnabled = true
 	return cfg
 }
+
+// testConfigWithSMTP returns a Config that looks (to consumers) like the
+// admin configured an SMTP relay. Tests that exercise email-using RPCs
+// like EmailRegistrationInstructions need this so the FailedPrecondition
+// check at the top of the handler doesn't short-circuit them.
+func testConfigWithSMTP() *config.Config {
+	cfg := testConfig()
+	cfg.SmtpHost = "smtp.example.test"
+	cfg.SmtpPort = 587
+	cfg.SmtpFromAddress = "hub@example.test"
+	cfg.SmtpTLSMode = config.SmtpTLSModeSTARTTLS
+	return cfg
+}

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -88,11 +88,14 @@ type UserService struct {
 	cfg          *config.Config
 	sessionCache *auth.SessionCache
 	mail         mail.Sender
+	renderer     mail.Renderer
 }
 
-// NewUserService creates a new UserService.
-func NewUserService(st store.Store, cfg *config.Config, sc *auth.SessionCache, sender mail.Sender) *UserService {
-	return &UserService{store: st, cfg: cfg, sessionCache: sc, mail: sender}
+// NewUserService creates a new UserService. renderer carries the hub's
+// public URL used to build absolute deep-links in the verification
+// emails sent on email-change and resend.
+func NewUserService(st store.Store, cfg *config.Config, sc *auth.SessionCache, sender mail.Sender, renderer mail.Renderer) *UserService {
+	return &UserService{store: st, cfg: cfg, sessionCache: sc, mail: sender, renderer: renderer}
 }
 
 func (s *UserService) UpdateProfile(ctx context.Context, req *connect.Request[leapmuxv1.UpdateProfileRequest]) (*connect.Response[leapmuxv1.UpdateProfileResponse], error) {
@@ -219,7 +222,7 @@ func (s *UserService) RequestEmailChange(ctx context.Context, req *connect.Reque
 	// Non-admin, verification required: set pending email and dispatch
 	// the verification mail. On send failure the helper rolls back the
 	// row so the user can retry from a clean slate.
-	if err := issuePendingEmailVerificationOrRollback(ctx, s.store, s.mail, user.ID, newEmail); err != nil {
+	if err := issuePendingEmailVerificationOrRollback(ctx, s.store, s.mail, s.renderer, user.ID, newEmail); err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
 
@@ -266,7 +269,7 @@ func (s *UserService) ResendVerificationEmail(ctx context.Context, _ *connect.Re
 		}
 	}
 
-	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, full.ID, full.PendingEmail)
+	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, full.ID, full.PendingEmail)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -45,7 +45,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	err = st.Migrator().Migrate(context.Background())
 	require.NoError(t, err)
 
-	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender())
+	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender(), mail.Renderer{})
 
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
@@ -102,7 +102,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	err = st.Migrator().Migrate(context.Background())
 	require.NoError(t, err)
 
-	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender())
+	userSvc := service.NewUserService(st, testConfig(), nil, mail.NewStubSender(), mail.Renderer{})
 
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
@@ -469,7 +469,7 @@ func setupVerificationUserTestServer(t *testing.T) (leapmuxv1connect.UserService
 	cfg := testConfig()
 	cfg.EmailVerificationRequired = true
 
-	userSvc := service.NewUserService(st, cfg, nil, mail.NewStubSender())
+	userSvc := service.NewUserService(st, cfg, nil, mail.NewStubSender(), mail.Renderer{})
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(userPath, userHandler)
 
@@ -724,7 +724,7 @@ func setupResendUserTest(t *testing.T) (*userTestEnv, *recordingSender) {
 	require.NoError(t, st.Migrator().Migrate(context.Background()))
 
 	rec := &recordingSender{}
-	userSvc := service.NewUserService(st, testConfig(), nil, rec)
+	userSvc := service.NewUserService(st, testConfig(), nil, rec, mail.Renderer{})
 
 	mux := http.NewServeMux()
 	interceptor, _ := auth.NewInterceptor(st, nil, false, false)

--- a/backend/internal/hub/service/worker_mgmt_service.go
+++ b/backend/internal/hub/service/worker_mgmt_service.go
@@ -11,6 +11,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 	"github.com/leapmux/leapmux/internal/hub/notifier"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -38,11 +39,18 @@ type WorkerManagementService struct {
 	broadcaster *HubEventBroadcaster
 	notifier    *notifier.Notifier
 	mail        mail.Sender
+	renderer    mail.Renderer
+	cfg         *config.Config
 }
 
 // NewWorkerManagementService creates a new WorkerManagementService.
-func NewWorkerManagementService(st store.Store, mgr *workermgr.Manager, b *HubEventBroadcaster, n *notifier.Notifier, sender mail.Sender) *WorkerManagementService {
-	return &WorkerManagementService{store: st, workerMgr: mgr, broadcaster: b, notifier: n, mail: sender}
+//
+// cfg is required so the service can reject EmailRegistrationInstructions
+// when SMTP isn't configured (defense-in-depth — the frontend already
+// hides the button). renderer carries the hub URL used in the
+// registration email's footer.
+func NewWorkerManagementService(st store.Store, mgr *workermgr.Manager, b *HubEventBroadcaster, n *notifier.Notifier, sender mail.Sender, renderer mail.Renderer, cfg *config.Config) *WorkerManagementService {
+	return &WorkerManagementService{store: st, workerMgr: mgr, broadcaster: b, notifier: n, mail: sender, renderer: renderer, cfg: cfg}
 }
 
 func (s *WorkerManagementService) CreateRegistrationKey(
@@ -184,6 +192,15 @@ func (s *WorkerManagementService) EmailRegistrationInstructions(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("verified email address required to email instructions"))
 	}
 
+	// Defense in depth: reject if SMTP isn't configured. The frontend
+	// hides this button when GetSystemInfo reports email_enabled=false,
+	// but a direct RPC client could still hit us. Returning an explicit
+	// FailedPrecondition is friendlier than the disabledSender's
+	// ErrEmailDisabled bubbling up as a generic Unavailable.
+	if s.cfg == nil || s.cfg.SmtpHost == "" {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("hub is not configured to send email"))
+	}
+
 	// Ownership + liveness checks: never email instructions for a dead
 	// key — the recipient would just be confused.
 	row, err := s.getOwnedKey(ctx, keyID, user.ID)
@@ -194,8 +211,7 @@ func (s *WorkerManagementService) EmailRegistrationInstructions(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("registration key has expired"))
 	}
 
-	msg := mail.RenderRegistrationInstructions(user.Email, command)
-	if err := s.mail.Send(ctx, msg); err != nil {
+	if err := s.mail.Send(ctx, s.renderer.RegistrationInstructions(user.Email, command)); err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("send mail: %w", err))
 	}
 

--- a/backend/internal/hub/service/worker_registration_test.go
+++ b/backend/internal/hub/service/worker_registration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/channelmgr"
+	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 	"github.com/leapmux/leapmux/internal/hub/notifier"
 	"github.com/leapmux/leapmux/internal/hub/service"
@@ -67,10 +68,18 @@ type regKeyEnv struct {
 
 func setupRegKeyEnv(t *testing.T) *regKeyEnv {
 	t.Helper()
+	return setupRegKeyEnvWithCfg(t, testConfigWithSMTP())
+}
+
+// setupRegKeyEnvWithCfg builds a registration-key test env with a
+// caller-supplied config. Use this when the test cares about
+// email_enabled gating; setupRegKeyEnv (the default) configures SMTP so
+// EmailRegistrationInstructions can run.
+func setupRegKeyEnvWithCfg(t *testing.T, cfg *config.Config) *regKeyEnv {
+	t.Helper()
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
 
-	cfg := testConfig()
 	wMgr := workermgr.New()
 	cMgr := channelmgr.New()
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
@@ -81,7 +90,7 @@ func setupRegKeyEnv(t *testing.T) *regKeyEnv {
 	opts := connect.WithInterceptors(interceptor)
 
 	mailer := &recordingSender{}
-	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender())
+	authSvc := service.NewAuthService(st, cfg, sc, nil, mail.NewStubSender(), mail.Renderer{})
 	authPath, authHandler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
 	mux.Handle(authPath, authHandler)
 
@@ -90,7 +99,7 @@ func setupRegKeyEnv(t *testing.T) *regKeyEnv {
 	mux.Handle(connectorPath, connectorHandler)
 
 	notif := notifier.New(st, wMgr, pendingReqs, cfg)
-	mgmtSvc := service.NewWorkerManagementService(st, wMgr, service.NewHubEventBroadcaster(cMgr), notif, mailer)
+	mgmtSvc := service.NewWorkerManagementService(st, wMgr, service.NewHubEventBroadcaster(cMgr), notif, mailer, mail.Renderer{}, cfg)
 	mgmtPath, mgmtHandler := leapmuxv1connect.NewWorkerManagementServiceHandler(mgmtSvc, opts)
 	mux.Handle(mgmtPath, mgmtHandler)
 
@@ -404,6 +413,36 @@ func TestEmailRegistrationInstructions_RequiresVerifiedEmail(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 	assert.Nil(t, env.mailer.last(), "no mail should be sent without a verified email")
+}
+
+// TestEmailRegistrationInstructions_RejectsWhenSMTPUnconfigured locks
+// in the defense-in-depth precondition: even if a client bypasses the
+// frontend gate (which hides the button when email_enabled=false), the
+// RPC refuses to call the disabled mail backend.
+func TestEmailRegistrationInstructions_RejectsWhenSMTPUnconfigured(t *testing.T) {
+	env := setupRegKeyEnvWithCfg(t, testConfig()) // no SmtpHost set
+	token := env.login(t, "admin", "admin123")
+
+	// Mark the admin's email verified — otherwise the
+	// verified-email check fires first and we couldn't tell which
+	// precondition rejected us.
+	require.NoError(t, env.store.Users().UpdateEmail(context.Background(), store.UpdateUserEmailParams{
+		Email:         "admin@example.com",
+		EmailVerified: true,
+		ID:            env.adminID(t),
+	}))
+
+	createResp, err := env.mgmtClient.CreateRegistrationKey(context.Background(), authedReq(&leapmuxv1.CreateRegistrationKeyRequest{}, token))
+	require.NoError(t, err)
+
+	_, err = env.mgmtClient.EmailRegistrationInstructions(context.Background(), authedReq(&leapmuxv1.EmailRegistrationInstructionsRequest{
+		RegistrationKey: createResp.Msg.GetRegistrationKey(),
+		Command:         "leapmux worker --hub http://x --registration-key abc",
+	}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "not configured to send email")
+	assert.Nil(t, env.mailer.last(), "no mail should be sent when SMTP is unconfigured")
 }
 
 func TestEmailRegistrationInstructions_SendsToVerifiedAddress(t *testing.T) {

--- a/frontend/src/components/workers/RegisterWorkerDialog.test.tsx
+++ b/frontend/src/components/workers/RegisterWorkerDialog.test.tsx
@@ -36,9 +36,11 @@ vi.mock('~/context/AuthContext', () => ({
 
 const mockSoloMode = vi.fn<() => boolean>()
 const mockWorkerHubUrl = vi.fn<() => string>()
+const mockEmailEnabled = vi.fn<() => boolean>()
 vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => mockSoloMode(),
   getWorkerHubUrl: () => mockWorkerHubUrl(),
+  isEmailEnabled: () => mockEmailEnabled(),
 }))
 
 // Helpers --------------------------------------------------------------
@@ -72,6 +74,7 @@ beforeEach(() => {
   mockAuthUser.mockReturnValue({ email: 'me@example.com', emailVerified: true })
   mockSoloMode.mockReturnValue(false)
   mockWorkerHubUrl.mockReturnValue('')
+  mockEmailEnabled.mockReturnValue(true)
   mockCreate.mockResolvedValue({
     registrationKey: 'KEY-ABC',
     expiresAt: timestampFromDate(new Date(Date.now() + 5 * 60_000)),
@@ -182,6 +185,18 @@ describe('registerWorkerDialog', () => {
     // A disabled button with a "verify your email" tooltip would be
     // misleading, so the button is omitted from the action row.
     mockSoloMode.mockReturnValue(true)
+    renderDialog()
+
+    await screen.findByTestId('registration-command')
+    expect(screen.queryByTestId('email-registration-instructions')).toBeNull()
+  })
+
+  it('hides the email button when the hub has no SMTP configured', async () => {
+    // Hub mode without smtp_host: the corresponding RPC returns
+    // FailedPrecondition. Surfacing a disabled-on-the-frontend button
+    // would just confuse users — match the solo-mode behavior and omit
+    // the button entirely.
+    mockEmailEnabled.mockReturnValue(false)
     renderDialog()
 
     await screen.findByTestId('registration-command')

--- a/frontend/src/components/workers/RegisterWorkerDialog.tsx
+++ b/frontend/src/components/workers/RegisterWorkerDialog.tsx
@@ -9,7 +9,7 @@ import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
 import { useAuth } from '~/context/AuthContext'
 import { useCopyButton } from '~/hooks/useCopyButton'
-import { getWorkerHubUrl, isSoloMode } from '~/lib/systemInfo'
+import { getWorkerHubUrl, isEmailEnabled, isSoloMode } from '~/lib/systemInfo'
 import { errorText } from '~/styles/shared.css'
 import * as styles from './RegisterWorkerDialog.css'
 
@@ -153,8 +153,13 @@ export const RegisterWorkerDialog: Component<RegisterWorkerDialogProps> = (props
         <button type="button" class="outline" onClick={() => props.onClose()}>Cancel</button>
 
         <Show when={registrationKey()}>
-          {/* Solo mode has no SMTP and the bootstrap user has no email — hide the action instead of showing a permanently-disabled button. */}
-          <Show when={!isSoloMode()}>
+          {/* Hide the action when there's no way to send mail: solo mode
+              ships without SMTP and the bootstrap user has no email; on
+              hub mode, an unconfigured smtp_host means the corresponding
+              RPC would return FailedPrecondition. Either way, a
+              permanently-disabled button would mislead users — drop it
+              entirely. */}
+          <Show when={!isSoloMode() && isEmailEnabled()}>
             <button
               type="button"
               data-testid="email-registration-instructions"

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -15,6 +15,7 @@ let soloMode = false
 let signupEnabled = false
 let setupRequired = false
 let workerHubUrl = ''
+let emailEnabled = false
 let loaded = false
 
 let backendBuildInfo: BuildInfo = { version: '', commitHash: '', commitTime: '', buildTime: '', branch: '' }
@@ -36,6 +37,7 @@ export async function loadSystemInfo(force = false): Promise<void> {
     signupEnabled = resp.signupEnabled
     setupRequired = resp.setupRequired
     workerHubUrl = resp.workerHubUrl
+    emailEnabled = resp.emailEnabled
     backendBuildInfo = {
       version: resp.version,
       commitHash: resp.commitHash,
@@ -60,6 +62,15 @@ export function isSignupEnabled(): boolean {
 
 export function isSetupRequired(): boolean {
   return setupRequired
+}
+
+// isEmailEnabled returns whether the hub has SMTP configured. Components
+// gate optional email affordances (e.g. the "Send email" button on the
+// worker registration dialog) on this flag — the corresponding RPC
+// returns FailedPrecondition without SMTP, so showing a button that
+// can't possibly work would mislead users.
+export function isEmailEnabled(): boolean {
+  return emailEnabled
 }
 
 // getWorkerHubUrl returns the URL workers should target when registering.

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -101,6 +101,12 @@ message GetSystemInfoResponse {
   // the caller should fall back to window.location.origin, which already
   // reflects whatever proxy or hostname the user is connecting through.
   string worker_hub_url = 10;
+  // True when the hub has SMTP configured (smtp_host non-empty).
+  // Frontend gating: when false, the "Send email" affordance on the
+  // worker registration dialog is hidden — calling
+  // EmailRegistrationInstructions on a hub without SMTP returns
+  // FailedPrecondition, so showing the button would mislead users.
+  bool email_enabled = 11;
 }
 
 message GetOAuthProvidersRequest {}


### PR DESCRIPTION
## Motivation

The hub previously had no real email delivery path. Verification emails and worker registration instruction emails were silently swallowed by a stub sender that logged the body to stdout — leaking verification codes into log aggregation pipelines — and there was no way to configure an actual SMTP server. Additionally, `email_verification_required = true` could be set without an SMTP host, causing verification emails to be silently dropped rather than rejected at startup.

## Modifications

**Mail package (`backend/internal/hub/mail/`)**
- Added `SMTPSender` supporting three TLS modes: `none`, `starttls`, and `implicit`. Includes AUTH PLAIN, per-Send TLS config cloning to prevent concurrent mutation, CRLF header-injection defense, RFC 2047 Q-encoding for non-ASCII subjects, and context cancellation via a watchdog goroutine.
- Added `disabledSender` with exported sentinel `mail.ErrEmailDisabled`. All callers can distinguish "no SMTP configured" from a real delivery failure via `errors.Is(err, mail.ErrEmailDisabled)`.
- Replaced free functions `RenderVerificationEmail` / `RenderRegistrationInstructions` with a `mail.Renderer{HubURL string}` struct whose methods `VerificationEmail` / `RegistrationInstructions` now own link construction. Subject lines are prefixed `[LeapMux]`.
- `StubSender` is now TEST-ONLY and silent — body logging that leaked verification codes has been removed.

**Config (`backend/internal/hub/config/config.go`)**
- (Breaking change) `SmtpUseTLS bool` / CLI flag `--smtp-use-tls` replaced by `SmtpTLSMode string` / `--smtp-tls-mode` accepting `starttls` (default), `implicit`, or `none`.
- `Config.Validate()` now rejects: bogus TLS mode values; `smtp_host` set without a valid from-address or a valid port; `email_verification_required = true` without `smtp_host`; `tls_mode = none` with auth credentials on a non-localhost host (mirrors Go's `smtp.PlainAuth` restriction). `isLocalhost` uses `net.IP.IsLoopback()` so the full 127.0.0.0/8 range is recognized.
- New `email_enabled` value surfaced via `GetSystemInfoResponse.email_enabled` (computed from `cfg.SmtpHost != ""`).

**Server wiring (`backend/hub/server.go`)**
- `SMTPSender` is instantiated when `cfg.SmtpHost != ""`; otherwise `DisabledSender`.
- A single `mail.Renderer{HubURL: cfg.BaseURL()}` is constructed at startup and passed into `NewAuthService`, `NewUserService`, and `NewWorkerManagementService`, replacing the `hubURL string` parameter that previously had to thread through six call sites.
- (Breaking change) `NewAuthService`, `NewUserService`, and `NewWorkerManagementService` constructors now accept a `mail.Renderer` parameter; `NewWorkerManagementService` also accepts `*config.Config`.

**Services (`backend/internal/hub/service/`)**
- `WorkerManagementService.EmailRegistrationInstructions` now returns `FailedPrecondition` when SMTP is unconfigured, as a defense-in-depth guard.
- Verification email deep-links are now absolute URLs (`hubURL + /verify-email?code=…`) so real email clients can open them.

**Proto + Frontend**
- Added `email_enabled` (field 11) to `GetSystemInfoResponse`. Old clients treat it as `false`, preserving backward compatibility.
- `frontend/src/lib/systemInfo.ts` adds `emailEnabled` state and `isEmailEnabled()` getter.
- `RegisterWorkerDialog` hides the "Send email" button entirely when `!isEmailEnabled()`, rather than showing a non-functional disabled button.

## Result

Operators can now configure a real SMTP server via `--smtp-host`, `--smtp-port`, `--smtp-username`, `--smtp-password`, `--smtp-from-address`, and `--smtp-tls-mode`. Misconfigured or half-configured SMTP blocks are rejected at startup with a clear error rather than failing silently at send time. When no SMTP host is configured, the "Send registration instructions" button is hidden in the UI, and the corresponding RPC returns a `FailedPrecondition` error if called directly. Verification codes are no longer logged to stdout by the stub sender.

Example server configuration with implicit TLS:

```
--smtp-host=mail.example.com
--smtp-port=465
--smtp-tls-mode=implicit
--smtp-username=hub@example.com
--smtp-password=secret
--smtp-from-address=hub@example.com
```
