### PR TITLE
feat(agent): Discover Claude Code models dynamically from the CLI

### DIFF
--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -41,7 +41,30 @@ type claudeCodeControlResult struct {
 	OutputStyle           string
 	AvailableOutputStyles []string
 	FastModeState         string // "off", "cooldown", "on", or "" (unavailable)
-	RawResponse           json.RawMessage
+	// Models / UnavailableModels carry the model catalog from the initialize
+	// response (see claudeCodeModelInfo). UnavailableModels are the
+	// visible-but-not-selectable entries the CLI reports separately; we drop
+	// them during conversion. Note: Claude Code only emits unavailable_models to an
+	// allowlisted first-party host entrypoint (currently the VS Code extension), so
+	// for LeapMux's "cli" entrypoint this is effectively always empty -- the dynamic
+	// catalog drops only `disabled` rows. Parsing it anyway keeps us correct if that
+	// host allowlist ever widens.
+	Models            []claudeCodeModelInfo
+	UnavailableModels []claudeCodeModelInfo
+	RawResponse       json.RawMessage
+}
+
+// claudeCodeModelInfo is one entry of the `models` array in the Claude Code
+// initialize control response (SDK schema ModelInfoSchema). Only the fields
+// LeapMux consumes are decoded; adaptive-thinking/fast-mode/auto-mode flags are
+// derived separately (modelSupportsAdaptiveThinking) and omitted here.
+type claudeCodeModelInfo struct {
+	Value                 string   `json:"value"`                 // id passed to --model / set_model (e.g. "opus[1m]"); "default" is an alias sentinel
+	DisplayName           string   `json:"displayName"`           // e.g. "Opus (1M context)"
+	Description           string   `json:"description"`           // capability blurb shown on hover
+	SupportsEffort        bool     `json:"supportsEffort"`        // false ⇒ no effort selector (e.g. Haiku)
+	SupportedEffortLevels []string `json:"supportedEffortLevels"` // CLI levels, weakest→strongest: low|medium|high|xhigh|max
+	Disabled              bool     `json:"disabled"`              // visible but not selectable; dropped during conversion
 }
 
 // Extra settings keys for Claude Code option groups.
@@ -92,6 +115,13 @@ type ClaudeCodeAgent struct {
 	fastMode              string // "on" / "off"
 	alwaysThinking        string // "on" / "off"
 	autoModeAvailable     bool
+
+	// availableModels is the model catalog discovered from the initialize
+	// response. It is written once in StartClaudeCode before the agent is
+	// registered with the manager and never mutated afterward, so reads are
+	// safe without a.mu (callers may already hold it). nil/empty ⇒ fall back
+	// to the static claudeCodeAvailableModels catalog.
+	availableModels []*leapmuxv1.AvailableModel
 }
 
 // StartClaudeCode spawns a new Claude Code process and begins reading its output.
@@ -130,12 +160,28 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 
 	var modelEffortArgs []string
 	if !thirdPartyFromSettings {
-		modelEffortArgs = buildModelEffortArgs(opts.Model, opts.Effort)
+		// The dynamic catalog isn't known until the initialize response
+		// arrives (below), so launch-time effort resolution uses the static
+		// catalog. Fable and the other shipped models live there; a model
+		// known only to a newer CLI downgrades ultracode→xhigh here and is
+		// re-enabled post-init by buildStartupFlagSettings.
+		modelEffortArgs = newEffortResolver(claudeCodeAvailableModels).buildModelEffortArgs(opts.Model, opts.Effort)
 	}
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "claude", []string{"CLAUDECODE"}, baseArgs, modelEffortArgs, opts.WorkingDir,
-	)
+	// Always probe for a shell-profile third-party provider unless settings
+	// already flagged one: a default-model launch sends no --model/--effort
+	// (empty modelEffortArgs) but must still detect a provider configured in the
+	// user's rc files so AvailableModels() can hide the model/effort UI.
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:           opts.Shell,
+		LoginShell:      opts.LoginShell,
+		BinaryName:      "claude",
+		StripEnvKeys:    []string{"CLAUDECODE"},
+		BaseArgs:        baseArgs,
+		ModelEffortArgs: modelEffortArgs,
+		ProbeThirdParty: !thirdPartyFromSettings,
+		WorkingDir:      opts.WorkingDir,
+	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
 	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=cli")
@@ -189,6 +235,26 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		_ = a.Wait()
 	}
 
+	// Run the control-protocol startup handshake (initialize -> extract settings ->
+	// permission mode -> apply persisted flag settings -> refresh). On a hard failure
+	// tear down the just-spawned process so no orphan process or goroutine survives.
+	if err := a.runStartupHandshake(ctx, opts); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// runStartupHandshake drives the control-protocol exchange that must complete before
+// StartClaudeCode hands back a usable agent: it sends initialize, captures the model
+// catalog and the other settings the response carries, applies the permission mode and
+// any persisted flag settings, then refreshes the stored settings from the CLI. It
+// returns a formatted startup error on a hard failure (initialize / set_permission_mode);
+// the caller tears the process down. Every field write here runs on the StartClaudeCode
+// goroutine before the agent is registered with the manager -- the same lock-free
+// pre-registration window buildStartupFlagSettings documents -- so no a.mu is taken.
+func (a *ClaudeCodeAgent) runStartupHandshake(ctx context.Context, opts Options) error {
 	timeout := opts.startupTimeout()
 
 	// Send "initialize" as the first control request, matching the Agent SDK
@@ -197,8 +263,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	TraceStartupPhase(opts.AgentID, "before_initialize")
 	initResp, err := a.sendControlAndWait(ctx, `{"subtype":"initialize"}`, timeout)
 	if err != nil {
-		cleanup()
-		return nil, a.formatStartupError("initialize", err)
+		return a.formatStartupError("initialize", err)
 	}
 	TraceStartupPhase(opts.AgentID, "after_initialize")
 
@@ -207,6 +272,13 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		a.outputStyle = initResp.OutputStyle
 	}
 	a.availableOutputStyles = initResp.AvailableOutputStyles
+	// Discover the model catalog from the initialize response. An empty result
+	// (old CLI or parse failure) leaves a.availableModels nil and AvailableModels()
+	// falls back to the static catalog. For a third-party provider AvailableModels()
+	// returns nil regardless (the UI hides model/effort), but effortResolver() still
+	// resolves over whatever the response carried (with the static fallback) so
+	// effort/window resolution has a usable catalog.
+	a.availableModels = convertClaudeModels(initResp.Models, initResp.UnavailableModels)
 	if initResp.FastModeState == FastModeOn || initResp.FastModeState == "cooldown" {
 		a.fastMode = FastModeOn
 	} else {
@@ -216,8 +288,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	TraceStartupPhase(opts.AgentID, "before_permission_mode")
 	resp, err := a.applyStartupPermissionMode(ctx, StringOrDefault(opts.PermissionMode, PermissionModeDefault), timeout)
 	if err != nil {
-		cleanup()
-		return nil, a.formatStartupError("set_permission_mode", err)
+		return a.formatStartupError("set_permission_mode", err)
 	}
 	a.confirmedPermissionMode = resp.Mode
 	TraceStartupPhase(opts.AgentID, "after_permission_mode")
@@ -234,8 +305,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 	// "auto"). Run even if apply_flag_settings failed so the DB mirrors
 	// the CLI's actual state rather than what we tried to set.
 	a.refreshSettingsFromAgent(timeout)
-
-	return a, nil
+	return nil
 }
 
 // buildStartupFlagSettings builds an apply_flag_settings payload for extra
@@ -247,17 +317,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 // fields, so the lock-free read is safe. Do not call it post-registration.
 func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[string]interface{} {
 	fs := map[string]interface{}{}
-	// We launched with --effort xhigh as the ultracode base (see
-	// buildModelEffortArgs), so the CLI's current effort is already xhigh.
-	// Enable the ultracode boolean on top to complete the combo -- but only when
-	// the model actually supports it. buildModelEffortArgs downgrades an
-	// unsupported ultracode launch to --effort high, so for a Sonnet/Haiku/unknown
-	// agent whose stored effort was somehow "ultracode" we must NOT re-enable it
-	// here, or startup would contradict the launch flag and force xhigh+ultracode
-	// onto a model that can't run it.
-	if a.effort == EffortUltracode && modelSupportsUltracode(a.model) {
-		maps.Copy(fs, ultracodeFlagSettings())
-	}
+	maps.Copy(fs, a.reconcileStartupEffortFlags())
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != a.outputStyle {
 		fs[ExtraKeyOutputStyle] = v
 	}
@@ -268,6 +328,117 @@ func (a *ClaudeCodeAgent) buildStartupFlagSettings(extra map[string]string) map[
 		fs[ExtraKeyAlwaysThinking] = flagSettingThinking(v)
 	}
 	return fs
+}
+
+// reconcileStartupEffortFlags returns the apply_flag_settings needed to bring a
+// freshly launched session's effort into agreement with the dynamic catalog, or nil
+// for a third-party session (which has no model/effort UI -- see hidesModelEffortUI).
+// The capability reconciliation itself lives on effortResolver (reconcileStartupFlags);
+// this method applies the agent-level gate and hands the launch-time a.model/a.effort
+// to the resolver it reconciles against.
+func (a *ClaudeCodeAgent) reconcileStartupEffortFlags() map[string]interface{} {
+	// A third-party session presents no model/effort UI and (when detected from
+	// settings) launches with no --model/--effort; pushing effort/ultracode flags
+	// would apply settings its user can neither see nor control, so leave it at the
+	// CLI's own resolution. Gated on the same predicate AvailableModels uses so the
+	// "hidden UI" and "no effort push" decisions can't drift.
+	if a.hidesModelEffortUI() {
+		return nil
+	}
+	return a.effortResolver().reconcileStartupFlags(a.model, a.effort)
+}
+
+// reconcileStartupFlags returns the apply_flag_settings that bring a freshly launched
+// model+effort into agreement with this (dynamic) resolver. The effort was resolved
+// at LAUNCH against the static catalog (the dynamic one wasn't known pre-init); the
+// model/effort passed here still hold the launch values, since refreshSettingsFromAgent
+// runs later. We reconstruct what launch sent as a launchEffortPlan (against the static
+// catalog) and compare it against r (dynamic, with the static fallback that still
+// recognizes a model the live CLI filtered out):
+//
+//   - Omitted: launch sent no --effort, so the CLI is at its own default. Usually
+//     nothing to do -- except the S9 case handled by reconcileOmittedLaunch.
+//   - Ultracode: the resolver confirms ultracode for the model, so complete the
+//     combo (re-pin effortLevel:xhigh + ultracode:true) whether launch sent the
+//     xhigh base (re-pin) or a lower one (upgrade). The launch path deferred the
+//     ultracode boolean to here -- it is applied nowhere else -- so this also
+//     re-enables a filtered model's ultracode the static fallback still vouches for.
+//     Re-pinning is safe even if the live CLI no longer offers xhigh for the model:
+//     Claude Code clamps an unsupported effortLevel to "high" at resolution and never
+//     rejects apply_flag_settings (verified against the 2.1.170 binary), so an
+//     over-pin degrades gracefully instead of stranding the session.
+//   - Downgrade: the dynamic catalog runs the model at a different level than launch
+//     sent (e.g. the live CLI dropped xhigh), so emit the corrected level and clear
+//     ultracode defensively.
+//
+// Returns nil when launch and the dynamic resolution already agree (the common case)
+// or when the model is unknown to both catalogs (nothing to reconcile against).
+func (r effortResolver) reconcileStartupFlags(model, effort string) map[string]interface{} {
+	plan := newEffortResolver(claudeCodeAvailableModels).planLaunch(model, effort)
+	if plan.omitted {
+		return r.reconcileOmittedLaunch(model, effort)
+	}
+	if _, known := r.definedEfforts(model); !known {
+		// Unknown to both the dynamic catalog and the static fallback: we can't
+		// reconcile against capabilities we don't have, so leave the session at
+		// whatever --effort launch sent. (launchRunsUltracode implies known, so this
+		// check can precede the ultracode/downgrade tail without dropping that case.)
+		return nil
+	}
+	// Launch sent plan.level; emit only when the dynamic resolution differs from it.
+	// The non-empty skipLevel also clears ultracode defensively on a downgrade.
+	return r.reconciledEffortFlags(model, effort, plan.level)
+}
+
+// reconciledEffortFlags returns the apply_flag_settings that bring model/effort into
+// agreement with this resolver: the xhigh+ultracode combo when the resolver confirms
+// ultracode for the model, otherwise the resolved effortLevel. skipLevel suppresses
+// emission when the resolved level already equals it (the startup "launch already
+// sent this" no-op); pass "" to always emit a non-auto level (the omitted-launch
+// path, which has no launch level to compare against). A non-empty skipLevel also
+// means launch sent a level -- and so may have set an ultracode boolean a downgrade
+// must undo -- so the effortLevel carries an explicit ultracode:false then; the
+// omitted path (skipLevel "") sent no effort and so has no ultracode to clear.
+// (clearUltracode is thus fully determined by skipLevel, not a separate knob.)
+// Returns nil when there is nothing to apply (auto/empty resolution, or the level
+// already matches skipLevel). Shared by reconcileStartupFlags and reconcileOmittedLaunch
+// so the two can't drift on the ultracode-combo and auto-passthrough rules.
+func (r effortResolver) reconciledEffortFlags(model, effort, skipLevel string) map[string]interface{} {
+	if r.launchRunsUltracode(model, effort) {
+		return ultracodeFlagSettings()
+	}
+	target := r.resolveEffort(model, effort)
+	if target == "" || target == EffortAuto || target == skipLevel {
+		return nil
+	}
+	fs := map[string]interface{}{"effortLevel": target}
+	if skipLevel != "" {
+		fs["ultracode"] = false
+	}
+	return fs
+}
+
+// reconcileOmittedLaunch handles the launch-omitted-effort case. Launch sends no
+// --effort for the sentinel, EffortAuto/"" (the CLI keeps its own default -- nothing
+// to reconcile), and a model the STATIC catalog considers effort-less. The last is
+// the only omit that leaves a CONCRETE stored effort on a real model, so it is the
+// only one that can disagree with the dynamic catalog: if the live CLI actually
+// offers efforts for that model (S9 -- a model effort-less in the static catalog but
+// effort-bearing in the dynamic one), apply the dynamic-resolved effort so the live
+// selector and the running session agree instead of silently running the CLI default.
+func (r effortResolver) reconcileOmittedLaunch(model, effort string) map[string]interface{} {
+	if effort == "" || effort == EffortAuto || model == DefaultModelSentinel {
+		return nil
+	}
+	efforts, known := r.definedEfforts(model)
+	if !known || len(efforts) == 0 {
+		// The dynamic catalog agrees the model is effort-less (or doesn't know it):
+		// nothing to apply.
+		return nil
+	}
+	// Launch sent no --effort, so there is no launch level to match against (skipLevel
+	// ""), which also signals there is no launch-sent ultracode boolean to clear.
+	return r.reconciledEffortFlags(model, effort, "")
 }
 
 // Interrupt aborts the current turn by sending the Claude Code
@@ -397,20 +568,51 @@ func (a *ClaudeCodeAgent) CurrentSettings() *leapmuxv1.AgentSettings {
 	}
 }
 
-// AvailableModels returns the hardcoded Claude Code model/effort list.
-// Returns nil when a third-party LLM provider is detected (either from
-// settings at startup, or from the shell wrapper's
-// can_change_model_and_effort=false metadata), which tells the frontend
-// to hide model and effort settings.
+// AvailableModels returns the Claude Code model/effort catalog: the per-agent
+// list discovered from the initialize response when present, else the static
+// claudeCodeAvailableModels fallback (see effortCatalog). Returns nil when a
+// third-party LLM provider is detected (either from settings at startup, or from
+// the shell wrapper's can_change_model_and_effort=false metadata), which tells
+// the frontend to hide model and effort settings.
 //
 // The returned slice and every AvailableModel/AvailableEffort it points at are
 // shared, immutable catalog data: the same effortTier* pointers back multiple
