### PR TITLE
feat(fileviewer): Stream large file saves via chunked IPC pipeline

### DIFF
--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1778,32 +1778,63 @@ fn decode_b64(b64: &str) -> Result<Vec<u8>, String> {
 // in a custom header, base64-encoded so HTTP-style ASCII restrictions
 // don't mangle Unicode names.
 //
-// File I/O runs on `spawn_blocking` so the Tokio executor thread that
-// services other Tauri commands isn't tied up by a slow disk write.
+// Saves are streamed through a `file_save_open[_dialog] → file_save_write* →
+// file_save_commit | file_save_abort` chain. The Rust side keeps the
+// destination `File` open in a registry between calls, so the JS caller
+// can pipe each 1 MiB worker chunk straight through `file_save_write`
+// without ever materializing the whole file. This bounds the peak
+// transient memory (per chunk × ~3 copies across the IPC boundary) to
+// a few MiB even for multi-hundred-MB downloads.
+//
+// Writes go to a sibling `.tmp` file (`<final>.tmp`); on commit we
+// atomic-rename `.tmp` → final, and on abort we delete the `.tmp`.
+// Consequence: the final name never appears on disk until the save is
+// complete, and (for Save as...) the user's existing file at the chosen
+// path is preserved if the save fails. The Downloads variant iterates
+// candidate names ("foo.ext",
+// "foo (1).ext", ...) skipping any whose final path already exists and
+// claiming each candidate's `<name>.tmp` with `create_new` — that
+// single open both reserves the iteration spot against concurrent
+// LeapMux saves of the same basename and provides the file the bytes
+// stream into.
 
-fn read_bytes_from_request(request: &tauri::ipc::Request<'_>) -> Result<Vec<u8>, String> {
-    match request.body() {
-        tauri::ipc::InvokeBody::Raw(b) => Ok(b.clone()),
-        _ => Err("expected raw bytes body".to_string()),
-    }
-}
-
-fn read_b64_header(request: &tauri::ipc::Request<'_>, name: &str) -> Result<String, String> {
-    let value = request
+fn read_header_str<'a>(
+    request: &'a tauri::ipc::Request<'_>,
+    name: &str,
+) -> Result<&'a str, String> {
+    request
         .headers()
         .get(name)
         .ok_or_else(|| format!("missing {name} header"))?
         .to_str()
-        .map_err(|err| format!("invalid {name} header: {err}"))?;
-    let bytes = decode_b64(value)?;
+        .map_err(|err| format!("invalid {name} header: {err}"))
+}
+
+fn read_b64_header(request: &tauri::ipc::Request<'_>, name: &str) -> Result<String, String> {
+    let bytes = decode_b64(read_header_str(request, name)?)?;
     String::from_utf8(bytes).map_err(|err| format!("invalid {name} utf-8: {err}"))
 }
 
-async fn write_bytes_blocking(path: PathBuf, bytes: Vec<u8>) -> Result<(), String> {
-    tokio::task::spawn_blocking(move || std::fs::write(&path, &bytes))
+/// Parse the decimal `handle-id` header shared by `file_save_write`,
+/// `file_save_commit`, and `file_save_abort`.
+fn read_handle_id(request: &tauri::ipc::Request<'_>) -> Result<u64, String> {
+    read_header_str(request, "handle-id")?
+        .parse()
+        .map_err(|err| format!("invalid handle-id: {err}"))
+}
+
+/// Run a blocking closure on the dedicated blocking-thread pool and
+/// return its result, surfacing a join failure as an error string. Used
+/// for save-stream operations that touch the disk and shouldn't tie up
+/// the async executor thread servicing other Tauri commands.
+async fn run_blocking<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
         .await
         .map_err(|err| format!("spawn_blocking join: {err}"))?
-        .map_err(|err| format!("write file: {err}"))
 }
 
 /// Cap on collision-dedup attempts. With "foo (N).ext" picking from
@@ -1812,54 +1843,266 @@ async fn write_bytes_blocking(path: PathBuf, bytes: Vec<u8>) -> Result<(), Strin
 /// filename is more useful than another increment).
 const MAX_SAVE_COLLISION_ATTEMPTS: u32 = 1024;
 
-/// Write `bytes` into `dir` under a name derived from `filename`,
-/// appending " (N)" before the extension to avoid clobbering an
-/// existing file. Returns the final absolute path written.
-///
-/// Race-free: each attempt opens with `create_new(true)`, so
-/// concurrent saves of the same name produce distinct files instead
-/// of one silently overwriting the other.
-async fn write_bytes_unique(dir: PathBuf, filename: String, bytes: Vec<u8>) -> Result<PathBuf, String> {
-    tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
-        use std::io::Write;
-        let as_path = std::path::Path::new(&filename);
-        let stem = as_path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
-        let ext = as_path.extension().map(|s| s.to_string_lossy().into_owned());
-        for i in 0..MAX_SAVE_COLLISION_ATTEMPTS {
-            let candidate_name = if i == 0 {
-                filename.clone()
-            } else {
-                match &ext {
-                    Some(e) if !e.is_empty() => format!("{stem} ({i}).{e}"),
-                    _ => format!("{stem} ({i})"),
-                }
-            };
-            let candidate = dir.join(&candidate_name);
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&candidate)
-            {
-                Ok(mut f) => {
-                    f.write_all(&bytes).map_err(|err| format!("write file: {err}"))?;
-                    return Ok(candidate);
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                Err(err) => return Err(format!("create file: {err}")),
-            }
-        }
-        Err(format!(
-            "too many collisions for {filename} (gave up after {MAX_SAVE_COLLISION_ATTEMPTS})"
-        ))
-    })
-    .await
-    .map_err(|err| format!("spawn_blocking join: {err}"))?
+/// How often the idle-handle GC scans the registry for handles whose
+/// JS pump appears to have died. 60s keeps the scan cost negligible
+/// while still bounding orphan-disk-junk lifetime to roughly
+/// `SAVE_HANDLE_GC_INTERVAL + SAVE_HANDLE_IDLE_TIMEOUT`.
+const SAVE_HANDLE_GC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a handle can sit without a `write_chunk` (or `close`)
+/// before the GC discards it. An active save touches `last_write_at`
+/// per chunk, so the gap can only widen if the JS pump is wedged or
+/// the renderer process died. 5 min is well above any realistic
+/// per-chunk latency (1 MiB chunks rarely take more than seconds) but
+/// short enough that an orphan `.tmp` is gone before the user notices.
+const SAVE_HANDLE_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Registry entry for a save in progress: the open file plus the
+/// paths needed to finalize or discard. Distinct from
+/// `SaveStreamHandle`, which is the id+path token JS holds; this
+/// struct is Rust-only and never crosses the IPC boundary.
+struct OpenSaveStream {
+    /// `Arc<Mutex<File>>` rather than `Mutex<File>` so `write_chunk` can
+    /// short-lock the registry to clone the Arc, drop the registry
+    /// lock, and then take the per-file lock — writes to different
+    /// streams run in parallel instead of serializing on a registry-
+    /// wide mutex.
+    file: Arc<Mutex<std::fs::File>>,
+    /// Sibling `<final>.tmp` path that bytes stream into.
+    tmp_path: PathBuf,
+    /// Final destination — `.tmp` is atomic-renamed onto this on success.
+    final_path: PathBuf,
+    /// Updated on insert and on every `write_chunk`. The idle-handle
+    /// GC compares this against `SAVE_HANDLE_IDLE_TIMEOUT` to detect
+    /// JS pumps that died without calling `file_save_commit` or
+    /// `file_save_abort`. Lives under the registry `Mutex<HashMap>`
+    /// lock so it shares the existing critical section instead of
+    /// needing its own atomic.
+    last_write_at: Instant,
 }
 
