### PR TITLE
feat(agent): Extend thinking-token counter to Codex, Pi, and ACP agents

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -90,12 +90,33 @@ type acpBase struct {
 	// Flushed when interrupted by any non-thought event (preserves chronology
 	// with tool calls) and at end-of-turn.
 	turnThoughtText strings.Builder
+	// thinkingTokens is the per-phase generated-token estimate driving the
+	// thinking-indicator counter. Fed from both the reader and the prompt-response
+	// goroutines, so it self-locks; see thinkingTokenEstimator and thinkingResetSink.
+	thinkingTokens thinkingTokenEstimator
 }
 
 // handleACPPromptResponse extracts accumulated turn text, calls the optional
 // prePersist hook, persists the prompt response, and resets the tool-use count.
 func (b *acpBase) handleACPPromptResponse(resp json.RawMessage, prePersist func(json.RawMessage)) {
 	if resp == nil {
+		// A nil result ends the turn via error/abort, NOT the normal path: the
+		// persistPromptResponse turn-end below -- which flushes the buffered thought,
+		// persists the reply, and emits the result divider the frontend clears on --
+		// is skipped. So nothing here commits the in-flight assistant/thought text,
+		// and (unlike the normal path) no frontend clear fires for this turn end.
+		// Drop the buffered turn state so an aborted turn's text can't leak into the
+		// next turn -- both as a stale handoff signal and as text prepended to the
+		// next reply -- since ACP has no turn-start reset. Then clear() the estimate:
+		// it broadcasts an explicit zero (no result divider does it for us) so the
+		// live counter drops now instead of freezing on its last value until the next
+		// turn streams.
+		b.mu.Lock()
+		b.turnAssistantText.Reset()
+		b.turnThoughtText.Reset()
+		b.turnToolUses = 0
+		b.mu.Unlock()
+		b.thinkingTokens.clear(b.sink)
 		return
 	}
 
@@ -234,6 +255,8 @@ func (b *acpBase) ClearContext() (string, bool) {
 	b.turnAssistantText.Reset()
 	b.turnThoughtText.Reset()
 	b.mu.Unlock()
+	// The session was replaced; drop any in-flight thinking-token estimate too.
+	b.thinkingTokens.reset()
 
 	b.sink.UpdateSessionID(session.SessionID)
 
@@ -728,6 +751,7 @@ func (b *acpBase) broadcastACPChunk(content json.RawMessage, builder *strings.Bu
 	builder.WriteString(text)
 	b.mu.Unlock()
 	b.sink.BroadcastStreamChunk([]byte(text), "", eventType)
+	b.thinkingTokens.observe(b.sink, text)
 }
 
 // handleAgentThoughtChunk buffers an agent_thought_chunk notification's text
@@ -745,13 +769,33 @@ func (b *acpBase) handleAgentThoughtChunk(content json.RawMessage) {
 		return
 	}
 	b.mu.Lock()
-	if b.turnThoughtText.Len() > 0 {
+	// freshSegment is true when this chunk opens a new reasoning segment: the
+	// thought buffer was empty before it (live thought deltas keep appending to a
+	// non-empty buffer; a flush between segments empties it).
+	freshSegment := b.turnThoughtText.Len() == 0
+	if !freshSegment {
 		if sep := thoughtChunkSeparator(b.turnThoughtText.String(), text); sep != "" {
 			b.turnThoughtText.WriteString(sep)
 		}
 	}
 	b.turnThoughtText.WriteString(text)
 	b.mu.Unlock()
+	// A reasoning segment that opens while the live counter still holds uncommitted
+	// assistant chars is a new phase: the assistant chunks were only buffered in
+	// turnAssistantText and not committed until turn end, so they triggered no
+	// frontend clear. clear() supplies one so the reasoning reads as its own phase
+	// rather than inheriting the assistant total (which would also spin the
+	// forward-only odometer backward from the larger assistant count to the smaller
+	// reasoning count). Gating on the estimator's own pending chars -- not on
+	// turnAssistantText, which stays non-empty all turn for end-of-turn persistence
+	// -- keeps a committed tool call between assistant text and a later reasoning
+	// segment from re-firing a redundant clear: that commit already reset the
+	// estimator and cleared the frontend, so hasPending then reports false.
+	if freshSegment && b.thinkingTokens.hasPending() {
+		b.thinkingTokens.clear(b.sink)
+	}
+	// Reasoning is model generation too: feed it into the live token estimate.
+	b.thinkingTokens.observe(b.sink, text)
 }
 
 // flushThoughtBuffer persists the buffered thought text (if any) as one
@@ -1196,6 +1240,13 @@ func (b *acpBase) startACPHandshake(
 	sessionCfg acpSessionConfig,
 ) (*acpSessionResult, error) {
 	b.drainStderr(stderr)
+
+	// Install the thinking-token reset decorator once, centrally, so every ACP
+	// provider (Gemini, Cursor, Copilot, Kilo, OpenCode, Goose) gets the per-phase
+	// reset without each Start* constructor remembering to wrap -- and before the
+	// reader goroutine below drives any persist/broadcast through b.sink. Codex and
+	// Pi wrap in their own constructors; they do not run this handshake.
+	b.sink = newThinkingResetSink(b.sink, &b.thinkingTokens)
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -56,7 +56,13 @@ func scheduleOrCancelAPIErrorAutoContinue(sink OutputSink, retry bool, payload [
 // agent output. Implemented by the service layer and injected into providers.
 type OutputSink interface {
 	PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error
-	PersistNotification(source leapmuxv1.MessageSource, content []byte) error
+	// PersistNotification persists an agent notification (appending it to the
+	// active notification thread when one is open). It returns whether the
+	// notification produced a frontend-visible broadcast: a flapping notification
+	// that collapses byte-identically into the existing thread tail is persisted
+	// without a broadcast, and callers (the thinking-token reset decorator) use
+	// this to stay in lockstep with the frontend, which only clears on a broadcast.
+	PersistNotification(source leapmuxv1.MessageSource, content []byte) (broadcast bool, err error)
 	// PersistTurnEnd persists the agent's turn-end divider envelope and
 	// fires the sink-level git-status auto-broadcast. Each provider's
 	// terminal envelope (Claude type:"result", Codex turn/completed,

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -103,7 +103,7 @@ func (a *ClaudeCodeAgent) handleClaudeOutput(content []byte, msgType string) {
 		if msgType == NotificationTypeInterrupted {
 			a.sink.ResetSpans()
 		}
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, content); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, content); err != nil {
 			slog.Error("persist agent notification", "agent_id", a.agentID, "type", msgType, "error", err)
 		}
 
@@ -295,7 +295,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 			// threaded subtypes — the renderer extracts `subtype`/`status`
 			// from the raw envelope so future fields like `tokensBefore`/
 			// `durationMs` don't get discarded.
-			if err := a.sink.PersistNotification(source, content); err != nil {
+			if _, err := a.sink.PersistNotification(source, content); err != nil {
 				slog.Error("persist notification-threaded system message", "agent_id", a.agentID, "error", err)
 			}
 			return
@@ -601,7 +601,7 @@ func (a *ClaudeCodeAgent) claudeCodeHandleRateLimitEvent(content []byte) {
 	// notification renderer reads `rate_limit_info` from this raw
 	// Claude-native shape (camelCase) — the persisted side stays in
 	// the SDK's format so notification rendering remains a passthrough.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
+	if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("persist rate_limit notification", "agent_id", a.agentID, "error", err)
 	}
 

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -83,9 +83,19 @@ type CodexAgent struct {
 	turnPlanText      string // final text of the current turn's plan item
 	turnAssistantText string // final assistant message text for the current turn
 	streamingPlan     bool   // whether we've sent streamingType session info for the current plan stream
-	availableModels   []*leapmuxv1.AvailableModel
-	collabThreadSpans map[string]string // child thread ID -> owning spawnAgent span ID
-	collabSpanThreads map[string]int    // spawnAgent span ID -> active child thread count
+	// thinkingTokens is the per-phase generated-token estimate driving the
+	// thinking-indicator counter; see thinkingTokenEstimator and thinkingResetSink.
+	thinkingTokens thinkingTokenEstimator
+	// reasoningStreamKind records, per reasoning itemId, which reasoning sub-stream
+	// ("summary" or "raw") was seen first, so the thinking-token estimate counts
+	// only one of them. Codex can emit both summaryTextDelta and textDelta for the
+	// SAME reasoning item (they are the same generation surfaced two ways), which
+	// would otherwise double-count. Locking onto whichever arrives first keeps the
+	// counter moving for models that stream only one of the two.
+	reasoningStreamKind map[string]string
+	availableModels     []*leapmuxv1.AvailableModel
+	collabThreadSpans   map[string]string // child thread ID -> owning spawnAgent span ID
+	collabSpanThreads   map[string]int    // spawnAgent span ID -> active child thread count
 }
 
 // StartCodex starts a Codex agent process and performs the JSON-RPC handshake.
@@ -117,6 +127,8 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Agent, erro
 		workingDir:  opts.WorkingDir,
 		sink:        sink,
 	}
+	// Reset the thinking-token estimate centrally at every frontend-clear boundary.
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 
 	if err := a.startCmd(cmd, cancel); err != nil {
 		return nil, err
@@ -362,7 +374,13 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 	a.turnPlanText = ""
 	a.turnAssistantText = ""
 	a.streamingPlan = false
+	clear(a.reasoningStreamKind)
 	a.mu.Unlock()
+	// The thread was replaced; drop any in-flight thinking-token estimate so it
+	// doesn't leak into the new context (mirrors acpBase.ClearContext). The next
+	// turn/started also resets, but resetting here keeps every provider's context
+	// clear consistent rather than relying on that follow-up.
+	a.thinkingTokens.reset()
 
 	a.sink.UpdateSessionID(threadID)
 	return threadID, true

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -32,7 +32,7 @@ func handleCodexOutput(a *CodexAgent, line *parsedLine) {
 	slog.Debug("codex HandleOutput", "agent_id", a.agentID, "method", line.Method, "len", len(line.Raw))
 
 	if _, ok := codexSystemMetadataMethods[line.Method]; ok {
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
 			slog.Error("codex persist system metadata", "agent_id", a.agentID, "method", line.Method, "error", err)
 		}
 		return
@@ -117,13 +117,32 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 		} `json:"turn"`
 	}
 	if json.Unmarshal(params, &notif) == nil && notif.Turn.ID != "" {
+		// Gate the thinking-token restart on the main thread -- a collab subagent's
+		// turn/started carries its own child threadId, and the frontend has no counter
+		// clear for turn/started, so an ungated reset would zero the primary agent's
+		// counter mid-phase and spin the odometer backward. Mirrors
+		// handleTurnCompleted's main-thread gate and observeMainThreadText. Resolved
+		// before the lock below (isMainThreadID takes a.mu itself) so the main-only
+		// reasoning-map clear folds into the single turn-state critical section.
+		main := a.isMainThreadID(notif.ThreadID)
 		a.mu.Lock()
 		a.turnID = notif.Turn.ID
 		a.turnToolUses = 0
 		a.turnSawPlan = false
 		a.turnPlanText = ""
 		a.streamingPlan = false
+		if main {
+			// Drop any per-item reasoning-stream locks from a prior turn so itemIds
+			// can't leak across turns (e.g. a reasoning item left open by an abort).
+			clear(a.reasoningStreamKind)
+		}
 		a.mu.Unlock()
+		if main {
+			// A fresh turn begins: restart the thinking-token estimate from zero. The
+			// reset is lock-free (the estimator self-locks), so it stays outside the
+			// critical section above.
+			a.thinkingTokens.reset()
+		}
 
 		// Broadcast the turn ID so the frontend can use it for interrupts.
 		a.sink.BroadcastSessionInfo(map[string]interface{}{
@@ -132,20 +151,77 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 	}
 }
 
+// observeMainThreadText feeds a streamed model-text delta into the thinking-token
+// estimate, but only for the main thread. A collab subagent's deltas arrive
+// through these same handlers carrying a child threadId; counting them would
+// inflate the primary agent's counter with text the user attributes to a
+// subagent. The visible stream chunk is still broadcast regardless of thread --
+// only the token estimate is gated.
+func (a *CodexAgent) observeMainThreadText(threadID, text string) {
+	if a.isMainThreadID(threadID) {
+		a.thinkingTokens.observe(a.sink, text)
+	}
+}
+
+// Codex reasoning sub-stream kinds. A single reasoning item can surface as a
+// condensed summary stream and/or the raw reasoning stream, both under one
+// itemId; observeReasoningText counts only the first-seen kind per item.
+const (
+	codexReasoningKindSummary = "summary"
+	codexReasoningKindRaw     = "raw"
+)
+
+// observeReasoningText feeds a reasoning delta into the thinking-token estimate,
+// counting only the FIRST reasoning sub-stream ("summary" or "raw") seen for a
+// given reasoning itemId. Codex can stream both summaryTextDelta and textDelta
+// for the SAME item -- the same generation surfaced two ways -- so counting both
+// would roughly double the estimate. Locking onto whichever kind arrives first
+// avoids the double count while still moving the counter for models that stream
+// only one kind. The main-thread gate still applies via observeMainThreadText, so
+// a subagent's reasoning (child threadId) is excluded regardless of kind.
+func (a *CodexAgent) observeReasoningText(itemID, kind, threadID, text string) {
+	if a.shouldCountReasoningKind(itemID, kind) {
+		a.observeMainThreadText(threadID, text)
+	}
+}
+
+// shouldCountReasoningKind records the first reasoning sub-stream kind seen for
+// itemID and reports whether kind is that first-seen kind. Separating the locked
+// map bookkeeping from observeReasoningText's delegation lets the lock use a plain
+// defer: observeMainThreadText re-acquires a.mu (via isMainThreadID), so the
+// inline form had to unlock manually before delegating. See observeReasoningText
+// for why only the first-seen kind is counted.
+func (a *CodexAgent) shouldCountReasoningKind(itemID, kind string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.reasoningStreamKind == nil {
+		a.reasoningStreamKind = make(map[string]string)
+	}
+	locked, ok := a.reasoningStreamKind[itemID]
+	if !ok {
+		a.reasoningStreamKind[itemID] = kind
+		return true
+	}
+	return locked == kind
+}
+
 // handleAgentMessageDelta processes item/agentMessage/delta — streaming text.
 func (a *CodexAgent) handleAgentMessageDelta(params json.RawMessage) {
 	var delta struct {
-		Delta string `json:"delta"`
+		Delta    string `json:"delta"`
+		ThreadID string `json:"threadId"`
 	}
 	if json.Unmarshal(params, &delta) == nil && delta.Delta != "" {
 		a.sink.BroadcastStreamChunk([]byte(delta.Delta), "", "item/agentMessage/delta")
+		a.observeMainThreadText(delta.ThreadID, delta.Delta)
 	}
 }
 
 // handlePlanDelta processes item/plan/delta — streaming plan text.
 func (a *CodexAgent) handlePlanDelta(params json.RawMessage) {
 	var delta struct {
-		Delta string `json:"delta"`
+		Delta    string `json:"delta"`
+		ThreadID string `json:"threadId"`
 	}
 	if json.Unmarshal(params, &delta) == nil && delta.Delta != "" {
 		a.mu.Lock()
@@ -159,16 +235,19 @@ func (a *CodexAgent) handlePlanDelta(params json.RawMessage) {
 			a.mu.Unlock()
 		}
 		a.sink.BroadcastStreamChunk([]byte(delta.Delta), "", "item/plan/delta")
+		a.observeMainThreadText(delta.ThreadID, delta.Delta)
 	}
 }
 
 func (a *CodexAgent) handleReasoningSummaryTextDelta(params json.RawMessage) {
 	var notif struct {
-		ItemID string `json:"itemId"`
-		Delta  string `json:"delta"`
+		ItemID   string `json:"itemId"`
+		Delta    string `json:"delta"`
+		ThreadID string `json:"threadId"`
 	}
 	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
 		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/reasoning/summaryTextDelta")
+		a.observeReasoningText(notif.ItemID, codexReasoningKindSummary, notif.ThreadID, notif.Delta)
 	}
 }
 
@@ -183,11 +262,13 @@ func (a *CodexAgent) handleReasoningSummaryPartAdded(params json.RawMessage) {
 
 func (a *CodexAgent) handleReasoningTextDelta(params json.RawMessage) {
 	var notif struct {
-		ItemID string `json:"itemId"`
-		Delta  string `json:"delta"`
+		ItemID   string `json:"itemId"`
+		Delta    string `json:"delta"`
+		ThreadID string `json:"threadId"`
 	}
 	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
 		a.sink.BroadcastStreamChunk([]byte(notif.Delta), notif.ItemID, "item/reasoning/textDelta")
+		a.observeReasoningText(notif.ItemID, codexReasoningKindRaw, notif.ThreadID, notif.Delta)
 	}
 }
 
@@ -244,7 +325,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		// notification consolidator and frontend classifier route by
 		// method) and Codex-specific fields under `params.item.*` that a
 		// synthesized `{type:"compacting"}` would discard.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("codex persist compacting notification", "agent_id", a.agentID, "error", err)
 		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
@@ -347,6 +428,11 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		}); err != nil {
 			slog.Error("codex persist reasoning", "agent_id", a.agentID, "error", err)
 		}
+		// The reasoning item is done; drop its stream-kind lock so the map stays
+		// bounded to in-flight items.
+		a.mu.Lock()
+		delete(a.reasoningStreamKind, itemID)
+		a.mu.Unlock()
 		a.sink.BroadcastStreamEnd(itemID)
 	case "contextCompaction":
 		// No-op: completion is represented by thread/compacted, which is emitted as
@@ -480,7 +566,7 @@ func (a *CodexAgent) handleTokenUsageUpdated(content []byte, params json.RawMess
 
 	// Persist the raw Codex notification so reconnect/catch-up can rehydrate
 	// context usage from history. Codex-emitted metadata → AGENT source.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
+	if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("codex persist tokenUsage", "agent_id", a.agentID, "error", err)
 	}
 
@@ -554,7 +640,7 @@ func (a *CodexAgent) handleErrorNotification(params json.RawMessage) {
 // rate limit info is broadcast via BroadcastSessionInfo for the live popover.
 func (a *CodexAgent) handleRateLimitsUpdated(content []byte, params json.RawMessage) {
 	// Persist the raw Codex notification — agent-emitted metadata, AGENT source.
-	if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
+	if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content); err != nil {
 		slog.Error("codex persist rateLimits", "agent_id", a.agentID, "error", err)
 	}
 

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -22,13 +23,15 @@ func (s *startupStatusGuardSink) PersistMessage(source leapmuxv1.MessageSource, 
 }
 
 func newCodexAgentWithSink(sink OutputSink) *CodexAgent {
-	return &CodexAgent{
+	a := &CodexAgent{
 		jsonrpcBase: jsonrpcBase{processBase: processBase{
 			agentID: "test-agent",
 		}},
 		sink:     sink,
 		threadID: "main-thread",
 	}
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
+	return a
 }
 
 func TestHandleCodexOutput_TurnStartedBroadcastsTurnID(t *testing.T) {
@@ -146,17 +149,20 @@ func TestHandleCodexOutput_PlanDelta(t *testing.T) {
 	require.Equal(t, "", got.SpanID)
 	require.Equal(t, "# Plan\n", string(got.Content))
 
-	// Verify the session info was broadcast with streaming_type "plan".
-	require.Equal(t, 1, sink.SessionInfoCount())
-	info := sink.LastSessionInfo()
-	assert.Equal(t, "plan", info["streaming_type"])
+	// Verify the streaming_type session info was broadcast with "plan". (The
+	// plan delta also broadcasts a thinking_tokens estimate, so assert on the
+	// streaming_type key rather than the total broadcast count.)
+	streamingType, ok := lastSessionInfoValue(sink, "streaming_type")
+	require.True(t, ok)
+	assert.Equal(t, "plan", streamingType)
+	require.Equal(t, 1, countSessionInfoWithKey(sink, "streaming_type"))
 
-	// Second delta should NOT broadcast session info again.
+	// Second delta should NOT broadcast streaming_type again.
 	input2 := `{"method":"item/plan/delta","params":{"delta":"Step 1\n"}}`
 	handleCodexOutput(agent, parseLine([]byte(input2)))
 
 	require.Equal(t, 2, sink.StreamChunkCount())
-	assert.Equal(t, 1, sink.SessionInfoCount())
+	assert.Equal(t, 1, countSessionInfoWithKey(sink, "streaming_type"))
 
 	// Should NOT be persisted as a regular message.
 	assert.Equal(t, 0, sink.MessageCount())
@@ -650,20 +656,24 @@ func TestHandleCodexOutput_PlanDeltaThenCompleted(t *testing.T) {
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 
-	// Send a plan delta first.
+	// Send a plan delta first. (It also broadcasts a thinking_tokens estimate on
+	// the same channel, so assert on the streaming_type key specifically rather
+	// than on raw broadcast counts / the last payload.)
 	delta := `{"method":"item/plan/delta","params":{"delta":"# Plan\n"}}`
 	handleCodexOutput(agent, parseLine([]byte(delta)))
 
-	require.Equal(t, 1, sink.SessionInfoCount())
+	streamingType, ok := lastSessionInfoValue(sink, "streaming_type")
+	require.True(t, ok)
+	assert.Equal(t, "plan", streamingType)
 
 	// Send item/completed with plan type.
 	completed := `{"method":"item/completed","params":{"item":{"type":"plan","id":"plan1","text":"# Plan\nStep 1"}}}`
 	handleCodexOutput(agent, parseLine([]byte(completed)))
 
 	// Session info should now have streaming_type "" to clear the plan streaming.
-	require.Equal(t, 2, sink.SessionInfoCount())
-	info := sink.LastSessionInfo()
-	assert.Equal(t, "", info["streaming_type"])
+	streamingType, ok = lastSessionInfoValue(sink, "streaming_type")
+	require.True(t, ok)
+	assert.Equal(t, "", streamingType)
 
 	// Plan message should be persisted.
 	require.Equal(t, 1, sink.MessageCount())
@@ -672,9 +682,15 @@ func TestHandleCodexOutput_PlanDeltaThenCompleted(t *testing.T) {
 	delta2 := `{"method":"item/plan/delta","params":{"delta":"New plan\n"}}`
 	handleCodexOutput(agent, parseLine([]byte(delta2)))
 
-	require.Equal(t, 3, sink.SessionInfoCount())
-	info2 := sink.LastSessionInfo()
-	assert.Equal(t, "plan", info2["streaming_type"])
+	streamingType, ok = lastSessionInfoValue(sink, "streaming_type")
+	require.True(t, ok)
+	assert.Equal(t, "plan", streamingType)
+
+	// The exact streaming_type lifecycle: "plan" on the first delta, "" exactly
+	// once when the plan item completes, then "plan" again because item/completed
+	// cleared the streamingPlan flag. (Guards against a regression where
+	// item/completed double-broadcasts "" or the second delta fails to re-arm.)
+	assert.Equal(t, []interface{}{"plan", "", "plan"}, sessionInfoValues(sink, "streaming_type"))
 }
 
 func TestHandleCodexOutput_CommandExecutionCompletedBroadcastsStreamEnd(t *testing.T) {
@@ -862,4 +878,333 @@ func TestHandleCodexOutput_TurnCompletedPlanModeWithEmptyPlanTextDoesNotPersist(
 	require.Equal(t, 0, sink.PlanUpdateCount())
 	require.Equal(t, 0, sink.PersistedControlCount())
 	require.Equal(t, 0, sink.BroadcastControlCount())
+}
+
+// lastSessionInfoValue returns the value of the most recent BroadcastSessionInfo
+// payload that carried key, and whether any did. Used to assert on one key while
+// ignoring unrelated broadcasts (e.g. streaming_type vs thinking_tokens) that may
+// interleave on the same channel.
+func lastSessionInfoValue(sink *testSink, key string) (interface{}, bool) {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	for i := len(sink.sessionInfos) - 1; i >= 0; i-- {
+		if v, ok := sink.sessionInfos[i][key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// countSessionInfoWithKey counts how many BroadcastSessionInfo payloads carried
+// key. Used to assert a key was broadcast exactly N times while other keys
+// (e.g. thinking_tokens) interleave on the same channel.
+func countSessionInfoWithKey(sink *testSink, key string) int {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	n := 0
+	for _, info := range sink.sessionInfos {
+		if _, ok := info[key]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+// sessionInfoValues returns, in broadcast order, every value carried under key.
+// Lets a test assert the exact sequence (and therefore count) of a key's
+// broadcasts while other keys interleave on the same channel.
+func sessionInfoValues(sink *testSink, key string) []interface{} {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	var out []interface{}
+	for _, info := range sink.sessionInfos {
+		if v, ok := info[key]; ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// lastThinkingTokens returns the most recently broadcast thinking_tokens value,
+// or -1 when none has been broadcast yet. -1 (not 0) is the sentinel so a test
+// can tell "never broadcast" apart from a real 0.
+func lastThinkingTokens(sink *testSink) int64 {
+	if v, ok := lastSessionInfoValue(sink, SessionInfoKeyThinkingTokens); ok {
+		return v.(int64)
+	}
+	return -1
+}
+
+func TestHandleCodexOutput_AgentMessageDeltaAccumulatesThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	// 8-char delta -> 8/4 = 2 tokens; a second 8-char delta accumulates to
+	// 16/4 = 4. The estimate climbs cumulatively across deltas of the same phase.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"ijklmnop"}}`)))
+	assert.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A live estimate is broadcast, never persisted to the timeline.
+	assert.Equal(t, 0, sink.MessageCount(), "thinking_tokens deltas must not persist")
+	assert.Equal(t, 0, sink.NotificationCount())
+}
+
+func TestHandleCodexOutput_ReasoningAndPlanDeltasAccumulateThinkingTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"reasoning text", `{"method":"item/reasoning/textDelta","params":{"itemId":"r1","delta":"%s"}}`},
+		{"reasoning summary", `{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"r1","delta":"%s"}}`},
+		{"plan", `{"method":"item/plan/delta","params":{"delta":"%s"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &testSink{}
+			agent := newCodexAgentWithSink(sink)
+			agent.threadID = "main-thread"
+
+			handleCodexOutput(agent, parseLine([]byte(fmt.Sprintf(tc.input, "abcdefgh"))))
+			assert.Equal(t, int64(2), lastThinkingTokens(sink))
+			handleCodexOutput(agent, parseLine([]byte(fmt.Sprintf(tc.input, "ijklmnop"))))
+			assert.Equal(t, int64(4), lastThinkingTokens(sink))
+		})
+	}
+}
+
+func TestHandleCodexOutput_ReasoningSummaryAndRawCountOncePerItem(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	// Codex can stream BOTH a summary and the raw reasoning for one reasoning item
+	// (same itemId, same generation surfaced twice). The summary arrives first and
+	// locks item r1 onto "summary" (8 chars -> 2 tokens).
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"r1","delta":"abcdefgh","threadId":"main-thread"}}`)))
+	require.Equal(t, int64(2), lastThinkingTokens(sink))
+
+	// Raw reasoning for the SAME item must NOT be counted -- it would double the
+	// estimate for the same underlying generation.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/textDelta","params":{"itemId":"r1","delta":"ZZZZZZZZZZZZZZZZ","threadId":"main-thread"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "raw reasoning for the locked item is not double-counted")
+
+	// More summary deltas for the locked item still climb (16 chars -> 4 tokens).
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"r1","delta":"ijklmnop","threadId":"main-thread"}}`)))
+	assert.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A different reasoning item locks independently: raw arrives first for r2.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/textDelta","params":{"itemId":"r2","delta":"qrstuvwx","threadId":"main-thread"}}`)))
+	assert.Equal(t, int64(6), lastThinkingTokens(sink), "a separate item counts its own first-seen kind (24 chars -> 6)")
+}
+
+func TestHandleCodexOutput_ReasoningCountsWhicheverStreamArrivesFirst(t *testing.T) {
+	// A model that streams only one reasoning kind must still move the counter, so
+	// the estimator locks onto whichever arrives first rather than preferring one.
+	for _, tc := range []struct {
+		name   string
+		method string
+	}{
+		{"raw only", "item/reasoning/textDelta"},
+		{"summary only", "item/reasoning/summaryTextDelta"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &testSink{}
+			agent := newCodexAgentWithSink(sink)
+			agent.threadID = "main-thread"
+
+			handleCodexOutput(agent, parseLine([]byte(fmt.Sprintf(
+				`{"method":%q,"params":{"itemId":"r1","delta":"abcdefgh","threadId":"main-thread"}}`, tc.method))))
+			assert.Equal(t, int64(2), lastThinkingTokens(sink), "a single reasoning stream still counts")
+		})
+	}
+}
+
+func TestHandleCodexOutput_ReasoningItemCompletedReleasesStreamLock(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	// Item r1 locks onto "summary".
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"r1","delta":"abcdefgh","threadId":"main-thread"}}`)))
+	require.Equal(t, int64(2), lastThinkingTokens(sink))
+
+	// Completing the reasoning item resets the estimate (a main-scope AGENT commit)
+	// AND releases r1's stream-kind lock so the map stays bounded.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"reasoning","id":"r1","summary":[{"text":"done"}]}}}`)))
+	agent.mu.Lock()
+	_, stillLocked := agent.reasoningStreamKind["r1"]
+	agent.mu.Unlock()
+	assert.False(t, stillLocked, "the completed item's stream-kind lock is released")
+}
+
+func TestHandleCodexOutput_ChildThreadDeltasDoNotCountThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink) // threadID = "main-thread"
+
+	// A main-thread delta counts (explicit main threadId).
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh","threadId":"main-thread"}}`)))
+	require.Equal(t, int64(2), lastThinkingTokens(sink))
+
+	// A collab subagent (child thread) delta is still broadcast as a stream chunk
+	// but must NOT inflate the primary agent's estimate.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/textDelta","params":{"itemId":"r1","delta":"ignoredchildtext","threadId":"child-1"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "child-thread text must not count")
+
+	// A subsequent main-thread delta (empty threadId == main) resumes from the
+	// main total, unaffected by the child text in between.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"ijklmnop"}}`)))
+	assert.Equal(t, int64(4), lastThinkingTokens(sink))
+}
+
+func TestHandleCodexOutput_CommandAndFileOutputDeltasDoNotCountThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	// Tool output (shell stdout, file diffs) is not model generation, so it must
+	// NOT inflate the thinking-token estimate.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/commandExecution/outputDelta","params":{"itemId":"c1","delta":"lots of stdout here"}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/fileChange/outputDelta","params":{"itemId":"f1","delta":"@@ -1 +1 @@ big diff"}}`)))
+
+	assert.Equal(t, int64(-1), lastThinkingTokens(sink), "tool output must not broadcast thinking_tokens")
+}
+
+func TestHandleCodexOutput_ItemCompletedResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefghijklmnop"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// Committing the message is a phase boundary the frontend clears on; the
+	// backend estimate must reset so the next phase restarts from zero.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"agentMessage","id":"m1","text":"hi"}}}`)))
+
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "next phase restarts at 8/4, not the cumulative total")
+}
+
+func TestHandleCodexOutput_ItemStartedAndApprovalResetThinkingTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset string
+	}{
+		// A started tool item commits an AGENT message the frontend clears on.
+		{"item started", `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"commandExecution","id":"cmd-1","status":"inProgress","command":"ls","cwd":"/tmp","processId":"123","commandActions":[]}}}`},
+		// An approval request is a live control request the frontend clears on.
+		{"approval request", `{"jsonrpc":"2.0","id":7,"method":"item/commandExecution/requestApproval","params":{"command":"ls","reason":"x"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &recordingControlSink{}
+			agent := newCodexAgentWithSink(sink)
+			agent.threadID = "main-thread"
+
+			handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefghijklmnop"}}`)))
+			require.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+			handleCodexOutput(agent, parseLine([]byte(tc.reset)))
+
+			handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh"}}`)))
+			assert.Equal(t, int64(2), lastThinkingTokens(&sink.testSink), "the boundary restarts the estimate")
+		})
+	}
+}
+
+func TestHandleCodexOutput_ChildThreadTurnStartedDoesNotResetThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink) // threadID = "main-thread"
+
+	// Accumulate a main-thread estimate (16 chars -> 4 tokens).
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefghijklmnop","threadId":"main-thread"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A collab subagent's turn/started carries its own child threadId. It must NOT
+	// reset the primary agent's estimate -- the frontend has no counter clear for
+	// turn/started, so an ungated reset would spin the odometer backward mid-phase.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"child-turn"}}}`)))
+
+	// The next main-thread delta keeps climbing from the cumulative total (24/4=6),
+	// proving the child-thread turn/started did not reset the estimate.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"qrstuvwx","threadId":"main-thread"}}`)))
+	assert.Equal(t, int64(6), lastThinkingTokens(sink), "a child-thread turn/started must not reset the primary estimate")
+}
+
+func TestHandleCodexOutput_TurnStartedClearsReasoningStreamLocksOnMainThreadOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		turnStarted string
+		wantCleared bool
+	}{
+		{"main thread clears", `{"method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-2"}}}`, true},
+		{"child thread keeps", `{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"child-turn"}}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &testSink{}
+			agent := newCodexAgentWithSink(sink)
+			agent.threadID = "main-thread"
+
+			// Lock reasoning item r1 onto its first-seen sub-stream kind.
+			handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/summaryTextDelta","params":{"itemId":"r1","delta":"abcdefgh","threadId":"main-thread"}}`)))
+			agent.mu.Lock()
+			_, locked := agent.reasoningStreamKind["r1"]
+			agent.mu.Unlock()
+			require.True(t, locked, "the reasoning item is locked before the turn boundary")
+
+			// A new turn on the main thread drops stale per-item locks so itemIds can't
+			// leak across turns (e.g. a reasoning item left open by an abort); a
+			// child-thread turn/started belongs to a collab subagent and must leave the
+			// primary agent's locks intact, mirroring the main-thread gate on the reset.
+			handleCodexOutput(agent, parseLine([]byte(tc.turnStarted)))
+
+			agent.mu.Lock()
+			_, stillLocked := agent.reasoningStreamKind["r1"]
+			agent.mu.Unlock()
+			assert.Equal(t, !tc.wantCleared, stillLocked)
+		})
+	}
+}
+
+func TestHandleCodexOutput_ReasoningItemCompletedResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	// Reasoning streams and climbs (16 chars -> 4 tokens).
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/reasoning/textDelta","params":{"itemId":"r1","delta":"abcdefghijklmnop","threadId":"main-thread"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// Codex has no explicit reasoning->answer hand-off (unlike ACP); it relies on
+	// the reasoning item/completed persisting an AGENT message the frontend clears
+	// on, which the decorator mirrors with a reset. Without it, the reasoning chars
+	// would stack onto the following answer's count.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"reasoning","id":"r1","summary":[{"text":"done"}]}}}`)))
+
+	// The answer phase restarts from zero (8/4 = 2), not the reasoning total.
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh","threadId":"main-thread"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "reasoning item/completed resets so the answer restarts from zero")
+}
+
+func TestHandleCodexOutput_TurnBoundariesResetThinkingTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset string
+	}{
+		{"turn started", `{"method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-2"}}}`},
+		{"turn completed", `{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &testSink{}
+			agent := newCodexAgentWithSink(sink)
+			agent.threadID = "main-thread"
+
+			handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefghijklmnop"}}`)))
+			require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+			handleCodexOutput(agent, parseLine([]byte(tc.reset)))
+
+			handleCodexOutput(agent, parseLine([]byte(`{"method":"item/agentMessage/delta","params":{"delta":"abcdefgh"}}`)))
+			assert.Equal(t, int64(2), lastThinkingTokens(sink), "the new turn restarts the estimate")
+		})
+	}
 }

