### PR TITLE
feat(desktop): Embed leapmux CLI in app bundles with PATH setup prompt

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -297,16 +297,28 @@ tasks:
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
+      - leapmux
     generates:
       - "LeapMux Desktop.app/**/*"
       - "LeapMuxDesktop_{{.VERSION}}_{{ARCH}}.dmg"
     cmds:
+      # build-backend isn't implied by build-desktop-darwin on its own (only
+      # by the top-level `task build`), but the cp step below embeds the CLI
+      # into the .app bundle, so leapmux must exist at the repo root first.
+      - task: build-backend
       - task: prepare-desktop
       - task: build-desktop-sidecar
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --bundles app --config '{"version":"{{.VERSION}}"}'
       # Move sidecar from Resources/_up_/go/bin/ to MacOS/ for a cleaner bundle layout.
       - mv "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/Resources/_up_/go/bin/"* "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/MacOS/"
       - rm -rf "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/Resources/_up_"
+      # Embed the leapmux CLI inside Contents/MacOS/. The inside-out
+      # signing sweep in sign-macos.sh discovers it as a Mach-O and applies
+      # Developer ID + hardened runtime alongside the sidecar; the runtime
+      # PATH check in the Go sidecar resolves it via
+      # filepath.Join(filepath.Dir(os.Executable()), "leapmux") at startup.
+      - cp leapmux "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/MacOS/leapmux"
+      - chmod 0755 "desktop/rust/target/release/bundle/macos/LeapMux Desktop.app/Contents/MacOS/leapmux"
       # Sign the .app. With MACOS_CODESIGN_IDENTITY set, sign-macos.sh applies
       # Developer ID + hardened runtime + entitlements to nested Mach-O code
       # inside-out; without it, falls back to ad-hoc signing for local dev.
@@ -346,6 +358,12 @@ tasks:
       - xcrun stapler staple {{.APP_PATH}}
       - xcrun stapler validate {{.APP_PATH}}
       - rm -f notarize-app.zip
+      # Explicit assertion that the inside-out signer actually picked up the
+      # embedded leapmux CLI binary and that Gatekeeper accepts it. Without
+      # this check, a regression in sign-macos.sh's Mach-O discovery could
+      # silently ship an unsigned CLI inside an otherwise-notarized .app.
+      - codesign --verify --strict --verbose=2 "{{.APP_PATH}}/Contents/MacOS/leapmux"
+      - spctl --assess --verbose --type exec "{{.APP_PATH}}/Contents/MacOS/leapmux"
       # Confirm Gatekeeper accepts the now-stapled .app before we wrap it.
       - spctl --assess --verbose --type exec {{.APP_PATH}}
       # Rebuild the DMG from the stapled .app, then sign + notarize + staple
@@ -413,12 +431,17 @@ tasks:
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
+      - leapmux
     generates:
       - leapmux-desktop
       - leapmux-desktop-service-*
       - leapmux-desktop*.deb
       - leapmux-desktop*.AppImage
     cmds:
+      # build-backend is not implied by build-desktop-linux on its own (only by
+      # the top-level `task build`), but tauri.linux.conf.json's `deb.files`
+      # references ../../leapmux, so the CLI must exist before tauri build.
+      - task: build-backend
       - task: prepare-desktop
       - task: build-desktop-sidecar
       - desktop/rust/scripts/patch-linuxdeploy.sh
@@ -427,6 +450,26 @@ tasks:
       - cp -f desktop/go/bin/leapmux-desktop-service-* .
       - cp -f desktop/rust/target/release/bundle/deb/leapmux-desktop*.deb .
       - cp -f desktop/rust/target/release/bundle/appimage/leapmux-desktop*.AppImage .
+      # Tauri's deb bundler hardcodes /usr/bin/<mainBinaryName> for the app
+      # binary; there's no config knob to relocate it. Post-process the .deb
+      # so `leapmux-desktop` lands under /usr/lib/ (off PATH) while
+      # /usr/bin/leapmux (added via deb.files) stays as the only CLI on PATH.
+      # dpkg-deb -R/-b is round-tripped by Debian itself — md5sums regenerate
+      # automatically. The grep -q is a tripwire: if desktop-template.desktop
+      # ever stops pointing at /usr/lib/..., the relocation falls out of sync
+      # and we want a loud failure rather than a silent broken .desktop file.
+      - |
+        set -euo pipefail
+        for deb in leapmux-desktop_*.deb; do
+          work="$(mktemp -d)"
+          dpkg-deb -R "$deb" "$work"
+          mkdir -p "$work/usr/lib/leapmux-desktop"
+          mv "$work/usr/bin/leapmux-desktop" "$work/usr/lib/leapmux-desktop/leapmux-desktop"
+          grep -q '^Exec=/usr/lib/leapmux-desktop/leapmux-desktop$' \
+            "$work/usr/share/applications/"*.desktop
+          dpkg-deb -b "$work" "$deb"
+          rm -rf "$work"
+        done
 
   build-desktop-windows:
     desc: Build desktop for Windows
@@ -444,45 +487,47 @@ tasks:
       - desktop/rust/capabilities/**/*
       - desktop/rust/tauri.conf.json
       - desktop/rust/tauri.windows.conf.json
+      - desktop/rust/windows/**/*
       - desktop/rust/icons/icon.ico
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
+      - leapmux.exe
     generates:
-      - LeapMuxDesktop*.exe
       - LeapMuxDesktop*.msi
       - leapmux-desktop-service-*.exe
     cmds:
+      # build-backend isn't implied by build-desktop-windows on its own; only
+      # the top-level `task build` calls it first. The WiX fragment references
+      # $(env.LEAPMUX_CLI_PATH), which we point at the CLI built right here.
+      - task: build-backend
       - task: prepare-desktop
       - task: build-desktop-sidecar
-      - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION | replace "-dev" ""}}"}'
-      - cp -f desktop/rust/target/release/LeapMuxDesktop.exe .
-      - cp -f desktop/go/bin/leapmux-desktop-service-*.exe .
-      # Tauri's NSIS and WiX bundlers name the installer after productName
-      # ("LeapMux Desktop" — with a space), regardless of our mainBinaryName
-      # override. Copy with a space-stripping rename so we ship spaceless
-      # filenames. The WiX bundler additionally appends "_en-US"; strip
-      # that too. Both bundlers also embed whatever version we passed to
-      # `tauri build` — which is {{.VERSION}} with "-dev" stripped, since
-      # WiX's ProductVersion rejects semver prerelease tags — so re-insert
-      # the full {{.VERSION}} in the output filename to match the other
-      # desktop bundles. The MSI's internal ProductVersion and the NSIS
-      # installer's internal version string stay at the stripped form;
-      # that's a Windows Installer / NSIS limitation we can't work around,
-      # but the filename is what users download. We cd into the bundle
-      # dir first so the glob expands to bare filenames: on Windows,
-      # mvdan/sh expands globs with directory segments to native backslash
-      # paths, and the resulting behavior of `${##*/}` varies with the
-      # parent shell (bash vs PowerShell).
+      # LEAPMUX_CLI_PATH is consumed by desktop/rust/windows/wix-peruser.wxs
+      # via WiX's $(env.NAME) preprocessor. tauri build invokes
+      # candle.exe/light.exe in this same env, so the path resolves at
+      # bundling time. --bundles msi drops Tauri's default NSIS .exe — we
+      # ship MSI only because only WiX exposes the `<Environment>` machinery
+      # we use for the scoped HKCU PATH append.
       - |
-        repo_root="$(pwd)"
-        cd desktop/rust/target/release/bundle/nsis
-        for src in LeapMux*-setup.exe; do
-          [ -e "$src" ] || continue
-          dest="${src// /}"
-          dest="${dest/_{{.VERSION | replace "-dev" ""}}_/_{{.VERSION}}_}"
-          cp -f "$src" "$repo_root/$dest"
-        done
+        export LEAPMUX_CLI_PATH="$(pwd)/leapmux.exe"
+        cd desktop/rust && ../../frontend/node_modules/.bin/tauri build \
+          --bundles msi \
+          --config '{"version":"{{.VERSION | replace "-dev" ""}}"}'
+      - cp -f desktop/go/bin/leapmux-desktop-service-*.exe .
+      # Tauri's WiX bundler names the installer after productName ("LeapMux
+      # Desktop" — with a space) regardless of mainBinaryName, and appends
+      # "_en-US" before the extension. Strip both for the published filename.
+      # Tauri also embeds whatever version we passed to `tauri build` —
+      # {{.VERSION}} with "-dev" stripped, since WiX's ProductVersion rejects
+      # semver prerelease tags — so we re-insert the full {{.VERSION}} in the
+      # output filename to match the .deb/.dmg artifacts. The MSI's internal
+      # ProductVersion stays at the stripped form; that's a Windows Installer
+      # limitation we can't work around, but the filename is what users
+      # download. We cd into the bundle dir first so the glob expands to bare
+      # filenames: on Windows, mvdan/sh expands globs with directory segments
+      # to native backslash paths and `${##*/}` then varies with the parent
+      # shell (bash vs PowerShell).
       - |
         repo_root="$(pwd)"
         cd desktop/rust/target/release/bundle/msi
@@ -505,7 +550,7 @@ tasks:
         if: '[ "{{OS}}" = "darwin" ]'
       - cmd: ./leapmux-desktop {{.CLI_ARGS}}
         if: '[ "{{OS}}" = "linux" ]'
-      - cmd: ./LeapMuxDesktop.exe {{.CLI_ARGS}}
+      - cmd: ./desktop/rust/target/release/LeapMuxDesktop.exe {{.CLI_ARGS}}
         if: '[ "{{OS}}" = "windows" ]'
 
   # --- Testing ---
@@ -670,7 +715,7 @@ tasks:
     desc: Start desktop app for development
     cmds:
       - task: generate
