### PR TITLE
feat(chat): Add an animated thinking-token counter to the indicator

### DIFF
--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,6 +31,23 @@ const (
 	claudeMsgTypeControlCancelRequest = "control_cancel_request"
 	claudeMsgTypeControlResponse      = "control_response"
 )
+
+// claudeSystemSubtypeThinkingTokens is the `subtype` of the `system` telemetry
+// line Claude Code emits during extended thinking. It carries a running
+// `estimated_tokens` count for the in-flight turn and streams frequently. Like
+// thinking-text deltas, it is live progress rather than timeline content, so we
+// broadcast the latest estimate over the ephemeral agent_session_info channel
+// and never persist it.
+const claudeSystemSubtypeThinkingTokens = "thinking_tokens"
+
+// SessionInfoKeyThinkingTokens is the agent_session_info wire key under which the
+// running thinking-token estimate is broadcast. It happens to share the literal
+// "thinking_tokens" with the Claude `subtype` above but is a distinct concept (a
+// platform session-info key, not a Claude wire `subtype`); they are kept as
+// separate consts so one can change without silently dragging the other.
+// Exported so the service layer's dedup exemption keys off the exact same string
+// the broadcast uses rather than a hand-copied literal that could drift.
+const SessionInfoKeyThinkingTokens = "thinking_tokens"
 
 // contextUsageSnapshot tracks token usage for debounced broadcasting.
 type contextUsageSnapshot struct {
@@ -253,6 +271,14 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	}
 
 	if msgType == claudeMsgTypeSystem {
+		// thinking_tokens is broadcast-only telemetry — intercept it before
+		// session-init handling so its per-delta session_id doesn't needlessly
+		// re-fire UpdateSessionID/BroadcastStatusActive, and before the persist
+		// fallthrough so it never lands in the timeline.
+		if a.handleThinkingTokens(content) {
+			return
+		}
+
 		a.claudeCodeHandleSystemInit(content)
 
 		if isNotificationThreadable(content, source) {
@@ -388,6 +414,66 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// Reset all span tracking so the next turn starts clean.
 		a.sink.ResetSpans()
 	}
+}
+
+// handleThinkingTokens intercepts Claude Code's `system`/`thinking_tokens`
+// telemetry. When the line is a thinking-token update it broadcasts the latest
+// running estimate over the ephemeral agent_session_info channel (seq -1, never
+// written to the messages table) and returns true so the caller skips both
+// session-init handling and persistence. Returns false for any other system
+// message, which continues down the normal persist path.
+func (a *ClaudeCodeAgent) handleThinkingTokens(content []byte) bool {
+	estimate, ok := parseThinkingTokens(content)
+	if !ok {
+		return false
+	}
+	a.sink.BroadcastSessionInfo(map[string]interface{}{
+		SessionInfoKeyThinkingTokens: estimate,
+	})
+	return true
+}
+
+// parseThinkingTokens extracts the sanitized running thinking-token estimate
+// from a Claude `system` line and reports whether the line is a thinking_tokens
+// update at all. Kept pure (no sink, no I/O) so the sanitize rules below can be
+// unit-tested directly rather than only through a full HandleOutput round-trip.
+//
+// estimated_tokens is captured as RawMessage, not a typed number, so the subtype
+// match never depends on the count's wire form. A typed float64 (or int64) field
+// would make json.Unmarshal error on a malformed or out-of-range count -- a
+// quoted "230", an overflowing 1e400 -- returning ok=false and letting the
+// telemetry fall through to session-init + persistence, i.e. the exact timeline
+// bloat this interception exists to prevent. Matching the subtype first
+// decouples "is this a thinking_tokens line?" from "did the count parse?".
+//
+// The count is parsed leniently as float64 so a fractional or exponent form
+// (`230.0`, `1.5e4`) still reads, then sanitized to a non-negative int64 that is
+// always a faithful, in-range count:
+//   - a malformed, absent, or float64-overflowing count (1e400 -> +Inf ->
+//     parse error, leaving the zero value) broadcasts 0;
+//   - a negative count clamps to 0 (a running estimate is non-negative by
+//     definition; a truncated -0.5 or a genuinely negative wire value both
+//     become 0) so no consumer ever sees a negative count;
+//   - a finite count at or above 2^63 (e.g. 1e300, which parses cleanly yet
+//     saturates the int64 conversion to a garbage value) is out of range like
+//     the overflowing 1e400, so it also broadcasts 0 rather than a nonsense
+//     9.2-quintillion count.
+func parseThinkingTokens(content []byte) (estimate int64, ok bool) {
+	var msg struct {
+		Subtype         string          `json:"subtype"`
+		EstimatedTokens json.RawMessage `json:"estimated_tokens"`
+	}
+	if err := json.Unmarshal(content, &msg); err != nil || msg.Subtype != claudeSystemSubtypeThinkingTokens {
+		return 0, false
+	}
+	var f float64
+	if len(msg.EstimatedTokens) > 0 {
+		_ = json.Unmarshal(msg.EstimatedTokens, &f)
+	}
+	if f < 0 || f >= float64(math.MaxInt64) {
+		f = 0
+	}
+	return int64(f), true
 }
 
 // claudeCodeHandleSystemInit extracts session_id from system init messages.
@@ -652,12 +738,21 @@ func findPrimaryContextWindow(modelUsage map[string]json.RawMessage, shortModelI
 			}
 		}
 
-		var mu struct {
-			ContextWindow int64 `json:"contextWindow"`
+		if cw := contextWindowOf(raw); cw > 0 {
+			return cw
 		}
-		if json.Unmarshal(raw, &mu) == nil && mu.ContextWindow > 0 {
-			return mu.ContextWindow
-		}
+	}
+	return 0
+}
+
+// contextWindowOf unmarshals a single modelUsage entry and returns its
+// contextWindow, or 0 when the entry is malformed or carries no positive window.
+func contextWindowOf(raw json.RawMessage) int64 {
+	var mu struct {
+		ContextWindow int64 `json:"contextWindow"`
+	}
+	if json.Unmarshal(raw, &mu) == nil {
+		return mu.ContextWindow
 	}
 	return 0
 }