--- a/backend/internal/worker/agent/copilot_output_test.go
+++ b/backend/internal/worker/agent/copilot_output_test.go
@@ -18,6 +18,7 @@ func newCopilotAgentWithSink(sink OutputSink) *CopilotCLIAgent {
 		},
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 	return a
 }
 

--- a/backend/internal/worker/agent/cursor_output_test.go
+++ b/backend/internal/worker/agent/cursor_output_test.go
@@ -23,6 +23,7 @@ func newCursorAgentWithSink(sink OutputSink) *CursorCLIAgent {
 	}
 	a.extraSessionUpdate = configOptionSessionUpdateHandler(a.handleConfigOptionUpdate)
 	a.extraMethod = a.handleExtraMethod
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 	return a
 }
 

--- a/backend/internal/worker/agent/gemini_output_test.go
+++ b/backend/internal/worker/agent/gemini_output_test.go
@@ -19,6 +19,7 @@ func newGeminiAgentWithSink(sink OutputSink) *GeminiCLIAgent {
 		},
 	}
 	a.extraSessionUpdate = a.handleExtraSessionUpdate
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 	return a
 }
 

--- a/backend/internal/worker/agent/kilo_output_test.go
+++ b/backend/internal/worker/agent/kilo_output_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newKiloAgentWithSink(sink OutputSink) *KiloAgent {
-	return &KiloAgent{
+	a := &KiloAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:      "test-agent",
@@ -20,6 +20,8 @@ func newKiloAgentWithSink(sink OutputSink) *KiloAgent {
 			sessionID: "test-session",
 		},
 	}
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
+	return a
 }
 
 func TestHandleKiloOutput_AgentMessageChunk(t *testing.T) {

--- a/backend/internal/worker/agent/opencode_output_test.go
+++ b/backend/internal/worker/agent/opencode_output_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newOpenCodeAgentWithSink(sink OutputSink) *OpenCodeAgent {
-	return &OpenCodeAgent{
+	a := &OpenCodeAgent{
 		acpBase: acpBase{
 			jsonrpcBase: jsonrpcBase{processBase: processBase{
 				agentID:      "test-agent",
@@ -20,6 +20,8 @@ func newOpenCodeAgentWithSink(sink OutputSink) *OpenCodeAgent {
 			sessionID: "test-session",
 		},
 	}
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
+	return a
 }
 
 func TestHandleOpenCodeOutput_AgentMessageChunk(t *testing.T) {
@@ -528,4 +530,245 @@ func TestHandleOpenCodeOutput_ToolCallUpdateCompletedIncrementsToolUses(t *testi
 	agent.mu.Unlock()
 
 	require.Equal(t, 3, count)
+}
+
+// acpChunk builds a session/update envelope carrying one streamed chunk of the
+// given sessionUpdate kind and text. acpMessageChunk / acpThoughtChunk are the
+// two kinds the thinking-token tests drive.
+func acpChunk(sessionUpdate, text string) []byte {
+	return []byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"` + sessionUpdate + `","content":{"type":"text","text":"` + text + `"}}}}`)
+}
+
+func acpMessageChunk(text string) []byte { return acpChunk("agent_message_chunk", text) }
+func acpThoughtChunk(text string) []byte { return acpChunk("agent_thought_chunk", text) }
+
+func TestHandleACPOutput_MessageChunkAccumulatesThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// 8-char chunk -> 2 tokens; a second 8-char chunk accumulates to 4. Assistant
+	// text streams here; thought chunks accumulate the same way but buffer.
+	agent.HandleOutput(acpMessageChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink))
+	agent.HandleOutput(acpMessageChunk("ijklmnop"))
+	assert.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A live estimate is broadcast, never persisted (assistant text persists only
+	// at end-of-turn).
+	assert.Equal(t, 0, sink.MessageCount(), "streamed chunks must not persist")
+}
+
+func TestHandleACPOutput_ThoughtChunkAccumulatesThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	agent.HandleOutput(acpThoughtChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink))
+	agent.HandleOutput(acpThoughtChunk("ijklmnop"))
+	assert.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	assert.Equal(t, 0, sink.MessageCount(), "thought chunks buffer, not persist")
+	// Reasoning that is NOT preceded by assistant text must NOT trigger the
+	// assistant->reasoning hand-off (no spurious 0 clear); it just climbs.
+	assert.Equal(t, []interface{}{int64(2), int64(4)}, sessionInfoValues(sink, "thinking_tokens"),
+		"a leading reasoning segment climbs without an explicit clear")
+}
+
+func TestHandleACPOutput_AssistantTextAfterReasoningResetsViaFlush(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// Reasoning streams first (buffered).
+	agent.HandleOutput(acpThoughtChunk("abcdefghijklmnop")) // 16 chars -> 4
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// An assistant message chunk flushes the buffered thought as a committed
+	// AGENT message (the decorator resets on that persist), so the assistant text
+	// is counted on its own from zero -- the thought->message direction of the
+	// per-phase reset.
+	agent.HandleOutput(acpMessageChunk("abcdefgh")) // 8 chars -> 2
+
+	require.Equal(t, 1, sink.MessageCount(), "the buffered thought is flushed as one message")
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "assistant text restarts from zero after the reasoning flush")
+}
+
+func TestHandleACPOutput_ToolCallResetsThinkingTokens(t *testing.T) {
+	// Covers both sources: a tool call after assistant text (message->tool, no
+	// buffered thought to flush) and after reasoning (thought->tool). Either way
+	// the next phase's estimate must restart from zero.
+	for _, src := range []struct {
+		name  string
+		chunk func(string) []byte
+	}{
+		{"after message", acpMessageChunk},
+		{"after thought", acpThoughtChunk},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			sink := &testSink{}
+			agent := newOpenCodeAgentWithSink(sink)
+
+			agent.HandleOutput(src.chunk("abcdefghijklmnop"))
+			require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+			// A tool call commits an AGENT message the frontend clears on.
+			agent.HandleOutput([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"read","kind":"read","status":"pending"}}}`))
+
+			agent.HandleOutput(src.chunk("abcdefgh"))
+			assert.Equal(t, int64(2), lastThinkingTokens(sink), "the next phase restarts at 8/4")
+		})
+	}
+}
+
+func TestHandleACPOutput_TurnEndResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop"))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// End of turn: the assistant message + result divider commit, and the
+	// per-turn estimate resets.
+	agent.handleACPPromptResponse(json.RawMessage(`{"stopReason":"end_turn"}`), nil)
+
+	agent.HandleOutput(acpMessageChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "the next turn restarts the estimate")
+}
+
+func TestHandleACPOutput_ReasoningAfterAssistantTextStartsFreshPhase(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// Assistant text streams first; it is buffered until turn end, so it never
+	// commits an AGENT message and never triggers a frontend clear.
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop")) // 16 chars -> 4
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A reasoning chunk then opens a new phase. Because the assistant chars were
+	// never committed, the backend must explicitly clear the frontend counter (0)
+	// and restart, so the reasoning is counted on its own rather than stacked on
+	// the assistant total (which would also spin the forward-only odometer back).
+	agent.HandleOutput(acpThoughtChunk("abcdefgh")) // 8 chars -> 2
+
+	assert.Equal(t, []interface{}{int64(4), int64(0), int64(2)}, sessionInfoValues(sink, "thinking_tokens"),
+		"assistant total, then an explicit clear, then the reasoning counted fresh")
+}
+
+func TestHandleACPOutput_NilResultResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop"))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// A nil result (errored/aborted turn) still ends the turn. No result divider is
+	// persisted, so the frontend gets no turn-end clear of its own -- the abort must
+	// broadcast an explicit 0 so the live counter drops now instead of freezing on 4
+	// until the next turn streams. The estimate must also not leak into the next
+	// turn (ACP has no turn-start reset).
+	agent.handleACPPromptResponse(nil, nil)
+	assert.Equal(t, int64(0), lastThinkingTokens(sink), "the abort broadcasts an explicit clear")
+
+	agent.HandleOutput(acpMessageChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "a nil-result turn end restarts the estimate")
+	assert.Equal(t, []interface{}{int64(4), int64(0), int64(2)}, sessionInfoValues(sink, "thinking_tokens"),
+		"assistant total, then the abort's explicit clear, then the next turn counted fresh")
+}
+
+func TestHandleACPOutput_NilResultDropsBufferedAssistantText(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// Turn 1 streams assistant text, then aborts with a nil result. The buffered
+	// text was never committed; it must NOT survive into the next turn's reply.
+	agent.HandleOutput(acpMessageChunk("STALE-TURN-1"))
+	agent.handleACPPromptResponse(nil, nil)
+
+	// Turn 2 streams its own assistant text and ends normally.
+	agent.HandleOutput(acpMessageChunk("turn-2-text"))
+	agent.handleACPPromptResponse(json.RawMessage(`{"stopReason":"end_turn"}`), nil)
+
+	// The persisted assistant message for turn 2 must carry only turn 2's text --
+	// the aborted turn's buffer was dropped, not prepended.
+	assert.Equal(t, "turn-2-text", persistedACPAssistantText(t, sink),
+		"the aborted turn's buffered assistant text does not leak into the next reply")
+}
+
+func TestHandleACPOutput_ReasoningAfterCommittedToolDoesNotReclear(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	// Assistant text streams (buffered), then a reasoning segment opens -> a real
+	// hand-off clear (the assistant chars were never committed).
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop")) // 16 -> 4
+	agent.HandleOutput(acpThoughtChunk("abcdefgh"))         // hand-off 0, then 2
+
+	// A tool call commits an AGENT message: the estimator resets and the frontend
+	// clears.
+	agent.HandleOutput([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"read","kind":"read","status":"pending"}}}`))
+
+	// The next reasoning segment must NOT re-fire the hand-off clear: the tool call
+	// already cleared the frontend, so a second 0 would be redundant wire traffic.
+	// The hand-off gates on the estimator's pending chars (now 0), not the
+	// turn-scoped assistant builder (still non-empty), so it stays quiet and the
+	// reasoning just climbs from the post-tool reset.
+	agent.HandleOutput(acpThoughtChunk("abcdefgh")) // 8 -> 2
+
+	assert.Equal(t, []interface{}{int64(4), int64(0), int64(2), int64(2)}, sessionInfoValues(sink, "thinking_tokens"),
+		"no redundant clear after a committed tool call between assistant text and later reasoning")
+}
+
+// persistedACPAssistantText returns the text of the single persisted
+// agent_message_chunk (the turn-end assistant reply), failing the test if none or
+// more than one is present.
+func persistedACPAssistantText(t *testing.T, sink *testSink) string {
+	t.Helper()
+	var found []string
+	for _, m := range sink.Messages() {
+		if m.TurnEnd {
+			continue
+		}
+		var parsed struct {
+			SessionUpdate string `json:"sessionUpdate"`
+			Content       struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		if json.Unmarshal(m.Content, &parsed) != nil {
+			continue
+		}
+		if parsed.SessionUpdate == "agent_message_chunk" {
+			found = append(found, parsed.Content.Text)
+		}
+	}
+	require.Len(t, found, 1, "expected exactly one persisted assistant message")
+	return found[0]
+}
+
+func TestHandleACPOutput_PermissionRequestResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop"))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// The agent paused for permission -- the frontend clears its counter on the
+	// control request, so the backend resets to mirror it.
+	agent.HandleOutput([]byte(`{"jsonrpc":"2.0","id":5,"method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"tc-1","title":"Run","kind":"execute","status":"pending"},"options":[{"optionId":"once","kind":"allow_once","name":"Allow"}]}}`))
+
+	agent.HandleOutput(acpMessageChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "a permission prompt restarts the estimate")
+}
+
+func TestHandleACPOutput_UnknownMethodResetsThinkingTokens(t *testing.T) {
+	sink := &testSink{}
+	agent := newOpenCodeAgentWithSink(sink)
+
+	agent.HandleOutput(acpMessageChunk("abcdefghijklmnop"))
+	require.Equal(t, int64(4), lastThinkingTokens(sink))
+
+	// An unknown method persists as an AGENT message the frontend clears on.
+	agent.HandleOutput([]byte(`{"jsonrpc":"2.0","method":"some/unknown/method","params":{"foo":"bar"}}`))
+
+	agent.HandleOutput(acpMessageChunk("abcdefgh"))
+	assert.Equal(t, int64(2), lastThinkingTokens(sink), "an unknown AGENT-message method restarts the estimate")
 }

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -42,6 +42,9 @@ type PiAgent struct {
 	sessionID         string // Pi's runtime sessionId (rotates on new_session)
 	sessionFile       string // Pi's persistent session file path (durable identifier)
 	currentTurnActive bool   // true between agent_start and agent_end
+	// thinkingTokens is the per-phase generated-token estimate driving the
+	// thinking-indicator counter; see thinkingTokenEstimator and thinkingResetSink.
+	thinkingTokens thinkingTokenEstimator
 
 	// Pi exposes token/cost information in assistant messages and via
 	// get_session_stats. Keep the latest normalized snapshot here so persisted
@@ -92,6 +95,8 @@ func StartPi(ctx context.Context, opts Options, sink OutputSink) (Agent, error) 
 		workingDir:    opts.WorkingDir,
 		sink:          sink,
 	}
