### PR TITLE
ci: share rustc compile cache across CI and desktop-artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,17 +17,6 @@ env:
   # Node-24 releases (or once the forced-switch date passes and the override
   # becomes a no-op).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # sccache fronts rustc to cache individual compilation units in the GHA
-  # cache backend. SCCACHE_GHA_ENABLED switches the storage layer on;
-  # RUSTC_WRAPPER points cargo at sccache; CARGO_INCREMENTAL=0 disables
-  # incremental compilation (which conflicts with sccache and would otherwise
-  # pollute target/ with non-cacheable artifacts). Every job that compiles
-  # Rust must install sccache via `mozilla-actions/sccache-action` before
-  # `cargo` runs — jobs that don't run cargo are unaffected because rustc
-  # never invokes the wrapper.
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
-  CARGO_INCREMENTAL: "0"
 
 jobs:
   linux:
@@ -138,13 +127,6 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Setup sccache
-        # Wraps rustc to cache individual compilation units in the GHA cache
-        # backend. Must run before any `cargo` invocation; the workflow-level
-        # RUSTC_WRAPPER=sccache env var causes cargo to fail if the binary is
-        # not on PATH.
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Cache Cargo dependencies
         # Swatinem/rust-cache replaces a raw actions/cache for desktop/rust/
@@ -353,9 +335,6 @@ jobs:
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
       - name: Cache Cargo dependencies
         # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
         uses: Swatinem/rust-cache@v2
@@ -456,9 +435,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Cache Cargo dependencies
         # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,17 @@ env:
   # Node-24 releases (or once the forced-switch date passes and the override
   # becomes a no-op).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # sccache fronts rustc to cache individual compilation units in the GHA
+  # cache backend. SCCACHE_GHA_ENABLED switches the storage layer on;
+  # RUSTC_WRAPPER points cargo at sccache; CARGO_INCREMENTAL=0 disables
+  # incremental compilation (which conflicts with sccache and would otherwise
+  # pollute target/ with non-cacheable artifacts). Every job that compiles
+  # Rust must install sccache via `mozilla-actions/sccache-action` before
+  # `cargo` runs — jobs that don't run cargo are unaffected because rustc
+  # never invokes the wrapper.
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   linux:
@@ -45,7 +56,13 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .apt-cache
-          key: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('.github/workflows/ci.yaml') }}
+          # Hash both workflow files so adding or removing a package in
+          # either ci.yaml or desktop-artifacts.yaml rotates the cache. The
+          # two workflows install identical package sets and share the
+          # cache scope; if only ci.yaml were hashed, a desktop-artifacts-
+          # only edit would silently re-download every run.
+          key: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('.github/workflows/ci.yaml', '.github/workflows/desktop-artifacts.yaml') }}
+          restore-keys: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-
 
       - name: Configure APT cache directories
         run: |
@@ -122,15 +139,27 @@ jobs:
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Setup sccache
+        # Wraps rustc to cache individual compilation units in the GHA cache
+        # backend. Must run before any `cargo` invocation; the workflow-level
+        # RUSTC_WRAPPER=sccache env var causes cargo to fail if the binary is
+        # not on PATH.
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # Swatinem/rust-cache replaces a raw actions/cache for desktop/rust/
+        # target: it splits the key by rustc + target triple automatically,
+        # only stores fingerprinted artifacts that match the current
+        # Cargo.lock, and prunes stale outputs before save — so the saved
+        # blob stays tight and a `RUST_VERSION` bump rotates the key
+        # cleanly instead of restoring 1+ GB of artifacts cargo then
+        # discards. `shared-key: desktop` keeps ci.yaml and
+        # desktop-artifacts.yaml on the same key so push-to-main's
+        # desktop-artifacts run reuses the cache CI just populated.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         # The cached ~/.cache/tauri contents (linuxdeploy AppImage, the
@@ -151,17 +180,24 @@ jobs:
         with:
           path: ~/.cache/tauri
           key: tauri-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('desktop/rust/scripts/patch-linuxdeploy.sh', 'desktop/rust/scripts/linuxdeploy-wrapper.c') }}
+          # Fall back to last week's cache at the Monday CACHE_WEEK rotation
+          # boundary so we don't redownload the linuxdeploy AppImage + GTK
+          # plugins every Monday.
+          restore-keys: tauri-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache awesome-claude-spinners
         # Spinner JSON files are fetched by `task generate-spinners` with
         # a fresh git clone every run. Caching the generated directory
         # keyed on CACHE_WEEK lets us skip the clone on subsequent runs
         # within the same ISO week while still refreshing weekly (matching
