### PR TITLE
feat(todos): Add persistent cross-provider to-do list with Claude Task* tool support

### DIFF
--- a/backend/internal/cli/remote/cmd/agent_test.go
+++ b/backend/internal/cli/remote/cmd/agent_test.go
@@ -151,9 +151,7 @@ func TestResolveProvider_EmptyPropagatesCodedRPCError(t *testing.T) {
 // up a transport. Without this, scripts that forget the flag would
 // see a network error rather than a clear hint.
 func TestRunAgentInterrupt_RequiresAgentID(t *testing.T) {
-	t.Setenv("LEAPMUX_HUB", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_ID", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_TYPE", "")
+	clearRemoteEnv(t)
 	out := withCapturedStdout(t, func() {
 		err := RunAgentInterrupt(fakeCmdCtx{}, []string{"--hub", "https://stub"})
 		require.Error(t, err)
@@ -170,9 +168,7 @@ func TestRunAgentInterrupt_RequiresAgentID(t *testing.T) {
 // provided. The CLI must surface this clearly so scripts don't send
 // empty turns to the agent by accident.
 func TestRunAgentSend_RequiresMessageOrStdin(t *testing.T) {
-	t.Setenv("LEAPMUX_HUB", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_ID", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_TYPE", "")
+	clearRemoteEnv(t)
 	out := withCapturedStdout(t, func() {
 		err := RunAgentSend(fakeCmdCtx{}, []string{"--hub", "https://stub", "--tab-id", "ag-1"})
 		require.Error(t, err)
@@ -266,9 +262,7 @@ func TestApplyPermissionMode_FailureReturnsErrorMessage(t *testing.T) {
 // (the agent treats absent content as "no decision provided"), so
 // missing --content must hard-fail rather than silently send "{}".
 func TestRunAgentSendControlResponse_RequiresAgentAndContent(t *testing.T) {
-	t.Setenv("LEAPMUX_HUB", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_ID", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_TYPE", "")
+	clearRemoteEnv(t)
 	out := withCapturedStdout(t, func() {
 		err := RunAgentSendControlResponse(fakeCmdCtx{}, []string{"--hub", "https://stub", "--tab-id", "ag-1"})
 		require.Error(t, err)

--- a/backend/internal/cli/remote/cmd/tab_test.go
+++ b/backend/internal/cli/remote/cmd/tab_test.go
@@ -93,9 +93,7 @@ func TestTerminalInfoToMap_ScreenEmittedAsString(t *testing.T) {
 // invalid_request rather than silently shipping a zero-byte write to
 // the PTY. Mirrors TestRunAgentSend_RequiresMessageOrStdin.
 func TestRunTerminalSend_RequiresDataOrStdin(t *testing.T) {
-	t.Setenv("LEAPMUX_HUB", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_ID", "")
-	t.Setenv("LEAPMUX_REMOTE_TAB_TYPE", "")
+	clearRemoteEnv(t)
 	out := withCapturedStdout(t, func() {
 		err := RunTerminalSend(fakeCmdCtx{}, []string{"--hub", "https://stub", "--tab-id", "term-1"})
 		require.Error(t, err)

--- a/backend/internal/cli/remote/cmd/version_test.go
+++ b/backend/internal/cli/remote/cmd/version_test.go
@@ -33,6 +33,28 @@ func withCapturedStdout(t *testing.T, fn func()) []byte {
 	return buf.Bytes()
 }
 
+// clearRemoteEnv blanks every LEAPMUX_REMOTE_*_ID env var that
+// resolve.BindEntityFlags consults as a flag default, plus the related
+// LEAPMUX_HUB / LEAPMUX_REMOTE_TAB_TYPE pair. Without this, tests that
+// pin the "missing flag" code paths flake (and produce `resolve_failed`
+// instead of `invalid_request`) when run inside a worker-spawned
+// process that inherits these variables.
+func clearRemoteEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"LEAPMUX_HUB",
+		"LEAPMUX_REMOTE_TAB_ID",
+		"LEAPMUX_REMOTE_TAB_TYPE",
+		"LEAPMUX_REMOTE_WORKER_ID",
+		"LEAPMUX_REMOTE_WORKSPACE_ID",
+		"LEAPMUX_REMOTE_TILE_ID",
+		"LEAPMUX_REMOTE_ORG_ID",
+		"LEAPMUX_REMOTE_USER_ID",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 // TestRunVersion_NoHubPrintsCLIOnly is the happy-path case when no
 // `--hub` is provided: the envelope's data carries only the cli
 // fields, never a hub key.

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -46,6 +46,10 @@ CREATE TABLE messages (
     created_at          DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     UNIQUE(agent_id, seq)
 );
+-- Covers the (agent_id, span_id, source, seq) lookup the to-do extractor
+-- uses to find a tool_result's paired tool_use, so SQLite serves the
+-- ORDER BY seq ASC LIMIT 1 from the index rather than re-sorting matches.
+CREATE INDEX idx_messages_span_id ON messages(agent_id, span_id, source, seq) WHERE span_id <> '';
 
 -- Pending control requests
 CREATE TABLE control_requests (
@@ -126,7 +130,29 @@ CREATE TABLE worker_file_tabs (
 );
 CREATE INDEX idx_worker_file_tabs_workspace ON worker_file_tabs(org_id, workspace_id);
 
+-- Provider-neutral to-do rows. Populated incrementally by the worker
+-- output handler in response to Claude TodoWrite/Task*, Codex
+-- turn/plan/updated, and ACP sessionUpdate=plan events so the sidebar
+-- survives page reloads and cross-machine opens. row_key is the
+-- task_id for Claude Task* (which addresses rows by id) and a synthetic
+-- "snap-<seq>" for snapshot-only providers; snapshot replacements
+-- delete-all-then-insert-all in a single transaction.
+CREATE TABLE agent_todos (
+    agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    row_key     TEXT NOT NULL,
+    seq         INTEGER NOT NULL,
+    task_id     TEXT NOT NULL DEFAULT '',
+    content     TEXT NOT NULL,
+    active_form TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL CHECK (status IN ('pending','in_progress','completed')),
+    updated_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (agent_id, row_key)
+);
+CREATE INDEX idx_agent_todos_seq ON agent_todos(agent_id, seq);
+
 -- +goose Down
+DROP TABLE IF EXISTS agent_todos;
 DROP TABLE IF EXISTS worker_file_tabs;
 DROP TABLE IF EXISTS terminals;
 DROP TABLE IF EXISTS worktree_tabs;

--- a/backend/internal/worker/db/queries/agent_todos.sql
+++ b/backend/internal/worker/db/queries/agent_todos.sql
@@ -1,0 +1,45 @@
+-- name: ListAgentTodos :many
+SELECT * FROM agent_todos WHERE agent_id = ? ORDER BY seq LIMIT ?;
+
+-- UpsertAgentTodo inserts a new row or updates an existing one keyed by
+-- (agent_id, row_key). Used by `create` and `detail` events (Claude
+-- TaskCreate / TaskGet) where the row is addressed by task_id.
+-- name: UpsertAgentTodo :exec
+INSERT INTO agent_todos (
+    agent_id, row_key, seq, task_id, content, active_form, description, status, updated_at
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now')
+)
+ON CONFLICT(agent_id, row_key) DO UPDATE SET
+    task_id     = excluded.task_id,
+    content     = excluded.content,
+    active_form = excluded.active_form,
+    description = excluded.description,
+    status      = excluded.status,
+    updated_at  = excluded.updated_at;
+
+-- UpdateAgentTodo overwrites every column with the caller-merged value.
+-- The handler reads the row first and applies the Patch's nil-or-set
+-- semantics in app code, so the caller is responsible for passing the
+-- existing value when a field should stay unchanged.
+-- name: UpdateAgentTodo :exec
+UPDATE agent_todos SET
+    content     = ?,
+    active_form = ?,
+    description = ?,
+    status      = ?,
+    updated_at  = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE agent_id = ? AND row_key = ?;
+
+-- DeleteAgentTodoByRowKey returns the affected-row count so the caller
+-- can short-circuit the broadcast on an unknown-id no-op delete.
+-- name: DeleteAgentTodoByRowKey :execresult
+DELETE FROM agent_todos WHERE agent_id = ? AND row_key = ?;
+
+-- name: DeleteAllAgentTodos :exec
+DELETE FROM agent_todos WHERE agent_id = ?;
+
+-- name: InsertAgentTodo :exec
+INSERT INTO agent_todos (
+    agent_id, row_key, seq, task_id, content, active_form, description, status
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?);

--- a/backend/internal/worker/db/queries/messages.sql
+++ b/backend/internal/worker/db/queries/messages.sql
@@ -44,6 +44,16 @@ LIMIT ?;
 -- name: GetMessageByAgentAndID :one
 SELECT * FROM messages WHERE id = ? AND agent_id = ?;
 
+-- GetAgentMessageBySpanIDAndSource finds the first message that opened the
+-- given span (the tool_use / item-started side). Used by the to-do extractor
+-- when a tool_result arrives and needs the paired request's input fields
+-- (subject/description/activeForm for Claude TaskCreate).
+-- name: GetAgentMessageBySpanIDAndSource :one
+SELECT * FROM messages
+WHERE agent_id = ? AND span_id = ? AND source = ?
+ORDER BY seq ASC
+LIMIT 1;
+
 -- name: SetMessageDeliveryError :exec
 UPDATE messages SET delivery_error = ? WHERE id = ? AND agent_id = ?;
 

--- a/backend/internal/worker/service/access_control_test.go
+++ b/backend/internal/worker/service/access_control_test.go
@@ -106,7 +106,6 @@ func TestAccessControl_AgentHandlers_RejectInaccessibleWorkspace(t *testing.T) {
 	for _, tc := range agentHandlerCases {
 		t.Run(tc.method, func(t *testing.T) {
 			svc, d, w := setupTestService(t, "ws-1")
-			svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 			seedAgent(t, svc, "agent-other", "ws-other")
 
 			dispatch(d, tc.method, tc.req("agent-other"), w)
@@ -123,8 +122,7 @@ func TestAccessControl_AgentHandlers_RejectInaccessibleWorkspace(t *testing.T) {
 func TestAccessControl_AgentHandlers_NotFound(t *testing.T) {
 	for _, tc := range agentHandlerCases {
 		t.Run(tc.method, func(t *testing.T) {
-			svc, d, w := setupTestService(t, "ws-1")
-			svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+			_, d, w := setupTestService(t, "ws-1")
 
 			dispatch(d, tc.method, tc.req("agent-missing"), w)
 
@@ -140,8 +138,7 @@ func TestAccessControl_AgentHandlers_NotFound(t *testing.T) {
 func TestAccessControl_AgentHandlers_EmptyID(t *testing.T) {
 	for _, tc := range agentHandlerCases {
 		t.Run(tc.method, func(t *testing.T) {
-			svc, d, w := setupTestService(t, "ws-1")
-			svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+			_, d, w := setupTestService(t, "ws-1")
 
 			dispatch(d, tc.method, tc.req(""), w)
 
@@ -204,7 +201,6 @@ func TestAccessControl_TerminalHandlers_EmptyID(t *testing.T) {
 func TestAccessControl_AgentHandlers_HappyPath(t *testing.T) {
 	t.Run("RenameAgent", func(t *testing.T) {
 		svc, d, w := setupTestService(t, "ws-1")
-		svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 		seedAgent(t, svc, "agent-1", "ws-1")
 
 		dispatch(d, "RenameAgent", &leapmuxv1.RenameAgentRequest{
@@ -218,7 +214,6 @@ func TestAccessControl_AgentHandlers_HappyPath(t *testing.T) {
 
 	t.Run("ListAgentMessages", func(t *testing.T) {
 		svc, d, w := setupTestService(t, "ws-1")
-		svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 		seedAgent(t, svc, "agent-1", "ws-1")
 
 		dispatch(d, "ListAgentMessages", &leapmuxv1.ListAgentMessagesRequest{AgentId: "agent-1"}, w)
@@ -336,7 +331,6 @@ func TestCleanupWorkspace_RejectsInaccessibleWorkspace(t *testing.T) {
 
 func TestCleanupWorkspace_AllowsAccessibleWorkspace(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	seedAgent(t, svc, "agent-1", "ws-1")
 
 	dispatch(d, "CleanupWorkspace", &leapmuxv1.CleanupWorkspaceRequest{

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -23,6 +23,7 @@ import (
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
+	"github.com/leapmux/leapmux/internal/worker/todoevents"
 	"github.com/leapmux/leapmux/util/validate"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -532,6 +533,19 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		afterSeq := r.GetAfterSeq()
 		beforeSeq := r.GetBeforeSeq()
 
+		// Only ship the to-do list on the initial "latest" page — scroll
+		// pagination requests don't need to re-fetch it (the client
+		// already has the authoritative snapshot from cold start and
+		// receives live mutations via AgentTodosChanged broadcasts).
+		var todoItems []todoevents.Item
+		if afterSeq == 0 && beforeSeq == 0 {
+			items, todoErr := svc.Output.LoadTodos(bgCtx(), agentID)
+			if todoErr != nil {
+				slog.Warn("failed to load agent_todos", "agent_id", agentID, "error", todoErr)
+			}
+			todoItems = items
+		}
+
 		var dbMessages []db.Message
 		var queryErr error
 
@@ -584,6 +598,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		sendProtoResponse(sender, &leapmuxv1.ListAgentMessagesResponse{
 			Messages: protoMessages,
 			HasMore:  hasMore,
+			Todos:    todoevents.ItemsToProto(todoItems),
 		})
 	})
 

--- a/backend/internal/worker/service/agent_attachment_test.go
+++ b/backend/internal/worker/service/agent_attachment_test.go
@@ -17,7 +17,6 @@ import (
 func TestSendAgentMessage_OneCharMinimum(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-1",
@@ -37,7 +36,6 @@ func TestSendAgentMessage_OneCharMinimum(t *testing.T) {
 func TestSendAgentMessage_EmptyTextRejectedWithoutAttachments(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-2",
@@ -58,7 +56,6 @@ func TestSendAgentMessage_EmptyTextRejectedWithoutAttachments(t *testing.T) {
 func TestSendAgentMessage_EmptyTextAllowedWithAttachments(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-3",
@@ -81,7 +78,6 @@ func TestSendAgentMessage_EmptyTextAllowedWithAttachments(t *testing.T) {
 func TestSendAgentMessage_AttachmentSizeLimitEnforced(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-4",
@@ -106,7 +102,6 @@ func TestSendAgentMessage_AttachmentSizeLimitEnforced(t *testing.T) {
 func TestSendAgentMessage_AttachmentMetadataPersistedInJSON(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-5",
@@ -161,7 +156,6 @@ func TestSendAgentMessage_AttachmentMetadataPersistedInJSON(t *testing.T) {
 func TestSendAgentMessage_TextOnlyNoAttachmentsFieldInJSON(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-6",

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -23,7 +23,6 @@ import (
 func TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Mock a successful auto-start so the happy path is exercised without
 	// spawning a real subprocess.
@@ -82,7 +81,6 @@ func TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning(t *test
 func TestSendAgentMessage_AutoStartFailureRevertsToInactive(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, assert.AnError

--- a/backend/internal/worker/service/agent_clear_test.go
+++ b/backend/internal/worker/service/agent_clear_test.go
@@ -87,7 +87,6 @@ func decodeAgentChatMessageContent(t *testing.T, msg *leapmuxv1.AgentChatMessage
 func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Mock a successful restart so we can validate the happy-path ordering
 	// without spawning a real agent process. context_cleared is only
@@ -154,7 +153,6 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 func TestSendAgentMessage_SlashClearBroadcastsStartingDuringRestart(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Mock a successful restart so we exercise the happy path without
 	// spawning a real agent process.
@@ -232,7 +230,6 @@ func TestSendAgentMessage_SlashClearBroadcastsStartingDuringRestart(t *testing.T
 func TestSendAgentMessage_SlashClearRestartFailureSkipsContextCleared(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-1",
@@ -286,7 +283,6 @@ func TestSendAgentMessage_SlashClearRestartFailureSkipsContextCleared(t *testing
 func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-codex",
@@ -338,7 +334,6 @@ func TestIsInterruptRequestRecognizesProviderFormats(t *testing.T) {
 func TestSendAgentRawMessage_ClaudeInterruptDoesNotPersistSyntheticUserMarker(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-claude",

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -20,7 +20,6 @@ import (
 func TestUpdateAgentSettings_ClearsSessionIDOnRestartFailure(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	workDir := t.TempDir()
 
@@ -217,8 +216,6 @@ func TestUpdateAgentSettings_DoesNotResumeSessionOnRestart(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
-
 	// Create an agent with a session ID.
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:          "agent-1",
@@ -259,7 +256,6 @@ func TestUpdateAgentSettings_DoesNotResumeSessionOnRestart(t *testing.T) {
 func TestUpdateAgentSettings_BroadcastsGenericExtraSettingChanges(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -468,7 +464,6 @@ func TestPersistConfirmedAgentSettings_PersistsAvailableModelsAndGroups(t *testi
 func TestUpdateAgentSettings_BroadcastsGeminiPermissionModeLabels(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-gemini",
@@ -537,7 +532,6 @@ func TestUpdateAgentSettings_BroadcastsGeminiPermissionModeLabels(t *testing.T) 
 func TestSendAgentRawMessage_SetPermissionModePersistsToDBWhileRunning(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -37,7 +37,7 @@ func TestAutoContinueSchedule_SurvivesRestart(t *testing.T) {
 	}))
 
 	var fired atomic.Int32
-	h2 := NewOutputHandler(queries, nil, nil, nil)
+	h2 := NewOutputHandler(nil, queries, nil, nil, nil)
 	h2.SetSendMessageFunc(func(agentID, content string) {
 		if agentID == "agent-1" && content == autoContinueContent {
 			fired.Add(1)
@@ -59,7 +59,7 @@ func TestAutoContinueSchedule_RescheduleUpdatesSingleRow(t *testing.T) {
 	_, queries := setupTestDB(t)
 	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	h := NewOutputHandler(queries, nil, nil, nil)
+	h := NewOutputHandler(nil, queries, nil, nil, nil)
 	firstDueAt := time.Now().UTC().Add(10 * time.Minute)
 	secondDueAt := firstDueAt.Add(20 * time.Minute)
 
@@ -85,7 +85,7 @@ func TestAutoContinueSchedule_ReasonsCanCoexist(t *testing.T) {
 	_, queries := setupTestDB(t)
 	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	h := NewOutputHandler(queries, nil, nil, nil)
+	h := NewOutputHandler(nil, queries, nil, nil, nil)
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
 		Reason: agent.AutoContinueReasonAPIError,
 		DueAt:  time.Now().UTC(),
@@ -105,7 +105,7 @@ func TestAutoContinueSchedule_CancelOneReasonLeavesOtherIntact(t *testing.T) {
 	_, queries := setupTestDB(t)
 	createAutoContinueTestAgent(t, queries, "agent-1")
 
-	h := NewOutputHandler(queries, nil, nil, nil)
+	h := NewOutputHandler(nil, queries, nil, nil, nil)
 	h.scheduleAutoContinue("agent-1", agent.AutoContinueSchedule{
 		Reason: agent.AutoContinueReasonAPIError,
 		DueAt:  time.Now().UTC(),
@@ -146,7 +146,7 @@ func TestAutoContinueSchedule_FiresOnceAndDoesNotRefireAfterRestart(t *testing.T
 	}))
 
 	var fired atomic.Int32
-	h1 := NewOutputHandler(queries, nil, nil, nil)
+	h1 := NewOutputHandler(nil, queries, nil, nil, nil)
 	h1.SetSendMessageFunc(func(agentID, content string) {
 		if agentID == "agent-1" && content == autoContinueContent {
 			fired.Add(1)
@@ -155,7 +155,7 @@ func TestAutoContinueSchedule_FiresOnceAndDoesNotRefireAfterRestart(t *testing.T
 	h1.restoreAutoContinueSchedules()
 	require.Eventually(t, func() bool { return fired.Load() == 1 }, 2*time.Second, 25*time.Millisecond)
 
-	h2 := NewOutputHandler(queries, nil, nil, nil)
+	h2 := NewOutputHandler(nil, queries, nil, nil, nil)
 	h2.SetSendMessageFunc(func(agentID, content string) {
 		if agentID == "agent-1" && content == autoContinueContent {
 			fired.Add(1)

--- a/backend/internal/worker/service/close_during_startup_test.go
+++ b/backend/internal/worker/service/close_during_startup_test.go
@@ -42,7 +42,6 @@ func TestCloseAgent_DuringStartup_SuppressesActiveAndCleansUp(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Subscribe before OpenAgent so an accidental ACTIVE broadcast would
 	// be captured regardless of where in the sequence it fires.
@@ -137,7 +136,6 @@ func TestCloseAgent_DuringStartup_RollsBackCreatedWorktree(t *testing.T) {
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var closeOnce sync.Once
 	svc.startAgentFn = func(sCtx context.Context, opts agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -114,7 +114,7 @@ func setupTestService(t *testing.T, workspaceIDs ...string) (*Context, *channel.
 		AgentStartup:    newAgentStartupRegistry(),
 		TerminalStartup: newTerminalStartupRegistry(),
 	}
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
+	svc.Output = NewOutputHandler(svc.DB, svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.Output.DataDir = svc.DataDir
 
 	d := channel.NewDispatcher()

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -30,7 +30,6 @@ func decodeMessageContent(t *testing.T, content []byte, compression leapmuxv1.Co
 func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -94,7 +93,6 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -153,7 +151,6 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -220,7 +217,6 @@ func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T
 func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",
@@ -279,7 +275,6 @@ func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 func TestSendControlResponse_PersistsGeminiPermissionSelectionLabel(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/git_mode_test.go
+++ b/backend/internal/worker/service/git_mode_test.go
@@ -235,7 +235,6 @@ func osSymlink(target, link string) error { return os.Symlink(target, link) }
 func TestOpenAgent_CreateWorktree_EndToEnd(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return &leapmuxv1.AgentSettings{}, nil
 	}
@@ -273,7 +272,6 @@ func TestOpenAgent_CreateWorktree_EndToEnd(t *testing.T) {
 func TestOpenAgent_CreateBranch_EndToEnd(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return &leapmuxv1.AgentSettings{}, nil
 	}

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -27,7 +27,6 @@ import (
 func TestOpenAgent_SyncPrologueReturnsFast(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	released := make(chan struct{})
 	svc.startAgentFn = func(ctx context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
@@ -66,7 +65,6 @@ func TestOpenAgent_SyncPrologueReturnsFast(t *testing.T) {
 func TestOpenAgent_DelayedStartupBroadcastsActive(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	releaseAfter := 150 * time.Millisecond
 	svc.startAgentFn = func(_ context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
@@ -116,7 +114,6 @@ func TestOpenAgent_SettingsChangedDuringStartupSurviveActiveBroadcast(t *testing
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	startCalled := make(chan agent.Options, 1)
 	releaseStart := make(chan struct{})
@@ -216,7 +213,6 @@ func TestOpenAgent_RawPermissionModeChangedDuringStartupSurvivesActiveBroadcast(
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	startCalled := make(chan agent.Options, 1)
 	releaseStart := make(chan struct{})
@@ -310,7 +306,6 @@ func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testi
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	agentID := "agent-late-mode"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -361,7 +356,6 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	agentID := "agent-pre-start-mode"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -414,7 +408,6 @@ func TestOpenAgent_CodexUsesProviderDefaultPermissionMode(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	startCalled := make(chan agent.Options, 1)
 	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
@@ -461,7 +454,6 @@ func TestOpenAgent_CodexUsesProviderDefaultPermissionMode(t *testing.T) {
 func TestOpenAgent_ResponseHasNilGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	blocked := make(chan struct{})
 	svc.startAgentFn = func(ctx context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
@@ -716,7 +708,6 @@ func TestOpenTerminal_TitlePersistedBeforePTYRegistrationHydratesManagerMeta(t *
 func TestOpenAgent_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	// Block startAgent so the goroutine settles after setting phase 2
 	// ("Starting Claude Code…") and waits there — the registry entry
 	// then holds that phase label for replay.
@@ -783,7 +774,6 @@ func TestOpenAgent_CatchUpReplaySurfacesStartupMessage(t *testing.T) {
 func TestOpenAgent_ActiveBroadcastCarriesGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	// Block startAgent briefly so the test can subscribe before ACTIVE lands.
 	svc.startAgentFn = func(_ context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
@@ -911,7 +901,6 @@ func TestBuildTerminalStatusChange(t *testing.T) {
 func TestOpenAgent_StartupFailurePhaseCarriesGitStatus(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(_ context.Context, _ agent.Options, _ agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced startup failure")
 	}
@@ -959,7 +948,6 @@ func TestOpenAgent_StartupFailureBroadcastsFailureAndRollsBack(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var startCalls sync.WaitGroup
 	startCalls.Add(1)
@@ -1030,7 +1018,6 @@ func TestExecuteCreateWorktree_FailureIsRecoverable(t *testing.T) {
 func TestOpenAgent_BroadcastsRollbackLabelOnStartFailure(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
 	}

--- a/backend/internal/worker/service/open_default_effort_test.go
+++ b/backend/internal/worker/service/open_default_effort_test.go
@@ -21,7 +21,6 @@ import (
 func TestOpenAgent_DefaultsEffortToAuto(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var capturedMu sync.Mutex
 	var captured agent.Options
@@ -76,7 +75,6 @@ func TestOpenAgent_RespectsEnvOverride(t *testing.T) {
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_EFFORT", "high")
 
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var capturedMu sync.Mutex
 	var captured agent.Options
@@ -117,7 +115,6 @@ func TestOpenAgent_PreservesExplicitEffort(t *testing.T) {
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_EFFORT", "high")
 
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	var capturedMu sync.Mutex
 	var captured agent.Options

--- a/backend/internal/worker/service/open_rollback_test.go
+++ b/backend/internal/worker/service/open_rollback_test.go
@@ -45,7 +45,6 @@ func TestOpenAgent_RollsBackCreatedWorktreeOnStartFailure(t *testing.T) {
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
 	}
@@ -84,7 +83,6 @@ func TestOpenAgent_RollsBackCreatedBranchOnStartFailure(t *testing.T) {
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
 	}
@@ -113,7 +111,6 @@ func TestOpenAgent_RollsBackCreatedBranchToDetachedHEADOnStartFailure(t *testing
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("forced start failure")
 	}
@@ -231,7 +228,6 @@ func TestOpenAgent_NoWorktreeMutationOnCreateRecordFailure(t *testing.T) {
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
 		return errors.New("forced create failure")
 	}
@@ -262,7 +258,6 @@ func TestOpenAgent_NoBranchMutationOnCreateRecordFailure(t *testing.T) {
 
 	svc, d, w := setupTestService(t, "ws-1")
 	defer drainAllInFlight(svc)
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.createAgentRecordFn = func(context.Context, db.CreateAgentParams) error {
 		return errors.New("forced create failure")
 	}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -5,6 +5,8 @@ package service
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,6 +25,7 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
+	"github.com/leapmux/leapmux/internal/worker/todoevents"
 	"github.com/leapmux/leapmux/internal/worker/wakelock"
 )
 
@@ -553,10 +556,41 @@ func unwrapNotifContent(data []byte) (*notifThreadWrapper, error) {
 
 // --- OutputHandler ---
 
+// agentTodoCache mirrors an agent's agent_todos rows in memory so the
+// worker can build the post-mutation broadcast without re-fetching
+// after each event, and pick the next seq for an INSERT without a
+// pre-SELECT round-trip. Initialized lazily from the DB on first
+// touch per agent; the cache and DB stay in lock-step because every
+// successful write goes through applyTodoEvent.
+//
+// `mu` serializes the multi-step "check existence → DB write →
+// in-place mutation" sequences and also gates the lazy DB seed.
+type agentTodoCache struct {
+	mu      sync.Mutex
+	seeded  bool
+	rows    []cachedTodo
+	nextSeq int64
+}
+
+// cachedTodo pairs an Item with the agent_todos `row_key` it persists
+// under. The row_key is the Item's ID when set (incremental Task*
+// path) and a synthetic `snap-N` otherwise (snapshot path for
+// providers without stable per-task ids — TodoWrite / Codex plan /
+// ACP plan). Eviction and per-row updates address rows by row_key.
+type cachedTodo struct {
+	item   todoevents.Item
+	rowKey string
+}
+
 // OutputHandler manages agent output persistence and broadcasting.
 // It holds shared state accessed by per-agent OutputSink instances.
 type OutputHandler struct {
 	queries *db.Queries
+	// db backs the agent_todos snapshot transaction (delete-all + N
+	// inserts). Tests that don't exercise the snapshot path may pass
+	// nil; the snapshot writer then falls back to a non-transactional
+	// loop.
+	db      *sql.DB
 	watcher *WatcherManager
 	agents  *agent.Manager
 	DataDir string
@@ -567,6 +601,12 @@ type OutputHandler struct {
 
 	// Per-agent span tracking (concurrent access).
 	spanTrackers sync.Map // agentID -> *SpanTracker
+
+	// Per-agent in-memory to-do mirror. Keyed by agent_id; each
+	// agentTodoCache carries its own mutex for the multi-step event
+	// transitions, matching the sync.Map pattern used by the other
+	// per-agent state above.
+	todos sync.Map // agentID -> *agentTodoCache
 
 	// Plan mode tool_use tracking (shared across agents).
 	planModeToolUse sync.Map // tool_use_id -> target mode string ("plan" or "default")
@@ -584,10 +624,13 @@ type OutputHandler struct {
 	now func() time.Time
 }
 
-// NewOutputHandler creates a new OutputHandler.
-func NewOutputHandler(queries *db.Queries, watcher *WatcherManager, agents *agent.Manager, wl *wakelock.ActivityTracker) *OutputHandler {
+// NewOutputHandler creates a new OutputHandler. sqlDB is used for the
+// agent_todos snapshot transaction; tests that never trigger a
+// snapshot may pass nil.
+func NewOutputHandler(sqlDB *sql.DB, queries *db.Queries, watcher *WatcherManager, agents *agent.Manager, wl *wakelock.ActivityTracker) *OutputHandler {
 	return &OutputHandler{
 		queries:  queries,
+		db:       sqlDB,
 		watcher:  watcher,
 		agents:   agents,
 		wakeLock: wl,
@@ -616,6 +659,7 @@ func (h *OutputHandler) CleanupAgent(agentID string) {
 	h.notifMu.Delete(agentID)
 	h.lastNotifThread.Delete(agentID)
 	h.spanTrackers.Delete(agentID)
+	h.todos.Delete(agentID)
 	h.cleanupAutoContinue(agentID)
 }
 
@@ -1145,7 +1189,410 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 		SpanColor:          spanColor,
 		SpanLines:          spanLines,
 	})
+
+	// Update the provider-neutral to-do list off the just-persisted
+	// message. Failures are logged but do not propagate — the chat
+	// transcript is the source of truth, and the next event can
+	// reconcile any transient inconsistency.
+	if err := h.applyTodoEventForMessage(agentID, span, contentJSON); err != nil {
+		slog.Warn("apply todo event", "agent_id", agentID, "span_type", span.SpanType, "error", err)
+	}
 	return nil
+}
+
+// couldProduceTodoEvent is a cheap gate keeping the >99% of messages
+// that can't produce a to-do mutation out of the extract / paired-use
+// lookup hot path. Claude tool spans carry span_type for every message
+// — when one is present, only the to-do family matters. Only the
+// span-typeless path (Codex JSON-RPC notifications, ACP session
+// updates) needs the byte-pattern probe.
+func couldProduceTodoEvent(span agent.SpanInfo, contentJSON []byte) bool {
+	if span.SpanType != "" {
+		return todoevents.IsTodoToolSpanType(span.SpanType)
+	}
+	return todoevents.LooksLikeProviderPlan(contentJSON)
+}
+
+// applyTodoEventForMessage extracts a to-do event from the just-persisted
+// message, applies it to agent_todos, and broadcasts AgentTodosChanged
+// on mutation. No-ops (unknown-id update, unknown-id delete, empty
+// snapshot replay) skip the broadcast.
+func (h *OutputHandler) applyTodoEventForMessage(agentID string, span agent.SpanInfo, contentJSON []byte) error {
+	if !couldProduceTodoEvent(span, contentJSON) {
+		return nil
+	}
+	pairedJSON, err := h.lookupPairedToolUseJSON(agentID, span)
+	if err != nil {
+		return err
+	}
+	ev, ok := todoevents.Extract(span.SpanType, contentJSON, pairedJSON)
+	if !ok {
+		return nil
+	}
+	items, mutated, err := h.applyTodoEvent(agentID, ev)
+	if err != nil {
+		return err
+	}
+	if !mutated {
+		return nil
+	}
+	h.watcher.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
+		AgentId: agentID,
+		Event: &leapmuxv1.AgentEvent_TodosChanged{
+			TodosChanged: &leapmuxv1.AgentTodosChanged{
+				AgentId: agentID,
+				Todos:   todoevents.ItemsToProto(items),
+			},
+		},
+	})
+	return nil
+}
+
+// lookupPairedToolUseJSON returns the decompressed JSON of the paired
+// tool_use message for Claude Task* tool_results that need their input
+// fields. Returns nil with no error when not applicable.
+func (h *OutputHandler) lookupPairedToolUseJSON(agentID string, span agent.SpanInfo) ([]byte, error) {
+	switch span.SpanType {
+	case todoevents.ToolTaskCreate, todoevents.ToolTaskUpdate:
+		// fall through — these need the paired tool_use input.
+	default:
+		return nil, nil
+	}
+	if span.SpanID == "" {
+		return nil, nil
+	}
+	row, err := h.queries.GetAgentMessageBySpanIDAndSource(bgCtx(), db.GetAgentMessageBySpanIDAndSourceParams{
+		AgentID: agentID,
+		SpanID:  span.SpanID,
+		Source:  leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		// Race or rolled-up tool_use — extraction proceeds with the
+		// result-only fields and returns a less detailed row.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup paired tool_use %s: %w", span.SpanID, err)
+	}
+	return msgcodec.Decompress(row.Content, row.ContentCompression)
+}
+
+// applyTodoEvent persists a single to-do event into agent_todos AND
+// applies it to the in-memory mirror. Returns the post-mutation list
+// (so the caller can broadcast without re-fetching) and a `mutated`
+// flag that is false when the event was a no-op (unknown-id update,
+// unknown-id delete, empty id).
+func (h *OutputHandler) applyTodoEvent(agentID string, ev todoevents.Event) ([]todoevents.Item, bool, error) {
+	ctx := bgCtx()
+	cache := h.todoCache(agentID)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if err := cache.ensureSeededLocked(ctx, h.queries, agentID); err != nil {
+		return nil, false, err
+	}
+
+	switch ev.Kind {
+	case todoevents.KindSnapshot:
+		return h.applySnapshotLocked(ctx, agentID, cache, ev.Snapshot)
+
+	case todoevents.KindCreate, todoevents.KindDetail:
+		if ev.Item.ID == "" {
+			return nil, false, nil
+		}
+		existingIdx := cache.indexByID(ev.Item.ID)
+		merged := ev.Item
+		if existingIdx >= 0 {
+			if ev.Kind == todoevents.KindDetail {
+				merged = todoevents.MergeDetail(cache.rows[existingIdx].item, ev.Item)
+			}
+			// Idempotent replay: skip the DB write and the broadcast
+			// when the post-merge row equals the existing row.
+			if cache.rows[existingIdx].item == merged {
+				return cache.snapshot(), false, nil
+			}
+		} else if len(cache.rows) >= todoevents.MaxTodos {
+			// At cap: evict the oldest completed row to make room for
+			// the new task. When no completed row exists, drop the new
+			// task and log so operators see the cap pressure.
+			evicted, err := h.evictOldestCompletedLocked(ctx, agentID, cache)
+			if err != nil {
+				return nil, false, err
+			}
+			if !evicted {
+				slog.Warn("agent_todos cap reached, no completed task to evict; dropping new task",
+					"agent_id", agentID, "task_id", ev.Item.ID, "cap", todoevents.MaxTodos)
+				return cache.snapshot(), false, nil
+			}
+		}
+		// Pick the next seq from the in-memory mirror so a fresh insert
+		// gets the right ordering without a `MAX(seq)` round-trip. On
+		// CONFLICT the existing row's seq is preserved (the UPSERT
+		// excludes seq from the SET list), so the choice is harmless
+		// when we end up updating in place.
+		if err := h.queries.UpsertAgentTodo(ctx, db.UpsertAgentTodoParams{
+			AgentID:     agentID,
+			RowKey:      ev.Item.ID,
+			Seq:         cache.nextSeq,
+			TaskID:      ev.Item.ID,
+			Content:     merged.Content,
+			ActiveForm:  merged.ActiveForm,
+			Description: merged.Description,
+			Status:      todoevents.StatusWire(merged.Status),
+		}); err != nil {
+			return nil, false, err
+		}
+		if existingIdx < 0 {
+			cache.rows = append(cache.rows, cachedTodo{item: merged, rowKey: ev.Item.ID})
+			cache.nextSeq++
+		} else {
+			cache.rows[existingIdx].item = merged
+		}
+		return cache.snapshot(), true, nil
+
+	case todoevents.KindUpdate:
+		if ev.ID == "" {
+			return nil, false, nil
+		}
+		idx := cache.indexByID(ev.ID)
+		if idx < 0 {
+			return nil, false, nil
+		}
+		merged := todoevents.ApplyPatch(cache.rows[idx].item, ev.Patch)
+		// No-op patch (every Patch field nil or already-matching): skip
+		// the DB write and broadcast.
+		if merged == cache.rows[idx].item {
+			return cache.snapshot(), false, nil
+		}
+		if err := h.queries.UpdateAgentTodo(ctx, db.UpdateAgentTodoParams{
+			Content:     merged.Content,
+			ActiveForm:  merged.ActiveForm,
+			Description: merged.Description,
+			Status:      todoevents.StatusWire(merged.Status),
+			AgentID:     agentID,
+			RowKey:      cache.rows[idx].rowKey,
+		}); err != nil {
+			return nil, false, err
+		}
+		cache.rows[idx].item = merged
+		return cache.snapshot(), true, nil
+
+	case todoevents.KindDelete:
+		if ev.ID == "" {
+			return nil, false, nil
+		}
+		idx := cache.indexByID(ev.ID)
+		if idx < 0 {
+			return nil, false, nil
+		}
+		res, err := h.queries.DeleteAgentTodoByRowKey(ctx, db.DeleteAgentTodoByRowKeyParams{
+			AgentID: agentID,
+			RowKey:  cache.rows[idx].rowKey,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		if affected, _ := res.RowsAffected(); affected == 0 {
+			return nil, false, nil
+		}
+		cache.rows = slices.Delete(cache.rows, idx, idx+1)
+		return cache.snapshot(), true, nil
+	}
+	return nil, false, nil
+}
+
+// evictOldestCompletedLocked removes the oldest completed row from
+// the cache and the DB. Returns false (with no error) when no
+// completed row exists; the caller drops the incoming event in that
+// case. Caller must hold cache.mu.
+func (h *OutputHandler) evictOldestCompletedLocked(ctx context.Context, agentID string, cache *agentTodoCache) (bool, error) {
+	evictIdx := slices.IndexFunc(cache.rows, func(r cachedTodo) bool {
+		return r.item.Status == todoevents.StatusCompleted
+	})
+	if evictIdx < 0 {
+		return false, nil
+	}
+	evicted := cache.rows[evictIdx]
+	if _, err := h.queries.DeleteAgentTodoByRowKey(ctx, db.DeleteAgentTodoByRowKeyParams{
+		AgentID: agentID,
+		RowKey:  evicted.rowKey,
+	}); err != nil {
+		return false, fmt.Errorf("evict agent_todo: %w", err)
+	}
+	cache.rows = slices.Delete(cache.rows, evictIdx, evictIdx+1)
+	slog.Info("agent_todos cap reached; evicted oldest completed task",
+		"agent_id", agentID, "evicted_task_id", evicted.item.ID, "cap", todoevents.MaxTodos)
+	return true, nil
+}
+
+// applySnapshotLocked replaces every agent_todos row with the supplied
+// list, capped at todoevents.MaxTodos. The delete-all + N inserts are
+// wrapped in a transaction when h.db is set (production); tests that
+// construct the handler with a nil *sql.DB fall through to a
+// non-transactional loop.
+func (h *OutputHandler) applySnapshotLocked(ctx context.Context, agentID string, cache *agentTodoCache, snapshot []todoevents.Item) ([]todoevents.Item, bool, error) {
+	capped := snapshot
+	if len(capped) > todoevents.MaxTodos {
+		capped = capped[:todoevents.MaxTodos]
+	}
+	// Re-emitted plans (Codex re-broadcasts on every tick; TaskList
+	// polled twice with no change) carry a structurally identical
+	// snapshot. Skip the delete-and-insert tx + broadcast on a no-op.
+	if cache.itemsEqual(capped) {
+		return cache.snapshot(), false, nil
+	}
+	if err := h.snapshotWriteToDB(ctx, agentID, capped); err != nil {
+		return nil, false, err
+	}
+	cache.rows = make([]cachedTodo, len(capped))
+	for i, it := range capped {
+		cache.rows[i] = cachedTodo{item: it, rowKey: rowKeyFor(it, i+1)}
+	}
+	cache.nextSeq = int64(len(capped)) + 1
+	return cache.snapshot(), true, nil
+}
+
+func (h *OutputHandler) snapshotWriteToDB(ctx context.Context, agentID string, capped []todoevents.Item) error {
+	if h.db == nil {
+		return h.snapshotWriteNonTx(ctx, h.queries, agentID, capped)
+	}
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := h.snapshotWriteNonTx(ctx, h.queries.WithTx(tx), agentID, capped); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit snapshot: %w", err)
+	}
+	return nil
+}
+
+func (h *OutputHandler) snapshotWriteNonTx(ctx context.Context, q *db.Queries, agentID string, capped []todoevents.Item) error {
+	if err := q.DeleteAllAgentTodos(ctx, agentID); err != nil {
+		return fmt.Errorf("delete agent_todos: %w", err)
+	}
+	for i, it := range capped {
+		if err := q.InsertAgentTodo(ctx, db.InsertAgentTodoParams{
+			AgentID:     agentID,
+			RowKey:      rowKeyFor(it, i+1),
+			Seq:         int64(i + 1),
+			TaskID:      it.ID,
+			Content:     it.Content,
+			ActiveForm:  it.ActiveForm,
+			Description: it.Description,
+			Status:      todoevents.StatusWire(it.Status),
+		}); err != nil {
+			return fmt.Errorf("insert agent_todo: %w", err)
+		}
+	}
+	return nil
+}
+
+// rowKeyFor returns the agent_todos.row_key for a snapshot Item:
+// the Item's ID when set (Claude TaskList), else a synthetic
+// `snap-<seq>` (TodoWrite / Codex / ACP carry no stable per-row id).
+func rowKeyFor(it todoevents.Item, seq int) string {
+	if it.ID != "" {
+		return it.ID
+	}
+	return fmt.Sprintf("snap-%d", seq)
+}
+
+// itemFromRow projects a persisted agent_todos row into the in-memory
+// Item shape. Used by ensureSeededLocked when populating the cache
+// from DB.
+func itemFromRow(r db.AgentTodo) todoevents.Item {
+	return todoevents.Item{
+		ID:          r.TaskID,
+		Content:     r.Content,
+		Status:      todoevents.StatusFromWire(r.Status),
+		ActiveForm:  r.ActiveForm,
+		Description: r.Description,
+	}
+}
+
+// todoCache returns the per-agent cache, creating an empty (unseeded)
+// one if none exists. Concurrent first-touch callers receive the same
+// instance via sync.Map.LoadOrStore; the actual DB seed runs once via
+// ensureSeededLocked under the cache's own mutex.
+func (h *OutputHandler) todoCache(agentID string) *agentTodoCache {
+	if v, ok := h.todos.Load(agentID); ok {
+		return v.(*agentTodoCache)
+	}
+	fresh := &agentTodoCache{}
+	actual, _ := h.todos.LoadOrStore(agentID, fresh)
+	return actual.(*agentTodoCache)
+}
+
+// LoadTodos returns the agent's to-do list, seeding the in-memory
+// cache from agent_todos on first access. Cold-start RPCs route
+// through here so a warm cache returns without a DB read and every
+// subsequent caller observes the same authoritative snapshot.
+func (h *OutputHandler) LoadTodos(ctx context.Context, agentID string) ([]todoevents.Item, error) {
+	cache := h.todoCache(agentID)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if err := cache.ensureSeededLocked(ctx, h.queries, agentID); err != nil {
+		return nil, err
+	}
+	return cache.snapshot(), nil
+}
+
+// ensureSeededLocked loads the agent's existing rows from the DB on
+// first touch. On failure the cache remains unseeded so a later call
+// can retry. Caller must hold c.mu.
+func (c *agentTodoCache) ensureSeededLocked(ctx context.Context, queries *db.Queries, agentID string) error {
+	if c.seeded {
+		return nil
+	}
+	rows, err := queries.ListAgentTodos(ctx, db.ListAgentTodosParams{
+		AgentID: agentID,
+		Limit:   todoevents.MaxTodos,
+	})
+	if err != nil {
+		return fmt.Errorf("list agent_todos: %w", err)
+	}
+	c.rows = make([]cachedTodo, len(rows))
+	for i, r := range rows {
+		c.rows[i] = cachedTodo{item: itemFromRow(r), rowKey: r.RowKey}
+	}
+	c.nextSeq = int64(len(rows)) + 1
+	c.seeded = true
+	return nil
+}
+
+// snapshot returns a freshly-allocated slice of the cache's items
+// (no row_keys). Used to build the post-mutation broadcast payload.
+// Caller must hold c.mu.
+func (c *agentTodoCache) snapshot() []todoevents.Item {
+	out := make([]todoevents.Item, len(c.rows))
+	for i, r := range c.rows {
+		out[i] = r.item
+	}
+	return out
+}
+
+// indexByID returns the row index for the given task id, or -1 when
+// not present. Caller must hold c.mu.
+func (c *agentTodoCache) indexByID(id string) int {
+	return slices.IndexFunc(c.rows, func(r cachedTodo) bool { return r.item.ID == id })
+}
+
+// itemsEqual reports whether the cache's items are element-wise equal
+// to `other`. Used by the snapshot path to short-circuit no-op
+// re-broadcasts. Caller must hold c.mu.
+func (c *agentTodoCache) itemsEqual(other []todoevents.Item) bool {
+	if len(c.rows) != len(other) {
+		return false
+	}
+	for i := range c.rows {
+		if c.rows[i].item != other[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // persistNotificationThreaded persists a notification message, appending it

--- a/backend/internal/worker/service/output_git_status_test.go
+++ b/backend/internal/worker/service/output_git_status_test.go
@@ -67,7 +67,6 @@ func newGitStatusFixture(t *testing.T) (*agentOutputSink, *agentEventCapturingWr
 	t.Helper()
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/output_plan_test.go
+++ b/backend/internal/worker/service/output_plan_test.go
@@ -77,7 +77,7 @@ func newPlanHandler(t *testing.T) (*OutputHandler, *db.Queries, string) {
 	t.Helper()
 	_, queries := setupTestDB(t)
 	dataDir := t.TempDir()
-	h := NewOutputHandler(queries, NewWatcherManager(), nil, nil)
+	h := NewOutputHandler(nil, queries, NewWatcherManager(), nil, nil)
 	h.DataDir = dataDir
 	h.now = func() time.Time { return time.Date(2026, time.April, 14, 9, 0, 0, 0, time.UTC) }
 	return h, queries, dataDir

--- a/backend/internal/worker/service/output_session_info_dedup_test.go
+++ b/backend/internal/worker/service/output_session_info_dedup_test.go
@@ -71,7 +71,6 @@ func newSessionInfoFixture(t *testing.T) (agent.OutputSink, *sessionInfoCapturin
 	t.Helper()
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/output_settings_refreshed_test.go
+++ b/backend/internal/worker/service/output_settings_refreshed_test.go
@@ -22,7 +22,6 @@ func newRefreshTestFixture(t *testing.T, seed db.UpdateAgentAllSettingsParams) r
 	t.Helper()
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/output_thread_test.go
+++ b/backend/internal/worker/service/output_thread_test.go
@@ -32,7 +32,6 @@ func setupNotifThreadTest(t *testing.T, provider leapmuxv1.AgentProvider) (agent
 	t.Helper()
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "agent-1",

--- a/backend/internal/worker/service/output_todos_test.go
+++ b/backend/internal/worker/service/output_todos_test.go
@@ -1,0 +1,440 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+	"github.com/leapmux/leapmux/internal/worker/todoevents"
+)
+
+// setupTodoTest provisions a worker service with one Claude-code agent and
+// returns the sink, the agent_id, and a row-listing helper bound to that
+// agent. Used by the to-do persistence/broadcast tests.
+func setupTodoTest(t *testing.T) (agent.OutputSink, string, func() []db.AgentTodo) {
+	t.Helper()
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, "ws-1")
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	listRows := func() []db.AgentTodo {
+		t.Helper()
+		rows, err := svc.Queries.ListAgentTodos(ctx, db.ListAgentTodosParams{AgentID: "agent-1", Limit: 1000})
+		require.NoError(t, err)
+		return rows
+	}
+	return sink, "agent-1", listRows
+}
+
+func marshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func TestOutputTodos_TodoWriteSnapshotPersists(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	body := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TodoWrite",
+					"input": map[string]any{
+						"todos": []any{
+							map[string]any{"content": "A", "status": "pending", "activeForm": "Doing A"},
+							map[string]any{"content": "B", "status": "in_progress", "activeForm": "Doing B"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, body, agent.SpanInfo{
+		SpanID: "span-todowrite", SpanType: "TodoWrite",
+	}))
+	rows := listRows()
+	require.Len(t, rows, 2)
+	assert.Equal(t, "A", rows[0].Content)
+	assert.Equal(t, "pending", rows[0].Status)
+	assert.Equal(t, "Doing A", rows[0].ActiveForm)
+	assert.Equal(t, "B", rows[1].Content)
+	assert.Equal(t, "in_progress", rows[1].Status)
+}
+
+func TestOutputTodos_TaskCreateInsertsRowAfterResult(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	// 1. Persist the tool_use side first (so the result-side lookup
+	//    finds it via GetAgentMessageBySpanIDAndSource).
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{
+						"subject": "Add proto messages", "description": "Edit proto", "activeForm": "Adding proto",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-tc1", SpanType: "TaskCreate",
+	}))
+	// Nothing yet — the tool_use has no id.
+	assert.Empty(t, listRows())
+
+	// 2. Persist the tool_result with the assigned id.
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "1", "subject": "Add proto messages"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-tc1", SpanType: "TaskCreate",
+	}))
+
+	rows := listRows()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "1", rows[0].TaskID)
+	assert.Equal(t, "Add proto messages", rows[0].Content)
+	assert.Equal(t, "Adding proto", rows[0].ActiveForm)
+	assert.Equal(t, "Edit proto", rows[0].Description)
+	assert.Equal(t, "pending", rows[0].Status)
+}
+
+func TestOutputTodos_TaskUpdateStatusOnlyPreservesActiveForm(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	// Seed via TaskCreate (tool_use + tool_result).
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{"subject": "Run tests", "activeForm": "Running tests"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "1", "subject": "Run tests"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+
+	// TaskUpdate: only status changes; activeForm must survive.
+	useU := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskUpdate",
+					"input": map[string]any{"taskId": "1", "status": "in_progress"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, useU, agent.SpanInfo{
+		SpanID: "span-u", SpanType: "TaskUpdate",
+	}))
+	resultU := marshalJSON(t, map[string]any{
+		"type":    "user",
+		"message": map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{
+			"success": true, "taskId": "1", "updatedFields": []any{"status"},
+			"statusChange": map[string]any{"from": "pending", "to": "in_progress"},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, resultU, agent.SpanInfo{
+		SpanID: "span-u", SpanType: "TaskUpdate",
+	}))
+
+	rows := listRows()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "in_progress", rows[0].Status)
+	assert.Equal(t, "Running tests", rows[0].ActiveForm, "activeForm must survive a status-only patch")
+}
+
+func TestOutputTodos_TaskUpdateDeletedRemovesRow(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	// Seed.
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{"subject": "tmp"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "7", "subject": "tmp"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+	require.Len(t, listRows(), 1)
+
+	// Delete.
+	resultD := marshalJSON(t, map[string]any{
+		"type":    "user",
+		"message": map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{
+			"success": true, "taskId": "7", "updatedFields": []any{"status"},
+			"statusChange": map[string]any{"from": "completed", "to": "deleted"},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, resultD, agent.SpanInfo{
+		SpanID: "span-d", SpanType: "TaskUpdate",
+	}))
+	assert.Empty(t, listRows())
+}
+
+func TestOutputTodos_TodoWriteReplacesPriorTaskList(t *testing.T) {
+	// Most-recent-wins: a snapshot must wipe rows accumulated by Task*.
+	sink, _, listRows := setupTodoTest(t)
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{"subject": "keep me"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "1", "subject": "keep me"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-c", SpanType: "TaskCreate",
+	}))
+	require.Len(t, listRows(), 1)
+
+	// Now a TodoWrite snapshot arrives.
+	snap := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TodoWrite",
+					"input": map[string]any{
+						"todos": []any{
+							map[string]any{"content": "fresh", "status": "pending", "activeForm": ""},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, snap, agent.SpanInfo{
+		SpanID: "span-tw", SpanType: "TodoWrite",
+	}))
+	rows := listRows()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "fresh", rows[0].Content)
+	assert.Empty(t, rows[0].TaskID, "snapshot rows have no task_id")
+}
+
+func TestOutputTodos_CodexPlanSnapshotPopulates(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	body := marshalJSON(t, map[string]any{
+		"method": "turn/plan/updated",
+		"params": map[string]any{
+			"plan": []any{
+				map[string]any{"step": "Investigate", "status": "in_progress"},
+				map[string]any{"step": "Fix", "status": "pending"},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, body, agent.SpanInfo{}))
+	rows := listRows()
+	require.Len(t, rows, 2)
+	assert.Equal(t, "Investigate", rows[0].Content)
+	assert.Equal(t, "in_progress", rows[0].Status)
+	assert.Equal(t, "Fix", rows[1].Content)
+}
+
+func TestOutputTodos_AcpPlanSnapshotPopulates(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	body := marshalJSON(t, map[string]any{
+		"sessionUpdate": "plan",
+		"entries": []any{
+			map[string]any{"content": "one", "status": "pending"},
+			map[string]any{"content": "two", "status": "completed"},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, body, agent.SpanInfo{}))
+	rows := listRows()
+	require.Len(t, rows, 2)
+	assert.Equal(t, "one", rows[0].Content)
+	assert.Equal(t, "two", rows[1].Content)
+	assert.Equal(t, "completed", rows[1].Status)
+}
+
+// Note: AgentTodosChanged broadcast is a one-line call adjacent to the
+// already-tested broadcast for AgentMessage; covering it would require a
+// second-level test harness around channel.Sender. The above persistence
+// tests prove the upstream extract/apply pipeline; the broadcast is a
+// trivial mechanical fan-out via WatcherManager.BroadcastAgentEvent.
+
+// TestOutputTodos_TaskCreateAtCapEvictsOldestCompleted seeds the
+// agent's to-do list at the MaxTodos cap (first five rows completed,
+// the rest in_progress), then fires a TaskCreate. The oldest
+// completed row should be evicted and the new task inserted at the
+// tail.
+func TestOutputTodos_TaskCreateAtCapEvictsOldestCompleted(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	// Seed MaxTodos rows via TaskList snapshot. Mark the first five
+	// completed, rest in_progress, so eviction has a target.
+	const completedPrefix = 5
+	tasks := make([]any, todoevents.MaxTodos)
+	for i := range tasks {
+		status := "in_progress"
+		if i < completedPrefix {
+			status = "completed"
+		}
+		tasks[i] = map[string]any{
+			"id":      fmt.Sprintf("t%d", i+1),
+			"subject": fmt.Sprintf("task %d", i+1),
+			"status":  status,
+		}
+	}
+	listBody := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"tasks": tasks},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, listBody, agent.SpanInfo{
+		SpanID: "span-list", SpanType: "TaskList",
+	}))
+	require.Len(t, listRows(), todoevents.MaxTodos)
+
+	// Fire a TaskCreate: cap is reached and t1 is the oldest completed
+	// row, so it should be evicted before the new row is appended.
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{"subject": "fresh"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-new", SpanType: "TaskCreate",
+	}))
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "new", "subject": "fresh"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-new", SpanType: "TaskCreate",
+	}))
+
+	rows := listRows()
+	require.Len(t, rows, todoevents.MaxTodos)
+	for _, r := range rows {
+		assert.NotEqual(t, "t1", r.TaskID, "oldest completed row should have been evicted")
+	}
+	// Other completed rows should remain (only one eviction per insert).
+	taskIDs := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		taskIDs[r.TaskID] = struct{}{}
+	}
+	assert.Contains(t, taskIDs, "t2")
+	assert.Contains(t, taskIDs, "new")
+}
+
+// TestOutputTodos_TaskCreateAtCapNoCompletedDrops verifies that when
+// the cap is reached and no completed rows exist to evict, the new
+// task is dropped silently (with a warn log) and the list stays
+// unchanged.
+func TestOutputTodos_TaskCreateAtCapNoCompletedDrops(t *testing.T) {
+	sink, _, listRows := setupTodoTest(t)
+	// Seed MaxTodos in_progress rows — nothing for eviction to take.
+	tasks := make([]any, todoevents.MaxTodos)
+	for i := range tasks {
+		tasks[i] = map[string]any{
+			"id":      fmt.Sprintf("t%d", i+1),
+			"subject": fmt.Sprintf("task %d", i+1),
+			"status":  "in_progress",
+		}
+	}
+	listBody := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"tasks": tasks},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, listBody, agent.SpanInfo{
+		SpanID: "span-list", SpanType: "TaskList",
+	}))
+	require.Len(t, listRows(), todoevents.MaxTodos)
+
+	use := marshalJSON(t, map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "tool_use", "name": "TaskCreate",
+					"input": map[string]any{"subject": "dropped"},
+				},
+			},
+		},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, use, agent.SpanInfo{
+		SpanID: "span-drop", SpanType: "TaskCreate",
+	}))
+	result := marshalJSON(t, map[string]any{
+		"type":            "user",
+		"message":         map[string]any{"content": []any{}},
+		"tool_use_result": map[string]any{"task": map[string]any{"id": "dropme", "subject": "dropped"}},
+	})
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, result, agent.SpanInfo{
+		SpanID: "span-drop", SpanType: "TaskCreate",
+	}))
+
+	rows := listRows()
+	require.Len(t, rows, todoevents.MaxTodos)
+	for _, r := range rows {
+		assert.NotEqual(t, "dropme", r.TaskID, "new task should have been dropped — no completed row to evict")
+	}
+}

--- a/backend/internal/worker/service/output_user_span_lines_test.go
+++ b/backend/internal/worker/service/output_user_span_lines_test.go
@@ -77,12 +77,12 @@ func setupAgentWithWatcher(t *testing.T, svc *Context, w *testResponseWriter, ag
 }
 
 func TestSnapshotPassthroughSpanLines_EmptyTracker(t *testing.T) {
-	h := NewOutputHandler(nil, NewWatcherManager(), nil, nil)
+	h := NewOutputHandler(nil, nil, NewWatcherManager(), nil, nil)
 	assert.Equal(t, "[]", h.snapshotPassthroughSpanLines("agent-1"))
 }
 
 func TestSnapshotPassthroughSpanLines_SingleOpenSpan(t *testing.T) {
-	h := NewOutputHandler(nil, NewWatcherManager(), nil, nil)
+	h := NewOutputHandler(nil, nil, NewWatcherManager(), nil, nil)
 	h.spanTracker("agent-1").OpenSpan("span-A", "")
 
 	parsed := parseSpanLinesJSON(t, h.snapshotPassthroughSpanLines("agent-1"))
@@ -94,7 +94,7 @@ func TestSnapshotPassthroughSpanLines_SingleOpenSpan(t *testing.T) {
 }
 
 func TestSnapshotPassthroughSpanLines_NestedSpans(t *testing.T) {
-	h := NewOutputHandler(nil, NewWatcherManager(), nil, nil)
+	h := NewOutputHandler(nil, nil, NewWatcherManager(), nil, nil)
 	h.spanTracker("agent-1").OpenSpan("span-A", "")
 	h.spanTracker("agent-1").OpenSpan("span-B", "span-A")
 
@@ -109,7 +109,7 @@ func TestSnapshotPassthroughSpanLines_NestedSpans(t *testing.T) {
 }
 
 func TestSnapshotPassthroughSpanLines_PerAgentIsolation(t *testing.T) {
-	h := NewOutputHandler(nil, NewWatcherManager(), nil, nil)
+	h := NewOutputHandler(nil, nil, NewWatcherManager(), nil, nil)
 	h.spanTracker("agent-1").OpenSpan("span-A", "")
 
 	// Other agents must see an empty snapshot — span trackers are per-agent.

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -161,7 +161,7 @@ func (svc *Context) agentAPITimeout() time.Duration {
 func NewContext(sqlDB *sql.DB, agents *agent.Manager, terminals *terminal.Manager, homeDir, dataDir string, wl *wakelock.ActivityTracker) *Context {
 	queries := db.New(sqlDB)
 	watchers := NewWatcherManager()
-	output := NewOutputHandler(queries, watchers, agents, wl)
+	output := NewOutputHandler(sqlDB, queries, watchers, agents, wl)
 	output.DataDir = dataDir
 	svc := &Context{
 		DB:              sqlDB,

--- a/backend/internal/worker/service/startup_error_persist_test.go
+++ b/backend/internal/worker/service/startup_error_persist_test.go
@@ -105,7 +105,6 @@ func TestDeriveTerminalStatus_AllBranches(t *testing.T) {
 func TestOpenAgent_PersistsStartupErrorOnFailure(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("boom: forced start failure")
 	}
@@ -144,7 +143,6 @@ func TestOpenAgent_PersistsStartupErrorOnFailure(t *testing.T) {
 func TestOpenAgent_ClearsStartupErrorOnSuccess(t *testing.T) {
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	agentID := "agent-clear-1"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -186,7 +184,6 @@ func TestOpenAgent_ClearsStartupErrorOnSuccess(t *testing.T) {
 func TestListAgents_ReportsStartupFailedFromDBColumnAfterRegistryWipe(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("doom")
 	}
@@ -229,7 +226,6 @@ func TestListAgents_ReportsStartupFailedFromDBColumnAfterRegistryWipe(t *testing
 func TestSendAgentMessage_RejectedByPersistedStartupError(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 
 	agentID := "agent-send-reject"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -261,7 +257,6 @@ func TestSendAgentMessage_RejectedByPersistedStartupError(t *testing.T) {
 // persisted DB column.
 func TestWatchEvents_CatchUpBroadcastsStartupFailedFromDBColumn(t *testing.T) {
 	svc, d, w := setupTestService(t, "ws-1")
-	svc.Output = NewOutputHandler(svc.Queries, svc.Watchers, svc.Agents, nil)
 	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (*leapmuxv1.AgentSettings, error) {
 		return nil, errors.New("kaput")
 	}

--- a/backend/internal/worker/todoevents/extract.go
+++ b/backend/internal/worker/todoevents/extract.go
@@ -1,0 +1,401 @@
+package todoevents
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Wire tool names from Claude Code's to-do list family. Centralized so
+// the dispatcher, the output-handler integration, and tests can't drift.
+const (
+	ToolTodoWrite  = "TodoWrite"
+	ToolTaskCreate = "TaskCreate"
+	ToolTaskUpdate = "TaskUpdate"
+	ToolTaskList   = "TaskList"
+	ToolTaskGet    = "TaskGet"
+)
+
+// IsTodoToolSpanType reports whether a message's span_type is one of
+// the to-do family tools this package consumes. Used by the worker
+// output handler as a cheap early-exit gate so the hot path skips JSON
+// parsing for every free-form assistant/user/bash message.
+func IsTodoToolSpanType(spanType string) bool {
+	switch spanType {
+	case ToolTodoWrite, ToolTaskCreate, ToolTaskUpdate, ToolTaskList, ToolTaskGet:
+		return true
+	}
+	return false
+}
+
+// claudeToolUseEnvelope is the assistant-shape JSON Claude emits for
+// tool_use messages: `{ type: "assistant", message: { content: [{ type:
+// "tool_use", name, input }, ...] } }`.
+type claudeToolUseEnvelope struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content []json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+type claudeToolUse struct {
+	Type  string          `json:"type"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// claudeToolResultEnvelope is the minimal slice of a Claude
+// tool_result message the to-do extractor needs: just the structured
+// `tool_use_result` payload. The full envelope's `message.content`
+// array is not read here (the result-side parsers branch on the
+// `tool_use_result` shape directly).
+type claudeToolResultEnvelope struct {
+	ToolUseResult json.RawMessage `json:"tool_use_result"`
+}
+
+// todoWriteInput is the input shape for Claude TodoWrite.
+type todoWriteInput struct {
+	Todos []rawTodo `json:"todos"`
+}
+
+type rawTodo struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"activeForm"`
+}
+
+// taskCreateInput captures the input fields the extractor needs from
+// the paired Claude TaskCreate tool_use.
+type taskCreateInput struct {
+	Subject     string `json:"subject"`
+	Description string `json:"description"`
+	ActiveForm  string `json:"activeForm"`
+}
+
+// taskUpdateInput captures Claude TaskUpdate's tool_use input.
+type taskUpdateInput struct {
+	TaskID      string  `json:"taskId"`
+	Subject     *string `json:"subject,omitempty"`
+	Description *string `json:"description,omitempty"`
+	ActiveForm  *string `json:"activeForm,omitempty"`
+	Status      *string `json:"status,omitempty"`
+}
+
+type taskCreateResult struct {
+	Task struct {
+		ID      string `json:"id"`
+		Subject string `json:"subject"`
+	} `json:"task"`
+}
+
+type taskUpdateResult struct {
+	Success       bool     `json:"success"`
+	TaskID        string   `json:"taskId"`
+	UpdatedFields []string `json:"updatedFields"`
+	StatusChange  *struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"statusChange"`
+}
+
+type taskGetResult struct {
+	Task *struct {
+		ID          string `json:"id"`
+		Subject     string `json:"subject"`
+		Description string `json:"description"`
+		Status      string `json:"status"`
+	} `json:"task"`
+}
+
+type taskListResult struct {
+	Tasks []struct {
+		ID      string `json:"id"`
+		Subject string `json:"subject"`
+		Status  string `json:"status"`
+	} `json:"tasks"`
+}
+
+// codexPlanNotification is the Codex turn/plan/updated JSON-RPC shape:
+// `{ method: "turn/plan/updated", params: { plan: [{step, status}] } }`.
+type codexPlanNotification struct {
+	Method string `json:"method"`
+	Params struct {
+		Plan []struct {
+			Step   string `json:"step"`
+			Status string `json:"status"`
+		} `json:"plan"`
+	} `json:"params"`
+}
+
+// acpPlanNotification is the ACP `sessionUpdate=plan` shape:
+// `{ sessionUpdate: "plan", entries: [{content, status}] }`.
+type acpPlanNotification struct {
+	SessionUpdate string `json:"sessionUpdate"`
+	Entries       []struct {
+		Content string `json:"content"`
+		Status  string `json:"status"`
+	} `json:"entries"`
+}
+
+// Extract derives a TodoEvent from a single message. contentJSON is
+// the decompressed message body. pairedToolUseJSON is the decompressed
+// body of the paired tool_use message when contentJSON is a Claude
+// tool_result (nil otherwise — caller resolves the span_id lookup).
+// Returns false when the message does not affect the to-do list (any
+// non-Task* tool, unrelated notifications, etc.).
+func Extract(spanType string, contentJSON, pairedToolUseJSON []byte) (Event, bool) {
+	if len(contentJSON) == 0 {
+		return Event{}, false
+	}
+
+	// Claude tool spans carry span_type on every message — dispatch
+	// directly and skip the notification-shape probes below.
+	switch spanType {
+	case ToolTodoWrite:
+		return tryTodoWrite(contentJSON)
+	case ToolTaskCreate:
+		return tryTaskCreate(contentJSON, pairedToolUseJSON)
+	case ToolTaskUpdate:
+		return tryTaskUpdate(contentJSON, pairedToolUseJSON)
+	case ToolTaskList:
+		return tryTaskList(contentJSON)
+	case ToolTaskGet:
+		return tryTaskGet(contentJSON)
+	}
+
+	// Codex turn/plan/updated and ACP sessionUpdate=plan are top-level
+	// JSON-RPC notifications with no span_type. Byte-pattern pre-filters
+	// inside the try* helpers gate the full unmarshal.
+	if ev, ok := tryCodexPlan(contentJSON); ok {
+		return ev, true
+	}
+	if ev, ok := tryAcpPlan(contentJSON); ok {
+		return ev, true
+	}
+	return Event{}, false
+}
+
+func tryTodoWrite(content []byte) (Event, bool) {
+	var env claudeToolUseEnvelope
+	if err := json.Unmarshal(content, &env); err != nil || env.Type != "assistant" {
+		return Event{}, false
+	}
+	for _, raw := range env.Message.Content {
+		var tu claudeToolUse
+		if err := json.Unmarshal(raw, &tu); err != nil || tu.Type != "tool_use" {
+			continue
+		}
+		if tu.Name != ToolTodoWrite {
+			continue
+		}
+		var input todoWriteInput
+		if err := json.Unmarshal(tu.Input, &input); err != nil {
+			return Event{}, false
+		}
+		items := make([]Item, 0, len(input.Todos))
+		for _, t := range input.Todos {
+			items = append(items, Item{
+				Content:    t.Content,
+				Status:     StatusFromWire(t.Status),
+				ActiveForm: t.ActiveForm,
+			})
+		}
+		return Event{Kind: KindSnapshot, Snapshot: items}, true
+	}
+	return Event{}, false
+}
+
+func tryTaskCreate(content, pairedToolUse []byte) (Event, bool) {
+	var env claudeToolResultEnvelope
+	if err := json.Unmarshal(content, &env); err != nil {
+		return Event{}, false
+	}
+	var result taskCreateResult
+	if err := json.Unmarshal(env.ToolUseResult, &result); err != nil || result.Task.ID == "" {
+		return Event{}, false
+	}
+	// The result only carries id + subject; the paired tool_use input
+	// has description/activeForm. The lookup is best-effort — a race
+	// where the tool_use isn't yet visible just yields a less detailed
+	// row (subject only).
+	var input taskCreateInput
+	parsePairedToolUseInput(pairedToolUse, ToolTaskCreate, &input)
+	subject := input.Subject
+	if subject == "" {
+		subject = result.Task.Subject
+	}
+	return Event{
+		Kind: KindCreate,
+		Item: Item{
+			ID:          result.Task.ID,
+			Content:     subject,
+			Status:      StatusPending,
+			ActiveForm:  input.ActiveForm,
+			Description: input.Description,
+		},
+	}, true
+}
+
+func tryTaskUpdate(content, pairedToolUse []byte) (Event, bool) {
+	var env claudeToolResultEnvelope
+	if err := json.Unmarshal(content, &env); err != nil {
+		return Event{}, false
+	}
+	var result taskUpdateResult
+	if err := json.Unmarshal(env.ToolUseResult, &result); err != nil {
+		return Event{}, false
+	}
+	if !result.Success || result.TaskID == "" {
+		return Event{}, false
+	}
+	if result.StatusChange != nil && result.StatusChange.To == "deleted" {
+		return Event{Kind: KindDelete, ID: result.TaskID}, true
+	}
+	patch := Patch{}
+	if result.StatusChange != nil {
+		s := StatusFromWire(result.StatusChange.To)
+		patch.Status = &s
+	}
+	// Merge in the input-side patch fields.
+	var input taskUpdateInput
+	parsePairedToolUseInput(pairedToolUse, ToolTaskUpdate, &input)
+	if input.Subject != nil {
+		patch.Content = input.Subject
+	}
+	if input.ActiveForm != nil {
+		patch.ActiveForm = input.ActiveForm
+	}
+	if input.Description != nil {
+		patch.Description = input.Description
+	}
+	return Event{Kind: KindUpdate, ID: result.TaskID, Patch: patch}, true
+}
+
+// parsePairedToolUseInput unmarshals the named tool_use block's input
+// from a paired tool_use envelope into out. No-op when bytes are empty
+// or the envelope doesn't contain the named tool. out is expected to
+// be a pointer to a struct shaped like the tool's input.
+func parsePairedToolUseInput(pairedToolUse []byte, name string, out any) {
+	if len(pairedToolUse) == 0 {
+		return
+	}
+	var env claudeToolUseEnvelope
+	if err := json.Unmarshal(pairedToolUse, &env); err != nil {
+		return
+	}
+	for _, raw := range env.Message.Content {
+		var tu claudeToolUse
+		if err := json.Unmarshal(raw, &tu); err != nil || tu.Type != "tool_use" || tu.Name != name {
+			continue
+		}
+		_ = json.Unmarshal(tu.Input, out)
+		return
+	}
+}
+
+func tryTaskList(content []byte) (Event, bool) {
+	var env claudeToolResultEnvelope
+	if err := json.Unmarshal(content, &env); err != nil {
+		return Event{}, false
+	}
+	var result taskListResult
+	if err := json.Unmarshal(env.ToolUseResult, &result); err != nil {
+		return Event{}, false
+	}
+	items := make([]Item, 0, len(result.Tasks))
+	for _, t := range result.Tasks {
+		items = append(items, Item{
+			ID:      t.ID,
+			Content: t.Subject,
+			Status:  StatusFromWire(t.Status),
+		})
+	}
+	return Event{Kind: KindSnapshot, Snapshot: items}, true
+}
+
+func tryTaskGet(content []byte) (Event, bool) {
+	var env claudeToolResultEnvelope
+	if err := json.Unmarshal(content, &env); err != nil {
+		return Event{}, false
+	}
+	var result taskGetResult
+	if err := json.Unmarshal(env.ToolUseResult, &result); err != nil || result.Task == nil {
+		return Event{}, false
+	}
+	return Event{
+		Kind: KindDetail,
+		Item: Item{
+			ID:          result.Task.ID,
+			Content:     result.Task.Subject,
+			Status:      StatusFromWire(result.Task.Status),
+			Description: result.Task.Description,
+		},
+	}, true
+}
+
+func tryCodexPlan(content []byte) (Event, bool) {
+	// Cheap discriminator before the full parse.
+	if !looksLikeCodexPlan(content) {
+		return Event{}, false
+	}
+	var n codexPlanNotification
+	if err := json.Unmarshal(content, &n); err != nil || n.Method != "turn/plan/updated" {
+		return Event{}, false
+	}
+	items := make([]Item, 0, len(n.Params.Plan))
+	for _, p := range n.Params.Plan {
+		if p.Step == "" {
+			continue
+		}
+		items = append(items, Item{
+			Content:    p.Step,
+			Status:     StatusFromWire(p.Status),
+			ActiveForm: p.Step,
+		})
+	}
+	return Event{Kind: KindSnapshot, Snapshot: items}, true
+}
+
+func tryAcpPlan(content []byte) (Event, bool) {
+	if !looksLikeAcpPlan(content) {
+		return Event{}, false
+	}
+	var n acpPlanNotification
+	if err := json.Unmarshal(content, &n); err != nil || n.SessionUpdate != "plan" {
+		return Event{}, false
+	}
+	items := make([]Item, 0, len(n.Entries))
+	for _, e := range n.Entries {
+		items = append(items, Item{
+			Content: e.Content,
+			Status:  StatusFromWire(e.Status),
+		})
+	}
+	return Event{Kind: KindSnapshot, Snapshot: items}, true
+}
+
+// LooksLikeProviderPlan is a cheap byte-pattern check that returns
+// true when the content body has a plausible chance of being a
+// Codex turn/plan/updated or ACP sessionUpdate=plan notification.
+// Worker callers use this as a hot-path gate so non-todo messages
+// skip the full JSON parse pipeline.
+//
+// Each marker is a distinctive whole-string token, so a single
+// bytes.Contains is sufficient — searching for a key/value adjacency
+// would silently miss occurrences where the same key appears earlier
+// with a different value.
+func LooksLikeProviderPlan(b []byte) bool {
+	return looksLikeCodexPlan(b) || looksLikeAcpPlan(b)
+}
+
+func looksLikeCodexPlan(b []byte) bool {
+	return bytes.Contains(b, []byte(`"turn/plan/updated"`))
+}
+
+func looksLikeAcpPlan(b []byte) bool {
+	// Two independent substring probes so the gate accepts both the
+	// compact ({"sessionUpdate":"plan",...}) and pretty-printed
+	// ({"sessionUpdate": "plan", ...}) forms. False positives are fine
+	// because callers follow up with a real Unmarshal.
+	return bytes.Contains(b, []byte(`"sessionUpdate"`)) && bytes.Contains(b, []byte(`"plan"`))
+}

--- a/backend/internal/worker/todoevents/todoevents.go
+++ b/backend/internal/worker/todoevents/todoevents.go
@@ -1,0 +1,185 @@
+// Package todoevents reduces a heterogeneous stream of agent messages
+// (Claude TodoWrite/TaskCreate/TaskUpdate/TaskGet/TaskList, Codex
+// turn/plan/updated, ACP sessionUpdate=plan) into a provider-neutral
+// to-do list. The worker owns the canonical state in agent_todos and
+// broadcasts the post-mutation snapshot to clients via
+// AgentTodosChanged; the frontend does not reduce these events
+// locally.
+package todoevents
+
+import (
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// MaxTodos caps the size of an agent's to-do list shipped to clients
+// and held in memory by the reducer. Practically, Claude's Task* tool
+// rarely produces more than a few dozen rows per agent; the cap is a
+// guardrail against a runaway agent flooding `agent_todos` and making
+// every cold-start payload pathologically large.
+const MaxTodos = 64
+
+// Item mirrors leapmuxv1.TodoItem in a plain-Go shape so the reducer
+// stays decoupled from the proto generated types.
+type Item struct {
+	ID          string
+	Content     string
+	Status      Status
+	ActiveForm  string
+	Description string
+}
+
+// Status is the canonical three-state to-do status. Mirrors
+// leapmuxv1.TodoStatus with friendlier zero-value semantics
+// (zero == pending instead of "unspecified").
+type Status int
+
+const (
+	StatusPending Status = iota
+	StatusInProgress
+	StatusCompleted
+)
+
+// Patch carries the fields of a KindUpdate event. Each *string is nil
+// for "no change", non-nil (even if empty) for "set to this value" —
+// matching TypeScript's `Partial<TodoItem>` semantics. Status is
+// represented by a *Status for the same reason.
+type Patch struct {
+	Content     *string
+	ActiveForm  *string
+	Description *string
+	Status      *Status
+}
+
+// EventKind discriminates the five event variants.
+type EventKind int
+
+const (
+	// KindSnapshot replaces the whole list (TodoWrite, Codex plan,
+	// ACP plan, Claude TaskList).
+	KindSnapshot EventKind = iota
+	// KindCreate appends one row (or replaces by ID for idempotent
+	// replay of Claude TaskCreate).
+	KindCreate
+	// KindUpdate merges fields into the row identified by ID
+	// (Claude TaskUpdate).
+	KindUpdate
+	// KindDelete removes the row identified by ID (Claude TaskUpdate
+	// with status="deleted").
+	KindDelete
+	// KindDetail merges fields into the row identified by ID,
+	// appending it when unseen (Claude TaskGet).
+	KindDetail
+)
+
+// Event is the discriminated union of mutation variants. Fields are
+// populated based on Kind; readers must switch on Kind before reading.
+type Event struct {
+	Kind     EventKind
+	Snapshot []Item // KindSnapshot
+	Item     Item   // KindCreate / KindDetail (full row)
+	ID       string // KindUpdate / KindDelete (target id)
+	Patch    Patch  // KindUpdate
+}
+
+// ApplyPatch overlays a Patch onto base; nil fields preserve base.
+// Used by the worker's persistence layer to apply incremental
+// TaskUpdate mutations.
+func ApplyPatch(base Item, patch Patch) Item {
+	out := base
+	if patch.Content != nil {
+		out.Content = *patch.Content
+	}
+	if patch.ActiveForm != nil {
+		out.ActiveForm = *patch.ActiveForm
+	}
+	if patch.Description != nil {
+		out.Description = *patch.Description
+	}
+	if patch.Status != nil {
+		out.Status = *patch.Status
+	}
+	return out
+}
+
+// MergeDetail overlays the non-zero fields of detail onto base.
+// KindDetail carries a TaskGet snapshot of the row; missing fields
+// map to empty strings via StatusFromWire / json zero values, which
+// we treat as "preserve". StatusPending is the zero value of Status
+// and the default for an empty wire string, so we preserve base on
+// that case too — TaskGet is a read-only query and never legitimately
+// downgrades a row from in_progress/completed back to pending. Real
+// status transitions arrive via KindUpdate (TaskUpdate).
+func MergeDetail(base, detail Item) Item {
+	out := base
+	if detail.Content != "" {
+		out.Content = detail.Content
+	}
+	if detail.ActiveForm != "" {
+		out.ActiveForm = detail.ActiveForm
+	}
+	if detail.Description != "" {
+		out.Description = detail.Description
+	}
+	if detail.Status != StatusPending {
+		out.Status = detail.Status
+	}
+	return out
+}
+
+// ToProto converts an in-memory Item to the wire-format proto message.
+func (i Item) ToProto() *leapmuxv1.TodoItem {
+	return &leapmuxv1.TodoItem{
+		Id:          i.ID,
+		Content:     i.Content,
+		Status:      statusToProto(i.Status),
+		ActiveForm:  i.ActiveForm,
+		Description: i.Description,
+	}
+}
+
+// ItemsToProto bulk-converts a slice for proto-shaped responses.
+func ItemsToProto(items []Item) []*leapmuxv1.TodoItem {
+	out := make([]*leapmuxv1.TodoItem, len(items))
+	for i, it := range items {
+		out[i] = it.ToProto()
+	}
+	return out
+}
+
+// StatusWire returns the lowercase wire-format string used by the
+// agent_todos.status column and the TS reducer ("pending" |
+// "in_progress" | "completed").
+func StatusWire(s Status) string {
+	switch s {
+	case StatusInProgress:
+		return "in_progress"
+	case StatusCompleted:
+		return "completed"
+	default:
+		return "pending"
+	}
+}
+
+// StatusFromWire parses the lowercase wire-format string; unknown
+// values fall through to StatusPending.
+func StatusFromWire(s string) Status {
+	switch s {
+	case "in_progress", "inProgress":
+		return StatusInProgress
+	case "completed":
+		return StatusCompleted
+	default:
+		return StatusPending
+	}
+}
+
+func statusToProto(s Status) leapmuxv1.TodoStatus {
+	switch s {
+	case StatusInProgress:
+		return leapmuxv1.TodoStatus_TODO_STATUS_IN_PROGRESS
+	case StatusCompleted:
+		return leapmuxv1.TodoStatus_TODO_STATUS_COMPLETED
+	default:
+		return leapmuxv1.TodoStatus_TODO_STATUS_PENDING
+	}
+}

--- a/backend/internal/worker/todoevents/todoevents_test.go
+++ b/backend/internal/worker/todoevents/todoevents_test.go
@@ -1,0 +1,285 @@
+package todoevents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/util/ptrconv"
+)
+
+// --- ApplyPatch / MergeDetail ----------------------------------------
+
+func TestApplyPatch_OverlaysProvidedFields(t *testing.T) {
+	base := Item{ID: "1", Content: "Run tests", ActiveForm: "Running tests", Status: StatusPending}
+	got := ApplyPatch(base, Patch{Status: ptrconv.Ptr(StatusInProgress)})
+	assert.Equal(t, StatusInProgress, got.Status)
+	// Untouched fields preserved.
+	assert.Equal(t, "Run tests", got.Content)
+	assert.Equal(t, "Running tests", got.ActiveForm)
+}
+
+func TestApplyPatch_NilFieldsPreserveBase(t *testing.T) {
+	base := Item{ID: "1", Content: "x", ActiveForm: "Doing x"}
+	got := ApplyPatch(base, Patch{Status: ptrconv.Ptr(StatusCompleted)})
+	assert.Equal(t, "Doing x", got.ActiveForm)
+	assert.Equal(t, "x", got.Content)
+}
+
+func TestMergeDetail_OverlaysNonZeroFields(t *testing.T) {
+	base := Item{ID: "1", Content: "old", Status: StatusPending}
+	got := MergeDetail(base, Item{
+		ID: "1", Content: "new", Description: "details", Status: StatusInProgress,
+	})
+	assert.Equal(t, "new", got.Content)
+	assert.Equal(t, "details", got.Description)
+	assert.Equal(t, StatusInProgress, got.Status)
+}
+
+// Regression: a KindDetail event whose Item carries the zero Status
+// (StatusPending) must not silently downgrade the existing row's
+// status. TaskGet's response may omit a populated status, which maps
+// to StatusPending via StatusFromWire; preserving the existing status
+// matches the wire's "field absent" intent.
+func TestMergeDetail_PreservesStatusOnZeroValue(t *testing.T) {
+	base := Item{ID: "1", Content: "old", Status: StatusInProgress}
+	got := MergeDetail(base, Item{ID: "1", Content: "new", Status: StatusPending})
+	assert.Equal(t, "new", got.Content)
+	assert.Equal(t, StatusInProgress, got.Status)
+}
+
+// --- Extractor -------------------------------------------------------
+
+func TestExtract_TodoWriteSnapshot(t *testing.T) {
+	body := `{
+		"type": "assistant",
+		"message": {"content": [{
+			"type": "tool_use",
+			"name": "TodoWrite",
+			"input": {"todos": [
+				{"content": "Run tests", "status": "in_progress", "activeForm": "Running tests"},
+				{"content": "Lint", "status": "pending", "activeForm": "Linting"}
+			]}
+		}]}
+	}`
+	ev, ok := Extract("TodoWrite", []byte(body), nil)
+	require.True(t, ok)
+	require.Equal(t, KindSnapshot, ev.Kind)
+	require.Len(t, ev.Snapshot, 2)
+	assert.Equal(t, "Run tests", ev.Snapshot[0].Content)
+	assert.Equal(t, StatusInProgress, ev.Snapshot[0].Status)
+	assert.Equal(t, "Running tests", ev.Snapshot[0].ActiveForm)
+}
+
+func TestExtract_TodoWriteUserSideEnvelopeIgnored(t *testing.T) {
+	// USER-side echoes are not assistant messages; should not produce events.
+	body := `{"type": "user", "message": {"content": [{"type": "tool_result"}]}}`
+	_, ok := Extract("TodoWrite", []byte(body), nil)
+	assert.False(t, ok)
+}
+
+func TestExtract_TaskCreate(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": [{"type": "tool_result", "tool_use_id": "x", "content": "Task #1 created successfully: Add proto"}]},
+		"tool_use_result": {"task": {"id": "1", "subject": "Add proto"}}
+	}`
+	use := `{
+		"type": "assistant",
+		"message": {"content": [{
+			"type": "tool_use",
+			"name": "TaskCreate",
+			"input": {"subject": "Add proto", "description": "Edit proto/agent.proto", "activeForm": "Adding proto"}
+		}]}
+	}`
+	ev, ok := Extract("TaskCreate", []byte(result), []byte(use))
+	require.True(t, ok)
+	require.Equal(t, KindCreate, ev.Kind)
+	assert.Equal(t, "1", ev.Item.ID)
+	assert.Equal(t, "Add proto", ev.Item.Content)
+	assert.Equal(t, "Adding proto", ev.Item.ActiveForm)
+	assert.Equal(t, "Edit proto/agent.proto", ev.Item.Description)
+	assert.Equal(t, StatusPending, ev.Item.Status)
+}
+
+func TestExtract_TaskCreateWithoutPairedToolUse(t *testing.T) {
+	// Race: tool_use not yet visible. We still emit a create with
+	// just the subject from the result.
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"task": {"id": "1", "subject": "fallback subject"}}
+	}`
+	ev, ok := Extract("TaskCreate", []byte(result), nil)
+	require.True(t, ok)
+	assert.Equal(t, "1", ev.Item.ID)
+	assert.Equal(t, "fallback subject", ev.Item.Content)
+	assert.Empty(t, ev.Item.Description)
+}
+
+func TestExtract_TaskCreateOnUseSideNoEvent(t *testing.T) {
+	// The tool_use side has no `task.id` yet — return false.
+	use := `{
+		"type": "assistant",
+		"message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "x"}}]}
+	}`
+	_, ok := Extract("TaskCreate", []byte(use), nil)
+	assert.False(t, ok)
+}
+
+func TestExtract_TaskUpdate(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"success": true, "taskId": "1", "updatedFields": ["status"], "statusChange": {"from": "pending", "to": "in_progress"}}
+	}`
+	use := `{
+		"type": "assistant",
+		"message": {"content": [{
+			"type": "tool_use",
+			"name": "TaskUpdate",
+			"input": {"taskId": "1", "status": "in_progress", "activeForm": "Running tests"}
+		}]}
+	}`
+	ev, ok := Extract("TaskUpdate", []byte(result), []byte(use))
+	require.True(t, ok)
+	require.Equal(t, KindUpdate, ev.Kind)
+	assert.Equal(t, "1", ev.ID)
+	require.NotNil(t, ev.Patch.Status)
+	assert.Equal(t, StatusInProgress, *ev.Patch.Status)
+	require.NotNil(t, ev.Patch.ActiveForm)
+	assert.Equal(t, "Running tests", *ev.Patch.ActiveForm)
+}
+
+func TestExtract_TaskUpdateDeleted(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"success": true, "taskId": "5", "updatedFields": ["status"], "statusChange": {"from": "completed", "to": "deleted"}}
+	}`
+	ev, ok := Extract("TaskUpdate", []byte(result), nil)
+	require.True(t, ok)
+	require.Equal(t, KindDelete, ev.Kind)
+	assert.Equal(t, "5", ev.ID)
+}
+
+func TestExtract_TaskUpdateFailureNoEvent(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"success": false, "taskId": "1", "updatedFields": [], "error": "not found"}
+	}`
+	_, ok := Extract("TaskUpdate", []byte(result), nil)
+	assert.False(t, ok)
+}
+
+func TestExtract_TaskList(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"tasks": [
+			{"id": "1", "subject": "A", "status": "completed"},
+			{"id": "2", "subject": "B", "status": "in_progress"}
+		]}
+	}`
+	ev, ok := Extract("TaskList", []byte(result), nil)
+	require.True(t, ok)
+	require.Equal(t, KindSnapshot, ev.Kind)
+	require.Len(t, ev.Snapshot, 2)
+	assert.Equal(t, "1", ev.Snapshot[0].ID)
+	assert.Equal(t, StatusCompleted, ev.Snapshot[0].Status)
+	assert.Equal(t, "2", ev.Snapshot[1].ID)
+	assert.Equal(t, StatusInProgress, ev.Snapshot[1].Status)
+}
+
+func TestExtract_TaskListEmpty(t *testing.T) {
+	result := `{"type": "user", "message": {"content": []}, "tool_use_result": {"tasks": []}}`
+	ev, ok := Extract("TaskList", []byte(result), nil)
+	require.True(t, ok)
+	assert.Empty(t, ev.Snapshot)
+}
+
+func TestExtract_TaskGet(t *testing.T) {
+	result := `{
+		"type": "user",
+		"message": {"content": []},
+		"tool_use_result": {"task": {"id": "3", "subject": "T3", "description": "details", "status": "pending"}}
+	}`
+	ev, ok := Extract("TaskGet", []byte(result), nil)
+	require.True(t, ok)
+	require.Equal(t, KindDetail, ev.Kind)
+	assert.Equal(t, "3", ev.Item.ID)
+	assert.Equal(t, "T3", ev.Item.Content)
+	assert.Equal(t, "details", ev.Item.Description)
+}
+
+func TestExtract_TaskGetNullTask(t *testing.T) {
+	result := `{"type": "user", "message": {"content": []}, "tool_use_result": {"task": null}}`
+	_, ok := Extract("TaskGet", []byte(result), nil)
+	assert.False(t, ok)
+}
+
+func TestExtract_CodexPlan(t *testing.T) {
+	body := `{
+		"method": "turn/plan/updated",
+		"params": {"plan": [
+			{"step": "Investigate", "status": "in_progress"},
+			{"step": "Write tests", "status": "pending"}
+		]}
+	}`
+	ev, ok := Extract("", []byte(body), nil)
+	require.True(t, ok)
+	require.Equal(t, KindSnapshot, ev.Kind)
+	require.Len(t, ev.Snapshot, 2)
+	assert.Equal(t, "Investigate", ev.Snapshot[0].Content)
+	assert.Equal(t, StatusInProgress, ev.Snapshot[0].Status)
+}
+
+func TestExtract_CodexPlanMalformedDropped(t *testing.T) {
+	body := `{
+		"method": "turn/plan/updated",
+		"params": {"plan": [
+			{"step": "", "status": "in_progress"},
+			{"step": "real", "status": "pending"}
+		]}
+	}`
+	ev, ok := Extract("", []byte(body), nil)
+	require.True(t, ok)
+	require.Len(t, ev.Snapshot, 1)
+	assert.Equal(t, "real", ev.Snapshot[0].Content)
+}
+
+func TestExtract_AcpPlan(t *testing.T) {
+	body := `{
+		"sessionUpdate": "plan",
+		"entries": [
+			{"content": "one", "status": "pending"},
+			{"content": "two", "status": "completed"}
+		]
+	}`
+	ev, ok := Extract("", []byte(body), nil)
+	require.True(t, ok)
+	require.Equal(t, KindSnapshot, ev.Kind)
+	require.Len(t, ev.Snapshot, 2)
+	assert.Equal(t, "one", ev.Snapshot[0].Content)
+	assert.Equal(t, StatusCompleted, ev.Snapshot[1].Status)
+}
+
+func TestExtract_AcpPlanEmpty(t *testing.T) {
+	body := `{"sessionUpdate": "plan", "entries": []}`
+	ev, ok := Extract("", []byte(body), nil)
+	require.True(t, ok)
+	assert.Empty(t, ev.Snapshot)
+}
+
+func TestExtract_UnknownSpanTypeNoEvent(t *testing.T) {
+	body := `{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]}}`
+	_, ok := Extract("Bash", []byte(body), nil)
+	assert.False(t, ok)
+}
+
+func TestExtract_EmptyContentJSON(t *testing.T) {
+	_, ok := Extract("TaskCreate", nil, nil)
+	assert.False(t, ok)
+}

--- a/frontend/src/components/chat/providers/claude/extractors/taskCard.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/taskCard.ts
@@ -1,0 +1,92 @@
+import type { TodoListSource } from '../../../todoListMessage'
+import { pickObject, pickString } from '~/lib/jsonPick'
+import { normalizeTodoStatus } from '~/stores/chat.store'
+import { CLAUDE_TOOL, TASK_DELETE_SENTINEL } from '~/types/toolMessages'
+
+function isTaskDeleteRequest(
+  toolUseInput: Record<string, unknown> | null | undefined,
+  statusChange: Record<string, unknown> | null,
+): boolean {
+  return pickString(statusChange, 'to') === TASK_DELETE_SENTINEL
+    || pickString(toolUseInput, 'status') === TASK_DELETE_SENTINEL
+}
+
+/**
+ * Build a TodoListSource for an inline TaskCreate card. Accepts the
+ * tool_use input (always present once persisted) and the optional
+ * tool_use_result envelope (present after the agent assigns the id).
+ * Used from both the tool_use renderer and the tool_result re-render.
+ */
+export function buildTaskCreateSource(
+  toolUseInput: Record<string, unknown> | null | undefined,
+  toolUseResult: Record<string, unknown> | null | undefined,
+): TodoListSource {
+  const taskFromResult = pickObject(toolUseResult, 'task')
+  const taskId = pickString(taskFromResult, 'id')
+  const subject = pickString(toolUseInput, 'subject') || pickString(taskFromResult, 'subject')
+  const description = pickString(toolUseInput, 'description')
+  return {
+    toolName: CLAUDE_TOOL.TASK_CREATE,
+    title: taskId ? `Task #${taskId}` : 'Task created',
+    todos: [{
+      id: taskId || undefined,
+      content: subject,
+      status: 'pending',
+      activeForm: pickString(toolUseInput, 'activeForm'),
+      description: description || undefined,
+    }],
+    bordered: false,
+  }
+}
+
+/**
+ * Build a TodoListSource for an inline TaskUpdate card. Dispatches to
+ * the delete branch when the wire carries the delete sentinel; the
+ * regular path funnels status through `normalizeTodoStatus` so
+ * `inProgress` / `in_progress` variants normalize uniformly.
+ */
+export function buildTaskUpdateSource(
+  toolUseInput: Record<string, unknown> | null | undefined,
+  toolUseResult: Record<string, unknown> | null | undefined,
+): TodoListSource | null {
+  const taskId = pickString(toolUseInput, 'taskId') || pickString(toolUseResult, 'taskId')
+  if (!taskId)
+    return null
+  const statusChange = pickObject(toolUseResult, 'statusChange')
+  if (isTaskDeleteRequest(toolUseInput, statusChange))
+    return buildTaskDeleteSource(taskId, toolUseInput)
+  return {
+    toolName: CLAUDE_TOOL.TASK_UPDATE,
+    title: `Task #${taskId} updated`,
+    todos: [{
+      id: taskId,
+      content: pickString(toolUseInput, 'subject') || `Task #${taskId}`,
+      status: normalizeTodoStatus(pickString(statusChange, 'to') || pickString(toolUseInput, 'status')),
+      activeForm: pickString(toolUseInput, 'activeForm'),
+      description: pickString(toolUseInput, 'description') || undefined,
+    }],
+    bordered: false,
+  }
+}
+
+function buildTaskDeleteSource(
+  taskId: string,
+  toolUseInput: Record<string, unknown> | null | undefined,
+): TodoListSource {
+  return {
+    toolName: CLAUDE_TOOL.TASK_UPDATE,
+    title: `Task #${taskId} deleted`,
+    todos: [{
+      id: taskId,
+      content: pickString(toolUseInput, 'subject') || `Task #${taskId}`,
+      status: 'completed',
+      activeForm: '',
+    }],
+    bordered: false,
+  }
+}
+
+/** Pull the paired tool_result's `tool_use_result` envelope, if any. */
+export function readToolUseResult(parsed: { parentObject?: Record<string, unknown> } | null | undefined): Record<string, unknown> | null {
+  return pickObject(parsed?.parentObject, 'tool_use_result')
+}

--- a/frontend/src/components/chat/providers/claude/extractors/todo.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/todo.ts
@@ -1,6 +1,8 @@
 import type { TodoListSource } from '../../../todoListMessage'
+import type { TodoItem } from '~/stores/chat.store'
+import { isObject, pickString } from '~/lib/jsonPick'
 import { pluralize } from '~/lib/plural'
-import { rawTodosToItems } from '~/stores/chat.store'
+import { normalizeTodoStatus, rawTodosToItems } from '~/stores/chat.store'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 
 /**
@@ -21,4 +23,40 @@ export function claudeTodoWriteFromInput(
     title: pluralize(todos.length, 'task'),
     todos,
   }
+}
+
+/**
+ * Convert one Claude Task* result `task` record to a TodoItem, or null
+ * when the record is missing an id. Set `includeDescription` for
+ * TaskGet (which carries the long-form description); TaskList's per-
+ * task records omit it.
+ */
+export function claudeTaskToTodoItem(
+  task: unknown,
+  options: { includeDescription?: boolean } = {},
+): TodoItem | null {
+  if (!isObject(task))
+    return null
+  const id = pickString(task, 'id')
+  if (!id)
+    return null
+  const description = options.includeDescription ? pickString(task, 'description') : ''
+  return {
+    id,
+    content: pickString(task, 'subject'),
+    status: normalizeTodoStatus(task.status),
+    activeForm: '',
+    description: description || undefined,
+  }
+}
+
+/**
+ * Convert a Claude TaskList tool_result `tasks[]` to TodoItem[]. Used by
+ * the TaskList result-side renderer to feed the shared TodoListMessage.
+ */
+export function claudeTaskListToTodos(tasks: unknown[]): TodoItem[] {
+  return tasks.flatMap((t) => {
+    const item = claudeTaskToTodoItem(t)
+    return item ? [item] : []
+  })
 }

--- a/frontend/src/components/chat/providers/claude/toolResults/index.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/index.tsx
@@ -12,6 +12,7 @@ import { ReadFileResultBody } from '../../../results/readFileResult'
 import { SearchResultBody } from '../../../results/searchResult'
 import { WebFetchResultBody } from '../../../results/webFetchResult'
 import { WebSearchResultsBody } from '../../../results/webSearchResults'
+import { TodoListMessage } from '../../../todoListMessage'
 import { ToolResultMessage } from '../../../toolRenderers'
 import { getAssistantContent, getMessageContentArray } from '../extractors/assistantContent'
 import { claudeBashFromToolResult } from '../extractors/bash'
@@ -20,6 +21,7 @@ import { claudeGlobFromToolResult, claudeGrepFromToolResult } from '../extractor
 import { claudeMcpFromToolResult, isClaudeMcpTool } from '../extractors/mcp'
 import { claudeReadFromToolResult } from '../extractors/read'
 import { claudeRemoteTriggerFromToolResult } from '../extractors/remoteTrigger'
+import { buildTaskCreateSource, buildTaskUpdateSource } from '../extractors/taskCard'
 import { claudeWebFetchFromToolResult } from '../extractors/webFetch'
 import { claudeWebSearchFromToolResult } from '../extractors/webSearch'
 import { AgentResultView } from './agent'
@@ -27,6 +29,7 @@ import { AskUserQuestionResultView } from './askUserQuestion'
 import { ExitPlanModeResultView } from './exitPlanMode'
 import { RemoteTriggerResultView } from './remoteTrigger'
 import { TaskOutputResultView } from './taskOutput'
+import { TaskGetResultView, TaskListResultView } from './taskTools'
 import { ToolSearchResultView } from './toolSearch'
 
 /** Extract tool name and input from a parsed tool_use message. */
@@ -167,6 +170,47 @@ const TOOL_RESULT_ENTRIES: Record<string, ToolResultEntry> = {
     if (!source)
       return null
     return <RemoteTriggerResultView source={source} context={ctx} />
+  },
+
+  // Claude TaskCreate result: re-render the single-row card now that
+  // the assigned task.id is known. The use-side renderer also tries
+  // to surface the id via context.toolResultParsed, so this is for the
+  // case where the result message is rendered standalone (e.g. when
+  // its tool_use has been trimmed from the window).
+  [CLAUDE_TOOL.TASK_CREATE]: (info, ctx) => {
+    if (!info.toolUseResult)
+      return null
+    return <TodoListMessage source={buildTaskCreateSource(info.toolInput, info.toolUseResult)} context={ctx} />
+  },
+
+  // Claude TaskUpdate result: re-render with the resolved status.
+  [CLAUDE_TOOL.TASK_UPDATE]: (info, ctx) => {
+    if (!info.toolUseResult)
+      return null
+    const source = buildTaskUpdateSource(info.toolInput, info.toolUseResult)
+    if (!source)
+      return null
+    return <TodoListMessage source={source} context={ctx} />
+  },
+
+  // Claude TaskList result: render the full snapshot as a TodoList.
+  [CLAUDE_TOOL.TASK_LIST]: (info, ctx) => {
+    if (!info.toolUseResult || !Array.isArray(info.toolUseResult.tasks))
+      return null
+    return <TaskListResultView tasks={info.toolUseResult.tasks} context={ctx} />
+  },
+
+  // Claude TaskGet result: render a single-row card with secondary
+  // detail lines (description, blockedBy, blocks).
+  [CLAUDE_TOOL.TASK_GET]: (info, ctx) => {
+    if (!info.toolUseResult || !isObject(info.toolUseResult.task))
+      return null
+    return (
+      <TaskGetResultView
+        task={info.toolUseResult.task as Record<string, unknown>}
+        context={ctx}
+      />
+    )
   },
 }
 

--- a/frontend/src/components/chat/providers/claude/toolResults/taskTools.css.ts
+++ b/frontend/src/components/chat/providers/claude/toolResults/taskTools.css.ts
@@ -1,0 +1,16 @@
+import { style } from '@vanilla-extract/css'
+
+export const detailList = style({
+  margin: 'var(--space-2) 0 0 var(--space-6)',
+  listStyle: 'none',
+  padding: 0,
+})
+
+export const detailLine = style({
+  color: 'var(--color-muted-foreground)',
+  fontSize: 'var(--font-size-sm)',
+})
+
+export const idRef = style({
+  marginRight: 'var(--space-1)',
+})

--- a/frontend/src/components/chat/providers/claude/toolResults/taskTools.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/taskTools.tsx
@@ -1,0 +1,90 @@
+import type { JSX } from 'solid-js'
+import type { RenderContext } from '../../../messageRenderers'
+import { For, Show } from 'solid-js'
+import { pickString, pickStringArray } from '~/lib/jsonPick'
+import { pluralize } from '~/lib/plural'
+import { CLAUDE_TOOL } from '~/types/toolMessages'
+import { TodoListMessage } from '../../../todoListMessage'
+import { claudeTaskListToTodos, claudeTaskToTodoItem } from '../extractors/todo'
+import * as styles from './taskTools.css'
+
+/**
+ * Result-side view for Claude TaskList. The full authoritative task
+ * array renders as a TodoListMessage so it matches the sidebar visuals.
+ */
+export function TaskListResultView(props: {
+  tasks: unknown[]
+  context?: RenderContext
+}): JSX.Element {
+  const todos = () => claudeTaskListToTodos(props.tasks)
+  return (
+    <TodoListMessage
+      source={{
+        toolName: CLAUDE_TOOL.TASK_LIST,
+        title: pluralize(todos().length, 'task'),
+        todos: todos(),
+      }}
+      context={props.context}
+    />
+  )
+}
+
+/**
+ * Result-side view for Claude TaskGet. A single-row card plus secondary
+ * lines for `description`, `blockedBy`, and `blocks` (only the
+ * non-empty ones).
+ */
+export function TaskGetResultView(props: {
+  task: Record<string, unknown>
+  context?: RenderContext
+}): JSX.Element {
+  const todos = () => {
+    const item = claudeTaskToTodoItem(props.task, { includeDescription: true })
+    return item ? [item] : []
+  }
+  const description = () => pickString(props.task, 'description')
+  const blockedBy = () => pickStringArray(props.task, 'blockedBy')
+  const blocks = () => pickStringArray(props.task, 'blocks')
+  const taskId = () => todos()[0]?.id ?? ''
+
+  return (
+    <Show when={taskId()}>
+      <TodoListMessage
+        source={{
+          toolName: CLAUDE_TOOL.TASK_GET,
+          title: `Task #${taskId()}`,
+          todos: todos(),
+        }}
+        context={props.context}
+      />
+      <Show when={description() || blockedBy().length > 0 || blocks().length > 0}>
+        <ul class={styles.detailList}>
+          <Show when={description()}>
+            <li class={styles.detailLine}>{description()}</li>
+          </Show>
+          <IdListLine label="Blocked by" ids={blockedBy()} />
+          <IdListLine label="Blocks" ids={blocks()} />
+        </ul>
+      </Show>
+    </Show>
+  )
+}
+
+/** Renders one detail line listing referenced task IDs (e.g. "Blocked by: #3 #7"). */
+function IdListLine(props: { label: string, ids: readonly string[] }): JSX.Element {
+  return (
+    <Show when={props.ids.length > 0}>
+      <li class={styles.detailLine}>
+        {`${props.label}: `}
+        <For each={props.ids}>
+          {id => (
+            <span class={styles.idRef}>
+              #
+              {id}
+            </span>
+          )}
+        </For>
+      </li>
+    </Show>
+  )
+}

--- a/frontend/src/components/chat/providers/claude/toolUse/icons.ts
+++ b/frontend/src/components/chat/providers/claude/toolUse/icons.ts
@@ -7,6 +7,7 @@ import FilePen from 'lucide-solid/icons/file-pen'
 import FilePlus from 'lucide-solid/icons/file-plus'
 import FolderSearch from 'lucide-solid/icons/folder-search'
 import Globe from 'lucide-solid/icons/globe'
+import ListChecks from 'lucide-solid/icons/list-checks'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import OctagonX from 'lucide-solid/icons/octagon-x'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
@@ -34,6 +35,10 @@ export function toolIconFor(name: string): LucideIcon {
     case CLAUDE_TOOL.WEB_FETCH: return Globe
     case CLAUDE_TOOL.WEB_SEARCH: return Globe
     case CLAUDE_TOOL.TODO_WRITE: return ListTodo
+    case CLAUDE_TOOL.TASK_CREATE: return ListTodo
+    case CLAUDE_TOOL.TASK_UPDATE: return ListTodo
+    case CLAUDE_TOOL.TASK_LIST: return ListTodo
+    case CLAUDE_TOOL.TASK_GET: return ListChecks
     case CLAUDE_TOOL.ENTER_PLAN_MODE: return TicketsPlane
     case CLAUDE_TOOL.EXIT_PLAN_MODE: return PlaneTakeoff
     case CLAUDE_TOOL.ASK_USER_QUESTION: return Vote

--- a/frontend/src/components/chat/providers/claude/toolUse/index.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/index.tsx
@@ -10,6 +10,7 @@ import { renderExitPlanMode } from './exitPlanMode'
 import { ToolUseMessage } from './genericToolUse'
 import { toolIconFor } from './icons'
 import { deriveToolSummary } from './summary'
+import { renderTaskCreate, renderTaskUpdate } from './taskTools'
 import { renderClaudeToolTitle } from './title'
 import { renderTodoWrite } from './todoWrite'
 
@@ -25,6 +26,15 @@ export function renderClaudeToolUse(
   // Special tool_use renderers
   if (toolName === CLAUDE_TOOL.TODO_WRITE)
     return renderTodoWrite(toolUse, context)
+  if (toolName === CLAUDE_TOOL.TASK_CREATE)
+    return renderTaskCreate(toolUse, context)
+  if (toolName === CLAUDE_TOOL.TASK_UPDATE)
+    return renderTaskUpdate(toolUse, context)
+  // TaskList/TaskGet render the full content on the tool_result side
+  // (TaskListResultView / TaskGetResultView). Suppress the tool_use
+  // bubble so the timeline doesn't double-up.
+  if (toolName === CLAUDE_TOOL.TASK_LIST || toolName === CLAUDE_TOOL.TASK_GET)
+    return null
   if (toolName === CLAUDE_TOOL.ASK_USER_QUESTION)
     return renderAskUserQuestion(toolUse, context)
   if (toolName === CLAUDE_TOOL.EXIT_PLAN_MODE)

--- a/frontend/src/components/chat/providers/claude/toolUse/taskTools.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/taskTools.tsx
@@ -1,0 +1,31 @@
+import type { JSX } from 'solid-js'
+import type { RenderContext } from '../../../messageRenderers'
+import { pickObject } from '~/lib/jsonPick'
+import { TodoListMessage } from '../../../todoListMessage'
+import { buildTaskCreateSource, buildTaskUpdateSource, readToolUseResult } from '../extractors/taskCard'
+
+/**
+ * Render a TaskCreate tool_use as a single-row card matching one row
+ * of the sidebar TodoList. When the paired tool_result is available
+ * (post-resolve), the title surfaces the agent-assigned `task.id`.
+ */
+export function renderTaskCreate(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element | null {
+  const input = pickObject(toolUse, 'input')
+  if (!input)
+    return null
+  return <TodoListMessage source={buildTaskCreateSource(input, readToolUseResult(context?.toolResultParsed))} context={context} />
+}
+
+/**
+ * Render a TaskUpdate tool_use as a single-row card. Pulls the
+ * authoritative final status from the paired tool_result when present;
+ * the input's status is used as a fallback so unresolved requests still
+ * paint a meaningful state.
+ */
+export function renderTaskUpdate(toolUse: Record<string, unknown>, context?: RenderContext): JSX.Element | null {
+  const input = pickObject(toolUse, 'input')
+  const source = buildTaskUpdateSource(input, readToolUseResult(context?.toolResultParsed))
+  if (!source)
+    return null
+  return <TodoListMessage source={source} context={context} />
+}

--- a/frontend/src/components/chat/providers/claude/toolUse/title.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/title.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, RemoteTriggerInput, TaskStopInput, ToolSearchInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
+import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, RemoteTriggerInput, TaskCreateInput, TaskStopInput, TaskUpdateInput, ToolSearchInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { joinMetaParts } from '../../../rendererUtils'
 import { toolInputCode, toolInputText } from '../../../toolStyles.css'
@@ -77,6 +77,15 @@ export function renderClaudeToolTitle(toolName: string, input: Record<string, un
     }
     case CLAUDE_TOOL.ENTER_PLAN_MODE:
       return <span class={toolInputText}>Entering Plan Mode</span>
+    case CLAUDE_TOOL.TASK_CREATE: {
+      const { subject } = input as TaskCreateInput
+      return <span class={toolInputText}>{subject ? `Create task: ${subject}` : 'Create task'}</span>
+    }
+    case CLAUDE_TOOL.TASK_UPDATE: {
+      const { taskId, status } = input as TaskUpdateInput
+      const label = taskId ? `Update task #${taskId}` : 'Update task'
+      return <span class={toolInputText}>{status ? `${label} → ${status}` : label}</span>
+    }
     case CLAUDE_TOOL.SKILL: {
       const skillName = String(input.skill || '')
       return <span class={toolInputText}>{`Skill: /${skillName}`}</span>

--- a/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
+++ b/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
@@ -107,6 +107,43 @@ describe('claude TodoWrite renders via shared TodoListMessage', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Claude Code TaskCreate / TaskUpdate / TaskList / TaskGet (2.1.142+)
+// ---------------------------------------------------------------------------
+
+describe('claude TaskCreate renders a single-row card via TodoListMessage', () => {
+  it('renders the subject as the only row with pending status', () => {
+    const { container } = renderClaudeToolUse('TaskCreate', {
+      subject: 'Add proto messages',
+      description: 'Edit proto/agent.proto',
+      activeForm: 'Adding proto',
+    })
+    const text = container.textContent ?? ''
+    expect(text).toContain('Task created')
+    expect(text).toContain('Add proto messages')
+  })
+})
+
+describe('claude TaskUpdate renders a single-row card', () => {
+  it('renders the new status in the title (status-only patch)', () => {
+    const { container } = renderClaudeToolUse('TaskUpdate', {
+      taskId: '1',
+      status: 'in_progress',
+    })
+    const text = container.textContent ?? ''
+    expect(text).toContain('Task #1 updated')
+  })
+
+  it('renders the deleted sentinel when status=deleted', () => {
+    const { container } = renderClaudeToolUse('TaskUpdate', {
+      taskId: '5',
+      status: 'deleted',
+    })
+    const text = container.textContent ?? ''
+    expect(text).toContain('Task #5 deleted')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Codex turn/plan/updated
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -585,6 +585,14 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         chatStore.removeMessage(md.agentId, md.messageId)
         break
       }
+      case 'todosChanged': {
+        // Sole driver of the sidebar to-do list. The worker persists
+        // every to-do event in agent_todos and ships the post-mutation
+        // snapshot here; clients replace wholesale.
+        const tc = inner.value
+        chatStore.replaceTodos(tc.agentId, tc.todos)
+        break
+      }
       case 'catchUpComplete':
         catchUpPhases.set(agentId, 'live')
         break

--- a/frontend/src/lib/jsonPick.ts
+++ b/frontend/src/lib/jsonPick.ts
@@ -64,6 +64,17 @@ export function pickObject(
 }
 
 /**
+ * Read a string-array property from an untyped record. Non-string entries
+ * are dropped; missing or non-array values yield an empty array.
+ */
+export function pickStringArray(obj: Record<string, unknown> | null | undefined, key: string): string[] {
+  const v = obj?.[key]
+  if (!Array.isArray(v))
+    return []
+  return v.filter((x): x is string => typeof x === 'string')
+}
+
+/**
  * Return the first string-typed value found across a list of candidate keys.
  * Useful for payloads that disagree on snake/camelCase naming
  * (`filePath`/`file_path`/`path`). Returns undefined when no key matched.

--- a/frontend/src/lib/messageParser.test.ts
+++ b/frontend/src/lib/messageParser.test.ts
@@ -9,8 +9,6 @@ import {
   extractRateLimitInfo,
   extractResultMetadata,
   extractSettingsChanges,
-  extractTodos,
-  findLatestTodos,
   getInnerMessage,
   getInnerMessageType,
   NOTIFICATION_THREAD_TYPE,
@@ -18,8 +16,14 @@ import {
 } from './messageParser'
 
 /** Build a mock AgentChatMessage with the given JSON content (uncompressed). */
-function makeMsg(source: MessageSource, content: unknown, opts?: { seq?: bigint }) {
-  return makeMessage({ source, content: rawContent(content), seq: opts?.seq })
+function makeMsg(source: MessageSource, content: unknown, opts?: { seq?: bigint, spanId?: string, spanType?: string }) {
+  return makeMessage({
+    source,
+    content: rawContent(content),
+    seq: opts?.seq,
+    spanId: opts?.spanId,
+    spanType: opts?.spanType,
+  })
 }
 
 /** Wrap inner messages in a notification-thread wrapper envelope. */
@@ -136,171 +140,6 @@ describe('getInnerMessageType', () => {
   it('returns undefined when no type', () => {
     const msg = makeMsg(MessageSource.AGENT, { message: {} })
     expect(getInnerMessageType(parseMessageContent(msg))).toBeUndefined()
-  })
-})
-
-// ---------------------------------------------------------------------------
-// extractTodos
-// ---------------------------------------------------------------------------
-
-describe('extractTodos', () => {
-  const todoContent = {
-    type: 'assistant',
-    message: {
-      content: [
-        {
-          type: 'tool_use',
-          name: 'TodoWrite',
-          input: {
-            todos: [
-              { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
-              { content: 'Deploy', status: 'in_progress', activeForm: 'Deploying' },
-              { content: 'Review', status: 'pending', activeForm: 'Reviewing' },
-            ],
-          },
-        },
-      ],
-    },
-  }
-
-  it('extracts todos from a valid TodoWrite message', () => {
-    const msg = makeMsg(MessageSource.AGENT, todoContent)
-    const parsed = parseMessageContent(msg)
-    const todos = extractTodos(msg, parsed)
-
-    expect(todos).toEqual([
-      { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
-      { content: 'Deploy', status: 'in_progress', activeForm: 'Deploying' },
-      { content: 'Review', status: 'pending', activeForm: 'Reviewing' },
-    ])
-  })
-
-  it('returns null for non-AGENT source', () => {
-    const msg = makeMsg(MessageSource.USER, todoContent)
-    const parsed = parseMessageContent(msg)
-    expect(extractTodos(msg, parsed)).toBeNull()
-  })
-
-  it('returns null for non-TodoWrite tool_use', () => {
-    const content = {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }],
-      },
-    }
-    const msg = makeMsg(MessageSource.AGENT, content)
-    const parsed = parseMessageContent(msg)
-    expect(extractTodos(msg, parsed)).toBeNull()
-  })
-
-  it('returns null for assistant message with only text', () => {
-    const content = {
-      type: 'assistant',
-      message: { content: [{ type: 'text', text: 'Hello' }] },
-    }
-    const msg = makeMsg(MessageSource.AGENT, content)
-    const parsed = parseMessageContent(msg)
-    expect(extractTodos(msg, parsed)).toBeNull()
-  })
-
-  it('defaults unknown status to pending', () => {
-    const content = {
-      type: 'assistant',
-      message: {
-        content: [{
-          type: 'tool_use',
-          name: 'TodoWrite',
-          input: { todos: [{ content: 'Task', status: 'unknown_status', activeForm: 'Working' }] },
-        }],
-      },
-    }
-    const msg = makeMsg(MessageSource.AGENT, content)
-    const parsed = parseMessageContent(msg)
-    const todos = extractTodos(msg, parsed)
-    expect(todos![0].status).toBe('pending')
-  })
-
-  it('extracts todos from a Codex turn/plan/updated message', () => {
-    const msg = makeMsg(MessageSource.AGENT, {
-      method: 'turn/plan/updated',
-      params: {
-        threadId: 'thread-1',
-        turnId: 'turn-1',
-        explanation: 'Need a plan',
-        plan: [
-          { step: 'Inspect messages', status: 'inProgress' },
-          { step: 'Patch renderer', status: 'pending' },
-          { step: 'Run tests', status: 'completed' },
-        ],
-      },
-    })
-    const parsed = parseMessageContent(msg)
-    const todos = extractTodos(msg, parsed)
-
-    expect(todos).toEqual([
-      { content: 'Inspect messages', status: 'in_progress', activeForm: 'Inspect messages' },
-      { content: 'Patch renderer', status: 'pending', activeForm: 'Patch renderer' },
-      { content: 'Run tests', status: 'completed', activeForm: 'Run tests' },
-    ])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// findLatestTodos
-// ---------------------------------------------------------------------------
-
-describe('findLatestTodos', () => {
-  const makeTodoMsg = (seq: bigint, tasks: Array<{ content: string, status: string, activeForm: string }>) =>
-    makeMsg(MessageSource.AGENT, {
-      type: 'assistant',
-      message: {
-        content: [{
-          type: 'tool_use',
-          name: 'TodoWrite',
-          input: { todos: tasks },
-        }],
-      },
-    }, { seq })
-
-  it('finds the latest TodoWrite scanning backward', () => {
-    const messages = [
-      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
-      makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
-      makeMsg(MessageSource.AGENT, { type: 'assistant', message: { content: [{ type: 'text', text: 'response' }] } }, { seq: 3n }),
-      makeTodoMsg(4n, [{ content: 'New task', status: 'in_progress', activeForm: 'New' }]),
-      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'bye' } }, { seq: 5n }),
-    ]
-    const todos = findLatestTodos(messages)
-    expect(todos).toEqual([{ content: 'New task', status: 'in_progress', activeForm: 'New' }])
-  })
-
-  it('returns null when no TodoWrite exists', () => {
-    const messages = [
-      makeMsg(MessageSource.USER, { type: 'user', message: { content: 'hello' } }, { seq: 1n }),
-      makeMsg(MessageSource.AGENT, { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }, { seq: 2n }),
-    ]
-    expect(findLatestTodos(messages)).toBeNull()
-  })
-
-  it('returns null for empty array', () => {
-    expect(findLatestTodos([])).toBeNull()
-  })
-
-  it('finds the latest Codex turn/plan/updated scanning backward', () => {
-    const messages = [
-      makeTodoMsg(2n, [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]),
-      makeMsg(MessageSource.AGENT, {
-        method: 'turn/plan/updated',
-        params: {
-          threadId: 'thread-1',
-          turnId: 'turn-1',
-          explanation: null,
-          plan: [{ step: 'New Codex task', status: 'inProgress' }],
-        },
-      }, { seq: 4n }),
-    ]
-    const todos = findLatestTodos(messages)
-    expect(todos).toEqual([{ content: 'New Codex task', status: 'in_progress', activeForm: 'New Codex task' }])
   })
 })
 

--- a/frontend/src/lib/messageParser.ts
+++ b/frontend/src/lib/messageParser.ts
@@ -1,11 +1,10 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ContextUsageInfo, RateLimitInfo } from '~/stores/agentSession.store'
 import type { TodoItem } from '~/stores/chat.store'
-import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { decompressContentToString } from '~/lib/decompress'
 import { isObject, pickFirstNumber, pickNumber } from '~/lib/jsonPick'
 import { CODEX_RATE_LIMITS_METHOD, iterCodexRateLimitTiers } from '~/lib/rateLimitUtils'
-import { normalizeTodoStatus, rawTodosToItems } from '~/stores/chat.store'
+import { normalizeTodoStatus } from '~/stores/chat.store'
 
 /**
  * Content-type discriminator emitted by the backend's `wrapNotifContent`
@@ -39,8 +38,8 @@ const EMPTY_PARSED: ParsedMessageContent = {
 // AgentChatMessage is immutable once persisted, so caching by message
 // reference avoids the repeated decompress + JSON.parse cost across
 // every caller of parseMessageContent (isAgentWorking scans, the
-// MessageBubble render path, findLatestTodos, etc.). The WeakMap lets
-// trimmed/replaced messages get GC'd without manual eviction.
+// MessageBubble render path, the to-do extractor, etc.). The WeakMap
+// lets trimmed/replaced messages get GC'd without manual eviction.
 const parseCache = new WeakMap<AgentChatMessage, ParsedMessageContent>()
 
 /**
@@ -151,54 +150,6 @@ export function codexPlanToTodos(plan: unknown[]): TodoItem[] {
       activeForm: step,
     }]
   })
-}
-
-/** Extract TodoWrite todos from a parsed assistant message. Returns null if not applicable. */
-export function extractTodos(message: AgentChatMessage, parsed: ParsedMessageContent): TodoItem[] | null {
-  // Source gate: a USER-side row may legitimately echo back an
-  // assistant-shape tool_use envelope (Claude tool_result chunks
-  // arrive with role:"user" on the wire). Treating those as todos
-  // would surface stale TodoWrite contents on the user side.
-  if (message.source !== MessageSource.AGENT)
-    return null
-  const parent = parsed.parentObject
-  if (!parent)
-    return null
-
-  if (parent.type === 'assistant') {
-    const msg = parent.message as Record<string, unknown> | undefined
-    const content = msg?.content
-    if (!Array.isArray(content))
-      return null
-    const toolUse = content.find(
-      (c: Record<string, unknown>) => typeof c === 'object' && c !== null && c.type === 'tool_use' && c.name === 'TodoWrite',
-    )
-    if (!toolUse?.input?.todos || !Array.isArray(toolUse.input.todos))
-      return null
-    return rawTodosToItems(toolUse.input.todos)
-  }
-
-  if (parent.method === 'turn/plan/updated') {
-    const params = parent.params as Record<string, unknown> | undefined
-    const plan = params?.plan
-    if (!Array.isArray(plan))
-      return null
-    const todos = codexPlanToTodos(plan)
-    return todos.length > 0 ? todos : null
-  }
-
-  return null
-}
-
-/** Scan messages backward for the latest TodoWrite, returning todos or null. */
-export function findLatestTodos(messages: AgentChatMessage[]): TodoItem[] | null {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const parsed = parseMessageContent(messages[i])
-    const todos = extractTodos(messages[i], parsed)
-    if (todos)
-      return todos
-  }
-  return null
 }
 
 /** Normalize a snake_case context_usage broadcast payload into AgentSessionInfo shape. */

--- a/frontend/src/lib/shallowEqual.test.ts
+++ b/frontend/src/lib/shallowEqual.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shallowEqual, shallowEqualArrays, shallowEqualExcept } from './shallowEqual'
+import { shallowEqual, shallowEqualArrays, shallowEqualArraysDeep, shallowEqualExcept } from './shallowEqual'
 
 describe('shallowequal', () => {
   it('returns true for same reference', () => {
@@ -66,6 +66,18 @@ describe('shallowequalarrays', () => {
     const obj = { a: 1 }
     expect(shallowEqualArrays([obj], [obj])).toBe(true)
     expect(shallowEqualArrays([{ a: 1 }], [{ a: 1 }])).toBe(false)
+  })
+})
+
+describe('shallowequalarraysdeep', () => {
+  it('compares object elements by shallowEqual (recurses one level)', () => {
+    expect(shallowEqualArraysDeep([{ a: 1 }], [{ a: 1 }])).toBe(true)
+    expect(shallowEqualArraysDeep([{ a: 1, b: 2 }], [{ a: 1, b: 2 }])).toBe(true)
+  })
+
+  it('returns false when an element key differs', () => {
+    expect(shallowEqualArraysDeep([{ a: 1 }], [{ a: 2 }])).toBe(false)
+    expect(shallowEqualArraysDeep([{ a: 1 }, { a: 2 }], [{ a: 1 }, { a: 3 }])).toBe(false)
   })
 })
 

--- a/frontend/src/lib/shallowEqual.ts
+++ b/frontend/src/lib/shallowEqual.ts
@@ -23,17 +23,35 @@ export function shallowEqual(a: unknown, b: unknown): boolean {
   return true
 }
 
-/** Element-wise `Object.is` equality for two arrays. Same-reference early-exit. */
-export function shallowEqualArrays(a: readonly unknown[], b: readonly unknown[]): boolean {
+function arraysEqualBy(
+  a: readonly unknown[],
+  b: readonly unknown[],
+  eq: (x: unknown, y: unknown) => boolean,
+): boolean {
   if (Object.is(a, b))
     return true
   if (a.length !== b.length)
     return false
   for (let i = 0; i < a.length; i++) {
-    if (!Object.is(a[i], b[i]))
+    if (!eq(a[i], b[i]))
       return false
   }
   return true
+}
+
+/** Element-wise `Object.is` equality for two arrays. Same-reference early-exit. */
+export function shallowEqualArrays(a: readonly unknown[], b: readonly unknown[]): boolean {
+  return arraysEqualBy(a, b, Object.is)
+}
+
+/**
+ * Like `shallowEqualArrays`, but compares each element with `shallowEqual`
+ * (per-key Object.is) instead of by reference. Useful for stores that
+ * rebuild element objects every update — same content, different refs —
+ * where reference equality would always fail.
+ */
+export function shallowEqualArraysDeep(a: readonly unknown[], b: readonly unknown[]): boolean {
+  return arraysEqualBy(a, b, shallowEqual)
 }
 
 /**

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -1,10 +1,11 @@
-import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentChatMessage, TodoItem as ProtoTodoItem } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import { createStore } from 'solid-js/store'
 import * as workerRpc from '~/api/workerRpc'
-import { ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { ContentCompression, MessageSource, TodoStatus } from '~/generated/leapmux/v1/agent_pb'
 import { PREFIX_LOCAL_MESSAGES, safeGetJson, safeRemoveItem, safeSetJson } from '~/lib/browserStorage'
-import { extractTodos, findLatestTodos, parseMessageContent } from '~/lib/messageParser'
+import { parseMessageContent } from '~/lib/messageParser'
+import { shallowEqualArraysDeep } from '~/lib/shallowEqual'
 
 // ---------------------------------------------------------------------------
 // Local (optimistic) message persistence via localStorage
@@ -116,9 +117,18 @@ function hydrateLocalMessage(p: PersistedLocalMessage): AgentChatMessage {
 }
 
 export interface TodoItem {
+  /**
+   * Stable identifier for incremental providers (Claude TaskCreate /
+   * TaskUpdate / TaskGet target rows by this). Snapshot-only providers
+   * (TodoWrite, Codex turn/plan/updated, ACP sessionUpdate=plan) leave
+   * this undefined.
+   */
+  id?: string
   content: string
   status: 'pending' | 'in_progress' | 'completed'
   activeForm: string
+  /** Long-form description from Claude Task* tools; absent elsewhere. */
+  description?: string
 }
 
 /**
@@ -133,6 +143,26 @@ export function normalizeTodoStatus(raw: unknown): TodoItem['status'] {
   if (raw === 'in_progress' || raw === 'inProgress')
     return 'in_progress'
   return 'pending'
+}
+
+/**
+ * Convert a server-authoritative proto TodoItem (delivered via
+ * ListAgentMessages or AgentTodosChanged) into the store shape. Maps
+ * the proto TodoStatus enum to the canonical string union.
+ */
+export function protoTodoToStore(t: ProtoTodoItem): TodoItem {
+  let status: TodoItem['status'] = 'pending'
+  if (t.status === TodoStatus.IN_PROGRESS)
+    status = 'in_progress'
+  else if (t.status === TodoStatus.COMPLETED)
+    status = 'completed'
+  return {
+    id: t.id || undefined,
+    content: t.content,
+    status,
+    activeForm: t.activeForm,
+    description: t.description || undefined,
+  }
 }
 
 /**
@@ -297,11 +327,6 @@ export function createChatStore() {
         setState('messageErrors', msg.id, msg.deliveryError)
       }
     }
-    // Extract todos from the last TodoWrite message in the loaded history.
-    const todos = findLatestTodos(messages)
-    if (todos) {
-      setState('todosByAgent', agentId, todos)
-    }
   }
 
   return {
@@ -450,13 +475,6 @@ export function createChatStore() {
         setState('messageErrors', message.id, message.deliveryError)
       }
 
-      // Track latest TodoWrite
-      const parsed = parsedFor(message)
-      const todos = extractTodos(message, parsed)
-      if (todos) {
-        setState('todosByAgent', agentId, todos)
-      }
-
       // Bump version so auto-scroll effects can detect notification updates
       // (which don't change messages.length).
       setState('messageVersion', agentId, (prev = 0) => prev + 1)
@@ -598,6 +616,23 @@ export function createChatStore() {
       setState('todosByAgent', agentId, [])
     },
 
+    /**
+     * Replace the agent's to-do list with the server-authoritative value
+     * delivered via AgentTodosChanged broadcasts or the initial cold-start
+     * ListAgentMessages response. Converts the proto-shape TodoItem to the
+     * store-shape in one place.
+     */
+    replaceTodos(agentId: string, protoTodos: ProtoTodoItem[]) {
+      const next = protoTodos.map(protoTodoToStore)
+      const prev = state.todosByAgent[agentId]
+      // KindDetail / no-op patches can re-broadcast a structurally
+      // identical list; skip the setState so reactive consumers
+      // (sidebar list, badges) don't re-run on identical content.
+      if (prev && shallowEqualArraysDeep(prev, next))
+        return
+      setState('todosByAgent', agentId, next)
+    },
+
     setLoading(loading: boolean) {
       setState('loading', loading)
     },
@@ -613,6 +648,14 @@ export function createChatStore() {
           limit: 50,
         })
         applyMessages(agentId, resp.messages, resp.hasMore)
+        // The server ships the authoritative to-do list on the
+        // cold-start page; subsequent live updates arrive via
+        // AgentTodosChanged broadcasts. An empty array is meaningful
+        // ("no todos") and overwrites; only an undefined field is
+        // left alone.
+        if (resp.todos !== undefined) {
+          this.replaceTodos(agentId, resp.todos)
+        }
       }
       finally {
         setState('fetchingOlder', agentId, false)
@@ -647,13 +690,6 @@ export function createChatStore() {
             return [...newMsgs, ...prev]
           })
           indexBySpanId(agentId, ...resp.messages)
-          // Extract todos from older messages if none found yet.
-          if (!state.todosByAgent[agentId] || state.todosByAgent[agentId].length === 0) {
-            const todos = findLatestTodos(resp.messages)
-            if (todos) {
-              setState('todosByAgent', agentId, todos)
-            }
-          }
         }
         setState('hasMoreOlder', agentId, resp.hasMore)
       }

--- a/frontend/src/types/toolMessages.ts
+++ b/frontend/src/types/toolMessages.ts
@@ -84,6 +84,47 @@ export interface TaskStopInput {
   task_id?: string
 }
 
+/**
+ * Claude Code 2.1.142+ to-do list tools. TaskCreate / TaskUpdate /
+ * TaskGet / TaskList replace TodoWrite's single snapshot model with
+ * incremental mutations addressed by `taskId`.
+ */
+export interface TaskCreateInput {
+  subject?: string
+  description?: string
+  activeForm?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Wire sentinel passed in `TaskUpdateInput.status` (or echoed as
+ * `tool_use_result.statusChange.to`) to permanently remove a task.
+ * Not a real status — handle it as a delete request, not a status
+ * value to display.
+ */
+export const TASK_DELETE_SENTINEL = 'deleted'
+
+export interface TaskUpdateInput {
+  taskId?: string
+  subject?: string
+  description?: string
+  activeForm?: string
+  status?: 'pending' | 'in_progress' | 'completed' | typeof TASK_DELETE_SENTINEL
+  addBlocks?: string[]
+  addBlockedBy?: string[]
+  owner?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface TaskGetInput {
+  taskId?: string
+}
+
+export interface TaskListInput {
+  // intentionally empty — TaskList takes no arguments.
+  [key: string]: never
+}
+
 export interface AskUserQuestionInput {
   questions?: Array<{
     question?: string
@@ -119,6 +160,10 @@ export const CLAUDE_TOOL = {
   WEB_FETCH: 'WebFetch',
   WEB_SEARCH: 'WebSearch',
   TODO_WRITE: 'TodoWrite',
+  TASK_CREATE: 'TaskCreate',
+  TASK_UPDATE: 'TaskUpdate',
+  TASK_GET: 'TaskGet',
+  TASK_LIST: 'TaskList',
   TASK_OUTPUT: 'TaskOutput',
   TASK_STOP: 'TaskStop',
   TOOL_SEARCH: 'ToolSearch',
@@ -144,6 +189,10 @@ export type KnownToolInput
     | { toolName: typeof CLAUDE_TOOL.WEB_FETCH, input: WebFetchInput }
     | { toolName: typeof CLAUDE_TOOL.WEB_SEARCH, input: WebSearchInput }
     | { toolName: typeof CLAUDE_TOOL.TODO_WRITE, input: TodoWriteInput }
+    | { toolName: typeof CLAUDE_TOOL.TASK_CREATE, input: TaskCreateInput }
+    | { toolName: typeof CLAUDE_TOOL.TASK_UPDATE, input: TaskUpdateInput }
+    | { toolName: typeof CLAUDE_TOOL.TASK_GET, input: TaskGetInput }
+    | { toolName: typeof CLAUDE_TOOL.TASK_LIST, input: TaskListInput }
     | { toolName: typeof CLAUDE_TOOL.TASK_OUTPUT, input: TaskOutputInput }
     | { toolName: typeof CLAUDE_TOOL.TOOL_SEARCH, input: ToolSearchInput }
     | { toolName: typeof CLAUDE_TOOL.TASK_STOP, input: TaskStopInput }
@@ -166,6 +215,10 @@ const KNOWN_TOOLS = new Set<string>([
   CLAUDE_TOOL.WEB_SEARCH,
   CLAUDE_TOOL.TASK_OUTPUT,
   CLAUDE_TOOL.TODO_WRITE,
+  CLAUDE_TOOL.TASK_CREATE,
+  CLAUDE_TOOL.TASK_UPDATE,
+  CLAUDE_TOOL.TASK_GET,
+  CLAUDE_TOOL.TASK_LIST,
   CLAUDE_TOOL.TOOL_SEARCH,
   CLAUDE_TOOL.TASK_STOP,
   CLAUDE_TOOL.ASK_USER_QUESTION,

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -1,7 +1,7 @@
 import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageSource, TodoItemSchema, TodoStatus } from '~/generated/leapmux/v1/agent_pb'
 import { createChatStore } from '~/stores/chat.store'
 
 // Mock workerRpc for loadInitialMessages / loadOlderMessages / loadNewerMessages
@@ -636,90 +636,77 @@ describe('createChatStore', () => {
     })
   })
 
-  describe('todo extraction', () => {
+  describe('to-do list (server-authoritative)', () => {
+    // The chat store does not extract todos from message content — the
+    // worker persists every event in agent_todos and ships the current
+    // snapshot via ListAgentMessagesResponse.todos and the
+    // AgentTodosChanged broadcast. These tests cover the
+    // server-authoritative hydration path.
+
     const sampleTodos = [
-      { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
-      { content: 'Deploy', status: 'in_progress', activeForm: 'Deploying' },
+      create(TodoItemSchema, { content: 'Write tests', status: TodoStatus.COMPLETED, activeForm: 'Writing tests' }),
+      create(TodoItemSchema, { content: 'Deploy', status: TodoStatus.IN_PROGRESS, activeForm: 'Deploying' }),
     ]
 
-    it('should extract todos from setMessages', () => {
-      createRoot((dispose) => {
-        const store = createChatStore()
-        store.setMessages('a1', [
-          makeMessage('m1', 1n),
-          makeTodoWriteMessage('m2', 2n, sampleTodos),
-          makeMessage('m3', 3n),
-        ])
-        expect(store.getTodos('a1')).toEqual(sampleTodos)
-        dispose()
-      })
-    })
-
-    it('should extract todos from addMessage', () => {
-      createRoot((dispose) => {
-        const store = createChatStore()
-        store.addMessage('a1', makeTodoWriteMessage('m1', 1n, sampleTodos))
-        expect(store.getTodos('a1')).toEqual(sampleTodos)
-        dispose()
-      })
-    })
-
-    it('should extract todos from loadInitialMessages', async () => {
+    it('hydrates todos from ListAgentMessagesResponse.todos on cold start', async () => {
       await createRoot(async (dispose) => {
         const store = createChatStore()
-        const messages = [
-          makeMessage('m1', 1n),
-          makeTodoWriteMessage('m2', 2n, sampleTodos),
-          makeMessage('m3', 3n),
-        ]
-        mockListAgentMessages.mockResolvedValueOnce({ messages, hasMore: false })
+        mockListAgentMessages.mockResolvedValueOnce({
+          messages: [makeMessage('m1', 1n)],
+          hasMore: false,
+          todos: sampleTodos,
+        })
 
         await store.loadInitialMessages('w1', 'a1')
-        expect(store.getTodos('a1')).toEqual(sampleTodos)
+        expect(store.getTodos('a1')).toEqual([
+          { id: undefined, content: 'Write tests', status: 'completed', activeForm: 'Writing tests', description: undefined },
+          { id: undefined, content: 'Deploy', status: 'in_progress', activeForm: 'Deploying', description: undefined },
+        ])
         dispose()
       })
     })
 
-    it('should extract todos from loadOlderMessages when none found yet', async () => {
+    it('treats an empty todos response as authoritative ("agent has none")', async () => {
       await createRoot(async (dispose) => {
         const store = createChatStore()
-        // Initial messages have no TodoWrite
-        store.setMessages('a1', [makeMessage('m10', 10n)], true)
+        mockListAgentMessages.mockResolvedValueOnce({
+          messages: [makeMessage('m1', 1n)],
+          hasMore: false,
+          todos: [],
+        })
+
+        await store.loadInitialMessages('w1', 'a1')
         expect(store.getTodos('a1')).toEqual([])
-
-        // Older messages contain a TodoWrite
-        const older = [makeTodoWriteMessage('m5', 5n, sampleTodos)]
-        mockListAgentMessages.mockResolvedValueOnce({ messages: older, hasMore: false })
-
-        await store.loadOlderMessages('w1', 'a1')
-        expect(store.getTodos('a1')).toEqual(sampleTodos)
         dispose()
       })
     })
 
-    it('should not overwrite existing todos from loadOlderMessages', async () => {
-      await createRoot(async (dispose) => {
-        const store = createChatStore()
-        const newerTodos = [{ content: 'New task', status: 'pending', activeForm: 'New' }]
-        // Initial messages have a TodoWrite
-        store.setMessages('a1', [makeTodoWriteMessage('m10', 10n, newerTodos)], true)
-        expect(store.getTodos('a1')).toEqual(newerTodos)
-
-        // Older messages also contain a TodoWrite — should NOT overwrite
-        const olderTodos = [{ content: 'Old task', status: 'completed', activeForm: 'Old' }]
-        const older = [makeTodoWriteMessage('m5', 5n, olderTodos)]
-        mockListAgentMessages.mockResolvedValueOnce({ messages: older, hasMore: false })
-
-        await store.loadOlderMessages('w1', 'a1')
-        expect(store.getTodos('a1')).toEqual(newerTodos)
-        dispose()
-      })
-    })
-
-    it('should return empty array for agent with no todos', () => {
+    it('addMessage does not mutate todos (broadcasts drive the list)', () => {
       createRoot((dispose) => {
         const store = createChatStore()
-        store.setMessages('a1', [makeMessage('m1', 1n)])
+        store.addMessage('a1', makeTodoWriteMessage('m1', 1n, [
+          { content: 'Write tests', status: 'completed', activeForm: 'Writing tests' },
+        ]))
+        expect(store.getTodos('a1')).toEqual([])
+        dispose()
+      })
+    })
+
+    it('replaceTodos applies the wire payload wholesale', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.replaceTodos('a1', sampleTodos)
+        expect(store.getTodos('a1')).toHaveLength(2)
+        // A subsequent broadcast wins, including a clear.
+        store.replaceTodos('a1', [])
+        expect(store.getTodos('a1')).toEqual([])
+        dispose()
+      })
+    })
+
+    it('returns empty array for an agent with no todos', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
         expect(store.getTodos('a1')).toEqual([])
         dispose()
       })

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -285,6 +285,36 @@ message ListAgentMessagesRequest {
 message ListAgentMessagesResponse {
   repeated AgentChatMessage messages = 1;
   bool has_more = 2;
+  // Authoritative provider-agnostic to-do list at the time the response is
+  // served. Drives the sidebar without re-scanning message history; survives
+  // page reloads and cross-client opens via the worker's agent_todos table.
+  repeated TodoItem todos = 3;
+}
+
+// TodoItem is the provider-neutral to-do row used by the sidebar list and
+// inline TaskCreate/TaskUpdate/TaskList/TaskGet cards. Sources include
+// Claude TodoWrite/Task*, Codex turn/plan/updated, and ACP sessionUpdate=plan.
+message TodoItem {
+  string id = 1;          // Claude Task* taskId; empty for snapshot-only providers
+  string content = 2;     // Imperative title (e.g. "Run tests")
+  TodoStatus status = 3;
+  string active_form = 4; // Present-continuous label shown while in_progress
+  string description = 5; // Claude Task* description; empty elsewhere
+}
+
+enum TodoStatus {
+  TODO_STATUS_UNSPECIFIED = 0;
+  TODO_STATUS_PENDING = 1;
+  TODO_STATUS_IN_PROGRESS = 2;
+  TODO_STATUS_COMPLETED = 3;
+}
+
+// AgentTodosChanged is broadcast whenever a message mutates an agent's
+// to-do list (after persistence). Recipients should replace the agent's
+// list with todos verbatim — this event is authoritative.
+message AgentTodosChanged {
+  string agent_id = 1;
+  repeated TodoItem todos = 2;
 }
 
 // --- Control Request/Response ---

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -231,6 +231,7 @@ message AgentEvent {
     AgentMessageError message_error = 8;
     AgentMessageDeleted message_deleted = 9;
     CatchUpComplete catch_up_complete = 10;
+    AgentTodosChanged todos_changed = 11;
   }
 }
 


### PR DESCRIPTION
## Motivation

Claude Code 2.1.142 introduced four new task management tools — `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList` — that agents use to maintain a structured to-do list during a session. Previously, the frontend reconstructed the to-do list client-side by scanning message history for `TodoWrite` tool calls, which caused stale contents to resurface when user-echoed messages were processed. There was no persistence across reconnects and no unified model spanning providers.

This change introduces a provider-neutral, DB-backed to-do list. The worker becomes the authoritative source; clients hydrate on cold start via `ListAgentMessages.todos` and receive live updates via the new `AgentTodosChanged` event. Claude `TodoWrite`, Claude Code 2.x `Task*` tools, Codex `turn/plan/updated`, and ACP `sessionUpdate=plan` all funnel through the same reducer.

## Modifications

**New `todoevents` package** (`backend/internal/worker/todoevents/`)
- `Extract` converts heterogeneous wire shapes from all supported providers into normalized mutations: `Snapshot`, `Create`, `Update`, `Delete`, `Detail`.
- `ApplyPatch` / `MergeDetail` reduce a stream of events into a final item list.
- `LooksLikeProviderPlan`, `IsTodoToolSpanType`, `StatusWire`, `StatusFromWire` are the public classification helpers.

**DB schema and queries** (`backend/internal/worker/db/`)
- New `agent_todos` table persists the to-do list per agent with a 64-item cap (`MaxTodos`).
- New sqlc queries: `ListAgentTodos`, `UpsertAgentTodo`, `UpdateAgentTodo`, `DeleteAgentTodoByRowKey`, `DeleteAllAgentTodos`, `InsertAgentTodo`.
- `idx_messages_span_id` widened to `(agent_id, span_id, source, seq)` to serve the paired `tool_use` lookup efficiently.

**Worker service integration** (`backend/internal/worker/service/output.go`, `agent.go`, `service.go`)
- Per-agent `agentTodoCache` mirrors the DB and gates redundant writes and broadcasts.
- `applyTodoEventForMessage` is called on every persisted message; guarded by `couldProduceTodoEvent` for a cheap hot-path skip.
- Transactional snapshot replacement (delete-all + N inserts) wrapped in a DB transaction when a `*sql.DB` is set.
- Eviction of oldest completed task when the 64-item cap is reached.
- `OutputHandler.LoadTodos(ctx, agentID)` seeds the cache from DB for cold-start `ListAgentMessages` responses; pagination requests skip seeding.
- (Breaking) `NewOutputHandler` now takes `*sql.DB` as its first parameter. All test call sites updated accordingly.

**Proto** (`proto/leapmux/v1/agent.proto`, `workspace.proto`)
- New `TodoItem`, `TodoStatus`, `AgentTodosChanged` event.
- `ListAgentMessagesResponse` gains a `todos` field.

**Frontend** (`frontend/src/`)
- `chat.store`: removed client-side `extractTodos`/`findLatestTodos` snapshot fold; added `replaceTodos` that converts proto → store `TodoItem` and dedups via `shallowEqualArraysDeep`. Both cold start and live events route through it.
- `useWorkspaceConnection`: new `todosChanged` handler delegates to `replaceTodos`.
- New renderers for `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList` tool use and tool result sides, reusing the existing `TodoListMessage` primitive for visual consistency with the sidebar.
- `toolMessages.ts`: added input types for all four `Task*` tools, `TASK_DELETE_SENTINEL` constant, widened `KNOWN_TOOLS`/`CLAUDE_TOOL`/`KnownToolInput`.
- `shallowEqual.ts`: added `shallowEqualArraysDeep`; refactored internals around a shared `arraysEqualBy` helper.
- `jsonPick.ts`: new `pickStringArray` utility.
- (Breaking) `extractTodos`/`findLatestTodos` removed from `messageParser` (were internal to the module).

**CLI tests** (`backend/internal/cli/remote/cmd/`)
- New `clearRemoteEnv(t)` helper consolidates env-var blanking so tests that pin "missing flag" code paths do not inherit `LEAPMUX_REMOTE_*` vars from worker-spawned processes.

## Result

- Claude Code 2.1.142 `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList` tool calls render inline cards in the chat thread and are reflected in the sidebar to-do list.
- The to-do list survives reconnects: clients receive the current list on the first `ListAgentMessages` response and stay in sync via `AgentTodosChanged` broadcasts thereafter.
- The stale-`TodoWrite` bug — where old to-do contents resurfaced when user-echoed messages were re-processed client-side — is eliminated because the snapshot fold no longer runs in the browser.
- All providers (Claude `TodoWrite`, Codex plans, ACP plans, Claude Code `Task*`) share one normalized to-do list per agent, capped at 64 items with automatic eviction of the oldest completed task.