+	// Reset the thinking-token estimate centrally at every frontend-clear boundary.
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 
 	if err := a.startCmd(cmd, cancel); err != nil {
 		return nil, err
@@ -345,6 +350,11 @@ func (a *PiAgent) ClearContext() (string, bool) {
 	a.usageGeneration++
 	handle := a.sessionHandleLocked()
 	a.mu.Unlock()
+	// The session was replaced; drop any in-flight thinking-token estimate so it
+	// doesn't leak into the new context (mirrors acpBase.ClearContext). The next
+	// agent_start also resets, but resetting here keeps every provider's context
+	// clear consistent rather than relying on that follow-up.
+	a.thinkingTokens.reset()
 	if handle == "" {
 		return "", false
 	}

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -116,7 +116,7 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 		PiEventExtensionError:
 		// Pi-emitted lifecycle / extension events — AGENT source per the
 		// proto rule (LEAPMUX is reserved for worker-synthesized envelopes).
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, line.Raw); err != nil {
 			slog.Error("pi persist notification", "agent_id", a.agentID, "type", line.Type, "error", err)
 		}
 	case PiEventExtensionUIRequest:
@@ -137,6 +137,8 @@ func (a *PiAgent) handlePiAgentStart() {
 	a.mu.Lock()
 	a.currentTurnActive = true
 	a.mu.Unlock()
+	// A fresh turn begins: start the thinking-token estimate from zero.
+	a.thinkingTokens.reset()
 }
 
 func (a *PiAgent) handlePiAgentEnd(raw []byte) {
@@ -199,16 +201,18 @@ func (a *PiAgent) handlePiMessageUpdate(raw []byte) {
 	}
 
 	switch env.AssistantMessageEvent.Type {
-	case PiAssistantEventTextDelta:
+	case PiAssistantEventTextDelta, PiAssistantEventThinkingDelta:
+		// Text and thinking deltas are handled identically: stream the chunk under
+		// its own event type, then feed it to the live token estimate. Pi persists
+		// both as one message_end with no per-phase split, so a thinking->text
+		// transition inside a single message shares one thinking-token phase by
+		// design. The broadcast method is taken from the event type so the frontend
+		// still distinguishes the two stream kinds.
 		if env.AssistantMessageEvent.Delta == "" {
 			return
 		}
-		a.sink.BroadcastStreamChunk([]byte(env.AssistantMessageEvent.Delta), "", PiAssistantEventTextDelta)
-	case PiAssistantEventThinkingDelta:
-		if env.AssistantMessageEvent.Delta == "" {
-			return
-		}
-		a.sink.BroadcastStreamChunk([]byte(env.AssistantMessageEvent.Delta), "", PiAssistantEventThinkingDelta)
+		a.sink.BroadcastStreamChunk([]byte(env.AssistantMessageEvent.Delta), "", env.AssistantMessageEvent.Type)
+		a.thinkingTokens.observe(a.sink, env.AssistantMessageEvent.Delta)
 	default:
 		// All other delta sub-types (text_start/end, thinking_start/end,
 		// toolcall_*, start, done, error) are handled via message_end and
@@ -349,7 +353,7 @@ func (a *PiAgent) handlePiExtensionUIRequest(raw []byte) {
 		// Persist the raw extension_ui_request envelope as AGENT. The
 		// frontend's Pi notification renderer derives level/message from
 		// `notifyType`/`message` on the raw payload — no synthesis needed.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("pi persist notify", "agent_id", a.agentID, "error", err)
 		}
 	case PiExtensionMethodSetStatus:
@@ -383,7 +387,7 @@ func (a *PiAgent) handlePiExtensionUIRequest(raw []byte) {
 	default:
 		// Unknown extension UI method — record so the user can see it.
 		// Pi-emitted, so AGENT source.
-		if err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
+		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
 			slog.Error("pi persist unknown extension_ui_request",
 				"agent_id", a.agentID, "method", head.Method, "error", err)
 		}

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -10,11 +10,13 @@ import (
 )
 
 func newPiAgentWithSink(sink OutputSink) *PiAgent {
-	return &PiAgent{
+	a := &PiAgent{
 		processBase: processBase{agentID: "test-agent"},
 		sink:        sink,
 		sessionFile: "/tmp/pi-session.jsonl",
 	}
+	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
+	return a
 }
 
 func TestHandlePiOutput_AgentStart_SetsTurnFlag(t *testing.T) {
@@ -599,4 +601,123 @@ func TestHandlePiOutput_UnknownEventType_PersistedAsAgent(t *testing.T) {
 
 	require.Equal(t, 1, sink.MessageCount())
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, sink.Messages()[0].Source)
+}
+
+func TestHandlePiOutput_TextAndThinkingDeltasAccumulateThinkingTokens(t *testing.T) {
+	for _, deltaType := range []string{"text_delta", "thinking_delta"} {
+		t.Run(deltaType, func(t *testing.T) {
+			sink := &recordingControlSink{}
+			a := newPiAgentWithSink(sink)
+
+			// 8-char delta -> 2 tokens; a second 8-char delta accumulates to 4.
+			handlePiOutput(a, parseLine([]byte(
+				`{"type":"message_update","assistantMessageEvent":{"type":"`+deltaType+`","delta":"abcdefgh"}}`)))
+			assert.Equal(t, int64(2), lastThinkingTokens(&sink.testSink))
+			handlePiOutput(a, parseLine([]byte(
+				`{"type":"message_update","assistantMessageEvent":{"type":"`+deltaType+`","delta":"ijklmnop"}}`)))
+			assert.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+			assert.Equal(t, 0, sink.MessageCount(), "thinking_tokens deltas must not persist")
+		})
+	}
+}
+
+func TestHandlePiOutput_ThinkingThenTextInOneMessageSharePhase(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	// Pi streams thinking then the visible answer within a single message and
+	// persists both as one message_end -- there is no per-phase split or AGENT
+	// commit between them (unlike ACP, which hands off and resets). So a
+	// thinking->text transition inside one message must keep accumulating into one
+	// thinking-token phase rather than restarting at the text delta.
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"abcdefghijklmnop"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"qrstuvwx"}}`)))
+	assert.Equal(t, int64(6), lastThinkingTokens(&sink.testSink), "text after thinking keeps climbing (24/4), it does not reset")
+}
+
+func TestHandlePiOutput_EmptyDeltaDoesNotBroadcastThinkingTokens(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":""}}`)))
+
+	assert.Equal(t, int64(-1), lastThinkingTokens(&sink.testSink), "empty delta is a no-op")
+}
+
+func TestHandlePiOutput_ToolExecutionUpdateDoesNotCountThinkingTokens(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	// Tool output is not model generation; it must not inflate the estimate.
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"tool_execution_update","toolCallId":"call-1","partialResult":{"content":[{"type":"text","text":"big tool output here"}]}}`)))
+
+	assert.Equal(t, int64(-1), lastThinkingTokens(&sink.testSink), "tool output must not broadcast thinking_tokens")
+}
+
+func TestHandlePiOutput_MessageEndResetsThinkingTokens(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefghijklmnop"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+	// Committing the assistant message is a phase boundary; the estimate resets.
+	handlePiOutput(a, parseLine([]byte(`{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"x"}]}}`)))
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefgh"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(&sink.testSink), "next phase restarts at 8/4")
+}
+
+func TestHandlePiOutput_DialogRequestResetsThinkingTokens(t *testing.T) {
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefghijklmnop"}}`)))
+	require.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+	// A blocking dialog (confirm) is a live control request the frontend clears
+	// its counter on, so the backend resets to mirror it.
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"extension_ui_request","id":"d1","method":"confirm","title":"Clear?","message":"all gone"}`)))
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefgh"}}`)))
+	assert.Equal(t, int64(2), lastThinkingTokens(&sink.testSink), "a dialog prompt restarts the estimate")
+}
+
+func TestHandlePiOutput_TurnAndToolBoundariesResetThinkingTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset string
+	}{
+		{"agent_start", `{"type":"agent_start"}`},
+		{"agent_end", `{"type":"agent_end","messages":[]}`},
+		{"tool_execution_start", `{"type":"tool_execution_start","toolCallId":"call-1","toolName":"bash"}`},
+		{"tool_execution_end", `{"type":"tool_execution_end","toolCallId":"call-1","toolName":"bash"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &recordingControlSink{}
+			a := newPiAgentWithSink(sink)
+
+			handlePiOutput(a, parseLine([]byte(
+				`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefghijklmnop"}}`)))
+			require.Equal(t, int64(4), lastThinkingTokens(&sink.testSink))
+
+			handlePiOutput(a, parseLine([]byte(tc.reset)))
+
+			handlePiOutput(a, parseLine([]byte(
+				`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"abcdefgh"}}`)))
+			assert.Equal(t, int64(2), lastThinkingTokens(&sink.testSink), "the boundary restarts the estimate")
+		})
+	}
 }

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -33,6 +33,11 @@ type testSink struct {
 	autoSchedules     []AutoContinueSchedule
 	autoCancels       []AutoContinueReason
 	planModeToolUses  sync.Map
+	// notifSuppressBroadcast makes PersistNotification report broadcast=false,
+	// simulating the service layer collapsing a flapping notification
+	// byte-identically into the existing thread tail (no frontend clear). Default
+	// false: notifications report a broadcast, like a normal standalone persist.
+	notifSuppressBroadcast bool
 }
 
 type testSinkMessage struct {
@@ -83,11 +88,11 @@ func (s *testSink) PersistTurnEnd(content []byte, span SpanInfo) error {
 	return nil
 }
 
-func (s *testSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) error {
+func (s *testSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.notifications = append(s.notifications, testSinkMessage{Source: source, Content: append([]byte(nil), content...)})
-	return nil
+	return !s.notifSuppressBroadcast, nil
 }
 
 func (s *testSink) OpenSpan(spanID string, parentSpanID string) {
@@ -386,28 +391,28 @@ type noopSink struct{}
 func (noopSink) PersistMessage(leapmuxv1.MessageSource, []byte, SpanInfo) error {
 	return nil
 }
-func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                            { return nil }
-func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) error        { return nil }
-func (noopSink) OpenSpan(string, string)                                          {}
-func (noopSink) CloseSpan(string)                                                 {}
-func (noopSink) ResetSpans()                                                      {}
-func (noopSink) SetSpanType(string, string)                                       {}
-func (noopSink) GetSpanType(string) string                                        { return "" }
-func (noopSink) ReserveSpanColor(string, string) int32                            { return 0 }
-func (noopSink) BroadcastStreamChunk([]byte, string, string)                      {}
-func (noopSink) BroadcastStreamEnd(string)                                        {}
-func (noopSink) PersistControlRequest(string, []byte)                             {}
-func (noopSink) DeleteControlRequest(string)                                      {}
-func (noopSink) BroadcastControlRequest(string, []byte)                           {}
-func (noopSink) BroadcastControlCancel(string)                                    {}
-func (noopSink) UpdateSessionID(string)                                           {}
-func (noopSink) UpdatePermissionMode(string)                                      {}
-func (noopSink) PersistSettingsRefresh(string, string, string, map[string]string) {}
-func (noopSink) BroadcastStatusActive(string)                                     {}
-func (noopSink) BroadcastSessionInfo(map[string]interface{})                      {}
-func (noopSink) PersistLeapMuxNotification(map[string]interface{})                {}
-func (noopSink) StorePlanModeToolUse(string, string)                              {}
-func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)               { return "", false }
-func (noopSink) UpdatePlan([]byte, leapmuxv1.ContentCompression, string)          {}
-func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                        {}
-func (noopSink) CancelAutoContinue(AutoContinueReason)                            {}
+func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                             { return nil }
+func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) (bool, error) { return true, nil }
+func (noopSink) OpenSpan(string, string)                                           {}
+func (noopSink) CloseSpan(string)                                                  {}
+func (noopSink) ResetSpans()                                                       {}
+func (noopSink) SetSpanType(string, string)                                        {}
+func (noopSink) GetSpanType(string) string                                         { return "" }
+func (noopSink) ReserveSpanColor(string, string) int32                             { return 0 }
+func (noopSink) BroadcastStreamChunk([]byte, string, string)                       {}
+func (noopSink) BroadcastStreamEnd(string)                                         {}
+func (noopSink) PersistControlRequest(string, []byte)                              {}
+func (noopSink) DeleteControlRequest(string)                                       {}
+func (noopSink) BroadcastControlRequest(string, []byte)                            {}
+func (noopSink) BroadcastControlCancel(string)                                     {}
+func (noopSink) UpdateSessionID(string)                                            {}
+func (noopSink) UpdatePermissionMode(string)                                       {}
+func (noopSink) PersistSettingsRefresh(string, string, string, map[string]string)  {}
+func (noopSink) BroadcastStatusActive(string)                                      {}
+func (noopSink) BroadcastSessionInfo(map[string]interface{})                       {}
+func (noopSink) PersistLeapMuxNotification(map[string]interface{})                 {}
+func (noopSink) StorePlanModeToolUse(string, string)                               {}
+func (noopSink) LoadAndDeletePlanModeToolUse(string) (string, bool)                { return "", false }
+func (noopSink) UpdatePlan([]byte, leapmuxv1.ContentCompression, string)           {}
+func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                         {}
+func (noopSink) CancelAutoContinue(AutoContinueReason)                             {}