-      - task: prepare-frontend
+      - task: build-backend
       - task: prepare-desktop
       - task: build-desktop-sidecar
       - mprocs --config mprocs-desktop.yaml
@@ -824,7 +869,6 @@ tasks:
       - rm -f  leapmux-desktop-service-*
       - rm -f  leapmux-desktop*.deb
       - rm -f  leapmux-desktop*.AppImage
-      - rm -f  LeapMux*.exe
       - rm -f  LeapMux*.msi
       - rm -f  desktop/go/leapmux-desktop desktop/go/leapmux-desktop.exe
       - rm -rf desktop/go/bin/

--- a/desktop/go/app.go
+++ b/desktop/go/app.go
@@ -270,3 +270,19 @@ func (a *App) ListEditors(refresh bool) []DetectedEditor {
 func (a *App) OpenInEditor(editorID, path string) error {
 	return a.editors.Open(editorID, path)
 }
+
+// CliPathStatus reports whether the bundled `leapmux` CLI is discoverable on
+// the current user's PATH. macOS only — other platforms always report
+// STATE_UNAVAILABLE because PATH integration is handled by the installer.
+func (a *App) CliPathStatus() *desktoppb.CliPathStatusResponse {
+	return cliPathStatusFromSidecar()
+}
+
+// CliInstallSymlink attempts to create the on-PATH symlink pointing at the
+// bundled `leapmux`. macOS only. `force` lets the caller overwrite a real
+// (non-symlink) file at the destination — the UI sets it on the user's
+// "Replace" confirmation after a prior call reported
+// RESULT_ALREADY_EXISTS_REAL_FILE.
+func (a *App) CliInstallSymlink(force bool) *desktoppb.CliInstallSymlinkResponse {
+	return cliInstallSymlinkFromSidecar(force)
+}

--- a/desktop/go/cli_path_darwin.go
+++ b/desktop/go/cli_path_darwin.go
@@ -1,0 +1,313 @@
+//go:build darwin
+
+package main
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+// cliSymlinkDst is the on-PATH location we install the leapmux symlink at.
+// /usr/local/bin is the conventional macOS spot writable by an admin user on
+// Intel and a no-op on a clean Apple Silicon machine (no Homebrew).
+const cliSymlinkDst = "/usr/local/bin/leapmux"
+
+// cliBinaryName is the basename of the CLI both inside the .app and on PATH.
+const cliBinaryName = "leapmux"
+
+func bundledCliPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return resolveBundledCli(exe)
+}
+
+// resolveBundledCli returns the path to the bundled leapmux CLI given the
+// running sidecar's executable path. Two layouts are supported:
+//
+//  1. Production .app: the desktop build's `cp leapmux …/Contents/MacOS/`
+//     step puts the CLI as a direct sibling of the sidecar inside the
+//     .app bundle. <exe-dir>/leapmux is the production path.
+//
+//  2. Dev (`task dev-desktop`): the sidecar runs from
+//     <repo>/desktop/go/bin/leapmux-desktop-service-<triple>, and the
+//     CLI is built into <repo>/leapmux by `task build-backend`. Climb
+//     four parents above the exe to reach the repo root and look there.
+//
+// The production check runs first, so a real .app install never accidentally
+// resolves to a stray `leapmux` file four levels up its parent chain.
+func resolveBundledCli(exe string) string {
+	if p := filepath.Join(filepath.Dir(exe), cliBinaryName); isRegularExecutable(p) {
+		return p
+	}
+	if root := parentN(exe, 4); root != "" {
+		if p := filepath.Join(root, cliBinaryName); isRegularExecutable(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// parentN returns the directory n levels above path, or "" if the chain
+// bottoms out at the filesystem root before n hops complete. filepath.Dir
+// is idempotent at "/" / drive roots, so the loop has to detect that
+// itself rather than trust a fixed N applications.
+func parentN(path string, n int) string {
+	for i := 0; i < n; i++ {
+		next := filepath.Dir(path)
+		if next == path {
+			return ""
+		}
+		path = next
+	}
+	return path
+}
+
+func lookupOnSystemPath() string {
+	return findOnPath(os.Getenv("PATH"))
+}
+
+// findOnPath walks PATH entries left-to-right and returns the first
+// `<dir>/leapmux` that's a regular file with any exec bit set. Symlinks are
+// returned as-is — classify() canonicalizes them.
+func findOnPath(pathEnv string) string {
+	if pathEnv == "" {
+		return ""
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, cliBinaryName)
+		if isRegularExecutable(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// isRegularExecutable returns true when path is a regular file (after
+// following symlinks) with at least one exec bit set. Directories named
+// "leapmux" and unreadable entries are rejected.
+func isRegularExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// classify returns the PATH status comparing the bundled CLI against the
+// on-PATH copy. The compare is two-stage: realpath equality first (cheap),
+// then sha256 content equality (so a user who copied the bundled binary to
+// /usr/local/bin still classifies as STATE_OK rather than STATE_MISMATCH).
+//
+// target_kind is filled in every response. It describes what currently
+// occupies the install destination (cliSymlinkDst) — independent of state —
+// so the UI can pick the right button treatment (regular vs. two-click
+// danger ConfirmButton) and message upfront, rather than learning about a
+// real file at the destination only after the user clicks Install.
+func classify(bundled, onPath string) *desktoppb.CliPathStatusResponse {
+	if bundled == "" {
+		return &desktoppb.CliPathStatusResponse{State: desktoppb.CliPathStatusResponse_STATE_UNAVAILABLE}
+	}
+	targetKind := inspectTargetKind(cliSymlinkDst)
+	if onPath == "" {
+		return &desktoppb.CliPathStatusResponse{
+			State:      desktoppb.CliPathStatusResponse_STATE_MISSING,
+			Bundled:    bundled,
+			Target:     cliSymlinkDst,
+			TargetKind: targetKind,
+		}
+	}
+
+	bundledReal, errA := filepath.EvalSymlinks(bundled)
+	onPathReal, errB := filepath.EvalSymlinks(onPath)
+	if errA == nil && errB == nil && bundledReal == onPathReal {
+		return &desktoppb.CliPathStatusResponse{
+			State:      desktoppb.CliPathStatusResponse_STATE_OK,
+			Bundled:    bundled,
+			TargetKind: targetKind,
+		}
+	}
+
+	same, err := contentsEqual(bundled, onPath)
+	if err == nil && same {
+		return &desktoppb.CliPathStatusResponse{
+			State:      desktoppb.CliPathStatusResponse_STATE_OK,
+			Bundled:    bundled,
+			TargetKind: targetKind,
+		}
+	}
+
+	return &desktoppb.CliPathStatusResponse{
+		State:      desktoppb.CliPathStatusResponse_STATE_MISMATCH,
+		Bundled:    bundled,
+		Resolved:   onPath,
+		TargetKind: targetKind,
+	}
+}
+
+// inspectTargetKind classifies what currently sits at cliSymlinkDst, so
+// the UI can decide whether the Install button needs a two-click "danger"
+// arming (only for a real file — never for symlinks, which we always
+// replace silently). Permission errors fall through to UNSPECIFIED; the
+// UI plays it safe and treats UNSPECIFIED the same as REGULAR_FILE.
+func inspectTargetKind(path string) desktoppb.CliPathStatusResponse_TargetKind {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return desktoppb.CliPathStatusResponse_TARGET_KIND_ABSENT
+		}
+		return desktoppb.CliPathStatusResponse_TARGET_KIND_UNSPECIFIED
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return desktoppb.CliPathStatusResponse_TARGET_KIND_SYMLINK
+	}
+	if info.Mode().IsRegular() {
+		return desktoppb.CliPathStatusResponse_TARGET_KIND_REGULAR_FILE
+	}
+	return desktoppb.CliPathStatusResponse_TARGET_KIND_UNSPECIFIED
+}
+
+// contentsEqual compares two files by SHA-256 digest. A nil error with a true
+// return means the files have identical bytes; a non-nil error means one
+// could not be read (treat as "not equal" at the caller — classify falls
+// through to MISMATCH so the user sees a warning instead of a silent OK).
+func contentsEqual(a, b string) (bool, error) {
+	ha, err := fileSha256(a)
+	if err != nil {
+		return false, err
+	}
+	hb, err := fileSha256(b)
+	if err != nil {
+		return false, err
+	}
+	return ha == hb, nil
+}
+
+func fileSha256(path string) ([32]byte, error) {
+	var zero [32]byte
+	f, err := os.Open(path)
+	if err != nil {
+		return zero, err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return zero, err
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// installSymlink creates dst → bundled. Existing dangling/wrong symlinks at
+// dst are always removed and replaced — the goal is just to make the link
+// point at the bundled binary, and an outdated symlink isn't user content.
+// A non-symlink regular file at dst is treated as user-installed: when
+// `force` is false we refuse with RESULT_ALREADY_EXISTS_REAL_FILE so the UI
+// can confirm before clobbering, and when true we remove it first. On
+// EACCES/EROFS/EPERM the install returns RESULT_NEEDS_SUDO with the exact
+// sudo command (including `-f` so the user's manual retry also overwrites).
+func installSymlink(bundled, dst string, force bool) *desktoppb.CliInstallSymlinkResponse {
+	if bundled == "" {
+		return &desktoppb.CliInstallSymlinkResponse{
+			Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+			Message: "bundled leapmux binary not found inside the app",
+		}
+	}
+
+	parent := filepath.Dir(dst)
+	if _, err := os.Stat(parent); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &desktoppb.CliInstallSymlinkResponse{
+				Result:  desktoppb.CliInstallSymlinkResponse_RESULT_PARENT_MISSING,
+				Path:    parent,
+				Command: fmt.Sprintf("sudo mkdir -p %q && sudo ln -sf %q %q", parent, bundled, dst),
+			}
+		}
+		return &desktoppb.CliInstallSymlinkResponse{
+			Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+			Message: err.Error(),
+		}
+	}
+
+	if info, err := os.Lstat(dst); err == nil {
+		isSymlink := info.Mode()&os.ModeSymlink != 0
+		if !isSymlink && !force {
+			return &desktoppb.CliInstallSymlinkResponse{
+				Result: desktoppb.CliInstallSymlinkResponse_RESULT_ALREADY_EXISTS_REAL_FILE,
+				Path:   dst,
+			}
+		}
+		if err := os.Remove(dst); err != nil {
+			return &desktoppb.CliInstallSymlinkResponse{
+				Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+				Message: fmt.Sprintf("remove existing entry: %s", err),
+			}
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return &desktoppb.CliInstallSymlinkResponse{
+			Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+			Message: err.Error(),
+		}
+	}
+
+	if err := os.Symlink(bundled, dst); err != nil {
+		if isPermissionDenied(err) {
+			return &desktoppb.CliInstallSymlinkResponse{
+				Result:  desktoppb.CliInstallSymlinkResponse_RESULT_NEEDS_SUDO,
+				Command: fmt.Sprintf("sudo ln -sf %q %q", bundled, dst),
+			}
+		}
+		return &desktoppb.CliInstallSymlinkResponse{
+			Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+			Message: err.Error(),
+		}
+	}
+
+	return &desktoppb.CliInstallSymlinkResponse{
+		Result: desktoppb.CliInstallSymlinkResponse_RESULT_OK,
+	}
+}
+
+// isPermissionDenied catches the three POSIX errnos macOS surfaces when the
+// CLI install target sits in a directory the current user can't write to
+// (typical for /usr/local/bin on a fresh, unmodified machine). We use
+// errors.Is against the standard fs.ErrPermission sentinel plus explicit
+// syscall checks to cover ReadOnlyFilesystem and EPERM, which macOS returns
+// for SIP-protected directories.
+func isPermissionDenied(err error) bool {
+	if errors.Is(err, fs.ErrPermission) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.EACCES, syscall.EROFS, syscall.EPERM:
+			return true
+		}
+	}
+	return false
+}
+
+func cliPathStatusFromSidecar() *desktoppb.CliPathStatusResponse {
+	return classify(bundledCliPath(), lookupOnSystemPath())
+}
+
+func cliInstallSymlinkFromSidecar(force bool) *desktoppb.CliInstallSymlinkResponse {
+	return installSymlink(bundledCliPath(), cliSymlinkDst, force)
+}

--- a/desktop/go/cli_path_darwin_test.go
+++ b/desktop/go/cli_path_darwin_test.go
@@ -1,0 +1,313 @@
+//go:build darwin
+
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeExec(t *testing.T, dir, name string, contents []byte, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, contents, mode))
+	return path
+}
+
+func TestFindOnPath_FindsFirstExecutable(t *testing.T) {
+	t.Parallel()
+	a := t.TempDir()
+	b := t.TempDir()
+	writeExec(t, b, "leapmux", []byte("real"), 0o755)
+	// Only b's leapmux exists; a is empty.
+	got := findOnPath(a + string(filepath.ListSeparator) + b)
+	assert.Equal(t, filepath.Join(b, "leapmux"), got)
+}
+
+func TestFindOnPath_IgnoresNonExecutable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeExec(t, dir, "leapmux", []byte("readable"), 0o644)
+	assert.Empty(t, findOnPath(dir))
+}
+
+func TestFindOnPath_IgnoresDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "leapmux"), 0o755))
+	assert.Empty(t, findOnPath(dir))
+}
+
+func TestFindOnPath_EmptyPath(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, findOnPath(""))
+}
+
+func TestFindOnPath_SkipsEmptyEntries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeExec(t, dir, "leapmux", []byte("x"), 0o755)
+	// Leading/trailing/double colons must not blow up SplitList.
+	got := findOnPath(string(filepath.ListSeparator) + dir + string(filepath.ListSeparator))
+	assert.Equal(t, filepath.Join(dir, "leapmux"), got)
+}
+
+func TestClassify_UnavailableWhenBundledAbsent(t *testing.T) {
+	t.Parallel()
+	resp := classify("", "/usr/local/bin/leapmux")
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_UNAVAILABLE, resp.State)
+}
+
+func TestClassify_MissingWhenPathEmpty(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("b"), 0o755)
+	resp := classify(bundled, "")
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_MISSING, resp.State)
+	assert.Equal(t, bundled, resp.Bundled)
+	assert.Equal(t, cliSymlinkDst, resp.Target)
+}
+
+func TestClassify_OkWhenRealpathEqual(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("b"), 0o755)
+	// /usr/local/bin/leapmux scenario: symlink to bundled in a PATH dir.
+	pathDir := t.TempDir()
+	link := filepath.Join(pathDir, "leapmux")
+	require.NoError(t, os.Symlink(bundled, link))
+
+	resp := classify(bundled, link)
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_OK, resp.State)
+	assert.Equal(t, bundled, resp.Bundled)
+}
+
+func TestClassify_OkWhenContentsEqual(t *testing.T) {
+	t.Parallel()
+	contents := []byte("leapmux-bytes")
+	bundled := writeExec(t, t.TempDir(), "leapmux", contents, 0o755)
+	// User-copied identical binary at a different location.
+	onPath := writeExec(t, t.TempDir(), "leapmux", contents, 0o755)
+
+	resp := classify(bundled, onPath)
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_OK, resp.State)
+}
+
+func TestClassify_MismatchWhenContentsDiffer(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("bundled-bytes"), 0o755)
+	onPath := writeExec(t, t.TempDir(), "leapmux", []byte("other-bytes"), 0o755)
+
+	resp := classify(bundled, onPath)
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_MISMATCH, resp.State)
+	assert.Equal(t, onPath, resp.Resolved)
+	assert.Equal(t, bundled, resp.Bundled)
+}
+
+func TestInstallSymlink_HappyPath(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("x"), 0o755)
+	dst := filepath.Join(t.TempDir(), "leapmux")
+
+	resp := installSymlink(bundled, dst, false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_OK, resp.Result)
+
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	assert.Equal(t, bundled, target)
+}
+
+func TestInstallSymlink_ReplacesDanglingSymlink(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("x"), 0o755)
+	dstDir := t.TempDir()
+	dst := filepath.Join(dstDir, "leapmux")
+	// Pre-existing dangling symlink should be silently replaced even without force.
+	require.NoError(t, os.Symlink("/nonexistent/path/leapmux", dst))
+
+	resp := installSymlink(bundled, dst, false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_OK, resp.Result)
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	assert.Equal(t, bundled, target)
+}
+
+func TestInstallSymlink_ReplacesOutdatedSymlink(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("new"), 0o755)
+	stale := writeExec(t, t.TempDir(), "leapmux-old", []byte("old"), 0o755)
+	dst := filepath.Join(t.TempDir(), "leapmux")
+	// Symlink pointing at a different valid binary (e.g. an older app's
+	// embedded CLI) — must be replaced without requiring force.
+	require.NoError(t, os.Symlink(stale, dst))
+
+	resp := installSymlink(bundled, dst, false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_OK, resp.Result)
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	assert.Equal(t, bundled, target)
+}
+
+func TestInstallSymlink_RefusesRealFileWithoutForce(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("x"), 0o755)
+	dst := writeExec(t, t.TempDir(), "leapmux", []byte("user-installed"), 0o755)
+
+	resp := installSymlink(bundled, dst, false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_ALREADY_EXISTS_REAL_FILE, resp.Result)
+	assert.Equal(t, dst, resp.Path)
+
+	// The user-installed binary must remain untouched.
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "user-installed", string(got))
+}
+
+func TestInstallSymlink_ForceReplacesRealFile(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("new"), 0o755)
+	dst := writeExec(t, t.TempDir(), "leapmux", []byte("user-installed"), 0o755)
+
+	resp := installSymlink(bundled, dst, true)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_OK, resp.Result)
+
+	// dst should now be a symlink to the new bundled binary, not the
+	// regular file we wrote earlier.
+	info, err := os.Lstat(dst)
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, info.Mode()&os.ModeSymlink, "dst should be a symlink after force-overwrite")
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	assert.Equal(t, bundled, target)
+}
+
+func TestInstallSymlink_ParentMissing(t *testing.T) {
+	t.Parallel()
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("x"), 0o755)
+	// Synthesize a non-existent parent directory.
+	dst := filepath.Join(t.TempDir(), "does-not-exist", "leapmux")
+
+	resp := installSymlink(bundled, dst, false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_PARENT_MISSING, resp.Result)
+	assert.Equal(t, filepath.Dir(dst), resp.Path)
+	assert.Contains(t, resp.Command, "sudo mkdir -p")
+	assert.Contains(t, resp.Command, "sudo ln -sf")
+}
+
+func TestInstallSymlink_BundledMissing(t *testing.T) {
+	t.Parallel()
+	resp := installSymlink("", filepath.Join(t.TempDir(), "leapmux"), false)
+	assert.Equal(t, desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR, resp.Result)
+}
+
+func TestResolveBundledCli_ProductionLayout(t *testing.T) {
+	t.Parallel()
+	// Simulate Contents/MacOS/ — sidecar and leapmux as direct siblings.
+	dir := t.TempDir()
+	exe := writeExec(t, dir, "leapmux-desktop-service-aarch64-apple-darwin", []byte("svc"), 0o755)
+	cli := writeExec(t, dir, "leapmux", []byte("cli"), 0o755)
+
+	assert.Equal(t, cli, resolveBundledCli(exe))
+}
+
+func TestResolveBundledCli_DevLayoutClimbsFourLevels(t *testing.T) {
+	t.Parallel()
+	// Simulate <repo>/desktop/go/bin/leapmux-desktop-service-...; the CLI is
+	// at <repo>/leapmux. The sidecar dir has no sibling leapmux, so the
+	// dev fallback should kick in and find the repo-root binary.
+	root := t.TempDir()
+	binDir := filepath.Join(root, "desktop", "go", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	exe := writeExec(t, binDir, "leapmux-desktop-service-aarch64-apple-darwin", []byte("svc"), 0o755)
+	cli := writeExec(t, root, "leapmux", []byte("cli"), 0o755)
+
+	assert.Equal(t, cli, resolveBundledCli(exe))
+}
+
+func TestResolveBundledCli_DevLayoutBundledTakesPriority(t *testing.T) {
+	t.Parallel()
+	// If both the sibling and a 4-up candidate happen to exist (paranoid
+	// test for someone with a stray ~/leapmux file installing the app at
+	// ~/Apps/X.app), the sibling wins — that's the canonical production
+	// path and the dev fallback must not steal it.
+	root := t.TempDir()
+	binDir := filepath.Join(root, "Contents", "MacOS", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	exe := writeExec(t, binDir, "leapmux-desktop-service-aarch64-apple-darwin", []byte("svc"), 0o755)
+	sibling := writeExec(t, binDir, "leapmux", []byte("canonical"), 0o755)
+	_ = writeExec(t, root, "leapmux", []byte("decoy"), 0o755)
+
+	assert.Equal(t, sibling, resolveBundledCli(exe))
+}
+
+func TestResolveBundledCli_NoneFound(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	exe := writeExec(t, dir, "leapmux-desktop-service-aarch64-apple-darwin", []byte("svc"), 0o755)
+	assert.Empty(t, resolveBundledCli(exe))
+}
+
+func TestResolveBundledCli_ShallowExeDoesNotCrash(t *testing.T) {
+	t.Parallel()
+	// Synthesize an exe path whose parent chain bottoms out before 4 hops
+	// — parentN must return "" without filepath.Dir spinning at the root.
+	assert.Empty(t, resolveBundledCli("/leapmux-desktop-service"))
+}
+
+func TestInspectTargetKind(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Absent
+	assert.Equal(t,
+		desktoppb.CliPathStatusResponse_TARGET_KIND_ABSENT,
+		inspectTargetKind(filepath.Join(dir, "nope")),
+	)
+
+	// Symlink (even when pointing nowhere — Lstat doesn't follow).
+	dangling := filepath.Join(dir, "dangling")
+	require.NoError(t, os.Symlink("/nonexistent", dangling))
+	assert.Equal(t,
+		desktoppb.CliPathStatusResponse_TARGET_KIND_SYMLINK,
+		inspectTargetKind(dangling),
+	)
+
+	// Regular file
+	regular := writeExec(t, dir, "real", []byte("x"), 0o755)
+	assert.Equal(t,
+		desktoppb.CliPathStatusResponse_TARGET_KIND_REGULAR_FILE,
+		inspectTargetKind(regular),
+	)
+}
+
+func TestClassify_PopulatesTargetKindForActiveStates(t *testing.T) {
+	t.Parallel()
+	// Smoke test: classify must set target_kind on missing/mismatch/ok so
+	// the dialog can decide button treatment without round-tripping again.
+	// We can't easily override cliSymlinkDst here, but we at least confirm
+	// the field is non-UNSPECIFIED on the missing path (where the production
+	// /usr/local/bin/leapmux is inspected).
+	bundled := writeExec(t, t.TempDir(), "leapmux", []byte("b"), 0o755)
+	resp := classify(bundled, "")
+	assert.Equal(t, desktoppb.CliPathStatusResponse_STATE_MISSING, resp.State)
+	// The actual TargetKind depends on the host machine's /usr/local/bin/leapmux —
+	// could be ABSENT, SYMLINK, or REGULAR_FILE — but never UNSPECIFIED
+	// unless lstat actually fails with a non-NotExist error.
+	assert.NotEqual(t, desktoppb.CliPathStatusResponse_TARGET_KIND_UNSPECIFIED, resp.TargetKind,
+		"classify should populate target_kind for MISSING; got UNSPECIFIED")
+}
+
+func TestIsPermissionDenied(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isPermissionDenied(syscall.EACCES))
+	assert.True(t, isPermissionDenied(syscall.EROFS))
+	assert.True(t, isPermissionDenied(syscall.EPERM))
+	assert.True(t, isPermissionDenied(fs.ErrPermission))
+	assert.False(t, isPermissionDenied(errors.New("random")))
+}

--- a/desktop/go/cli_path_other.go
+++ b/desktop/go/cli_path_other.go
@@ -1,0 +1,25 @@
+//go:build !darwin
+
+package main
+
+import (
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+// CLI PATH integration is macOS-only. On Windows the installer writes
+// HKCU\Environment\Path directly; on Linux the .deb drops /usr/bin/leapmux
+// during package install. Both happen outside the running app, so the
+// sidecar has nothing to do for those platforms.
+
+func cliPathStatusFromSidecar() *desktoppb.CliPathStatusResponse {
+	return &desktoppb.CliPathStatusResponse{
+		State: desktoppb.CliPathStatusResponse_STATE_UNAVAILABLE,
+	}
+}
+
+func cliInstallSymlinkFromSidecar(_ bool) *desktoppb.CliInstallSymlinkResponse {
+	return &desktoppb.CliInstallSymlinkResponse{
+		Result:  desktoppb.CliInstallSymlinkResponse_RESULT_IO_ERROR,
+		Message: "CLI symlink install is supported only on macOS",
+	}
+}

--- a/desktop/go/rpc.go
+++ b/desktop/go/rpc.go
@@ -322,6 +322,18 @@ func (s *RPCSession) handleRequest(req *desktoppb.Request) {
 			go s.onShutdown()
 		}
 
+	case *desktoppb.Request_CliPathStatus:
+		s.writeResponse(&desktoppb.Response{
+			Id:     id,
+			Result: &desktoppb.Response_CliPathStatus{CliPathStatus: s.app.CliPathStatus()},
+		})
+
+	case *desktoppb.Request_CliInstallSymlink:
+		s.writeResponse(&desktoppb.Response{
+			Id:     id,
+			Result: &desktoppb.Response_CliInstallSymlink{CliInstallSymlink: s.app.CliInstallSymlink(m.CliInstallSymlink.Force)},
+		})
+
 	default:
 		s.writeError(id, fmt.Errorf("unknown method: %T", req.Method))
 	}

--- a/desktop/rust/desktop-template.desktop
+++ b/desktop/rust/desktop-template.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Development;Utility;
-Exec=leapmux-desktop
+Exec=/usr/lib/leapmux-desktop/leapmux-desktop
 StartupWMClass=leapmux-desktop
 Icon=leapmux-desktop
 Name=LeapMux Desktop

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1488,6 +1488,74 @@ async fn proxy_http(
     }
 }
 
