### PR TITLE
fix(shortcuts): Revive key shortcuts after tinykeys 4 upgrade

### DIFF
--- a/frontend/src/lib/shortcuts/keybindings.test.ts
+++ b/frontend/src/lib/shortcuts/keybindings.test.ts
@@ -325,6 +325,58 @@ describe('activateBindings (slots)', () => {
   })
 })
 
+describe('activateBindings (events from form fields)', () => {
+  afterEach(() => {
+    unbindAll()
+    resetCommands()
+  })
+
+  // tinykeys 4 added a default `ignore` filter that drops keydown events whose
+  // target is an input/select/textarea/contenteditable element. Because we bind
+  // at `window`, that filter would swallow nearly every shortcut — the user is
+  // almost always focused in the chat input (contenteditable), a terminal
+  // (textarea), or a form field. We do our own focus-aware filtering in
+  // resolve(), so events from form fields must still reach the handler.
+  it('fires a modifier shortcut dispatched from a focused input', () => {
+    const handler = vi.fn()
+    registerCommand({ id: 'test.fromInput', title: 'Test', handler })
+    activateBindings([{ key: '$mod+k', command: 'test.fromInput' }], 'workspace')
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    input.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k',
+      code: 'KeyK',
+      ctrlKey: true,
+      bubbles: true,
+    }))
+    document.body.removeChild(input)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a contenteditable-scoped shortcut from a contenteditable element', () => {
+    const handler = vi.fn()
+    registerCommand({ id: 'test.fromEditable', title: 'Test', handler })
+    activateBindings([{ key: '$mod+j', command: 'test.fromEditable' }], 'workspace')
+
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    document.body.appendChild(editable)
+    editable.focus()
+    editable.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'j',
+      code: 'KeyJ',
+      ctrlKey: true,
+      bubbles: true,
+    }))
+    document.body.removeChild(editable)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('activateBindings (IME composition)', () => {
   afterEach(() => {
     unbindAll()

--- a/frontend/src/lib/shortcuts/keybindings.ts
+++ b/frontend/src/lib/shortcuts/keybindings.ts
@@ -194,7 +194,15 @@ export function activateBindings(bindings: readonly Keybinding[], slot: BindingS
     }
   }
 
-  const unsubscribe = tinykeys(window, keyMap, { capture: true })
+  // tinykeys 4 added a default `ignore` filter (defaultKeybindingsHandlerIgnore)
+  // that drops keydown events whose target is an input/select/textarea/
+  // contenteditable element. Because we bind at `window` and the user is almost
+  // always focused inside the chat input (ProseMirror contenteditable), a
+  // terminal (xterm textarea), or a form field, that filter would swallow nearly
+  // every shortcut before it reaches us. We already do focus-aware filtering in
+  // resolve() (and skip IME composition in the handler above), so disable the
+  // built-in ignore and let every event through.
+  const unsubscribe = tinykeys(window, keyMap, { capture: true, ignore: () => false })
   slotState.set(slot, { unsubscribe, bindings })
   recomputeActiveBindings()
   log.debug(`Bound ${groups.length} key groups (${bindings.length} bindings) for slot=${slot}`)


### PR DESCRIPTION
## Motivation

After the `tinykeys 3 -> 4` bump in `a6ddd2ea`, keyboard shortcuts stopped working entirely. tinykeys 4 added a new default `ignore` filter, `defaultKeybindingsHandlerIgnore`, that drops any keydown whose `event.target` is an `input`, `select`, `textarea`, or `[contenteditable]` element (when that target isn't the listener's `currentTarget`).

We bind the keymap at `window` (`keybindings.ts`), so `event.currentTarget` is always `window`, and in this UI focus is almost always inside one of those elements -- the chat input is a ProseMirror **contenteditable**, terminals are an xterm **textarea**, dialogs hold **inputs**. The filter therefore swallowed nearly every keypress before our handler ran, including modifier shortcuts like Cmd+N that our own `resolve()` is designed to allow through while typing, and shortcuts that *must* fire from within a field (`chat.sendMessage` Cmd+J `when: chatInputFocused`, terminal cursor nav `when: terminalFocused`).

The upgrade commit only bumped the version and removed a type shim; the call site was never adjusted. The existing unit tests missed the regression because they `dispatchEvent` directly on `window` (so `target === currentTarget`, bypassing the filter) -- the one scenario that never occurs in the real app.

## Modifications

- Pass `ignore: () => false` to the `tinykeys(window, keyMap, ...)` call in `keybindings.ts`, restoring tinykeys 3 delivery semantics. We already do focus-aware filtering in `resolve()` (suppressing plain non-modifier keys while typing, while allowing modifier and dedicated function keys) and skip IME composition in the handler, so the built-in filter was both redundant and wrong for this design.
- Add regression tests in `keybindings.test.ts` that dispatch a keydown from a focused `<input>` and from a `contenteditable` `<div>` -- both fail before the fix (handler called 0 times) and pass after.

## Result

Shortcuts work again across the app, including while focused in the chat input, terminals, and dialog fields. Disabling the built-in `ignore` also means tinykeys 4's `event.repeat` suppression no longer applies, which matches the prior tinykeys 3 behavior and is desirable here -- held-key repeat is wanted for the scroll (`Alt+PageUp/Down`) and zoom (`Cmd+pm`) bindings. The new tests guard against re-introducing the filter, dispatching from real form/contenteditable targets rather than `window`.