--- a/backend/internal/worker/agent/thinking_tokens.go
+++ b/backend/internal/worker/agent/thinking_tokens.go
@@ -1,0 +1,233 @@
+package agent
+
+import (
+	"sync"
+	"unicode/utf8"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// thinkingTokensCharsPerToken is the rough characters-per-token ratio used to
+// turn streamed model text into a running token estimate. ~4 characters per
+// token is the common rule of thumb for English/code; the thinking-token
+// counter is only a coarse "the agent is generating something" signal, so an
+// exact tokenizer is unnecessary.
+const thinkingTokensCharsPerToken = 4
+
+// thinkingTokenEstimator accumulates a rough running token estimate from the
+// text a provider streams while the model is generating (assistant text plus
+// reasoning/thinking/plan deltas), for ONE turn-phase. It exists because every
+// provider except Claude Code emits no per-delta token telemetry of its own --
+// their usage numbers arrive only at response/turn boundaries, too coarse to
+// animate the counter -- so we estimate from the streamed characters instead.
+//
+// It carries its own mutex so it is uniformly safe regardless of how a provider
+// drives it: Codex and Pi feed it only from their single serial stdout reader
+// goroutine, but the ACP base also touches turn state from the prompt-response
+// goroutine, so the estimator self-synchronizes rather than relying on each
+// agent's existing lock.
+//
+// PRECONDITION: observe() must never run concurrently with itself for a given
+// estimator -- every provider drives observe() from exactly one goroutine (its
+// single stdout reader). accumulate and ship deliberately drop the lock between
+// computing an estimate and broadcasting it (ship must not hold the lock across
+// the blocking BroadcastSessionInfo), and the gen guard catches a concurrent
+// reset()/clear() but NOT a newer accumulate; so two observe() calls racing on
+// one estimator could ship out of order and spin the forward-only odometer
+// backward. reset() and clear() MAY be driven from a second goroutine (the ACP
+// prompt-response goroutine calls both at turn end) -- they are gen-guarded and
+// safe against a concurrent observe().
+type thinkingTokenEstimator struct {
+	mu    sync.Mutex
+	chars int64
+	// reported is the last estimate observe shipped. It suppresses byte-identical
+	// re-broadcasts within a phase (the running estimate only changes every
+	// charsPerToken characters, so several consecutive sub-token deltas yield the
+	// same number). reset() zeroes it so the next phase re-ships even an unchanged
+	// value -- restoring a counter the frontend cleared on a boundary the worker
+	// can't observe -- which is why the wire key stays exempt from the
+	// service-layer dedup cache.
+	reported int64
+	// gen counts phase boundaries: every reset()/clear() bumps it. observe()
+	// captures gen while computing an estimate under the lock, then re-checks it
+	// before shipping; a reset that lands on another goroutine in between ends the
+	// phase, so the now-stale estimate is dropped instead of being broadcast after
+	// the frontend already cleared (which would spin the forward-only odometer
+	// backward). We re-check rather than hold mu across BroadcastSessionInfo
+	// because that call performs a blocking network write -- holding the estimator
+	// lock across it would stall every observe/reset on the hot streaming path.
+	gen uint64
+}
+
+// observe folds a streamed model-text delta into the running per-phase estimate
+// and broadcasts the updated running total over the ephemeral agent_session_info
+// channel under the shared SessionInfoKeyThinkingTokens key. Accumulation (under
+// the lock) is split from the broadcast (a blocking network write, done unlocked)
+// so the estimator lock is never held across I/O.
+func (e *thinkingTokenEstimator) observe(sink OutputSink, text string) {
+	est, gen, ok := e.accumulate(text)
+	if !ok {
+		return
+	}
+	e.ship(sink, est, gen)
+}
+
+// accumulate folds a delta into the running estimate under the lock and returns
+// the running token estimate, the phase generation it belongs to, and whether it
+// is worth shipping (positive AND changed since the last broadcast). The rune
+// count (not the byte length, so multibyte text isn't inflated by its UTF-8
+// width) is accumulated and divided ONCE at read time, so a burst of
+// sub-charsPerToken deltas can't each truncate to zero and lose the count.
+func (e *thinkingTokenEstimator) accumulate(text string) (est int64, gen uint64, ok bool) {
+	if text == "" {
+		return 0, 0, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.chars += int64(utf8.RuneCountInString(text))
+	est = e.chars / thinkingTokensCharsPerToken
+	if est <= 0 || est == e.reported {
+		return 0, 0, false
+	}
+	e.reported = est
+	return est, e.gen, true
+}
+
+// ship broadcasts est, unless a reset()/clear() bumped the phase generation since
+// est's generation was computed -- in which case the phase ended and est belongs
+// to a counter the frontend was already told to drop, so shipping it would spin
+// the odometer backward. The frontend forwards only positive estimates and
+// derives <= 0 as a reset; accumulate never returns a non-positive est, so the
+// only non-positive value ship sends is the explicit zero clear() hands it to
+// drop the counter (reusing this same generation guard).
+func (e *thinkingTokenEstimator) ship(sink OutputSink, est int64, gen uint64) {
+	e.mu.Lock()
+	stale := e.gen != gen
+	e.mu.Unlock()
+	if stale {
+		return
+	}
+	sink.BroadcastSessionInfo(map[string]interface{}{
+		SessionInfoKeyThinkingTokens: est,
+	})
+}
+
+// reset zeroes the accumulator at a phase/turn boundary so the next phase's
+// first delta restarts near zero instead of re-broadcasting a stale cumulative
+// total that would fight the frontend's clear. Most resets are driven centrally
+// by thinkingResetSink (every committed main-scope AGENT-source message, a
+// broadcast AGENT notification, the turn-end divider, each control-request
+// prompt) so a provider can't forget one; the few silent boundaries that commit
+// no message yet DO produce a frontend clear of their own (a context clear, a
+// provider's turn-start marker) reset explicitly. The reset is in-memory only
+// (no broadcast): the frontend already clears on those events. The boundaries
+// the frontend can NOT observe on its own -- the ACP assistant->reasoning
+// hand-off and a nil-result (aborted) turn end, neither of which persists a
+// message -- use clear() instead, which broadcasts the zero itself. reset clears
+// `reported` so the next phase re-ships even an unchanged running value, and
+// bumps `gen` so an in-flight observe from the ending phase drops its broadcast.
+func (e *thinkingTokenEstimator) reset() {
+	e.mu.Lock()
+	e.chars = 0
+	e.reported = 0
+	e.gen++
+	e.mu.Unlock()
+}
+
+// hasPending reports whether streamed text has accumulated in the current phase
+// with no intervening reset()/clear(). The ACP hand-off uses it to gate the
+// assistant->reasoning clear on the estimator's own state rather than on the
+// turn-scoped turnAssistantText builder (which stays non-empty for the whole turn
+// to accumulate the reply for end-of-turn persistence): a tool call committed
+// between assistant text and a later reasoning segment resets the estimator and
+// clears the frontend, so hasPending then reports false and no redundant clear is
+// sent. It tracks raw accumulated chars, not the divided estimate, so assistant
+// text that has streamed but not yet crossed a whole-token boundary still counts
+// as pending.
+func (e *thinkingTokenEstimator) hasPending() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.chars > 0
+}
+
+// clear resets the accumulator and broadcasts an explicit zero -- which the
+// frontend reads as "drop the counter". Unlike reset(), which is silent because
+// the frontend already cleared on the triggering event, clear() supplies the
+// clear itself, for the phase boundaries the frontend cannot observe on its own:
+// the ACP assistant->reasoning hand-off (the assistant text was only buffered,
+// never committed, so it triggered no frontend clear) and a nil-result (aborted)
+// turn end (no result divider is persisted, so the frontend gets no turn-end
+// clear). The zero broadcast goes through ship's generation guard, so clear() is
+// safe to drive from a goroutine other than the streaming observe() -- the
+// nil-result turn end runs on the ACP prompt-response goroutine while reasoning
+// chunks may still arrive on the reader goroutine -- and a later reset()/clear()
+// drops this now-stale zero rather than letting it land out of order.
+func (e *thinkingTokenEstimator) clear(sink OutputSink) {
+	e.mu.Lock()
+	e.chars = 0
+	e.reported = 0
+	e.gen++
+	gen := e.gen
+	e.mu.Unlock()
+	e.ship(sink, 0, gen)
+}
+
+// thinkingResetSink wraps an OutputSink and resets a thinkingTokenEstimator at
+// exactly the points the frontend clears its thinking-token counter: every
+// committed main-scope AGENT-source message (the frontend clears on any main-agent
+// AGENT entry it adds to the timeline), every AGENT notification that actually
+// reaches the frontend, the turn-end divider, and each control-request prompt.
+// Centralizing the reset here keeps the backend estimate in lockstep with the
+// frontend without each provider handler having to remember a reset at every
+// commit site -- the dominant source of the per-phase counter drifting. The
+// streaming/accumulation path is untouched: BroadcastStreamChunk and
+// BroadcastSessionInfo (which observe() uses to ship the running estimate) are
+// inherited unchanged and never trigger a reset.
+type thinkingResetSink struct {
+	OutputSink
+	est *thinkingTokenEstimator
+}
+
+func newThinkingResetSink(inner OutputSink, est *thinkingTokenEstimator) *thinkingResetSink {
+	return &thinkingResetSink{OutputSink: inner, est: est}
+}
+
+func (s *thinkingResetSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
+	// Reset only for MAIN-scope AGENT commits. A collab subagent's committed item
+	// carries a non-empty ParentSpanID (it nests under the spawning span); resetting
+	// on it would zero the primary agent's counter on activity the user attributes
+	// to a subagent -- whose streamed text the estimator already excludes via the
+	// provider's main-thread gate. SpanInfo is the only thread-derived signal the
+	// decorator sees: the originating thread is collapsed into ParentSpanID before
+	// reaching the sink. The frontend applies the same ParentSpanID==="" gate, so
+	// both sides keep/drop the counter on exactly the same commits.
+	if source == leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT && span.ParentSpanID == "" {
+		s.est.reset()
+	}
+	return s.OutputSink.PersistMessage(source, content, span)
+}
+
+func (s *thinkingResetSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) (bool, error) {
+	broadcast, err := s.OutputSink.PersistNotification(source, content)
+	// Reset only when the notification actually reached the frontend. The service
+	// layer suppresses the broadcast when a flapping notification collapses
+	// byte-identically into the existing thread tail; in that case the frontend
+	// never clears, so resetting here would drift the estimate ahead of the display
+	// and spin the odometer backward on the next delta. Gating on the broadcast
+	// signal keeps this reset in lockstep with the frontend's own clear, which is
+	// why the reset moved AFTER the inner call.
+	if err == nil && broadcast && source == leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT {
+		s.est.reset()
+	}
+	return broadcast, err
+}
+
+func (s *thinkingResetSink) PersistTurnEnd(content []byte, span SpanInfo) error {
+	s.est.reset()
+	return s.OutputSink.PersistTurnEnd(content, span)
+}
+
+func (s *thinkingResetSink) BroadcastControlRequest(requestID string, payload []byte) {
+	s.est.reset()
+	s.OutputSink.BroadcastControlRequest(requestID, payload)
+}

--- a/backend/internal/worker/agent/thinking_tokens_test.go
+++ b/backend/internal/worker/agent/thinking_tokens_test.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThinkingTokenEstimator_AccumulatesAndDividesOnce(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	// Sub-ratio deltas must not each truncate to zero: four 1-char deltas total
+	// 4 chars -> 1 token (the first three add nothing yet, so they don't ship).
+	est.observe(sink, "a")
+	est.observe(sink, "b")
+	est.observe(sink, "c")
+	assert.Equal(t, 0, sink.SessionInfoCount(), "sub-token deltas ship nothing until a whole token accrues")
+	est.observe(sink, "d")
+	require.Equal(t, 1, sink.SessionInfoCount())
+	assert.Equal(t, int64(1), lastThinkingTokens(sink))
+
+	// Growth is cumulative and monotonic: +8 chars -> 12 chars total -> 3 tokens.
+	est.observe(sink, "efghijkl")
+	assert.Equal(t, int64(3), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_CountsRunesNotBytes(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	// Eight multibyte runes (each 3 bytes in UTF-8). The estimate must use the
+	// rune count (8 -> 2 tokens), not the 24-byte length (which would give 6).
+	est.observe(sink, "あいうえおかきく")
+	assert.Equal(t, int64(2), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_SuppressesUnchangedEstimate(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	// 8 chars -> 2 tokens (ships). A following 1-char delta is still 2 tokens
+	// (9/4), so it must NOT re-broadcast -- the displayed number is unchanged and
+	// the key is dedup-exempt, so shipping it would be wasted wire traffic.
+	est.observe(sink, "12345678")
+	require.Equal(t, 1, sink.SessionInfoCount())
+	est.observe(sink, "x")
+	assert.Equal(t, 1, sink.SessionInfoCount(), "an unchanged estimate is not re-broadcast")
+
+	// Crossing the next token boundary ships again.
+	est.observe(sink, "xyz") // 12 chars -> 3 tokens
+	assert.Equal(t, 2, sink.SessionInfoCount())
+	assert.Equal(t, int64(3), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_ResetRestartsAndReshipsUnchangedValue(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	est.observe(sink, "12345678") // -> 2, ships
+	require.Equal(t, int64(2), lastThinkingTokens(sink))
+
+	est.reset()
+
+	// After a reset the next phase restarts from zero, AND an identical running
+	// value must re-ship -- the frontend cleared on the boundary the reset
+	// mirrors, so the suppression cache must not hide the restored count.
+	est.observe(sink, "12345678") // -> 2 again
+	assert.Equal(t, 2, sink.SessionInfoCount(), "the same value re-ships after a reset")
+	assert.Equal(t, int64(2), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_EmptyAndNonPositiveDeltasShipNothing(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	est.observe(sink, "")    // empty -> no-op
+	est.observe(sink, "abc") // 3 chars -> 0 tokens -> nothing to show yet
+	assert.Equal(t, 0, sink.SessionInfoCount())
+	assert.Equal(t, int64(-1), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_ShipDropsValueFromEndedPhase(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+
+	// accumulate computes the estimate and captures the phase generation it
+	// belongs to, under the lock.
+	gotEst, gen, ok := est.accumulate("abcdefgh") // 8 chars -> 2 tokens
+	require.True(t, ok)
+	require.Equal(t, int64(2), gotEst)
+
+	// A reset on another goroutine ends the phase between accumulate and ship --
+	// the race the split exists to neutralize. ship must drop the now-stale value
+	// (its generation is gone) so the forward-only odometer never ticks backward.
+	est.reset()
+	est.ship(sink, gotEst, gen)
+	assert.Equal(t, 0, sink.SessionInfoCount(), "a broadcast from an ended phase is dropped")
+
+	// A value from the live generation still ships.
+	gotEst, gen, ok = est.accumulate("abcd") // post-reset: 4 chars -> 1 token
+	require.True(t, ok)
+	est.ship(sink, gotEst, gen)
+	require.Equal(t, 1, sink.SessionInfoCount())
+	assert.Equal(t, int64(1), lastThinkingTokens(sink))
+}
+
+func TestThinkingTokenEstimator_HasPendingTracksUnclearedChars(t *testing.T) {
+	sink := &testSink{}
+	var est thinkingTokenEstimator
+	assert.False(t, est.hasPending(), "a fresh estimator has nothing pending")
+
+	// Sub-token chars (below the divide threshold, so nothing ships yet) still
+	// count as pending: hasPending tracks raw accumulated chars, which is what the
+	// ACP hand-off needs -- assistant text that has streamed but not yet cleared.
+	est.observe(sink, "ab")
+	assert.Equal(t, 0, sink.SessionInfoCount(), "sub-token chars ship nothing")
+	assert.True(t, est.hasPending(), "but they are pending")
+
+	est.reset()
+	assert.False(t, est.hasPending(), "reset drops pending")
+
+	est.observe(sink, "abcd") // 4 chars -> 1 token, ships
+	require.Equal(t, int64(1), lastThinkingTokens(sink))
+	assert.True(t, est.hasPending())
+
+	est.clear(sink)
+	assert.Equal(t, int64(0), lastThinkingTokens(sink), "clear broadcasts an explicit zero")
+	assert.False(t, est.hasPending(), "clear drops pending")
+}
+
+func TestThinkingResetSink_ResetsOnFrontendClearBoundariesOnly(t *testing.T) {
+	const (
+		agent   = leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT
+		user    = leapmuxv1.MessageSource_MESSAGE_SOURCE_USER
+		leapmux = leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX
+	)
+	for _, tc := range []struct {
+		name string
+		// suppress makes the inner sink report PersistNotification broadcast=false,
+		// mimicking the service layer collapsing a flapping notification
+		// byte-identically into the existing thread tail (no frontend clear).
+		suppress bool
+		call     func(s OutputSink)
+		reset    bool
+	}{
+		{name: "AGENT message (main scope) resets", call: func(s OutputSink) { _ = s.PersistMessage(agent, nil, SpanInfo{}) }, reset: true},
+		// A subagent's committed item nests under a span (non-empty ParentSpanID);
+		// it must not reset the primary agent's counter.
+		{name: "AGENT subagent message (nested span) does NOT reset", call: func(s OutputSink) { _ = s.PersistMessage(agent, nil, SpanInfo{ParentSpanID: "collab-span"}) }, reset: false},
+		{name: "AGENT notification (broadcast) resets", call: func(s OutputSink) { _, _ = s.PersistNotification(agent, nil) }, reset: true},
+		// A collapsed notification produces no broadcast, so the frontend never
+		// clears -- the estimate must not reset either.
+		{name: "AGENT notification (collapsed, no broadcast) does NOT reset", suppress: true, call: func(s OutputSink) { _, _ = s.PersistNotification(agent, nil) }, reset: false},
+		{name: "turn-end divider resets", call: func(s OutputSink) { _ = s.PersistTurnEnd(nil, SpanInfo{}) }, reset: true},
+		{name: "control request resets", call: func(s OutputSink) { s.BroadcastControlRequest("id", nil) }, reset: true},
+		{name: "USER message does NOT reset", call: func(s OutputSink) { _ = s.PersistMessage(user, nil, SpanInfo{}) }, reset: false},
+		{name: "LEAPMUX notification does NOT reset", call: func(s OutputSink) { _, _ = s.PersistNotification(leapmux, nil) }, reset: false},
+		{name: "stream chunk does NOT reset", call: func(s OutputSink) { s.BroadcastStreamChunk(nil, "", "m") }, reset: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var est thinkingTokenEstimator
+			inner := &testSink{notifSuppressBroadcast: tc.suppress}
+			sink := newThinkingResetSink(inner, &est)
+
+			est.observe(inner, "abcdefgh") // 8 chars -> 2 tokens
+			require.Equal(t, int64(2), lastThinkingTokens(inner))
+
+			tc.call(sink)
+
+			est.observe(inner, "abcd") // +4 chars
+			// If the boundary reset, the accumulator restarted: 4 chars -> 1.
+			// Otherwise it kept climbing: 12 chars -> 3.
+			want := int64(3)
+			if tc.reset {
+				want = int64(1)
+			}
+			assert.Equal(t, want, lastThinkingTokens(inner))
+		})
+	}
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -767,7 +767,7 @@ func (s *agentOutputSink) PersistTurnEnd(content []byte, span agent.SpanInfo) er
 	return nil
 }
 
-func (s *agentOutputSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) error {
+func (s *agentOutputSink) PersistNotification(source leapmuxv1.MessageSource, content []byte) (bool, error) {
 	return s.h.persistNotificationThreaded(s.agentID, s.agentProvider, s.plugin, source, content)
 }
 
@@ -1646,8 +1646,11 @@ func (c *agentTodoCache) itemsEqual(other []todoevents.Item) bool {
 }
 
 // persistNotificationThreaded persists a notification message, appending it
-// to the current notification thread if one exists.
-func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, source leapmuxv1.MessageSource, contentJSON []byte) error {
+// to the current notification thread if one exists. It reports whether the
+// notification produced a frontend-visible broadcast (false when a flapping
+// notification collapses byte-identically into the existing thread tail and the
+// broadcast is skipped).
+func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, source leapmuxv1.MessageSource, contentJSON []byte) (bool, error) {
 	if h.wakeLock != nil {
 		h.wakeLock.RecordActivity()
 	}
@@ -1657,9 +1660,9 @@ func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvide
 
 	if ref, ok := h.lastNotifThread.Load(agentID); ok {
 		threadRef := ref.(*notifThreadRef)
-		err := h.appendToNotificationThread(agentID, agentProvider, plugin, threadRef, source, contentJSON)
+		broadcast, err := h.appendToNotificationThread(agentID, agentProvider, plugin, threadRef, source, contentJSON)
 		if err == nil {
-			return nil
+			return broadcast, nil
 		}
 		// errSourceMismatch is the documented fall-through signal — start a
 		// fresh standalone thread silently. Any other error is a real failure
@@ -1680,18 +1683,19 @@ func (h *OutputHandler) persistNotificationThreaded(agentID string, agentProvide
 var errSourceMismatch = errors.New("notification thread source mismatch")
 
 // appendToNotificationThread appends a message to an existing notification thread.
-// Returns an error if the thread's source does not match the new
-// notification's source — adjacent cross-source notifications must
-// produce separate threads so that the persisted source remains a
-// truthful per-thread provenance signal. The caller treats the error
-// as a normal "fall through to a new standalone thread" signal, not as
-// a failure.
-func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, threadRef *notifThreadRef, source leapmuxv1.MessageSource, contentJSON []byte) error {
+// Returns whether a frontend-visible broadcast was emitted (false when the
+// notification collapses byte-identically into the existing tail), and an error
+// if the thread's source does not match the new notification's source — adjacent
+// cross-source notifications must produce separate threads so that the persisted
+// source remains a truthful per-thread provenance signal. The caller treats the
+// error as a normal "fall through to a new standalone thread" signal, not as a
+// failure.
+func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider leapmuxv1.AgentProvider, plugin agent.Provider, threadRef *notifThreadRef, source leapmuxv1.MessageSource, contentJSON []byte) (bool, error) {
 	// Short-circuit cross-source flips before the DB hit — the in-memory
 	// threadRef carries the source that was persisted when the thread
 	// opened, so we don't need to fetch + decompress the row to learn it.
 	if threadRef.source != source {
-		return errSourceMismatch
+		return false, errSourceMismatch
 	}
 
 	parentRow, err := h.queries.GetMessageByAgentAndID(bgCtx(), db.GetMessageByAgentAndIDParams{
@@ -1699,27 +1703,29 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		AgentID: agentID,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	parentData, err := msgcodec.Decompress(parentRow.Content, parentRow.ContentCompression)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	wrapper, err := unwrapNotifContent(parentData)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// If a flapping ProviderScoped notification (e.g.
 	// remoteControl/status/changed) collapses into the existing tail and
-	// produces a byte-identical slice, skip the DB write + broadcast.
+	// produces a byte-identical slice, skip the DB write + broadcast. The
+	// false return tells the reset decorator no frontend clear fired, so it must
+	// not reset the thinking-token estimate for this collapsed notification.
 	oldMessages := wrapper.Messages
 	nextMessages := append(slices.Clone(oldMessages), contentJSON)
 	nextMessages = consolidateNotificationThread(nextMessages, plugin)
 	if rawMessageSlicesEqual(oldMessages, nextMessages) {
-		return nil
+		return false, nil
 	}
 
 	wrapper.Messages = nextMessages
@@ -1730,7 +1736,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 
 	merged, err := json.Marshal(wrapper)
 	if err != nil {
-		return fmt.Errorf("marshal notification thread: %w", err)
+		return false, fmt.Errorf("marshal notification thread: %w", err)
 	}
 
 	mergedCompressed, mergedCompType := msgcodec.Compress(merged)
@@ -1749,7 +1755,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		AgentID:            agentID,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	threadRef.seq = newSeq
@@ -1767,11 +1773,12 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		SpanLines:          spanLines,
 	})
 
-	return nil
+	return true, nil
 }
 
 // createNotificationStandalone creates a new standalone notification message.
-func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvider leapmuxv1.AgentProvider, source leapmuxv1.MessageSource, contentJSON []byte) error {
+// It always broadcasts on success, so it reports broadcast=true.
+func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvider leapmuxv1.AgentProvider, source leapmuxv1.MessageSource, contentJSON []byte) (bool, error) {
 	msgID := id.Generate()
 	wrapped := wrapNotifContent(contentJSON)
 	compressed, compressionType := msgcodec.Compress(wrapped)
@@ -1796,7 +1803,7 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 		CreatedAt:          now,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	h.lastNotifThread.Store(agentID, &notifThreadRef{
@@ -1816,7 +1823,7 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 		Depth:              0,
 		SpanLines:          spanLines,
 	})
-	return nil
+	return true, nil
 }
 
 // broadcastMessage broadcasts a single agent message event to all watchers.
@@ -1857,7 +1864,7 @@ func (h *OutputHandler) PersistLeapMuxNotification(agentID string, agentProvider
 		slog.Warn("marshal notification content", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := h.persistNotificationThreaded(agentID, agentProvider, agent.ProviderFor(agentProvider), leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, contentJSON); err != nil {
+	if _, err := h.persistNotificationThreaded(agentID, agentProvider, agent.ProviderFor(agentProvider), leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, contentJSON); err != nil {
 		slog.Warn("failed to persist notification", "agent_id", agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/service/output_notification_span_lines_test.go
+++ b/backend/internal/worker/service/output_notification_span_lines_test.go
@@ -25,7 +25,7 @@ func TestPersistNotification_StandaloneCapturesActiveSpans(t *testing.T) {
 
 	notif, err := json.Marshal(map[string]any{"type": "context_cleared"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, notif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, notif)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",
@@ -58,7 +58,7 @@ func TestPersistNotification_AppendRefreshesSpanLines(t *testing.T) {
 
 	first, err := json.Marshal(map[string]any{"type": "context_cleared"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, first))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, first)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",
@@ -75,7 +75,7 @@ func TestPersistNotification_AppendRefreshesSpanLines(t *testing.T) {
 
 	second, err := json.Marshal(map[string]any{"type": "interrupted"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, second))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, second)
 
 	rows, err = svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",
@@ -108,13 +108,13 @@ func TestPersistNotification_AppendDropsClosedSpan(t *testing.T) {
 
 	first, err := json.Marshal(map[string]any{"type": "context_cleared"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, first))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, first)
 
 	svc.Output.spanTracker("agent-1").CloseSpan("span-A")
 
 	second, err := json.Marshal(map[string]any{"type": "interrupted"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, second))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, second)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",
@@ -136,7 +136,7 @@ func TestPersistNotification_StandaloneEmptyTracker(t *testing.T) {
 
 	notif, err := json.Marshal(map[string]any{"type": "context_cleared"})
 	require.NoError(t, err)
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, notif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, notif)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",

--- a/backend/internal/worker/service/output_thread_test.go
+++ b/backend/internal/worker/service/output_thread_test.go
@@ -62,8 +62,8 @@ func TestNotificationThreading_MergesOnlyAdjacentNotifications(t *testing.T) {
 	secondNotif, err := json.Marshal(map[string]any{"type": "interrupted"})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif)
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -85,8 +85,8 @@ func TestNotificationThreading_CrossSourceProducesSeparateThreads(t *testing.T) 
 	leapmuxNotif, err := json.Marshal(map[string]any{"type": "context_cleared"})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, agentNotif))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, leapmuxNotif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, agentNotif)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, leapmuxNotif)
 
 	rows := listRows()
 	require.Len(t, rows, 2, "cross-source adjacent notifications must not consolidate")
@@ -113,9 +113,9 @@ func TestNotificationThreading_NonNotificationBreaksAdjacency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, firstNotif)
 	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, assistantMsg, agent.SpanInfo{}))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, secondNotif)
 
 	rows := listRows()
 	require.Len(t, rows, 3)
@@ -140,9 +140,9 @@ func TestNotificationThreading_CodexStartupStatusConsolidatesInWrapper(t *testin
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, starting))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, ready))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, settingsChanged))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, starting)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, ready)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, settingsChanged)
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -165,8 +165,8 @@ func TestNotificationThreading_CodexMetadataNotificationsPersistAsAgentWrapper(t
 		"environmentId": nil,
 	}))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged)
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -187,10 +187,10 @@ func TestNotificationThreading_CodexMetadataNotificationsSurviveMixedThread(t *t
 	}))
 	ready := raw(t, codexStartupStatus("codex_apps", "ready", nil))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, starting))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged))
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, ready))
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, starting)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, skillsChanged)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, remoteControlChanged)
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, ready)
 
 	rows := listRows()
 	require.Len(t, rows, 1)