-// model slices (see the var block below), so a mutation through any returned
-// entry would corrupt every model that shares it. Callers MUST treat the result
-// as read-only; copy before mutating.
+// model slices (both the static catalog and the converted dynamic list), so a
+// mutation through any returned entry would corrupt every model that shares it.
+// Callers MUST treat the result as read-only; copy before mutating.
 func (a *ClaudeCodeAgent) AvailableModels() []*leapmuxv1.AvailableModel {
-	if a.thirdPartyFromSettings || a.preambleMetaValue("can_change_model_and_effort") == "false" {
+	if a.hidesModelEffortUI() {
 		return nil
+	}
+	return a.effortCatalog()
+}
+
+// hidesModelEffortUI reports whether this session presents no model/effort UI: a
+// third-party LLM provider detected from settings at startup, or one the shell
+// wrapper flagged via can_change_model_and_effort=false. AvailableModels returns
+// nil in that case (hiding the model/effort settings), and the startup effort
+// reconcile is skipped, so a session whose user can neither see nor control effort
+// is never pushed an effort/ultracode apply_flag_settings.
+func (a *ClaudeCodeAgent) hidesModelEffortUI() bool {
+	return a.thirdPartyFromSettings || a.preambleMetaValue("can_change_model_and_effort") == "false"
+}
+
+// effortCatalog returns the dynamic-first model list backing AvailableModels: the
+// per-agent list discovered from the initialize response when present, else the
+// static claudeCodeAvailableModels fallback. AvailableModels layers the third-party
+// gate on top; effortCatalog itself is ungated, so that gate lives in one place.
+//
+// This is the picker view -- a whole-list dynamic-or-static swap that shows only the
+// models the CLI reported. Effort/ultracode/context-window resolution does NOT use it:
+// those go through effortResolver, which carries the static catalog as a PER-ENTRY
+// fallback so a model the live CLI dropped from its list still resolves its
+// capabilities and window.
+//
+// availableModels is written once before the agent is published and never mutated,
+// so this read is safe without a.mu.
+func (a *ClaudeCodeAgent) effortCatalog() []*leapmuxv1.AvailableModel {
+	if len(a.availableModels) > 0 {
+		return a.availableModels
 	}
 	return claudeCodeAvailableModels
 }
@@ -527,7 +729,7 @@ func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{
 	return fs
 }
 
-// claudeEffortUpdateFlagSettings builds the effort/ultracode portion of a live
+// updateFlagSettings builds the effort/ultracode portion of a live
 // apply_flag_settings payload for moving curEffort -> the requested newEffort on
 // targetModel (the model the change lands on). It resolves newEffort against the
 // model first, so an unsupported combo can't be pushed to the CLI.
@@ -537,8 +739,10 @@ func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{
 // returns nil and the CLI's per-session `ultracode` boolean would persist even
 // after switching onto a model that can't run it (e.g. opus+ultracode ->
 // sonnet). We force ultracode:false whenever the session is leaving ultracode for
-// a model whose catalog doesn't offer it, so the boolean never outlives the model
-// that supports it.
+// a KNOWN model whose catalog doesn't offer it, so the boolean never outlives the
+// model that supports it. A model unknown to BOTH catalogs is exempted (the
+// `known &&` gate): like the decode side, we trust the CLI's own ultracode report
+// for a model the catalog can't speak to rather than downgrading a running session.
 //
 // Clearing the boolean alone is not enough: the CLI's apply_flag_settings treats
 // model/effortLevel/ultracode as independent keys and does NOT re-resolve
@@ -549,9 +753,9 @@ func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{
 // model may not support -- and the session would keep running at xhigh. When the
 // caller requested no explicit effort (so claudeEffortFlagSettings left no
 // effortLevel key), we therefore also pin the level to the target model's
-// xhigh-resolved fallback, which mirrors the decode side (claudeEffortFromApplied
+// xhigh-resolved fallback, which mirrors the decode side (effortFromApplied
 // falls back to the xhigh base when ultracode is cleared) and lands the live path
-// on the same effort a relaunch would pick. resolveClaudeEffortForModel downgrades
+// on the same effort a relaunch would pick. resolveEffort downgrades
 // xhigh to "high" for models that don't offer it (e.g. sonnet -> "high", its
 // default), so the pinned level is always one the target model can run.
 //
@@ -559,59 +763,106 @@ func claudeEffortFlagSettings(newEffort, curEffort string) map[string]interface{
 // short-circuits UpdateSettings before this runs), so today this whole branch only
 // matters for non-UI/raw callers; it is defensive so such a caller can't strand an
 // unsupported effortLevel on the live session.
-func claudeEffortUpdateFlagSettings(targetModel, newEffort, curEffort string) map[string]interface{} {
-	fs := claudeEffortFlagSettings(resolveClaudeEffortForModel(targetModel, newEffort), curEffort)
-	if unsupportedUltracode(curEffort, targetModel) {
+func (r effortResolver) updateFlagSettings(targetModel, newEffort, curEffort string) map[string]interface{} {
+	if targetModel == DefaultModelSentinel {
+		// A session stuck on the unresolved account-default sentinel (the degraded path
+		// where get_settings never echoed a concrete applied.model) has no concrete model
+		// to resolve an effort against. Pushing an effortLevel here would pin a level the
+		// CLI's actual resolved model may not support, so emit no effort delta -- the same
+		// "the sentinel keeps the CLI's own resolution" stance the launch path takes by
+		// omitting --effort. The effort settles once the model resolves.
+		return nil
+	}
+	fs := claudeEffortFlagSettings(r.resolveEffort(targetModel, newEffort), curEffort)
+	// Gate the ultracode strip on the model being KNOWN, mirroring effortFromApplied's
+	// final guard (the `known &&` at the decode side): a model in NEITHER catalog
+	// running ultracode is trusted as the CLI's own authoritative report (see
+	// trustCLIUltracodeReport) -- the live path must not relabel it just because the
+	// catalog can't confirm xhigh support. Without this guard supportsUltracode rejects
+	// the unknown model, so unsupportedUltracode(curEffort, unknown) is true and an
+	// unrelated/model-only update (newEffort=="") would silently push {ultracode:false,
+	// effortLevel:"xhigh"} and downgrade a session the CLI is happily running at
+	// ultracode -- directly contradicting the decode side that just trusted the same
+	// model. The primary "leaving ultracode for a KNOWN unsupporting model" case
+	// (opus+ultracode -> sonnet) still fires: sonnet is known.
+	_, known := r.definedEfforts(targetModel)
+	if known && r.unsupportedUltracode(curEffort, targetModel) {
 		if fs == nil {
 			fs = map[string]interface{}{}
 		}
 		fs["ultracode"] = false
 		if _, ok := fs["effortLevel"]; !ok {
-			fs["effortLevel"] = resolveClaudeEffortForModel(targetModel, EffortXHigh)
+			fs["effortLevel"] = r.resolveEffort(targetModel, EffortXHigh)
 		}
 	}
 	return fs
 }
 
-// claudeEffortFromApplied decodes the effort/ultracode pair that get_settings
-// reports back into LeapMux's internal effort value -- the decode-side inverse of
+// effortFromApplied decodes the effort/ultracode pair that get_settings reports
+// back into LeapMux's internal effort value -- the decode-side inverse of
 // claudeEffortFlagSettings. The CLI reports an active ultracode session as
 // effortLevel:"xhigh" plus ultracode:true, so applied.ultracode==true maps to the
-// internal "ultracode" -- but only when the model's catalog confirms it supports
-// ultracode (modelSupportsUltracode), so we never mislabel a Sonnet/Haiku/unknown
-// session as ultracode even if the CLI were to report it. An unentitled session
-// reports ultracode:false and we keep the reported level (e.g. "xhigh"). When
-// ultracode is explicitly turned off but applied.effort
-// is omitted, we fall back to ultracode's "xhigh" launch base instead of leaving a
-// stale "ultracode". curEffort is retained when applied.effort is omitted or empty.
+// internal "ultracode" -- trusted as the CLI's authoritative report, EXCEPT for a
+// model the catalog KNOWS lacks ultracode (Sonnet/Haiku), which is never promoted.
+// A model the catalog does NOT know (e.g. one the CLI reported in unavailable_models,
+// so convertClaudeModels filtered it from the dynamic catalog) is trusted too: the
+// CLI is the authority on what it actually applied, so a running ultracode session
+// is not relabeled to xhigh just because its model dropped out of the catalog. The
+// account-default sentinel is the one unknown model NOT trusted here: a session
+// stuck on the literal "default" (the CLI never echoed a concrete applied.model) has
+// no real model behind it, so a CLI ultracode:true report passes the effort through
+// (e.g. "xhigh") rather than minting a phantom "ultracode" against the placeholder. An
+// unentitled session reports ultracode:false and we keep the reported level (e.g.
+// "xhigh"). When ultracode is explicitly turned off but applied.effort is omitted,
+// we fall back to ultracode's "xhigh" launch base instead of leaving a stale
+// "ultracode". curEffort is retained when applied.effort is omitted or empty.
 //
 // applied.effort is reported as a concrete effort enum or null (get_settings
 // sends `typeof effort === "string" ? effort : null`), never an empty string,
 // so the `!= ""` guard below is purely defensive: a malformed/empty report
 // retains curEffort rather than blanking the stored effort to "".
 //
-// The final guard catches the remaining mislabel path the switch can't: when
-// the CLI omits the ultracode field entirely (ultracode == nil) a stale
-// curEffort=="ultracode" would otherwise survive onto a model that can't run it
-// (e.g. a model switch that didn't touch effort), so we clear it to the xhigh
-// base unless the model's catalog confirms ultracode support.
-func claudeEffortFromApplied(appliedEffort *string, ultracode *bool, curEffort, model string) string {
+// The final guard catches the remaining mislabel path the switch can't: when the
+// CLI omits the ultracode field entirely (ultracode == nil) a stale
+// curEffort=="ultracode" would otherwise survive onto a model the catalog KNOWS
+// can't run it (e.g. a model switch that didn't touch effort), so we clear it to
+// the xhigh base. An unknown model is left alone here for the same trust reason.
+func (r effortResolver) effortFromApplied(appliedEffort *string, ultracode *bool, curEffort, model string) string {
 	effort := curEffort
 	if appliedEffort != nil && *appliedEffort != "" {
 		effort = *appliedEffort
 	}
+	_, known := r.definedEfforts(model)
 	if ultracode != nil {
 		switch {
-		case *ultracode && modelSupportsUltracode(model):
+		case *ultracode && r.trustCLIUltracodeReport(model, known):
 			effort = EffortUltracode // overrides the "xhigh" reported in applied.effort
 		case !*ultracode && effort == EffortUltracode:
 			effort = EffortXHigh // ultracode cleared; fall back to its xhigh launch base
 		}
 	}
-	if unsupportedUltracode(effort, model) {
+	if known && r.unsupportedUltracode(effort, model) {
 		effort = EffortXHigh
 	}
 	return effort
+}
+
+// trustCLIUltracodeReport reports whether a CLI applied.ultracode==true report
+// should be promoted to the internal EffortUltracode for this model. The CLI is
+// the authority on what it actually applied, so we trust the report both for a
+// model the catalog confirms supports ultracode AND for a model the catalog does
+// NOT know (e.g. one the live CLI filtered into unavailable_models but that the
+// session is still running) -- a running ultracode session is not relabeled to
+// xhigh just because its model dropped out of the catalog. The one exception is
+// the account-default sentinel: it has no concrete model behind it, so a session
+// stuck on the literal "default" must not mint a phantom ultracode against the
+// placeholder. `known` is effortFromApplied's definedEfforts verdict for `model`,
+// reused here for the unknown-model short-circuit; the known-model case defers to
+// supportsUltracode so the "the catalog advertises ultracode" membership test lives
+// in exactly one place. This is the inverse of supportsUltracode on an unknown
+// model (which rejects it) -- the CLI report is trusted where the catalog is silent.
+func (r effortResolver) trustCLIUltracodeReport(model string, known bool) bool {
+	return model != DefaultModelSentinel && (!known || r.supportsUltracode(model))
 }
 
 // UpdateSettings applies settings changes via the apply_flag_settings control
@@ -633,6 +884,15 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 		return false
 	}
 
+	// Switching to the account-default sentinel can't be done live either:
+	// apply_flag_settings stores the model string verbatim (it does NOT resolve
+	// "default" the way set_model and the --model-omitted launch path do), so it
+	// would strand the session on a bogus "default" model. Re-launch so startup
+	// resolves it to the concrete model, mirroring the EffortAuto restart above.
+	if s.Model == DefaultModelSentinel && s.Model != curModel {
+		return false
+	}
+
 	flagSettings := map[string]interface{}{}
 
 	if s.Model != "" && s.Model != curModel {
@@ -648,7 +908,7 @@ func (a *ClaudeCodeAgent) UpdateSettings(s *leapmuxv1.AgentSettings) bool {
 	if s.Model != "" {
 		targetModel = s.Model
 	}
-	maps.Copy(flagSettings, claudeEffortUpdateFlagSettings(targetModel, s.Effort, curEffort))
+	maps.Copy(flagSettings, a.effortResolver().updateFlagSettings(targetModel, s.Effort, curEffort))
 
 	extra := s.ExtraSettings
 	if v := extra[ExtraKeyOutputStyle]; v != "" && v != curOutputStyle {
@@ -717,10 +977,24 @@ func (a *ClaudeCodeAgent) refreshSettingsFromAgent(timeout time.Duration) {
 	a.mu.Lock()
 	if settings.Applied.Model != "" {
 		a.model = normalizeClaudeCodeModel(settings.Applied.Model)
+	} else if a.model == DefaultModelSentinel {
+		// The account-default sentinel launches without --model and relies on
+		// get_settings echoing the concrete model the CLI resolved. Claude Code 2.1.x
+		// always populates applied.model with a concrete id -- get_settings computes it
+		// eagerly via getMainLoopModel(), which resolves the account default and never
+		// returns empty or the literal "default" (verified against the 2.1.170 binary).
+		// So this branch is defense-in-depth against a malformed/forward-incompatible
+		// response: an empty applied.model would otherwise strand a.model on the literal
+		// "default" and leak it into persistence, the broadcast, and the settings-changed
+		// notification. We can't synthesize the concrete model, so surface it.
+		slog.Warn("get_settings omitted applied.model for the account-default launch; model stays unresolved",
+			"agent_id", a.agentID)
 	}
 	// a.model is updated just above from applied.model, so the ultracode/model
-	// gate inside claudeEffortFromApplied sees the model the CLI actually applied.
-	a.effort = claudeEffortFromApplied(settings.Applied.Effort, settings.Applied.Ultracode, a.effort, a.model)
+	// gate inside effortFromApplied sees the model the CLI actually applied.
+	// effortResolver reads a.availableModels lock-free, so it is safe to call here
+	// while a.mu is held.
+	a.effort = a.effortResolver().effortFromApplied(settings.Applied.Effort, settings.Applied.Ultracode, a.effort, a.model)
 	if settings.Effective.OutputStyle != "" {
 		a.outputStyle = settings.Effective.OutputStyle
 	}
@@ -798,21 +1072,38 @@ func normalizeClaudeCodeModel(model string) string {
 	if model == "" {
 		return ""
 	}
-	core := strings.TrimPrefix(model, "claude-")
+	// Lowercase first so a mixed-case CLI value (e.g. "OPUS[1M]", "Claude-Sonnet")
+	// collapses to the same canonical alias the static catalog and a.model use; the
+	// catalog id space is all lowercase, so an uppercased value would otherwise
+	// never match its own entry.
+	core := strings.TrimPrefix(strings.ToLower(model), "claude-")
 	var suffix string
 	if i := strings.IndexByte(core, '['); i >= 0 {
 		suffix = core[i:]
 		core = core[:i]
 	}
-	end := 0
+	// The family alias is the first run of [a-z], AFTER skipping any leading non-alpha
+	// (digits/hyphens). Family-first ids ("opus-4-6") have the family first, but a
+	// version-first id ("3-5-sonnet") leads with numeric version tokens; skipping them
+	// finds the family in either layout, where a from-position-0 scan returned "" for
+	// the version-first shape and leaked the raw id (so a running version-first model
+	// never matched its own catalog entry). A purely-numeric core ("123") still yields
+	// "" and falls through to the raw-display fallback below.
+	start := 0
+	for start < len(core) {
+		if c := core[start]; c >= 'a' && c <= 'z' {
+			break
+		}
+		start++
+	}
+	end := start
 	for end < len(core) {
-		c := core[end]
-		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+		if c := core[end]; c < 'a' || c > 'z' {
 			break
 		}
 		end++
 	}
-	alias := core[:end]
+	alias := core[start:end]
 	if alias == "" {
 		// Unrecognized shape — return the original input unchanged so the
 		// caller can still display it.
@@ -873,12 +1164,322 @@ var claudeEffortMax = []*leapmuxv1.AvailableEffort{
 	effortTierAuto, effortTierMax, effortTierHigh, effortTierMedium, effortTierLow,
 }
 
+// Claude context-window sizes. The CLI does not report a window, so we infer it
+// from the model id (see claudeContextWindowForValue). Naming the two values
+// single-sources the "[1m]-suffix ⇒ 1M, else 200K" rule shared by the static
+// catalog entries, claudeContextWindowForValue, and the unresolved-sentinel
+// fallback in extractAndBroadcastUsage.
+const (
+	claudeStandardContextWindow   = 200_000
+	claudeOneMillionContextWindow = 1_000_000
+)
+
+// claudeCodeAvailableModels is the static model catalog. It is the source of
+// truth for DefaultModel(provider) (registry defaultModels) and the fallback
+// AvailableModels() returns when the per-agent dynamic catalog is empty (old
+// CLI, third-party provider, or parse failure). When the live CLI reports its
+// own catalog, the dynamic list (convertClaudeModels) supersedes this.
+//
+// The leading DefaultModelSentinel entry is the IsDefault choice: a new tab (and
+// any account, including non-Opus tiers) starts on it, and buildModelEffortArgs
+// omits --model so the CLI resolves it to that account's concrete default --
+// which get_settings then reports back, so the tab settles on the real model
+// after startup. It carries no efforts: the effort menu appears once the
+// concrete model is known, which also keeps a fresh launch from forwarding an
+// --effort the resolved model may not support. The concrete models follow in
+// most→least powerful order, matching Claude Code's own ordering ("Fable for the
+// hardest problems, Opus for complex work, Sonnet for most tasks, Haiku for
+// quick questions").
 var claudeCodeAvailableModels = []*leapmuxv1.AvailableModel{
-	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 200_000},
-	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", IsDefault: true, DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: 1_000_000},
-	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: 200_000},
-	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: 1_000_000},
-	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", DefaultEffort: EffortHigh, ContextWindow: 200_000},
+	{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", Description: "Use your account's default model", IsDefault: true},
+	{Id: "fable", DisplayName: "Fable 5", Description: "Most powerful for the hardest problems", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: claudeStandardContextWindow},
+	{Id: "fable[1m]", DisplayName: "Fable 5 (1M context)", Description: "Most powerful for the hardest problems", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: claudeOneMillionContextWindow},
+	{Id: "opus", DisplayName: "Opus", Description: "Most capable for complex work", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: claudeStandardContextWindow},
+	{Id: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", DefaultEffort: EffortXHigh, SupportedEfforts: claudeEffortXHighMax, ContextWindow: claudeOneMillionContextWindow},
+	{Id: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: claudeStandardContextWindow},
+	{Id: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", DefaultEffort: EffortHigh, SupportedEfforts: claudeEffortMax, ContextWindow: claudeOneMillionContextWindow},
+	{Id: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", ContextWindow: claudeStandardContextWindow},
+}
+
+// claudeEffortLevels lists the Claude Code CLI effort levels weakest->strongest,
+// each paired with the shared AvailableEffort tier pointer. Its order IS the rank
+// (claudeSupportedEfforts walks it in reverse for a strongest->weakest menu) and
+// its membership defines which CLI levels we recognize, so ordering and tier
+// mapping are single-sourced -- a new tier can't be added to one without the
+// other (the previous parallel rank/tier maps could silently disagree, sorting an
+// unmapped level as rank 0). Reusing the shared effortTier* pointers keeps the
+// descriptions identical to the static catalog.
+type claudeEffortLevel struct {
+	level string
+	tier  *leapmuxv1.AvailableEffort
+}
+
+var claudeEffortLevels = []claudeEffortLevel{
+	{"low", effortTierLow},
+	{"medium", effortTierMedium},
+	{EffortHigh, effortTierHigh},
+	{EffortXHigh, effortTierXHigh},
+	{"max", effortTierMax},
+}
+
+// recognizedClaudeEffortLevels returns the claudeEffortLevels entries the model
+// supports, ordered strongest->weakest (the rank table walked in reverse), with
+// levels the model doesn't list dropped. It single-sources the reverse rank walk
+// shared by claudeSupportedEfforts (which maps the entries to tier pointers) and
+// claudeDefaultEffort's fallback (which takes the strongest entry's level).
+func recognizedClaudeEffortLevels(supported map[string]bool) []claudeEffortLevel {
+	out := make([]claudeEffortLevel, 0, len(claudeEffortLevels))
+	for i := len(claudeEffortLevels) - 1; i >= 0; i-- {
+		if supported[claudeEffortLevels[i].level] {
+			out = append(out, claudeEffortLevels[i])
+		}
+	}
+	return out
+}
+
+// convertClaudeModels converts the model list from the Claude Code initialize
+// response into LeapMux's AvailableModel catalog, mirroring Codex's
+// queryAvailableModels: efforts are ordered strongest→weakest with an "auto"
+// sentinel prepended, and the LeapMux-only "ultracode" tier is offered for any
+// model whose CLI effort levels include xhigh (ultracode == xhigh + standing
+// workflow orchestration, so xhigh support is the entitlement we key off).
+//
+// Entries the user can't actually select are dropped: disabled entries and
+// anything reported in unavailable_models. The DefaultModelSentinel ("default")
+// entry IS surfaced -- it is a real "let the CLI pick the account default"
+// option (the model-side analogue of EffortAuto); buildModelEffortArgs omits
+// --model for it and withDefaultModelMarked gives it the IsDefault badge.
+// IsDefault is left unset here -- the manager applies it. Returns nil when
+// models is empty so AvailableModels() falls back to the static catalog.
+//
+// The returned entries reuse the shared effortTier* pointers, so the same
+// read-only contract as claudeCodeAvailableModels applies (see AvailableModels).
+func convertClaudeModels(models, unavailable []claudeCodeModelInfo) []*leapmuxv1.AvailableModel {
+	if len(models) == 0 {
+		return nil
+	}
+	skip := buildModelSkipSet(unavailable)
+	out := make([]*leapmuxv1.AvailableModel, 0, len(models))
+	seen := make(map[string]bool, len(models))
+	sentinelSeen := false
+	for _, m := range models {
+		if m.Value == "" || m.Disabled {
+			continue
+		}
+		// The account-default sentinel is identified by its RAW value ("default")
+		// and OWNS the reserved DefaultModelSentinel id deterministically. Route it
+		// before normalizing so its dedup can't race a concrete model that merely
+		// normalizes to "default" (below); keep only the first occurrence. This also
+		// precedes the unavailable_models (skip) filter -- the account default is
+		// always selectable, so a "default" reported in unavailable_models is ignored
+		// (a disabled:true sentinel IS dropped, via the m.Disabled guard above).
+		if isDefaultSentinel(m.Value) {
+			if !sentinelSeen {
+				sentinelSeen = true
+				out = append(out, convertClaudeModel(m, DefaultModelSentinel))
+			}
+			continue
+		}
+		// Normalize the CLI value into the same alias space a.model lives in
+		// (refreshSettingsFromAgent stores normalizeClaudeCodeModel(applied.model)).
+		// The CLI may report a fully-qualified value (e.g. "claude-fable-5[1m]")
+		// for the account-resolved model; storing it verbatim would mean a running
+		// model never matches its own catalog entry, breaking effort/ultracode
+		// lookups and the frontend's effort selector and display name.
+		id := normalizeClaudeCodeModel(m.Value)
+		// A concrete model can't claim the sentinel's reserved id: launch
+		// (buildModelEffortArgs) and the badge logic (defaultModelForList) treat
+		// id=="default" as the sentinel, so a concrete model whose value merely
+		// normalizes to "default" (e.g. "default5") would be mishandled as the
+		// sentinel. Drop it -- deterministically, regardless of CLI ordering --
+		// rather than letting it masquerade.
+		if id == DefaultModelSentinel {
+			continue
+		}
+		// Drop unavailable and duplicate entries, both keyed by normalized id: an
+		// unavailable model reported under a different spelling than its models
+		// entry is still filtered, and two entries that normalize to the same id
+		// (or a malformed payload repeating a value) collapse to one rather than
+		// rendering twice and making the catalog lookups (first match wins)
+		// ambiguous.
+		if skip[id] || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, convertClaudeModel(m, id))
+	}
+	return out
+}
+
+// buildModelSkipSet collects the normalized ids of unavailable_models so
+// convertClaudeModels can filter them. Keying by normalized id, not raw value,
+// matters because the models and unavailable_models arrays may spell the same
+// model differently (one fully-qualified like "claude-fable-5[1m]", one aliased
+// like "fable[1m]"); both collapse to the same id, so matching on the raw value
+// could leak an unavailable model through.
+func buildModelSkipSet(unavailable []claudeCodeModelInfo) map[string]bool {
+	skip := make(map[string]bool, len(unavailable))
+	for _, m := range unavailable {
+		if m.Value == "" {
+			continue
+		}
+		skip[normalizeClaudeCodeModel(m.Value)] = true
+	}
+	return skip
+}
+
+// convertClaudeModel converts one CLI model entry (already normalized to id) into
+// an AvailableModel. IsDefault is left unset -- the manager applies it. The caller
+// (convertClaudeModels) owns sentinel routing: it passes id == DefaultModelSentinel
+// only for the genuine account-default entry (matched on the RAW value) and has
+// already dropped any concrete model whose value merely normalizes to "default", so
+// the id check below is exact -- no need to re-examine the raw value here.
+func convertClaudeModel(m claudeCodeModelInfo, id string) *leapmuxv1.AvailableModel {
+	displayName := m.DisplayName
+	if displayName == "" {
+		displayName = claudeFallbackDisplayName(id)
+	}
+	am := &leapmuxv1.AvailableModel{
+		Id:          id,
+		DisplayName: displayName,
+		Description: m.Description,
+	}
+	// The account-default sentinel carries no efforts or context window: those
+	// belong to the concrete model it resolves to, which isn't known until after
+	// startup. This mirrors the static catalog's "default" entry and keeps a fresh
+	// launch from forwarding an --effort/ultracode the resolved model may not
+	// support (the CLI reports the sentinel WITH a full effort menu, which we
+	// deliberately drop here).
+	if id == DefaultModelSentinel {
+		return am
+	}
+	supported := normalizedEffortLevelSet(m)
+	am.DefaultEffort = claudeDefaultEffort(supported)
+	am.SupportedEfforts = claudeSupportedEfforts(supported)
+	am.ContextWindow = claudeContextWindowForValue(id)
+	return am
+}
+
+// claudeFallbackDisplayName builds a display name from a normalized model id when
+// the CLI omits one. It title-cases the alias and renders a 1M-context variant's
+// bracket suffix as " (1M context)" -- matching the static catalog's "Opus (1M
+// context)" rather than the raw "Opus[1m]" titleCaseID would otherwise produce.
+// It detects the variant through is1MContextVariant (the single home for the "[1m]"
+// marker) rather than a literal "[1m]" suffix, so a decorated spelling like
+// "opus[1m-beta]" -- which claudeContextWindowForValue already sizes at 1M -- is
+// named consistently instead of falling through to a garbled "Opus[1m Beta]".
+func claudeFallbackDisplayName(id string) string {
+	if is1MContextVariant(id) {
+		// is1MContextVariant guarantees a '[' (and a trailing ']'), so the bracket
+		// group is the suffix to strip; LastIndexByte cannot return -1 here.
+		return titleCaseID(id[:strings.LastIndexByte(id, '[')], "") + " (1M context)"
+	}
+	return titleCaseID(id, "")
+}
+
+// isDefaultSentinel reports whether a raw CLI model value is the account-default
+// sentinel. Case-insensitive so a "Default" spelling is still recognized; matched
+// against the RAW value (not the normalized id) so a concrete model that merely
+// normalizes to "default" keeps its own efforts (see convertClaudeModel).
+func isDefaultSentinel(value string) bool {
+	return strings.EqualFold(value, DefaultModelSentinel)
+}
+
+// normalizedEffortLevelSet returns the set of recognized-or-not CLI effort levels
+// a model reports, lowercased so a mixed-case "XHigh" still matches. Returns nil
+// when the model has no effort support (Haiku), which both claudeSupportedEfforts
+// and claudeDefaultEffort read as "hide the selector / no default". Building it
+// once lets both share a single scan of SupportedEffortLevels.
+func normalizedEffortLevelSet(m claudeCodeModelInfo) map[string]bool {
+	if !m.SupportsEffort {
+		return nil
+	}
+	set := make(map[string]bool, len(m.SupportedEffortLevels))
+	for _, lvl := range m.SupportedEffortLevels {
+		set[strings.ToLower(lvl)] = true
+	}
+	return set
+}
+
+// claudeSupportedEfforts builds the AvailableEffort list from a model's level set
+// (normalizedEffortLevelSet), reusing the shared tier pointers. Models without
+// effort support, or whose reported levels we don't recognize at all, get no
+// efforts -- which hides the effort selector rather than showing an auto-only stub.
+// The "auto" sentinel always leads; "ultracode" follows when the model supports
+// xhigh; the recognized CLI levels then follow strongest->weakest. The order comes
+// from claudeEffortLevels (walked in reverse), not the CLI's reported order, so an
+// unexpected ordering can't scramble the menu.
+func claudeSupportedEfforts(supported map[string]bool) []*leapmuxv1.AvailableEffort {
+	recognized := recognizedClaudeEffortLevels(supported)
+	// A model that claims effort support but lists only levels we don't recognize
+	// has no usable menu, so hide the selector instead of emitting a lone "auto".
+	if len(recognized) == 0 {
+		return nil
+	}
+	efforts := make([]*leapmuxv1.AvailableEffort, 0, len(recognized)+2)
+	efforts = append(efforts, effortTierAuto)
+	if supported[EffortXHigh] {
+		efforts = append(efforts, effortTierUltracode)
+	}
+	for _, lvl := range recognized {
+		efforts = append(efforts, lvl.tier)
+	}
+	return efforts
+}
+
+// claudeDefaultEffort picks a model's default effort from its level set. The CLI
+// does not report one, so we prefer xhigh (Opus/Fable), else high (Sonnet) -- the
+// product-chosen sweet spot, deliberately NOT merely the strongest level (max is
+// overkill as a default for a model that also offers xhigh). A model with no
+// effort support gets "" -- inert, since the effort selector is hidden and the
+// launch path omits --effort for it.
+func claudeDefaultEffort(supported map[string]bool) string {
+	if supported[EffortXHigh] {
+		return EffortXHigh
+	}
+	if supported[EffortHigh] {
+		return EffortHigh
+	}
+	// Neither xhigh nor high is offered (e.g. a max-only model). Fall back to the
+	// strongest recognized level the model does support so an effort-bearing model
+	// never ends up with a non-empty selector but an empty default -- a state the
+	// frontend's effortValueForModel would otherwise have to coerce. Returns ""
+	// only when no level is recognized, matching claudeSupportedEfforts hiding the
+	// selector.
+	if recognized := recognizedClaudeEffortLevels(supported); len(recognized) > 0 {
+		return recognized[0].level // strongest-first ordering
+	}
+	return ""
+}
+
+// claudeContextWindowForValue infers a model's context window from its id. The CLI
+// does not report one; the only signal it exposes is the bracketed 1M-context marker
+// (is1MContextVariant). Everything else uses Claude's standard 200K window. This
+// follows the same suffix rule the concrete static-catalog entries use (the "default"
+// sentinel is the exception -- it has no window until it resolves), so new models stay
+// correct without a per-model table.
+func claudeContextWindowForValue(value string) int64 {
+	if is1MContextVariant(value) {
+		return claudeOneMillionContextWindow
+	}
+	return claudeStandardContextWindow
+}
+
+// is1MContextVariant reports whether a model id carries the CLI's 1M-context marker: a
+// bracketed suffix whose content begins with "1m" (case-insensitive). This matches the
+// plain "[1m]" the CLI ships today and tolerates a decorated spelling ("[1M]",
+// "[1m-beta]", "[1m-preview]") so a future labelling of the 1M beta still resolves to
+// the larger window instead of silently reporting the 200K standard one. Anchored on a
+// trailing bracket group, so a stray "1m" elsewhere in the id can't false-positive.
+// This is THE single place that recognizes the marker -- widen it here, not at call
+// sites, if the CLI changes the spelling.
+func is1MContextVariant(id string) bool {
+	open := strings.LastIndexByte(id, '[')
+	if open < 0 || !strings.HasSuffix(id, "]") {
+		return false
+	}
+	inner := strings.ToLower(id[open+1 : len(id)-1])
+	return strings.HasPrefix(inner, "1m")
 }
 
 // sendControlAndWait sends a control request to the agent and waits for the
@@ -1058,13 +1659,22 @@ func (a *ClaudeCodeAgent) handlePendingControlResponse(line *parsedLine) bool {
 
 	// Parse known fields from the inner response object.
 	var innerResponse struct {
-		Mode                  string   `json:"mode"`
-		OutputStyle           string   `json:"output_style"`
-		AvailableOutputStyles []string `json:"available_output_styles"`
-		FastModeState         string   `json:"fast_mode_state"`
+		Mode                  string                `json:"mode"`
+		OutputStyle           string                `json:"output_style"`
+		AvailableOutputStyles []string              `json:"available_output_styles"`
+		FastModeState         string                `json:"fast_mode_state"`
+		Models                []claudeCodeModelInfo `json:"models"`
+		UnavailableModels     []claudeCodeModelInfo `json:"unavailable_models"`
 	}
 	if len(envelope.Response.Response) > 0 {
-		_ = json.Unmarshal(envelope.Response.Response, &innerResponse)
+		// Best-effort: a partial/unknown response shape still yields the fields it
+		// does carry. But log a type-mismatch failure (e.g. a schema-drifted models
+		// array) so dynamic model discovery silently falling back to the static
+		// catalog is diagnosable rather than indistinguishable from an old CLI.
+		if err := json.Unmarshal(envelope.Response.Response, &innerResponse); err != nil {
+			slog.Warn("failed to parse control response inner fields",
+				"agent_id", a.agentID, "request_id", reqID, "error", err)
+		}
 	}
 
 	result := claudeCodeControlResult{
@@ -1074,6 +1684,8 @@ func (a *ClaudeCodeAgent) handlePendingControlResponse(line *parsedLine) bool {
 		OutputStyle:           innerResponse.OutputStyle,
 		AvailableOutputStyles: innerResponse.AvailableOutputStyles,
 		FastModeState:         innerResponse.FastModeState,
+		Models:                innerResponse.Models,
+		UnavailableModels:     innerResponse.UnavailableModels,
 		RawResponse:           envelope.Response.Response,
 	}
 	ch <- result
@@ -1099,38 +1711,151 @@ func generateRequestID() string {
 	return string(b)
 }
 
-// buildModelEffortArgs constructs the --model and --effort CLI arguments for
-// Claude Code. Haiku does not support --effort at all. EffortAuto also omits
-// --effort so the CLI picks its own default. Other models each expose a
-// subset of effort levels via claudeCodeAvailableModels; any effort not in
-// the subset is downgraded to "high" as a universal safe fallback.
-func buildModelEffortArgs(model, effort string) []string {
-	args := []string{"--model", model}
-	if effort == "" || effort == EffortAuto || model == "haiku" {
-		return args
-	}
-	effort = resolveClaudeEffortForModel(model, effort)
-	// The --effort launch flag accepts only low|medium|high|xhigh|max. "ultracode"
-	// is enabled post-init via apply_flag_settings (it forces xhigh), so launch with
-	// xhigh as the base. resolveClaudeEffortForModel only leaves effort == "ultracode"
-	// for a model that supports it, so this substitution is reached only then.
-	if effort == EffortUltracode {
-		effort = EffortXHigh
-	}
-	return append(args, "--effort", effort)
+// effortResolver answers model effort/ultracode capability questions against one
+// catalog. The launch path constructs it over the static claudeCodeAvailableModels
+// (the dynamic catalog isn't known until initialize completes); post-init paths
+// construct it over the per-agent catalog via a.effortResolver. Wrapping the
+// catalog once removes the trailing parameter every resolution helper used to
+// thread, and makes "which catalog" an explicit choice at the few construction
+// sites instead of an argument carried through the whole chain.
+type effortResolver struct {
+	// catalog is the primary catalog consulted first: the static one at launch, the
+	// per-agent dynamic one post-init.
+	catalog []*leapmuxv1.AvailableModel
+	// fallback is consulted only when catalog doesn't list a model, so a model the
+	// live CLI dropped from the dynamic list (e.g. reported in unavailable_models)
+	// but that the agent is actually running still resolves to its real
+	// capabilities instead of being treated as unknown. nil for the launch resolver
+	// and the single-catalog resolvers tests build via newEffortResolver.
+	fallback []*leapmuxv1.AvailableModel
 }
 
-// modelDefinedEfforts returns the catalog-defined effort list for modelID and
-// whether the model is known to the catalog at all. The single lookup is shared
-// by effortSupported and modelSupportsUltracode, which differ only in how they
-// treat an unknown model.
-func modelDefinedEfforts(modelID string) (efforts []*leapmuxv1.AvailableEffort, known bool) {
-	for _, m := range claudeCodeAvailableModels {
-		if m.Id == modelID {
-			return m.SupportedEfforts, true
+func newEffortResolver(catalog []*leapmuxv1.AvailableModel) effortResolver {
+	return effortResolver{catalog: catalog}
+}
+
+// effortResolver returns a resolver over the agent's per-agent dynamic catalog,
+// with the static claudeCodeAvailableModels as a fallback for models the dynamic
+// list omits. Dynamic takes precedence, so a capability the live CLI genuinely
+// dropped (the model is still listed, minus a level) still wins; the fallback only
+// rescues a model the CLI filtered out entirely (e.g. into unavailable_models) but
+// that the session is still running -- keeping the decode (effortFromApplied),
+// live-update (updateFlagSettings), and startup (reconcileStartupEffortFlags) paths
+// from downgrading a filtered session's effort/ultracode out of agreement with each
+// other. availableModels is written once before the agent is published and never
+// mutated, so this read is safe without a.mu (callers may already hold it).
+func (a *ClaudeCodeAgent) effortResolver() effortResolver {
+	return effortResolver{catalog: a.availableModels, fallback: claudeCodeAvailableModels}
+}
+
+// launchEffortPlan captures what the --effort launch flag did for a model+effort,
+// resolved over the static catalog at launch: whether --effort was omitted and the
+// level it was set to (the xhigh base for an ultracode launch). buildModelEffortArgs
+// and reconcileStartupEffortFlags both derive it from planLaunch, so the "what launch
+// sent" view is single-sourced and the launch flags can't drift from what startup
+// reconciles against. Whether the launch was the xhigh+ultracode combo is deliberately
+// NOT stored here: both consumers re-derive it from launchRunsUltracode (startup
+// against the DYNAMIC catalog, buildModelEffortArgs against the static one), so there
+// is no captured boolean to fall out of sync with the level.
+type launchEffortPlan struct {
+	omitted bool   // launch sent no --effort (CLI stays at its own default)
+	level   string // the --effort value sent ("" when omitted; "xhigh" for the ultracode base)
+}
+
+// planLaunch resolves model+effort into the launch flag plan. See launchEffortPlan.
+func (r effortResolver) planLaunch(model, effort string) launchEffortPlan {
+	if r.launchOmitsEffort(model, effort) {
+		return launchEffortPlan{omitted: true}
+	}
+	if r.launchRunsUltracode(model, effort) {
+		// The --effort launch flag accepts only low|medium|high|xhigh|max: ultracode
+		// has no flag value, so launch at its xhigh base and let buildStartupFlagSettings
+		// layer the ultracode boolean on post-init.
+		return launchEffortPlan{level: EffortXHigh}
+	}
+	return launchEffortPlan{level: r.resolveEffort(model, effort)}
+}
+
+// buildModelEffortArgs constructs the --model and --effort CLI arguments for
+// Claude Code. The DefaultModelSentinel (and the empty model) omits BOTH --model
+// and --effort so the CLI resolves the account's own default model AND that model's
+// own default effort (get_settings then reports the concrete model/effort, which
+// refreshSettingsFromAgent stores -- the model-side analogue of EffortAuto for
+// effort). Forwarding a concrete --effort here would be resolved against the
+// sentinel's empty effort menu and could push an unsupported level onto whatever the
+// default resolves to (e.g. --effort on a Haiku account default). Haiku does not
+// support --effort at all. EffortAuto also omits --effort so the CLI picks its own
+// default. A consequence: a LEAPMUX_CLAUDE_DEFAULT_EFFORT set without a concrete
+// LEAPMUX_CLAUDE_DEFAULT_MODEL is not applied to a sentinel-default agent (see
+// effortOrDefault). Other models each expose a subset of effort levels in the catalog;
+// any effort not in the subset is downgraded to "high" as a universal safe fallback.
+// Called at launch over the static catalog (the dynamic one isn't known until
+// initialize completes).
+func (r effortResolver) buildModelEffortArgs(model, effort string) []string {
+	var args []string
+	if model != "" && model != DefaultModelSentinel {
+		args = []string{"--model", model}
+	}
+	plan := r.planLaunch(model, effort)
+	if plan.omitted {
+		return args
+	}
+	return append(args, "--effort", plan.level)
+}
+
+// definedEfforts returns the effort list the catalog defines for modelID and
+// whether the model is known at all. It checks the primary catalog first, then the
+// fallback, so a model the dynamic list omits but the static catalog still has
+// resolves to its real efforts (see effortResolver). The single lookup is shared by
+// supports and supportsUltracode, which differ only in how they treat an unknown
+// model.
+func (r effortResolver) definedEfforts(modelID string) (efforts []*leapmuxv1.AvailableEffort, known bool) {
+	if modelID == DefaultModelSentinel {
+		// The account-default sentinel is a placeholder, not a concrete model: its
+		// real efforts belong to whatever the CLI resolves it to. Report it as
+		// unresolved so effort resolution passes the requested effort through rather
+		// than clamping it against the empty effort list the sentinel's catalog entry
+		// carries. Reached only in the degraded path where get_settings never echoed a
+		// concrete applied.model, so a.model is stuck on "default".
+		return nil, false
+	}
+	// Prefer a catalog entry that actually carries efforts. The dynamic catalog
+	// takes precedence, but a known model can land in it with an EMPTY effort list
+	// -- the live CLI reported it with supportsEffort:false, or with only effort
+	// levels we don't recognize (schema drift) -- and such an empty dynamic entry
+	// must not shadow a populated static-fallback entry for the same model. So we
+	// keep scanning past an empty match for a populated one, while still reporting
+	// the model as known. When no populated entry exists (a genuinely effort-less
+	// model like Haiku, whose fallback entry is empty too) the known-but-empty
+	// verdict stands. This preserves the legitimate "CLI dropped a level" case: a
+	// dynamic entry with FEWER but non-empty efforts still wins over the fallback.
+	for _, cat := range [][]*leapmuxv1.AvailableModel{r.catalog, r.fallback} {
+		for _, m := range cat {
+			// Guard nil entries to match FindAvailableModel/withDefaultModelMarked,
+			// which already treat catalogs as possibly nil-bearing; convertClaudeModels
+			// never emits nil today, but this keeps the catalog-walking helpers uniform.
+			if m != nil && m.Id == modelID {
+				if len(m.SupportedEfforts) > 0 {
+					return m.SupportedEfforts, true
+				}
+				known = true // matched, but no efforts here; keep looking for a populated entry
+			}
 		}
 	}
-	return nil, false
+	return nil, known
+}
+
+// contextWindow returns the context window for modelID, consulting the primary
+// catalog first and then the fallback -- mirroring definedEfforts so a model the
+// live CLI dropped from its list but the session is still running resolves its
+// window from the static fallback instead of reporting "unknown". Returns 0 when
+// neither catalog knows the model (the unresolved account-default sentinel, whose
+// catalog entry carries no window) -- the usage broadcast then omits context_window.
+func (r effortResolver) contextWindow(modelID string) int64 {
+	if w := modelContextWindow(r.catalog, modelID); w > 0 {
+		return w
+	}
+	return modelContextWindow(r.fallback, modelID)
 }
 
 // effortListContains reports whether efforts holds an entry with the given ID.
@@ -1138,56 +1863,80 @@ func effortListContains(efforts []*leapmuxv1.AvailableEffort, id string) bool {
 	return slices.ContainsFunc(efforts, func(e *leapmuxv1.AvailableEffort) bool { return e.Id == id })
 }
 
-// effortSupported reports whether the given effort ID is in the known
-// SupportedEfforts list for the given model. Unknown models are trusted
-// (returns true) so new aliases work without a code change.
-func effortSupported(modelID, effort string) bool {
-	efforts, known := modelDefinedEfforts(modelID)
+// supports reports whether the given effort ID is in the known SupportedEfforts
+// list for the given model. Unknown models are trusted (returns true) so new
+// aliases work without a code change.
+func (r effortResolver) supports(modelID, effort string) bool {
+	efforts, known := r.definedEfforts(modelID)
 	if !known {
 		return true
 	}
 	return effortListContains(efforts, effort)
 }
 
-// modelSupportsUltracode reports whether the model's catalog explicitly offers the
-// ultracode tier. Unlike effortSupported, it does NOT trust unknown models: ultracode
-// is a narrow Opus-only combo, so launching or enabling it on a model we can't confirm
-// supports it would risk forcing an --effort xhigh the model may reject. A genuinely
-// new ultracode-capable model must be added to claudeCodeAvailableModels to be
-// selectable at all, so requiring an explicit catalog entry costs no real forward
-// compatibility.
-func modelSupportsUltracode(modelID string) bool {
-	efforts, known := modelDefinedEfforts(modelID)
+// supportsUltracode reports whether the model's catalog entry offers the ultracode
+// tier. Unlike supports, it does NOT trust unknown models: ultracode forces
+// --effort xhigh, so enabling it on a model we can't confirm supports xhigh would
+// risk a level the model rejects. Because convertClaudeModels adds ultracode to any
+// catalog entry whose CLI levels include xhigh, this stays consistent with the UI:
+// a model is ultracode-capable here exactly when its AvailableModels entry
+// advertises it (Opus, Fable, and any future xhigh model the live CLI reports).
+func (r effortResolver) supportsUltracode(modelID string) bool {
+	efforts, known := r.definedEfforts(modelID)
 	return known && effortListContains(efforts, EffortUltracode)
+}
+
+// launchRunsUltracode reports whether launching model+effort runs the
+// xhigh+ultracode combo: the requested effort is ultracode AND the model supports
+// it. It is the single source of truth shared by buildModelEffortArgs (which
+// launches at the xhigh base) and buildStartupFlagSettings (which layers the
+// ultracode boolean back on), so the two can't disagree about whether a launch is
+// an ultracode launch.
+func (r effortResolver) launchRunsUltracode(model, effort string) bool {
+	return effort == EffortUltracode && r.supportsUltracode(model)
+}
+
+// launchOmitsEffort reports whether launching model+effort sends no --effort flag,
+// leaving the CLI at its own resolved default for the model. The account-default
+// sentinel (and an empty model, which likewise sends no --model so the CLI picks
+// the account default) and EffortAuto/"" always omit it; a model the catalog KNOWS
+// has no effort support (Haiku) also omits it -- expressed via the catalog rather
+// than a "haiku" literal, so an effort-less model the CLI introduces is handled
+// without a code change. Unknown models are trusted and pass their effort through.
+// Shared by buildModelEffortArgs (which omits --effort) and planLaunch, so the
+// launch flags and the startup reconcile see the same "sent nothing" set.
+func (r effortResolver) launchOmitsEffort(model, effort string) bool {
+	if effort == "" || effort == EffortAuto || model == "" || model == DefaultModelSentinel {
+		return true
+	}
+	efforts, known := r.definedEfforts(model)
+	return known && len(efforts) == 0
 }
 
 // unsupportedUltracode reports whether effort is the ultracode tier while model
 // can't run it. This is the recurring "ultracode requested/stored/being-left on a
-// model whose catalog doesn't offer it" condition that the resolve
-// (resolveClaudeEffortForModel), decode (claudeEffortFromApplied), and live-update
-// (claudeEffortUpdateFlagSettings) paths each must guard -- naming it once keeps a
-// future model-capability change (e.g. Sonnet gaining ultracode) to a single edit
+// model whose catalog doesn't offer it" condition that the resolve (resolveEffort),
+// decode (effortFromApplied), and live-update (updateFlagSettings) paths each must
+// guard -- naming it once keeps a future model-capability change to a single edit
 // instead of three that must be kept in agreement.
-func unsupportedUltracode(effort, model string) bool {
-	return effort == EffortUltracode && !modelSupportsUltracode(model)
+func (r effortResolver) unsupportedUltracode(effort, model string) bool {
+	return effort == EffortUltracode && !r.supportsUltracode(model)
 }
 
-// resolveClaudeEffortForModel resolves a requested effort against the model it will
-// run under: an effort the model's catalog doesn't support is downgraded to the
-// universal-safe EffortHigh, and "ultracode" stays "ultracode" only for a model that
-// actually supports it (otherwise it too becomes EffortHigh -- this catches unknown
-// models, which effortSupported trusts but which we can't confirm are xhigh-capable).
-// EffortAuto and "" pass through for the caller to handle. Shared by the --effort
-// launch flag (buildModelEffortArgs) and the live apply_flag_settings path
-// (UpdateSettings) so neither can push an unsupported effort to the CLI.
-func resolveClaudeEffortForModel(model, effort string) string {
+// resolveEffort resolves a requested effort against the model it will run under: an
+// effort the model's catalog doesn't support is downgraded to the universal-safe
+// EffortHigh, and "ultracode" stays "ultracode" only for a model that actually
+// supports it (otherwise it too becomes EffortHigh -- this catches unknown models,
+// which supports trusts but which we can't confirm are xhigh-capable). EffortAuto
+// and "" pass through for the caller to handle.
+func (r effortResolver) resolveEffort(model, effort string) string {
 	if effort == "" || effort == EffortAuto {
 		return effort
 	}
-	if !effortSupported(model, effort) {
+	if !r.supports(model, effort) {
 		return EffortHigh
 	}
-	if unsupportedUltracode(effort, model) {
+	if r.unsupportedUltracode(effort, model) {
 		return EffortHigh
 	}
 	return effort

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -210,6 +210,17 @@ func TestNormalizeClaudeCodeModel(t *testing.T) {
 		"claude-haiku-4-5-20251001":  "haiku",
 		"claude-haiku-4-5":           "haiku",
 		"claude-sonnet-4-5-20240101": "sonnet",
+		// Version-first ids (numeric tokens leading the family): the family alias is
+		// found by skipping the leading version tokens, where a from-position-0 alpha
+		// scan would return "" and leak the raw id.
+		"claude-3-5-sonnet":         "sonnet",
+		"claude-3-5-haiku-20241022": "haiku",
+		"3-7-sonnet":                "sonnet",
+		// Mixed-case CLI values collapse to the lowercase alias space (S3), so a
+		// running model still matches its own (lowercase) catalog entry.
+		"OPUS[1M]":          "opus[1m]",
+		"Claude-Sonnet-4-6": "sonnet",
+		"Opus":              "opus",
 		// Degenerate input.
 		"":              "",
 		"unknown-thing": "unknown",
@@ -529,6 +540,55 @@ func TestHandlePendingControlResponse_ParsesInitializeFields(t *testing.T) {
 	assert.Equal(t, "on", result.FastModeState)
 	assert.Equal(t, "default", result.Mode)
 	assert.NotEmpty(t, result.RawResponse)
+}
+
+func TestHandlePendingControlResponse_ParsesModels(t *testing.T) {
+	a := &ClaudeCodeAgent{
+		processBase:    processBase{agentID: "test"},
+		pendingControl: make(map[string]chan<- claudeCodeControlResult),
+	}
+
+	ch := make(chan claudeCodeControlResult, 1)
+	a.registerPendingControl("req-models", ch)
+
+	// An initialize response carrying the model catalog: a "default" alias
+	// sentinel, a disabled entry, the [1m] variants, an effort-bearing Fable, a
+	// no-effort Haiku, plus a separate unavailable_models list.
+	raw := []byte(`{"type":"control_response","response":{` +
+		`"subtype":"success","request_id":"req-models","response":{` +
+		`"models":[` +
+		`{"value":"default","displayName":"Default","description":"d"},` +
+		`{"value":"fable","displayName":"Fable 5","description":"Most powerful for the hardest problems","supportsEffort":true,"supportedEffortLevels":["low","medium","high","xhigh","max"]},` +
+		`{"value":"fable[1m]","displayName":"Fable 5 (1M context)","description":"Most powerful for the hardest problems","supportsEffort":true,"supportedEffortLevels":["low","medium","high","xhigh","max"]},` +
+		`{"value":"haiku","displayName":"Haiku","description":"Fastest for quick answers","supportsEffort":false},` +
+		`{"value":"internal-preview","displayName":"Internal","disabled":true}` +
+		`],` +
+		`"unavailable_models":[{"value":"zdr-blocked","displayName":"Blocked"}]` +
+		`}}}`)
+
+	line := &parsedLine{Type: "control_response", Raw: raw}
+	assert.True(t, a.handlePendingControlResponse(line))
+
+	result := <-ch
+	assert.True(t, result.Success)
+	require.Len(t, result.Models, 5, "all raw entries decode, including default/disabled")
+	require.Len(t, result.UnavailableModels, 1)
+	assert.Equal(t, "fable", result.Models[1].Value)
+	assert.True(t, result.Models[1].SupportsEffort)
+	assert.Equal(t, []string{"low", "medium", "high", "xhigh", "max"}, result.Models[1].SupportedEffortLevels)
+	assert.True(t, result.Models[4].Disabled)
+	assert.Equal(t, "zdr-blocked", result.UnavailableModels[0].Value)
+
+	// Conversion drops the disabled entry, surfaces the "default" sentinel as a
+	// selectable option, and surfaces Fable with its full effort menu and
+	// inferred context windows.
+	converted := claudeModelsByID(convertClaudeModels(result.Models, result.UnavailableModels))
+	require.Contains(t, converted, "fable")
+	require.Contains(t, converted, "default")
+	require.NotContains(t, converted, "internal-preview")
+	assert.Equal(t, "xhigh", converted["fable"].DefaultEffort)
+	assert.Equal(t, int64(1_000_000), converted["fable[1m]"].ContextWindow)
+	assert.Empty(t, converted["haiku"].SupportedEfforts)
 }
 
 func TestHandlePendingControlResponse_ParsesGetSettingsResponse(t *testing.T) {

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -57,7 +57,81 @@ type contextUsageSnapshot struct {
 	CacheCreationInputTokens int64
 	CacheReadInputTokens     int64
 	ContextWindow            int64
-	LastBroadcast            time.Time
+	// windowModel is the model id ContextWindow was derived for. The snapshot
+	// outlives a model change (a live model switch, or the account-default sentinel
+	// resolving to a concrete model after startup), so the window is re-seeded from
+	// the catalog whenever the current model no longer matches this -- otherwise a
+	// session that began on the 200K sentinel placeholder (or a smaller-window model)
+	// would under-report a larger window until a result message happened to refresh it.
+	windowModel   string
+	LastBroadcast time.Time
+}
+
+// reseedWindow updates the snapshot's catalog window estimate when the model it was
+// derived for no longer matches the current model: the snapshot outlives a model change
+// (a live switch, or the account-default sentinel resolving to a concrete model after
+// startup). It runs even when estimate is 0 (an unknown/unresolved model), so switching
+// to such a model CLEARS a stale larger window carried over from the previous model --
+// reverting to "unknown" rather than over-reporting -- and switching to a known model
+// picks up its estimate immediately. A result message's window stays authoritative for
+// its model because adoptResultWindow stamps windowModel too, so this estimate doesn't
+// clobber it for the same model.
+func (s *contextUsageSnapshot) reseedWindow(model string, estimate int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.windowModel != model {
+		s.ContextWindow = estimate
+		s.windowModel = model
+	}
+}
+
+// adoptResultWindow records the authoritative context window a result message reported
+// for model, stamping windowModel so the catalog re-seed (reseedWindow) won't overwrite
+// it for the same model. A non-positive window is ignored: top-level result messages
+// always carry the primary model's window, but a subagent result that slipped past the
+// parent_tool_use_id guard would not, and must not clear the real window.
+func (s *contextUsageSnapshot) adoptResultWindow(model string, cw int64) {
+	if cw <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ContextWindow = cw
+	s.windowModel = model
+}
+
+// buildBroadcast assembles the context_usage broadcast payload from the current
+// snapshot and reports whether it should be sent. It returns (nil, false) when no
+// token usage has been recorded yet, or when the 10s debounce window has not elapsed
+// for a non-result message; a result message always broadcasts. When it decides to
+// broadcast it stamps LastBroadcast and includes context_window only when known
+// (> 0), matching the "omit when unknown" contract reseedWindow/adoptResultWindow
+// maintain. Takes s.mu, so the caller must not already hold it. now is passed in so
+// the debounce is testable without a real clock.
+func (s *contextUsageSnapshot) buildBroadcast(msgType string, now time.Time) (map[string]interface{}, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hasUsage := s.InputTokens > 0 || s.OutputTokens > 0 ||
+		s.CacheCreationInputTokens > 0 || s.CacheReadInputTokens > 0
+	if !hasUsage {
+		return nil, false
+	}
+	shouldBroadcast := msgType == claudeMsgTypeResult ||
+		now.Sub(s.LastBroadcast) >= 10*time.Second
+	if !shouldBroadcast {
+		return nil, false
+	}
+	s.LastBroadcast = now
+	usageMap := map[string]interface{}{
+		"input_tokens":                s.InputTokens,
+		"output_tokens":               s.OutputTokens,
+		"cache_creation_input_tokens": s.CacheCreationInputTokens,
+		"cache_read_input_tokens":     s.CacheReadInputTokens,
+	}
+	if s.ContextWindow > 0 {
+		usageMap["context_window"] = s.ContextWindow
+	}
+	return usageMap, true
 }
 
 // HandleOutput processes a single NDJSON line from Claude Code.
@@ -627,7 +701,39 @@ func (a *ClaudeCodeAgent) extractAndBroadcastUsage(env *messageEnvelope, msgType
 		info["total_cost_usd"] = *env.CostUSD
 	}
 
+	// Snapshot a.model and the effort resolver under a.mu in one acquisition: this
+	// runs on the readOutputLoop goroutine while refreshSettingsFromAgent may
+	// concurrently rewrite a.model under the same lock. a.availableModels (which the
+	// resolver captures) is written once at startup -- before any assistant/result
+	// output arrives (those need a user turn) -- and never mutated. The startup write
+	// happens-before this read through the a.mu release/acquire pair: the startup
+	// goroutine LOCKS a.mu in refreshSettingsFromAgent (which runs after the field
+	// write) and the Lock below re-acquires it; the field need not be WRITTEN under the
+	// lock, only released-then-acquired across goroutines. So the resolver needs the
+	// lock only for the a.model read it pairs with here. The catalog entries are
+	// immutable shared data, so the window lookup is safe to compute after unlocking.
+	a.mu.Lock()
+	model := a.model
+	resolver := a.effortResolver()
+	a.mu.Unlock()
+	// The catalog window is an ESTIMATE inferred from the model id ("[1m]" => 1M, else
+	// 200K). resolver.contextWindow resolves it over the dynamic catalog with the static
+	// fallback -- the same dynamic-first-then-fallback the effort lookups use -- so a
+	// model the live CLI dropped from its list but a resumed session is still running
+	// keeps its known window instead of going dark. It is 0 only when the model has no
+	// known window in EITHER catalog: the unresolved account-default sentinel (its entry
+	// is a placeholder), or a model absent from both lists. We deliberately do NOT
+	// fabricate a window then -- 0 means "unknown" and the broadcast omits context_window
+	// below, matching the frontend, which likewise shows no window when it can't resolve
+	// one. For a concrete model absent from both catalogs, a result message's modelUsage
+	// supplies the real window once one arrives (findPrimaryContextWindow matches its
+	// concrete key). The unresolved sentinel ("default") can't: it matches no concrete
+	// usage key, so it stays unknown until the model resolves off the sentinel (a later
+	// refreshSettingsFromAgent), whose model change re-seeds the window here.
+	contextWindow := resolver.contextWindow(model)
+
 	snapshot := a.getOrCreateUsageSnapshot()
+	snapshot.reseedWindow(model, contextWindow)
 
 	if msgType == claudeMsgTypeAssistant && env.Message.Usage != nil {
 		u := env.Message.Usage
@@ -640,104 +746,67 @@ func (a *ClaudeCodeAgent) extractAndBroadcastUsage(env *messageEnvelope, msgType
 	}
 
 	if msgType == claudeMsgTypeResult && env.ModelUsage != nil {
-		// Find the context window for the primary model in the usage map.
-		// Top-level result messages include cumulative session-level usage
-		// that always contains the primary model's entry. Subagent results
-		// (if they bypass the outer parent_tool_use_id guard) only contain
-		// the subagent's model and will not match the primary, so we skip
-		// the update to avoid overwriting with a smaller context window.
-		if cw := findPrimaryContextWindow(env.ModelUsage, a.model); cw > 0 {
-			snapshot.mu.Lock()
-			snapshot.ContextWindow = cw
-			snapshot.mu.Unlock()
-		}
+		// Find the context window for the primary model in the usage map. Top-level
+		// result messages include cumulative session-level usage that always contains
+		// the primary model's entry. Subagent results (if they bypass the outer
+		// parent_tool_use_id guard) only contain the subagent's model and will not
+		// match the primary; findPrimaryContextWindow returns 0 for that, and
+		// adoptResultWindow ignores it rather than overwriting with a smaller window.
+		snapshot.adoptResultWindow(model, findPrimaryContextWindow(env.ModelUsage, model))
 	}
 
-	snapshot.mu.Lock()
-	hasUsage := snapshot.InputTokens > 0 || snapshot.OutputTokens > 0 ||
-		snapshot.CacheCreationInputTokens > 0 || snapshot.CacheReadInputTokens > 0
-	if hasUsage {
-		now := time.Now()
-		shouldBroadcast := msgType == claudeMsgTypeResult ||
-			now.Sub(snapshot.LastBroadcast) >= 10*time.Second
-		if shouldBroadcast {
-			snapshot.LastBroadcast = now
-			usageMap := map[string]interface{}{
-				"input_tokens":                snapshot.InputTokens,
-				"output_tokens":               snapshot.OutputTokens,
-				"cache_creation_input_tokens": snapshot.CacheCreationInputTokens,
-				"cache_read_input_tokens":     snapshot.CacheReadInputTokens,
-			}
-			if snapshot.ContextWindow > 0 {
-				usageMap["context_window"] = snapshot.ContextWindow
-			}
-			info["context_usage"] = usageMap
-		}
+	if usageMap, ok := snapshot.buildBroadcast(msgType, time.Now()); ok {
+		info["context_usage"] = usageMap
 	}
-	snapshot.mu.Unlock()
 
 	if len(info) > 0 {
 		a.sink.BroadcastSessionInfo(info)
 	}
 }
 
+// getOrCreateUsageSnapshot returns the usage snapshot, creating an empty one on
+// first use. The window is NOT seeded here: every caller calls reseedWindow
+// immediately afterward, which is the single source of the estimated window (it
+// also stamps windowModel, which a constructor seed cannot). a.contextUsage is only
+// ever touched from the readOutputLoop goroutine, so it needs no lock of its own;
+// the snapshot's own fields are guarded by snapshot.mu.
 func (a *ClaudeCodeAgent) getOrCreateUsageSnapshot() *contextUsageSnapshot {
 	if a.contextUsage == nil {
-		a.contextUsage = &contextUsageSnapshot{
-			ContextWindow: modelContextWindow(claudeCodeAvailableModels, a.model),
-		}
+		a.contextUsage = &contextUsageSnapshot{}
 	}
 	return a.contextUsage
 }
 
 // modelContextWindow looks up the context window for a model ID from a list
-// of available models. Returns 0 if the model is not found.
+// of available models. Returns 0 if the model is not found. Delegates to
+// FindAvailableModel so the nil-entry guard and id match live in one place
+// rather than a fourth hand-copied catalog walk.
 func modelContextWindow(models []*leapmuxv1.AvailableModel, modelID string) int64 {
-	for _, m := range models {
-		if m.Id == modelID {
-			return m.ContextWindow
-		}
+	if m := FindAvailableModel(models, modelID); m != nil {
+		return m.ContextWindow
 	}
 	return 0
 }
 
-// findPrimaryContextWindow extracts the context window for the primary model
-// from a modelUsage map. The modelUsage keys are full API model IDs (e.g.
-// "claude-opus-4-6[1m]") while shortModelID uses the short form (e.g.
-// "opus[1m]"). Returns 0 if the primary model is not found.
+// findPrimaryContextWindow extracts the context window for the primary model from a
+// modelUsage map. The modelUsage keys are full API model IDs (e.g.
+// "claude-opus-4-6[1m]") while shortModelID is the short alias (e.g. "opus[1m]").
+// Each key is collapsed into the alias space with normalizeClaudeCodeModel -- the
+// same normalization a.model and the catalog ids use -- and compared for EQUALITY,
+// so the match is exact rather than a substring scan: "opus" no longer matches an
+// unrelated "claude-opusplus-1" key, the "[1m]" variant is disambiguated by the
+// normalized suffix, and a "[1M]" spelling is handled (normalize lowercases). Returns
+// 0 if the primary model is not found.
 func findPrimaryContextWindow(modelUsage map[string]json.RawMessage, shortModelID string) int64 {
 	if shortModelID == "" {
-		// No primary model configured — fall back to max across all models.
+		// No primary model configured -- fall back to max across all models.
 		return maxContextWindow(modelUsage)
 	}
-
-	// Extract the family prefix and optional variant suffix from the short
-	// model ID (e.g. "opus[1m]" → family "opus", suffix "[1m]").
-	family := shortModelID
-	suffix := ""
-	if idx := strings.Index(shortModelID, "["); idx >= 0 {
-		family = shortModelID[:idx]
-		suffix = shortModelID[idx:]
-	}
-
+	want := normalizeClaudeCodeModel(shortModelID)
 	for key, raw := range modelUsage {
-		if !strings.Contains(key, family) {
+		if normalizeClaudeCodeModel(key) != want {
 			continue
 		}
-		// When the short ID has a variant suffix (e.g. "[1m]"), the full
-		// API ID must also contain it. When there is no suffix, reject
-		// keys that contain a bracket-variant so "opus" does not match
-		// "claude-opus-4-6[1m]".
-		if suffix != "" {
-			if !strings.Contains(key, suffix) {
-				continue
-			}
-		} else {
-			if strings.Contains(key, "[") {
-				continue
-			}
-		}
-
 		if cw := contextWindowOf(raw); cw > 0 {
 			return cw
 		}

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -1040,6 +1040,244 @@ func TestHandleOutput_SubagentResultWithoutParentIDDoesNotOverwriteContextWindow
 		"subagent result without parent_tool_use_id must not overwrite context window")
 }
 
+// TestGetOrCreateUsageSnapshot_SeedsFromDynamicCatalog verifies the context-usage
+// snapshot seeds its window from the per-agent dynamic catalog (effortCatalog),
+// not the static catalog alone. A model discovered only from the live CLI -- the
+// whole point of dynamic discovery -- is absent from claudeCodeAvailableModels, so
+// a static-only seed would report no window until the first result message; the
+// dynamic seed reports the [1m]-inferred window immediately.
+func TestGetOrCreateUsageSnapshot_SeedsFromDynamicCatalog(t *testing.T) {
+	// Precondition: the model is unknown to the static catalog, so a static seed
+	// would be 0.
+	require.Equal(t, int64(0), modelContextWindow(claudeCodeAvailableModels, "mythos"),
+		"precondition: mythos is not in the static catalog")
+
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = "mythos"
+	agent.availableModels = convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "mythos[1m]", DisplayName: "Mythos (1M)", SupportsEffort: true, SupportedEffortLevels: []string{"high", "xhigh"}},
+		{Value: "mythos", DisplayName: "Mythos", SupportsEffort: true, SupportedEffortLevels: []string{"high", "xhigh"}},
+	}, nil)
+
+	// An assistant usage message seeds the snapshot (getOrCreateUsageSnapshot); the
+	// result message (no modelUsage) broadcasts the seeded window without overwriting it.
+	agent.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [{"type": "text", "text": "hi"}],
+			"usage": {"input_tokens": 100, "output_tokens": 50}
+		}
+	}`))
+	agent.HandleOutput([]byte(`{"type": "result", "subtype": "success"}`))
+
+	require.GreaterOrEqual(t, sink.SessionInfoCount(), 1)
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok, "expected context_usage in session info")
+	assert.Equal(t, int64(200_000), usage["context_window"],
+		"window seeded from the dynamic catalog entry (mythos, no [1m] suffix -> 200K)")
+}
+
+// TestExtractAndBroadcastUsage_WindowFallsBackToStaticCatalog verifies that a model the
+// live CLI dropped from its dynamic list -- but that the session is still running and
+// the static catalog still knows -- reports its real context window via the
+// effortResolver's static fallback, the same per-entry fallback effort/ultracode
+// resolution uses. Before the fix the window resolved over the dynamic catalog alone (a
+// whole-list swap with no per-entry fallback), so such a model reported "unknown" until
+// a result message supplied a window -- diverging from how its effort still resolved.
+func TestExtractAndBroadcastUsage_WindowFallsBackToStaticCatalog(t *testing.T) {
+	// Precondition: opus[1m] is a static-catalog model with a 1M window.
+	require.Equal(t, int64(1_000_000), modelContextWindow(claudeCodeAvailableModels, "opus[1m]"),
+		"precondition: opus[1m] carries a 1M window in the static catalog")
+
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = "opus[1m]"
+	// The live CLI reported a dynamic list that does NOT include opus[1m] (e.g. it
+	// dropped the model the resumed session is still running). effortCatalog returns
+	// this list verbatim, so a dynamic-only window lookup would miss.
+	agent.availableModels = convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"high"}},
+	}, nil)
+	require.Nil(t, FindAvailableModel(agent.availableModels, "opus[1m]"),
+		"precondition: opus[1m] is absent from the dynamic catalog")
+
+	agent.HandleOutput([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50}}}`))
+	agent.HandleOutput([]byte(`{"type":"result","subtype":"success"}`)) // no modelUsage -> window from the catalog seed
+
+	require.GreaterOrEqual(t, sink.SessionInfoCount(), 1)
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok, "expected context_usage in session info")
+	assert.Equal(t, int64(1_000_000), usage["context_window"],
+		"window resolved from the static fallback (opus[1m] = 1M), not reported unknown")
+}
+
+// TestGetOrCreateUsageSnapshot_SentinelWindowIsUnknown verifies a session stuck on the
+// unresolved account-default sentinel ("default") reports NO context window. The
+// sentinel catalog entry is a placeholder with no concrete window, and we deliberately
+// do not fabricate one: the broadcast omits context_window so the indicator shows
+// "unknown" (matching the frontend) until the sentinel resolves to a concrete model or
+// a result message supplies the real window.
+func TestGetOrCreateUsageSnapshot_SentinelWindowIsUnknown(t *testing.T) {
+	// Precondition: the sentinel entry carries no context window.
+	require.Equal(t, int64(0), modelContextWindow(claudeCodeAvailableModels, DefaultModelSentinel),
+		"precondition: the sentinel has no concrete window")
+
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = DefaultModelSentinel // stuck: the CLI never echoed a concrete applied.model
+
+	agent.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [{"type": "text", "text": "hi"}],
+			"usage": {"input_tokens": 100, "output_tokens": 50}
+		}
+	}`))
+	agent.HandleOutput([]byte(`{"type": "result", "subtype": "success"}`))
+
+	require.GreaterOrEqual(t, sink.SessionInfoCount(), 1)
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok, "expected context_usage in session info")
+	_, hasWindow := usage["context_window"]
+	assert.False(t, hasWindow,
+		"unresolved sentinel reports no context window (unknown), not a fabricated value")
+}
+
+// TestExtractAndBroadcastUsage_ReseedsWindowOnModelChange covers the usage snapshot
+// outliving a model change: a session that starts on the unresolved account-default
+// sentinel reports no window (unknown), and once the sentinel resolves to a concrete
+// 1M-context model the window is re-seeded from the catalog -- not left unknown until a
+// result message with matching modelUsage happens to refresh it.
+func TestExtractAndBroadcastUsage_ReseedsWindowOnModelChange(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = DefaultModelSentinel // unresolved at the first turn -> window unknown
+
+	assistant := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50}}}`
+	result := `{"type":"result","subtype":"success"}` // no modelUsage -> window comes from the catalog re-seed
+
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	_, hasWindow := usage["context_window"]
+	require.False(t, hasWindow, "unresolved sentinel reports no window")
+
+	// The sentinel resolves to a 1M-context model (refreshSettingsFromAgent stored it).
+	agent.model = "opus[1m]"
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok = sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, int64(1_000_000), usage["context_window"],
+		"window re-seeded from the catalog when the model resolves off the sentinel")
+}
+
+// TestExtractAndBroadcastUsage_ReseedsDownwardOnModelDowngrade locks the re-seed's
+// DOWNGRADE direction. The re-seed comment claims it rescues a session that began on
+// "a smaller-window model", but the only other re-seed test goes the other way
+// (200K sentinel -> 1M). The more dangerous direction is a session on a 1M model that
+// live-switches to a 200K model: if the re-seed regressed, the indicator would keep
+// over-reporting 1M (showing far more headroom than real) until a result message with
+// matching modelUsage happened to correct it.
+func TestExtractAndBroadcastUsage_ReseedsDownwardOnModelDowngrade(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = "opus[1m]" // known 1M model via the static catalog fallback
+
+	assistant := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50}}}`
+	result := `{"type":"result","subtype":"success"}` // no modelUsage -> window comes from the catalog re-seed
+
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, int64(1_000_000), usage["context_window"], "opus[1m] seeds the 1M window")
+
+	// Live-switch to Sonnet (200K): the window must re-seed DOWN, not stay at 1M.
+	agent.model = "sonnet"
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok = sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, int64(200_000), usage["context_window"],
+		"window re-seeded down to 200K on a 1M->Sonnet downgrade")
+}
+
+// TestExtractAndBroadcastUsage_ClearsWindowOnSwitchToUnknownModel verifies that
+// switching to a model unknown to BOTH catalogs (e.g. a resumed session running a model
+// the live CLI dropped into unavailable_models, so it is in neither the dynamic list
+// nor the static fallback) CLEARS the window to "unknown" rather than continuing to
+// over-report the previous model's larger window. modelContextWindow returns 0 for such
+// a model, and the re-seed fires on the model change even though the new window is 0, so
+// the broadcast omits context_window. A result message's modelUsage supplies the real
+// window once one arrives.
+func TestExtractAndBroadcastUsage_ClearsWindowOnSwitchToUnknownModel(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = "opus[1m]" // known 1M model via the static catalog fallback
+
+	assistant := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50}}}`
+	result := `{"type":"result","subtype":"success"}` // no modelUsage -> window comes from the catalog re-seed
+
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, int64(1_000_000), usage["context_window"], "opus[1m] seeds the 1M window")
+
+	// Precondition: the switched-to model is in neither catalog.
+	require.Equal(t, int64(0), modelContextWindow(agent.effortCatalog(), "ghost-model"),
+		"precondition: ghost-model is unknown to both catalogs")
+
+	// Switch to a model neither catalog knows (filtered/unavailable but still running).
+	agent.model = "ghost-model"
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(result))
+	usage, ok = sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	_, hasWindow := usage["context_window"]
+	assert.False(t, hasWindow,
+		"switching to a model unknown to both catalogs clears the stale 1M window to unknown")
+}
+
+// TestExtractAndBroadcastUsage_ResultWindowSurvivesReseed verifies the authoritative
+// window from a result message's modelUsage is NOT clobbered by the catalog re-seed on a
+// later turn for the SAME model. The re-seed runs every turn now (it must, to clear a
+// stale window when the model switches to an unknown one), so the windowModel guard is
+// the only thing protecting a CLI-reported window from being overwritten by the coarser
+// catalog estimate.
+func TestExtractAndBroadcastUsage_ResultWindowSurvivesReseed(t *testing.T) {
+	sink := &outputTestSink{}
+	agent := newTestAgent(sink)
+	agent.model = "opus[1m]" // catalog estimate for this id is 1M
+
+	assistant := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":100,"output_tokens":50}}}`
+	// A result whose modelUsage reports a CLI-adjusted window (500K) that differs from
+	// the catalog's 1M estimate for the same model.
+	resultWithUsage := `{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-6[1m]":{"contextWindow":500000}}}`
+	resultNoUsage := `{"type":"result","subtype":"success"}`
+
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(resultWithUsage))
+	usage, ok := sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, int64(500000), usage["context_window"],
+		"result modelUsage is authoritative (500K, not the 1M catalog estimate)")
+
+	// A later turn on the SAME model: the always-running catalog re-seed must not
+	// overwrite the authoritative 500K with the 1M estimate.
+	agent.HandleOutput([]byte(assistant))
+	agent.HandleOutput([]byte(resultNoUsage))
+	usage, ok = sink.LastSessionInfo()["context_usage"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, int64(500000), usage["context_window"],
+		"catalog re-seed must not clobber the authoritative window for the same model")
+}
+
 func TestFindPrimaryContextWindow(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1090,6 +1328,28 @@ func TestFindPrimaryContextWindow(t *testing.T) {
 			expected: 0,
 		},
 		{
+			// S6: the normalized-equality match rejects an unrelated family whose API id
+			// merely contains "opus" as a substring (e.g. a hypothetical "opusplus"),
+			// where the old substring scan would have false-matched it.
+			name:  "opus does not match an unrelated opusplus family",
+			model: "opus",
+			usage: map[string]json.RawMessage{
+				"claude-opusplus-1": json.RawMessage(`{"contextWindow": 500000}`),
+				"claude-opus-4-8":   json.RawMessage(`{"contextWindow": 200000}`),
+			},
+			expected: 200000,
+		},
+		{
+			// S6: normalization lowercases, so a "[1M]" spelling matches "opus[1m]" --
+			// the old case-sensitive suffix Contains would have missed it (returned 0).
+			name:  "uppercase [1M] suffix still matches opus[1m]",
+			model: "opus[1m]",
+			usage: map[string]json.RawMessage{
+				"claude-opus-4-8[1M]": json.RawMessage(`{"contextWindow": 1000000}`),
+			},
+			expected: 1000000,
+		},
+		{
 			name:  "empty model falls back to max",
 			model: "",
 			usage: map[string]json.RawMessage{
@@ -1112,4 +1372,62 @@ func TestFindPrimaryContextWindow(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// TestContextUsageSnapshot_BuildBroadcast exercises the debounce and window-omission
+// rules of buildBroadcast directly. The integration tests (HandleOutput) cover the
+// result-message path, but the 10s debounce for non-result messages and the
+// LastBroadcast stamping were previously only reachable through a real clock; passing
+// `now` in makes them deterministic.
+func TestContextUsageSnapshot_BuildBroadcast(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+
+	t.Run("no usage yields no broadcast", func(t *testing.T) {
+		s := &contextUsageSnapshot{ContextWindow: 200_000}
+		m, ok := s.buildBroadcast(claudeMsgTypeAssistant, base)
+		assert.False(t, ok)
+		assert.Nil(t, m)
+		assert.True(t, s.LastBroadcast.IsZero(), "a suppressed broadcast must not stamp LastBroadcast")
+	})
+
+	t.Run("result with usage broadcasts and includes a known window", func(t *testing.T) {
+		s := &contextUsageSnapshot{InputTokens: 10, OutputTokens: 5, CacheReadInputTokens: 3, ContextWindow: 200_000}
+		m, ok := s.buildBroadcast(claudeMsgTypeResult, base)
+		require.True(t, ok)
+		assert.Equal(t, int64(10), m["input_tokens"])
+		assert.Equal(t, int64(5), m["output_tokens"])
+		assert.Equal(t, int64(3), m["cache_read_input_tokens"])
+		assert.Equal(t, int64(200_000), m["context_window"])
+		assert.Equal(t, base, s.LastBroadcast, "broadcasting stamps LastBroadcast")
+	})
+
+	t.Run("unknown window is omitted", func(t *testing.T) {
+		s := &contextUsageSnapshot{InputTokens: 1} // ContextWindow == 0
+		m, ok := s.buildBroadcast(claudeMsgTypeResult, base)
+		require.True(t, ok)
+		_, has := m["context_window"]
+		assert.False(t, has, "ContextWindow==0 must omit context_window so the indicator shows unknown")
+	})
+
+	t.Run("non-result is debounced within the 10s window", func(t *testing.T) {
+		s := &contextUsageSnapshot{InputTokens: 1, LastBroadcast: base}
+		m, ok := s.buildBroadcast(claudeMsgTypeAssistant, base.Add(9*time.Second))
+		assert.False(t, ok, "9s < 10s debounce: no broadcast")
+		assert.Nil(t, m)
+		assert.Equal(t, base, s.LastBroadcast, "a suppressed broadcast must not move LastBroadcast")
+	})
+
+	t.Run("non-result broadcasts once the 10s window elapses", func(t *testing.T) {
+		s := &contextUsageSnapshot{InputTokens: 1, LastBroadcast: base}
+		at := base.Add(10 * time.Second)
+		_, ok := s.buildBroadcast(claudeMsgTypeAssistant, at)
+		assert.True(t, ok, ">=10s elapsed: broadcast")
+		assert.Equal(t, at, s.LastBroadcast)
+	})
+
+	t.Run("result bypasses the debounce window", func(t *testing.T) {
+		s := &contextUsageSnapshot{InputTokens: 1, LastBroadcast: base}
+		_, ok := s.buildBroadcast(claudeMsgTypeResult, base.Add(time.Second))
+		assert.True(t, ok, "a result message always broadcasts, even mid-debounce")
+	})
 }

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -1156,7 +1156,7 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 	assert.False(t, foundClaudeCode, "CLAUDECODE=1 should NOT be in env without login shell")
 
 	// With login shell - verify the env is set on the command.
-	shellCmd, _, _ := buildShellWrappedCommand(ctx, testutil.TestShell(), true, "claude", []string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "test"}, t.TempDir())
+	shellCmd, _, _ := wrapShellCmd(ctx, testutil.TestShell(), true, "claude", []string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "test"}, false, t.TempDir())
 	shellCmd.Env = envutil.FilterEnv(shellCmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
 	shellCmd.Env = append(shellCmd.Env, "CLAUDE_CODE_ENTRYPOINT=sdk-ts", "LEAPMUX_WORKER=1", "CLAUDECODE=1")
 
@@ -1175,49 +1175,247 @@ func TestAgent_LeapmuxWorkerEnvAlwaysSet(t *testing.T) {
 }
 
 func TestClaudeCodeAvailableModels_EffortsMatchDocs(t *testing.T) {
-	byID := map[string]*leapmuxv1.AvailableModel{}
-	for _, m := range claudeCodeAvailableModels {
-		byID[m.Id] = m
-	}
-
-	effortIDs := func(m *leapmuxv1.AvailableModel) []string {
-		ids := make([]string, 0, len(m.SupportedEfforts))
-		for _, e := range m.SupportedEfforts {
-			ids = append(ids, e.Id)
-		}
-		return ids
-	}
+	byID := claudeModelsByID(claudeCodeAvailableModels)
 
 	opusEfforts := []string{"auto", "ultracode", "max", "xhigh", "high", "medium", "low"}
 	sonnetEfforts := []string{"auto", "max", "high", "medium", "low"}
 
-	for _, id := range []string{"opus", "opus[1m]"} {
+	// Fable and Opus share the full xhigh+ultracode effort menu.
+	for _, id := range []string{"fable", "fable[1m]", "opus", "opus[1m]"} {
 		m := byID[id]
 		require.NotNil(t, m, "model %q missing", id)
-		assert.Equal(t, opusEfforts, effortIDs(m), "opus effort list for %q", id)
-		assert.Equal(t, "xhigh", m.DefaultEffort, "opus default effort for %q", id)
+		assert.Equal(t, opusEfforts, claudeEffortIDs(m), "xhigh effort list for %q", id)
+		assert.Equal(t, "xhigh", m.DefaultEffort, "xhigh default effort for %q", id)
 	}
 
 	for _, id := range []string{"sonnet", "sonnet[1m]"} {
 		m := byID[id]
 		require.NotNil(t, m, "model %q missing", id)
-		assert.Equal(t, sonnetEfforts, effortIDs(m), "sonnet effort list for %q", id)
+		assert.Equal(t, sonnetEfforts, claudeEffortIDs(m), "sonnet effort list for %q", id)
 		assert.Equal(t, "high", m.DefaultEffort, "sonnet default effort for %q", id)
 	}
 
 	haiku := byID["haiku"]
 	require.NotNil(t, haiku)
 	assert.Empty(t, haiku.SupportedEfforts, "haiku has no effort UI")
+	assert.Equal(t, "", haiku.DefaultEffort, "a no-effort model carries no default effort (matches the dynamic conversion)")
 }
 
-// TestClaudeEffortCatalog_UltracodeIsOpusOnly guards the design decision that
-// "ultracode" is offered only by xhigh-capable (Opus) models. Sonnet's catalog
-// must not list it, so switching to Sonnet downgrades ultracode cleanly.
-func TestClaudeEffortCatalog_UltracodeIsOpusOnly(t *testing.T) {
+// TestClaudeEffortCatalog_UltracodeFollowsXHigh guards the design decision that
+// "ultracode" is offered exactly by the xhigh-capable effort menu and not the
+// max-only one, so switching to a non-xhigh model (Sonnet) downgrades ultracode
+// cleanly. convertClaudeModels keys ultracode off the same xhigh signal, so this
+// keeps the static and dynamic catalogs in agreement.
+func TestClaudeEffortCatalog_UltracodeFollowsXHigh(t *testing.T) {
 	// Use the production effortListContains so this guard exercises the same
-	// lookup modelSupportsUltracode relies on, rather than a parallel copy.
-	assert.True(t, effortListContains(claudeEffortXHighMax, EffortUltracode), "Opus catalog must offer ultracode")
-	assert.False(t, effortListContains(claudeEffortMax, EffortUltracode), "Sonnet catalog must not offer ultracode")
+	// lookup supportsUltracode relies on, rather than a parallel copy.
+	assert.True(t, effortListContains(claudeEffortXHighMax, EffortUltracode), "xhigh catalog must offer ultracode")
+	assert.False(t, effortListContains(claudeEffortMax, EffortUltracode), "max-only catalog must not offer ultracode")
+}
+
+// TestClaudeDefaultEffort_FallsBackToStrongest verifies that a model which
+// supports effort but offers neither xhigh nor high (e.g. a max-only model) still
+// gets a concrete default effort -- the strongest recognized level -- rather than
+// an empty default while its selector is shown. The xhigh/high product preference
+// is preserved when those levels are present.
+func TestClaudeDefaultEffort_FallsBackToStrongest(t *testing.T) {
+	defaultEffort := func(supportsEffort bool, levels ...string) string {
+		return claudeDefaultEffort(normalizedEffortLevelSet(claudeCodeModelInfo{
+			SupportsEffort: supportsEffort, SupportedEffortLevels: levels,
+		}))
+	}
+	// Product preference: xhigh wins over max even though max ranks higher.
+	assert.Equal(t, "xhigh", defaultEffort(true, "low", "medium", "high", "xhigh", "max"))
+	assert.Equal(t, "high", defaultEffort(true, "low", "medium", "high", "max"))
+	// Mixed-case CLI levels still resolve (S3 case-normalization).
+	assert.Equal(t, "xhigh", defaultEffort(true, "Low", "Medium", "High", "XHigh", "Max"))
+	// Neither xhigh nor high: fall back to the strongest recognized level.
+	assert.Equal(t, "max", defaultEffort(true, "low", "medium", "max"))
+	assert.Equal(t, "medium", defaultEffort(true, "low", "medium"))
+	// Only unrecognized levels -> "" (selector hidden, matches claudeSupportedEfforts).
+	assert.Equal(t, "", defaultEffort(true, "ludicrous"))
+	// No effort support -> "".
+	assert.Equal(t, "", defaultEffort(false))
+
+	// End-to-end: a max-only model surfaces with a non-empty selector AND a
+	// non-empty default effort (no "selector shown but empty default" state).
+	m := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "maxer", DisplayName: "Maxer", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "max"}},
+	}, nil))["maxer"]
+	require.NotNil(t, m)
+	assert.Equal(t, []string{"auto", "max", "medium", "low"}, claudeEffortIDs(m))
+	assert.Equal(t, "max", m.DefaultEffort)
+}
+
+// TestLaunchOmitsEffort locks the shared predicate that decides when no --effort is
+// sent at launch (and so nothing needs reconciling at startup): the account-default
+// sentinel and EffortAuto/"" always omit, a model the catalog KNOWS has no effort
+// support (Haiku) omits, and unknown models pass their effort through.
+func TestLaunchOmitsEffort(t *testing.T) {
+	static := newEffortResolver(claudeCodeAvailableModels)
+	assert.True(t, static.launchOmitsEffort("default", "high"), "sentinel always omits --effort")
+	// S4: an empty model sends no --model so the CLI picks the account default; it
+	// must omit --effort too, just like the sentinel.
+	assert.True(t, static.launchOmitsEffort("", "high"), "empty model omits --effort")
+	assert.True(t, static.launchOmitsEffort("haiku", "high"), "haiku has no efforts in the catalog -> omit")
+	assert.True(t, static.launchOmitsEffort("opus", ""), "empty effort omits --effort")
+	assert.True(t, static.launchOmitsEffort("opus", EffortAuto), "auto omits --effort")
+	assert.False(t, static.launchOmitsEffort("opus", "xhigh"), "a concrete effort on a normal model is sent")
+	assert.False(t, static.launchOmitsEffort("sonnet", EffortUltracode))
+	// S4: an unknown (not-in-catalog) model is trusted, so its effort is sent.
+	assert.False(t, static.launchOmitsEffort("claude-future-preview", "xhigh"), "unknown model passes effort through")
+	// S4: an effort-less model discovered dynamically (no "haiku" literal) is handled
+	// by the catalog, so it omits --effort just like Haiku.
+	dynamic := newEffortResolver(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "quickie", DisplayName: "Quickie", SupportsEffort: false},
+	}, nil))
+	assert.True(t, dynamic.launchOmitsEffort("quickie", "high"), "catalog-known effort-less model omits --effort")
+}
+
+// TestEffortResolver_NilGuard verifies the catalog-walking capability checks
+// tolerate nil entries (matching FindAvailableModel/withDefaultModelMarked), so a
+// nil-bearing catalog can't panic the effort/ultracode lookups.
+func TestEffortResolver_NilGuard(t *testing.T) {
+	r := newEffortResolver([]*leapmuxv1.AvailableModel{nil, {Id: "opus", SupportedEfforts: claudeEffortXHighMax}, nil})
+	assert.True(t, r.supportsUltracode("opus"))
+	assert.False(t, r.supportsUltracode("missing"), "absent model is not trusted for ultracode")
+	assert.True(t, r.supports("opus", "xhigh"))
+	assert.True(t, r.supports("mystery", "xhigh"), "unknown model is trusted, no panic on nil entries")
+}
+
+// TestEffortResolver_StaticFallbackTrustsFilteredModel covers S2: the per-agent
+// resolver falls back to the static catalog for a model the live CLI dropped from
+// the dynamic list, so the decode, live-update, and startup paths all keep agreeing
+// that a still-running filtered model (e.g. opus reported in unavailable_models) is
+// ultracode-capable instead of silently downgrading it. The genuine downgrade case
+// (model still listed, minus xhigh) still wins because dynamic takes precedence.
+func TestEffortResolver_StaticFallbackTrustsFilteredModel(t *testing.T) {
+	// Dynamic catalog lists only sonnet -> opus is "filtered".
+	filtered := &ClaudeCodeAgent{availableModels: convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+	}, nil)}
+	r := filtered.effortResolver()
+	assert.True(t, r.supportsUltracode("opus"), "filtered opus resolves via the static fallback")
+	assert.Equal(t, EffortUltracode, r.resolveEffort("opus", EffortUltracode), "filtered opus keeps ultracode")
+	// A live edit echoing the current ultracode must NOT strip it for the filtered model.
+	assert.Empty(t, r.updateFlagSettings("opus", EffortUltracode, EffortUltracode),
+		"an unrelated live edit preserves a filtered model's ultracode")
+
+	// Dynamic precedence: a model the live CLI lists WITHOUT xhigh is genuinely not
+	// ultracode-capable even though the static catalog says it is.
+	dropped := &ClaudeCodeAgent{availableModels: convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "opus", DisplayName: "Opus", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+	}, nil)}
+	assert.False(t, dropped.effortResolver().supportsUltracode("opus"),
+		"a live CLI that dropped xhigh wins over the static fallback")
+}
+
+// TestEffortResolver_ContextWindowFallsBackToStatic verifies contextWindow resolves
+// over the dynamic catalog first and the static catalog as a per-entry fallback --
+// mirroring definedEfforts -- so a model the live CLI dropped from its list but the
+// session is still running keeps its known window instead of reporting "unknown".
+func TestEffortResolver_ContextWindowFallsBackToStatic(t *testing.T) {
+	// Dynamic catalog lists only sonnet (200K); opus[1m] is "filtered".
+	r := (&ClaudeCodeAgent{availableModels: convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"high"}},
+	}, nil)}).effortResolver()
+
+	assert.Equal(t, int64(200_000), r.contextWindow("sonnet"), "dynamic entry wins")
+	assert.Equal(t, int64(1_000_000), r.contextWindow("opus[1m]"),
+		"filtered opus[1m] resolves its 1M window via the static fallback")
+	assert.Equal(t, int64(0), r.contextWindow(DefaultModelSentinel),
+		"the unresolved sentinel has no window in either catalog")
+	assert.Equal(t, int64(0), r.contextWindow("ghost"),
+		"a model absent from both catalogs is unknown")
+}
+
+// TestEffortResolver_SentinelIsUnresolved covers S1: the account-default sentinel is
+// treated as unresolved by definedEfforts, so a session stuck on "default" (the CLI
+// never echoed a concrete applied.model) passes its effort through rather than
+// clamping it against the sentinel's empty effort list.
+func TestEffortResolver_SentinelIsUnresolved(t *testing.T) {
+	r := (&ClaudeCodeAgent{}).effortResolver() // static fallback only
+	_, known := r.definedEfforts(DefaultModelSentinel)
+	assert.False(t, known, "the sentinel is reported as unresolved, not known-with-empty-efforts")
+	assert.Equal(t, "max", r.resolveEffort(DefaultModelSentinel, "max"), "effort passes through, not clamped to high")
+	assert.False(t, r.unsupportedUltracode("max", DefaultModelSentinel))
+	// An effort-only live edit on a stuck sentinel pushes NO effort delta: the sentinel
+	// has no concrete model to resolve an effort against, so the live path emits nothing
+	// (mirroring the launch path's omitted --effort), and the effort settles when the
+	// model resolves. Pushing an effortLevel against the placeholder risks a level the
+	// CLI's resolved model can't run.
+	assert.Nil(t, r.updateFlagSettings(DefaultModelSentinel, "max", "high"))
+}
+
+// TestEffortResolver_EmptyDynamicEntryDefersToFallback covers E4: a KNOWN model the
+// live CLI reports with no recognizable efforts -- supportsEffort:false, or only
+// unrecognized level names (schema drift) -- lands in the dynamic catalog with an
+// empty effort list. That empty entry must NOT shadow the populated static-fallback
+// entry for the same model, or the user's stored effort would be silently downgraded
+// post-init. definedEfforts prefers a populated entry, so the fallback's menu wins.
+func TestEffortResolver_EmptyDynamicEntryDefersToFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cli  claudeCodeModelInfo
+	}{
+		{"supportsEffort false", claudeCodeModelInfo{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: false}},
+		{"only unrecognized levels", claudeCodeModelInfo{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"ultra", "blazing"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dyn := convertClaudeModels([]claudeCodeModelInfo{tc.cli}, nil)
+			// Precondition: the dynamic sonnet entry really is present-but-empty.
+			dynSonnet := FindAvailableModel(dyn, "sonnet")
+			require.NotNil(t, dynSonnet)
+			require.Empty(t, dynSonnet.SupportedEfforts)
+
+			r := (&ClaudeCodeAgent{availableModels: dyn}).effortResolver()
+			efforts, known := r.definedEfforts("sonnet")
+			assert.True(t, known, "sonnet is known")
+			assert.NotEmpty(t, efforts, "empty dynamic entry defers to the populated static fallback")
+			assert.True(t, r.supports("sonnet", "max"), "the fallback menu rescues a recognized level")
+			assert.Equal(t, "max", r.resolveEffort("sonnet", "max"), "stored effort is not downgraded")
+			assert.False(t, r.launchOmitsEffort("sonnet", "max"), "sonnet is not treated as effort-less")
+		})
+	}
+}
+
+// TestEffortResolver_GenuinelyEffortlessModelStaysEmpty is E4's negative case: a model
+// effort-less in BOTH catalogs (Haiku) stays known-with-no-efforts -- the
+// populated-entry preference must not invent a menu for it -- so the launch path still
+// omits --effort (Haiku does not accept the flag).
+func TestEffortResolver_GenuinelyEffortlessModelStaysEmpty(t *testing.T) {
+	dyn := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "haiku", DisplayName: "Haiku", SupportsEffort: false},
+	}, nil)
+	r := (&ClaudeCodeAgent{availableModels: dyn}).effortResolver()
+	efforts, known := r.definedEfforts("haiku")
+	assert.True(t, known, "haiku is known")
+	assert.Empty(t, efforts, "haiku has no efforts in either catalog")
+	assert.True(t, r.launchOmitsEffort("haiku", "high"), "an effort-less model still omits --effort")
+}
+
+// TestClaudeFallbackDisplayName covers S6: a "[1m]" model id with no CLI displayName
+// renders as "X (1M context)" instead of the raw "X[1m]".
+func TestClaudeFallbackDisplayName(t *testing.T) {
+	assert.Equal(t, "Opus (1M context)", claudeFallbackDisplayName("opus[1m]"))
+	assert.Equal(t, "Opus", claudeFallbackDisplayName("opus"))
+	assert.Equal(t, "Fable (1M context)", claudeFallbackDisplayName("fable[1m]"))
+	// A decorated 1M marker is sized at 1M by claudeContextWindowForValue, so the
+	// fallback name must agree (detect via is1MContextVariant, not a literal "[1m]"
+	// suffix) instead of falling through to a garbled "Fable[1m Beta]".
+	assert.Equal(t, "Fable (1M context)", claudeFallbackDisplayName("fable[1m-beta]"))
+	assert.Equal(t, "Opus (1M context)", claudeFallbackDisplayName("opus[1m-preview]"))
+	require.True(t, is1MContextVariant("fable[1m-beta]"),
+		"guards the predicate the display name now relies on")
+	// A bracket whose content is not a 1M marker is not treated as a 1M variant.
+	require.False(t, is1MContextVariant("opus[preview]"))
+	assert.NotContains(t, claudeFallbackDisplayName("opus[preview]"), "1M context")
+	// Via the full conversion, with the CLI omitting displayName.
+	got := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "opus[1m]", SupportsEffort: true, SupportedEffortLevels: []string{"high", "xhigh"}},
+	}, nil))["opus[1m]"]
+	require.NotNil(t, got)
+	assert.Equal(t, "Opus (1M context)", got.DisplayName, "missing displayName falls back to the [1m]-aware name")
 }
 
 func TestClaudeEffortFlagSettings(t *testing.T) {
@@ -1341,10 +1539,27 @@ func TestClaudeEffortUpdateFlagSettings(t *testing.T) {
 			curEffort:   "high",
 			expected:    nil,
 		},
+		{
+			// An unknown model (in NEITHER the dynamic nor the static catalog -- e.g.
+			// one the live CLI filtered into unavailable_models but the session is still
+			// running) at ultracode is TRUSTED, mirroring effortFromApplied/
+			// trustCLIUltracodeReport: the CLI is the authority on what it actually
+			// applied, so a model-only or unrelated live update must NOT strip the
+			// ultracode boolean just because the catalog can't confirm xhigh support.
+			// Without the `known &&` gate this would emit {ultracode:false,
+			// effortLevel:"xhigh"} and silently downgrade a session the CLI is happily
+			// running at ultracode, contradicting the decode side that trusts the same
+			// model. The two paths must agree.
+			name:        "model-only update on an unknown model running ultracode preserves the flag",
+			targetModel: "ghost",
+			newEffort:   "",
+			curEffort:   "ultracode",
+			expected:    nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, claudeEffortUpdateFlagSettings(tt.targetModel, tt.newEffort, tt.curEffort))
+			assert.Equal(t, tt.expected, newEffortResolver(claudeCodeAvailableModels).updateFlagSettings(tt.targetModel, tt.newEffort, tt.curEffort))
 		})
 	}
 }
