### PR TITLE
fix(chat): Trust is_error for result styling instead of num_turns heuristic

### DIFF
--- a/frontend/src/components/chat/notificationRenderers.test.tsx
+++ b/frontend/src/components/chat/notificationRenderers.test.tsx
@@ -310,24 +310,95 @@ describe('resultRenderer', () => {
     expect(renderResultText(parsed)).toBe('Something went wrong')
   })
 
-  it('renders missing stop_reason with num_turns<=1 as error', () => {
-    const parsed = { type: 'result', stop_reason: null, subtype: 'success', num_turns: 1, result: 'Unknown skill: foo', duration_ms: 5 }
-    expect(isRenderedAsError(parsed)).toBe(true)
-    expect(renderResultText(parsed)).toBe('Unknown skill: foo')
-  })
-
-  it('renders missing stop_reason with num_turns>1 as normal (not error)', () => {
+  it('renders a zero-turn unknown-command result (is_error:false) as a plain divider, not a danger dump', () => {
+    // Claude Code reports unknown slash commands as is_error:false results that
+    // echo their already-shown message. Trust is_error: show "Took Xs" rather
+    // than a red dump of the result text. (The renderer ignores stop_reason /
+    // num_turns now, so the fixture omits them.)
     const parsed = {
       type: 'result',
       is_error: false,
-      stop_reason: null,
       subtype: 'success',
-      num_turns: 4,
+      result: 'Unknown command: /non-existent-skill',
+      duration_ms: 24,
+    }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    const text = renderResultText(parsed)
+    expect(text).toBe('Took 24ms')
+    expect(text).not.toContain('Unknown command')
+  })
+
+  it('renders the /usage subscription result as a plain divider, not a danger dump', () => {
+    const parsed = {
+      type: 'result',
+      is_error: false,
+      subtype: 'success',
+      result: 'You are currently using your subscription to power your Claude Code usage',
+      duration_ms: 3,
+    }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    const text = renderResultText(parsed)
+    expect(text).toBe('Took 3ms')
+    expect(text).not.toContain('subscription')
+  })
+
+  it('renders a success result as a plain "Took Xs" divider, discarding its raw result text', () => {
+    const parsed = {
+      type: 'result',
+      is_error: false,
+      subtype: 'success',
       result: '## Context Usage\n\nSome output...',
       duration_ms: 1095,
     }
     expect(isRenderedAsError(parsed)).toBe(false)
-    expect(renderResultText(parsed)).toContain('Took')
+    const text = renderResultText(parsed)
+    expect(text).toBe('Took 1.1s')
+    expect(text).not.toContain('Context Usage')
+  })
+
+  it('renders a non-error result with an absent subtype as a plain divider, not its raw text', () => {
+    // A non-error result that omits `subtype` must be treated as success-like
+    // (mirroring the error branch's `subtype && ...` guard), so it collapses to
+    // "Took Xs" rather than leaking the raw echo text into the label.
+    const parsed = {
+      type: 'result',
+      is_error: false,
+      result: 'You are currently using your subscription to power your Claude Code usage',
+      duration_ms: 7,
+    }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    const text = renderResultText(parsed)
+    expect(text).toBe('Took 7ms')
+    expect(text).not.toContain('subscription')
+  })
+
+  it('renders a non-error success result with a missing duration_ms as "Turn ended"', () => {
+    // A missing duration_ms has no meaningful "Took" value, so the duration-only
+    // divider falls back to "Turn ended" instead of a fake "Took 0ms".
+    const parsed = { type: 'result', is_error: false, subtype: 'success', result: 'done' }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    expect(renderResultText(parsed)).toBe('Turn ended')
+  })
+
+  it('renders a non-error success result with a real zero duration_ms as "Took 0ms"', () => {
+    // A genuine zero is distinct from missing — an instant turn is "Took 0ms".
+    const parsed = { type: 'result', is_error: false, subtype: 'success', result: 'done', duration_ms: 0 }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    expect(renderResultText(parsed)).toBe('Took 0ms')
+  })
+
+  it('renders a non-success non-error result with a missing duration_ms as just its text', () => {
+    // displayText present + no duration -> the suffix is dropped, not "(0ms)".
+    const parsed = { type: 'result', is_error: false, subtype: 'cancelled', result: 'Cancelled' }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    expect(renderResultText(parsed)).toBe('Cancelled')
+  })
+
+  it('renders a non-success non-error result with a real zero duration_ms as "<text> (0ms)"', () => {
+    // displayText present + real zero -> the suffix is kept, mirroring "Took 0ms".
+    const parsed = { type: 'result', is_error: false, subtype: 'cancelled', result: 'Cancelled', duration_ms: 0 }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    expect(renderResultText(parsed)).toBe('Cancelled (0ms)')
   })
 
   it('renders success subtype with duration', () => {
@@ -373,5 +444,27 @@ describe('resultRenderer', () => {
     const text = renderResultText(parsed)
     expect(text).toBe('Something went wrong (100ms)')
     expect(text).not.toContain('\n')
+  })
+
+  it('renders the zero-turn /context result as a plain divider, not a danger dump', () => {
+    // The `/context` table is already shown as an assistant bubble above, so the
+    // redundant result envelope renders as a normal "Took Xs" turn-end divider
+    // rather than dumping its table in danger red.
+    const parsed = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: '## Context Usage\n\n**Model:** claude-opus-4-8[1m]\n',
+      duration_ms: 2062,
+    }
+    expect(isRenderedAsError(parsed)).toBe(false)
+    const text = renderResultText(parsed)
+    expect(text).toBe('Took 2.1s')
+    expect(text).not.toContain('Context Usage')
+  })
+
+  it('still renders a genuinely failed result red even when its text starts with the context-usage header', () => {
+    const parsed = { type: 'result', is_error: true, result: '## Context Usage\nboom', duration_ms: 5 }
+    expect(isRenderedAsError(parsed)).toBe(true)
   })
 })

--- a/frontend/src/components/chat/providers/claude/notifications.tsx
+++ b/frontend/src/components/chat/providers/claude/notifications.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable solid/components-return-once -- render methods are not Solid components */
+import type { JSX } from 'solid-js'
 import type { MessageContentRenderer } from '../../messageRenderers'
 import type { NotificationThreadEntry } from '../registry'
 import type { RateLimitInfo } from '~/stores/agentSession.store'
@@ -56,50 +57,85 @@ export const rateLimitRenderer: MessageContentRenderer = {
   },
 }
 
