### PR TITLE
feat(agent): Add ultracode effort tier and scrub inherited agent env

### DIFF
--- a/backend/internal/util/envutil/env.go
+++ b/backend/internal/util/envutil/env.go
@@ -113,6 +113,19 @@ func FilterEnv(environ []string, keys ...string) []string {
 	return filtered
 }
 
+// HasKey reports whether environ contains an entry whose name (the part
+// before the first '=') matches key case-insensitively, mirroring FilterEnv's
+// matching semantics. Useful in tests asserting that a key survived or was
+// scrubbed.
+func HasKey(environ []string, key string) bool {
+	for _, e := range environ {
+		if name, _, _ := strings.Cut(e, "="); strings.EqualFold(name, key) {
+			return true
+		}
+	}
+	return false
+}
+
 // StripByPrefix returns a copy of environ with entries whose name
 // (the part before the first '=') starts with prefix removed. Useful
 // for namespaced env-var groups (e.g. `LEAPMUX_REMOTE_*`) where the

--- a/backend/internal/util/envutil/env_test.go
+++ b/backend/internal/util/envutil/env_test.go
@@ -93,17 +93,6 @@ func TestStripByPrefix_EmptyInputs(t *testing.T) {
 	assert.Equal(t, []string{}, StripByPrefix([]string{}, "X_"))
 }
 