@@ -1385,11 +1600,29 @@ func TestClaudeEffortFromApplied(t *testing.T) {
 			want:      "xhigh", // keep the reported level; never mislabel Sonnet as ultracode
 		},
 		{
-			name:      "unknown model ultracode:true is ignored - catalog can't confirm support",
+			// S1: a model the catalog does NOT know (e.g. the CLI reported it in
+			// unavailable_models, so convertClaudeModels filtered it) is trusted when
+			// the CLI confirms ultracode:true -- we don't relabel a running ultracode
+			// session to xhigh just because its model dropped out of the catalog. This
+			// differs from Sonnet above, which the catalog KNOWS lacks ultracode.
+			name:      "unknown model ultracode:true is trusted - CLI is the authority",
 			applied:   strPtr("xhigh"),
 			ultracode: boolPtr(true),
 			curEffort: "xhigh",
 			model:     "claude-future-preview",
+			want:      "ultracode",
+		},
+		{
+			// S2: the account-default sentinel is the one unknown model NOT trusted
+			// for ultracode. A session stuck on the literal "default" (the CLI never
+			// echoed a concrete applied.model) has no real model behind it, so a CLI
+			// ultracode:true report passes the reported effort through instead of
+			// minting a phantom "ultracode" against the placeholder.
+			name:      "stuck sentinel ultracode:true is not promoted - no model behind it",
+			applied:   strPtr("xhigh"),
+			ultracode: boolPtr(true),
+			curEffort: "xhigh",
+			model:     DefaultModelSentinel,
 			want:      "xhigh",
 		},
 		{
@@ -1455,6 +1688,23 @@ func TestClaudeEffortFromApplied(t *testing.T) {
 			want:      "ultracode",
 		},
 		{
+			// A model unknown to BOTH catalogs with a stale curEffort=="ultracode"
+			// and the CLI omitting the ultracode field is LEFT ALONE: the final
+			// clear-stale guard is gated on `known`, so an unknown model keeps its
+			// value for the same "trust the CLI / can't confirm it lacks ultracode"
+			// reason that promotes an unknown model's ultracode:true report. The
+			// launch flags and startup reconcile never actually drive an unknown
+			// model into ultracode (both downgrade it over the static catalog), so
+			// the CLI side stays safe; only the stored/broadcast label reads
+			// "ultracode" until a concrete CLI report overrides it.
+			name:      "unknown model with omitted fields retains stale ultracode",
+			applied:   nil,
+			ultracode: nil,
+			curEffort: "ultracode",
+			model:     "claude-future-preview",
+			want:      "ultracode",
+		},
+		{
 			// Defensive: the CLI reports applied.effort as a concrete enum or
 			// null, never "". An unexpected empty string must be treated like
 			// omitted (retain curEffort) rather than blanking the effort to "".
@@ -1479,7 +1729,7 @@ func TestClaudeEffortFromApplied(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, claudeEffortFromApplied(tt.applied, tt.ultracode, tt.curEffort, tt.model))
+			assert.Equal(t, tt.want, newEffortResolver(claudeCodeAvailableModels).effortFromApplied(tt.applied, tt.ultracode, tt.curEffort, tt.model))
 		})
 	}
 }