+/**
+ * Render a failed result (is_error===true) as a danger divider. Non-success
+ * subtypes get a humanized label plus an errors/result detail block; generic
+ * errors get the cleaned API-error message inline. `durationMs` is null when
+ * the envelope omitted `duration_ms`, in which case the duration suffix is
+ * dropped.
+ */
+function renderErrorResult(
+  parsed: Record<string, unknown>,
+  resultText: string,
+  durationMs: number | null,
+  subtype: string,
+): JSX.Element {
+  const errors = Array.isArray(parsed.errors) ? parsed.errors as string[] : []
+  const durationSuffix = durationMs !== null && durationMs > 0 ? ` (${formatDuration(durationMs)})` : ''
+
+  if (subtype && subtype !== 'success') {
+    const label = humanizeSubtype(subtype) + durationSuffix
+    const errorDetail = errors.length > 0 ? errors.join('\n') : resultText || ''
+    return (
+      <>
+        <div class={resultDivider} style={{ color: 'var(--danger)' }}>{label}</div>
+        {errorDetail && <pre class={resultErrorDetail}>{errorDetail}</pre>}
+      </>
+    )
+  }
+
+  const errorMsg = errors.length > 0 ? errors.join('; ') : resultText || 'Unknown error'
+  const label = cleanAPIErrorMessage(errorMsg) + durationSuffix
+  return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{label}</div>
+}
+
+/**
+ * Render a non-error result as a plain turn-end divider. Past the
+ * is_error===true branch, Claude Code itself says this turn did not error, so
+ * never surface the raw `result` text as a danger divider. Zero-turn local
+ * commands (`/context`, `/usage`, even "Unknown command: ...") echo their
+ * already-shown output through this envelope with is_error:false; rendering
+ * that echo in red was a false alarm. Trust is_error and collapse to a plain
+ * "Took Xs" divider, keeping the result text only for a genuine non-success
+ * subtype (e.g. "cancelled"). Mirror the error branch's `subtype && ...` guard
+ * so an absent subtype is treated as success-like instead of leaking the raw
+ * echo into the label.
+ */
+function renderPlainResult(
+  resultText: string,
+  durationMs: number | null,
+  subtype: string,
+): JSX.Element {
+  const displayText = subtype && subtype !== 'success' ? resultText : ''
+  let label: string
+  if (displayText) {
+    const suffix = durationMs !== null ? ` (${formatDuration(durationMs)})` : ''
+    label = displayText + suffix
+  }
+  else {
+    // Duration-only divider. A missing duration_ms (null) has no meaningful
+    // "Took" value, so fall back to a plain "Turn ended"; a real zero stays
+    // "Took 0ms".
+    label = durationMs !== null ? `Took ${formatDuration(durationMs)}` : 'Turn ended'
+  }
+  return <div class={resultDivider}>{label}</div>
+}
+
 /** Handles Claude result messages: {"type":"result","duration_ms":865,"num_turns":558,...} */
 export const resultRenderer: MessageContentRenderer = {
   render(parsed, _context) {
     if (!isObject(parsed) || parsed.type !== 'result')
       return null
 
-    if (parsed.is_error === true) {
-      const errors = Array.isArray(parsed.errors) ? parsed.errors as string[] : []
-      const resultText = pickString(parsed, 'result')
-      const durationMs = pickNumber(parsed, 'duration_ms', 0)
-      const durationSuffix = durationMs > 0 ? ` (${formatDuration(durationMs)})` : ''
-
-      const subtype = pickString(parsed, 'subtype')
-      if (subtype && subtype !== 'success') {
-        const humanSubtype = humanizeSubtype(subtype)
-        const label = humanSubtype + durationSuffix
-        const errorDetail = errors.length > 0 ? errors.join('\n') : resultText || ''
-        return (
-          <>
-            <div class={resultDivider} style={{ color: 'var(--danger)' }}>{label}</div>
-            {errorDetail && <pre class={resultErrorDetail}>{errorDetail}</pre>}
-          </>
-        )
-      }
-
-      const errorMsg = errors.length > 0 ? errors.join('; ') : resultText || 'Unknown error'
-      const label = cleanAPIErrorMessage(errorMsg) + durationSuffix
-      return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{label}</div>
-    }
-
-    const durationMs = pickNumber(parsed, 'duration_ms', 0)
+    // Shared reads — both branches need these fields. `duration_ms` defaults to
+    // null (not 0) so the renderers can tell a missing duration from a real 0.
     const resultText = pickString(parsed, 'result')
-    const durationStr = formatDuration(durationMs)
+    const durationMs = pickNumber(parsed, 'duration_ms')
+    const subtype = pickString(parsed, 'subtype')
 
-    const numTurns = pickNumber(parsed, 'num_turns', 0)
-    if (!parsed.stop_reason && numTurns <= 1 && resultText) {
-      return <div class={resultDivider} style={{ color: 'var(--danger)' }}>{resultText}</div>
-    }
-
-    const displayText = parsed.subtype !== 'success' ? resultText : ''
-    const label = displayText
-      ? `${displayText} (${durationStr})`
-      : `Took ${durationStr}`
-    return <div class={resultDivider}>{label}</div>
+    return parsed.is_error === true
+      ? renderErrorResult(parsed, resultText, durationMs, subtype)
+      : renderPlainResult(resultText, durationMs, subtype)
   },
 }
 