-        # the Tauri cache policy above).
+        # the Tauri cache policy above). The content is pure JSON,
+        # identical across all OS/arch combinations, so the key omits
+        # runner.os/runner.arch — the first job in any run populates it
+        # for the rest.
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
@@ -317,27 +353,28 @@ jobs:
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/tauri
           key: tauri-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          restore-keys: tauri-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache awesome-claude-spinners
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
@@ -420,27 +457,28 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         uses: actions/cache@v5
         with:
           path: ~/AppData/Local/tauri
           key: tauri-${{ runner.os }}-${{ env.CACHE_WEEK }}
+          restore-keys: tauri-${{ runner.os }}-
 
       - name: Cache awesome-claude-spinners
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -35,14 +35,6 @@ env:
   # ship Node-24 releases. Reusable workflows do not inherit env from the
   # caller, so this has to be redeclared here.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Match ci.yaml: route rustc through sccache so the GHA-backed compile
-  # cache fills in any artifacts the Swatinem/rust-cache restore missed.
-  # Workflow-level so every Rust-compiling job inherits the same wrapper;
-  # signing jobs that don't run cargo are unaffected. See ci.yaml for the
-  # full rationale.
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
-  CARGO_INCREMENTAL: "0"
 
 jobs:
   linux:
@@ -153,9 +145,6 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Cache Cargo dependencies
         # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
@@ -342,9 +331,6 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Cache Cargo dependencies
         # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
@@ -655,9 +641,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Cache Cargo dependencies
         # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.

--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -35,6 +35,14 @@ env:
   # ship Node-24 releases. Reusable workflows do not inherit env from the
   # caller, so this has to be redeclared here.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Match ci.yaml: route rustc through sccache so the GHA-backed compile
+  # cache fills in any artifacts the Swatinem/rust-cache restore missed.
+  # Workflow-level so every Rust-compiling job inherits the same wrapper;
+  # signing jobs that don't run cargo are unaffected. See ci.yaml for the
+  # full rationale.
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   linux:
@@ -70,7 +78,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .apt-cache
-          key: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('.github/workflows/ci.yaml') }}
+          # Hash both workflow files: see ci.yaml for the rationale. Keeping
+          # the keys identical between the two workflows means push-to-main
+          # populates the cache in ci.yaml's linux job and desktop-artifacts
+          # reads it back here.
+          key: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('.github/workflows/ci.yaml', '.github/workflows/desktop-artifacts.yaml') }}
+          restore-keys: apt-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-
 
       - name: Configure APT cache directories
         run: |
@@ -141,15 +154,15 @@ jobs:
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         # See ci.yaml's matching step for why both patch-linuxdeploy.sh and
@@ -158,12 +171,13 @@ jobs:
         with:
           path: ~/.cache/tauri
           key: tauri-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}-${{ hashFiles('desktop/rust/scripts/patch-linuxdeploy.sh', 'desktop/rust/scripts/linuxdeploy-wrapper.c') }}
+          restore-keys: tauri-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache awesome-claude-spinners
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
@@ -189,6 +203,75 @@ jobs:
 
       - name: Build
         run: task build