+// --- CLI PATH integration (macOS only at the sidecar level) ---
+
+#[derive(Serialize)]
+struct CliPathStatusPayload {
+    state: i32,
+    bundled: String,
+    resolved: String,
+    target: String,
+    #[serde(rename = "targetKind")]
+    target_kind: i32,
+}
+
+#[tauri::command]
+async fn cli_path_status(
+    shell: State<'_, Arc<DesktopShell>>,
+) -> Result<CliPathStatusPayload, String> {
+    let resp = check_response(
+        shell
+            .send_request_async(proto::request::Method::CliPathStatus(
+                proto::CliPathStatusRequest {},
+            ))
+            .await?,
+    )?;
+
+    match resp.result {
+        Some(proto::response::Result::CliPathStatus(r)) => Ok(CliPathStatusPayload {
+            state: r.state,
+            bundled: r.bundled,
+            resolved: r.resolved,
+            target: r.target,
+            target_kind: r.target_kind,
+        }),
+        _ => Err("unexpected response for cli_path_status".to_string()),
+    }
+}
+
+#[derive(Serialize)]
+struct CliInstallSymlinkPayload {
+    result: i32,
+    command: String,
+    path: String,
+    message: String,
+}
+
+#[tauri::command]
+async fn cli_install_symlink(
+    shell: State<'_, Arc<DesktopShell>>,
+    force: bool,
+) -> Result<CliInstallSymlinkPayload, String> {
+    let resp = check_response(
+        shell
+            .send_request_async(proto::request::Method::CliInstallSymlink(
+                proto::CliInstallSymlinkRequest { force },
+            ))
+            .await?,
+    )?;
+
+    match resp.result {
+        Some(proto::response::Result::CliInstallSymlink(r)) => Ok(CliInstallSymlinkPayload {
+            result: r.result,
+            command: r.command,
+            path: r.path,
+            message: r.message,
+        }),
+        _ => Err("unexpected response for cli_install_symlink".to_string()),
+    }
+}
+
 #[tauri::command]
 async fn open_channel_relay(shell: State<'_, Arc<DesktopShell>>) -> Result<(), String> {
     check_response(
@@ -2093,6 +2161,8 @@ fn main() {
             connect_solo,
             connect_distributed,
             proxy_http,
+            cli_path_status,
+            cli_install_symlink,
             open_channel_relay,
             send_channel_message,
             close_channel_relay,

--- a/desktop/rust/tauri.linux.conf.json
+++ b/desktop/rust/tauri.linux.conf.json
@@ -12,7 +12,10 @@
         "bundleMediaFramework": true
       },
       "deb": {
-        "desktopTemplate": "desktop-template.desktop"
+        "desktopTemplate": "desktop-template.desktop",
+        "files": {
+          "/usr/bin/leapmux": "../../leapmux"
+        }
       }
     }
   }

