### PR TITLE
fix(agent/acp): Persist each thought chunk immediately in chronological order

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -84,7 +84,6 @@ type acpBase struct {
 	availableModes         []*leapmuxv1.AvailableOption
 	availablePrimaryAgents []*leapmuxv1.AvailableOption
 	turnAssistantText      strings.Builder
-	turnThinkingText       strings.Builder
 }
 
 // handleACPPromptResponse extracts accumulated turn text, calls the optional
@@ -95,8 +94,6 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(
 	}
 
 	b.mu.Lock()
-	thinkingText := b.turnThinkingText.String()
-	b.turnThinkingText.Reset()
 	assistantText := b.turnAssistantText.String()
 	b.turnAssistantText.Reset()
 	b.turnToolUses = 0
@@ -106,7 +103,7 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(
 		prePersist(resp)
 	}
 
-	b.persistPromptResponse(thinkingText, assistantText, resp, func(resp json.RawMessage) json.RawMessage {
+	b.persistPromptResponse(assistantText, resp, func(resp json.RawMessage) json.RawMessage {
 		return b.enrichWithToolUses(resp)
 	})
 }
@@ -161,7 +158,7 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 	case acpUpdateAgentMessageChunk:
 		b.broadcastACPChunk(header.Content, &b.turnAssistantText, acpUpdateAgentMessageChunk)
 	case acpUpdateAgentThoughtChunk:
-		b.broadcastACPChunk(header.Content, &b.turnThinkingText, acpUpdateAgentThoughtChunk)
+		b.handleAgentThoughtChunk(header.Content)
 	case acpUpdateToolCall:
 		b.handleToolCall(update)
 	case acpUpdateToolCallUpdate:
@@ -209,7 +206,6 @@ func (b *acpBase) ClearContext() (string, bool) {
 	b.mu.Lock()
 	b.sessionID = session.SessionID
 	b.turnAssistantText.Reset()
-	b.turnThinkingText.Reset()
 	b.mu.Unlock()
 
 	b.sink.UpdateSessionID(session.SessionID)
@@ -678,24 +674,47 @@ func (b *acpBase) sendPrompt(
 	handleResponse(resp)
 }
 
-// broadcastACPChunk extracts text from a pre-parsed content RawMessage and
-// broadcasts it. The content JSON is already extracted from the header parse,
-// avoiding a full re-unmarshal of the update on the streaming hot path.
-func (b *acpBase) broadcastACPChunk(content json.RawMessage, builder *strings.Builder, eventType string) {
+// extractACPChunkText pulls the `text` field from an ACP content envelope.
+// Returns "" when the field is absent, empty, or the unmarshal fails (a warning
+// is logged in the failure case). The `kind` argument labels the warning so
+// failures can be attributed to a specific session update type.
+func (b *acpBase) extractACPChunkText(content json.RawMessage, kind string) string {
 	var c struct {
 		Text string `json:"text"`
 	}
 	if err := json.Unmarshal(content, &c); err != nil {
-		slog.Warn("acp broadcast chunk unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "error", err)
-		return
+		slog.Warn("acp content unmarshal failed", "provider", b.providerName, "agent_id", b.agentID, "kind", kind, "error", err)
+		return ""
 	}
-	if c.Text == "" {
+	return c.Text
+}
+
+// broadcastACPChunk extracts text from a pre-parsed content RawMessage and
+// broadcasts it. The content JSON is already extracted from the header parse,
+// avoiding a full re-unmarshal of the update on the streaming hot path.
+func (b *acpBase) broadcastACPChunk(content json.RawMessage, builder *strings.Builder, eventType string) {
+	text := b.extractACPChunkText(content, eventType)
+	if text == "" {
 		return
 	}
 	b.mu.Lock()
-	builder.WriteString(c.Text)
+	builder.WriteString(text)
 	b.mu.Unlock()
-	b.sink.BroadcastStreamChunk([]byte(c.Text), "", eventType)
+	b.sink.BroadcastStreamChunk([]byte(text), "", eventType)
+}
+
+// handleAgentThoughtChunk persists each agent_thought_chunk notification as
+// its own discrete message at its real chronological position. Mirrors the
+// per-item persistence model Codex uses for `reasoning` items: each notification
+// is a complete summary block, so concatenating them across the whole turn
+// (the previous behavior) collapsed section boundaries and pushed thinking
+// past any tool calls that interrupted it.
+func (b *acpBase) handleAgentThoughtChunk(content json.RawMessage) {
+	text := b.extractACPChunkText(content, acpUpdateAgentThoughtChunk)
+	if text == "" {
+		return
+	}
+	b.persistTextMessage(acpUpdateAgentThoughtChunk, text)
 }
 
 func (b *acpBase) persistTextMessage(sessionUpdate, text string) {
@@ -720,11 +739,10 @@ func (b *acpBase) persistTextMessage(sessionUpdate, text string) {
 }
 
 func (b *acpBase) persistPromptResponse(
-	thinkingText, assistantText string,
+	assistantText string,
 	resp json.RawMessage,
 	enrich func(json.RawMessage) json.RawMessage,
 ) {
-	b.persistTextMessage(acpUpdateAgentThoughtChunk, thinkingText)
 	b.persistTextMessage(acpUpdateAgentMessageChunk, assistantText)
 
 	resp = unwrapACPResult(resp)

--- a/backend/internal/worker/agent/gemini_output_test.go
+++ b/backend/internal/worker/agent/gemini_output_test.go
@@ -91,7 +91,8 @@ func TestGeminiHandlePromptResponsePersistsTurn(t *testing.T) {
 	sink := &testSink{}
 	agent := newGeminiAgentWithSink(sink)
 
-	agent.turnThinkingText.WriteString("thinking")
+	// End-of-turn flush handles only the assistant-text buffer and result
+	// divider. Thought chunks persist per notification, not here.
 	agent.turnAssistantText.WriteString("answer")
 
 	resp := json.RawMessage(`{"stopReason":"end_turn","_meta":{"quota":{"token_count":{"input_tokens":1,"output_tokens":2}}}}`)
@@ -99,8 +100,8 @@ func TestGeminiHandlePromptResponsePersistsTurn(t *testing.T) {
 		broadcastGeminiQuotaSessionInfo(agent.sink, r)
 	})
 
-	require.Equal(t, 3, sink.MessageCount())
-	require.True(t, sink.Messages()[2].TurnEnd, "prompt response must route through PersistTurnEnd")
+	require.Equal(t, 2, sink.MessageCount())
+	require.True(t, sink.Messages()[1].TurnEnd, "prompt response must route through PersistTurnEnd")
 	require.Equal(t, 1, sink.SessionInfoCount())
 }
 

--- a/backend/internal/worker/agent/kilo_output_test.go
+++ b/backend/internal/worker/agent/kilo_output_test.go
@@ -44,46 +44,39 @@ func TestHandleKiloOutput_AgentThoughtChunk(t *testing.T) {
 	input := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking..."}}}}`
 	agent.HandleOutput([]byte(input))
 
-	require.Equal(t, 1, sink.StreamChunkCount())
-	got := sink.LastStreamChunk()
-	require.Equal(t, "agent_thought_chunk", got.Method)
-	require.Equal(t, "thinking...", string(got.Content))
-	require.Equal(t, 0, sink.MessageCount())
-	agent.mu.Lock()
-	require.Equal(t, "thinking...", agent.turnThinkingText.String())
-	agent.mu.Unlock()
+	// Each agent_thought_chunk persists as its own discrete message.
+	require.Equal(t, 0, sink.StreamChunkCount())
+	require.Equal(t, 1, sink.MessageCount())
+
+	msg := sink.Messages()[0]
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(msg.Content, &parsed))
+	require.Equal(t, "agent_thought_chunk", parsed["sessionUpdate"])
+	content := parsed["content"].(map[string]interface{})
+	require.Equal(t, "thinking...", content["text"])
 }
 
-func TestHandleKiloPromptResponse_PersistsThinkingText(t *testing.T) {
+func TestHandleKiloPromptResponse_PersistsAssistantText(t *testing.T) {
 	sink := &testSink{}
 	agent := newKiloAgentWithSink(sink)
 
-	agent.turnThinkingText.WriteString("let me think about this")
 	agent.turnAssistantText.WriteString("Here is the answer.")
 
 	resp := json.RawMessage(`{"stopReason":"end_turn","usage":{"totalTokens":100}}`)
 	agent.handleACPPromptResponse(resp, nil)
 
-	require.Equal(t, 3, sink.MessageCount())
+	require.Equal(t, 2, sink.MessageCount())
 
-	thinkingMsg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, thinkingMsg.Source)
-	var thinkingParsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(thinkingMsg.Content, &thinkingParsed))
-	require.Equal(t, "agent_thought_chunk", thinkingParsed["sessionUpdate"])
-	content := thinkingParsed["content"].(map[string]interface{})
-	require.Equal(t, "let me think about this", content["text"])
-
-	assistantMsg := sink.Messages()[1]
+	assistantMsg := sink.Messages()[0]
 	var assistantParsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(assistantMsg.Content, &assistantParsed))
 	require.Equal(t, "agent_message_chunk", assistantParsed["sessionUpdate"])
 
-	resultMsg := sink.Messages()[2]
+	resultMsg := sink.Messages()[1]
 	require.True(t, resultMsg.TurnEnd, "prompt response must route through PersistTurnEnd")
 
 	agent.mu.Lock()
-	require.Equal(t, "", agent.turnThinkingText.String())
 	require.Equal(t, "", agent.turnAssistantText.String())
 	agent.mu.Unlock()
 }

--- a/backend/internal/worker/agent/opencode_output_test.go
+++ b/backend/internal/worker/agent/opencode_output_test.go
@@ -44,53 +44,89 @@ func TestHandleOpenCodeOutput_AgentThoughtChunk(t *testing.T) {
 	input := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking..."}}}}`
 	agent.HandleOutput([]byte(input))
 
-	require.Equal(t, 1, sink.StreamChunkCount())
-	got := sink.LastStreamChunk()
-	require.Equal(t, "agent_thought_chunk", got.Method)
-	require.Equal(t, "thinking...", string(got.Content))
-	// Thought chunks are streamed but not persisted immediately — they accumulate.
-	require.Equal(t, 0, sink.MessageCount())
-	agent.mu.Lock()
-	require.Equal(t, "thinking...", agent.turnThinkingText.String())
-	agent.mu.Unlock()
+	// Each agent_thought_chunk notification persists as its own discrete
+	// message at its real chronological position (matching Codex's per-item
+	// reasoning model). No streaming buffer is used.
+	require.Equal(t, 0, sink.StreamChunkCount())
+	require.Equal(t, 1, sink.MessageCount())
+
+	msg := sink.Messages()[0]
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, msg.Source)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(msg.Content, &parsed))
+	require.Equal(t, "agent_thought_chunk", parsed["sessionUpdate"])
+	content := parsed["content"].(map[string]interface{})
+	require.Equal(t, "thinking...", content["text"])
 }
 
-func TestHandlePromptResponse_PersistsThinkingText(t *testing.T) {
+func TestHandleOpenCodeOutput_AgentThoughtChunk_MultipleNotifications(t *testing.T) {
 	sink := &testSink{}
 	agent := newOpenCodeAgentWithSink(sink)
 
-	// Simulate accumulated thinking and assistant text.
-	agent.turnThinkingText.WriteString("let me think about this")
+	// Each summary block arrives as a separate agent_thought_chunk
+	// notification. Each must persist as its own message — the previous
+	// behavior of concatenating them into one buffer collapsed section
+	// boundaries (e.g. "structure.**Refining grid mechanics**").
+	first := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"**Analyzing tiles**\n\nbody one"}}}}`
+	second := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"**Refining grid**\n\nbody two"}}}}`
+	agent.HandleOutput([]byte(first))
+	agent.HandleOutput([]byte(second))
+
+	require.Equal(t, 2, sink.MessageCount())
+	for i, want := range []string{"**Analyzing tiles**\n\nbody one", "**Refining grid**\n\nbody two"} {
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal(sink.Messages()[i].Content, &parsed))
+		require.Equal(t, "agent_thought_chunk", parsed["sessionUpdate"])
+		require.Equal(t, want, parsed["content"].(map[string]interface{})["text"])
+	}
+}
+
+func TestHandleOpenCodeOutput_ThoughtThenToolCallPreservesOrder(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// Mid-turn tool calls used to wipe the in-flight thinking display
+	// because thinking sat in a builder until end-of-turn. Each chunk now
+	// persists immediately, so the chronological order is thought → tool_call.
+	thought := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"about to read a file"}}}}`
+	toolCall := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"read","kind":"read","status":"pending"}}}`
+	agent.HandleOutput([]byte(thought))
+	agent.HandleOutput([]byte(toolCall))
+
+	require.Equal(t, 2, sink.MessageCount())
+
+	var thoughtParsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(sink.Messages()[0].Content, &thoughtParsed))
+	require.Equal(t, "agent_thought_chunk", thoughtParsed["sessionUpdate"])
+
+	require.Equal(t, "tc-1", sink.Messages()[1].SpanID)
+	require.Equal(t, "read", sink.Messages()[1].SpanType)
+}
+
+func TestHandleOpenCodePromptResponse_PersistsAssistantText(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// The end-of-turn flush is responsible only for the assistant-text buffer
+	// and the result divider — thought chunks persist per notification, not here.
 	agent.turnAssistantText.WriteString("Here is the answer.")
 
 	resp := json.RawMessage(`{"stopReason":"end_turn","usage":{"totalTokens":100}}`)
 	agent.handleACPPromptResponse(resp, nil)
 
-	// Expect 3 messages: thinking, assistant text, result divider.
-	require.Equal(t, 3, sink.MessageCount())
+	// Expect 2 messages: assistant text, result divider.
+	require.Equal(t, 2, sink.MessageCount())
 
-	// First message: thinking text.
-	thinkingMsg := sink.Messages()[0]
-	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, thinkingMsg.Source)
-	var thinkingParsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(thinkingMsg.Content, &thinkingParsed))
-	require.Equal(t, "agent_thought_chunk", thinkingParsed["sessionUpdate"])
-	content := thinkingParsed["content"].(map[string]interface{})
-	require.Equal(t, "let me think about this", content["text"])
-
-	// Second message: assistant text.
-	assistantMsg := sink.Messages()[1]
+	assistantMsg := sink.Messages()[0]
+	require.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, assistantMsg.Source)
 	var assistantParsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(assistantMsg.Content, &assistantParsed))
 	require.Equal(t, "agent_message_chunk", assistantParsed["sessionUpdate"])
 