@@ -220,13 +220,22 @@ func TestNotificationThreading_RepeatedIdenticalProviderScopedSkipsWrite(t *test
 		"environmentId": nil,
 	}))
 
-	require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload))
+	// The first notification opens a standalone thread and is broadcast.
+	broadcast, err := sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload)
+	require.NoError(t, err)
+	assert.True(t, broadcast, "the first notification is broadcast to the frontend")
 	rows := listRows()
 	require.Len(t, rows, 1)
 	seqAfterFirst := rows[0].Seq
 
+	// Each repeat collapses byte-identically into the tail: no DB write AND no
+	// broadcast. The broadcast=false return is what keeps the thinking-token
+	// reset decorator in lockstep with the frontend, which never clears here.
 	for i := 0; i < 5; i++ {
-		require.NoError(t, sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload))
+		broadcast, err := sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, payload)
+		require.NoError(t, err)
+		assert.False(t, broadcast,
+			"an identical ProviderScoped notification collapses and must not report a broadcast")
 	}
 	rows = listRows()
 	require.Len(t, rows, 1)

--- a/backend/internal/worker/service/output_user_span_lines_test.go
+++ b/backend/internal/worker/service/output_user_span_lines_test.go
@@ -76,6 +76,15 @@ func setupAgentWithWatcher(t *testing.T, svc *Context, w *testResponseWriter, ag
 	return sink
 }
 
