### PR TITLE
fix(terminal): Bound WebGL contexts with a pooled renderer

### DIFF
--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -9,7 +9,8 @@ import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { isMac } from '~/lib/shortcuts/platform'
-import { applyTerminalData, bufferHasVisibleContent, createTerminalInstance, reloadFontsAndClearAtlas, resolveTerminalTheme, resolveTerminalThemeMode, serializeXtermBuffer } from '~/lib/terminal'
+import { applyTerminalData, bufferHasVisibleContent, createTerminalInstance, DEFAULT_FONT_SIZE, refreshTerminalFont, resolveTerminalTheme, resolveTerminalThemeMode, serializeXtermBuffer } from '~/lib/terminal'
+import { webglPool } from '~/lib/webglTerminalPool'
 import * as styles from './TerminalView.css'
 import '@xterm/xterm/css/xterm.css'
 
@@ -44,6 +45,10 @@ export function disposeTerminalInstance(id: string): void {
   const instance = instances.get(id)
   if (!instance)
     return
+  // Relinquish any pooled WebGL context first so the slot frees up for
+  // another terminal. This is the single teardown chokepoint reached by every
+  // path — explicit close, HMR dispose, and the unmount microtask below.
+  webglPool.release(id)
   instance.dispose()
   instances.delete(id)
   screenApplied.delete(id)
@@ -137,6 +142,10 @@ if (typeof window !== 'undefined') {
     instance.sendInput(new TextEncoder().encode(text))
     return true
   }
+  // E2E hooks for the WebGL context pool: assert that the number of live
+  // contexts stays bounded and that hidden tabs hold none.
+  ;(window as any).__webglTerminalCount = () => webglPool.size()
+  ;(window as any).__terminalRendererFor = (id: string) => (instances.get(id)?.webglAddon ? 'webgl' : 'dom')
 }
 
 /**
@@ -316,6 +325,32 @@ const TerminalContainer: Component<{
     }
   })
 
+  // Grant or relinquish a pooled WebGL context as this terminal moves on and
+  // off screen. Only the visible terminal in a tile (`active && visible`)
+  // competes for the bounded WebGL pool; hidden tabs and any overflow beyond
+  // the pool's capacity render via xterm's DOM renderer. `focused` is passed
+  // synchronously so the terminal the user is typing in always wins a slot,
+  // even on an initial multi-tile render where mount order would otherwise
+  // decide. Deliberately no `onCleanup(release)`: a cross-tile move unmounts
+  // this container and mounts another for the same id, and the pool's
+  // coalesced reconcile already keeps that transient safe — unmount-driven
+  // release is owned solely by disposeTerminalInstance (guarded by the
+  // element-`isConnected` check below), so a move never releases.
+  //
+  // `instances.get` is read non-reactively: the entry is created by `onMount`
+  // above, which — being registered before this effect — always runs first, so
+  // the instance is present on this effect's first (and every) run while the
+  // container is mounted. The only removal is disposeTerminalInstance, which
+  // unmounts the container (disposing this effect) in the same breath.
+  createEffect(() => {
+    const onScreen = props.active && props.visible
+    const instance = instances.get(props.terminalId)
+    if (onScreen && instance)
+      webglPool.acquire(props.terminalId, instance, { focused: props.tileFocused })
+    else
+      webglPool.release(props.terminalId)
+  })
+
   return (
     <div
       class={styles.terminalWrapper}
@@ -351,15 +386,30 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
   }
 
   // React to font preference changes and update existing terminal instances.
-  // After the new family's variants finish loading, clear each terminal's
-  // atlas so the WebGL renderer drops any fallback glyphs it rasterized
-  // before the swap.
+  // refreshTerminalFont re-arms each instance's `fontsReady` for the new
+  // family (so a later or in-flight pool attach builds the atlas from the new
+  // font) and, once the variants load, clears the atlas of any terminal that
+  // currently holds a WebGL context (a no-op on DOM-rendered ones).
+  //
+  // Guard on a real family change: `monoFontFamily()` re-emits whenever the
+  // preferences store hydrates (a fresh `monoFonts` array is a new signal
+  // value even when the resolved string is identical), and re-fitting every
+  // instance on each spurious re-fire is wasted layout/reflow work.
+  //
+  // `instances` is the module-level map shared by every mounted TerminalView,
+  // so each tile's copy of this effect iterates all instances. Fit only the
+  // instances refreshTerminalFont actually re-armed (it returns `false` once a
+  // sibling view already applied the swap), so a font change costs M reflows,
+  // not tiles x M.
+  let lastFontFamily: string | undefined
   createEffect(() => {
     const family = preferences.monoFontFamily()
+    if (family === lastFontFamily)
+      return
+    lastFontFamily = family
     for (const [, instance] of instances) {
-      instance.terminal.options.fontFamily = family
-      instance.fitAddon.fit()
-      reloadFontsAndClearAtlas(instance.terminal, family, 13)
+      if (refreshTerminalFont(instance, family, DEFAULT_FONT_SIZE))
+        instance.fitAddon.fit()
     }
   })
 
@@ -380,14 +430,36 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
 
   // React to terminal/UI theme preference and OS-theme changes — all
   // three feed into the resolved theme when the user picks `match-ui`.
+  //
+  // Guard on a real theme change, mirroring the font effect above:
+  // `resolveTerminalTheme` returns one of two module-level ITheme constants,
+  // so a reference compare cheaply skips redundant re-applies when a
+  // theme-adjacent signal fires without changing the resolved theme (e.g.
+  // prefers-color-scheme flips while the terminal theme is pinned to
+  // light/dark). Because `instances` is the module-level map shared by every
+  // mounted TerminalView, an unguarded re-fire costs tiles x instances xterm
+  // palette rebuilds — each `options.theme` write recomputes the color table.
+  let lastTheme: ITheme | undefined
   createEffect(() => {
     const theme = resolveTerminalTheme(
       preferences.terminalTheme(),
       preferences.theme(),
       prefersDark(),
     )
+    if (theme === lastTheme)
+      return
+    lastTheme = theme
     for (const [, instance] of instances) {
-      instance.terminal.options.theme = theme
+      // Skip instances already on this theme. `instances` is the shared
+      // module-level map, so every mounted TerminalView (one per tile) runs
+      // this effect; without the per-instance guard a theme flip costs
+      // tiles x instances palette rebuilds instead of one per instance, since
+      // each write recomputes xterm's color table. `options.theme` returns the
+      // stored reference and `resolveTerminalTheme` yields stable constants, so
+      // the compare is exact. Mirrors refreshTerminalFont's per-instance guard
+      // in the font effect above.
+      if (instance.terminal.options.theme !== theme)
+        instance.terminal.options.theme = theme
     }
   })
 
@@ -466,7 +538,7 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
                   cols={terminal.cols}
                   rows={terminal.rows}
                   fontFamily={preferences.monoFontFamily()}
-                  fontSize={13}
+                  fontSize={DEFAULT_FONT_SIZE}
                   theme={terminalTheme()}
                   contentReady={(terminal.contentReady ?? false)
                     || terminal.status === TerminalStatus.EXITED

--- a/frontend/src/lib/sleep.ts
+++ b/frontend/src/lib/sleep.ts
@@ -1,0 +1,4 @@
+/** Resolve after `ms` milliseconds. A promisified `setTimeout`. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { KEY_BROWSER_PREFS, localStorageSet } from './browserStorage'
-import { createTerminalInstance, getTerminalRendererPreference, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
+import { attachWebgl, createTerminalInstance, detachWebgl, getTerminalRendererPreference, loadTerminalFonts, refreshTerminalFont, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
 
 // xterm.js requires a DOM element for open(), but we can still test
 // the suppressInput mechanism without rendering.
@@ -226,5 +227,255 @@ describe('getTerminalRendererPreference', () => {
     })
 
     expect(resolveTerminalRendererPreference('webgl')).toBe('webgl')
+  })
+})
+
+describe('lazy WebGL renderer', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as any
+    // Reset globals a prior describe may have left set (Object.defineProperty
+    // leaks across blocks in jsdom), so the renderer preference resolves as a
+    // plain non-Tauri browser rather than Linux desktop Tauri (→ canvas).
+    Object.defineProperty(window, '__TAURI_INTERNALS__', { configurable: true, value: undefined })
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+    })
+  })
+
+  it('does not attach a WebGL context at construction', () => {
+    const instance = createTerminalInstance()
+    // The renderer is chosen lazily by the pool, not eagerly here.
+    expect(instance.webglAddon).toBeUndefined()
+    // Outside Linux desktop Tauri the default preference resolves to WebGL,
+    // so the terminal is eligible for a pooled context.
+    expect(instance.webglAllowed).toBe(true)
+    expect(typeof instance.fontsReady.then).toBe('function')
+    instance.dispose()
+  })
+
+  it('marks a canvas-preference terminal WebGL-ineligible', () => {
+    localStorageSet(KEY_BROWSER_PREFS, { terminalRenderer: 'canvas' })
+    const instance = createTerminalInstance()
+    expect(instance.webglAllowed).toBe(false)
+    // attachWebgl must refuse an ineligible terminal without touching WebGL.
+    expect(attachWebgl(instance, () => {})).toBe(false)
+    expect(instance.webglAddon).toBeUndefined()
+    instance.dispose()
+  })
+
+  it('fetches font variants only for WebGL-eligible terminals', () => {
+    // The four-variant fetch fan-out exists solely to gate the WebGL atlas, so a
+    // WebGL-ineligible terminal (DOM renderer, no atlas) must not trigger it --
+    // its `fontsReady` is never awaited by the pool.
+    const load = vi.fn(() => Promise.resolve([]))
+    const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
+    Object.defineProperty(document, 'fonts', { configurable: true, value: { load } })
+    try {
+      localStorageSet(KEY_BROWSER_PREFS, { terminalRenderer: 'canvas' })
+      const canvas = createTerminalInstance()
+      expect(canvas.webglAllowed).toBe(false)
+      expect(load).not.toHaveBeenCalled()
+      canvas.dispose()
+
+      // A WebGL-eligible terminal still fetches all four (weight, style) variants.
+      localStorageSet(KEY_BROWSER_PREFS, { terminalRenderer: 'webgl' })
+      const webgl = createTerminalInstance()
+      expect(webgl.webglAllowed).toBe(true)
+      expect(load).toHaveBeenCalledTimes(4)
+      webgl.dispose()
+    }
+    finally {
+      if (originalFonts)
+        Object.defineProperty(document, 'fonts', originalFonts)
+      else
+        delete (document as any).fonts
+    }
+  })
+
+  it('attaches idempotently and detaches back to the DOM renderer, without throwing', () => {
+    const instance = createTerminalInstance()
+    // WebGL may or may not be available in the test environment; either way
+    // attach must not throw, and its return value must agree with whether an
+    // addon actually got installed.
+    let ok = false
+    expect(() => {
+      ok = attachWebgl(instance, () => {})
+    }).not.toThrow()
+    expect(ok).toBe(instance.webglAddon !== undefined)
+
+    // A second attach never installs a second addon.
+    const addon = instance.webglAddon
+    expect(attachWebgl(instance, () => {})).toBe(ok)
+    expect(instance.webglAddon).toBe(addon)
+
+    // Detach reverts to the DOM renderer.
+    detachWebgl(instance)
+    expect(instance.webglAddon).toBeUndefined()
+    instance.dispose()
+  })
+
+  it('detachWebgl is a no-op when nothing is attached', () => {
+    const instance = createTerminalInstance()
+    expect(() => detachWebgl(instance)).not.toThrow()
+    expect(instance.webglAddon).toBeUndefined()
+    instance.dispose()
+  })
+
+  it('refreshTerminalFont re-arms fontsReady and reports change only when the family actually changes', () => {
+    const instance = createTerminalInstance()
+    const before = instance.fontsReady
+    const currentFamily = instance.terminal.options.fontFamily!
+
+    // Same family (the font effect re-firing on preference hydration) must not
+    // replace fontsReady -- that would needlessly delay a pending WebGL attach --
+    // and must report `false` so the caller skips the re-fit.
+    expect(refreshTerminalFont(instance, currentFamily, 13)).toBe(false)
+    expect(instance.fontsReady).toBe(before)
+    expect(instance.terminal.options.fontFamily).toBe(currentFamily)
+
+    // A genuine family change re-arms the gate and reports `true` so the caller
+    // re-fits exactly the instances it mutated.
+    expect(refreshTerminalFont(instance, '"Some Other Mono", monospace', 13)).toBe(true)
+    expect(instance.fontsReady).not.toBe(before)
+    expect(instance.terminal.options.fontFamily).toBe('"Some Other Mono", monospace')
+
+    instance.dispose()
+  })
+})
+
+describe('loadTerminalFonts cold-start retry', () => {
+  // jsdom does not implement document.fonts; install a controllable stub so we
+  // can drive the load/fail/retry sequence deterministically with fake timers.
+  let originalFonts: PropertyDescriptor | undefined
+  let load: ReturnType<typeof vi.fn>
+
+  function installFonts(loadImpl: (spec: string) => Promise<unknown>) {
+    load = vi.fn(loadImpl)
+    Object.defineProperty(document, 'fonts', { configurable: true, value: { load } })
+  }
+
+  function fakeTerminal(): { terminal: Terminal, clearTextureAtlas: ReturnType<typeof vi.fn> } {
+    const clearTextureAtlas = vi.fn()
+    return { terminal: { clearTextureAtlas } as unknown as Terminal, clearTextureAtlas }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
+  })
+
+  afterEach(async () => {
+    // Drain any pending retry timers before tearing down the stub so a
+    // background retry can't throw into a floating promise mid-restore.
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+    if (originalFonts)
+      Object.defineProperty(document, 'fonts', originalFonts)
+    else
+      delete (document as any).fonts
+    vi.restoreAllMocks()
+  })
+
+  it('resolves after the first attempt even when every variant fails, without blocking', async () => {
+    installFonts(() => Promise.reject(new Error('server down')))
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+
+    // Must resolve on the first attempt (4 variants) -- not hang on failures.
+    await loadTerminalFonts(terminal, '"Hack NF", monospace', 13)
+    expect(load).toHaveBeenCalledTimes(4)
+    // No retry has fired yet (its backoff timer is still pending).
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+  })
+
+  it('retries failed variants with backoff and clears the atlas once they load', async () => {
+    let attempt = 0
+    installFonts(() => {
+      attempt++
+      // The first batch (4 variants) fails; every later attempt succeeds.
+      return attempt <= 4 ? Promise.reject(new Error('server down')) : Promise.resolve([{}])
+    })
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+
+    await loadTerminalFonts(terminal, '"Hack NF", monospace', 13)
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+
+    // Advance past the first backoff: the retry loads the variants and clears
+    // the atlas so an attached WebGL renderer re-rasterizes with the real font.
+    await vi.advanceTimersByTimeAsync(300)
+    expect(load.mock.calls.length).toBeGreaterThan(4)
+    expect(clearTextureAtlas).toHaveBeenCalled()
+  })
+
+  it('retries only the variants that failed on the first attempt', async () => {
+    let firstPass = true
+    installFonts((spec: string) => {
+      // The italic variants fail on the first pass; everything else -- and the
+      // retry -- loads cleanly.
+      if (firstPass && spec.includes('italic'))
+        return Promise.reject(new Error('server down'))
+      return Promise.resolve([{}])
+    })
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+
+    await loadTerminalFonts(terminal, '"Hack NF", monospace', 13)
+    expect(load).toHaveBeenCalledTimes(4) // all four variants attempted once
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+
+    firstPass = false
+    load.mockClear()
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Only the two italic variants -- the ones that failed -- are retried.
+    expect(load).toHaveBeenCalledTimes(2)
+    for (const [spec] of load.mock.calls)
+      expect(spec).toContain('italic')
+    expect(clearTextureAtlas).toHaveBeenCalled()
+  })
+
+  it('gives up after the bounded retry budget when the font never loads', async () => {
+    installFonts(() => Promise.reject(new Error('server down')))
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+
+    await loadTerminalFonts(terminal, '"Hack NF", monospace', 13)
+    await vi.runAllTimersAsync()
+    const callsAfterGivingUp = load.mock.calls.length
+
+    // 4 variants x (1 initial + 4 retries) = 20 attempts, then it stops.
+    expect(callsAfterGivingUp).toBe(20)
+    // Nothing ever loaded, so the atlas is never needlessly cleared.
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+
+    // Draining more time triggers no further attempts.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(load.mock.calls.length).toBe(callsAfterGivingUp)
+  })
+
+  it('is a no-op when the platform has no FontFaceSet', async () => {
+    delete (document as any).fonts
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+    await expect(loadTerminalFonts(terminal, '"Hack NF", monospace', 13)).resolves.toBeUndefined()
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+  })
+
+  it('degrades a spec that throws synchronously to a failed variant, never rejecting', async () => {
+    // document.fonts.load throws a SyntaxError *synchronously* on an unparseable
+    // font shorthand. loadTerminalFonts must swallow it (treating the variant as
+    // failed) rather than rejecting `fontsReady` -- which would otherwise throw
+    // out of createTerminalInstance at the call site that assigns it.
+    installFonts(() => {
+      throw new SyntaxError('unparseable font shorthand')
+    })
+    const { terminal, clearTextureAtlas } = fakeTerminal()
+
+    await expect(loadTerminalFonts(terminal, 'not a valid family', 13)).resolves.toBeUndefined()
+    // All four variants were attempted and each threw-then-degraded to a failure.
+    expect(load).toHaveBeenCalledTimes(4)
+
+    // The bounded retry keeps throwing-then-degrading and gives up without ever
+    // clearing the atlas (nothing loaded) and without an unhandled rejection.
+    await vi.runAllTimersAsync()
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -8,6 +8,7 @@ import { Terminal } from '@xterm/xterm'
 import { loadBrowserPrefs } from './browserStorage'
 import { copyTextToClipboard } from './clipboard'
 import { createLogger } from './logger'
+import { sleep } from './sleep'
 
 const DEFAULT_MONO_FONT_FAMILY = '"Hack NF", Hack, "SF Mono", Consolas, monospace'
 const log = createLogger('terminal')
@@ -45,6 +46,26 @@ export interface TerminalInstance {
   serializeAddon: SerializeAddon
   /** When true, onData responses are suppressed (e.g. during snapshot replay). */
   suppressInput: boolean
