### PR TITLE
Broadcast refreshed catalog after settings restart

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -2282,8 +2282,15 @@ func (svc *Context) applySettingsViaRestart(dbAgent db.Agent, newOptions OptionM
 	// Pass the pre-settle newOptions as `stored` (what the optimistic write left on the row,
 	// carrying the orphaned axes) so the persisted delta DELETES the axes the relaunched session
 	// no longer surfaces, while `settled` is the option set we want to keep.
-	if _, err := svc.persistConfirmedAgentSettings(agentID, provider, newOptions, settled); err != nil {
+	activeDbAgent, err := svc.persistConfirmedAgentSettings(agentID, provider, newOptions, settled)
+	if err != nil {
 		slog.Warn("failed to persist confirmed settings after restart", "agent_id", agentID, "error", err)
+	} else {
+		// RestartAgent registers the new provider before returning, so this read serves the
+		// relaunched process's live catalog. Broadcast it explicitly: the provider's own early
+		// ACTIVE push can happen before dynamic catalogs (e.g. Codex model/list) are populated,
+		// while the RPC response carries only option values, not the refreshed option list.
+		svc.broadcastSettingsStatusChange(activeDbAgent)
 	}
 	slog.Info("agent restarted with new settings",
 		"agent_id", agentID, "model", settled[agent.OptionIDModel], "effort", settled[agent.OptionIDEffort])

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -974,6 +974,57 @@ func TestUpdateAgentSettings_ResponseCarriesConfirmedOptions(t *testing.T) {
 	assert.False(t, hasEffort, "Cursor's reply carries no effort (it has no effort axis)")
 }
 
+// TestApplySettingsViaRestartBroadcastsConfirmedCatalog guards the restart-apply path: the
+// RPC response carries only confirmed option values, so the freshly registered provider's
+// option-group catalog must be broadcast separately after the restart handoff persists it.
+func TestApplySettingsViaRestartBroadcastsConfirmedCatalog(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, withWorkspaces("ws-1"))
+	const agentID = "agent-1"
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            agentID,
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "high"}),
+	}))
+	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:       agentID,
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		WorkingDir:    t.TempDir(),
+		Options:       map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "high"},
+	}, sink)
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent(agentID)
+
+	svc.Watchers.WatchAgent(agentID, &EventWatcher{ChannelID: w.channelID, Sender: channel.NewSender(w)})
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	settled := svc.applySettingsViaRestart(dbAgent, map[string]string{
+		agent.OptionIDModel:  "opus[1m]",
+		agent.OptionIDEffort: agent.EffortAuto,
+	})
+	assert.NotEmpty(t, settled[agent.OptionIDEffort])
+
+	var sawCatalog bool
+	for _, stream := range w.streamsSnapshot() {
+		var resp leapmuxv1.WatchEventsResponse
+		if proto.Unmarshal(stream.GetPayload(), &resp) != nil {
+			continue
+		}
+		sc := resp.GetAgentEvent().GetStatusChange()
+		if sc != nil && len(sc.GetOptionGroups()) > 0 {
+			sawCatalog = true
+			break
+		}
+	}
+	assert.True(t, sawCatalog, "restart-applied settings must broadcast the confirmed option-group catalog")
+}
+
 // mustMarshalOptionGroups marshals a catalog for a test fixture, failing the test on error. Test
 // fixtures are always valid (no invalid-UTF-8 labels), so an error means a fixture bug rather than
 // the runtime truncation marshalOptionGroups now guards against.


### PR DESCRIPTION
## Motivation
Restart-backed agent settings changes persisted the relaunched session's confirmed option values, but the frontend only received the RPC response carrying those values. The refreshed option-group catalog from the restarted provider was not broadcast after registration, so dynamic catalogs could stay stale after a settings restart.

For Codex, that meant a model switch could successfully settle on a newly available model such as GPT-5.5 while the settings popover still held the old model list. Because the selected model id was absent from that catalog, the trigger label fell back to the raw id (`gpt-5.5`) and the popover did not list GPT-5.5.

## Modifications
- Broadcast a settings status change after restart-backed settings persistence succeeds, using the refreshed row so the broadcast reads the relaunched provider's live option-group catalog.
- Keep the existing persistence error path unchanged; failed restart persistence still logs without broadcasting a misleading catalog update.
- Add a regression test covering restart-applied settings so the confirmed option-group catalog is emitted to watchers after the restart handoff.

## Result
After a restart-backed model or effort switch, connected clients receive the relaunched agent's current option-group catalog as well as the confirmed option values. The agent settings trigger can resolve display labels from the refreshed catalog, and the settings popover lists dynamically discovered models such as GPT-5.5 instead of showing only stale options.