@@ -1491,6 +1741,7 @@ func TestBuildStartupFlagSettings_Ultracode(t *testing.T) {
 		effort        string
 		wantUltracode bool
 	}{
+		{"fable ultracode enables the combo", "fable", EffortUltracode, true},
 		{"opus ultracode enables the combo", "opus", EffortUltracode, true},
 		{"opus[1m] ultracode enables the combo", "opus[1m]", EffortUltracode, true},
 		{"sonnet ultracode is not enabled (unsupported)", "sonnet", EffortUltracode, false},
@@ -1516,15 +1767,30 @@ func TestBuildStartupFlagSettings_Ultracode(t *testing.T) {
 }
 
 func TestModelSupportsUltracode(t *testing.T) {
-	// Only Opus models list ultracode in their catalog; unlike effortSupported,
-	// unknown models are NOT trusted.
-	assert.True(t, modelSupportsUltracode("opus"))
-	assert.True(t, modelSupportsUltracode("opus[1m]"))
-	assert.False(t, modelSupportsUltracode("sonnet"))
-	assert.False(t, modelSupportsUltracode("sonnet[1m]"))
-	assert.False(t, modelSupportsUltracode("haiku"))
-	assert.False(t, modelSupportsUltracode("claude-future-preview"), "unknown models are not trusted for ultracode")
-	assert.False(t, modelSupportsUltracode(""))
+	// Against the static catalog: the xhigh-capable models (Fable, Opus) list
+	// ultracode; Sonnet/Haiku do not. Unlike supports, unknown models are NOT trusted.
+	static := newEffortResolver(claudeCodeAvailableModels)
+	assert.True(t, static.supportsUltracode("fable"))
+	assert.True(t, static.supportsUltracode("fable[1m]"))
+	assert.True(t, static.supportsUltracode("opus"))
+	assert.True(t, static.supportsUltracode("opus[1m]"))
+	assert.False(t, static.supportsUltracode("sonnet"))
+	assert.False(t, static.supportsUltracode("sonnet[1m]"))
+	assert.False(t, static.supportsUltracode("haiku"))
+	assert.False(t, static.supportsUltracode("claude-future-preview"), "unknown models are not trusted for ultracode")
+	assert.False(t, static.supportsUltracode(""))
+
+	// Against a dynamic catalog: a model the static catalog never heard of is
+	// ultracode-capable when the live CLI advertises xhigh for it (this is what
+	// makes "auto from xhigh" work for future models without a code change), and
+	// not otherwise.
+	dynamic := newEffortResolver(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "mythos", DisplayName: "Mythos 6", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "xhigh", "max"}},
+		{Value: "sprite", DisplayName: "Sprite 1", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high"}},
+	}, nil))
+	assert.True(t, dynamic.supportsUltracode("mythos"), "xhigh-capable dynamic model is ultracode-capable")
+	assert.False(t, dynamic.supportsUltracode("sprite"), "non-xhigh dynamic model is not ultracode-capable")
+	assert.False(t, dynamic.supportsUltracode("opus"), "model absent from the dynamic catalog is not trusted")
 }
 
 func TestResolveClaudeEffortForModel(t *testing.T) {
@@ -1534,6 +1800,7 @@ func TestResolveClaudeEffortForModel(t *testing.T) {
 		effort string
 		want   string
 	}{
+		{"fable keeps ultracode", "fable", "ultracode", "ultracode"},
 		{"opus keeps ultracode", "opus", "ultracode", "ultracode"},
 		{"opus[1m] keeps ultracode", "opus[1m]", "ultracode", "ultracode"},
 		{"sonnet downgrades ultracode to high", "sonnet", "ultracode", "high"},
@@ -1548,7 +1815,497 @@ func TestResolveClaudeEffortForModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, resolveClaudeEffortForModel(tt.model, tt.effort))
+			assert.Equal(t, tt.want, newEffortResolver(claudeCodeAvailableModels).resolveEffort(tt.model, tt.effort))
 		})
 	}