+  /**
+   * Whether this terminal is allowed to use the WebGL renderer at all
+   * (renderer preference resolves to 'webgl'). When false the terminal stays
+   * on the DOM renderer for its whole life and the pool never grants it a
+   * context.
+   */
+  webglAllowed: boolean
+  /**
+   * Resolves once every (weight, style) variant of the current font family
+   * has loaded. The WebGL renderer is only ever attached after this settles,
+   * so its glyph atlas is always rasterized with the real font -- never a
+   * fallback glyph. Re-assigned by refreshTerminalFont on a font-family swap.
+   */
+  fontsReady: Promise<void>
+  /**
+   * The live WebGL addon while this terminal holds a pooled context, else
+   * undefined (DOM renderer). Managed exclusively by attachWebgl/detachWebgl
+   * driven by the WebGL terminal pool.
+   */
+  webglAddon?: WebglAddon
   /** Send raw input data to the PTY backing this terminal. */
   sendInput?: (data: Uint8Array) => void
   dispose: () => void
@@ -67,7 +88,7 @@ export function serializeXtermBuffer(instance: TerminalInstance): Uint8Array {
   return new Uint8Array(encoded.buffer, encoded.byteOffset, encoded.byteLength)
 }
 
-const DEFAULT_FONT_SIZE = 13
+export const DEFAULT_FONT_SIZE = 13
 
 export const darkTerminalTheme: ITheme = {
   background: '#1a1917', // --background
@@ -275,33 +296,28 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   const serializeAddon = new SerializeAddon()
   terminal.loadAddon(serializeAddon)
 
+  // Renderer selection is deferred: terminals start on xterm's DOM renderer
+  // and the WebGL terminal pool lazily attaches a bounded number of WebGL
+  // contexts to the on-screen terminals that most need one (see
+  // webglTerminalPool). `webglAllowed` records whether this terminal may ever
+  // receive a context; the DOM renderer is the fallback for everyone else.
   const preference = getTerminalRendererPreference(prefs)
-  if (resolveTerminalRendererPreference(preference) === 'canvas') {
-    log.debug('terminal_renderer', { renderer: 'canvas', preference })
-  }
-  else {
-    try {
-      const webglAddon = new WebglAddon()
-      terminal.loadAddon(webglAddon)
-      webglAddon.onContextLoss(() => {
-        log.warn('terminal_renderer_webgl_context_lost')
-        webglAddon.dispose()
-      })
-      log.debug('terminal_renderer', { renderer: 'webgl', preference })
-    }
-    catch (error) {
-      log.warn('terminal_renderer', { renderer: 'canvas', preference, reason: 'webgl_unavailable', error })
-    }
-  }
+  const webglAllowed = resolveTerminalRendererPreference(preference) === 'webgl'
 
   // Web fonts (e.g. Hack NF) are declared with font-display: swap and load
-  // asynchronously. xterm's WebGL/canvas renderer rasterizes glyphs into a
-  // texture atlas as cells paint — if a given (weight, style) variant
-  // hasn't loaded yet, those cells are filled with fallback-font glyphs
-  // and never refreshed once the real font arrives. Trigger explicit
-  // fetches for every variant, then clear the atlas once they settle so
-  // the next paint re-rasterizes with the now-loaded font.
-  reloadFontsAndClearAtlas(terminal, fontFamily, fontSize)
+  // asynchronously. The WebGL renderer rasterizes glyphs into a texture atlas
+  // as cells paint, caching fallback-font glyphs for any (weight, style)
+  // variant that hasn't loaded yet. Kick off fetches for every variant now and
+  // expose the promise so the pool can hold WebGL attach until the real font
+  // is ready — the atlas is then always built from the loaded font.
+  //
+  // Only terminals that may receive a WebGL context need this gate: the DOM
+  // renderer has no atlas and paints via CSS font-family, so a WebGL-ineligible
+  // terminal would fetch four variants (and arm their cold-start retry timers)
+  // whose readiness `fontsReady` nobody ever awaits. Skip the fan-out for them.
+  const fontsReady = webglAllowed
+    ? loadTerminalFonts(terminal, fontFamily, fontSize)
+    : Promise.resolve()
 
   // Auto-copy the selection so users don't have to press Cmd/Ctrl+C
   // (mirrors iTerm2's "Copy on Select" behavior). Empty selections
@@ -316,9 +332,73 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     fitAddon,
     serializeAddon,
     suppressInput: false,
+    webglAllowed,
+    fontsReady,
+    webglAddon: undefined,
     dispose() {
       terminal.dispose()
     },
+  }
+}
+
+/**
+ * Attach the WebGL renderer to a terminal, wiring context-loss handling.
+ *
+ * Called only by the WebGL terminal pool, which has already awaited the
+ * instance's `fontsReady` and verified the terminal is on-screen and within
+ * the context budget. The pool-supplied `onContextLoss` lets the pool free the
+ * slot and re-attach elsewhere when the browser force-drops the GPU context.
+ *
+ * Returns whether the renderer attached. A false return (WebGL unavailable,
+ * e.g. jsdom or a lost driver) leaves the terminal on the DOM renderer, which
+ * is fully correct.
+ */
+export function attachWebgl(instance: TerminalInstance, onContextLoss: () => void): boolean {
+  if (!instance.webglAllowed)
+    return false
+  if (instance.webglAddon)
+    return true
+  try {
+    const addon = new WebglAddon()
+    instance.terminal.loadAddon(addon)
+    addon.onContextLoss(() => {
+      log.warn('terminal_renderer_webgl_context_lost')
+      // Drop our reference before disposing so a re-entrant detach is a no-op,
+      // then notify the pool so it can re-attach if the terminal is still on
+      // screen and within budget.
+      if (instance.webglAddon === addon)
+        instance.webglAddon = undefined
+      try {
+        addon.dispose()
+      }
+      catch {
+        // Already torn down by the context loss itself.
+      }
+      onContextLoss()
+    })
+    instance.webglAddon = addon
+    return true
+  }
+  catch (error) {
+    log.warn('terminal_renderer', { renderer: 'canvas', reason: 'webgl_unavailable', error })
+    return false
+  }
+}
+
+/**
+ * Detach the WebGL renderer, reverting the terminal to the DOM renderer.
+ * Idempotent: a no-op when no WebGL addon is attached.
+ */
+export function detachWebgl(instance: TerminalInstance): void {
+  const addon = instance.webglAddon
+  if (!addon)
+    return
+  instance.webglAddon = undefined
+  try {
+    addon.dispose()
+  }
+  catch {
+    // Terminal (and its addons) may already have been disposed.
   }
 }
 
