### PR TITLE
ci(macos-sign): Fail fast when Apple signing secrets are missing

### DIFF
--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -392,6 +392,41 @@ jobs:
           tar -xf macos-app-unsigned.tar
           rm -f macos-app-unsigned.tar
 
+      - name: Verify Apple signing secrets are configured
+        # Fail fast with a named list of missing secrets if the apple-signing
+        # environment isn't fully populated. Without this, an empty secret
+        # silently feeds an empty file into `security import` / `notarytool`,
+        # which surface as cryptic errors like "SecKeychainItemImport: One or
+        # more parameters passed to a function were not valid" — leaving the
+        # operator to guess that a secret was missing.
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_P12_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_P12_PASSWORD }}
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            MACOS_CERTIFICATE_P12_BASE64 \
+            MACOS_CERTIFICATE_P12_PASSWORD \
+            MACOS_CODESIGN_IDENTITY \
+            APPLE_API_KEY_P8_BASE64 \
+            APPLE_API_KEY_ID \
+            APPLE_API_KEY_ISSUER_ID
+          do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error title=Apple signing secrets missing::Missing in the apple-signing environment: ${missing[*]}"
+            echo "Configure them under Settings → Environments → apple-signing." >&2
+            exit 1
+          fi
+
       - name: Pre-record keychain path for cleanup
         # Set $KEYCHAIN_PATH BEFORE we try to create/import, so the
         # `if: always()` cleanup below can still find the keychain even if
@@ -414,6 +449,13 @@ jobs:
           security unlock-keychain -p "$KP" "$KEYCHAIN_PATH"
           # `--decode` is supported by both BSD (macOS) and GNU base64.
           printf '%s' "$MACOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH"
+          # Belt-and-braces: if the secret somehow round-tripped to empty or
+          # non-base64 garbage, fail with a clear message instead of letting
+          # `security import` return errSecParam.
+          if [ ! -s "$CERT_PATH" ]; then
+            echo "::error::Decoded p12 is empty — MACOS_CERTIFICATE_P12_BASE64 is missing or not valid base64."
+            exit 1
+          fi
           security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_P12_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KP" "$KEYCHAIN_PATH"
@@ -423,8 +465,13 @@ jobs:
         env:
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
         run: |
+          set -euo pipefail
           P8="${RUNNER_TEMP}/apple_api.p8"
           printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$P8"
+          if [ ! -s "$P8" ]; then
+            echo "::error::Decoded .p8 is empty — APPLE_API_KEY_P8_BASE64 is missing or not valid base64."
+            exit 1
+          fi
           chmod 600 "$P8"
           echo "APPLE_API_KEY_P8_PATH=$P8" >> "$GITHUB_ENV"
 

--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -456,8 +456,23 @@ jobs:
             echo "::error::Decoded p12 is empty — MACOS_CERTIFICATE_P12_BASE64 is missing or not valid base64."
             exit 1
           fi
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_P12_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/security
+          # Pre-flight the .p12 with openssl. openssl 3.x reads both legacy
+          # (PBE-SHA1-3DES) and modern (AES-256-CBC + PBKDF2) PKCS12 PBE,
+          # whereas macOS's SecKeychainItemImport rejects the modern variant
+          # with errSecParam ("One or more parameters passed to a function
+          # were not valid"). If openssl can read the file but `security
+          # import` later refuses it, the .p12 was exported with a PBE
+          # macOS won't parse — re-export with `-legacy`.
+          if ! openssl pkcs12 -in "$CERT_PATH" -info -noout -nokeys \
+                -passin "pass:${MACOS_CERTIFICATE_P12_PASSWORD}" >/dev/null 2>&1; then
+            echo "::error::openssl could not parse the .p12 — wrong MACOS_CERTIFICATE_P12_PASSWORD or malformed export."
+            exit 1
+          fi
+          if ! security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_P12_PASSWORD" \
+                -T /usr/bin/codesign -T /usr/bin/security; then
+            echo "::error title=security import rejected the .p12::macOS Security parsed the file's structure but rejected its PBE algorithm. Re-export the certificate with 'openssl pkcs12 -export -legacy ...' so it uses PBE-SHA1-3DES, then update MACOS_CERTIFICATE_P12_BASE64."
+            exit 1
+          fi
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KP" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 