+}
+
+// claudeEffortIDs returns the ordered effort IDs of a model, for catalog assertions.
+func claudeEffortIDs(m *leapmuxv1.AvailableModel) []string {
+	ids := make([]string, 0, len(m.SupportedEfforts))
+	for _, e := range m.SupportedEfforts {
+		ids = append(ids, e.Id)
+	}
+	return ids
+}
+
+func claudeModelsByID(models []*leapmuxv1.AvailableModel) map[string]*leapmuxv1.AvailableModel {
+	byID := make(map[string]*leapmuxv1.AvailableModel, len(models))
+	for _, m := range models {
+		byID[m.Id] = m
+	}
+	return byID
+}
+
+func TestConvertClaudeModels(t *testing.T) {
+	xhighLevels := []string{"low", "medium", "high", "xhigh", "max"}
+	models := []claudeCodeModelInfo{
+		{Value: "default", DisplayName: "Default (recommended)", Description: "the account default", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "fable", DisplayName: "Fable 5", Description: "Most powerful for the hardest problems", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "fable[1m]", DisplayName: "Fable 5 (1M context)", Description: "Most powerful for the hardest problems", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "opus", DisplayName: "Opus", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+		{Value: "haiku", DisplayName: "Haiku", SupportsEffort: false},
+		{Value: "zdr-blocked", DisplayName: "Blocked", SupportsEffort: true, SupportedEffortLevels: []string{"high"}},
+		{Value: "internal-preview", DisplayName: "Internal", Disabled: true, SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+	}
+	unavailable := []claudeCodeModelInfo{{Value: "zdr-blocked"}}
+
+	got := convertClaudeModels(models, unavailable)
+
+	// The disabled entry and the unavailable entry are dropped; the "default"
+	// sentinel IS surfaced (a selectable "let the CLI pick" option) and keeps
+	// its leading CLI order.
+	var ids []string
+	for _, m := range got {
+		ids = append(ids, m.Id)
+	}
+	assert.Equal(t, []string{"default", "fable", "fable[1m]", "opus", "sonnet", "haiku"}, ids)
+
+	byID := claudeModelsByID(got)
+	xhighEfforts := []string{"auto", "ultracode", "max", "xhigh", "high", "medium", "low"}
+
+	// The "default" sentinel is a selectable entry, but carries NO efforts or
+	// context window even when the CLI reports them (input sets supportsEffort +
+	// xhigh levels) -- those belong to the concrete model it resolves to. The
+	// manager (not convert) gives it the IsDefault badge.
+	def := byID["default"]
+	require.NotNil(t, def)
+	assert.Equal(t, "Default (recommended)", def.DisplayName)
+	assert.Equal(t, "the account default", def.Description, "sentinel keeps its CLI-provided description")
+	assert.Empty(t, def.SupportedEfforts, "default sentinel must not expose an effort menu")
+	assert.Equal(t, "", def.DefaultEffort)
+	assert.Equal(t, int64(0), def.ContextWindow, "default sentinel has no context window until resolved")
+	assert.False(t, def.IsDefault, "convert leaves IsDefault for the manager to set")
+
+	// Fable: full xhigh+ultracode menu, xhigh default, 200K window, not marked default.
+	fable := byID["fable"]
+	require.NotNil(t, fable)
+	assert.Equal(t, "Fable 5", fable.DisplayName)
+	assert.Equal(t, "Most powerful for the hardest problems", fable.Description)
+	assert.Equal(t, xhighEfforts, claudeEffortIDs(fable))
+	assert.Equal(t, "xhigh", fable.DefaultEffort)
+	assert.Equal(t, int64(200_000), fable.ContextWindow)
+	assert.False(t, fable.IsDefault, "convert leaves IsDefault for the manager to set")
+
+	// The [1m] suffix is the only context-window signal.
+	assert.Equal(t, int64(1_000_000), byID["fable[1m]"].ContextWindow)
+	assert.Equal(t, xhighEfforts, claudeEffortIDs(byID["fable[1m]"]))
+
+	// Sonnet: max but no xhigh ⇒ no ultracode, high default.
+	sonnet := byID["sonnet"]
+	require.NotNil(t, sonnet)
+	assert.Equal(t, []string{"auto", "max", "high", "medium", "low"}, claudeEffortIDs(sonnet))
+	assert.Equal(t, "high", sonnet.DefaultEffort)
+
+	// Haiku: no effort support ⇒ no selector, no default effort.
+	haiku := byID["haiku"]
+	require.NotNil(t, haiku)
+	assert.Empty(t, haiku.SupportedEfforts)
+	assert.Equal(t, "", haiku.DefaultEffort)
+	assert.Equal(t, int64(200_000), haiku.ContextWindow)
+
+	// Falls back to a missing display name from the id.
+	assert.Equal(t, "Sonnet", byID["sonnet"].DisplayName)
+
+	// Empty input ⇒ nil so AvailableModels() falls back to the static catalog.
+	assert.Nil(t, convertClaudeModels(nil, nil))
+}
+
+func TestClaudeContextWindowForValue(t *testing.T) {
+	assert.Equal(t, int64(1_000_000), claudeContextWindowForValue("opus[1m]"))
+	assert.Equal(t, int64(1_000_000), claudeContextWindowForValue("claude-fable-5[1m]"))
+	assert.Equal(t, int64(1_000_000), claudeContextWindowForValue("opus[1M]"), "case-insensitive")
+	// A decorated 1M marker (a future beta/preview label on the bracketed suffix) still
+	// resolves to the 1M window rather than silently dropping to 200K.
+	assert.Equal(t, int64(1_000_000), claudeContextWindowForValue("opus[1m-beta]"))
+	assert.Equal(t, int64(1_000_000), claudeContextWindowForValue("claude-opus-4-8[1M-preview]"))
+	assert.Equal(t, int64(200_000), claudeContextWindowForValue("opus"))
+	assert.Equal(t, int64(200_000), claudeContextWindowForValue("default"))
+	assert.Equal(t, int64(200_000), claudeContextWindowForValue("haiku"))
+	// A stray "1m" that is not a trailing bracket group must not false-positive.
+	assert.Equal(t, int64(200_000), claudeContextWindowForValue("1m-context"))
+	assert.Equal(t, int64(200_000), claudeContextWindowForValue("opus[1m]x"))
+}
+
+// TestConvertClaudeModels_NormalizesFullIdValues locks the fix for the
+// catalog-id/a.model mismatch: the CLI reports the account-resolved model's
+// `value` as a fully-qualified id (verified against the live CLI:
+// "claude-fable-5[1m]"), while refreshSettingsFromAgent stores
+// normalizeClaudeCodeModel(applied.model) = "fable[1m]". convertClaudeModels must
+// normalize the value so a running model matches its own catalog entry (efforts,
+// ultracode, display name, frontend effort selector all key off the id).
+func TestConvertClaudeModels_NormalizesFullIdValues(t *testing.T) {
+	got := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "claude-fable-5[1m]", DisplayName: "Fable", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "xhigh", "max"}},
+		{Value: "claude-sonnet-4-6", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+	}, nil))
+
+	// Fully-qualified values collapse to the alias space a.model uses.
+	require.Contains(t, got, "fable[1m]")
+	require.NotContains(t, got, "claude-fable-5[1m]")
+	require.Contains(t, got, "sonnet")
+	assert.Equal(t, int64(1_000_000), got["fable[1m]"].ContextWindow, "[1m] suffix survives normalization")
+	assert.True(t, effortListContains(got["fable[1m]"].SupportedEfforts, EffortUltracode), "normalized Fable keeps its xhigh⇒ultracode menu")
+	assert.Equal(t, int64(200_000), got["sonnet"].ContextWindow)
+}
+
+// TestConvertClaudeModels_DedupAndEffortOrdering covers two robustness fixes:
+// duplicate ids collapse to one entry, and a model's effort menu is ordered by
+// rank regardless of the order the CLI reports the levels in (unknown levels
+// dropped).
+func TestConvertClaudeModels_DedupAndEffortOrdering(t *testing.T) {
+	got := convertClaudeModels([]claudeCodeModelInfo{
+		// Two entries that normalize to the same id collapse to one; the first
+		// (effort-bearing) wins. Its levels are reported out of order.
+		{Value: "claude-fable-5[1m]", DisplayName: "Fable", SupportsEffort: true, SupportedEffortLevels: []string{"max", "low", "xhigh", "high", "medium"}},
+		{Value: "fable[1m]", DisplayName: "Fable dup"},
+		// Scrambled levels, no xhigh ⇒ no ultracode.
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"high", "low", "max", "medium"}},
+		// An unrecognized level is dropped rather than panicking or appearing.
+		{Value: "probemodel", DisplayName: "Probe", SupportsEffort: true, SupportedEffortLevels: []string{"medium", "ludicrous", "low"}},
+	}, nil)
+
+	byID := claudeModelsByID(got)
+	require.Len(t, got, 3, "duplicate fable[1m] collapses")
+	assert.Equal(t, []string{"auto", "ultracode", "max", "xhigh", "high", "medium", "low"}, claudeEffortIDs(byID["fable[1m]"]), "out-of-order xhigh levels sorted strongest→weakest")
+	assert.Equal(t, []string{"auto", "max", "high", "medium", "low"}, claudeEffortIDs(byID["sonnet"]))
+	assert.Equal(t, []string{"auto", "medium", "low"}, claudeEffortIDs(byID["probemodel"]), "unknown 'ludicrous' level dropped")
+}
+
+// TestConvertClaudeModels_UnavailableSkipNormalized verifies the unavailable_models
+// filter matches on normalized id, so an entry reported in unavailable_models under
+// a different spelling than its models-array counterpart (one fully-qualified, one
+// aliased) is still dropped rather than leaking through as selectable.
+func TestConvertClaudeModels_UnavailableSkipNormalized(t *testing.T) {
+	got := claudeModelsByID(convertClaudeModels(
+		[]claudeCodeModelInfo{
+			// models lists the alias; unavailable_models lists the fully-qualified
+			// value (and vice-versa). Both must be filtered.
+			{Value: "fable[1m]", DisplayName: "Fable", SupportsEffort: true, SupportedEffortLevels: []string{"xhigh"}},
+			{Value: "claude-opus-4-8", DisplayName: "Opus", SupportsEffort: true, SupportedEffortLevels: []string{"high"}},
+			{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"high"}},
+		},
+		[]claudeCodeModelInfo{
+			{Value: "claude-fable-5[1m]"}, // fully-qualified form of fable[1m]
+			{Value: "opus"},               // aliased form of claude-opus-4-8
+		},
+	))
+
+	require.NotContains(t, got, "fable[1m]", "unavailable reported as claude-fable-5[1m] still filters fable[1m]")
+	require.NotContains(t, got, "opus", "unavailable reported as opus still filters claude-opus-4-8")
+	require.Contains(t, got, "sonnet")
+	assert.Len(t, got, 1)
+}
+
+// TestClaudeSupportedEfforts_OnlyUnknownLevels verifies a model that claims effort
+// support but lists only levels we don't recognize gets no effort menu (nil), not a
+// lone "auto" stub -- so the UI hides the selector instead of showing a useless one.
+func TestClaudeSupportedEfforts_OnlyUnknownLevels(t *testing.T) {
+	got := claudeSupportedEfforts(normalizedEffortLevelSet(claudeCodeModelInfo{
+		Value: "probe", SupportsEffort: true, SupportedEffortLevels: []string{"ludicrous", "plaid"},
+	}))
+	assert.Nil(t, got, "all-unrecognized levels ⇒ no effort menu")
+
+	// And via the full conversion: the model surfaces with no effort selector.
+	m := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "probe", DisplayName: "Probe", SupportsEffort: true, SupportedEffortLevels: []string{"ludicrous"}},
+	}, nil))["probe"]
+	require.NotNil(t, m)
+	assert.Empty(t, m.SupportedEfforts)
+}
+
+// TestConvertClaudeModels_SentinelOwnsReservedDefaultID verifies the account-default
+// sentinel is identified by its RAW value ("default") and OWNS the reserved "default"
+// id. Launch (buildModelEffortArgs) and the badge logic (defaultModelForList) treat
+// id=="default" as the sentinel, so a concrete model whose value merely normalizes to
+// "default" can't share that id: it is dropped deterministically rather than
+// masquerading as the sentinel (S3).
+func TestConvertClaudeModels_SentinelOwnsReservedDefaultID(t *testing.T) {
+	xhigh := []string{"low", "medium", "high", "xhigh", "max"}
+
+	// "default5" normalizes to "default" (leading alphabetic token) but its raw value
+	// is not the sentinel. It cannot claim the reserved "default" id, so it is dropped
+	// entirely rather than surfaced under that id.
+	require.Equal(t, "default", normalizeClaudeCodeModel("default5"), "precondition")
+	require.NotContains(t,
+		claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+			{Value: "default5", DisplayName: "Default Five", SupportsEffort: true, SupportedEffortLevels: xhigh},
+		}, nil)),
+		"default", "a concrete model normalizing to 'default' is dropped, not surfaced")
+
+	// The real sentinel (raw value exactly "default") is surfaced and stripped of
+	// efforts/window.
+	sentinel := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "default", DisplayName: "Default", SupportsEffort: true, SupportedEffortLevels: xhigh},
+	}, nil))["default"]
+	require.NotNil(t, sentinel)
+	assert.Empty(t, sentinel.SupportedEfforts, "the raw 'default' sentinel carries no effort menu")
+	assert.Equal(t, int64(0), sentinel.ContextWindow)
+
+	// Detection is case-insensitive (isDefaultSentinel uses EqualFold), so a
+	// "Default" spelling is still treated as the sentinel and stripped.
+	cased := claudeModelsByID(convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "Default", DisplayName: "Default", SupportsEffort: true, SupportedEffortLevels: xhigh},
+	}, nil))["default"]
+	require.NotNil(t, cased)
+	assert.Empty(t, cased.SupportedEfforts, "a 'Default' spelling is still the sentinel")
+	assert.Equal(t, int64(0), cased.ContextWindow)
+
+	// S3 determinism: when the CLI reports BOTH the sentinel and a concrete model
+	// normalizing to "default", the sentinel always wins and the concrete is dropped,
+	// regardless of their order -- so the catalog is the same either way.
+	for _, order := range [][]claudeCodeModelInfo{
+		{{Value: "default", DisplayName: "Default"}, {Value: "default5", DisplayName: "Default Five", SupportsEffort: true, SupportedEffortLevels: xhigh}},
+		{{Value: "default5", DisplayName: "Default Five", SupportsEffort: true, SupportedEffortLevels: xhigh}, {Value: "default", DisplayName: "Default"}},
+	} {
+		got := convertClaudeModels(order, nil)
+		require.Len(t, got, 1, "the concrete model normalizing to 'default' is dropped")
+		require.Equal(t, "default", got[0].Id)
+		assert.Empty(t, got[0].SupportedEfforts, "the sentinel (not the concrete model) owns the 'default' id")
+	}
+}
+
+// TestConvertClaudeModels_ReproducesStaticCatalog locks the invariant that a CLI
+// payload describing the current models converts to the same catalog the static
+// fallback hardcodes (modulo IsDefault, which the manager applies). A no-effort
+// model carries DefaultEffort "" in both -- the static catalog matches the
+// conversion -- so this is compared unconditionally. If the static catalog and the
+// conversion ever drift, this fails.
+func TestConvertClaudeModels_ReproducesStaticCatalog(t *testing.T) {
+	xhighLevels := []string{"low", "medium", "high", "xhigh", "max"}
+	maxLevels := []string{"low", "medium", "high", "max"}
+	payload := []claudeCodeModelInfo{
+		{Value: "fable", DisplayName: "Fable 5", Description: "Most powerful for the hardest problems", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "fable[1m]", DisplayName: "Fable 5 (1M context)", Description: "Most powerful for the hardest problems", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "opus", DisplayName: "Opus", Description: "Most capable for complex work", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "opus[1m]", DisplayName: "Opus (1M context)", Description: "Most capable for complex work", SupportsEffort: true, SupportedEffortLevels: xhighLevels},
+		{Value: "sonnet", DisplayName: "Sonnet", Description: "Best for everyday tasks", SupportsEffort: true, SupportedEffortLevels: maxLevels},
+		{Value: "sonnet[1m]", DisplayName: "Sonnet (1M context)", Description: "Best for everyday tasks", SupportsEffort: true, SupportedEffortLevels: maxLevels},
+		{Value: "haiku", DisplayName: "Haiku", Description: "Fastest for quick answers", SupportsEffort: false},
+	}
+
+	got := claudeModelsByID(convertClaudeModels(payload, nil))
+	for _, want := range claudeCodeAvailableModels {
+		// The "default" sentinel is a hand-authored placeholder (no concrete
+		// model behind it), not a convert output, so it has no equivalent here.
+		if want.Id == DefaultModelSentinel {
+			continue
+		}
+		m := got[want.Id]
+		require.NotNil(t, m, "converted catalog missing %q", want.Id)
+		assert.Equal(t, want.DisplayName, m.DisplayName, "%q displayName", want.Id)
+		assert.Equal(t, want.Description, m.Description, "%q description", want.Id)
+		assert.Equal(t, want.ContextWindow, m.ContextWindow, "%q contextWindow", want.Id)
+		assert.Equal(t, claudeEffortIDs(want), claudeEffortIDs(m), "%q efforts", want.Id)
+		assert.False(t, m.IsDefault, "%q: convert never marks default", want.Id)
+		assert.Equal(t, want.DefaultEffort, m.DefaultEffort, "%q defaultEffort", want.Id)
+	}
+}
+
+func TestClaudeAvailableModels_DynamicFirstStaticFallback(t *testing.T) {
+	dynamic := []*leapmuxv1.AvailableModel{
+		{Id: "mythos", DisplayName: "Mythos 6"},
+		{Id: "opus", DisplayName: "Opus"},
+	}
+
+	// Dynamic catalog present ⇒ returned verbatim.
+	a := &ClaudeCodeAgent{availableModels: dynamic}
+	assert.Equal(t, dynamic, a.AvailableModels())
+	assert.Equal(t, dynamic, a.effortCatalog())
+
+	// No dynamic catalog ⇒ static fallback.
+	empty := &ClaudeCodeAgent{}
+	assert.Equal(t, claudeCodeAvailableModels, empty.AvailableModels())
+	assert.Equal(t, claudeCodeAvailableModels, empty.effortCatalog())
+
+	// Third-party provider ⇒ AvailableModels hides everything, but effortCatalog
+	// (the ungated picker backing) still returns the dynamic list -- AvailableModels
+	// owns the third-party gate, not effortCatalog.
+	thirdParty := &ClaudeCodeAgent{thirdPartyFromSettings: true, availableModels: dynamic}
+	assert.Nil(t, thirdParty.AvailableModels())
+	assert.Equal(t, dynamic, thirdParty.effortCatalog())
+}
+
+// TestBuildStartupFlagSettings_DynamicCatalogUltracode proves the end-to-end
+// "auto from xhigh" path: a model the static catalog never heard of, discovered
+// from the live CLI with xhigh support, gets ultracode enabled at startup.
+func TestBuildStartupFlagSettings_DynamicCatalogUltracode(t *testing.T) {
+	dynamic := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "mythos", DisplayName: "Mythos 6", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "xhigh", "max"}},
+	}, nil)
+
+	a := &ClaudeCodeAgent{model: "mythos", effort: EffortUltracode, availableModels: dynamic}
+	fs := a.buildStartupFlagSettings(nil)
+	assert.Equal(t, "xhigh", fs["effortLevel"])
+	assert.Equal(t, true, fs["ultracode"])
+}
+
+// TestBuildStartupFlagSettings_DowngradesWhenDynamicDropsXHigh covers the other
+// direction of the launch(static)-vs-startup(dynamic) catalog split: a model the
+// static catalog launched at --effort xhigh (because static lists it as
+// ultracode/xhigh-capable) but the LIVE CLI reports WITHOUT xhigh. Startup must
+// correct the session DOWN to a level the dynamic catalog allows, not leave it
+// stranded at an xhigh the CLI rejects.
+func TestBuildStartupFlagSettings_DowngradesWhenDynamicDropsXHigh(t *testing.T) {
+	// Live CLI reports opus without xhigh -- so dynamically it is not
+	// ultracode-capable, even though the static catalog says it is.
+	dynamic := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "opus", DisplayName: "Opus", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+	}, nil)
+
+	a := &ClaudeCodeAgent{model: "opus", effort: EffortUltracode, availableModels: dynamic}
+	fs := a.buildStartupFlagSettings(nil)
+	// Launch sent --effort xhigh (static opus is ultracode-capable); the dynamic
+	// catalog resolves ultracode->high and clears the ultracode boolean.
+	assert.Equal(t, "high", fs["effortLevel"])
+	assert.Equal(t, false, fs["ultracode"])
+}
+
+// TestBuildStartupFlagSettings_SentinelEmitsNoEffort guards the S1+S3 interaction:
+// the account-default sentinel launches without --model/--effort, and startup must
+// not emit any effort flags (the resolved model's own default effort stands), even
+// if a concrete effort was somehow stored alongside the sentinel.
+func TestBuildStartupFlagSettings_SentinelEmitsNoEffort(t *testing.T) {
+	a := &ClaudeCodeAgent{model: DefaultModelSentinel, effort: EffortUltracode}
+	fs := a.buildStartupFlagSettings(nil)
+	_, hasLevel := fs["effortLevel"]
+	_, hasUltra := fs["ultracode"]
+	assert.False(t, hasLevel, "sentinel must not emit effortLevel at startup")
+	assert.False(t, hasUltra, "sentinel must not emit ultracode at startup")
+}
+
+// TestBuildStartupFlagSettings_FilteredModelHonorsLaunchVerdict covers the
+// startup reconcile for a running model the dynamic catalog doesn't list (e.g. the
+// CLI reported it in unavailable_models, so convertClaudeModels filtered it). We
+// cannot reconcile against capabilities we don't have, so we honor what LAUNCH
+// committed to instead -- resolved over the static catalog, the authority launch
+// actually used:
+//   - An ultracode launch of a static-ultracode model (opus/fable) DEFERRED the
+//     ultracode boolean to this step (launch sent only --effort xhigh; the boolean
+//     is applied nowhere else), so we complete the combo rather than silently
+//     running the model the user picked ultracode for at plain xhigh.
+//   - A non-ultracode launch (sonnet+max) and a model unknown to BOTH catalogs are
+//     left exactly as launched -- no downgrade, no spurious flags.
+func TestBuildStartupFlagSettings_FilteredModelHonorsLaunchVerdict(t *testing.T) {
+	// Dynamic catalog lists only sonnet, so opus/fable/unknown are all "filtered".
+	dynamic := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "sonnet", DisplayName: "Sonnet", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "max"}},
+	}, nil)
+
+	// opus+ultracode: static knows opus is ultracode-capable and launch deferred the
+	// boolean here, so completing the combo preserves the user's choice.
+	opus := &ClaudeCodeAgent{model: "opus", effort: EffortUltracode, availableModels: dynamic}
+	fs := opus.buildStartupFlagSettings(nil)
+	assert.Equal(t, EffortXHigh, fs["effortLevel"], "filtered ultracode model completes the combo (xhigh base)")
+	assert.Equal(t, true, fs["ultracode"], "filtered static-ultracode model keeps its ultracode boolean")
+
+	// sonnet+max: launch sent --effort max (no deferred boolean); a filtered model is
+	// left as launched, never downgraded.
+	sonnet := &ClaudeCodeAgent{model: "sonnet", effort: "max", availableModels: dynamic}
+	fs = sonnet.buildStartupFlagSettings(nil)
+	_, hasLevel := fs["effortLevel"]
+	_, hasUltra := fs["ultracode"]
+	assert.False(t, hasLevel, "a filtered non-ultracode model is not downgraded")
+	assert.False(t, hasUltra, "a filtered non-ultracode model emits no ultracode flag")
+
+	// claude-future-preview+ultracode: unknown to BOTH catalogs. Launch (static)
+	// resolved ultracode->high for an untrusted model, so it never ran ultracode;
+	// startup must not invent it.
+	unknown := &ClaudeCodeAgent{model: "claude-future-preview", effort: EffortUltracode, availableModels: dynamic}
+	fs = unknown.buildStartupFlagSettings(nil)
+	_, hasLevel = fs["effortLevel"]
+	_, hasUltra = fs["ultracode"]
+	assert.False(t, hasLevel, "a model unknown to both catalogs gets no startup effort flags")
+	assert.False(t, hasUltra, "a model unknown to both catalogs gets no ultracode flag")
+}
+
+// TestBuildStartupFlagSettings_ThirdPartyEmitsNoEffort covers S2: a third-party-LLM
+// session presents no model/effort UI (AvailableModels returns nil) and must not be
+// pushed any effort/ultracode flags at startup -- even when its stored model+effort
+// would otherwise resolve to the ultracode combo -- since its user can neither see nor
+// control effort. Gated on the same hidesModelEffortUI predicate AvailableModels uses.
+func TestBuildStartupFlagSettings_ThirdPartyEmitsNoEffort(t *testing.T) {
+	dynamic := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "opus", DisplayName: "Opus", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high", "xhigh", "max"}},
+	}, nil)
+
+	a := &ClaudeCodeAgent{model: "opus", effort: EffortUltracode, availableModels: dynamic, thirdPartyFromSettings: true}
+	fs := a.buildStartupFlagSettings(nil)
+	_, hasLevel := fs["effortLevel"]
+	_, hasUltra := fs["ultracode"]
+	assert.False(t, hasLevel, "third-party session emits no startup effortLevel")
+	assert.False(t, hasUltra, "third-party session emits no startup ultracode flag")
+
+	// Control: the identical agent WITHOUT the third-party flag DOES complete the combo,
+	// proving the suppression is the third-party gate, not an unrelated no-op.
+	a.thirdPartyFromSettings = false
+	fs = a.buildStartupFlagSettings(nil)
+	assert.Equal(t, true, fs["ultracode"], "a non-third-party session emits the ultracode combo")
+}
+
+// TestBuildStartupFlagSettings_AppliesEffortWhenDynamicAddsEfforts covers S9: a model
+// the STATIC catalog treats as effort-less (so launch omitted --effort) but the live
+// CLI reports WITH efforts. Startup must apply the stored effort against the dynamic
+// catalog so the live selector and the running session agree, instead of leaving the
+// session at the CLI's own default while the UI shows a concrete level.
+func TestBuildStartupFlagSettings_AppliesEffortWhenDynamicAddsEfforts(t *testing.T) {
+	// Haiku is effort-less in the static catalog, but here the live CLI reports it
+	// with an effort menu (the hypothetical static/dynamic disagreement S9 guards).
+	dynamic := convertClaudeModels([]claudeCodeModelInfo{
+		{Value: "haiku", DisplayName: "Haiku", SupportsEffort: true, SupportedEffortLevels: []string{"low", "medium", "high"}},
+	}, nil)
+	a := &ClaudeCodeAgent{model: "haiku", effort: EffortHigh, availableModels: dynamic}
+	fs := a.buildStartupFlagSettings(nil)
+	assert.Equal(t, EffortHigh, fs["effortLevel"], "launch omitted --effort (static effort-less); startup applies the dynamic level")
+	_, hasUltra := fs["ultracode"]
+	assert.False(t, hasUltra, "no ultracode for a non-xhigh model")
+
+	// EffortAuto on the same model still keeps the CLI default (nothing to apply).
+	autoAgent := &ClaudeCodeAgent{model: "haiku", effort: EffortAuto, availableModels: dynamic}
+	_, hasLevel := autoAgent.buildStartupFlagSettings(nil)["effortLevel"]
+	assert.False(t, hasLevel, "auto effort keeps the CLI default even when dynamic offers efforts")
+}
+
+// TestWithDefaultModelMarked_ClaudeDefaultSentinel verifies the default badge
+// tracks the account: the CLI's "default" sentinel entry is marked when present,
+// an operator env override wins over it, and a list without the sentinel falls
+// back to the configured default.
+func TestWithDefaultModelMarked_ClaudeDefaultSentinel(t *testing.T) {
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+
+	// Account-specific list (no opus[1m]) that includes the CLI "default"
+	// sentinel: the sentinel carries the IsDefault badge.
+	withSentinel := []*leapmuxv1.AvailableModel{
+		{Id: "default", DisplayName: "Default (recommended)"},
+		{Id: "claude-fable-5[1m]", DisplayName: "Fable"},
+		{Id: "sonnet", DisplayName: "Sonnet"},
+	}
+	assert.Equal(t, "default", markedModelID(withDefaultModelMarked(withSentinel, claude)))
+
+	// The static catalog carries the sentinel, so it is marked there too.
+	assert.Equal(t, "default", DefaultModel(claude))
+	assert.Equal(t, "default", markedModelID(withDefaultModelMarked(claudeCodeAvailableModels, claude)))
+
+	// A list missing the sentinel (a CLI that doesn't report it) falls back to
+	// the highest-preference entry present, so the picker still shows a default
+	// badge -- the configured default ("default") isn't in the list to mark.
+	noSentinel := []*leapmuxv1.AvailableModel{
+		{Id: "opus[1m]", DisplayName: "Opus (1M context)"},
+		{Id: "sonnet", DisplayName: "Sonnet"},
+	}
+	assert.Equal(t, "opus[1m]", markedModelID(withDefaultModelMarked(noSentinel, claude)))
+
+	// Operator override wins over the CLI sentinel.
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "sonnet")
+	assert.Equal(t, "sonnet", markedModelID(withDefaultModelMarked(withSentinel, claude)))
+}
+
+// TestUpdateSettings_SwitchToDefaultRestarts verifies that switching to the
+// account-default sentinel signals a restart (returns false) rather than
+// pushing an unresolvable "default" model through apply_flag_settings.
+func TestUpdateSettings_SwitchToDefaultRestarts(t *testing.T) {
+	a := &ClaudeCodeAgent{model: "claude-fable-5[1m]", effort: EffortHigh}
+	assert.False(t, a.UpdateSettings(&leapmuxv1.AgentSettings{Model: DefaultModelSentinel}))
 }

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -105,9 +105,14 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Agent, erro
 	// Codex doesn't have third-party provider detection or model/effort
 	// conditional args, so we pass empty modelEffortArgs for a simple command.
 	binary := resolveBinaryName(ctx, opts.Shell, opts.LoginShell, codexBinaryCandidates)
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, binary, []string{"CODEX_CI"}, []string{"app-server"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:        opts.Shell,
+		LoginShell:   opts.LoginShell,
+		BinaryName:   binary,
+		StripEnvKeys: []string{"CODEX_CI"},
+		BaseArgs:     []string{"app-server"},
+		WorkingDir:   opts.WorkingDir,
+	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "CODEX_CI", "CODEX_THREAD_ID")
 	if opts.LoginShell {

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -22,9 +22,13 @@ type CopilotCLIAgent struct {
 func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "copilot", nil, []string{"--acp", "--stdio"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:      opts.Shell,
+		LoginShell: opts.LoginShell,
+		BinaryName: "copilot",
+		BaseArgs:   []string{"--acp", "--stdio"},
+		WorkingDir: opts.WorkingDir,
+	})
 
 	cmd.Env = FinalizeAgentEnv(cmd.Environ(), opts)
 

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -25,9 +25,13 @@ type CursorCLIAgent struct {
 func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "cursor-agent", nil, []string{"acp"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:      opts.Shell,
+		LoginShell: opts.LoginShell,
+		BinaryName: "cursor-agent",
+		BaseArgs:   []string{"acp"},
+		WorkingDir: opts.WorkingDir,
+	})
 
 	cmd.Env = FinalizeAgentEnv(cmd.Environ(), opts)
 

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -48,6 +48,14 @@ const DefaultAPITimeout = time.Duration(config.DefaultAPITimeoutSeconds) * time.
 // that don't recognize newer effort names (e.g. "xhigh") still work.
 const EffortAuto = "auto"
 
+// DefaultModelSentinel is the model id meaning "let the CLI pick the account's
+// own default model". Claude Code reports it as a distinct entry in the
+// initialize response (displayName "Default (recommended)"); selecting it makes
+// the provider omit --model at launch (and relaunch on a live switch) so the CLI
+// resolves it to the concrete model, which get_settings then reports back -- the
+// model-side analogue of EffortAuto.
+const DefaultModelSentinel = "default"
+
 // EffortUltracode is LeapMux's internal name for the CLI's xhigh+ultracode combo.
 // At the provider wire boundary it maps to {effortLevel:"xhigh", ultracode:true};
 // the CLI's --effort launch flag does not accept it.
@@ -56,12 +64,12 @@ const EffortUltracode = "ultracode"
 // EffortXHigh is the "xhigh" effort level. It is also the launch/wire base for
 // the ultracode combo (which layers the `ultracode` boolean on top of xhigh),
 // so it is a load-bearing value shared by the encode path (ultracodeFlagSettings,
-// buildModelEffortArgs) and the decode path (claudeEffortFromApplied). Naming it
+// buildModelEffortArgs) and the decode path (effortFromApplied). Naming it
 // once keeps those sites from drifting to inconsistent literals.
 const EffortXHigh = "xhigh"
 
 // EffortHigh is the "high" effort level. It is the universal-safe fallback every
-// model supports, so resolveClaudeEffortForModel downgrades any unsupported
+// model supports, so resolveEffort downgrades any unsupported
 // effort to it. Like EffortXHigh it is load-bearing (the fallback target and the
 // Sonnet/Haiku catalog default), so naming it once keeps those sites from
 // drifting to inconsistent literals.
@@ -146,6 +154,18 @@ func registerAgentFactory(
 	}
 }
 