@@ -332,28 +412,92 @@ const FONT_VARIANTS: ReadonlyArray<{ weight: string, style: string }> = [
   { weight: 'bold', style: 'italic' },
 ]
 
-/**
- * Initiate font-face fetches for every (weight, style) variant xterm
- * rasterizes into its glyph atlas. More reliable than waiting on
- * `document.fonts.ready`: that promise only awaits loads already in
- * flight, and at the moment a terminal is constructed the renderer may
- * not have referenced the font yet — so `.ready` can resolve before any
- * fetch has even started.
- */
-function loadMonoFontVariants(fontFamily: string, fontSize: number): Promise<void> {
-  if (typeof document === 'undefined' || !document.fonts?.load)
-    return Promise.resolve()
-  return Promise.all(
-    FONT_VARIANTS.map(({ weight, style }) =>
-      document.fonts.load(`${style} ${weight} ${fontSize}px ${fontFamily}`).catch(() => []),
-    ),
-  ).then(() => {})
+// Cold-start font fetches can fail transiently -- e.g. Tauri's static-file
+// server is briefly unavailable right after launch. Retry a failed variant a
+// bounded number of times with exponential backoff, then give up so a
+// genuinely-missing font doesn't spin forever.
+const FONT_LOAD_MAX_RETRIES = 4
+const FONT_LOAD_RETRY_BASE_MS = 300
+
+/** Load one font variant, resolving to whether it settled without a fetch error. */
+function tryLoadFontVariant(spec: string): Promise<boolean> {
+  // A resolve (even with zero matched faces, e.g. a pure system-font family)
+  // means "nothing failed"; only a reject signals a matched @font-face whose
+  // fetch failed and is worth retrying.
+  //
+  // `document.fonts.load` throws a SyntaxError *synchronously* when `spec` is
+  // not a parseable CSS font shorthand (e.g. a malformed custom family from a
+  // corrupted preference). Catch it so a bad spec degrades to a failed variant
+  // rather than rejecting `fontsReady` -- which would throw into the pool's
+  // attach and, at construction, out of createTerminalInstance itself.
+  try {
+    return document.fonts.load(spec).then(() => true, () => false)
+  }
+  catch {
+    return Promise.resolve(false)
+  }
 }
 
 /**
- * Trigger explicit fetches for every (weight, style) variant, then clear
- * the terminal's glyph atlas so the next paint re-rasterizes with the
- * now-loaded font.
+ * Fetch every (weight, style) variant xterm rasterizes into its glyph atlas
+ * and keep `terminal`'s atlas honest across cold-start fetch failures.
+ *
+ * The returned promise (assigned to `fontsReady`) resolves as soon as the
+ * FIRST attempt settles -- success or failure -- so the pool's WebGL attach is
+ * never blocked on a slow or failing fetch. Kicking off explicit fetches is
+ * more reliable than waiting on `document.fonts.ready`: that promise only
+ * awaits loads already in flight, and at construction the renderer may not have
+ * referenced the font yet, so `.ready` can resolve before any fetch starts.
+ *
+ * If a variant fails on the first attempt (a matched @font-face rejected), it
+ * is retried in the background with backoff; once it finally loads, the glyph
+ * atlas is cleared so a WebGL renderer that cached fallback glyphs re-paints
+ * with the real font. Without this, a terminal that attached WebGL during the
+ * outage would show fallback glyphs until the next font-family change or a
+ * reload. `clearTextureAtlas()` is a no-op on the DOM renderer, so the retry
+ * clear is harmless for terminals without a WebGL context.
+ */
+export function loadTerminalFonts(terminal: Terminal, fontFamily: string, fontSize: number): Promise<void> {
+  if (typeof document === 'undefined' || !document.fonts?.load)
+    return Promise.resolve()
+  const specs = FONT_VARIANTS.map(({ weight, style }) => `${style} ${weight} ${fontSize}px ${fontFamily}`)
+  return Promise.all(specs.map(tryLoadFontVariant)).then((settled) => {
+    const failed = specs.filter((_, i) => !settled[i])
+    if (failed.length > 0)
+      void retryFontVariants(terminal, failed)
+  })
+}
+
+/**
+ * Retry the given font-variant specs with exponential backoff until they load
+ * or the attempt budget is exhausted, clearing `terminal`'s atlas whenever a
+ * batch makes progress so an attached WebGL renderer drops its cached fallback
+ * glyphs.
+ */
+async function retryFontVariants(terminal: Terminal, specs: string[]): Promise<void> {
+  let pending = specs
+  for (let attempt = 0; attempt < FONT_LOAD_MAX_RETRIES && pending.length > 0; attempt++) {
+    await sleep(FONT_LOAD_RETRY_BASE_MS * 2 ** attempt)
+    // The document (and its FontFaceSet) can go away mid-retry during teardown;
+    // stop rather than throw into this floating promise.
+    if (typeof document === 'undefined' || !document.fonts?.load)
+      return
+    const settled = await Promise.all(pending.map(tryLoadFontVariant))
+    if (settled.some(Boolean))
+      scheduleAtlasClear(terminal)
+    pending = pending.filter((_, i) => !settled[i])
+  }
+}
+
+/**
+ * React to a font-family change on a live terminal instance: point xterm at
+ * the new family, re-arm `fontsReady` for the new variants, and — once they
+ * load — clear the glyph atlas so an attached WebGL renderer re-rasterizes
+ * with the new font.
+ *
+ * Re-arming `fontsReady` is what keeps the atlas correct across a swap: a
+ * later (or in-flight) pool attach awaits the *current* `fontsReady`, so it
+ * never builds the atlas from the outgoing font.
  *
  * Why a promise-based clear and not a `FontFaceSet` `loadingdone` listener:
  * when the first fetch attempt fails (e.g. Tauri's static-file server is
@@ -361,21 +505,49 @@ function loadMonoFontVariants(fontFamily: string, fontSize: number): Promise<voi
  * transition `error → loaded` and Chromium does not emit `loadingdone`.
  * `document.fonts.load(...)` resolves cleanly in that case.
  *
- * Two passes — once after our `load()` promises settle, once on the next
- * animation frame — cover the case where xterm's first paint rasterized
- * fallback glyphs in the brief window between the load completing and
- * our `.then()` callback running.
+ * Two clear passes — once after our `load()` promises settle, once on the
+ * next animation frame — cover the case where the renderer's first paint
+ * rasterized fallback glyphs in the brief window between the load completing
+ * and our `.then()` callback running. `clearTextureAtlas()` is a no-op on the
+ * DOM renderer, so this is harmless for terminals without a WebGL context.
+ *
+ * Returns whether the family actually changed, so callers can gate follow-up
+ * work (e.g. re-fitting) on a real swap: because every mounted TerminalView
+ * iterates the shared `instances` map, the first view to see a swap does the
+ * work and the rest get `false` and skip it, avoiding N-views x M-terminals
+ * redundant reflows on a single font change.
  */
-export function reloadFontsAndClearAtlas(
-  terminal: Terminal,
+export function refreshTerminalFont(
+  instance: TerminalInstance,
   fontFamily: string,
   fontSize: number,
-): Promise<void> {
-  return loadMonoFontVariants(fontFamily, fontSize).then(() => {
-    clearAtlas(terminal)
-    if (typeof requestAnimationFrame !== 'undefined')
-      requestAnimationFrame(() => clearAtlas(terminal))
-  })
+): boolean {
+  // Skip when the family is unchanged. The font-preference effect re-fires
+  // whenever the preferences store hydrates -- a fresh `monoFonts` array is a
+  // new signal value even when the resolved family string is byte-identical --
+  // and re-arming `fontsReady` with a new unsettled promise on every such fire
+  // would needlessly delay the pool's WebGL attach (which awaits it) and
+  // re-fetch every font variant.
+  if (instance.terminal.options.fontFamily === fontFamily)
+    return false
+  instance.terminal.options.fontFamily = fontFamily
+  const ready = loadTerminalFonts(instance.terminal, fontFamily, fontSize)
+  instance.fontsReady = ready
+  void ready.then(() => scheduleAtlasClear(instance.terminal))
+  return true
+}
+
+/**
+ * Clear the glyph atlas now and once more on the next animation frame. The
+ * second pass covers the window where the renderer's first paint rasterized
+ * fallback glyphs between a font load completing and this callback running.
+ * Shared by the font-swap path and the cold-start retry so both drop stale
+ * fallback glyphs identically. A no-op on the DOM renderer (which has no atlas).
+ */
+function scheduleAtlasClear(terminal: Terminal): void {
+  clearAtlas(terminal)
+  if (typeof requestAnimationFrame !== 'undefined')
+    requestAnimationFrame(() => clearAtlas(terminal))
 }
 
 function clearAtlas(terminal: Terminal): void {

--- a/frontend/src/lib/webglTerminalPool.test.ts
+++ b/frontend/src/lib/webglTerminalPool.test.ts
@@ -1,0 +1,391 @@
+import type { Mock } from 'vitest'
+import type { TerminalInstance } from './terminal'
+import type { WebglTerminalPool } from './webglTerminalPool'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWebglTerminalPool } from './webglTerminalPool'
+
+// Drain all pending microtasks (the pool coalesces reconcile onto a microtask,
+// and attach awaits `fontsReady`). A macrotask tick guarantees every chained
+// microtask has run.
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+function fakeInstance(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    webglAllowed: true,
+    fontsReady: Promise.resolve(),
+    webglAddon: undefined,
+    terminal: { element: { isConnected: true } },
+    ...overrides,
+  } as unknown as TerminalInstance
+}
+
+describe('createWebglTerminalPool', () => {
+  let attach: Mock<(instance: TerminalInstance, onContextLoss: () => void) => boolean>
+  let detach: Mock<(instance: TerminalInstance) => void>
+  // The most recent onContextLoss callback handed to `attach`, so tests can
+  // simulate the browser force-dropping a context.
+  let lastOnContextLoss: (() => void) | undefined
+
+  const makePool = (capacity: number): WebglTerminalPool =>
+    createWebglTerminalPool({ capacity, attach, detach })
+
+  beforeEach(() => {
+    lastOnContextLoss = undefined
+    attach = vi.fn<(instance: TerminalInstance, onContextLoss: () => void) => boolean>((_instance, onContextLoss) => {
+      lastOnContextLoss = onContextLoss
+      return true
+    })
+    detach = vi.fn<(instance: TerminalInstance) => void>()
+  })
+
+  it('attaches only up to capacity, keeping the hottest ids and dropping the coldest', async () => {
+    const pool = makePool(3)
+    const ids = ['a', 'b', 'c', 'd', 'e']
+    for (const id of ids)
+      pool.acquire(id, fakeInstance())
+    await flush()
+
+    // order (cold -> hot) is a,b,c,d,e; the hottest 3 win contexts.
+    expect(pool.size()).toBe(3)
+    expect(pool.has('a')).toBe(false)
+    expect(pool.has('b')).toBe(false)
+    expect(pool.has('c')).toBe(true)
+    expect(pool.has('d')).toBe(true)
+    expect(pool.has('e')).toBe(true)
+    expect(attach).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-attaches a waiting desired terminal when a slot frees up', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance())
+    pool.acquire('b', fakeInstance())
+    pool.acquire('c', fakeInstance()) // evicts a (order a,b,c -> keep b,c)
+    await flush()
+    expect(pool.has('a')).toBe(false)
+    expect(pool.has('b')).toBe(true)
+    expect(pool.has('c')).toBe(true)
+
+    pool.release('c')
+    await flush()
+    // desired is now {a, b}; a was waiting on DOM and now gets the freed slot.
+    expect(pool.has('c')).toBe(false)
+    expect(pool.has('a')).toBe(true)
+    expect(pool.has('b')).toBe(true)
+    expect(pool.size()).toBe(2)
+  })
+
+  it('never evicts the focused terminal even when it is the coldest', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance(), { focused: true })
+    pool.acquire('b', fakeInstance())
+    pool.acquire('c', fakeInstance())
+    await flush()
+
+    // Without the focus pin, `a` (coldest) would lose to b/c. It's protected.
+    expect(pool.has('a')).toBe(true)
+    expect(pool.has('c')).toBe(true)
+    expect(pool.has('b')).toBe(false)
+    expect(pool.size()).toBe(2)
+  })
+
+  it('admits a newly focused terminal by evicting the coldest attached one', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance())
+    pool.acquire('b', fakeInstance())
+    await flush()
+    expect(pool.has('a')).toBe(true)
+    expect(pool.has('b')).toBe(true)
+
+    // A cold, unattached terminal gains focus -> must get a slot.
+    pool.acquire('c', fakeInstance(), { focused: true })
+    await flush()
+    expect(pool.has('c')).toBe(true)
+    expect(pool.size()).toBe(2)
+    // The coldest previously-attached (a) is the eviction victim, not b.
+    expect(pool.has('a')).toBe(false)
+    expect(pool.has('b')).toBe(true)
+  })
+
+  it('never attaches a WebGL-ineligible terminal', async () => {
+    const pool = makePool(4)
+    pool.acquire('a', fakeInstance({ webglAllowed: false }))
+    await flush()
+    expect(pool.has('a')).toBe(false)
+    expect(pool.size()).toBe(0)
+    expect(attach).not.toHaveBeenCalled()
+  })
+
+  it('does not attach a terminal whose element is detached', async () => {
+    const pool = makePool(4)
+    pool.acquire('a', fakeInstance({ terminal: { element: { isConnected: false } } as any }))
+    await flush()
+    expect(pool.has('a')).toBe(false)
+    expect(attach).not.toHaveBeenCalled()
+  })
+
+  it('re-attaches after a context loss while the terminal is still desired', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance())
+    await flush()
+    expect(pool.has('a')).toBe(true)
+    expect(attach).toHaveBeenCalledTimes(1)
+
+    // Simulate the browser dropping the GPU context.
+    lastOnContextLoss!()
+    await flush()
+
+    expect(detach).toHaveBeenCalledTimes(1)
+    expect(attach).toHaveBeenCalledTimes(2)
+    expect(pool.has('a')).toBe(true)
+  })
+
+  it('stops re-attaching after repeated context losses, then recovers on re-acquire', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance())
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+
+    // Each loss triggers exactly one re-attach, up to the retry budget.
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(2)
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(3)
+
+    // Budget exhausted: the pool stops thrashing and leaves it on DOM.
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(3)
+    expect(pool.has('a')).toBe(false)
+
+    // A release + re-acquire (e.g. tab switch) resets the budget and recovers.
+    pool.release('a')
+    await flush()
+    pool.acquire('a', fakeInstance())
+    await flush()
+    expect(pool.has('a')).toBe(true)
+    expect(attach).toHaveBeenCalledTimes(4)
+  })
+
+  it('resets the loss budget once a context survives the decay window, without a release', async () => {
+    // A persistently-visible terminal that is never released must still recover
+    // WebGL after transient GPU pressure eases -- otherwise its lifetime loss
+    // count, which release would normally reset, pins it to DOM forever.
+    let clock = 0
+    const pool = createWebglTerminalPool({ capacity: 2, attach, detach, now: () => clock })
+    pool.acquire('a', fakeInstance())
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+
+    // Two quick losses (inside the decay window) accumulate the budget to its
+    // ceiling -- a third un-reset loss would exhaust it and leave 'a' on DOM.
+    lastOnContextLoss!()
+    await flush()
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(3)
+    expect(pool.has('a')).toBe(true)
+
+    // The context now survives past the decay window before the next loss: the
+    // storm is treated as over, the budget resets, and the loss re-attaches
+    // instead of giving up (which the un-reset budget would do here).
+    clock += 30_001
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(4)
+    expect(pool.has('a')).toBe(true)
+
+    // It keeps recovering as long as each loss follows a healthy spell.
+    clock += 30_001
+    lastOnContextLoss!()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(5)
+    expect(pool.has('a')).toBe(true)
+  })
+
+  it('still gives up on a rapid loss storm within the decay window', async () => {
+    // The decay reset must not weaken the anti-thrash bound: losses that all
+    // land inside the window keep accumulating and still exhaust the budget.
+    let clock = 0
+    const pool = createWebglTerminalPool({ capacity: 2, attach, detach, now: () => clock })
+    pool.acquire('a', fakeInstance())
+    await flush()
+
+    // Three losses, each only a little later but all well within the window.
+    for (let i = 0; i < 3; i++) {
+      clock += 1000
+      lastOnContextLoss!()
+      await flush()
+    }
+    expect(attach).toHaveBeenCalledTimes(3)
+    expect(pool.has('a')).toBe(false)
+  })
+
+  it('keeps a context attached across a same-tick cross-tile move (no churn)', async () => {
+    const pool = makePool(4)
+    const instance = fakeInstance()
+    pool.acquire('a', instance)
+    await flush()
+    expect(pool.has('a')).toBe(true)
+    expect(attach).toHaveBeenCalledTimes(1)
+
+    // A move: the source tile releases and the destination tile re-acquires
+    // the same id in the same synchronous tick, before the coalesced reconcile
+    // runs. Net effect must be "still attached" with zero detach/re-attach.
+    pool.release('a')
+    pool.acquire('a', instance)
+    await flush()
+
+    expect(pool.has('a')).toBe(true)
+    expect(detach).not.toHaveBeenCalled()
+    expect(attach).toHaveBeenCalledTimes(1)
+  })
+
+  it('detaches the old instance and re-attaches when the instance is swapped for a still-attached id', async () => {
+    const pool = makePool(2)
+    const first = fakeInstance()
+    pool.acquire('a', first)
+    await flush()
+    expect(pool.has('a')).toBe(true)
+    expect(attach).toHaveBeenCalledTimes(1)
+    expect(attach).toHaveBeenLastCalledWith(first, expect.any(Function))
+
+    // A DIFFERENT instance object arrives for the same id without an
+    // intervening release (a dispose+recreate that lands before the slot
+    // settled). The old instance's context must be detached and the new
+    // instance must get its own -- otherwise the stale 'webgl' slot wedges the
+    // new instance onto DOM forever while the pool still reports it attached.
+    const second = fakeInstance()
+    pool.acquire('a', second)
+    await flush()
+
+    expect(detach).toHaveBeenCalledWith(first)
+    expect(attach).toHaveBeenCalledTimes(2)
+    expect(attach).toHaveBeenLastCalledWith(second, expect.any(Function))
+    expect(pool.has('a')).toBe(true)
+  })
+
+  it('a swapped-in instance resets a retry-exhausted id and attaches fresh', async () => {
+    const pool = makePool(2)
+    const first = fakeInstance()
+    pool.acquire('a', first)
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+
+    // Exhaust the context-loss retry budget for `first`: each loss triggers one
+    // re-attach up to MAX_CONTEXT_LOSS_RETRIES, then the pool gives up and
+    // leaves the id ineligible on DOM.
+    lastOnContextLoss!()
+    await flush()
+    lastOnContextLoss!()
+    await flush()
+    lastOnContextLoss!()
+    await flush()
+    expect(pool.has('a')).toBe(false)
+    const attachesAfterGivingUp = attach.mock.calls.length
+
+    // A fresh instance for the same id (dispose+recreate, no release) must clear
+    // the ineligible mark and earn its own attach attempt.
+    const second = fakeInstance()
+    pool.acquire('a', second)
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(attachesAfterGivingUp + 1)
+    expect(attach).toHaveBeenLastCalledWith(second, expect.any(Function))
+    expect(pool.has('a')).toBe(true)
+  })
+
+  it('re-attaches the new instance when a swap lands mid-attach (pending slot not wedged)', async () => {
+    const pool = makePool(2)
+    const firstFonts = deferred()
+    const first = fakeInstance({ fontsReady: firstFonts.promise })
+    pool.acquire('a', first)
+    await flush()
+    // first is still 'pending' -- its fonts have not resolved.
+    expect(attach).not.toHaveBeenCalled()
+
+    // Swap in a new instance (whose fonts are ready) while the old attach is
+    // still pending. The new instance must attach; the stale pending attach for
+    // `first` must be invalidated (its later font resolution is a no-op).
+    const second = fakeInstance()
+    pool.acquire('a', second)
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+    expect(attach).toHaveBeenLastCalledWith(second, expect.any(Function))
+    expect(pool.has('a')).toBe(true)
+
+    // The abandoned first attach resolving late must not attach a second context.
+    firstFonts.resolve()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+  })
+
+  it('defers attach until fonts are ready and skips it if released first', async () => {
+    const pool = makePool(2)
+    const fonts = deferred()
+    pool.acquire('a', fakeInstance({ fontsReady: fonts.promise }))
+    await flush()
+    // Fonts have not loaded yet: no attach.
+    expect(attach).not.toHaveBeenCalled()
+
+    // The terminal goes off screen before fonts finish loading.
+    pool.release('a')
+    await flush()
+    fonts.resolve()
+    await flush()
+
+    // The stale in-flight attach must not fire.
+    expect(attach).not.toHaveBeenCalled()
+    expect(pool.has('a')).toBe(false)
+  })
+
+  it('rasterizes with the font that wins a swap that lands mid-attach', async () => {
+    const pool = makePool(2)
+    const firstFont = deferred()
+    const secondFont = deferred()
+    const instance = fakeInstance({ fontsReady: firstFont.promise })
+    pool.acquire('a', instance)
+    await flush()
+    expect(attach).not.toHaveBeenCalled()
+
+    // A font-family swap replaces fontsReady while the attach still awaits.
+    instance.fontsReady = secondFont.promise
+    firstFont.resolve()
+    await flush()
+    // Attach must keep waiting for the *new* font, not proceed on the old one.
+    expect(attach).not.toHaveBeenCalled()
+
+    secondFont.resolve()
+    await flush()
+    expect(attach).toHaveBeenCalledTimes(1)
+    expect(pool.has('a')).toBe(true)
+  })
+
+  it('release is a no-op for an unknown id', async () => {
+    const pool = makePool(2)
+    expect(() => pool.release('never-acquired')).not.toThrow()
+    await flush()
+    expect(pool.size()).toBe(0)
+  })
+
+  it('disposeAll detaches live contexts and clears all state', async () => {
+    const pool = makePool(2)
+    pool.acquire('a', fakeInstance())
+    pool.acquire('b', fakeInstance())
+    await flush()
+    expect(pool.size()).toBe(2)
+
+    pool.disposeAll()
+    expect(pool.size()).toBe(0)
+    expect(pool.has('a')).toBe(false)
+    expect(detach).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/lib/webglTerminalPool.ts
+++ b/frontend/src/lib/webglTerminalPool.ts
@@ -1,0 +1,442 @@
+import type { TerminalInstance } from './terminal'
+import { createLogger } from './logger'
+import { attachWebgl, detachWebgl } from './terminal'
+
+const log = createLogger('webgl-pool')
+
+/**
+ * Maximum number of terminals that may hold a live WebGL context at once.
+ *
+ * Browsers cap simultaneous WebGL contexts (~16 on Chrome/Blink, stricter on
+ * WKWebView/Safari) and force-drop the oldest past the cap, which corrupts the
+ * evicted terminal's glyphs. We keep well under that ceiling to leave headroom
+ * for the transient double-context that exists during an eviction hand-off and
+ * for any other WebGL in the app.
+ *
+ * Only on-screen (`active && visible`) terminals ever compete for a slot, so
+ * the realistic contender set is the number of visible tiles showing a
+ * terminal -- almost always <= K. When it does exceed K (a pathological large
+ * grid), the overflow terminals fall back to xterm's DOM renderer, which is
+ * fully correct just not GPU-accelerated: eviction is a performance event,
+ * never a corruption event.
+ */
+export const MAX_WEBGL_TERMINAL_CONTEXTS = 8
+
+/**
+ * How many times a terminal may have its WebGL context force-dropped by the
+ * browser before the pool stops re-attaching and leaves it on the DOM
+ * renderer. Without this bound, a machine under system-wide GPU pressure
+ * (other tabs/apps holding contexts) would thrash: lose -> re-attach -> lose,
+ * spamming warnings and burning CPU instead of settling on the correct DOM
+ * fallback. The counter resets when the terminal is released and re-acquired
+ * (e.g. a tab switch) OR when a context survives CONTEXT_LOSS_BUDGET_RESET_MS
+ * before failing, so recovery is automatic once pressure eases even for a
+ * terminal that is never switched away.
+ */
+const MAX_CONTEXT_LOSS_RETRIES = 2
+
+/**
+ * How long (ms) a WebGL context must stay continuously attached before a
+ * subsequent loss is treated as a fresh storm rather than a continuation of the
+ * previous one. Past this window the loss-retry budget resets. Without it, a
+ * persistently-visible terminal (a split-tile pane never released to reset the
+ * count) that loses its context more than MAX_CONTEXT_LOSS_RETRIES times over
+ * its whole life -- even with hours of healthy uptime between losses -- would be
+ * pinned to the DOM renderer forever. The window keeps the anti-thrash bound for
+ * genuinely rapid lose -> re-attach -> lose loops (each loss lands well inside
+ * it) while letting a terminal recover after transient pressure eases.
+ */
+const CONTEXT_LOSS_BUDGET_RESET_MS = 30_000
+
+export interface WebglTerminalPool {
+  /**
+   * Mark a terminal as on-screen and wanting a WebGL context. Idempotent.
+   * `focused` pins the terminal to the top priority so the one the user is
+   * typing in is never the eviction victim, even on an initial grid render
+   * where mount order would otherwise decide.
+   */
+  acquire: (id: string, instance: TerminalInstance, opts?: { focused?: boolean }) => void
+  /** Relinquish a terminal's claim on a WebGL context (off-screen or disposed). */
+  release: (id: string) => void
+  /** True when the terminal currently holds a live WebGL context. */
+  has: (id: string) => boolean
+  /** Number of terminals currently holding a live WebGL context. */
+  size: () => number
+  /** Detach every context and reset all state. For HMR teardown and tests. */
+  disposeAll: () => void
+}
+
+export interface WebglTerminalPoolDeps {
+  capacity: number
+  /**
+   * Attach a WebGL renderer to the instance, wiring `onContextLoss` to the
+   * supplied callback. Returns whether the attach succeeded (false when WebGL
+   * is unavailable, e.g. jsdom). Must be synchronous -- the pool has already
+   * awaited font readiness before calling it.
+   */
+  attach: (instance: TerminalInstance, onContextLoss: () => void) => boolean
+  /** Detach the WebGL renderer, reverting the instance to the DOM renderer. */
+  detach: (instance: TerminalInstance) => void
+  /**
+   * Wall-clock source (ms) for the context-loss decay window. Injected so tests
+   * can drive it deterministically; defaults to Date.now.
+   */
+  now?: () => number
+}
+
+type SlotState = 'dom' | 'pending' | 'webgl'
+
+/**
+ * All per-id bookkeeping for one terminal, held in a single record so the
+ * facts that must describe the same terminal -- its instance, renderer state,
+ * in-flight-attach token, and eligibility -- can't fall out of sync across the
+ * detach/attach/loss paths that mutate them. The genuinely cross-cutting
+ * structures (recency `order`, the `desired` on-screen set, `focusedId`) stay
+ * separate because they relate ids to each other, not to one id's own state.
+ */
+interface Slot {
+  instance: TerminalInstance
+  state: SlotState
+  /**
+   * Monotonic token. Bumped on every detach / context-loss / instance swap so
+   * an async attach that was in flight across the change becomes a no-op
+   * instead of attaching to a terminal that no longer wants it.
+   */
+  epoch: number
+  /**
+   * True once the attach threw (WebGL genuinely unavailable) or the terminal
+   * exhausted its context-loss retries. Skipped by reconcile until the id is
+   * released, so we don't retry a doomed attach every tick.
+   */
+  ineligible: boolean
+  /** Count of browser-forced context losses, for the retry bound. */
+  contextLossCount: number
+  /**
+   * Wall-clock time (ms) this slot last reached the 'webgl' state, or undefined
+   * while on DOM / mid-attach. Used to decay the context-loss budget: a loss
+   * that arrives after the context survived CONTEXT_LOSS_BUDGET_RESET_MS resets
+   * the count. Cleared by doDetach so a re-attach re-stamps it.
+   */
+  attachedAt?: number
+}
+
+/**
+ * Bounds the number of live WebGL contexts across an unbounded number of
+ * terminals. Terminals render with xterm's DOM renderer by default; the pool
+ * hands out at most `capacity` WebGL contexts to the most-recently-used
+ * on-screen terminals and detaches the rest.
+ *
+ * `attach`/`detach` are injected so the reconciliation logic is unit-testable
+ * without a real GPU; the production singleton (`webglPool`) wires them to
+ * `attachWebgl`/`detachWebgl` in `./terminal`.
+ *
+ * Reconciliation is coalesced onto a microtask: `acquire`/`release` only
+ * mutate bookkeeping synchronously, and a single `reconcile()` runs after the
+ * current reactive flush settles. This is what makes a cross-tile move safe --
+ * the source tile's `release` and the destination tile's `acquire` for the
+ * same id land in the same tick and net to "still desired", so the terminal
+ * never briefly loses (and re-rasterizes) its renderer.
+ */
+export function createWebglTerminalPool(deps: WebglTerminalPoolDeps): WebglTerminalPool {
+  const { capacity, attach, detach } = deps
+  const now = deps.now ?? (() => Date.now())
+
+  // The per-id record for every terminal the pool knows about. A slot is
+  // created on the first `acquire` for an id and dropped by `reconcile` once
+  // the id is released and has settled back on the DOM renderer.
+  const slots = new Map<string, Slot>()
+  // On-screen ids, ordered cold -> hot (hot end == most recently touched).
+  const order: string[] = []
+  const desired = new Set<string>()
+  let focusedId: string | null = null
+  let reconcileScheduled = false
+
+  // A slot "holds or is claiming a context" when it is attached ('webgl') or
+  // mid-attach ('pending') -- both own a teardown obligation. The three paths
+  // that must tear a context down (reconcile eviction, instance swap, and
+  // disposeAll) key off this one predicate rather than re-listing the states,
+  // so a future fourth state can't silently slip past one of them.
+  function holdsContext(slot: Slot): boolean {
+    return slot.state === 'webgl' || slot.state === 'pending'
+  }
+
+  // Detach the addon backing `id`, swallowing (and logging) any teardown
+  // error. Centralizes the guard the three detach paths share so they can't
+  // drift on what a failed detach means.
+  function safeDetach(id: string) {
+    const slot = slots.get(id)
+    if (!slot)
+      return
+    try {
+      detach(slot.instance)
+    }
+    catch (error) {
+      log.warn('webgl_detach_failed', { error })
+    }
+  }
+
+  function removeFromOrder(id: string) {
+    const i = order.indexOf(id)
+    if (i !== -1)
+      order.splice(i, 1)
+  }
+
+  function touch(id: string) {
+    removeFromOrder(id)
+    order.push(id)
+  }
+
+  // An id turns ineligible once its attach threw (WebGL unavailable) or its
+  // context-loss retries were exhausted; the mark stays until the id is
+  // released. Eligible ids are the only ones `computeTarget` hands a context.
+  function isEligible(id: string): boolean {
+    return !slots.get(id)?.ineligible
+  }
+
+  // The set of ids that should hold a WebGL context right now: the focused
+  // terminal (pinned) plus the hottest desired ids until `capacity` is full.
+  function computeTarget(): Set<string> {
+    const target = new Set<string>()
+    if (focusedId && desired.has(focusedId) && isEligible(focusedId))
+      target.add(focusedId)
+    for (let i = order.length - 1; i >= 0 && target.size < capacity; i--) {
+      const id = order[i]
+      if (isEligible(id))
+        target.add(id)
+    }
+    return target
+  }
+
+  function scheduleReconcile() {
+    if (reconcileScheduled)
+      return
+    reconcileScheduled = true
+    queueMicrotask(() => {
+      reconcileScheduled = false
+      reconcile()
+    })
+  }
+
+  function reconcile() {
+    const target = computeTarget()
+
+    // Detach anything attached or mid-attach that no longer belongs.
+    for (const [id, slot] of slots) {
+      if (holdsContext(slot) && !target.has(id))
+        doDetach(id)
+    }
+
+    // Attach any target id not already attached or mid-attach.
+    for (const id of target) {
+      if ((slots.get(id)?.state ?? 'dom') === 'dom')
+        doAttach(id)
+    }
+
+    // Drop the slot for ids that are fully released and settled on DOM.
+    for (const [id, slot] of [...slots]) {
+      if (!desired.has(id) && slot.state === 'dom')
+        slots.delete(id)
+    }
+  }
+
+  function doDetach(id: string) {
+    const slot = slots.get(id)
+    if (!slot)
+      return
+    slot.epoch++ // invalidate any in-flight attach for this id
+    safeDetach(id)
+    slot.state = 'dom'
+    slot.attachedAt = undefined
+  }
+
+  function doAttach(id: string) {
+    const slot = slots.get(id)
+    if (!slot || !slot.instance.webglAllowed || slot.ineligible) {
+      if (slot)
+        slot.state = 'dom'
+      return
+    }
+    const instance = slot.instance
+    slot.state = 'pending'
+    const myEpoch = slot.epoch
+    void (async () => {
+      try {
+        // Wait until fonts have loaded before building the atlas, so the WebGL
+        // renderer never caches fallback glyphs. Re-read `fontsReady` after
+        // each await: a font-family swap replaces it mid-wait and we must
+        // rasterize with the family that will actually be shown.
+        let ready = instance.fontsReady
+        await ready
+        while (instance.fontsReady !== ready) {
+          ready = instance.fontsReady
+          await ready
+        }
+
+        // Bail if anything changed while we awaited: the slot was dropped, the
+        // id was detached or re-prioritized (epoch bumped), the instance was
+        // swapped, or a concurrent reconcile already moved this id off
+        // `pending`. Re-read the live slot -- a swap may have replaced it.
+        const live = slots.get(id)
+        if (!live || live.epoch !== myEpoch || live.instance !== instance || live.state !== 'pending')
+          return
+        // Attaching a WebGL renderer to a terminal whose element is detached
+        // corrupts its dimensions; leave it on DOM until a later reconcile.
+        if (!instance.terminal.element?.isConnected) {
+          live.state = 'dom'
+          return
+        }
+        if (instance.webglAddon) {
+          live.state = 'webgl'
+          return
+        }
+
+        if (attach(instance, () => onContextLoss(id))) {
+          live.state = 'webgl'
+          live.attachedAt = now()
+        }
+        else {
+          // WebGL genuinely unavailable -- stop retrying until release.
+          live.state = 'dom'
+          live.ineligible = true
+        }
+      }
+      catch (error) {
+        // Never leave the id wedged in `pending` on an unexpected throw --
+        // reset it to DOM so a later reconcile can retry.
+        log.warn('webgl_attach_failed', { error })
+        const live = slots.get(id)
+        if (live && live.state === 'pending')
+          live.state = 'dom'
+      }
+    })()
+  }
+
+  // The browser force-dropped this terminal's GPU context. Treat it as an
+  // involuntary detach and let reconcile re-attach if the terminal is still
+  // desired and within capacity -- NOT a user-level release, which would
+  // permanently demote a still-visible terminal to the DOM renderer. Bound the
+  // re-attach so a machine under system-wide GPU pressure settles on DOM
+  // instead of thrashing lose -> re-attach -> lose forever.
+  function onContextLoss(id: string) {
+    const slot = slots.get(id)
+    // A context that stayed attached past the reset window before the browser
+    // dropped it signals the earlier loss storm has passed, so clear the retry
+    // budget before counting this loss. Read attachedAt now -- doDetach below
+    // clears it. Without this, a persistently-visible terminal (never released
+    // to reset the count) would accumulate losses spread over hours and stay
+    // pinned to DOM for the rest of its life even after the pressure eased.
+    if (slot?.attachedAt !== undefined && now() - slot.attachedAt > CONTEXT_LOSS_BUDGET_RESET_MS)
+      slot.contextLossCount = 0
+
+    // Same teardown as a voluntary eviction (dispose the addon, invalidate any
+    // in-flight attach, reset the slot to 'dom'); the loss-count bookkeeping and
+    // reschedule below are what make it involuntary.
+    doDetach(id)
+    if (!slot)
+      return
+    slot.contextLossCount++
+    if (slot.contextLossCount > MAX_CONTEXT_LOSS_RETRIES) {
+      slot.ineligible = true
+      log.warn('terminal_renderer_webgl_giving_up', { losses: slot.contextLossCount })
+    }
+    scheduleReconcile()
+  }
+
+  return {
+    acquire(id, instance, opts) {
+      const existing = slots.get(id)
+      if (!existing) {
+        // First time this id is on-screen: give it a slot on the DOM renderer.
+        slots.set(id, { instance, state: 'dom', epoch: 0, ineligible: false, contextLossCount: 0 })
+      }
+      else if (existing.instance !== instance) {
+        // A fresh instance object for a reused id (e.g. the terminal was
+        // disposed and recreated before this id's slot settled). Tear down any
+        // context the OLD instance still holds and reset its slot to 'dom' --
+        // otherwise the stale 'webgl'/'pending' state wedges the new instance
+        // out of an attach (reconcile's attach loop only acts on 'dom' slots)
+        // and the old context is never detached, leaking a slot and diverging
+        // the pool's accounting from reality. doDetach runs against the
+        // still-registered old instance, so swap it in only afterwards. Reset
+        // eligibility too so the new terminal gets its own attempt.
+        if (holdsContext(existing))
+          doDetach(id) // detaches the old instance, bumps epoch, resets to 'dom'
+        else
+          existing.epoch++ // still invalidate any in-flight attach for the old instance
+        existing.instance = instance
+        existing.ineligible = false
+        existing.contextLossCount = 0
+      }
+      desired.add(id)
+      touch(id)
+      if (opts?.focused)
+        focusedId = id
+      else if (focusedId === id)
+        focusedId = null
+      scheduleReconcile()
+    },
+
+    release(id) {
+      desired.delete(id)
+      removeFromOrder(id)
+      // Reset the retry budget so a later re-acquire (e.g. a tab switch back)
+      // gets a fresh attempt. The slot itself is dropped by the next reconcile
+      // once it has settled back on DOM.
+      const slot = slots.get(id)
+      if (slot) {
+        slot.ineligible = false
+        slot.contextLossCount = 0
+      }
+      if (focusedId === id)
+        focusedId = null
+      scheduleReconcile()
+    },
+
+    has(id) {
+      return slots.get(id)?.state === 'webgl'
+    },
+
+    size() {
+      let count = 0
+      for (const slot of slots.values()) {
+        if (slot.state === 'webgl')
+          count++
+      }
+      return count
+    },
+
+    disposeAll() {
+      for (const [id, slot] of slots) {
+        if (holdsContext(slot))
+          safeDetach(id)
+      }
+      slots.clear()
+      order.length = 0
+      desired.clear()
+      focusedId = null
+      reconcileScheduled = false
+    },
+  }
+}
+
+/**
+ * Process-wide pool wired to the real xterm WebGL attach/detach. Shared by
+ * every mounted TerminalView so the WebGL context budget is enforced across
+ * all tiles and workspaces, not per-view.
+ */
+export const webglPool: WebglTerminalPool = createWebglTerminalPool({
+  capacity: MAX_WEBGL_TERMINAL_CONTEXTS,
+  attach: attachWebgl,
+  detach: detachWebgl,
+})
+
+// During Vite HMR the module is re-evaluated with fresh closure state; detach
+// every live context first so the old Terminal objects' renderers are torn
+// down cleanly instead of leaking WebGL contexts and firing stray callbacks
+// against a half-disposed renderer (mirrors the `instances`-map HMR hook in
+// TerminalView).
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    webglPool.disposeAll()
+  })
+}