@@ -666,11 +761,8 @@ func findPrimaryContextWindow(modelUsage map[string]json.RawMessage, shortModelI
 func maxContextWindow(modelUsage map[string]json.RawMessage) int64 {
 	var maxCW int64
 	for _, raw := range modelUsage {
-		var mu struct {
-			ContextWindow int64 `json:"contextWindow"`
-		}
-		if json.Unmarshal(raw, &mu) == nil && mu.ContextWindow > maxCW {
-			maxCW = mu.ContextWindow
+		if cw := contextWindowOf(raw); cw > maxCW {
+			maxCW = cw
 		}
 	}
 	return maxCW

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -565,6 +565,207 @@ func TestHandleOutput_TopLevelAssistantBroadcastsContextUsage(t *testing.T) {
 	assert.Equal(t, int64(30), usage["cache_read_input_tokens"])
 }
 
+func TestHandleOutput_ThinkingTokensBroadcastNotPersisted(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A `system`/`thinking_tokens` line is live telemetry: it must be
+	// broadcast over the ephemeral agent_session_info channel and never
+	// persisted to the timeline. Its per-delta session_id must NOT re-fire
+	// session-init side effects.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 230,
+		"estimated_tokens_delta": 163,
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.NotificationCount(), "thinking_tokens must not be notification-threaded")
+	assert.Equal(t, 0, sink.SessionIDCount(), "thinking_tokens must not re-fire session init")
+	assert.Empty(t, sink.statusActives, "thinking_tokens must not re-broadcast status active")
+
+	require.Equal(t, 1, sink.SessionInfoCount(), "thinking_tokens must broadcast session info")
+	assert.Equal(t, int64(230), sink.LastSessionInfo()["thinking_tokens"])
+}
+
+func TestHandleOutput_ThinkingTokensZeroEstimateStillSwallowed(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A thinking_tokens line with no estimated_tokens yet (the first delta of a
+	// turn can report 0) must still be intercepted: it is broadcast-only and
+	// must never reach the timeline, even though the count is zero. The
+	// frontend's own `> 0` gate decides whether to render it.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "zero-estimate thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.SessionIDCount(), "zero-estimate thinking_tokens must not re-fire session init")
+	require.Equal(t, 1, sink.SessionInfoCount(), "zero-estimate thinking_tokens must still broadcast")
+	assert.Equal(t, int64(0), sink.LastSessionInfo()["thinking_tokens"])
+}
+
+func TestHandleOutput_ThinkingTokensFractionalEstimateStillSwallowed(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A thinking_tokens line whose estimated_tokens arrives in a fractional or
+	// exponent form must still be intercepted. estimated_tokens is decoded as
+	// float64, so `230.0`/`1.5e4` parse cleanly; an int64 field would make the
+	// unmarshal error and let the line fall through to persistence -- the exact
+	// timeline bloat the interception prevents. The count is truncated to int64
+	// for the broadcast.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 15000.0,
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "fractional thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.SessionIDCount(), "fractional thinking_tokens must not re-fire session init")
+	require.Equal(t, 1, sink.SessionInfoCount(), "fractional thinking_tokens must still broadcast")
+	assert.Equal(t, int64(15000), sink.LastSessionInfo()["thinking_tokens"])
+}
+
+func TestHandleOutput_ThinkingTokensMalformedEstimateStillSwallowed(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A thinking_tokens line whose estimated_tokens arrives in an unexpected
+	// wire form -- here a JSON string instead of a number -- must STILL be
+	// intercepted. estimated_tokens is captured as RawMessage, so the subtype
+	// match does not depend on the count parsing; the count is parsed leniently
+	// and a failure broadcasts 0. A typed-number field would error on the
+	// outer unmarshal, return false, and let the line fall through to
+	// session-init + persistence -- the exact timeline bloat this prevents.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": "230",
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "malformed thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.SessionIDCount(), "malformed thinking_tokens must not re-fire session init")
+	require.Equal(t, 1, sink.SessionInfoCount(), "malformed thinking_tokens must still broadcast")
+	assert.Equal(t, int64(0), sink.LastSessionInfo()["thinking_tokens"], "an unparseable count broadcasts 0")
+}
+
+func TestHandleOutput_ThinkingTokensOverflowEstimateStillSwallowed(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// An estimated_tokens that overflows float64 (1e400) makes the lenient
+	// inner parse error; it must still be swallowed (broadcast 0, not
+	// persisted) and must not produce a NaN/Inf -> int64 conversion.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 1e400,
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "overflowing thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.SessionIDCount(), "overflowing thinking_tokens must not re-fire session init")
+	require.Equal(t, 1, sink.SessionInfoCount(), "overflowing thinking_tokens must still broadcast")
+	assert.Equal(t, int64(0), sink.LastSessionInfo()["thinking_tokens"], "an out-of-range count broadcasts 0")
+}
+
+func TestHandleOutput_ThinkingTokensNegativeEstimateClampedToZero(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A running token estimate is non-negative by definition. A negative wire
+	// value must be clamped to 0 at the source (still swallowed, never
+	// persisted) so no consumer ever sees a negative count.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": -42.9,
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "negative thinking_tokens must not be persisted")
+	assert.Equal(t, 0, sink.SessionIDCount(), "negative thinking_tokens must not re-fire session init")
+	require.Equal(t, 1, sink.SessionInfoCount(), "negative thinking_tokens must still broadcast")
+	assert.Equal(t, int64(0), sink.LastSessionInfo()["thinking_tokens"], "a negative count clamps to 0")
+}
+
+func TestHandleOutput_ThinkingTokensFiniteHugeEstimateClampedToZero(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A finite but absurd estimate (1e300) parses cleanly into float64 -- unlike
+	// 1e400, it does NOT overflow the inner unmarshal -- yet it is far above
+	// math.MaxInt64, so int64(1e300) would saturate to a garbage ~9.2-quintillion
+	// count. It must be treated as out of range like 1e400 and broadcast 0, not a
+	// nonsense count, so the two huge-input paths agree.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 1e300,
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 0, sink.MessageCount(), "finite-huge thinking_tokens must not be persisted")
+	require.Equal(t, 1, sink.SessionInfoCount(), "finite-huge thinking_tokens must still broadcast")
+	assert.Equal(t, int64(0), sink.LastSessionInfo()["thinking_tokens"], "a finite-huge count broadcasts 0")
+}
+
+func TestParseThinkingTokens(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantEstimate int64
+		wantOK       bool
+	}{
+		{"plain integer", `{"subtype":"thinking_tokens","estimated_tokens":230}`, 230, true},
+		{"fractional", `{"subtype":"thinking_tokens","estimated_tokens":15000.0}`, 15000, true},
+		{"exponent", `{"subtype":"thinking_tokens","estimated_tokens":1.5e4}`, 15000, true},
+		{"truncates toward zero", `{"subtype":"thinking_tokens","estimated_tokens":230.9}`, 230, true},
+		{"absent count broadcasts 0", `{"subtype":"thinking_tokens"}`, 0, true},
+		{"string count broadcasts 0", `{"subtype":"thinking_tokens","estimated_tokens":"230"}`, 0, true},
+		{"null count broadcasts 0", `{"subtype":"thinking_tokens","estimated_tokens":null}`, 0, true},
+		{"float64-overflow (1e400) broadcasts 0", `{"subtype":"thinking_tokens","estimated_tokens":1e400}`, 0, true},
+		{"finite-huge (1e300) broadcasts 0", `{"subtype":"thinking_tokens","estimated_tokens":1e300}`, 0, true},
+		{"negative clamps to 0", `{"subtype":"thinking_tokens","estimated_tokens":-42.9}`, 0, true},
+		{"non-thinking subtype is not a match", `{"subtype":"init","estimated_tokens":230}`, 0, false},
+		{"missing subtype is not a match", `{"estimated_tokens":230}`, 0, false},
+		{"invalid JSON is not a match", `{"subtype":`, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			estimate, ok := parseThinkingTokens([]byte(tt.content))
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantEstimate, estimate)
+		})
+	}
+}
+
+func TestHandleOutput_NonThinkingSystemMessageStillPersists(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+
+	// A plain `system` message that is neither a thinking_tokens line nor a
+	// notification-threaded subtype falls through to persistence unchanged —
+	// the thinking_tokens interception must not swallow other system lines.
+	agent.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "init",
+		"session_id": "a40e65f9-f1f2-4e8b-b089-abc9692345b2"
+	}`))
+
+	assert.Equal(t, 1, sink.MessageCount(), "non-thinking system message must persist")
+	assert.Equal(t, 0, sink.SessionInfoCount(), "non-thinking system message must not broadcast thinking session info")
+	assert.Equal(t, 1, sink.SessionIDCount(), "init message should update session id")
+}
+
 func TestIsRetryableClaudeResultError(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -1036,6 +1036,22 @@ func (s *agentOutputSink) BroadcastGitStatus() {
 	})
 }
 
+// thinkingTokensSessionInfoKey is the agent_session_info key carrying Claude's
+// per-turn thinking-token estimate. Unlike cost/rate-limit/context-usage keys
+// (which carry meaningfully across turns and benefit from dedup), this is a
+// per-turn running count the frontend clears at several boundaries the worker
+// can't all observe (the turn-end divider, each interleaved thinking phase, a
+// pause for input). Deduping it here would suppress a re-broadcast of a value
+// the frontend already cleared -- leaving the counter hidden until a strictly
+// different estimate arrives. It streams unique monotonic values normally and
+// the frontend store dedups identical updates itself, so BroadcastSessionInfo
+// skips the dedup cache for this one key entirely (always ship, never cache).
+//
+// Sourced from the agent package's broadcast key so the exemption keys off the
+// exact same string the Claude handler ships, instead of a hand-copied literal
+// that could silently drift and re-enable the dedup.
+const thinkingTokensSessionInfoKey = agent.SessionInfoKeyThinkingTokens
+
 // BroadcastSessionInfo emits an ephemeral agent_session_info update,
 // but only for keys whose values changed since the previous broadcast.
 // Agent handlers commonly re-emit identical payloads (Pi especially,
@@ -1062,6 +1078,13 @@ func (s *agentOutputSink) BroadcastSessionInfo(info map[string]interface{}) {
 	}
 	changed := make(map[string]interface{}, len(info))
 	for k, v := range info {
+		// thinking_tokens is exempt from dedup -- always ship it and never cache
+		// it, so a re-broadcast after a frontend-side clear is never suppressed.
+		// See thinkingTokensSessionInfoKey.
+		if k == thinkingTokensSessionInfoKey {
+			changed[k] = v
+			continue
+		}
 		encoded, err := json.Marshal(v)
 		if err != nil {
 			// Can't dedup without canonical bytes — pass through.

--- a/backend/internal/worker/service/output_session_info_dedup_test.go
+++ b/backend/internal/worker/service/output_session_info_dedup_test.go
@@ -215,6 +215,37 @@ func TestBroadcastSessionInfo_ValueTypeChangeShips(t *testing.T) {
 	assert.Equal(t, "one", infos[1]["a"])
 }
 
+// TestBroadcastSessionInfo_ThinkingTokensNeverDeduped: the per-turn
+// thinking_tokens estimate is exempt from the per-key dedup. The frontend clears
+// its counter at several boundaries the worker can't all observe (turn end, each
+// interleaved thinking phase, a pause for input), so a re-broadcast of an
+// unchanged estimate must still ship -- otherwise the cleared counter would stay
+// hidden until a strictly different value arrived. Other keys stay deduped.
+func TestBroadcastSessionInfo_ThinkingTokensNeverDeduped(t *testing.T) {
+	sink, mock := newSessionInfoFixture(t)
+
+	// Two byte-identical thinking_tokens broadcasts both ship -- no dedup.
+	sink.BroadcastSessionInfo(map[string]interface{}{"thinking_tokens": int64(230)})
+	sink.BroadcastSessionInfo(map[string]interface{}{"thinking_tokens": int64(230)})
+	require.Len(t, mock.snapshot(), 2, "an equal thinking_tokens repeat re-ships (exempt from dedup)")
+
+	// A non-thinking key is still deduped: an unchanged repeat is dropped.
+	sink.BroadcastSessionInfo(map[string]interface{}{"total_cost_usd": float64(0.5)})
+	sink.BroadcastSessionInfo(map[string]interface{}{"total_cost_usd": float64(0.5)})
+	assert.Len(t, mock.snapshot(), 3, "a non-thinking key remains deduped")
+
+	// In a mixed payload, only the non-thinking key dedups: an unchanged
+	// thinking_tokens alongside an unchanged cost still ships (carrying just the
+	// estimate), and the cost is filtered out as a no-op delta.
+	sink.BroadcastSessionInfo(map[string]interface{}{"thinking_tokens": int64(230), "total_cost_usd": float64(0.5)})
+	infos := mock.snapshot()
+	require.Len(t, infos, 4, "a mixed payload re-ships because thinking_tokens is never deduped")
+	// The capturing writer round-trips through JSON, so the count returns as float64.
+	assert.Equal(t, float64(230), infos[3]["thinking_tokens"])
+	_, hasCost := infos[3]["total_cost_usd"]
+	assert.False(t, hasCost, "the unchanged cost is still deduped out of the mixed payload")
+}
+
 // TestBroadcastSessionInfo_ConcurrentCallsAreRaceFree drives many
 // goroutines through the same sink under -race. The cache may produce
 // either 1 or 2 broadcasts depending on interleaving (last-writer-wins

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -47,6 +47,12 @@ interface ChatViewProps {
   /** Whether the agent is actively working (for showing the thinking indicator). */
   agentWorking?: boolean
   /**
+   * Running estimate of the in-flight turn's thinking (reasoning) tokens,
+   * forwarded to the thinking indicator. Broadcast-only telemetry, cleared at
+   * turn boundaries.
+   */
+  thinkingTokens?: number
+  /**
    * Whether this ChatView is the active tab in its tile. Forwarded to the
    * thinking indicator so it can suspend its compass simulation when the
    * user can't see it (every agent tab is mounted, including hidden ones).
@@ -400,6 +406,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                 <ThinkingIndicator
                   id={props.agentId}
                   visible={props.agentWorking ?? false}
+                  thinkingTokens={props.thinkingTokens}
                   paused={props.tabActive === false}
                   onExpandTick={() => {
                     if (scroll.isAtBottomFresh())

--- a/frontend/src/components/chat/rendererUtils.test.ts
+++ b/frontend/src/components/chat/rendererUtils.test.ts
@@ -83,6 +83,41 @@ describe('formatTokenCount', () => {
   })
 })
 
+describe('formatTokenCount with a custom decimal precision', () => {
+  it('defaults to one decimal when precision is omitted', () => {
+    expect(formatTokenCount(1234)).toBe('1.2k')
+    expect(formatTokenCount(1_234_567)).toBe('1.2M')
+  })
+
+  it('renders k/M to the requested number of decimals', () => {
+    // The thinking-token counter passes 2 so its fast increments read finely.
+    expect(formatTokenCount(4950, 2)).toBe('4.95k')
+    expect(formatTokenCount(1234, 2)).toBe('1.23k')
+    expect(formatTokenCount(1_234_567, 2)).toBe('1.23M')
+    expect(formatTokenCount(1_000_000, 2)).toBe('1.00M')
+  })
+
+  it('leaves sub-1k values undecorated regardless of precision', () => {
+    expect(formatTokenCount(999, 2)).toBe('999')
+    expect(formatTokenCount(0, 2)).toBe('0')
+  })
+
+  it('tightens the M-promotion boundary as precision grows', () => {
+    // At two decimals "1000.00k" appears only at 999_995+, so the cutoff moves
+    // up from the one-decimal 999_950: 999_994 stays k, 999_995 promotes to M.
+    expect(formatTokenCount(999_994, 2)).toBe('999.99k')
+    expect(formatTokenCount(999_995, 2)).toBe('1.00M')
+  })
+
+  it('falls back to "0" for non-finite input rather than emitting a broken string', () => {
+    // No caller in the thinking-token pipeline passes these, but formatTokenCount
+    // is shared: NaN/Infinity must not render as "NaN" / "InfinityM".
+    expect(formatTokenCount(Number.NaN)).toBe('0')
+    expect(formatTokenCount(Number.POSITIVE_INFINITY, 2)).toBe('0')
+    expect(formatTokenCount(Number.NEGATIVE_INFINITY)).toBe('0')
+  })
+})
+
 describe('joinMetaParts', () => {
   it('joins truthy strings with ` · `', () => {
     expect(joinMetaParts(['a', 'b', 'c'])).toBe('a · b · c')

--- a/frontend/src/components/chat/rendererUtils.ts
+++ b/frontend/src/components/chat/rendererUtils.ts
@@ -60,19 +60,31 @@ export function formatNumber(n: number): string {
   return n.toLocaleString('en-US')
 }
 
-/** Format a token count with a fixed decimal (e.g. 1.0k, 12.3M). */
-export function formatTokenCount(n: number): string {
+/**
+ * Format a token count with a fixed number of decimals (default 1: "1.0k",
+ * "12.3M"). `decimals` controls the k/M precision — the thinking-token counter
+ * passes 2 ("4.95k", "1.23M") so its fast increments read at finer resolution.
+ */
+export function formatTokenCount(n: number, decimals = 1): string {
+  // Guard non-finite input (NaN/Infinity) before bucketing: Math.round leaves
+  // them non-finite and toFixed would render "InfinityM"/"NaN". No caller in
+  // this pipeline passes a non-finite count, but this is a shared util -- fall
+  // back to "0" rather than emitting a broken string.
+  if (!Number.isFinite(n))
+    return '0'
   // Token counts are conceptually integers; round a stray fractional input
   // (e.g. a server-estimated size) before bucketing so the sub-1k branch
   // can't leak decimals as "999.5" -- and round BEFORE the threshold checks so
   // a value like 999.6 promotes to the "1.0k" bucket instead of "1000".
   const rounded = Math.round(n)
-  // 999_950+ would round up to "1000.0k" at one decimal, so promote it to the M
-  // unit ("1.0M") rather than rendering a four-digit thousands value.
-  if (rounded >= 999_950)
-    return `${(rounded / 1_000_000).toFixed(1)}M`
+  // Promote to M before the k value would round up to a four-digit thousands
+  // display ("1000.0k" at 1 decimal, "1000.00k" at 2). The cutoff tightens as
+  // precision grows: 1_000_000 - 5 * 10**(2 - decimals) (== 999_950 at 1dp).
+  const promoteToM = 1_000_000 - 5 * 10 ** (2 - decimals)
+  if (rounded >= promoteToM)
+    return `${(rounded / 1_000_000).toFixed(decimals)}M`
   if (rounded >= 1_000)
-    return `${(rounded / 1_000).toFixed(1)}k`
+    return `${(rounded / 1_000).toFixed(decimals)}k`
   return String(rounded)
 }
 

--- a/frontend/src/components/chat/widgets/ThinkingIndicator.css.ts
+++ b/frontend/src/components/chat/widgets/ThinkingIndicator.css.ts
@@ -25,6 +25,20 @@ export const compass = style({
   flexShrink: 0,
 })
 
+// verbRow pairs the verb with the optional thinking-token count on a shared
+// text baseline. The outer container centers the 24px compass against this
+// row, but its `align-items: center` would otherwise center the smaller count
+// against the larger verb — aligning their visual centers, not their
+// baselines, so the count rides high. Grouping them in a baseline row pins the
+// count's baseline to the verb's regardless of the font-size difference. The
+// per-char wave transform on the verb doesn't shift the baseline (transforms
+// are applied after layout), so the count stays put while the verb bobs.
+export const verbRow = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 'var(--space-1)',
+})
+
 // verbStack hosts two overlapping verb spans so we can crossfade
 // between them on each 60s in-turn rotation. Grid layout with
 // `grid-template: 1fr / 1fr` puts both spans in the same cell;
@@ -37,17 +51,42 @@ export const verbStack = style({
   gridTemplate: '1fr / 1fr',
 })
 
-export const verb = style({
+// Shared metrics for everything stacked in the single verb grid cell: the same
+// cell anchor (gridArea), baseline alignment, and font so each slot — and the
+// strut — synthesizes an identical text baseline. The strut depends on matching
+// the verb's font EXACTLY (see baselineStrut), so sharing this base makes the
+// two provably agree instead of relying on two hand-kept-in-sync copies.
+const verbSlotBase = {
   gridArea: '1 / 1',
+  // Align to the shared cell baseline (the strut's) so a slot's text always
+  // sits on the same baseline; default `stretch` would let an empty slot
+  // shift the grid baseline. See baselineStrut.
+  alignSelf: 'baseline',
   fontSize: 'var(--text-7)',
   fontWeight: 'var(--font-bold)',
   userSelect: 'none',
+} as const
+
+// baselineStrut is an always-present, zero-width, never-painted anchor that
+// fixes the grid's baseline. Without it, `verbRow`'s baseline alignment reads
+// the grid's baseline from whichever slot currently holds text — and after a
+// 60s rotation the active verb moves to the other slot while the first is
+// cleared to '', leaving an empty slot whose synthesized baseline yanks the
+// whole verb vertically. The strut carries the verb's exact font metrics, so
+// it always supplies the same text baseline regardless of which slot is empty.
+export const baselineStrut = style([verbSlotBase, {
+  width: 0,
+  overflow: 'hidden',
+  visibility: 'hidden',
+}])
+
+export const verb = style([verbSlotBase, {
   opacity: 0,
   // ROTATION_FADE_MS in ThinkingIndicator.tsx tracks this duration —
   // keep them in lockstep so the inactive-slot clear lands exactly
   // when the fade visually completes.
   transition: 'opacity 500ms ease-in-out',
-})
+}])
 
 // Applied to whichever of the two stacked slots is currently the
 // "live" one. The other slot stays opacity 0; CSS transitions on

--- a/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
@@ -1,0 +1,84 @@
+/// <reference types="vitest/globals" />
+import { render } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { ThinkingIndicator } from './ThinkingIndicator'
+
+// The token-count <Show> gates on BOTH `visible` and a positive estimate, so the
+// count's presence is asserted against the visibility it is meant to track.
+//
+// Rendering visible=true normally drives the expand-tick rAF loop, which the
+// synchronous test rAF stub would recurse into forever; `renderVisible` stubs
+// rAF to a no-op for the render and passes paused=true so the compass sim and
+// verb-rotation interval stay idle. Hidden cases render visible=false directly.
+function renderVisible(thinkingTokens?: number) {
+  const realRaf = globalThis.requestAnimationFrame
+  globalThis.requestAnimationFrame = (() => 0) as typeof globalThis.requestAnimationFrame
+  try {
+    return render(() => (
+      <ThinkingIndicator visible={true} paused={true} thinkingTokens={thinkingTokens} />
+    ))
+  }
+  finally {
+    globalThis.requestAnimationFrame = realRaf
+  }
+}
+
+describe('thinking indicator token count', () => {
+  it('renders the running thinking-token count when visible and positive', () => {
+    const { getByText } = renderVisible(1234)
+    expect(getByText('1.23k tokens')).toBeInTheDocument()
+  })
+
+  it('renders a sub-1k estimate verbatim, without a k suffix', () => {
+    // 230 is the literal value from the original thinking_tokens payload.
+    const { getByText } = renderVisible(230)
+    expect(getByText('230 tokens')).toBeInTheDocument()
+  })
+
+  it('does not render the count while hidden, even with a positive estimate', () => {
+    // The estimate's clear is event-driven, so a stale value can briefly outlive
+    // the indicator; gating the count on `visible` keeps it from rendering (and
+    // running its roll effects) inside a collapsed, invisible row.
+    const { queryByText } = render(() => (
+      <ThinkingIndicator visible={false} thinkingTokens={1234} />
+    ))
+    expect(queryByText(/tokens/)).toBeNull()
+  })
+
+  it('renders nothing when the estimate is absent', () => {
+    const { queryByText } = renderVisible(undefined)
+    expect(queryByText(/tokens/)).toBeNull()
+  })
+
+  it('renders nothing when the estimate is zero', () => {
+    const { queryByText } = renderVisible(0)
+    expect(queryByText(/tokens/)).toBeNull()
+  })
+
+  it('keeps the count mounted through the row fade after hiding, then unmounts it', () => {
+    vi.useFakeTimers()
+    const realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = (() => 0) as typeof globalThis.requestAnimationFrame
+    try {
+      const [visible, setVisible] = createSignal(true)
+      const { queryByText } = render(() => (
+        <ThinkingIndicator visible={visible()} paused={true} thinkingTokens={500} />
+      ))
+      expect(queryByText('500 tokens')).toBeInTheDocument()
+
+      // The indicator hides (turn end). The count must NOT pop — it stays
+      // mounted (frozen on its last value) to fade out with the collapsing row.
+      setVisible(false)
+      expect(queryByText('500 tokens')).toBeInTheDocument()
+
+      // Once the wrapper's opacity fade (ROW_FADE_MS = 300) elapses, it unmounts.
+      vi.advanceTimersByTime(300)
+      expect(queryByText('500 tokens')).toBeNull()
+    }
+    finally {
+      globalThis.requestAnimationFrame = realRaf
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/components/chat/widgets/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingIndicator.tsx
@@ -1,8 +1,9 @@
 import type { Component, JSX } from 'solid-js'
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, untrack } from 'solid-js'
 import { createCompassSimulation } from '../compassPhysics'
 import { getRandomVerb } from '../spinnerVerbs'
 import * as styles from './ThinkingIndicator.css'
+import { ThinkingTokenCount } from './ThinkingTokenCount'
 
 export interface ThinkingIndicatorProps {
   visible: boolean
@@ -25,6 +26,13 @@ export interface ThinkingIndicatorProps {
    * on the 60s in-turn rotation, with a crossfade).
    */
   id?: string
+  /**
+   * Running estimate of the in-flight turn's thinking (reasoning) tokens,
+   * surfaced as a small count beside the verb. Broadcast-only telemetry that
+   * is cleared at turn boundaries; rendered only while positive so an idle
+   * indicator shows nothing.
+   */
+  thinkingTokens?: number
 }
 
 // How often the verb rotates while the indicator is visible (and not
@@ -37,6 +45,11 @@ const ROTATION_INTERVAL_MS = 60_000
 // content can be cleared without affecting the grid cell width during
 // the fade itself.
 const ROTATION_FADE_MS = 500
+// The wrapper's opacity-fade duration when the indicator collapses (the 0.3s
+// `opacity` transition in the render style below). The token count holds its
+// last value mounted for this long after the gate closes so it fades out WITH
+// the collapsing row instead of popping; see `countTokens`.
+const ROW_FADE_MS = 300
 
 // Module-level cache of the indicator's persistent state per id —
 // the verb currently displayed and the last compass angle (in
@@ -78,28 +91,29 @@ function trimCache(): void {
   }
 }
 
-function cacheVerb(id: string | undefined, verb: string): void {
+// Merge a patch into id's cached snapshot: mutate the existing entry in place
+// (so the FIFO insertion order isn't disturbed and only first-seen ids advance
+// the eviction queue), or insert + trim for a new id. cacheVerb/cacheAngle are
+// thin single-field wrappers so call sites read as intent ("cache the verb")
+// and an accidental multi-key patch can't clobber an unrelated cached field.
+function cacheSnapshot(id: string | undefined, patch: Partial<IndicatorSnapshot>): void {
   if (id === undefined)
     return
   const existing = indicatorCache.get(id)
   if (existing) {
-    existing.verb = verb
+    Object.assign(existing, patch)
     return
   }
-  indicatorCache.set(id, { verb })
+  indicatorCache.set(id, { ...patch })
   trimCache()
 }
 
+function cacheVerb(id: string | undefined, verb: string): void {
+  cacheSnapshot(id, { verb })
+}
+
 function cacheAngle(id: string | undefined, angleRad: number): void {
-  if (id === undefined)
-    return
-  const existing = indicatorCache.get(id)
-  if (existing) {
-    existing.angleRad = angleRad
-    return
-  }
-  indicatorCache.set(id, { angleRad })
-  trimCache()
+  cacheSnapshot(id, { angleRad })
 }
 
 function pickAndCacheVerb(id: string | undefined): string {
@@ -176,6 +190,35 @@ export const ThinkingIndicator: Component<ThinkingIndicatorProps> = (props) => {
   let rotateIntervalId: ReturnType<typeof setInterval> | undefined
   const pendingClearTimers = new Set<ReturnType<typeof setTimeout>>()
   let wasVisible = initiallyVisible
+
+  // The token count's mounted value, decoupled from the live estimate so it can
+  // fade out WITH the collapsing row instead of popping. While the count should
+  // show (indicator visible + a positive estimate) it tracks the live value; when
+  // the gate closes it freezes the last value mounted for ROW_FADE_MS (the
+  // wrapper's opacity fade) and then unmounts. The frozen value means no roll
+  // effects fire during the fade.
+  const [countTokens, setCountTokens] = createSignal<number | undefined>(undefined)
+  let countFadeTimer: ReturnType<typeof setTimeout> | undefined
+  createEffect(() => {
+    const tokens = props.thinkingTokens
+    if (props.visible && (tokens ?? 0) > 0) {
+      if (countFadeTimer !== undefined) {
+        clearTimeout(countFadeTimer)
+        countFadeTimer = undefined
+      }
+      setCountTokens(tokens)
+      return
+    }
+    // Gate closed: keep the last value mounted through the wrapper's opacity
+    // fade, then unmount. untrack the read so this effect doesn't depend on its
+    // own write (it tracks only props.visible / props.thinkingTokens).
+    if (untrack(countTokens) !== undefined && countFadeTimer === undefined) {
+      countFadeTimer = setTimeout(() => {
+        countFadeTimer = undefined
+        setCountTokens(undefined)
+      }, ROW_FADE_MS)
+    }
+  })
 
   // Drive `onExpandTick` for ~700ms so the parent's scroll-sticky
   // binding can re-pin to the bottom on every frame while the
@@ -306,6 +349,8 @@ export const ThinkingIndicator: Component<ThinkingIndicatorProps> = (props) => {
     for (const t of pendingClearTimers)
       clearTimeout(t)
     pendingClearTimers.clear()
+    if (countFadeTimer !== undefined)
+      clearTimeout(countFadeTimer)
   })
 
   const verbSpan = (
@@ -398,9 +443,21 @@ export const ThinkingIndicator: Component<ThinkingIndicatorProps> = (props) => {
               </g>
             </g>
           </svg>
-          <span class={styles.verbStack}>
-            {verbSpan(true, charsA, highlightPosA)}
-            {verbSpan(false, charsB, highlightPosB)}
+          <span class={styles.verbRow}>
+            <span class={styles.verbStack}>
+              {/* Stable baseline anchor — see baselineStrut in the CSS. */}
+              <span class={styles.baselineStrut} aria-hidden="true">{' '}</span>
+              {verbSpan(true, charsA, highlightPosA)}
+              {verbSpan(false, charsB, highlightPosB)}
+            </span>
+            {/* `countTokens` (not the raw prop) gates the count: it tracks the
+                live estimate while the indicator is visible, then holds the last
+                value for ROW_FADE_MS so the count fades out WITH the collapsing
+                row instead of popping — and unmounts after, so a stale estimate
+                can't keep it (or its roll effects) alive in a collapsed row. */}
+            <Show when={countTokens() !== undefined}>
+              <ThinkingTokenCount tokens={countTokens()!} />
+            </Show>
           </span>
         </div>
       </div>

--- a/frontend/src/components/chat/widgets/ThinkingTokenCount.css.ts
+++ b/frontend/src/components/chat/widgets/ThinkingTokenCount.css.ts
@@ -1,0 +1,143 @@
+import { keyframes, style } from '@vanilla-extract/css'
+
+// Vertical size of one digit cell — also the per-digit roll distance. Tied to
+// the count's font-size (em) so the strip scales with the surrounding text.
+const CELL = '1.3em'
+
+// Crossfade duration for a format change. Imported by the component (as
+// styles.SWAP_MS) for the fade-out layer's removal timer, so the timer and this
+// CSS animation share one source of truth.
+export const SWAP_MS = 180
+
+// root is the baseline-aligned item inside the verb row.
+export const root = style({
+  display: 'inline-block',
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  // Fixed-width digits so a rolling column never changes width mid-roll and the
+  // hidden ghost matches the visible digits' advance exactly.
+  fontVariantNumeric: 'tabular-nums',
+  userSelect: 'none',
+  whiteSpace: 'nowrap',
+  lineHeight: CELL,
+})
+
+// Screen-reader-only copy of the full "<n> tokens" text. The visual odometer is
+// aria-hidden (its DOM is a pile of 0-9 strips that read as gibberish), so this
+// carries the real value for assistive tech — and gives tests a stable hook.
+export const srOnly = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  border: 0,
+  overflow: 'hidden',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+})
+
+// numberBox sizes and baselines the number from an in-flow hidden ghost; the
+// rolling digits are painted by absolutely-positioned overlays on top of it, so
+// the overlays' clipped (baseline-less) columns never affect where the number
+// sits relative to " tokens" and the verb.
+export const numberBox = style({
+  position: 'relative',
+  display: 'inline-block',
+})
+
+export const numberGhost = style({
+  visibility: 'hidden',
+})
+
+const fadeIn = keyframes({ from: { opacity: 0 }, to: { opacity: 1 } })
+const fadeOut = keyframes({ from: { opacity: 1 }, to: { opacity: 0 } })
+
+// Fades a freshly-mounted slot in: the new leading column when the number grows
+// a digit, or every slot of the live layer when it is swapped for a unit
+// crossfade. Runs once on mount, so persisting (rolling) columns never re-fade.
+export const slotEnter = style({
+  'animation': `${fadeIn} ${SWAP_MS}ms ease-out`,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
+})
+
+// A layer of rendered digits overlaid on the ghost, and the base both layers
+// share. flex-start keeps every column and static char top-aligned in an
+// equal-height (CELL) line, so their glyphs line up with each other and with the
+// ghost beneath. row-reverse lays the slots out right-to-left so the number is
+// anchored at its right edge — a new leading digit is appended (in DOM) and
+// appears on the left without reshuffling the existing columns' identities. The
+// live layer stays at full opacity; on a format change the prior value is
+// overlaid on top (see exitingLayer) and fades out, dissolving to reveal this.
+export const liveLayer = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  display: 'flex',
+  flexDirection: 'row-reverse',
+  alignItems: 'flex-start',
+})
+
+// A snapshot of the prior value — the live layer's layout plus a fade-out —
+// drawn over the live layer during a format change.
+export const exitingLayer = style([liveLayer, {
+  'animation': `${fadeOut} ${SWAP_MS}ms ease-out forwards`,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 },
+  },
+}])
+
+// One digit position: a window onto a 0-9 strip, clipped by overflow:hidden.
+// Its width and height come from an in-flow hidden sizer digit (see columnSizer)
+// rather than the `ch` unit — `ch` does not track the tabular-figure advance, so
+// 1ch left visible gaps around each digit and pushed the unit char into
+// " tokens" (worse under zoom, where ch and glyph widths round apart). The sizer
+// uses the real rendered digit, so columns match the ghost exactly.
+//
+// position:relative is the containing block for the absolutely-positioned strip.
+export const column = style({
+  position: 'relative',
+  display: 'inline-block',
+  overflow: 'hidden',
+})
+
+export const columnSizer = style({
+  visibility: 'hidden',
+})
+
+export const strip = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  // transform + transition are driven imperatively per column (a forward-rolling
+  // odometer that always travels upward, even across a 9->0 carry); only the
+  // per-cell metric lives here, read by the inline transform via var(--cell).
+  vars: { '--cell': CELL },
+})
+
+// One CELL-tall, centered line. Shared by the rolling strip cells and the
+// static point/unit chars so both sit on the same row; kept in one place so the
+// cell height can't drift between them (a mismatch would misalign the digits
+// against the decimal point and k/M unit).
+const cellLine = {
+  height: CELL,
+  lineHeight: CELL,
+  textAlign: 'center',
+} as const
+
+export const stripCell = style([cellLine, {
+  // block (not the span default of inline) so the strip's cells stack vertically
+  // at CELL intervals — the whole premise of the translateY roll. As inline text
+  // they flow into one horizontal "0123456789" line and the roll slides it out
+  // of view for every non-zero digit.
+  display: 'block',
+}])
+
+// Non-digit characters (the decimal point and the k/M unit), sized like a cell
+// so they share the columns' line.
+export const staticChar = style([cellLine, {
+  display: 'inline-block',
+}])

--- a/frontend/src/components/chat/widgets/ThinkingTokenCount.test.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingTokenCount.test.tsx
@@ -1,0 +1,129 @@
+/// <reference types="vitest/globals" />
+import { render, waitFor } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { forwardDelta, shapeFamily, ThinkingTokenCount } from './ThinkingTokenCount'
+import * as styles from './ThinkingTokenCount.css'
+
+// The visible odometer reads data-digit off each rolling column, so tests can
+// assert the displayed value without depending on CSS transforms. Columns are
+// laid out right-to-left (row-reverse), so reverse the DOM order to read them in
+// most-significant-first order.
+function visibleDigits(container: HTMLElement): string {
+  return Array.from(container.querySelectorAll('[data-testid="odo-digit"]'))
+    .map(el => el.getAttribute('data-digit'))
+    .reverse()
+    .join('')
+}
+
+describe('forwardDelta', () => {
+  it('advances forward through the 9->0 wrap, never backward', () => {
+    expect(forwardDelta(9, 0)).toBe(1) // the carry: up through the wrap, not -9
+    expect(forwardDelta(2, 5)).toBe(3)
+    expect(forwardDelta(7, 2)).toBe(5) // 7->8->9->0->1->2
+    expect(forwardDelta(5, 5)).toBe(0)
+    expect(forwardDelta(0, 9)).toBe(9)
+  })
+})
+
+describe('shapeFamily', () => {
+  it('groups values by unit so same-unit growth shares a family', () => {
+    // Bare integers are one family, regardless of digit count.
+    expect(shapeFamily('99')).toBe('')
+    expect(shapeFamily('100')).toBe('')
+    expect(shapeFamily('999')).toBe('')
+    // k is its own family across the column-growth boundary.
+    expect(shapeFamily('1.0k')).toBe('k')
+    expect(shapeFamily('9.9k')).toBe('k')
+    expect(shapeFamily('10.0k')).toBe('k')
+    expect(shapeFamily('999.9k')).toBe('k')
+    // M likewise.
+    expect(shapeFamily('1.0M')).toBe('M')
+  })
+
+  it('changes family only when the unit changes (the crossfade trigger)', () => {
+    expect(shapeFamily('999') === shapeFamily('1.0k')).toBe(false) // integer -> k
+    expect(shapeFamily('999.9k') === shapeFamily('1.0M')).toBe(false) // k -> M
+    expect(shapeFamily('9.9k') === shapeFamily('10.0k')).toBe(true) // growth within k
+  })
+})
+
+describe('thinking token count', () => {
+  it('exposes the formatted value as accessible text', () => {
+    const { getByText } = render(() => <ThinkingTokenCount tokens={230} />)
+    expect(getByText('230 tokens')).toBeInTheDocument()
+  })
+
+  it('compacts large values in the accessible text, to two decimals', () => {
+    const { getByText } = render(() => <ThinkingTokenCount tokens={1234} />)
+    expect(getByText('1.23k tokens')).toBeInTheDocument()
+  })
+
+  it('renders one rolling column per digit of the formatted value', () => {
+    const { container } = render(() => <ThinkingTokenCount tokens={230} />)
+    expect(visibleDigits(container)).toBe('230')
+  })
+
+  it('rolls digits in place while the digit-shape is stable', () => {
+    const [tokens, setTokens] = createSignal(230)
+    const { container, queryAllByTestId } = render(() => <ThinkingTokenCount tokens={tokens()} />)
+    expect(visibleDigits(container)).toBe('230')
+
+    setTokens(265)
+
+    expect(visibleDigits(container)).toBe('265')
+    // Same family => roll, not crossfade: no outgoing snapshot layer.
+    expect(queryAllByTestId('odo-exiting')).toHaveLength(0)
+  })
+
+  it('grows a new leading column without crossfading when the unit is unchanged', () => {
+    const [tokens, setTokens] = createSignal(99)
+    const { container, queryAllByTestId } = render(() => <ThinkingTokenCount tokens={tokens()} />)
+    expect(visibleDigits(container)).toBe('99')
+
+    setTokens(100) // "99" -> "100": same family (bare integer), one digit longer
+
+    expect(visibleDigits(container)).toBe('100')
+    expect(queryAllByTestId('odo-digit')).toHaveLength(3) // grew a column
+    expect(queryAllByTestId('odo-exiting')).toHaveLength(0) // no crossfade
+  })
+
+  it('grows a leading digit within the k family, around the decimal/unit', () => {
+    const [tokens, setTokens] = createSignal(9900)
+    const { container, queryAllByTestId } = render(() => <ThinkingTokenCount tokens={tokens()} />)
+    expect(visibleDigits(container)).toBe('990') // "9.90k"
+
+    setTokens(10000) // "9.90k" -> "10.00k": same family, new leading digit
+
+    expect(visibleDigits(container)).toBe('1000') // "10.00k"
+    expect(queryAllByTestId('odo-digit')).toHaveLength(4) // 9,9,0 -> 1,0,0,0
+    expect(queryAllByTestId('odo-exiting')).toHaveLength(0) // grow, don't crossfade
+  })
+
+  it('crossfades a fading-out snapshot when the unit family changes', async () => {
+    const [tokens, setTokens] = createSignal(999)
+    const { queryAllByTestId } = render(() => <ThinkingTokenCount tokens={tokens()} />)
+    expect(queryAllByTestId('odo-exiting')).toHaveLength(0)
+
+    setTokens(1234) // "999" (integer) -> "1.23k" (k): unit family changes
+
+    await waitFor(() => expect(queryAllByTestId('odo-exiting')).toHaveLength(1))
+    // The snapshot is removed once its fade completes.
+    await waitFor(() => expect(queryAllByTestId('odo-exiting')).toHaveLength(0))
+  })
+
+  it('fades the outgoing snapshot as a whole, not digit-by-digit', async () => {
+    const [tokens, setTokens] = createSignal(999)
+    const { getByTestId, queryAllByTestId } = render(() => <ThinkingTokenCount tokens={tokens()} />)
+
+    setTokens(1234) // "999" -> "1.23k": family change -> crossfade
+
+    await waitFor(() => expect(queryAllByTestId('odo-exiting')).toHaveLength(1))
+    const snapshotDigits = getByTestId('odo-exiting').querySelectorAll('[data-testid="odo-digit"]')
+    expect(snapshotDigits.length).toBeGreaterThan(0)
+    // The snapshot's digits must not carry the entry fade — only the layer fades
+    // out. Otherwise the old digits would fade in while the layer fades out.
+    for (const digit of snapshotDigits)
+      expect(digit.classList.contains(styles.slotEnter)).toBe(false)
+  })
+})

--- a/frontend/src/components/chat/widgets/ThinkingTokenCount.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingTokenCount.tsx
@@ -1,0 +1,339 @@
+import type { Component } from 'solid-js'
+import { createEffect, createMemo, For, Index, onCleanup, onMount, Show } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
+import { formatTokenCount } from '../rendererUtils'
+import * as styles from './ThinkingTokenCount.css'
+
+// The strip repeats 0-9 several times so a forward roll always has cells ahead
+// of it; `pos` (the shown cell index) only increases between resets, and a
+// settled roll folds it back by whole 0-9 cycles — invisibly, since a cell and
+// its lower copy render the same digit. RESET_HEADROOM cells are kept below the
+// top of the strip as slack for update bursts that outpace the roll.
+//
+// Load-bearing invariant tying these together: after the eager reset (which
+// fires when pos + delta >= STRIP_CELLS - RESET_HEADROOM), pos is folded into
+// [0, 9] and then advanced by delta <= 9, so the post-update pos is at most 18;
+// without a reset it is at most (STRIP_CELLS - RESET_HEADROOM - 1) + 9. Both
+// must stay < STRIP_CELLS so the target cell exists. That holds as long as
+// RESET_HEADROOM >= max-delta (9) AND STRIP_CELLS - RESET_HEADROOM > max-delta,
+// i.e. RESET_HEADROOM in [9, STRIP_CELLS - 10]. The 30/10 split satisfies it
+// with margin; a runtime assert below fails fast if someone breaks it.
+const STRIP_CELLS = 30
+const RESET_HEADROOM = 10
+const MAX_FORWARD_DELTA = 9
+if (RESET_HEADROOM < MAX_FORWARD_DELTA || STRIP_CELLS - RESET_HEADROOM <= MAX_FORWARD_DELTA) {
+  throw new Error(
+    `odometer strip misconfigured: RESET_HEADROOM=${RESET_HEADROOM}, STRIP_CELLS=${STRIP_CELLS} `
+    + `must satisfy ${MAX_FORWARD_DELTA} <= RESET_HEADROOM <= ${STRIP_CELLS - MAX_FORWARD_DELTA}`,
+  )
+}
+const STRIP_DIGITS = Array.from({ length: STRIP_CELLS }, (_, i) => i % 10)
+const ROLL_TRANSITION = 'transform 0.32s cubic-bezier(0.2, 0.75, 0.25, 1)'
+
+// The imperative digit roll reads prefersReducedMotion() (from ~/lib) fresh on
+// every roll rather than caching it, so toggling the OS setting mid-turn stops
+// (or resumes) the roll immediately; the CSS @media rules react to the same
+// change for the fade animations, keeping the JS-driven roll in step.
+
+// Forward-only advance from one digit to the next: 9->0 is +1 (up through the
+// wrap), 2->5 is +3, an unchanged digit is 0. Never negative, so accumulating
+// it into `pos` keeps the strip rolling strictly upward.
+//
+// INTENTIONAL: the roll is forward-only by design — an odometer counts up. The
+// thinking-token estimate is a cumulative per-turn count, monotonic within the
+// continuous display the counter shows (it is cleared at every turn/phase
+// boundary), so a digit never needs to roll backward. If a value ever did
+// decrease mid-display, the columns would spin forward to the smaller number
+// rather than reverse; that is the accepted trade for the always-up aesthetic,
+// not a bug to "fix".
+export function forwardDelta(prevDigit: number, nextDigit: number): number {
+  return (nextDigit - prevDigit + 10) % 10
+}
+
+// The unit family of a formatted count: '' (bare integer), 'k', or 'M'. Values
+// in the same family share a digit structure (right-aligned: ones, ., tenths,
+// unit), so a count growing a leading digit (9.9k -> 10.0k, 99 -> 100) keeps the
+// existing columns — they roll, the unit/point stay, and the new leading column
+// fades in. Crossing 1k/1M changes family: the number re-scales (999 -> 1.0k has
+// no digit-to-digit mapping), so those transitions crossfade instead.
+export function shapeFamily(formatted: string): string {
+  const last = formatted[formatted.length - 1]
+  return last === 'k' || last === 'M' ? last : ''
+}
+
+// A single digit position. An in-flow hidden sizer gives the column the real
+// tabular-digit width/height (so it matches the ghost); the strip rides
+// absolutely on top and is rolled imperatively so it always travels upward —
+// 9->0 continues up through the wrap (a +1 advance) instead of snapping back.
+const DigitColumn: Component<{ digit: number, enter: boolean }> = (props) => {
+  let stripEl!: HTMLSpanElement
+  // pos = the strip cell index currently shown. Monotonic between resets, so
+  // the strip only ever rolls up. pos % 10 is the visible digit.
+  // eslint-disable-next-line solid/reactivity -- intentional one-time initial read; the effect below tracks changes.
+  let pos = props.digit
+  // Count of roll transitions started but not yet ended/cancelled. The settle
+  // fold (below) runs only when this returns to 0 — i.e. the LATEST roll has
+  // come to rest — so a stale transitionend from a roll the burst-reset already
+  // interrupted can never fold (and thus snap) the strip mid-animation.
+  let pending = 0
+
+  // Current rendered translateY of the strip, in cell units (negative = rolled
+  // up), read from the live computed matrix so it reflects an in-flight roll's
+  // interpolated position — not the inline target. null when the browser can't
+  // report a matrix (jsdom, or no layout), so callers fall back to the settled
+  // target.
+  const liveOffsetCells = (): number | null => {
+    const m = /matrix\([^)]*,\s*([-\d.e+]+)\)/.exec(getComputedStyle(stripEl).transform)
+    if (!m)
+      return null
+    const cellPx = stripEl.getBoundingClientRect().height / STRIP_CELLS
+    if (!cellPx)
+      return null
+    return Number.parseFloat(m[1]) / cellPx
+  }
+
+  // Commit an offset (in cells, negative = up) to the strip WITHOUT animating:
+  // disable the transition, set the transform, force a reflow so the jump
+  // commits, then re-arm the roll transition for the next change.
+  const placeInstant = (offsetCells: number) => {
+    stripEl.style.transition = 'none'
+    stripEl.style.transform = `translateY(calc(${offsetCells} * var(--cell)))`
+    stripEl.getBoundingClientRect()
+    stripEl.style.transition = prefersReducedMotion() ? 'none' : ROLL_TRANSITION
+  }
+
+  // Apply pos to the strip. animate=false commits instantly (initial placement,
+  // cycle folds); animate=true rolls there.
+  const apply = (animate: boolean) => {
+    if (!animate) {
+      placeInstant(-pos)
+      return
+    }
+    pending++
+    // Re-arm the roll transition before the transform write: a prior reduced-
+    // motion placeInstant leaves it 'none', and prefersReducedMotion() flipping
+    // back is a plain read with no DOM write, so without this an animated roll
+    // after the OS setting is re-enabled mid-turn would snap instead of roll AND
+    // leak a `pending` with no transitionend to balance it. No-op once already
+    // ROLL_TRANSITION; assigning it doesn't itself start a transition (only the
+    // transform change below, against a live transition, does), and no reflow is
+    // forced between the two writes so they land in one style-change event.
+    stripEl.style.transition = ROLL_TRANSITION
+    stripEl.style.transform = `translateY(calc(${-pos} * var(--cell)))`
+  }
+
+  // Fold pos down by whole 0-9 cycles. The landing cell and the copy 10 below it
+  // render the same digit, so a whole-cycle fold is invisible. Mid-animation the
+  // strip sits at a fractional offset, so snapping to the folded *settled* cell
+  // (-pos) would jump by that in-flight fraction; instead shift the live
+  // fractional offset down by the same whole cycles. At rest, or when the offset
+  // can't be read (jsdom), -pos IS the exact position, so use it directly.
+  const foldCycle = () => {
+    const cycles = Math.floor(pos / 10)
+    if (cycles <= 0)
+      return
+    pos -= cycles * 10
+    const live = liveOffsetCells()
+    placeInstant(live === null ? -pos : live + cycles * 10)
+  }
+
+  // A roll transition ended (`settled`) or was interrupted by a newer one
+  // (`!settled`, a transitioncancel); a started roll fires exactly one. Decrement
+  // the in-flight counter, then on a genuine end fold the cycle only if the strip
+  // has actually come to rest — its live offset matches the target -pos, meaning
+  // no newer roll superseded this one. That geometric at-rest check also
+  // reconciles `pending` to 0, so a browser that elides a transitioncancel can't
+  // leave it stuck > 0 and permanently disable the fold. When the offset can't be
+  // read (jsdom), fall back to the pending===0 counter.
+  const onRollDone = (settled: boolean) => (e: TransitionEvent) => {
+    if (e.propertyName !== 'transform')
+      return
+    if (pending > 0)
+      pending--
+    if (!settled)
+      return
+    const live = liveOffsetCells()
+    const atRest = live === null ? pending === 0 : Math.abs(live + pos) < 0.01
+    if (!atRest)
+      return
+    pending = 0
+    if (pos >= 10)
+      foldCycle()
+  }
+  const onEnd = onRollDone(true)
+  const onCancel = onRollDone(false)
+
+  onMount(() => {
+    apply(false)
+    stripEl.addEventListener('transitionend', onEnd)
+    stripEl.addEventListener('transitioncancel', onCancel)
+  })
+  onCleanup(() => {
+    stripEl.removeEventListener('transitionend', onEnd)
+    stripEl.removeEventListener('transitioncancel', onCancel)
+  })
+
+  createEffect(() => {
+    const next = props.digit
+    if (prefersReducedMotion()) {
+      // No animation to preserve direction — just show the digit.
+      pos = next
+      apply(false)
+      return
+    }
+    const prevDigit = pos % 10
+    if (next === prevDigit)
+      return
+    // Forward advance only: 9->0 is +1 (rolls up through the wrap), never -9.
+    const delta = forwardDelta(prevDigit, next)
+    // Safety for bursts that outpace transitionend: fold down before the strip
+    // runs out. Only bites on the fast-spinning low digit, where it's unseen.
+    if (pos + delta >= STRIP_CELLS - RESET_HEADROOM)
+      foldCycle()
+    pos += delta
+    apply(true)
+  })
+
+  return (
+    <span
+      classList={{ [styles.column]: true, [styles.slotEnter]: props.enter }}
+      data-testid="odo-digit"
+      // The TARGET digit, not the one currently painted: the visible glyph is
+      // driven by the imperative strip transform and lags during a roll. Tests
+      // read this to assert the logical value without waiting on the animation;
+      // don't "fix" it to track `pos` or the odometer test helpers break.
+      data-digit={props.digit}
+    >
+      <span class={styles.columnSizer} aria-hidden="true">0</span>
+      <span ref={stripEl} class={styles.strip}>
+        <Index each={STRIP_DIGITS}>{d => <span class={styles.stripCell}>{d()}</span>}</Index>
+      </span>
+    </span>
+  )
+}
+
+// Renders one formatted value as a row of rolling digit columns and static
+// chars. The chars are reversed and laid out right-to-left (the layer is
+// flex-direction: row-reverse), so Index keys each slot by its distance from
+// the RIGHT edge: a count growing a leading digit appends a slot (the existing
+// columns keep their identity and roll) instead of shifting every position.
+// `animateEntry` fades freshly-mounted slots in — the new leading digit on
+// growth, and every slot of a freshly-swapped live layer on a unit crossfade;
+// the outgoing snapshot passes false so it only fades out as a whole.
+const RollingNumber: Component<{ value: string, animateEntry: boolean }> = (props) => {
+  const chars = createMemo(() => [...props.value].reverse())
+  const isDigit = (ch: string) => ch >= '0' && ch <= '9'
+  return (
+    <Index each={chars()}>
+      {ch => (
+        <Show
+          when={isDigit(ch())}
+          fallback={(
+            <span classList={{ [styles.staticChar]: true, [styles.slotEnter]: props.animateEntry }}>
+              {ch()}
+            </span>
+          )}
+        >
+          <DigitColumn digit={Number(ch())} enter={props.animateEntry} />
+        </Show>
+      )}
+    </Index>
+  )
+}
+
+// Keeps prior values of `value` around as fading-out snapshots, minting one
+// whenever `shouldSnapshot(prev, next)` fires and removing it after `durationMs`
+// (matched to the CSS fade). The crossfade bookkeeping — id minting, the removal
+// timers, and their cleanup — lives here so the consumer reads as declarative
+// layout and renders the returned list as fading-out layers. A `hasPrev` flag
+// (not an `undefined` sentinel for `prev`) tracks first appearance, so the hook
+// stays honest for a `T` that legitimately includes `undefined`.
+function useFadingSnapshots<T>(
+  value: () => T,
+  options: { shouldSnapshot: (prev: T, next: T) => boolean, durationMs: number },
+): { id: number, value: T }[] {
+  const [snapshots, setSnapshots] = createStore<{ id: number, value: T }[]>([])
+  let nextId = 1
+  const timers = new Set<ReturnType<typeof setTimeout>>()
+  let hasPrev = false
+  let prev!: T
+  createEffect(() => {
+    const next = value()
+    if (hasPrev && options.shouldSnapshot(prev, next)) {
+      const id = nextId++
+      const snapshot = prev
+      // Append via the functional updater rather than `setSnapshots(length, …)`:
+      // reading `snapshots.length` inside this tracked effect would subscribe it
+      // to the store, so a later removal (which shrinks the list) would re-run
+      // the effect for no reason. The functional form depends only on `value()`.
+      setSnapshots(rows => [...rows, { id, value: snapshot }])
+      const timer = setTimeout(() => {
+        timers.delete(timer)
+        setSnapshots(rows => rows.filter(row => row.id !== id))
+      }, options.durationMs)
+      timers.add(timer)
+    }
+    prev = next
+    hasPrev = true
+  })
+  onCleanup(() => {
+    for (const timer of timers)
+      clearTimeout(timer)
+  })
+  return snapshots
+}
+
+/**
+ * Animated thinking-token count: "<n> tokens" where the number's digits roll up
+ * while the digit-shape is stable and crossfade when the format changes.
+ *
+ * The number's width and baseline come from an in-flow hidden ghost; the visible
+ * rolling digits are painted by absolutely-positioned overlays on top of it, so
+ * the overlays' clipped (baseline-less) columns never disturb where the count
+ * sits next to " tokens" and the verb.
+ */
+export const ThinkingTokenCount: Component<{ tokens: number }> = (props) => {
+  const display = createMemo(() => formatTokenCount(props.tokens, 2))
+  // Single-item list keyed by the unit family: For reuses the live layer while
+  // the family is stable (so digits roll and a new leading column fades in) and
+  // remounts it — for the unit crossfade — only when the family changes.
+  const familyKey = createMemo(() => [shapeFamily(display())])
+
+  // On a unit-family change (crossing 1k/1M) the number re-scales with no
+  // digit-to-digit mapping, so snapshot the prior value and fade it out over the
+  // freshly-swapped live number, dissolving to reveal it. Same-family growth
+  // does NOT snapshot — the live layer persists and only the new leading column
+  // fades in.
+  // eslint-disable-next-line solid/reactivity -- `display` is invoked inside the hook's createEffect (a tracked scope); passing the accessor is intended.
+  const exiting = useFadingSnapshots(display, {
+    shouldSnapshot: (prev, next) => shapeFamily(prev) !== shapeFamily(next),
+    durationMs: styles.SWAP_MS,
+  })
+
+  return (
+    <span class={styles.root}>
+      {/* Real value for assistive tech and tests; the visual odometer is aria-hidden. */}
+      <span class={styles.srOnly}>{`${display()} tokens`}</span>
+      <span class={styles.numberBox}>
+        {/* In-flow, hidden: owns the number's width and baseline. */}
+        <span class={styles.numberGhost} aria-hidden="true">{display()}</span>
+        <For each={familyKey()}>
+          {() => (
+            <span class={styles.liveLayer} aria-hidden="true">
+              <RollingNumber value={display()} animateEntry={true} />
+            </span>
+          )}
+        </For>
+        <For each={exiting}>
+          {snap => (
+            <span class={styles.exitingLayer} data-testid="odo-exiting" aria-hidden="true">
+              <RollingNumber value={snap.value} animateEntry={false} />
+            </span>
+          )}
+        </For>
+      </span>
+      {' tokens'}
+    </span>
+  )
+}

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -598,6 +598,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                     messageVersion={chatStore.getMessageVersion(agentId)}
                     streamingText={chatStore.state.streamingText[agentId] ?? ''}
                     streamingType={agentSessionStore.getInfo(agentId).streamingType}
+                    thinkingTokens={agentSessionStore.getInfo(agentId).thinkingTokens}
                     agentWorking={agentThinking(agentId)}
                     tabActive={agentTab()?.id === at.id}
                     messageErrors={chatStore.state.messageErrors}

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from '~/components/common/Tooltip'
 import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { formatErrorMessage } from '~/lib/errors'
 import { basename, detectFlavor, isAbsolute, lastSepIndex, relativeUnder, tildify, untildify } from '~/lib/paths'
+import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
 import { emptyState } from '~/styles/shared.css'
 import * as styles from './DirectoryTree.css'
 import { getGitFileIconClass, RowLabelWithStats } from './gitStatusUtils'
@@ -283,8 +284,7 @@ const TreeNode: Component<{
     // so that wrapperRef has its full height when we measure.
     // When prefers-reduced-motion is enabled, transitions are instant
     // so transitionend never fires — use requestAnimationFrame instead.
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (prefersReducedMotion) {
+    if (prefersReducedMotion()) {
       requestAnimationFrame(doScroll)
       return
     }

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { wireSessionInfoToUpdates } from './useWorkspaceConnection'
+
+describe('wireSessionInfoToUpdates', () => {
+  it('returns an empty object for undefined or empty payloads', () => {
+    expect(wireSessionInfoToUpdates(undefined)).toEqual({})
+    expect(wireSessionInfoToUpdates({})).toEqual({})
+  })
+
+  it('maps snake_case wire keys to the camelCase store shape', () => {
+    const updates = wireSessionInfoToUpdates({
+      total_cost_usd: 1.5,
+      context_usage: { input_tokens: 100 },
+      codex_turn_id: 'turn-7',
+      streaming_type: 'plan',
+    })
+    expect(updates.totalCostUsd).toBe(1.5)
+    expect(updates.contextUsage).toMatchObject({ inputTokens: 100 })
+    expect(updates.codexTurnId).toBe('turn-7')
+    expect(updates.streamingType).toBe('plan')
+  })
+
+  it('deep-maps rate_limits tiers', () => {
+    const updates = wireSessionInfoToUpdates({
+      rate_limits: { five_hour: { status: 'allowed', utilization: 0.5 } },
+    })
+    expect(updates.rateLimits).toEqual({ five_hour: { status: 'allowed', utilization: 0.5 } })
+  })
+
+  it('only forwards a positive numeric thinking_tokens estimate', () => {
+    expect(wireSessionInfoToUpdates({ thinking_tokens: 230 }).thinkingTokens).toBe(230)
+    // 0 (the zero-estimate first delta), NaN, and non-numbers are all dropped,
+    // so the indicator never has to defend against "0 tokens" or a NaN.
+    expect('thinkingTokens' in wireSessionInfoToUpdates({ thinking_tokens: 0 })).toBe(false)
+    expect('thinkingTokens' in wireSessionInfoToUpdates({ thinking_tokens: Number.NaN })).toBe(false)
+    expect('thinkingTokens' in wireSessionInfoToUpdates({ thinking_tokens: '5' })).toBe(false)
+  })
+
+  it('skips keys that are absent or fail their type guard', () => {
+    // A non-number cost and a context_usage with no token data contribute nothing.
+    expect(wireSessionInfoToUpdates({ total_cost_usd: 'free', context_usage: {} })).toEqual({})
+  })
+
+  it('keeps an empty-string streaming_type (the "not streaming plan" signal)', () => {
+    // streaming_type uses `!== undefined`, so "" is a meaningful value, not a skip.
+    expect(wireSessionInfoToUpdates({ streaming_type: '' }).streamingType).toBe('')
+  })
+})

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -67,6 +67,40 @@ function wireRateLimitsToCamel(value: unknown): Record<string, RateLimitInfo> | 
   return out
 }
 
+/**
+ * Translate an `agent_session_info` wire payload (provider-agnostic snake_case)
+ * into the store's camelCase `AgentSessionInfo` updates. Each field carries its
+ * own predicate + transform and is included only when present/valid, so a
+ * provider that omits keys (or sends a dropped-only payload) produces an empty
+ * object and the caller skips the store write. Pure and exported so the
+ * wire->camel boundary can be unit-tested directly without a live connection.
+ */
+export function wireSessionInfoToUpdates(
+  info: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const updates: Record<string, unknown> = {}
+  if (!info)
+    return updates
+  if (typeof info.total_cost_usd === 'number')
+    updates.totalCostUsd = info.total_cost_usd
+  const contextUsage = normalizeContextUsage(info.context_usage)
+  if (contextUsage)
+    updates.contextUsage = contextUsage
+  if (info.rate_limits !== undefined)
+    updates.rateLimits = wireRateLimitsToCamel(info.rate_limits)
+  if (info.codex_turn_id !== undefined)
+    updates.codexTurnId = info.codex_turn_id as string
+  if (info.streaming_type !== undefined)
+    updates.streamingType = info.streaming_type as string
+  // Only positive estimates: `> 0` rejects both the zero-estimate first delta
+  // (nothing to show yet) and a NaN a future provider might emit (NaN > 0 is
+  // false), so the indicator never has to defend against "0 tokens" or a NaN
+  // serialized to null in storage.
+  if (typeof info.thinking_tokens === 'number' && info.thinking_tokens > 0)
+    updates.thinkingTokens = info.thinking_tokens
+  return updates
+}
+
 export interface WorkspaceConnectionParams {
   chatStore: ReturnType<typeof createChatStore>
   tabStore: ReturnType<typeof createTabStore>
@@ -189,18 +223,15 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // forcing snake_case identifiers throughout the frontend.
         if (parsed.topLevel !== null && !parsed.wrapper && parsed.topLevel.type === 'agent_session_info') {
           const info = parsed.topLevel.info as Record<string, unknown> | undefined
-          const updates: Record<string, unknown> = {}
-          if (typeof info?.total_cost_usd === 'number')
-            updates.totalCostUsd = info.total_cost_usd
-          const contextUsage = normalizeContextUsage(info?.context_usage)
-          if (contextUsage)
-            updates.contextUsage = contextUsage
-          if (info?.rate_limits !== undefined)
-            updates.rateLimits = wireRateLimitsToCamel(info.rate_limits)
-          if (info?.codex_turn_id !== undefined)
-            updates.codexTurnId = info.codex_turn_id as string
-          if (info?.streaming_type !== undefined)
-            updates.streamingType = info.streaming_type as string
+          const updates = wireSessionInfoToUpdates(info)
+          // A zero (or, defensively, negative) thinking-token estimate is the
+          // backend's per-phase reset signal — the first delta of a thinking
+          // phase reports 0. Honor it as a clear so a stale count from a prior
+          // phase/turn can't linger; the positive path keeps streaming via
+          // `updates`. wireSessionInfoToUpdates only forwards positive estimates,
+          // so a 0 never arrives as an update and must be handled here.
+          if (typeof info?.thinking_tokens === 'number' && info.thinking_tokens <= 0)
+            agentSessionStore.clearThinkingTokens(agentId)
           // Pi (and any future provider) may broadcast session_info
           // payloads whose keys are all dropped here — skip the store
           // write so reactive consumers aren't woken for nothing.
@@ -288,6 +319,22 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         }
 
         chatStore.addMessage(agentId, msg)
+        // Agent output means the current thinking phase produced something, so
+        // drop the live thinking-token estimate — otherwise the counter lingers
+        // beside the indicator (frozen on its last value) until turn end, and
+        // the next thinking phase would briefly flash the stale total before its
+        // own deltas arrive. Gated to AGENT source: user echoes (queued input,
+        // tool_result) and LeapMux notifications can land mid-think and must not
+        // clear a still-climbing counter. No-op when no estimate is set.
+        //
+        // INTENTIONAL per-phase reset: this also fires on an intermediate
+        // persisted reasoning block (Claude `assistant_thinking`) during
+        // interleaved thinking (think -> tool -> think), so the counter restarts
+        // from each new phase's first delta rather than accumulating across a
+        // whole turn. That per-phase semantics is the desired behavior — do not
+        // "fix" it to only clear at true turn boundaries.
+        if (msg.source === MessageSource.AGENT)
+          agentSessionStore.clearThinkingTokens(agentId)
         if (
           !isAgentTabVisible(agentId)
           && chatStore.getMessages(agentId).length > MAX_BACKGROUND_CHAT_MESSAGES
@@ -352,6 +399,13 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // type:"result", Codex turn/completed, ACP stopReason, Pi agent_end)
         // as `result_divider`, so this gate is provider-agnostic.
         if (category.kind === 'result_divider') {
+          // Clear the per-turn thinking-token estimate on the turn-end divider
+          // itself, not just via the AGENT-message clear above. The divider is
+          // the structural turn boundary for every provider; gating the clear on
+          // message source/status would miss a terminal envelope whose source is
+          // not AGENT, or a catch-up replay where the INACTIVE-driven onTurnEnd
+          // is skipped — leaving the counter frozen on its last value.
+          agentSessionStore.clearThinkingTokens(agentId)
           const modelId = tabStore.getAgentTab(agentId)?.model
           const meta = extractResultMetadata(parsed, modelId)
           if (meta) {
@@ -542,6 +596,9 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           // so the user can send a regular message (which auto-starts the
           // agent) instead of being stuck on an unanswerable prompt.
           controlStore.clearAgent(agentId)
+          // Drop the per-turn thinking-token estimate; the agent stopped, so
+          // there is no live thinking to count.
+          agentSessionStore.clearThinkingTokens(agentId)
           if (
             catchUpPhase === 'live'
             && sc.agentSessionId
@@ -586,6 +643,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           if (tabStore.state.activeTabKey !== tabKey({ type: TabType.AGENT, id: cr.agentId })) {
             tabStore.setNotification(TabType.AGENT, cr.agentId, true)
           }
+          // The agent paused mid-turn to wait on the user (permission / plan
+          // prompt). It is no longer thinking, and this pause may produce no
+          // agent message and no INACTIVE, so drop the per-turn estimate here
+          // too — otherwise the counter lingers frozen until the next turn.
+          agentSessionStore.clearThinkingTokens(agentId)
           params.onTurnEnd?.(agentId)
         }
         break

--- a/frontend/src/lib/prefersReducedMotion.test.ts
+++ b/frontend/src/lib/prefersReducedMotion.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Each test imports the module fresh (vi.resetModules) so the module-load-time
+// `matchMedia` read re-resolves against the window state the test set up.
+describe('prefersReducedMotion', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+    vi.resetModules()
+  })
+
+  it('returns false when matchMedia is unavailable (SSR / jsdom)', async () => {
+    vi.resetModules()
+    // @ts-expect-error force-remove to exercise the guard path
+    delete window.matchMedia
+    const { prefersReducedMotion } = await import('./prefersReducedMotion')
+    expect(prefersReducedMotion()).toBe(false)
+  })
+
+  it('reflects the live MediaQueryList.matches on each call', async () => {
+    vi.resetModules()
+    let matches = true
+    // A getter so the query handle the module caches at load time reports the
+    // CURRENT value, mirroring a real MediaQueryList toggling mid-session.
+    window.matchMedia = ((query: string) => ({
+      get matches() {
+        return matches
+      },
+      media: query,
+      onchange: null,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as unknown as typeof window.matchMedia
+
+    const { prefersReducedMotion } = await import('./prefersReducedMotion')
+    expect(prefersReducedMotion()).toBe(true)
+
+    // Flip the underlying preference: the next read reflects it without any
+    // listener wiring (the value is read fresh, not cached).
+    matches = false
+    expect(prefersReducedMotion()).toBe(false)
+  })
+})

--- a/frontend/src/lib/prefersReducedMotion.ts
+++ b/frontend/src/lib/prefersReducedMotion.ts
@@ -1,0 +1,15 @@
+// Live "prefers reduced motion" read, shared by the UIs that gate JS-driven
+// motion on it (the thinking-token odometer's imperative digit roll, the
+// directory-tree expand scroll). `MediaQueryList.matches` is always current, so
+// callers read it fresh on demand — toggling the OS setting takes effect on the
+// next read with no listener to register, leak, or fall out of sync. The query
+// handle is resolved once at module load and guarded for SSR / jsdom (no
+// `window`, no `matchMedia`), where it reports false (motion allowed).
+const reducedMotionQuery
+  = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : undefined
+
+export function prefersReducedMotion(): boolean {
+  return reducedMotionQuery?.matches ?? false
+}

--- a/frontend/src/stores/agentSession.store.test.ts
+++ b/frontend/src/stores/agentSession.store.test.ts
@@ -1,0 +1,167 @@
+import { createRoot } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { localStorageGet, PREFIX_AGENT_SESSION } from '~/lib/browserStorage'
+import { createAgentSessionStore } from './agentSession.store'
+
+describe('agentSessionStore thinkingTokens', () => {
+  it('merges the thinking-token estimate without clobbering other keys', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-merge', { totalCostUsd: 0.5 })
+      store.updateInfo('a-merge', { thinkingTokens: 230 })
+
+      const info = store.getInfo('a-merge')
+      expect(info.thinkingTokens).toBe(230)
+      expect(info.totalCostUsd).toBe(0.5)
+      dispose()
+    })
+  })
+
+  it('clearThinkingTokens drops only the estimate', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-clear', { totalCostUsd: 0.5, thinkingTokens: 230 })
+
+      store.clearThinkingTokens('a-clear')
+
+      const info = store.getInfo('a-clear')
+      expect(info.thinkingTokens).toBeUndefined()
+      expect(info.totalCostUsd).toBe(0.5)
+      dispose()
+    })
+  })
+
+  it('clearThinkingTokens is a no-op when no estimate is set', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-noop', { totalCostUsd: 0.5 })
+
+      expect(() => store.clearThinkingTokens('a-noop')).not.toThrow()
+      expect(store.getInfo('a-noop').totalCostUsd).toBe(0.5)
+      dispose()
+    })
+  })
+
+  it('clearThinkingTokens on an untouched agent is a safe no-op', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      // The turn-end clear fires for every provider, including agents whose
+      // session info was never loaded or never carried a thinking estimate.
+      expect(() => store.clearThinkingTokens('a-untouched')).not.toThrow()
+      expect(store.getInfo('a-untouched')).toEqual({})
+      dispose()
+    })
+  })
+
+  it('persists the cleared state so a reload does not resurrect the count', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-persist', { totalCostUsd: 0.5, thinkingTokens: 230 })
+      store.clearThinkingTokens('a-persist')
+      dispose()
+    })
+
+    // A fresh store rehydrates 'a-persist' from localStorage; the cleared
+    // estimate must not come back while the surviving keys do.
+    createRoot((dispose) => {
+      const reloaded = createAgentSessionStore()
+      const info = reloaded.getInfo('a-persist')
+      expect(info.thinkingTokens).toBeUndefined()
+      expect(info.totalCostUsd).toBe(0.5)
+      dispose()
+    })
+  })
+
+  it('writes nothing to localStorage for an estimate-only update', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-eph-only', { thinkingTokens: 500 })
+
+      // The estimate is live in the reactive store...
+      expect(store.getInfo('a-eph-only').thinkingTokens).toBe(500)
+      // ...but an estimate-only update skips the write entirely (no entry is
+      // even created), so the per-delta stream never thrashes localStorage.
+      expect(localStorageGet(`${PREFIX_AGENT_SESSION}a-eph-only`)).toBeUndefined()
+      dispose()
+    })
+  })
+
+  it('never persists thinkingTokens, even when set alongside a persisted key', () => {
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      // A single update carrying both a persisted key and the ephemeral
+      // estimate: the estimate is live in memory but must never reach disk.
+      store.updateInfo('a-ephemeral', { totalCostUsd: 0.5, thinkingTokens: 230 })
+      expect(store.getInfo('a-ephemeral').thinkingTokens).toBe(230)
+      dispose()
+    })
+
+    createRoot((dispose) => {
+      const reloaded = createAgentSessionStore()
+      const info = reloaded.getInfo('a-ephemeral')
+      expect(info.thinkingTokens).toBeUndefined() // ephemeral: never written
+      expect(info.totalCostUsd).toBe(0.5) // the persisted sibling survived
+      dispose()
+    })
+  })
+})
+
+describe('agentSessionStore clearContextUsage', () => {
+  it('preserves sibling keys when clearing a not-yet-loaded agent', () => {
+    // Persist an agent with context usage AND unrelated keys.
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-unhydrated', {
+        totalCostUsd: 1,
+        contextUsage: {
+          inputTokens: 10,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+        },
+        rateLimits: { five_hour: { status: 'allowed' } },
+      })
+      dispose()
+    })
+
+    // A fresh store has 'a-unhydrated' on disk but not in memory. Clearing
+    // context usage before any getInfo/updateInfo must hydrate first, so it
+    // does not persist a bare object over the stored rateLimits.
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.clearContextUsage('a-unhydrated')
+      dispose()
+    })
+
+    createRoot((dispose) => {
+      const reloaded = createAgentSessionStore()
+      const info = reloaded.getInfo('a-unhydrated')
+      expect(info.contextUsage).toBeUndefined()
+      expect(info.totalCostUsd).toBeUndefined() // clearContextUsage clears cost too
+      expect(info.rateLimits).toEqual({ five_hour: { status: 'allowed' } }) // survived
+      dispose()
+    })
+  })
+
+  it('is a no-op that preserves siblings when there is no context usage to clear', () => {
+    // Persist an agent that never carried contextUsage/cost, only rateLimits.
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.updateInfo('a-nocontext', { rateLimits: { five_hour: { status: 'allowed' } } })
+      dispose()
+    })
+
+    // Clearing context usage when neither key is present must short-circuit
+    // without writing a bare object over the stored rateLimits.
+    createRoot((dispose) => {
+      const store = createAgentSessionStore()
+      store.clearContextUsage('a-nocontext')
+      dispose()
+    })
+
+    createRoot((dispose) => {
+      const reloaded = createAgentSessionStore()
+      expect(reloaded.getInfo('a-nocontext').rateLimits).toEqual({ five_hour: { status: 'allowed' } })
+      dispose()
+    })
+  })
+})

--- a/frontend/src/stores/agentSession.store.ts
+++ b/frontend/src/stores/agentSession.store.ts
@@ -30,6 +30,12 @@ export interface AgentSessionInfo {
   planFilePath?: string
   codexTurnId?: string // Codex active turn ID for interrupt
   streamingType?: string // "plan" when streaming plan text, "" otherwise
+  /**
+   * Running estimate of the in-flight turn's thinking (reasoning) tokens.
+   * Broadcast-only telemetry (never persisted as a timeline message); cleared
+   * at each turn boundary so a stale per-turn count never lingers.
+   */
+  thinkingTokens?: number
 }
 
 /**
@@ -54,12 +60,24 @@ export function compactionContextUsage(
   }
 }
 
+// Keys that live in the reactive store for the UI but must never be persisted.
+// thinkingTokens is a per-turn running estimate that streams many deltas per
+// turn: persisting it would thrash localStorage with a synchronous write per
+// delta AND rehydrate a stale count on reload (the indicator would show the
+// pre-reload total until a fresh broadcast or turn-end clear corrects it).
+// Stripped from every write, so the store mutates reactively but the value
+// never reaches disk.
+const EPHEMERAL_KEYS = ['thinkingTokens'] as const satisfies readonly (keyof AgentSessionInfo)[]
+
 function loadFromStorage(agentId: string): AgentSessionInfo {
   return localStorageGet<AgentSessionInfo>(`${PREFIX_AGENT_SESSION}${agentId}`) ?? {}
 }
 
 function saveToStorage(agentId: string, info: AgentSessionInfo) {
-  localStorageSet(`${PREFIX_AGENT_SESSION}${agentId}`, info)
+  const persisted = { ...info }
+  for (const key of EPHEMERAL_KEYS)
+    delete persisted[key]
+  localStorageSet(`${PREFIX_AGENT_SESSION}${agentId}`, persisted)
 }
 
 interface AgentSessionStoreState {
@@ -74,31 +92,38 @@ export function createAgentSessionStore() {
   // Track which agents have been loaded from localStorage.
   const loaded = new Set<string>()
 
+  // Hydrate an agent's persisted info into the reactive store on first touch.
+  // Every mutator must call this before reading/clearing keys: otherwise a
+  // clear on a not-yet-loaded agent would see an empty in-memory entry and
+  // could overwrite real persisted data (e.g. clearContextUsage saving a bare
+  // `rest` over stored rateLimits/cost).
+  const ensureLoaded = (agentId: string) => {
+    if (loaded.has(agentId))
+      return
+    loaded.add(agentId)
+    const stored = loadFromStorage(agentId)
+    if (Object.keys(stored).length > 0)
+      setState('infoByAgent', agentId, stored)
+  }
+
   return {
     state,
 
     getInfo(agentId: string): AgentSessionInfo {
-      if (!loaded.has(agentId)) {
-        loaded.add(agentId)
-        const stored = loadFromStorage(agentId)
-        if (Object.keys(stored).length > 0) {
-          setState('infoByAgent', agentId, stored)
-        }
-      }
+      ensureLoaded(agentId)
       return state.infoByAgent[agentId] ?? {}
     },
 
     updateInfo(agentId: string, partial: Partial<AgentSessionInfo>) {
-      if (!loaded.has(agentId)) {
-        loaded.add(agentId)
-        const stored = loadFromStorage(agentId)
-        if (Object.keys(stored).length > 0) {
-          setState('infoByAgent', agentId, stored)
-        }
-      }
+      ensureLoaded(agentId)
       setState('infoByAgent', agentId, (prev = {}) => {
         const merged = { ...prev }
         let changed = false
+        // Tracks whether a *persisted* (non-ephemeral) key changed. A
+        // thinkingTokens-only update mutates the reactive store but must not
+        // hit localStorage -- it streams many deltas per turn, so writing on
+        // each would thrash disk for a value that is never persisted anyway.
+        let persistedChanged = false
         for (const [key, value] of Object.entries(partial)) {
           if (value === undefined || value === null)
             continue
@@ -117,6 +142,7 @@ export function createAgentSessionStore() {
             if (rlChanged) {
               merged.rateLimits = next
               changed = true
+              persistedChanged = true
             }
             continue
           }
@@ -124,27 +150,48 @@ export function createAgentSessionStore() {
           if (!shallowEqual(current, value)) {
             (merged as Record<string, unknown>)[key] = value
             changed = true
+            if (!(EPHEMERAL_KEYS as readonly string[]).includes(key))
+              persistedChanged = true
           }
         }
         if (!changed)
           return prev
-        saveToStorage(agentId, merged)
+        if (persistedChanged)
+          saveToStorage(agentId, merged)
         return merged
       })
     },
 
     clearContextUsage(agentId: string) {
+      // Hydrate first: without it, clearing a not-yet-loaded agent would build
+      // `rest` from an empty in-memory entry and persist a bare object over the
+      // agent's stored rateLimits/planFilePath/etc., silently wiping them.
+      ensureLoaded(agentId)
+      const info = state.infoByAgent[agentId]
+      // Nothing tracked to drop and nothing on disk to scrub when neither key is
+      // present -- skip the setState churn and the redundant localStorage write.
+      if (!info || (info.contextUsage === undefined && info.totalCostUsd === undefined))
+        return
       // Explicitly set properties to undefined so that Solid's store proxy
       // drops the tracked values. A functional updater that simply omits the
       // keys does NOT work because setState merges the returned object,
       // leaving the old properties on the proxy.
       setState('infoByAgent', agentId, 'contextUsage', undefined)
       setState('infoByAgent', agentId, 'totalCostUsd', undefined)
-      const info = state.infoByAgent[agentId]
-      if (info) {
-        const { contextUsage: _, totalCostUsd: __, ...rest } = info
-        saveToStorage(agentId, rest as AgentSessionInfo)
-      }
+      const { contextUsage: _, totalCostUsd: __, ...rest } = info
+      saveToStorage(agentId, rest as AgentSessionInfo)
+    },
+
+    clearThinkingTokens(agentId: string) {
+      // Drop the per-turn thinking-token estimate at turn boundaries. Setting
+      // the property to undefined (rather than omitting it from a merged
+      // object) is required so Solid's store proxy actually removes the
+      // tracked value — see clearContextUsage for the same rationale. No
+      // localStorage write: thinkingTokens is an EPHEMERAL_KEY that is never
+      // persisted, so there is nothing on disk to scrub.
+      if (state.infoByAgent[agentId]?.thinkingTokens === undefined)
+        return
+      setState('infoByAgent', agentId, 'thinkingTokens', undefined)
     },
   }
 }


### PR DESCRIPTION
## Motivation

Claude Code emits a `system/thinking_tokens` telemetry line during extended thinking that carries a running `estimated_tokens` count for the in-flight turn. This data was previously discarded. Surfacing it gives users a live signal of how much reasoning work the model is doing, which is otherwise invisible during long thinking pauses.

## Modifications

**Backend**

- Added `handleThinkingTokens()` in `claude_output.go` to intercept `system/thinking_tokens` telemetry before session-init and persistence, broadcasting the running estimate over the ephemeral `agent_session_info` channel and returning early so it never lands in the persistent timeline.
- Added `parseThinkingTokens()`, a pure helper that safely extracts `estimated_tokens` from the telemetry payload. It returns 0 for malformed input, absent fields, float64 overflow (`1e400`), finite-huge values that would saturate int64 conversion (`1e300`), and negative numbers.
- Exported `SessionInfoKeyThinkingTokens` (`"thinking_tokens"`) as a shared constant between the agent broadcast and the service-layer dedup exemption, so the two cannot drift via hand-copied literals.
- `BroadcastSessionInfo()` now exempts `thinking_tokens` from its dedup cache: the frontend clears its counter at boundaries the worker cannot observe (turn end, interleaved thinking phases, pauses), so a re-broadcast of an unchanged estimate must still be delivered to restore the visible counter.
- Extracted a `contextWindowOf()` helper, deduplicating the `{contextWindow}` unmarshal shared by `findPrimaryContextWindow()` and `maxContextWindow()`.

**Frontend - ThinkingTokenCount component**

- New `ThinkingTokenCount` component: a forward-rolling, unit-family-aware digit odometer. Digits roll upward via imperative CSS transforms and never roll backward. Within a unit family (bare integer, `k`, `M`) a new leading digit column fades in; crossing a `1k`/`1M` boundary crossfades the entire display because the digit structure changes. The odometer is `aria-hidden` and paired with a screen-reader label.
- `formatTokenCount()` gained an optional `decimals` parameter (default `1`; the counter passes `2` for values like `"4.95k"`) and a non-finite fallback (returns `"0"` for `NaN`/`Infinity`).
- `prefersReducedMotion()`: new shared SSR/jsdom-guarded utility in `~/lib/prefersReducedMotion` that reads `MediaQueryList.matches` fresh on each call (no listener to leak). Adopted by `ThinkingTokenCount` so the JS-driven roll respects the OS reduced-motion preference, and by `DirectoryTree` which previously had an unguarded `window.matchMedia` read.

**Frontend - ThinkingIndicator integration**

- `ThinkingIndicator` wires the token count into the existing row: a `countTokens` signal freezes the last known value through the row's 300 ms collapse fade so the count fades out with the row instead of popping to zero.
- Fixed a pre-existing verb baseline drift: a hidden zero-width `baselineStrut` anchors the grid baseline using the verb's exact font metrics, preventing the verb from shifting vertically when the active rotation slot switches to an empty one.

**Frontend - store and wiring**

- `agentSession.store` gained an ephemeral `thinkingTokens` key: reactive for the UI but stripped from every `localStorage` write and skipped when it is the only changed key, so the per-delta stream never thrashes disk or rehydrates a stale count.
- `wireSessionInfoToUpdates()` in `useWorkspaceConnection` translates the snake_case `thinking_tokens` wire key to camelCase and forwards only positive estimates; a zero value (phase reset from the backend) maps to a clear.
- `clearThinkingTokens()` resets the estimate at lifecycle boundaries: per-phase `AGENT` message, `result_divider`, `INACTIVE` state, and permission/plan pauses.
- Fixed a pre-existing bug in `clearContextUsage()`: it now calls `ensureLoaded` before clearing to avoid overwriting a not-yet-loaded agent's stored keys with a bare object, and skips the `localStorage` write entirely when there is nothing to clear.
- `ChatView` and `TileRenderer` thread the `thinkingTokens` prop from the store to `ThinkingIndicator`.

## Result

While Claude is thinking, the thinking indicator now shows a live animated token counter (e.g., `4.95k tokens`) that rolls upward as the estimate grows. The counter fades out together with the indicator row when thinking ends rather than snapping away. Users with the OS reduced-motion preference enabled see a static number instead of the rolling animation. The counter is cleared at each turn and thinking-phase boundary so it always reflects the current phase, not a cumulative lifetime total.