+// DefaultModelEnvOverride returns the value of the provider's
+// LEAPMUX_*_DEFAULT_MODEL environment variable, or "" if unset. It is the
+// explicit operator override that takes precedence over both a CLI-reported
+// default and the static catalog's preferred model (see withDefaultModelMarked).
+func DefaultModelEnvOverride(provider leapmuxv1.AgentProvider) string {
+	reg, ok := agentFactoryRegistry[provider]
+	if !ok || reg.envModelKey == "" {
+		return ""
+	}
+	return os.Getenv(reg.envModelKey)
+}
+
 // DefaultModel returns the default model ID for a provider, checking the
 // provider's environment variable first, then falling back to the model
 // marked IsDefault in the registered model list.
@@ -154,10 +174,8 @@ func DefaultModel(provider leapmuxv1.AgentProvider) string {
 	if !ok {
 		return ""
 	}
-	if reg.envModelKey != "" {
-		if env := os.Getenv(reg.envModelKey); env != "" {
-			return env
-		}
+	if env := DefaultModelEnvOverride(provider); env != "" {
+		return env
 	}
 	for _, m := range reg.defaultModels {
 		if m.IsDefault {
@@ -168,6 +186,23 @@ func DefaultModel(provider leapmuxv1.AgentProvider) string {
 		return reg.defaultModels[0].Id
 	}
 	return ""
+}
+
+// NormalizeModelID canonicalizes a provider's model id into the alias space the
+// provider stores and compares against, so two spellings of the same model -- e.g.
+// the CLI's fully-qualified "claude-opus-4-8[1m]" and the alias "opus[1m]" -- compare
+// equal. Providers without an alias space return the id unchanged. Used by the
+// settings-change notification so a model that merely re-normalizes (not a user
+// switch) isn't reported as a change.
+func NormalizeModelID(provider leapmuxv1.AgentProvider, model string) string {
+	switch provider {
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE:
+		return normalizeClaudeCodeModel(model)
+	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR:
+		return normalizeCursorModelID(model)
+	default:
+		return model
+	}
 }
 
 // EffortEnvOverride returns the value of the provider's
@@ -189,7 +224,9 @@ func EffortEnvOverride(provider leapmuxv1.AgentProvider) string {
 // (e.g. DefaultEffort) from a catalog returned by the CLI.
 func FindAvailableModel(models []*leapmuxv1.AvailableModel, id string) *leapmuxv1.AvailableModel {
 	for _, m := range models {
-		if m.Id == id {
+		// Guard nil entries: callers (defaultModelForList, withDefaultModelMarked)
+		// already treat the slice as possibly nil-bearing, so this must too.
+		if m != nil && m.Id == id {
 			return m
 		}
 	}

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -136,3 +136,21 @@ func TestPermissionModeOrDefault(t *testing.T) {
 		})
 	}
 }
+
+// TestFindAvailableModel verifies the lookup matches by id and, critically,
+// tolerates nil entries in the slice (its callers treat the catalog as possibly
+// nil-bearing, so the lookup must not panic on one).
+func TestFindAvailableModel(t *testing.T) {
+	models := []*leapmuxv1.AvailableModel{
+		nil,
+		{Id: "opus"},
+		nil,
+		{Id: "sonnet"},
+	}
+
+	assert.Equal(t, "sonnet", FindAvailableModel(models, "sonnet").GetId())
+	assert.Equal(t, "opus", FindAvailableModel(models, "opus").GetId())
+	assert.Nil(t, FindAvailableModel(models, "missing"), "no match returns nil")
+	assert.Nil(t, FindAvailableModel([]*leapmuxv1.AvailableModel{nil, nil}, "x"), "all-nil slice does not panic")
+	assert.Nil(t, FindAvailableModel(nil, "x"))
+}

--- a/backend/internal/worker/agent/gemini.go
+++ b/backend/internal/worker/agent/gemini.go
@@ -26,9 +26,14 @@ type GeminiCLIAgent struct {
 func StartGeminiCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "gemini", []string{"GEMINI_CLI"}, []string{"--acp"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:        opts.Shell,
+		LoginShell:   opts.LoginShell,
+		BinaryName:   "gemini",
+		StripEnvKeys: []string{"GEMINI_CLI"},
+		BaseArgs:     []string{"--acp"},
+		WorkingDir:   opts.WorkingDir,
+	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "GEMINI_CLI", "GEMINI_CLI_NO_RELAUNCH")
 	if opts.LoginShell {

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -23,9 +23,13 @@ type GooseCLIAgent struct {
 func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "goose", nil, []string{"acp"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:      opts.Shell,
+		LoginShell: opts.LoginShell,
+		BinaryName: "goose",
+		BaseArgs:   []string{"acp"},
+		WorkingDir: opts.WorkingDir,
+	})
 
 	cmd.Env = FinalizeAgentEnv(cmd.Environ(), opts)
 

--- a/backend/internal/worker/agent/kilo.go
+++ b/backend/internal/worker/agent/kilo.go
@@ -19,9 +19,14 @@ type KiloAgent struct {
 func StartKilo(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "kilo", []string{"KILO_CLIENT"}, []string{"acp"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:        opts.Shell,
+		LoginShell:   opts.LoginShell,
+		BinaryName:   "kilo",
+		StripEnvKeys: []string{"KILO_CLIENT"},
+		BaseArgs:     []string{"acp"},
+		WorkingDir:   opts.WorkingDir,
+	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "KILO_CLIENT")
 	if opts.LoginShell {

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -309,12 +309,113 @@ func (m *Manager) AvailableModels(agentID string, provider leapmuxv1.AgentProvid
 	return nil
 }
 
+// defaultModelForList resolves which model id should carry the IsDefault badge
+// for this (possibly account-specific) list. Priority:
+//  1. The explicit LEAPMUX_*_DEFAULT_MODEL operator override.
+//  2. A provider-reported default the list itself designates -- for Claude Code
+//     this is the CLI's DefaultModelSentinel ("default") entry, which tracks the
+//     account's own default across plan tiers (e.g. Sonnet vs Fable).
+//  3. The provider's configured default. When the list contains it, return it;
+//     when the list omits it (an account-specific list whose configured default
+//     isn't offered, e.g. a Claude CLI reporting concrete models but no "default"
+//     sentinel), fall back to the highest-preference entry present so the picker
+//     still shows a badge.
+//
+// Returning "" means "don't touch the list's existing badges": that's the case
+// for a provider with no configured default at all (ACP providers registered with
+// nil defaultModels, which self-mark the currently-selected model in
+// buildACPModels). The step-3 fallback is gated on a non-empty configured default
+// precisely so it doesn't clobber that per-agent marking.
+func defaultModelForList(models []*leapmuxv1.AvailableModel, provider leapmuxv1.AgentProvider) string {
+	if env := DefaultModelEnvOverride(provider); env != "" {
+		// Honor the operator override only when it actually names a model in this
+		// (possibly account-specific) list, matching by exact id or provider-
+		// normalized alias. A stale or differently-spelled override -- a fully-
+		// qualified "claude-opus-4-8[1m]" against the catalog's "opus[1m]", or a
+		// model the account simply doesn't offer -- falls through to the rest of
+		// the ladder so the picker still shows a default badge. Returning an absent
+		// id unconditionally would make withDefaultModelMarked clear IsDefault from
+		// every entry (none match) and badge nothing.
+		if id := matchModelID(models, provider, env); id != "" {
+			return id
+		}
+	}
+	// DefaultModelSentinel is a Claude-Code-specific concept (the CLI's "default"
+	// entry); gate the check to that provider so a non-Claude provider that
+	// happens to report a model literally id'd "default" doesn't get its
+	// self-marked/CLI-marked badge hijacked onto that entry.
+	if provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE && FindAvailableModel(models, DefaultModelSentinel) != nil {
+		return DefaultModelSentinel
+	}
+	configured := DefaultModel(provider)
+	if configured == "" {
+		// No configured default: preserve whatever IsDefault the per-agent list
+		// already set (e.g. buildACPModels marking the current model) instead of
+		// moving the badge to the first entry.
+		return ""
+	}
+	if FindAvailableModel(models, configured) != nil {
+		return configured
+	}
+	// The configured default isn't in this (account-specific) list. Respect a
+	// default the provider already designated on the list itself -- e.g. Codex's
+	// queryAvailableModels copies the CLI's isDefault onto an entry -- before
+	// falling back, so a stale registry default (configured but absent from the
+	// live list) doesn't move the badge off the model the CLI actually marked.
+	if id := markedModelID(models); id != "" {
+		return id
+	}
+	// Nothing designated: mark the highest-preference entry the list does contain
+	// so the picker always shows a default badge (e.g. a Claude CLI reporting
+	// concrete models but no "default" sentinel falls back to its first model).
+	return firstModelID(models)
+}
+
+// matchModelID returns the id of the model in the list the given id refers to,
+// matched first by exact id then by provider-normalized alias (so a fully-
+// qualified spelling like "claude-opus-4-8[1m]" resolves to the catalog's
+// "opus[1m]"). Returns "" when the list contains no such model. Used to resolve
+// an operator default-model override against an account-specific catalog.
+func matchModelID(models []*leapmuxv1.AvailableModel, provider leapmuxv1.AgentProvider, id string) string {
+	if m := FindAvailableModel(models, id); m != nil {
+		return m.Id
+	}
+	want := NormalizeModelID(provider, id)
+	for _, m := range models {
+		if m != nil && NormalizeModelID(provider, m.Id) == want {
+			return m.Id
+		}
+	}
+	return ""
+}
+
+// markedModelID returns the id of the first model already flagged IsDefault, or ""
+// if none is. firstModelID returns the id of the first non-nil model, or "". Both
+// tolerate nil-bearing slices (the catalogs are treated as possibly nil-bearing).
+func markedModelID(models []*leapmuxv1.AvailableModel) string {
+	for _, m := range models {
+		if m != nil && m.IsDefault {
+			return m.Id
+		}
+	}
+	return ""
+}
+
+func firstModelID(models []*leapmuxv1.AvailableModel) string {
+	for _, m := range models {
+		if m != nil {
+			return m.Id
+		}
+	}
+	return ""
+}
+
 func withDefaultModelMarked(models []*leapmuxv1.AvailableModel, provider leapmuxv1.AgentProvider) []*leapmuxv1.AvailableModel {
 	if len(models) == 0 {
 		return nil
 	}
 
-	defaultModel := DefaultModel(provider)
+	defaultModel := defaultModelForList(models, provider)
 	if defaultModel == "" {
 		return models
 	}

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -403,3 +403,182 @@ func TestManager_AvailableModelsFallsBackToGeminiDefaults(t *testing.T) {
 	assert.Equal(t, "auto", models[0].GetId())
 	assert.True(t, models[0].GetIsDefault())
 }
+
+// TestWithDefaultModelMarked_PreservesACPCurrentModel verifies that for a
+// provider with no configured default (registered with nil defaultModels, like
+// the ACP providers that self-mark the currently-selected model in
+// buildACPModels), withDefaultModelMarked leaves the per-agent IsDefault badge in
+// place instead of promoting the first entry. Regression guard: defaultModelForList
+// must return "" rather than falling through to "mark the first entry" when there
+// is no configured default to anchor on.
+func TestWithDefaultModelMarked_PreservesACPCurrentModel(t *testing.T) {
+	t.Setenv("LEAPMUX_OPENCODE_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
+	opencode := leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE
+	require.Empty(t, DefaultModel(opencode), "precondition: opencode has no configured default")
+
+	// buildACPModels marks the active model; here that's the 2nd entry.
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "anthropic/claude-x", DisplayName: "Claude X"},
+		{Id: "openai/gpt-y", DisplayName: "GPT Y", IsDefault: true},
+		{Id: "google/gemini-z", DisplayName: "Gemini Z"},
+	}
+
+	got := withDefaultModelMarked(models, opencode)
+	require.Len(t, got, 3)
+	assert.False(t, got[0].GetIsDefault(), "first entry must not be promoted")
+	assert.True(t, got[1].GetIsDefault(), "current model keeps its badge")
+	assert.False(t, got[2].GetIsDefault())
+
+	// An operator override still wins and moves the badge to the override target.
+	t.Setenv("LEAPMUX_OPENCODE_DEFAULT_MODEL", "google/gemini-z")
+	got = withDefaultModelMarked(models, opencode)
+	require.Len(t, got, 3)
+	assert.False(t, got[1].GetIsDefault(), "override clears the per-agent badge")
+	assert.True(t, got[2].GetIsDefault(), "override target is marked")
+}
+
+// TestWithDefaultModelMarked_SentinelIsClaudeOnly verifies the DefaultModelSentinel
+// ("default") badge rule is scoped to Claude Code. A non-Claude ACP provider whose
+// live list happens to contain a model literally id'd "default" must NOT have its
+// self-marked current-model badge hijacked onto that entry -- the sentinel is a
+// Claude-Code concept, so for other providers "default" is just another model id.
+func TestWithDefaultModelMarked_SentinelIsClaudeOnly(t *testing.T) {
+	t.Setenv("LEAPMUX_OPENCODE_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "")
+	opencode := leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE
+	require.Empty(t, DefaultModel(opencode), "precondition: opencode has no configured default")
+
+	// An ACP list containing a model id'd "default" with a DIFFERENT self-marked
+	// current model. The self-marked model must keep the badge.
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "default", DisplayName: "Some Local Default Model"},
+		{Id: "openai/gpt-y", DisplayName: "GPT Y", IsDefault: true},
+	}
+	got := withDefaultModelMarked(models, opencode)
+	require.Len(t, got, 2)
+	assert.False(t, got[0].GetIsDefault(), "non-Claude 'default'-id model is not treated as the sentinel")
+	assert.True(t, got[1].GetIsDefault(), "the ACP self-marked current model keeps its badge")
+
+	// Same list under Claude Code: the sentinel rule DOES apply, so the "default"
+	// entry is badged.
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+	got = withDefaultModelMarked(models, claude)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].GetIsDefault(), "Claude Code badges the 'default' sentinel entry")
+	assert.False(t, got[1].GetIsDefault())
+}
+
+// TestWithDefaultModelMarked_PreservesProviderDefaultWhenConfiguredAbsent verifies
+// that for a provider WITH a configured default (e.g. Codex), when that configured
+// default is absent from an account-specific list, withDefaultModelMarked respects
+// a default the provider already designated on the list itself (Codex's
+// queryAvailableModels copies the CLI's isDefault) rather than promoting the first
+// entry. Regression guard: the step-3 fallback must not move the badge off the
+// model the CLI marked just because the registry default isn't offered.
+func TestWithDefaultModelMarked_PreservesProviderDefaultWhenConfiguredAbsent(t *testing.T) {
+	t.Setenv("LEAPMUX_CODEX_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
+	codex := leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX
+	configured := DefaultModel(codex)
+	require.NotEmpty(t, configured, "precondition: codex has a configured default")
+
+	// An account-specific list that does NOT contain the configured default, with
+	// the CLI's own default marked on the 2nd (non-first) entry.
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "codex-mini", DisplayName: "Mini"},
+		{Id: "codex-pro", DisplayName: "Pro", IsDefault: true},
+	}
+	require.Nil(t, FindAvailableModel(models, configured), "precondition: configured default absent from list")
+
+	got := withDefaultModelMarked(models, codex)
+	require.Len(t, got, 2)
+	assert.False(t, got[0].GetIsDefault(), "first entry must not be promoted over the CLI-marked default")
+	assert.True(t, got[1].GetIsDefault(), "the provider-marked default keeps its badge")
+
+	// Sanity: with NO entry pre-marked, the badge still falls back to the first
+	// entry so the picker always shows a default.
+	unmarked := []*leapmuxv1.AvailableModel{{Id: "codex-mini"}, {Id: "codex-pro"}}
+	got = withDefaultModelMarked(unmarked, codex)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].GetIsDefault(), "no designated default -> first entry marked")
+	assert.False(t, got[1].GetIsDefault())
+}
+
+// TestWithDefaultModelMarked_EnvOverrideAbsentFallsThrough verifies that an operator
+// default-model override pointing at a model the (account-specific) list does not
+// contain -- or naming it with a different spelling than the catalog stores -- does
+// NOT strip every entry's badge. defaultModelForList honors the override only when it
+// resolves to a model in the list (by exact id or provider-normalized alias);
+// otherwise it falls through the ladder so the picker still shows a default.
+func TestWithDefaultModelMarked_EnvOverrideAbsentFallsThrough(t *testing.T) {
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+
+	// A Claude list with the account-default sentinel present.
+	models := []*leapmuxv1.AvailableModel{
+		{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", IsDefault: true},
+		{Id: "sonnet", DisplayName: "Sonnet"},
+	}
+
+	// Override names a model the account does not offer -> falls through to the
+	// sentinel (Claude's list-designated default); the badge is preserved.
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "opus[1m]")
+	got := withDefaultModelMarked(models, claude)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].GetIsDefault(), "absent override falls through to the sentinel")
+	assert.False(t, got[1].GetIsDefault())
+	require.NotEmpty(t, markedModelID(got), "some entry stays badged")
+
+	// Override names a PRESENT model with a fully-qualified spelling: it resolves to
+	// the catalog's normalized alias and wins, moving the badge off the sentinel.
+	present := []*leapmuxv1.AvailableModel{
+		{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", IsDefault: true},
+		{Id: "opus[1m]", DisplayName: "Opus (1M context)"},
+	}
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "claude-opus-4-8[1m]")
+	got = withDefaultModelMarked(present, claude)
+	require.Len(t, got, 2)
+	assert.False(t, got[0].GetIsDefault(), "override resolves to the present alias; sentinel loses the badge")
+	assert.True(t, got[1].GetIsDefault(), "fully-qualified override matches the normalized opus[1m]")
+}
+
+// TestWithDefaultModelMarked_ClaudeNoSentinelFallsBackToFirst covers the documented
+// Claude branch of defaultModelForList step 3: a Claude CLI reporting concrete models
+// but NO "default" sentinel (and no operator override) falls back to badging the first
+// model so the picker still shows a default.
+func TestWithDefaultModelMarked_ClaudeNoSentinelFallsBackToFirst(t *testing.T) {
+	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "")
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+	require.Equal(t, DefaultModelSentinel, DefaultModel(claude), "precondition: Claude's configured default is the sentinel")
+
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "opus", DisplayName: "Opus"},
+		{Id: "sonnet", DisplayName: "Sonnet"},
+	}
+	require.Nil(t, FindAvailableModel(models, DefaultModelSentinel), "precondition: no sentinel in the list")
+
+	got := withDefaultModelMarked(models, claude)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].GetIsDefault(), "no sentinel -> first concrete model badged")
+	assert.False(t, got[1].GetIsDefault())
+}
+
+// TestFirstAndMarkedModelID verifies the small id-extraction helpers tolerate nil
+// entries and return the right id (or "").
+func TestFirstAndMarkedModelID(t *testing.T) {
+	models := []*leapmuxv1.AvailableModel{
+		nil,
+		{Id: "a"},
+		{Id: "b", IsDefault: true},
+		nil,
+		{Id: "c", IsDefault: true},
+	}
+	assert.Equal(t, "a", firstModelID(models), "first non-nil id, skipping nils")
+	assert.Equal(t, "b", markedModelID(models), "first IsDefault id")
+
+	none := []*leapmuxv1.AvailableModel{nil, {Id: "x"}, {Id: "y"}}
+	assert.Equal(t, "", markedModelID(none), "no marked entry -> empty")
+	assert.Equal(t, "x", firstModelID(none))
+
+	assert.Equal(t, "", firstModelID([]*leapmuxv1.AvailableModel{nil, nil}), "all-nil -> empty, no panic")
+	assert.Equal(t, "", markedModelID(nil))
+	assert.Equal(t, "", firstModelID(nil))
+}

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -30,9 +30,14 @@ type OpenCodeAgent struct {
 func StartOpenCode(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, "opencode", []string{"OPENCODE_CLIENT"}, []string{"acp"}, nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:        opts.Shell,
+		LoginShell:   opts.LoginShell,
+		BinaryName:   "opencode",
+		StripEnvKeys: []string{"OPENCODE_CLIENT"},
+		BaseArgs:     []string{"acp"},
+		WorkingDir:   opts.WorkingDir,
+	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "OPENCODE_CLIENT")
 	if opts.LoginShell {

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -75,11 +75,13 @@ func StartPi(ctx context.Context, opts Options, sink OutputSink) (Agent, error) 
 	// Pi has no --working-dir flag (it uses the process cwd). buildShellWrappedCommand
 	// already sets cmd.Dir to opts.WorkingDir, so the agent picks up the right
 	// directory implicitly.
-	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(
-		ctx, opts.Shell, opts.LoginShell, binary, nil,
-		[]string{"--mode", "rpc"},
-		nil, opts.WorkingDir,
-	)
+	cmd, preambleDelimiter, metaPrefix := buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:      opts.Shell,
+		LoginShell: opts.LoginShell,
+		BinaryName: binary,
+		BaseArgs:   []string{"--mode", "rpc"},
+		WorkingDir: opts.WorkingDir,
+	})
 	cmd.Env = FinalizeAgentEnv(cmd.Environ(), opts)
 
 	stdin, stdout, stderrPipe, err := setupProcessPipes(cmd, cancel)

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -11,67 +11,84 @@ import (
 	"github.com/leapmux/leapmux/util/procutil"
 )
 