--- a/desktop/rust/tauri.windows.conf.json
+++ b/desktop/rust/tauri.windows.conf.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "mainBinaryName": "LeapMuxDesktop"
+  "mainBinaryName": "LeapMuxDesktop",
+  "bundle": {
+    "targets": ["msi"],
+    "windows": {
+      "wix": {
+        "fragmentPaths": ["windows/wix-peruser.wxs"],
+        "componentRefs": ["LeapmuxCliComponent"]
+      }
+    }
+  }
 }

--- a/desktop/rust/windows/wix-peruser.wxs
+++ b/desktop/rust/windows/wix-peruser.wxs
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Per-user MSI fragment, referenced from desktop/rust/tauri.windows.conf.json
+  via bundle.windows.wix.{fragmentPaths,componentRefs}. Tauri 2.10's WiX
+  bundler doesn't expose `installMode`, so we override the install scope by
+  pre-setting the WI5 single-package per-user properties that Tauri's stock
+  main.wxs honours, plus a SetDirectory that retargets INSTALLDIR from
+  ProgramFiles64Folder to %LocalAppData%\Programs.
+
+  The CLI ships in its own `cli` subdirectory of INSTALLDIR. Only `cli` is
+  appended to the user's PATH — neither LeapMuxDesktop.exe nor the Go
+  sidecar at INSTALLDIR's root is exposed to user shells.
+
+  $(env.LEAPMUX_CLI_PATH) is set by Taskfile.yaml's build-desktop-windows
+  before invoking `tauri build`; it resolves to the freshly-compiled
+  leapmux.exe at the repo root.
+
+  GUID is committed (not regenerated) so MajorUpgrade can match the
+  component across releases.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <Property Id="ALLUSERS" Secure="yes"/>
+    <Property Id="MSIINSTALLPERUSER" Value="1" Secure="yes"/>
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
+
+    <SetDirectory Id="INSTALLDIR"
+                  Value="[LocalAppDataFolder]Programs\LeapMux Desktop"
+                  Sequence="first">1</SetDirectory>
+
+    <DirectoryRef Id="INSTALLDIR">
+      <Directory Id="CliDir" Name="cli">
+        <Component Id="LeapmuxCliComponent"
+                   Guid="E1435041-FC1D-45F9-9733-4D7B50B9667F"
+                   Win64="yes">
+          <File Id="LeapmuxCliExe"
+                Source="$(env.LEAPMUX_CLI_PATH)"
+                KeyPath="yes"/>
+          <Environment Id="LeapmuxCliPath"
+                       Name="PATH"
+                       Value="[CliDir]"
+                       Permanent="no"
+                       Part="last"
+                       Action="set"
+                       System="no"/>
+        </Component>
+      </Directory>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
         // Terminal
         '@xterm/xterm',
         '@xterm/addon-fit',