+// persistNotif persists a notification through the sink and asserts no error,
+// discarding the broadcast flag PersistNotification returns. Keeps the many
+// notification-thread tests terse now that the signature returns (bool, error).
+func persistNotif(t *testing.T, sink agent.OutputSink, source leapmuxv1.MessageSource, content []byte) {
+	t.Helper()
+	_, err := sink.PersistNotification(source, content)
+	require.NoError(t, err)
+}
+
 func TestSnapshotPassthroughSpanLines_EmptyTracker(t *testing.T) {
 	h := NewOutputHandler(nil, nil, NewWatcherManager(), nil, nil)
 	assert.Equal(t, "[]", h.snapshotPassthroughSpanLines("agent-1"))

--- a/frontend/src/components/chat/AgentInfoCard.test.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.test.tsx
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { formatAgentSessionIdForDisplay, useAgentInfoCard } from './AgentInfoCard'
 
+// Side-effect imports: register the Claude and Pi plugins so the session-id
+// display/copy logic can resolve `sessionIdIsFilePath` through the registry.
+import './providers/claude/plugin'
+import './providers/pi/plugin'
+
 function InfoCardContent(props: { agent: AgentInfo }) {
   const { infoHoverCardContent } = useAgentInfoCard(props)
   return <div>{infoHoverCardContent()}</div>

--- a/frontend/src/components/chat/AgentInfoCard.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.tsx
@@ -1,4 +1,4 @@
-import type { AgentInfo } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentInfo, AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { AgentSessionInfo } from '~/stores/agentSession.store'
 import Check from 'lucide-solid/icons/check'
 import Copy from 'lucide-solid/icons/copy'
@@ -6,11 +6,11 @@ import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js'
 import { AgentProviderIcon, agentProviderLabel } from '~/components/common/AgentProviderIcon'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
-import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { useCopyButton } from '~/hooks/useCopyButton'
 import { basename, tildify } from '~/lib/paths'
 import { formatCountdown, formatResetTimestamp, getResetsAt, pickUrgentRateLimit, RATE_LIMIT_POPOVER_LABELS } from '~/lib/rateLimitUtils'
 import * as styles from './ChatView.css'
+import { pluginFor } from './providers/registry'
 import { formatTokenCount } from './rendererUtils'
 import { computePercentage, contextBufferPct, contextSize, resolveContextWindow } from './widgets/ContextUsageGrid'
 
@@ -20,7 +20,7 @@ export interface AgentInfoCardProps {
 }
 
 export function formatAgentSessionIdForDisplay(agentProvider: AgentProvider | undefined, sessionId: string): string {
-  if (agentProvider !== AgentProvider.PI)
+  if (!pluginFor(agentProvider)?.sessionIdIsFilePath)
     return sessionId
 
   const tail = basename(sessionId) || sessionId
@@ -57,7 +57,7 @@ export function useAgentInfoCard(props: AgentInfoCardProps) {
     const sessionId = props.agent?.agentSessionId
     return sessionId ? formatAgentSessionIdForDisplay(props.agent?.agentProvider, sessionId) : undefined
   })
-  const sessionIdCopyTitle = () => props.agent?.agentProvider === AgentProvider.PI ? 'Copy session file path' : 'Copy session ID'
+  const sessionIdCopyTitle = () => pluginFor(props.agent?.agentProvider)?.sessionIdIsFilePath ? 'Copy session file path' : 'Copy session ID'
 
   // 1-minute timer for countdown refresh
   const [now, setNow] = createSignal(Date.now())

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -2,10 +2,10 @@ import type { Accessor } from 'solid-js'
 import type { FileAttachment } from './attachments'
 import type { AskQuestionState, EditorContentRef } from './controls/types'
 import type { ProviderSettingChange } from './providers/registry'
+import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ControlRequest } from '~/stores/control.store'
 import { createEffect, createMemo, on } from 'solid-js'
 import { showWarnToast } from '~/components/common/Toast'
-import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { localStorageGet, localStorageRemove, localStorageSet, PREFIX_ASK_STATE } from '~/lib/browserStorage'
 import { clearDraft } from '~/lib/editor/draftPersistence'
 import { trySubmitAskUserQuestion } from './controls/AskUserQuestionControl'
@@ -186,7 +186,7 @@ export function useControlResponseHandling(
         content,
         sendAskResponse,
         editorContentRefAccessor(),
-        provider === AgentProvider.CODEX,
+        Boolean(plugin.preservesSelectionNotes),
       )
       if (!submitted)
         return false

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -1,15 +1,16 @@
 import type { Component } from 'solid-js'
 import type { ActionsProps, AskQuestionState, EditorContentRef, Question } from './types'
+import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ControlRequest } from '~/stores/control.store'
 import { createUniqueId, For, Show } from 'solid-js'
 import { apiLoadingTimeoutMs } from '~/api/transport'
 import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