--- a/frontend/src/lib/workspacePrivateEvents.ts
+++ b/frontend/src/lib/workspacePrivateEvents.ts
@@ -15,6 +15,7 @@ import {
   WorkspacePrivateEventSchema,
 } from '~/generated/leapmux/v1/workspace_private_pb'
 import { createLogger } from '~/lib/logger'
+import { sleep } from '~/lib/sleep'
 
 const log = createLogger('workspacePrivateEvents')
 
@@ -124,8 +125,4 @@ export function openWorkerPrivateEventStream(opts: OpenStreamOpts): () => void {
     }
     catch { /* ignore */ }
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/frontend/tests/e2e/063-terminal-webgl-pool.spec.ts
+++ b/frontend/tests/e2e/063-terminal-webgl-pool.spec.ts
@@ -1,0 +1,90 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+
+/** Open a new terminal via the dedicated terminal button in the tab bar. */
+async function openTerminalViaUI(page: Page) {
+  await page.locator('[data-testid="new-terminal-button"]').click()
+}
+
+/** Number of terminals currently holding a live WebGL context. */
+function webglTerminalCount(page: Page): Promise<number> {
+  return page.evaluate(() => (window as any).__webglTerminalCount?.() ?? -1)
+}
+
+/** Which renderer ('webgl' | 'dom') the given terminal id is currently using. */
+function rendererFor(page: Page, terminalId: string): Promise<string> {
+  return page.evaluate(id => (window as any).__terminalRendererFor?.(id) ?? 'unknown', terminalId)
+}
+
+/** The terminal ids currently mounted, split by whether the tab is active. */
+function terminalIds(page: Page): Promise<{ active: string[], hidden: string[] }> {
+  return page.evaluate(() => {
+    const active: string[] = []
+    const hidden: string[] = []
+    for (const el of document.querySelectorAll<HTMLElement>('[data-terminal-id]')) {
+      const id = el.dataset.terminalId!
+      ;(el.dataset.active === 'true' ? active : hidden).push(id)
+    }
+    return { active, hidden }
+  })
+}
+
+/**
+ * The xterm surface of the currently-visible terminal. Scoped to the active
+ * container because hidden terminal tabs stay mounted (each with its own
+ * `.xterm` element on the DOM renderer), so a bare `.xterm` locator matches
+ * every open terminal.
+ */
+function activeXterm(page: Page) {
+  return page.locator('[data-terminal-id][data-active="true"] .xterm')
+}
+
+test.describe('Terminal WebGL context pool', () => {
+  // Only the visible terminal in a tile should hold a WebGL context. Hidden
+  // terminal tabs -- which stay mounted -- must NOT each keep their own
+  // context, or a workspace with many terminals would blow past the browser's
+  // simultaneous-WebGL-context cap and corrupt the evicted terminals' glyphs.
+  test('keeps only the visible terminal on WebGL as tabs are opened and switched', async ({ page, authenticatedWorkspace }) => {
+    // A dropped GPU context logs this marker; assert it never fires.
+    const contextLostLogs: string[] = []
+    page.on('console', (msg) => {
+      if (msg.text().includes('terminal_renderer_webgl_context_lost'))
+        contextLostLogs.push(msg.text())
+    })
+
+    // Open three terminals in the same tile. Each new terminal becomes the
+    // active tab, hiding the previous one.
+    await openTerminalViaUI(page)
+    await expect(activeXterm(page)).toBeVisible()
+    await openTerminalViaUI(page)
+    await openTerminalViaUI(page)
+
+    const terminalTabs = page.locator('[data-testid="tab"][data-tab-type="terminal"]')
+    await expect(terminalTabs).toHaveCount(3)
+
+    // Exactly one context: only the active terminal. The two hidden tabs are
+    // mounted but render via the DOM renderer.
+    await expect.poll(() => webglTerminalCount(page)).toBe(1)
+
+    // Concretely: the visible terminal is on WebGL, each hidden one on DOM.
+    const { active, hidden } = await terminalIds(page)
+    expect(active).toHaveLength(1)
+    expect(hidden).toHaveLength(2)
+    await expect.poll(() => rendererFor(page, active[0])).toBe('webgl')
+    for (const id of hidden)
+      expect(await rendererFor(page, id)).toBe('dom')
+
+    // Switching tabs must move the single context to whichever terminal is
+    // now visible -- never accumulate one per tab.
+    await terminalTabs.nth(0).click()
+    await expect(activeXterm(page)).toBeVisible()
+    await expect.poll(() => webglTerminalCount(page)).toBe(1)
+
+    await terminalTabs.nth(1).click()
+    await expect(activeXterm(page)).toBeVisible()
+    await expect.poll(() => webglTerminalCount(page)).toBe(1)
+
+    // No terminal ever lost its GPU context (which would corrupt its glyphs).
+    expect(contextLostLogs).toEqual([])
+  })
+})