+        '@xterm/addon-serialize',
         '@xterm/addon-webgl',
         // Protobuf / ConnectRPC
         '@bufbuild/protobuf',
@@ -140,6 +141,7 @@ export default defineConfig({
         '@noble/curves/ed25519.js',
         '@noble/hashes/blake2.js',
         '@noble/hashes/hmac.js',
+        '@noble/hashes/utils.js',
         '@noble/post-quantum/ml-kem.js',
         '@noble/post-quantum/slh-dsa.js',
         // UI / misc

--- a/frontend/src/api/platformBridge.test.ts
+++ b/frontend/src/api/platformBridge.test.ts
@@ -1,6 +1,15 @@
 import { clearMocks, mockIPC } from '@tauri-apps/api/mocks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { readClipboardImage } from './platformBridge'
+import { platformBridge, readClipboardImage } from './platformBridge'
+
+// isMac() in ~/lib/shortcuts/platform caches the UA-detected platform on
+// first call, so flipping navigator.userAgent between tests doesn't actually
+// flip its return value. Mock it directly so each test controls the gate.
+const isMacMock = vi.hoisted(() => vi.fn<() => boolean>())
+vi.mock('~/lib/shortcuts/platform', () => ({
+  isMac: isMacMock,
+  getPlatform: () => (isMacMock() ? 'mac' : 'linux'),
+}))
 
 describe('readClipboardImage', () => {
   let originalGetContext: typeof HTMLCanvasElement.prototype.getContext
@@ -117,5 +126,150 @@ describe('readClipboardImage', () => {
 
     expect(await readClipboardImage()).toBeNull()
     expect(calls).toContain('plugin:resources|close')
+  })
+})
+
+describe('cliPathStatus', () => {
+  beforeEach(() => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    isMacMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    isMacMock.mockReset()
+  })
+
+  it('returns null when not running in Tauri', async () => {
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    expect(await platformBridge.cliPathStatus()).toBeNull()
+  })
+
+  it('returns null when running on a non-macOS platform', async () => {
+    isMacMock.mockReturnValue(false)
+    expect(await platformBridge.cliPathStatus()).toBeNull()
+  })
+
+  it('decodes STATE_OK (1) into { state: "ok", bundled }', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'cli_path_status')
+        return { state: 1, bundled: '/Applications/X.app/Contents/MacOS/leapmux', resolved: '', target: '', targetKind: 2 }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    const got = await platformBridge.cliPathStatus()
+    expect(got).toEqual({ state: 'ok', bundled: '/Applications/X.app/Contents/MacOS/leapmux' })
+  })
+
+  it('decodes STATE_MISSING (2) and surfaces install target + targetKind', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'cli_path_status')
+        return { state: 2, bundled: '/b/leapmux', resolved: '', target: '/usr/local/bin/leapmux', targetKind: 1 }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    const got = await platformBridge.cliPathStatus()
+    expect(got).toEqual({ state: 'missing', bundled: '/b/leapmux', target: '/usr/local/bin/leapmux', targetKind: 'absent' })
+  })
+
+  it('decodes STATE_MISMATCH (3) and surfaces resolved + targetKind', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'cli_path_status')
+        return { state: 3, bundled: '/b/leapmux', resolved: '/opt/homebrew/bin/leapmux', target: '', targetKind: 3 }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    const got = await platformBridge.cliPathStatus()
+    expect(got).toEqual({ state: 'mismatch', bundled: '/b/leapmux', resolved: '/opt/homebrew/bin/leapmux', targetKind: 'regular_file' })
+  })
+
+  it('decodes each targetKind variant', async () => {
+    const cases = [
+      { code: 1, decoded: 'absent' },
+      { code: 2, decoded: 'symlink' },
+      { code: 3, decoded: 'regular_file' },
+      { code: 0, decoded: 'unknown' },
+      { code: 99, decoded: 'unknown' },
+    ]
+    for (const c of cases) {
+      mockIPC((cmd) => {
+        if (cmd === 'cli_path_status')
+          return { state: 2, bundled: '/b/leapmux', resolved: '', target: '/usr/local/bin/leapmux', targetKind: c.code }
+        throw new Error(`unmocked: ${cmd}`)
+      })
+      const got = await platformBridge.cliPathStatus()
+      expect(got).toMatchObject({ state: 'missing', targetKind: c.decoded })
+    }
+  })
+
+  it('decodes STATE_UNAVAILABLE (4) and an unknown numeric value into "unavailable"', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'cli_path_status')
+        return { state: 4, bundled: '', resolved: '', target: '', targetKind: 0 }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    expect(await platformBridge.cliPathStatus()).toEqual({ state: 'unavailable' })
+
+    mockIPC((cmd) => {
+      if (cmd === 'cli_path_status')
+        return { state: 99, bundled: '', resolved: '', target: '', targetKind: 0 }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    expect(await platformBridge.cliPathStatus()).toEqual({ state: 'unavailable' })
+  })
+})
+
+describe('cliInstallSymlink', () => {
+  beforeEach(() => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+  })
+
+  afterEach(() => {
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('decodes each tagged result variant', async () => {
+    const cases = [
+      { in: { result: 1, command: '', path: '', message: '' }, out: { result: 'ok' } },
+      { in: { result: 2, command: 'sudo ln -sf a b', path: '', message: '' }, out: { result: 'needs_sudo', command: 'sudo ln -sf a b' } },
+      { in: { result: 3, command: '', path: '/usr/local/bin/leapmux', message: '' }, out: { result: 'already_exists_real_file', path: '/usr/local/bin/leapmux' } },
+      { in: { result: 4, command: 'sudo mkdir -p /usr/local/bin && ...', path: '/usr/local/bin', message: '' }, out: { result: 'parent_missing', path: '/usr/local/bin', command: 'sudo mkdir -p /usr/local/bin && ...' } },
+      { in: { result: 5, command: '', path: '', message: 'disk full' }, out: { result: 'io_error', message: 'disk full' } },
+    ]
+    for (const c of cases) {
+      mockIPC((cmd) => {
+        if (cmd === 'cli_install_symlink')
+          return c.in
+        throw new Error(`unmocked: ${cmd}`)
+      })
+      expect(await platformBridge.cliInstallSymlink()).toEqual(c.out)
+    }
+  })
+
+  it('forwards the force flag to the Rust forwarder', async () => {
+    const received: { force: boolean }[] = []
+    mockIPC((cmd, args) => {
+      if (cmd === 'cli_install_symlink') {
+        received.push(args as { force: boolean })
+        return { result: 1, command: '', path: '', message: '' }
+      }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+
+    await platformBridge.cliInstallSymlink()
+    await platformBridge.cliInstallSymlink(true)
+    await platformBridge.cliInstallSymlink(false)
+    expect(received).toEqual([{ force: false }, { force: true }, { force: false }])
+  })
+
+  it('falls back to an io_error for unknown result codes', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'cli_install_symlink')
+        return { result: 0, command: '', path: '', message: '' }
+      throw new Error(`unmocked: ${cmd}`)
+    })
+    expect(await platformBridge.cliInstallSymlink()).toEqual({
+      result: 'io_error',
+      message: 'unknown sidecar response',
+    })
   })
 })

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -3,6 +3,7 @@ import type { BuildInfo } from '~/lib/systemInfo'
 import { arrayBufferToBase64, base64ToArrayBuffer } from '~/lib/base64'
 import { trailingDebounce } from '~/lib/debounce'
 import { createLogger } from '~/lib/logger'