--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -83,7 +83,10 @@ describe('claude classify', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'result_divider' })
   })
 
-  it('hides the /context local-command result (already shown as an assistant bubble)', () => {
+  it('classifies the /context local-command result as a divider, not hidden', () => {
+    // The redundant-with-the-assistant-bubble and danger-styling concerns are
+    // both handled by resultRenderer, so the classifier keeps every result a
+    // turn-end divider (see notificationRenderers.test.tsx).
     const parent = {
       type: 'result',
       subtype: 'success',
@@ -92,15 +95,6 @@ describe('claude classify', () => {
       stop_reason: null,
       result: '## Context Usage\n\n**Model:** claude-opus-4-8[1m]\n',
       duration_ms: 2062,
-    }
-    expect(plugin.classify(input(parent))).toEqual({ kind: 'hidden' })
-  })
-
-  it('does not hide an error result even when its text starts with the context-usage header', () => {
-    const parent = {
-      type: 'result',
-      is_error: true,
-      result: '## Context Usage\nboom',
     }
     expect(plugin.classify(input(parent))).toEqual({ kind: 'result_divider' })
   })

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -107,19 +107,7 @@ const CLAUDE_NOTIFICATION_CLASSIFIERS: Record<string, ClaudeTypeClassifier> = {
   context_cleared: () => ({ kind: 'notification' }),
   settings_changed: () => ({ kind: 'notification' }),
   plan_updated: () => ({ kind: 'notification' }),
-  result: (parent) => {
-    // The `/context` local command emits its usage table twice: once as a
-    // normal assistant text bubble, then again as this type:"result"
-    // envelope (num_turns:0, is_error:false). resultRenderer's zero-turn
-    // heuristic paints that envelope red as if it were an error. Since the
-    // assistant bubble already shows the table, hide the redundant result
-    // envelope. Guarded on is_error so a genuinely failed turn is never
-    // suppressed, and matched on the exact header so every other result
-    // still renders as a turn-end divider.
-    if (parent.is_error !== true && pickString(parent, 'result').startsWith('## Context Usage\n'))
-      return { kind: 'hidden' }
-    return { kind: 'result_divider' }
-  },
+  result: () => ({ kind: 'result_divider' }),
 }
 
 /**


### PR DESCRIPTION
## Motivation

Claude Code `type:"result"` envelopes are rendered as turn-end dividers in the chat transcript. The previous renderer used a zero-turn heuristic to decide whether to color a result red:

```js
if (!parsed.stop_reason && numTurns <= 1 && resultText) {
  return <div style={{ color: 'var(--danger)' }}>{resultText}</div>
}
```

This incorrectly painted any zero-turn result carrying `result` text in red, even when `is_error` was `false`. Local commands such as `/context` and `/usage` echo their already-displayed output through a second `is_error:false` result envelope, so they were wrongly styled as failures.

Commit 2c780051 worked around this by hiding the `/context` envelope outright, matched on the literal `## Context Usage\n` header prefix. That patch only covered `/context` and left the underlying mis-styling in place for all other zero-turn `is_error:false` results.

## Modifications

- Remove the zero-turn heuristic from `resultRenderer` in `notifications.tsx`. The renderer now branches solely on `is_error`; if `is_error` is not `true`, the result is never colored red.
- Revert the classifier workaround in `plugin.tsx`. The `result` classifier is reduced back to `result: () => ({ kind: 'result_divider' })`, moving all styling decisions into the renderer.
- Fix an absent-subtype leak. The old non-error branch used `parsed.subtype !== 'success'`, which also matched when `subtype` was absent, leaking raw echoed text into the divider label. The new code uses `subtype && subtype !== 'success'` so an absent subtype collapses to a plain turn-end divider.
- Split `resultRenderer` into `renderErrorResult` (danger divider with error detail) and `renderPlainResult` (plain turn-end divider), with a thin dispatcher that branches on `is_error`.
- Distinguish missing vs zero `duration_ms`. A missing duration renders "Turn ended"; a real zero renders "Took 0ms".
- Extend `notificationRenderers.test.tsx` with cases covering absent-subtype non-error results, missing and zero `duration_ms`, non-success non-error subtypes (e.g. "cancelled"), and the `is_error:true` red-styling path.
- Update `plugin.test.ts` to assert `/context` classifies as `result_divider` (not `hidden`), documenting the reverted workaround.

## Result

Zero-turn `is_error:false` results that carry echoed text -- `/usage`, "Unknown command: ...", and similar local commands -- are no longer mis-styled as red errors; they render as plain "Took Xs" turn-end dividers. `/context`, previously hidden via a header-matching special case, now renders as a plain turn-end divider like any other successful result, with the styling decision made entirely from `is_error`. Results with an absent `subtype` no longer leak raw echo text into the divider label.
