### PR TITLE
fix(chat): Hide Claude /context result instead of rendering as error

### DIFF
--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -83,6 +83,28 @@ describe('claude classify', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'result_divider' })
   })
 
+  it('hides the /context local-command result (already shown as an assistant bubble)', () => {
+    const parent = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      num_turns: 0,
+      stop_reason: null,
+      result: '## Context Usage\n\n**Model:** claude-opus-4-8[1m]\n',
+      duration_ms: 2062,
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
+  })
+
+  it('does not hide an error result even when its text starts with the context-usage header', () => {
+    const parent = {
+      type: 'result',
+      is_error: true,
+      result: '## Context Usage\nboom',
+    }
+    expect(plugin.classify(input(parent))).toEqual({ kind: 'result_divider' })
+  })
+
   it('hides EnterPlanMode tool_result wrappers persisted as user messages', () => {
     const parent = {
       role: 'user',

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -107,7 +107,19 @@ const CLAUDE_NOTIFICATION_CLASSIFIERS: Record<string, ClaudeTypeClassifier> = {
   context_cleared: () => ({ kind: 'notification' }),
   settings_changed: () => ({ kind: 'notification' }),
   plan_updated: () => ({ kind: 'notification' }),
-  result: () => ({ kind: 'result_divider' }),
+  result: (parent) => {
+    // The `/context` local command emits its usage table twice: once as a
+    // normal assistant text bubble, then again as this type:"result"
+    // envelope (num_turns:0, is_error:false). resultRenderer's zero-turn
+    // heuristic paints that envelope red as if it were an error. Since the
+    // assistant bubble already shows the table, hide the redundant result
+    // envelope. Guarded on is_error so a genuinely failed turn is never
+    // suppressed, and matched on the exact header so every other result
+    // still renders as a turn-end divider.
+    if (parent.is_error !== true && pickString(parent, 'result').startsWith('## Context Usage\n'))
+      return { kind: 'hidden' }
+    return { kind: 'result_divider' }
+  },
 }
 
 /**


### PR DESCRIPTION
## Motivation

When Claude Code runs the `/context` local slash command, it emits its usage table twice: once as a normal assistant text bubble, and again as a `type:"result"` envelope. That envelope is a *local* command result -- no model turn ran (`num_turns: 0`, `duration_api_ms: 0`, `is_error: false`). `resultRenderer`'s zero-turn heuristic in `notifications.tsx` (`!stop_reason && num_turns <= 1 && resultText`) treats any such result as an error and paints it red. So the `/context` output rendered as a red error divider duplicating the assistant bubble directly above it.

## Modifications

- Change the `result` classifier in `CLAUDE_NOTIFICATION_CLASSIFIERS` (`plugin.tsx`) to return `{ kind: 'hidden' }` when `is_error !== true` and the `result` text starts with `## Context Usage\n`; otherwise it stays `{ kind: 'result_divider' }`.
- Guard on `is_error` so a genuinely failed turn is never suppressed, and match the exact header so every other result still renders as a normal turn-end divider.
- Add classification tests: `/context` output classifies as `hidden`, and an `is_error: true` result whose text happens to start with the same header still classifies as `result_divider`.

## Result

The `/context` table now appears only once, in the assistant bubble -- the redundant red error divider is gone. Because `hidden` is already in `NON_STREAM_CLEAR_KINDS`, hiding the envelope doesn't disturb the streaming buffer behind the assistant bubble, and the renderer needs no change (`hidden` already renders as an empty span). The fix is intentionally surgical and fail-safe: if Claude Code rewords the header, the message reverts to today's divider behavior rather than dropping any content.