+import { isMac } from '~/lib/shortcuts/platform'
 
 export type PlatformMode = 'web' | 'tauri-desktop-solo' | 'tauri-desktop-distributed' | 'tauri-mobile-distributed'
 
@@ -78,6 +79,83 @@ export interface TunnelInfo {
 export interface DetectedEditor {
   id: string
   displayName: string
+}
+
+// Tagged unions the UI consumes. Mirror CliPathStatusResponse and
+// CliInstallSymlinkResponse in proto/leapmux/desktop/v1/frame.proto.
+export type CliPathTargetKind = 'absent' | 'symlink' | 'regular_file' | 'unknown'
+
+export type CliPathStatus
+  = | { state: 'ok', bundled: string }
+    | { state: 'missing', bundled: string, target: string, targetKind: CliPathTargetKind }
+    | { state: 'mismatch', bundled: string, resolved: string, targetKind: CliPathTargetKind }
+    | { state: 'unavailable' }
+
+export type CliInstallResult
+  = | { result: 'ok' }
+    | { result: 'needs_sudo', command: string }
+    | { result: 'already_exists_real_file', path: string }
+    | { result: 'parent_missing', path: string, command: string }
+    | { result: 'io_error', message: string }
+
+interface CliPathStatusPayload {
+  state: number
+  bundled: string
+  resolved: string
+  target: string
+  targetKind: number
+}
+
+interface CliInstallSymlinkPayload {
+  result: number
+  command: string
+  path: string
+  message: string
+}
+
+// Numeric codes mirror the proto enums in frame.proto. The Tauri commands
+// return raw i32 (prost-generated enums aren't serde-Serialize), so we
+// translate here once at the boundary.
+const PathState = { OK: 1, MISSING: 2, MISMATCH: 3 } as const
+const TargetKind = { ABSENT: 1, SYMLINK: 2, REGULAR_FILE: 3 } as const
+const InstallResultCode = {
+  OK: 1,
+  NEEDS_SUDO: 2,
+  ALREADY_EXISTS_REAL_FILE: 3,
+  PARENT_MISSING: 4,
+  IO_ERROR: 5,
+} as const
+
+function decodeTargetKind(n: number): CliPathTargetKind {
+  switch (n) {
+    case TargetKind.ABSENT: return 'absent'
+    case TargetKind.SYMLINK: return 'symlink'
+    case TargetKind.REGULAR_FILE: return 'regular_file'
+    // UNSPECIFIED (0) or any unknown value collapses to 'unknown' so the
+    // dialog defaults to the safer two-click danger button — a permission
+    // error reading the target shouldn't silently downgrade.
+    default: return 'unknown'
+  }
+}
+
+function decodeCliPathStatus(p: CliPathStatusPayload): CliPathStatus {
+  switch (p.state) {
+    case PathState.OK: return { state: 'ok', bundled: p.bundled }
+    case PathState.MISSING: return { state: 'missing', bundled: p.bundled, target: p.target, targetKind: decodeTargetKind(p.targetKind) }
+    case PathState.MISMATCH: return { state: 'mismatch', bundled: p.bundled, resolved: p.resolved, targetKind: decodeTargetKind(p.targetKind) }
+    default: return { state: 'unavailable' }
+  }
+}
+
+function decodeCliInstallResult(p: CliInstallSymlinkPayload): CliInstallResult {
+  switch (p.result) {
+    case InstallResultCode.OK: return { result: 'ok' }
+    case InstallResultCode.NEEDS_SUDO: return { result: 'needs_sudo', command: p.command }
+    case InstallResultCode.ALREADY_EXISTS_REAL_FILE: return { result: 'already_exists_real_file', path: p.path }
+    case InstallResultCode.PARENT_MISSING: return { result: 'parent_missing', path: p.path, command: p.command }
+    case InstallResultCode.IO_ERROR: return { result: 'io_error', message: p.message }
+    default: return { result: 'io_error', message: p.message || 'unknown sidecar response' }
+  }
 }
 
 declare global {
@@ -474,6 +552,19 @@ export const platformBridge = {
         bodyBase64,
       },
     })
