### PR TITLE
feat(desktop): Persist and restore fullscreen window state

### DIFF
--- a/desktop/go/app.go
+++ b/desktop/go/app.go
@@ -109,14 +109,17 @@ func (a *App) GetConfig() *DesktopConfig {
 	return a.config
 }
 
-func (a *App) SetWindowSize(width, height int, maximized bool) error {
+// SetWindowSize persists the window geometry and display mode. width/height of
+// 0 leave the stored windowed size untouched -- the frontend sends 0 while
+// maximized or fullscreen so the last windowed dimensions survive.
+func (a *App) SetWindowSize(width, height int, mode string) error {
 	if width > 0 {
 		a.config.WindowWidth = width
 	}
 	if height > 0 {
 		a.config.WindowHeight = height
 	}
-	a.config.WindowMaximized = maximized
+	a.config.WindowMode = mode
 	return SaveConfig(a.config)
 }
 

--- a/desktop/go/app_test.go
+++ b/desktop/go/app_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+func TestSetWindowSizePersistsMode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	a := &App{config: &DesktopConfig{WindowWidth: 1280, WindowHeight: 800, WindowMode: WindowModeNormal}}
+
+	// Entering fullscreen: the frontend sends 0 dimensions so the last windowed
+	// size survives while the mode flips.
+	if err := a.SetWindowSize(0, 0, WindowModeFullscreen); err != nil {
+		t.Fatalf("SetWindowSize: %v", err)
+	}
+	if a.config.WindowWidth != 1280 || a.config.WindowHeight != 800 {
+		t.Fatalf("windowed size not preserved: got %dx%d", a.config.WindowWidth, a.config.WindowHeight)
+	}
+	if a.config.WindowMode != WindowModeFullscreen {
+		t.Fatalf("mode = %q, want %q", a.config.WindowMode, WindowModeFullscreen)
+	}
+
+	// The change round-trips to disk.
+	reloaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if reloaded.WindowMode != WindowModeFullscreen || reloaded.WindowWidth != 1280 || reloaded.WindowHeight != 800 {
+		t.Fatalf("reloaded config = %+v", reloaded)
+	}
+
+	// Returning to a windowed size updates both dimensions and mode.
+	if err := a.SetWindowSize(1000, 700, WindowModeNormal); err != nil {
+		t.Fatalf("SetWindowSize: %v", err)
+	}
+	if a.config.WindowWidth != 1000 || a.config.WindowHeight != 700 || a.config.WindowMode != WindowModeNormal {
+		t.Fatalf("windowed restore failed: %+v", a.config)
+	}
+}
+
+func TestWindowModeProtoRoundTrip(t *testing.T) {
+	for _, mode := range []string{WindowModeNormal, WindowModeMaximized, WindowModeFullscreen} {
+		if got := windowModeFromProto(windowModeToProto(mode)); got != mode {
+			t.Errorf("round-trip %q -> %q", mode, got)
+		}
+	}
+
+	// Empty / unknown strings collapse to normal (fresh-config default).
+	if got := windowModeToProto(""); got != desktoppb.WindowMode_WINDOW_MODE_NORMAL {
+		t.Errorf("empty mode -> %v, want NORMAL", got)
+	}
+	if got := windowModeToProto("bogus"); got != desktoppb.WindowMode_WINDOW_MODE_NORMAL {
+		t.Errorf("bogus mode -> %v, want NORMAL", got)
+	}
+
+	// UNSPECIFIED on the wire maps back to normal.
+	if got := windowModeFromProto(desktoppb.WindowMode_WINDOW_MODE_UNSPECIFIED); got != WindowModeNormal {
+		t.Errorf("unspecified -> %q, want %q", got, WindowModeNormal)
+	}
+}

--- a/desktop/go/config.go
+++ b/desktop/go/config.go
@@ -7,13 +7,22 @@ import (
 	"path/filepath"
 )
 
+// Window display modes persisted in DesktopConfig.WindowMode. The states are
+// mutually exclusive; WindowWidth/Height always hold the last *windowed*
+// geometry so exiting maximized/fullscreen returns to a sensible size.
+const (
+	WindowModeNormal     = "normal"
+	WindowModeMaximized  = "maximized"
+	WindowModeFullscreen = "fullscreen"
+)
+
 // DesktopConfig persists the user's last connection mode, hub URL, and window size.
 type DesktopConfig struct {
-	Mode            string `json:"mode"`                       // "solo" or "distributed"
-	HubURL          string `json:"hub_url"`                    // Only for distributed
-	WindowWidth     int    `json:"window_width,omitempty"`     // Saved window width
-	WindowHeight    int    `json:"window_height,omitempty"`    // Saved window height
-	WindowMaximized bool   `json:"window_maximized,omitempty"` // Saved maximized state
+	Mode         string `json:"mode"`                    // "solo" or "distributed"
+	HubURL       string `json:"hub_url"`                 // Only for distributed
+	WindowWidth  int    `json:"window_width,omitempty"`  // Saved windowed width
+	WindowHeight int    `json:"window_height,omitempty"` // Saved windowed height
+	WindowMode   string `json:"window_mode,omitempty"`   // "normal" | "maximized" | "fullscreen"
 }
 
 func configPath() (string, error) {

--- a/desktop/go/rpc.go
+++ b/desktop/go/rpc.go
@@ -126,7 +126,7 @@ func (s *RPCSession) handleRequest(req *desktoppb.Request) {
 		})
 
 	case *desktoppb.Request_SetWindowSize:
-		err := s.app.SetWindowSize(int(m.SetWindowSize.Width), int(m.SetWindowSize.Height), m.SetWindowSize.Maximized)
+		err := s.app.SetWindowSize(int(m.SetWindowSize.Width), int(m.SetWindowSize.Height), windowModeFromProto(m.SetWindowSize.Mode))
 		if err != nil {
 			s.writeError(id, err)
 			return
@@ -341,11 +341,37 @@ func (s *RPCSession) handleRequest(req *desktoppb.Request) {
 
 func configToProto(cfg *DesktopConfig) *desktoppb.DesktopConfig {
 	return &desktoppb.DesktopConfig{
-		Mode:            cfg.Mode,
-		HubUrl:          cfg.HubURL,
-		WindowWidth:     int32(cfg.WindowWidth),
-		WindowHeight:    int32(cfg.WindowHeight),
-		WindowMaximized: cfg.WindowMaximized,
+		Mode:         cfg.Mode,
+		HubUrl:       cfg.HubURL,
+		WindowWidth:  int32(cfg.WindowWidth),
+		WindowHeight: int32(cfg.WindowHeight),
+		WindowMode:   windowModeToProto(cfg.WindowMode),
+	}
+}
+
+// windowModeToProto maps the config's string window mode onto the wire enum.
+// Empty/unknown becomes NORMAL (the fresh-config default).
+func windowModeToProto(mode string) desktoppb.WindowMode {
+	switch mode {
+	case WindowModeMaximized:
+		return desktoppb.WindowMode_WINDOW_MODE_MAXIMIZED
+	case WindowModeFullscreen:
+		return desktoppb.WindowMode_WINDOW_MODE_FULLSCREEN
+	default:
+		return desktoppb.WindowMode_WINDOW_MODE_NORMAL
+	}
+}
+
+// windowModeFromProto maps the wire enum back to the config's string mode.
+// UNSPECIFIED/unknown becomes "normal".
+func windowModeFromProto(mode desktoppb.WindowMode) string {
+	switch mode {
+	case desktoppb.WindowMode_WINDOW_MODE_MAXIMIZED:
+		return WindowModeMaximized
+	case desktoppb.WindowMode_WINDOW_MODE_FULLSCREEN:
+		return WindowModeFullscreen
+	default:
+		return WindowModeNormal
 	}
 }
 

--- a/desktop/rust/capabilities/default.json
+++ b/desktop/rust/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-set-size",
+    "core:window:allow-set-fullscreen",
     "core:window:allow-show",
     "core:window:allow-center",
     "core:window:allow-maximize",
@@ -18,7 +19,6 @@
     "core:window:allow-close",
     "core:window:allow-unmaximize",
     "core:window:allow-toggle-maximize",
-    "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",
     "core:webview:allow-create-webview-window"
   ]

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -173,7 +173,7 @@ struct DesktopConfigResponse {
     hub_url: String,
     window_width: i32,
     window_height: i32,
-    window_maximized: bool,
+    window_mode: String,
 }
 
 #[derive(Serialize)]
@@ -1093,14 +1093,14 @@ impl DesktopShell {
         &self,
         width: u32,
         height: u32,
-        maximized: bool,
+        mode: String,
     ) -> Result<(), String> {
         let _ = self
             .send_request_async(proto::request::Method::SetWindowSize(
                 proto::SetWindowSizeRequest {
                     width: width as i32,
                     height: height as i32,
-                    maximized,
+                    mode: window_mode_to_proto(&mode) as i32,
                 },
             ))
             .await?;
@@ -1173,6 +1173,32 @@ fn shell_mode_from_proto(info: &proto::SidecarInfo) -> ShellMode {
         proto::SidecarShellMode::Distributed => ShellMode::Distributed,
         _ => ShellMode::Launcher,
     }
+}
+
+// The JSON string spellings of each window display mode, shared with the
+// frontend and the persisted config. Mirrors the Go constants in
+// desktop/go/config.go so the vocabulary is single-sourced within each binary.
+const WINDOW_MODE_NORMAL: &str = "normal";
+const WINDOW_MODE_MAXIMIZED: &str = "maximized";
+const WINDOW_MODE_FULLSCREEN: &str = "fullscreen";
+
+// Bridge the persisted window mode between the JSON string used with the
+// frontend and the proto enum on the sidecar wire. Empty/unknown -> normal.
+fn window_mode_to_proto(mode: &str) -> proto::WindowMode {
+    match mode {
+        WINDOW_MODE_MAXIMIZED => proto::WindowMode::Maximized,
+        WINDOW_MODE_FULLSCREEN => proto::WindowMode::Fullscreen,
+        _ => proto::WindowMode::Normal,
+    }
+}
+
+fn window_mode_from_proto(mode: proto::WindowMode) -> String {
+    match mode {
+        proto::WindowMode::Maximized => WINDOW_MODE_MAXIMIZED,
+        proto::WindowMode::Fullscreen => WINDOW_MODE_FULLSCREEN,
+        _ => WINDOW_MODE_NORMAL,
+    }
+    .to_string()
 }
 
 fn apply_sidecar_info(state: &Mutex<ShellState>, info: proto::SidecarInfo) {
@@ -1358,11 +1384,11 @@ async fn get_startup_info(
             let build = info.build_info.unwrap_or_default();
             Ok(StartupInfoResponse {
                 config: DesktopConfigResponse {
+                    window_mode: window_mode_from_proto(cfg.window_mode()),
                     mode: cfg.mode,
                     hub_url: cfg.hub_url,
                     window_width: cfg.window_width,
                     window_height: cfg.window_height,
-                    window_maximized: cfg.window_maximized,
                 },
                 build_info: BuildInfoResponse {
                     version: build.version,
@@ -2313,9 +2339,9 @@ async fn save_window_geometry(
     shell: State<'_, Arc<DesktopShell>>,
     width: u32,
     height: u32,
-    maximized: bool,
+    mode: String,
 ) -> Result<(), String> {
-    shell.save_window_size(width, height, maximized).await
+    shell.save_window_size(width, height, mode).await
 }
 
 #[tauri::command]
@@ -3277,6 +3303,31 @@ mod tests {
         // not silently flip the shell into Solo/Distributed.
         let info = sidecar_info(proto::SidecarShellMode::Unspecified, true, "https://hub");
         assert_eq!(shell_mode_from_proto(&info), ShellMode::Launcher);
+    }
+
+    #[test]
+    fn window_mode_proto_round_trips_every_state() {
+        for mode in ["normal", "maximized", "fullscreen"] {
+            assert_eq!(window_mode_from_proto(window_mode_to_proto(mode)), mode);
+        }
+    }
+
+    #[test]
+    fn window_mode_to_proto_defaults_unknown_to_normal() {
+        // The JSON string from the frontend is untrusted; empty or unexpected
+        // values must land on Normal rather than a stray enum.
+        assert_eq!(window_mode_to_proto(""), proto::WindowMode::Normal);
+        assert_eq!(window_mode_to_proto("bogus"), proto::WindowMode::Normal);
+    }
+
+    #[test]
+    fn window_mode_from_proto_maps_unspecified_to_normal() {
+        // A fresh config or an older sidecar sends UNSPECIFIED; it must read
+        // back as the windowed default, not an empty string.
+        assert_eq!(
+            window_mode_from_proto(proto::WindowMode::Unspecified),
+            "normal",
+        );
     }
 
     #[test]

--- a/frontend/src/api/platformBridge.test.ts
+++ b/frontend/src/api/platformBridge.test.ts
@@ -1,6 +1,8 @@
-import { clearMocks, mockIPC } from '@tauri-apps/api/mocks'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { clearMocks, mockIPC, mockWindows } from '@tauri-apps/api/mocks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { platformBridge, readClipboardImage } from './platformBridge'
+import { observeWindowMode, platformBridge, readClipboardImage, restoreWindowGeometry, windowExitFullscreen } from './platformBridge'
 
 // isMac() in ~/lib/shortcuts/platform caches the UA-detected platform on
 // first call, so flipping navigator.userAgent between tests doesn't actually
@@ -271,5 +273,286 @@ describe('cliInstallSymlink', () => {
       result: 'io_error',
       message: 'unknown sidecar response',
     })
+  })
+})
+
+describe('restoreWindowGeometry', () => {
+  let calls: Array<{ cmd: string, args: Record<string, unknown> }>
+
+  // Record every IPC call and answer the window-state queries with `state`,
+  // so the mode the save handler computes is controllable per test.
+  function installIPC(state: { fullscreen: boolean, maximized: boolean }) {
+    mockIPC((cmd, args) => {
+      calls.push({ cmd, args: (args ?? {}) as Record<string, unknown> })
+      switch (cmd) {
+        case 'plugin:window|is_fullscreen':
+          return state.fullscreen
+        case 'plugin:window|is_maximized':
+          return state.maximized
+        default:
+          return null
+      }
+    })
+  }
+
+  const cmds = () => calls.map(c => c.cmd)
+  const saved = () => calls.find(c => c.cmd === 'save_window_geometry')?.args
+
+  beforeEach(() => {
+    calls = []
+    mockWindows('main')
+  })
+
+  afterEach(() => {
+    clearMocks()
+    vi.useRealTimers()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('sizes to the saved windowed geometry then enters fullscreen', async () => {
+    installIPC({ fullscreen: true, maximized: false })
+    await restoreWindowGeometry(1280, 800, 'fullscreen')
+
+    expect(cmds()).toContain('plugin:window|set_size')
+    expect(cmds()).toContain('plugin:window|show')
+    expect(cmds()).not.toContain('plugin:window|maximize')
+    const fs = calls.find(c => c.cmd === 'plugin:window|set_fullscreen')
+    expect(fs?.args).toMatchObject({ value: true })
+  })
+
+  it('maximizes without entering fullscreen when mode is maximized', async () => {
+    installIPC({ fullscreen: false, maximized: true })
+    await restoreWindowGeometry(1280, 800, 'maximized')
+
+    expect(cmds()).toContain('plugin:window|maximize')
+    expect(cmds()).not.toContain('plugin:window|set_fullscreen')
+  })
+
+  it('never sets size when the saved windowed geometry is absent', async () => {
+    installIPC({ fullscreen: false, maximized: false })
+    await restoreWindowGeometry(0, 0, 'normal')
+
+    expect(cmds()).not.toContain('plugin:window|set_size')
+    expect(cmds()).toContain('plugin:window|show')
+  })
+
+  it('saves fullscreen with zeroed dims so the windowed size is preserved', async () => {
+    vi.useFakeTimers()
+    installIPC({ fullscreen: true, maximized: false })
+    await restoreWindowGeometry(1280, 800, 'fullscreen')
+
+    calls.length = 0
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(saved()).toMatchObject({ width: 0, height: 0, mode: 'fullscreen' })
+  })
+
+  it('saves the live viewport dimensions with normal mode when windowed', async () => {
+    vi.useFakeTimers()
+    installIPC({ fullscreen: false, maximized: false })
+    await restoreWindowGeometry(1000, 700, 'normal')
+
+    calls.length = 0
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(saved()).toMatchObject({
+      width: window.innerWidth,
+      height: window.innerHeight,
+      mode: 'normal',
+    })
+  })
+
+  it('saves maximized with zeroed dims so the windowed size is preserved', async () => {
+    vi.useFakeTimers()
+    installIPC({ fullscreen: false, maximized: true })
+    await restoreWindowGeometry(1280, 800, 'maximized')
+
+    calls.length = 0
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(saved()).toMatchObject({ width: 0, height: 0, mode: 'maximized' })
+  })
+
+  it('prefers fullscreen over maximized when the window reports both', async () => {
+    // A native-fullscreen window can simultaneously report zoomed; fullscreen
+    // must win, else exiting fullscreen would restore into a maximized state
+    // the user never chose.
+    vi.useFakeTimers()
+    installIPC({ fullscreen: true, maximized: true })
+    await restoreWindowGeometry(1280, 800, 'fullscreen')
+
+    calls.length = 0
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(saved()).toMatchObject({ width: 0, height: 0, mode: 'fullscreen' })
+  })
+
+  it('replaces the resize saver on re-entry instead of stacking listeners', async () => {
+    // The launcher can remount (switching connection mode returns to it), which
+    // re-runs restoreWindowGeometry. Each re-entry must replace the prior saver,
+    // not leak another resize listener -- otherwise one resize fans out into N
+    // duplicate save_window_geometry IPC calls.
+    vi.useFakeTimers()
+    installIPC({ fullscreen: false, maximized: false })
+    await restoreWindowGeometry(1000, 700, 'normal')
+    await restoreWindowGeometry(1000, 700, 'normal')
+    await restoreWindowGeometry(1000, 700, 'normal')
+
+    calls.length = 0
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(600)
+
+    const saves = calls.filter(c => c.cmd === 'save_window_geometry')
+    expect(saves).toHaveLength(1)
+  })
+})
+
+// The behavior tests above mock the IPC layer, so they bypass Tauri's
+// permission allowlist entirely. A window command the frontend invokes but
+// the Rust capabilities never grant fails only at runtime -- exactly the
+// `set_fullscreen not allowed` class of bug. This guard drives the real
+// restore path, captures the commands it emits, and asserts each is granted
+// in capabilities/default.json so the two stay in sync.
+describe('desktop window capabilities', () => {
+  // `plugin:window|set_fullscreen` -> `core:window:allow-set-fullscreen`.
+  function permissionFor(ipcCommand: string): string {
+    const command = ipcCommand.replace('plugin:window|', '').replace(/_/g, '-')
+    return `core:window:allow-${command}`
+  }
+
+  function grantedPermissions(): string[] {
+    // import.meta.dirname is frontend/src/api; the capabilities live at the
+    // repo root under desktop/rust.
+    const path = resolve(
+      (import.meta as { dirname: string }).dirname,
+      '../../../desktop/rust/capabilities/default.json',
+    )
+    const config = JSON.parse(readFileSync(path, 'utf8')) as { permissions: string[] }
+    return config.permissions
+  }
+
+  afterEach(() => {
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('grants every window command the geometry-restore path invokes', async () => {
+    const invoked = new Set<string>()
+    mockWindows('main')
+    mockIPC((cmd) => {
+      if (cmd.startsWith('plugin:window|'))
+        invoked.add(cmd)
+      return null
+    })
+
+    // Both branches together exercise every mutating command on the restore
+    // path: set_size + show (shared), maximize (maximized), set_fullscreen
+    // (fullscreen). No resize is dispatched, so only mutating commands --
+    // which must be granted explicitly -- are captured, not the is_* reads
+    // that ride on core:default.
+    await restoreWindowGeometry(1280, 800, 'fullscreen')
+    await restoreWindowGeometry(1280, 800, 'maximized')
+
+    const commands = [...invoked]
+    const granted = grantedPermissions()
+    expect(commands).toContain('plugin:window|set_fullscreen')
+    for (const cmd of commands) {
+      expect(granted, `${cmd} needs ${permissionFor(cmd)} in capabilities/default.json`)
+        .toContain(permissionFor(cmd))
+    }
+  })
+})
+
+describe('observeWindowMode', () => {
+  // Answer the window-state reads so the derived mode is controllable, and
+  // give the event listener a real rid so onResized resolves cleanly.
+  function installIPC(state: { fullscreen: boolean, maximized: boolean }) {
+    mockIPC((cmd) => {
+      switch (cmd) {
+        case 'plugin:window|is_fullscreen':
+          return state.fullscreen
+        case 'plugin:window|is_maximized':
+          return state.maximized
+        case 'plugin:event|listen':
+          return 1
+        default:
+          return null
+      }
+    })
+  }
+
+  beforeEach(() => {
+    mockWindows('main')
+  })
+
+  afterEach(() => {
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('pushes the derived mode once on attach', async () => {
+    installIPC({ fullscreen: false, maximized: true })
+    const onChange = vi.fn()
+
+    const dispose = observeWindowMode(onChange)
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+
+    expect(onChange).toHaveBeenCalledWith('maximized')
+    expect(() => dispose()).not.toThrow()
+  })
+
+  it('reports fullscreen even when the window also reports maximized', async () => {
+    installIPC({ fullscreen: true, maximized: true })
+    const onChange = vi.fn()
+
+    observeWindowMode(onChange)
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+
+    expect(onChange).toHaveBeenCalledWith('fullscreen')
+  })
+
+  it('is inert outside the Tauri app (no window global)', () => {
+    // No mockWindows here -> isTauriApp() is false; the observer must no-op
+    // and hand back a disposer that is safe to call.
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    const onChange = vi.fn()
+
+    const dispose = observeWindowMode(onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(() => dispose()).not.toThrow()
+  })
+})
+
+describe('windowExitFullscreen', () => {
+  afterEach(() => {
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('invokes set_fullscreen(false) on the current window', async () => {
+    // The CustomTitlebar tests mock this bridge, so they can't catch a
+    // setFullscreen(true) copy-paste bug -- assert the actual IPC value here.
+    const calls: Array<{ cmd: string, args: Record<string, unknown> }> = []
+    mockWindows('main')
+    mockIPC((cmd, args) => {
+      calls.push({ cmd, args: (args ?? {}) as Record<string, unknown> })
+      return null
+    })
+
+    await windowExitFullscreen()
+
+    const fs = calls.find(c => c.cmd === 'plugin:window|set_fullscreen')
+    expect(fs).toBeDefined()
+    expect(fs!.args).toMatchObject({ value: false })
+  })
+
+  it('is inert outside the Tauri app (no window global)', async () => {
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    await expect(windowExitFullscreen()).resolves.toBeUndefined()
   })
 })

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -17,12 +17,19 @@ export interface PlatformCapabilities {
   localSolo: boolean
 }
 
+/**
+ * Mutually-exclusive top-level window display state. `window_width`/`height`
+ * always hold the last *windowed* geometry, so exiting maximized/fullscreen
+ * returns to a sensible size.
+ */
+export type WindowMode = 'normal' | 'maximized' | 'fullscreen'
+
 export interface DesktopConfig {
   mode: '' | 'solo' | 'distributed'
   hub_url: string
   window_width: number
   window_height: number
-  window_maximized: boolean
+  window_mode: WindowMode
 }
 
 export interface StartupInfo {
@@ -334,15 +341,39 @@ export async function refreshRuntimeState(): Promise<DesktopRuntimeState> {
   return getRuntimeState()
 }
 
+/** Minimal shape of the Tauri window needed to derive the display mode. */
+interface WindowModeQueryable {
+  isFullscreen: () => Promise<boolean>
+  isMaximized: () => Promise<boolean>
+}
+
 /**
- * Restore the window to the saved geometry on startup and install a
+ * Derive the current mutually-exclusive window mode. Fullscreen takes
+ * precedence over maximized (a native-fullscreen window may also report
+ * zoomed, but fullscreen is the state that matters for save/restore).
+ */
+async function readWindowMode(win: WindowModeQueryable): Promise<WindowMode> {
+  const [fullscreen, maximized] = await Promise.all([win.isFullscreen(), win.isMaximized()])
+  return fullscreen ? 'fullscreen' : maximized ? 'maximized' : 'normal'
+}
+
+// Disposes the resize saver installed by the most recent restoreWindowGeometry
+// call. The saver must outlive the launcher (geometry keeps saving after the
+// user connects), so it can't be tied to a component's lifecycle — but the
+// launcher can remount (switching connection mode returns to it), which re-runs
+// restoreWindowGeometry. Tracking it here lets each restore replace the prior
+// saver instead of stacking another resize listener + debounce timer.
+let removeGeometrySaver: (() => void) | null = null
+
+/**
+ * Restore the window to the saved geometry + mode on startup and install a
  * resize listener that debounces and saves via the Rust sidecar.
  *
  * Uses `window.innerWidth/Height` (CSS viewport) which matches what
  * Tauri's `setSize()` expects — this avoids the GTK CSD offset issue
  * where `appWindow.innerSize()` includes shadow + header bar.
  */
-export async function restoreWindowGeometry(width: number, height: number, maximized: boolean): Promise<void> {
+export async function restoreWindowGeometry(width: number, height: number, mode: WindowMode): Promise<void> {
   if (!isTauriApp())
     return
 
@@ -351,33 +382,48 @@ export async function restoreWindowGeometry(width: number, height: number, maxim
     const { getCurrentWindow } = await loadTauriWindow()
     const appWindow = getCurrentWindow()
 
-    if (maximized) {
-      await appWindow.maximize()
-    }
-    else if (width > 0 && height > 0) {
+    // Establish the windowed size first so exiting maximized/fullscreen
+    // returns to the saved geometry.
+    if (width > 0 && height > 0)
       await appWindow.setSize(new LogicalSize(width, height))
-    }
 
-    // Show the window now that it's at the correct size.
-    // The window starts hidden (visible: false in tauri.conf.json) so
-    // the Wayland compositor sees the final size at first map.
+    if (mode === 'maximized')
+      await appWindow.maximize()
+
+    // Show the window now that it's at the correct size. The window starts
+    // hidden (visible: false in tauri.conf.json) so the Wayland compositor
+    // sees the final size at first map. macOS only performs the fullscreen
+    // transition on a visible window, so show before entering fullscreen.
     await appWindow.show()
 
-    // Save window geometry on resize / maximize / unmaximize, debounced.
+    if (mode === 'fullscreen')
+      await appWindow.setFullscreen(true)
+
+    // Save window geometry + mode on resize / maximize / fullscreen, debounced.
     const saveGeometry = trailingDebounce(async () => {
       try {
-        const isMax = await appWindow.isMaximized()
+        const nextMode = await readWindowMode(appWindow)
+        // innerWidth/Height report the screen size while maximized/fullscreen;
+        // send 0 so the sidecar preserves the last windowed dimensions.
+        const windowed = nextMode === 'normal'
         tauriInvoke('save_window_geometry', {
-          width: window.innerWidth,
-          height: window.innerHeight,
-          maximized: isMax,
+          width: windowed ? window.innerWidth : 0,
+          height: windowed ? window.innerHeight : 0,
+          mode: nextMode,
         }).catch(err => log.warn('save_window_geometry failed', err))
       }
       catch (err) {
         log.warn('save_window_geometry failed', err)
       }
     }, 500)
+    // Replace the saver from any previous restore so remounts don't leak a
+    // resize listener + debounce timer (each closure also pins `appWindow`).
+    removeGeometrySaver?.()
     window.addEventListener('resize', saveGeometry)
+    removeGeometrySaver = () => {
+      window.removeEventListener('resize', saveGeometry)
+      saveGeometry.cancel()
+    }
   }
   catch (err) {
     log.warn('restoreWindowGeometry failed', err)
@@ -574,23 +620,28 @@ export async function revealInFileManager(path: string): Promise<void> {
 export const windowMinimize = () => tauriWindowOp(w => w.minimize())
 export const windowClose = () => tauriWindowOp(w => w.close())
 export const windowToggleMaximize = () => tauriWindowOp(w => w.toggleMaximize())
+// Leave native fullscreen. The custom titlebar (Linux/Windows) offers no other
+// exit affordance once a window is restored into fullscreen, so this backs the
+// "Exit Full Screen" control.
+export const windowExitFullscreen = () => tauriWindowOp(w => w.setFullscreen(false))
 
 /**
- * Subscribe to window maximize-state changes. Invokes `onChange` with the
- * current state on attach and whenever Tauri reports a resize — but only
- * when the state actually flips, so drag-resize doesn't fire an IPC storm.
+ * Subscribe to window display-mode changes (normal / maximized / fullscreen).
+ * Invokes `onChange` with the current mode on attach and whenever Tauri reports
+ * a resize — but only when the mode actually changes, so drag-resize doesn't
+ * fire an IPC storm. Native fullscreen enter/exit also surfaces as a resize.
  * Returns an unlisten function.
  */
-export function observeWindowMaximized(onChange: (maximized: boolean) => void): () => void {
+export function observeWindowMode(onChange: (mode: WindowMode) => void): () => void {
   if (!isTauriApp())
     return () => {}
 
   let disposed = false
   let unlisten: (() => void) | undefined
-  let last: boolean | undefined
+  let last: WindowMode | undefined
   let refresh: TrailingDebounced | undefined
 
-  const push = (next: boolean) => {
+  const push = (next: WindowMode) => {
     if (disposed || next === last)
       return
     last = next
@@ -603,7 +654,7 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
       return
     const win = getCurrentWindow()
     try {
-      push(await win.isMaximized())
+      push(await readWindowMode(win))
     }
     catch { /* best-effort */ }
     if (disposed)
@@ -611,7 +662,7 @@ export function observeWindowMaximized(onChange: (maximized: boolean) => void): 
     try {
       refresh = trailingDebounce(async () => {
         try {
-          push(await win.isMaximized())
+          push(await readWindowMode(win))
         }
         catch { /* best-effort */ }
       }, 150)

--- a/frontend/src/components/desktop/LauncherView.tsx
+++ b/frontend/src/components/desktop/LauncherView.tsx
@@ -131,7 +131,7 @@ export const LauncherView: Component<{ onConnected: () => void }> = (props) => {
         setVersionLine(formatVersionLine(buildInfo))
 
       // Restore saved window geometry on startup.
-      await restoreWindowGeometry(config.window_width, config.window_height, config.window_maximized)
+      await restoreWindowGeometry(config.window_width, config.window_height, config.window_mode)
 
       if (config.mode === 'distributed' && config.hub_url) {
         setHubUrl(config.hub_url)

--- a/frontend/src/components/shell/CustomTitlebar.mac.test.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.mac.test.tsx
@@ -1,0 +1,93 @@
+/// <reference types="vitest/globals" />
+import type { WindowMode } from '~/api/platformBridge'
+import { render } from '@solidjs/testing-library'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CustomTitlebar } from './CustomTitlebar'
+
+// The titlebar captures `platform`/`desktop` at module load, so the macOS inset
+// path can only be exercised in a file that mocks the platform to 'mac' up
+// front (the sibling CustomTitlebar.test.tsx pins it to 'linux').
+const { initialMode, modeCb } = vi.hoisted(() => ({
+  initialMode: { value: 'normal' as WindowMode },
+  // Captures observeWindowMode's callback so tests can drive fullscreen
+  // transitions and assert the inset reacts.
+  modeCb: { fn: undefined as ((mode: WindowMode) => void) | undefined },
+}))
+
+vi.mock('~/lib/shortcuts/platform', () => ({
+  getPlatform: () => 'mac',
+  isMac: () => true,
+}))
+
+vi.mock('~/lib/systemInfo', () => ({
+  isDesktopApp: () => true,
+}))
+
+vi.mock('~/api/platformBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/api/platformBridge')>()
+  return {
+    ...actual,
+    observeWindowMode: (onChange: (mode: WindowMode) => void) => {
+      modeCb.fn = onChange
+      onChange(initialMode.value)
+      return () => {}
+    },
+  }
+})
+
+vi.mock('~/components/shell/UserMenuItems', () => ({
+  AppAboutMenuItem: () => <button role="menuitem">About LeapMux Desktop...</button>,
+  UserMenuItems: () => <button role="menuitem">Profile...</button>,
+}))
+vi.mock('~/components/shell/UserMenuState', () => ({
+  setShowAboutDialog: vi.fn(),
+}))
+
+// Stub the native Popover API (jsdom doesn't implement it) so DropdownMenu renders.
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn()
+  HTMLElement.prototype.hidePopover = vi.fn()
+  HTMLElement.prototype.togglePopover = vi.fn(() => true)
+})
+
+beforeEach(() => {
+  initialMode.value = 'normal'
+  modeCb.fn = undefined
+})
+
+function renderTitlebar() {
+  const result = render(() => <CustomTitlebar variant="minimal" />)
+  return result.container.firstElementChild as HTMLElement
+}
+
+describe('customTitlebar macOS traffic-light inset', () => {
+  it('reserves the 78px inset for the native traffic lights when windowed', () => {
+    const titlebar = renderTitlebar()
+    expect(titlebar.style.paddingLeft).toBe('78px')
+  })
+
+  it('starts without the inset when the window is already fullscreen', () => {
+    initialMode.value = 'fullscreen'
+    const titlebar = renderTitlebar()
+    expect(titlebar.style.paddingLeft).toBe('')
+  })
+
+  it('drops the inset on entering fullscreen and restores it on exit', () => {
+    const titlebar = renderTitlebar()
+    expect(titlebar.style.paddingLeft).toBe('78px')
+
+    // Traffic lights vanish in fullscreen -> the reserved gap must collapse.
+    modeCb.fn!('fullscreen')
+    expect(titlebar.style.paddingLeft).toBe('')
+
+    modeCb.fn!('normal')
+    expect(titlebar.style.paddingLeft).toBe('78px')
+  })
+
+  it('keeps the inset while maximized (traffic lights remain)', () => {
+    const titlebar = renderTitlebar()
+    modeCb.fn!('maximized')
+    expect(titlebar.style.paddingLeft).toBe('78px')
+  })
+})

--- a/frontend/src/components/shell/CustomTitlebar.test.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.test.tsx
@@ -1,14 +1,15 @@
 /// <reference types="vitest/globals" />
+import type { WindowMode } from '~/api/platformBridge'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { openWebInspector, quitApp, windowClose, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
+import { openWebInspector, quitApp, windowClose, windowExitFullscreen, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
 import { CustomTitlebar } from './CustomTitlebar'
 
 // Hoisted so the vi.mock factories below can close over them — vi.mock
 // runs above any top-level `const` in the file.
-const { initialMaximized, setShowAboutDialog, runtimeLocalSolo, detectedEditors } = vi.hoisted(() => ({
-  initialMaximized: { value: false },
+const { initialMode, setShowAboutDialog, runtimeLocalSolo, detectedEditors } = vi.hoisted(() => ({
+  initialMode: { value: 'normal' as WindowMode },
   setShowAboutDialog: vi.fn(),
   runtimeLocalSolo: { value: false },
   detectedEditors: { value: [] as Array<{ id: string, displayName: string }> },
@@ -41,8 +42,8 @@ vi.mock('~/api/platformBridge', async (importOriginal) => {
         localSolo: runtimeLocalSolo.value,
       },
     }),
-    observeWindowMaximized: (onChange: (max: boolean) => void) => {
-      onChange(initialMaximized.value)
+    observeWindowMode: (onChange: (mode: WindowMode) => void) => {
+      onChange(initialMode.value)
       return () => {}
     },
     openWebInspector: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock('~/api/platformBridge', async (importOriginal) => {
     windowClose: vi.fn(() => Promise.resolve()),
     windowMinimize: vi.fn(() => Promise.resolve()),
     windowToggleMaximize: vi.fn(() => Promise.resolve()),
+    windowExitFullscreen: vi.fn(() => Promise.resolve()),
   }
 })
 
@@ -91,7 +93,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  initialMaximized.value = false
+  initialMode.value = 'normal'
 })
 
 function renderTitlebar(activeWorkingDir?: () => string | undefined) {
@@ -179,7 +181,7 @@ describe('customTitlebar hamburger menu', () => {
   })
 
   it('menu item reads "Restore" when the window is maximized', () => {
-    initialMaximized.value = true
+    initialMode.value = 'maximized'
     const { container } = renderTitlebar()
     const labels = getMenuItemLabels(container)
     expect(labels).toContain('Restore')
@@ -187,11 +189,29 @@ describe('customTitlebar hamburger menu', () => {
   })
 
   it('right-side window-control button title switches between Maximize and Restore', () => {
-    initialMaximized.value = true
+    initialMode.value = 'maximized'
     renderTitlebar()
     // The Linux window-controls cluster exposes the maximize/restore button via aria-label.
     expect(screen.getByLabelText('Restore')).toBeInTheDocument()
     expect(screen.queryByLabelText('Maximize')).toBeNull()
+  })
+
+  it('menu item reads "Exit Full Screen" and exits fullscreen when the window is fullscreen', () => {
+    initialMode.value = 'fullscreen'
+    clickMenuItem('Exit Full Screen')
+    // Must route to setFullscreen(false); toggleMaximize can't leave fullscreen.
+    expect(windowExitFullscreen).toHaveBeenCalledTimes(1)
+    expect(windowToggleMaximize).not.toHaveBeenCalled()
+  })
+
+  it('right-side window-control button relabels to "Exit Full Screen" in fullscreen and exits it', () => {
+    initialMode.value = 'fullscreen'
+    renderTitlebar()
+    expect(screen.queryByLabelText('Maximize')).toBeNull()
+    const button = screen.getByLabelText('Exit Full Screen')
+    fireEvent.click(button)
+    expect(windowExitFullscreen).toHaveBeenCalledTimes(1)
+    expect(windowToggleMaximize).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/components/shell/CustomTitlebar.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.tsx
@@ -1,9 +1,10 @@
 import type { Component } from 'solid-js'
+import type { WindowMode } from '~/api/platformBridge'
 import MenuIcon from 'lucide-solid/icons/menu'
 import PanelLeft from 'lucide-solid/icons/panel-left'
 import PanelRight from 'lucide-solid/icons/panel-right'
 import { createSignal, onCleanup, Show } from 'solid-js'
-import { observeWindowMaximized, openWebInspector, quitApp, windowClose, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
+import { observeWindowMode, openWebInspector, quitApp, windowClose, windowExitFullscreen, windowMinimize, windowToggleMaximize } from '~/api/platformBridge'
 import { DropdownMenu, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
 import { IconButton } from '~/components/common/IconButton'
 import { getShortcutHintsText, shortcutHint } from '~/lib/shortcuts/display'
@@ -20,8 +21,8 @@ const desktop = isDesktopApp()
 // Linux and Windows run with `decorations: false`, so the app renders its own
 // min/max/close buttons. macOS keeps native traffic lights.
 const showCustomWindowControls = desktop && (platform === 'linux' || platform === 'windows')
+const isMacDesktop = desktop && platform === 'mac'
 const MAC_TRAFFIC_LIGHT_INSET_PX = 78
-const macPadding = desktop && platform === 'mac' ? `${MAC_TRAFFIC_LIGHT_INSET_PX}px` : undefined
 
 interface WorkspaceCustomTitlebarProps {
   variant?: 'workspace'
@@ -61,16 +62,25 @@ const WorkspaceActions: Component<WorkspaceCustomTitlebarProps> = props => (
 )
 
 export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
-  const [isMaximized, setIsMaximized] = createSignal(false)
-  onCleanup(observeWindowMaximized(setIsMaximized))
+  const [windowMode, setWindowMode] = createSignal<WindowMode>('normal')
+  onCleanup(observeWindowMode(setWindowMode))
 
-  const maximizeLabel = () => (isMaximized() ? 'Restore' : 'Maximize')
+  const isMaximized = () => windowMode() === 'maximized'
+  const isFullscreen = () => windowMode() === 'fullscreen'
+  // In fullscreen the maximize control becomes the only in-titlebar way out, so
+  // it relabels and routes to setFullscreen(false) instead of toggleMaximize
+  // (which can't leave fullscreen).
+  const maximizeLabel = () => (isFullscreen() ? 'Exit Full Screen' : isMaximized() ? 'Restore' : 'Maximize')
+  const onMaximizeControl = () => (isFullscreen() ? void windowExitFullscreen() : void windowToggleMaximize())
+  // Reserve space for the macOS native traffic lights, except in fullscreen
+  // where they are hidden — otherwise the menu is stranded past an empty gap.
+  const macPadding = () => (isMacDesktop && !isFullscreen() ? `${MAC_TRAFFIC_LIGHT_INSET_PX}px` : undefined)
 
   return (
     <div
       class={styles.titlebar}
       style={{
-        'padding-left': macPadding,
+        'padding-left': macPadding(),
       }}
     >
       <DropdownMenu
@@ -95,7 +105,7 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
           <button role="menuitem" onClick={() => void windowMinimize()}>
             <DropdownMenuItemContent label="Minimize" />
           </button>
-          <button role="menuitem" onClick={() => void windowToggleMaximize()}>
+          <button role="menuitem" onClick={onMaximizeControl}>
             <DropdownMenuItemContent label={maximizeLabel()} />
           </button>
           <button role="menuitem" onClick={() => openWebInspector()}>
@@ -123,11 +133,11 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
             onClick={() => void windowMinimize()}
           />
           <IconButton
-            icon={isMaximized() ? WindowRestoreIcon : WindowMaximizeIcon}
+            icon={isMaximized() || isFullscreen() ? WindowRestoreIcon : WindowMaximizeIcon}
             iconSize="lg"
             size="md"
             title={maximizeLabel()}
-            onClick={() => void windowToggleMaximize()}
+            onClick={onMaximizeControl}
           />
           <IconButton
             icon={WindowCloseIcon}

--- a/frontend/tests/unit/components/ChatView.test.tsx
+++ b/frontend/tests/unit/components/ChatView.test.tsx
@@ -661,7 +661,7 @@ describe('chatView', () => {
     await waitFor(() => expect(view.container.querySelector('[data-seq="2"]')).not.toBeNull())
   })
 
-  it('keeps unmeasured interior rows invisible without collapsing the live tail', async () => {
+  it('keeps unmeasured interior and tail rows invisible while reserving their estimated space', async () => {
     const messages = [
       { ...makeMessage('assistant', 'Older tall output', 'msg-1'), seq: 1n },
       { ...makeMessage('assistant', 'Current message', 'msg-2'), seq: 2n },
@@ -688,10 +688,12 @@ describe('chatView', () => {
     expect(row.style.opacity).toBe('0')
     const tailRow = view.container.querySelector('[data-seq="2"]') as HTMLElement | null
     expect(tailRow).not.toBeNull()
-    expect(tailRow!.style.visibility).toBe('')
-    expect(tailRow!.style.opacity).toBe('1')
-    // Both rows are unmeasured and reserve the seed estimate (96) -- the interior row is
-    // hidden but still reserves space (no collapse-to-0), so the spacer is 96 + 20 gap + 96.
+    // The live tail is hidden-until-measured like any other in-range row, so its
+    // unmeasured content can't overflow its estimated slot onto the trailing tail UI.
+    expect(tailRow!.style.visibility).toBe('hidden')
+    expect(tailRow!.style.opacity).toBe('0')
+    // Both rows are unmeasured and reserve the seed estimate (96); hidden means invisible,
+    // NOT collapsed-to-0, so both still reserve space -- the spacer is 96 + 20 gap + 96.
     expect(spacer!.style.height).toBe('212px')
 
     vi.spyOn(tailRow!, 'getBoundingClientRect').mockImplementation(() => ({ height: 32 }) as DOMRect)
@@ -706,6 +708,10 @@ describe('chatView', () => {
 
     await waitFor(() => expect(row.style.visibility).toBe(''))
     expect(row.style.opacity).toBe('1')
+    // The tail measured first but was held until the earlier interior row revealed
+    // (ordered append reveal); with both measured it is now visible too.
+    expect(tailRow!.style.visibility).toBe('')
+    expect(tailRow!.style.opacity).toBe('1')
     expect(spacer!.style.height).toBe('532px')
   })
 
@@ -792,6 +798,13 @@ describe('chatView', () => {
     await waitFor(() => expect(screen.getByText('Streaming answer')).toBeInTheDocument())
 
     await reportChatViewportSize(view)
+
+    // Measure the prior row so the ordered-reveal gate doesn't hold the replacement
+    // tail behind it -- in the running app an existing message is already measured, so
+    // this isolates the stream->row handoff (the tail reveals on its OWN measurement).
+    const priorRow = view.container.querySelector('[data-seq="1"]') as HTMLElement
+    vi.spyOn(priorRow, 'getBoundingClientRect').mockImplementation(() => ({ height: 40 }) as DOMRect)
+    await triggerResizeObserverFor(priorRow)
 
     batch(() => {
       setStreamingText('')

--- a/proto/leapmux/desktop/v1/frame.proto
+++ b/proto/leapmux/desktop/v1/frame.proto
@@ -96,7 +96,7 @@ message ListEditorsRequest {
 message SetWindowSizeRequest {
   int32 width = 1;
   int32 height = 2;
-  bool maximized = 3;
+  WindowMode mode = 3;
 }
 
 message ConnectDistributedRequest {
@@ -289,12 +289,24 @@ message SidecarLogEvent {
 
 // --- Shared types ---
 
+// WindowMode is the top-level display state of the desktop window. The three
+// states are mutually exclusive: a window is windowed, macOS-zoomed, or in
+// native fullscreen -- never a combination. window_width/height on
+// DesktopConfig always hold the last *windowed* geometry so exiting
+// maximized/fullscreen returns to a sensible size.
+enum WindowMode {
+  WINDOW_MODE_UNSPECIFIED = 0; // treated as NORMAL (fresh config default)
+  WINDOW_MODE_NORMAL = 1;
+  WINDOW_MODE_MAXIMIZED = 2;
+  WINDOW_MODE_FULLSCREEN = 3;
+}
+
 message DesktopConfig {
   string mode = 1;
   string hub_url = 2;
   int32 window_width = 3;
   int32 window_height = 4;
-  bool window_maximized = 5;
+  WindowMode window_mode = 5;
 }
 
 message BuildInfo {


### PR DESCRIPTION
## Motivation

The desktop app previously tracked window state as a boolean `window_maximized` flag. This meant fullscreen mode was not persisted at all — relaunching after going fullscreen would open in a normal window. It also meant there was no titlebar affordance to exit fullscreen on Linux/Windows, and on macOS the traffic-light inset remained visible in fullscreen, stranding the menu bar past an empty gap.

Additionally, the resize-listener registered by `restoreWindowGeometry` was stacking on each launcher remount rather than replacing the previous one, causing a listener leak.

## Modifications

- Replaced the boolean `window_maximized` field with a three-state `WindowMode` enum (`NORMAL`, `MAXIMIZED`, `FULLSCREEN`) across the entire internal contract: proto definition, Go sidecar config/RPC, Rust Tauri layer, and the frontend `platformBridge`.
- Window width/height always store the last *windowed* dimensions. While maximized or fullscreen the frontend sends 0-size updates, and the sidecar's `SetWindowSize` ignores zero values, preserving the stored geometry so the window returns to a sensible size on exit.
- Added `windowExitFullscreen()` bridge method (`setFullscreen(false)`) and updated the maximize toggle in `CustomTitlebar` to label itself "Exit Full Screen" and route to it when the window is in fullscreen mode.
- `restoreWindowGeometry` now restores mode on startup: restores windowed size, then maximizes or enters fullscreen as appropriate. On macOS the window is shown before entering fullscreen so the OS transition runs on a visible window.
- macOS titlebar: the 78px traffic-light inset collapses in fullscreen (when the system controls are hidden) so the menu title is not stranded past an empty gap.
- Fixed resize-listener leak: `restoreWindowGeometry` now replaces any previously registered module-scoped saver instead of stacking listeners, timers, and captured window references on each remount.
- Added `core:window:allow-set-fullscreen` to Tauri capabilities; removed the now-redundant `core:window:allow-is-maximized` (covered by `core:default`).
- Added Go tests (`app_test.go`) for windowed-size preservation and proto round-trip; added Rust unit tests for the mode converters (round-trip and unknown/UNSPECIFIED → normal); added frontend tests for restore/observe behavior, a capability-sync guard (every invoked IPC command must be listed in `capabilities/default.json`), the listener-leak regression guard, and `windowExitFullscreen` → `set_fullscreen(false)` IPC-value guard.
- `CustomTitlebar.mac.test.tsx` is a new test file covering macOS-specific titlebar layout in fullscreen.
- `ChatView.test.tsx` expectations updated to match the current hidden-until-measured virtualized-tail behavior (no `ChatView` source change).

All proto/RPC/config field changes are internal to this repository and regenerated together; they are not external breaking changes.

## Result

Fullscreen window state is now persisted across launches. Reopening the app after going fullscreen restores the fullscreen window. Exiting maximized or fullscreen mode returns the window to its previous windowed dimensions. Linux and Windows users have an explicit "Exit Full Screen" control in the titlebar. macOS users have a menu path out of fullscreen and no longer see a stranded menu title caused by the traffic-light inset in fullscreen. The resize-listener leak on launcher remount is resolved.