--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -440,9 +440,14 @@ jobs:
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
+          # Files containing the cert and (briefly) the unencrypted private
+          # key. umask 0077 ensures both land as 0600 so other users on the
+          # ephemeral runner can't read them.
+          umask 0077
           CERT_PATH="${RUNNER_TEMP}/cert.p12"
-          # Always remove the cert file even if a later command in this step fails.
-          trap 'rm -f "$CERT_PATH"' EXIT
+          PEM_PATH="${RUNNER_TEMP}/cert.pem"
+          # Always remove the cert files even if a later command in this step fails.
+          trap 'rm -f "$CERT_PATH" "$PEM_PATH"' EXIT
           KP="${MACOS_KEYCHAIN_PASSWORD:-$(openssl rand -base64 24)}"
           security create-keychain -p "$KP" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
@@ -456,23 +461,29 @@ jobs:
             echo "::error::Decoded p12 is empty — MACOS_CERTIFICATE_P12_BASE64 is missing or not valid base64."
             exit 1
           fi
-          # Pre-flight the .p12 with openssl. openssl 3.x reads both legacy
-          # (PBE-SHA1-3DES) and modern (AES-256-CBC + PBKDF2) PKCS12 PBE,
-          # whereas macOS's SecKeychainItemImport rejects the modern variant
-          # with errSecParam ("One or more parameters passed to a function
-          # were not valid"). If openssl can read the file but `security
-          # import` later refuses it, the .p12 was exported with a PBE
-          # macOS won't parse — re-export with `-legacy`.
-          if ! openssl pkcs12 -in "$CERT_PATH" -info -noout -nokeys \
-                -passin "pass:${MACOS_CERTIFICATE_P12_PASSWORD}" >/dev/null 2>&1; then
+          # Re-encode the .p12 with legacy PBE-SHA1-3DES so macOS's
+          # SecKeychainItemImport accepts it. OpenSSL 3.x's default export
+          # uses AES-256-CBC + PBKDF2/HMAC-SHA-256, which `security import`
+          # rejects with errSecParam ("One or more parameters passed to a
+          # function were not valid"). Round-tripping through PEM is a
+          # no-op for already-legacy .p12 files. Both ends use the original
+          # passphrase, so MACOS_CERTIFICATE_P12_PASSWORD still applies.
+          # The intermediate PEM holds the unencrypted private key — it's
+          # written 0600 (umask above) and removed before `security import`
+          # touches the keychain.
+          if ! openssl pkcs12 -in "$CERT_PATH" -nodes \
+                -passin "pass:${MACOS_CERTIFICATE_P12_PASSWORD}" \
+                -out "$PEM_PATH" 2>/dev/null; then
             echo "::error::openssl could not parse the .p12 — wrong MACOS_CERTIFICATE_P12_PASSWORD or malformed export."
             exit 1
           fi
-          if ! security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_P12_PASSWORD" \
-                -T /usr/bin/codesign -T /usr/bin/security; then
-            echo "::error title=security import rejected the .p12::macOS Security parsed the file's structure but rejected its PBE algorithm. Re-export the certificate with 'openssl pkcs12 -export -legacy ...' so it uses PBE-SHA1-3DES, then update MACOS_CERTIFICATE_P12_BASE64."
-            exit 1
-          fi
+          openssl pkcs12 -export -legacy \
+            -in "$PEM_PATH" \
+            -passout "pass:${MACOS_CERTIFICATE_P12_PASSWORD}" \
+            -out "$CERT_PATH"
+          rm -f "$PEM_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_P12_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KP" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 


### PR DESCRIPTION
Surface a named list of missing secrets up front, so an unconfigured apple-signing environment fails with a clear "MACOS_CERTIFICATE_P12_BASE64 is missing" instead of `security`'s opaque "SecKeychainItemImport: One or more parameters passed to a function were not valid" later in the run. Also add a non-empty sanity check after each base64 → file decode so a malformed secret can't silently feed an empty .p12 / .p8 into the next tool.