+
+      - name: Diagnose linuxdeploy (on failure)
+        # Tauri captures linuxdeploy's stdout/stderr and silently discards
+        # them on failure, leaving only "failed to run linuxdeploy" in the
+        # log. Re-run the wrapper and the extracted AppRun directly so
+        # their real output surfaces in the CI log. Runs only if a
+        # preceding step failed, so the success path stays quiet. Mirrors
+        # the matching step in ci.yaml's linux job — desktop-artifacts and
+        # CI share the same Tauri linuxdeploy build path, so they share
+        # the same flake surface.
+        if: failure()
+        run: |
+          set +e
+          echo "=== ~/.cache/tauri contents ==="
+          ls -la ~/.cache/tauri/
+          echo
+          echo "=== Tauri's AppImage bundle dir ==="
+          ls -la desktop/rust/target/release/bundle/appimage/ 2>/dev/null
+          echo
+          echo "=== linuxdeploy wrapper --version (exit=?) ==="
+          ~/.cache/tauri/linuxdeploy-$(uname -m).AppImage --version
+          echo "wrapper exit=$?"
+          echo
+          echo "=== extracted AppRun --list-plugins (exit=?) ==="
+          ~/.cache/tauri/linuxdeploy-extracted/AppRun --list-plugins
+          echo "AppRun exit=$?"
+          echo
+          echo "=== Re-run linuxdeploy against Tauri's partial AppDir ==="
+          appdir="$(ls -d desktop/rust/target/release/bundle/appimage/*.AppDir 2>/dev/null | head -1)"
+          if [ -n "$appdir" ]; then
+            echo "appdir=$appdir"
+            ~/.cache/tauri/linuxdeploy-$(uname -m).AppImage \
+              --appdir "$appdir" \
+              --output appimage \
+              --plugin gtk 2>&1 | tail -80
+            echo "direct linuxdeploy exit=${PIPESTATUS[0]}"
+          else
+            echo "No AppDir found — Tauri didn't reach the linuxdeploy step."
+          fi
+          echo
+          echo "=== Go sidecar linkage (source copy) ==="
+          src_sidecar="$(ls desktop/go/bin/leapmux-desktop-service-* 2>/dev/null | head -1)"
+          if [ -n "$src_sidecar" ]; then
+            echo "path=$src_sidecar"
+            file "$src_sidecar"
+            echo "--- readelf -l | grep INTERP ---"
+            readelf -l "$src_sidecar" 2>&1 | grep -E 'INTERP|interpreter' || echo "(no INTERP segment — static binary)"
+            echo "--- ldd output ---"
+            ldd "$src_sidecar" 2>&1
+            echo "ldd exit=$?"
+          else
+            echo "No sidecar found under desktop/go/bin/"
+          fi
+          echo
+          echo "=== Go sidecar linkage (AppDir copy) ==="
+          ad_sidecar="$(find "$appdir" -name 'leapmux-desktop-service-*' 2>/dev/null | head -1)"
+          if [ -n "$ad_sidecar" ]; then
+            echo "path=$ad_sidecar"
+            file "$ad_sidecar"
+            ldd "$ad_sidecar" 2>&1
+            echo "ldd exit=$?"
+          else
+            echo "No sidecar found inside AppDir."
+          fi
+          echo
+          echo "=== Toolchain sanity ==="
+          echo "gcc: $(command -v gcc) $(gcc --version 2>/dev/null | head -1)"
+          echo "CGO_ENABLED (go env): $(go env CGO_ENABLED)"
+          echo "/lib/ld-linux-aarch64.so.1: $(ls -la /lib/ld-linux-aarch64.so.1 2>&1 || true)"
 
       - name: Package CLI server tarball
         run: |
@@ -260,27 +343,28 @@ jobs:
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/tauri
           key: tauri-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          restore-keys: tauri-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache awesome-claude-spinners
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
@@ -572,27 +656,28 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        # See ci.yaml's linux job for why Swatinem/rust-cache + shared-key.
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/rust/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('desktop/rust/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+          workspaces: desktop/rust
+          shared-key: desktop
 
       - name: Cache Tauri downloads
         uses: actions/cache@v5
         with:
           path: ~/AppData/Local/tauri
           key: tauri-${{ runner.os }}-${{ env.CACHE_WEEK }}
+          restore-keys: tauri-${{ runner.os }}-
 
       - name: Cache awesome-claude-spinners
         uses: actions/cache@v5
         with:
           path: frontend/src/spinners
-          key: spinners-${{ runner.os }}-${{ env.CACHE_WEEK }}
+          key: spinners-${{ env.CACHE_WEEK }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

The cache keys in `ci.yaml` and `desktop-artifacts.yaml` were already structurally identical, but several settings left compile time on the table. This PR makes four paired changes in both workflows so the two share caches on push-to-main, plus ports one missing diagnostic step.

### Changes

- **Swatinem/rust-cache@v2** replaces the raw `actions/cache` for Cargo in all six jobs (linux/macos/windows × ci/desktop-artifacts). Splits the key by rustc + target triple automatically, only stores fingerprinted artifacts that match the current `Cargo.lock`, and prunes stale outputs before save — so a `RUST_VERSION` bump rotates the key cleanly instead of restoring 1+ GB of artifacts cargo then discards. `shared-key: desktop` keeps both workflows on the same key.
- **`restore-keys` on the Tauri cache** in every job. The cache is keyed on `CACHE_WEEK`, so without a fallback both workflows missed every Monday at the ISO-week rotation and redownloaded the linuxdeploy AppImage + GTK plugins.
- **APT cache key now hashes both workflow files** (was only `ci.yaml`). A package edit in only `desktop-artifacts.yaml` previously didn't rotate the key, leaving the new package re-downloaded on every run.
- **Spinners cache key dropped `runner.os`/`runner.arch`**. The content is pure JSON pulled from a git clone — identical across all OS/arch combinations — so one populate covers every job in the run.

Also ported the `if: failure()` linuxdeploy diagnostic step from `ci.yaml`'s linux job into `desktop-artifacts.yaml`'s linux job so flakes there surface the same diagnostic logs (Tauri otherwise discards linuxdeploy's stdout/stderr on failure).