-// hasKey reports whether env contains an entry whose name (the part
-// before '=') case-insensitively matches key.
-func hasKey(env []string, key string) bool {
-	for _, e := range env {
-		if name, _, _ := strings.Cut(e, "="); strings.EqualFold(name, key) {
-			return true
-		}
-	}
-	return false
-}
-
 // getValue returns the value of the first env entry whose name matches
 // key (case-insensitive), or "", false if no such entry exists.
 func getValue(env []string, key string) (string, bool) {
@@ -127,9 +116,9 @@ func TestScrubAppImageEnv_InsideAppImage_DropsKeys(t *testing.T) {
 
 	require.NotNil(t, cmd.Env, "ScrubAppImageEnv must materialize cmd.Env when APPIMAGE is set")
 	for _, key := range AppImageEnvKeys {
-		assert.False(t, hasKey(cmd.Env, key), "env var %q should be scrubbed inside an AppImage", key)
+		assert.False(t, HasKey(cmd.Env, key), "env var %q should be scrubbed inside an AppImage", key)
 	}
-	assert.True(t, hasKey(cmd.Env, "PATH_SHOULD_SURVIVE"), "non-AppImage env vars must not be touched")
+	assert.True(t, HasKey(cmd.Env, "PATH_SHOULD_SURVIVE"), "non-AppImage env vars must not be touched")
 }
 
 func TestScrubAppImageEnv_OutsideAppImage_PreservesEnv(t *testing.T) {
@@ -227,7 +216,7 @@ func TestScrubAppImageEnv_DropsAppRunWholesaleVars(t *testing.T) {
 		"GTK_IM_MODULE_FILE", "GDK_PIXBUF_MODULE_FILE", "GIO_EXTRA_MODULES",
 		"GDK_BACKEND",
 	} {
-		assert.False(t, hasKey(cmd.Env, key), "env var %q must be wholesale-dropped inside an AppImage", key)
+		assert.False(t, HasKey(cmd.Env, key), "env var %q must be wholesale-dropped inside an AppImage", key)
 	}
 }
 
@@ -348,7 +337,7 @@ func TestScrubAppImageEnv_DropsPathListsWithNoUserOriginal(t *testing.T) {
 	ScrubAppImageEnv(cmd)
 
 	for _, key := range []string{"LD_LIBRARY_PATH", "PYTHONPATH", "PERLLIB"} {
-		assert.False(t, hasKey(cmd.Env, key),
+		assert.False(t, HasKey(cmd.Env, key),
 			"%s must be dropped when only AppDir entries remain (rather than set-to-empty)", key)
 	}
 }
@@ -403,7 +392,7 @@ func TestScrubAppImageEnvSlice_StripsAppDirFromPathLists(t *testing.T) {
 	ldVal, ok := getValue(got, "LD_LIBRARY_PATH")
 	require.True(t, ok)
 	assert.Equal(t, "/opt/cuda/lib64", ldVal)
-	assert.False(t, hasKey(got, "PYTHONPATH"),
+	assert.False(t, HasKey(got, "PYTHONPATH"),
 		"PYTHONPATH must be dropped when only AppDir entries remain")
 }
 
@@ -426,5 +415,5 @@ func TestScrubAppImageEnv_PreservesCallerSetEnv(t *testing.T) {
 		return false
 	}
 	assert.True(t, hasEntry(cmd.Env, "TERM=xterm-256color"), "caller's pre-seeded env must survive the scrub")
-	assert.False(t, hasKey(cmd.Env, "ARGV0"), "ARGV0 must be scrubbed")
+	assert.False(t, HasKey(cmd.Env, "ARGV0"), "ARGV0 must be scrubbed")
 }

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math/rand/v2"
 	"slices"
 	"strings"
@@ -223,11 +224,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 
 	// Apply persisted extra settings that differ from initialized defaults.
 	if flagSettings := a.buildStartupFlagSettings(opts.ExtraSettings); len(flagSettings) > 0 {
-		body, _ := json.Marshal(map[string]interface{}{
-			"subtype":  "apply_flag_settings",
-			"settings": flagSettings,
-		})
-		if _, err := a.sendControlAndWait(ctx, string(body), timeout); err != nil {
+		if err := a.sendApplyFlagSettings(ctx, flagSettings, timeout); err != nil {
 			slog.Warn("apply_flag_settings at startup failed", "agent_id", a.agentID, "error", err)
 		}
 	}
@@ -243,8 +240,24 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 
 // buildStartupFlagSettings builds an apply_flag_settings payload for extra
 // settings that differ from the initialized defaults.
+//
+// Reads a.effort/a.model without holding a.mu: this runs only from
+// StartClaudeCode, before the agent is registered with the manager and thus
+// before any concurrent UpdateSettings/refreshSettingsFromAgent can touch those
+// fields, so the lock-free read is safe. Do not call it post-registration.
 func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[string]interface{} {
 	fs := map[string]interface{}{}
+	// We launched with --effort xhigh as the ultracode base (see
+	// buildModelEffortArgs), so the CLI's current effort is already xhigh.
+	// Enable the ultracode boolean on top to complete the combo -- but only when
+	// the model actually supports it. buildModelEffortArgs downgrades an
+	// unsupported ultracode launch to --effort high, so for a Sonnet/Haiku/unknown
+	// agent whose stored effort was somehow "ultracode" we must NOT re-enable it
+	// here, or startup would contradict the launch flag and force xhigh+ultracode
+	// onto a model that can't run it.
+	if a.effort == EffortUltracode && modelSupportsUltracode(a.model) {
+		maps.Copy(fs, ultracodeFlagSettings())
+	}
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
 		fs[ExtraKeyOutputStyle] = v
 	}
@@ -389,6 +402,12 @@ func (a *ClaudeCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
 // settings at startup, or from the shell wrapper's
 // can_change_model_and_effort=false metadata), which tells the frontend
 // to hide model and effort settings.
+//
+// The returned slice and every AvailableModel/AvailableEffort it points at are
+// shared, immutable catalog data: the same effortTier* pointers back multiple
+// model slices (see the var block below), so a mutation through any returned
+// entry would corrupt every model that shares it. Callers MUST treat the result
+// as read-only; copy before mutating.
 func (a *ClaudeCodeAgent) AvailableModels() []*leapmuxv1.AvailableModel {
 	if a.thirdPartyFromSettings || a.preambleMetaValue("can_change_model_and_effort") == "false" {
 		return nil
@@ -477,6 +496,102 @@ func filterPermissionModeGroup(group *leapmuxv1.AvailableOptionGroup, autoAvail 
 	}
 }
 
+// ultracodeFlagSettings is the apply_flag_settings payload that enables the
+// xhigh+ultracode combo. "ultracode" is not a real --effort value: the CLI
+// models it as the boolean settings key `ultracode` layered on top of
+// effortLevel:"xhigh". Shared by the startup path (buildStartupFlagSettings)
+// and the live path (claudeEffortFlagSettings) so the wire encoding -- in
+// particular the "xhigh base" -- is defined in exactly one place. Returns a
+// fresh map each call so callers can mutate it freely.
+func ultracodeFlagSettings() map[string]interface{} {
+	return map[string]interface{}{"effortLevel": EffortXHigh, "ultracode": true}
+}
+
+// claudeEffortFlagSettings returns the effortLevel/ultracode keys to merge into an
+// apply_flag_settings payload to move curEffort -> newEffort. nil = no change.
+//
+// Selecting ultracode sends {effortLevel:"xhigh", ultracode:true} (see
+// ultracodeFlagSettings); switching away from it sends the new level plus an
+// explicit ultracode:false so the boolean is cleared.
+func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{} {
+	if newEffort == "" || newEffort == EffortAuto || newEffort == curEffort {
+		return nil
+	}
+	if newEffort == EffortUltracode {
+		return ultracodeFlagSettings()
+	}
+	fs := map[string]interface{}{"effortLevel": newEffort}
+	if curEffort == EffortUltracode {
+		fs["ultracode"] = false // explicitly clear when leaving ultracode
+	}
+	return fs
+}
+
+// claudeEffortUpdateFlagSettings builds the effort/ultracode portion of a live
+// apply_flag_settings payload for moving curEffort -> the requested newEffort on
+// targetModel (the model the change lands on). It resolves newEffort against the
+// model first, so an unsupported combo can't be pushed to the CLI.
+//
+// The extra clause beyond claudeEffortFlagSettings handles the model-only change:
+// when newEffort is empty there is no effort delta, so claudeEffortFlagSettings
+// returns nil and the CLI's per-session `ultracode` boolean would persist even
+// after switching onto a model that can't run it (e.g. opus+ultracode ->
+// sonnet). We force ultracode:false whenever the session is leaving ultracode for
+// a model whose catalog doesn't offer it, so the boolean never outlives the model
+// that supports it. (The UI resets effort to auto on a model change and restarts,
+// so this only matters for non-UI/raw callers.)
+func claudeEffortUpdateFlagSettings(targetModel, newEffort, curEffort string) map[string]interface{} {
+	fs := claudeEffortFlagSettings(resolveClaudeEffortForModel(targetModel, newEffort), curEffort)
+	if curEffort == EffortUltracode && !modelSupportsUltracode(targetModel) {
+		if fs == nil {
+			fs = map[string]interface{}{}
+		}
+		fs["ultracode"] = false
+	}
+	return fs
+}
+
+// claudeEffortFromApplied decodes the effort/ultracode pair that get_settings
+// reports back into LeapMux's internal effort value -- the decode-side inverse of
+// claudeEffortFlagSettings. The CLI reports an active ultracode session as
+// effortLevel:"xhigh" plus ultracode:true, so applied.ultracode==true maps to the
+// internal "ultracode" -- but only when the model's catalog confirms it supports
+// ultracode (modelSupportsUltracode), so we never mislabel a Sonnet/Haiku/unknown
+// session as ultracode even if the CLI were to report it. An unentitled session
+// reports ultracode:false and we keep the reported level (e.g. "xhigh"). When
+// ultracode is explicitly turned off but applied.effort
+// is omitted, we fall back to ultracode's "xhigh" launch base instead of leaving a
+// stale "ultracode". curEffort is retained when applied.effort is omitted or empty.
+//
+// applied.effort is reported as a concrete effort enum or null (get_settings
+// sends `typeof effort === "string" ? effort : null`), never an empty string,
+// so the `!= ""` guard below is purely defensive: a malformed/empty report
+// retains curEffort rather than blanking the stored effort to "".
+//
+// The final guard catches the remaining mislabel path the switch can't: when
+// the CLI omits the ultracode field entirely (ultracode == nil) a stale
+// curEffort=="ultracode" would otherwise survive onto a model that can't run it
+// (e.g. a model switch that didn't touch effort), so we clear it to the xhigh
+// base unless the model's catalog confirms ultracode support.
+func claudeEffortFromApplied(appliedEffort *string, ultracode *bool, curEffort, model string) string {
+	effort := curEffort
+	if appliedEffort != nil && *appliedEffort != "" {
+		effort = *appliedEffort
+	}
+	if ultracode != nil {
+		switch {
+		case *ultracode && modelSupportsUltracode(model):
+			effort = EffortUltracode // overrides the "xhigh" reported in applied.effort
+		case !*ultracode && effort == EffortUltracode:
+			effort = EffortXHigh // ultracode cleared; fall back to its xhigh launch base
+		}
+	}
+	if effort == EffortUltracode && !modelSupportsUltracode(model) {
+		effort = EffortXHigh
+	}
+	return effort
+}
+
 // UpdateSettings applies settings changes via the apply_flag_settings control
 // request, avoiding a process restart. Returns true if the update was handled
 // (or nothing changed), false if a restart is needed.
@@ -501,9 +616,17 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	if s.Model != "" && s.Model != curModel {
 		flagSettings["model"] = s.Model
 	}
-	if s.Effort != "" && s.Effort != EffortAuto && s.Effort != curEffort {
-		flagSettings["effortLevel"] = s.Effort
+	// Resolve the requested effort against the model it will run under (the new model
+	// when this update also switches model) so a combined model+effort change can't
+	// push an unsupported effort -- e.g. {model:"sonnet", ultracode:true} -- to the
+	// CLI. The UI sends single-field updates, so this only bites non-UI/raw callers,
+	// but it keeps the live path consistent with buildModelEffortArgs's launch-time
+	// downgrade.
+	targetModel := curModel
+	if s.Model != "" {
+		targetModel = s.Model
 	}
+	maps.Copy(flagSettings, claudeEffortUpdateFlagSettings(targetModel, s.Effort, curEffort))
 
 	extra := s.ExtraSettings
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != curOutputStyle {
@@ -520,11 +643,7 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	}
 
 	if len(flagSettings) > 0 {
-		body, _ := json.Marshal(map[string]interface{}{
-			"subtype":  "apply_flag_settings",
-			"settings": flagSettings,
-		})
-		if _, err := a.sendControlAndWait(a.ctx, string(body), a.APITimeout()); err != nil {
+		if err := a.sendApplyFlagSettings(a.ctx, flagSettings, a.APITimeout()); err != nil {
 			slog.Error("apply_flag_settings failed", "agent_id", a.agentID, "error", err)
 			return false
 		}
@@ -563,8 +682,9 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 			AlwaysThinkingEnabled *bool  `json:"alwaysThinkingEnabled"`
 		} `json:"effective"`
 		Applied struct {
-			Model  string  `json:"model"`
-			Effort *string `json:"effort"`
+			Model     string  `json:"model"`
+			Effort    *string `json:"effort"`
+			Ultracode *bool   `json:"ultracode"`
 		} `json:"applied"`
 	}
 	if err := json.Unmarshal(resp.RawResponse, &settings); err != nil {
@@ -576,9 +696,9 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 	if settings.Applied.Model != "" {
 		a.model = normalizeClaudeCodeModel(settings.Applied.Model)
 	}
-	if settings.Applied.Effort != nil {
-		a.effort = *settings.Applied.Effort
-	}
+	// a.model is updated just above from applied.model, so the ultracode/model
+	// gate inside claudeEffortFromApplied sees the model the CLI actually applied.
+	a.effort = claudeEffortFromApplied(settings.Applied.Effort, settings.Applied.Ultracode, a.effort, a.model)
 	if settings.Effective.OutputStyle != "" {
 		a.outputStyle = settings.Effective.OutputStyle
 	}
@@ -695,32 +815,45 @@ func modelSupportsAdaptiveThinking(model string) bool {
 }
 
 // Claude Code effort levels are model-dependent. Keep each slice ordered
-// strongest → weakest so the RadioGroup renders in the same order.
+// strongest → weakest so the RadioGroup renders in the same order. Descriptions
+// mirror Claude Code's own effort copy (binary MP5()/ultracode strings) so the
+// LeapMux selector reads identically to the CLI's /effort menu.
 
-// claudeEffortXHighMax is used by models that support both xhigh and max
-// (currently Opus 4.7).
+// Individual effort tiers, defined once and composed into the per-model slices
+// below. Sharing one definition per tier keeps the descriptions single-sourced
+// so a copy edit (like the one this list just received) can't drift between the
+// Opus and Sonnet menus. The entries are immutable catalog data; the slices
+// reference the same pointers (as opus and opus[1m] already share a whole slice).
+//
+// Because the pointers are shared, they MUST be treated as read-only after init:
+// mutating one tier (e.g. its Description) would change it for every model slice
+// that references it. AvailableModels() hands these out without copying, so the
+// read-only contract extends to its callers (see its doc).
+var (
+	effortTierAuto      = &leapmuxv1.AvailableEffort{Id: "auto", Name: "Auto", Description: "Let Claude decide the appropriate effort"}
+	effortTierUltracode = &leapmuxv1.AvailableEffort{Id: "ultracode", Name: "Ultracode", Description: "xhigh effort plus standing dynamic-workflow orchestration"}
+	effortTierMax       = &leapmuxv1.AvailableEffort{Id: "max", Name: "Max", Description: "Maximum capability with deepest reasoning"}
+	effortTierXHigh     = &leapmuxv1.AvailableEffort{Id: EffortXHigh, Name: "X-High", Description: "Deeper reasoning than high, just below maximum"}
+	effortTierHigh      = &leapmuxv1.AvailableEffort{Id: "high", Name: "High", Description: "Comprehensive implementation with extensive testing and documentation"}
+	effortTierMedium    = &leapmuxv1.AvailableEffort{Id: "medium", Name: "Medium", Description: "Balanced approach with standard implementation and testing"}
+	effortTierLow       = &leapmuxv1.AvailableEffort{Id: "low", Name: "Low", Description: "Quick, straightforward implementation with minimal overhead"}
+)
+
+// claudeEffortXHighMax is used by models that support both xhigh and max,
+// plus the xhigh+ultracode combo (currently Opus).
 var claudeEffortXHighMax = []*leapmuxv1.AvailableEffort{
-	{Id: "auto", Name: "Auto", Description: "Let Claude decide the appropriate effort"},
-	{Id: "max", Name: "Max", Description: "Deepest reasoning; no constraints on token spend"},
-	{Id: "xhigh", Name: "X-High", Description: "Extended capability for long-horizon agentic tasks"},
-	{Id: "high", Name: "High", Description: "Thorough reasoning for complex tasks"},
-	{Id: "medium", Name: "Medium", Description: "Balanced speed and reasoning depth"},
-	{Id: "low", Name: "Low", Description: "Faster responses with lighter reasoning"},
+	effortTierAuto, effortTierUltracode, effortTierMax, effortTierXHigh, effortTierHigh, effortTierMedium, effortTierLow,
 }
 
 // claudeEffortMax is used by models that support max but not xhigh
 // (currently Sonnet 4.6, older Opus).
 var claudeEffortMax = []*leapmuxv1.AvailableEffort{
-	{Id: "auto", Name: "Auto", Description: "Let Claude decide the appropriate effort"},
-	{Id: "max", Name: "Max", Description: "Deepest reasoning; no constraints on token spend"},
-	{Id: "high", Name: "High", Description: "Thorough reasoning for complex tasks"},
-	{Id: "medium", Name: "Medium", Description: "Balanced speed and reasoning depth"},
-	{Id: "low", Name: "Low", Description: "Faster responses with lighter reasoning"},
+	effortTierAuto, effortTierMax, effortTierHigh, effortTierMedium, effortTierLow,
 }
 
 var claudeCodeAvailableModels = []*leapmuxv1.AvailableModel{
-	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: "xhigh", SupportedEfforts: claudeEffortXHighMax, ContextWindow: 200_000},
-	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: "xhigh", SupportedEfforts: claudeEffortXHighMax, ContextWindow: 1_000_000},
+	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 200_000},
+	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 1_000_000},
 	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 200_000},
 	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 1_000_000},
 	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", DefaultEffort: "high", ContextWindow: 200_000},
@@ -771,6 +904,19 @@ func (a *ClaudeCodeAgent) sendControlAndWait(ctx context.Context, requestBody st
 		a.unregisterPendingControl(requestID)
 		return claudeCodeControlResult{}, fmt.Errorf("timeout waiting for agent to respond")
 	}
+}
+
+// sendApplyFlagSettings marshals flagSettings into an apply_flag_settings
+// control request and sends it, returning the control error (if any). The
+// envelope shape lives here so the startup path (StartClaudeCode) and the live
+// path (UpdateSettings) don't each hand-roll the same JSON literal.
+func (a *ClaudeCodeAgent) sendApplyFlagSettings(ctx context.Context, flagSettings map[string]interface{}, timeout time.Duration) error {
+	body, _ := json.Marshal(map[string]interface{}{
+		"subtype":  "apply_flag_settings",
+		"settings": flagSettings,
+	})
+	_, err := a.sendControlAndWait(ctx, string(body), timeout)
+	return err
 }
 
 // applyStartupPermissionMode sets the agent's permission mode during startup
@@ -941,28 +1087,77 @@ func buildModelEffortArgs(model, effort string) []string {
 	if effort == "" || effort == EffortAuto || model == "haiku" {
 		return args
 	}
-	if !effortSupported(model, effort) {
-		effort = "high"
+	effort = resolveClaudeEffortForModel(model, effort)
+	// The --effort launch flag accepts only low|medium|high|xhigh|max. "ultracode"
+	// is enabled post-init via apply_flag_settings (it forces xhigh), so launch with
+	// xhigh as the base. resolveClaudeEffortForModel only leaves effort == "ultracode"
+	// for a model that supports it, so this substitution is reached only then.
+	if effort == EffortUltracode {
+		effort = EffortXHigh
 	}
 	return append(args, "--effort", effort)
+}
+
+// modelDefinedEfforts returns the catalog-defined effort list for modelID and
+// whether the model is known to the catalog at all. The single lookup is shared
+// by effortSupported and modelSupportsUltracode, which differ only in how they
+// treat an unknown model.
+func modelDefinedEfforts(modelID string) (efforts []*leapmuxv1.AvailableEffort, known bool) {
+	for _, m := range claudeCodeAvailableModels {
+		if m.Id == modelID {
+			return m.SupportedEfforts, true
+		}
+	}
+	return nil, false
+}
+
+// effortListContains reports whether efforts holds an entry with the given ID.
+func effortListContains(efforts []*leapmuxv1.AvailableEffort, id string) bool {
+	return slices.ContainsFunc(efforts, func(e *leapmuxv1.AvailableEffort) bool { return e.Id == id })
 }
 
 // effortSupported reports whether the given effort ID is in the known
 // SupportedEfforts list for the given model. Unknown models are trusted
 // (returns true) so new aliases work without a code change.
 func effortSupported(modelID, effort string) bool {
-	for _, m := range claudeCodeAvailableModels {
-		if m.Id != modelID {
-			continue
-		}
-		for _, e := range m.SupportedEfforts {
-			if e.Id == effort {
-				return true
-			}
-		}
-		return false
+	efforts, known := modelDefinedEfforts(modelID)
+	if !known {
+		return true
 	}
-	return true
+	return effortListContains(efforts, effort)
+}
+
+// modelSupportsUltracode reports whether the model's catalog explicitly offers the
+// ultracode tier. Unlike effortSupported, it does NOT trust unknown models: ultracode
+// is a narrow Opus-only combo, so launching or enabling it on a model we can't confirm
+// supports it would risk forcing an --effort xhigh the model may reject. A genuinely
+// new ultracode-capable model must be added to claudeCodeAvailableModels to be
+// selectable at all, so requiring an explicit catalog entry costs no real forward
+// compatibility.
+func modelSupportsUltracode(modelID string) bool {
+	efforts, known := modelDefinedEfforts(modelID)
+	return known && effortListContains(efforts, EffortUltracode)
+}
+
+// resolveClaudeEffortForModel resolves a requested effort against the model it will
+// run under: an effort the model's catalog doesn't support is downgraded to the
+// universal-safe "high", and "ultracode" stays "ultracode" only for a model that
+// actually supports it (otherwise it too becomes "high" -- this catches unknown
+// models, which effortSupported trusts but which we can't confirm are xhigh-capable).
+// EffortAuto and "" pass through for the caller to handle. Shared by the --effort
+// launch flag (buildModelEffortArgs) and the live apply_flag_settings path
+// (UpdateSettings) so neither can push an unsupported effort to the CLI.
+func resolveClaudeEffortForModel(model, effort string) string {
+	if effort == "" || effort == EffortAuto {
+		return effort
+	}
+	if !effortSupported(model, effort) {
+		return "high"
+	}
+	if effort == EffortUltracode && !modelSupportsUltracode(model) {
+		return "high"
+	}
+	return effort
 }
 
 func init() {

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -538,15 +538,37 @@ func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{
 // after switching onto a model that can't run it (e.g. opus+ultracode ->
 // sonnet). We force ultracode:false whenever the session is leaving ultracode for
 // a model whose catalog doesn't offer it, so the boolean never outlives the model
-// that supports it. (The UI resets effort to auto on a model change and restarts,
-// so this only matters for non-UI/raw callers.)
+// that supports it.
+//
+// Clearing the boolean alone is not enough: the CLI's apply_flag_settings treats
+// model/effortLevel/ultracode as independent keys and does NOT re-resolve
+// effortLevel on a model change (verified against the Claude Code 2.1.x binary --
+// the handler is three separate `if (key in settings)` blocks, and the effective
+// effort is `ultracode ? "xhigh" : effortLevel`). So a bare {model, ultracode:false}
+// would leave effortLevel pinned at the ultracode base "xhigh" -- a level the new
+// model may not support -- and the session would keep running at xhigh. When the
+// caller requested no explicit effort (so claudeEffortFlagSettings left no
+// effortLevel key), we therefore also pin the level to the target model's
+// xhigh-resolved fallback, which mirrors the decode side (claudeEffortFromApplied
+// falls back to the xhigh base when ultracode is cleared) and lands the live path
+// on the same effort a relaunch would pick. resolveClaudeEffortForModel downgrades
+// xhigh to "high" for models that don't offer it (e.g. sonnet -> "high", its
+// default), so the pinned level is always one the target model can run.
+//
+// The UI resets effort to auto on a model change and restarts (IsEffortAutoTransition
+// short-circuits UpdateSettings before this runs), so today this whole branch only
+// matters for non-UI/raw callers; it is defensive so such a caller can't strand an
+// unsupported effortLevel on the live session.
 func claudeEffortUpdateFlagSettings(targetModel, newEffort, curEffort string) map[string]interface{} {
 	fs := claudeEffortFlagSettings(resolveClaudeEffortForModel(targetModel, newEffort), curEffort)
-	if curEffort == EffortUltracode && !modelSupportsUltracode(targetModel) {
+	if unsupportedUltracode(curEffort, targetModel) {
 		if fs == nil {
 			fs = map[string]interface{}{}
 		}
 		fs["ultracode"] = false
+		if _, ok := fs["effortLevel"]; !ok {
+			fs["effortLevel"] = resolveClaudeEffortForModel(targetModel, EffortXHigh)
+		}
 	}
 	return fs
 }
@@ -586,7 +608,7 @@ func claudeEffortFromApplied(appliedEffort *string, ultracode *bool, curEffort, 
 			effort = EffortXHigh // ultracode cleared; fall back to its xhigh launch base
 		}
 	}
-	if effort == EffortUltracode && !modelSupportsUltracode(model) {
+	if unsupportedUltracode(effort, model) {
 		effort = EffortXHigh
 	}
 	return effort
@@ -834,7 +856,7 @@ var (
 	effortTierUltracode = &leapmuxv1.AvailableEffort{Id: "ultracode", Name: "Ultracode", Description: "xhigh effort plus standing dynamic-workflow orchestration"}
 	effortTierMax       = &leapmuxv1.AvailableEffort{Id: "max", Name: "Max", Description: "Maximum capability with deepest reasoning"}
 	effortTierXHigh     = &leapmuxv1.AvailableEffort{Id: EffortXHigh, Name: "X-High", Description: "Deeper reasoning than high, just below maximum"}
-	effortTierHigh      = &leapmuxv1.AvailableEffort{Id: "high", Name: "High", Description: "Comprehensive implementation with extensive testing and documentation"}
+	effortTierHigh      = &leapmuxv1.AvailableEffort{Id: EffortHigh, Name: "High", Description: "Comprehensive implementation with extensive testing and documentation"}
 	effortTierMedium    = &leapmuxv1.AvailableEffort{Id: "medium", Name: "Medium", Description: "Balanced approach with standard implementation and testing"}
 	effortTierLow       = &leapmuxv1.AvailableEffort{Id: "low", Name: "Low", Description: "Quick, straightforward implementation with minimal overhead"}
 )
@@ -854,9 +876,9 @@ var claudeEffortMax = []*leapmuxv1.AvailableEffort{
 var claudeCodeAvailableModels = []*leapmuxv1.AvailableModel{
 	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 200_000},
 	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 1_000_000},
-	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 200_000},
-	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: "high", SupportedEfforts: claudeEffortMax, ContextWindow: 1_000_000},
-	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", DefaultEffort: "high", ContextWindow: 200_000},
+	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: 200_000},
+	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: 1_000_000},
+	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", DefaultEffort: EffortHigh, ContextWindow: 200_000},
 }
 
 // sendControlAndWait sends a control request to the agent and waits for the
@@ -1139,10 +1161,21 @@ func modelSupportsUltracode(modelID string) bool {
 	return known && effortListContains(efforts, EffortUltracode)
 }
 
+// unsupportedUltracode reports whether effort is the ultracode tier while model
+// can't run it. This is the recurring "ultracode requested/stored/being-left on a
+// model whose catalog doesn't offer it" condition that the resolve
+// (resolveClaudeEffortForModel), decode (claudeEffortFromApplied), and live-update
+// (claudeEffortUpdateFlagSettings) paths each must guard -- naming it once keeps a
+// future model-capability change (e.g. Sonnet gaining ultracode) to a single edit
+// instead of three that must be kept in agreement.
+func unsupportedUltracode(effort, model string) bool {
+	return effort == EffortUltracode && !modelSupportsUltracode(model)
+}
+
 // resolveClaudeEffortForModel resolves a requested effort against the model it will
 // run under: an effort the model's catalog doesn't support is downgraded to the
-// universal-safe "high", and "ultracode" stays "ultracode" only for a model that
-// actually supports it (otherwise it too becomes "high" -- this catches unknown
+// universal-safe EffortHigh, and "ultracode" stays "ultracode" only for a model that
+// actually supports it (otherwise it too becomes EffortHigh -- this catches unknown
 // models, which effortSupported trusts but which we can't confirm are xhigh-capable).
 // EffortAuto and "" pass through for the caller to handle. Shared by the --effort
 // launch flag (buildModelEffortArgs) and the live apply_flag_settings path
@@ -1152,10 +1185,10 @@ func resolveClaudeEffortForModel(model, effort string) string {
 		return effort
 	}
 	if !effortSupported(model, effort) {
-		return "high"
+		return EffortHigh
 	}
-	if effort == EffortUltracode && !modelSupportsUltracode(model) {
-		return "high"
+	if unsupportedUltracode(effort, model) {
+		return EffortHigh
 	}
 	return effort
 }

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1188,7 +1188,7 @@ func TestClaudeCodeAvailableModels_EffortsMatchDocs(t *testing.T) {
 		return ids
 	}
 
-	opusEfforts := []string{"auto", "max", "xhigh", "high", "medium", "low"}
+	opusEfforts := []string{"auto", "ultracode", "max", "xhigh", "high", "medium", "low"}
 	sonnetEfforts := []string{"auto", "max", "high", "medium", "low"}
 
 	for _, id := range []string{"opus", "opus[1m]"} {
@@ -1208,4 +1208,343 @@ func TestClaudeCodeAvailableModels_EffortsMatchDocs(t *testing.T) {
 	haiku := byID["haiku"]
 	require.NotNil(t, haiku)
 	assert.Empty(t, haiku.SupportedEfforts, "haiku has no effort UI")
+}
+
+// TestClaudeEffortCatalog_UltracodeIsOpusOnly guards the design decision that
+// "ultracode" is offered only by xhigh-capable (Opus) models. Sonnet's catalog
+// must not list it, so switching to Sonnet downgrades ultracode cleanly.
+func TestClaudeEffortCatalog_UltracodeIsOpusOnly(t *testing.T) {
+	// Use the production effortListContains so this guard exercises the same
+	// lookup modelSupportsUltracode relies on, rather than a parallel copy.
+	assert.True(t, effortListContains(claudeEffortXHighMax, EffortUltracode), "Opus catalog must offer ultracode")
+	assert.False(t, effortListContains(claudeEffortMax, EffortUltracode), "Sonnet catalog must not offer ultracode")
+}
+
+func TestClaudeEffortFlagSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		newEffort string
+		curEffort string
+		expected  map[string]interface{}
+	}{
+		{
+			name:      "enable ultracode sets xhigh base + ultracode true",
+			newEffort: "ultracode",
+			curEffort: "high",
+			expected:  map[string]interface{}{"effortLevel": "xhigh", "ultracode": true},
+		},
+		{
+			name:      "leaving ultracode clears the ultracode flag",
+			newEffort: "max",
+			curEffort: "ultracode",
+			expected:  map[string]interface{}{"effortLevel": "max", "ultracode": false},
+		},
+		{
+			name:      "ordinary effort change carries no ultracode key",
+			newEffort: "high",
+			curEffort: "medium",
+			expected:  map[string]interface{}{"effortLevel": "high"},
+		},
+		{
+			name:      "ultracode unchanged is a no-op",
+			newEffort: "ultracode",
+			curEffort: "ultracode",
+			expected:  nil,
+		},
+		{
+			name:      "auto transition is handled elsewhere (no flag settings)",
+			newEffort: "auto",
+			curEffort: "ultracode",
+			expected:  nil,
+		},
+		{
+			name:      "empty effort is a no-op",
+			newEffort: "",
+			curEffort: "high",
+			expected:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, claudeEffortFlagSettings(tt.newEffort, tt.curEffort))
+		})
+	}
+}
+
+func TestClaudeEffortUpdateFlagSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetModel string
+		newEffort   string
+		curEffort   string
+		expected    map[string]interface{}
+	}{
+		{
+			// Model-only change off opus+ultracode onto sonnet: no effort delta,
+			// but the stale ultracode boolean must still be cleared.
+			name:        "model-only switch leaving ultracode for an unsupported model clears the flag",
+			targetModel: "sonnet",
+			newEffort:   "",
+			curEffort:   "ultracode",
+			expected:    map[string]interface{}{"ultracode": false},
+		},
+		{
+			// Model-only change to another ultracode-capable model keeps the
+			// combo: nothing to send (the model key is added by the caller).
+			name:        "model-only switch between ultracode-capable models is a no-op",
+			targetModel: "opus[1m]",
+			newEffort:   "",
+			curEffort:   "ultracode",
+			expected:    nil,
+		},
+		{
+			// Combined change already routes through claudeEffortFlagSettings,
+			// which clears ultracode when leaving it; the guard is idempotent.
+			name:        "combined model+effort leaving ultracode clears the flag once",
+			targetModel: "sonnet",
+			newEffort:   "high",
+			curEffort:   "ultracode",
+			expected:    map[string]interface{}{"effortLevel": "high", "ultracode": false},
+		},
+		{
+			// Requesting ultracode on a model that can't run it downgrades the
+			// level to high and never sets the ultracode boolean true (sent here
+			// because high differs from the current "medium").
+			name:        "ultracode requested on unsupported model downgrades without setting the flag",
+			targetModel: "sonnet",
+			newEffort:   "ultracode",
+			curEffort:   "medium",
+			expected:    map[string]interface{}{"effortLevel": "high"},
+		},
+		{
+			name:        "enabling ultracode on a supported model sets the combo",
+			targetModel: "opus",
+			newEffort:   "ultracode",
+			curEffort:   "high",
+			expected:    map[string]interface{}{"effortLevel": "xhigh", "ultracode": true},
+		},
+		{
+			name:        "ordinary effort change is unaffected",
+			targetModel: "sonnet",
+			newEffort:   "max",
+			curEffort:   "high",
+			expected:    map[string]interface{}{"effortLevel": "max"},
+		},
+		{
+			name:        "no requested effort and not leaving ultracode is a no-op",
+			targetModel: "sonnet",
+			newEffort:   "",
+			curEffort:   "high",
+			expected:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, claudeEffortUpdateFlagSettings(tt.targetModel, tt.newEffort, tt.curEffort))
+		})
+	}
+}
+
+func TestClaudeEffortFromApplied(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	boolPtr := func(b bool) *bool { return &b }
+	tests := []struct {
+		name      string
+		applied   *string
+		ultracode *bool
+		curEffort string
+		model     string
+		want      string
+	}{
+		{
+			name:      "opus ultracode:true maps xhigh-base back to ultracode",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(true),
+			curEffort: "xhigh",
+			model:     "opus",
+			want:      "ultracode",
+		},
+		{
+			name:      "opus[1m] ultracode:true maps to ultracode",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(true),
+			curEffort: "ultracode",
+			model:     "opus[1m]",
+			want:      "ultracode",
+		},
+		{
+			name:      "sonnet ultracode:true is ignored - model cannot run it",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(true),
+			curEffort: "high",
+			model:     "sonnet",
+			want:      "xhigh", // keep the reported level; never mislabel Sonnet as ultracode
+		},
+		{
+			name:      "unknown model ultracode:true is ignored - catalog can't confirm support",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(true),
+			curEffort: "xhigh",
+			model:     "claude-future-preview",
+			want:      "xhigh",
+		},
+		{
+			name:      "unentitled opus reports ultracode:false + xhigh - graceful downgrade",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(false),
+			curEffort: "ultracode",
+			model:     "opus",
+			want:      "xhigh",
+		},
+		{
+			name:      "ultracode cleared with omitted effort falls back to xhigh base",
+			applied:   nil,
+			ultracode: boolPtr(false),
+			curEffort: "ultracode",
+			model:     "opus",
+			want:      "xhigh",
+		},
+		{
+			name:      "ultracode:false with non-ultracode current is unchanged",
+			applied:   nil,
+			ultracode: boolPtr(false),
+			curEffort: "high",
+			model:     "opus",
+			want:      "high",
+		},
+		{
+			name:      "nil ultracode passes the reported effort through",
+			applied:   strPtr("max"),
+			ultracode: nil,
+			curEffort: "high",
+			model:     "opus",
+			want:      "max",
+		},
+		{
+			name:      "nil applied effort retains current effort",
+			applied:   nil,
+			ultracode: nil,
+			curEffort: "medium",
+			model:     "sonnet",
+			want:      "medium",
+		},
+		{
+			// CLI omits both fields (e.g. a model switch that didn't touch
+			// effort) while curEffort is still "ultracode" on a model that
+			// can't run it: the guard must clear the stale value to xhigh
+			// rather than mislabel a Sonnet session as ultracode.
+			name:      "stale ultracode on a model that lost support is cleared",
+			applied:   nil,
+			ultracode: nil,
+			curEffort: "ultracode",
+			model:     "sonnet",
+			want:      "xhigh",
+		},
+		{
+			// Same shape, but Opus genuinely supports ultracode, so the guard
+			// must NOT clear it.
+			name:      "stale ultracode on opus with omitted fields is retained",
+			applied:   nil,
+			ultracode: nil,
+			curEffort: "ultracode",
+			model:     "opus",
+			want:      "ultracode",
+		},
+		{
+			// Defensive: the CLI reports applied.effort as a concrete enum or
+			// null, never "". An unexpected empty string must be treated like
+			// omitted (retain curEffort) rather than blanking the effort to "".
+			name:      "empty applied effort is treated as omitted (retains curEffort)",
+			applied:   strPtr(""),
+			ultracode: nil,
+			curEffort: "high",
+			model:     "opus",
+			want:      "high",
+		},
+		{
+			// Empty applied.effort with curEffort=="ultracode" on opus: the ""
+			// is ignored, so the ultracode value survives (opus supports it)
+			// instead of being blanked.
+			name:      "empty applied effort retains stale ultracode on opus",
+			applied:   strPtr(""),
+			ultracode: nil,
+			curEffort: "ultracode",
+			model:     "opus",
+			want:      "ultracode",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, claudeEffortFromApplied(tt.applied, tt.ultracode, tt.curEffort, tt.model))
+		})
+	}
+}
+
+func TestBuildStartupFlagSettings_Ultracode(t *testing.T) {
+	tests := []struct {
+		name          string
+		model         string
+		effort        string
+		wantUltracode bool
+	}{
+		{"opus ultracode enables the combo", "opus", EffortUltracode, true},
+		{"opus[1m] ultracode enables the combo", "opus[1m]", EffortUltracode, true},
+		{"sonnet ultracode is not enabled (unsupported)", "sonnet", EffortUltracode, false},
+		{"haiku ultracode is not enabled (unsupported)", "haiku", EffortUltracode, false},
+		{"unknown model ultracode is not enabled", "claude-future-preview", EffortUltracode, false},
+		{"opus non-ultracode adds no effort keys", "opus", "xhigh", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &ClaudeCodeAgent{model: tt.model, effort: tt.effort}
+			fs := a.buildStartupFlagSettings(nil)
+			if tt.wantUltracode {
+				assert.Equal(t, "xhigh", fs["effortLevel"])
+				assert.Equal(t, true, fs["ultracode"])
+			} else {
+				_, hasUltra := fs["ultracode"]
+				assert.False(t, hasUltra, "ultracode key should be absent")
+				_, hasLevel := fs["effortLevel"]
+				assert.False(t, hasLevel, "effortLevel key should be absent for non-ultracode startup")
+			}
+		})
+	}
+}
+
+func TestModelSupportsUltracode(t *testing.T) {
+	// Only Opus models list ultracode in their catalog; unlike effortSupported,
+	// unknown models are NOT trusted.
+	assert.True(t, modelSupportsUltracode("opus"))
+	assert.True(t, modelSupportsUltracode("opus[1m]"))
+	assert.False(t, modelSupportsUltracode("sonnet"))
+	assert.False(t, modelSupportsUltracode("sonnet[1m]"))
+	assert.False(t, modelSupportsUltracode("haiku"))
+	assert.False(t, modelSupportsUltracode("claude-future-preview"), "unknown models are not trusted for ultracode")
+	assert.False(t, modelSupportsUltracode(""))
+}
+
+func TestResolveClaudeEffortForModel(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		effort string
+		want   string
+	}{
+		{"opus keeps ultracode", "opus", "ultracode", "ultracode"},
+		{"opus[1m] keeps ultracode", "opus[1m]", "ultracode", "ultracode"},
+		{"sonnet downgrades ultracode to high", "sonnet", "ultracode", "high"},
+		{"haiku downgrades ultracode to high", "haiku", "ultracode", "high"},
+		{"unknown downgrades ultracode to high", "claude-future-preview", "ultracode", "high"},
+		{"sonnet downgrades xhigh to high", "sonnet", "xhigh", "high"},
+		{"opus keeps xhigh", "opus", "xhigh", "xhigh"},
+		{"unknown trusts xhigh", "claude-future-preview", "xhigh", "xhigh"},
+		{"supported effort passes through", "sonnet", "high", "high"},
+		{"auto passes through", "sonnet", "auto", "auto"},
+		{"empty passes through", "opus", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveClaudeEffortForModel(tt.model, tt.effort))
+		})
+	}
 }

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1281,12 +1281,16 @@ func TestClaudeEffortUpdateFlagSettings(t *testing.T) {
 	}{
 		{
 			// Model-only change off opus+ultracode onto sonnet: no effort delta,
-			// but the stale ultracode boolean must still be cleared.
-			name:        "model-only switch leaving ultracode for an unsupported model clears the flag",
+			// but the stale ultracode boolean must be cleared AND the stale
+			// effortLevel pinned to a sonnet-supported level. Clearing only the
+			// boolean would leave the CLI at the ultracode base "xhigh" (which the
+			// CLI does not re-resolve on a model-only change), so we also pin
+			// effortLevel to xhigh resolved for sonnet -> "high" (its default).
+			name:        "model-only switch leaving ultracode for an unsupported model clears the flag and pins a safe effort",
 			targetModel: "sonnet",
 			newEffort:   "",
 			curEffort:   "ultracode",
-			expected:    map[string]interface{}{"ultracode": false},
+			expected:    map[string]interface{}{"effortLevel": "high", "ultracode": false},
 		},
 		{
 			// Model-only change to another ultracode-capable model keeps the

--- a/backend/internal/worker/agent/env.go
+++ b/backend/internal/worker/agent/env.go
@@ -24,8 +24,13 @@ import "github.com/leapmux/leapmux/internal/util/envutil"
 var agentIdentityEnvScrubKeys = []string{
 	// Cross-harness: W3C distributed-trace context + generic "running as an agent" marker.
 	"TRACEPARENT", "TRACESTATE", "AI_AGENT",
-	// Claude Code (CLI child-env injector $tH + MCP spawn + effort hard-override).
+	// Claude Code (CLI child-env injector $tH + IDE/MCP SSE bridge + effort hard-override).
+	// CLAUDE_CODE_SSE_PORT is the port an IDE/MCP-integrated session injects into its
+	// terminal env; an inheriting child auto-connects to the PARENT's IDE bridge
+	// (gated by `...||process.env.CLAUDE_CODE_SSE_PORT||...` in the CLI), so a worker
+	// launched from an IDE terminal would otherwise spawn an agent wired to the parent.
 	"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_EFFORT_LEVEL", "CLAUDE_EFFORT", "CLAUDE_PROJECT_DIR",
+	"CLAUDE_CODE_SSE_PORT",
 	// Codex (thread id, sandbox + network-proxy markers, rollout trace root).
 	"CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK_DISABLED",
 	"CODEX_NETWORK_PROXY_ACTIVE", "CODEX_NETWORK_ALLOW_LOCAL_BINDING", "CODEX_ROLLOUT_TRACE_ROOT",

--- a/backend/internal/worker/agent/env.go
+++ b/backend/internal/worker/agent/env.go
@@ -1,0 +1,65 @@
+package agent
+
+import "github.com/leapmux/leapmux/internal/util/envutil"
+
+// agentIdentityEnvScrubKeys are environment variables that coding-agent harnesses
+// (Claude Code, Codex, OpenCode/Kilo/Goose ACP agents, Pi) inject into the processes they
+// spawn to mark session identity, nesting, sandbox state, or distributed tracing. When a
+// LeapMux worker is itself launched from inside one of these harnesses (e.g. a developer
+// running the test suite from their Claude Code / Codex / Pi terminal), these leak into the
+// agent LeapMux spawns and make it behave as a nested session. We strip the whole union from
+// every spawned agent so each starts as a clean, top-level session, regardless of which
+// harness LeapMux ran under.
+//
+// Deliberately surgical -- only identity/session/nesting/sandbox/trace markers. Auth tokens
+// (*_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, CODEX_API_KEY, AWS_*), home/config dirs (CODEX_HOME,
+// OPENCODE_CONFIG, PI_CODING_AGENT_DIR, GOOSE_MODEL/GOOSE_PROVIDER user overrides), and
+// provider-selection config (CLAUDE_CODE_USE_BEDROCK/VERTEX/FOUNDRY) are preserved.
+//
+// Each harness's rc-detection marker (CLAUDECODE, CODEX_CI, OPENCODE_CLIENT, KILO_CLIENT,
+// GEMINI_CLI/GEMINI_CLI_NO_RELAUNCH) and Claude's CLAUDE_CODE_ENTRYPOINT are intentionally
+// NOT listed: each provider strips them from the inherited env and re-adds its own value
+// before this runs. CODEX_THREAD_ID is also stripped in codex.go; listing it here too is a
+// harmless redundant strip that also protects non-codex launches.
+var agentIdentityEnvScrubKeys = []string{
+	// Cross-harness: W3C distributed-trace context + generic "running as an agent" marker.
+	"TRACEPARENT", "TRACESTATE", "AI_AGENT",
+	// Claude Code (CLI child-env injector $tH + MCP spawn + effort hard-override).
+	"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_EFFORT_LEVEL", "CLAUDE_EFFORT", "CLAUDE_PROJECT_DIR",
+	// Codex (thread id, sandbox + network-proxy markers, rollout trace root).
+	"CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK_DISABLED",
+	"CODEX_NETWORK_PROXY_ACTIVE", "CODEX_NETWORK_ALLOW_LOCAL_BINDING", "CODEX_ROLLOUT_TRACE_ROOT",
+	// OpenCode (ACP) run identity.
+	"OPENCODE_RUN_ID", "OPENCODE_PROCESS_ROLE", "_EXTENSION_OPENCODE_PORT",
+	// Kilo (ACP) run identity (OpenCode fork).
+	"KILO_RUN_ID", "KILO_PROCESS_ROLE",
+	// Goose (ACP) -- injected session/terminal markers (no rc marker of its own).
+	"GOOSE_TERMINAL", "AGENT_SESSION_ID",
+	// Pi.
+	"PI_CODING_AGENT",
+}
+
+// FinalizeAgentEnv applies the env-mutations every spawned agent
+// process needs in one place: strips inherited agent-harness identity
+// vars (see agentIdentityEnvScrubKeys) so a worker launched from inside
+// another agent's session doesn't spawn a nested one, strips any
+// inherited `LEAPMUX_REMOTE_*` values so a worker spawned inside another
+// worker's session never inherits the parent's remote context (any
+// fresh values arrive via opts.ExtraEnv), appends the `LEAPMUX_WORKER=1`
+// marker (downstream CLI/agent code keys off it to detect "running
+// inside a LeapMux worker"), and appends `opts.ExtraEnv`.
+//
+// Provider-specific env additions (CLAUDE_CODE_ENTRYPOINT, CODEX_CI,
+// etc.) go BEFORE this call so they survive both the identity scrub and
+// the LEAPMUX_REMOTE_* strip and stack with the marker.
+func FinalizeAgentEnv(env []string, opts Options) []string {
+	// Both scrubs must run before the ExtraEnv append so opts.ExtraEnv's
+	// fresh LEAPMUX_REMOTE_* values aren't stripped.
+	env = envutil.FilterEnv(env, agentIdentityEnvScrubKeys...)
+	env = envutil.StripByPrefix(env, "LEAPMUX_REMOTE_")
+	env = append(env, "LEAPMUX_WORKER=1")
+	if len(opts.ExtraEnv) == 0 {
+		return env
+	}
+	return append(env, opts.ExtraEnv...)
+}

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
-	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/leapmux/leapmux/internal/worker/config"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
 	"github.com/leapmux/leapmux/util/procutil"
@@ -49,6 +48,18 @@ const DefaultAPITimeout = time.Duration(config.DefaultAPITimeoutSeconds) * time.
 // that don't recognize newer effort names (e.g. "xhigh") still work.
 const EffortAuto = "auto"
 
+// EffortUltracode is LeapMux's internal name for the CLI's xhigh+ultracode combo.
+// At the provider wire boundary it maps to {effortLevel:"xhigh", ultracode:true};
+// the CLI's --effort launch flag does not accept it.
+const EffortUltracode = "ultracode"
+
+// EffortXHigh is the "xhigh" effort level. It is also the launch/wire base for
+// the ultracode combo (which layers the `ultracode` boolean on top of xhigh),
+// so it is a load-bearing value shared by the encode path (ultracodeFlagSettings,
+// buildModelEffortArgs) and the decode path (claudeEffortFromApplied). Naming it
+// once keeps those sites from drifting to inconsistent literals.
+const EffortXHigh = "xhigh"
+
 // ExitHandler is called when an agent process exits.
 // agentID identifies the agent, exitCode is the process exit code,
 // and err is non-nil if the process exited with an error.
@@ -76,22 +87,7 @@ type Options struct {
 	ExtraEnv []string
 }
 
-// FinalizeAgentEnv applies the env-mutations every spawned agent
-// process needs in one place: appends the `LEAPMUX_WORKER=1` marker
-// (downstream CLI/agent code keys off it to detect "running inside a
-// LeapMux worker"), strips any inherited `LEAPMUX_REMOTE_*` values
-// (the new injection wins) and appends `opts.ExtraEnv`.
-//
-// Provider-specific env additions (CLAUDE_CODE_ENTRYPOINT, CODEX_CI,
-// etc.) go BEFORE this call so they survive the LEAPMUX_REMOTE_*
-// strip and stack with the marker.
-func FinalizeAgentEnv(env []string, opts Options) []string {
-	env = append(env, "LEAPMUX_WORKER=1")
-	if len(opts.ExtraEnv) == 0 {
-		return env
-	}
-	return append(envutil.StripByPrefix(env, "LEAPMUX_REMOTE_"), opts.ExtraEnv...)
-}
+// FinalizeAgentEnv and the agent-harness env scrub it applies live in env.go.
 
 func (o Options) startupTimeout() time.Duration {
 	if o.StartupTimeout > 0 {

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -60,6 +60,13 @@ const EffortUltracode = "ultracode"
 // once keeps those sites from drifting to inconsistent literals.
 const EffortXHigh = "xhigh"
 
+// EffortHigh is the "high" effort level. It is the universal-safe fallback every
+// model supports, so resolveClaudeEffortForModel downgrades any unsupported
+// effort to it. Like EffortXHigh it is load-bearing (the fallback target and the
+// Sonnet/Haiku catalog default), so naming it once keeps those sites from
+// drifting to inconsistent literals.
+const EffortHigh = "high"
+
 // ExitHandler is called when an agent process exits.
 // agentID identifies the agent, exitCode is the process exit code,
 // and err is non-nil if the process exited with an error.

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -4,9 +4,91 @@ import (
 	"testing"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestFinalizeAgentEnv_ScrubsAgentIdentity verifies the single chokepoint
+// every provider funnels through strips inherited agent-harness identity vars
+// (so a worker launched from inside another agent's session doesn't spawn a
+// nested one) while preserving the per-provider rc markers and auth/config the
+// providers re-add before the call.
+func TestFinalizeAgentEnv_ScrubsAgentIdentity(t *testing.T) {
+	// Assert against the production list itself rather than a hand-maintained
+	// subset, so EVERY scrub key is exercised and a newly-added key (or a typo
+	// in an oddly-shaped one like "_EXTENSION_OPENCODE_PORT") is automatically
+	// covered.
+	identity := agentIdentityEnvScrubKeys
+	// Must survive: per-provider rc markers / entrypoint re-added BEFORE
+	// FinalizeAgentEnv, plus auth tokens, provider-selection, and config dirs.
+	mustSurvive := []string{
+		"CLAUDECODE", "CODEX_CI", "OPENCODE_CLIENT", "KILO_CLIENT", "GEMINI_CLI", "CLAUDE_CODE_ENTRYPOINT",
+		"CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY", "CODEX_API_KEY",
+		"CLAUDE_CODE_USE_BEDROCK", "CODEX_HOME", "GOOSE_MODEL", "PI_CODING_AGENT_DIR", "PATH",
+	}
+
+	buildEnv := func() []string {
+		var env []string
+		for _, k := range identity {
+			env = append(env, k+"=leaked")
+		}
+		env = append(env,
+			"CLAUDECODE=1", "CODEX_CI=1", "OPENCODE_CLIENT=1", "KILO_CLIENT=1", "GEMINI_CLI=1",
+			"CLAUDE_CODE_ENTRYPOINT=cli",
+			"CLAUDE_CODE_OAUTH_TOKEN=tok", "OPENAI_API_KEY=sk-test", "CODEX_API_KEY=sk-codex",
+			"CLAUDE_CODE_USE_BEDROCK=1", "CODEX_HOME=/home/u/.codex", "GOOSE_MODEL=gpt-x",
+			"PI_CODING_AGENT_DIR=/home/u/.pi", "PATH=/usr/bin:/bin",
+		)
+		return env
+	}
+
+	t.Run("strips identity, keeps markers, adds worker flag", func(t *testing.T) {
+		out := FinalizeAgentEnv(buildEnv(), Options{})
+
+		for _, k := range identity {
+			assert.Falsef(t, envutil.HasKey(out, k), "identity var %q must be scrubbed", k)
+		}
+		for _, k := range mustSurvive {
+			assert.Truef(t, envutil.HasKey(out, k), "var %q must survive the scrub", k)
+		}
+		assert.True(t, envutil.HasKey(out, "LEAPMUX_WORKER"), "LEAPMUX_WORKER=1 must be added")
+		assert.Contains(t, out, "LEAPMUX_WORKER=1")
+	})
+
+	t.Run("scrub precedes LEAPMUX_REMOTE strip and ExtraEnv append", func(t *testing.T) {
+		env := append(buildEnv(), "LEAPMUX_REMOTE_OLD=stale")
+		out := FinalizeAgentEnv(env, Options{ExtraEnv: []string{"LEAPMUX_REMOTE_NEW=fresh"}})
+
+		// Identity scrub still applied even on the ExtraEnv path.
+		for _, k := range identity {
+			assert.Falsef(t, envutil.HasKey(out, k), "identity var %q must be scrubbed", k)
+		}
+		// Inherited LEAPMUX_REMOTE_* stripped; the injected one wins.
+		assert.NotContains(t, out, "LEAPMUX_REMOTE_OLD=stale")
+		assert.Contains(t, out, "LEAPMUX_REMOTE_NEW=fresh")
+		assert.Contains(t, out, "LEAPMUX_WORKER=1")
+		// Markers + auth still survive on this path too.
+		for _, k := range mustSurvive {
+			assert.Truef(t, envutil.HasKey(out, k), "var %q must survive the scrub", k)
+		}
+	})
+
+	t.Run("strips inherited LEAPMUX_REMOTE even with no ExtraEnv", func(t *testing.T) {
+		// A worker spawned inside another worker's session inherits the
+		// parent's LEAPMUX_REMOTE_* but injects no fresh ExtraEnv. The stale
+		// remote context must still be shed so the child doesn't act on it.
+		env := append(buildEnv(), "LEAPMUX_REMOTE_OLD=stale")
+		out := FinalizeAgentEnv(env, Options{})
+
+		assert.NotContains(t, out, "LEAPMUX_REMOTE_OLD=stale")
+		assert.False(t, envutil.HasKey(out, "LEAPMUX_REMOTE_OLD"), "inherited LEAPMUX_REMOTE_* must be stripped")
+		assert.Contains(t, out, "LEAPMUX_WORKER=1")
+		for _, k := range mustSurvive {
+			assert.Truef(t, envutil.HasKey(out, k), "var %q must survive the scrub", k)
+		}
+	})
+}
 
 func TestAvailableOptionGroups_DefaultOptionMetadata(t *testing.T) {
 	for _, provider := range []leapmuxv1.AgentProvider{

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -405,6 +405,21 @@ func (m *Manager) UpdateSettings(agentID string, s *leapmuxv1.AgentSettings) boo
 	return p.UpdateSettings(s)
 }
 
+// CurrentSettings returns a snapshot of the running agent's confirmed settings,
+// or nil if no agent is running with that ID. The snapshot reflects the
+// in-memory state that the live-update (refreshSettingsFromAgent) and restart
+// paths write synchronously, so callers can read back the model/effort the
+// agent actually confirmed without a DB round-trip.
+func (m *Manager) CurrentSettings(agentID string) *leapmuxv1.AgentSettings {
+	m.mu.RLock()
+	p, ok := m.agents[agentID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return p.CurrentSettings()
+}
+
 // HasAgent returns true if an agent is running with the given agent ID.
 func (m *Manager) HasAgent(agentID string) bool {
 	m.mu.RLock()

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -18,19 +18,25 @@ import (
 )
 
 type stubProvider struct {
-	groups []*leapmuxv1.AvailableOptionGroup
+	groups   []*leapmuxv1.AvailableOptionGroup
+	settings *leapmuxv1.AgentSettings
 }
 
-func (s *stubProvider) AgentID() string                                          { return "stub" }
-func (s *stubProvider) SendInput(string, []*leapmuxv1.Attachment) error          { return nil }
-func (s *stubProvider) SendRawInput([]byte) error                                { return nil }
-func (s *stubProvider) Stop()                                                    {}
-func (s *stubProvider) IsStopped() bool                                          { return false }
-func (s *stubProvider) DiscardOutput()                                           {}
-func (s *stubProvider) ClearContext() (string, bool)                             { return "", false }
-func (s *stubProvider) Wait() error                                              { return nil }
-func (s *stubProvider) Stderr() string                                           { return "" }
-func (s *stubProvider) CurrentSettings() *leapmuxv1.AgentSettings                { return &leapmuxv1.AgentSettings{} }
+func (s *stubProvider) AgentID() string                                 { return "stub" }
+func (s *stubProvider) SendInput(string, []*leapmuxv1.Attachment) error { return nil }
+func (s *stubProvider) SendRawInput([]byte) error                       { return nil }
+func (s *stubProvider) Stop()                                           {}
+func (s *stubProvider) IsStopped() bool                                 { return false }
+func (s *stubProvider) DiscardOutput()                                  {}
+func (s *stubProvider) ClearContext() (string, bool)                    { return "", false }
+func (s *stubProvider) Wait() error                                     { return nil }
+func (s *stubProvider) Stderr() string                                  { return "" }
+func (s *stubProvider) CurrentSettings() *leapmuxv1.AgentSettings {
+	if s.settings != nil {
+		return s.settings
+	}
+	return &leapmuxv1.AgentSettings{}
+}
 func (s *stubProvider) HandleOutput([]byte)                                      {}
 func (s *stubProvider) AvailableModels() []*leapmuxv1.AvailableModel             { return nil }
 func (s *stubProvider) AvailableOptionGroups() []*leapmuxv1.AvailableOptionGroup { return s.groups }
@@ -306,6 +312,24 @@ func TestManager_AvailableOptionGroupsPrefersRuntimeGroups(t *testing.T) {
 	require.Len(t, staticGroups, 1)
 	assert.Equal(t, OptionGroupKeyPrimaryAgent, staticGroups[0].Key)
 	assert.Equal(t, OpenCodePrimaryAgentBuild, staticGroups[0].Options[0].Id)
+}
+
+func TestManager_CurrentSettings(t *testing.T) {
+	m := NewManager(nil)
+
+	// No agent registered → nil, so callers fall back to their own value.
+	assert.Nil(t, m.CurrentSettings("missing-agent"))
+
+	// Registered agent → the provider's in-memory confirmed settings, letting
+	// callers read back the effort the agent actually confirmed (e.g. an
+	// ultracode request downgraded to xhigh) without a DB round-trip.
+	m.mu.Lock()
+	m.agents["running-agent"] = &stubProvider{settings: &leapmuxv1.AgentSettings{Effort: "xhigh"}}
+	m.mu.Unlock()
+
+	got := m.CurrentSettings("running-agent")
+	require.NotNil(t, got)
+	assert.Equal(t, "xhigh", got.GetEffort())
 }
 
 func TestManager_PreloadCache(t *testing.T) {

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -423,6 +423,24 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			expected: []string{"--model", "sonnet[1m]", "--effort", "high"},
 		},
 		{
+			name:     "opus with ultracode launches with xhigh base",
+			model:    "opus",
+			effort:   "ultracode",
+			expected: []string{"--model", "opus", "--effort", "xhigh"},
+		},
+		{
+			name:     "opus[1m] with ultracode launches with xhigh base",
+			model:    "opus[1m]",
+			effort:   "ultracode",
+			expected: []string{"--model", "opus[1m]", "--effort", "xhigh"},
+		},
+		{
+			name:     "sonnet with ultracode falls back to high",
+			model:    "sonnet",
+			effort:   "ultracode",
+			expected: []string{"--model", "sonnet", "--effort", "high"},
+		},
+		{
 			name:     "sonnet with high effort unchanged",
 			model:    "sonnet",
 			effort:   "high",
@@ -475,6 +493,15 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			model:    "claude-future-preview",
 			effort:   "xhigh",
 			expected: []string{"--model", "claude-future-preview", "--effort", "xhigh"},
+		},
+		{
+			// effortSupported trusts unknown models, but ultracode must not be
+			// assumed: an unknown model we can't confirm is xhigh-capable falls
+			// back to high rather than launching --effort xhigh it may reject.
+			name:     "unknown model with ultracode falls back to high",
+			model:    "claude-future-preview",
+			effort:   "ultracode",
+			expected: []string{"--model", "claude-future-preview", "--effort", "high"},
 		},
 	}
 	for _, tt := range tests {

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -750,6 +750,20 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 
+		// The effort the agent actually confirmed can differ from what was
+		// requested, so we report the confirmed value -- captured below from
+		// whichever path runs -- rather than the request:
+		//   - Selecting ultracode on an account without the workflows
+		//     entitlement silently lands on xhigh.
+		//   - Selecting Auto (or a model switch, which resets effort to Auto)
+		//     relaunches without --effort and the CLI resolves Auto to a
+		//     concrete level (e.g. "high"). Reporting that resolved level rather
+		//     than "auto" is INTENTIONAL: the notification states the effort the
+		//     session is actually running at. Do not "fix" this back to "auto".
+		// Defaults to the requested value for an offline edit or a failed
+		// restart, where no running agent confirmed anything.
+		notifyEffort := newEffort
+
 		// If the agent is currently running, try a live update first.
 		// Providers apply what they can without a restart (Codex applies to
 		// the next turn; Claude Code applies model/effort/permission changes
@@ -758,12 +772,29 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// back to auto, which needs a relaunch without --effort -- and we then
 		// fall back to stop+restart.
 		if svc.Agents.HasAgent(agentID) {
+			// Hold the per-agent lifecycle lock across the live update and the
+			// confirmed-effort readback so a concurrent UpdateAgentSettings for
+			// the same agent can't land between them and make us report its
+			// effort instead of ours. The live update writes the confirmed
+			// effort into the agent's in-memory state synchronously
+			// (refreshSettingsFromAgent), so reading it back while still holding
+			// the lock yields exactly the value this update confirmed.
+			// RestartAgent takes this same (non-reentrant) lock itself, so the
+			// restart path runs outside this section and reports the confirmed
+			// settings it returns directly.
+			unlock := svc.Agents.LockAgent(agentID)
 			updated := svc.Agents.UpdateSettings(agentID, &leapmuxv1.AgentSettings{
 				Model:          newModel,
 				Effort:         newEffort,
 				PermissionMode: newPermissionMode,
 				ExtraSettings:  newExtraSettings,
 			})
+			if updated {
+				if confirmed := svc.Agents.CurrentSettings(agentID); confirmed != nil && confirmed.GetEffort() != "" {
+					notifyEffort = confirmed.GetEffort()
+				}
+			}
+			unlock()
 
 			if !updated {
 				resumeSessionID := svc.resolveResumeSessionID(agentID, dbAgent.AgentSessionID, dbAgent.Resumed)
@@ -804,23 +835,13 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 					if _, err := svc.persistConfirmedAgentSettings(agentID, dbAgent.AgentProvider, newModel, newEffort, newPermissionMode, newExtraSettings, confirmedSettings); err != nil {
 						slog.Warn("failed to persist confirmed settings after restart", "agent_id", agentID, "error", err)
 					}
+					if confirmedSettings != nil && confirmedSettings.GetEffort() != "" {
+						notifyEffort = confirmedSettings.GetEffort()
+					}
 					slog.Info("agent restarted with new settings",
 						"agent_id", agentID, "model", newModel, "effort", newEffort)
 				}
 			}
-		}
-
-		// The effort the agent actually confirmed can differ from what was requested:
-		// selecting ultracode on an account without the workflows entitlement silently
-		// lands on xhigh, and a model switch resets effort to auto which the CLI then
-		// resolves to a concrete level. Report the confirmed effort so the chat
-		// notification isn't misleading. The live update (refreshSettingsFromAgent) and
-		// restart paths write the confirmed effort into the running agent's in-memory
-		// state synchronously, so reading it back here is race-free; fall back to the
-		// requested value when no agent is running (offline edit or failed restart).
-		notifyEffort := newEffort
-		if confirmed := svc.Agents.CurrentSettings(agentID); confirmed != nil && confirmed.GetEffort() != "" {
-			notifyEffort = confirmed.GetEffort()
 		}
 
 		// Broadcast settings_changed notification for the chat view.

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -751,9 +751,12 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		}
 
 		// If the agent is currently running, try a live update first.
-		// Providers that support it (e.g. Codex) apply settings to the
-		// next turn without a restart. Providers that don't (e.g. Claude
-		// Code) return false and we fall back to stop+restart.
+		// Providers apply what they can without a restart (Codex applies to
+		// the next turn; Claude Code applies model/effort/permission changes
+		// via apply_flag_settings) and return true. They return false only for
+		// changes they can't apply live -- e.g. Claude Code switching effort
+		// back to auto, which needs a relaunch without --effort -- and we then
+		// fall back to stop+restart.
 		if svc.Agents.HasAgent(agentID) {
 			updated := svc.Agents.UpdateSettings(agentID, &leapmuxv1.AgentSettings{
 				Model:          newModel,
@@ -807,6 +810,19 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			}
 		}
 
+		// The effort the agent actually confirmed can differ from what was requested:
+		// selecting ultracode on an account without the workflows entitlement silently
+		// lands on xhigh, and a model switch resets effort to auto which the CLI then
+		// resolves to a concrete level. Report the confirmed effort so the chat
+		// notification isn't misleading. The live update (refreshSettingsFromAgent) and
+		// restart paths write the confirmed effort into the running agent's in-memory
+		// state synchronously, so reading it back here is race-free; fall back to the
+		// requested value when no agent is running (offline edit or failed restart).
+		notifyEffort := newEffort
+		if confirmed := svc.Agents.CurrentSettings(agentID); confirmed != nil && confirmed.GetEffort() != "" {
+			notifyEffort = confirmed.GetEffort()
+		}
+
 		// Broadcast settings_changed notification for the chat view.
 		// Include display labels so the frontend can show human-readable names
 		// without maintaining its own label maps.
@@ -819,11 +835,11 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 				"oldLabel": modelLabel(oldID), "newLabel": modelLabel(newModel),
 			}
 		}
-		if dbAgent.Effort != newEffort {
+		if dbAgent.Effort != notifyEffort {
 			oldID := effortOrDefault(dbAgent.Effort, dbAgent.AgentProvider)
 			changes["effort"] = map[string]string{
-				"old": oldID, "new": newEffort,
-				"oldLabel": effortLabel(oldID), "newLabel": effortLabel(newEffort),
+				"old": oldID, "new": notifyEffort,
+				"oldLabel": effortLabel(oldID), "newLabel": effortLabel(notifyEffort),
 			}
 		}
 		if dbAgent.PermissionMode != newPermissionMode {

--- a/frontend/src/components/chat/providers/claude/settings.tsx
+++ b/frontend/src/components/chat/providers/claude/settings.tsx
@@ -2,15 +2,18 @@ import type { LucideIcon } from 'lucide-solid'
 import type { JSX } from 'solid-js'
 import type { ProviderSettingsPanelProps } from '../registry'
 import Flame from 'lucide-solid/icons/flame'
+import Rocket from 'lucide-solid/icons/rocket'
 import Zap from 'lucide-solid/icons/zap'
 import { createUniqueId, Show } from 'solid-js'
 import { EFFORT_AUTO } from '~/utils/controlResponse'
 import * as styles from '../../ChatView.css'
-import { effortIcon, effortItems, hasEfforts, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupDefaultValue, optionGroupItems, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../../settingsShared'
+import { effortIcon, effortItems, effortValidForModel, effortValueForModel, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupDefaultValue, optionGroupItems, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../../settingsShared'
 
 // Claude swaps the default xhigh→Zap mapping for Flame to free up Zap for
-// its `max` tier (an effort level Pi/Codex don't expose).
+// its `max` tier (an effort level Pi/Codex don't expose). `ultracode` (Opus
+// only) gets a rocket to signal its xhigh+workflow-orchestration combo.
 const CLAUDE_EFFORT_ICONS: Record<string, LucideIcon> = {
+  ultracode: Rocket,
   xhigh: Flame,
   max: Zap,
 }
@@ -38,6 +41,12 @@ export function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.
   const models = () => modelItems(props.availableModels)
   const efforts = () => effortItems(props.availableModels, currentModel())
   const hasEffort = () => efforts().length > 0
+  // During an optimistic model switch the effort can briefly be a value the new
+  // model doesn't offer (e.g. "ultracode"/"xhigh" left over from Opus after
+  // switching to Sonnet); effortValueForModel falls back to Auto so the
+  // RadioGroup never renders with no selection, mirroring the trigger label
+  // hiding its icon in the same window.
+  const effortValue = () => effortValueForModel(props.availableModels, currentModel(), currentEffort())
   const modeGroup = () => permissionModeGroup(props.availableOptionGroups)
   const modeItems = () => permissionModeItems(props.availableOptionGroups)
   const outputStyleItems = () => optionGroupItems(props.availableOptionGroups, OUTPUT_STYLE_KEY)
@@ -72,7 +81,7 @@ export function ClaudeCodeSettingsPanel(props: ProviderSettingsPanelProps): JSX.
               items={efforts()}
               testIdPrefix="effort"
               name={`${menuId}-effort`}
-              current={currentEffort()}
+              current={effortValue()}
               onChange={v => props.onChange?.({ kind: 'effort', value: v })}
               fieldsetClass={firstLeftClass('effort')}
             />
@@ -131,14 +140,19 @@ export function ClaudeCodeTriggerLabel(props: ProviderSettingsPanelProps): JSX.E
 
   const displayName = () => modelDisplayName(props.availableModels, currentModel())
 
-  const hasEffort = () => hasEfforts(props.availableModels, currentModel())
+  // Only render the effort icon when the current effort is actually one of the
+  // current model's tiers. During an optimistic model switch the effort can briefly
+  // be a value the new model doesn't offer (e.g. "ultracode"/"xhigh" left over from
+  // Opus after switching to Sonnet); showing its icon then would contradict the
+  // effort RadioGroup, which has no matching selection.
+  const currentEffortValid = () => effortValidForModel(props.availableModels, currentModel(), currentEffort())
   const mode = () => optionLabel(props.availableOptionGroups, PERMISSION_MODE_KEY, currentMode())
 
   return (
     <>
       <Show when={props.availableModels && props.availableModels.length > 0}>
         {displayName()}
-        <Show when={hasEffort()}>{effortIcon(currentEffort(), CLAUDE_EFFORT_ICONS)}</Show>
+        <Show when={currentEffortValid()}>{effortIcon(currentEffort(), CLAUDE_EFFORT_ICONS)}</Show>
       </Show>
       {mode()}
     </>

--- a/frontend/src/components/chat/providers/codex/settings.tsx
+++ b/frontend/src/components/chat/providers/codex/settings.tsx
@@ -3,7 +3,7 @@ import type { ProviderSettingsPanelProps } from '../registry'
 import { createUniqueId, Show } from 'solid-js'
 import { EFFORT_AUTO } from '~/utils/controlResponse'
 import * as styles from '../../ChatView.css'
-import { defaultModelId, effortIcon, effortItems, hasEfforts, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupItems, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../../settingsShared'
+import { defaultModelId, effortIcon, effortItems, effortValidForModel, effortValueForModel, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupItems, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../../settingsShared'
 
 /** Default model for Codex agents. */
 const DEFAULT_CODEX_MODEL = import.meta.env.LEAPMUX_CODEX_DEFAULT_MODEL || 'gpt-5.4'
@@ -33,6 +33,11 @@ export function CodexSettingsPanel(props: ProviderSettingsPanelProps): JSX.Eleme
 
   const models = () => modelItems(props.availableModels)
   const efforts = () => effortItems(props.availableModels, currentModel())
+  // Codex builds SupportedEfforts per-model at runtime, so an optimistic model
+  // switch can briefly leave an effort the new model doesn't offer;
+  // effortValueForModel falls back to Auto so the RadioGroup never renders with
+  // no selection, mirroring the trigger label hiding its icon in the same window.
+  const effortValue = () => effortValueForModel(props.availableModels, currentModel(), currentEffort())
   const serviceTierGroup = () => optionGroup(props.availableOptionGroups, CODEX_EXTRA_SERVICE_TIER)
   const serviceTierItems = () => optionGroupItems(props.availableOptionGroups, CODEX_EXTRA_SERVICE_TIER)
   const collaborationModeGroup = () => optionGroup(props.availableOptionGroups, CODEX_EXTRA_COLLABORATION_MODE)
@@ -78,7 +83,7 @@ export function CodexSettingsPanel(props: ProviderSettingsPanelProps): JSX.Eleme
           items={efforts()}
           testIdPrefix="effort"
           name={`${menuId}-effort`}
-          current={currentEffort()}
+          current={effortValue()}
           onChange={v => props.onChange?.({ kind: 'effort', value: v })}
           fieldsetClass={firstLeftClass('effort')}
         />
@@ -162,14 +167,18 @@ export function CodexTriggerLabel(props: ProviderSettingsPanelProps): JSX.Elemen
   const currentCollaborationMode = () => extra()[CODEX_EXTRA_COLLABORATION_MODE] || DEFAULT_CODEX_COLLABORATION_MODE
   const displayName = () => modelDisplayName(props.availableModels, currentModel())
 
-  const hasEffort = () => hasEfforts(props.availableModels, currentModel())
+  // Only render the effort icon when the current effort is actually one of the
+  // current model's tiers. Codex populates SupportedEfforts per-model at runtime,
+  // so an optimistic model switch can briefly leave an effort the new model
+  // doesn't offer; showing its icon then would contradict the effort RadioGroup.
+  const currentEffortValid = () => effortValidForModel(props.availableModels, currentModel(), currentEffort())
   const mode = () => currentCollaborationMode() === 'plan'
     ? optionLabel(props.availableOptionGroups, CODEX_EXTRA_COLLABORATION_MODE, currentCollaborationMode())
     : optionLabel(props.availableOptionGroups, PERMISSION_MODE_KEY, currentMode())
   return (
     <>
       {displayName()}
-      <Show when={hasEffort()}>{effortIcon(currentEffort())}</Show>
+      <Show when={currentEffortValid()}>{effortIcon(currentEffort())}</Show>
       {' '}
       {mode()}
     </>

--- a/frontend/src/components/chat/providers/pi/settings.tsx
+++ b/frontend/src/components/chat/providers/pi/settings.tsx
@@ -7,7 +7,8 @@ import {
   defaultModelId,
   effortIcon,
   effortItems,
-  hasEfforts,
+  effortValidForModel,
+  effortValueForModel,
   modelDisplayName,
   modelItems,
   ModelSelect,
@@ -26,6 +27,11 @@ export function PiSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element 
 
   const models = () => modelItems(props.availableModels)
   const efforts = () => effortItems(props.availableModels, currentModel())
+  // During an optimistic model switch the effort can briefly be a tier the new
+  // model doesn't offer; effortValueForModel falls back to Auto so the
+  // RadioGroup never renders with no selection (mirroring the trigger label
+  // hiding its icon in the same window).
+  const effortValue = () => effortValueForModel(props.availableModels, currentModel(), currentEffort())
 
   return (
     <div class={[styles.settingsPanelColumn, styles.settingsPanelColumnPrimary].join(' ')}>
@@ -34,7 +40,7 @@ export function PiSettingsPanel(props: ProviderSettingsPanelProps): JSX.Element 
         items={efforts()}
         testIdPrefix="effort"
         name={`${menuId}-effort`}
-        current={currentEffort()}
+        current={effortValue()}
         onChange={v => props.onChange?.({ kind: 'effort', value: v })}
         fieldsetClass={styles.settingsFieldsetFirst}
       />
@@ -54,12 +60,16 @@ export function PiTriggerLabel(props: ProviderSettingsPanelProps): JSX.Element {
   const currentModel = () => props.model || defaultModelId(props.availableModels) || DEFAULT_PI_MODEL
   const currentEffort = () => props.effort || DEFAULT_PI_EFFORT
   const displayName = () => modelDisplayName(props.availableModels, currentModel())
-  const hasEffort = () => hasEfforts(props.availableModels, currentModel())
+  // Only show the effort icon when the current effort is one of the current
+  // model's tiers. Pi populates SupportedEfforts per-model at runtime, so an
+  // optimistic model switch can briefly leave an effort the new model doesn't
+  // offer; showing its icon then would contradict the effort RadioGroup.
+  const currentEffortValid = () => effortValidForModel(props.availableModels, currentModel(), currentEffort())
 
   return (
     <>
       {displayName()}
-      <Show when={hasEffort()}>{effortIcon(currentEffort())}</Show>
+      <Show when={currentEffortValid()}>{effortIcon(currentEffort())}</Show>
     </>
   )
 }

--- a/frontend/src/components/chat/settingsShared.test.ts
+++ b/frontend/src/components/chat/settingsShared.test.ts
@@ -1,0 +1,63 @@
+import type { AvailableModel } from '~/generated/leapmux/v1/agent_pb'
+import { describe, expect, it } from 'vitest'
+import { effortValidForModel, effortValueForModel } from './settingsShared'
+
+/** Build a minimal AvailableModel fixture (only the fields the helper reads). */
+function model(id: string, effortIds: string[]): AvailableModel {
+  return {
+    id,
+    supportedEfforts: effortIds.map(eid => ({ id: eid })),
+  } as unknown as AvailableModel
+}
+
+const models = [
+  model('opus', ['auto', 'ultracode', 'max', 'xhigh', 'high', 'medium', 'low']),
+  model('sonnet', ['auto', 'max', 'high', 'medium', 'low']),
+  model('haiku', []),
+]
+
+describe('effortValidForModel', () => {
+  it('returns true when the effort is one of the model tiers', () => {
+    expect(effortValidForModel(models, 'opus', 'ultracode')).toBe(true)
+    expect(effortValidForModel(models, 'sonnet', 'max')).toBe(true)
+  })
+
+  it('returns false when the effort is not offered by the model', () => {
+    // "ultracode"/"xhigh" left over from Opus after switching to Sonnet.
+    expect(effortValidForModel(models, 'sonnet', 'ultracode')).toBe(false)
+    expect(effortValidForModel(models, 'sonnet', 'xhigh')).toBe(false)
+  })
+
+  it('returns false for a model that offers no efforts', () => {
+    expect(effortValidForModel(models, 'haiku', 'auto')).toBe(false)
+  })
+
+  it('returns false for an unknown model id', () => {
+    expect(effortValidForModel(models, 'gpt-not-a-model', 'auto')).toBe(false)
+  })
+
+  it('returns false when the model list is empty or undefined', () => {
+    expect(effortValidForModel(undefined, 'opus', 'auto')).toBe(false)
+    expect(effortValidForModel([], 'opus', 'auto')).toBe(false)
+  })
+})
+
+describe('effortValueForModel', () => {
+  it('returns the current effort when the model still offers it', () => {
+    expect(effortValueForModel(models, 'opus', 'ultracode')).toBe('ultracode')
+    expect(effortValueForModel(models, 'sonnet', 'max')).toBe('max')
+  })
+
+  it('falls back to auto when the effort is not offered by the model', () => {
+    // The exact optimistic-switch case: "ultracode"/"xhigh" left over from Opus
+    // after switching to Sonnet must not stay selected in the RadioGroup.
+    expect(effortValueForModel(models, 'sonnet', 'ultracode')).toBe('auto')
+    expect(effortValueForModel(models, 'sonnet', 'xhigh')).toBe('auto')
+  })
+
+  it('falls back to auto for an unknown model or empty list', () => {
+    expect(effortValueForModel(models, 'gpt-not-a-model', 'high')).toBe('auto')
+    expect(effortValueForModel(undefined, 'opus', 'ultracode')).toBe('auto')
+    expect(effortValueForModel([], 'opus', 'ultracode')).toBe('auto')
+  })
+})

--- a/frontend/src/components/chat/settingsShared.tsx
+++ b/frontend/src/components/chat/settingsShared.tsx
@@ -135,15 +135,6 @@ export function modelDisplayName(availableModels: AvailableModel[] | undefined, 
   return currentModel
 }
 
-/** Check if the current model has efforts. */
-export function hasEfforts(availableModels: AvailableModel[] | undefined, currentModel: string): boolean {
-  if (availableModels && availableModels.length > 0) {
-    const model = availableModels.find(m => m.id === currentModel)
-    return model ? model.supportedEfforts.length > 0 : false
-  }
-  return false
-}
-
 /** Resolve any option-group label from available option groups. */
 export function optionLabel(availableOptionGroups: AvailableOptionGroup[] | undefined, key: string, currentValue: string): string {
   const group = optionGroup(availableOptionGroups, key)

--- a/frontend/src/components/chat/settingsShared.tsx
+++ b/frontend/src/components/chat/settingsShared.tsx
@@ -73,6 +73,29 @@ export function effortItems(availableModels: AvailableModel[] | undefined, curre
   return []
 }
 
+/**
+ * Whether `effort` is one of the tiers the given model currently offers. Used
+ * to guard effort UI during an optimistic model switch, where the effort can
+ * briefly be a value the new model doesn't support (e.g. "ultracode"/"xhigh"
+ * left over from Opus after switching to Sonnet). Returns false when the model
+ * list is empty/loading or the model is unknown.
+ */
+export function effortValidForModel(availableModels: AvailableModel[] | undefined, currentModel: string, effort: string): boolean {
+  return effortItems(availableModels, currentModel).some(e => e.value === effort)
+}
+
+/**
+ * The current effort if the model still offers it, else `EFFORT_AUTO`. Use this
+ * for the effort RadioGroup's `current` value so it never renders with no
+ * selection during an optimistic model switch, where the effort can briefly be
+ * a tier the new model doesn't offer (e.g. "ultracode"/"xhigh" left over from
+ * Opus after switching to Sonnet). `EFFORT_AUTO` is offered by every
+ * effort-bearing model and is the value the backend resets to on a model change.
+ */
+export function effortValueForModel(availableModels: AvailableModel[] | undefined, currentModel: string, effort: string): string {
+  return effortValidForModel(availableModels, currentModel, effort) ? effort : EFFORT_AUTO
+}
+
 /** Find an option group by key. */
 export function optionGroup(availableOptionGroups: AvailableOptionGroup[] | undefined, key: string) {
   return availableOptionGroups?.find(g => g.key === key)

--- a/frontend/tests/e2e/044-agent-settings.spec.ts
+++ b/frontend/tests/e2e/044-agent-settings.spec.ts
@@ -165,6 +165,52 @@ test.describe('Agent Settings', () => {
     await page.keyboard.press('Escape')
   })
 
+  test('ultracode effort is opus-only and selectable', async ({ authenticatedWorkspace, page }) => {
+    const trigger = page.locator('[data-testid="agent-settings-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Default (Sonnet): ultracode must not be offered (not xhigh-capable).
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-ultracode"]')).not.toBeVisible()
+
+    // Switch to Opus — ultracode appears as the top concrete effort tier.
+    await page.locator('[data-testid="model-opus"]').click()
+    await expect(trigger).toContainText('Opus')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-ultracode"]')).toBeVisible()
+
+    // Select ultracode. CI accounts lack the dynamic-workflows entitlement, so
+    // the CLI gracefully downgrades to xhigh (apply_flag_settings no-ops and
+    // get_settings reports ultracode:false). We therefore assert the agent
+    // stays functional rather than that the selection persists as ultracode.
+    await page.locator('[data-testid="effort-ultracode"]').click()
+    await waitForSettingsIdle(page)
+
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+    await editor.click()
+    // Use a distinctive sentinel word as the answer, not a number. Don't use
+    // lastAssistantBubble(): the per-turn "Took Ns" meta bubble also carries
+    // data-role="agent" and can be the last one, so .last() races it — we
+    // filter by text instead. A numeric answer would be unsafe here because the
+    // "Took Ns" bubble's duration (e.g. "Took 11s") shares data-role="agent"
+    // and would substring-match a numeric sentinel like "11", letting the test
+    // pass on the duration bubble even if the agent never answered.
+    await page.keyboard.type('Reply with exactly the word PINEAPPLE and nothing else.')
+    await page.keyboard.press('Meta+Enter')
+    await expect(page.locator(ASSISTANT_BUBBLE_SELECTOR).filter({ hasText: 'PINEAPPLE' })).toBeVisible()
+
+    // Switch back to Sonnet — ultracode disappears again.
+    await openSettingsMenu(page)
+    await page.locator('[data-testid="model-sonnet"]').click()
+    await expect(trigger).toContainText('Sonnet')
+    await waitForSettingsIdle(page)
+    await openSettingsMenu(page)
+    await expect(page.locator('[data-testid="effort-ultracode"]')).not.toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+
   test('Extended Thinking label reflects model', async ({ authenticatedWorkspace, page }) => {
     const trigger = page.locator('[data-testid="agent-settings-trigger"]')
     const onOpt = page.locator('[data-testid="thinking-on"]')


### PR DESCRIPTION
## Motivation

Claude Code's `--effort` flag tops out at `xhigh`, but Opus models support an additional capability layer (ultracode) that requires a separate `apply_flag_settings` call after launch. There was no way to expose this tier from LeapMux, and no safeguard preventing a worker spawned inside another agent's session from inheriting that parent session's effort overrides, IDE port bindings, or identity markers — which could silently sabotage the child's configuration.

Additionally, after an optimistic model switch in the UI, effort controls could be left showing a tier (e.g. ultracode or xhigh) that the newly selected model does not support, producing a stale or contradictory display.

## Modifications

**Ultracode effort tier (backend)**
- Adds `EffortUltracode`, `EffortXHigh`, and `EffortHigh` constants to standardize the effort identifiers across encode/decode paths.
- Models ultracode internally and translates it at the provider wire boundary: launch with `--effort xhigh`, then call `apply_flag_settings({effortLevel:"xhigh", ultracode:true})`; read back via `get_settings` which maps `applied.ultracode` to the internal value.
- Accounts without the `workflows` entitlement silently downgrade from ultracode to xhigh; the confirmed settings notification reports the resolved tier, not the requested one.
- Ultracode is Opus-only; Sonnet and Haiku downgrade to high so an unsupported effort/model combination can never reach the CLI.
- Adds encode/decode helpers: `ultracodeFlagSettings`, `claudeEffortFlagSettings`, `claudeEffortUpdateFlagSettings`, `claudeEffortFromApplied`, `resolveClaudeEffortForModel`, `modelSupportsUltracode`, `unsupportedUltracode`.
- Effort tier catalog refactored into shared immutable `effortTier*` pointers, single-sourced across Opus and Sonnet effort slices.
- Fixes a model-only live switch that leaves ultracode active for a model that cannot run it: pins a safe effort level, since the CLI's `apply_flag_settings` does not re-resolve `effortLevel` on a model change.

**Inherited environment scrubbing (backend — new `env.go`)**
- Adds `agentIdentityEnvScrubKeys` and `FinalizeAgentEnv` (moved from `factory.go`) to strip coding-agent harness identity, session, nesting, sandbox, and trace markers from every spawned agent environment.
- Scrubbed variables include `CLAUDE_CODE_EFFORT_LEVEL` (which would override ultracode) and `CLAUDE_CODE_SSE_PORT` (which would auto-connect a child to the parent's IDE). Auth tokens, config dirs, provider-selection variables, and each provider's own rc markers are deliberately preserved.
- Covers markers from Claude Code, Codex, OpenCode/Kilo/Goose, and Pi.

**Settings notification accuracy (backend — `service/agent.go`)**
- `UpdateAgentSettings` now reports the agent's confirmed in-memory effort (via the new `Manager.CurrentSettings` method) rather than the requested effort, so silent downgrades and Auto resolutions surface correctly to the client.
- The per-agent lifecycle lock is held across the live update and confirmed readback so concurrent `UpdateAgentSettings` calls cannot interleave their notifications.

**`envutil.HasKey` (backend)**
- Promotes a test-local helper to an exported function reporting whether an environ slice contains a given key (case-insensitive).

**Ultracode effort tier UI (frontend)**
- Adds an ultracode option (rocket icon) to the Claude settings effort RadioGroup; option is only offered for Opus models.
- Replaces `hasEfforts` with two focused helpers in `settingsShared.tsx`:
  - `effortValidForModel` — is this effort one of the model's tiers?
  - `effortValueForModel` — returns the effort if valid, otherwise Auto.
- Applies the new helpers to Claude, Pi, and Codex settings panels and their trigger labels (all former `hasEfforts` call sites are migrated, and `hasEfforts` is removed). Codex had the same latent stale-effort bug as Claude; both are now fixed.
- Adds unit tests for both new helpers and an E2E test verifying ultracode is Opus-only, selectable, and absent when switching to Sonnet.

## Result

- A new ultracode effort tier is available in the Claude settings panel when an Opus model is selected. Accounts without the `workflows` entitlement automatically fall back to xhigh with no user action required.
- Workers launched inside another agent's session no longer inherit the parent's effort override, IDE port, or session identity, preventing silent misconfiguration of nested agents.
- The effort shown in chat notifications and the UI always reflects the effort the agent is actually running at, including after silent downgrades or model switches.
- Switching models in the UI no longer leaves a stale effort tier selected or displayed when the new model does not support it.
