### PR TITLE
chore(ci): drop FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env override

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Opt arduino/setup-protoc, arduino/setup-task, and bufbuild/buf-setup-action
-  # into Node.js 24 ahead of GitHub's June 2 2026 forced switch — those three
-  # still ship `using: node20` in their action.yml. Drop this once they cut
-  # Node-24 releases (or once the forced-switch date passes and the override
-  # becomes a no-op).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
   # Shrink the desktop/rust debug artifacts that `cargo test` (dev profile)
   # bakes into the cached `target/` -- full DWARF debuginfo is the single
   # largest slice of the Swatinem/rust-cache blob. `line-tables-only` keeps

--- a/.github/workflows/desktop-artifacts.yaml
+++ b/.github/workflows/desktop-artifacts.yaml
@@ -31,11 +31,6 @@ on:
         default: true
 
 env:
-  # Match ci.yaml: keep arduino + bufbuild actions on Node.js 24 until they
-  # ship Node-24 releases. Reusable workflows do not inherit env from the
-  # caller, so this has to be redeclared here.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
   # Match ci.yaml: trim dev-profile debuginfo so the cached desktop/rust
   # `target/` stays small. This value is hashed into the rust-cache key, so
   # it MUST equal ci.yaml's setting or the `shared-key: desktop` cache the

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,12 +11,6 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Opt arduino/setup-protoc, arduino/setup-task, and bufbuild/buf-setup-action
-  # into Node.js 24 ahead of GitHub's June 2 2026 forced switch — those three
-  # still ship `using: node20` in their action.yml. Drop this once they cut
-  # Node-24 releases (or once the forced-switch date passes and the override
-  # becomes a no-op).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Opt arduino/setup-protoc, arduino/setup-task, and bufbuild/buf-setup-action
-  # into Node.js 24 ahead of GitHub's June 2 2026 forced switch — those three
-  # still ship `using: node20` in their action.yml. Drop this once they cut
-  # Node-24 releases (or once the forced-switch date passes and the override
-  # becomes a no-op).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 for JavaScript actions and force-switched all JS actions to Node.js 24 on **2026-06-02**. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow env var, which opted us in early, is now a no-op on all runners.

- Removed the var (and its surrounding explanatory comment) from all four workflow files that declared it: `ci.yaml`, `desktop-artifacts.yaml`, `release.yaml`, `docker.yaml`.
- In `ci.yaml` and `desktop-artifacts.yaml` only the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` entry was removed; the `CARGO_PROFILE_DEV_DEBUG` entry in the same `env:` block is preserved.
- In `release.yaml` and `docker.yaml` the `REGISTRY`/`IMAGE_NAME` entries are preserved; only the now-dead var is dropped.

## Action runtime check

Verified the three actions that originally prompted this override still ship `using: node20` in their `action.yml` — they haven't cut Node 24 releases yet. That's fine: GitHub's forced switch means they execute under Node 24 regardless of what their `action.yml` declares. No version bumps are needed.

| Action | `using:` |
|---|---|
| `arduino/setup-protoc@v3` | `node20` |
| `arduino/setup-task@v2` | `node20` |
| `bufbuild/buf-setup-action@v1` | `node20` |

## Test plan

- [ ] Verify `grep -rn FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 .github` returns no matches (done locally before push)
- [ ] CI passes on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoFX1QzJEjnpBcPBKTpdfG)_