### PR TITLE
fix(desktop): Fix AppImage launch failure after binary relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Install the remaining dependencies from the [AUR](https://wiki.archlinux.org/tit
 yay -S mprocs-bin
 ```
 
-For desktop app builds, install the [Tauri prerequisites for Arch Linux](https://v2.tauri.app/start/prerequisites/#linux) plus GStreamer (bundled into the AppImage by `bundleMediaFramework`):
+For desktop app builds, install the [Tauri prerequisites for Arch Linux](https://v2.tauri.app/start/prerequisites/#linux) plus GStreamer (bundled into the AppImage by `bundleMediaFramework`) and `dpkg` (its `dpkg-deb` builds the `.deb` bundle; not installed by default on Arch):
 
 ```bash
-sudo pacman -S webkit2gtk-4.1 libayatana-appindicator librsvg patchelf \
+sudo pacman -S webkit2gtk-4.1 libayatana-appindicator librsvg patchelf dpkg \
   gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad \
   gst-plugins-ugly gst-libav
 ```

--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ For desktop app builds, install the [Tauri prerequisites for Arch Linux](https:/
 
 ```bash
 sudo pacman -S webkit2gtk-4.1 libayatana-appindicator librsvg patchelf dpkg \
-  gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad \
-  gst-plugins-ugly gst-libav
+  gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad-libs gst-libav
 ```
 
 ### Windows

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -455,6 +455,43 @@ tasks:
       - task: build-desktop-sidecar
       - desktop/rust/scripts/patch-linuxdeploy.sh
       - cd desktop/rust && ../../frontend/node_modules/.bin/tauri build --config '{"version":"{{.VERSION}}"}'
+      # Relocate the AppImage's app binary to /usr/lib/leapmux-desktop/ for
+      # layout parity with the .deb: the binary and the sidecar then live
+      # together under /usr/lib/, and nothing named leapmux-desktop sits on the
+      # launcher PATH. Tauri's AppImage bundler reuses the deb data tree, so the
+      # binary starts at usr/bin/leapmux-desktop; move it beside the sidecar,
+      # which is already in usr/lib/leapmux-desktop/ via the resources glob.
+      #
+      # linuxdeploy's AppRun resolves the desktop Exec by searching a fixed PATH
+      # (usr/bin, usr/sbin, ...) that excludes usr/lib, and an absolute Exec is
+      # execvp'd as a literal host path (the bug that broke launch before). So
+      # instead of leaving a usr/bin symlink, prepend usr/lib/leapmux-desktop to
+      # PATH inside the AppRun script: AppRun.wrapped appends the inherited PATH,
+      # so the shared template's bare `Exec=leapmux-desktop` resolves to the
+      # relocated binary, and /proc/self/exe reports the real usr/lib path so the
+      # Go sidecar resolves "next to exe" exactly like the deb. Then repack the
+      # AppDir with the linuxdeploy appimage plugin Tauri already cached,
+      # overwriting Tauri's AppImage (which still had the binary in usr/bin).
+      #
+      # The greps are tripwires: they fail the build loudly if a future
+      # linuxdeploy changes the AppRun exec line (so the PATH injection would
+      # silently no-op) or if the shared template stops emitting the bare Exec.
+      - |
+        set -euo pipefail
+        appdir="desktop/rust/target/release/bundle/appimage/leapmux-desktop.AppDir"
+        img="$(ls desktop/rust/target/release/bundle/appimage/leapmux-desktop_*.AppImage)"
+        grep -q '^Exec=leapmux-desktop$' "$appdir"/*.desktop
+        grep -q '^exec "$this_dir"/AppRun.wrapped' "$appdir/AppRun"
+        mv "$appdir/usr/bin/leapmux-desktop" "$appdir/usr/lib/leapmux-desktop/leapmux-desktop"
+        sed -i 's|^exec "$this_dir"/AppRun\.wrapped|export PATH="$this_dir/usr/lib/leapmux-desktop:$PATH"  # leapmux: app binary relocated under usr/lib for .deb parity\nexec "$this_dir"/AppRun.wrapped|' "$appdir/AppRun"
+        test -x "$appdir/usr/lib/leapmux-desktop/leapmux-desktop"
+        test ! -e "$appdir/usr/bin/leapmux-desktop"
+        grep -q 'usr/lib/leapmux-desktop:\$PATH' "$appdir/AppRun"
+        plugin="${HOME}/.cache/tauri/linuxdeploy-plugin-appimage.AppImage"
+        test -x "$plugin"
+        rm -f "$img"
+        ( cd "$(dirname "$img")" && ARCH="$(uname -m)" NO_APPSTREAM=1 APPIMAGE_EXTRACT_AND_RUN=1 OUTPUT="$(basename "$img")" "$plugin" --appdir leapmux-desktop.AppDir )
+        test -f "$img"
       - cp -f desktop/rust/target/release/leapmux-desktop .
       - cp -f desktop/go/bin/leapmux-desktop-service-* .
       - cp -f desktop/rust/target/release/bundle/deb/leapmux-desktop*.deb .
@@ -463,10 +500,16 @@ tasks:
       # binary; there's no config knob to relocate it. Post-process the .deb
       # so `leapmux-desktop` lands under /usr/lib/ (off PATH) while
       # /usr/bin/leapmux (added via deb.files) stays as the only CLI on PATH.
-      # dpkg-deb -R/-b is round-tripped by Debian itself — md5sums regenerate
-      # automatically. The grep -q is a tripwire: if desktop-template.desktop
-      # ever stops pointing at /usr/lib/..., the relocation falls out of sync
-      # and we want a loud failure rather than a silent broken .desktop file.
+      # The .desktop Exec must follow the binary, so rewrite the template's
+      # bare `Exec=leapmux-desktop` to the absolute relocated path — under
+      # /usr/lib/ the bare name would no longer resolve for the system launcher.
+      # (The AppImage reaches the same /usr/lib layout differently — via a
+      # PATH-injected AppRun — because its Exec is resolved by linuxdeploy, not
+      # the system launcher; see the AppImage step above.) dpkg-deb -R/-b is
+      # round-tripped by Debian itself — md5sums regenerate automatically. The
+      # grep -q is a tripwire: if the sed ever stops matching (e.g. the
+      # template's Exec changes), the rewrite silently no-ops and we want a loud
+      # failure rather than a .desktop pointing off PATH.
       - |
         set -euo pipefail
         for deb in leapmux-desktop_*.deb; do
@@ -474,6 +517,8 @@ tasks:
           dpkg-deb -R "$deb" "$work"
           mkdir -p "$work/usr/lib/leapmux-desktop"
           mv "$work/usr/bin/leapmux-desktop" "$work/usr/lib/leapmux-desktop/leapmux-desktop"
+          sed -i 's#^Exec=leapmux-desktop$#Exec=/usr/lib/leapmux-desktop/leapmux-desktop#' \
+            "$work/usr/share/applications/"*.desktop
           grep -q '^Exec=/usr/lib/leapmux-desktop/leapmux-desktop$' \
             "$work/usr/share/applications/"*.desktop
           dpkg-deb -b "$work" "$deb"

--- a/desktop/rust/desktop-template.desktop
+++ b/desktop/rust/desktop-template.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Development;Utility;
-Exec=/usr/lib/leapmux-desktop/leapmux-desktop
+Exec=leapmux-desktop
 StartupWMClass=leapmux-desktop
 Icon=leapmux-desktop
 Name=LeapMux Desktop


### PR DESCRIPTION
## Motivation

PR #225 ("Embed leapmux CLI in app bundles") moved the GUI binary in the `.deb` bundle to `/usr/lib/leapmux-desktop/leapmux-desktop` and updated the shared `desktop-template.desktop` `Exec` to that absolute path. The `.deb` layout was correct, but the AppImage uses the same template and keeps its binary at `usr/bin/leapmux-desktop`. linuxdeploy's `AppRun` executes an absolute `Exec` path as a literal host path — not prefixed with `$APPDIR` — so every AppImage launch failed immediately:

```
Error: Error executing '/usr/lib/leapmux-desktop/leapmux-desktop': No such file or directory
```

## Modifications

- Revert `desktop-template.desktop` `Exec` to the bare `leapmux-desktop` so the AppImage's linuxdeploy `AppRun` resolves it against in-image PATH.
- Move the deb's absolute-path rewrite into the Taskfile's deb post-processing step as a `sed` invocation (`Exec=leapmux-desktop` -> `Exec=/usr/lib/leapmux-desktop/leapmux-desktop`), co-located with the existing binary relocation logic.
- Add an AppImage post-processing step: relocate the AppImage binary from `usr/bin/leapmux-desktop` into `usr/lib/leapmux-desktop/` (beside the Go sidecar), then prepend `usr/lib/leapmux-desktop` to PATH inside the `AppRun` script so the bare `Exec=leapmux-desktop` resolves to the relocated binary. Repack using the linuxdeploy appimage plugin Tauri already caches.
- Add build-time `grep` tripwires that fail loudly if a future linuxdeploy changes the `AppRun` exec line (which would make the PATH injection silently no-op) or if the shared template stops emitting the bare `Exec`.

## Result

The AppImage launches correctly again. Both the `.deb` and the `.AppImage` now place the GUI binary and the Go sidecar together under `usr/lib/leapmux-desktop/`, with nothing named `leapmux-desktop` on PATH. `/proc/self/exe` inside the AppImage reports the real `usr/lib` path, so the sidecar is found next to the executable exactly as in the deb.