-// buildShellWrappedCommand constructs an exec.Cmd that launches a binary
-// inside the user's shell. When interactive is true, the shell is invoked
-// with interactive+login flags (e.g. -i -l -c) so that profile scripts
-// are sourced. When false, only -c is used (no profile sourcing).
-//
-// binaryName is the executable to invoke (e.g. "claude", "codex").
-// stripEnvKeys are removed by the shell wrapper before the binary is started.
-// baseArgs are always passed to the binary. modelEffortArgs (--model/--effort)
-// are conditionally included only when no third-party LLM provider env vars
-// are detected at shell runtime. When modelEffortArgs is empty, no conditional
-// logic is emitted.
+// shellWrapSpec describes how to wrap an agent binary launch inside the user's
+// login shell. Grouping the knobs as one value keeps the nine provider call sites
+// readable (named fields instead of a long positional tail like `..., nil, false,
+// dir`) and makes the next per-launch knob a new field rather than another argument
+// threaded through buildShellWrappedCommand and the three dialect builders.
+type shellWrapSpec struct {
+	Shell      string // the user's shell path (terminal.ShellBaseName picks the dialect)
+	LoginShell bool   // invoke the shell with interactive+login flags so profile scripts are sourced
+	BinaryName string // the executable to invoke (e.g. "claude", "codex")
+	// StripEnvKeys are removed by the shell wrapper before the binary is started.
+	StripEnvKeys []string
+	BaseArgs     []string // always passed to the binary
+	// ModelEffortArgs (--model/--effort) are included only when no third-party LLM
+	// provider env vars are detected at shell runtime.
+	ModelEffortArgs []string
+	// ProbeThirdParty forces the runtime third-party-provider probe (and its
+	// can_change_model_and_effort metadata line) to be emitted even when
+	// ModelEffortArgs is empty. Claude passes this so a default-model launch that
+	// sends no --model/--effort still detects a provider configured in the user's
+	// shell profile (which detectThirdPartyProvider, reading only the worker's own
+	// env, cannot see). Other providers pass false and keep the simple no-probe path.
+	ProbeThirdParty bool
+	WorkingDir      string // cmd.Dir for the launched process
+}
+
+// buildShellWrappedCommand constructs an exec.Cmd that launches spec.BinaryName
+// inside the user's shell. When spec.LoginShell is true, the shell is invoked with
+// interactive+login flags (e.g. -i -l -c) so that profile scripts are sourced. When
+// false, only -c is used (no profile sourcing). When both spec.ModelEffortArgs is
+// empty and spec.ProbeThirdParty is false, no conditional logic is emitted.
 //
 // It returns the command, a unique delimiter string, and a metadata line prefix.
 // The caller should scan stdout for lines starting with metaPrefix to extract
 // key=value metadata, then for the delimiter to detect the end of preamble.
