### PR TITLE
fix(agent/pi): Auto-retry on transient WebSocket errors

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -35,6 +35,23 @@ type AutoContinueSchedule struct {
 	SourcePayload []byte
 }
 
+// scheduleOrCancelAPIErrorAutoContinue schedules an immediate API-error
+// auto-continue when retry is true, or cancels any pending API-error
+// schedule otherwise. The payload is defensively copied because the
+// caller's buffer may be reused by the stdout reader before the schedule
+// is consumed.
+func scheduleOrCancelAPIErrorAutoContinue(sink OutputSink, retry bool, payload []byte) {
+	if !retry {
+		sink.CancelAutoContinue(AutoContinueReasonAPIError)
+		return
+	}
+	sink.ScheduleAutoContinue(AutoContinueSchedule{
+		Reason:        AutoContinueReasonAPIError,
+		DueAt:         time.Now().UTC(),
+		SourcePayload: append([]byte(nil), payload...),
+	})
+}
+
 // OutputSink provides generic primitives for persisting and broadcasting
 // agent output. Implemented by the service layer and injected into providers.
 type OutputSink interface {

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -383,16 +383,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	}
 
 	if msgType == claudeMsgTypeResult {
-		// Auto-continue on retryable Claude result errors; reset on normal results.
-		if env.IsError && isRetryableClaudeResultError(env.Result) {
-			a.sink.ScheduleAutoContinue(AutoContinueSchedule{
-				Reason:        AutoContinueReasonAPIError,
-				DueAt:         time.Now().UTC(),
-				SourcePayload: append([]byte(nil), content...),
-			})
-		} else {
-			a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
-		}
+		scheduleOrCancelAPIErrorAutoContinue(a.sink, env.IsError && isRetryableClaudeResultError(env.Result), content)
 
 		// Reset all span tracking so the next turn starts clean.
 		a.sink.ResetSpans()

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -417,15 +417,9 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	a.resetCollabReceivers()
 
 	if turnStatus != "" {
-		if turnStatus == "failed" && (turnErrorInfo == "serverOverloaded" || isRetryableCodexTurnFailure(turnErrorMessage)) {
-			a.sink.ScheduleAutoContinue(AutoContinueSchedule{
-				Reason:        AutoContinueReasonAPIError,
-				DueAt:         time.Now().UTC(),
-				SourcePayload: append([]byte(nil), params...),
-			})
-		} else {
-			a.sink.CancelAutoContinue(AutoContinueReasonAPIError)
-		}
+		retryable := turnStatus == "failed" &&
+			(turnErrorInfo == "serverOverloaded" || isRetryableCodexTurnFailure(turnErrorMessage))
+		scheduleOrCancelAPIErrorAutoContinue(a.sink, retryable, params)
 		if turnStatus == "completed" && collaborationMode == CodexCollaborationPlan && sawPlan && planText != "" {
 			// Persist plan content so initiatePlanExecution can use it.
 			compressed, compression := msgcodec.Compress([]byte(planText))

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -63,6 +63,21 @@ type piQueueUpdateEnvelope struct {
 	FollowUp []json.RawMessage `json:"followUp"`
 }
 
+// piAgentEndEnvelope captures the per-message stop info on agent_end so we
+// can inspect the final assistant turn's outcome and decide whether to
+// auto-continue.
+type piAgentEndEnvelope struct {
+	Messages []struct {
+		Role         string `json:"role"`
+		StopReason   string `json:"stopReason"`
+		ErrorMessage string `json:"errorMessage"`
+	} `json:"messages"`
+}
+
+// piRetryableWebSocketError is the exact errorMessage Pi emits for transient
+// WebSocket disconnects that we auto-retry via the auto-continue pipeline.
+const piRetryableWebSocketError = "WebSocket error"
+
 // piDialogMethods is the set of extension UI methods that block waiting for an
 // extension_ui_response. These are surfaced as control requests so the
 // frontend can render a dialog and ship a response back.
@@ -140,6 +155,7 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	// live popover; the stdout read loop must remain free to deliver that RPC
 	// response.
 	a.persistPiAgentEnd(raw, a.currentPiUsageSnapshot())
+	scheduleOrCancelAPIErrorAutoContinue(a.sink, isRetryablePiAgentEndFailure(raw), raw)
 	a.sink.ResetSpans()
 	a.sink.BroadcastSessionInfo(map[string]any{
 		"pi_turn_active": false,
@@ -149,6 +165,23 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 			_, _ = a.refreshPiSessionStats(piSessionStatsTimeout(a.APITimeout()))
 		}()
 	}
+}
+
+func isRetryablePiAgentEndFailure(raw []byte) bool {
+	var env piAgentEndEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return false
+	}
+	// Walk from the end: only the final assistant message reflects the
+	// turn's terminal outcome; earlier assistant entries are intra-turn.
+	for i := len(env.Messages) - 1; i >= 0; i-- {
+		msg := env.Messages[i]
+		if msg.Role != PiRoleAssistant {
+			continue
+		}
+		return msg.StopReason == PiStopReasonError && msg.ErrorMessage == piRetryableWebSocketError
+	}
+	return false
 }
 
 func (a *PiAgent) handlePiMessageEnd(raw []byte) {

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -183,6 +183,59 @@ func TestHandlePiOutput_AgentEnd_AugmentsWithLatestUsageSnapshot(t *testing.T) {
 	assert.Equal(t, float64(200000), usage["context_window"])
 }
 
+func TestHandlePiOutput_AgentEnd_WebSocketErrorSchedulesAutoContinue(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	raw := []byte(`{"type":"agent_end","messages":[{"role":"user"},{"role":"assistant","stopReason":"error","errorMessage":"WebSocket error"}]}`)
+
+	handlePiOutput(a, parseLine(raw))
+
+	require.Equal(t, 1, sink.AutoScheduleCount())
+	schedule := sink.LastAutoSchedule()
+	assert.Equal(t, AutoContinueReasonAPIError, schedule.Reason)
+	assert.False(t, schedule.DueAt.IsZero())
+	assert.JSONEq(t, string(raw), string(schedule.SourcePayload))
+	assert.Equal(t, 0, sink.AutoCancelCount())
+}
+
+func TestHandlePiOutput_AgentEnd_NonRetryableResultCancelsAutoContinue(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	raw := []byte(`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"stop"}]}`)
+
+	handlePiOutput(a, parseLine(raw))
+
+	require.Equal(t, 1, sink.AutoCancelCount())
+	assert.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
+	assert.Equal(t, 0, sink.AutoScheduleCount())
+}
+
+func TestHandlePiOutput_AgentEnd_NonWebSocketErrorMessageCancelsAutoContinue(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	raw := []byte(`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"rate limited"}]}`)
+
+	handlePiOutput(a, parseLine(raw))
+
+	require.Equal(t, 1, sink.AutoCancelCount())
+	assert.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
+	assert.Equal(t, 0, sink.AutoScheduleCount())
+}
+
+func TestHandlePiOutput_AgentEnd_UnexpectedMessagesShapeCancelsAutoContinue(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	// messages is a string instead of an array — the inner unmarshal in
+	// isRetryablePiAgentEndFailure fails, so we fall through to cancel.
+	raw := []byte(`{"type":"agent_end","messages":"unexpected"}`)
+
+	handlePiOutput(a, parseLine(raw))
+
+	require.Equal(t, 1, sink.AutoCancelCount())
+	assert.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
+	assert.Equal(t, 0, sink.AutoScheduleCount())
+}
+
 func TestHandlePiOutput_ToolExecutionLifecycle(t *testing.T) {
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)

--- a/backend/internal/worker/agent/pi_protocol.go
+++ b/backend/internal/worker/agent/pi_protocol.go
@@ -94,3 +94,13 @@ const PiStreamingBehaviorSteer = "steer"
 // and result envelopes carry an array of typed content blocks; the
 // streaming delta walker concatenates only "text" blocks.
 const PiContentBlockText = "text"
+
+// Pi message roles — the `role` field on entries inside `agent_end.messages`
+// and on `message_end.message`. Only assistant entries carry the terminal
+// stop-reason for a turn.
+const PiRoleAssistant = "assistant"
+
+// Pi assistant stop reasons — the `stopReason` field on the final
+// assistant entry of an `agent_end` envelope. "error" pairs with a
+// non-empty `errorMessage` describing the failure.
+const PiStopReasonError = "error"

--- a/backend/internal/worker/agent/pi_usage.go
+++ b/backend/internal/worker/agent/pi_usage.go
@@ -280,7 +280,7 @@ func (a *PiAgent) augmentPiMessageEnd(raw []byte) []byte {
 	if !ok {
 		return raw
 	}
-	if role, _ := message["role"].(string); role != "assistant" {
+	if role, _ := message["role"].(string); role != PiRoleAssistant {
 		return raw
 	}
 	usageMap, ok := message["usage"].(map[string]any)


### PR DESCRIPTION
## Motivation

Claude and Codex providers already auto-retry on transient backend errors (5xx, idle timeouts, server overload, disconnects) by routing them through the auto-continue pipeline. Pi had no equivalent protection: a `"WebSocket error"` `agent_end` would silently terminate the turn with no recovery attempt, leaving the user's session dead until they manually intervened.

Additionally, the auto-continue scheduling and cancellation logic was duplicated across the Claude and Codex handlers, making the Pi gap easy to miss and future maintenance error-prone.

## Modifications

- Extracted `scheduleOrCancelAPIErrorAutoContinue()` into `agent.go` as a shared helper; `claude_output.go` and `codex_output.go` now delegate to it instead of duplicating the Schedule/Cancel block.
- Added `piAgentEndEnvelope` struct and `isRetryablePiAgentEndFailure()` in `pi_output.go` to inspect the terminal `agent_end` envelope and identify retryable failures (currently: `stopReason="error"` with `errorMessage="WebSocket error"` on the final assistant message).
- Added `PiRoleAssistant` and `PiStopReasonError` constants to `pi_protocol.go` alongside the rest of the Pi wire vocabulary; switched `pi_usage.go` to use the role constant.
- Added four tests in `pi_output_test.go` covering: WebSocket error schedules retry, normal stop cancels retry, non-retryable error message cancels retry, and unexpected `messages` shape is handled defensively.

## Result

Pi sessions that drop due to a transient WebSocket error now automatically retry, matching the resilience behavior already present in the Claude and Codex providers. No user-facing API or protocol changes are introduced.