-	// Third message: result divider.
-	resultMsg := sink.Messages()[2]
+	resultMsg := sink.Messages()[1]
 	require.True(t, resultMsg.TurnEnd, "prompt response must route through PersistTurnEnd")
 
-	// Accumulated text should be reset.
 	agent.mu.Lock()
-	require.Equal(t, "", agent.turnThinkingText.String())
 	require.Equal(t, "", agent.turnAssistantText.String())
 	agent.mu.Unlock()
 }


### PR DESCRIPTION
## Motivation

ACP-based providers (OpenCode, Gemini CLI, Copilot CLI, Kilo, Cursor, Goose) accumulated all `agent_thought_chunk` notifications into a single `strings.Builder` per turn and flushed the result at end-of-turn. This caused two visible bugs:

1. **Section titles glued to previous body**: consecutive thought blocks were concatenated with no separator, turning "previous sentence.**Next Section Title**" into a single unreadable run-on.
2. **Thinking disappeared after a tool call**: thought content was broadcast into the global streaming buffer (`streamingText[agentId]`). When a `tool_call` was persisted mid-turn, the frontend's `shouldClearStreamingText` wiped that buffer. The accumulated text only reappeared at the end-of-turn flush — out of chronological order, after all tool calls.

## Modifications

- Removed the `turnThinkingText strings.Builder` field from `acpBase` and all associated read, write, and reset sites in `handleACPPromptResponse`, `persistPromptResponse`, and `ClearContext`.
- Added `handleAgentThoughtChunk(content json.RawMessage)` which persists each notification immediately as a discrete `agent_thought_chunk` message via the existing `persistTextMessage` helper.
- Extracted `extractACPChunkText(content, kind) string` as a shared helper used by both `broadcastACPChunk` and the new `handleAgentThoughtChunk`, eliminating duplicated unmarshal logic.
- Switched the `agent_thought_chunk` case in `handleACPSessionUpdate` from `broadcastACPChunk` to the new handler.
- Simplified the `persistPromptResponse` signature by dropping the `thinkingText` parameter.
- Updated `opencode_output_test.go`, `kilo_output_test.go`, and `gemini_output_test.go` to match the new per-notification persistence model; added `TestHandleOpenCodeOutput_AgentThoughtChunk_MultipleNotifications` and `TestHandleOpenCodeOutput_ThoughtThenToolCallPreservesOrder` to cover section-boundary and ordering correctness.

## Result

Consecutive thinking blocks from ACP providers now each appear as their own collapsible thinking message at their true chronological position in the conversation. Section titles no longer run into the preceding block's last sentence, and thinking content is no longer wiped when a tool call is interleaved mid-turn. The live streaming indicator for thoughts is replaced by per-chunk persisted messages; the `ThinkingIndicator` spinner (driven by agent status) is unaffected. Pi, Claude Code, and Codex are unaffected.