-func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive bool,
-	binaryName string, stripEnvKeys, baseArgs []string, modelEffortArgs []string, workingDir string) (*exec.Cmd, string, string) {
-
+func buildShellWrappedCommand(ctx context.Context, spec shellWrapSpec) (*exec.Cmd, string, string) {
 	id := generateRequestID()
 	delimiter := "__LEAPMUX_READY_" + id + "__"
 	metaPrefix := ""
-	if len(modelEffortArgs) > 0 {
+	if len(spec.ModelEffortArgs) > 0 || spec.ProbeThirdParty {
 		metaPrefix = "__LEAPMUX_META_" + id + "__ "
 	}
-	shellName := terminal.ShellBaseName(shellPath)
+	shellName := terminal.ShellBaseName(spec.Shell)
 
 	var cmdArgs []string
 	switch {
 	case terminal.IsPwsh(shellName):
-		inner := buildPwshCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
-		if interactive {
-			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-Command", inner)
+		inner := buildPwshCommand(spec, delimiter, metaPrefix)
+		if spec.LoginShell {
+			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-Command", inner)
 		} else {
 			cmdArgs = []string{"-Command", inner}
 		}
 	case shellName == "tcsh" || shellName == "csh":
-		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
-		if interactive {
+		inner := buildPosixCommand(spec, delimiter, metaPrefix)
+		if spec.LoginShell {
 			cmdArgs = []string{"-ic", inner} // tcsh: -l must be the only flag
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
 	case shellName == "nu":
-		inner := buildNuCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
-		if interactive {
-			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-c", inner)
+		inner := buildNuCommand(spec, delimiter, metaPrefix)
+		if spec.LoginShell {
+			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-c", inner)
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
 	default:
 		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
-		inner := buildPosixCommand(binaryName, stripEnvKeys, delimiter, metaPrefix, baseArgs, modelEffortArgs)
-		if interactive {
-			cmdArgs = append(terminal.LoginShellArgs(shellPath), "-c", inner)
+		inner := buildPosixCommand(spec, delimiter, metaPrefix)
+		if spec.LoginShell {
+			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-c", inner)
 		} else {
 			cmdArgs = []string{"-c", inner}
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, shellPath, cmdArgs...)
-	cmd.Dir = workingDir
+	cmd := exec.CommandContext(ctx, spec.Shell, cmdArgs...)
+	cmd.Dir = spec.WorkingDir
 	envutil.ScrubAppImageEnv(cmd)
 	procutil.HideConsoleWindow(cmd)
 	return cmd, delimiter, metaPrefix
@@ -79,26 +96,30 @@ func buildShellWrappedCommand(ctx context.Context, shellPath string, interactive
 
 // buildPosixCommand builds the inner command string for POSIX-like shells.
 // The command is always prefixed with `exec` so the shell process is
-// replaced. When modelEffortArgs is non-empty, a conditional is emitted to
-// check for third-party provider env vars at runtime.
-func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
-	quotedBase := make([]string, len(baseArgs))
-	for i, arg := range baseArgs {
+// replaced. When metaPrefix is set, a conditional is emitted to check for
+// third-party provider env vars at runtime.
+func buildPosixCommand(spec shellWrapSpec, delimiter, metaPrefix string) string {
+	quotedBase := make([]string, len(spec.BaseArgs))
+	for i, arg := range spec.BaseArgs {
 		quotedBase[i] = posixQuote(arg)
 	}
 
 	baseArgsStr := strings.Join(quotedBase, " ")
-	clearEnvPrefix := posixClearEnv(stripEnvKeys)
+	clearEnvPrefix := posixClearEnv(spec.StripEnvKeys)
 
-	// Simple path: no model/effort args (third-party detected from settings).
-	if len(modelEffortArgs) == 0 {
+	// Simple path: no probe wanted (empty metaPrefix means neither model/effort
+	// args nor a forced third-party probe). When metaPrefix is set but
+	// ModelEffortArgs is empty (Claude's default-model launch), the conditional
+	// path below still runs: both branches exec the binary with no extra args,
+	// differing only in the can_change_model_and_effort line.
+	if metaPrefix == "" {
 		return fmt.Sprintf("%secho '%s' && exec %s %s",
-			clearEnvPrefix, delimiter, binaryName, baseArgsStr)
+			clearEnvPrefix, delimiter, spec.BinaryName, baseArgsStr)
 	}
 
 	// Conditional path: check env vars at runtime.
-	quotedME := make([]string, len(modelEffortArgs))
-	for i, arg := range modelEffortArgs {
+	quotedME := make([]string, len(spec.ModelEffortArgs))
+	for i, arg := range spec.ModelEffortArgs {
 		quotedME[i] = posixQuote(arg)
 	}
 	meArgsStr := strings.Join(quotedME, " ")
@@ -113,30 +134,30 @@ func buildPosixCommand(binaryName string, stripEnvKeys []string, delimiter, meta
 			"echo '%s' && exec %s %s %s; "+
 			"fi",
 		clearEnvPrefix,
-		metaPrefix, delimiter, binaryName, baseArgsStr,
-		metaPrefix, delimiter, binaryName, baseArgsStr, meArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr, meArgsStr,
 	)
 }
 
 // buildNuCommand builds the inner command string for Nushell.
-func buildNuCommand(binaryName string, stripEnvKeys []string, delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
-	quotedBase := make([]string, len(baseArgs))
-	for i, arg := range baseArgs {
+func buildNuCommand(spec shellWrapSpec, delimiter, metaPrefix string) string {
+	quotedBase := make([]string, len(spec.BaseArgs))
+	for i, arg := range spec.BaseArgs {
 		quotedBase[i] = nuQuote(arg)
 	}
 
 	baseArgsStr := strings.Join(quotedBase, " ")
-	clearEnvPrefix := nuClearEnv(stripEnvKeys)
+	clearEnvPrefix := nuClearEnv(spec.StripEnvKeys)
 
-	// Simple path: no model/effort args.
-	if len(modelEffortArgs) == 0 {
+	// Simple path: no probe wanted (empty metaPrefix). See buildPosixCommand.
+	if metaPrefix == "" {
 		return fmt.Sprintf("%secho '%s'; ^%s %s",
-			clearEnvPrefix, delimiter, binaryName, baseArgsStr)
+			clearEnvPrefix, delimiter, spec.BinaryName, baseArgsStr)
 	}
 
 	// Conditional path.
-	quotedME := make([]string, len(modelEffortArgs))
-	for i, arg := range modelEffortArgs {
+	quotedME := make([]string, len(spec.ModelEffortArgs))
+	for i, arg := range spec.ModelEffortArgs {
 		quotedME[i] = nuQuote(arg)
 	}
 	meArgsStr := strings.Join(quotedME, " ")
@@ -151,30 +172,30 @@ func buildNuCommand(binaryName string, stripEnvKeys []string, delimiter, metaPre
 			"echo '%s'; ^%s %s %s "+
 			"}",
 		clearEnvPrefix,
-		metaPrefix, delimiter, binaryName, baseArgsStr,
-		metaPrefix, delimiter, binaryName, baseArgsStr, meArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr, meArgsStr,
 	)
 }
 
 // buildPwshCommand builds the inner command string for PowerShell.
-func buildPwshCommand(binaryName string, stripEnvKeys []string, delimiter, metaPrefix string, baseArgs, modelEffortArgs []string) string {
-	quotedBase := make([]string, len(baseArgs))
-	for i, arg := range baseArgs {
+func buildPwshCommand(spec shellWrapSpec, delimiter, metaPrefix string) string {
+	quotedBase := make([]string, len(spec.BaseArgs))
+	for i, arg := range spec.BaseArgs {
 		quotedBase[i] = pwshQuote(arg)
 	}
 
 	baseArgsStr := strings.Join(quotedBase, " ")
-	clearEnvPrefix := pwshClearEnv(stripEnvKeys)
+	clearEnvPrefix := pwshClearEnv(spec.StripEnvKeys)
 
-	// Simple path: no model/effort args.
-	if len(modelEffortArgs) == 0 {
+	// Simple path: no probe wanted (empty metaPrefix). See buildPosixCommand.
+	if metaPrefix == "" {
 		return fmt.Sprintf("%sWrite-Output '%s'; & %s %s",
-			clearEnvPrefix, delimiter, binaryName, baseArgsStr)
+			clearEnvPrefix, delimiter, spec.BinaryName, baseArgsStr)
 	}
 
 	// Conditional path.
-	quotedME := make([]string, len(modelEffortArgs))
-	for i, arg := range modelEffortArgs {
+	quotedME := make([]string, len(spec.ModelEffortArgs))
+	for i, arg := range spec.ModelEffortArgs {
 		quotedME[i] = pwshQuote(arg)
 	}
 	meArgsStr := strings.Join(quotedME, " ")
@@ -189,8 +210,8 @@ func buildPwshCommand(binaryName string, stripEnvKeys []string, delimiter, metaP
 			"Write-Output '%s'; & %s %s %s "+
 			"}",
 		clearEnvPrefix,
-		metaPrefix, delimiter, binaryName, baseArgsStr,
-		metaPrefix, delimiter, binaryName, baseArgsStr, meArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr,
+		metaPrefix, delimiter, spec.BinaryName, baseArgsStr, meArgsStr,
 	)
 }
 

--- a/backend/internal/worker/agent/shell_test.go
+++ b/backend/internal/worker/agent/shell_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -10,10 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// wrapShellCmd is a positional adapter over buildShellWrappedCommand(ctx,
+// shellWrapSpec) for the table-style tests below, which predate the struct and
+// vary mostly by shell path. It names the positional arguments in one place so the
+// tests stay compact; production call sites use the shellWrapSpec literal directly.
+func wrapShellCmd(ctx context.Context, shell string, loginShell bool, binaryName string,
+	stripEnvKeys, baseArgs, modelEffortArgs []string, probeThirdParty bool, workingDir string) (*exec.Cmd, string, string) {
+	return buildShellWrappedCommand(ctx, shellWrapSpec{
+		Shell:           shell,
+		LoginShell:      loginShell,
+		BinaryName:      binaryName,
+		StripEnvKeys:    stripEnvKeys,
+		BaseArgs:        baseArgs,
+		ModelEffortArgs: modelEffortArgs,
+		ProbeThirdParty: probeThirdParty,
+		WorkingDir:      workingDir,
+	})
+}
+
 func TestBuildShellWrappedCommand_Bash_Interactive(t *testing.T) {
-	cmd, delimiter, metaPrefix := buildShellWrappedCommand(
+	cmd, delimiter, metaPrefix := wrapShellCmd(
 		context.Background(), "/bin/bash", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	require.NotEmpty(t, delimiter)
 	assert.True(t, strings.HasPrefix(delimiter, "__LEAPMUX_READY_"))
@@ -41,9 +60,9 @@ func TestBuildShellWrappedCommand_Bash_Interactive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Bash_NonInteractive(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/bin/bash", false, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/bin/bash", cmd.Path)
 	require.Len(t, cmd.Args, 3) // bash -c <cmd>
@@ -52,9 +71,9 @@ func TestBuildShellWrappedCommand_Bash_NonInteractive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Zsh(t *testing.T) {
-	cmd, delimiter, _ := buildShellWrappedCommand(
+	cmd, delimiter, _ := wrapShellCmd(
 		context.Background(), "/bin/zsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "sonnet"}, "/home/user",
+		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "sonnet"}, false, "/home/user",
 	)
 	assert.Equal(t, "/bin/zsh", cmd.Path)
 	require.Len(t, cmd.Args, 5) // zsh -i -l -c <cmd>
@@ -67,9 +86,9 @@ func TestBuildShellWrappedCommand_Zsh(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Fish(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/fish", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--model", "sonnet"}, []string{}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--model", "sonnet"}, []string{}, false, "/tmp",
 	)
 	assert.Equal(t, "/usr/bin/fish", cmd.Path)
 	require.Len(t, cmd.Args, 5) // fish -i -l -c <cmd>
@@ -83,9 +102,9 @@ func TestBuildShellWrappedCommand_Fish(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Tcsh_Interactive(t *testing.T) {
-	cmd, delimiter, _ := buildShellWrappedCommand(
+	cmd, delimiter, _ := wrapShellCmd(
 		context.Background(), "/bin/tcsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/bin/tcsh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // tcsh -ic <cmd>
@@ -96,9 +115,9 @@ func TestBuildShellWrappedCommand_Tcsh_Interactive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Tcsh_NonInteractive(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/bin/tcsh", false, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/bin/tcsh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // tcsh -c <cmd>
@@ -106,9 +125,9 @@ func TestBuildShellWrappedCommand_Tcsh_NonInteractive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Csh(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/bin/csh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/bin/csh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // csh -ic <cmd>
@@ -118,9 +137,9 @@ func TestBuildShellWrappedCommand_Csh(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Nu_Interactive(t *testing.T) {
-	cmd, delimiter, _ := buildShellWrappedCommand(
+	cmd, delimiter, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/nu", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/usr/bin/nu", cmd.Path)
 	require.Len(t, cmd.Args, 5) // nu -i -l -c <cmd>
@@ -140,18 +159,21 @@ func TestBuildShellWrappedCommand_Nu_Interactive(t *testing.T) {
 }
 
 func TestBuildNuCommand_SingleQuoteInArgs(t *testing.T) {
-	inner := buildNuCommand("claude", []string{"CLAUDECODE"}, "__DELIM__", "__META__ ",
-		[]string{"--output-format", "stream-json"},
-		[]string{"--model", "it's-a-model"})
+	inner := buildNuCommand(shellWrapSpec{
+		BinaryName:      "claude",
+		StripEnvKeys:    []string{"CLAUDECODE"},
+		BaseArgs:        []string{"--output-format", "stream-json"},
+		ModelEffortArgs: []string{"--model", "it's-a-model"},
+	}, "__DELIM__", "__META__ ")
 	// Single quotes in args must be safely double-quoted, not POSIX-quoted.
 	assert.Contains(t, inner, `"it's-a-model"`)
 	assert.NotContains(t, inner, `'\''`)
 }
 
 func TestBuildShellWrappedCommand_Nu_NonInteractive(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/nu", false, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/usr/bin/nu", cmd.Path)
 	require.Len(t, cmd.Args, 3) // nu -c <cmd>
@@ -161,9 +183,9 @@ func TestBuildShellWrappedCommand_Nu_NonInteractive(t *testing.T) {
 func TestBuildShellWrappedCommand_PwshCore_Interactive(t *testing.T) {
 	for _, shell := range []string{"/usr/bin/pwsh", "/usr/bin/pwsh-preview"} {
 		t.Run(shell, func(t *testing.T) {
-			cmd, delimiter, _ := buildShellWrappedCommand(
+			cmd, delimiter, _ := wrapShellCmd(
 				context.Background(), shell, true, "claude",
-				[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+				[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 			)
 			assert.Equal(t, shell, cmd.Path)
 			require.Len(t, cmd.Args, 4) // pwsh -Login -Command <cmd>
@@ -186,9 +208,9 @@ func TestBuildShellWrappedCommand_PwshCore_Interactive(t *testing.T) {
 func TestBuildShellWrappedCommand_WindowsPowerShell_Interactive(t *testing.T) {
 	for _, shell := range []string{"/usr/bin/powershell", "/usr/bin/powershell-preview"} {
 		t.Run(shell, func(t *testing.T) {
-			cmd, delimiter, _ := buildShellWrappedCommand(
+			cmd, delimiter, _ := wrapShellCmd(
 				context.Background(), shell, true, "claude",
-				[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+				[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 			)
 			assert.Equal(t, shell, cmd.Path)
 			require.Len(t, cmd.Args, 3) // powershell -Command <cmd>
@@ -203,9 +225,9 @@ func TestBuildShellWrappedCommand_WindowsPowerShell_Interactive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_Pwsh_NonInteractive(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/pwsh", false, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/usr/bin/pwsh", cmd.Path)
 	require.Len(t, cmd.Args, 3) // pwsh -Command <cmd>
@@ -213,9 +235,9 @@ func TestBuildShellWrappedCommand_Pwsh_NonInteractive(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_UnknownShell(t *testing.T) {
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/xonsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "opus"}, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--verbose"}, []string{"--model", "opus"}, false, "/tmp",
 	)
 	assert.Equal(t, "/usr/bin/xonsh", cmd.Path)
 	require.Len(t, cmd.Args, 5) // defaults to -i -l -c
@@ -242,9 +264,9 @@ func TestBuildShellWrappedCommand_AppImage_ScrubsEnv(t *testing.T) {
 	t.Setenv("OWD", "/home/user")
 	t.Setenv("PATH_SHOULD_SURVIVE", "/usr/bin:/bin")
 
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/bin/zsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, false, "/tmp",
 	)
 
 	// Shell invocation itself must not change — the bug is in the env,
@@ -279,9 +301,9 @@ func TestBuildShellWrappedCommand_NoAppImage_PreservesEnv(t *testing.T) {
 	t.Setenv("APPIMAGE", "")
 	t.Setenv("ARGV0", "should-survive-when-not-in-appimage")
 
-	cmd, _, _ := buildShellWrappedCommand(
+	cmd, _, _ := wrapShellCmd(
 		context.Background(), "/bin/zsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, false, "/tmp",
 	)
 
 	assert.Equal(t, "/bin/zsh", cmd.Path)
@@ -294,9 +316,9 @@ func TestBuildShellWrappedCommand_NoAppImage_PreservesEnv(t *testing.T) {
 func TestBuildShellWrappedCommand_NoModelEffort(t *testing.T) {
 	// When third-party provider was detected from settings, modelEffortArgs is nil.
 	// No conditional logic should be generated.
-	cmd, _, metaPrefix := buildShellWrappedCommand(
+	cmd, _, metaPrefix := wrapShellCmd(
 		context.Background(), "/bin/bash", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, false, "/tmp",
 	)
 	assert.Empty(t, metaPrefix)
 	assert.Contains(t, cmd.Args[4], "'--output-format'")
@@ -306,25 +328,79 @@ func TestBuildShellWrappedCommand_NoModelEffort(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_NoModelEffort_Nu(t *testing.T) {
-	cmd, _, metaPrefix := buildShellWrappedCommand(
+	cmd, _, metaPrefix := wrapShellCmd(
 		context.Background(), "/usr/bin/nu", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, false, "/tmp",
 	)
 	assert.Empty(t, metaPrefix)
 	assert.NotContains(t, cmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
 }
 
 func TestBuildShellWrappedCommand_NoModelEffort_Pwsh(t *testing.T) {
-	cmd, _, metaPrefix := buildShellWrappedCommand(
+	cmd, _, metaPrefix := wrapShellCmd(
 		context.Background(), "/usr/bin/pwsh", true, "claude",
-		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, "/tmp",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, false, "/tmp",
 	)
 	assert.Empty(t, metaPrefix)
 	assert.NotContains(t, cmd.Args[3], "CLAUDE_CODE_USE_BEDROCK")
 }
 
+// TestBuildShellWrappedCommand_ProbeThirdPartyDefaultModel covers the
+// account-default ("sentinel") launch path: Claude sends no --model/--effort
+// (nil modelEffortArgs) but passes probeThirdParty=true so the runtime
+// third-party probe still fires. Without it, a Bedrock/Vertex/Foundry provider
+// configured only in the user's shell profile would go undetected on the default
+// tab and AvailableModels would wrongly show the model/effort UI.
+func TestBuildShellWrappedCommand_ProbeThirdPartyDefaultModel(t *testing.T) {
+	cmd, _, metaPrefix := wrapShellCmd(
+		context.Background(), "/bin/bash", true, "claude",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, true, "/tmp",
+	)
+	require.NotEmpty(t, metaPrefix, "probe forces a metadata prefix even with no model/effort args")
+	inner := cmd.Args[4]
+	// The probe and both capability lines are emitted.
+	assert.Contains(t, inner, "CLAUDE_CODE_USE_BEDROCK")
+	assert.Contains(t, inner, metaPrefix+"can_change_model_and_effort=false")
+	assert.Contains(t, inner, metaPrefix+"can_change_model_and_effort=true")
+	// But neither branch forwards a --model/--effort, since there are none.
+	assert.NotContains(t, inner, "'--model'")
+	assert.NotContains(t, inner, "'--effort'")
+	// Both branches still exec claude with the base args.
+	parts := strings.SplitN(inner, "else", 2)
+	require.Len(t, parts, 2, "expected if/else probe structure")
+	assert.Contains(t, parts[0], "exec claude")
+	assert.Contains(t, parts[1], "exec claude")
+}
+
+// TestBuildShellWrappedCommand_ProbeThirdPartyDefaultModel_NuAndPwsh checks the
+// same forced-probe behavior in the other two shell dialects.
+func TestBuildShellWrappedCommand_ProbeThirdPartyDefaultModel_NuAndPwsh(t *testing.T) {
+	nuCmd, _, nuMeta := wrapShellCmd(
+		context.Background(), "/usr/bin/nu", true, "claude",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, true, "/tmp",
+	)
+	require.NotEmpty(t, nuMeta)
+	assert.Contains(t, nuCmd.Args[4], "CLAUDE_CODE_USE_BEDROCK")
+	assert.Contains(t, nuCmd.Args[4], nuMeta+"can_change_model_and_effort=true")
+	assert.NotContains(t, nuCmd.Args[4], `"--model"`)
+
+	pwshCmd, _, pwshMeta := wrapShellCmd(
+		context.Background(), "/usr/bin/pwsh", true, "claude",
+		[]string{"CLAUDECODE"}, []string{"--output-format", "stream-json"}, nil, true, "/tmp",
+	)
+	require.NotEmpty(t, pwshMeta)
+	assert.Contains(t, pwshCmd.Args[3], "CLAUDE_CODE_USE_BEDROCK")
+	assert.Contains(t, pwshCmd.Args[3], pwshMeta+"can_change_model_and_effort=true")
+	assert.NotContains(t, pwshCmd.Args[3], "'--model'")
+}
+
 func TestBuildShellWrappedCommand_ModelEffortInElseBranch(t *testing.T) {
-	inner := buildPosixCommand("claude", []string{"CLAUDECODE"}, "__DELIM__", "__META__ ", []string{"--output-format", "stream-json"}, []string{"--model", "opus", "--effort", "high"})
+	inner := buildPosixCommand(shellWrapSpec{
+		BinaryName:      "claude",
+		StripEnvKeys:    []string{"CLAUDECODE"},
+		BaseArgs:        []string{"--output-format", "stream-json"},
+		ModelEffortArgs: []string{"--model", "opus", "--effort", "high"},
+	}, "__DELIM__", "__META__ ")
 
 	// The else branch should contain model/effort args
 	parts := strings.SplitN(inner, "else", 2)
@@ -340,9 +416,9 @@ func TestBuildShellWrappedCommand_ModelEffortInElseBranch(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_CodexUsesCodexEnvMarkers(t *testing.T) {
-	cmd, delimiter, metaPrefix := buildShellWrappedCommand(
+	cmd, delimiter, metaPrefix := wrapShellCmd(
 		context.Background(), "/bin/zsh", true, "codex",
-		[]string{"CODEX_CI"}, []string{"app-server"}, nil, "/tmp",
+		[]string{"CODEX_CI"}, []string{"app-server"}, nil, false, "/tmp",
 	)
 	assert.Empty(t, metaPrefix)
 	assert.Contains(t, cmd.Args[4], "unset CODEX_CI")
@@ -352,16 +428,16 @@ func TestBuildShellWrappedCommand_CodexUsesCodexEnvMarkers(t *testing.T) {
 }
 
 func TestBuildShellWrappedCommand_CodexUsesCodexEnvMarkers_NuAndPwsh(t *testing.T) {
-	nuCmd, _, _ := buildShellWrappedCommand(
+	nuCmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/nu", true, "codex",
-		[]string{"CODEX_CI"}, []string{"app-server"}, nil, "/tmp",
+		[]string{"CODEX_CI"}, []string{"app-server"}, nil, false, "/tmp",
 	)
 	assert.Contains(t, nuCmd.Args[4], "hide-env CODEX_CI")
 	assert.NotContains(t, nuCmd.Args[4], "CLAUDECODE")
 
-	pwshCmd, _, _ := buildShellWrappedCommand(
+	pwshCmd, _, _ := wrapShellCmd(
 		context.Background(), "/usr/bin/pwsh", true, "codex",
-		[]string{"CODEX_CI"}, []string{"app-server"}, nil, "/tmp",
+		[]string{"CODEX_CI"}, []string{"app-server"}, nil, false, "/tmp",
 	)
 	assert.Contains(t, pwshCmd.Args[3], "Remove-Item Env:CODEX_CI")
 	assert.NotContains(t, pwshCmd.Args[3], "CLAUDECODE")
@@ -503,10 +579,45 @@ func TestBuildModelEffortArgs(t *testing.T) {
 			effort:   "ultracode",
 			expected: []string{"--model", "claude-future-preview", "--effort", "high"},
 		},
+		{
+			// The "default" sentinel omits --model so the CLI resolves the
+			// account's own default model; auto effort omits --effort too.
+			name:     "default sentinel omits --model entirely",
+			model:    "default",
+			effort:   "auto",
+			expected: nil,
+		},
+		{
+			// The sentinel omits --effort even for an explicit effort: the
+			// resolved default model's own default effort is used, so we never
+			// push a concrete --effort the resolved model may not support.
+			name:     "default sentinel omits --effort even when explicit",
+			model:    "default",
+			effort:   "high",
+			expected: nil,
+		},
+		{
+			// S4: an empty model sends no --model (CLI picks the account default)
+			// and, like the sentinel, omits --effort even for an explicit level.
+			name:     "empty model omits both --model and --effort",
+			model:    "",
+			effort:   "high",
+			expected: nil,
+		},
+		{
+			// An empty model with ultracode also omits both flags: launchOmitsEffort
+			// short-circuits on model=="" before launchRunsUltracode could call
+			// supportsUltracode(""), so the planLaunch omit-check ordering -- not a
+			// model lookup -- is what keeps a stray --effort off an empty-model launch.
+			name:     "empty model with ultracode omits both flags",
+			model:    "",
+			effort:   "ultracode",
+			expected: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := buildModelEffortArgs(tt.model, tt.effort)
+			args := newEffortResolver(claudeCodeAvailableModels).buildModelEffortArgs(tt.model, tt.effort)
 			assert.Equal(t, tt.expected, args)
 		})
 	}

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -764,6 +764,15 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// restart, where no running agent confirmed anything.
 		notifyEffort := newEffort
 
+		// Likewise report the model the session actually settled on, not the
+		// request. Selecting the account-default sentinel ("default") launches
+		// without --model; the CLI resolves a concrete model, which is what we
+		// persist (confirmedAgentSettings) and broadcast -- so the notification
+		// must name that concrete model, not "default" (and shows no change when
+		// the default resolves back to the model already in use). Defaults to the
+		// requested value for an offline edit or a failed restart.
+		notifyModel := newModel
+
 		// If the agent is currently running, try a live update first.
 		// Providers apply what they can without a restart (Codex applies to
 		// the next turn; Claude Code applies model/effort/permission changes
@@ -772,13 +781,13 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// back to auto, which needs a relaunch without --effort -- and we then
 		// fall back to stop+restart.
 		if svc.Agents.HasAgent(agentID) {
-			// Hold the per-agent lifecycle lock across the live update and the
-			// confirmed-effort readback so a concurrent UpdateAgentSettings for
-			// the same agent can't land between them and make us report its
-			// effort instead of ours. The live update writes the confirmed
-			// effort into the agent's in-memory state synchronously
-			// (refreshSettingsFromAgent), so reading it back while still holding
-			// the lock yields exactly the value this update confirmed.
+			// Hold the per-agent lifecycle lock across the live update, the
+			// confirmed-settings readback, AND the corrective DB write below so a
+			// concurrent UpdateAgentSettings for the same agent can't land between
+			// them and make us report its effort instead of ours. The live update
+			// writes the confirmed effort into the agent's in-memory state
+			// synchronously (refreshSettingsFromAgent), so reading it back while
+			// still holding the lock yields exactly the value this update confirmed.
 			// RestartAgent takes this same (non-reentrant) lock itself, so the
 			// restart path runs outside this section and reports the confirmed
 			// settings it returns directly.
@@ -790,8 +799,35 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 				ExtraSettings:  newExtraSettings,
 			})
 			if updated {
-				if confirmed := svc.Agents.CurrentSettings(agentID); confirmed != nil && confirmed.GetEffort() != "" {
-					notifyEffort = confirmed.GetEffort()
+				notifyModel, notifyEffort = confirmedOrDefault(svc.Agents.CurrentSettings(agentID), notifyModel, notifyEffort)
+
+				// If the live update settled on a different model than requested (e.g. a
+				// provider that re-spells the model id on echo), persist the settled
+				// model AND effort so the DB row -- and the AgentInfo broadcast built from
+				// it -- agree with the settings_changed notification below. The optimistic
+				// write above stored newModel/newEffort; correct both to the confirmed
+				// values. Effort must be the confirmed level, not the requested one: the
+				// live update already wrote the confirmed effort to the DB via
+				// PersistSettingsRefresh, and the notification reports notifyEffort, so
+				// re-storing the requested newEffort here would clobber that with a value
+				// the session isn't running (e.g. an unentitled ultracode request that
+				// landed on xhigh), splitting the DB from the broadcast/notification.
+				//
+				// This write stays INSIDE the lifecycle lock (with the readback above),
+				// not after unlock: two concurrent UpdateAgentSettings for the same agent
+				// each confirm their own settled model/effort, so the corrective writes
+				// must serialize with the in-memory confirmation. Done after unlock they
+				// could reorder -- the earlier update's stale row landing last -- and leave
+				// the DB disagreeing with both the agent's running state and the
+				// broadcast/notification, the very split this lock exists to prevent.
+				if notifyModel != newModel {
+					if err := svc.Queries.UpdateAgentModelAndEffort(bgCtx(), db.UpdateAgentModelAndEffortParams{
+						Model:  notifyModel,
+						Effort: notifyEffort,
+						ID:     agentID,
+					}); err != nil {
+						slog.Warn("failed to persist settled model after live update", "agent_id", agentID, "error", err)
+					}
 				}
 			}
 			unlock()
@@ -835,9 +871,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 					if _, err := svc.persistConfirmedAgentSettings(agentID, dbAgent.AgentProvider, newModel, newEffort, newPermissionMode, newExtraSettings, confirmedSettings); err != nil {
 						slog.Warn("failed to persist confirmed settings after restart", "agent_id", agentID, "error", err)
 					}
-					if confirmedSettings != nil && confirmedSettings.GetEffort() != "" {
-						notifyEffort = confirmedSettings.GetEffort()
-					}
+					notifyModel, notifyEffort = confirmedOrDefault(confirmedSettings, notifyModel, notifyEffort)
 					slog.Info("agent restarted with new settings",
 						"agent_id", agentID, "model", newModel, "effort", newEffort)
 				}
@@ -845,41 +879,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		}
 
 		// Broadcast settings_changed notification for the chat view.
-		// Include display labels so the frontend can show human-readable names
-		// without maintaining its own label maps.
-		modelLabel, effortLabel := svc.settingsDisplayLabels(agentID, dbAgent.AgentProvider)
-		changes := map[string]interface{}{}
-		if dbAgent.Model != newModel {
-			oldID := modelOrDefault(dbAgent.Model, dbAgent.AgentProvider)
-			changes["model"] = map[string]string{
-				"old": oldID, "new": newModel,
-				"oldLabel": modelLabel(oldID), "newLabel": modelLabel(newModel),
-			}
-		}
-		if dbAgent.Effort != notifyEffort {
-			oldID := effortOrDefault(dbAgent.Effort, dbAgent.AgentProvider)
-			changes["effort"] = map[string]string{
-				"old": oldID, "new": notifyEffort,
-				"oldLabel": effortLabel(oldID), "newLabel": effortLabel(notifyEffort),
-			}
-		}
-		if dbAgent.PermissionMode != newPermissionMode {
-			changes[agent.OptionGroupKeyPermissionMode] = map[string]string{
-				"old": dbAgent.PermissionMode, "new": newPermissionMode,
-				"oldLabel": svc.permissionModeLabel(agentID, dbAgent.PermissionMode, dbAgent.AgentProvider), "newLabel": svc.permissionModeLabel(agentID, newPermissionMode, dbAgent.AgentProvider),
-			}
-		}
-		for _, key := range sortedExtraSettingKeys(oldExtraSettings, newExtraSettings) {
-			oldVal, newVal := oldExtraSettings[key], newExtraSettings[key]
-			if oldVal != newVal {
-				changes[key] = map[string]string{
-					"old": oldVal, "new": newVal,
-					"label":    svc.optionGroupLabel(agentID, key, dbAgent.AgentProvider),
-					"oldLabel": svc.optionLabel(agentID, key, oldVal, dbAgent.AgentProvider),
-					"newLabel": svc.optionLabel(agentID, key, newVal, dbAgent.AgentProvider),
-				}
-			}
-		}
+		changes := svc.buildSettingsChanges(&dbAgent, notifyModel, notifyEffort, newPermissionMode, oldExtraSettings, newExtraSettings)
 		if len(changes) > 0 {
 			svc.Output.PersistLeapMuxNotification(agentID, dbAgent.AgentProvider, map[string]interface{}{
 				"type":    agent.NotificationTypeSettingsChanged,
@@ -1914,6 +1914,106 @@ func confirmedAgentSettings(provider leapmuxv1.AgentProvider, model, effort, per
 		permissionMode: confirmedPermissionMode,
 		extraSettings:  confirmedExtraSettings,
 	}
+}
+
+// reportModelChange decides whether the settings_changed notification should carry
+// a model change: true when the prior stored model (oldModel) and the model the
+// session settled on (settledModel) differ after normalizing into the provider's
+// alias space, so a model that merely re-spelled (e.g. stored "claude-opus-4-8" vs
+// settled "opus" on an effort-only edit) is NOT reported as a change.
+//
+// The account-default sentinel resolving to its concrete model ("default" ->
+// "sonnet") IS reported: it is a real, user-visible transition that the settings
+// panel (built from the same settled model in AgentInfo) shows too, so chat and
+// panel agree. This deliberately also announces the resolution on a new tab's first
+// edit -- there is no signal distinguishing that from a session that was stuck on an
+// unresolved "default" and only now resolved (the stuck resolution is itself a first
+// resolution), and announcing the concrete model is informative rather than noise. A
+// sentinel that has NOT resolved stays "default" on both sides and so compares equal
+// -- no spurious change.
+func reportModelChange(provider leapmuxv1.AgentProvider, oldModel, settledModel string) bool {
+	return agent.NormalizeModelID(provider, oldModel) != agent.NormalizeModelID(provider, settledModel)
+}
+
+// settingsChangeEntry builds the {old,new,oldLabel,newLabel} map a settings_changed
+// notification carries for one changed field, resolving both labels through label.
+// Shared by the model/effort/permission-mode entries so their shape stays identical.
+func settingsChangeEntry(oldID, newID string, label func(string) string) map[string]string {
+	return map[string]string{
+		"old": oldID, "new": newID,
+		"oldLabel": label(oldID), "newLabel": label(newID),
+	}
+}
+
+// optionGroupChangeEntry builds the settings_changed entry for an extra-settings
+// option group: the standard {old,new,oldLabel,newLabel} shape from
+// settingsChangeEntry plus a "label" key naming the group. Encapsulating the extra
+// key here keeps callers from reaching into settingsChangeEntry's result to mutate
+// the shared shape post-construction. valueLabel resolves the option value labels;
+// groupLabel is the human-readable group name (e.g. "Output Style").
+func optionGroupChangeEntry(oldID, newID string, valueLabel func(string) string, groupLabel string) map[string]string {
+	entry := settingsChangeEntry(oldID, newID, valueLabel)
+	entry["label"] = groupLabel
+	return entry
+}
+
+// buildSettingsChanges assembles the settings_changed "changes" map for the chat view:
+// one {old,new,oldLabel,newLabel} entry per field that actually changed between the
+// stored row (dbAgent) and the settled values (notifyModel/notifyEffort/
+// newPermissionMode plus the extra-settings maps). Display labels are resolved here so
+// the frontend needs no label maps of its own. Returns an empty map when nothing
+// changed. Extracted from the UpdateAgentSettings handler so the field-diff lives in one
+// named, testable place instead of inline in the RPC body.
+func (svc *Context) buildSettingsChanges(
+	dbAgent *db.Agent,
+	notifyModel, notifyEffort, newPermissionMode string,
+	oldExtraSettings, newExtraSettings map[string]string,
+) map[string]interface{} {
+	agentID, provider := dbAgent.ID, dbAgent.AgentProvider
+	modelLabel, effortLabel := svc.settingsDisplayLabels(agentID, provider)
+	changes := map[string]interface{}{}
+	if reportModelChange(provider, dbAgent.Model, notifyModel) {
+		changes["model"] = settingsChangeEntry(modelOrDefault(dbAgent.Model, provider), notifyModel, modelLabel)
+	}
+	if dbAgent.Effort != notifyEffort {
+		changes["effort"] = settingsChangeEntry(effortOrDefault(dbAgent.Effort, provider), notifyEffort, effortLabel)
+	}
+	if dbAgent.PermissionMode != newPermissionMode {
+		changes[agent.OptionGroupKeyPermissionMode] = settingsChangeEntry(
+			dbAgent.PermissionMode, newPermissionMode,
+			func(m string) string { return svc.permissionModeLabel(agentID, m, provider) },
+		)
+	}
+	for _, key := range sortedExtraSettingKeys(oldExtraSettings, newExtraSettings) {
+		oldVal, newVal := oldExtraSettings[key], newExtraSettings[key]
+		if oldVal != newVal {
+			changes[key] = optionGroupChangeEntry(
+				oldVal, newVal,
+				func(v string) string { return svc.optionLabel(agentID, key, v, provider) },
+				svc.optionGroupLabel(agentID, key, provider),
+			)
+		}
+	}
+	return changes
+}
+
+// confirmedOrDefault resolves the model/effort to report in the settings_changed
+// notification: the values the session actually confirmed (e.g. the concrete model
+// the account-default sentinel resolved to, or the level Claude Code clamped an
+// effort down to), falling back to the requested model/effort when the confirmed
+// settings are nil (offline edit / failed restart) or omit a field. The live-update
+// and restart paths share it so they report the settled values identically.
+func confirmedOrDefault(confirmed *leapmuxv1.AgentSettings, model, effort string) (string, string) {
+	if confirmed == nil {
+		return model, effort
+	}
+	if m := confirmed.GetModel(); m != "" {
+		model = m
+	}
+	if e := confirmed.GetEffort(); e != "" {
+		effort = e
+	}
+	return model, effort
 }
 
 // persistConfirmedAgentSettings writes the confirmed request settings

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -464,6 +464,53 @@ func TestPersistConfirmedAgentSettings_PersistsAvailableModelsAndGroups(t *testi
 	assert.Len(t, parsedGroups[0].GetOptions(), 2)
 }
 
+// TestMarshalAvailableModels_StripsDerivedDefaultBadge covers S6: the IsDefault badge is
+// derived from the LEAPMUX_*_DEFAULT_MODEL override (re-applied on every read by the
+// manager), so persisting it would store a value that goes stale when the override
+// changes. marshalAvailableModels strips it, and must not mutate the shared catalog
+// pointer it strips from.
+func TestMarshalAvailableModels_StripsDerivedDefaultBadge(t *testing.T) {
+	badged := &leapmuxv1.AvailableModel{Id: "opus[1m]", DisplayName: "Opus (1M)", IsDefault: true}
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "sonnet", DisplayName: "Sonnet"},
+		badged,
+	}
+
+	parsed := unmarshalAvailableModels(marshalAvailableModels(models))
+	require.Len(t, parsed, 2)
+	for _, m := range parsed {
+		assert.False(t, m.GetIsDefault(), "persisted %q must carry no default badge", m.GetId())
+	}
+	assert.Equal(t, "opus[1m]", parsed[1].GetId(), "intrinsic fields survive the strip")
+
+	// The shared, immutable catalog pointer must not be mutated in place by the strip.
+	assert.True(t, badged.IsDefault, "marshaling must not clear IsDefault on the shared input entry")
+}
+
+// TestStripDefaultModelBadge_DropsNilEntries guards that a nil catalog entry is
+// dropped rather than passed through to protojson (which would persist it as a
+// hollow "{}"), matching the nil-as-absent convention the rest of the catalog
+// plumbing uses.
+func TestStripDefaultModelBadge_DropsNilEntries(t *testing.T) {
+	models := []*leapmuxv1.AvailableModel{
+		{Id: "sonnet", DisplayName: "Sonnet"},
+		nil,
+		{Id: "opus[1m]", DisplayName: "Opus (1M)", IsDefault: true},
+	}
+
+	stripped := stripDefaultModelBadge(models)
+	require.Len(t, stripped, 2, "the nil entry is dropped")
+	for _, m := range stripped {
+		require.NotNil(t, m)
+		assert.False(t, m.GetIsDefault(), "the badge is cleared on the surviving entries")
+	}
+
+	// End to end: the persisted round-trip carries no hollow entry.
+	parsed := unmarshalAvailableModels(marshalAvailableModels(models))
+	require.Len(t, parsed, 2)
+	assert.Equal(t, []string{"sonnet", "opus[1m]"}, []string{parsed[0].GetId(), parsed[1].GetId()})
+}
+
 func TestUpdateAgentSettings_BroadcastsGeminiPermissionModeLabels(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
@@ -570,4 +617,73 @@ func TestSendAgentRawMessage_SetPermissionModePersistsToDBWhileRunning(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, "bypassPermissions", dbAgent.PermissionMode,
 		"permission mode should be persisted to DB when set_permission_mode is sent while agent is running")
+}
+
+// TestConfirmedOrDefault verifies the settings_changed notification resolves the
+// model/effort the session actually settled on, falling back to the requested
+// values when the confirmed settings are nil or omit a field. Both the
+// live-update and restart branches share this helper.
+func TestConfirmedOrDefault(t *testing.T) {
+	// nil confirmed settings -> requested values unchanged (offline edit / failed restart).
+	model, effort := confirmedOrDefault(nil, "default", "auto")
+	assert.Equal(t, "default", model)
+	assert.Equal(t, "auto", effort)
+
+	// Both fields confirmed -> both override (sentinel resolved to a concrete model;
+	// effort clamped to a concrete level).
+	model, effort = confirmedOrDefault(&leapmuxv1.AgentSettings{Model: "sonnet", Effort: "high"}, "default", "auto")
+	assert.Equal(t, "sonnet", model)
+	assert.Equal(t, "high", effort)
+
+	// Empty fields in confirmed settings don't clobber the requested values.
+	model, effort = confirmedOrDefault(&leapmuxv1.AgentSettings{Model: "", Effort: "max"}, "opus[1m]", "auto")
+	assert.Equal(t, "opus[1m]", model, "empty confirmed model keeps the requested model")
+	assert.Equal(t, "max", effort)
+
+	// The common live case: the session confirms the requested model unchanged, so the
+	// returned model equals the request -- which keeps the notifyModel != newModel
+	// guard (gating the corrective UpdateAgentModelAndEffort write) from firing.
+	model, effort = confirmedOrDefault(&leapmuxv1.AgentSettings{Model: "opus", Effort: "xhigh"}, "opus", "ultracode")
+	assert.Equal(t, "opus", model, "confirmed model equal to the request is returned unchanged")
+	assert.Equal(t, "xhigh", effort, "confirmed effort (clamped from ultracode) overrides the request")
+}
+
+// TestReportModelChange verifies the settings_changed notification reports a model
+// change whenever the stored model and the settled model differ after normalization,
+// suppressing only a model that merely re-normalizes to the same alias. The
+// account-default sentinel resolving to a concrete model IS reported (S7): a stuck
+// "default" finally resolving is a real, user-visible transition, and there is no
+// signal distinguishing it from a new tab's first resolution.
+func TestReportModelChange(t *testing.T) {
+	sentinel := agent.DefaultModelSentinel
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+	// S7: the sentinel resolving to a concrete model is reported -- the panel shows
+	// the resolved model too, so chat and panel agree.
+	assert.True(t, reportModelChange(claude, sentinel, "sonnet"),
+		"sentinel resolving to a concrete model is a real transition")
+	// Explicit switch away from the sentinel reports.
+	assert.True(t, reportModelChange(claude, sentinel, "opus"),
+		"explicit switch from default is reported")
+	// Normal concrete switch reports.
+	assert.True(t, reportModelChange(claude, "sonnet", "opus"))
+	// An unresolved sentinel stays "default" on both sides -> no spurious change.
+	assert.False(t, reportModelChange(claude, sentinel, sentinel),
+		"an unresolved sentinel is not a change")
+	// No change -> nothing to report.
+	assert.False(t, reportModelChange(claude, "sonnet", "sonnet"))
+	// A concrete model resolving to the same model (effort-only edit) -> no report.
+	assert.False(t, reportModelChange(claude, "opus", "opus"))
+	// A stored fully-qualified model that re-normalizes to the settled alias on an
+	// effort-only edit is NOT a model change (both normalize to "opus").
+	assert.False(t, reportModelChange(claude, "claude-opus-4-8", "opus"),
+		"a model that only re-normalizes is not a change")
+	assert.False(t, reportModelChange(claude, "claude-opus-4-8[1m]", "opus[1m]"),
+		"the [1m] variant re-normalizes too")
+	// A genuine switch whose spellings normalize differently still reports.
+	assert.True(t, reportModelChange(claude, "claude-opus-4-8", "sonnet"),
+		"a genuine switch (opus -> sonnet) still reports despite normalization")
+	// A provider without an alias space (Codex) compares raw, unchanged behavior.
+	codex := leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX
+	assert.True(t, reportModelChange(codex, "gpt-5-codex", "gpt-5"))
+	assert.False(t, reportModelChange(codex, "gpt-5", "gpt-5"))
 }

--- a/backend/internal/worker/service/extras.go
+++ b/backend/internal/worker/service/extras.go
@@ -164,8 +164,35 @@ func unmarshalProtoSlice[T any, PT interface {
 	return result
 }
 
+// marshalAvailableModels serializes the model list for persistence, stripping the
+// IsDefault badge first. That flag is DERIVED from the LEAPMUX_*_DEFAULT_MODEL operator
+// override (re-applied by the manager's withDefaultModelMarked on every read), not
+// intrinsic model data, so persisting it would store a value that goes stale the moment
+// the override changes. Every read path re-derives the badge, so the DB stays badge-free
+// and a future reader that forgets to re-mark can't surface a stale default.
 func marshalAvailableModels(models []*leapmuxv1.AvailableModel) string {
-	return marshalProtoSlice(models, "AvailableModel")
+	return marshalProtoSlice(stripDefaultModelBadge(models), "AvailableModel")
+}
+
+// stripDefaultModelBadge returns models with IsDefault cleared. The catalog pointers are
+// shared, immutable data, so the one badged entry is cloned before clearing rather than
+// mutated in place; every other entry passes through by reference. A nil entry is dropped
+// rather than passed through -- protojson would persist it as a hollow "{}", and the rest
+// of the catalog plumbing (FindAvailableModel) already treats nil entries as absent.
+func stripDefaultModelBadge(models []*leapmuxv1.AvailableModel) []*leapmuxv1.AvailableModel {
+	out := make([]*leapmuxv1.AvailableModel, 0, len(models))
+	for _, m := range models {
+		if m == nil {
+			continue
+		}
+		if m.GetIsDefault() {
+			clone := proto.Clone(m).(*leapmuxv1.AvailableModel)
+			clone.IsDefault = false
+			m = clone
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 func unmarshalAvailableModels(raw string) []*leapmuxv1.AvailableModel {

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -447,6 +447,14 @@ func modelOrDefault(model string, provider leapmuxv1.AgentProvider) string {
 // The sentinel tells the CLI layer to omit the --effort flag (Claude) or
 // the reasoning_effort field (Codex) so the agent binary picks its own
 // default.
+//
+// Caveat for Claude Code: LEAPMUX_CLAUDE_DEFAULT_EFFORT only takes effect when
+// LEAPMUX_CLAUDE_DEFAULT_MODEL also names a CONCRETE model. With the default model left
+// at the account-default sentinel ("default"), launch omits BOTH --model and --effort
+// (forwarding --effort against the sentinel risks an unsupported level on whatever the
+// account resolves to -- e.g. Haiku, which takes no --effort; see buildModelEffortArgs),
+// so the configured default effort is not applied to a sentinel-default agent. Pin a
+// concrete LEAPMUX_CLAUDE_DEFAULT_MODEL for the default effort to take effect.
 func effortOrDefault(effort string, provider leapmuxv1.AgentProvider) string {
 	if effort != "" {
 		return effort

--- a/frontend/src/components/chat/providers/claude/settings.tsx
+++ b/frontend/src/components/chat/providers/claude/settings.tsx
@@ -10,8 +10,9 @@ import * as styles from '../../ChatView.css'
 import { effortIcon, effortItems, effortValidForModel, effortValueForModel, modelDisplayName, modelItems, ModelSelect, optionGroup, optionGroupDefaultValue, optionGroupItems, optionLabel, PERMISSION_MODE_KEY, permissionModeGroup, permissionModeItems, RadioGroup } from '../../settingsShared'
 
 // Claude swaps the default xhigh→Zap mapping for Flame to free up Zap for
-// its `max` tier (an effort level Pi/Codex don't expose). `ultracode` (Opus
-// only) gets a rocket to signal its xhigh+workflow-orchestration combo.
+// its `max` tier (an effort level Pi/Codex don't expose). `ultracode` (offered
+// by any xhigh-capable model, e.g. Fable/Opus) gets a rocket to signal its
+// xhigh+workflow-orchestration combo.
 const CLAUDE_EFFORT_ICONS: Record<string, LucideIcon> = {
   ultracode: Rocket,
   xhigh: Flame,
@@ -23,7 +24,11 @@ export const OUTPUT_STYLE_KEY = 'outputStyle' as const
 export const FAST_MODE_KEY = 'fastMode' as const
 export const ALWAYS_THINKING_KEY = 'alwaysThinkingEnabled' as const
 
-export const DEFAULT_CLAUDE_MODEL = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_MODEL || 'opus[1m]'
+// 'default' is the CLI's account-default sentinel: a new tab starts on it and
+// the backend omits --model so Claude Code resolves it to the account's concrete
+// model (Sonnet, Fable, Opus, …), which the tab then settles on after startup.
+// Matches the IsDefault entry in the backend's claudeCodeAvailableModels.
+export const DEFAULT_CLAUDE_MODEL = import.meta.env.LEAPMUX_CLAUDE_DEFAULT_MODEL || 'default'
 // LEAPMUX_CLAUDE_DEFAULT_EFFORT still exists as a backend escape hatch;
 // it's no longer plumbed through the frontend build.
 export const DEFAULT_CLAUDE_EFFORT = EFFORT_AUTO


### PR DESCRIPTION
## Motivation

Previously, LeapMux used a static catalog to determine which Claude Code
models and effort levels were available. This meant the catalog could fall
out of sync with what the user's installed CLI actually supports -- new
models would be missing, removed models would appear, and plan-tier
differences were invisible to the system.

The Claude Code CLI already reports its full model list (including
unavailable ones) in the `initialize` response. This change harvests that
data to build a per-agent dynamic catalog at runtime, with the static
catalog retained as a fallback for CLIs that predate the feature.

## Modifications

- Added `claudeCodeModelInfo` struct and `convertClaudeModels()` to parse
  the `models`/`unavailable_models` arrays from the CLI initialize
  response into LeapMux `AvailableModels`, including effort ordering,
  context-window inference from the `[1m]` marker, and deduplication.
- Introduced `effortResolver`, which wraps a dynamic catalog plus a
  static fallback for all capability queries (`supports`,
  `supportsUltracode`, `resolveEffort`, `contextWindow`). Constructed
  static-only at launch and promoted to dynamic+fallback post-init, so a
  model the live CLI dropped still resolves real capabilities from the
  fallback.
- Extracted `runStartupHandshake()` from `StartClaudeCode` and moved
  startup effort reconciliation onto `effortResolver`
  (`reconcileStartupFlags`, `reconciledEffortFlags`,
  `reconcileOmittedLaunch`).
- Added the "default" model sentinel (`DefaultModelSentinel`) -- a
  selectable entry that tracks the account's own default. Launch omits
  `--model`/`--effort` when it is selected so the CLI resolves the
  concrete model; the resolved identity is reported back via
  `get_settings`.
- Extended Ultracode (xhigh+workflow tier) to any model whose CLI effort
  levels include `xhigh`, removing the previous Opus-only restriction.
  The decode and live-update paths gate the ultracode strip on the model
  being *known*, so a model in neither catalog running ultracode is left
  as the CLI applied it rather than silently downgraded.
- Added `windowModel` to `contextUsageSnapshot` and three focused methods
  (`reseedWindow`, `adoptResultWindow`, `buildBroadcast`) to re-seed the
  context window on model change, omit it when unknown, and debounce the
  usage broadcast.
- Fixed `findPrimaryContextWindow` to use `normalizeClaudeCodeModel`
  equality instead of substring matching, eliminating false positives
  such as "opus" matching "opusplus".
- Replaced `buildShellWrappedCommand`'s positional parameter tail with a
  `shellWrapSpec` struct (all 9 provider `Start` functions migrated to
  named-field literals), and added a `ProbeThirdParty` field so Claude's
  default-model launch still detects a provider configured only in the
  user's shell profile.
- Added `defaultModelForList()` with 3-tier badge priority (operator env
  override -> provider-reported sentinel -> configured default);
  `reportModelChange()`/`buildSettingsChanges()` suppress spurious
  model-change events on re-spelling but report the sentinel resolving to
  a concrete model as a real transition; the live-update path persists
  the settled model/effort to prevent DB drift.
- `stripDefaultModelBadge()` strips the transient `IsDefault` badge and
  drops nil catalog entries before persistence, so the DB never stores a
  derived badge or a hollow `{}`.
- Frontend: `DEFAULT_CLAUDE_MODEL` changed from `'opus[1m]'` to
  `'default'`; the sentinel renders as "Default (recommended)". Fable
  added to the static fallback catalog.

## Result

The model picker in the Claude agent settings panel is now populated
from the live CLI response rather than a hard-coded list. Models
unavailable on the current plan are hidden automatically, and new
models appear as soon as the CLI reports them -- no LeapMux update
required.

Selecting "Default (recommended)" lets the CLI pick the concrete model
based on the user's account and plan tier. The resolved model is
reflected back to the UI via `get_settings` so the chat header and
settings panel stay in sync.

Old CLI versions that do not include a `models` array in their
initialize response fall back to the static catalog transparently, with
no change in behavior.
