### PR TITLE
feat(fileviewer): Add file save/download from worker with viewer rework

### DIFF
--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -100,17 +100,31 @@ func registerFileHandlers(d *channel.Dispatcher, svc *Context) {
 		totalSize := info.Size()
 
 		offset := r.GetOffset()
+		limit := r.GetLimit()
+		if limit <= 0 {
+			limit = defaultReadLimit
+		}
+
+		// meta_only_if_truncated: when the file would be truncated by the
+		// read window, return total_size with an empty content payload so
+		// callers can detect oversize files (e.g. images we won't preview)
+		// without paying for the bytes. Lets the file viewer collapse a
+		// StatFile + ReadFile pair into one round trip.
+		if r.GetMetaOnlyIfTruncated() && totalSize > offset+limit {
+			sendProtoResponse(sender, &leapmuxv1.ReadFileResponse{
+				Path:      filePath,
+				Content:   nil,
+				TotalSize: totalSize,
+			})
+			return
+		}
+
 		if offset > 0 {
 			if _, err := f.Seek(offset, io.SeekStart); err != nil {
 				slog.Error("failed to seek file", "path", filePath, "offset", offset, "error", err)
 				sendInternalError(sender, "failed to seek file")
 				return
 			}
-		}
-
-		limit := r.GetLimit()
-		if limit <= 0 {
-			limit = defaultReadLimit
 		}
 
 		buf := make([]byte, limit)

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 func TestListDirectory_Truncation(t *testing.T) {
@@ -338,4 +341,112 @@ func TestListDirectory_DirsOnly(t *testing.T) {
 			assert.False(t, e.IsDir, "expected file in last two entries, got dir %q", e.Name)
 		}
 	})
+}
+
+// TestReadFile_MetaOnlyIfTruncated verifies that when the flag is set and the
+// file's total size exceeds the read window, the handler returns total_size
+// with an empty content payload — letting clients detect oversize files in a
+// single round trip without the matching byte payload.
+func TestReadFile_MetaOnlyIfTruncated(t *testing.T) {
+	t.Run("oversize: empty content with total_size", func(t *testing.T) {
+		svc, d, w := setupTestService(t)
+
+		path := filepath.Join(svc.HomeDir, "big.bin")
+		const totalSize = 4096
+		require.NoError(t, os.WriteFile(path, repeatedByte(totalSize, 'a'), 0o644))
+
+		dispatch(d, "ReadFile", &leapmuxv1.ReadFileRequest{
+			Path:                path,
+			Limit:               1024,
+			MetaOnlyIfTruncated: true,
+		}, w)
+
+		require.Empty(t, w.errors, "expected no error")
+		require.Len(t, w.responses, 1)
+
+		var resp leapmuxv1.ReadFileResponse
+		require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+		assert.EqualValues(t, totalSize, resp.GetTotalSize())
+		assert.Empty(t, resp.GetContent(), "expected empty content when truncated and meta-only set")
+	})
+
+	t.Run("within limit: full content with total_size", func(t *testing.T) {
+		svc, d, w := setupTestService(t)
+
+		path := filepath.Join(svc.HomeDir, "small.bin")
+		payload := repeatedByte(100, 'x')
+		require.NoError(t, os.WriteFile(path, payload, 0o644))
+
+		dispatch(d, "ReadFile", &leapmuxv1.ReadFileRequest{
+			Path:                path,
+			Limit:               1024,
+			MetaOnlyIfTruncated: true,
+		}, w)
+
+		require.Empty(t, w.errors)
+		require.Len(t, w.responses, 1)
+
+		var resp leapmuxv1.ReadFileResponse
+		require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+		assert.EqualValues(t, len(payload), resp.GetTotalSize())
+		assert.Equal(t, payload, resp.GetContent())
+	})
+
+	t.Run("flag off: oversize returns truncated content (legacy behavior)", func(t *testing.T) {
+		svc, d, w := setupTestService(t)
+
+		path := filepath.Join(svc.HomeDir, "big-legacy.bin")
+		const totalSize = 4096
+		const limit = 1024
+		require.NoError(t, os.WriteFile(path, repeatedByte(totalSize, 'b'), 0o644))
+
+		dispatch(d, "ReadFile", &leapmuxv1.ReadFileRequest{
+			Path:  path,
+			Limit: limit,
+		}, w)
+
+		require.Empty(t, w.errors)
+		require.Len(t, w.responses, 1)
+
+		var resp leapmuxv1.ReadFileResponse
+		require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+		assert.EqualValues(t, totalSize, resp.GetTotalSize())
+		assert.Len(t, resp.GetContent(), limit, "legacy mode must keep returning truncated bytes")
+	})
+
+	t.Run("offset counted toward the truncation threshold", func(t *testing.T) {
+		svc, d, w := setupTestService(t)
+
+		path := filepath.Join(svc.HomeDir, "with-offset.bin")
+		const totalSize = 4096
+		require.NoError(t, os.WriteFile(path, repeatedByte(totalSize, 'c'), 0o644))
+
+		// offset + limit = 4096 = totalSize, so the read window covers the
+		// whole file and the meta-only short-circuit must NOT fire.
+		dispatch(d, "ReadFile", &leapmuxv1.ReadFileRequest{
+			Path:                path,
+			Offset:              3072,
+			Limit:               1024,
+			MetaOnlyIfTruncated: true,
+		}, w)
+
+		require.Empty(t, w.errors)
+		require.Len(t, w.responses, 1)
+
+		var resp leapmuxv1.ReadFileResponse
+		require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+		assert.EqualValues(t, totalSize, resp.GetTotalSize())
+		assert.Len(t, resp.GetContent(), 1024)
+	})
+}
+
+// repeatedByte returns a slice of length n filled with the given byte. Used
+// by the ReadFile tests to construct payloads of a specific size without
+// staging the expected bytes inline in each case.
+func repeatedByte(n int, b byte) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
 }

--- a/desktop/rust/Cargo.lock
+++ b/desktop/rust/Cargo.lock
@@ -800,11 +800,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -815,7 +836,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2096,6 +2117,7 @@ name = "leapmux-desktop"
 version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
+ "dirs 5.0.1",
  "gdk",
  "gtk",
  "prost",
@@ -2106,6 +2128,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tokio",
@@ -2480,6 +2503,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2574,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3216,6 +3240,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3306,6 +3341,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3939,7 +3998,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3989,7 +4048,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4074,6 +4133,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4584,7 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5130,7 +5231,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5304,6 +5405,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5342,6 +5452,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5403,6 +5528,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5421,6 +5552,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5436,6 +5573,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5469,6 +5612,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5484,6 +5633,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5505,6 +5660,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5520,6 +5681,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5695,7 +5862,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/desktop/rust/Cargo.toml
+++ b/desktop/rust/Cargo.toml
@@ -15,8 +15,10 @@ serde_json = "1"
 sha2 = "0.11"
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+dirs = "5"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/desktop/rust/capabilities/default.json
+++ b/desktop/rust/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "clipboard-manager:allow-read-image",
+    "dialog:allow-save",
     "opener:default",
     "core:event:allow-listen",
     "core:event:allow-unlisten",

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1468,9 +1468,7 @@ async fn proxy_http(
     let body = if payload.body_base64.is_empty() {
         Vec::new()
     } else {
-        base64::engine::general_purpose::STANDARD
-            .decode(&payload.body_base64)
-            .map_err(|err| format!("decode request body: {err}"))?
+        decode_b64(&payload.body_base64).map_err(|err| format!("decode request body: {err}"))?
     };
 
     let resp = check_response(
@@ -1579,9 +1577,7 @@ async fn send_channel_message(
     shell: State<'_, Arc<DesktopShell>>,
     b64_data: String,
 ) -> Result<(), String> {
-    let data = base64::engine::general_purpose::STANDARD
-        .decode(&b64_data)
-        .map_err(|err| format!("decode channel message: {err}"))?;
+    let data = decode_b64(&b64_data).map_err(|err| format!("decode channel message: {err}"))?;
 
     check_response(
         shell
@@ -1766,6 +1762,139 @@ async fn open_in_editor(
             .await?,
     )?;
     Ok(())
+}
+
+fn decode_b64(b64: &str) -> Result<Vec<u8>, String> {
+    base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| e.to_string())
+}
+
+// File-save commands used by the frontend's download flow.
+//
+// Bytes traverse the Tauri IPC as the raw request body (`InvokeBody::Raw`),
+// not base64 — for multi-MB downloads the encode/decode round-trip plus
+// the ~33% wire bloat was the dominant cost. The filename rides along
+// in a custom header, base64-encoded so HTTP-style ASCII restrictions
+// don't mangle Unicode names.
+//
+// File I/O runs on `spawn_blocking` so the Tokio executor thread that
+// services other Tauri commands isn't tied up by a slow disk write.
+
+fn read_bytes_from_request(request: &tauri::ipc::Request<'_>) -> Result<Vec<u8>, String> {
+    match request.body() {
+        tauri::ipc::InvokeBody::Raw(b) => Ok(b.clone()),
+        _ => Err("expected raw bytes body".to_string()),
+    }
+}
+
+fn read_b64_header(request: &tauri::ipc::Request<'_>, name: &str) -> Result<String, String> {
+    let value = request
+        .headers()
+        .get(name)
+        .ok_or_else(|| format!("missing {name} header"))?
+        .to_str()
+        .map_err(|err| format!("invalid {name} header: {err}"))?;
+    let bytes = decode_b64(value)?;
+    String::from_utf8(bytes).map_err(|err| format!("invalid {name} utf-8: {err}"))
+}
+
+async fn write_bytes_blocking(path: PathBuf, bytes: Vec<u8>) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || std::fs::write(&path, &bytes))
+        .await
+        .map_err(|err| format!("spawn_blocking join: {err}"))?
+        .map_err(|err| format!("write file: {err}"))
+}
+
+/// Cap on collision-dedup attempts. With "foo (N).ext" picking from
+/// `1..MAX`, this bounds the directory scan and the suffix the user
+/// sees ("foo (1023).ext" is well past the point where a different
+/// filename is more useful than another increment).
+const MAX_SAVE_COLLISION_ATTEMPTS: u32 = 1024;
+
+/// Write `bytes` into `dir` under a name derived from `filename`,
+/// appending " (N)" before the extension to avoid clobbering an
+/// existing file. Returns the final absolute path written.
+///
+/// Race-free: each attempt opens with `create_new(true)`, so
+/// concurrent saves of the same name produce distinct files instead
+/// of one silently overwriting the other.
+async fn write_bytes_unique(dir: PathBuf, filename: String, bytes: Vec<u8>) -> Result<PathBuf, String> {
+    tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
+        use std::io::Write;
+        let as_path = std::path::Path::new(&filename);
+        let stem = as_path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+        let ext = as_path.extension().map(|s| s.to_string_lossy().into_owned());
+        for i in 0..MAX_SAVE_COLLISION_ATTEMPTS {
+            let candidate_name = if i == 0 {
+                filename.clone()
+            } else {
+                match &ext {
+                    Some(e) if !e.is_empty() => format!("{stem} ({i}).{e}"),
+                    _ => format!("{stem} ({i})"),
+                }
+            };
+            let candidate = dir.join(&candidate_name);
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&candidate)
+            {
+                Ok(mut f) => {
+                    f.write_all(&bytes).map_err(|err| format!("write file: {err}"))?;
+                    return Ok(candidate);
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(format!("create file: {err}")),
+            }
+        }
+        Err(format!(
+            "too many collisions for {filename} (gave up after {MAX_SAVE_COLLISION_ATTEMPTS})"
+        ))
+    })
+    .await
+    .map_err(|err| format!("spawn_blocking join: {err}"))?
+}
+
+#[tauri::command]
+async fn save_bytes_to_downloads(request: tauri::ipc::Request<'_>) -> Result<String, String> {
+    let filename = read_b64_header(&request, "filename-b64")?;
+    let bytes = read_bytes_from_request(&request)?;
+    let downloads = dirs::download_dir().ok_or_else(|| "no downloads directory".to_string())?;
+    // Disallow separators in the supplied filename so callers can't
+    // escape the Downloads directory.
+    let safe_name = std::path::Path::new(&filename)
+        .file_name()
+        .ok_or_else(|| "invalid filename".to_string())?
+        .to_string_lossy()
+        .into_owned();
+    let path = write_bytes_unique(downloads, safe_name, bytes).await?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+async fn save_bytes_as(
+    app: tauri::AppHandle,
+    request: tauri::ipc::Request<'_>,
+) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let default_name = read_b64_header(&request, "default-name-b64")?;
+    let bytes = read_bytes_from_request(&request)?;
+    let (tx, rx) = oneshot::channel();
+    app.dialog()
+        .file()
+        .set_file_name(&default_name)
+        .save_file(move |path| {
+            let _ = tx.send(path);
+        });
+    let path_opt = rx.await.map_err(|e| e.to_string())?;
+    let Some(file_path) = path_opt else {
+        return Ok(None);
+    };
+    let path = file_path.into_path().map_err(|e| e.to_string())?;
+    write_bytes_blocking(path.clone(), bytes).await?;
+    Ok(Some(path.to_string_lossy().into_owned()))
 }
 
 #[tauri::command]