+  },
+  // Returns null off-Tauri or off-macOS so callers can skip the IPC.
+  async cliPathStatus(): Promise<CliPathStatus | null> {
+    if (!isTauriApp() || !isMac())
+      return null
+    const payload = await tauriInvoke<CliPathStatusPayload>('cli_path_status')
+    return decodeCliPathStatus(payload)
+  },
+  // `force=true` overwrites a regular (non-symlink) file at the install
+  // destination. Symlinks are always replaced regardless of `force`.
+  async cliInstallSymlink(force = false): Promise<CliInstallResult> {
+    const payload = await tauriInvoke<CliInstallSymlinkPayload>('cli_install_symlink', { force })
+    return decodeCliInstallResult(payload)
   },
   async openChannelRelay(): Promise<void> {
     await tauriInvoke('open_channel_relay')

--- a/frontend/src/components/desktop/CliPathDialog.tsx
+++ b/frontend/src/components/desktop/CliPathDialog.tsx
@@ -1,0 +1,276 @@
+import type { Component } from 'solid-js'
+import type { CliInstallResult, CliPathStatus, CliPathTargetKind } from '~/api/platformBridge'
+import { createSignal, Match, Show, Switch } from 'solid-js'
+import { platformBridge } from '~/api/platformBridge'
+import { ConfirmButton } from '~/components/common/ConfirmButton'
+import { Dialog } from '~/components/common/Dialog'
+import { useCopyButton } from '~/hooks/useCopyButton'
+
+// When the install action will clobber a real (non-symlink) file at the
+// destination, render the primary action as a two-click danger ConfirmButton
+// matching the rest of the app's destructive-confirmation pattern (see
+// AppShellDialogs.tsx). Symlinks — even outdated ones — aren't user
+// content, so they get the regular single-click primary. 'unknown' (e.g. a
+// permission error reading the target) defaults to the safer two-click flow.
+function clobbersRealFile(targetKind: CliPathTargetKind): boolean {
+  return targetKind === 'regular_file' || targetKind === 'unknown'
+}
+
+interface CliPathDialogProps {
+  // The status reported by the sidecar. Callers should only mount the dialog
+  // for `missing` / `mismatch`; `ok` and `unavailable` short-circuit before
+  // reaching the UI.
+  status: CliPathStatus & { state: 'missing' | 'mismatch' }
+  onClose: () => void
+}
+
+// After invoking cliInstallSymlink, the dialog body switches to one of these
+// terminal sub-states until the user dismisses it. ALREADY_EXISTS_REAL_FILE
+// is intentionally not represented: the sidecar's status pre-check feeds
+// `targetKind` into the dialog so we send force=true upfront for the
+// regular-file case (via the ConfirmButton two-click arming) and never
+// land in that response branch.
+type InstallOutcome
+  = | { kind: 'needs_sudo', command: string }
+    | { kind: 'parent_missing', path: string, command: string }
+    | { kind: 'io_error', message: string }
+
+export const CliPathDialog: Component<CliPathDialogProps> = (props) => {
+  const [busy, setBusy] = createSignal(false)
+  const [outcome, setOutcome] = createSignal<InstallOutcome | null>(null)
+
+  // Single copy-button instance for whichever sudo command the outcome
+  // happens to surface. The hook handles the 2-second "Copied" flicker.
+  const { copied, copy } = useCopyButton(() => {
+    const o = outcome()
+    if (!o)
+      return undefined
+    if (o.kind === 'needs_sudo' || o.kind === 'parent_missing')
+      return o.command
+    return undefined
+  })
+
+  const handleResult = (result: CliInstallResult) => {
+    switch (result.result) {
+      case 'ok':
+        // Symlink installed successfully — close the dialog. The sessionStorage
+        // gate in AppShell prevents the check from re-firing in the same session,
+        // so the user won't see this dialog again until app restart.
+        props.onClose()
+        return
+      case 'needs_sudo':
+        setOutcome({ kind: 'needs_sudo', command: result.command })
+        return
+      case 'parent_missing':
+        setOutcome({ kind: 'parent_missing', path: result.path, command: result.command })
+        return
+      case 'already_exists_real_file':
+        // Should be unreachable: the pre-checked targetKind upgrades the
+        // primary action to the danger ConfirmButton and the second click
+        // sends force=true. If we still get here (filesystem race between
+        // status and install), fall through to a generic error.
+        setOutcome({ kind: 'io_error', message: `Unexpected file at ${result.path}` })
+        return
+      case 'io_error':
+        setOutcome({ kind: 'io_error', message: result.message })
+    }
+  }
+
+  const install = async (force = false) => {
+    setBusy(true)
+    try {
+      const result = await platformBridge.cliInstallSymlink(force)
+      handleResult(result)
+    }
+    catch (err) {
+      setOutcome({ kind: 'io_error', message: err instanceof Error ? err.message : String(err) })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  // The dialog renders one of three layouts:
+  //   1. mismatch warning — no install offered
+  //   2. missing prompt — primary "Install" CTA, secondary "Not now"
+  //   3. install outcome — sudo command + Copy, or error explanation
+  return (
+    <Show
+      when={outcome()}
+      fallback={(
+        <Switch>
+          <Match when={props.status.state === 'mismatch' && props.status}>
+            {(s) => {
+              const status = s() as Extract<CliPathStatus, { state: 'mismatch' }>
+              const dangerous = clobbersRealFile(status.targetKind)
+              return (
+                <Dialog title="A different leapmux is on your PATH" onClose={props.onClose} busy={busy()}>
+                  <section>
+                    <p>
+                      The
+                      {' '}
+                      <code>leapmux</code>
+                      {' '}
+                      command on your PATH resolves to a different binary
+                      than the one shipped with this app. Using the existing
+                      one may produce unexpected results.
+                    </p>
+                    <p>
+                      Resolved to:
+                      {' '}
+                      <code>{status.resolved}</code>
+                    </p>
+                  </section>
+                  <footer>
+                    <button type="button" class="outline" disabled={busy()} onClick={props.onClose}>
+                      Dismiss
+                    </button>
+                    {/* Mismatch always passes force=true: the user has read
+                        the warning and is opting to replace whatever sits at
+                        /usr/local/bin/leapmux. When that entry is a real
+                        file we render the two-click danger ConfirmButton;
+                        for symlinks (the common case) a single click is
+                        enough since symlinks aren't user content. */}
+                    <Show
+                      when={dangerous}
+                      fallback={(
+                        <button type="button" disabled={busy()} onClick={() => install(true)}>
+                          Replace
+                        </button>
+                      )}
+                    >
+                      <ConfirmButton
+                        data-variant="danger"
+                        disabled={busy()}
+                        onClick={() => install(true)}
+                      >
+                        Replace
+                      </ConfirmButton>
+                    </Show>
+                  </footer>
+                </Dialog>
+              )
+            }}
+          </Match>
+          <Match when={props.status.state === 'missing' && props.status}>
+            {(s) => {
+              const status = s() as Extract<CliPathStatus, { state: 'missing' }>
+              const dangerous = clobbersRealFile(status.targetKind)
+              return (
+                <Dialog title="Install leapmux command-line tool?" onClose={props.onClose} busy={busy()}>
+                  <section>
+                    <p>
+                      Add the
+                      {' '}
+                      <code>leapmux</code>
+                      {' '}
+                      command to your PATH by creating a symlink at
+                      {' '}
+                      <code>{status.target}</code>
+                      .
+                    </p>
+                    <Show when={dangerous}>
+                      <p>
+                        A file already exists at
+                        {' '}
+                        <code>{status.target}</code>
+                        . Installing will replace it.
+                      </p>
+                    </Show>
+                  </section>
+                  <footer>
+                    <button type="button" class="outline" disabled={busy()} onClick={props.onClose}>
+                      Not now
+                    </button>
+                    <Show
+                      when={dangerous}
+                      fallback={(
+                        <button type="button" disabled={busy()} onClick={() => install(false)}>
+                          Install
+                        </button>
+                      )}
+                    >
+                      <ConfirmButton
+                        data-variant="danger"
+                        disabled={busy()}
+                        onClick={() => install(true)}
+                      >
+                        Replace and Install
+                      </ConfirmButton>
+                    </Show>
+                  </footer>
+                </Dialog>
+              )
+            }}
+          </Match>
+        </Switch>
+      )}
+    >
+      {(o) => {
+        const outcomeValue = o()
+        return (
+          <Dialog title="Install leapmux command-line tool" onClose={props.onClose}>
+            <section>
+              <Switch>
+                <Match when={outcomeValue.kind === 'needs_sudo' && outcomeValue}>
+                  {(v) => {
+                    const out = v() as Extract<InstallOutcome, { kind: 'needs_sudo' }>
+                    return (
+                      <>
+                        <p>
+                          Creating the symlink requires elevated permissions. Run this in a
+                          terminal:
+                        </p>
+                        <pre><code>{out.command}</code></pre>
+                      </>
+                    )
+                  }}
+                </Match>
+                <Match when={outcomeValue.kind === 'parent_missing' && outcomeValue}>
+                  {(v) => {
+                    const out = v() as Extract<InstallOutcome, { kind: 'parent_missing' }>
+                    return (
+                      <>
+                        <p>
+                          The directory
+                          {' '}
+                          <code>{out.path}</code>
+                          {' '}
+                          does not exist on this machine.
+                          Run this in a terminal to create it and install the CLI:
+                        </p>
+                        <pre><code>{out.command}</code></pre>
+                      </>
+                    )
+                  }}
+                </Match>
+                <Match when={outcomeValue.kind === 'io_error' && outcomeValue}>
+                  {(v) => {
+                    const out = v() as Extract<InstallOutcome, { kind: 'io_error' }>
+                    return (
+                      <p>
+                        Could not install the CLI:
+                        {' '}
+                        <code>{out.message}</code>
+                      </p>
+                    )
+                  }}
+                </Match>
+              </Switch>
+            </section>
+            <footer>
+              <Show when={outcomeValue.kind === 'needs_sudo' || outcomeValue.kind === 'parent_missing'}>
+                <button type="button" class="outline" onClick={copy}>
+                  {copied() ? 'Copied' : 'Copy command'}
+                </button>
+              </Show>
+              <button type="button" onClick={props.onClose}>
+                Close
+              </button>
+            </footer>
+          </Dialog>
+        )
+      }}
+    </Show>
+  )
+}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -3,17 +3,20 @@ import type { KeyPinConfirmState } from './AppShellDialogs'
 import type { SidebarElementsOpts } from './SidebarElements'
 import type { TabContext } from './tabContext'
 import type { BatchOutcome } from './useOpsSubmitter'
+import type { CliPathStatus } from '~/api/platformBridge'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { Worker } from '~/generated/leapmux/v1/worker_pb'
 import { useLocation, useNavigate, useParams, useSearchParams } from '@solidjs/router'
 import { createEffect, createMemo, createSignal, Match, on, Show, Switch, untrack } from 'solid-js'
 import { workerClient } from '~/api/clients'
+import { isTauriApp, platformBridge } from '~/api/platformBridge'
 import { apiLoadingTimeoutMs } from '~/api/transport'
 import { channelManager, renameAgent, setConfirmKeyPin, setGetUserId } from '~/api/workerRpc'
 import { NotFoundPage } from '~/components/common/NotFoundPage'
 import { showWarnToast } from '~/components/common/Toast'
+import { CliPathDialog } from '~/components/desktop/CliPathDialog'
 import { isWorkspaceMutatable } from '~/components/shell/sectionUtils'
-import { ACTIVE_WORKSPACE_KEY } from '~/components/shell/tabPersistenceKeys'
+import { ACTIVE_WORKSPACE_KEY, CLI_PATH_CHECKED_KEY } from '~/components/shell/tabPersistenceKeys'
 import { AddTunnelDialog } from '~/components/workers/AddTunnelDialog'
 import { RegisterWorkerDialog } from '~/components/workers/RegisterWorkerDialog'
 import { WorkerSettingsDialog } from '~/components/workers/WorkerSettingsDialog'
@@ -40,6 +43,7 @@ import { setDashboardTitle, setWorkspaceTitle } from '~/lib/pageTitle'
 import { parentDirectory } from '~/lib/paths'
 import { createActiveClientStore } from '~/lib/presence/activeClient'
 import { mountPresenceHeartbeat } from '~/lib/presence/heartbeat'
+import { isMac } from '~/lib/shortcuts/platform'
 import { printConsoleBanner } from '~/lib/systemInfo'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
 import { createChatStore } from '~/stores/chat.store'
@@ -126,6 +130,10 @@ export const AppShell: ParentComponent = (props) => {
   const [confirmDeleteWs, setConfirmDeleteWs] = createSignal<{ workspaceId: string, resolve: (confirmed: boolean) => void } | null>(null)
   const [confirmArchiveWs, setConfirmArchiveWs] = createSignal<{ workspaceId: string, resolve: (confirmed: boolean) => void } | null>(null)
   const [keyPinConfirm, setKeyPinConfirm] = createSignal<KeyPinConfirmState | null>(null)
+  // Set to a `missing` / `mismatch` status when the macOS PATH check should
+  // show its dialog. `null` keeps the dialog unmounted (ok / unavailable /
+  // not-yet-checked / non-macOS).
+  const [cliPathInfo, setCliPathInfo] = createSignal<(CliPathStatus & { state: 'missing' | 'mismatch' }) | null>(null)
 
   // Worker section state
   const workerInfoStore = createWorkerInfoStore()
@@ -501,6 +509,33 @@ export const AppShell: ParentComponent = (props) => {
   })
 
   const isWorkspaceRoute = createMemo(() => hasWorkspaceDesktopChrome(location.pathname))
+
+  // macOS-only: when the user enters the workspace view in Solo mode, ask
+  // the sidecar whether the bundled `leapmux` CLI is reachable on PATH.
+  // Solo is the only mode where users invoke leapmux against the local hub
+  // from a shell. The sessionStorage flag is set BEFORE the IPC so a slow
+  // sidecar can't trigger duplicate prompts if the route flips during the
+  // await — accepted trade-off: a transient sidecar failure suppresses the
+  // prompt for the rest of the session.
+  createEffect(() => {
+    if (!isWorkspaceRoute())
+      return
+    if (!isTauriApp() || !isMac())
+      return
+    if (sessionStorage.getItem(CLI_PATH_CHECKED_KEY) === '1')
+      return
+    void (async () => {
+      const runtime = await platformBridge.getRuntimeState()
+      if (runtime.shellMode !== 'solo')
+        return
+      sessionStorage.setItem(CLI_PATH_CHECKED_KEY, '1')
+      const status = await platformBridge.cliPathStatus()
+      if (!status)
+        return
+      if (status.state === 'missing' || status.state === 'mismatch')
+        setCliPathInfo(status)
+    })()
+  })
 
   // True when the URL has a workspace ID but it doesn't exist in the loaded list
   const workspaceNotFound = createMemo(() => {
@@ -1134,6 +1169,15 @@ export const AppShell: ParentComponent = (props) => {
       </Switch>
 
       <tileRenderer.CloseDialogs />
+
+      <Show when={cliPathInfo()}>
+        {info => (
+          <CliPathDialog
+            status={info()}
+            onClose={() => setCliPathInfo(null)}
+          />
+        )}
+      </Show>
 
       <AppShellDialogs
         showNewAgentDialog={showNewAgentDialog()}

--- a/frontend/src/components/shell/tabPersistenceKeys.ts
+++ b/frontend/src/components/shell/tabPersistenceKeys.ts
@@ -13,6 +13,11 @@
 
 export const ACTIVE_WORKSPACE_KEY = 'leapmux:activeWorkspace'
 
+// One-shot gate for AppShell's macOS "install leapmux on PATH" prompt:
+// the check runs at most once per browser session regardless of how many
+// times the user enters/leaves the workspace route.
+export const CLI_PATH_CHECKED_KEY = 'leapmux:cli-path-checked'
+
 export function activeTabKey(workspaceId: string): string {
   return `leapmux:activeTab:${workspaceId}`
 }

--- a/proto/leapmux/desktop/v1/frame.proto
+++ b/proto/leapmux/desktop/v1/frame.proto
@@ -44,6 +44,8 @@ message Request {
     // is read-only — the frontend never writes to /ws/orgevents.
     OpenOrgEventsRelayRequest open_org_events_relay = 32;
     CloseOrgEventsRelayRequest close_org_events_relay = 33;
+    CliPathStatusRequest cli_path_status = 34;
+    CliInstallSymlinkRequest cli_install_symlink = 35;
   }
 }
 
@@ -61,6 +63,19 @@ message CloseOrgEventsRelayRequest {}
 message SwitchModeRequest {}
 message ListTunnelsRequest {}
 message ShutdownRequest {}
+message CliPathStatusRequest {}
+
+// CliInstallSymlinkRequest creates the on-PATH symlink for the bundled
+// `leapmux` CLI. `force` controls overwriting an existing entry at the
+// symlink destination: when false (default), a regular (non-symlink) file
+// at the destination causes RESULT_ALREADY_EXISTS_REAL_FILE so the UI can
+// confirm with the user before clobbering it. When true, any existing file
+// or symlink is removed before the new symlink is created. Either way, a
+// dangling/outdated symlink is silently replaced — the prompt only guards
+// against clobbering a real file the user explicitly put there.
+message CliInstallSymlinkRequest {
+  bool force = 1;
+}
 
 // OpenOrgEventsRelay names the org subscription the sidecar should
 // establish. `workspace_ids` is empty for the standard "all my
@@ -129,7 +144,61 @@ message Response {
     StartupInfo startup_info = 19;
     SidecarInfo sidecar_info = 20;
     ListEditorsResponse list_editors = 21;
+    CliPathStatusResponse cli_path_status = 22;
+    CliInstallSymlinkResponse cli_install_symlink = 23;
   }
+}
+
+// --- CLI PATH integration (macOS) ---
+//
+// CliPathStatusResponse classifies whether the `leapmux` CLI shipped inside
+// the desktop app bundle is discoverable on the user's PATH. Used by the
+// frontend to offer a one-click symlink install at /usr/local/bin/leapmux.
+// On non-darwin builds the sidecar always returns STATE_UNAVAILABLE.
+message CliPathStatusResponse {
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    STATE_OK = 1;          // leapmux on PATH and (realpath or sha256) matches the bundled binary
+    STATE_MISSING = 2;     // leapmux not on PATH; symlink target reported in `target`
+    STATE_MISMATCH = 3;    // leapmux on PATH but is a different binary (different content); path reported in `resolved`
+    STATE_UNAVAILABLE = 4; // not applicable (non-macOS, or bundled binary absent — dev runs)
+  }
+  // TargetKind describes what (if anything) currently exists at the
+  // install destination (`target` below). The UI uses this to decide
+  // upfront whether the Install button needs a "replaces existing file"
+  // warning and whether to send `force=true` — without it, MISSING +
+  // non-exec real file at the destination requires a two-click flow
+  // (Install → ALREADY_EXISTS_REAL_FILE → Replace).
+  enum TargetKind {
+    TARGET_KIND_UNSPECIFIED = 0;  // permission error or unclassifiable; clients should treat as REGULAR_FILE (safer prompt)
+    TARGET_KIND_ABSENT = 1;       // nothing at target path
+    TARGET_KIND_SYMLINK = 2;      // any symlink (valid, dangling, points elsewhere)
+    TARGET_KIND_REGULAR_FILE = 3; // user-placed file (non-symlink)
+  }
+  State state = 1;
+  string bundled = 2;    // absolute path to the bundled leapmux inside the .app
+  string resolved = 3;   // absolute on-PATH path; only set when state = STATE_MISMATCH
+  string target = 4;     // suggested install destination; only set when state = STATE_MISSING
+  TargetKind target_kind = 5; // populated for every state; describes what's at `target` (or cliSymlinkDst when target is empty)
+}
+
+// CliInstallSymlinkResponse reports the outcome of attempting to create the
+// symlink at /usr/local/bin/leapmux. NEEDS_SUDO surfaces the exact sudo
+// command for the UI to display; PARENT_MISSING fires when /usr/local/bin
+// itself is absent (clean Apple Silicon without Homebrew).
+message CliInstallSymlinkResponse {
+  enum Result {
+    RESULT_UNSPECIFIED = 0;
+    RESULT_OK = 1;
+    RESULT_NEEDS_SUDO = 2;
+    RESULT_ALREADY_EXISTS_REAL_FILE = 3;
+    RESULT_PARENT_MISSING = 4;
+    RESULT_IO_ERROR = 5;
+  }
+  Result result = 1;
+  string command = 2; // populated for NEEDS_SUDO / PARENT_MISSING (suggested sudo command)
+  string path = 3;    // populated for ALREADY_EXISTS_REAL_FILE / PARENT_MISSING
+  string message = 4; // populated for IO_ERROR
 }
 
 message SetWindowSizeResponse {}


### PR DESCRIPTION
## Motivation

The `leapmux` CLI is a companion tool to the desktop app, but users had no in-app guidance for installing it on their PATH. On macOS, the CLI was not shipped inside the `.app` bundle at all, requiring a separate install step. On Linux and Windows the bundled CLI was also absent from the platform-specific package formats. This PR unifies CLI distribution by embedding the binary in every desktop bundle and adds an in-app prompt on macOS to create the PATH symlink for the user.

## Modifications

- **Proto** (`frame.proto`): Two new request/response message pairs — `CliPathStatusRequest`/`CliPathStatusResponse` and `CliInstallSymlinkRequest`/`CliInstallSymlinkResponse` — with state enums (`STATE_OK`, `STATE_MISSING`, `STATE_MISMATCH`, `STATE_UNAVAILABLE`) and install result codes (`RESULT_OK`, `RESULT_NEEDS_SUDO`, `RESULT_ALREADY_EXISTS_REAL_FILE`, `RESULT_PARENT_MISSING`, `RESULT_IO_ERROR`).

- **Go sidecar** (`cli_path_darwin.go`, `cli_path_other.go`, `app.go`, `rpc.go`): macOS-only PATH classifier using realpath equality then SHA-256 content comparison; symlink installer with granular result codes; bundled CLI resolver supporting both production (`.app` sibling) and dev (repo-root climb) layouts; cross-platform stub returning `STATE_UNAVAILABLE` on non-macOS; 22 test cases covering all branches.

- **Tauri** (`main.rs`): Two new Tauri commands (`cli_path_status`, `cli_install_symlink`) delegating to the sidecar via the existing `send_request_async`/`check_response` pattern.

- **macOS bundle** (`Taskfile.yaml`): `build-desktop-darwin` copies `leapmux` into `Contents/MacOS/` so the existing inside-out codesign sweep covers it; `sign-and-notarize-darwin-app` adds explicit `codesign --verify` and `spctl --assess` assertions on the embedded CLI.

- **Linux bundle** (`tauri.linux.conf.json`, `desktop-template.desktop`, `Taskfile.yaml`): `deb.files` places the CLI at `/usr/bin/leapmux`; `Exec=` updated to the library path so only the CLI is exposed on PATH; `build-desktop-linux` adds a `dpkg-deb` post-process step to relocate the app binary.

- **Windows bundle** (`tauri.windows.conf.json`, `wix-peruser.wxs`, `Taskfile.yaml`): Drops NSIS; produces MSI-only with per-user install (`MSIINSTALLPERUSER=1`), retargets `INSTALLDIR` to `LocalAppDataFolder`, places `leapmux.exe` in a `cli\` subdir, and adds an HKCU PATH `<Environment>` entry via a WiX fragment.
  - (Breaking) NSIS `.exe` installer is no longer produced for Windows; only MSI is built.
  - (Breaking) Existing per-machine Windows installs must be manually uninstalled before upgrading to the per-user MSI.

- **Frontend** (`platformBridge.ts`, `platformBridge.test.ts`, `AppShell.tsx`, `CliPathDialog.tsx`, `tabPersistenceKeys.ts`): New `cliPathStatus()` / `cliInstallSymlink(force)` bridge methods gated on `isMac()` and `isTauriApp()`; `AppShell` fires the check once per session (via `CLI_PATH_CHECKED_KEY` in sessionStorage) in Solo mode; `CliPathDialog` renders missing/mismatch flows with a pre-checked `targetKind` driving the button choice — danger `ConfirmButton` (two clicks) when a real file would be overwritten, single-click otherwise.

- All three platform builds now explicitly depend on `build-backend` so the CLI binary exists before the embedding step runs.

## Result

macOS users in Solo mode see a one-click dialog on first workspace entry offering to install `leapmux` at `/usr/local/bin/leapmux`. If the destination already holds a symlink (even an outdated one) it is replaced silently; a real file prompts a two-click danger confirmation. When the install requires elevated permissions the dialog surfaces the exact `sudo` command with a one-click "Copy command" button. On Linux the CLI is available at `/usr/bin/leapmux` after installing the `.deb`. On Windows the CLI is on the user's PATH via an HKCU environment entry after installing the MSI.