+/// Open destination files keyed by a monotonic u64 id. The JS caller
+/// receives the id from `file_save_open[_dialog]` and submits it back
+/// with each `file_save_write` and the final `file_save_commit` or
+/// `file_save_abort`.
+struct SaveStreamRegistry {
+    /// Starts at 1 so a freshly constructed registry never hands out 0 —
+    /// keeps "0 == sentinel" assumptions on the JS side safe.
+    next_id: AtomicU64,
+    handles: Mutex<HashMap<u64, OpenSaveStream>>,
+}
+
+impl SaveStreamRegistry {
+    fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            handles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Insert a freshly-opened file into the registry and return the
+    /// JS-facing handle (id + the final path as a UTF-8 string).
+    /// Both `file_save_open` and `file_save_open_dialog` end with this,
+    /// so it lives here to keep the id/path packaging in one spot.
+    fn insert(
+        &self,
+        file: std::fs::File,
+        tmp_path: PathBuf,
+        final_path: PathBuf,
+    ) -> SaveStreamHandle {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let path = final_path.to_string_lossy().into_owned();
+        self.handles.lock().unwrap().insert(
+            id,
+            OpenSaveStream {
+                file: Arc::new(Mutex::new(file)),
+                tmp_path,
+                final_path,
+                last_write_at: Instant::now(),
+            },
+        );
+        SaveStreamHandle { id, path }
+    }
+
+    fn take(&self, id: u64) -> Option<OpenSaveStream> {
+        self.handles.lock().unwrap().remove(&id)
+    }
+
+    fn write_chunk(&self, id: u64, bytes: &[u8]) -> Result<(), String> {
+        // Lock the registry only long enough to refresh the idle
+        // timestamp and clone the per-handle Arc, then drop the
+        // registry lock before acquiring the file lock. Concurrent
+        // writes targeting different handles can then proceed in
+        // parallel.
+        let file = {
+            let mut guard = self.handles.lock().unwrap();
+            let handle = guard
+                .get_mut(&id)
+                .ok_or_else(|| format!("unknown save handle {id}"))?;
+            handle.last_write_at = Instant::now();
+            handle.file.clone()
+        };
+        let mut guard = file.lock().unwrap();
+        guard
+            .write_all(bytes)
+            .map_err(|err| format!("write: {err}"))
+    }
+
+    /// Drop all open handles and remove any partial files. Called from
+    /// the app exit path so an interrupted save doesn't leave junk on
+    /// disk.
+    fn cleanup_all(&self) {
+        let drained: Vec<_> = self.handles.lock().unwrap().drain().collect();
+        for (_, stream) in drained {
+            discard_stream(stream);
+        }
+    }
+
+    /// Discard handles whose `last_write_at` is older than `max_idle`.
+    /// Two-phase: snapshot stale ids under a brief lock, then `take`
+    /// each individually so the per-discard `remove_file` syscalls
+    /// never run under the registry lock. A handle being actively
+    /// written to during the scan window is fine — a racing
+    /// `write_chunk` refreshes `last_write_at`, and the take in phase
+    /// 2 re-checks against `max_idle` and skips it.
+    fn gc_idle(&self, max_idle: Duration) {
+        let now = Instant::now();
+        let stale_ids: Vec<u64> = {
+            let guard = self.handles.lock().unwrap();
+            guard
+                .iter()
+                .filter(|(_, h)| now.duration_since(h.last_write_at) >= max_idle)
+                .map(|(id, _)| *id)
+                .collect()
+        };
+        for id in stale_ids {
+            // Re-check under lock: a `write_chunk` racing between
+            // snapshot and take may have refreshed the timestamp. If
+            // it has, leave the stream alone.
+            let stream = {
+                let mut guard = self.handles.lock().unwrap();
+                match guard.get(&id) {
+                    Some(h) if now.duration_since(h.last_write_at) >= max_idle => {
+                        guard.remove(&id)
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(stream) = stream {
+                discard_stream(stream);
+            }
+        }
+    }
+}
+
+/// Append `.tmp` to `path` while preserving the existing OsString
+/// (handles non-UTF-8 paths cleanly).
+fn tmp_path_for(final_path: &Path) -> PathBuf {
+    let mut name = final_path.as_os_str().to_owned();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
+/// Open (or create+truncate) the `.tmp` sibling of `final_path` for
+/// streaming writes. Shared by `file_save_open` and
+/// `file_save_open_dialog`; the Downloads-flow caller wraps the error
+/// to also undo its name reservation.
+fn open_tmp_for_write(final_path: &Path) -> Result<(std::fs::File, PathBuf), String> {
+    let tmp_path = tmp_path_for(final_path);
+    let tmp_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+        .map_err(|err| format!("open tmp file: {err}"))?;
+    Ok((tmp_file, tmp_path))
+}
+
+/// Remove the partial `.tmp`. Used by both `discard_stream` and the
+/// failure branches of `file_save_commit`, which have already dropped
+/// the `File` themselves. The final path is never ours to remove —
+/// nothing was ever created there.
+fn discard_partials(tmp_path: &Path) {
+    let _ = std::fs::remove_file(tmp_path);
+}
+
+/// Drop the file handle and remove the partial `.tmp`.
+fn discard_stream(stream: OpenSaveStream) {
+    let OpenSaveStream { file, tmp_path, .. } = stream;
+    // Drop before remove: Windows refuses `remove_file` while the
+    // file handle is open.
+    drop(file);
+    discard_partials(&tmp_path);
+}
+
+/// JS-facing handle to an open save stream. Returned by
+/// `file_save_open[_dialog]` and submitted back (as `id`) with each
+/// `file_save_write` and the final `file_save_commit` /
+/// `file_save_abort`. Mirrors the `SaveStreamHandle` interface in
+/// `platformBridge.ts`.
+#[derive(Serialize)]
+struct SaveStreamHandle {
+    id: u64,
+    path: String,
+}
+
+/// Pick a non-colliding "foo (N).ext" candidate under `dir` and open
+/// its `<candidate>.tmp` sibling with `create_new`. The `.tmp` open
+/// serves double duty: it both reserves the iteration spot against
+/// concurrent LeapMux saves of the same basename and provides the file
+/// the bytes stream into. The candidate itself is skipped if it already
+/// exists, preserving the "don't silently overwrite a user file in
+/// Downloads" behavior.
+fn open_unique_tmp(
+    dir: PathBuf,
+    filename: String,
+) -> Result<(std::fs::File, PathBuf, PathBuf), String> {
+    let as_path = std::path::Path::new(&filename);
+    let stem = as_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let ext = as_path.extension().map(|s| s.to_string_lossy().into_owned());
+    for i in 0..MAX_SAVE_COLLISION_ATTEMPTS {
+        let candidate_name = if i == 0 {
+            filename.clone()
+        } else {
+            match &ext {
+                Some(e) if !e.is_empty() => format!("{stem} ({i}).{e}"),
+                _ => format!("{stem} ({i})"),
+            }
+        };
+        let final_path = dir.join(&candidate_name);
+        match final_path.try_exists() {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(err) => return Err(format!("stat {candidate_name}: {err}")),
+        }
+        let tmp_path = tmp_path_for(&final_path);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            Ok(f) => return Ok((f, tmp_path, final_path)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(format!("create tmp file: {err}")),
+        }
+    }
+    Err(format!(
+        "too many collisions for {filename} (gave up after {MAX_SAVE_COLLISION_ATTEMPTS})"
+    ))
+}
+
+/// Open a destination in the OS Downloads directory and return a
+/// streaming handle. `filename` (from the `filename-b64` header) is
+/// sanitized to its basename and collision-dedupped with " (N)".
 #[tauri::command]
-async fn save_bytes_to_downloads(request: tauri::ipc::Request<'_>) -> Result<String, String> {
+async fn file_save_open(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<SaveStreamHandle, String> {
     let filename = read_b64_header(&request, "filename-b64")?;
-    let bytes = read_bytes_from_request(&request)?;
     let downloads = dirs::download_dir().ok_or_else(|| "no downloads directory".to_string())?;
     // Disallow separators in the supplied filename so callers can't
     // escape the Downloads directory.
@@ -1868,19 +2111,25 @@ async fn save_bytes_to_downloads(request: tauri::ipc::Request<'_>) -> Result<Str
         .ok_or_else(|| "invalid filename".to_string())?
         .to_string_lossy()
         .into_owned();
-    let path = write_bytes_unique(downloads, safe_name, bytes).await?;
-    Ok(path.to_string_lossy().into_owned())
+    let registry = registry.inner().clone();
+    let (file, tmp_path, final_path) =
+        run_blocking(move || open_unique_tmp(downloads, safe_name)).await?;
+    Ok(registry.insert(file, tmp_path, final_path))
 }
 
+/// Show a native save-as dialog and return a streaming handle for the
+/// chosen path. Returns `None` when the user cancels — JS callers
+/// should short-circuit before any worker fetch so a cancellation
+/// costs nothing.
 #[tauri::command]
-async fn save_bytes_as(
+async fn file_save_open_dialog(
     app: tauri::AppHandle,
+    registry: State<'_, Arc<SaveStreamRegistry>>,
     request: tauri::ipc::Request<'_>,
-) -> Result<Option<String>, String> {
+) -> Result<Option<SaveStreamHandle>, String> {
     use tauri_plugin_dialog::DialogExt;
 
     let default_name = read_b64_header(&request, "default-name-b64")?;
-    let bytes = read_bytes_from_request(&request)?;
     let (tx, rx) = oneshot::channel();
     app.dialog()
         .file()
@@ -1892,9 +2141,121 @@ async fn save_bytes_as(
     let Some(file_path) = path_opt else {
         return Ok(None);
     };
-    let path = file_path.into_path().map_err(|e| e.to_string())?;
-    write_bytes_blocking(path.clone(), bytes).await?;
-    Ok(Some(path.to_string_lossy().into_owned()))
+    let final_path = file_path.into_path().map_err(|e| e.to_string())?;
+    let registry = registry.inner().clone();
+    let (file, tmp_path) = run_blocking({
+        let final_path = final_path.clone();
+        move || open_tmp_for_write(&final_path)
+    })
+    .await?;
+    Ok(Some(registry.insert(file, tmp_path, final_path)))
+}
+
+/// Append the request body bytes to the open file identified by the
+/// decimal `handle-id` header. Uses `block_in_place` rather than
+/// `spawn_blocking` so the body slice can be borrowed directly from
+/// the request without a per-chunk clone — for a 100 MB save that
+/// avoids ~100 MiB of memcpy traffic.
+#[tauri::command]
+async fn file_save_write(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let bytes = match request.body() {
+        tauri::ipc::InvokeBody::Raw(b) => b.as_slice(),
+        _ => return Err("expected raw bytes body".to_string()),
+    };
+    // Tauri's command executor runs on a multi-thread tokio runtime,
+    // so `block_in_place` is safe here: it parks the current worker
+    // for the duration of the write and lets the runtime steal other
+    // tasks. The write is bounded to one chunk (~1 MiB). The debug
+    // assertion makes a future runtime-config regression (e.g. switching
+    // to `current_thread`) fail with a clear message instead of tokio's
+    // generic "can call `blocking` only from a `MultiThread`" panic.
+    debug_assert_eq!(
+        tokio::runtime::Handle::current().runtime_flavor(),
+        tokio::runtime::RuntimeFlavor::MultiThread,
+        "file_save_write uses block_in_place; requires a multi-thread runtime",
+    );
+    tokio::task::block_in_place(|| registry.write_chunk(handle_id, bytes))
+}
+
+/// Finalize the save identified by `handle-id`: sync bytes to disk and
+/// atomic-rename `.tmp` onto the final path. Discards partials on
+/// failure so a partial sync doesn't leave a junk file under the
+/// chosen name.
+#[tauri::command]
+async fn file_save_commit(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let registry = registry.inner().clone();
+    run_blocking(move || {
+        let Some(stream) = registry.take(handle_id) else {
+            return Err(format!("unknown save handle {handle_id}"));
+        };
+        let OpenSaveStream {
+            file,
+            tmp_path,
+            final_path,
+            last_write_at: _,
+        } = stream;
+        // No `sync_all` before the rename — intentional. A `sync_all`
+        // on a multi-hundred-MB save blocks for seconds while the OS
+        // flushes the page cache, and neither flow has a contract that
+        // needs it: the Downloads variant only ever writes to a path
+        // that was empty when we picked the name (so a power-loss
+        // window between rename and OS flush just loses the new file,
+        // it can't corrupt anything else), and the Save-as variant's
+        // overwrite is already non-atomic at the user-content level
+        // (the user picked a path knowing it would be replaced, and
+        // can re-save on crash). Don't add a sync here without
+        // matching the latency cost to a concrete guarantee we
+        // actually need to make.
+        //
+        // Drop the Arc<Mutex<File>> before the rename: Windows refuses
+        // `rename`/`remove_file` while the handle is open. `take` above
+        // removed the registry's clone, so unless a concurrent
+        // `write_chunk` is still holding a clone (impossible while the
+        // caller awaits each write sequentially) this drop releases
+        // the underlying File.
+        drop(file);
+        // `std::fs::rename` replaces the destination on both Unix and
+        // Windows. For save-as that overwrites the user's prior content
+        // (the path they chose). For the Downloads flow the final path
+        // was empty when we picked the name (`open_unique_tmp` skips
+        // candidates whose final already exists); a file appearing
+        // there mid-stream is a TOCTOU race we accept.
+        let result = std::fs::rename(&tmp_path, &final_path)
+            .map_err(|err| format!("rename: {err}"));
+        if result.is_err() {
+            discard_partials(&tmp_path);
+        }
+        result
+    })
+    .await
+}
+
+/// Discard the save identified by `handle-id`: drop the open file and
+/// remove the partial `.tmp`. Idempotent against an already-removed
+/// handle (e.g. the idle GC raced the JS pump) so the failure path on
+/// the JS side stays simple.
+#[tauri::command]
+async fn file_save_abort(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let registry = registry.inner().clone();
+    run_blocking(move || {
+        if let Some(stream) = registry.take(handle_id) {
+            discard_stream(stream);
+        }
+        Ok(())
+    })
+    .await
 }
 
 #[tauri::command]
@@ -2287,6 +2648,22 @@ fn main() {
                 }
             }
             app.manage(shell);
+            let save_registry = Arc::new(SaveStreamRegistry::new());
+            // Background GC for orphan save handles: when the renderer
+            // dies mid-stream (page reload, crash) the JS pump never
+            // calls `file_save_commit` or `file_save_abort`, leaving
+            // the handle + its `.tmp` file alive until `cleanup_all`
+            // at app exit. The GC bounds that lifetime to roughly
+            // `IDLE_TIMEOUT + GC_INTERVAL`.
+            let gc_registry = save_registry.clone();
+            tauri::async_runtime::spawn(async move {
+                let mut interval = tokio::time::interval(SAVE_HANDLE_GC_INTERVAL);
+                loop {
+                    interval.tick().await;
+                    gc_registry.gc_idle(SAVE_HANDLE_IDLE_TIMEOUT);
+                }
+            });
+            app.manage(save_registry);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -2309,8 +2686,11 @@ fn main() {
             list_tunnels,
             list_editors,
             open_in_editor,
-            save_bytes_to_downloads,
-            save_bytes_as,
+            file_save_open,
+            file_save_open_dialog,
+            file_save_write,
+            file_save_commit,
+            file_save_abort,
             switch_mode,
             #[cfg(target_os = "macos")]
             restart_app,
@@ -2328,6 +2708,13 @@ fn main() {
             if let RunEvent::ExitRequested { api, .. } = event {
                 if let Some(shell) = app.try_state::<Arc<DesktopShell>>() {
                     if !shell.exit_in_progress.load(Ordering::SeqCst) {
+                        // Drop any open save handles and remove their
+                        // partial files before shutting the sidecar
+                        // down. The CAS inside `handle_app_exit`
+                        // guarantees we run this exactly once.
+                        if let Some(registry) = app.try_state::<Arc<SaveStreamRegistry>>() {
+                            registry.cleanup_all();
+                        }
                         api.prevent_exit();
                         handle_app_exit(shell.inner().clone());
                     }

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -257,9 +257,13 @@ function loadTauriOpener() {
   return (cachedTauriOpener ??= import('@tauri-apps/plugin-opener'))
 }
 
-async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+async function tauriInvoke<T>(
+  cmd: string,
+  args?: import('@tauri-apps/api/core').InvokeArgs,
+  options?: import('@tauri-apps/api/core').InvokeOptions,
+): Promise<T> {
   const { invoke } = await loadTauriCore()
-  return invoke<T>(cmd, args)
+  return invoke<T>(cmd, args, options)
 }
 
 export function resetPlatformRuntimeState(): void {
@@ -476,32 +480,77 @@ export async function readClipboardImage(): Promise<File | null> {
 }
 
 /**
- * Write `bytes` to the OS Downloads directory as `filename` and return
- * the absolute path written. Tauri-only — call sites must gate on
- * `isTauriApp()` first. The Rust command sanitizes `filename` to its
- * basename so callers can't escape the Downloads dir.
+ * Streaming save handle returned by `fileSaveOpen` / `fileSaveOpenDialog`.
+ * `id` is the Rust-side registry id (a monotonic u64); `path` is the
+ * absolute path that was opened so callers can pass it to
+ * `revealInFileManager` after a successful close.
+ */
+export interface SaveStreamHandle {
+  id: number
+  path: string
+}
+
+/**
+ * Open a destination file under the OS Downloads directory and return
+ * a streaming handle. The Rust side keeps the `File` open between
+ * calls; the caller streams bytes through `fileSaveWrite` and finalizes
+ * with `fileSaveCommit` (or `fileSaveAbort` on failure).
  *
- * Bytes ride the Tauri IPC as a raw request body (transferred without
- * JSON or base64 conversion). The filename goes through a header,
+ * The Rust command sanitizes `filename` to its basename so callers can't
+ * escape the Downloads dir. The filename rides through a header,
  * base64-encoded so non-ASCII names survive the HTTP-style header
  * value restrictions.
  */
-export async function saveBytesToDownloads(bytes: Uint8Array, filename: string): Promise<string> {
-  const { invoke } = await loadTauriCore()
-  return invoke<string>('save_bytes_to_downloads', bytes, {
+export async function fileSaveOpen(filename: string): Promise<SaveStreamHandle> {
+  return tauriInvoke<SaveStreamHandle>('file_save_open', undefined, {
     headers: { 'filename-b64': arrayBufferToBase64(filename) },
   })
 }
 
 /**
- * Show a native save-as dialog, write `bytes` to the chosen path, and
- * return the absolute path. Returns `null` if the user cancelled the
- * dialog. Tauri-only.
+ * Show a native save-as dialog, open the chosen path, and return a
+ * streaming handle. Returns `null` if the user cancelled the dialog —
+ * callers should short-circuit before any worker fetch so a cancelled
+ * save doesn't pay the full read cost. Tauri-only.
  */
-export async function saveBytesAs(bytes: Uint8Array, defaultName: string): Promise<string | null> {
-  const { invoke } = await loadTauriCore()
-  return invoke<string | null>('save_bytes_as', bytes, {
+export async function fileSaveOpenDialog(defaultName: string): Promise<SaveStreamHandle | null> {
+  return tauriInvoke<SaveStreamHandle | null>('file_save_open_dialog', undefined, {
     headers: { 'default-name-b64': arrayBufferToBase64(defaultName) },
+  })
+}
+
+/**
+ * Append `chunk` to the file identified by `id`. Bytes ride the Tauri
+ * IPC as a raw request body (no JSON / base64 conversion). Per-chunk,
+ * so the transient memory peak is bounded to the chunk size across the
+ * entire JS-webview-Rust copy chain.
+ */
+export async function fileSaveWrite(id: number, chunk: Uint8Array): Promise<void> {
+  await tauriInvoke<void>('file_save_write', chunk, {
+    headers: { 'handle-id': String(id) },
+  })
+}
+
+/**
+ * Finalize the handle identified by `id` by atomic-renaming the `.tmp`
+ * onto the final path. Errors on rename remove the partial so a
+ * half-save doesn't land under the user's chosen name.
+ */
+export async function fileSaveCommit(id: number): Promise<void> {
+  await tauriInvoke<void>('file_save_commit', undefined, {
+    headers: { 'handle-id': String(id) },
+  })
+}
+
+/**
+ * Discard the handle identified by `id` and remove its partial file.
+ * Idempotent against an already-removed handle, so the JS pump's
+ * failure path can call this without checking whether the Rust side
+ * already cleaned up.
+ */
+export async function fileSaveAbort(id: number): Promise<void> {
+  await tauriInvoke<void>('file_save_abort', undefined, {
+    headers: { 'handle-id': String(id) },
   })
 }
 
@@ -585,8 +634,11 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
 export const platformBridge = {
   getCapabilities,
   getRuntimeState,
-  saveBytesToDownloads,
-  saveBytesAs,
+  fileSaveOpen,
+  fileSaveOpenDialog,
+  fileSaveWrite,
+  fileSaveCommit,
+  fileSaveAbort,
   revealInFileManager,
   async connectSolo(): Promise<void> {
     await tauriInvoke('connect_solo')

--- a/frontend/src/components/common/FileActionsMenu.tsx
+++ b/frontend/src/components/common/FileActionsMenu.tsx
@@ -95,7 +95,7 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
     return ownedActions
   }
   const actions = (): FileSaveActions => props.actions ?? ensureOwnedActions()
-  // Reading `actions().currentOp()` here triggers `ensureOwnedActions`.
+  // Reading `actions().op()` here triggers `ensureOwnedActions`.
   // Gate it on `menuOpen()` so the disabled-binding refire at mount
   // (popover hidden) doesn't allocate for rows the user never opens.
   // Externally-injected actions skip the gate — their busy state is
@@ -103,8 +103,8 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
   // menu's popover is closed.
   const busy = () => {
     if (props.actions)
-      return props.actions.currentOp() !== null
-    return menuOpen() && actions().currentOp() !== null
+      return props.actions.op() !== null
+    return menuOpen() && actions().op() !== null
   }
 
   return (

--- a/frontend/src/components/common/fileSaveActions.ts
+++ b/frontend/src/components/common/fileSaveActions.ts
@@ -1,3 +1,4 @@
+import type { DownloadProgress } from '~/lib/fileDownload'
 import type { PathFlavor } from '~/lib/paths'
 import { createSignal } from 'solid-js'
 import { platformBridge } from '~/api/platformBridge'
@@ -7,20 +8,34 @@ import { downloadFileFromWorker, saveFileAs, saveFileToDownloads } from '~/lib/f
 import { basename } from '~/lib/paths'
 
 /**
- * Which save/download operation is in flight (`null` when idle).
+ * Which save/download operation is in flight.
  *
  *   - `'download'`        — web-mode anchor-click download
  *   - `'save-as'`         — desktop save-as dialog
  *   - `'save-to-downloads'` — desktop silent save to $DOWNLOAD
- *
- * Callers use this to drive per-button spinners and to disable the
- * other action buttons while one is in flight.
  */
-export type FileSaveOp = 'download' | 'save-as' | 'save-to-downloads' | null
+export type FileSaveOp = 'download' | 'save-as' | 'save-to-downloads'
+
+/**
+ * In-flight save/download state. `kind` identifies which operation is
+ * running; `progress` is a floored percent (0..100) once the worker
+ * reports a total, or `null` before then (and during the save-as
+ * dialog, where there's no transfer yet). The "idle" state lives
+ * outside this type as a top-level `null` in `FileSaveActions.op`, so
+ * `progress` is never spuriously meaningful while no save is running.
+ */
+export interface ActiveOp {
+  kind: FileSaveOp
+  progress: number | null
+}
 
 export interface FileSaveActions {
-  /** Non-null iff an op is in flight; identifies which one. */
-  currentOp: () => FileSaveOp
+  /**
+   * The in-flight op (kind + progress), or `null` when idle. Callers
+   * drive per-button spinners off `op()?.kind === 'download'` etc. and
+   * read `op()?.progress` for the percent.
+   */
+  op: () => ActiveOp | null
   /** Trigger a web-mode anchor-click download. No-op while busy. */
   handleDownload: () => void
   /** Trigger a desktop save-as dialog. No-op while busy. */
@@ -49,27 +64,45 @@ export interface FileSaveActionsInput {
  */
 export function createFileSaveActions(input: FileSaveActionsInput): FileSaveActions {
   const prefs = usePreferences()
-  const [currentOp, setCurrentOp] = createSignal<FileSaveOp>(null)
+  const [op, setOp] = createSignal<ActiveOp | null>(null)
 
   const errLabel = () => basename(input.path(), input.flavor())
 
   interface OpSpec {
-    fn: (workerId: string, path: string, flavor: PathFlavor) => Promise<string | null | void>
+    fn: (
+      workerId: string,
+      path: string,
+      flavor: PathFlavor,
+      onProgress: DownloadProgress,
+    ) => Promise<string | null | void>
     errPrefix: string
   }
-  const OPS: Record<Exclude<FileSaveOp, null>, OpSpec> = {
+  const OPS: Record<FileSaveOp, OpSpec> = {
     'download': { fn: downloadFileFromWorker, errPrefix: 'Failed to download' },
     'save-as': { fn: saveFileAs, errPrefix: 'Failed to save' },
     'save-to-downloads': { fn: saveFileToDownloads, errPrefix: 'Failed to save' },
   }
 
-  const dispatch = (op: Exclude<FileSaveOp, null>) => {
-    if (currentOp() !== null)
+  const dispatch = (kind: FileSaveOp) => {
+    if (op() !== null)
       return
-    const { fn, errPrefix } = OPS[op]
-    setCurrentOp(op)
+    const { fn, errPrefix } = OPS[kind]
+    setOp({ kind, progress: null })
     const label = errLabel()
-    fn(input.workerId(), input.path(), input.flavor())
+    const onProgress: DownloadProgress = (received, total) => {
+      // Skip until totalSize is known. The first worker response carries
+      // it; before then there's nothing meaningful to show alongside the
+      // spinner. `Math.min(100, …)` defends against a malformed worker
+      // response that overshoots — pin the label at 100% rather than
+      // render "101%".
+      if (total <= 0)
+        return
+      const percent = Math.min(100, Math.floor((received / total) * 100))
+      // Guard against a late emit after `.finally` cleared the op (e.g.
+      // a worker response that races the rejection from a failed save).
+      setOp(prev => prev === null ? null : { kind, progress: percent })
+    }
+    fn(input.workerId(), input.path(), input.flavor(), onProgress)
       .then((savedPath) => {
         // `saveFileAs` returns null when the user cancels the dialog;
         // the web download path returns void. Reveal only fires for
@@ -81,12 +114,12 @@ export function createFileSaveActions(input: FileSaveActionsInput): FileSaveActi
         showWarnToast(`${errPrefix} ${label}`, err)
       })
       .finally(() => {
-        setCurrentOp(null)
+        setOp(null)
       })
   }
 
   return {
-    currentOp,
+    op,
     handleDownload: () => dispatch('download'),
     handleSaveAs: () => dispatch('save-as'),
     handleSaveToDownloads: () => dispatch('save-to-downloads'),

--- a/frontend/src/components/fileviewer/FileViewer.tsx
+++ b/frontend/src/components/fileviewer/FileViewer.tsx
@@ -641,7 +641,7 @@ export const FileViewer: Component<{
                       flavor={flavor()}
                       totalSize={totalSize()}
                       reason={cardReason()!}
-                      currentOp={saveActions.currentOp()}
+                      op={saveActions.op()}
                       loadingAnyway={loadingAnyway()}
                       canShowAnyway={totalSize() > 0}
                       onDownload={saveActions.handleDownload}

--- a/frontend/src/components/fileviewer/UnsupportedFileView.tsx
+++ b/frontend/src/components/fileviewer/UnsupportedFileView.tsx
@@ -1,5 +1,5 @@
 import type { Component, JSX } from 'solid-js'
-import type { FileSaveOp } from '~/components/common/fileSaveActions'
+import type { ActiveOp } from '~/components/common/fileSaveActions'
 import type { PathFlavor } from '~/lib/paths'
 import { createMemo, createUniqueId, Show } from 'solid-js'
 import { StartupBody, StartupSpinner } from '~/components/common/StartupPanel'
@@ -7,13 +7,19 @@ import { formatBytes } from '~/lib/formatBytes'
 import { basename } from '~/lib/paths'
 import * as styles from './FileViewer.css'
 
-// Save-button content: idle label, or spinner when this button's op is
-// in flight. Three call sites in this file (Download, Save as, Save to
-// Downloads) only differ in the `active`/`label`/`busyLabel` triple.
-function SaveButtonContent(props: { active: boolean, label: string, busyLabel: string }): JSX.Element {
+// Save-button content: idle label, or spinner-plus-percent when this
+// button's op is in flight. Three call sites in this file (Download,
+// Save as, Save to Downloads) only differ in the
+// `active`/`label`/`busyLabel` triple.
+function SaveButtonContent(props: {
+  active: boolean
+  label: string
+  busyLabel: string
+  progress: number | null
+}): JSX.Element {
   return (
     <Show when={props.active} fallback={<>{props.label}</>}>
-      <StartupSpinner label={props.busyLabel} />
+      <StartupSpinner label={props.progress === null ? props.busyLabel : `${props.busyLabel} ${props.progress}%`} />
     </Show>
   )
 }
@@ -24,11 +30,11 @@ export type UnsupportedReason = 'binary' | 'oversize-image'
  * Desktop-mode save controls: render two save buttons (Save as / Save
  * to Downloads) and a "reveal in file manager" checkbox below.
  *
- * The in-flight save (or null) is read from the parent `currentOp`
- * prop — both buttons disable while any save runs, but only the active
- * one shows the spinner. Web-mode callers leave this slot undefined and
- * pass `onDownload` instead, yielding a single anchor-click Download
- * button.
+ * The in-flight save (or null) is read from the parent `op` prop —
+ * both buttons disable while any save runs, but only the active one
+ * (matching `op.kind`) shows the spinner. Web-mode callers leave this
+ * slot undefined and pass `onDownload` instead, yielding a single
+ * anchor-click Download button.
  */
 export interface DesktopSaveControls {
   onSaveAs: () => void
@@ -49,11 +55,16 @@ export interface UnsupportedFileViewProps {
    */
   canShowAnyway: boolean
   onShowAnyway: () => void
-  // Web variant: single "Download" anchor-click button.
-  // `currentOp === 'download'` shows the spinner; both other ops also
-  // disable the button (UnsupportedFileView never sees those today,
-  // but the shared signal means it's well-defined).
-  currentOp: FileSaveOp
+  /**
+   * In-flight save/download state, or `null` when idle. Drives the
+   * per-button spinner (`op.kind` selects which button is active) and
+   * the percent label suffix (`op.progress` becomes "... 45%" when
+   * non-null; `null` keeps the bare spinner — used during the save-as
+   * dialog and the first worker round-trip before the total is known).
+   * Both web and desktop variants share this state; the web variant
+   * only ever sees `kind === 'download'`.
+   */
+  op: ActiveOp | null
   onDownload: () => void
   // Desktop variant: when present, replaces the single "Download" with
   // "Save as..." / "Save to Downloads" and shows the reveal checkbox.
@@ -79,7 +90,8 @@ export const UnsupportedFileView: Component<UnsupportedFileViewProps> = (props) 
   const name = createMemo(() => basename(props.filePath, props.flavor))
   const titleId = createUniqueId()
   const revealId = createUniqueId()
-  const busy = () => props.currentOp !== null
+  const busy = () => props.op !== null
+  const progress = () => props.op?.progress ?? null
 
   return (
     <div
@@ -108,9 +120,10 @@ export const UnsupportedFileView: Component<UnsupportedFileViewProps> = (props) 
               onClick={() => props.onDownload()}
             >
               <SaveButtonContent
-                active={props.currentOp === 'download'}
+                active={props.op?.kind === 'download'}
                 label="Download"
                 busyLabel="Downloading..."
+                progress={progress()}
               />
             </button>
           )}
@@ -125,9 +138,10 @@ export const UnsupportedFileView: Component<UnsupportedFileViewProps> = (props) 
                 onClick={() => desktop().onSaveAs()}
               >
                 <SaveButtonContent
-                  active={props.currentOp === 'save-as'}
+                  active={props.op?.kind === 'save-as'}
                   label="Save as..."
                   busyLabel="Saving..."
+                  progress={progress()}
                 />
               </button>
               <button
@@ -139,9 +153,10 @@ export const UnsupportedFileView: Component<UnsupportedFileViewProps> = (props) 
                 onClick={() => desktop().onSaveToDownloads()}
               >
                 <SaveButtonContent
-                  active={props.currentOp === 'save-to-downloads'}
+                  active={props.op?.kind === 'save-to-downloads'}
                   label="Save to Downloads"
                   busyLabel="Saving..."
+                  progress={progress()}
                 />
               </button>
             </>

--- a/frontend/src/components/tree/DirectoryTree.windows.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.windows.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { platformBridgeFileSaveStubs } from '../../../tests/unit/helpers/saveActionsMocks'
 import { DirectoryTree } from './DirectoryTree'
 
 // Stub the listDirectory RPC — these tests only exercise the path-input.
@@ -19,8 +20,7 @@ vi.mock('~/api/platformBridge', () => ({
   isTauriApp: () => false,
   platformBridge: {
     revealInFileManager: () => Promise.resolve(),
-    saveBytesToDownloads: () => Promise.resolve(''),
-    saveBytesAs: () => Promise.resolve(null),
+    ...platformBridgeFileSaveStubs(),
   },
 }))
 

--- a/frontend/src/lib/fileDownload.ts
+++ b/frontend/src/lib/fileDownload.ts
@@ -1,3 +1,4 @@
+import type { SaveStreamHandle } from '~/api/platformBridge'
 import type { PathFlavor } from '~/lib/paths'
 import { platformBridge } from '~/api/platformBridge'
 import * as workerRpc from '~/api/workerRpc'
@@ -5,8 +6,15 @@ import { basename } from '~/lib/paths'
 
 // 1 MiB chunks: large enough to keep round-trip count manageable for
 // multi-megabyte files, small enough to stay well under the worker's
-// max-message ceiling.
+// max-message ceiling and to bound the IPC clone peak when each chunk
+// is piped through `platformBridge.fileSaveWrite`.
 const DOWNLOAD_CHUNK_SIZE = 1 << 20
+
+/**
+ * `total` is `-1` until the worker's first response delivers `totalSize`;
+ * callers should render an indeterminate state until then.
+ */
+export type DownloadProgress = (received: number, total: number) => void
 
 /**
  * Hub-blindness invariant for the download path.
@@ -26,19 +34,32 @@ const DOWNLOAD_CHUNK_SIZE = 1 << 20
  * precedes the burst, so the "stat then read" signature is absent.
  */
 
+interface FileChunk {
+  /**
+   * Newly read bytes (not concatenated with prior chunks). Backed by a
+   * plain `ArrayBuffer` (not `SharedArrayBuffer`) so consumers can hand
+   * it straight to `Blob` / Tauri IPC without a second copy.
+   */
+  chunk: Uint8Array<ArrayBuffer>
+  /** Cumulative bytes received including this chunk. */
+  received: number
+  /** Total file size from the first response, or `-1` before that. */
+  totalSize: number
+}
+
 /**
- * Stream `filePath` from the worker, accumulating chunks into a single
- * in-memory `Uint8Array`. The first response's `totalSize` drives the
- * loop bound; no separate `statFile` round-trip is needed.
+ * Stream `filePath` from the worker, yielding each `readFile` response
+ * as a `FileChunk`. The first response carries `totalSize`; once known
+ * the loop bound switches from "until empty" to "until totalSize". No
+ * accumulator is allocated — callers that need the full bytes must
+ * concatenate themselves. Each yielded chunk is laundered through
+ * `ensurePlainArrayBufferView` so callers can hand it to `Blob` / Tauri
+ * IPC without an extra copy.
  */
-async function fetchFileBytes(workerId: string, filePath: string): Promise<Uint8Array> {
-  // First response carries totalSize; once it's known we allocate the
-  // final ArrayBuffer-backed Uint8Array and `set` each chunk into it
-  // directly. The protobuf-runtime chunk view's buffer type
-  // (`ArrayBufferLike`) admits `SharedArrayBuffer`, which `Blob` / Tauri
-  // serialization reject — copying into our fresh ArrayBuffer-backed
-  // `merged` simultaneously launders that and concatenates.
-  let merged: Uint8Array | null = null
+async function* streamFileChunks(
+  workerId: string,
+  filePath: string,
+): AsyncGenerator<FileChunk, void, void> {
   let received = 0
   let totalSize = -1
   while (totalSize < 0 || received < totalSize) {
@@ -48,39 +69,109 @@ async function fetchFileBytes(workerId: string, filePath: string): Promise<Uint8
       offset: BigInt(received),
       limit: BigInt(DOWNLOAD_CHUNK_SIZE),
     })
-    if (totalSize < 0) {
+    if (totalSize < 0)
       totalSize = Number(resp.totalSize)
-      merged = new Uint8Array(totalSize)
-    }
-    const chunk = resp.content
-    if (chunk.length === 0)
+    const view = resp.content
+    if (view.length === 0)
       break
-    merged!.set(chunk, received)
+    const chunk = ensurePlainArrayBufferView(view)
     received += chunk.length
+    yield { chunk, received, totalSize }
   }
-  if (merged === null)
-    return new Uint8Array(0)
-  // Worker truncated below the advertised size (file shrank
-  // mid-download, sparse-file edge case): trim to what we actually got.
-  if (received < merged.length)
-    return merged.subarray(0, received)
-  return merged
 }
 
 /**
- * Web-mode download: assemble bytes into a Blob and trigger a browser
- * anchor click. The browser owns the destination directory; the caller
- * cannot know where the file landed. Pass `flavor` to skip the
- * `detectFlavor` sniff inside `basename` when the caller already knows
- * it (keeps the download filename consistent with the toast label).
+ * Pass-through if `view` already covers an entire plain `ArrayBuffer`;
+ * otherwise copy into a fresh `ArrayBuffer`. Avoids the per-chunk
+ * memcpy on the common protobuf-runtime case (full-buffer view, plain
+ * ArrayBuffer backing) while still defending against `SharedArrayBuffer`
+ * backings and surprise-aliasing sub-slices that `Blob`/Tauri callers
+ * downstream would otherwise inherit.
+ */
+function ensurePlainArrayBufferView(view: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (
+    view.buffer instanceof ArrayBuffer
+    && view.byteOffset === 0
+    && view.byteLength === view.buffer.byteLength
+  ) {
+    return view as Uint8Array<ArrayBuffer>
+  }
+  const copy = new Uint8Array(view.length)
+  copy.set(view)
+  return copy
+}
+
+/**
+ * Minimum gap between intermediate `onProgress` callbacks. The first
+ * chunk and the final chunk always fire so the spinner labels its
+ * starting and ending state precisely; in between we coalesce to one
+ * fire per ~100 ms so a 100-chunk save renders ~10 progress events
+ * instead of 100 (each event drives a Solid signal write + render).
+ */
+const PROGRESS_THROTTLE_MS = 100
+
+/**
+ * Wrap `onProgress` so intermediate calls coalesce to one per
+ * `intervalMs`. The first call (`lastEmittedAt === -Infinity` is
+ * trivially past the gap) and the final call (signaled by
+ * `total >= 0 && received >= total`) always pass through, so the
+ * spinner labels its starting and ending state precisely. Returns
+ * `undefined` when `onProgress` itself is undefined, so call sites
+ * can keep the `?.()` short-circuit.
+ */
+function throttleProgress(
+  onProgress: DownloadProgress | undefined,
+  intervalMs: number,
+): DownloadProgress | undefined {
+  if (!onProgress)
+    return undefined
+  let lastEmittedAt = Number.NEGATIVE_INFINITY
+  return (received, total) => {
+    const now = performance.now()
+    const isFinal = total >= 0 && received >= total
+    if (isFinal || now - lastEmittedAt >= intervalMs) {
+      onProgress(received, total)
+      lastEmittedAt = now
+    }
+  }
+}
+
+/**
+ * Web-mode download: stream chunks into a `Blob` and trigger a browser
+ * anchor click. All chunks stay alive in `parts` until the `Blob` is
+ * constructed, but memory is fragmented across N × 1 MiB views rather
+ * than one contiguous `Uint8Array(totalSize)` — which lets large files
+ * complete on engines that fail the single contiguous allocation. The
+ * browser owns the destination directory; the caller cannot know where
+ * the file landed.
+ *
+ * `flavor` skips the `detectFlavor` sniff inside `basename` when the
+ * caller already knows it (keeps the download filename consistent with
+ * the toast label).
  */
 export async function downloadFileFromWorker(
   workerId: string,
   filePath: string,
   flavor?: PathFlavor,
+  onProgress?: DownloadProgress,
 ): Promise<void> {
-  const bytes = await fetchFileBytes(workerId, filePath)
-  const url = URL.createObjectURL(new Blob([bytes as BlobPart]))
+  const emit = throttleProgress(onProgress, PROGRESS_THROTTLE_MS)
+  const parts: BlobPart[] = []
+  let lastReceived = 0
+  let lastTotalSize = 0
+  for await (const { chunk, received, totalSize } of streamFileChunks(workerId, filePath)) {
+    parts.push(chunk)
+    emit?.(received, totalSize)
+    lastReceived = received
+    lastTotalSize = totalSize
+  }
+  // Truncation: worker stopped before delivering `totalSize` bytes, so
+  // the throttle's isFinal trigger never fired. Force a final emit at
+  // (received, received) — total=received makes isFinal true and the
+  // spinner reaches 100% for the actual bytes we got.
+  if (lastReceived < lastTotalSize)
+    emit?.(lastReceived, lastReceived)
+  const url = URL.createObjectURL(new Blob(parts))
   try {
     const a = document.createElement('a')
     a.href = url
@@ -99,29 +190,111 @@ export async function downloadFileFromWorker(
 }
 
 /**
- * Desktop-mode silent save: write the streamed bytes into the user's
- * OS Downloads directory and return the absolute path written.
- * Caller may then pass the path to `platformBridge.revealInFileManager`.
+ * Pipe streamed chunks into an already-open save handle. Keeps at most
+ * one outstanding `fileSaveWrite` while the next worker `readFile` is
+ * in flight — bounds peak memory to two chunks (~2 MiB) while halving
+ * the round-trip stalls of strictly sequential issue/await.
+ *
+ * Async generators are pull-based, so a plain `for await` would only
+ * start the next `readFile` after awaiting the previous `fileSaveWrite`
+ * — defeating the overlap. We pre-issue `iterator.next()` *before*
+ * awaiting the pending write so the worker read and the disk write run
+ * concurrently.
+ *
+ * On any error mid-stream, drains the outstanding write, aborts the
+ * handle so the Rust side removes the partial file, and re-throws the
+ * original error. Abort errors on the failure path are swallowed so
+ * they don't mask the cause; on success a commit error propagates
+ * (a rename failure is itself a save failure).
+ */
+async function pumpChunksToHandle(
+  workerId: string,
+  filePath: string,
+  handle: SaveStreamHandle,
+  onProgress: DownloadProgress | undefined,
+): Promise<void> {
+  const emit = throttleProgress(onProgress, PROGRESS_THROTTLE_MS)
+  const reader = streamFileChunks(workerId, filePath)
+  let pendingWrite: Promise<void> | undefined
+  let nextRead = reader.next()
+  let lastReceived = 0
+  let lastTotalSize = 0
+  try {
+    while (true) {
+      const result = await nextRead
+      if (result.done)
+        break
+      const { chunk, received, totalSize } = result.value
+      // Kick off the next worker read *before* awaiting the prior write,
+      // so the read and write overlap on the wire.
+      nextRead = reader.next()
+      if (pendingWrite)
+        await pendingWrite
+      pendingWrite = platformBridge.fileSaveWrite(handle.id, chunk)
+      emit?.(received, totalSize)
+      lastReceived = received
+      lastTotalSize = totalSize
+    }
+    // Drain the final outstanding write before declaring success.
+    if (pendingWrite)
+      await pendingWrite
+    // Truncation: worker stopped early so throttle's isFinal trigger
+    // never fired. Force a final emit at (received, received) so the
+    // spinner reaches 100% for the bytes we actually wrote.
+    if (lastReceived < lastTotalSize)
+      emit?.(lastReceived, lastReceived)
+    await platformBridge.fileSaveCommit(handle.id)
+  }
+  catch (err) {
+    // Drain any still-in-flight read and write before abort — otherwise
+    // `fileSaveAbort` races with `fileSaveWrite` on the Rust side, and
+    // a stray `readFile` rejection becomes an unhandled promise. Swallow
+    // both drains and the abort error so they don't mask the cause.
+    await nextRead.catch(() => {})
+    if (pendingWrite)
+      await pendingWrite.catch(() => {})
+    await platformBridge.fileSaveAbort(handle.id).catch(() => {})
+    throw err
+  }
+}
+
+/**
+ * Desktop-mode silent save: open a destination in the user's OS
+ * Downloads directory, then pipe each worker chunk through
+ * `fileSaveWrite`. Returns the absolute path written. Caller may then
+ * pass the path to `platformBridge.revealInFileManager`.
+ *
+ * Peak memory is bounded to two chunks (~2 MiB total, the pipelined
+ * "just-read + in-flight write" pair from `pumpChunksToHandle`) across
+ * the JS heap + IPC + Rust clone chain, so the transient cost stays in
+ * single-digit MB even for multi-hundred-MB files.
  */
 export async function saveFileToDownloads(
   workerId: string,
   filePath: string,
   flavor?: PathFlavor,
+  onProgress?: DownloadProgress,
 ): Promise<string> {
-  const bytes = await fetchFileBytes(workerId, filePath)
-  return platformBridge.saveBytesToDownloads(bytes, basename(filePath, flavor))
+  const handle = await platformBridge.fileSaveOpen(basename(filePath, flavor))
+  await pumpChunksToHandle(workerId, filePath, handle, onProgress)
+  return handle.path
 }
 
 /**
- * Desktop-mode save-as: show a native save dialog, write the bytes to
- * the chosen path, and return the absolute path. Returns `null` if the
- * user cancelled the dialog.
+ * Desktop-mode save-as: show a native save dialog *first*, then stream
+ * the bytes to the chosen path. Returns `null` if the user cancelled
+ * the dialog — in that case the worker is never asked for the file, so
+ * a cancellation costs nothing in fetch + memory time.
  */
 export async function saveFileAs(
   workerId: string,
   filePath: string,
   flavor?: PathFlavor,
+  onProgress?: DownloadProgress,
 ): Promise<string | null> {
-  const bytes = await fetchFileBytes(workerId, filePath)
-  return platformBridge.saveBytesAs(bytes, basename(filePath, flavor))
+  const handle = await platformBridge.fileSaveOpenDialog(basename(filePath, flavor))
+  if (handle === null)
+    return null
+  await pumpChunksToHandle(workerId, filePath, handle, onProgress)
+  return handle.path
 }

--- a/frontend/tests/unit/components/FileActionsMenu.test.tsx
+++ b/frontend/tests/unit/components/FileActionsMenu.test.tsx
@@ -111,7 +111,7 @@ describe('fileActionsMenu — web mode', () => {
     expect(screen.queryByTestId('file-actions-save-as-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('file-actions-save-to-downloads-button')).not.toBeInTheDocument()
     fireEvent.click(dl)
-    await waitFor(() => expect(spies.downloadImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix'))
+    await waitFor(() => expect(spies.downloadImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix', expect.any(Function)))
   })
 })
 
@@ -130,7 +130,7 @@ describe('fileActionsMenu — desktop mode', () => {
   it('save to Downloads reveals when the preference is on', async () => {
     renderMenu()
     fireEvent.click(screen.getByTestId('file-actions-save-to-downloads-button'))
-    await waitFor(() => expect(spies.saveToDownloadsImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix'))
+    await waitFor(() => expect(spies.saveToDownloadsImpl).toHaveBeenCalledWith('w1', '/repo/src/file.ts', 'posix', expect.any(Function)))
     await waitFor(() => expect(spies.revealImpl).toHaveBeenCalledWith('/home/alice/Downloads/file.ts'))
   })
 

--- a/frontend/tests/unit/components/FileViewer.unsupported.test.tsx
+++ b/frontend/tests/unit/components/FileViewer.unsupported.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { platformBridgeFileSaveStubs } from '../helpers/saveActionsMocks'
+import { readResp, statResp } from '../helpers/workerRpcMocks'
 
 const statFileImpl = vi.fn()
 const readFileImpl = vi.fn()
@@ -63,25 +65,13 @@ vi.mock('~/api/platformBridge', () => ({
   isTauriApp: () => false,
   platformBridge: {
     revealInFileManager: () => Promise.resolve(),
-    saveBytesToDownloads: () => Promise.resolve(''),
-    saveBytesAs: () => Promise.resolve(null),
+    ...platformBridgeFileSaveStubs(),
   },
 }))
 
 const { FileViewer } = await import('~/components/fileviewer/FileViewer')
 
 const MAX = 256 * 1024
-
-function statResp(size: number) {
-  return { info: { size: BigInt(size) } }
-}
-
-function readResp(content: Uint8Array, totalSize?: number) {
-  return {
-    content,
-    totalSize: BigInt(totalSize ?? content.length),
-  }
-}
 
 describe('fileViewer dispatch with unsupported view', () => {
   beforeEach(() => {
@@ -270,7 +260,7 @@ describe('fileViewer dispatch with unsupported view', () => {
     )
     fireEvent.click(screen.getByTestId('unsupported-download-button'))
     await waitFor(() => expect(downloadImpl).toHaveBeenCalledTimes(1))
-    expect(downloadImpl).toHaveBeenCalledWith('w-42', '/repo/archive.zip', 'posix')
+    expect(downloadImpl).toHaveBeenCalledWith('w-42', '/repo/archive.zip', 'posix', expect.any(Function))
   })
 
   it('discards lazy-fetched bytes if filePath changes during the in-flight readFile', async () => {

--- a/frontend/tests/unit/components/UnsupportedFileView.test.tsx
+++ b/frontend/tests/unit/components/UnsupportedFileView.test.tsx
@@ -10,7 +10,7 @@ function renderView(overrides: Partial<Parameters<typeof UnsupportedFileView>[0]
     flavor: 'posix' as const,
     totalSize: 2048,
     reason: 'binary' as const,
-    currentOp: null,
+    op: null,
     loadingAnyway: false,
     canShowAnyway: true,
     onDownload: noop,
@@ -66,11 +66,24 @@ describe('unsupportedFileView', () => {
     expect(screen.getByTestId('unsupported-download-button')).toBeInTheDocument()
   })
 
-  it('disables Download and shows a spinner while currentOp is "download"', () => {
-    renderView({ currentOp: 'download' })
+  it('disables Download and shows a spinner while op.kind is "download"', () => {
+    renderView({ op: { kind: 'download', progress: null } })
     const btn = screen.getByTestId('unsupported-download-button') as HTMLButtonElement
     expect(btn.disabled).toBe(true)
     expect(btn.textContent).toMatch(/Downloading/i)
+  })
+
+  it('appends a percent to the busy label when op.progress is non-null', () => {
+    renderView({ op: { kind: 'download', progress: 45 } })
+    const btn = screen.getByTestId('unsupported-download-button') as HTMLButtonElement
+    expect(btn.textContent).toMatch(/Downloading\.\.\. 45%/)
+  })
+
+  it('omits the percent when op.progress is null', () => {
+    renderView({ op: { kind: 'download', progress: null } })
+    const btn = screen.getByTestId('unsupported-download-button') as HTMLButtonElement
+    expect(btn.textContent).toMatch(/Downloading\.\.\./)
+    expect(btn.textContent).not.toMatch(/%/)
   })
 
   it('disables Show anyway and shows a spinner while loadingAnyway is true', () => {
@@ -148,15 +161,15 @@ describe('unsupportedFileView', () => {
     })
 
     it('disables both save buttons while a save is in flight', () => {
-      renderDesktopView({ currentOp: 'save-as' })
+      renderDesktopView({ op: { kind: 'save-as', progress: null } })
       const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
       const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
       expect(saveAs.disabled).toBe(true)
       expect(toDownloads.disabled).toBe(true)
     })
 
-    it('shows the spinner on the Save-as button when currentOp is "save-as"', () => {
-      renderDesktopView({ currentOp: 'save-as' })
+    it('shows the spinner on the Save-as button when op.kind is "save-as"', () => {
+      renderDesktopView({ op: { kind: 'save-as', progress: null } })
       const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
       const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
       expect(saveAs.textContent).toMatch(/Saving/i)
@@ -164,8 +177,20 @@ describe('unsupportedFileView', () => {
       expect(toDownloads.textContent).toMatch(/Save to Downloads/i)
     })
 
-    it('shows the spinner on the Save-to-Downloads button when currentOp is "save-to-downloads"', () => {
-      renderDesktopView({ currentOp: 'save-to-downloads' })
+    it('shows percent progress alongside the spinner during a Save as...', () => {
+      renderDesktopView({ op: { kind: 'save-as', progress: 25 } })
+      const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
+      expect(saveAs.textContent).toMatch(/Saving\.\.\. 25%/)
+    })
+
+    it('shows percent progress during a Save to Downloads', () => {
+      renderDesktopView({ op: { kind: 'save-to-downloads', progress: 90 } })
+      const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
+      expect(toDownloads.textContent).toMatch(/Saving\.\.\. 90%/)
+    })
+
+    it('shows the spinner on the Save-to-Downloads button when op.kind is "save-to-downloads"', () => {
+      renderDesktopView({ op: { kind: 'save-to-downloads', progress: null } })
       const saveAs = screen.getByTestId('unsupported-save-as-button') as HTMLButtonElement
       const toDownloads = screen.getByTestId('unsupported-save-to-downloads-button') as HTMLButtonElement
       expect(toDownloads.textContent).toMatch(/Saving/i)

--- a/frontend/tests/unit/helpers/saveActionsMocks.ts
+++ b/frontend/tests/unit/helpers/saveActionsMocks.ts
@@ -35,9 +35,30 @@ export function platformBridgeMock(spies: SaveActionsSpies) {
     isTauriApp: () => spies.isTauriAppImpl(),
     platformBridge: {
       revealInFileManager: (...args: unknown[]) => spies.revealImpl(...args),
-      saveBytesToDownloads: () => Promise.resolve(''),
-      saveBytesAs: () => Promise.resolve(null),
+      ...platformBridgeFileSaveStubs(),
     },
+  }
+}
+
+/**
+ * The five `fileSave*` methods on `platformBridge`, stubbed to no-op
+ * resolved promises. Tests that don't exercise the save-stream flow but
+ * mock `~/api/platformBridge` (e.g. components that just need
+ * `platformBridge` defined) can spread this into their mock so the
+ * stubs stay in sync with the production interface.
+ *
+ * `fileSaveOpen` resolves a non-empty sentinel path so callers that
+ * propagate it into `revealInFileManager` see a truthy value (matching
+ * production behavior); tests asserting on the exact path should pin
+ * their own mock.
+ */
+export function platformBridgeFileSaveStubs() {
+  return {
+    fileSaveOpen: () => Promise.resolve({ id: 1, path: '/tmp/stub' }),
+    fileSaveOpenDialog: () => Promise.resolve(null),
+    fileSaveWrite: () => Promise.resolve(),
+    fileSaveCommit: () => Promise.resolve(),
+    fileSaveAbort: () => Promise.resolve(),
   }
 }
 

--- a/frontend/tests/unit/helpers/workerRpcMocks.ts
+++ b/frontend/tests/unit/helpers/workerRpcMocks.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared shape for mocked `workerRpc.readFile` responses.
+ *
+ * Both `content` and `totalSize` mirror the protobuf wire shape:
+ *
+ *   - `content` is a `Uint8Array` of the bytes for this chunk
+ *   - `totalSize` is a `BigInt` of the whole file size (the worker
+ *     responds with this on every chunk so the caller can detect EOF
+ *     even when a chunk arrives short)
+ *
+ * `totalSize` defaults to `content.length` so callers building a
+ * single-chunk response don't have to repeat themselves.
+ */
+export function readResp(content: Uint8Array, totalSize?: number) {
+  return {
+    content,
+    totalSize: BigInt(totalSize ?? content.length),
+  }
+}
+
+/**
+ * Shared shape for mocked `workerRpc.statFile` responses — just the
+ * `info.size` field as a BigInt, matching the protobuf wire shape.
+ */
+export function statResp(size: number) {
+  return { info: { size: BigInt(size) } }
+}

--- a/frontend/tests/unit/lib/fileDownload.test.ts
+++ b/frontend/tests/unit/lib/fileDownload.test.ts
@@ -1,18 +1,45 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readResp } from '../helpers/workerRpcMocks'
 
 const readFileImpl = vi.fn()
+const fileSaveOpenImpl = vi.fn()
+const fileSaveOpenDialogImpl = vi.fn()
+const fileSaveWriteImpl = vi.fn()
+const fileSaveCommitImpl = vi.fn()
+const fileSaveAbortImpl = vi.fn()
 
 vi.mock('~/api/workerRpc', () => ({
   readFile: (...args: unknown[]) => readFileImpl(...args),
 }))
 
-const { downloadFileFromWorker } = await import('~/lib/fileDownload')
+vi.mock('~/api/platformBridge', () => ({
+  platformBridge: {
+    fileSaveOpen: (...args: unknown[]) => fileSaveOpenImpl(...args),
+    fileSaveOpenDialog: (...args: unknown[]) => fileSaveOpenDialogImpl(...args),
+    fileSaveWrite: (...args: unknown[]) => fileSaveWriteImpl(...args),
+    fileSaveCommit: (...args: unknown[]) => fileSaveCommitImpl(...args),
+    fileSaveAbort: (...args: unknown[]) => fileSaveAbortImpl(...args),
+  },
+}))
 
-function readResp(content: Uint8Array, totalSize?: number) {
-  return {
-    content,
-    totalSize: BigInt(totalSize ?? content.length),
-  }
+const { downloadFileFromWorker, saveFileAs, saveFileToDownloads } = await import('~/lib/fileDownload')
+
+/**
+ * Reset every save-stream mock and default the side-effect-free ones
+ * (write / commit / abort) to a resolved no-op. Shared by the
+ * SAVE_FN_CASES driver and the dialog-specific describe so they stay
+ * in sync.
+ */
+function resetSaveMocks() {
+  readFileImpl.mockReset()
+  fileSaveOpenImpl.mockReset()
+  fileSaveOpenDialogImpl.mockReset()
+  fileSaveWriteImpl.mockReset()
+  fileSaveCommitImpl.mockReset()
+  fileSaveAbortImpl.mockReset()
+  fileSaveWriteImpl.mockResolvedValue(undefined)
+  fileSaveCommitImpl.mockResolvedValue(undefined)
+  fileSaveAbortImpl.mockResolvedValue(undefined)
 }
 
 interface AnchorSpy {
@@ -44,6 +71,25 @@ function spyAnchor(): AnchorSpy {
     return el
   })
   return { clickSpy, downloadName, restore: () => createSpy.mockRestore() }
+}
+
+/**
+ * Configure `readFile` to serve `total` bytes back in 1 MiB chunks,
+ * advancing the in-memory offset between calls and asserting each
+ * request's offset/limit matches the production chunk size.
+ */
+function mockChunkedRead(total: number) {
+  let offset = 0
+  readFileImpl.mockImplementation(async (_workerId, req) => {
+    const reqOffset = Number(req.offset)
+    const reqLimit = Number(req.limit)
+    expect(reqOffset).toBe(offset)
+    expect(reqLimit).toBe(1 << 20) // production constant
+    const size = Math.min(reqLimit, total - offset)
+    const buf = new Uint8Array(size)
+    offset += size
+    return readResp(buf, total)
+  })
 }
 
 describe('downloadFileFromWorker', () => {
@@ -94,18 +140,7 @@ describe('downloadFileFromWorker', () => {
   it('streams a large file in multiple 1 MiB chunks until totalSize is reached', async () => {
     const CHUNK = 1 << 20
     const total = CHUNK * 3 + 7
-    let offset = 0
-    readFileImpl.mockImplementation(async (_workerId, req) => {
-      const reqOffset = Number(req.offset)
-      const reqLimit = Number(req.limit)
-      expect(reqOffset).toBe(offset)
-      expect(reqLimit).toBe(CHUNK)
-      const remaining = total - offset
-      const size = Math.min(reqLimit, remaining)
-      const buf = new Uint8Array(size)
-      offset += size
-      return readResp(buf, total)
-    })
+    mockChunkedRead(total)
 
     await downloadFileFromWorker('w1', '/repo/big.bin')
 
@@ -142,5 +177,259 @@ describe('downloadFileFromWorker', () => {
     expect(anchor.clickSpy).not.toHaveBeenCalled()
     expect(createUrlSpy).not.toHaveBeenCalled()
     expect(revokeUrlSpy).not.toHaveBeenCalled()
+  })
+
+  it('fires onProgress with the first and final chunks (throttled in between)', async () => {
+    // Three chunks fire within microseconds → the shared 100 ms throttle
+    // keeps only the first emit (lastEmittedAt starts at -Infinity) and
+    // the isFinal emit; chunk 2 is coalesced.
+    const CHUNK = 1 << 20
+    const total = CHUNK * 2 + 100
+    mockChunkedRead(total)
+    const onProgress = vi.fn()
+
+    await downloadFileFromWorker('w1', '/repo/big.bin', undefined, onProgress)
+
+    expect(onProgress).toHaveBeenCalledTimes(2)
+    expect(onProgress.mock.calls.map(c => c[0])).toEqual([CHUNK, total])
+    expect(onProgress.mock.calls.every(c => c[1] === total)).toBe(true)
+  })
+
+  it('fires a final onProgress at received-bytes when the stream truncates below totalSize', async () => {
+    // Worker advertises 10_000 bytes but yields 4096 then an empty
+    // chunk. Without the post-loop force-emit, the throttle never
+    // sees `received >= total` and the spinner is stuck at the
+    // intermediate percent. The dedup guard keeps the count tight.
+    readFileImpl.mockResolvedValueOnce(readResp(new Uint8Array(4096), 10_000))
+    readFileImpl.mockResolvedValueOnce(readResp(new Uint8Array(0), 10_000))
+    const onProgress = vi.fn()
+
+    await downloadFileFromWorker('w1', '/repo/short.bin', undefined, onProgress)
+
+    const lastCall = onProgress.mock.calls[onProgress.mock.calls.length - 1]
+    expect(lastCall[0]).toBe(4096)
+    expect(lastCall[1]).toBe(4096)
+  })
+
+  it('emits intermediate onProgress when ≥ 100 ms elapse between chunks', async () => {
+    const CHUNK = 1 << 20
+    const total = CHUNK * 3
+    mockChunkedRead(total)
+    const onProgress = vi.fn()
+    let nowMs = 1000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => {
+      const v = nowMs
+      nowMs += 150
+      return v
+    })
+    try {
+      await downloadFileFromWorker('w1', '/repo/big.bin', undefined, onProgress)
+      expect(onProgress.mock.calls.map(c => c[0])).toEqual([CHUNK, CHUNK * 2, total])
+    }
+    finally {
+      nowSpy.mockRestore()
+    }
+  })
+})
+
+// `saveFileToDownloads` and `saveFileAs` differ only in which
+// `platformBridge` open call they use; the chunk-streaming and handle
+// finalization that follows is shared (`pumpChunksToHandle`). Run the
+// shared behaviors against both fns from one driver so a regression in
+// either entry point fails both rows. Per-fn divergences (the save-as
+// dialog ordering and cancellation) live in their own describe below.
+interface SaveFnCase {
+  label: string
+  /** The exported `fileDownload` function under test. */
+  fn: (workerId: string, path: string, flavor?: undefined, onProgress?: (received: number, total: number) => void) => Promise<string | null>
+  /** The `platformBridge` open mock the fn delegates to. */
+  open: typeof fileSaveOpenImpl
+  /** Handle id and final path the open mock resolves to. */
+  id: number
+  finalPath: string
+}
+
+const SAVE_FN_CASES: SaveFnCase[] = [
+  { label: 'saveFileToDownloads', fn: saveFileToDownloads, open: fileSaveOpenImpl, id: 7, finalPath: '/home/alice/Downloads/big.bin' },
+  { label: 'saveFileAs', fn: saveFileAs, open: fileSaveOpenDialogImpl, id: 22, finalPath: '/home/alice/saved.bin' },
+]
+
+for (const c of SAVE_FN_CASES) {
+  describe(`${c.label} (shared streaming flow)`, () => {
+    beforeEach(() => {
+      resetSaveMocks()
+      c.open.mockResolvedValue({ id: c.id, path: c.finalPath })
+    })
+
+    it('opens a destination then writes each worker chunk in order', async () => {
+      const CHUNK = 1 << 20
+      const total = CHUNK * 2 + 7
+      mockChunkedRead(total)
+
+      const path = await c.fn('w1', '/repo/big.bin')
+
+      expect(path).toBe(c.finalPath)
+      expect(c.open).toHaveBeenCalledWith('big.bin')
+      expect(fileSaveWriteImpl).toHaveBeenCalledTimes(3)
+      for (const call of fileSaveWriteImpl.mock.calls)
+        expect(call[0]).toBe(c.id)
+      expect(fileSaveCommitImpl).toHaveBeenCalledWith(c.id)
+      expect(fileSaveAbortImpl).not.toHaveBeenCalled()
+    })
+
+    it('aborts the handle and propagates a readFile error', async () => {
+      readFileImpl.mockRejectedValue(new Error('worker exploded'))
+
+      await expect(c.fn('w1', '/repo/big.bin')).rejects.toThrow('worker exploded')
+      expect(fileSaveWriteImpl).not.toHaveBeenCalled()
+      expect(fileSaveAbortImpl).toHaveBeenCalledWith(c.id)
+      expect(fileSaveCommitImpl).not.toHaveBeenCalled()
+    })
+
+    it('aborts and propagates a mid-stream readFile error', async () => {
+      const CHUNK = 1 << 20
+      let calls = 0
+      readFileImpl.mockImplementation(async () => {
+        calls += 1
+        if (calls === 1)
+          return readResp(new Uint8Array(CHUNK), CHUNK * 3)
+        throw new Error('worker died')
+      })
+
+      await expect(c.fn('w1', '/repo/big.bin')).rejects.toThrow('worker died')
+      expect(fileSaveWriteImpl).toHaveBeenCalledTimes(1)
+      expect(fileSaveAbortImpl).toHaveBeenCalledWith(c.id)
+      expect(fileSaveCommitImpl).not.toHaveBeenCalled()
+    })
+
+    it('fires onProgress after each successful chunk write', async () => {
+      const CHUNK = 1 << 20
+      mockChunkedRead(CHUNK * 2)
+      const onProgress = vi.fn()
+
+      await c.fn('w1', '/repo/big.bin', undefined, onProgress)
+
+      expect(onProgress).toHaveBeenCalledTimes(2)
+      expect(onProgress.mock.calls[0]).toEqual([CHUNK, CHUNK * 2])
+      expect(onProgress.mock.calls[1]).toEqual([CHUNK * 2, CHUNK * 2])
+    })
+
+    it('forwards a zero-offset full-buffer view straight through without copying', async () => {
+      const bytes = new Uint8Array(64)
+      bytes[0] = 0xAB
+      bytes[63] = 0xCD
+      readFileImpl.mockResolvedValue(readResp(bytes))
+
+      await c.fn('w1', '/repo/x.bin')
+
+      expect(fileSaveWriteImpl).toHaveBeenCalledTimes(1)
+      const written = fileSaveWriteImpl.mock.calls[0][1] as Uint8Array
+      expect(written.buffer).toBe(bytes.buffer)
+    })
+
+    it('copies a sub-slice view so callers see an isolated ArrayBuffer', async () => {
+      const big = new ArrayBuffer(256)
+      const slice = new Uint8Array(big, 64, 128)
+      slice[0] = 0xAB
+      slice[127] = 0xCD
+      readFileImpl.mockResolvedValue(readResp(slice))
+
+      await c.fn('w1', '/repo/x.bin')
+
+      expect(fileSaveWriteImpl).toHaveBeenCalledTimes(1)
+      const written = fileSaveWriteImpl.mock.calls[0][1] as Uint8Array
+      expect(written.buffer).not.toBe(big)
+      expect(written.byteOffset).toBe(0)
+      expect(written.byteLength).toBe(128)
+      expect(written[0]).toBe(0xAB)
+      expect(written[127]).toBe(0xCD)
+    })
+
+    it('pipelines the next worker read with the in-flight fileSaveWrite', async () => {
+      // Hold each fileSaveWrite open until the test releases it. The
+      // first write being in flight should NOT block the next worker
+      // read — a strictly sequential pump would have exactly 1
+      // readFile call before write 1 resolves, but pipelining means
+      // at least one more read is already in flight.
+      const CHUNK = 1 << 20
+      mockChunkedRead(CHUNK * 3)
+      const writeReleases: Array<() => void> = []
+      fileSaveWriteImpl.mockImplementation(() => new Promise<void>((resolve) => {
+        writeReleases.push(resolve)
+      }))
+
+      const done = c.fn('w1', '/repo/big.bin')
+      await vi.waitFor(() => expect(writeReleases.length).toBe(1))
+      expect(readFileImpl.mock.calls.length).toBeGreaterThan(1)
+      writeReleases[0]()
+      await vi.waitFor(() => expect(writeReleases.length).toBe(2))
+      writeReleases[1]()
+      await vi.waitFor(() => expect(writeReleases.length).toBe(3))
+      writeReleases[2]()
+      await done
+      expect(fileSaveCommitImpl).toHaveBeenCalledWith(c.id)
+    })
+
+    it('throttles intermediate onProgress to ~100 ms but always emits the first and final chunks', async () => {
+      // 5 chunks; each fileSaveWrite advances the simulated clock 60 ms.
+      // Chunks 1 (first) and 5 (final) always emit. Chunk 2 lands 60 ms
+      // after the chunk-1 emit (< 100, skipped); chunk 3 lands 120 ms
+      // after (>= 100, emits); chunk 4 lands 60 ms after the chunk-3
+      // emit (< 100, skipped).
+      const CHUNK = 1 << 20
+      mockChunkedRead(CHUNK * 5)
+      const onProgress = vi.fn()
+      let nowMs = 1000
+      const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs)
+      fileSaveWriteImpl.mockImplementation(async () => {
+        nowMs += 60
+      })
+      try {
+        await c.fn('w1', '/repo/big.bin', undefined, onProgress)
+
+        const receivedAt = onProgress.mock.calls.map(c => c[0] as number)
+        expect(receivedAt).toEqual([CHUNK, CHUNK * 3, CHUNK * 5])
+      }
+      finally {
+        nowSpy.mockRestore()
+      }
+    })
+  })
+}
+
+describe('saveFileAs (dialog-specific)', () => {
+  beforeEach(() => {
+    resetSaveMocks()
+  })
+
+  it('shows the save-as dialog before any worker readFile', async () => {
+    // The order check: track first call across both spies.
+    const order: string[] = []
+    fileSaveOpenDialogImpl.mockImplementation(async () => {
+      order.push('dialog')
+      return { id: 11, path: '/home/alice/Documents/saved.bin' }
+    })
+    readFileImpl.mockImplementation(async () => {
+      order.push('read')
+      return readResp(new Uint8Array(8))
+    })
+
+    await saveFileAs('w1', '/repo/big.bin')
+
+    expect(order[0]).toBe('dialog')
+    expect(order).toContain('read')
+    expect(fileSaveOpenDialogImpl).toHaveBeenCalledWith('big.bin')
+  })
+
+  it('returns null without ever calling readFile when the dialog is cancelled', async () => {
+    fileSaveOpenDialogImpl.mockResolvedValue(null)
+
+    const result = await saveFileAs('w1', '/repo/big.bin')
+
+    expect(result).toBeNull()
+    expect(readFileImpl).not.toHaveBeenCalled()
+    expect(fileSaveWriteImpl).not.toHaveBeenCalled()
+    expect(fileSaveCommitImpl).not.toHaveBeenCalled()
+    expect(fileSaveAbortImpl).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Motivation

The previous save/download implementation transferred the entire file
contents as a single `Vec<u8>` over Tauri IPC before writing to disk.
This required allocating the full file in memory on both the Rust and
JS sides simultaneously, making it impractical for large files and
risking OOM failures on constrained devices. Additionally, cancelled
save dialogs still triggered a full worker read before the cancellation
was detected.

## Modifications

**Rust sidecar (`desktop/rust/src/main.rs`)**
- Replaced `save_bytes_to_downloads` and `save_bytes_as` commands with a
  streaming protocol: `file_save_open` / `file_save_open_dialog` →
  `file_save_write` (repeated) → `file_save_commit` | `file_save_abort`.
- Added `SaveStreamRegistry` to track open file handles keyed by a
  monotonic u64 id, enabling parallel saves without contention.
- Writes target a sibling `.tmp` file; commit performs an atomic rename
  so the destination path never appears on disk until the save
  completes. Abort deletes the `.tmp`.
- Candidate name iteration ("foo.ext", "foo (1).ext", …) uses
  `create_new` on the `.tmp` to prevent concurrent saves of the same
  basename from colliding.
- Background GC reclaims orphaned `.tmp` handles after a 5-minute idle
  timeout with a 60-second scan interval, covering renderer crashes
  mid-save.
- `file_save_write` uses `block_in_place` so chunk writes do not tie up
  the Tokio executor; the chunk bytes are borrowed directly from the
  IPC body with no intermediate `Vec` clone.
- (Breaking) `save_bytes_to_downloads` and `save_bytes_as` Tauri
  commands are removed.

**Frontend save pipeline**
- Added `platformBridge` methods `fileSaveOpen`, `fileSaveOpenDialog`,
  `fileSaveWrite`, `fileSaveCommit`, and `fileSaveAbort` matching the
  new Rust chain.
- New `streamFileChunks` async generator yields 1 MiB chunks from the
  worker. `pumpChunksToHandle` pre-issues the next `readFile` before
  awaiting the prior `fileSaveWrite`, so disk writes and worker reads
  overlap instead of serializing.
- Web fallback `downloadFileFromWorker` builds the `Blob` from N × 1
  MiB views rather than one contiguous `Uint8Array`, so large files
  complete on engines that reject a single large allocation.
- Save-as dialog is resolved before any worker `readFile`, so a
  cancelled dialog incurs no worker overhead.
- `FileSaveOp` state gains a `progress: number | null` field;
  `UnsupportedFileView` renders the current percentage ("Downloading…
  45%") next to the spinner once the worker reports `totalSize`.
- New `throttleProgress` helper coalesces intermediate progress events
  to ~100 ms intervals while guaranteeing the first and final chunks
  always emit.
- Truncation guard: if the worker stops short of the advertised
  `totalSize`, a final emit at `(received, received)` is forced so the
  UI reaches 100%.
- Error cleanup: outstanding reads and writes are drained before
  `fileSaveAbort` is called, preventing unhandled rejections and
  Rust-side races.
- `currentOp` prop renamed to `op` on `FileActionsMenu`,
  `UnsupportedFileView`, and related surfaces.
- (Breaking) `saveBytesToDownloads` and `saveBytesAs` bridge methods
  are removed.

**Tests**
- Added `frontend/tests/unit/helpers/workerRpcMocks.ts` with shared
  `readResp` / `statResp` builders.
- `saveActionsMocks.ts` gains `platformBridgeFileSaveStubs()` covering
  the five new `fileSave*` methods.
- `fileDownload.test.ts` adds ~325 lines: chunked reads aligned to the
  1 MiB constant, mid-stream abort propagation, dialog ordering and
  cancellation, sub-slice copy isolation, progress throttle with
  simulated write latency, truncation final-emit, and a dedicated
  pipelining test asserting that a second `readFile` is dispatched
  while the first `fileSaveWrite` is still in flight.
- `UnsupportedFileView.test.tsx` adds 6 tests for progress-percent
  rendering across download / save-as / save-to-downloads, with and
  without `totalSize`.

## Result

Saving or downloading files of any size no longer requires holding the
full contents in memory. A 1 GiB file transfers in 1 MiB chunks, with
reads and writes overlapping in a pipeline. On the desktop, the
destination file only appears at its final path after the write
completes, so interrupted saves leave no partial files behind. Users
see a live percentage counter ("Downloading… 45%") during the transfer,
and a cancelled save dialog costs no worker I/O at all.