--- a/frontend/tests/unit/components/TerminalView.test.tsx
+++ b/frontend/tests/unit/components/TerminalView.test.tsx
@@ -7,6 +7,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { darkTerminalTheme, lightTerminalTheme } from '~/lib/terminal'
+import { webglPool } from '~/lib/webglTerminalPool'
 
 const mockCreateTerminalInstance = vi.fn()
 
@@ -53,6 +55,8 @@ function makeMockTerminalInstance(): TerminalInstance {
     }),
     focus: vi.fn(),
     scrollPages: vi.fn(),
+    loadAddon: vi.fn(),
+    clearTextureAtlas: vi.fn(),
     options: {},
     buffer: {
       active: {
@@ -70,6 +74,12 @@ function makeMockTerminalInstance(): TerminalInstance {
     fitAddon: { fit: vi.fn() } as any,
     serializeAddon: { serialize: vi.fn() } as any,
     suppressInput: false,
+    // WebGL-ineligible so the shared pool never tries to attach a real context
+    // to this mock during the on-screen effect; the acquire/release wiring is
+    // still exercised and spyable.
+    webglAllowed: false,
+    fontsReady: Promise.resolve(),
+    webglAddon: undefined,
     dispose: vi.fn(),
   }
 }
@@ -77,6 +87,50 @@ function makeMockTerminalInstance(): TerminalInstance {
 describe('terminalView', () => {
   beforeEach(() => {
     mockCreateTerminalInstance.mockReset()
+    // Reset shared pool state between tests (module-level singleton).
+    webglPool.disposeAll()
+  })
+
+  it('acquires a pooled WebGL context only for the visible terminal', async () => {
+    const instanceA = makeMockTerminalInstance()
+    const instanceB = makeMockTerminalInstance()
+    mockCreateTerminalInstance
+      .mockReturnValueOnce(instanceA)
+      .mockReturnValueOnce(instanceB)
+    const acquireSpy = vi.spyOn(webglPool, 'acquire')
+    const releaseSpy = vi.spyOn(webglPool, 'release')
+
+    const baseTab = { type: TabType.TERMINAL as const, screen: new Uint8Array() }
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={[
+            { id: 'vis-A', ...baseTab },
+            { id: 'hid-B', ...baseTab },
+          ]}
+          activeTerminalId="vis-A"
+          visible
+          tileFocused
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onTitleChange={vi.fn()}
+          onBell={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+
+    // The active + visible terminal claims a slot with focus priority.
+    await waitFor(() => {
+      expect(acquireSpy).toHaveBeenCalledWith('vis-A', instanceA, { focused: true })
+    })
+    // The hidden sibling never acquires; it releases instead.
+    const acquiredIds = acquireSpy.mock.calls.map(call => call[0])
+    expect(acquiredIds).not.toContain('hid-B')
+    expect(releaseSpy).toHaveBeenCalledWith('hid-B')
+
+    acquireSpy.mockRestore()
+    releaseSpy.mockRestore()
   })
 
   it('does not forward bell notifications during snapshot replay', async () => {
@@ -253,14 +307,231 @@ describe('terminalView', () => {
     // Mirror the production close path: explicit dispose, then drop the
     // tab from the prop list. With per-view ownership tracking, removing
     // alone does not auto-dispose (the id may have moved to another tile).
+    const releaseSpy = vi.spyOn(webglPool, 'release')
     disposeTerminalInstance('dispose-test-A')
     setTerminals([{ id: 'dispose-test-B', ...baseTab }])
 
     expect(getTerminalInstance('dispose-test-A')).toBeUndefined()
     expect(instanceA.dispose).toHaveBeenCalledTimes(1)
+    // Disposal must also relinquish the pool's WebGL slot for that id.
+    expect(releaseSpy).toHaveBeenCalledWith('dispose-test-A')
     // B stays live — only the closed tab's instance should be disposed.
     expect(getTerminalInstance('dispose-test-B')).toBe(instanceB)
     expect(instanceB.dispose).not.toHaveBeenCalled()
+    releaseSpy.mockRestore()
+  })
+
+  it('moves the pooled WebGL context when the active terminal changes', async () => {
+    const instanceA = makeMockTerminalInstance()
+    const instanceB = makeMockTerminalInstance()
+    mockCreateTerminalInstance
+      .mockReturnValueOnce(instanceA)
+      .mockReturnValueOnce(instanceB)
+
+    const baseTab = { type: TabType.TERMINAL as const, screen: new Uint8Array() }
+    const [activeId, setActiveId] = createSignal('switch-A')
+    const acquireSpy = vi.spyOn(webglPool, 'acquire')
+    const releaseSpy = vi.spyOn(webglPool, 'release')
+
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={[
+            { id: 'switch-A', ...baseTab },
+            { id: 'switch-B', ...baseTab },
+          ]}
+          activeTerminalId={activeId()}
+          visible
+          tileFocused
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onTitleChange={vi.fn()}
+          onBell={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+
+    // Initially A is the visible tab and claims the slot.
+    await waitFor(() => {
+      expect(acquireSpy).toHaveBeenCalledWith('switch-A', instanceA, { focused: true })
+    })
+
+    // Switch the active tab to B: A must relinquish its slot, B must claim one.
+    setActiveId('switch-B')
+    await waitFor(() => {
+      expect(acquireSpy).toHaveBeenCalledWith('switch-B', instanceB, { focused: true })
+    })
+    expect(releaseSpy).toHaveBeenCalledWith('switch-A')
+
+    acquireSpy.mockRestore()
+    releaseSpy.mockRestore()
+  })
+
+  it('re-applies a genuine terminal-theme change to every live instance', async () => {
+    localStorage.clear()
+    const instance = makeMockTerminalInstance()
+    mockCreateTerminalInstance.mockReturnValue(instance)
+
+    // Drive an OS prefers-color-scheme flip through the change handler the view
+    // registers. With the default match-ui terminal theme + system UI theme the
+    // resolved theme follows the OS, so this exercises the (guarded) theme
+    // effect end to end. matchMedia starts in light.
+    const originalMatchMedia = window.matchMedia
+    let colorSchemeHandler: ((e: { matches: boolean }) => void) | undefined
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: (_type: string, cb: (e: { matches: boolean }) => void) => {
+        colorSchemeHandler = cb
+      },
+      removeEventListener: vi.fn(),
+    }) as any
+
+    try {
+      const baseTab = { type: TabType.TERMINAL as const, screen: new Uint8Array() }
+      render(() => (
+        <PreferencesProvider>
+          <TerminalView
+            terminals={[{ id: 'theme-A', ...baseTab }]}
+            activeTerminalId="theme-A"
+            visible
+            tileFocused
+            onInput={vi.fn()}
+            onResize={vi.fn()}
+            onTitleChange={vi.fn()}
+            onBell={vi.fn()}
+            onContentReady={vi.fn()}
+          />
+        </PreferencesProvider>
+      ))
+
+      await waitFor(() => expect(colorSchemeHandler).toBeDefined())
+
+      // Flip the OS to dark: the effect's change guard must let a genuine
+      // change through and re-apply the dark theme to the live instance.
+      colorSchemeHandler!({ matches: true })
+      await waitFor(() => {
+        expect(instance.terminal.options.theme).toBe(darkTerminalTheme)
+      })
+
+      // Flip back to light: a second genuine change must also propagate,
+      // proving the guard updates its last-applied theme rather than latching
+      // on the first one it saw.
+      colorSchemeHandler!({ matches: false })
+      await waitFor(() => {
+        expect(instance.terminal.options.theme).toBe(lightTerminalTheme)
+      })
+    }
+    finally {
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
+  it('writes each instance theme once on a change, not once per mounted view', async () => {
+    localStorage.clear()
+
+    // Two tiles (two TerminalView instances) share the module-level `instances`
+    // map, so BOTH views' theme effects iterate BOTH instances on a theme flip.
+    // The per-instance guard must collapse that to one write per instance
+    // instead of tiles x instances writes (each xterm theme write rebuilds the
+    // color table). Count writes via a defined accessor on each mock.
+    function withThemeCounter(inst: TerminalInstance): () => number {
+      let stored: unknown
+      let writes = 0
+      Object.defineProperty(inst.terminal, 'options', {
+        configurable: true,
+        value: Object.defineProperties({} as Record<string, unknown>, {
+          theme: {
+            configurable: true,
+            get: () => stored,
+            set: (v: unknown) => {
+              stored = v
+              writes++
+            },
+          },
+        }),
+      })
+      return () => writes
+    }
+
+    const instanceA = makeMockTerminalInstance()
+    const instanceB = makeMockTerminalInstance()
+    const writesA = withThemeCounter(instanceA)
+    const writesB = withThemeCounter(instanceB)
+    mockCreateTerminalInstance
+      .mockReturnValueOnce(instanceA)
+      .mockReturnValueOnce(instanceB)
+
+    // Collect every view's prefers-color-scheme handler so we can flip both.
+    const originalMatchMedia = window.matchMedia
+    const colorSchemeHandlers: Array<(e: { matches: boolean }) => void> = []
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: (_type: string, cb: (e: { matches: boolean }) => void) => {
+        colorSchemeHandlers.push(cb)
+      },
+      removeEventListener: vi.fn(),
+    }) as any
+
+    try {
+      const baseTab = { type: TabType.TERMINAL as const, screen: new Uint8Array() }
+      render(() => (
+        <PreferencesProvider>
+          <TerminalView
+            terminals={[{ id: 'themed-A', ...baseTab }]}
+            activeTerminalId="themed-A"
+            visible
+            tileFocused
+            onInput={vi.fn()}
+            onResize={vi.fn()}
+            onTitleChange={vi.fn()}
+            onBell={vi.fn()}
+            onContentReady={vi.fn()}
+          />
+          <TerminalView
+            terminals={[{ id: 'themed-B', ...baseTab }]}
+            activeTerminalId="themed-B"
+            visible
+            tileFocused
+            onInput={vi.fn()}
+            onResize={vi.fn()}
+            onTitleChange={vi.fn()}
+            onBell={vi.fn()}
+            onContentReady={vi.fn()}
+          />
+        </PreferencesProvider>
+      ))
+
+      // Both views mount, both register a handler, both instances exist.
+      await waitFor(() => {
+        expect(colorSchemeHandlers.length).toBe(2)
+        expect(getTerminalInstance('themed-A')).toBe(instanceA)
+        expect(getTerminalInstance('themed-B')).toBe(instanceB)
+      })
+
+      // The mount-time application (light) already exercised the guard across
+      // both views; zero the counters so we measure only the flip below.
+      const baselineA = writesA()
+      const baselineB = writesB()
+
+      // Flip the OS to dark and drive every view's handler.
+      for (const handler of colorSchemeHandlers)
+        handler({ matches: true })
+
+      await waitFor(() => {
+        expect(instanceA.terminal.options.theme).toBe(darkTerminalTheme)
+        expect(instanceB.terminal.options.theme).toBe(darkTerminalTheme)
+      })
+
+      // Exactly one write per instance for the flip — the second view finds the
+      // theme already applied and skips. Without the guard each instance would
+      // be written twice (once per view).
+      expect(writesA() - baselineA).toBe(1)
+      expect(writesB() - baselineB).toBe(1)
+    }
+    finally {
+      window.matchMedia = originalMatchMedia
+    }
   })
 
   it('scrolls the active terminal by one page', async () => {

--- a/frontend/tests/unit/hooks/applyTerminalData.test.ts
+++ b/frontend/tests/unit/hooks/applyTerminalData.test.ts
@@ -20,6 +20,9 @@ function makeStubInstance(): TerminalInstance & { _log: string[] } {
     fitAddon: { fit: vi.fn() } as any,
     serializeAddon: { serialize: vi.fn(() => '') } as any,
     suppressInput: false,
+    webglAllowed: false,
+    fontsReady: Promise.resolve(),
+    webglAddon: undefined,
     dispose: vi.fn(),
     _log: log,
   }


### PR DESCRIPTION
## Motivation

Every terminal eagerly loaded its own `@xterm/addon-webgl` instance, so the number of live WebGL contexts tracked the number of open terminal tabs (hidden tabs included), not the number visible. Browsers cap simultaneous WebGL contexts per page (~16 on Chrome/Blink, stricter on WKWebView/Safari) and force-drop the oldest once the cap is exceeded, corrupting the evicted terminals' glyphs — the "corrupted glyphs with more than one terminal tab" report.

A secondary issue compounded this: terminals attached the WebGL renderer before their fonts had finished loading, so the glyph atlas was built over fallback glyphs, and a later font-load completion did not automatically clear that corrupt atlas.

## Modifications

- Added `frontend/src/lib/webglTerminalPool.ts` — a singleton pool that manages a bounded set of 8 WebGL contexts across an unlimited number of terminal instances. Terminals render on xterm's DOM renderer by default; the pool distributes WebGL contexts to the most-recently-used on-screen terminals, with the focused terminal getting priority. When the pool is full, the coldest (least-recently-used) terminal is evicted to make room, and eviction is a performance event, never a corruption one.
- Removed eager WebGL addon loading from `createTerminalInstance`. Terminals now start on the DOM renderer; `TerminalView` calls `webglPool.acquire()` as a terminal moves on-screen and `webglPool.release()` off-screen and on dispose, with the context moved between instances on active-tab changes. Reconcile is coalesced onto a microtask so cross-tile tab moves stay renderer-churn-free.
- Replaced `reloadFontsAndClearAtlas` with `loadTerminalFonts` + `refreshTerminalFont`, which add exponential-backoff retry (up to 4 attempts) for transient cold-start font-fetch failures, and a shared `scheduleAtlasClear` step that coordinates atlas clearing on cold-start retries and font-family swaps.
- Added a `fontsReady` promise gate so the pool defers WebGL attachment until fonts are confirmed loaded, preventing the corrupt-atlas-at-startup scenario. Bounded context-loss retries (with a decay-window reset) settle a terminal on DOM under sustained GPU pressure instead of thrashing.
- Added reference-equality guards in the theme and font effects so a resolved value that has not changed skips redundant work. The theme effect additionally guards per-instance, so a theme flip costs one write per instance rather than tiles × instances palette rebuilds across the shared instance map.
- Extracted a shared `sleep()` helper into `frontend/src/lib/sleep.ts`, reused by both `workspacePrivateEvents.ts` and the new font-retry logic. Exported `DEFAULT_FONT_SIZE` as a named constant from `terminal.ts`.
- Added `frontend/src/lib/webglTerminalPool.test.ts` (391 lines) covering capacity limits, cold-to-hot eviction, re-attach on freed slot, focus pinning, WebGL-ineligible and detached-element skips, instance-swap handling, pending-attach swap, font-ready deferral, disposeAll, and GPU context-loss recovery with bounded retry budgets and decay-window reset.
- Added `frontend/tests/e2e/063-terminal-webgl-pool.spec.ts` verifying that only the visible terminal in a tile holds a WebGL context as tabs open and switch, and that no context-loss log fires.
- Extended `frontend/src/lib/terminal.test.ts` and `frontend/tests/unit/components/TerminalView.test.tsx` to cover pool acquire/release lifecycle, per-instance theme writes (including that a theme change writes each instance once across multiple mounted tiles, not once per view), and font-load retry paths.

## Result

Opening many terminal tabs no longer exhausts the browser's WebGL context budget. At most 8 terminals hold a WebGL context at any time; the rest use the DOM renderer invisibly in the background, and the focused and most-recently-visible terminals are always the ones with hardware-accelerated rendering.

Terminals that previously showed glyph corruption (missing or placeholder characters) due to context exhaustion or premature atlas builds now render correctly. Transient font-fetch failures are retried with backoff rather than silently producing a corrupt atlas that persists for the session.