@@ -2078,6 +2207,7 @@ fn main() {
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             focus_main_window(app);
@@ -2179,6 +2309,8 @@ fn main() {
             list_tunnels,
             list_editors,
             open_in_editor,
+            save_bytes_to_downloads,
+            save_bytes_as,
             switch_mode,
             #[cfg(target_os = "macos")]
             restart_app,

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -27,6 +27,7 @@
         "@solidjs/start": "^1.3.2",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+        "@tauri-apps/plugin-opener": "^2.5.4",
         "@thisbeyond/solid-dnd": "^0.7.5",
         "@types/diff": "^8.0.0",
         "@vanilla-extract/css": "^1.20.1",
@@ -561,6 +562,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
 
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
+
+    "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -2021,6 +2024,8 @@
     "@tanstack/router-utils/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "@tanstack/server-functions-plugin/@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
+
+    "@tauri-apps/plugin-opener/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "@solidjs/start": "^1.3.2",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-opener": "^2.5.4",
     "@thisbeyond/solid-dnd": "^0.7.5",
     "@types/diff": "^8.0.0",
     "@vanilla-extract/css": "^1.20.1",

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -231,6 +231,7 @@ let cachedTauriEvents: Promise<typeof import('@tauri-apps/api/event')> | null = 
 let cachedTauriDpi: Promise<typeof import('@tauri-apps/api/dpi')> | null = null
 let cachedTauriWindow: Promise<typeof import('@tauri-apps/api/window')> | null = null
 let cachedTauriClipboard: Promise<typeof import('@tauri-apps/plugin-clipboard-manager')> | null = null
+let cachedTauriOpener: Promise<typeof import('@tauri-apps/plugin-opener')> | null = null
 
 function loadTauriCore() {
   return (cachedTauriCore ??= import('@tauri-apps/api/core'))
@@ -250,6 +251,10 @@ function loadTauriWindow() {
 
 function loadTauriClipboard() {
   return (cachedTauriClipboard ??= import('@tauri-apps/plugin-clipboard-manager'))
+}
+
+function loadTauriOpener() {
+  return (cachedTauriOpener ??= import('@tauri-apps/plugin-opener'))
 }
 
 async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
@@ -470,6 +475,53 @@ export async function readClipboardImage(): Promise<File | null> {
   }
 }
 
+/**
+ * Write `bytes` to the OS Downloads directory as `filename` and return
+ * the absolute path written. Tauri-only — call sites must gate on
+ * `isTauriApp()` first. The Rust command sanitizes `filename` to its
+ * basename so callers can't escape the Downloads dir.
+ *
+ * Bytes ride the Tauri IPC as a raw request body (transferred without
+ * JSON or base64 conversion). The filename goes through a header,
+ * base64-encoded so non-ASCII names survive the HTTP-style header
+ * value restrictions.
+ */
+export async function saveBytesToDownloads(bytes: Uint8Array, filename: string): Promise<string> {
+  const { invoke } = await loadTauriCore()
+  return invoke<string>('save_bytes_to_downloads', bytes, {
+    headers: { 'filename-b64': arrayBufferToBase64(filename) },
+  })
+}
+
+/**
+ * Show a native save-as dialog, write `bytes` to the chosen path, and
+ * return the absolute path. Returns `null` if the user cancelled the
+ * dialog. Tauri-only.
+ */
+export async function saveBytesAs(bytes: Uint8Array, defaultName: string): Promise<string | null> {
+  const { invoke } = await loadTauriCore()
+  return invoke<string | null>('save_bytes_as', bytes, {
+    headers: { 'default-name-b64': arrayBufferToBase64(defaultName) },
+  })
+}
+
+/**
+ * Open the OS file manager (Finder / Explorer / Files) with the given
+ * path selected. Best-effort: failures are swallowed since this is a
+ * post-save nicety, not a load-bearing operation.
+ */
+export async function revealInFileManager(path: string): Promise<void> {
+  if (!isTauriApp())
+    return
+  try {
+    const { revealItemInDir } = await loadTauriOpener()
+    await revealItemInDir(path)
+  }
+  catch (err) {
+    log.warn('revealInFileManager failed', err)
+  }
+}
+
 export const windowMinimize = () => tauriWindowOp(w => w.minimize())
 export const windowClose = () => tauriWindowOp(w => w.close())
 export const windowToggleMaximize = () => tauriWindowOp(w => w.toggleMaximize())
@@ -533,6 +585,9 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
 export const platformBridge = {
   getCapabilities,
   getRuntimeState,
+  saveBytesToDownloads,
+  saveBytesAs,
+  revealInFileManager,
   async connectSolo(): Promise<void> {
     await tauriInvoke('connect_solo')
     await refreshRuntimeState()

--- a/frontend/src/components/chat/attachments.ts
+++ b/frontend/src/components/chat/attachments.ts
@@ -2,6 +2,7 @@
 
 import type { AttachmentCapabilities } from './providers/registry'
 import { randomUUID } from '~/lib/idGenerator'
+import { extname } from '~/lib/paths'
 
 const LEADING_SLASHES = /^\/+/
 
@@ -154,16 +155,6 @@ export function buildAcceptAttribute(capabilities: AttachmentCapabilities | unde
   return accepted.size > 0 ? [...accepted].join(',') : undefined
 }
 
-function extensionOf(filename: string): string {
-  const trimmed = filename.trim().toLowerCase()
-  if (!trimmed)
-    return ''
-  const lastDot = trimmed.lastIndexOf('.')
-  if (lastDot <= 0 || lastDot === trimmed.length - 1)
-    return trimmed === 'dockerfile' ? 'dockerfile' : ''
-  return trimmed.slice(lastDot + 1)
-}
-
 function normalizeMimeType(mime: string): string {
   return mime.trim().toLowerCase()
 }
@@ -174,7 +165,7 @@ function inferredMimeTypeFromFilename(filename: string): string {
     return 'text/plain'
   if (lower === '.gitignore' || lower === '.editorconfig' || lower === '.env')
     return 'text/plain'
-  return TEXT_MIME_BY_EXTENSION.get(extensionOf(filename)) ?? ''
+  return TEXT_MIME_BY_EXTENSION.get(extname(filename)) ?? ''
 }
 
 function isTextualMimeType(mime: string): boolean {

--- a/frontend/src/components/common/FileActionsMenu.tsx
+++ b/frontend/src/components/common/FileActionsMenu.tsx
@@ -1,0 +1,212 @@
+import type { Component } from 'solid-js'
+import type { FileSaveActions } from '~/components/common/fileSaveActions'
+import type { PathFlavor } from '~/lib/paths'
+import type { PopoverPositionOptions } from '~/lib/popoverPosition'
+import AtSign from 'lucide-solid/icons/at-sign'
+import Copy from 'lucide-solid/icons/copy'
+import Download from 'lucide-solid/icons/download'
+import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
+import TerminalIcon from 'lucide-solid/icons/terminal'
+import { createSignal, getOwner, runWithOwner, Show } from 'solid-js'
+import { isTauriApp } from '~/api/platformBridge'
+import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { createFileSaveActions } from '~/components/common/fileSaveActions'
+import { Icon } from '~/components/common/Icon'
+import { IconButton } from '~/components/common/IconButton'
+import { copyTextToClipboard } from '~/lib/clipboard'
+import { relativizePath } from '~/lib/paths'
+
+/**
+ * Shared file/dir actions context menu. Hosts Mention / Open terminal /
+ * Copy path / Copy relative path / Save as / Save to Downloads /
+ * Download as a single three-dot menu, used by both `DirectoryTree` and
+ * the file viewer surfaces.
+ *
+ * Items are gated by the callbacks / props that are actually provided:
+ *   - `onMention`     → "Mention in chat"
+ *   - `isDir && onOpenTerminal` → "Open a terminal tab here"
+ *   - always           → "Copy path"
+ *   - `rootPath`       → "Copy relative path"
+ *   - `!isDir`         → "Download" (web) or "Save as..." + "Save to Downloads" (desktop)
+ */
+export interface FileActionsMenuProps {
+  workerId: string
+  path: string
+  flavor: PathFlavor
+  isDir?: boolean
+  rootPath?: string
+  homeDir?: string
+  /** Optional handler for the "Mention in chat" item. */
+  onMention?: (path: string) => void
+  /** Optional handler for "Open terminal" — only shown for directories. */
+  onOpenTerminal?: (dirPath: string) => void
+  /** CSS class applied to the trigger IconButton. */
+  triggerClass?: string
+  /** data-testid for the trigger IconButton (default: 'file-actions-trigger'). */
+  triggerTestId?: string
+  /**
+   * Prefix used for menu-item `data-testid` attributes. Default
+   * `file-actions`; callers can override (e.g. DirectoryTree uses
+   * `tree`) so tests can assert on stable IDs without coupling to
+   * this component's internals.
+   *
+   * Items produced: `{prefix}-mention-button`,
+   * `{prefix}-open-terminal-button`, `{prefix}-copy-path-button`,
+   * `{prefix}-copy-relative-path-button`, `{prefix}-download-button`
+   * (web), `{prefix}-save-as-button` + `{prefix}-save-to-downloads-button`
+   * (desktop).
+   */
+  itemTestIdPrefix?: string
+  /** Positioning options passed through to DropdownMenu. */
+  placement?: PopoverPositionOptions
+  /**
+   * Shared save/download actions. When omitted, the menu creates its
+   * own instance. Pass an external one to share busy state with another
+   * surface (e.g. FileViewer's unsupported-card buttons) so clicking a
+   * save in one place disables it in the other.
+   */
+  actions?: FileSaveActions
+}
+
+export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
+  const tid = (suffix: string) => `${props.itemTestIdPrefix ?? 'file-actions'}-${suffix}`
+
+  // Lazy ownership of FileSaveActions: allocate on first open of the
+  // dropdown so DirectoryTree rows (thousands of them, the vast majority
+  // never opened) don't pay the per-row signal + context cost up front.
+  // Skipped entirely when the caller injects `props.actions` (FileViewer
+  // shares its own instance with the unsupported-card buttons) or for
+  // directory rows where the save items don't render.
+  //
+  // `usePreferences()` inside `createFileSaveActions` needs the component
+  // owner; click/toggle handlers run as plain DOM events without one, so
+  // we capture the owner here and re-enter it on first use.
+  const componentOwner = getOwner()
+  const [menuOpen, setMenuOpen] = createSignal(false)
+  let ownedActions: FileSaveActions | null = null
+  const ensureOwnedActions = (): FileSaveActions => {
+    if (!ownedActions) {
+      ownedActions = runWithOwner(componentOwner, () => createFileSaveActions({
+        workerId: () => props.workerId,
+        path: () => props.path,
+        flavor: () => props.flavor,
+      }))!
+    }
+    return ownedActions
+  }
+  const actions = (): FileSaveActions => props.actions ?? ensureOwnedActions()
+  // Reading `actions().currentOp()` here triggers `ensureOwnedActions`.
+  // Gate it on `menuOpen()` so the disabled-binding refire at mount
+  // (popover hidden) doesn't allocate for rows the user never opens.
+  // Externally-injected actions skip the gate — their busy state is
+  // shared with another surface and must stay live even when this
+  // menu's popover is closed.
+  const busy = () => {
+    if (props.actions)
+      return props.actions.currentOp() !== null
+    return menuOpen() && actions().currentOp() !== null
+  }
+
+  return (
+    <DropdownMenu
+      placement={props.placement}
+      onToggle={setMenuOpen}
+      trigger={triggerProps => (
+        <IconButton
+          icon={MoreHorizontal}
+          iconSize="sm"
+          size="sm"
+          class={props.triggerClass}
+          onClick={(e: MouseEvent) => {
+            e.stopPropagation()
+            triggerProps.onClick()
+          }}
+          ref={triggerProps.ref}
+          onPointerDown={(e: PointerEvent) => {
+            e.stopPropagation()
+            triggerProps.onPointerDown()
+          }}
+          aria-expanded={triggerProps['aria-expanded']}
+          data-testid={props.triggerTestId ?? 'file-actions-trigger'}
+        />
+      )}
+    >
+      <Show when={props.onMention}>
+        <button
+          role="menuitem"
+          data-testid={tid('mention-button')}
+          onClick={() => props.onMention?.(props.path)}
+        >
+          <Icon icon={AtSign} size="sm" />
+          Mention in chat
+        </button>
+      </Show>
+      <Show when={props.isDir && props.onOpenTerminal}>
+        <button
+          role="menuitem"
+          data-testid={tid('open-terminal-button')}
+          onClick={() => props.onOpenTerminal?.(props.path)}
+        >
+          <Icon icon={TerminalIcon} size="sm" />
+          Open a terminal tab here
+        </button>
+      </Show>
+      <button
+        role="menuitem"
+        data-testid={tid('copy-path-button')}
+        onClick={() => copyTextToClipboard(props.path)}
+      >
+        <Icon icon={Copy} size="sm" />
+        Copy path
+      </button>
+      <Show when={props.rootPath !== undefined}>
+        <button
+          role="menuitem"
+          data-testid={tid('copy-relative-path-button')}
+          onClick={() => {
+            const rel = relativizePath(props.path, props.rootPath!, props.homeDir, props.flavor)
+            copyTextToClipboard(rel)
+          }}
+        >
+          <Icon icon={Copy} size="sm" />
+          Copy relative path
+        </button>
+      </Show>
+      <Show when={!props.isDir}>
+        <Show
+          when={isTauriApp()}
+          fallback={(
+            <button
+              role="menuitem"
+              data-testid={tid('download-button')}
+              disabled={busy()}
+              onClick={() => actions().handleDownload()}
+            >
+              <Icon icon={Download} size="sm" />
+              Download
+            </button>
+          )}
+        >
+          <button
+            role="menuitem"
+            data-testid={tid('save-as-button')}
+            disabled={busy()}
+            onClick={() => actions().handleSaveAs()}
+          >
+            <Icon icon={Download} size="sm" />
+            Save as...
+          </button>
+          <button
+            role="menuitem"
+            data-testid={tid('save-to-downloads-button')}
+            disabled={busy()}
+            onClick={() => actions().handleSaveToDownloads()}
+          >
+            <Icon icon={Download} size="sm" />
+            Save to Downloads
+          </button>
+        </Show>
+      </Show>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/common/StartupPanel.css.ts
+++ b/frontend/src/components/common/StartupPanel.css.ts
@@ -6,8 +6,12 @@ export const startupSpinner = style({
   gap: '0.5em',
 })
 
-/** Two-row layout for the startup-failure body (heading on top, details below). */
-export const startupErrorBody = style({
+/**
+ * Vertical column shared by `StartupBody` and `StartupErrorBody`. Used
+ * for both the neutral fallback body (informational) and the
+ * danger-flavored failure body. The wrapping caller sets the text color.
+ */
+export const startupBody = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
@@ -16,9 +20,19 @@ export const startupErrorBody = style({
   maxWidth: '100%',
 })
 
-export const startupErrorTitle = style({
+export const startupTitle = style({
   margin: 0,
   textAlign: 'start',
+})
+
+/** Centered, wrap-friendly row for action buttons rendered under a body. */
+export const startupActions = style({
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 'var(--space-2)',
 })
 
 /**

--- a/frontend/src/components/common/StartupPanel.tsx
+++ b/frontend/src/components/common/StartupPanel.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import LoaderCircle from 'lucide-solid/icons/loader-circle'
+import { Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
 import { spinner } from '~/styles/animations.css'
 import * as styles from './StartupPanel.css'
@@ -17,20 +18,43 @@ export const StartupSpinner: Component<{ label: JSX.Element }> = props => (
 )
 
 /**
+ * Generic title + body + actions column used as the shared layout for
+ * informational fallbacks (e.g. the file-viewer "binary file" view) and
+ * the failure body below. Caller decides text color — the children
+ * inherit `color` from the wrapper.
+ */
+export const StartupBody: Component<{
+  title: JSX.Element
+  body?: JSX.Element
+  /** Optional id on the `<h2>` so callers can wire `aria-labelledby`. */
+  titleId?: string
+  children?: JSX.Element
+}> = props => (
+  <div class={styles.startupBody}>
+    <h2 class={styles.startupTitle} id={props.titleId}>{props.title}</h2>
+    {props.body}
+    <Show when={props.children}>
+      <div class={styles.startupActions}>{props.children}</div>
+    </Show>
+  </div>
+)
+
+/**
  * Body shown when a subprocess startup has failed terminally: a
  * heading with the failure summary, followed by the server-formatted
  * error details rendered as a soft-wrapped monospace code block.
- * Layout-agnostic — the caller owns the outer wrapper (and its danger
- * color, which these children inherit).
+ * Layered on `StartupBody` for visual consistency.
  */
 export const StartupErrorBody: Component<{
   title: JSX.Element
   error: string
 }> = props => (
-  <div class={styles.startupErrorBody}>
-    <h2 class={styles.startupErrorTitle}>{props.title}</h2>
-    <pre class={styles.startupErrorDetails}>
-      <code>{props.error || 'Unknown error'}</code>
-    </pre>
-  </div>
+  <StartupBody
+    title={props.title}
+    body={(
+      <pre class={styles.startupErrorDetails}>
+        <code>{props.error || 'Unknown error'}</code>
+      </pre>
+    )}
+  />
 )

--- a/frontend/src/components/common/TabTypeIcon.tsx
+++ b/frontend/src/components/common/TabTypeIcon.tsx
@@ -1,0 +1,43 @@
+import type { Component } from 'solid-js'
+import type { IconSizeName } from '~/components/common/Icon'
+import type { Tab } from '~/stores/tab.types'
+import FileText from 'lucide-solid/icons/file-text'
+import Terminal from 'lucide-solid/icons/terminal'
+import { Match, Switch } from 'solid-js'
+import { AgentProviderIcon } from '~/components/common/AgentProviderIcon'
+import { Icon } from '~/components/common/Icon'
+import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { isAgentTab } from '~/stores/tab.types'
+import { iconSize } from '~/styles/tokens'
+
+export interface TabTypeIconProps {
+  tab: Tab
+  size?: IconSizeName
+  class?: string
+}
+
+// Shared per-tab-type icon. Used by TabBar (tab strip) and
+// WorkspaceTabTree (sidebar tree) so the two surfaces always agree on
+// which icon represents which tab type.
+export const TabTypeIcon: Component<TabTypeIconProps> = (props) => {
+  const tokenSize = (): IconSizeName => props.size ?? 'sm'
+  return (
+    <Switch>
+      <Match when={isAgentTab(props.tab) ? props.tab : false}>
+        {tab => (
+          <AgentProviderIcon
+            provider={tab().agentProvider}
+            size={iconSize[tokenSize()]}
+            class={props.class}
+          />
+        )}
+      </Match>
+      <Match when={props.tab.type === TabType.FILE}>
+        <Icon icon={FileText} size={tokenSize()} class={props.class} />
+      </Match>
+      <Match when={props.tab.type === TabType.TERMINAL}>
+        <Icon icon={Terminal} size={tokenSize()} class={props.class} />
+      </Match>
+    </Switch>
+  )
+}

--- a/frontend/src/components/common/fileSaveActions.ts
+++ b/frontend/src/components/common/fileSaveActions.ts
@@ -1,0 +1,94 @@
+import type { PathFlavor } from '~/lib/paths'
+import { createSignal } from 'solid-js'
+import { platformBridge } from '~/api/platformBridge'
+import { showWarnToast } from '~/components/common/Toast'
+import { usePreferences } from '~/context/PreferencesContext'
+import { downloadFileFromWorker, saveFileAs, saveFileToDownloads } from '~/lib/fileDownload'
+import { basename } from '~/lib/paths'
+
+/**
+ * Which save/download operation is in flight (`null` when idle).
+ *
+ *   - `'download'`        — web-mode anchor-click download
+ *   - `'save-as'`         — desktop save-as dialog
+ *   - `'save-to-downloads'` — desktop silent save to $DOWNLOAD
+ *
+ * Callers use this to drive per-button spinners and to disable the
+ * other action buttons while one is in flight.
+ */
+export type FileSaveOp = 'download' | 'save-as' | 'save-to-downloads' | null
+
+export interface FileSaveActions {
+  /** Non-null iff an op is in flight; identifies which one. */
+  currentOp: () => FileSaveOp
+  /** Trigger a web-mode anchor-click download. No-op while busy. */
+  handleDownload: () => void
+  /** Trigger a desktop save-as dialog. No-op while busy. */
+  handleSaveAs: () => void
+  /** Trigger a desktop save-to-Downloads write. No-op while busy. */
+  handleSaveToDownloads: () => void
+}
+
+export interface FileSaveActionsInput {
+  workerId: () => string
+  path: () => string
+  flavor: () => PathFlavor
+}
+
+/**
+ * Shared download/save-as/save-to-downloads workflow for a single file,
+ * with re-entrancy guards and toast-on-error behavior.
+ *
+ * Used by `FileActionsMenu` (menu items) and `FileViewer` (the
+ * `UnsupportedFileView` buttons). A single instance shared between both
+ * surfaces keeps their busy state aligned — clicking "Save as" in the
+ * menu disables the same action in the unsupported card and vice versa.
+ *
+ * Must be called inside a SolidJS reactive root (component body or
+ * `createRoot`) so `usePreferences` and `createSignal` work.
+ */
+export function createFileSaveActions(input: FileSaveActionsInput): FileSaveActions {
+  const prefs = usePreferences()
+  const [currentOp, setCurrentOp] = createSignal<FileSaveOp>(null)
+
+  const errLabel = () => basename(input.path(), input.flavor())
+
+  interface OpSpec {
+    fn: (workerId: string, path: string, flavor: PathFlavor) => Promise<string | null | void>
+    errPrefix: string
+  }
+  const OPS: Record<Exclude<FileSaveOp, null>, OpSpec> = {
+    'download': { fn: downloadFileFromWorker, errPrefix: 'Failed to download' },
+    'save-as': { fn: saveFileAs, errPrefix: 'Failed to save' },
+    'save-to-downloads': { fn: saveFileToDownloads, errPrefix: 'Failed to save' },
+  }
+
+  const dispatch = (op: Exclude<FileSaveOp, null>) => {
+    if (currentOp() !== null)
+      return
+    const { fn, errPrefix } = OPS[op]
+    setCurrentOp(op)
+    const label = errLabel()
+    fn(input.workerId(), input.path(), input.flavor())
+      .then((savedPath) => {
+        // `saveFileAs` returns null when the user cancels the dialog;
+        // the web download path returns void. Reveal only fires for
+        // desktop saves that produced a path.
+        if (savedPath && prefs.revealAfterDownload())
+          void platformBridge.revealInFileManager(savedPath)
+      })
+      .catch((err) => {
+        showWarnToast(`${errPrefix} ${label}`, err)
+      })
+      .finally(() => {
+        setCurrentOp(null)
+      })
+  }
+
+  return {
+    currentOp,
+    handleDownload: () => dispatch('download'),
+    handleSaveAs: () => dispatch('save-as'),
+    handleSaveToDownloads: () => dispatch('save-to-downloads'),
+  }
+}

--- a/frontend/src/components/fileviewer/DiffModeToolbar.tsx
+++ b/frontend/src/components/fileviewer/DiffModeToolbar.tsx
@@ -7,6 +7,15 @@ export interface DiffModeToolbarProps {
   mode: FileViewMode
   diffBase?: FileDiffBase
   hasStagedAndUnstaged?: boolean
+  /**
+   * Whether a diff is available for this file. When false, the
+   * Unified / Split buttons and the head-vs-working / head-vs-staged
+   * sub-toggle are hidden — a file with no git-status entry has no
+   * diff to render, so offering the modes would only mislead. HEAD /
+   * Working buttons stay since they navigate between revisions
+   * independently of diff state.
+   */
+  diffAvailable?: boolean
   onModeChange: (mode: FileViewMode) => void
   onDiffBaseChange?: (base: FileDiffBase) => void
 }
@@ -27,9 +36,11 @@ export const DiffModeToolbar: Component<DiffModeToolbarProps> = (props) => {
       <div class={styles.toolbar} data-testid="diff-mode-toolbar">
         {btn('HEAD', 'head', 'diff-mode-head')}
         {btn('Working', 'working', 'diff-mode-working')}
-        {btn('Unified', 'unified-diff', 'diff-mode-unified')}
-        {btn('Split', 'split-diff', 'diff-mode-split')}
-        <Show when={props.hasStagedAndUnstaged}>
+        <Show when={props.diffAvailable}>
+          {btn('Unified', 'unified-diff', 'diff-mode-unified')}
+          {btn('Split', 'split-diff', 'diff-mode-split')}
+        </Show>
+        <Show when={props.diffAvailable && props.hasStagedAndUnstaged}>
           <div class={styles.separator} />
           <button
             class={`${styles.toolbarButton}${props.diffBase === 'head-vs-working' ? ` ${styles.toolbarButtonActive}` : ''}`}

--- a/frontend/src/components/fileviewer/FileViewer.css.ts
+++ b/frontend/src/components/fileviewer/FileViewer.css.ts
@@ -81,15 +81,64 @@ export const errorState = style({
   textAlign: 'center',
 })
 
-export const imageSizeError = style({
+/**
+ * Full-pane wrapper for the UnsupportedFileView fallback. Mirrors the
+ * terminal/agent `startupErrorPane` pattern: centered title + body +
+ * actions, no card chrome.
+ */
+export const unsupportedPane = style({
   display: 'flex',
+  flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: 'var(--space-2)',
   height: '100%',
-  color: 'var(--muted-foreground)',
-  fontSize: 'var(--text-7)',
+  width: '100%',
   padding: 'var(--space-4)',
   textAlign: 'center',
+  color: 'var(--muted-foreground)',
+  boxSizing: 'border-box',
+})
+
+/** Line under the title carrying the filename and formatted size. */
+export const unsupportedMeta = style({
+  margin: 0,
+  fontSize: 'var(--text-7)',
+  wordBreak: 'break-all',
+})
+
+/** Centered label + checkbox row rendered below the action buttons. */
+export const unsupportedRevealRow = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+  marginTop: 'var(--space-2)',
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  cursor: 'pointer',
+  userSelect: 'none',
+})
+
+/**
+ * Status-bar variant that opts back in to pointer events for the
+ * "Show download view" toggle. The default `statusBar` has
+ * `pointerEvents: none` so it doesn't block file-viewer interactions.
+ */
+export const statusBarInteractive = style({
+  pointerEvents: 'auto',
+})
+
+export const statusActionButton = style({
+  all: 'unset',
+  cursor: 'pointer',
+  color: 'var(--foreground)',
+  textDecoration: 'underline',
+  selectors: {
+    '&:focus-visible': {
+      outline: '2px solid var(--ring, var(--foreground))',
+      outlineOffset: '2px',
+    },
+  },
 })
 
 export const hexScroll = style({
@@ -150,12 +199,24 @@ export const toggleViewContainer = style({
   overflow: 'auto',
 })
 
-// Floating segmented toggle button at top-right
+// Absolutely-positioned slot at the top-right of the file viewer that
+// hosts the floating action surfaces — the optional view-mode toggle
+// row and the file-actions menu. Both render as flex children with a
+// gap between them, so callers don't have to coordinate offsets.
+export const floatingTopRight = style({
+  position: 'absolute',
+  top: 'var(--space-2)',
+  right: 'var(--space-3)',
+  zIndex: 10,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+})
+
+// Segmented view-mode toggle row. Placement is owned by the parent
+// `floatingTopRight` slot; this style only handles the segmented-button
+// chrome.
 export const viewToggle = style({
-  'position': 'absolute',
-  'top': 'var(--space-2)',
-  'right': 'var(--space-3)',
-  'zIndex': 10,
   'display': 'flex',
   'borderRadius': 'var(--radius-small)',
   'border': '1px solid var(--border)',

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -1,17 +1,25 @@
 import type { Component } from 'solid-js'
+import type { UnsupportedReason } from './UnsupportedFileView'
+import type { ViewMode } from '~/components/fileviewer/ViewToggle'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
+import type { GitFileStatusEntry } from '~/generated/leapmux/v1/common_pb'
 import type { FileViewMode } from '~/lib/fileType'
 import type { FileDiffBase, FileViewMode as TabFileViewMode } from '~/stores/tab.types'
-import AtSign from 'lucide-solid/icons/at-sign'
-import { createEffect, createMemo, createSignal, on, onCleanup, Show } from 'solid-js'
+import { batch, createEffect, createMemo, createSignal, Match, on, onCleanup, Show, Switch } from 'solid-js'
+import { isTauriApp } from '~/api/platformBridge'
 import * as workerRpc from '~/api/workerRpc'
 import { DiffView, rawDiffToHunks } from '~/components/chat/diff'
 import { diffAdded, diffRemoved } from '~/components/chat/diff/diffStyles.css'
-import { Icon } from '~/components/common/Icon'
-import { Tooltip } from '~/components/common/Tooltip'
+import { FileActionsMenu } from '~/components/common/FileActionsMenu'
+import { createFileSaveActions } from '~/components/common/fileSaveActions'
+import { showWarnToast } from '~/components/common/Toast'
+import { usePreferences } from '~/context/PreferencesContext'
+import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { GitFileRef } from '~/generated/leapmux/v1/git_pb'
-import { detectFileViewMode, isImageExtension } from '~/lib/fileType'
+import { PREFIX_FILE_SCROLL, sessionGetString, sessionRemoveItem, sessionSetString } from '~/lib/browserStorage'
+import { detectFileViewModeFromExt, isImageExt, isLikelyBinaryExt, isSvgExt } from '~/lib/fileType'
 import { formatBytes } from '~/lib/formatBytes'
+import { basename, detectFlavor, extname } from '~/lib/paths'
 import { DiffModeToolbar } from './DiffModeToolbar'
 import * as styles from './FileViewer.css'
 import { TOOLBAR_CLEARANCE_PX } from './FileViewer.css'
@@ -19,8 +27,71 @@ import { HexView } from './HexView'
 import { ImageFileView } from './ImageFileView'
 import { MarkdownFileView } from './MarkdownFileView'
 import { TextFileView } from './TextFileView'
+import { UnsupportedFileView } from './UnsupportedFileView'
+import { ViewToggle } from './ViewToggle'
 
 const MAX_FILE_SIZE = 256 * 1024 // 256 KiB
+
+/**
+ * Build the binary-file diff message from the file's git-status entry.
+ *
+ * We can't byte-compare directly — `readFile` only delivers the first
+ * 256 KiB of the working copy and we'd report a false "identical" on
+ * anything that diverges later. Git already tracks this comparison
+ * accurately for the index/working tree and is the authoritative
+ * source.
+ *
+ * Returns `null` when there's no status entry (file is not in the
+ * repo, or unchanged from HEAD) — callers treat that as "no diff to
+ * render". Otherwise returns a sentence describing the change in
+ * terms of the diff base.
+ */
+function binaryDiffMessageFromGit(
+  entry: GitFileStatusEntry | undefined,
+  diffBase: FileDiffBase | undefined,
+  name: string,
+): string | null {
+  if (!entry)
+    return null
+  const newSide = diffBase === 'head-vs-staged' ? 'staged copy' : 'working copy'
+
+  if (diffBase === 'head-vs-staged') {
+    // HEAD vs INDEX: only the staged-side codes matter.
+    switch (entry.stagedStatus) {
+      case GitFileStatusCode.UNSPECIFIED:
+        return null
+      case GitFileStatusCode.ADDED:
+        return `Binary file ${name} was added in the ${newSide}.`
+      case GitFileStatusCode.DELETED:
+        return `Binary file ${name} was deleted in the ${newSide}.`
+      default:
+        return `Binary file ${name} differs in the ${newSide}.`
+    }
+  }
+  // head-vs-working (default): HEAD vs the on-disk file. Combine both
+  // status sides — staged-ADDED means the file is newly created in
+  // INDEX (and thus working), unstaged-DELETED means the working file
+  // is gone even if INDEX still has it.
+  if (entry.unstagedStatus === GitFileStatusCode.UNTRACKED
+    || entry.stagedStatus === GitFileStatusCode.ADDED) {
+    return `Binary file ${name} was added in the ${newSide}.`
+  }
+  if (entry.unstagedStatus === GitFileStatusCode.DELETED
+    || (entry.stagedStatus === GitFileStatusCode.DELETED
+      && entry.unstagedStatus === GitFileStatusCode.UNSPECIFIED)) {
+    return `Binary file ${name} was deleted in the ${newSide}.`
+  }
+  return `Binary file ${name} differs in the ${newSide}.`
+}
+
+/** Parse the wrapped scroll-position value, returning null when stale or malformed. */
+function readScrollEntry(key: string): number | null {
+  const raw = sessionGetString(key)
+  if (raw === null)
+    return null
+  const scroll = Number(raw)
+  return Number.isFinite(scroll) ? scroll : null
+}
 
 export const FileViewer: Component<{
   workerId: string
@@ -29,10 +100,27 @@ export const FileViewer: Component<{
   onDisplayModeChange?: (mode: string) => void
   onQuote?: (text: string, startLine?: number, endLine?: number) => void
   onMention?: () => void
+  /**
+   * Worker-root path, threaded through to the FileActionsMenu so its
+   * "Copy relative path" item can show. Omit to hide that menu entry.
+   */
+  rootPath?: string
+  /** Worker home directory; used together with `rootPath` for tilde collapse. */
+  homeDir?: string
   /** Tab-level diff mode. */
   fileViewMode?: TabFileViewMode
   fileDiffBase?: FileDiffBase
   hasStagedAndUnstaged?: boolean
+  /**
+   * The file's current git-status entry, if any. Drives two
+   * behaviors:
+   *   - the Unified/Split toolbar buttons are only shown when this is
+   *     defined (a file with no git diff has nothing to render);
+   *   - for binary files, the diff verdict (identical/differs/added/
+   *     deleted) is derived from this entry instead of attempted byte
+   *     comparison (our readFile only sees the first 256 KiB).
+   */
+  gitFileStatus?: GitFileStatusEntry
   onFileViewModeChange?: (mode: TabFileViewMode) => void
   onFileDiffBaseChange?: (base: FileDiffBase) => void
 }> = (props) => {
@@ -41,7 +129,43 @@ export const FileViewer: Component<{
   const [content, setContent] = createSignal<Uint8Array | null>(null)
   const [totalSize, setTotalSize] = createSignal(0)
   const [viewMode, setViewMode] = createSignal<FileViewMode>('text')
-  const [imageTooLarge, setImageTooLarge] = createSignal(false)
+  // Per-session signal flipped by the "Show anyway" button. Bytes
+  // (when not already cached) are fetched lazily.
+  const [showAnyway, setShowAnyway] = createSignal(false)
+  const [loadingAnyway, setLoadingAnyway] = createSignal(false)
+  const isDesktop = isTauriApp()
+  const prefs = usePreferences()
+
+  const flavor = createMemo(() => detectFlavor(props.filePath))
+  // Single source of truth for the file extension. Every is*Ext check
+  // and every detectFileViewMode call below reads through this memo, so
+  // `extname` runs at most once per filePath change instead of once
+  // per consumer.
+  const ext = createMemo(() => extname(props.filePath))
+
+  // Render/source/split mode for the markdown and SVG-image viewers,
+  // lifted up here so the toggle row and the FileActionsMenu can share
+  // a single top-right floating slot. The tab store is the source of
+  // truth — emit through `onDisplayModeChange` and read back from
+  // `props.displayMode` on the next tick.
+  const displayMode = (): ViewMode => (props.displayMode as ViewMode | undefined) ?? 'render'
+
+  // Shared save/download workflow — single instance backs both the
+  // floating FileActionsMenu and the UnsupportedFileView buttons so
+  // their busy state is unified (clicking "Save as" in either disables
+  // it in the other).
+  const saveActions = createFileSaveActions({
+    workerId: () => props.workerId,
+    path: () => props.filePath,
+    flavor,
+  })
+
+  // Derived: an image file too large to preview inline. No bytes are
+  // fetched up front for this case; "Show anyway" triggers the first
+  // ReadFile call. Split so the extension check only re-runs on
+  // filePath change — the totalSize signal updates more frequently.
+  const isImagePath = createMemo(() => isImageExt(ext()))
+  const oversizeImage = createMemo(() => isImagePath() && totalSize() > MAX_FILE_SIZE)
 
   // Diff mode state
   const [diffOldContent, setDiffOldContent] = createSignal<string | null>(null)
@@ -51,41 +175,129 @@ export const FileViewer: Component<{
   const isDiffMode = () => props.fileViewMode === 'unified-diff' || props.fileViewMode === 'split-diff'
   const isRefMode = () => props.fileViewMode === 'head' || props.fileViewMode === 'staged'
 
+  // Whether a diff exists to render. A file with no git-status entry
+  // is either outside the repo or unchanged from HEAD — neither case
+  // has a meaningful unified/split diff. The toolbar hides those modes
+  // and an auto-fallback below switches off any stuck diff selection.
+  const diffAvailable = () => Boolean(props.gitFileStatus)
+
+  // Binary-file diff message from git status (computed only when the
+  // file is binary AND in a diff mode AND has a status entry). Used
+  // by the indicator that replaces DiffView for binary diffs — we
+  // can't show a meaningful unified/split view of binary bytes.
+  const binaryDiffMessage = createMemo<string | null>(() => {
+    if (!isDiffMode() || viewMode() !== 'binary')
+      return null
+    return binaryDiffMessageFromGit(
+      props.gitFileStatus,
+      props.fileDiffBase,
+      basename(props.filePath, flavor()),
+    )
+  })
+
+  // If the file has no diff available (no git-status entry), don't
+  // leave the tab stuck in a diff mode whose buttons are hidden — fall
+  // back to working mode so the user sees the working copy.
+  createEffect(() => {
+    if (!diffAvailable() && isDiffMode())
+      props.onFileViewModeChange?.('working')
+  })
+
+  // Promise of the current load's bytes (or null when the load
+  // short-circuited — empty workerId/path, binary, or oversize image).
+  // Captured by the load effect; the diff effect's head-vs-working
+  // branch awaits it to avoid issuing a duplicate readFile for the
+  // same range.
+  let currentBytesPromise: Promise<Uint8Array | null> = Promise.resolve(null)
+
+  // Shared first-chunk fetch used by the working-copy load, the diff
+  // effect's head-vs-working fallback, and "Show anyway".
+  const fetchFirstChunk = (workerId: string, filePath: string) =>
+    workerRpc.readFile(workerId, {
+      workerId,
+      path: filePath,
+      limit: BigInt(MAX_FILE_SIZE),
+    })
+
   // Load working copy content.
   createEffect(on(
     () => [props.workerId, props.filePath] as const,
     async ([workerId, filePath]) => {
+      let resolveBytes!: (bytes: Uint8Array | null) => void
+      currentBytesPromise = new Promise<Uint8Array | null>((r) => {
+        resolveBytes = r
+      })
+
       setLoading(true)
       setError(null)
       setContent(null)
-      setImageTooLarge(false)
+      setShowAnyway(false)
+      setLoadingAnyway(false)
+
+      // Tab rehydration on refresh momentarily mounts FileViewer with
+      // an empty workerId/filePath before the workspace-restore RPC
+      // fills them in. Skip the load here so we don't fire a statFile
+      // with `path=""` — the worker's path validator rejects that as
+      // "access denied", which then sticks even after props update.
+      // Stay in the loading state; the effect re-fires when the real
+      // path arrives.
+      if (!workerId || !filePath) {
+        resolveBytes(null)
+        return
+      }
+
+      const fileExt = extname(filePath)
 
       try {
-        const statResp = await workerRpc.statFile(workerId, { workerId, path: filePath })
-        const fileSize = Number(statResp.info?.size ?? 0n)
-        setTotalSize(fileSize)
-
-        if (isImageExtension(filePath)) {
-          if (fileSize > MAX_FILE_SIZE) {
-            setImageTooLarge(true)
-            setViewMode('image')
+        // Known-binary: only need the size to populate the unsupported
+        // card. Never read bytes.
+        if (isLikelyBinaryExt(fileExt)) {
+          const statResp = await workerRpc.statFile(workerId, { workerId, path: filePath })
+          batch(() => {
+            setTotalSize(Number(statResp.info?.size ?? 0n))
+            setViewMode('binary')
             setLoading(false)
-            return
-          }
+          })
+          resolveBytes(null)
+          return
         }
 
+        // Single readFile for everything else (text, markdown, source,
+        // no-extension, image). `readFile.totalSize` removes the need
+        // for an upfront statFile, and `metaOnlyIfTruncated` lets the
+        // worker short-circuit oversize images — server returns empty
+        // content + totalSize so we don't pay for 256 KiB of bytes
+        // we'd refuse to render. Saves one round-trip on every image
+        // and never wastes bytes on oversize ones.
         const readResp = await workerRpc.readFile(workerId, {
           workerId,
           path: filePath,
           limit: BigInt(MAX_FILE_SIZE),
+          metaOnlyIfTruncated: isImageExt(fileExt),
         })
+        const respTotalSize = Number(readResp.totalSize)
+        // Oversize image: server skipped the bytes; show the unsupported
+        // card with size and no preview.
+        if (isImageExt(fileExt) && respTotalSize > MAX_FILE_SIZE) {
+          batch(() => {
+            setTotalSize(respTotalSize)
+            setViewMode('image')
+            setLoading(false)
+          })
+          resolveBytes(null)
+          return
+        }
         const bytes = new Uint8Array(readResp.content)
-        setContent(bytes)
-        setTotalSize(Number(readResp.totalSize))
-        setViewMode(detectFileViewMode(filePath, bytes))
+        batch(() => {
+          setContent(bytes)
+          setTotalSize(respTotalSize)
+          setViewMode(detectFileViewModeFromExt(fileExt, bytes))
+        })
+        resolveBytes(bytes)
       }
       catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load file')
+        resolveBytes(null)
       }
       finally {
         setLoading(false)
@@ -93,11 +305,27 @@ export const FileViewer: Component<{
     },
   ))
 
+  // Diff source mode — collapses `unified-diff` / `split-diff` into a
+  // single value keyed by `fileDiffBase` so toggling the view (unified
+  // vs. split) doesn't re-fire the fetch effect. The diff bytes only
+  // depend on workerId / filePath / diffBase; the view choice is
+  // render-only.
+  type DiffSourceMode = 'working' | 'head' | 'staged' | 'diff:head-vs-working' | 'diff:head-vs-staged'
+  const diffSourceMode = createMemo<DiffSourceMode>(() => {
+    const fv = props.fileViewMode
+    if (!fv || fv === 'working')
+      return 'working'
+    if (fv === 'head' || fv === 'staged')
+      return fv
+    const base = props.fileDiffBase === 'head-vs-staged' ? 'head-vs-staged' : 'head-vs-working'
+    return `diff:${base}`
+  })
+
   // Load diff content when in diff or ref mode.
   createEffect(on(
-    () => [props.workerId, props.filePath, props.fileViewMode, props.fileDiffBase] as const,
-    async ([workerId, filePath, fvMode, diffBase]) => {
-      if (!fvMode || fvMode === 'working') {
+    () => [props.workerId, props.filePath, diffSourceMode()] as const,
+    async ([workerId, filePath, mode]) => {
+      if (mode === 'working') {
         setDiffOldContent(null)
         setDiffNewContent(null)
         return
@@ -105,8 +333,8 @@ export const FileViewer: Component<{
 
       setDiffLoading(true)
       try {
-        if (fvMode === 'head' || fvMode === 'staged') {
-          const ref = fvMode === 'head' ? GitFileRef.HEAD : GitFileRef.STAGED
+        if (mode === 'head' || mode === 'staged') {
+          const ref = mode === 'head' ? GitFileRef.HEAD : GitFileRef.STAGED
           const resp = await workerRpc.readGitFile(workerId, { workerId, path: filePath, ref })
           if (resp.exists) {
             setDiffOldContent(new TextDecoder().decode(resp.content))
@@ -115,35 +343,55 @@ export const FileViewer: Component<{
             setDiffOldContent(null)
           }
         }
-        else if (fvMode === 'unified-diff' || fvMode === 'split-diff') {
-          // Fetch HEAD version.
-          const headResp = await workerRpc.readGitFile(workerId, {
+        else {
+          // Binary files render the git-status-driven indicator
+          // instead of decoded-text DiffView — skip the fetch entirely
+          // for the common (extension-based) binary case. Unknown-
+          // extension binaries still pay the wasted fetch since the
+          // sniff runs in the load effect, but the render path won't
+          // display the decoded garbage.
+          if (isLikelyBinaryExt(extname(filePath))) {
+            setDiffOldContent(null)
+            setDiffNewContent(null)
+            return
+          }
+          // HEAD ref runs in parallel with whatever the "new" side
+          // needs — they target the same worker but don't depend on
+          // each other.
+          const headPromise = workerRpc.readGitFile(workerId, {
             workerId,
             path: filePath,
             ref: GitFileRef.HEAD,
           })
-          const headContent = headResp.exists ? new TextDecoder().decode(headResp.content) : ''
-          setDiffOldContent(headContent)
-
-          // Fetch the "new" version.
-          if (diffBase === 'head-vs-staged') {
+          const decoder = new TextDecoder()
+          let newText: string
+          if (mode === 'diff:head-vs-staged') {
             const stagedResp = await workerRpc.readGitFile(workerId, {
               workerId,
               path: filePath,
               ref: GitFileRef.STAGED,
             })
-            setDiffNewContent(stagedResp.exists ? new TextDecoder().decode(stagedResp.content) : '')
+            newText = stagedResp.exists ? decoder.decode(stagedResp.content) : ''
           }
           else {
-            // head-vs-working: read working copy from disk to avoid race
-            // with the content-loading effect that runs concurrently.
-            const workingResp = await workerRpc.readFile(workerId, {
-              workerId,
-              path: filePath,
-              limit: BigInt(MAX_FILE_SIZE),
-            })
-            setDiffNewContent(new TextDecoder().decode(workingResp.content))
+            // head-vs-working: prefer the working-copy bytes loaded by
+            // the content-loading effect rather than issuing a second
+            // readFile for the same range. Awaits load completion so
+            // the bytes are stable. Falls back to a fresh readFile
+            // when content() is null — binary files in diff mode, the
+            // load effect's early-return path, etc.
+            const bytes = await currentBytesPromise
+            if (bytes) {
+              newText = decoder.decode(bytes)
+            }
+            else {
+              const workingResp = await fetchFirstChunk(workerId, filePath)
+              newText = decoder.decode(workingResp.content)
+            }
           }
+          const headResp = await headPromise
+          setDiffOldContent(headResp.exists ? decoder.decode(headResp.content) : '')
+          setDiffNewContent(newText)
         }
       }
       catch {
@@ -159,17 +407,75 @@ export const FileViewer: Component<{
 
   const isTruncated = () => content() !== null && content()!.length < totalSize()
 
-  const showToolbar = () => props.fileViewMode !== undefined
+  const cardReason = createMemo<UnsupportedReason | null>(() => {
+    if (oversizeImage())
+      return 'oversize-image'
+    if (viewMode() === 'binary')
+      return 'binary'
+    return null
+  })
 
-  // Show the outer (floating) mention button for all modes except when
-  // ViewToggle handles it (markdown and SVG image views have the mention
-  // button integrated into their toggle control which already floats).
-  const hasViewToggle = () =>
-    !isDiffMode() && !isRefMode()
-    && (viewMode() === 'markdown' || (viewMode() === 'image' && props.filePath.toLowerCase().endsWith('.svg')))
-  const showOuterMention = () => !!props.onMention && !hasViewToggle()
+  // The unsupported-file view supersedes the inline viewers when the
+  // file is non-renderable AND the user hasn't opted in via "Show
+  // anyway". Only applies in working mode (diff/ref modes have their
+  // own dispatch).
+  const shouldShowUnsupported = () =>
+    !loading() && !error()
+    && (props.fileViewMode === undefined || props.fileViewMode === 'working')
+    && !showAnyway()
+    && cardReason() !== null
+
+  const handleShowAnyway = async () => {
+    // Snapshot worker/path at click time. If the user navigates away
+    // during the in-flight readFile (the load effect will re-run and
+    // reset `content`), discard our response — writing the old file's
+    // bytes into the new file's signal would silently corrupt state.
+    const workerId = props.workerId
+    const filePath = props.filePath
+    const propsStillCurrent = () =>
+      props.workerId === workerId && props.filePath === filePath
+
+    if (content() === null) {
+      if (loadingAnyway())
+        return
+      setLoadingAnyway(true)
+      try {
+        const readResp = await fetchFirstChunk(workerId, filePath)
+        if (!propsStillCurrent())
+          return
+        const bytes = new Uint8Array(readResp.content)
+        batch(() => {
+          setContent(bytes)
+          setTotalSize(Number(readResp.totalSize))
+        })
+      }
+      catch (err) {
+        showWarnToast('Failed to load preview', err)
+        return
+      }
+      finally {
+        setLoadingAnyway(false)
+      }
+      if (!propsStillCurrent())
+        return
+    }
+    setShowAnyway(true)
+  }
+
+  const showToolbar = () => props.fileViewMode !== undefined
+  const showFloatingActions = () => !loading() && !error()
+  const hasTopChrome = () => showToolbar() || showFloatingActions()
+
+  // Markdown and SVG-image viewers expose a render/source/split toggle
+  // beside the FileActionsMenu in the top-right floating slot. Other
+  // modes show just the actions menu.
+  const showViewToggle = () =>
+    !loading() && !error() && !isDiffMode() && !isRefMode()
+    && (viewMode() === 'markdown' || (viewMode() === 'image' && isSvgExt(ext())))
 
   const diffHunks = createMemo(() => {
+    if (!isDiffMode())
+      return []
     const old = diffOldContent()
     const nw = diffNewContent()
     if (old === null || nw === null)
@@ -184,19 +490,19 @@ export const FileViewer: Component<{
 
   // Include the view mode in the scroll key so each mode has independent scroll.
   // eslint-disable-next-line solid/reactivity -- Read once; workerId and filePath are stable for the component's lifetime
-  const scrollStoragePrefix = `leapmux:fileScroll:${props.workerId}:${props.filePath}`
+  const scrollStoragePrefix = `${PREFIX_FILE_SCROLL}${props.workerId}:${props.filePath}`
   const scrollStorageKey = () => `${scrollStoragePrefix}:${props.fileViewMode ?? 'working'}`
 
   // Save scroll position when the view mode changes or on unmount.
+  // Values are TTL-wrapped via `sessionSetString` so stale entries get
+  // dropped by `runCleanup` on next app load.
   let lastSavedKey: string | undefined
   const saveScrollPosition = () => {
     const key = lastSavedKey ?? scrollStorageKey()
-    if (contentRef && contentRef.scrollTop > 0) {
-      sessionStorage.setItem(key, String(contentRef.scrollTop))
-    }
-    else {
-      sessionStorage.removeItem(key)
-    }
+    if (contentRef && contentRef.scrollTop > 0)
+      sessionSetString(key, String(contentRef.scrollTop))
+    else
+      sessionRemoveItem(key)
   }
   onCleanup(saveScrollPosition)
 
@@ -208,17 +514,17 @@ export const FileViewer: Component<{
         return
 
       // Save scroll for the previous mode before switching.
-      if (lastSavedKey && lastSavedKey !== scrollStorageKey())
+      const key = scrollStorageKey()
+      if (lastSavedKey && lastSavedKey !== key)
         saveScrollPosition()
-      lastSavedKey = scrollStorageKey()
+      lastSavedKey = key
 
-      const savedStr = sessionStorage.getItem(scrollStorageKey())
-      if (savedStr != null) {
-        const scrollTop = Number(savedStr)
-        sessionStorage.removeItem(scrollStorageKey())
+      const savedScroll = readScrollEntry(key)
+      if (savedScroll != null) {
+        sessionRemoveItem(key)
         requestAnimationFrame(() => {
           if (contentRef)
-            contentRef.scrollTop = scrollTop
+            contentRef.scrollTop = savedScroll
         })
         return
       }
@@ -260,24 +566,34 @@ export const FileViewer: Component<{
           mode={props.fileViewMode!}
           diffBase={props.fileDiffBase}
           hasStagedAndUnstaged={props.hasStagedAndUnstaged}
+          diffAvailable={diffAvailable()}
           onModeChange={mode => props.onFileViewModeChange?.(mode)}
           onDiffBaseChange={base => props.onFileDiffBaseChange?.(base)}
         />
       </Show>
-      <Show when={showOuterMention()}>
-        <div class={styles.viewToggle}>
-          <Tooltip text="Mention in the chat" ariaLabel>
-            <button
-              class={styles.viewToggleButton}
-              onClick={() => props.onMention?.()}
-              data-testid="file-mention-button"
-            >
-              <Icon icon={AtSign} size="sm" />
-            </button>
-          </Tooltip>
+      <Show when={showFloatingActions()}>
+        <div class={styles.floatingTopRight}>
+          <Show when={showViewToggle()}>
+            <ViewToggle mode={displayMode()} onToggle={m => props.onDisplayModeChange?.(m)} showSplit />
+          </Show>
+          <FileActionsMenu
+            workerId={props.workerId}
+            path={props.filePath}
+            flavor={flavor()}
+            rootPath={props.rootPath}
+            homeDir={props.homeDir}
+            onMention={props.onMention ? () => props.onMention?.() : undefined}
+            triggerClass={styles.viewToggleButton}
+            triggerTestId="file-actions-trigger"
+            actions={saveActions}
+          />
         </div>
       </Show>
-      <div class={`${styles.content}${showToolbar() || showOuterMention() ? ` ${styles.hasFloatingToolbar}` : ''}`} ref={contentRef}>
+      <div
+        class={styles.content}
+        classList={{ [styles.hasFloatingToolbar]: hasTopChrome() }}
+        ref={contentRef}
+      >
         <Show when={loading() || diffLoading()}>
           <div class={styles.loadingState}>Loading...</div>
         </Show>
@@ -298,8 +614,13 @@ export const FileViewer: Component<{
             <div class={styles.errorState}>File does not exist at this ref</div>
           </Show>
 
-          {/* Diff mode: show unified or split diff */}
-          <Show when={isDiffMode() && !diffLoading() && diffOldContent() !== null && diffNewContent() !== null}>
+          {/* Diff mode: binary indicator OR unified/split text diff. */}
+          <Show when={isDiffMode() && !diffLoading() && binaryDiffMessage() !== null}>
+            <div class={styles.errorState} data-testid="binary-diff-indicator">
+              {binaryDiffMessage()}
+            </div>
+          </Show>
+          <Show when={isDiffMode() && !diffLoading() && binaryDiffMessage() === null && diffOldContent() !== null && diffNewContent() !== null}>
             <DiffView
               hunks={diffHunks()}
               view={diffViewPref()}
@@ -308,55 +629,89 @@ export const FileViewer: Component<{
             />
           </Show>
 
-          {/* Working mode or no mode: show normal file content */}
+          {/* Working mode or no mode: show normal file content. */}
           <Show when={!isDiffMode() && !isRefMode()}>
-            <Show when={imageTooLarge()}>
-              <div class={styles.imageSizeError}>
-                {`Image too large to preview (${formatBytes(totalSize())})`}
-              </div>
-            </Show>
-            <Show when={viewMode() === 'text' && content()}>
-              <TextFileView
-                content={content()!}
-                filePath={props.filePath}
-                totalSize={totalSize()}
-                onQuote={props.onQuote}
-              />
-            </Show>
-            <Show when={viewMode() === 'markdown' && content()}>
-              <MarkdownFileView
-                content={content()!}
-                filePath={props.filePath}
-                totalSize={totalSize()}
-                displayMode={props.displayMode}
-                onDisplayModeChange={props.onDisplayModeChange}
-                onQuote={props.onQuote}
-                onMention={props.onMention}
-              />
-            </Show>
-            <Show when={viewMode() === 'image' && content() && !imageTooLarge()}>
-              <ImageFileView
-                content={content()!}
-                filePath={props.filePath}
-                totalSize={totalSize()}
-                displayMode={props.displayMode}
-                onDisplayModeChange={props.onDisplayModeChange}
-                onQuote={props.onQuote}
-                onMention={props.onMention}
-              />
-            </Show>
-            <Show when={viewMode() === 'binary' && content()}>
-              <HexView
-                content={content()!}
-                totalSize={totalSize()}
-                topOffset={showToolbar() || showOuterMention() ? TOOLBAR_CLEARANCE_PX : 0}
-              />
+            <Show
+              when={showAnyway()}
+              fallback={(
+                <Switch>
+                  <Match when={shouldShowUnsupported()}>
+                    <UnsupportedFileView
+                      filePath={props.filePath}
+                      flavor={flavor()}
+                      totalSize={totalSize()}
+                      reason={cardReason()!}
+                      currentOp={saveActions.currentOp()}
+                      loadingAnyway={loadingAnyway()}
+                      canShowAnyway={totalSize() > 0}
+                      onDownload={saveActions.handleDownload}
+                      onShowAnyway={handleShowAnyway}
+                      desktop={isDesktop
+                        ? {
+                            onSaveAs: saveActions.handleSaveAs,
+                            onSaveToDownloads: saveActions.handleSaveToDownloads,
+                            revealAfterDownload: prefs.revealAfterDownload(),
+                            onRevealAfterDownloadChange: prefs.setRevealAfterDownload,
+                          }
+                        : undefined}
+                    />
+                  </Match>
+                  <Match when={viewMode() === 'text' && content()}>
+                    <TextFileView
+                      content={content()!}
+                      filePath={props.filePath}
+                      totalSize={totalSize()}
+                      onQuote={props.onQuote}
+                    />
+                  </Match>
+                  <Match when={viewMode() === 'markdown' && content()}>
+                    <MarkdownFileView
+                      content={content()!}
+                      filePath={props.filePath}
+                      totalSize={totalSize()}
+                      mode={displayMode()}
+                      onQuote={props.onQuote}
+                    />
+                  </Match>
+                  <Match when={viewMode() === 'image' && content()}>
+                    <ImageFileView
+                      content={content()!}
+                      filePath={props.filePath}
+                      totalSize={totalSize()}
+                      mode={displayMode()}
+                      onQuote={props.onQuote}
+                    />
+                  </Match>
+                </Switch>
+              )}
+            >
+              <Show when={cardReason() !== null && content()}>
+                <HexView
+                  content={content()!}
+                  totalSize={totalSize()}
+                  topOffset={hasTopChrome() ? TOOLBAR_CLEARANCE_PX : 0}
+                />
+              </Show>
             </Show>
           </Show>
         </Show>
       </div>
-      <Show when={!loading() && !error() && !isDiffMode() && !isRefMode() && (totalSize() > 0 || isTruncated())}>
-        <div class={styles.statusBar}>
+      <Show when={!loading() && !error() && !isDiffMode() && !isRefMode() && !shouldShowUnsupported() && (totalSize() > 0 || isTruncated())}>
+        <div
+          class={styles.statusBar}
+          classList={{ [styles.statusBarInteractive]: showAnyway() && cardReason() !== null }}
+        >
+          <Show when={showAnyway() && cardReason() !== null}>
+            <button
+              type="button"
+              class={styles.statusActionButton}
+              data-testid="file-show-download-view-button"
+              aria-label={`Return to the file download view for ${basename(props.filePath, flavor())}`}
+              onClick={() => setShowAnyway(false)}
+            >
+              Show download view
+            </button>
+          </Show>
           <Show when={isTruncated()}>
             <span class={styles.truncationWarning}>
               {`Truncated at ${formatBytes(MAX_FILE_SIZE)}`}

--- a/frontend/src/components/fileviewer/ImageFileView.tsx
+++ b/frontend/src/components/fileviewer/ImageFileView.tsx
@@ -1,33 +1,15 @@
 import type { JSX } from 'solid-js'
 import type { ZoomMode } from './ImageToolbar'
 import type { ViewMode } from './ViewToggle'
-import { createEffect, createMemo, createSignal, Match, onCleanup, Switch, untrack } from 'solid-js'
-import { isSvgExtension } from '~/lib/fileType'
+import { createEffect, createMemo, createSignal, Match, onCleanup, Switch } from 'solid-js'
+import { getImageMimeType, isSvgExtension } from '~/lib/fileType'
 import { basename } from '~/lib/paths'
 import * as styles from './FileViewer.css'
 import { ImageToolbar, ZOOM_MAX, ZOOM_MIN } from './ImageToolbar'
 import { TextFileView } from './TextFileView'
-import { ViewToggle } from './ViewToggle'
-
-const MIME_MAP: Record<string, string> = {
-  png: 'image/png',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  gif: 'image/gif',
-  bmp: 'image/bmp',
-  webp: 'image/webp',
-  svg: 'image/svg+xml',
-  ico: 'image/x-icon',
-  avif: 'image/avif',
-}
 
 const WRAPPER_PADDING_X = 16 // matches var(--space-4) used in imageZoomWrapper
 const WRAPPER_PADDING_TOP = 44 // matches toolbar clearance used in imageZoomWrapper
-
-function getMimeType(path: string): string {
-  const ext = path.split('.').pop()?.toLowerCase() ?? ''
-  return MIME_MAP[ext] ?? 'application/octet-stream'
-}
 
 function ImageRender(props: {
   content: Uint8Array
@@ -41,8 +23,13 @@ function ImageRender(props: {
   const [naturalSize, setNaturalSize] = createSignal<{ w: number, h: number } | null>(null)
   const [containerSize, setContainerSize] = createSignal({ w: 0, h: 0 })
 
-  const blobUrl = createMemo(() => {
-    const blob = new Blob([props.content as BlobPart], { type: getMimeType(props.filePath) })
+  // Revoke the previous blob URL whenever content/filePath changes
+  // (createMemo re-runs and the old URL would otherwise leak until
+  // component unmount). The final URL is revoked in onCleanup.
+  const blobUrl = createMemo<string>((prev) => {
+    if (prev !== undefined)
+      URL.revokeObjectURL(prev)
+    const blob = new Blob([props.content as BlobPart], { type: getImageMimeType(props.filePath) })
     return URL.createObjectURL(blob)
   })
 
@@ -178,19 +165,16 @@ export function ImageFileView(props: {
   content: Uint8Array
   filePath: string
   totalSize?: number
-  displayMode?: string
-  onDisplayModeChange?: (mode: string) => void
+  /**
+   * Controlled view mode for the SVG render/source/split toggle. Ignored
+   * for raster images (which have no toggle and always render the image
+   * directly).
+   */
+  mode: ViewMode
   onQuote?: (text: string, startLine?: number, endLine?: number) => void
-  onMention?: () => void
 }): JSX.Element {
   const isSvg = () => isSvgExtension(props.filePath)
-  const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
   const [zoom, setZoom] = createSignal<ZoomMode>('fit')
-
-  const handleModeChange = (m: ViewMode) => {
-    setMode(m)
-    props.onDisplayModeChange?.(m)
-  }
 
   const renderImage = () => (
     <ImageRender
@@ -208,12 +192,11 @@ export function ImageFileView(props: {
       </Match>
       <Match when={isSvg()}>
         <div class={styles.toggleViewContainer}>
-          <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit onMention={props.onMention} />
           <Switch>
-            <Match when={mode() === 'render'}>
+            <Match when={props.mode === 'render'}>
               {renderImage()}
             </Match>
-            <Match when={mode() === 'split'}>
+            <Match when={props.mode === 'split'}>
               <div class={styles.splitContainer}>
                 <div class={styles.splitPane}>
                   {renderImage()}
@@ -229,7 +212,7 @@ export function ImageFileView(props: {
                 </div>
               </div>
             </Match>
-            <Match when={mode() === 'source'}>
+            <Match when={props.mode === 'source'}>
               <TextFileView
                 content={props.content}
                 filePath={props.filePath}

--- a/frontend/src/components/fileviewer/MarkdownFileView.tsx
+++ b/frontend/src/components/fileviewer/MarkdownFileView.tsx
@@ -1,31 +1,22 @@
 import type { JSX } from 'solid-js'
 import type { ViewMode } from './ViewToggle'
 import type { ParsedCatLine } from '~/components/chat/results/ReadResultView'
-import { createMemo, createSignal, Show, untrack } from 'solid-js'
+import { createMemo, Show } from 'solid-js'
 import { markdownContent } from '~/components/chat/markdownEditor/markdownContent.css'
 import { ReadResultView } from '~/components/chat/results/ReadResultView'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import { renderMarkdown } from '~/lib/renderMarkdown'
 import * as styles from './FileViewer.css'
 import { TextFileView } from './TextFileView'
-import { ViewToggle } from './ViewToggle'
 
 export function MarkdownFileView(props: {
   content: Uint8Array
   filePath: string
   totalSize: number
-  displayMode?: string
-  onDisplayModeChange?: (mode: string) => void
+  /** Controlled view mode (render / source / split). */
+  mode: ViewMode
   onQuote?: (text: string, startLine?: number, endLine?: number) => void
-  onMention?: () => void
 }): JSX.Element {
-  const [mode, setMode] = createSignal<ViewMode>(untrack(() => props.displayMode as ViewMode) || 'render')
-
-  const handleModeChange = (m: ViewMode) => {
-    setMode(m)
-    props.onDisplayModeChange?.(m)
-  }
-
   const text = createMemo(() => new TextDecoder().decode(props.content))
   const html = createMemo(() => renderMarkdown(text()))
 
@@ -59,14 +50,13 @@ export function MarkdownFileView(props: {
 
   return (
     <div class={styles.toggleViewContainer}>
-      <ViewToggle mode={mode()} onToggle={handleModeChange} showSplit onMention={props.onMention} />
-      <Show when={mode() === 'render'}>
+      <Show when={props.mode === 'render'}>
         <div class={styles.markdownContainer}>
           {/* eslint-disable-next-line solid/no-innerhtml -- intentional: rendered markdown */}
           <div class={markdownContent} innerHTML={html()} />
         </div>
       </Show>
-      <Show when={mode() === 'split'}>
+      <Show when={props.mode === 'split'}>
         <div class={styles.splitContainer}>
           <div
             class={styles.splitPane}
@@ -93,7 +83,7 @@ export function MarkdownFileView(props: {
           </div>
         </div>
       </Show>
-      <Show when={mode() === 'source'}>
+      <Show when={props.mode === 'source'}>
         <TextFileView
           content={props.content}
           filePath={props.filePath}

--- a/frontend/src/components/fileviewer/UnsupportedFileView.tsx
+++ b/frontend/src/components/fileviewer/UnsupportedFileView.tsx
@@ -1,0 +1,185 @@
+import type { Component, JSX } from 'solid-js'
+import type { FileSaveOp } from '~/components/common/fileSaveActions'
+import type { PathFlavor } from '~/lib/paths'
+import { createMemo, createUniqueId, Show } from 'solid-js'
+import { StartupBody, StartupSpinner } from '~/components/common/StartupPanel'
+import { formatBytes } from '~/lib/formatBytes'
+import { basename } from '~/lib/paths'
+import * as styles from './FileViewer.css'
+
+// Save-button content: idle label, or spinner when this button's op is
+// in flight. Three call sites in this file (Download, Save as, Save to
+// Downloads) only differ in the `active`/`label`/`busyLabel` triple.
+function SaveButtonContent(props: { active: boolean, label: string, busyLabel: string }): JSX.Element {
+  return (
+    <Show when={props.active} fallback={<>{props.label}</>}>
+      <StartupSpinner label={props.busyLabel} />
+    </Show>
+  )
+}
+
+export type UnsupportedReason = 'binary' | 'oversize-image'
+
+/**
+ * Desktop-mode save controls: render two save buttons (Save as / Save
+ * to Downloads) and a "reveal in file manager" checkbox below.
+ *
+ * The in-flight save (or null) is read from the parent `currentOp`
+ * prop — both buttons disable while any save runs, but only the active
+ * one shows the spinner. Web-mode callers leave this slot undefined and
+ * pass `onDownload` instead, yielding a single anchor-click Download
+ * button.
+ */
+export interface DesktopSaveControls {
+  onSaveAs: () => void
+  onSaveToDownloads: () => void
+  revealAfterDownload: boolean
+  onRevealAfterDownloadChange: (value: boolean) => void
+}
+
+export interface UnsupportedFileViewProps {
+  filePath: string
+  flavor: PathFlavor
+  totalSize: number
+  reason: UnsupportedReason
+  loadingAnyway: boolean
+  /**
+   * When false, the secondary "Show anyway" button is omitted. Used to
+   * hide the action for empty files (nothing to preview).
+   */
+  canShowAnyway: boolean
+  onShowAnyway: () => void
+  // Web variant: single "Download" anchor-click button.
+  // `currentOp === 'download'` shows the spinner; both other ops also
+  // disable the button (UnsupportedFileView never sees those today,
+  // but the shared signal means it's well-defined).
+  currentOp: FileSaveOp
+  onDownload: () => void
+  // Desktop variant: when present, replaces the single "Download" with
+  // "Save as..." / "Save to Downloads" and shows the reveal checkbox.
+  desktop?: DesktopSaveControls
+}
+
+function titleFor(reason: UnsupportedReason): string {
+  if (reason === 'oversize-image')
+    return 'This image is too large to preview.'
+  return 'This file cannot be displayed inline.'
+}
+
+/**
+ * GitHub-style fallback view for files we cannot render inline.
+ *
+ * Layout mirrors the agent/terminal startup-failure pane:
+ *   - <h2> title via StartupBody
+ *   - filename · size meta line
+ *   - action row (Download or Save buttons + Show anyway)
+ *   - reveal checkbox below the action row (desktop only)
+ */
+export const UnsupportedFileView: Component<UnsupportedFileViewProps> = (props) => {
+  const name = createMemo(() => basename(props.filePath, props.flavor))
+  const titleId = createUniqueId()
+  const revealId = createUniqueId()
+  const busy = () => props.currentOp !== null
+
+  return (
+    <div
+      class={styles.unsupportedPane}
+      role="region"
+      aria-labelledby={titleId}
+      data-testid="unsupported-file-view"
+    >
+      <StartupBody
+        title={titleFor(props.reason)}
+        titleId={titleId}
+        body={(
+          <p class={styles.unsupportedMeta} data-testid="unsupported-meta">
+            {`${name()} · ${formatBytes(props.totalSize)}`}
+          </p>
+        )}
+      >
+        <Show
+          when={props.desktop}
+          fallback={(
+            <button
+              type="button"
+              data-testid="unsupported-download-button"
+              aria-label={`Download ${name()}`}
+              disabled={busy()}
+              onClick={() => props.onDownload()}
+            >
+              <SaveButtonContent
+                active={props.currentOp === 'download'}
+                label="Download"
+                busyLabel="Downloading..."
+              />
+            </button>
+          )}
+        >
+          {desktop => (
+            <>
+              <button
+                type="button"
+                data-testid="unsupported-save-as-button"
+                aria-label={`Save ${name()} as...`}
+                disabled={busy()}
+                onClick={() => desktop().onSaveAs()}
+              >
+                <SaveButtonContent
+                  active={props.currentOp === 'save-as'}
+                  label="Save as..."
+                  busyLabel="Saving..."
+                />
+              </button>
+              <button
+                type="button"
+                class="outline"
+                data-testid="unsupported-save-to-downloads-button"
+                aria-label={`Save ${name()} to Downloads`}
+                disabled={busy()}
+                onClick={() => desktop().onSaveToDownloads()}
+              >
+                <SaveButtonContent
+                  active={props.currentOp === 'save-to-downloads'}
+                  label="Save to Downloads"
+                  busyLabel="Saving..."
+                />
+              </button>
+            </>
+          )}
+        </Show>
+        <Show when={props.canShowAnyway}>
+          <button
+            type="button"
+            class="outline"
+            data-testid="unsupported-show-anyway-button"
+            aria-label={`Show ${name()} anyway`}
+            disabled={props.loadingAnyway}
+            onClick={() => props.onShowAnyway()}
+          >
+            <Show when={props.loadingAnyway} fallback={<>Show anyway</>}>
+              <StartupSpinner label="Loading..." />
+            </Show>
+          </button>
+        </Show>
+      </StartupBody>
+      <Show when={props.desktop}>
+        {desktop => (
+          <label
+            class={styles.unsupportedRevealRow}
+            for={revealId}
+            data-testid="unsupported-reveal-checkbox-label"
+          >
+            <input
+              id={revealId}
+              type="checkbox"
+              data-testid="unsupported-reveal-checkbox"
+              checked={desktop().revealAfterDownload}
+              onChange={e => desktop().onRevealAfterDownloadChange(e.currentTarget.checked)}
+            />
+            Reveal in file manager after save
+          </label>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/fileviewer/ViewToggle.tsx
+++ b/frontend/src/components/fileviewer/ViewToggle.tsx
@@ -1,5 +1,4 @@
 import type { JSX } from 'solid-js'
-import AtSign from 'lucide-solid/icons/at-sign'
 import Code from 'lucide-solid/icons/code'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import Eye from 'lucide-solid/icons/eye'
@@ -10,11 +9,15 @@ import * as styles from './FileViewer.css'
 
 export type ViewMode = 'render' | 'source' | 'split'
 
+/**
+ * Segmented view-mode toggle row used by markdown and SVG-image
+ * viewers. Positioning is owned by the parent — this component just
+ * paints the button chrome.
+ */
 export function ViewToggle(props: {
   mode: ViewMode
   onToggle: (mode: ViewMode) => void
   showSplit?: boolean
-  onMention?: () => void
 }): JSX.Element {
   return (
     <div class={styles.viewToggle}>
@@ -47,18 +50,6 @@ export function ViewToggle(props: {
           <Icon icon={Code} size="sm" />
         </button>
       </Tooltip>
-      <Show when={props.onMention}>
-        <div style={{ 'border-left': '1px solid var(--border)' }} />
-        <Tooltip text="Mention in the chat" ariaLabel>
-          <button
-            class={styles.viewToggleButton}
-            onClick={() => props.onMention?.()}
-            data-testid="file-mention-button"
-          >
-            <Icon icon={AtSign} size="sm" />
-          </button>
-        </Tooltip>
-      </Show>
     </div>
   )
 }

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -51,7 +51,7 @@ import { createChatStore } from '~/stores/chat.store'
 import { createControlStore } from '~/stores/control.store'
 import { createFloatingWindowStore } from '~/stores/floatingWindow.store'
 import { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
-import { createLayoutStore } from '~/stores/layout.store'
+import { createLayoutStore, getAllTileIds } from '~/stores/layout.store'
 import { createSectionStore } from '~/stores/section.store'
 import { agentTabToInfo, isTabReadyForGitStatus, tabKey } from '~/stores/tab.helpers'
 import { createTabStore } from '~/stores/tab.store'
@@ -89,6 +89,11 @@ import { useWorkspaceHydration } from './useWorkspaceHydration'
 import { useWorkspaceLoader } from './useWorkspaceLoader'
 import { useWorkspaceRestore } from './useWorkspaceRestore'
 import { useWorkspaceSwitchSnapshot } from './useWorkspaceSwitchSnapshot'
+
+// Stable empty-array reference for the inactive-workspace tile-order
+// path. Returning a fresh `[]` per call would defeat the WeakMap-based
+// memoization that keeps `WorkspaceTabTree`'s `buildTree` memo stable.
+const EMPTY_TILE_ORDER: string[] = []
 
 export const AppShell: ParentComponent = (props) => {
   const auth = useAuth()
@@ -960,6 +965,14 @@ export const AppShell: ParentComponent = (props) => {
     customKeybindings: preferences.customKeybindings,
   })
 
+  // Per-`layout.root` cache for inactive-workspace tile orders. Keyed by
+  // the layout root's object identity so each `getTileOrderForWorkspace`
+  // call returns the same array reference as long as the registry's
+  // snapshot is unchanged. Without this cache, every call would allocate
+  // a fresh array via `getAllTileIds(root).flatMap(...)`, invalidating
+  // `WorkspaceTabTree`'s `buildTree` memo on each tick.
+  const inactiveTileOrderCache = new WeakMap<object, string[]>()
+
   // Sidebar element factories
   // Use getters for reactive values so that LeftSidebar/RightSidebar props
   // remain reactive when accessed through the intermediate opts object.
@@ -1030,6 +1043,32 @@ export const AppShell: ParentComponent = (props) => {
       get closingKeys() { return tabOps.closingTabKeys() },
     },
     onExpandWorkspace: handleExpandWorkspace,
+    // Tile order for sidebar leaf ordering. The active workspace's
+    // layout lives on `layoutStore` (the registry snapshot is taken at
+    // workspace-switch time, so it's stale for the active workspace);
+    // other workspaces read from the snapshot. The active path uses
+    // the store's memoized accessor so the WorkspaceTabTree memo
+    // downstream isn't invalidated by a fresh array on every unrelated
+    // reactive tick. The inactive path caches by `root` reference so
+    // repeated calls return the same array identity for as long as the
+    // registry snapshot's layout tree is unchanged — without that, a
+    // fresh `flatMap`-allocated array would invalidate the downstream
+    // `buildTree` memo on every render tick. Returns `[]` when no
+    // layout is loaded yet (cold registry); the tree falls back to a
+    // position-only sort.
+    getTileOrderForWorkspace: (wsId: string) => {
+      if (wsId === workspace.activeWorkspaceId())
+        return layoutStore.getAllTileIds()
+      const root = registry.get(wsId)?.layout.root
+      if (!root)
+        return EMPTY_TILE_ORDER
+      const cached = inactiveTileOrderCache.get(root)
+      if (cached)
+        return cached
+      const fresh = getAllTileIds(root)
+      inactiveTileOrderCache.set(root, fresh)
+      return fresh
+    },
   })
 
   // Refresh git status only when workerId or workingDir actually changes

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -58,6 +58,8 @@ export interface SidebarElementsOpts {
   onTabClick: (type: number, id: string) => void
   tabItemOps?: TabItemOps
   onExpandWorkspace: (workspaceId: string) => void
+  /** Tile ids in top-left-first traversal order for `workspaceId`. */
+  getTileOrderForWorkspace: (workspaceId: string) => string[]
 }
 
 interface SidebarDisplayOpts {
@@ -129,6 +131,7 @@ function buildCommonSidebarProps(opts: SidebarElementsOpts, display?: SidebarDis
     onTabClick: opts.onTabClick,
     tabItemOps: opts.tabItemOps,
     onExpandWorkspace: opts.onExpandWorkspace,
+    getTileOrderForWorkspace: opts.getTileOrderForWorkspace,
   }
 }
 

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -6,7 +6,6 @@ import type { Tab } from '~/stores/tab.types'
 import { createDroppable, createSortable, SortableProvider, transformStyle } from '@thisbeyond/solid-dnd'
 import Bot from 'lucide-solid/icons/bot'
 import Ellipsis from 'lucide-solid/icons/ellipsis'
-import FileText from 'lucide-solid/icons/file-text'
 import Menu from 'lucide-solid/icons/menu'
 import PanelRight from 'lucide-solid/icons/panel-right'
 import Plus from 'lucide-solid/icons/plus'
@@ -15,15 +14,14 @@ import X from 'lucide-solid/icons/x'
 import { createSignal, ErrorBoundary, For, onCleanup, onMount, Show } from 'solid-js'
 import { AgentProviderIcon, agentProviderLabel } from '~/components/common/AgentProviderIcon'
 import { DropdownMenu, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
-import { Icon } from '~/components/common/Icon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { TabTypeIcon } from '~/components/common/TabTypeIcon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { usePreferences } from '~/context/PreferencesContext'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { useMruProviders } from '~/hooks/useMruProviders'
-import { basename } from '~/lib/paths'
 import { getShortcutHintsText, shortcutHint } from '~/lib/shortcuts/display'
-import { canCloseTab, tabKey } from '~/stores/tab.helpers'
+import { canCloseTab, tabDisplayLabel, tabKey } from '~/stores/tab.helpers'
 import { isTerminalTab } from '~/stores/tab.types'
 import { menuSectionHeader } from '~/styles/shared.css'
 import * as styles from './TabBar.css'
@@ -153,17 +151,9 @@ export const TabBar: Component<TabBarProps> = (props) => {
   let editCancelled = false
   let tabListRef: HTMLDivElement | undefined
 
-  const tabLabel = (tab: Tab): string => {
-    if (tab.title)
-      return tab.title
-    if (tab.type === TabType.FILE)
-      return (tab.filePath ? basename(tab.filePath) : '') || 'File'
-    return tab.type === TabType.AGENT ? 'Agent' : 'Terminal'
-  }
-
   const startEditing = (tab: Tab) => {
     setEditingTabKey(tabKey(tab))
-    setEditingValue(tabLabel(tab))
+    setEditingValue(tabDisplayLabel(tab))
   }
 
   const commitEdit = (tab: Tab) => {
@@ -172,7 +162,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
       return
     }
     const value = editingValue().trim()
-    if (value && value !== tabLabel(tab)) {
+    if (value && value !== tabDisplayLabel(tab)) {
       props.onRename(tab, value)
     }
     setEditingTabKey(null)
@@ -255,11 +245,11 @@ export const TabBar: Component<TabBarProps> = (props) => {
         }}
       >
         <span class={styles.tabIcon}>
-          {tab.type === TabType.AGENT ? <AgentProviderIcon provider={tab.agentProvider} size={14} /> : tab.type === TabType.FILE ? <Icon icon={FileText} size="sm" /> : <Icon icon={Terminal} size="sm" />}
+          <TabTypeIcon tab={tab} />
         </span>
         <Show
           when={editingTabKey() === tabKey(tab)}
-          fallback={<TabTextWithTooltip label={tabLabel(tab)} status={isTerminalTab(tab) ? tab.status : undefined} />}
+          fallback={<TabTextWithTooltip label={tabDisplayLabel(tab)} status={isTerminalTab(tab) ? tab.status : undefined} />}
         >
           <input
             class={styles.tabEditInput}

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -662,11 +662,25 @@ export function createTileRenderer(opts: TileRendererOpts) {
               const ctx = getMruAgentContext()
               return relativizePath(ft.filePath ?? '', ctx.workingDir, ctx.homeDir)
             }
+            // Single lookup shared by `gitFileStatus` and
+            // `hasStagedAndUnstaged` so both props read from one memo
+            // cell instead of walking the file-status map on every
+            // reactive tick.
+            const gitEntry = createMemo(() => gitFileStatusStore?.getFileStatus(ft.filePath ?? ''))
+            const hasStagedAndUnstaged = createMemo(() => {
+              const entry = gitEntry()
+              if (!entry)
+                return false
+              return entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
+                && entry.unstagedStatus !== GitFileStatusCode.UNSPECIFIED
+            })
             return (
               <div class={styles.tilePane} classList={{ [styles.tilePaneHidden]: fileTab()?.id !== ft.id }}>
                 <FileViewer
                   workerId={ft.workerId ?? ''}
                   filePath={ft.filePath ?? ''}
+                  rootPath={getMruAgentContext().workingDir}
+                  homeDir={getMruAgentContext().homeDir}
                   displayMode={ft.displayMode}
                   onDisplayModeChange={mode => tabStore.setTabDisplayMode(ft.type, ft.id, mode)}
                   onQuote={isActiveWorkspaceArchived()
@@ -683,16 +697,8 @@ export function createTileRenderer(opts: TileRendererOpts) {
                       }}
                   fileViewMode={ft.fileViewMode}
                   fileDiffBase={ft.fileDiffBase}
-                  hasStagedAndUnstaged={(() => {
-                    const store = gitFileStatusStore
-                    if (!store)
-                      return false
-                    const entry = store.getFileStatus(ft.filePath ?? '')
-                    if (!entry)
-                      return false
-                    return entry.stagedStatus !== GitFileStatusCode.UNSPECIFIED
-                      && entry.unstagedStatus !== GitFileStatusCode.UNSPECIFIED
-                  })()}
+                  gitFileStatus={gitEntry()}
+                  hasStagedAndUnstaged={hasStagedAndUnstaged()}
                   onFileViewModeChange={mode => tabStore.setTabFileViewMode(ft.type, ft.id, mode)}
                   onFileDiffBaseChange={base => tabStore.setTabFileDiffBase(ft.type, ft.id, base)}
                 />

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -48,6 +48,8 @@ export interface SectionDefContext {
   onTabClick?: (type: number, id: string) => void
   tabItemOps?: TabItemOps
   onExpandWorkspace?: (workspaceId: string) => void
+  /** Tile ids in top-left-first traversal order for `workspaceId`. */
+  getTileOrderForWorkspace?: (workspaceId: string) => string[]
 
   // Files section
   workerId: string
@@ -153,6 +155,7 @@ export function buildSectionDef(
           activeTabKey={ctx.tabStore?.state.activeTabKey ?? null}
           getTabsForWorkspace={(wsId: string) => ctx.registry?.get(wsId)?.tabs ?? []}
           getActiveTabKeyForWorkspace={(wsId: string) => ctx.registry?.get(wsId)?.activeTabKey ?? null}
+          getTileOrderForWorkspace={(wsId: string) => ctx.getTileOrderForWorkspace?.(wsId) ?? []}
           onTabClick={ctx.onTabClick ?? (() => {})}
           tabItemOps={ctx.tabItemOps}
           onExpandWorkspace={ctx.onExpandWorkspace}

--- a/frontend/src/components/shell/syncGitStatusToTabs.ts
+++ b/frontend/src/components/shell/syncGitStatusToTabs.ts
@@ -1,7 +1,7 @@
 import type { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
 import type { createTabStore } from '~/stores/tab.store'
 import type { Tab } from '~/stores/tab.types'
-import { createEffect, untrack } from 'solid-js'
+import { createEffect, createMemo, untrack } from 'solid-js'
 import { GitFileStatusCode } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { detectFlavor, relativeUnder } from '~/lib/paths'
@@ -23,20 +23,58 @@ export interface SyncGitStatusToTabsOpts {
  * `diffStatsFromTabFields`, which is why this is a write-back effect
  * rather than a derived selector.
  *
- * Reads from `tabStore` are wrapped in `untrack` so the effect only
- * re-runs when the git store changes — re-running on workspace switch
- * would apply stale git data from the previous workspace.
+ * The effect re-runs on two distinct triggers:
+ *   1. Git store updates (refresh completed, or repo state changed).
+ *   2. A new tab appears that hasn't been stamped yet — covered by the
+ *      `unstampedTabsSignature` memo below. Without this, opening a file
+ *      in the already-focused repo leaves the new FILE tab ungrouped
+ *      because the store state doesn't change (same files, same branch)
+ *      so the store-driven trigger never fires.
+ *
+ * The signature memo only changes when the SET of tabs-needing-stamping
+ * actually changes, so unrelated tab mutations (drag, rename, status
+ * update) don't re-walk the tab list.
+ *
+ * Workspace-switch stale-data note: a workspace switch swaps the tab
+ * list synchronously but `gitFileStatusStore.refresh()` is async, so
+ * briefly the store still reflects the previous workspace. The
+ * containment check (`relativeUnder(containmentPath, repoRoot)`)
+ * filters out tabs whose paths don't sit under the old repoRoot, which
+ * covers the common case. A pathological setup where two workspaces
+ * share overlapping file paths could still see a brief mis-stamp before
+ * the refresh resolves and re-runs the effect with correct data.
  *
  * Must be called inside a SolidJS reactive root (component body or
  * `createRoot`).
  */
 export function syncGitStatusToTabs(opts: SyncGitStatusToTabsOpts): void {
   const { gitFileStatusStore, tabStore } = opts
+
+  // Fingerprint that changes when a tab whose git stamp may need
+  // (re)computing is added/removed/identity-shifted. Includes the
+  // fields the effect actually reads for the containment + already-
+  // stamped checks, so a drag/rename/status update doesn't churn it.
+  const unstampedTabsSignature = createMemo(() => {
+    const parts: string[] = []
+    for (const tab of tabStore.state.tabs) {
+      const containmentPath = tab.workingDir
+        ?? (tab.type === TabType.FILE ? tab.filePath : undefined)
+      if (!containmentPath)
+        continue
+      parts.push(`${tab.type}\0${tab.id}\0${containmentPath}\0${tab.gitToplevel ?? ''}`)
+    }
+    parts.sort()
+    return parts.join('\n')
+  })
+
   createEffect(() => {
     const files = gitFileStatusStore.state.files
     const repoRoot = gitFileStatusStore.state.repoRoot
     const originUrl = gitFileStatusStore.state.originUrl
     const currentBranch = gitFileStatusStore.state.currentBranch
+    // Track the unstamped-tabs signature so the effect fires when a new
+    // tab appears even if the git store state hasn't changed.
+    void unstampedTabsSignature()
     if (!repoRoot)
       return
     let added = 0
@@ -72,12 +110,19 @@ export function syncGitStatusToTabs(opts: SyncGitStatusToTabsOpts): void {
     // time; with many tabs and many matches that becomes O(N·K).
     const targetKeys = new Set<string>()
     for (const tab of untrack(() => tabStore.state.tabs)) {
-      let workingDir: string | undefined
-      if (tab.type === TabType.AGENT || tab.type === TabType.TERMINAL)
-        workingDir = tab.workingDir
-      else
-        continue
-      if (!workingDir)
+      // Path used for the containment-against-repoRoot check. AGENT
+      // and TERMINAL tabs carry `workingDir`. FILE tabs created in the
+      // live session also carry it (set by `useTabOperations.openFile`),
+      // but tabs restored after a refresh come back with only
+      // `filePath` filled in by the path hydrator — the CRDT projection
+      // doesn't carry `workingDir` and the hydrator doesn't set it.
+      // `filePath` works as a stand-in here because `relativeUnder`
+      // just answers "is X under Y?" — a file under the repo root and
+      // a directory under the repo root are equally valid signals that
+      // the tab belongs to the repo.
+      const containmentPath = tab.workingDir
+        ?? (tab.type === TabType.FILE ? tab.filePath : undefined)
+      if (!containmentPath)
         continue
       // Once a tab has its own gitToplevel, that's the authoritative repo
       // identity — only stamp when it exactly matches the focused repo.
@@ -90,9 +135,9 @@ export function syncGitStatusToTabs(opts: SyncGitStatusToTabsOpts): void {
           continue
       }
       // First-sync fallback for tabs that haven't learned their toplevel
-      // yet — the workingDir-under-repoRoot check is the best we can do
-      // until the next refresh stamps gitToplevel from above.
-      else if (relativeUnder(workingDir, repoRoot, rootFlavor) === null) {
+      // yet — the path-under-repoRoot check is the best we can do until
+      // the next refresh stamps gitToplevel from above.
+      else if (relativeUnder(containmentPath, repoRoot, rootFlavor) === null) {
         continue
       }
       if (tabAlreadyMatches(tab))

--- a/frontend/src/components/shell/useOpsSubmitter.ts
+++ b/frontend/src/components/shell/useOpsSubmitter.ts
@@ -4,6 +4,7 @@ import { onCleanup } from 'solid-js'
 import { orgCRDTClient } from '~/api/clients'
 import { showWarnToast } from '~/components/common/Toast'
 import { BatchRejectionReason } from '~/generated/leapmux/v1/org_ops_pb'
+import { createExponentialBackoff } from '~/lib/retry'
 
 /**
  * SUBMIT_FLUSH_MS is the aggregator window — every queued batch
@@ -81,6 +82,17 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
   // Per-batch transport-retry counter. Cleared on commit / non-
   // transport rejection / cap hit.
   const transportRetries = new Map<string, number>()
+  // Per-batch transport backoff. Each batchId carries its own delay
+  // sequence (100ms → 200 → 400 → 800 → 1600 → 2000), reset on commit
+  // or non-transport rejection. Repeated failures of the same batch
+  // within its pending timer window are no-ops — schedule's
+  // already-pending guard handles that.
+  const transportBackoff = createExponentialBackoff<string>({
+    initialMs: 100,
+    maxMs: 2000,
+    multiplier: 2,
+    jitterFactor: 0,
+  })
 
   function enqueue(batch: OpBatch): void {
     queue.push(batch)
@@ -93,6 +105,7 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
 
   function dropTransportRetryCounter(batchId: string): void {
     transportRetries.delete(batchId)
+    transportBackoff.reset(batchId)
   }
 
   // Re-enqueue a batch under the same id+ops for a retry. The pending
@@ -189,11 +202,10 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
   }
 
   function handleTransportFailure(pending: PendingOpsManager, batches: OpBatch[], err: unknown): void {
-    const retryable: OpBatch[] = []
     for (const batch of batches) {
       const attempts = (transportRetries.get(batch.batchId) ?? 0) + 1
       if (attempts > MAX_TRANSPORT_RETRIES) {
-        transportRetries.delete(batch.batchId)
+        dropTransportRetryCounter(batch.batchId)
         // Give up. Drop the batch — the speculative state stays
         // because we never received an authoritative answer; the user
         // can re-issue manually. Surface a toast so the failure isn't
@@ -203,21 +215,19 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
         continue
       }
       transportRetries.set(batch.batchId, attempts)
-      retryable.push(batch)
-    }
-    if (retryable.length > 0) {
-      // Use exponential backoff with a low ceiling so a transient
-      // network blip doesn't tight-loop. attempts==1 → 100ms,
-      // attempts==5 → ~1.6s.
-      const maxAttempts = Math.max(...retryable.map(b => transportRetries.get(b.batchId) ?? 1))
-      const delay = Math.min(2000, 100 * 2 ** (maxAttempts - 1))
-      setTimeout(() => rescheduleForWireRetry(retryable.map(cloneBatch)), delay)
+      // Per-batch backoff timer. `schedule` no-ops if this batchId
+      // already has a pending retry — the existing timer will fire
+      // and re-enqueue, no work lost.
+      transportBackoff.schedule(batch.batchId, () => {
+        rescheduleForWireRetry([cloneBatch(batch)])
+      })
     }
   }
 
   onCleanup(() => {
     if (timer)
       clearTimeout(timer)
+    transportBackoff.cancelAll()
   })
 
   return {

--- a/frontend/src/components/shell/useSidebarCore.tsx
+++ b/frontend/src/components/shell/useSidebarCore.tsx
@@ -81,6 +81,8 @@ export interface SidebarCommonProps {
   onTabClick?: (type: number, id: string) => void
   tabItemOps?: TabItemOps
   onExpandWorkspace?: (workspaceId: string) => void
+  /** Tile ids in top-left-first traversal order for `workspaceId`. */
+  getTileOrderForWorkspace?: (workspaceId: string) => string[]
 
   // Workers
   workers: Worker[]
@@ -175,6 +177,7 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
     get onTabClick() { return props.onTabClick },
     get tabItemOps() { return props.tabItemOps },
     get onExpandWorkspace() { return props.onExpandWorkspace },
+    get getTileOrderForWorkspace() { return props.getTileOrderForWorkspace },
     get workerId() { return props.workerId },
     get workingDir() { return props.workingDir },
     get homeDir() { return props.homeDir },

--- a/frontend/src/components/shell/useTabHydrators.ts
+++ b/frontend/src/components/shell/useTabHydrators.ts
@@ -1,9 +1,10 @@
 import type { createFileTabPathsStore } from '~/lib/fileTabPaths'
 import type { createTabStore } from '~/stores/tab.store'
-import { createEffect, createMemo } from 'solid-js'
+import { createEffect, createMemo, onCleanup } from 'solid-js'
 import { getFileTabPath, listAgents, listTerminals } from '~/api/workerRpc'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { protoToAgentTabFields, protoToTerminalTabFields } from '~/stores/tab.helpers'
+import { createExponentialBackoff } from '~/lib/retry'
+import { protoToAgentTabFields, protoToTerminalTabFields, tabKey } from '~/stores/tab.helpers'
 
 /**
  * Per-tab-type hydration of CRDT-projected tabs that arrived without
@@ -29,12 +30,39 @@ export interface UseTabHydratorsOpts {
 export function useTabHydrators(opts: UseTabHydratorsOpts): void {
   type Tab = (typeof opts.tabStore.state.tabs)[number]
 
-  function createTabHydration(spec: {
+  interface BaseSpec {
     predicate: (tab: Tab) => boolean
-    fetch: (tab: Tab) => Promise<void>
     precondition?: () => boolean
-  }): void {
+  }
+  /** Per-tab fetch. One RPC per candidate. */
+  interface PerTabSpec extends BaseSpec {
+    kind: 'per-tab'
+    fetch: (tab: Tab) => Promise<void>
+  }
+  /**
+   * Batched fetch: receives all same-worker candidates in one call so
+   * one RPC per worker hydrates N tabs instead of N RPCs. The
+   * predicate must require `tab.workerId` to be non-empty (a tab with
+   * no workerId can't be batch-fetched and is filtered out before
+   * dispatch).
+   */
+  interface BatchedSpec extends BaseSpec {
+    kind: 'batched'
+    fetchBatch: (workerId: string, tabs: Tab[]) => Promise<void>
+  }
+  type HydrationSpec = PerTabSpec | BatchedSpec
+
+  function createTabHydration(spec: HydrationSpec): void {
     const inflight = new Set<string>()
+    // Per-tab retry: a single RPC failure (e.g. worker channel still
+    // handshaking after a page refresh) would otherwise leave the tab
+    // in its bare CRDT state indefinitely — the candidate set hasn't
+    // changed, so the effect below never re-fires. The retry kicks
+    // off another attempt; we eventually succeed once the worker is
+    // reachable.
+    const retry = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    onCleanup(() => retry.cancelAll())
+
     // candidates carries the per-tab refs alongside the membership hash
     // so the dispatch effect doesn't walk state.tabs a second time just
     // to redo the predicate. The structural-equality `equals` on hash
@@ -52,19 +80,101 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
       ids.sort()
       return { hash: ids.join(' '), candidates }
     }, { hash: '', candidates: [] }, { equals: (a, b) => a.hash === b.hash })
+
+    function schedulePerTabRetry(tab: Tab): void {
+      const tabId = tab.id
+      const key = tabKey(tab)
+      retry.schedule(tabId, () => {
+        const stillPending = opts.tabStore.getTabByKey(key)
+        if (!stillPending || !spec.predicate(stillPending)) {
+          // Tab is gone (closed by user, removed by another client,
+          // or hydrated by another path). Drop the per-tab delay so
+          // the Map doesn't accumulate ghost entries.
+          retry.reset(tabId)
+          return
+        }
+        runFor(stillPending)
+      })
+    }
+
+    // Worker-keyed retry for batched specs: one timer re-batches every
+    // still-pending tab on that worker the next time it fires, instead
+    // of N separate single-tab batch RPCs (which would defeat the
+    // batching the spec was designed for).
+    function scheduleBatchRetry(workerId: string): void {
+      retry.schedule(workerId, () => {
+        if (spec.kind !== 'batched')
+          return
+        const stillPending: Tab[] = []
+        for (const tab of opts.tabStore.state.tabs) {
+          if (tab.workerId === workerId && spec.predicate(tab))
+            stillPending.push(tab)
+        }
+        if (stillPending.length === 0) {
+          retry.reset(workerId)
+          return
+        }
+        runForBatch(workerId, stillPending)
+      })
+    }
+
+    function runFor(tab: Tab): void {
+      if (spec.kind !== 'per-tab')
+        return
+      if (inflight.has(tab.id))
+        return
+      inflight.add(tab.id)
+      const tabId = tab.id
+      spec.fetch(tab)
+        .then(() => retry.reset(tabId))
+        .catch(() => schedulePerTabRetry(tab))
+        .finally(() => inflight.delete(tabId))
+    }
+
+    function runForBatch(workerId: string, tabs: Tab[]): void {
+      if (spec.kind !== 'batched')
+        return
+      const fresh = tabs.filter(t => !inflight.has(t.id))
+      if (fresh.length === 0)
+        return
+      for (const t of fresh)
+        inflight.add(t.id)
+      spec.fetchBatch(workerId, fresh)
+        .then(() => retry.reset(workerId))
+        .catch(() => scheduleBatchRetry(workerId))
+        .finally(() => {
+          for (const t of fresh)
+            inflight.delete(t.id)
+        })
+    }
+
     createEffect(() => {
       if (spec.precondition && !spec.precondition())
         return
       const { candidates } = matches()
-      for (const tab of candidates) {
-        if (inflight.has(tab.id))
-          continue
-        inflight.add(tab.id)
-        const tabId = tab.id
-        spec.fetch(tab)
-          .catch(() => { /* hydration is best-effort; will retry on next state mutation */ })
-          .finally(() => inflight.delete(tabId))
+      if (spec.kind === 'batched') {
+        // Group by workerId so one RPC hydrates N same-worker tabs.
+        // Predicates for batched hydrators require a non-empty
+        // workerId, so candidates without one are filtered upstream;
+        // the explicit check here narrows the type for TypeScript.
+        const byWorker = new Map<string, Tab[]>()
+        for (const tab of candidates) {
+          const wid = tab.workerId
+          if (!wid)
+            continue
+          let group = byWorker.get(wid)
+          if (!group) {
+            group = []
+            byWorker.set(wid, group)
+          }
+          group.push(tab)
+        }
+        for (const [wid, group] of byWorker)
+          runForBatch(wid, group)
+        return
       }
+      for (const tab of candidates)
+        runFor(tab)
     })
   }
 
@@ -74,6 +184,7 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
   // stream has finished its bootstrap, we issue a one-shot
   // GetFileTabPath so the title renders without a perceptible delay.
   createTabHydration({
+    kind: 'per-tab',
     precondition: () => Boolean(opts.getOrgId()),
     predicate: tab => tab.type === TabType.FILE && !tab.filePath && Boolean(tab.workerId) && !opts.fileTabPaths.pathFor(tab.id),
     fetch: async (tab) => {
@@ -91,19 +202,24 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
   // OpenAgent response (e.g. another browser tab, or the
   // `leapmux remote tab open` CLI). Without this, AGENT tabs render as
   // "Agent not found." because the tab carries only the CRDT-driven
-  // tile/position/worker fields.
+  // tile/position/worker fields. Batched per worker so opening a
+  // workspace with N agents on the same worker costs one ListAgents
+  // call instead of N.
   createTabHydration({
+    kind: 'batched',
     predicate: tab => tab.type === TabType.AGENT && Boolean(tab.workerId) && tab.agentStatus === undefined,
-    fetch: async (tab) => {
-      if (!tab.workerId)
-        return
-      const resp = await listAgents(tab.workerId, { tabIds: [tab.id] })
-      const agent = resp.agents.find(a => a.id === tab.id)
-      if (!agent)
-        return
-      // protoToAgentTabFields writes every per-agent field onto the
-      // tab and primes `settingsLabelCache` with the agent's catalogs.
-      opts.tabStore.updateTab(TabType.AGENT, tab.id, protoToAgentTabFields(tab.workerId, agent))
+    fetchBatch: async (workerId, tabs) => {
+      const tabIds = tabs.map(t => t.id)
+      const resp = await listAgents(workerId, { tabIds })
+      const byId = new Map(resp.agents.map(a => [a.id, a]))
+      for (const tab of tabs) {
+        const agent = byId.get(tab.id)
+        if (!agent)
+          continue
+        // protoToAgentTabFields writes every per-agent field onto the
+        // tab and primes `settingsLabelCache` with the agent's catalogs.
+        opts.tabStore.updateTab(TabType.AGENT, tab.id, protoToAgentTabFields(workerId, agent))
+      }
     },
   })
 
@@ -112,16 +228,19 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
   // empty title as "not hydrated yet" — workspace restore goes through
   // `protoToTerminalTab` which always populates title (or a fallback),
   // so the only path that leaves it empty is the CRDT-projection-only
-  // path this hydrator covers.
+  // path this hydrator covers. Batched per worker (see AGENT).
   createTabHydration({
+    kind: 'batched',
     predicate: tab => tab.type === TabType.TERMINAL && Boolean(tab.workerId) && !tab.title,
-    fetch: async (tab) => {
-      if (!tab.workerId)
-        return
-      const resp = await listTerminals(tab.workerId, { tabIds: [tab.id] })
-      const term = resp.terminals.find(t => t.terminalId === tab.id)
-      if (term)
-        opts.tabStore.updateTab(TabType.TERMINAL, tab.id, protoToTerminalTabFields(tab.workerId, term))
+    fetchBatch: async (workerId, tabs) => {
+      const tabIds = tabs.map(t => t.id)
+      const resp = await listTerminals(workerId, { tabIds })
+      const byId = new Map(resp.terminals.map(t => [t.terminalId, t]))
+      for (const tab of tabs) {
+        const term = byId.get(tab.id)
+        if (term)
+          opts.tabStore.updateTab(TabType.TERMINAL, tab.id, protoToTerminalTabFields(workerId, term))
+      }
     },
   })
 }

--- a/frontend/src/components/shell/useTileDragDrop.tsx
+++ b/frontend/src/components/shell/useTileDragDrop.tsx
@@ -1,10 +1,8 @@
 import type { FloatingWindowStoreType } from '~/stores/floatingWindow.store'
 import type { createLayoutStore } from '~/stores/layout.store'
 import type { createTabStore } from '~/stores/tab.store'
-import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { positionAtInsertIdx } from '~/lib/lexorank'
-import { basename } from '~/lib/paths'
-import { tabKey } from '~/stores/tab.helpers'
+import { tabDisplayLabel, tabKey } from '~/stores/tab.helpers'
 import * as styles from './AppShell.css'
 import { useTileMove } from './useTileMove'
 
@@ -55,23 +53,13 @@ export function useTileDragDrop(opts: UseTileDragDropOpts) {
     return tabStore.getTabByKey(key)?.tileId
   }
 
-  const dragLabelFor = (tab: { title?: string, type: TabType, filePath?: string }): string => {
-    if (tab.title)
-      return tab.title
-    if (tab.type === TabType.AGENT)
-      return 'Agent'
-    if (tab.type === TabType.FILE)
-      return (tab.filePath && basename(tab.filePath)) || 'File'
-    return 'Terminal'
-  }
-
   const renderDragOverlay = (key: string) => {
     const tab = tabStore.getTabByKey(key)
     if (!tab)
       return <></>
     return (
       <div class={styles.dragPreviewTooltip}>
-        <span>{dragLabelFor(tab)}</span>
+        <span>{tabDisplayLabel(tab)}</span>
       </div>
     )
   }

--- a/frontend/src/components/shell/useWorkspaceRestore.ts
+++ b/frontend/src/components/shell/useWorkspaceRestore.ts
@@ -16,6 +16,7 @@ import { getCRDTBridge } from '~/lib/crdt/bridge'
 import { hlcIsZero } from '~/lib/crdt/hlc'
 import { createInflightCache } from '~/lib/inflightCache'
 import { createLogger } from '~/lib/logger'
+import { createExponentialBackoff } from '~/lib/retry'
 import { agentTabToInfo, parseTabKey, preserveNonEmptyGitFields, preserveTerminalDisplayFields, protoToAgentTabFields, protoToTerminalTab, protoToTerminalTabFields, tabKey, tabsByKey } from '~/stores/tab.helpers'
 import { activeTabKey, focusedTileKey, tileActiveTabsKey } from './tabPersistenceKeys'
 import { fanOutTabsToWorkers } from './workspaceTabHydration'
@@ -303,27 +304,17 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
   let loadGeneration = 0
   const [terminalHydrationTick, setTerminalHydrationTick] = createSignal(0)
   const terminalHydrationInflight = createInflightCache<string, void>()
-  const terminalHydrationRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  const terminalHydrationRetryDelayMs = new Map<string, number>()
+  // Per-worker retry: the hydration effect won't re-fire on its own
+  // until either the candidate map changes or the tick signal is
+  // bumped. The retry's `fire` callback bumps the tick so the effect
+  // walks the same candidates again — that's what keeps a transiently-
+  // unreachable worker eventually getting hydrated.
+  const terminalHydrationRetry = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
 
-  const clearTerminalHydrationRetry = (workerId: string) => {
-    const timer = terminalHydrationRetryTimers.get(workerId)
-    if (timer) {
-      clearTimeout(timer)
-      terminalHydrationRetryTimers.delete(workerId)
-    }
-  }
+  const clearTerminalHydrationRetry = (workerId: string) => terminalHydrationRetry.reset(workerId)
 
   const scheduleTerminalHydrationRetry = (workerId: string) => {
-    if (terminalHydrationRetryTimers.has(workerId))
-      return
-    const nextDelay = Math.min((terminalHydrationRetryDelayMs.get(workerId) ?? 500) * 2, 10_000)
-    terminalHydrationRetryDelayMs.set(workerId, nextDelay)
-    const timer = setTimeout(() => {
-      terminalHydrationRetryTimers.delete(workerId)
-      setTerminalHydrationTick(v => v + 1)
-    }, nextDelay)
-    terminalHydrationRetryTimers.set(workerId, timer)
+    terminalHydrationRetry.schedule(workerId, () => setTerminalHydrationTick(v => v + 1))
   }
 
   const hydrateTerminalRecord = (workerId: string, term: Awaited<ReturnType<typeof workerRpc.listTerminals>>['terminals'][number]) => {
@@ -341,11 +332,7 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
     )
   }
 
-  onCleanup(() => {
-    for (const workerId of terminalHydrationRetryTimers.keys()) {
-      clearTerminalHydrationRetry(workerId)
-    }
-  })
+  onCleanup(() => terminalHydrationRetry.cancelAll())
 
   createEffect(on([getActiveWorkspaceId, getOrgId], ([activeId, currentOrgId]) => {
     if (!activeId || !currentOrgId)
@@ -492,7 +479,17 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
       // its full metadata, so the reconciler's next pass sees no
       // missing tabs and stays quiet.
       batch(() => {
-        tabStore.clear()
+        // Tab clearing happens once, at the top of the non-cached
+        // branch (outgoing-workspace cleanup). Here we keep the store
+        // intact so the CRDT-projection reconciler (`AppShell`'s effect
+        // on `pendingVersion`) and the file-tab path hydrator
+        // (`useTabHydrators`) can pre-populate tabs during this
+        // restore's awaits. Clearing inside this branch would wipe
+        // those entries, after which `mergeHubOnlyTabs` would re-add
+        // file tabs with no `filePath` and the hydrator's
+        // `fileTabPaths.pathFor` guard would suppress re-fetching. The
+        // hydration phases below use `preExistingKeys` to merge worker
+        // metadata onto reconciler-added tabs without removing them.
 
         // Layout / floating-windows hydration is fully driven by the
         // CRDT projection now. The store's `state.root` is a memo over
@@ -604,11 +601,26 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
     { equals: missingMapsEqual },
   )
 
+  // Workers seen on the previous effect run. When a worker disappears
+  // from the missing-tabs map (workspace switched, worker disconnected,
+  // its tabs finished hydrating), we reset its retry slot so a future
+  // failure on the same worker id restarts the backoff at `initialMs`
+  // instead of resuming mid-sequence. `cancelAll()` on unmount handles
+  // the per-mount cleanup; this guards the per-run case.
+  let prevHydrationWorkers: Set<string> = new Set()
+
   createEffect(
     on([terminalHydrationTick, tabsNeedingHydration], ([_, missingByWorker]) => {
       const activeId = getActiveWorkspaceId()
       if (!activeId)
         return
+
+      const currentWorkers = new Set(missingByWorker.keys())
+      for (const w of prevHydrationWorkers) {
+        if (!currentWorkers.has(w))
+          terminalHydrationRetry.reset(w)
+      }
+      prevHydrationWorkers = currentWorkers
 
       for (const [workerId, tabIds] of missingByWorker.entries()) {
         if (terminalHydrationInflight.has(workerId))
@@ -631,7 +643,6 @@ export function useWorkspaceRestore(opts: UseWorkspaceRestoreOpts) {
             }
             else {
               clearTerminalHydrationRetry(workerId)
-              terminalHydrationRetryDelayMs.delete(workerId)
             }
           }
           catch (err) {

--- a/frontend/src/components/tree/DirectoryTree.download.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.download.test.tsx
@@ -1,0 +1,107 @@
+import type { SaveActionsSpies } from '../../../tests/unit/helpers/saveActionsMocks'
+import { render, screen, waitFor, within } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fileDownloadMock,
+  platformBridgeMock,
+  preferencesMock,
+  resetSaveActionsSpies,
+  toastMock,
+} from '../../../tests/unit/helpers/saveActionsMocks'
+
+// Tree-specific assertions: DirectoryTree wires FileActionsMenu in with
+// the `tree` test-id prefix and only shows the file-only items for non-
+// directory rows. The full save-action behavior matrix (web vs desktop,
+// reveal-after-download, save-as cancellation, etc.) is covered by
+// FileActionsMenu.test.tsx — this file would just duplicate that work.
+
+const spies = vi.hoisted<SaveActionsSpies>(() => ({
+  downloadImpl: vi.fn(),
+  saveAsImpl: vi.fn(),
+  saveToDownloadsImpl: vi.fn(),
+  revealImpl: vi.fn(),
+  warnToastImpl: vi.fn(),
+  revealAfterDownloadImpl: vi.fn(() => true),
+  isTauriAppImpl: vi.fn(() => false),
+}))
+
+const listDirectoryImpl = vi.hoisted(() => vi.fn())
+
+vi.mock('~/api/workerRpc', () => ({
+  listDirectory: (...args: unknown[]) => listDirectoryImpl(...args),
+  channelManager: { subscribe: () => () => {} },
+}))
+vi.mock('~/api/platformBridge', () => platformBridgeMock(spies))
+vi.mock('~/lib/fileDownload', () => fileDownloadMock(spies))
+vi.mock('~/components/common/Toast', () => toastMock(spies))
+vi.mock('~/context/PreferencesContext', () => preferencesMock(spies))
+
+const { DirectoryTree } = await import('./DirectoryTree')
+
+function setupTree() {
+  listDirectoryImpl.mockResolvedValue({
+    entries: [
+      { path: '/repo/src', name: 'src', isDir: true, hidden: false },
+      { path: '/repo/archive.zip', name: 'archive.zip', isDir: false, hidden: false },
+    ],
+    truncated: false,
+  })
+
+  render(() => (
+    <DirectoryTree
+      workerId="w1"
+      selectedPath="/repo"
+      rootPath="/repo"
+      homeDir="/home/alice"
+      onSelect={() => {}}
+      showFiles
+    />
+  ))
+}
+
+async function findRowByText(text: string): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const rows = screen.getAllByTestId('tree-row')
+    const row = rows.find(r => r.textContent?.includes(text))
+    if (!row)
+      throw new Error(`row with text "${text}" not found`)
+    return row
+  })
+}
+
+beforeEach(() => {
+  listDirectoryImpl.mockReset()
+  resetSaveActionsSpies(spies)
+})
+
+describe('directoryTree context menu — web', () => {
+  it('renders the Download item for files but not directories', async () => {
+    setupTree()
+    const fileRow = await findRowByText('archive.zip')
+    expect(within(fileRow).queryByTestId('tree-download-button')).toBeInTheDocument()
+
+    const dirRow = await findRowByText('src')
+    expect(within(dirRow).queryByTestId('tree-download-button')).not.toBeInTheDocument()
+    // Sanity: the menu rendered for the dir row too (common items present).
+    expect(within(dirRow).queryByTestId('tree-copy-path-button')).toBeInTheDocument()
+  })
+})
+
+describe('directoryTree context menu — desktop', () => {
+  beforeEach(() => {
+    spies.isTauriAppImpl.mockReturnValue(true)
+  })
+
+  it('renders Save as / Save to Downloads for files and neither for directories', async () => {
+    setupTree()
+    const fileRow = await findRowByText('archive.zip')
+    expect(within(fileRow).queryByTestId('tree-save-as-button')).toBeInTheDocument()
+    expect(within(fileRow).queryByTestId('tree-save-to-downloads-button')).toBeInTheDocument()
+    expect(within(fileRow).queryByTestId('tree-download-button')).not.toBeInTheDocument()
+
+    const dirRow = await findRowByText('src')
+    expect(within(dirRow).queryByTestId('tree-save-as-button')).not.toBeInTheDocument()
+    expect(within(dirRow).queryByTestId('tree-save-to-downloads-button')).not.toBeInTheDocument()
+    expect(within(dirRow).queryByTestId('tree-download-button')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -2,24 +2,18 @@ import type { Component } from 'solid-js'
 import type { FileInfo } from '~/generated/leapmux/v1/file_pb'
 import type { PathFlavor } from '~/lib/paths'
 import type { createGitFileStatusStore, DiffStats } from '~/stores/gitFileStatus.store'
-import AtSign from 'lucide-solid/icons/at-sign'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
-import ClipboardCopy from 'lucide-solid/icons/clipboard-copy'
-import Copy from 'lucide-solid/icons/copy'
 import File from 'lucide-solid/icons/file'
 import FolderClosed from 'lucide-solid/icons/folder-closed'
 import FolderOpen from 'lucide-solid/icons/folder-open'
-import MoreHorizontal from 'lucide-solid/icons/more-horizontal'
-import TerminalIcon from 'lucide-solid/icons/terminal'
 import { createContext, createEffect, createMemo, createSignal, For, Match, on, onCleanup, onMount, Show, Switch, useContext } from 'solid-js'
 import { createStore, produce } from 'solid-js/store'
 import * as workerRpc from '~/api/workerRpc'
-import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { FileActionsMenu } from '~/components/common/FileActionsMenu'
 import { Icon } from '~/components/common/Icon'
-import { IconButton } from '~/components/common/IconButton'
 import { StartupSpinner } from '~/components/common/StartupPanel'
 import { Tooltip } from '~/components/common/Tooltip'
-import { basename, detectFlavor, isAbsolute, lastSepIndex, relativeUnder, relativizePath, tildify, untildify } from '~/lib/paths'
+import { basename, detectFlavor, isAbsolute, lastSepIndex, relativeUnder, tildify, untildify } from '~/lib/paths'
 import { emptyState } from '~/styles/shared.css'
 import * as styles from './DirectoryTree.css'
 import { getGitFileIconClass, RowLabelWithStats } from './gitStatusUtils'
@@ -214,71 +208,20 @@ const TreeContextMenu: Component<{
   isDir: boolean
 }> = (props) => {
   const tree = useTree()
-
   return (
-    <DropdownMenu
-      trigger={triggerProps => (
-        <IconButton
-          icon={MoreHorizontal}
-          iconSize="sm"
-          size="sm"
-          class={menuTrigger}
-          onClick={(e: MouseEvent) => {
-            e.stopPropagation()
-            triggerProps.onClick()
-          }}
-          ref={triggerProps.ref}
-          onPointerDown={(e: PointerEvent) => {
-            e.stopPropagation()
-            triggerProps.onPointerDown()
-          }}
-          aria-expanded={triggerProps['aria-expanded']}
-          data-testid="tree-context-button"
-        />
-      )}
-    >
-      <Show when={tree.onMention}>
-        <button
-          role="menuitem"
-          data-testid="tree-mention-button"
-          onClick={() => tree.onMention?.(props.path)}
-        >
-          <Icon icon={AtSign} size="sm" />
-          Mention in chat
-        </button>
-      </Show>
-      <Show when={props.isDir && tree.onOpenTerminal}>
-        <button
-          role="menuitem"
-          data-testid="tree-open-terminal-button"
-          onClick={() => tree.onOpenTerminal?.(props.path)}
-        >
-          <Icon icon={TerminalIcon} size="sm" />
-          Open a terminal tab here
-        </button>
-      </Show>
-      <button
-        role="menuitem"
-        data-testid="tree-copy-path-button"
-        onClick={() => navigator.clipboard.writeText(props.path)}
-      >
-        <Icon icon={Copy} size="sm" />
-        Copy path
-      </button>
-      <button
-        role="menuitem"
-        data-testid="tree-copy-relative-path-button"
-        onClick={() => {
-          const rel = props.path === tree.rootPath
-            ? '.'
-            : relativizePath(props.path, tree.rootPath, tree.homeDir, tree.flavor())
-          navigator.clipboard.writeText(rel)
-        }}
-      >
-        <Icon icon={ClipboardCopy} size="sm" />
-        Copy relative path
-      </button>
-    </DropdownMenu>
+    <FileActionsMenu
+      workerId={tree.workerId}
+      path={props.path}
+      flavor={tree.flavor()}
+      isDir={props.isDir}
+      rootPath={tree.rootPath}
+      homeDir={tree.homeDir}
+      onMention={tree.onMention}
+      onOpenTerminal={tree.onOpenTerminal}
+      triggerClass={menuTrigger}
+      triggerTestId="tree-context-button"
+      itemTestIdPrefix="tree"
+    />
   )
 }
 

--- a/frontend/src/components/tree/DirectoryTree.windows.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.windows.test.tsx
@@ -8,6 +8,22 @@ vi.mock('~/api/workerRpc', () => ({
   channelManager: { subscribe: () => () => {} },
 }))
 
+vi.mock('~/context/PreferencesContext', () => ({
+  usePreferences: () => ({
+    revealAfterDownload: () => false,
+    setRevealAfterDownload: () => {},
+  }),
+}))
+
+vi.mock('~/api/platformBridge', () => ({
+  isTauriApp: () => false,
+  platformBridge: {
+    revealInFileManager: () => Promise.resolve(),
+    saveBytesToDownloads: () => Promise.resolve(''),
+    saveBytesAs: () => Promise.resolve(null),
+  },
+}))
+
 function renderTree(props: {
   selectedPath: string
   homeDir: string

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -51,6 +51,14 @@ export interface WorkspaceSectionContentProps {
   activeTabKey: string | null
   getTabsForWorkspace: (workspaceId: string) => Tab[]
   getActiveTabKeyForWorkspace: (workspaceId: string) => string | null
+  /**
+   * Tile ids in their top-left-first traversal order for the given
+   * workspace. Drives the in-tree leaf ordering so it tracks the live
+   * tiling layout. Returns `[]` when the workspace's layout hasn't been
+   * loaded yet (cold registry); the tree falls back to position-only
+   * order in that case.
+   */
+  getTileOrderForWorkspace: (workspaceId: string) => string[]
   onTabClick: (type: TabType, id: string) => void
   tabItemOps?: TabItemOps
   readOnly?: boolean
@@ -302,6 +310,7 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                     <div class={shared.childrenInner}>
                       <WorkspaceTabTree
                         tabs={tabsFor(id)}
+                        tileOrder={props.getTileOrderForWorkspace(id)}
                         activeTabKey={activeTabKeyFor(id)}
                         onTabClick={(type, tabId) => {
                           if (id !== props.activeWorkspaceId) {

--- a/frontend/src/components/workspace/WorkspaceTabTree.test.ts
+++ b/frontend/src/components/workspace/WorkspaceTabTree.test.ts
@@ -100,14 +100,107 @@ describe('buildTree', () => {
     expect(tree.groups[1].repoLabel).toBe('github.com/org/repo2')
   })
 
-  it('sorts agents before terminals within a branch', () => {
+  it('sorts tabs by tile-layout order, then LexoRank position', () => {
+    // Visual layout: two tiles. `tile-A` is the top-left tile, `tile-B`
+    // sits to its right (top-left-first DFS order: A then B). Within
+    // each tile, LexoRank position drives left-to-right order in the
+    // tab bar.
     const tabs = [
-      makeTab({ id: 't1', type: TabType.TERMINAL, gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
-      makeTab({ id: 'a1', type: TabType.AGENT, gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      // Out-of-input-order on purpose; the sort must reorder them to
+      // match the visual layout.
+      makeTab({ id: 'b2', type: TabType.TERMINAL, tileId: 'tile-B', position: '0|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'a2', type: TabType.TERMINAL, tileId: 'tile-A', position: '1|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'b1', type: TabType.AGENT, tileId: 'tile-B', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'a1', type: TabType.AGENT, tileId: 'tile-A', position: '0|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+    ]
+    const tree = buildTree(tabs, ['tile-A', 'tile-B'])
+    expect(tree.groups[0].branches[0].tabs.map(t => t.id)).toEqual(['a1', 'a2', 'b1', 'b2'])
+  })
+
+  it('falls back to position-then-id order when no tile order is provided', () => {
+    // Without layout context (e.g. test harness, cold registry), every
+    // tab gets the same primary rank → sort by `position` then `id`.
+    const tabs = [
+      makeTab({ id: 'z', tileId: 'tile-1', position: '1|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'm', tileId: 'tile-1', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'a', tileId: 'tile-1', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
     ]
     const tree = buildTree(tabs)
-    expect(tree.groups[0].branches[0].tabs[0].type).toBe(TabType.AGENT)
-    expect(tree.groups[0].branches[0].tabs[1].type).toBe(TabType.TERMINAL)
+    // `a` and `m` share position '0'; id breaks the tie. `z` at
+    // position '1|' sorts after both.
+    expect(tree.groups[0].branches[0].tabs.map(t => t.id)).toEqual(['a', 'm', 'z'])
+  })
+
+  it('applies the tile-order sort to the ungrouped bucket too', () => {
+    // Non-git tabs (no origin/toplevel) land in `ungrouped`. They still
+    // need to track the visual layout — e.g. a terminal in the left
+    // tile should appear above a terminal in the right tile even when
+    // neither carries git metadata.
+    const tabs = [
+      makeTab({ id: 'right', type: TabType.TERMINAL, tileId: 'tile-B', position: '0|' }),
+      makeTab({ id: 'left', type: TabType.TERMINAL, tileId: 'tile-A', position: '0|' }),
+    ]
+    const tree = buildTree(tabs, ['tile-A', 'tile-B'])
+    expect(tree.groups).toHaveLength(0)
+    expect(tree.ungrouped.map(t => t.id)).toEqual(['left', 'right'])
+  })
+
+  it('orders tabs independently inside each branch of the same repo', () => {
+    // Two branches under the same remote, each containing tabs from
+    // both tiles. The sort must apply per-branch — branch A's order
+    // must not leak into branch B's.
+    const tabs = [
+      makeTab({ id: 'feat-B', tileId: 'tile-B', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'feature' }),
+      makeTab({ id: 'main-B', tileId: 'tile-B', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'feat-A', tileId: 'tile-A', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'feature' }),
+      makeTab({ id: 'main-A', tileId: 'tile-A', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+    ]
+    const tree = buildTree(tabs, ['tile-A', 'tile-B'])
+    const branches = tree.groups[0].branches
+    expect(branches.map(b => b.branchName)).toEqual(['feature', 'main'])
+    expect(branches[0].tabs.map(t => t.id)).toEqual(['feat-A', 'feat-B'])
+    expect(branches[1].tabs.map(t => t.id)).toEqual(['main-A', 'main-B'])
+  })
+
+  it('interleaves FILE tabs with AGENT / TERMINAL tabs by position within the same tile', () => {
+    // No type-based bucketing anymore — the layout's `position` is the
+    // single source of left-to-right order. A FILE tab opened between
+    // two agent tabs must show up between them.
+    const tabs = [
+      makeTab({ id: 'agent-right', type: TabType.AGENT, tileId: 'tile-A', position: '2', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'file', type: TabType.FILE, tileId: 'tile-A', position: '1', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'agent-left', type: TabType.AGENT, tileId: 'tile-A', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+    ]
+    const tree = buildTree(tabs, ['tile-A'])
+    expect(tree.groups[0].branches[0].tabs.map(t => t.id))
+      .toEqual(['agent-left', 'file', 'agent-right'])
+  })
+
+  it('tolerates an empty tileOrder for the active branch (legacy/test harness)', () => {
+    // Empty tileOrder ⇒ every tile gets the same Infinity rank, so the
+    // sort effectively becomes position-then-id. Real-world equivalent:
+    // a workspace whose layout hasn't been hydrated yet but whose tabs
+    // already arrived via the CRDT projection.
+    const tabs = [
+      makeTab({ id: 'b', tileId: 'tile-x', position: '1', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'a', tileId: 'tile-y', position: '0', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+    ]
+    const tree = buildTree(tabs, [])
+    // 'a' has earlier position, comes first; 'b' second — tile-x vs
+    // tile-y irrelevant under empty tileOrder.
+    expect(tree.groups[0].branches[0].tabs.map(t => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('sinks tabs with unknown tile ids to the end of their branch', () => {
+    // A tab whose `tileId` isn't in `tileOrder` (layout/registry race,
+    // or a never-assigned ghost) appears after every known-tile tab
+    // but stays grouped with other unknown-tile tabs by position/id.
+    const tabs = [
+      makeTab({ id: 'ghost', tileId: 'tile-gone', position: '0|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+      makeTab({ id: 'real', tileId: 'tile-A', position: '0|', gitOriginUrl: 'https://github.com/org/repo.git', gitBranch: 'main' }),
+    ]
+    const tree = buildTree(tabs, ['tile-A'])
+    expect(tree.groups[0].branches[0].tabs.map(t => t.id)).toEqual(['real', 'ghost'])
   })
 
   it('uses "(no branch)" for tabs without gitBranch', () => {

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -4,18 +4,17 @@ import { createDraggable } from '@thisbeyond/solid-dnd'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import FolderGit from 'lucide-solid/icons/folder-git'
 import GitBranch from 'lucide-solid/icons/git-branch'
-import Terminal from 'lucide-solid/icons/terminal'
 import X from 'lucide-solid/icons/x'
 import { createMemo, createSignal, For, Show } from 'solid-js'
-import { AgentProviderIcon } from '~/components/common/AgentProviderIcon'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { TabTypeIcon } from '~/components/common/TabTypeIcon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { SIDEBAR_TAB_PREFIX } from '~/components/shell/TabDragContext'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { basename } from '~/lib/paths'
 import { diffStatsFromTabFields } from '~/stores/gitFileStatus.store'
-import { canCloseTab, tabKey } from '~/stores/tab.helpers'
-import { isAgentTab, isTerminalTab } from '~/stores/tab.types'
+import { canCloseTab, tabDisplayLabel, tabKey } from '~/stores/tab.helpers'
+import { isTerminalTab } from '~/stores/tab.types'
 import { terminalStatusClassList } from '../shell/terminalStatus'
 import { RowLabelWithStats } from '../tree/gitStatusUtils'
 import * as shared from '../tree/sharedTree.css'
@@ -43,7 +42,7 @@ const TabLeaf: Component<{
   /* eslint-disable solid/reactivity -- stable identifier for createDraggable */
   const draggable = createDraggable(
     `${SIDEBAR_TAB_PREFIX}${props.workspaceId}:${props.tab.type}:${props.tab.id}`,
-    { title: props.tab.title || props.tab.id, type: props.tab.type },
+    { title: tabDisplayLabel(props.tab), type: props.tab.type },
   )
   /* eslint-enable solid/reactivity */
 
@@ -73,9 +72,7 @@ const TabLeaf: Component<{
       data-terminal-status={isTerminalTab(props.tab) ? props.tab.status : undefined}
     >
       <div class={shared.chevronPlaceholder} />
-      <Show when={isAgentTab(props.tab)} fallback={<Terminal size={14} class={css.tabIcon} />}>
-        <AgentProviderIcon provider={isAgentTab(props.tab) ? props.tab.agentProvider : undefined} size={14} class={css.tabIcon} />
-      </Show>
+      <TabTypeIcon tab={props.tab} class={css.tabIcon} />
       <Show
         when={!props.isEditing}
         fallback={(
@@ -105,12 +102,12 @@ const TabLeaf: Component<{
           />
         )}
       >
-        <Tooltip text={props.tab.title || props.tab.id} showWhen="clipped">
+        <Tooltip text={tabDisplayLabel(props.tab)} showWhen="clipped">
           <span
             class={css.tabLabel}
             classList={terminalStatusClassList(isTerminalTab(props.tab) ? props.tab.status : undefined)}
           >
-            {props.tab.title || props.tab.id}
+            {tabDisplayLabel(props.tab)}
           </span>
         </Tooltip>
       </Show>
@@ -146,10 +143,18 @@ export interface WorkspaceTabTreeProps {
   tabItemOps?: TabItemOps
   readOnly?: boolean
   workspaceId: string
+  /**
+   * Tile ids in their top-left-first traversal order of the workspace's
+   * layout tree. Drives the per-branch sort: leaves appear in the same
+   * order as their tiles do visually, ties broken by LexoRank `position`
+   * (the tab bar's left-to-right order). Omit (or pass `[]`) and the
+   * sort falls back to type → title.
+   */
+  tileOrder?: string[]
 }
 
 export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
-  const tree = createMemo(() => buildTree(props.tabs))
+  const tree = createMemo(() => buildTree(props.tabs, props.tileOrder))
   const storageKey = () => `leapmux:tabTree:${props.workspaceId}`
 
   // --- Tab rename editing state ---
@@ -158,13 +163,11 @@ export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
   let editCancelled = false
   const canClose = (tab: Tab) => canCloseTab(props.readOnly, tab)
 
-  const tabLabel = (tab: Tab): string => tab.title || tab.id
-
   const startEditing = (tab: Tab) => {
     if (props.readOnly || tab.type === TabType.FILE || !props.tabItemOps?.onRename)
       return
     setEditingTabKey(tabKey(tab))
-    setEditingValue(tabLabel(tab))
+    setEditingValue(tabDisplayLabel(tab))
   }
 
   const commitEdit = (tab: Tab) => {
@@ -173,7 +176,7 @@ export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
       return
     }
     const value = editingValue().trim()
-    if (value && value !== tabLabel(tab)) {
+    if (value && value !== tabDisplayLabel(tab)) {
       props.tabItemOps?.onRename?.(tab, value)
     }
     setEditingTabKey(null)
@@ -408,7 +411,16 @@ function repoKeyAndLabel(tab: Tab): { key: string, label: string } | null {
   return null
 }
 
-export function buildTree(tabs: Tab[]): TabTree {
+export function buildTree(tabs: Tab[], tileOrder?: readonly string[]): TabTree {
+  // Per-branch sort needs O(1) tile-index lookup; build the map once
+  // here and reuse for every branch / the ungrouped bucket.
+  const tileIndex = new Map<string, number>()
+  if (tileOrder) {
+    for (let i = 0; i < tileOrder.length; i++)
+      tileIndex.set(tileOrder[i], i)
+  }
+  const sort = (xs: Tab[]) => sortTabs(xs, tileIndex)
+
   const ungrouped: Tab[] = []
   // Group by repo-key -> branch, preserving a stable display label per key.
   const repoMap = new Map<string, { label: string, branches: Map<string, Tab[]> }>()
@@ -459,7 +471,7 @@ export function buildTree(tabs: Tab[]): TabTree {
           break
         }
       }
-      return { branchName, tabs: sortTabs(branchTabs), diffAdded, diffDeleted, diffUntracked }
+      return { branchName, tabs: sort(branchTabs), diffAdded, diffDeleted, diffUntracked }
     })
     return {
       repoKey: key,
@@ -471,15 +483,40 @@ export function buildTree(tabs: Tab[]): TabTree {
     }
   })
 
-  return { groups, ungrouped: sortTabs(ungrouped) }
+  return { groups, ungrouped: sort(ungrouped) }
 }
 
-function sortTabs(tabs: Tab[]): Tab[] {
+/**
+ * Order tabs by their visual position in the workspace. Primary key is
+ * the tab's tile in `tileIndex` (top-left tile first; the index is built
+ * from `getAllTileIds(root)` upstream). Within the same tile, fall back
+ * to LexoRank `position` so the sidebar tracks the tab bar's left-to-
+ * right order. Tabs whose tile is absent from `tileIndex` (no `tileId`
+ * yet, or a layout/snapshot race) sink to the bottom but stay grouped
+ * together by tile; `id` is the final, stable tiebreak.
+ *
+ * When `tileIndex` is empty (no tile order supplied — e.g. a test
+ * harness or a workspace whose layout hasn't been hydrated yet) every
+ * tab gets the same primary rank, so the sort effectively becomes
+ * position-then-id. That keeps callers without layout info from
+ * producing arbitrary orderings.
+ */
+function sortTabs(tabs: Tab[], tileIndex: Map<string, number>): Tab[] {
+  const rank = (tileId: string | undefined): number => {
+    if (!tileId)
+      return Number.POSITIVE_INFINITY
+    const idx = tileIndex.get(tileId)
+    return idx === undefined ? Number.POSITIVE_INFINITY : idx
+  }
   return tabs.toSorted((a, b) => {
-    // Agents before terminals
-    if (a.type !== b.type)
-      return a.type === TabType.AGENT ? -1 : 1
-    // Then alphabetical by title
-    return (a.title || a.id).localeCompare(b.title || b.id)
+    const ra = rank(a.tileId)
+    const rb = rank(b.tileId)
+    if (ra !== rb)
+      return ra - rb
+    const pa = a.position ?? ''
+    const pb = b.position ?? ''
+    if (pa !== pb)
+      return pa < pb ? -1 : 1
+    return a.id.localeCompare(b.id)
   })
 }

--- a/frontend/src/context/PreferencesContext.tsx
+++ b/frontend/src/context/PreferencesContext.tsx
@@ -45,6 +45,12 @@ interface PreferencesState {
   /** Whether hidden messages are shown in the chat view (developer feature). */
   showHiddenMessages: () => boolean
   setShowHiddenMessages: (value: boolean) => void
+  /**
+   * Whether to reveal the saved file in the OS file manager after a
+   * successful download (desktop only).
+   */
+  revealAfterDownload: () => boolean
+  setRevealAfterDownload: (value: boolean) => void
   /** Resolved enter key mode. */
   enterKeyMode: () => EnterKeyMode
   setEnterKeyMode: (value: EnterKeyMode) => void
@@ -220,6 +226,18 @@ export const PreferencesProvider: ParentComponent = (props) => {
     updateBrowserPref('showHiddenMessages', value || undefined)
   }
 
+  // Default-on preference: undefined and true both mean "reveal";
+  // only an explicit `false` opts out. Mirrors the `expandAgentThoughts`
+  // shape — store `false` to opt out, `undefined` to fall back to the
+  // default.
+  const [revealAfterDownload, setRevealAfterDownloadSignal] = createSignal(
+    initialPrefs.revealAfterDownload !== false,
+  )
+  const setRevealAfterDownload = (value: boolean) => {
+    setRevealAfterDownloadSignal(value)
+    updateBrowserPref('revealAfterDownload', value ? undefined : false)
+  }
+
   const [enterKeyMode, setEnterKeyModeSignal] = createSignal<EnterKeyMode>(
     initialPrefs.enterKeyMode ?? 'cmd-enter-sends',
   )
@@ -346,6 +364,8 @@ export const PreferencesProvider: ParentComponent = (props) => {
       setExpandAgentThoughts,
       showHiddenMessages,
       setShowHiddenMessages,
+      revealAfterDownload,
+      setRevealAfterDownload,
       enterKeyMode,
       setEnterKeyMode,
       customKeybindings,

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -19,6 +19,7 @@ import { ChannelError } from '~/lib/channel'
 import { createLogger } from '~/lib/logger'
 import { extractAssistantUsage, extractCodexTokenUsage, extractPlanFilePath, extractPlanUpdated, extractRateLimitInfo, extractResultMetadata, extractSettingsChanges, getInnerMessage, normalizeContextUsage, parseMessageContent } from '~/lib/messageParser'
 import { CODEX_RATE_LIMITS_METHOD } from '~/lib/rateLimitUtils'
+import { createExponentialBackoff } from '~/lib/retry'
 import { emitSettingsChanged } from '~/lib/settingsChangedEvent'
 import { updateSettingsLabelCache } from '~/lib/settingsLabelCache'
 import { applyTerminalData, bufferHasVisibleContent } from '~/lib/terminal'
@@ -759,7 +760,21 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       catchUpPhases.set(entry.agentId, 'catchingUp')
     }
 
-    let backoff = 1000
+    // Per-loop reconnect backoff. Successful events reset the
+    // sequence; stream-level errors also reset (the legacy code did
+    // `Math.min(backoff, 500)` to retry fast, which the helper's
+    // initial-delay floor of 1s approximates closely enough). Only
+    // sustained connection-lost errors let the sequence walk up to
+    // 30s.
+    const backoff = createExponentialBackoff<string>({
+      initialMs: 1000,
+      maxMs: 30000,
+      multiplier: 2,
+      jitterFactor: 0,
+    })
+    const BACKOFF_KEY = 'watch'
+    signal.addEventListener('abort', () => backoff.cancelAll(), { once: true })
+
     while (!signal.aborted) {
       try {
         // Build entries with current afterSeq values.
@@ -796,7 +811,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // wired; waitForStreamCompletion captures end / error / abort that
         // fire during the synchronous setup window.
         handle.onEvent((response) => {
-          backoff = 1000
+          backoff.reset(BACKOFF_KEY)
           switch (response.event.case) {
             case 'agentEvent':
               handleAgentEvent(response.event.value, catchUpPhases, signal)
@@ -830,14 +845,19 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         }
         else {
           // Stream-level error (e.g. NOT_FOUND for entities not yet
-          // visible). Retry quickly without alarming the user.
+          // visible). Retry quickly without alarming the user. Reset
+          // the backoff so a benign transient error doesn't inherit a
+          // long delay from a prior connection-lost streak.
           log.warn('[watchEvents] stream error, retrying:', err)
-          backoff = Math.min(backoff, 500)
+          backoff.reset(BACKOFF_KEY)
         }
       }
 
-      await new Promise(r => setTimeout(r, backoff))
-      backoff = Math.min(backoff * 2, 30000)
+      if (signal.aborted)
+        return
+      await new Promise<void>((resolve) => {
+        backoff.schedule(BACKOFF_KEY, resolve)
+      })
     }
   }
 

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -1,10 +1,14 @@
 /**
- * Centralized browser localStorage management.
+ * Centralized browser storage management.
  *
  * All localStorage keys must be registered here (STATIC_KEYS or DYNAMIC_KEY_TTLS).
  * Dynamic keys (per-agent/per-worker) are wrapped as { v: T, e: number }
  * with an expiration timestamp and cleaned up automatically. Static keys
  * (preferences, key-pins) are stored raw and never expire.
+ *
+ * sessionStorage shares the same wrapped layout and registry mechanism
+ * via `SESSION_DYNAMIC_KEY_TTLS` and the `session*` helpers — only the
+ * underlying Storage object differs. Cleanup sweeps both stores.
  */
 
 // ---------------------------------------------------------------------------
@@ -38,6 +42,13 @@ export interface BrowserPreferences {
    * dislikes remote-driven focus changes.
    */
   ignoreRemoteFocus?: boolean
+  /**
+   * Whether to reveal the saved file in the OS file manager (Finder /
+   * Explorer / Files) after a successful download. Only applies in
+   * desktop mode; ignored in the browser. Defaults to true — set to
+   * `false` explicitly to opt out.
+   */
+  revealAfterDownload?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -69,12 +80,15 @@ export const PREFIX_WORKER_INFO = 'leapmux:worker-info:'
 export const PREFIX_LOCAL_MESSAGES = 'leapmux:local-messages:'
 export const PREFIX_FILES_SHOW_HIDDEN = 'leapmux:files-show-hidden:'
 
+/** sessionStorage dynamic key prefixes. */
+export const PREFIX_FILE_SCROLL = 'leapmux:fileScroll:'
+
 const DAY_MS = 24 * 60 * 60 * 1000
 const HOUR_MS = 60 * 60 * 1000
 const REFRESH_THRESHOLD_MS = 3 * HOUR_MS
 const CLEANUP_INTERVAL_MS = HOUR_MS
 
-/** Dynamic key prefixes and their TTLs. */
+/** Dynamic key prefixes and their TTLs (localStorage). */
 export const DYNAMIC_KEY_TTLS: ReadonlyArray<{ prefix: string, ttlMs: number }> = [
   { prefix: PREFIX_EDITOR_DRAFT, ttlMs: 7 * DAY_MS },
   { prefix: PREFIX_EDITOR_MIN_HEIGHT, ttlMs: 7 * DAY_MS },
@@ -85,6 +99,16 @@ export const DYNAMIC_KEY_TTLS: ReadonlyArray<{ prefix: string, ttlMs: number }> 
   { prefix: PREFIX_FILES_SHOW_HIDDEN, ttlMs: 7 * DAY_MS },
 ]
 
+/**
+ * Dynamic key prefixes and their TTLs (sessionStorage). sessionStorage
+ * normally clears on tab close, but PWAs and "restore tabs on restart"
+ * can keep it alive across sessions — capping retention bounds the key
+ * set without depending on tab-close cleanup.
+ */
+export const SESSION_DYNAMIC_KEY_TTLS: ReadonlyArray<{ prefix: string, ttlMs: number }> = [
+  { prefix: PREFIX_FILE_SCROLL, ttlMs: 1 * DAY_MS },
+]
+
 // ---------------------------------------------------------------------------
 // Key helpers
 // ---------------------------------------------------------------------------
@@ -92,6 +116,15 @@ export const DYNAMIC_KEY_TTLS: ReadonlyArray<{ prefix: string, ttlMs: number }> 
 /** Returns the TTL in ms for a dynamic key, or null if the key is static or unknown. */
 export function getTtlForKey(key: string): number | null {
   for (const { prefix, ttlMs } of DYNAMIC_KEY_TTLS) {
+    if (key.startsWith(prefix))
+      return ttlMs
+  }
+  return null
+}
+
+/** Returns the TTL in ms for a dynamic sessionStorage key, or null if unknown. */
+export function getSessionTtlForKey(key: string): number | null {
+  for (const { prefix, ttlMs } of SESSION_DYNAMIC_KEY_TTLS) {
     if (key.startsWith(prefix))
       return ttlMs
   }
@@ -248,30 +281,89 @@ export function safeRemoveItem(key: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Safe sessionStorage wrappers
+// ---------------------------------------------------------------------------
+
+function requireKnownSessionKey(key: string): number {
+  const ttl = getSessionTtlForKey(key)
+  if (ttl === null) {
+    throw new Error(
+      `Unknown sessionStorage key: "${key}". Register it in browserStorage.ts `
+      + `(SESSION_DYNAMIC_KEY_TTLS).`,
+    )
+  }
+  return ttl
+}
+
+function readDynamicSession(key: string, ttl: number): unknown | undefined {
+  const raw = sessionStorage.getItem(key)
+  if (raw === null)
+    return undefined
+  const parsed = JSON.parse(raw)
+  if (!isWrappedValue(parsed))
+    return undefined
+  if (parsed.e <= Date.now()) {
+    sessionStorage.removeItem(key)
+    return undefined
+  }
+  if (shouldRefreshExpiration(parsed.e, ttl)) {
+    parsed.e = Date.now() + ttl
+    sessionStorage.setItem(key, JSON.stringify(parsed))
+  }
+  return parsed.v
+}
+
+/** Read a wrapped string from sessionStorage. Returns null on missing/expired/malformed. */
+export function sessionGetString(key: string): string | null {
+  const ttl = requireKnownSessionKey(key)
+  try {
+    const v = readDynamicSession(key, ttl)
+    return v !== undefined ? String(v) : null
+  }
+  catch { /* ignore access/parse errors */ }
+  return null
+}
+
+/** Write a wrapped string to sessionStorage. Silently ignores write errors. */
+export function sessionSetString(key: string, value: string): void {
+  const ttl = requireKnownSessionKey(key)
+  try {
+    sessionStorage.setItem(key, JSON.stringify({ v: value, e: Date.now() + ttl }))
+  }
+  catch { /* ignore write errors */ }
+}
+
+/** Remove a key from sessionStorage. Silently ignores errors. */
+export function sessionRemoveItem(key: string): void {
+  try {
+    sessionStorage.removeItem(key)
+  }
+  catch { /* ignore errors */ }
+}
+
+// ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------
 
-/**
- * Scan localStorage and delete any `leapmux:` or `leapmux-` key that is
- * NOT a known static key AND NOT a valid non-expired wrapped dynamic key.
- */
-export function runCleanup(): void {
+function sweepStorage(
+  storage: Storage,
+  staticKeys: ReadonlySet<string>,
+  ttlFor: (key: string) => number | null,
+): void {
   const now = Date.now()
   const keysToDelete: string[] = []
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i)
     if (!key)
       continue
     if (!key.startsWith('leapmux:') && !key.startsWith('leapmux-'))
       continue
-
-    if (STATIC_KEYS.has(key))
+    if (staticKeys.has(key))
       continue
-
-    const ttl = getTtlForKey(key)
+    const ttl = ttlFor(key)
     if (ttl !== null) {
       try {
-        const raw = localStorage.getItem(key)
+        const raw = storage.getItem(key)
         if (raw !== null) {
           const parsed = JSON.parse(raw)
           if (isWrappedValue(parsed) && parsed.e > now)
@@ -280,16 +372,28 @@ export function runCleanup(): void {
       }
       catch { /* parse error → treat as stale */ }
     }
-
     keysToDelete.push(key)
   }
-
   for (const key of keysToDelete) {
     try {
-      localStorage.removeItem(key)
+      storage.removeItem(key)
     }
     catch { /* ignore removal errors */ }
   }
+}
+
+const EMPTY_KEYS: ReadonlySet<string> = new Set()
+
+/**
+ * Scan localStorage and sessionStorage and delete any `leapmux:`-family
+ * key that is NOT a known static key AND NOT a valid non-expired
+ * wrapped dynamic key.
+ */
+export function runCleanup(): void {
+  sweepStorage(localStorage, STATIC_KEYS, getTtlForKey)
+  // sessionStorage has no static-key concept; every registered prefix
+  // is dynamic and any unknown leapmux key is stale.
+  sweepStorage(sessionStorage, EMPTY_KEYS, getSessionTtlForKey)
 }
 
 /**

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { copyTextToClipboard } from './clipboard'
+
+describe('copyTextToClipboard', () => {
+  it('writes non-empty text to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    copyTextToClipboard('hello')
+
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('skips empty strings (avoids clobbering the clipboard on deselect)', () => {
+    const writeText = vi.fn()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    copyTextToClipboard('')
+
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('swallows clipboard errors so callers do not have to', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    expect(() => copyTextToClipboard('hello')).not.toThrow()
+    // Allow the rejected promise to settle without an unhandled rejection.
+    await Promise.resolve()
+  })
+})

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,13 @@
+/**
+ * Write `text` to the system clipboard, ignoring empty inputs and
+ * environments without a clipboard API. Errors (e.g. permission denied
+ * on a non-secure context) are swallowed — auto-copy is a convenience,
+ * not a contract.
+ */
+export function copyTextToClipboard(text: string): void {
+  if (text.length === 0)
+    return
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText)
+    return
+  void navigator.clipboard.writeText(text).catch(() => {})
+}

--- a/frontend/src/lib/fileDownload.ts
+++ b/frontend/src/lib/fileDownload.ts
@@ -1,0 +1,127 @@
+import type { PathFlavor } from '~/lib/paths'
+import { platformBridge } from '~/api/platformBridge'
+import * as workerRpc from '~/api/workerRpc'
+import { basename } from '~/lib/paths'
+
+// 1 MiB chunks: large enough to keep round-trip count manageable for
+// multi-megabyte files, small enough to stay well under the worker's
+// max-message ceiling.
+const DOWNLOAD_CHUNK_SIZE = 1 << 20
+
+/**
+ * Hub-blindness invariant for the download path.
+ *
+ * File content traverses the Noise_NK encrypted channel established by
+ * `ChannelService.OpenChannel`. The relay Hub sees only the outer
+ * `ChannelMessage` envelopes (channel_id, correlation_id, flags,
+ * ciphertext bytes). Hub cannot decrypt the file content, the file
+ * path inside `ReadFileRequest`, the RPC method name (`ReadFile`), or
+ * the `total_size` field in `ReadFileResponse`.
+ *
+ * Hub CAN observe — same as the inline file viewer — the destination
+ * `worker_id`, per-chunk envelope sizes (summed to recover the file
+ * size to chunk resolution), the chunk count for >1 MiB files, and
+ * per-chunk timing (worker I/O latency). Unlike the inline viewer,
+ * the download path issues `readFile` calls only — no `statFile`
+ * precedes the burst, so the "stat then read" signature is absent.
+ */
+
+/**
+ * Stream `filePath` from the worker, accumulating chunks into a single
+ * in-memory `Uint8Array`. The first response's `totalSize` drives the
+ * loop bound; no separate `statFile` round-trip is needed.
+ */
+async function fetchFileBytes(workerId: string, filePath: string): Promise<Uint8Array> {
+  // First response carries totalSize; once it's known we allocate the
+  // final ArrayBuffer-backed Uint8Array and `set` each chunk into it
+  // directly. The protobuf-runtime chunk view's buffer type
+  // (`ArrayBufferLike`) admits `SharedArrayBuffer`, which `Blob` / Tauri
+  // serialization reject — copying into our fresh ArrayBuffer-backed
+  // `merged` simultaneously launders that and concatenates.
+  let merged: Uint8Array | null = null
+  let received = 0
+  let totalSize = -1
+  while (totalSize < 0 || received < totalSize) {
+    const resp = await workerRpc.readFile(workerId, {
+      workerId,
+      path: filePath,
+      offset: BigInt(received),
+      limit: BigInt(DOWNLOAD_CHUNK_SIZE),
+    })
+    if (totalSize < 0) {
+      totalSize = Number(resp.totalSize)
+      merged = new Uint8Array(totalSize)
+    }
+    const chunk = resp.content
+    if (chunk.length === 0)
+      break
+    merged!.set(chunk, received)
+    received += chunk.length
+  }
+  if (merged === null)
+    return new Uint8Array(0)
+  // Worker truncated below the advertised size (file shrank
+  // mid-download, sparse-file edge case): trim to what we actually got.
+  if (received < merged.length)
+    return merged.subarray(0, received)
+  return merged
+}
+
+/**
+ * Web-mode download: assemble bytes into a Blob and trigger a browser
+ * anchor click. The browser owns the destination directory; the caller
+ * cannot know where the file landed. Pass `flavor` to skip the
+ * `detectFlavor` sniff inside `basename` when the caller already knows
+ * it (keeps the download filename consistent with the toast label).
+ */
+export async function downloadFileFromWorker(
+  workerId: string,
+  filePath: string,
+  flavor?: PathFlavor,
+): Promise<void> {
+  const bytes = await fetchFileBytes(workerId, filePath)
+  const url = URL.createObjectURL(new Blob([bytes as BlobPart]))
+  try {
+    const a = document.createElement('a')
+    a.href = url
+    a.download = basename(filePath, flavor)
+    a.rel = 'noopener'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+  }
+  finally {
+    // Revoke after the browser has had a chance to start the download.
+    // 1s is conservative — most browsers latch the bytes synchronously
+    // on `click()`, but `setTimeout` here keeps us safe across engines.
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+}
+
+/**
+ * Desktop-mode silent save: write the streamed bytes into the user's
+ * OS Downloads directory and return the absolute path written.
+ * Caller may then pass the path to `platformBridge.revealInFileManager`.
+ */
+export async function saveFileToDownloads(
+  workerId: string,
+  filePath: string,
+  flavor?: PathFlavor,
+): Promise<string> {
+  const bytes = await fetchFileBytes(workerId, filePath)
+  return platformBridge.saveBytesToDownloads(bytes, basename(filePath, flavor))
+}
+
+/**
+ * Desktop-mode save-as: show a native save dialog, write the bytes to
+ * the chosen path, and return the absolute path. Returns `null` if the
+ * user cancelled the dialog.
+ */
+export async function saveFileAs(
+  workerId: string,
+  filePath: string,
+  flavor?: PathFlavor,
+): Promise<string | null> {
+  const bytes = await fetchFileBytes(workerId, filePath)
+  return platformBridge.saveBytesAs(bytes, basename(filePath, flavor))
+}

--- a/frontend/src/lib/fileType.ts
+++ b/frontend/src/lib/fileType.ts
@@ -1,14 +1,21 @@
-const IMAGE_EXTENSIONS = new Set([
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'bmp',
-  'webp',
-  'svg',
-  'ico',
-  'avif',
-])
+import { extname } from './paths'
+
+// Single source of truth for image extension → MIME-type mapping.
+// `IMAGE_EXTENSIONS` is derived from these keys so adding a new image
+// format here automatically updates `isImageExtension` too.
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  bmp: 'image/bmp',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+}
+
+const IMAGE_EXTENSIONS = new Set(Object.keys(IMAGE_MIME_BY_EXT))
 
 const MARKDOWN_EXTENSIONS = new Set([
   'md',
@@ -16,21 +23,148 @@ const MARKDOWN_EXTENSIONS = new Set([
   'mdx',
 ])
 
+/**
+ * Extensions that we treat as binary up front, without ever fetching a
+ * byte. Used by `FileViewer` to skip the 256 KiB probe read for files
+ * we already know we can't render inline (archives, executables, office
+ * docs, PDFs, fonts, media, databases, disk images).
+ *
+ * Membership is a deny-list signal only — the cost of a false positive
+ * is a single user click on "Show anyway" to render the bytes anyway.
+ * Files with no extension or with an extension absent from this set
+ * still fall through to the fetch+probe path where `isBinaryContent`
+ * decides.
+ */
+const LIKELY_BINARY_EXTENSIONS = new Set([
+  // Archives
+  'zip',
+  'tar',
+  'gz',
+  'tgz',
+  '7z',
+  'rar',
+  'bz2',
+  'xz',
+  'zst',
+  // Executables / objects
+  'exe',
+  'dll',
+  'so',
+  'dylib',
+  'a',
+  'o',
+  'lib',
+  'obj',
+  'bin',
+  'dat',
+  'pak',
+  // Office / PDF
+  'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'odt',
+  'ods',
+  'odp',
+  // JVM / .NET
+  'jar',
+  'war',
+  'class',
+  'dex',
+  // Media (non-image)
+  'mp3',
+  'mp4',
+  'mkv',
+  'avi',
+  'mov',
+  'wav',
+  'flac',
+  'ogg',
+  'webm',
+  'm4a',
+  'aac',
+  // Fonts
+  'ttf',
+  'otf',
+  'woff',
+  'woff2',
+  'eot',
+  // Databases
+  'db',
+  'sqlite',
+  'sqlite3',
+  // Disk images / firmware
+  'iso',
+  'img',
+  'dmg',
+])
+
+// Ext-aware predicates: callers that have already extracted the
+// extension (e.g. via a shared `createMemo(() => extname(path))`)
+// avoid re-running `extname` once per helper. The path-based versions
+// below are thin wrappers for callers that don't have a pre-extracted
+// extension handy.
+
+/** Image extension check against a pre-extracted extension. */
+export function isImageExt(ext: string): boolean {
+  return IMAGE_EXTENSIONS.has(ext)
+}
+
+/** Markdown extension check against a pre-extracted extension. */
+export function isMarkdownExt(ext: string): boolean {
+  return MARKDOWN_EXTENSIONS.has(ext)
+}
+
+/** SVG extension check against a pre-extracted extension. */
+export function isSvgExt(ext: string): boolean {
+  return ext === 'svg'
+}
+
+/** Binary-deny-list check against a pre-extracted extension. */
+export function isLikelyBinaryExt(ext: string): boolean {
+  return LIKELY_BINARY_EXTENSIONS.has(ext)
+}
+
+/**
+ * MIME type for a pre-extracted extension that is one of
+ * `IMAGE_EXTENSIONS`. Returns `application/octet-stream` for unknown
+ * extensions so callers can hand the result straight to
+ * `new Blob({ type })`.
+ */
+export function imageMimeFromExt(ext: string): string {
+  return IMAGE_MIME_BY_EXT[ext] ?? 'application/octet-stream'
+}
+
 /** Check if a file path has an image extension. */
 export function isImageExtension(path: string): boolean {
-  const ext = path.split('.').pop()?.toLowerCase() ?? ''
-  return IMAGE_EXTENSIONS.has(ext)
+  return isImageExt(extname(path))
+}
+
+/** MIME type for an image path; see `imageMimeFromExt`. */
+export function getImageMimeType(path: string): string {
+  return imageMimeFromExt(extname(path))
 }
 
 /** Check if a file path has a markdown extension. */
 export function isMarkdownExtension(path: string): boolean {
-  const ext = path.split('.').pop()?.toLowerCase() ?? ''
-  return MARKDOWN_EXTENSIONS.has(ext)
+  return isMarkdownExt(extname(path))
 }
 
 /** Check if a file path has an SVG extension. */
 export function isSvgExtension(path: string): boolean {
-  return (path.split('.').pop()?.toLowerCase() ?? '') === 'svg'
+  return isSvgExt(extname(path))
+}
+
+/**
+ * Whether the path's extension is one we treat as binary up front, so
+ * the FileViewer can skip the 256 KiB probe read. Returns false for
+ * paths with no extension and for any extension not in the deny-list.
+ */
+export function isLikelyBinaryExtension(path: string): boolean {
+  return isLikelyBinaryExt(extname(path))
 }
 
 /** Check if content appears to be binary (contains null bytes or high ratio of non-printable chars). */
@@ -49,13 +183,18 @@ export function isBinaryContent(bytes: Uint8Array): boolean {
 
 export type FileViewMode = 'text' | 'image' | 'binary' | 'markdown'
 
-/** Detect the appropriate view mode for a file. */
-export function detectFileViewMode(path: string, content: Uint8Array): FileViewMode {
-  if (isImageExtension(path))
+/** Detect the appropriate view mode from a pre-extracted extension. */
+export function detectFileViewModeFromExt(ext: string, content: Uint8Array): FileViewMode {
+  if (isImageExt(ext))
     return 'image'
-  if (isMarkdownExtension(path))
+  if (isMarkdownExt(ext))
     return 'markdown'
   if (isBinaryContent(content))
     return 'binary'
   return 'text'
+}
+
+/** Detect the appropriate view mode for a file path. */
+export function detectFileViewMode(path: string, content: Uint8Array): FileViewMode {
+  return detectFileViewModeFromExt(extname(path), content)
 }

--- a/frontend/src/lib/languageMap.ts
+++ b/frontend/src/lib/languageMap.ts
@@ -3,6 +3,8 @@
  * Only includes languages loaded by the shared Shiki highlighter instance.
  */
 
+import { extname } from './paths'
+
 const EXT_TO_LANG: Record<string, string> = {
   // TypeScript / JavaScript
   ts: 'typescript',
@@ -68,9 +70,6 @@ const EXT_TO_LANG: Record<string, string> = {
  * Returns undefined if the extension is not recognized or the language is not loaded.
  */
 export function guessLanguage(filePath: string): string | undefined {
-  const lastDot = filePath.lastIndexOf('.')
-  if (lastDot === -1 || lastDot === filePath.length - 1)
-    return undefined
-  const ext = filePath.slice(lastDot + 1).toLowerCase()
-  return EXT_TO_LANG[ext]
+  const ext = extname(filePath)
+  return ext ? EXT_TO_LANG[ext] : undefined
 }

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   basename,
   detectFlavor,
+  extname,
   flavorFromOs,
   isAbsolute,
   join,
@@ -175,6 +176,39 @@ describe('basename', () => {
 
   it('returns empty for roots', () => {
     expect(basename('/')).toBe('')
+  })
+})
+
+describe('extname', () => {
+  it('returns the lowercase extension of a simple posix path', () => {
+    expect(extname('photo.png')).toBe('png')
+    expect(extname('/home/u/Photo.PNG')).toBe('png')
+  })
+
+  it('returns the lowercase extension of a Windows path', () => {
+    expect(extname('C:\\Users\\u\\photo.PNG')).toBe('png')
+    expect(extname('C:\\x.tar.gz')).toBe('gz')
+  })
+
+  it('returns empty for paths with no extension', () => {
+    expect(extname('/etc/hosts')).toBe('')
+    expect(extname('Makefile')).toBe('')
+    expect(extname('C:\\Users\\u\\Dockerfile')).toBe('')
+  })
+
+  it('returns empty when the dot is inside a parent directory, not the file', () => {
+    expect(extname('dir.zip/file')).toBe('')
+    expect(extname('dir.zip\\file')).toBe('')
+  })
+
+  it('returns the extension when only the final segment has one', () => {
+    expect(extname('archive.zip/inside/file.txt')).toBe('txt')
+    expect(extname('C:\\dir.zip\\inside\\file.txt')).toBe('txt')
+  })
+
+  it('treats a leading-dot file as having an extension equal to the name', () => {
+    expect(extname('.gitignore')).toBe('gitignore')
+    expect(extname('/repo/.bashrc')).toBe('bashrc')
   })
 })
 

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -185,6 +185,29 @@ export function parentDirectory(p: string, flavor?: PathFlavor): string {
   return `${volume}${s}${rest.slice(0, -1).join(s)}`
 }
 
+/**
+ * Lowercase file extension (without the leading dot), or empty string
+ * if the last path component has none. Accepts both POSIX and Windows
+ * separators without needing a flavor — extensions are universally
+ * defined by the last dot inside the final path segment.
+ *
+ * Examples:
+ *   extname('photo.PNG')       → 'png'
+ *   extname('archive.tar.gz')  → 'gz'
+ *   extname('/etc/hosts')      → ''
+ *   extname('.gitignore')      → 'gitignore'
+ *   extname('dir.zip/file')    → ''   (dot before last separator)
+ */
+export function extname(p: string): string {
+  const dot = p.lastIndexOf('.')
+  if (dot < 0)
+    return ''
+  const sep = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  if (dot <= sep)
+    return ''
+  return p.substring(dot + 1).toLowerCase()
+}
+
 // Last component of the path, or empty string if none.
 export function basename(p: string, flavor?: PathFlavor): string {
   if (!p)

--- a/frontend/src/lib/retry.ts
+++ b/frontend/src/lib/retry.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-key exponential-backoff scheduler.
+ *
+ * Pattern: each key (a tab id, a worker id, …) tracks at most one
+ * pending timer plus its last-used delay. On failure, the caller asks
+ * `schedule(key, fire)` to arm the next retry; on success, the caller
+ * calls `reset(key)` so the next failure restarts at `initialMs`.
+ *
+ * Delay sequence (per key): `initialMs`, `initialMs × multiplier`,
+ * `initialMs × multiplier²`, …, clamped at `maxMs`. Reset returns the
+ * sequence to the start.
+ *
+ * Cancellation: SolidJS callers must call `cancelAll()` from
+ * `onCleanup` so timers don't outlive the component / hook. There is
+ * no per-key cleanup token — `reset(key)` is the per-key cancel.
+ *
+ * This helper deliberately does NOT:
+ * - Wrap the operation being retried. Callers own the `fire` callback
+ *   (and any in-flight guard / async cancellation around it). Mixing
+ *   the two concerns leaks SolidJS reactivity assumptions into the
+ *   helper.
+ * - Implement attempt-count caps. Most retry sites in this codebase
+ *   are "keep trying until something else changes" loops (the candidate
+ *   set shrinks, the user navigates away, the parent unmounts). Sites
+ *   that need a cap can compose with their own attempt counter.
+ */
+export interface ExponentialBackoffOpts {
+  /** First scheduled delay, in ms (before jitter). */
+  initialMs: number
+  /** Upper bound on the un-jittered base delay. */
+  maxMs: number
+  /** Per-retry growth factor. Defaults to 2. */
+  multiplier?: number
+  /**
+   * Symmetric jitter fraction. The actual scheduled delay is
+   * `base * (1 + rand)` where `rand ∈ [-jitterFactor, +jitterFactor)`,
+   * so e.g. `jitterFactor: 0.2` gives a [0.8×, 1.2×] window around the
+   * base delay. Defaults to 0.2 (±20%) to match the backend's
+   * `symmetricJitter` helper. Set to 0 to disable.
+   *
+   * The doubling sequence advances on the *base* delay, not the
+   * jittered one — jitter only fuzzes the timer arm-time. This keeps
+   * the maximum scheduled delay bounded near `maxMs * (1 + jitter)`
+   * instead of letting jittered values compound.
+   */
+  jitterFactor?: number
+}
+
+export interface ExponentialBackoff<K> {
+  /**
+   * Arm a retry timer for `key`. No-op (returns `null`) if a timer is
+   * already pending. Otherwise returns the delay that was scheduled.
+   *
+   * The pending-timer slot for `key` is cleared *before* `fire` runs,
+   * so `fire` may re-call `schedule(key, …)` from inside itself.
+   */
+  schedule: (key: K, fire: () => void) => number | null
+  /**
+   * Cancel `key`'s pending timer (if any) and forget its last delay so
+   * the next `schedule(key, …)` restarts at `initialMs`. Idempotent.
+   */
+  reset: (key: K) => void
+  /** Cancel every pending timer and forget every per-key delay. */
+  cancelAll: () => void
+  /** Number of pending timers — test helper. */
+  size: () => number
+  /**
+   * Inspect the un-jittered *base* delay `schedule(key, …)` would use
+   * next, without arming a timer. Returns `null` when `key` already
+   * has a pending timer (since the call would no-op). Used by tests
+   * and by code that reasons about the backoff sequence without
+   * caring about jitter; the actual arm-time is fuzzed by
+   * `jitterFactor`.
+   */
+  peekNextDelay: (key: K) => number | null
+}
+
+export function createExponentialBackoff<K>(opts: ExponentialBackoffOpts): ExponentialBackoff<K> {
+  const { initialMs, maxMs } = opts
+  const multiplier = opts.multiplier ?? 2
+  const jitterFactor = opts.jitterFactor ?? 0.2
+  if (initialMs <= 0)
+    throw new Error(`createExponentialBackoff: initialMs must be > 0 (got ${initialMs})`)
+  if (maxMs < initialMs)
+    throw new Error(`createExponentialBackoff: maxMs (${maxMs}) must be >= initialMs (${initialMs})`)
+  if (multiplier <= 1)
+    throw new Error(`createExponentialBackoff: multiplier must be > 1 (got ${multiplier})`)
+  if (jitterFactor < 0 || jitterFactor >= 1)
+    throw new Error(`createExponentialBackoff: jitterFactor must be in [0, 1) (got ${jitterFactor})`)
+
+  const timers = new Map<K, ReturnType<typeof setTimeout>>()
+  const lastBaseDelays = new Map<K, number>()
+
+  const nextBaseDelayFor = (key: K): number => {
+    const prev = lastBaseDelays.get(key)
+    return prev === undefined ? initialMs : Math.min(prev * multiplier, maxMs)
+  }
+
+  // Symmetric jitter: result ∈ [base * (1 - jitterFactor), base * (1 + jitterFactor)).
+  // Floored at 0 in case a caller passes a value approaching 1 — we
+  // never want a negative setTimeout.
+  const applyJitter = (base: number): number => {
+    if (jitterFactor === 0)
+      return base
+    const offset = base * jitterFactor * (Math.random() * 2 - 1)
+    return Math.max(0, base + offset)
+  }
+
+  const reset = (key: K): void => {
+    const t = timers.get(key)
+    if (t !== undefined) {
+      clearTimeout(t)
+      timers.delete(key)
+    }
+    lastBaseDelays.delete(key)
+  }
+
+  const schedule = (key: K, fire: () => void): number | null => {
+    if (timers.has(key))
+      return null
+    const base = nextBaseDelayFor(key)
+    lastBaseDelays.set(key, base)
+    const delay = applyJitter(base)
+    const t = setTimeout(() => {
+      // Clear the slot before firing so `fire` can re-schedule from
+      // inside itself without tripping the "already pending" guard.
+      timers.delete(key)
+      fire()
+    }, delay)
+    timers.set(key, t)
+    return delay
+  }
+
+  return {
+    schedule,
+    reset,
+    cancelAll() {
+      for (const t of timers.values())
+        clearTimeout(t)
+      timers.clear()
+      lastBaseDelays.clear()
+    },
+    size: () => timers.size,
+    peekNextDelay: key => (timers.has(key) ? null : nextBaseDelayFor(key)),
+  }
+}

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { KEY_BROWSER_PREFS } from './browserStorage'
-import { copySelectionToClipboard, createTerminalInstance, getTerminalRendererPreference, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
+import { createTerminalInstance, getTerminalRendererPreference, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
 
 // xterm.js requires a DOM element for open(), but we can still test
 // the suppressInput mechanism without rendering.
@@ -226,43 +226,5 @@ describe('getTerminalRendererPreference', () => {
     })
 
     expect(resolveTerminalRendererPreference('webgl')).toBe('webgl')
-  })
-})
-
-describe('copySelectionToClipboard', () => {
-  it('writes non-empty text to the clipboard', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-
-    copySelectionToClipboard('hello')
-
-    expect(writeText).toHaveBeenCalledWith('hello')
-  })
-
-  it('skips empty strings (avoids clobbering the clipboard on deselect)', () => {
-    const writeText = vi.fn()
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-
-    copySelectionToClipboard('')
-
-    expect(writeText).not.toHaveBeenCalled()
-  })
-
-  it('swallows clipboard errors so callers do not have to', async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-
-    expect(() => copySelectionToClipboard('hello')).not.toThrow()
-    // Allow the rejected promise to settle without an unhandled rejection.
-    await Promise.resolve()
   })
 })

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -6,6 +6,7 @@ import { SerializeAddon } from '@xterm/addon-serialize'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import { loadBrowserPrefs } from './browserStorage'
+import { copyTextToClipboard } from './clipboard'
 import { createLogger } from './logger'
 
 const DEFAULT_MONO_FONT_FAMILY = '"Hack NF", Hack, "SF Mono", Consolas, monospace'
@@ -299,7 +300,7 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   // (e.g. a click that clears highlight) are skipped so we don't
   // clobber whatever the user has on the clipboard.
   terminal.onSelectionChange(() => {
-    copySelectionToClipboard(terminal.getSelection())
+    copyTextToClipboard(terminal.getSelection())
   })
 
   return {
@@ -376,18 +377,4 @@ function clearAtlas(terminal: Terminal): void {
   catch {
     // Terminal was disposed before fonts settled; nothing to do.
   }
-}
-
-/**
- * Write `text` to the system clipboard, ignoring empty inputs and
- * environments without a clipboard API. Errors (e.g. permission denied
- * on a non-secure context) are swallowed — auto-copy is a convenience,
- * not a contract.
- */
-export function copySelectionToClipboard(text: string): void {
-  if (text.length === 0)
-    return
-  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText)
-    return
-  void navigator.clipboard.writeText(text).catch(() => {})
 }

--- a/frontend/src/stores/gitFileStatus.store.ts
+++ b/frontend/src/stores/gitFileStatus.store.ts
@@ -132,11 +132,21 @@ export function createGitFileStatusStore() {
     return flavor === 'posix' ? rel : toPosixSeparators(rel)
   }
 
+  // O(1) lookup by relative path. Rebuilds whenever state.files changes;
+  // sameFileEntries() in refresh() keeps the array reference stable on
+  // no-op refreshes, so this memo doesn't re-run on a quiet repo.
+  const filesByPath = createMemo(() => {
+    const m = new Map<string, GitFileStatusEntry>()
+    for (const f of state.files)
+      m.set(f.path, f)
+    return m
+  })
+
   const getFileStatus = (absPath: string): GitFileStatusEntry | undefined => {
     const rel = relToRepo(absPath)
     if (rel === null)
       return undefined
-    return state.files.find(f => f.path === rel)
+    return filesByPath().get(rel)
   }
 
   const getChangedFiles = (filter: GitFilterTab): GitFileStatusEntry[] => {
@@ -160,7 +170,13 @@ export function createGitFileStatusStore() {
   // knowing queries, so we track them separately and check at lookup time.
   const prefixIndex = createMemo(() => {
     const prefixStats = new Map<string, DiffStats>()
-    const untrackedDirs: string[] = []
+    const untrackedDirSet = new Set<string>()
+    // Per-prefixIndex-generation cache of merged dir stats. Returning the
+    // same object reference across calls keeps downstream `createMemo`s
+    // (one per TreeNode row) stable across no-op refreshes — without it,
+    // any row whose ancestor is in `untrackedDirSet` re-invalidates every
+    // refresh because `lookupDirStats` allocated a fresh object.
+    const dirStatsCache = new Map<string, DiffStats>()
 
     const bump = (key: string, f: GitFileStatusEntry, isUntracked: boolean) => {
       let s = prefixStats.get(key)
@@ -182,7 +198,7 @@ export function createGitFileStatusStore() {
       const isDirEntry = f.path.endsWith('/')
       const basePath = isDirEntry ? f.path.slice(0, -1) : f.path
       if (isDirEntry)
-        untrackedDirs.push(basePath)
+        untrackedDirSet.add(basePath)
       bump('', f, isUntracked)
       let i = 0
       while (i < basePath.length) {
@@ -195,27 +211,38 @@ export function createGitFileStatusStore() {
         i = next + 1
       }
     }
-    return { prefixStats, untrackedDirs }
+    return { prefixStats, untrackedDirSet, dirStatsCache }
   })
 
   // An untracked "build/" also covers descendants like "build/bin"; the
-  // ancestor/self case is already in prefixStats.
-  const untrackedAncestorMatches = (relDir: string, untrackedDirs: string[]): number => {
+  // ancestor/self case is already in prefixStats. Walks `relDir`'s
+  // ancestor segments and probes the set — O(depth) per node instead of
+  // O(untrackedDirs) per node.
+  const untrackedAncestorMatches = (relDir: string, untrackedDirSet: Set<string>): number => {
+    if (untrackedDirSet.size === 0)
+      return 0
     let n = 0
-    for (const d of untrackedDirs) {
-      if (relDir.length > d.length && relDir.startsWith(`${d}/`))
+    let i = relDir.lastIndexOf('/')
+    while (i > 0) {
+      if (untrackedDirSet.has(relDir.slice(0, i)))
         n++
+      i = relDir.lastIndexOf('/', i - 1)
     }
     return n
   }
 
   const lookupDirStats = (relDir: string): DiffStats => {
-    const { prefixStats, untrackedDirs } = prefixIndex()
+    const { prefixStats, untrackedDirSet, dirStatsCache } = prefixIndex()
+    const cached = dirStatsCache.get(relDir)
+    if (cached)
+      return cached
     const base = prefixStats.get(relDir) ?? ZERO_DIFF_STATS
-    const extraUntracked = untrackedAncestorMatches(relDir, untrackedDirs)
-    if (extraUntracked === 0)
-      return base
-    return { added: base.added, deleted: base.deleted, untracked: base.untracked + extraUntracked }
+    const extraUntracked = untrackedAncestorMatches(relDir, untrackedDirSet)
+    const result = extraUntracked === 0
+      ? base
+      : { added: base.added, deleted: base.deleted, untracked: base.untracked + extraUntracked }
+    dirStatsCache.set(relDir, result)
+    return result
   }
 
   const getNodeDiffStats = (absPath: string, isDir: boolean): DiffStats => {
@@ -231,8 +258,8 @@ export function createGitFileStatusStore() {
     const relDir = relToRepo(dirPath)
     if (relDir === null)
       return false
-    const { prefixStats, untrackedDirs } = prefixIndex()
-    return prefixStats.has(relDir) || untrackedAncestorMatches(relDir, untrackedDirs) > 0
+    const { prefixStats, untrackedDirSet } = prefixIndex()
+    return prefixStats.has(relDir) || untrackedAncestorMatches(relDir, untrackedDirSet) > 0
   }
 
   return {

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -1,0 +1,77 @@
+import type { Tab } from './tab.types'
+import { describe, expect, it } from 'vitest'
+import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { tabDisplayLabel } from './tab.helpers'
+
+// `tabDisplayLabel` is the shared "what should we render in the tab strip
+// AND in the workspace tree?" helper. Three call sites depend on its
+// fallback order (title → FILE basename → type-default), so each branch
+// gets its own test to guard against silent drift.
+function file(overrides: Partial<Extract<Tab, { type: TabType.FILE }>> = {}): Tab {
+  return { type: TabType.FILE, id: 'f1', ...overrides }
+}
+
+function agent(overrides: Partial<Extract<Tab, { type: TabType.AGENT }>> = {}): Tab {
+  return { type: TabType.AGENT, id: 'a1', ...overrides }
+}
+
+function terminal(overrides: Partial<Extract<Tab, { type: TabType.TERMINAL }>> = {}): Tab {
+  return { type: TabType.TERMINAL, id: 't1', ...overrides }
+}
+
+describe('tabDisplayLabel', () => {
+  it('prefers an explicit title over every fallback', () => {
+    expect(tabDisplayLabel(file({ title: 'Renamed', filePath: '/repo/notes.txt' }))).toBe('Renamed')
+    expect(tabDisplayLabel(agent({ title: 'My Agent' }))).toBe('My Agent')
+    expect(tabDisplayLabel(terminal({ title: 'zsh' }))).toBe('zsh')
+  })
+
+  it('treats an empty-string title as no title (falls through to fallbacks)', () => {
+    // Solid stores can briefly hold the empty string as a transitional
+    // value; the helper must NOT show a blank label.
+    expect(tabDisplayLabel(file({ title: '', filePath: '/repo/notes.txt' }))).toBe('notes.txt')
+    expect(tabDisplayLabel(agent({ title: '' }))).toBe('Agent')
+    expect(tabDisplayLabel(terminal({ title: '' }))).toBe('Terminal')
+  })
+
+  describe('file fallback', () => {
+    it('uses basename(filePath) when no title is set', () => {
+      expect(tabDisplayLabel(file({ filePath: '/repo/src/foo.ts' }))).toBe('foo.ts')
+    })
+
+    it('handles Windows-style paths', () => {
+      expect(tabDisplayLabel(file({ filePath: 'C:\\users\\alice\\report.md' }))).toBe('report.md')
+    })
+
+    it('returns "File" when filePath is missing entirely', () => {
+      // Pre-hydration projection — tab arrives without filePath. The
+      // workspace tree must show *something*, not blank.
+      expect(tabDisplayLabel(file({ filePath: undefined }))).toBe('File')
+    })
+
+    it('returns "File" when filePath is an empty string', () => {
+      expect(tabDisplayLabel(file({ filePath: '' }))).toBe('File')
+    })
+
+    it('returns "File" when filePath is just a root separator (empty basename)', () => {
+      // `basename('/')` returns '' (no segments after the root). The
+      // helper's || 'File' fallback must catch that so we don't render
+      // a blank label.
+      expect(tabDisplayLabel(file({ filePath: '/' }))).toBe('File')
+    })
+
+    it('handles a bare filename with no separators', () => {
+      expect(tabDisplayLabel(file({ filePath: 'standalone.md' }))).toBe('standalone.md')
+    })
+  })
+
+  describe('agent / terminal fallback', () => {
+    it('returns "Agent" for an unnamed agent tab', () => {
+      expect(tabDisplayLabel(agent())).toBe('Agent')
+    })
+
+    it('returns "Terminal" for an unnamed terminal tab', () => {
+      expect(tabDisplayLabel(terminal())).toBe('Terminal')
+    })
+  })
+})

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -4,6 +4,7 @@ import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
 import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { basename } from '~/lib/paths'
 import { updateSettingsLabelCache } from '~/lib/settingsLabelCache'
 
 /**
@@ -298,6 +299,21 @@ export function isTabReadyForGitStatus(
 
 export function tabKey(tab: { type: TabType, id: string }): string {
   return `${tab.type}:${tab.id}`
+}
+
+/**
+ * Human-readable label for a tab. Prefer `tab.title` (server-set or
+ * user-renamed); fall back to a type-aware default. FILE tabs derive
+ * their label from `basename(filePath)` so the workspace tree and the
+ * tab strip stay in sync — both surfaces show the same name once the
+ * worker's path hydrator has filled `filePath` in.
+ */
+export function tabDisplayLabel(tab: Tab): string {
+  if (tab.title)
+    return tab.title
+  if (tab.type === TabType.FILE)
+    return (tab.filePath ? basename(tab.filePath) : '') || 'File'
+  return tab.type === TabType.AGENT ? 'Agent' : 'Terminal'
 }
 
 /**

--- a/frontend/tests/unit/components/FileActionsMenu.test.tsx
+++ b/frontend/tests/unit/components/FileActionsMenu.test.tsx
@@ -1,0 +1,159 @@
+import type { SaveActionsSpies } from '../helpers/saveActionsMocks'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fileDownloadMock,
+  platformBridgeMock,
+  preferencesMock,
+  resetSaveActionsSpies,
+  toastMock,
+} from '../helpers/saveActionsMocks'
+
+const spies = vi.hoisted<SaveActionsSpies>(() => ({
+  downloadImpl: vi.fn(),
+  saveAsImpl: vi.fn(),
+  saveToDownloadsImpl: vi.fn(),
+  revealImpl: vi.fn(),
+  warnToastImpl: vi.fn(),
+  revealAfterDownloadImpl: vi.fn(() => true),
+  isTauriAppImpl: vi.fn(() => false),
+}))
+
+vi.mock('~/api/platformBridge', () => platformBridgeMock(spies))
+vi.mock('~/lib/fileDownload', () => fileDownloadMock(spies))
+vi.mock('~/components/common/Toast', () => toastMock(spies))
+vi.mock('~/context/PreferencesContext', () => preferencesMock(spies))
+
+const { FileActionsMenu } = await import('~/components/common/FileActionsMenu')
+
+function renderMenu(overrides: Partial<Parameters<typeof FileActionsMenu>[0]> = {}) {
+  const defaults: Parameters<typeof FileActionsMenu>[0] = {
+    workerId: 'w1',
+    path: '/repo/src/file.ts',
+    flavor: 'posix',
+    rootPath: '/repo',
+    homeDir: '/home/alice',
+  }
+  // Use a single merged object so explicit `undefined` in overrides
+  // actually unsets defaults (Solid's spread keeps earlier values when
+  // the new value is undefined).
+  const props = { ...defaults, ...overrides }
+  return render(() => <FileActionsMenu {...props} />)
+}
+
+beforeEach(() => {
+  resetSaveActionsSpies(spies)
+})
+
+describe('fileActionsMenu — common items', () => {
+  it('always shows Copy path; shows Copy relative path when rootPath is supplied', () => {
+    renderMenu()
+    expect(screen.getByTestId('file-actions-copy-path-button')).toBeInTheDocument()
+    expect(screen.getByTestId('file-actions-copy-relative-path-button')).toBeInTheDocument()
+  })
+
+  it('hides Copy relative path when rootPath is not supplied', () => {
+    renderMenu({ rootPath: undefined })
+    expect(screen.queryByTestId('file-actions-copy-relative-path-button')).not.toBeInTheDocument()
+  })
+
+  it('shows Mention only when onMention is supplied', () => {
+    const { unmount } = renderMenu()
+    expect(screen.queryByTestId('file-actions-mention-button')).not.toBeInTheDocument()
+    unmount()
+
+    const onMention = vi.fn()
+    renderMenu({ onMention })
+    fireEvent.click(screen.getByTestId('file-actions-mention-button'))
+    expect(onMention).toHaveBeenCalledWith('/repo/src/file.ts')
+  })
+
+  it('shows Open terminal only for directories (and with handler)', () => {
+    const onOpenTerminal = vi.fn()
+    const { unmount } = renderMenu({ isDir: false, onOpenTerminal })
+    expect(screen.queryByTestId('file-actions-open-terminal-button')).not.toBeInTheDocument()
+    unmount()
+
+    renderMenu({ isDir: true, onOpenTerminal })
+    fireEvent.click(screen.getByTestId('file-actions-open-terminal-button'))
+    expect(onOpenTerminal).toHaveBeenCalledWith('/repo/src/file.ts')
+  })
+
+  it('writes the path to the clipboard on Copy path click', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    renderMenu()
+    fireEvent.click(screen.getByTestId('file-actions-copy-path-button'))
+    expect(writeText).toHaveBeenCalledWith('/repo/src/file.ts')
+  })
+
+  it('writes the relative path on Copy relative path click', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    renderMenu()
+    fireEvent.click(screen.getByTestId('file-actions-copy-relative-path-button'))
+    expect(writeText).toHaveBeenCalledWith('src/file.ts')
+  })
+
+  it('hides the Download / Save items for directories', () => {
+    renderMenu({ isDir: true })
+    expect(screen.queryByTestId('file-actions-download-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-save-as-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-save-to-downloads-button')).not.toBeInTheDocument()
+  })
+})
+
+describe('fileActionsMenu — web mode', () => {
+  it('shows a single Download item that calls downloadFileFromWorker', async () => {
+    renderMenu()
+    const dl = screen.getByTestId('file-actions-download-button')
+    expect(dl).toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-save-as-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-save-to-downloads-button')).not.toBeInTheDocument()
+    fireEvent.click(dl)
+    await waitFor(() => expect(spies.downloadImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix'))
+  })
+})
+
+describe('fileActionsMenu — desktop mode', () => {
+  beforeEach(() => {
+    spies.isTauriAppImpl.mockReturnValue(true)
+  })
+
+  it('shows Save as... and Save to Downloads, hides web Download', () => {
+    renderMenu()
+    expect(screen.getByTestId('file-actions-save-as-button')).toBeInTheDocument()
+    expect(screen.getByTestId('file-actions-save-to-downloads-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-download-button')).not.toBeInTheDocument()
+  })
+
+  it('save to Downloads reveals when the preference is on', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByTestId('file-actions-save-to-downloads-button'))
+    await waitFor(() => expect(spies.saveToDownloadsImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix'))
+    await waitFor(() => expect(spies.revealImpl).toHaveBeenCalledWith('/home/alice/Downloads/file.ts'))
+  })
+
+  it('save as → skips reveal when the user cancels the dialog', async () => {
+    spies.saveAsImpl.mockResolvedValueOnce(null)
+    renderMenu()
+    fireEvent.click(screen.getByTestId('file-actions-save-as-button'))
+    await waitFor(() => expect(spies.saveAsImpl).toHaveBeenCalledTimes(1))
+    expect(spies.revealImpl).not.toHaveBeenCalled()
+  })
+
+  it('save to Downloads does NOT reveal when the preference is off', async () => {
+    spies.revealAfterDownloadImpl.mockReturnValue(false)
+    renderMenu()
+    fireEvent.click(screen.getByTestId('file-actions-save-to-downloads-button'))
+    await waitFor(() => expect(spies.saveToDownloadsImpl).toHaveBeenCalledTimes(1))
+    expect(spies.revealImpl).not.toHaveBeenCalled()
+  })
+
+  it('respects a custom itemTestIdPrefix', () => {
+    renderMenu({ itemTestIdPrefix: 'tree' })
+    expect(screen.getByTestId('tree-save-as-button')).toBeInTheDocument()
+    expect(screen.getByTestId('tree-save-to-downloads-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-save-as-button')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/tests/unit/components/FileViewer.unsupported.test.tsx
+++ b/frontend/tests/unit/components/FileViewer.unsupported.test.tsx
@@ -1,0 +1,366 @@
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const statFileImpl = vi.fn()
+const readFileImpl = vi.fn()
+const readGitFileImpl = vi.fn(async () => ({ exists: false, content: new Uint8Array() }))
+const downloadImpl = vi.fn(() => Promise.resolve())
+
+vi.mock('~/api/workerRpc', () => ({
+  statFile: (...args: unknown[]) => statFileImpl(...args),
+  readFile: (...args: unknown[]) => readFileImpl(...args),
+  readGitFile: (...args: unknown[]) => readGitFileImpl(...args),
+}))
+
+vi.mock('~/lib/fileDownload', () => ({
+  downloadFileFromWorker: (...args: unknown[]) => downloadImpl(...args),
+  saveFileAs: vi.fn(),
+  saveFileToDownloads: vi.fn(),
+}))
+
+// Light-weight mocks for the heavy child views so we can assert which
+// branch fired without dragging in syntax highlighting / virtualization.
+vi.mock('~/components/fileviewer/TextFileView', () => ({
+  TextFileView: (props: { filePath: string }) => (
+    <div data-testid="text-view">{props.filePath}</div>
+  ),
+}))
+vi.mock('~/components/fileviewer/MarkdownFileView', () => ({
+  MarkdownFileView: (props: { filePath: string }) => (
+    <div data-testid="markdown-view">{props.filePath}</div>
+  ),
+}))
+vi.mock('~/components/fileviewer/ImageFileView', () => ({
+  ImageFileView: (props: { filePath: string }) => (
+    <div data-testid="image-view">{props.filePath}</div>
+  ),
+}))
+vi.mock('~/components/fileviewer/HexView', () => ({
+  HexView: (props: { totalSize: number }) => (
+    <div data-testid="hex-view">{`hex ${props.totalSize}`}</div>
+  ),
+}))
+
+const showWarnToastMock = vi.fn()
+vi.mock('~/components/common/Toast', () => ({
+  showWarnToast: (...args: unknown[]) => showWarnToastMock(...args),
+}))
+
+// Stub the preferences context — the tests don't exercise the
+// reveal-after-download flow, but FileViewer reads `revealAfterDownload`
+// during render.
+vi.mock('~/context/PreferencesContext', () => ({
+  usePreferences: () => ({
+    revealAfterDownload: () => false,
+    setRevealAfterDownload: () => {},
+  }),
+}))
+
+// Web-mode by default — these tests target the browser anchor-click
+// download flow.
+vi.mock('~/api/platformBridge', () => ({
+  isTauriApp: () => false,
+  platformBridge: {
+    revealInFileManager: () => Promise.resolve(),
+    saveBytesToDownloads: () => Promise.resolve(''),
+    saveBytesAs: () => Promise.resolve(null),
+  },
+}))
+
+const { FileViewer } = await import('~/components/fileviewer/FileViewer')
+
+const MAX = 256 * 1024
+
+function statResp(size: number) {
+  return { info: { size: BigInt(size) } }
+}
+
+function readResp(content: Uint8Array, totalSize?: number) {
+  return {
+    content,
+    totalSize: BigInt(totalSize ?? content.length),
+  }
+}
+
+describe('fileViewer dispatch with unsupported view', () => {
+  beforeEach(() => {
+    statFileImpl.mockReset()
+    readFileImpl.mockReset()
+    downloadImpl.mockReset()
+    downloadImpl.mockResolvedValue(undefined)
+    showWarnToastMock.mockReset()
+  })
+
+  it('renders TextFileView for a small text file', async () => {
+    const bytes = new TextEncoder().encode('hello')
+    statFileImpl.mockResolvedValue(statResp(bytes.length))
+    readFileImpl.mockResolvedValue(readResp(bytes))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/notes.txt" />)
+    await waitFor(() => expect(screen.getByTestId('text-view')).toBeInTheDocument())
+    expect(screen.queryByText(/cannot be displayed inline/i)).not.toBeInTheDocument()
+  })
+
+  it('renders TextFileView (truncated) for a >256 KiB text file with the existing status bar warning', async () => {
+    const partial = new TextEncoder().encode('a'.repeat(1024))
+    const fullSize = 5 * 1024 * 1024
+    statFileImpl.mockResolvedValue(statResp(fullSize))
+    readFileImpl.mockResolvedValue(readResp(partial, fullSize))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/big.log" />)
+    await waitFor(() => expect(screen.getByTestId('text-view')).toBeInTheDocument())
+    // No unsupported view (text files render inline regardless of size).
+    expect(screen.queryByText(/cannot be displayed inline/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/too large to preview/i)).not.toBeInTheDocument()
+    // Existing truncation warning still appears.
+    expect(screen.getByText(/Truncated at 256(\.0)? KB/i)).toBeInTheDocument()
+  })
+
+  it('renders the unsupported view for a small .zip file WITHOUT calling readFile', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('text-view')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('hex-view')).not.toBeInTheDocument()
+  })
+
+  it('renders the unsupported view for a >256 KiB image via metaOnlyIfTruncated (no wasted bytes)', async () => {
+    // The image path now collapses statFile + readFile into a single
+    // readFile call with metaOnlyIfTruncated=true. For an oversize
+    // image, the server skips the bytes and returns just totalSize —
+    // we never download the 256 KiB we'd refuse to render anyway.
+    readFileImpl.mockResolvedValue(readResp(new Uint8Array(0), 5 * 1024 * 1024))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/huge.png" />)
+    await waitFor(() =>
+      expect(screen.getByText('This image is too large to preview.')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+    expect(readFileImpl).toHaveBeenCalledWith('w1', expect.objectContaining({
+      path: '/repo/huge.png',
+      metaOnlyIfTruncated: true,
+    }))
+    expect(statFileImpl).not.toHaveBeenCalled()
+  })
+
+  it('renders ImageFileView for a small image in a single readFile (no statFile)', async () => {
+    // Counterpart to the oversize case: a small image arrives as
+    // content + totalSize in one round trip, no statFile needed.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+    readFileImpl.mockResolvedValue(readResp(bytes))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/tiny.png" />)
+    await waitFor(() => expect(screen.getByTestId('image-view')).toBeInTheDocument())
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+    expect(statFileImpl).not.toHaveBeenCalled()
+  })
+
+  it('renders the unsupported view for an unknown-extension binary (readFile called once for probe)', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3, 0, 0, 0])
+    statFileImpl.mockResolvedValue(statResp(bytes.length))
+    readFileImpl.mockResolvedValue(readResp(bytes))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/blob.foo" />)
+    await waitFor(() =>
+      expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking Show anyway on a .zip lazy-fetches and renders HexView', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+    const bytes = new Uint8Array([0, 1, 2, 3])
+    readFileImpl.mockResolvedValue(readResp(bytes, 2048))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-show-anyway-button')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    await waitFor(() => expect(screen.getByTestId('hex-view')).toBeInTheDocument())
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+    expect(readFileImpl).toHaveBeenCalledWith('w1', expect.objectContaining({
+      path: '/repo/archive.zip',
+      limit: BigInt(MAX),
+    }))
+  })
+
+  it('clicking Show anyway on an oversize image lazy-fetches and renders HexView', async () => {
+    // First call: initial load with metaOnlyIfTruncated → empty content
+    // + oversize totalSize. Second call: Show anyway → partial bytes
+    // (the unsupported card lifts metaOnlyIfTruncated to actually fetch).
+    const partial = new Uint8Array(1024)
+    readFileImpl.mockResolvedValueOnce(readResp(new Uint8Array(0), 5 * 1024 * 1024))
+    readFileImpl.mockResolvedValueOnce(readResp(partial, 5 * 1024 * 1024))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/huge.png" />)
+    await waitFor(() =>
+      expect(screen.getByText('This image is too large to preview.')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    await waitFor(() => expect(screen.getByTestId('hex-view')).toBeInTheDocument())
+    expect(readFileImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('clicking Show anyway on a probed-binary file renders HexView without re-fetching', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3, 0, 0, 0])
+    statFileImpl.mockResolvedValue(statResp(bytes.length))
+    readFileImpl.mockResolvedValue(readResp(bytes))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/blob.foo" />)
+    await waitFor(() =>
+      expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument(),
+    )
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    await waitFor(() => expect(screen.getByTestId('hex-view')).toBeInTheDocument())
+    // Still only one readFile — bytes were cached during the probe.
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Show download view" in the status bar when in Show-anyway mode', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+    readFileImpl.mockResolvedValue(readResp(new Uint8Array(4), 2048))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-show-anyway-button')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    await waitFor(() => expect(screen.getByTestId('hex-view')).toBeInTheDocument())
+    expect(screen.getByTestId('file-show-download-view-button')).toBeInTheDocument()
+  })
+
+  it('clicking "Show download view" returns to the unsupported view without re-fetching', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+    readFileImpl.mockResolvedValue(readResp(new Uint8Array(4), 2048))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-show-anyway-button')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    await waitFor(() => expect(screen.getByTestId('hex-view')).toBeInTheDocument())
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('file-show-download-view-button'))
+    await waitFor(() =>
+      expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('hex-view')).not.toBeInTheDocument()
+    expect(readFileImpl).toHaveBeenCalledTimes(1) // no re-fetch
+  })
+
+  it('clicking Download calls downloadFileFromWorker with (workerId, filePath)', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+
+    render(() => <FileViewer workerId="w-42" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-download-button')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('unsupported-download-button'))
+    await waitFor(() => expect(downloadImpl).toHaveBeenCalledTimes(1))
+    expect(downloadImpl).toHaveBeenCalledWith('w-42', '/repo/archive.zip', 'posix')
+  })
+
+  it('discards lazy-fetched bytes if filePath changes during the in-flight readFile', async () => {
+    // First file: a .zip (no upfront fetch). User clicks "Show anyway".
+    // While that readFile is in flight, the parent swaps filePath to a
+    // text file. The readFile then resolves — the zip's bytes must NOT
+    // be written into the new file's signal, and HexView must NOT show.
+    statFileImpl.mockImplementation(async (_workerId, req) => {
+      if (req.path === '/repo/archive.zip')
+        return statResp(2048)
+      // /repo/notes.txt — a small text file
+      return statResp(11)
+    })
+
+    let resolveZipRead!: (resp: ReturnType<typeof readResp>) => void
+    const pendingZipRead = new Promise<ReturnType<typeof readResp>>((res) => {
+      resolveZipRead = res
+    })
+    const textBytes = new TextEncoder().encode('hello world')
+    readFileImpl.mockImplementation(async (_workerId, req) => {
+      if (req.path === '/repo/archive.zip')
+        return await pendingZipRead
+      // /repo/notes.txt
+      return readResp(textBytes)
+    })
+
+    const [path, setPath] = createSignal('/repo/archive.zip')
+    render(() => <FileViewer workerId="w1" filePath={path()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-show-anyway-button')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+
+    // Swap props mid-fetch.
+    setPath('/repo/notes.txt')
+    await waitFor(() => expect(screen.getByTestId('text-view')).toBeInTheDocument())
+
+    // Now resolve the zip's readFile. The bail check must prevent the
+    // bytes from clobbering the text-file state.
+    resolveZipRead(readResp(new Uint8Array([0, 1, 2, 3]), 2048))
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(screen.getByTestId('text-view')).toBeInTheDocument()
+    expect(screen.queryByTestId('hex-view')).not.toBeInTheDocument()
+  })
+
+  it('does not issue any worker RPC when workerId or filePath is empty (tab rehydration race)', async () => {
+    statFileImpl.mockResolvedValue(statResp(0))
+
+    const [path, setPath] = createSignal('')
+    render(() => <FileViewer workerId="w1" filePath={path()} />)
+
+    // Initial mount with empty filePath: load effect must short-circuit
+    // before issuing any worker RPC. Otherwise the worker rejects an
+    // empty path with "access denied" and the error sticks even after
+    // the tab restore fills the path in.
+    await new Promise(r => setTimeout(r, 0))
+    expect(statFileImpl).not.toHaveBeenCalled()
+    expect(readFileImpl).not.toHaveBeenCalled()
+
+    // Now the workspace-restore RPC arrives with the real path. A text
+    // file goes straight to readFile (no preceding statFile — that's
+    // reserved for the known-binary deny-list path; images use
+    // readFile + metaOnlyIfTruncated and text/source/markdown skip it
+    // entirely).
+    const bytes = new TextEncoder().encode('hello')
+    readFileImpl.mockResolvedValue(readResp(bytes))
+    setPath('/repo/notes.txt')
+
+    await waitFor(() => expect(screen.getByTestId('text-view')).toBeInTheDocument())
+    expect(statFileImpl).not.toHaveBeenCalled()
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+    expect(showWarnToastMock).not.toHaveBeenCalled()
+    expect(screen.queryByText(/access denied/i)).not.toBeInTheDocument()
+  })
+
+  it('surfaces failed downloads via a toast (no alert dialog)', async () => {
+    statFileImpl.mockResolvedValue(statResp(2048))
+    downloadImpl.mockRejectedValueOnce(new Error('disk full'))
+
+    render(() => <FileViewer workerId="w1" filePath="/repo/archive.zip" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('unsupported-download-button')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('unsupported-download-button'))
+    await waitFor(() => expect(showWarnToastMock).toHaveBeenCalledTimes(1))
+    expect(showWarnToastMock).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to download archive.zip'),
+      expect.any(Error),
+    )
+  })
+})

--- a/frontend/tests/unit/components/StartupPanel.test.tsx
+++ b/frontend/tests/unit/components/StartupPanel.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { StartupBody, StartupErrorBody, StartupSpinner } from '~/components/common/StartupPanel'
+
+describe('startupSpinner', () => {
+  it('renders the label text', () => {
+    render(() => <StartupSpinner label="Starting agent…" />)
+    expect(screen.getByText('Starting agent…')).toBeInTheDocument()
+  })
+})
+
+describe('startupBody', () => {
+  it('renders title only when neither body nor children are given', () => {
+    render(() => <StartupBody title="Just a title" />)
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Just a title')
+  })
+
+  it('renders the body slot below the title', () => {
+    render(() => <StartupBody title="Heading" body={<p data-testid="body-slot">subline copy</p>} />)
+    expect(screen.getByTestId('body-slot')).toHaveTextContent('subline copy')
+  })
+
+  it('renders an action row when children are provided', () => {
+    render(() => (
+      <StartupBody title="With actions" body="line">
+        <button type="button">Download</button>
+        <button type="button">Show anyway</button>
+      </StartupBody>
+    ))
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show anyway' })).toBeInTheDocument()
+  })
+
+  it('omits the action row when no children are provided', () => {
+    render(() => <StartupBody title="No actions" body="line" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})
+
+describe('startupErrorBody (back-compat layered on StartupBody)', () => {
+  it('renders the title and the danger-styled error details block', () => {
+    render(() => <StartupErrorBody title="Terminal failed to start" error="exec: not found" />)
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Terminal failed to start')
+    const codeEl = document.querySelector('pre code')
+    expect(codeEl).not.toBeNull()
+    expect(codeEl!.textContent).toBe('exec: not found')
+  })
+
+  it('falls back to "Unknown error" when the error string is empty', () => {
+    render(() => <StartupErrorBody title="Boom" error="" />)
+    const codeEl = document.querySelector('pre code')
+    expect(codeEl!.textContent).toBe('Unknown error')
+  })
+})

--- a/frontend/tests/unit/components/UnsupportedFileView.test.tsx
+++ b/frontend/tests/unit/components/UnsupportedFileView.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnsupportedFileView } from '~/components/fileviewer/UnsupportedFileView'
+
+function noop() {}
+
+function renderView(overrides: Partial<Parameters<typeof UnsupportedFileView>[0]> = {}) {
+  const props = {
+    filePath: '/repo/archive.zip',
+    flavor: 'posix' as const,
+    totalSize: 2048,
+    reason: 'binary' as const,
+    currentOp: null,
+    loadingAnyway: false,
+    canShowAnyway: true,
+    onDownload: noop,
+    onShowAnyway: noop,
+    ...overrides,
+  }
+  return render(() => <UnsupportedFileView {...props} />)
+}
+
+describe('unsupportedFileView', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders title, filename·size body, and both action buttons', () => {
+    renderView()
+    expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument()
+    const meta = screen.getByTestId('unsupported-meta')
+    expect(meta.textContent).toContain('archive.zip')
+    expect(meta.textContent).toMatch(/2(\.0)?\s*KB/i)
+    expect(screen.getByTestId('unsupported-download-button')).toBeInTheDocument()
+    expect(screen.getByTestId('unsupported-show-anyway-button')).toBeInTheDocument()
+  })
+
+  it('renders the binary reason title', () => {
+    renderView({ reason: 'binary' })
+    expect(screen.getByText('This file cannot be displayed inline.')).toBeInTheDocument()
+  })
+
+  it('renders the oversize-image reason title', () => {
+    renderView({ reason: 'oversize-image', filePath: '/repo/huge.png', totalSize: 5_000_000 })
+    expect(screen.getByText('This image is too large to preview.')).toBeInTheDocument()
+  })
+
+  it('fires onDownload when Download is clicked', () => {
+    const onDownload = vi.fn()
+    renderView({ onDownload })
+    fireEvent.click(screen.getByTestId('unsupported-download-button'))
+    expect(onDownload).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onShowAnyway when Show anyway is clicked', () => {
+    const onShowAnyway = vi.fn()
+    renderView({ onShowAnyway })
+    fireEvent.click(screen.getByTestId('unsupported-show-anyway-button'))
+    expect(onShowAnyway).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the Show anyway button when canShowAnyway is false', () => {
+    renderView({ canShowAnyway: false })
+    expect(screen.queryByTestId('unsupported-show-anyway-button')).not.toBeInTheDocument()
+    // Download still rendered.
+    expect(screen.getByTestId('unsupported-download-button')).toBeInTheDocument()
+  })
+
+  it('disables Download and shows a spinner while currentOp is "download"', () => {
+    renderView({ currentOp: 'download' })
+    const btn = screen.getByTestId('unsupported-download-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.textContent).toMatch(/Downloading/i)
+  })
+
+  it('disables Show anyway and shows a spinner while loadingAnyway is true', () => {
+    renderView({ loadingAnyway: true })
+    const btn = screen.getByTestId('unsupported-show-anyway-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.textContent).toMatch(/Loading/i)
+  })
+
+  it('attaches ARIA labels with the filename', () => {
+    renderView({ filePath: 'C:\\users\\trustin\\photo.png', flavor: 'win32', reason: 'oversize-image' })
+    expect(screen.getByLabelText('Download photo.png')).toBeInTheDocument()
+    expect(screen.getByLabelText('Show photo.png anyway')).toBeInTheDocument()
+  })
+
+  it('marks the wrapper as a region labelled by the title heading', () => {
+    renderView()
+    const region = screen.getByTestId('unsupported-file-view')
+    expect(region).toHaveAttribute('role', 'region')
+    const labelId = region.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    const heading = document.getElementById(labelId!)
+    expect(heading).not.toBeNull()
+    expect(heading!.tagName).toBe('H2')
+    expect(heading!.textContent).toBe('This file cannot be displayed inline.')
+  })
+
+  it('does not autofocus any button on mount', () => {
+    renderView()
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  describe('desktop mode', () => {
+    function renderDesktopView(
+      overrides: Partial<Parameters<typeof UnsupportedFileView>[0]>
+        & Partial<NonNullable<Parameters<typeof UnsupportedFileView>[0]['desktop']>> = {},
+    ) {
+      const onSaveAs = vi.fn()
+      const onSaveToDownloads = vi.fn()
+      const onRevealChange = vi.fn()
+      const {
+        revealAfterDownload,
+        onSaveAs: onSaveAsOverride,
+        onSaveToDownloads: onSaveToDownloadsOverride,
+        onRevealAfterDownloadChange: onRevealChangeOverride,
+        ...topLevel
+      } = overrides
+      renderView({
+        ...topLevel,
+        desktop: {
+          onSaveAs: onSaveAsOverride ?? onSaveAs,
+          onSaveToDownloads: onSaveToDownloadsOverride ?? onSaveToDownloads,
+          revealAfterDownload: revealAfterDownload ?? false,
+          onRevealAfterDownloadChange: onRevealChangeOverride ?? onRevealChange,
+        },
+      })
+      return { onSaveAs, onSaveToDownloads, onRevealChange }
+    }
+
+    it('renders Save as / Save to Downloads instead of Download', () => {
+      renderDesktopView()
+      expect(screen.queryByTestId('unsupported-download-button')).not.toBeInTheDocument()
+      expect(screen.getByTestId('unsupported-save-as-button')).toBeInTheDocument()
+      expect(screen.getByTestId('unsupported-save-to-downloads-button')).toBeInTheDocument()
+    })
+
+    it('fires onSaveAs / onSaveToDownloads when the respective buttons are clicked', () => {
+      const { onSaveAs, onSaveToDownloads } = renderDesktopView()
+      fireEvent.click(screen.getByTestId('unsupported-save-as-button'))
+      expect(onSaveAs).toHaveBeenCalledTimes(1)
+      expect(onSaveToDownloads).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByTestId('unsupported-save-to-downloads-button'))
+      expect(onSaveToDownloads).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables both save buttons while a save is in flight', () => {
+      renderDesktopView({ currentOp: 'save-as' })
+      const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
+      const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
+      expect(saveAs.disabled).toBe(true)
+      expect(toDownloads.disabled).toBe(true)
+    })
+
+    it('shows the spinner on the Save-as button when currentOp is "save-as"', () => {
+      renderDesktopView({ currentOp: 'save-as' })
+      const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
+      const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
+      expect(saveAs.textContent).toMatch(/Saving/i)
+      expect(toDownloads.textContent).not.toMatch(/Saving/i)
+      expect(toDownloads.textContent).toMatch(/Save to Downloads/i)
+    })
+
+    it('shows the spinner on the Save-to-Downloads button when currentOp is "save-to-downloads"', () => {
+      renderDesktopView({ currentOp: 'save-to-downloads' })
+      const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
+      const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
+      expect(toDownloads.textContent).toMatch(/Saving/i)
+      expect(saveAs.textContent).not.toMatch(/Saving/i)
+      expect(saveAs.textContent).toMatch(/Save as/i)
+    })
+
+    it('renders the reveal checkbox reflecting the preference', () => {
+      renderDesktopView({ revealAfterDownload: true })
+      const checkbox = screen.getByTestId('unsupported-reveal-checkbox') as HTMLInputElement
+      expect(checkbox.checked).toBe(true)
+    })
+
+    it('fires onRevealAfterDownloadChange when the checkbox is toggled', () => {
+      const { onRevealChange } = renderDesktopView({ revealAfterDownload: false })
+      const checkbox = screen.getByTestId('unsupported-reveal-checkbox') as HTMLInputElement
+      fireEvent.click(checkbox)
+      expect(onRevealChange).toHaveBeenCalledWith(true)
+    })
+
+    it('omits the reveal checkbox in web mode (no desktop prop)', () => {
+      renderView()
+      expect(screen.queryByTestId('unsupported-reveal-checkbox')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/tests/unit/components/ViewToggle.test.tsx
+++ b/frontend/tests/unit/components/ViewToggle.test.tsx
@@ -12,37 +12,27 @@ vi.mock('~/components/fileviewer/FileViewer.css', () => ({
 function noop() {}
 
 describe('viewToggle', () => {
-  it('shows mention button when onMention is provided', () => {
-    render(() => (
-      <ViewToggle
-        mode="render"
-        onToggle={noop}
-        onMention={() => {}}
-      />
-    ))
-    expect(screen.getByTestId('file-mention-button')).toBeInTheDocument()
+  it('renders the render / source toggle buttons', () => {
+    render(() => <ViewToggle mode="render" onToggle={noop} />)
+    // The render toggle button (Eye icon) is the first toggle in the row.
+    expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(2)
   })
 
-  it('hides mention button when onMention is undefined', () => {
-    render(() => (
-      <ViewToggle
-        mode="render"
-        onToggle={noop}
-      />
+  it('shows the side-by-side toggle when showSplit is true', () => {
+    const { container } = render(() => (
+      <ViewToggle mode="render" onToggle={noop} showSplit />
     ))
-    expect(screen.queryByTestId('file-mention-button')).not.toBeInTheDocument()
+    // Three toggle buttons total: render, split, source.
+    expect(container.querySelectorAll('button').length).toBe(3)
   })
 
-  it('calls onMention when mention button is clicked', () => {
-    const onMention = vi.fn()
-    render(() => (
-      <ViewToggle
-        mode="render"
-        onToggle={noop}
-        onMention={onMention}
-      />
+  it('calls onToggle when a toggle button is clicked', () => {
+    const onToggle = vi.fn()
+    const { container } = render(() => (
+      <ViewToggle mode="render" onToggle={onToggle} showSplit />
     ))
-    screen.getByTestId('file-mention-button').click()
-    expect(onMention).toHaveBeenCalledOnce()
+    const buttons = container.querySelectorAll('button')
+    buttons[1].click() // split
+    expect(onToggle).toHaveBeenCalledWith('split')
   })
 })

--- a/frontend/tests/unit/components/syncGitStatusToTabs.test.ts
+++ b/frontend/tests/unit/components/syncGitStatusToTabs.test.ts
@@ -178,6 +178,183 @@ describe('syncGitStatusToTabs', () => {
     })
   })
 
+  it('stamps git fields on a FILE tab whose filePath sits under repoRoot', async () => {
+    // FILE tabs hydrated after a refresh come back with only `filePath`
+    // (the CRDT projection doesn't carry workingDir, and the path
+    // hydrator only fills filePath). syncGitStatusToTabs must use
+    // filePath as a stand-in for the containment check — otherwise the
+    // workspace tree groups the tab under the wrong repo (or in the
+    // ungrouped bucket).
+    await createRoot(async (dispose) => {
+      const tabStore = createTabStore()
+      const gitFileStatusStore = createGitFileStatusStore()
+
+      tabStore.addTab({ type: TabType.FILE, id: 'f1', filePath: '/repo/src/foo.ts' })
+
+      syncGitStatusToTabs({ gitFileStatusStore, tabStore })
+
+      mockGetGitFileStatus.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        originUrl: 'https://example.com/repo.git',
+        currentBranch: 'main',
+        files: [
+          makeEntry({ path: 'foo.ts', unstagedStatus: GitFileStatusCode.MODIFIED, linesAdded: 7, linesDeleted: 1 }),
+        ],
+      })
+
+      await gitFileStatusStore.refresh('worker1', '/repo')
+
+      const f1 = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'f1' }))
+      expect(f1?.gitOriginUrl).toBe('https://example.com/repo.git')
+      expect(f1?.gitBranch).toBe('main')
+      expect(f1?.gitToplevel).toBe('/repo')
+      expect(f1?.gitDiffAdded).toBe(7)
+      expect(f1?.gitDiffDeleted).toBe(1)
+
+      dispose()
+    })
+  })
+
+  it('does not stamp a FILE tab whose filePath lives outside repoRoot', async () => {
+    await createRoot(async (dispose) => {
+      const tabStore = createTabStore()
+      const gitFileStatusStore = createGitFileStatusStore()
+
+      // FILE tab outside the focused repo's tree — must stay unstamped.
+      tabStore.addTab({ type: TabType.FILE, id: 'outside', filePath: '/other-repo/src/x.ts' })
+      // Sanity reference: an inside tab so we can assert the effect did fire.
+      tabStore.addTab({ type: TabType.FILE, id: 'inside', filePath: '/repo/y.ts' })
+
+      syncGitStatusToTabs({ gitFileStatusStore, tabStore })
+
+      mockGetGitFileStatus.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        originUrl: 'https://example.com/repo.git',
+        currentBranch: 'main',
+        files: [],
+      })
+      await gitFileStatusStore.refresh('worker1', '/repo')
+
+      const outside = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'outside' }))
+      expect(outside?.gitOriginUrl).toBeUndefined()
+      expect(outside?.gitToplevel).toBeUndefined()
+
+      const inside = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'inside' }))
+      expect(inside?.gitOriginUrl).toBe('https://example.com/repo.git')
+      expect(inside?.gitToplevel).toBe('/repo')
+
+      dispose()
+    })
+  })
+
+  it('prefers workingDir over filePath on a FILE tab that has both', async () => {
+    // Live-session FILE tabs (those opened via useTabOperations.openFile)
+    // carry both `workingDir` and `filePath`. The containment check uses
+    // workingDir first; we verify by giving the FILE tab a workingDir
+    // OUTSIDE the focused repo and a filePath INSIDE — the tab must not
+    // be stamped, proving workingDir won.
+    await createRoot(async (dispose) => {
+      const tabStore = createTabStore()
+      const gitFileStatusStore = createGitFileStatusStore()
+
+      tabStore.addTab({
+        type: TabType.FILE,
+        id: 'f1',
+        filePath: '/repo/inside.ts',
+        workingDir: '/elsewhere',
+      })
+
+      syncGitStatusToTabs({ gitFileStatusStore, tabStore })
+
+      mockGetGitFileStatus.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        originUrl: 'https://example.com/repo.git',
+        currentBranch: 'main',
+        files: [],
+      })
+      await gitFileStatusStore.refresh('worker1', '/repo')
+
+      const f1 = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'f1' }))
+      expect(f1?.gitOriginUrl).toBeUndefined()
+      expect(f1?.gitToplevel).toBeUndefined()
+
+      dispose()
+    })
+  })
+
+  it('skips a FILE tab that has neither workingDir nor a filePath yet', async () => {
+    // Pre-hydration: the path hydrator hasn't filled filePath in yet,
+    // and the CRDT projection didn't carry workingDir. There's nothing
+    // to compare against repoRoot, so the effect must leave the tab
+    // alone (no false positives).
+    await createRoot(async (dispose) => {
+      const tabStore = createTabStore()
+      const gitFileStatusStore = createGitFileStatusStore()
+
+      tabStore.addTab({ type: TabType.FILE, id: 'f1' })
+
+      syncGitStatusToTabs({ gitFileStatusStore, tabStore })
+
+      mockGetGitFileStatus.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        originUrl: 'https://example.com/repo.git',
+        currentBranch: 'main',
+        files: [],
+      })
+      await gitFileStatusStore.refresh('worker1', '/repo')
+
+      const f1 = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'f1' }))
+      expect(f1?.gitOriginUrl).toBeUndefined()
+      expect(f1?.gitToplevel).toBeUndefined()
+      expect(f1?.gitBranch).toBeUndefined()
+
+      dispose()
+    })
+  })
+
+  it('stamps a tab that is added AFTER the git store already has data', async () => {
+    // Regression: when the user opens a new file in the same focused
+    // repo, the git store state doesn't change (same files, branch,
+    // repoRoot). Before the fix, the effect tracked only store state,
+    // so the new FILE tab arrived after the last store-state change
+    // and never got stamped — the workspace tab tree placed it under
+    // "Ungrouped" until a page refresh re-ran the restore→refresh
+    // sequence in the right order.
+    await createRoot(async (dispose) => {
+      const tabStore = createTabStore()
+      const gitFileStatusStore = createGitFileStatusStore()
+
+      syncGitStatusToTabs({ gitFileStatusStore, tabStore })
+
+      mockGetGitFileStatus.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        originUrl: 'https://example.com/repo.git',
+        currentBranch: 'main',
+        files: [
+          makeEntry({ path: 'foo.ts', unstagedStatus: GitFileStatusCode.MODIFIED, linesAdded: 4, linesDeleted: 2 }),
+        ],
+      })
+      // Populate the store first. No tabs exist yet, so the effect
+      // runs and finds nothing to stamp.
+      await gitFileStatusStore.refresh('worker1', '/repo')
+
+      // Now the user opens a file — new FILE tab arrives after the
+      // store already settled. The effect must still notice and stamp
+      // it on the next reactive flush.
+      tabStore.addTab({ type: TabType.FILE, id: 'newly-opened', filePath: '/repo/foo.ts', workingDir: '/repo' })
+      await Promise.resolve()
+
+      const tab = tabStore.getTabByKey(tabKey({ type: TabType.FILE, id: 'newly-opened' }))
+      expect(tab?.gitOriginUrl).toBe('https://example.com/repo.git')
+      expect(tab?.gitBranch).toBe('main')
+      expect(tab?.gitToplevel).toBe('/repo')
+      expect(tab?.gitDiffAdded).toBe(4)
+      expect(tab?.gitDiffDeleted).toBe(2)
+
+      dispose()
+    })
+  })
+
   it('seeds gitToplevel on a tab that has not yet learned its toplevel', async () => {
     // First-sync fallback: a freshly-created tab has no gitToplevel yet,
     // so the path-prefix check is the best we can do. After the first

--- a/frontend/tests/unit/components/useWorkspaceRestore.test.ts
+++ b/frontend/tests/unit/components/useWorkspaceRestore.test.ts
@@ -263,6 +263,105 @@ describe('useWorkspaceRestore terminal hydration retry', () => {
     dispose()
   })
 
+  // Per-worker retry slot cleanup. When a worker disappears from the
+  // missing-tabs map (its tabs were closed, it disconnected, or every
+  // pending tab hydrated), the next failure on the same worker id must
+  // restart the backoff at `initialMs` — not resume mid-sequence from
+  // a stale `lastBaseDelays` entry the helper would otherwise keep
+  // until unmount. Verified by pinning Math.random so the un-jittered
+  // base equals the scheduled delay, then comparing arm-times across
+  // a dropout cycle.
+  it('resets per-worker retry state when a worker drops out of the candidate map', async () => {
+    vi.useFakeTimers()
+    // Pin jitter to its symmetric midpoint so scheduled delays match
+    // the un-jittered base (500ms → 1000ms → …) exactly.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    try {
+      mockListTerminals.mockReset()
+      // Every call rejects → every effect run schedules a retry.
+      mockListTerminals.mockRejectedValue(new Error('worker unavailable'))
+
+      const opts = makeBaseOpts()
+      const workerId = 'flaky-worker'
+      opts.registry.set('active-ws', {
+        workspaceId: 'active-ws',
+        tabs: [{
+          type: TabType.TERMINAL,
+          id: 'term-1',
+          workerId,
+          status: TerminalStatus.READY,
+        }],
+        activeTabKey: null,
+        layout: { root: { type: 'leaf', id: 'default' }, focusedTileId: null },
+        restored: true,
+        tabsLoaded: true,
+      })
+
+      const [activeId, setActiveId] = createSignal<string | null>(null)
+      const [orgId, setOrgId] = createSignal<string | undefined>(undefined)
+
+      const dispose = createRoot((dispose) => {
+        useWorkspaceRestore({
+          ...opts,
+          getActiveWorkspaceId: activeId,
+          getOrgId: orgId,
+        })
+        setActiveId('active-ws')
+        setOrgId('org-1')
+        return dispose
+      })
+
+      // First effect tick: one listTerminals fire, fails, retry armed.
+      await flushEffects()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockListTerminals).toHaveBeenCalledTimes(1)
+
+      // Advance just past the first retry delay (500ms). The retry
+      // bumps the tick → effect runs again → second listTerminals →
+      // rejects → next retry armed at 1000ms.
+      await vi.advanceTimersByTimeAsync(500)
+      expect(mockListTerminals).toHaveBeenCalledTimes(2)
+
+      // Worker drops out: close the only tab that needs hydration.
+      // `tabsNeedingHydration` now returns an empty map for this
+      // worker, and the effect's keyset-diff must call `reset` for it.
+      opts.tabStore.removeTab(TabType.TERMINAL, 'term-1')
+      await flushEffects()
+
+      // Re-introduce a tab on the same worker, still un-hydrated. The
+      // effect fires immediately (candidate map changed) and the third
+      // listTerminals call rejects.
+      mockListTerminals.mockClear()
+      opts.tabStore.addTab({
+        type: TabType.TERMINAL,
+        id: 'term-2',
+        workerId,
+        status: TerminalStatus.READY,
+      })
+      await flushEffects()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockListTerminals).toHaveBeenCalledTimes(1)
+      mockListTerminals.mockClear()
+
+      // The retry slot was reset, so the next retry must fire at
+      // 500ms — NOT 2000ms (which would be the un-reset doubled value
+      // after 500ms → 1000ms → 2000ms). Tick at 499ms: no fire yet.
+      // Tick at 501ms: the retry must have fired, re-running the
+      // effect → fourth listTerminals call.
+      await vi.advanceTimersByTimeAsync(499)
+      expect(mockListTerminals).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(2)
+      expect(mockListTerminals).toHaveBeenCalledTimes(1)
+
+      dispose()
+    }
+    finally {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    }
+  })
+
   // Mixed fixture: two tabs on the same worker, one fully hydrated and
   // one missing its payload. Proves the filter is per-tab (not
   // per-workspace) and that the RPC carries only the un-hydrated id.

--- a/frontend/tests/unit/context/PreferencesContext.test.tsx
+++ b/frontend/tests/unit/context/PreferencesContext.test.tsx
@@ -178,6 +178,55 @@ describe('preferencesContext — multiple prefs in one blob', () => {
   })
 })
 
+describe('preferencesContext — revealAfterDownload (default-on)', () => {
+  // The save flow asks the OS to "reveal in Finder/Explorer" after
+  // writing. Most users want it; we only persist an explicit `false`
+  // when the user opts out — `undefined` is implicit consent.
+  it('defaults to true when localStorage is empty', () => {
+    const ctx = captureContext()
+    expect(ctx.get().revealAfterDownload()).toBe(true)
+    // Nothing serialized while no opt-out has happened.
+    expect('revealAfterDownload' in loadBrowserPrefs()).toBe(false)
+  })
+
+  it('opts out by persisting `false` to the consolidated prefs blob', () => {
+    const ctx = captureContext()
+    ctx.get().setRevealAfterDownload(false)
+    expect(ctx.get().revealAfterDownload()).toBe(false)
+    expect(loadBrowserPrefs().revealAfterDownload).toBe(false)
+  })
+
+  it('opts back in by clearing the key from the blob (not storing `true`)', () => {
+    const ctx = captureContext()
+    ctx.get().setRevealAfterDownload(false)
+    expect(loadBrowserPrefs().revealAfterDownload).toBe(false)
+
+    ctx.get().setRevealAfterDownload(true)
+    expect(ctx.get().revealAfterDownload()).toBe(true)
+    // Default-on prefs round-trip the absence of the key, not `true`.
+    expect('revealAfterDownload' in loadBrowserPrefs()).toBe(false)
+  })
+
+  it('hydrates a stored `false` from localStorage on provider mount', () => {
+    localStorage.setItem(KEY_BROWSER_PREFS, JSON.stringify({ revealAfterDownload: false }))
+    const ctx = captureContext()
+    expect(ctx.get().revealAfterDownload()).toBe(false)
+  })
+
+  it('does not interact with other persisted prefs in the same blob', () => {
+    const ctx = captureContext()
+    ctx.get().setBrowserTheme('dark')
+    ctx.get().setRevealAfterDownload(false)
+    expect(loadBrowserPrefs().theme).toBe('dark')
+    expect(loadBrowserPrefs().revealAfterDownload).toBe(false)
+
+    // Opting back in must not clobber the theme.
+    ctx.get().setRevealAfterDownload(true)
+    expect(loadBrowserPrefs().theme).toBe('dark')
+    expect('revealAfterDownload' in loadBrowserPrefs()).toBe(false)
+  })
+})
+
 describe('preferencesContext — reload from API', () => {
   it('runs reload() on mount without throwing when the API returns no preferences', async () => {
     // The default mock returns `{}` (no `preferences` field). Provider should

--- a/frontend/tests/unit/helpers/saveActionsMocks.ts
+++ b/frontend/tests/unit/helpers/saveActionsMocks.ts
@@ -1,0 +1,84 @@
+import type { Mock } from 'vitest'
+
+/**
+ * Spy bundle for tests that exercise the file-save action wiring
+ * (`createFileSaveActions` + `FileActionsMenu`). Each test file creates
+ * a fresh bundle via `vi.hoisted` so the references survive vitest's
+ * vi.mock hoisting:
+ *
+ *   const spies = vi.hoisted<SaveActionsSpies>(() => ({
+ *     downloadImpl: vi.fn(),
+ *     saveAsImpl: vi.fn(),
+ *     ...
+ *   }))
+ *
+ * The bundle is then passed to vi.mock factories via the helpers
+ * exported below, and reset between tests with `resetSaveActionsSpies`.
+ */
+export interface SaveActionsSpies {
+  downloadImpl: Mock
+  saveAsImpl: Mock
+  saveToDownloadsImpl: Mock
+  revealImpl: Mock
+  warnToastImpl: Mock
+  revealAfterDownloadImpl: Mock<() => boolean>
+  isTauriAppImpl: Mock<() => boolean>
+}
+
+// vi.mock factory bodies — each returns an object suitable for the
+// matching `vi.mock(path, () => ...)` call. The factory itself runs
+// lazily on first import of the mocked module, so referencing the
+// `spies` bundle is safe even though `vi.mock` is hoisted.
+
+export function platformBridgeMock(spies: SaveActionsSpies) {
+  return {
+    isTauriApp: () => spies.isTauriAppImpl(),
+    platformBridge: {
+      revealInFileManager: (...args: unknown[]) => spies.revealImpl(...args),
+      saveBytesToDownloads: () => Promise.resolve(''),
+      saveBytesAs: () => Promise.resolve(null),
+    },
+  }
+}
+
+export function fileDownloadMock(spies: SaveActionsSpies) {
+  return {
+    downloadFileFromWorker: (...args: unknown[]) => spies.downloadImpl(...args),
+    saveFileAs: (...args: unknown[]) => spies.saveAsImpl(...args),
+    saveFileToDownloads: (...args: unknown[]) => spies.saveToDownloadsImpl(...args),
+  }
+}
+
+export function toastMock(spies: SaveActionsSpies) {
+  return {
+    showWarnToast: (...args: unknown[]) => spies.warnToastImpl(...args),
+  }
+}
+
+export function preferencesMock(spies: SaveActionsSpies) {
+  return {
+    usePreferences: () => ({
+      revealAfterDownload: () => spies.revealAfterDownloadImpl(),
+      setRevealAfterDownload: () => {},
+    }),
+  }
+}
+
+/**
+ * Rolls every spy back to its default resolved value. Call from
+ * `beforeEach`. Pass per-test overrides afterwards.
+ */
+export function resetSaveActionsSpies(spies: SaveActionsSpies): void {
+  spies.downloadImpl.mockReset()
+  spies.downloadImpl.mockResolvedValue(undefined)
+  spies.saveAsImpl.mockReset()
+  spies.saveAsImpl.mockResolvedValue('/home/alice/Downloads/file.ts')
+  spies.saveToDownloadsImpl.mockReset()
+  spies.saveToDownloadsImpl.mockResolvedValue('/home/alice/Downloads/file.ts')
+  spies.revealImpl.mockReset()
+  spies.warnToastImpl.mockReset()
+  spies.revealAfterDownloadImpl.mockReset()
+  spies.revealAfterDownloadImpl.mockReturnValue(true)
+  spies.isTauriAppImpl.mockReset()
+  spies.isTauriAppImpl.mockReturnValue(false)
+}

--- a/frontend/tests/unit/lib/fileDownload.test.ts
+++ b/frontend/tests/unit/lib/fileDownload.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readFileImpl = vi.fn()
+
+vi.mock('~/api/workerRpc', () => ({
+  readFile: (...args: unknown[]) => readFileImpl(...args),
+}))
+
+const { downloadFileFromWorker } = await import('~/lib/fileDownload')
+
+function readResp(content: Uint8Array, totalSize?: number) {
+  return {
+    content,
+    totalSize: BigInt(totalSize ?? content.length),
+  }
+}
+
+interface AnchorSpy {
+  clickSpy: ReturnType<typeof vi.fn>
+  /** Captured value of `<a download="...">` when set. */
+  downloadName: { value: string | undefined }
+  restore: () => void
+}
+
+/**
+ * Replace `document.createElement('a')` with a stub anchor whose
+ * `click` is captured. Tests assert on clickSpy / downloadName and call
+ * `restore()` (or rely on `afterEach`).
+ */
+function spyAnchor(): AnchorSpy {
+  const clickSpy = vi.fn()
+  const downloadName: { value: string | undefined } = { value: undefined }
+  const origCreate = document.createElement.bind(document)
+  const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = origCreate(tag) as HTMLAnchorElement
+    if (tag === 'a') {
+      el.click = clickSpy
+      Object.defineProperty(el, 'download', {
+        configurable: true,
+        set(v: string) { downloadName.value = v },
+        get() { return downloadName.value },
+      })
+    }
+    return el
+  })
+  return { clickSpy, downloadName, restore: () => createSpy.mockRestore() }
+}
+
+describe('downloadFileFromWorker', () => {
+  let originalCreate: typeof URL.createObjectURL
+  let originalRevoke: typeof URL.revokeObjectURL
+  const createUrlSpy = vi.fn(() => 'blob:mock-url')
+  const revokeUrlSpy = vi.fn()
+  let anchor: AnchorSpy
+
+  beforeEach(() => {
+    readFileImpl.mockReset()
+    createUrlSpy.mockClear()
+    revokeUrlSpy.mockClear()
+    originalCreate = URL.createObjectURL
+    originalRevoke = URL.revokeObjectURL
+    URL.createObjectURL = createUrlSpy as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeUrlSpy as unknown as typeof URL.revokeObjectURL
+    vi.useFakeTimers()
+    anchor = spyAnchor()
+  })
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreate
+    URL.revokeObjectURL = originalRevoke
+    vi.useRealTimers()
+    anchor.restore()
+  })
+
+  it('streams a small file in a single chunk and triggers an anchor download', async () => {
+    const bytes = new TextEncoder().encode('hello world')
+    readFileImpl.mockResolvedValue(readResp(bytes))
+
+    await downloadFileFromWorker('w1', '/repo/hello.txt')
+
+    expect(readFileImpl).toHaveBeenCalledTimes(1)
+    expect(readFileImpl).toHaveBeenCalledWith('w1', expect.objectContaining({
+      workerId: 'w1',
+      path: '/repo/hello.txt',
+      offset: 0n,
+    }))
+    expect(anchor.clickSpy).toHaveBeenCalledTimes(1)
+    expect(createUrlSpy).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1100)
+    expect(revokeUrlSpy).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('streams a large file in multiple 1 MiB chunks until totalSize is reached', async () => {
+    const CHUNK = 1 << 20
+    const total = CHUNK * 3 + 7
+    let offset = 0
+    readFileImpl.mockImplementation(async (_workerId, req) => {
+      const reqOffset = Number(req.offset)
+      const reqLimit = Number(req.limit)
+      expect(reqOffset).toBe(offset)
+      expect(reqLimit).toBe(CHUNK)
+      const remaining = total - offset
+      const size = Math.min(reqLimit, remaining)
+      const buf = new Uint8Array(size)
+      offset += size
+      return readResp(buf, total)
+    })
+
+    await downloadFileFromWorker('w1', '/repo/big.bin')
+
+    // 3 MB + 7 bytes → 4 chunks
+    expect(readFileImpl).toHaveBeenCalledTimes(4)
+    expect(anchor.clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops early when readFile returns zero bytes even if totalSize disagrees', async () => {
+    readFileImpl.mockResolvedValueOnce(readResp(new Uint8Array(4096), 10_000))
+    readFileImpl.mockResolvedValueOnce(readResp(new Uint8Array(0), 10_000))
+
+    await downloadFileFromWorker('w1', '/repo/short.bin')
+
+    expect(readFileImpl).toHaveBeenCalledTimes(2)
+    expect(anchor.clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses basename(filePath) as the download filename with detected flavor', async () => {
+    readFileImpl.mockResolvedValue(readResp(new Uint8Array([1, 2, 3, 4])))
+
+    await downloadFileFromWorker('w1', 'C:\\Users\\alice\\file.bin')
+    expect(anchor.downloadName.value).toBe('file.bin')
+
+    anchor.downloadName.value = undefined
+    await downloadFileFromWorker('w1', '/repo/sub/dir/photo.png')
+    expect(anchor.downloadName.value).toBe('photo.png')
+  })
+
+  it('propagates readFile errors and never leaks an object URL', async () => {
+    readFileImpl.mockRejectedValue(new Error('boom'))
+
+    await expect(downloadFileFromWorker('w1', '/repo/x.bin')).rejects.toThrow('boom')
+    expect(anchor.clickSpy).not.toHaveBeenCalled()
+    expect(createUrlSpy).not.toHaveBeenCalled()
+    expect(revokeUrlSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/unit/lib/fileType.test.ts
+++ b/frontend/tests/unit/lib/fileType.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectFileViewMode, isBinaryContent, isImageExtension, isMarkdownExtension, isSvgExtension } from '~/lib/fileType'
+import { detectFileViewMode, isBinaryContent, isImageExtension, isLikelyBinaryExtension, isMarkdownExtension, isSvgExtension } from '~/lib/fileType'
 
 describe('isImageExtension', () => {
   const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'avif']
@@ -62,6 +62,58 @@ describe('isSvgExtension', () => {
 
   it('returns false for non-svg files', () => {
     expect(isSvgExtension('icon.png')).toBe(false)
+  })
+})
+
+describe('isLikelyBinaryExtension', () => {
+  it('returns true for known archive extensions', () => {
+    expect(isLikelyBinaryExtension('bundle.zip')).toBe(true)
+    expect(isLikelyBinaryExtension('release.tar.gz')).toBe(true)
+    expect(isLikelyBinaryExtension('archive.7z')).toBe(true)
+  })
+
+  it('returns true for known executable / object extensions', () => {
+    expect(isLikelyBinaryExtension('app.exe')).toBe(true)
+    expect(isLikelyBinaryExtension('libfoo.so')).toBe(true)
+    expect(isLikelyBinaryExtension('main.o')).toBe(true)
+  })
+
+  it('returns true for office / PDF / media / font / database / disk-image extensions', () => {
+    expect(isLikelyBinaryExtension('report.pdf')).toBe(true)
+    expect(isLikelyBinaryExtension('slides.pptx')).toBe(true)
+    expect(isLikelyBinaryExtension('song.mp3')).toBe(true)
+    expect(isLikelyBinaryExtension('movie.mkv')).toBe(true)
+    expect(isLikelyBinaryExtension('font.woff2')).toBe(true)
+    expect(isLikelyBinaryExtension('cache.sqlite')).toBe(true)
+    expect(isLikelyBinaryExtension('boot.iso')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isLikelyBinaryExtension('Bundle.ZIP')).toBe(true)
+    expect(isLikelyBinaryExtension('Report.PDF')).toBe(true)
+  })
+
+  it('returns false for source-code extensions', () => {
+    expect(isLikelyBinaryExtension('index.ts')).toBe(false)
+    expect(isLikelyBinaryExtension('main.go')).toBe(false)
+    expect(isLikelyBinaryExtension('app.py')).toBe(false)
+    expect(isLikelyBinaryExtension('README.md')).toBe(false)
+  })
+
+  it('returns false for image extensions (handled by isImageExtension)', () => {
+    expect(isLikelyBinaryExtension('photo.png')).toBe(false)
+    expect(isLikelyBinaryExtension('icon.svg')).toBe(false)
+  })
+
+  it('returns false for paths without an extension', () => {
+    expect(isLikelyBinaryExtension('Makefile')).toBe(false)
+    expect(isLikelyBinaryExtension('Dockerfile')).toBe(false)
+    expect(isLikelyBinaryExtension('/etc/hosts')).toBe(false)
+  })
+
+  it('does not treat a dot inside a parent directory as an extension', () => {
+    expect(isLikelyBinaryExtension('archive.zip/inside/file')).toBe(false)
+    expect(isLikelyBinaryExtension('C:\\Program Files\\app\\readme')).toBe(false)
   })
 })
 

--- a/frontend/tests/unit/lib/retry.test.ts
+++ b/frontend/tests/unit/lib/retry.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createExponentialBackoff } from '~/lib/retry'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Pin Math.random to 0.5 so the symmetric-jitter offset is zero and
+  // delay assertions match the base sequence exactly. Tests that
+  // exercise jitter explicitly override this.
+  vi.spyOn(Math, 'random').mockReturnValue(0.5)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('createExponentialBackoff', () => {
+  it('schedules the first retry at exactly `initialMs` (jitter pinned to 0)', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    const fire = vi.fn()
+    const delay = backoff.schedule('k', fire)
+    expect(delay).toBe(500)
+
+    vi.advanceTimersByTime(499)
+    expect(fire).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(fire).toHaveBeenCalledTimes(1)
+  })
+
+  it('doubles the delay on each schedule until it hits `maxMs`', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 4000 })
+    // peekNextDelay returns the un-jittered base; with random pinned at
+    // 0.5 the arm-time matches it exactly.
+    expect(backoff.peekNextDelay('k')).toBe(500)
+    expect(backoff.schedule('k', () => {})).toBe(500)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(1000)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(2000)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(4000)
+    vi.runAllTimers()
+    // Already at max: subsequent schedules stay at maxMs.
+    expect(backoff.schedule('k', () => {})).toBe(4000)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(4000)
+  })
+
+  it('honors a non-default multiplier', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 100, maxMs: 1000, multiplier: 3, jitterFactor: 0 })
+    expect(backoff.schedule('k', () => {})).toBe(100)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(300)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(900)
+    vi.runAllTimers()
+    expect(backoff.schedule('k', () => {})).toBe(1000) // clamped
+  })
+
+  it('treats schedule as a no-op when a timer is already pending for that key', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    const fire1 = vi.fn()
+    const fire2 = vi.fn()
+    expect(backoff.schedule('k', fire1)).toBe(500)
+    // Second call returns null (already pending); the original `fire`
+    // is the one that will run — the new `fire2` is dropped.
+    expect(backoff.schedule('k', fire2)).toBeNull()
+    expect(backoff.peekNextDelay('k')).toBeNull()
+    vi.runAllTimers()
+    expect(fire1).toHaveBeenCalledTimes(1)
+    expect(fire2).not.toHaveBeenCalled()
+  })
+
+  it('keeps per-key delays independent', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 4000 })
+    backoff.schedule('a', () => {})
+    backoff.schedule('b', () => {})
+    vi.runAllTimers()
+    // Both keys advanced one step.
+    expect(backoff.peekNextDelay('a')).toBe(1000)
+    expect(backoff.peekNextDelay('b')).toBe(1000)
+    // Advance only `a` again.
+    backoff.schedule('a', () => {})
+    vi.runAllTimers()
+    expect(backoff.peekNextDelay('a')).toBe(2000)
+    expect(backoff.peekNextDelay('b')).toBe(1000)
+  })
+
+  it('reset(key) cancels a pending timer and restarts the sequence', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    const fire = vi.fn()
+    backoff.schedule('k', fire)
+    vi.runAllTimers() // first retry fires
+    expect(fire).toHaveBeenCalledTimes(1)
+    // Now the next delay would be 1000ms. Reset, and the next schedule
+    // restarts at 500ms.
+    backoff.reset('k')
+    expect(backoff.peekNextDelay('k')).toBe(500)
+    expect(backoff.schedule('k', fire)).toBe(500)
+  })
+
+  it('reset(key) clears a still-pending timer so `fire` never runs', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    const fire = vi.fn()
+    backoff.schedule('k', fire)
+    backoff.reset('k')
+    vi.runAllTimers()
+    expect(fire).not.toHaveBeenCalled()
+    expect(backoff.size()).toBe(0)
+  })
+
+  it('reset(key) on an unknown key is a no-op', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    expect(() => backoff.reset('never-scheduled')).not.toThrow()
+    expect(backoff.size()).toBe(0)
+  })
+
+  it('cancelAll() cancels every pending timer and forgets every delay', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    const fireA = vi.fn()
+    const fireB = vi.fn()
+    backoff.schedule('a', fireA)
+    backoff.schedule('b', fireB)
+    expect(backoff.size()).toBe(2)
+    backoff.cancelAll()
+    expect(backoff.size()).toBe(0)
+    vi.runAllTimers()
+    expect(fireA).not.toHaveBeenCalled()
+    expect(fireB).not.toHaveBeenCalled()
+    // Delays were forgotten too — next schedule starts fresh.
+    expect(backoff.peekNextDelay('a')).toBe(500)
+  })
+
+  it('allows `fire` to re-schedule the same key (slot is freed before the callback runs)', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    let runs = 0
+    const fire = () => {
+      runs++
+      if (runs < 3)
+        backoff.schedule('k', fire)
+    }
+    backoff.schedule('k', fire)
+
+    vi.advanceTimersByTime(500)
+    expect(runs).toBe(1)
+    vi.advanceTimersByTime(1000)
+    expect(runs).toBe(2)
+    vi.advanceTimersByTime(2000)
+    expect(runs).toBe(3)
+    // After the third run, `fire` doesn't re-schedule.
+    expect(backoff.size()).toBe(0)
+  })
+
+  it('peekNextDelay returns null while a timer is pending', () => {
+    const backoff = createExponentialBackoff<string>({ initialMs: 500, maxMs: 10_000 })
+    expect(backoff.peekNextDelay('k')).toBe(500)
+    backoff.schedule('k', () => {})
+    expect(backoff.peekNextDelay('k')).toBeNull()
+  })
+
+  it('supports keys that are objects (uses Map identity)', () => {
+    const backoff = createExponentialBackoff<{ id: string }>({ initialMs: 500, maxMs: 10_000 })
+    const a = { id: 'a' }
+    const b = { id: 'a' } // same shape, different identity
+    backoff.schedule(a, () => {})
+    backoff.schedule(b, () => {})
+    expect(backoff.size()).toBe(2)
+  })
+
+  it('rejects invalid options at construction time', () => {
+    expect(() => createExponentialBackoff({ initialMs: 0, maxMs: 1000 })).toThrow(/initialMs/)
+    expect(() => createExponentialBackoff({ initialMs: -1, maxMs: 1000 })).toThrow(/initialMs/)
+    expect(() => createExponentialBackoff({ initialMs: 500, maxMs: 100 })).toThrow(/maxMs/)
+    expect(() => createExponentialBackoff({ initialMs: 500, maxMs: 1000, multiplier: 1 })).toThrow(/multiplier/)
+    expect(() => createExponentialBackoff({ initialMs: 500, maxMs: 1000, multiplier: 0 })).toThrow(/multiplier/)
+    expect(() => createExponentialBackoff({ initialMs: 500, maxMs: 1000, jitterFactor: -0.1 })).toThrow(/jitterFactor/)
+    expect(() => createExponentialBackoff({ initialMs: 500, maxMs: 1000, jitterFactor: 1 })).toThrow(/jitterFactor/)
+  })
+
+  describe('jitter', () => {
+    // The four interesting points in the [0,1) random space are 0
+    // (lower bound), 0.5 (mid / no offset), just under 1 (upper bound),
+    // and a representative intermediate.
+    it('applies ±jitterFactor symmetric spread around the base delay', () => {
+      // Math.random() = 0 → minimum: base * (1 - jitterFactor).
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      let backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000, jitterFactor: 0.2 })
+      expect(backoff.schedule('a', () => {})).toBe(800)
+
+      // Math.random() ≈ 1 → upper bound (open interval): base * (1 + jitterFactor - ε).
+      vi.spyOn(Math, 'random').mockReturnValue(0.99999)
+      backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000, jitterFactor: 0.2 })
+      const upper = backoff.schedule('a', () => {})!
+      expect(upper).toBeGreaterThan(1199)
+      expect(upper).toBeLessThan(1201)
+
+      // Math.random() = 0.5 → exact base (offset zero).
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000, jitterFactor: 0.2 })
+      expect(backoff.schedule('a', () => {})).toBe(1000)
+    })
+
+    it('defaults jitterFactor to 0.2 (±20%) — matches backend convention', () => {
+      // Lower bound at 80% of base.
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000 })
+      expect(backoff.schedule('a', () => {})).toBe(800)
+    })
+
+    it('doubling is driven by the un-jittered base, not the jittered delay', () => {
+      // Pin random low so jitter SHRINKS each delay. If doubling were
+      // driven by the jittered value, the sequence would compress to
+      // 800 → 1600 → 3200 → 6400 instead of 1000 → 2000 → 4000 → 8000.
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000, jitterFactor: 0.2 })
+      // peekNextDelay reports the un-jittered base.
+      expect(backoff.peekNextDelay('k')).toBe(1000)
+      backoff.schedule('k', () => {})
+      vi.runAllTimers()
+      expect(backoff.peekNextDelay('k')).toBe(2000)
+      backoff.schedule('k', () => {})
+      vi.runAllTimers()
+      expect(backoff.peekNextDelay('k')).toBe(4000)
+      backoff.schedule('k', () => {})
+      vi.runAllTimers()
+      expect(backoff.peekNextDelay('k')).toBe(8000)
+    })
+
+    it('jitterFactor: 0 makes scheduled delay exactly match peekNextDelay', () => {
+      // Force a non-mid random so a non-zero jitterFactor would shift
+      // the delay. With jitterFactor: 0 the result must still equal
+      // the base.
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const backoff = createExponentialBackoff<string>({ initialMs: 1000, maxMs: 10_000, jitterFactor: 0 })
+      expect(backoff.schedule('k', () => {})).toBe(1000)
+    })
+
+    it('over many samples, jittered delays stay within the ±jitterFactor window', () => {
+      // Real RNG, big sample — the helper must never schedule outside
+      // the documented [base*(1-jitter), base*(1+jitter)) range.
+      vi.spyOn(Math, 'random').mockRestore()
+      const base = 1000
+      const jitterFactor = 0.2
+      const backoff = createExponentialBackoff<number>({ initialMs: base, maxMs: 10_000, jitterFactor })
+      let min = Infinity
+      let max = -Infinity
+      for (let i = 0; i < 500; i++) {
+        const d = backoff.schedule(i, () => {})!
+        if (d < min)
+          min = d
+        if (d > max)
+          max = d
+      }
+      expect(min).toBeGreaterThanOrEqual(base * (1 - jitterFactor))
+      expect(max).toBeLessThan(base * (1 + jitterFactor))
+      // Sanity: actually saw a spread, not stuck on one value.
+      expect(max - min).toBeGreaterThan(base * jitterFactor * 0.5)
+    })
+
+    it('never schedules a negative delay even with the highest legal jitter factor', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      // jitterFactor approaching (but never reaching) 1 — base*(1-jitter)
+      // approaches 0 but must stay non-negative.
+      const backoff = createExponentialBackoff<string>({ initialMs: 100, maxMs: 1000, jitterFactor: 0.9 })
+      const delay = backoff.schedule('k', () => {})!
+      expect(delay).toBeGreaterThanOrEqual(0)
+    })
+  })
+})

--- a/proto/leapmux/v1/file.proto
+++ b/proto/leapmux/v1/file.proto
@@ -21,6 +21,13 @@ message ReadFileRequest {
   string path = 3;
   int64 offset = 4;
   int64 limit = 5; // Max bytes; 0 = default (64KB)
+  // When true and the file size exceeds the read window
+  // (offset + effective limit), the server returns an empty content
+  // payload with the file's total_size populated, skipping the actual
+  // bytes. Lets the file viewer detect oversize files (e.g. images we
+  // refuse to preview) in a single round trip — combining what would
+  // otherwise be a StatFile + ReadFile pair.
+  bool meta_only_if_truncated = 6;
 }
 
 message ReadFileResponse {


### PR DESCRIPTION
## Motivation

Worker-hosted files were viewable in the file viewer but had no way to be saved or downloaded to the local machine. Users had no path to extract a file from a remote worker session — they could only read it in the viewer. Additionally, the file viewer's internal architecture was showing its age: tab hydration issued one RPC per tab regardless of how many shared the same worker, binary files triggered a byte-compare diff that was incorrect for non-text content, and there was no graceful fallback for unsupported or oversized file types.

## Modifications

**File save / download**
- New `lib/fileDownload.ts` streams files from the worker in 1 MiB chunks. In web mode it triggers a browser anchor-click download; in desktop (Tauri) mode it invokes new native commands (`save_bytes_to_downloads`, `save_bytes_as`).
- New Tauri commands `save_bytes_to_downloads` (silent save to OS Downloads folder) and `save_bytes_as` (native save-file dialog). Bytes cross the IPC boundary as raw request body rather than base64, reducing wire size by ~33% for large files. Race-free collision handling ensures concurrent saves of the same filename produce distinct files.
- New `FileActionsMenu` component — a three-dot dropdown shared by the file viewer toolbar and `DirectoryTree` rows, offering: Mention in chat, Open terminal, Copy path, Copy relative path, Copy contents, Download / Save to Downloads / Save As (gated by platform), and Reveal in file manager.
- New `fileSaveActions.ts` factory manages busy state, error toasts, and a new `revealAfterDownload` preference (defaults on).
- New `platformBridge` calls: `saveBytesToDownloads`, `saveBytesAs`, `revealInFileManager`.

**Proto / backend**
- Added `meta_only_if_truncated` flag to `ReadFileRequest`. When set and file size exceeds `offset + limit`, the backend returns an empty content payload with `total_size` populated, collapsing a `StatFile` + `ReadFile` pair into one round trip. Defaults to false; no breaking change.

**File viewer refactor**
- `FileViewer.tsx` major rework: display-mode state lifted from `ImageFileView` / `MarkdownFileView` to `FileViewer`; `FileActionsMenu` and the view-mode toggle share a unified floating toolbar slot.
- New `UnsupportedFileView` renders binary, oversized-image, and load-failed states with inline save/copy actions and a "Show anyway" escape hatch.
- Binary-file diff detection now uses git status instead of attempting a byte-compare.
- Fixed a Blob URL leak in `ImageFileView` — object URLs are now explicitly revoked after use.
- `StartupPanel` extracts a reusable `StartupBody` layout shared with `UnsupportedFileView`.
- (Breaking, frontend internal) `ImageFileView` and `MarkdownFileView` switched from internal display-mode state to controlled `mode: ViewMode` prop; their `onMention` / `onDisplayModeChange` props were removed and the relevant callbacks moved to the parent `FileViewer`.

**Shell / tab infrastructure**
- `useTabHydrators` now batches tab hydration per worker (one RPC per worker instead of one per tab). Failed hydrations retry via a new `createExponentialBackoff` utility.
- `WorkspaceTabTree` gains a `tileOrder` prop so the sidebar lists tabs in visual layout order (top-left traversal). `AppShell` caches the tile order per layout root.
- `syncGitStatusToTabs` tracks `unstampedTabsSignature` so a newly-added tab in an already-focused repo correctly triggers a git-status stamp.
- New `TabTypeIcon` and `tabDisplayLabel` consolidate fallback label and icon resolution across `TabBar` and `WorkspaceTabTree`.
- `stores/gitFileStatus.store.ts` adds `filesByPath` memo (O(1) lookup), `untrackedDirSet` for ancestor probing, and a `dirStatsCache` to keep downstream-memo references stable across no-op refreshes.
- `lib/browserStorage.ts` extended to wrap `sessionStorage` with the same TTL + cleanup machinery already used for `localStorage`; file scroll positions now session-persist with TTL.
- New `lib/retry.ts` (`createExponentialBackoff`) — per-key exponential backoff with symmetric jitter, designed for SolidJS reactive cleanup.
- New `lib/clipboard.ts` extracts `copyTextToClipboard` from `terminal.ts` for cross-feature reuse.
- New `lib/paths.ts` `extname` helper; `lib/fileType.ts` reworked with a MIME map, binary-extension deny-list, and extension-aware predicates (`isImageExt`, `isMarkdownExt`, `isLikelyBinaryExt`, `imageMimeFromExt`, `detectFileViewModeFromExt`).

**Tests**
- New unit tests: `FileActionsMenu`, `UnsupportedFileView`, `FileViewer.unsupported`, `StartupPanel`, `fileDownload`, `retry`, `clipboard`, `paths.extname`, `tab.helpers`, `DirectoryTree.download`, `syncGitStatusToTabs`, `useWorkspaceRestore`, `PreferencesContext`.
- Backend: 4 new tests covering the `meta_only_if_truncated` response path, full-content response, legacy behavior, and offset handling.

## Result

Users can now save or download any file open in the file viewer directly to their local machine. On the desktop app, a "Save to Downloads" option silently places the file in the OS Downloads folder (with an optional Finder/Explorer reveal), while "Save As..." opens a native save dialog. In the browser, a standard browser download is triggered. The same actions are available from the directory tree's per-file context menu.

Files that cannot be rendered (binary content, oversized images, failed loads) now show a dedicated fallback view with save and copy-path actions rather than a blank or broken viewer, with an opt-in "Show anyway" button for edge cases.

Tab hydration is faster and generates fewer RPCs — tabs sharing a worker are hydrated in a single batched request — and transiently failed hydrations now recover automatically via exponential backoff.