-import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { pluralize } from '~/lib/plural'
 import { buildAllowResponse, buildDenyResponse, getToolInput } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
+import { pluginFor } from '../providers/registry'
 import { CollapsibleList } from './CollapsibleList'
 import { sendResponse } from './types'
 
@@ -18,7 +19,7 @@ import { sendResponse } from './types'
 // ---------------------------------------------------------------------------
 
 function preservesSelectionNotes(agentProvider?: AgentProvider): boolean {
-  return agentProvider === AgentProvider.CODEX
+  return pluginFor(agentProvider)?.preservesSelectionNotes ?? false
 }
 
 function toggleSelection(state: AskQuestionState, qIdx: number, label: string, multiSelect: boolean, totalQuestions: number, preserveCustomText = false) {

--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -6,6 +6,18 @@ import { input } from '../testUtils'
 // Side-effect import to register the Claude plugin.
 import './plugin'
 
+describe('claude clearsThinkingTokensForMessage', () => {
+  const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
+
+  it('always clears, even for a non-empty parentSpanId (telemetry-driven counter)', () => {
+    // Claude's parentSpanId is not a clean main-vs-subagent signal (a
+    // system-injected tool_use_id yields a non-empty parentSpanId on a main-agent
+    // message), so it must not gate on it like the estimator providers do.
+    expect(plugin.clearsThinkingTokensForMessage!({ parentSpanId: '' })).toBe(true)
+    expect(plugin.clearsThinkingTokensForMessage!({ parentSpanId: 'sys-tu-999' })).toBe(true)
+  })
+})
+
 describe('claude extractQuotableText', () => {
   const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
 

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -296,11 +296,16 @@ function claudeExtractQuotableText(category: MessageCategory, parsed: ParsedMess
   return null
 }
 
+// Claude reserves ~16.5% of the context window as an autocompact buffer, so the
+// context-usage percentage is measured against the remaining usable capacity.
+const CLAUDE_AUTOCOMPACT_BUFFER_PCT = 16.5
+
 const claudeCodePlugin: Provider = {
   defaultModel: DEFAULT_CLAUDE_MODEL,
   defaultEffort: DEFAULT_CLAUDE_EFFORT,
   defaultPermissionMode: 'default',
   bypassPermissionMode: 'bypassPermissions',
+  contextBufferPct: CLAUDE_AUTOCOMPACT_BUFFER_PCT,
   attachments: {
     text: true,
     image: true,
@@ -315,6 +320,13 @@ const claudeCodePlugin: Provider = {
   },
 
   classify: classifyClaudeCodeMessage,
+  // Claude's thinking-token counter is driven by real per-phase telemetry (the
+  // worker relays Claude's own estimated_tokens), not the streamed-text estimator
+  // the other providers use. Every committed AGENT message ends a phase, so always
+  // clear -- and unlike the estimator providers we cannot gate on parentSpanId,
+  // since a system-injected tool_use_id gives a main-agent message a non-empty
+  // parentSpanId that does not mark a subagent.
+  clearsThinkingTokensForMessage: () => true,
   renderMessage: renderClaudeMessage,
   toolResultMeta: claudeToolResultMeta,
   extractQuotableText: claudeExtractQuotableText,

--- a/frontend/src/components/chat/providers/codex/plugin.test.ts
+++ b/frontend/src/components/chat/providers/codex/plugin.test.ts
@@ -7,9 +7,22 @@ import { sendCodexDecision, sendCodexUserInputResponse, toRpcId } from '../../co
 import { renderDivider } from '../../messageRenderTestUtils'
 import { providerFor } from '../registry'
 import { input, model, option, optionGroup } from '../testUtils'
+import { CODEX_EXTRA_COLLABORATION_MODE, DEFAULT_CODEX_COLLABORATION_MODE } from './settings'
 
 // Side-effect import to register the Codex plugin.
 import './plugin'
+
+describe('codex provider capabilities', () => {
+  const plugin = providerFor(AgentProvider.CODEX)!
+
+  it('seeds the default collaboration mode as extra settings on a new agent', () => {
+    expect(plugin.defaultExtraSettings).toEqual({ [CODEX_EXTRA_COLLABORATION_MODE]: DEFAULT_CODEX_COLLABORATION_MODE })
+  })
+
+  it('preserves an option selection alongside the free-text note', () => {
+    expect(plugin.preservesSelectionNotes).toBe(true)
+  })
+})
 
 describe('codex extractQuotableText', () => {
   const plugin = providerFor(AgentProvider.CODEX)!

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -279,6 +279,11 @@ const codexPlugin: Provider = {
   defaultEffort: DEFAULT_CODEX_EFFORT,
   defaultPermissionMode: 'on-request',
   bypassPermissionMode: 'never',
+  // Seed a new Codex agent with its default collaboration mode.
+  defaultExtraSettings: { [CODEX_EXTRA_COLLABORATION_MODE]: DEFAULT_CODEX_COLLABORATION_MODE },
+  // Codex accepts an option selection AND a free-text note together, so the
+  // AskUserQuestion UI keeps both instead of treating them as mutually exclusive.
+  preservesSelectionNotes: true,
   attachments: {
     text: true,
     image: true,

--- a/frontend/src/components/chat/providers/pi/plugin.test.ts
+++ b/frontend/src/components/chat/providers/pi/plugin.test.ts
@@ -27,6 +27,10 @@ describe('pi plugin metadata', () => {
     expect(plugin.defaultEffort).toBe('auto')
   })
 
+  it('treats the session id as a file path (Pi sessions are .jsonl files)', () => {
+    expect(plugin.sessionIdIsFilePath).toBe(true)
+  })
+
   it('does not advertise a permission mode for Pi', () => {
     expect(plugin.defaultPermissionMode).toBeUndefined()
     expect(plugin.bypassPermissionMode).toBeUndefined()

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -204,6 +204,9 @@ const piPlugin: Provider = {
   defaultEffort: DEFAULT_PI_EFFORT,
   defaultPermissionMode: undefined,
   bypassPermissionMode: undefined,
+  // Pi's agentSessionId is a .jsonl session-file path, so the UI shortens it for
+  // display and labels the copy action "session file path".
+  sessionIdIsFilePath: true,
   attachments: {
     text: true,
     image: true,

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -122,9 +122,47 @@ export interface Provider {
   defaultEffort?: string
   /** Default permission mode identifier for this provider. */
   defaultPermissionMode?: PermissionMode
+  /**
+   * Extra per-provider settings to seed into a new agent's OpenAgent request.
+   * Omit when the provider needs none. Codex seeds its collaboration mode.
+   */
+  defaultExtraSettings?: Record<string, string>
+  /**
+   * Fraction of the context window (as a percentage, e.g. 16.5) this provider
+   * reserves as an autocompact buffer, subtracted from usable capacity when
+   * computing the context-usage percentage. Omit (treated as 0) for providers
+   * with no reserved headroom. Claude Code reserves a buffer.
+   */
+  contextBufferPct?: number
+  /**
+   * True when this provider's `agentSessionId` is a session FILE PATH rather
+   * than an opaque id, so the UI shortens it to a basename for display and
+   * labels the copy action "session file path". Pi uses session files.
+   */
+  sessionIdIsFilePath?: boolean
+  /**
+   * True when an AskUserQuestion option selection and the free-text note
+   * coexist (the agent accepts both), so picking an option does NOT clear the
+   * custom text and vice versa. Omit (mutually exclusive) for providers where
+   * an answer and a note are alternatives. Codex preserves both.
+   */
+  preservesSelectionNotes?: boolean
 
   /** Classify a parsed message into a rendering category. */
   classify: (input: ClassificationInput, context?: ClassificationContext) => MessageCategory
+
+  /**
+   * Decide whether a persisted AGENT message should clear the live thinking-token
+   * estimate (a per-phase reset). Called only for AGENT-source messages. Omit to
+   * use the default "main-scope only" policy (clear when `parentSpanId === ''`),
+   * which is correct for the streamed-text estimator that drives Codex/Pi/ACP: a
+   * subagent's commit nests under a span and must not reset the primary counter,
+   * and the backend applies the same gate. Claude overrides to always clear,
+   * because its counter is real per-phase telemetry (not the estimator) and its
+   * parentSpanId is not a clean main-vs-subagent signal (a system-injected
+   * tool_use_id yields a non-empty parentSpanId on a main-agent message).
+   */
+  clearsThinkingTokensForMessage?: (msg: { parentSpanId: string }) => boolean
 
   /**
    * Render a message given its category and parsed content.

--- a/frontend/src/components/chat/widgets/ContextUsageGrid.test.ts
+++ b/frontend/src/components/chat/widgets/ContextUsageGrid.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { computePercentage, contextSize } from './ContextUsageGrid'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { computePercentage, contextBufferPct, contextSize } from './ContextUsageGrid'
+
+// Side-effect import: register the Claude plugin so contextBufferPct can resolve
+// its autocompact buffer through the registry.
+import '../providers/claude/plugin'
 
 describe('context usage grid token math', () => {
   it('prefers provider-reported contextTokens when present', () => {
@@ -30,5 +35,19 @@ describe('context usage grid token math', () => {
       contextTokens: 50,
       contextWindow: 200,
     })).toBe(25)
+  })
+
+  it('applies the provider autocompact buffer from its plugin', () => {
+    // Claude reserves 16.5% headroom, so 50/200 measures against usable capacity
+    // 200*(1-0.165)=167 -> ~29.94%, not the bufferless 25%. Providers with no
+    // plugin buffer (default 0) keep the bufferless math.
+    expect(contextBufferPct(AgentProvider.CLAUDE_CODE)).toBe(16.5)
+    expect(contextBufferPct(AgentProvider.CODEX)).toBe(0)
+    const claudePct = computePercentage(
+      { inputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0, contextTokens: 50, contextWindow: 200 },
+      undefined,
+      AgentProvider.CLAUDE_CODE,
+    )
+    expect(claudePct).toBeCloseTo(29.94, 1)
   })
 })

--- a/frontend/src/components/chat/widgets/ContextUsageGrid.tsx
+++ b/frontend/src/components/chat/widgets/ContextUsageGrid.tsx
@@ -3,8 +3,8 @@ import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ContextUsageInfo } from '~/stores/agentSession.store'
 import Info from 'lucide-solid/icons/info'
 import { createMemo, For, Show } from 'solid-js'
+import { pluginFor } from '~/components/chat/providers/registry'
 import { Tooltip } from '~/components/common/Tooltip'
-import { AgentProvider as AgentProviderEnum } from '~/generated/leapmux/v1/agent_pb'
 
 interface ContextUsageGridProps {
   contextUsage?: ContextUsageInfo
@@ -13,11 +13,12 @@ interface ContextUsageGridProps {
   size: number
 }
 
-export const DEFAULT_BUFFER_PCT = 16.5
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 
+// The autocompact buffer (percentage of the context window a provider reserves)
+// is declared per-provider in its plugin; default 0 for providers with none.
 export function contextBufferPct(agentProvider?: AgentProvider): number {
-  return agentProvider === AgentProviderEnum.CLAUDE_CODE ? DEFAULT_BUFFER_PCT : 0
+  return pluginFor(agentProvider)?.contextBufferPct ?? 0
 }
 
 /** Resolve the effective context window from usage data, model metadata, or the default. */

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -13,7 +13,6 @@ import type { PermissionMode } from '~/utils/controlResponse'
 import { createEffect, createSignal, on } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { clearAttachments } from '~/components/chat/attachments'
-import { CODEX_EXTRA_COLLABORATION_MODE, DEFAULT_CODEX_COLLABORATION_MODE } from '~/components/chat/providers/codex/settings'
 import { providerFor } from '~/components/chat/providers/registry'
 import { optionGroupDefaultValue, optionGroupLabel } from '~/components/chat/settingsShared'
 import { showWarnToast } from '~/components/common/Toast'
@@ -104,6 +103,9 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
   // Open a new agent in the given workspace
   const openAgentInWorkspace = async (workspaceId: string, workerId: string, workingDir: string, sessionId?: string, agentProvider: AgentProvider = AgentProvider.CLAUDE_CODE) => {
     try {
+      // Per-provider seed settings for a fresh agent (e.g. Codex's collaboration
+      // mode); the plugin owns what, if anything, to send.
+      const extraSettings = providerFor(agentProvider)?.defaultExtraSettings
       // Title left empty: the worker picks "Agent <Name>" server-side
       // so CLI and UI paths share one pool (see worker/service/
       // tab_names.go). The response carries the resolved title back.
@@ -114,7 +116,7 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
         systemPrompt: '',
         workerId,
         workingDir,
-        ...(agentProvider === AgentProvider.CODEX ? { extraSettings: { [CODEX_EXTRA_COLLABORATION_MODE]: DEFAULT_CODEX_COLLABORATION_MODE } } : {}),
+        ...(extraSettings ? { extraSettings } : {}),
         ...(sessionId ? { agentSessionId: sessionId } : {}),
       })
       if (resp.agent) {

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { wireSessionInfoToUpdates } from './useWorkspaceConnection'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from './useWorkspaceConnection'
 
 describe('wireSessionInfoToUpdates', () => {
   it('returns an empty object for undefined or empty payloads', () => {
@@ -44,5 +45,33 @@ describe('wireSessionInfoToUpdates', () => {
   it('keeps an empty-string streaming_type (the "not streaming plan" signal)', () => {
     // streaming_type uses `!== undefined`, so "" is a meaningful value, not a skip.
     expect(wireSessionInfoToUpdates({ streaming_type: '' }).streamingType).toBe('')
+  })
+})
+
+describe('shouldClearThinkingTokensForMessage', () => {
+  const agentMsg = (parentSpanId = '') => ({ source: MessageSource.AGENT, parentSpanId })
+  // A plugin that always clears, mirroring Claude's telemetry-driven counter.
+  const alwaysClears = { clearsThinkingTokensForMessage: () => true }
+
+  it('clears on a main-agent AGENT message by default (empty parentSpanId)', () => {
+    expect(shouldClearThinkingTokensForMessage(agentMsg(''), undefined)).toBe(true)
+  })
+
+  it('does NOT clear on a subagent message by default (nested under a span)', () => {
+    expect(shouldClearThinkingTokensForMessage(agentMsg('collab-span'), undefined)).toBe(false)
+  })
+
+  it('does NOT clear on non-AGENT messages, even with an always-clear plugin', () => {
+    expect(shouldClearThinkingTokensForMessage({ source: MessageSource.USER, parentSpanId: '' }, undefined)).toBe(false)
+    expect(shouldClearThinkingTokensForMessage(
+      { source: MessageSource.LEAPMUX, parentSpanId: '' },
+      alwaysClears,
+    )).toBe(false)
+  })
+
+  it('delegates the AGENT-message policy to the provider plugin', () => {
+    // A plugin (e.g. Claude) that always clears overrides the default main-scope
+    // gate, so even a message with a non-empty parentSpanId clears.
+    expect(shouldClearThinkingTokensForMessage(agentMsg('sys-tu-999'), alwaysClears)).toBe(true)
   })
 })

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -1,3 +1,4 @@
+import type { Provider } from '~/components/chat/providers/registry'
 import type { AgentEvent, TerminalEvent, WatchAgentEntry } from '~/generated/leapmux/v1/workspace_pb'
 import type { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import type { createAgentSessionStore, RateLimitInfo } from '~/stores/agentSession.store'
@@ -9,6 +10,7 @@ import type { WorkspaceStoreRegistryType } from '~/stores/workspaceStoreRegistry
 import { batch, createEffect, createSignal, onCleanup, untrack } from 'solid-js'
 import { sendAgentMessage, watchEventsViaChannel } from '~/api/workerRpc'
 import { classifyAgentMessage, shouldClearStreamingText } from '~/components/chat/messageClassification'
+import { providerFor } from '~/components/chat/providers/registry'
 import { showWarnToast } from '~/components/common/Toast'
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
 import { AgentProvider, AgentStatus, MessageSource } from '~/generated/leapmux/v1/agent_pb'
@@ -99,6 +101,26 @@ export function wireSessionInfoToUpdates(
   if (typeof info.thinking_tokens === 'number' && info.thinking_tokens > 0)
     updates.thinkingTokens = info.thinking_tokens
   return updates
+}
+
+// shouldClearThinkingTokensForMessage decides whether a persisted message should
+// drop the live thinking-token estimate. Non-AGENT entries (user echoes such as
+// queued input or tool_result, and LeapMux notifications) can land mid-think and
+// must never clear a climbing counter, so they are rejected here universally. For
+// AGENT messages the per-provider policy is delegated to the provider plugin's
+// clearsThinkingTokensForMessage hook; the default (no hook) is "main-scope only"
+// -- clear when parentSpanId === '' -- so a collab subagent's nested commit does
+// not reset the primary counter (Claude overrides to always clear). The resolved
+// plugin is passed in so this stays a pure, registry-free unit.
+export function shouldClearThinkingTokensForMessage(
+  msg: { source: MessageSource, parentSpanId: string },
+  plugin: Pick<Provider, 'clearsThinkingTokensForMessage'> | undefined,
+): boolean {
+  if (msg.source !== MessageSource.AGENT)
+    return false
+  if (plugin?.clearsThinkingTokensForMessage)
+    return plugin.clearsThinkingTokensForMessage(msg)
+  return msg.parentSpanId === ''
 }
 
 export interface WorkspaceConnectionParams {
@@ -254,6 +276,12 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           if (innerType === 'context_cleared') {
             agentSessionStore.clearContextUsage(agentId)
             chatStore.clearTodos(agentId)
+            // The conversation was wiped; drop any in-flight thinking-token
+            // estimate too. The backend resets its own estimator on a context
+            // clear, but that reset is in-memory only (no broadcast), so the
+            // counter would otherwise linger frozen on its last value until the
+            // next turn produces a delta or a clear of its own.
+            agentSessionStore.clearThinkingTokens(agentId)
           }
 
           if (innerType === 'rate_limit_event' || innerMethod === CODEX_RATE_LIMITS_METHOD) {
@@ -319,21 +347,20 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         }
 
         chatStore.addMessage(agentId, msg)
-        // Agent output means the current thinking phase produced something, so
-        // drop the live thinking-token estimate — otherwise the counter lingers
-        // beside the indicator (frozen on its last value) until turn end, and
-        // the next thinking phase would briefly flash the stale total before its
-        // own deltas arrive. Gated to AGENT source: user echoes (queued input,
-        // tool_result) and LeapMux notifications can land mid-think and must not
-        // clear a still-climbing counter. No-op when no estimate is set.
+        // Main-agent output means the current thinking phase produced something,
+        // so drop the live thinking-token estimate — otherwise the counter lingers
+        // beside the indicator (frozen on its last value) until turn end, and the
+        // next thinking phase would briefly flash the stale total before its own
+        // deltas arrive. No-op when no estimate is set.
         //
-        // INTENTIONAL per-phase reset: this also fires on an intermediate
-        // persisted reasoning block (Claude `assistant_thinking`) during
-        // interleaved thinking (think -> tool -> think), so the counter restarts
-        // from each new phase's first delta rather than accumulating across a
-        // whole turn. That per-phase semantics is the desired behavior — do not
-        // "fix" it to only clear at true turn boundaries.
-        if (msg.source === MessageSource.AGENT)
+        // INTENTIONAL per-phase reset: this also fires on an intermediate persisted
+        // reasoning block (Claude `assistant_thinking`) during interleaved thinking
+        // (think -> tool -> think), so the counter restarts from each new phase's
+        // first delta rather than accumulating across a whole turn. That per-phase
+        // semantics is the desired behavior — do not "fix" it to only clear at true
+        // turn boundaries. See shouldClearThinkingTokensForMessage for the
+        // source/subagent/Claude gating rationale.
+        if (shouldClearThinkingTokensForMessage(msg, providerFor(msg.agentProvider)))
           agentSessionStore.clearThinkingTokens(agentId)
         if (
           !isAgentTabVisible(agentId)


### PR DESCRIPTION
## Motivation

The animated thinking-token odometer (shipped in c09dae34) was wired only to Claude. Codex, Pi, and the six ACP-backed agents (Copilot, Cursor, Goose, OpenCode, Gemini, Kilo) produced no estimates, so their indicator showed nothing during model generation.

In addition, several per-provider UI policies (context buffer percentage, default extra settings, selection-note coexistence, session-ID-as-file-path) were scattered as hardcoded provider-equality checks across unrelated frontend files, making it increasingly difficult to add or adjust per-provider behaviour.

## Modifications

**Backend — shared estimator infrastructure (`thinking_tokens.go`)**
- Introduces `thinkingTokenEstimator`: a streamed-text token counter (chars/4 heuristic) that accumulates rune counts from assistant and reasoning deltas and broadcasts running per-phase estimates over the existing `agent_session_info` channel under `SessionInfoKeyThinkingTokens`. Accumulation and broadcast are split so the estimator lock is never held across a blocking broadcast; a generation guard (forward-only odometer) drops broadcasts whose phase a concurrent reset has already ended.
- Introduces `thinkingResetSink`: a decorator that wraps every estimator-providing sink and resets the estimate at exactly the points the frontend clears its counter — a committed main-scope AGENT message, a broadcast AGENT notification, the turn-end divider, and each control request — so individual providers cannot accidentally miss a reset.
- Changes the internal `OutputSink.PersistNotification` signature to return `(broadcast bool, err error)` so the reset decorator can skip resets for collapsed/de-duplicated notifications that never reached the frontend.

**Backend — Codex wiring (`codex.go`, `codex_output.go`)**
- Counts the four model-text delta kinds (agentMessage, plan, reasoning summary, reasoning raw), gated to the main thread via `observeMainThreadText` to exclude collaborative subagent child-thread deltas.
- Locks each reasoning item to its first-seen sub-stream kind (summary vs. raw) via a `reasoningStreamKind` map so the two streams Codex emits for one item are not double-counted; the map is cleared at main-thread turn-start and released on item completion.

**Backend — Pi wiring (`pi.go`, `pi_output.go`)**
- Counts text and thinking deltas; Pi commits them as a single `message_end` with no per-phase split, so a thinking-to-text transition intentionally shares one phase.

**Backend — ACP wiring (`acp_common.go`)**
- Lights up all six ACP agents with the estimator.
- Counts assistant and reasoning chunks; the assistant-to-reasoning hand-off broadcasts an explicit clear (gated on pending chars) to avoid a redundant clear when a committed tool call separates the two streams.
- An aborted (nil-result) turn drops its buffered turn state and broadcasts an explicit clear because it persists no result divider.

**Backend — service layer (`service/output.go`)**
- `agentOutputSink.PersistNotification` (and its threaded/standalone helpers) now return `(broadcast bool, err error)`. Returns `false` when a ProviderScoped notification collapses byte-identically into the existing thread tail and skips the DB write and broadcast, preventing the reset decorator from advancing ahead of what the frontend actually received.

**Frontend — clear policy and plugin hooks**
- Adds a `clearsThinkingTokensForMessage` Provider plugin hook and a shared `shouldClearThinkingTokensForMessage` helper: Claude always clears (its counter is real per-phase telemetry); estimator-based providers clear only on main-scope messages (`parentSpanId === ''`). A `context_cleared` event also clears the counter.
- Moves four per-provider UI policies out of hardcoded provider-equality checks and into Provider plugin hooks registered in `registry.ts`: `contextBufferPct`, `defaultExtraSettings`, `preservesSelectionNotes`, and `sessionIdIsFilePath`. Call sites are undefined-guarded via `pluginFor`.

## Result

The animated thinking-token odometer now displays live estimates for Codex, Pi, Copilot, Cursor, Goose, OpenCode, Gemini, and Kilo — matching the existing Claude experience — while correctly resetting only when the frontend counter actually clears. Per-provider UI policy is consolidated into the Provider plugin registry, making it straightforward to adjust or add provider-specific behaviour in one place.
