### PR TITLE
feat(chat): Add seq-space scroll rail and harden control responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,40 @@ Lint Rust/desktop code with `task lint-desktop`, not `cargo clippy` directly. Th
 
 ## Coding conventions
 
+### Provider-specific logic belongs in the provider, not shared code
+
+LeapMux supports many agent providers (Claude Code, Codex, Pi, and ACP-based
+providers: OpenCode, Cursor, Copilot, Kilo, Goose, Reasonix). Anything that depends
+on a **single provider's wire format or message shapes** MUST live in that provider's
+plugin/implementation — never hardcoded into shared code (a package-level helper, a
+shared `default*` function, or a `switch` on provider). Shared code stays
+provider-neutral and delegates the provider-specific decision.
+
+- **Backend (Go):** the `Provider` interface in
+  `backend/internal/worker/agent/provider.go` is the home for per-provider decisions.
+  Add a method there (e.g. `IsSelfDisplayingControlTool`) and dispatch via
+  `agent.ProviderFor(provider)`. Do NOT put a provider's tool names / method names /
+  envelope shapes in a package-level function that shared service code calls.
+- **Frontend (TS):** the `Provider` plugin interface in
+  `frontend/src/components/chat/providers/registry.ts` is the home. Add a method
+  (e.g. `previewText`, sibling of `extractQuotableText`) and implement it per plugin;
+  a genuinely provider-neutral shape (`{content}`, `{controlResponse}`) can share a
+  `default*` helper that plugins delegate to, but the Anthropic/Codex/Pi/ACP-specific
+  parsing stays in that plugin. The renderer layer is where each provider's raw
+  message shapes are known — see the `frontend-owns-message-extraction` principle.
+
+Why: hardcoding one provider's shape into shared code silently breaks or half-serves
+every other provider and is a second source of truth that drifts. When you catch
+yourself writing a provider's tool/method name outside its plugin, move it into the
+plugin behind an interface method.
+
 ### Tests
 
 - Backend: `testify/assert`, `testify/require`.
 - Frontend: `vitest`. `describe` names must be lowercase.
 - E2E: do NOT pass per-call `{ timeout: … }` overrides to `expect`, `locator.waitFor`, etc. Playwright's global timeout (configured in `playwright.config.ts`) already applies; per-call overrides are redundant noise. If a specific assertion legitimately needs a longer-than-global timeout (e.g. waiting on a slow worker spawn), discuss it before silently adding one.
 - Unused imports cause lint failures (strict).
+- Test provider-specific logic in that provider's test file (e.g. Claude's `previewText` in `providers/claude/plugin.test.ts`), not in a shared module's test.
 
 ### Frontend CSS (vanilla-extract)
 

--- a/backend/internal/cli/remote/cmd/agent_messages.go
+++ b/backend/internal/cli/remote/cmd/agent_messages.go
@@ -77,7 +77,7 @@ func RunAgentMessages(rawCtx any, args []string) error {
 					return err
 				}
 			}
-			cursor := resumeCursorFor(req, resp.GetMessages(), resp.GetLatestSeq())
+			cursor := resumeCursorFor(req, resp.GetMessages(), resp.LatestSeq)
 
 			return tailAgentMessages(ctx, c, workerID, agentID, workspaceID, cursor, em)
 		},
@@ -87,32 +87,32 @@ func RunAgentMessages(rawCtx any, args []string) error {
 // resumeCursorFor picks the seq the live WatchEvents stream resumes after, given
 // the page-1 request, the messages it returned, and the response's authoritative
 // latest_seq. The last message shown wins (resume right after it). When page 1 is
-// empty, an explicit AFTER resume -- or an INDETERMINATE latest_seq (-1, the worker
+// empty, an explicit AFTER resume -- or an INDETERMINATE latest_seq (unset, the worker
 // couldn't read the tail; see ListAgentMessagesResponse.latest_seq) -- falls back to
 // the request's own --cursor-seq rather than trusting a tail we don't have.
 //
-// Otherwise (an empty page with a positive latest_seq) resume after latest_seq-1, NOT
-// latest_seq: the page rows and latest_seq are two non-atomic reads, so an empty
+// Otherwise (an empty page with a present, positive latest_seq) resume after latest_seq-1,
+// NOT latest_seq: the page rows and latest_seq are two non-atomic reads, so an empty
 // LATEST page with latest_seq > 0 is the race where the agent's first/only message
 // committed BETWEEN them -- resuming after latest_seq would skip that very message.
 // Resuming after latest_seq-1 delivers seq >= latest_seq (catching it) while a
 // populated agent still avoids the OLDEST full-history drain: latest_seq-1 stays a
 // positive resume cursor (drainFetch treats afterSeq <= 0 as "from the oldest
 // message"), and only a first-ever message at seq 1 drops to the oldest drain, which
-// is then a single message. A genuine latest_seq == 0 (truly empty agent) stays 0
+// is then a single message. A present latest_seq == 0 (truly empty agent) stays 0
 // ("tail from now"). Pure, so the empty-page fallback is table-testable without a
 // live RPC.
-func resumeCursorFor(req *leapmuxv1.ListAgentMessagesRequest, messages []*leapmuxv1.AgentChatMessage, latestSeq int64) int64 {
+func resumeCursorFor(req *leapmuxv1.ListAgentMessagesRequest, messages []*leapmuxv1.AgentChatMessage, latestSeq *int64) int64 {
 	if n := len(messages); n > 0 {
 		return messages[n-1].GetSeq()
 	}
-	if latestSeq < 0 || req.GetAnchor() == leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER {
+	if latestSeq == nil || req.GetAnchor() == leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER {
 		return req.GetCursorSeq()
 	}
-	if latestSeq > 0 {
-		return latestSeq - 1
+	if *latestSeq > 0 {
+		return *latestSeq - 1
 	}
-	return latestSeq
+	return *latestSeq
 }
 
 // followSelectorError rejects --follow combined with a backward/historical page

--- a/backend/internal/cli/remote/cmd/agent_messages_request_test.go
+++ b/backend/internal/cli/remote/cmd/agent_messages_request_test.go
@@ -148,14 +148,17 @@ func TestResumeCursorFor(t *testing.T) {
 	req := func(anchor leapmuxv1.MessagePageAnchor, cursor int64) *leapmuxv1.ListAgentMessagesRequest {
 		return &leapmuxv1.ListAgentMessagesRequest{Anchor: anchor, CursorSeq: cursor}
 	}
+	// latest_seq is now optional (explicit presence): a *int64 value = a present tail, nil =
+	// indeterminate (the worker couldn't read it). ptr wraps a present value.
+	ptr := func(v int64) *int64 { return &v }
 
 	t.Run("non-empty page resumes after the last message, ignoring the anchor/cursor/latest_seq", func(t *testing.T) {
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 5), msgs(10, 20, 30), 99)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 5), msgs(10, 20, 30), ptr(99))
 		assert.Equal(t, int64(30), got)
 	})
 
 	t.Run("empty page with --anchor after resumes from the explicit cursor (over latest_seq)", func(t *testing.T) {
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 42), nil, 99)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 42), nil, ptr(99))
 		assert.Equal(t, int64(42), got)
 	})
 
@@ -164,37 +167,37 @@ func TestResumeCursorFor(t *testing.T) {
 		// race: the agent's first/only message committed between the two reads. Resume
 		// after latest_seq-1 so seq >= latest_seq is delivered (the message isn't
 		// skipped), while staying a positive resume cursor (no OLDEST full drain).
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, 137)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, ptr(137))
 		assert.Equal(t, int64(136), got)
 	})
 
-	t.Run("empty latest page on a truly-empty agent tails from now (latest_seq 0)", func(t *testing.T) {
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, 0)
+	t.Run("empty latest page on a truly-empty agent tails from now (present latest_seq 0)", func(t *testing.T) {
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, ptr(0))
 		assert.Zero(t, got)
 	})
 
 	t.Run("a first-ever message at seq 1 (empty page, latest_seq 1) drops to the oldest drain of that single message", func(t *testing.T) {
 		// latest_seq-1 == 0 -> the oldest drain, but that is exactly the one message
 		// the empty page missed, not a history flood.
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, 1)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, ptr(1))
 		assert.Zero(t, got)
 	})
 
 	t.Run("empty oldest page resumes after latest_seq-1 even with a stray cursor", func(t *testing.T) {
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_OLDEST, 7), nil, 50)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_OLDEST, 7), nil, ptr(50))
 		assert.Equal(t, int64(49), got)
 	})
 
-	t.Run("indeterminate latest_seq (-1) falls back to the request cursor, NOT the bogus tail", func(t *testing.T) {
-		// The worker degrades latest_seq to -1 when it can't read the tail (a DB error).
-		// The CLI must NOT resume after -1 (drainFetch treats afterSeq <= 0 as the OLDEST
+	t.Run("indeterminate latest_seq (unset) falls back to the request cursor, NOT the bogus tail", func(t *testing.T) {
+		// The worker leaves latest_seq UNSET when it can't read the tail (a DB error).
+		// The CLI must NOT resume after 0 (drainFetch treats afterSeq <= 0 as the OLDEST
 		// full-history drain); it falls back to the request's own cursor instead.
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 88), nil, -1)
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER, 88), nil, nil)
 		assert.Equal(t, int64(88), got)
 	})
 
-	t.Run("indeterminate latest_seq (-1) on a latest page falls back to the request cursor", func(t *testing.T) {
-		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, -1)
+	t.Run("indeterminate latest_seq (unset) on a latest page falls back to the request cursor", func(t *testing.T) {
+		got := resumeCursorFor(req(leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST, 0), nil, nil)
 		assert.Zero(t, got)
 	})
 }

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -21,6 +21,10 @@ type SpanInfo struct {
 	SpanType        string
 	SpanColor       int32
 	Closing         bool
+	// MarkType rides the persist path into messages.mark_type, tagging the row
+	// as a scroll-rail jump target. Zero value (MARK_TYPE_UNSPECIFIED) leaves the
+	// row unmarked, so existing SpanInfo{...} literals need no change.
+	MarkType leapmuxv1.MarkType
 }
 
 type AutoContinueReason string

--- a/backend/internal/worker/agent/claude_mark_type_test.go
+++ b/backend/internal/worker/agent/claude_mark_type_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestClaudeUserEnvelopeMarkType covers the Claude `user`-envelope scroll-rail mark
+// classifier. Only a self-displaying control answer (an AskUserQuestion / ExitPlanMode
+// tool_result Claude re-emits into its own transcript) is marked at ingestion, as
+// CONTROL_RESPONSE. Everything else -- including a human-typed prompt (which resolves no
+// span, spanType "") -- is UNSPECIFIED, so ingestion never double-marks a send that the
+// SendAgentMessage handler already dotted. spanType is the resolved tool name for a
+// tool_result row (empty otherwise).
+func TestClaudeUserEnvelopeMarkType(t *testing.T) {
+	cases := []struct {
+		name     string
+		spanType string
+		want     leapmuxv1.MarkType
+	}{
+		{
+			name:     "AskUserQuestion tool_result is a control response",
+			spanType: ToolNameAskUserQuestion,
+			want:     leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE,
+		},
+		{
+			name:     "ExitPlanMode tool_result is a control response",
+			spanType: ToolNameExitPlanMode,
+			want:     leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE,
+		},
+		{
+			name:     "EnterPlanMode is not self-displaying, so unmarked",
+			spanType: ToolNameEnterPlanMode,
+			want:     leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED,
+		},
+		{
+			name:     "an ordinary tool_result (Bash) is unmarked",
+			spanType: "Bash",
+			want:     leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED,
+		},
+		{
+			name:     "a human-typed prompt (no resolved span) is unmarked, NOT USER_MESSAGE",
+			spanType: "",
+			want:     leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, claudeUserEnvelopeMarkType(tc.spanType))
+		})
+	}
+}
+
+// TestIsSelfDisplayingControlTool pins the provider-delegated set the rail's
+// CONTROL_RESPONSE mark and the synthetic-display-row skip both consult, so they can't
+// drift. Only Claude self-displays (its AskUserQuestion / ExitPlanMode tool_results);
+// EnterPlanMode is deliberately NOT self-displaying (no user-answer tool_result), and an
+// ordinary tool is not a control tool at all. Every other provider echoes no control
+// answer, so it defers to the synthesized display row -> false.
+func TestIsSelfDisplayingControlTool(t *testing.T) {
+	assert.True(t, claudeProvider{}.IsSelfDisplayingControlTool(ToolNameAskUserQuestion))
+	assert.True(t, claudeProvider{}.IsSelfDisplayingControlTool(ToolNameExitPlanMode))
+	assert.False(t, claudeProvider{}.IsSelfDisplayingControlTool(ToolNameEnterPlanMode))
+	assert.False(t, claudeProvider{}.IsSelfDisplayingControlTool("Bash"))
+	assert.False(t, claudeProvider{}.IsSelfDisplayingControlTool(""))
+
+	// Non-Claude providers never self-display -- they rely on the synthesized row.
+	assert.False(t, codexProvider{}.IsSelfDisplayingControlTool(ToolNameAskUserQuestion))
+	assert.False(t, piProvider{}.IsSelfDisplayingControlTool(ToolNameExitPlanMode))
+	assert.False(t, acpProvider{}.IsSelfDisplayingControlTool(ToolNameExitPlanMode))
+	assert.False(t, noopProvider{}.IsSelfDisplayingControlTool(ToolNameAskUserQuestion))
+}
+
+// TestNeedsSyntheticInterruptNotice pins the provider-delegated decision the raw-message
+// handler consults instead of a hardcoded `== CODEX` switch. Only Codex consumes its
+// interrupt silently (turn/interrupt resolves internally with no transcript row), so only it
+// needs the synthetic "[Request interrupted by user]" row; every other provider's interrupt
+// surfaces in its own transcript and defaults to false (ACP via the noopProvider embedding).
+func TestNeedsSyntheticInterruptNotice(t *testing.T) {
+	assert.True(t, codexProvider{}.NeedsSyntheticInterruptNotice())
+
+	assert.False(t, claudeProvider{}.NeedsSyntheticInterruptNotice())
+	assert.False(t, piProvider{}.NeedsSyntheticInterruptNotice())
+	assert.False(t, acpProvider{}.NeedsSyntheticInterruptNotice())
+	assert.False(t, noopProvider{}.NeedsSyntheticInterruptNotice())
+}
+
+// TestPlanModeControl pins provider-owned tool-name interpretation. Shared service code
+// consumes only these provider-neutral classifications, so provider wire names do not leak
+// back into service-level plan-mode policy.
+func TestPlanModeControl(t *testing.T) {
+	assert.Equal(t, PlanModeControlPrompt, codexProvider{}.PlanModeControl(ToolNameCodexPlanModePrompt))
+	assert.Equal(t, PlanModeControlNone, codexProvider{}.PlanModeControl(ToolNameEnterPlanMode))
+
+	assert.Equal(t, PlanModeControlEnter, claudeProvider{}.PlanModeControl(ToolNameEnterPlanMode))
+	assert.Equal(t, PlanModeControlExit, claudeProvider{}.PlanModeControl(ToolNameExitPlanMode))
+	assert.Equal(t, PlanModeControlNone, claudeProvider{}.PlanModeControl(ToolNameAskUserQuestion))
+
+	assert.Equal(t, PlanModeControlNone, piProvider{}.PlanModeControl(ToolNameExitPlanMode))
+	assert.Equal(t, PlanModeControlNone, acpProvider{}.PlanModeControl(ToolNameExitPlanMode))
+	assert.Equal(t, PlanModeControlNone, noopProvider{}.PlanModeControl(ToolNameCodexPlanModePrompt))
+}

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -238,6 +238,38 @@ type messageEnvelope struct {
 	contentParsed bool
 }
 
+// claudeUserEnvelopeMarkType classifies a persisted Claude `user`-envelope row for
+// the scroll rail's jump marks. The only Claude user row that carries a mark at
+// ingestion is a self-displaying control answer -- an AskUserQuestion / ExitPlanMode
+// tool_result Claude re-emits into its own transcript -- which is marked
+// CONTROL_RESPONSE. Everything else is unmarked. spanType is the resolved tool name
+// for tool_result rows (empty otherwise).
+//
+// A human-typed prompt is NOT marked here: HandleOutput drops string-content `user`
+// envelopes via isSimpleUserTextEcho before persist, and the live USER_MESSAGE dot is
+// written by the SendAgentMessage handler against the row it persists. Marking a
+// string-content echo here too would double the dot (SendAgentMessage already marked
+// the send), so this classifier deliberately leaves user text UNSPECIFIED -- an
+// un-dropped echo then persists dot-less rather than as a duplicate jump target.
+func claudeUserEnvelopeMarkType(spanType string) leapmuxv1.MarkType {
+	if (claudeProvider{}).IsSelfDisplayingControlTool(spanType) {
+		return leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE
+	}
+	return leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED
+}
+
+func claudeUserEnvelopeBlocksMarkType(blocks []contentBlock, spanTypeFor func(string) string) leapmuxv1.MarkType {
+	for _, block := range blocks {
+		if block.Type != "tool_result" || block.ToolUseID == "" {
+			continue
+		}
+		if claudeUserEnvelopeMarkType(spanTypeFor(block.ToolUseID)) == leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE {
+			return leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE
+		}
+	}
+	return leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED
+}
+
 // ContentBlocks returns the parsed content blocks from message.content.
 // Returns nil if content is not an array (e.g. a plain string).
 func (e *messageEnvelope) ContentBlocks() []contentBlock {
@@ -271,6 +303,8 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 
 		// Plan mode tracking (EnterPlanMode/ExitPlanMode).
 		if block.ID != "" {
+			a.sink.SetSpanType(block.ID, block.Name)
+
 			switch block.Name {
 			case ToolNameEnterPlanMode:
 				a.sink.StorePlanModeToolUse(block.ID, PermissionModePlan)
@@ -441,12 +475,17 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// so the assistant message stays at the parent depth.
 	// closing is true when this is a tool_result that will close its span.
 	closing := msgType == claudeMsgTypeUser && spanID != ""
+	var markType leapmuxv1.MarkType
+	if msgType == claudeMsgTypeUser {
+		markType = claudeUserEnvelopeBlocksMarkType(env.ContentBlocks(), a.sink.GetSpanType)
+	}
 	spanInfo := SpanInfo{
 		ParentSpanID: parentSpanID,
 		SpanID:       spanID,
 		SpanType:     spanType,
 		SpanColor:    spanColor,
 		Closing:      closing,
+		MarkType:     markType,
 	}
 	var persistErr error
 	if msgType == claudeMsgTypeResult {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -457,6 +457,8 @@ func TestAgent_ParallelToolUseClosesAllSpans(t *testing.T) {
 	}, "expected both spans to be opened")
 
 	assert.ElementsMatch(t, []string{"toolu_A", "toolu_B"}, []string{sink.OpenSpans()[0].SpanID, sink.OpenSpans()[1].SpanID})
+	assert.Equal(t, "Grep", sink.GetSpanType("toolu_A"))
+	assert.Equal(t, "Bash", sink.GetSpanType("toolu_B"))
 
 	// Single user message with two tool_result blocks.
 	toolResultMsg := `{"type":"user","message":{"role":"user","content":[` +
@@ -470,6 +472,54 @@ func TestAgent_ParallelToolUseClosesAllSpans(t *testing.T) {
 	}, "expected both spans to be closed")
 
 	assert.ElementsMatch(t, []string{"toolu_A", "toolu_B"}, sink.ClosedSpans())
+}
+
+func TestAgent_ParallelToolResultMarksLaterSelfDisplayingControlResponse(t *testing.T) {
+	ctx := context.Background()
+	sink := &testSink{}
+
+	agent, err := mockStartWithInit(ctx, Options{
+		AgentID:    "parallel-control-response-test",
+		Options:    map[string]string{OptionIDModel: "test"},
+		WorkingDir: t.TempDir(),
+	}, sink)
+	require.NoError(t, err, "mockStartWithInit")
+	defer func() {
+		agent.Stop()
+		_ = agent.Wait()
+	}()
+
+	testutil.AssertEventually(t, func() bool {
+		return sink.SessionIDCount() >= 1
+	}, "expected init message")
+
+	toolUseMsg := `{"type":"assistant","message":{"role":"assistant","content":[` +
+		`{"type":"tool_use","id":"toolu_A","name":"Bash","input":{"command":"ls"}},` +
+		`{"type":"tool_use","id":"toolu_B","name":"AskUserQuestion","input":{"question":"Proceed?"}}` +
+		`]},"session_id":"test-session","uuid":"uuid1"}` + "\n"
+	require.NoError(t, agent.SendRawInput([]byte(toolUseMsg)))
+
+	testutil.AssertEventually(t, func() bool {
+		return len(sink.OpenSpans()) >= 2
+	}, "expected both spans to be opened")
+
+	toolResultMsg := `{"type":"user","message":{"role":"user","content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_A","content":"file list"},` +
+		`{"type":"tool_result","tool_use_id":"toolu_B","content":"Yes, continue."}` +
+		`]},"session_id":"test-session","uuid":"uuid2"}` + "\n"
+	messageCountBeforeResult := len(sink.Messages())
+	require.NoError(t, agent.SendRawInput([]byte(toolResultMsg)))
+
+	testutil.AssertEventually(t, func() bool {
+		msgs := sink.Messages()
+		return len(msgs) > messageCountBeforeResult && msgs[len(msgs)-1].SpanID == "toolu_A"
+	}, "expected persisted user envelope")
+
+	msgs := sink.Messages()
+	toolResult := msgs[len(msgs)-1]
+	assert.Equal(t, "toolu_A", toolResult.SpanID, "span metadata still anchors the row on the first result")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, toolResult.MarkType,
+		"a later self-displaying control result in the same user envelope must still draw a rail dot")
 }
 
 // TestHelperProcessEarlyExit is a test helper that writes an error to stderr

--- a/backend/internal/worker/agent/control_response.go
+++ b/backend/internal/worker/agent/control_response.go
@@ -1,0 +1,635 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// ControlResponseContext is the pure provider input for interpreting a frontend
+// control response. The service loads the stored control request once, extracts the
+// shared metadata, and passes both payloads here; providers must not perform I/O.
+type ControlResponseContext struct {
+	RequestID       string
+	RequestPayload  json.RawMessage
+	ResponseContent []byte
+	ToolName        string
+	ToolUseID       string
+}
+
+// ControlResponseResolution is the provider-owned interpretation of a control
+// response. The service executes side effects from this plan: it persists display
+// rows, deletes control requests, mutates plan-mode settings, and forwards Content.
+type ControlResponseResolution struct {
+	Content         []byte
+	DisplayText     string
+	SelfDisplayed   bool
+	PlanModeControl PlanModeControlKind
+}
+
+func defaultControlResponseResolution(ctx ControlResponseContext) ControlResponseResolution {
+	return ControlResponseResolution{Content: ctx.ResponseContent}
+}
+
+func (noopProvider) ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution {
+	return defaultControlResponseResolution(ctx)
+}
+
+func (p codexProvider) ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution {
+	res := defaultControlResponseResolution(ctx)
+	if len(ctx.RequestPayload) == 0 {
+		return res
+	}
+	res.PlanModeControl = p.PlanModeControl(ctx.ToolName)
+
+	var req struct {
+		Method string `json:"method"`
+	}
+	if !warnUnmarshal(ctx.RequestPayload, &req, "codex control response request") {
+		return res
+	}
+	if req.Method == "item/tool/requestUserInput" {
+		res.DisplayText = codexUserInputAnswersText(ctx.RequestPayload, ctx.ResponseContent)
+		return res
+	}
+	if text := codexFeedbackMessageText(ctx.ResponseContent); text != "" {
+		res.DisplayText = text
+		return res
+	}
+	res.DisplayText = codexDecisionDisplayText(ctx.ResponseContent)
+	return res
+}
+
+func (p claudeProvider) ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution {
+	res := defaultControlResponseResolution(ctx)
+	res.SelfDisplayed = p.IsSelfDisplayingControlTool(ctx.ToolName)
+	res.PlanModeControl = p.PlanModeControl(ctx.ToolName)
+	return res
+}
+
+func (p piProvider) ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution {
+	res := defaultControlResponseResolution(ctx)
+	if len(ctx.RequestPayload) == 0 {
+		return res
+	}
+	var req struct {
+		Method string `json:"method"`
+	}
+	if !warnUnmarshal(ctx.RequestPayload, &req, "pi control response request") {
+		return res
+	}
+	res.DisplayText = piExtensionUIResponseDisplayText(req.Method, ctx.ResponseContent)
+	return res
+}
+
+func (p acpProvider) ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution {
+	res := defaultControlResponseResolution(ctx)
+	if len(ctx.RequestPayload) == 0 {
+		return res
+	}
+
+	var req struct {
+		Method string `json:"method"`
+		Type   string `json:"type"`
+	}
+	if !warnUnmarshal(ctx.RequestPayload, &req, "acp control response request") {
+		return res
+	}
+
+	// Cursor's question / create-plan flows are keyed on the JSON-RPC method and are unique to
+	// Cursor's ACP variant, so they stay Cursor-specific (a per-provider enum check) rather than a
+	// registration hook shared across providers.
+	if p.provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR {
+		switch req.Method {
+		case CursorMethodAskQuestion:
+			res.DisplayText = cursorQuestionAnswersText(ctx.RequestPayload, ctx.ResponseContent)
+			return res
+		case CursorMethodCreatePlan:
+			if transformed, text, ok := transformCursorControlResponse(ctx.RequestPayload, ctx.ResponseContent); ok {
+				res.Content = transformed
+				res.DisplayText = text
+				return res
+			}
+		}
+	}
+
+	// The OpenCode-protocol `question.asked` answer summary dispatches through a registration-time
+	// hook (set only for the providers that speak that protocol, see init()) rather than a provider
+	// enum allowlist -- so the membership lives at the single registration site, mirroring the
+	// frontend's registerOpenCodeProtocolProvider, not a second source of truth that drifts.
+	if p.questionAnswersText != nil && req.Type == "question.asked" {
+		res.DisplayText = p.questionAnswersText(ctx.RequestPayload, ctx.ResponseContent)
+		return res
+	}
+
+	res.DisplayText = acpPermissionResponseDisplayText(ctx.RequestPayload, ctx.ResponseContent)
+	return res
+}
+
+// warnUnmarshal decodes JSON into v, logging a "<label> unmarshal failed" warning and returning
+// false on error (the caller then returns its own zero result). The single home for the
+// decode-and-warn preamble the control-response resolvers and answer summaries all repeat.
+func warnUnmarshal(data []byte, v any, label string) bool {
+	if err := json.Unmarshal(data, v); err != nil {
+		slog.Warn(label+" unmarshal failed", "error", err)
+		return false
+	}
+	return true
+}
+
+// firstNonEmpty returns the first argument that is non-empty after trimming surrounding
+// whitespace, or "" when all are blank. Centralizes the "prefer this label, else fall back to
+// that one" idiom the answer summaries repeat -- and, because it trims the fallback too, a
+// display label chosen from a fallback never renders with stray whitespace.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if t := strings.TrimSpace(v); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// labeledAnswerLine formats one "label: v1, v2" answer line, trimming each value and dropping the
+// empties; ok is false when no value survives (the caller skips the line). The single home for the
+// per-line answer formatting the codex / opencode / cursor answer summaries all repeat, so a change
+// to the separator or the empty-value rule happens once.
+func labeledAnswerLine(label string, values []string) (string, bool) {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		if t := strings.TrimSpace(v); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%s: %s", label, strings.Join(parts, ", ")), true
+}
+
+func codexUserInputAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Params struct {
+			Questions []struct {
+				ID     string `json:"id"`
+				Header string `json:"header"`
+			} `json:"questions"`
+		} `json:"params"`
+	}
+	var resp struct {
+		Result struct {
+			Answers map[string]struct {
+				Answers []string `json:"answers"`
+			} `json:"answers"`
+		} `json:"result"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "codex user input request") {
+		return ""
+	}
+	if !warnUnmarshal(responseContent, &resp, "codex user input response") {
+		return ""
+	}
+
+	if len(resp.Result.Answers) == 0 {
+		return ""
+	}
+
+	labels := make(map[string]string, len(req.Params.Questions))
+	order := make([]string, 0, len(req.Params.Questions))
+	for _, q := range req.Params.Questions {
+		key := firstNonEmpty(q.ID, q.Header)
+		if key == "" {
+			continue
+		}
+		labels[key] = firstNonEmpty(q.Header, key)
+		order = append(order, key)
+	}
+
+	lines := make([]string, 0, len(resp.Result.Answers))
+	seen := make(map[string]bool, len(resp.Result.Answers))
+	appendLine := func(key string) {
+		answer, ok := resp.Result.Answers[key]
+		if !ok || seen[key] {
+			return
+		}
+		// seen is set ONLY when a non-empty line is emitted, so the empty-filter and the dedup
+		// stay entangled -- an all-empty answer neither renders nor marks the key seen.
+		if line, ok := labeledAnswerLine(labels[key], answer.Answers); ok {
+			lines = append(lines, line)
+			seen[key] = true
+		}
+	}
+
+	for _, key := range order {
+		appendLine(key)
+	}
+	// Any answer whose key wasn't in the request's questions is absent from `order`. Append
+	// these in a STABLE (sorted) order rather than Go's randomized map-iteration order, so the
+	// same control response always renders the same lines (a map range would reorder them
+	// nondeterministically between renders).
+	extraKeys := make([]string, 0, len(resp.Result.Answers))
+	for key := range resp.Result.Answers {
+		if !seen[key] {
+			extraKeys = append(extraKeys, key)
+		}
+	}
+	sort.Strings(extraKeys)
+	for _, key := range extraKeys {
+		if _, ok := labels[key]; !ok {
+			labels[key] = key
+		}
+		appendLine(key)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// ControlBehaviorEnvelope is the frontend's neutral approve/reject control-response envelope --
+// {response:{request_id, response:{behavior, message}}}. The SINGLE Go home for this wire shape:
+// DecodeControlBehavior decodes it directly, and the service's plan-mode payload EMBEDS it (adding
+// the permissionMode/clearContext siblings) rather than re-declaring the same nested struct, so a
+// wire-field rename lands in exactly one place instead of drifting between two hand-copied shapes.
+type ControlBehaviorEnvelope struct {
+	Response struct {
+		RequestID string `json:"request_id"`
+		Response  struct {
+			Behavior string `json:"behavior"`
+			Message  string `json:"message"`
+		} `json:"response"`
+	} `json:"response"`
+}
+
+// DecodeControlBehavior decodes the frontend's neutral approve/reject control-response envelope
+// (ControlBehaviorEnvelope), returning the trimmed request id, behavior, and rejection
+// message. ok is false only when the bytes don't parse as JSON. The message is the user's typed
+// rejection reason, with the ControlRejectedByUserMessage sentinel (an auto-filled placeholder,
+// not a real reason) collapsed to "". The SINGLE home for the sentinel rule, shared by the Codex
+// feedback path, the Cursor create-plan transform, and the service's request-id lookup, so a
+// sentinel change lands in exactly one place.
+func DecodeControlBehavior(content []byte) (requestID, behavior, message string, ok bool) {
+	var cr ControlBehaviorEnvelope
+	if err := json.Unmarshal(content, &cr); err != nil {
+		return "", "", "", false
+	}
+	requestID = strings.TrimSpace(cr.Response.RequestID)
+	behavior = strings.TrimSpace(cr.Response.Response.Behavior)
+	message = NormalizeRejectionMessage(cr.Response.Response.Message)
+	return requestID, behavior, message, true
+}
+
+// NormalizeRejectionMessage trims a control-response reject reason and collapses the
+// ControlRejectedByUserMessage placeholder (the auto-filled "declined without a reason" text) to
+// "". The SINGLE home for the deny-feedback rule, shared by DecodeControlBehavior (which decodes
+// the raw wire bytes) and the service's controlResponsePlan.rejectionMessage accessor (which reads
+// the already-decoded plan), so a sentinel-value change lands in exactly one place instead of two.
+func NormalizeRejectionMessage(message string) string {
+	message = strings.TrimSpace(message)
+	if message == ControlRejectedByUserMessage {
+		return ""
+	}
+	return message
+}
+
+func codexFeedbackMessageText(responseContent []byte) string {
+	_, _, message, _ := DecodeControlBehavior(responseContent)
+	return message
+}
+
+func codexDecisionDisplayText(responseContent []byte) string {
+	var resp struct {
+		Result struct {
+			Decision json.RawMessage `json:"decision"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil || len(resp.Result.Decision) == 0 || string(resp.Result.Decision) == "null" {
+		return ""
+	}
+
+	var decision string
+	if err := json.Unmarshal(resp.Result.Decision, &decision); err == nil {
+		switch strings.TrimSpace(decision) {
+		case "accept":
+			return "Allow"
+		case "acceptForSession":
+			return "Allow for Session"
+		case "decline":
+			return "Reject"
+		case "cancel":
+			return "Cancel"
+		default:
+			return strings.TrimSpace(decision)
+		}
+	}
+
+	var objectDecision map[string]json.RawMessage
+	if err := json.Unmarshal(resp.Result.Decision, &objectDecision); err != nil {
+		return ""
+	}
+	if _, ok := objectDecision["acceptWithExecpolicyAmendment"]; ok {
+		return "Allow & Remember"
+	}
+	if _, ok := objectDecision["applyNetworkPolicyAmendment"]; ok {
+		return "Apply Network Policy"
+	}
+	if len(objectDecision) > 0 {
+		return "Allow"
+	}
+	return ""
+}
+
+func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Properties struct {
+			Questions []struct {
+				Header   string `json:"header"`
+				Question string `json:"question"`
+			} `json:"questions"`
+		} `json:"properties"`
+	}
+	var resp struct {
+		Result struct {
+			Rejected bool       `json:"rejected"`
+			Answers  [][]string `json:"answers"`
+		} `json:"result"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "opencode question request") {
+		return ""
+	}
+	if !warnUnmarshal(responseContent, &resp, "opencode question response") {
+		return ""
+	}
+	if resp.Result.Rejected {
+		return "Reject"
+	}
+
+	lines := make([]string, 0, len(resp.Result.Answers))
+	for i, answers := range resp.Result.Answers {
+		label := fmt.Sprintf("Question %d", i+1)
+		if i < len(req.Properties.Questions) {
+			q := req.Properties.Questions[i]
+			if v := firstNonEmpty(q.Header, q.Question); v != "" {
+				label = v
+			}
+		}
+		if line, ok := labeledAnswerLine(label, answers); ok {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func cursorQuestionAnswersText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Params struct {
+			Questions []struct {
+				ID      string `json:"id"`
+				Prompt  string `json:"prompt"`
+				Options []struct {
+					ID    string `json:"id"`
+					Label string `json:"label"`
+				} `json:"options"`
+			} `json:"questions"`
+		} `json:"params"`
+	}
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+				Answers []struct {
+					QuestionID        string   `json:"questionId"`
+					SelectedOptionIDs []string `json:"selectedOptionIds"`
+				} `json:"answers"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "cursor question request") {
+		return ""
+	}
+	if !warnUnmarshal(responseContent, &resp, "cursor question response") {
+		return ""
+	}
+
+	switch resp.Result.Outcome.Outcome {
+	case "answered":
+		labels := make(map[string]string, len(req.Params.Questions))
+		optionLabels := make(map[string]map[string]string, len(req.Params.Questions))
+		order := make([]string, 0, len(req.Params.Questions))
+		for _, q := range req.Params.Questions {
+			if strings.TrimSpace(q.ID) == "" {
+				continue
+			}
+			labels[q.ID] = strings.TrimSpace(q.Prompt)
+			options := make(map[string]string, len(q.Options))
+			for _, option := range q.Options {
+				if strings.TrimSpace(option.ID) == "" {
+					continue
+				}
+				options[option.ID] = firstNonEmpty(option.Label, option.ID)
+			}
+			optionLabels[q.ID] = options
+			order = append(order, q.ID)
+		}
+
+		answerByQuestion := make(map[string][]string, len(resp.Result.Outcome.Answers))
+		for _, answer := range resp.Result.Outcome.Answers {
+			if strings.TrimSpace(answer.QuestionID) == "" {
+				continue
+			}
+			mapped := make([]string, 0, len(answer.SelectedOptionIDs))
+			for _, optionID := range answer.SelectedOptionIDs {
+				optionID = strings.TrimSpace(optionID)
+				if optionID == "" {
+					continue
+				}
+				label := optionID
+				if options := optionLabels[answer.QuestionID]; options != nil {
+					if mappedLabel := strings.TrimSpace(options[optionID]); mappedLabel != "" {
+						label = mappedLabel
+					}
+				}
+				mapped = append(mapped, label)
+			}
+			if len(mapped) > 0 {
+				answerByQuestion[answer.QuestionID] = mapped
+			}
+		}
+
+		lines := make([]string, 0, len(answerByQuestion))
+		for _, questionID := range order {
+			mapped := answerByQuestion[questionID]
+			if len(mapped) == 0 {
+				continue
+			}
+			label := firstNonEmpty(labels[questionID], questionID)
+			if line, ok := labeledAnswerLine(label, mapped); ok {
+				lines = append(lines, line)
+			}
+		}
+		return strings.Join(lines, "\n")
+	case "cancelled", "skipped":
+		return strings.TrimSpace(resp.Result.Outcome.Reason)
+	default:
+		return ""
+	}
+}
+
+func cursorCreatePlanDisplayText(outcome, reason string) string {
+	switch outcome {
+	case "accepted":
+		return "Accept"
+	case "rejected":
+		if reason := strings.TrimSpace(reason); reason != "" {
+			return reason
+		}
+		return "Reject"
+	case "cancelled":
+		if reason := strings.TrimSpace(reason); reason != "" {
+			return reason
+		}
+		return "Cancel"
+	default:
+		return ""
+	}
+}
+
+func transformCursorControlResponse(requestPayload, responseContent []byte) ([]byte, string, bool) {
+	var req struct {
+		Method string `json:"method"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "cursor control response method") {
+		return nil, "", false
+	}
+	if req.Method != CursorMethodCreatePlan {
+		return nil, "", false
+	}
+
+	respRequestID, behavior, message, ok := DecodeControlBehavior(responseContent)
+	if !ok {
+		return nil, "", false
+	}
+
+	idRaw, requestID, ok := ExtractJSONRPCID(requestPayload)
+	if !ok {
+		return nil, "", false
+	}
+
+	if respRequestID == "" || respRequestID != requestID {
+		return nil, "", false
+	}
+
+	outcome := "accepted"
+	reason := ""
+	switch behavior {
+	case ControlBehaviorAllow:
+	case ControlBehaviorDeny:
+		outcome = "rejected"
+		// message is already trimmed and the ControlRejectedByUserMessage placeholder collapsed
+		// to "" by DecodeControlBehavior, so a bare rejection carries no reason.
+		reason = message
+	default:
+		return nil, "", false
+	}
+
+	outcomeBody := map[string]interface{}{
+		"outcome": outcome,
+	}
+	if reason != "" {
+		outcomeBody["reason"] = reason
+	}
+
+	encoded, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(idRaw),
+		"result":  map[string]interface{}{"outcome": outcomeBody},
+	})
+	if err != nil {
+		return nil, "", false
+	}
+	return encoded, cursorCreatePlanDisplayText(outcome, reason), true
+}
+
+// piExtensionUIResponseDisplayText extracts a human-readable summary of a Pi
+// extension_ui_response so the user's choice shows up as a synthetic message
+// in the transcript.
+func piExtensionUIResponseDisplayText(method string, responseContent []byte) string {
+	var resp struct {
+		Cancelled bool   `json:"cancelled"`
+		Confirmed *bool  `json:"confirmed"`
+		Value     string `json:"value"`
+	}
+	if err := json.Unmarshal(responseContent, &resp); err != nil {
+		return ""
+	}
+
+	if resp.Cancelled {
+		return "Cancelled"
+	}
+
+	switch method {
+	case PiDialogMethodConfirm:
+		if resp.Confirmed != nil && *resp.Confirmed {
+			return "Approve"
+		}
+		return "Deny"
+	case PiDialogMethodSelect, PiDialogMethodInput, PiDialogMethodEditor:
+		return strings.TrimSpace(resp.Value)
+	default:
+		return ""
+	}
+}
+
+// acpPermissionResponseDisplayText extracts a human-readable display text from
+// an ACP permission response by matching the selected optionId against the
+// original request payload's option list.
+func acpPermissionResponseDisplayText(requestPayload, responseContent []byte) string {
+	var req struct {
+		Params struct {
+			Options []struct {
+				OptionID string `json:"optionId"`
+				Name     string `json:"name"`
+			} `json:"options"`
+		} `json:"params"`
+	}
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				OptionID string `json:"optionId"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "acp permission request") {
+		return ""
+	}
+	if !warnUnmarshal(responseContent, &resp, "acp permission response") {
+		return ""
+	}
+
+	optionID := strings.TrimSpace(resp.Result.Outcome.OptionID)
+	if optionID == "" {
+		return ""
+	}
+	for _, option := range req.Params.Options {
+		if strings.TrimSpace(option.OptionID) == optionID {
+			if name := strings.TrimSpace(option.Name); name != "" {
+				return name
+			}
+			break
+		}
+	}
+
+	switch optionID {
+	case "once", "proceed_once":
+		return "Allow once"
+	case "always", "proceed_always":
+		return "Always allow"
+	case "reject", "cancel":
+		return "Reject"
+	default:
+		return optionID
+	}
+}

--- a/backend/internal/worker/agent/control_response_test.go
+++ b/backend/internal/worker/agent/control_response_test.go
@@ -1,0 +1,487 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+func TestResolveControlResponse_NoopKeepsRawResponse(t *testing.T) {
+	content := []byte(`{"id":1,"result":{"ok":true}}`)
+	res := noopProvider{}.ResolveControlResponse(ControlResponseContext{ResponseContent: content})
+
+	assert.Equal(t, content, res.Content)
+	assert.Empty(t, res.DisplayText)
+	assert.False(t, res.SelfDisplayed)
+	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CodexUserInputAnswer(t *testing.T) {
+	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"method":"item/tool/requestUserInput",
+			"params":{"questions":[{"header":"Task","id":"task"},{"header":"Reason","id":"reason"}]}
+		}`),
+		ResponseContent: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"result":{"answers":{"task":{"answers":["Inspect"]},"reason":{"answers":["Parity"]}}}
+		}`),
+	})
+
+	assert.Equal(t, "Task: Inspect\nReason: Parity", res.DisplayText)
+	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CodexUserInputAnswerStableExtraOrdering(t *testing.T) {
+	// The response carries answer keys NOT present in the request's questions ("alpha", "mango",
+	// "zebra"). Those are absent from the request-derived order, so they must render in a STABLE
+	// (sorted) order rather than Go's randomized map-iteration order -- otherwise the same control
+	// response would render its trailing lines differently across renders.
+	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0","id":7,"method":"item/tool/requestUserInput",
+			"params":{"questions":[{"header":"Task","id":"task"}]}
+		}`),
+		ResponseContent: []byte(`{
+			"jsonrpc":"2.0","id":7,
+			"result":{"answers":{
+				"task":{"answers":["Inspect"]},
+				"zebra":{"answers":["Z"]},
+				"alpha":{"answers":["A"]},
+				"mango":{"answers":["M"]}
+			}}
+		}`),
+	})
+
+	// The request-ordered question first, then the extra keys alphabetically.
+	assert.Equal(t, "Task: Inspect\nalpha: A\nmango: M\nzebra: Z", res.DisplayText)
+}
+
+func TestResolveControlResponse_CodexPlanModePrompt(t *testing.T) {
+	content := []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`)
+	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+		ResponseContent: content,
+		ToolName:        ToolNameCodexPlanModePrompt,
+	})
+
+	assert.Equal(t, content, res.Content)
+	assert.Empty(t, res.DisplayText)
+	assert.Equal(t, PlanModeControlPrompt, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CodexFeedbackMessage(t *testing.T) {
+	content := []byte(`{"response":{"response":{"behavior":"deny","message":"Add tests first."}}}`)
+	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"method":"item/commandExecution/requestApproval"}`),
+		ResponseContent: content,
+	})
+
+	assert.Equal(t, content, res.Content)
+	assert.Equal(t, "Add tests first.", res.DisplayText)
+	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CodexDecisionDisplayText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{
+			name:    "accept",
+			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`),
+			want:    "Allow",
+		},
+		{
+			name:    "decline",
+			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"decline"}}`),
+			want:    "Reject",
+		},
+		{
+			name:    "exec policy amendment",
+			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":{"acceptWithExecpolicyAmendment":{"match":"npm test"}}}}`),
+			want:    "Allow & Remember",
+		},
+		{
+			name:    "network policy amendment",
+			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":{"applyNetworkPolicyAmendment":true}}}`),
+			want:    "Apply Network Policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+				RequestPayload:  []byte(`{"method":"item/commandExecution/requestApproval"}`),
+				ResponseContent: tt.content,
+			})
+
+			assert.Equal(t, tt.want, res.DisplayText)
+		})
+	}
+}
+
+func TestResolveControlResponse_ClaudeSelfDisplayAndPlanMode(t *testing.T) {
+	res := claudeProvider{}.ResolveControlResponse(ControlResponseContext{
+		ResponseContent: []byte(`{"type":"control_response","response":{"request_id":"req-1","response":{"behavior":"allow"}}}`),
+		ToolName:        ToolNameExitPlanMode,
+	})
+
+	assert.True(t, res.SelfDisplayed)
+	assert.Equal(t, PlanModeControlExit, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CursorCreatePlanTransformsResponse(t *testing.T) {
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"method":"cursor/create_plan",
+			"params":{}
+		}`),
+		ResponseContent: []byte(`{
+			"response":{
+				"request_id":"7",
+				"response":{"behavior":"deny","message":"Needs tests."}
+			}
+		}`),
+	})
+
+	require.Equal(t, "Needs tests.", res.DisplayText)
+	var normalized struct {
+		ID     int `json:"id"`
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(res.Content, &normalized))
+	assert.Equal(t, 7, normalized.ID)
+	assert.Equal(t, "rejected", normalized.Result.Outcome.Outcome)
+	assert.Equal(t, "Needs tests.", normalized.Result.Outcome.Reason)
+}
+
+func TestResolveControlResponse_CursorCreatePlanAcceptsResponse(t *testing.T) {
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":"plan-7",
+			"method":"cursor/create_plan",
+			"params":{}
+		}`),
+		ResponseContent: []byte(`{
+			"response":{
+				"request_id":"plan-7",
+				"response":{"behavior":"allow"}
+			}
+		}`),
+	})
+
+	require.Equal(t, "Accept", res.DisplayText)
+	var normalized struct {
+		ID     string `json:"id"`
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(res.Content, &normalized))
+	assert.Equal(t, "plan-7", normalized.ID)
+	assert.Equal(t, "accepted", normalized.Result.Outcome.Outcome)
+	assert.Empty(t, normalized.Result.Outcome.Reason)
+}
+
+func TestResolveControlResponse_CursorCreatePlanRejectsDefaultMessageAsReject(t *testing.T) {
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":"plan-7",
+			"method":"cursor/create_plan",
+			"params":{}
+		}`),
+		ResponseContent: []byte(`{
+			"response":{
+				"request_id":"plan-7",
+				"response":{"behavior":"deny","message":"Rejected by user."}
+			}
+		}`),
+	})
+
+	require.Equal(t, "Reject", res.DisplayText)
+	var normalized struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(res.Content, &normalized))
+	assert.Equal(t, "rejected", normalized.Result.Outcome.Outcome)
+	assert.Empty(t, normalized.Result.Outcome.Reason)
+}
+
+func TestResolveControlResponse_CursorCreatePlanIgnoresMalformedEnvelope(t *testing.T) {
+	content := []byte(`{"jsonrpc":"2.0","id":7,"result":{"outcome":{"outcome":"rejected","reason":"No"}}}`)
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0",
+			"id":7,
+			"method":"cursor/create_plan",
+			"params":{}
+		}`),
+		ResponseContent: content,
+	})
+
+	assert.Equal(t, content, res.Content)
+	assert.Empty(t, res.DisplayText)
+}
+
+func TestResolveControlResponse_CursorQuestionAnsweredMapsOptionLabels(t *testing.T) {
+	// Cursor AskQuestion "answered": each selected optionId maps to its option LABEL, formatted as
+	// "prompt: label1, label2" per question in request order. This exercises cursorQuestionAnswersText's
+	// answered path (option-label mapping + labeled-line formatting), which had no direct coverage.
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload: []byte(`{
+			"jsonrpc":"2.0","id":7,"method":"` + CursorMethodAskQuestion + `",
+			"params":{"questions":[
+				{"id":"q1","prompt":"Pick a color","options":[{"id":"o1","label":"Red"},{"id":"o2","label":"Blue"}]},
+				{"id":"q2","prompt":"Pick a size","options":[{"id":"s1","label":"Large"}]}
+			]}
+		}`),
+		ResponseContent: []byte(`{
+			"jsonrpc":"2.0","id":7,
+			"result":{"outcome":{"outcome":"answered","answers":[
+				{"questionId":"q1","selectedOptionIds":["o1","o2"]},
+				{"questionId":"q2","selectedOptionIds":["s1"]}
+			]}}
+		}`),
+	})
+
+	assert.Equal(t, "Pick a color: Red, Blue\nPick a size: Large", res.DisplayText)
+}
+
+func TestResolveControlResponse_OpenCodeStyleQuestionAnswer(t *testing.T) {
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
+	} {
+		t.Run(provider.String(), func(t *testing.T) {
+			// Resolve through ProviderFor (not an inline acpProvider literal) so the test exercises
+			// the real registration: the OpenCode question summary now dispatches through the
+			// questionAnswersText hook that init() sets only for OpenCode/Kilo.
+			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
+				RequestPayload: []byte(`{
+					"type":"question.asked",
+					"properties":{"questions":[{"header":"Task"},{"header":"Env"}]}
+				}`),
+				ResponseContent: []byte(`{"jsonrpc":"2.0","id":"q1","result":{"answers":[["Build"],["Dev"]]}}`),
+			})
+
+			assert.Equal(t, "Task: Build\nEnv: Dev", res.DisplayText)
+		})
+	}
+}
+
+func TestResolveControlResponse_OpenCodeStyleQuestionReject(t *testing.T) {
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
+	} {
+		t.Run(provider.String(), func(t *testing.T) {
+			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
+				RequestPayload: []byte(`{
+					"type":"question.asked",
+					"properties":{"questions":[{"header":"Task"}]}
+				}`),
+				ResponseContent: []byte(`{"jsonrpc":"2.0","id":"q1","result":{"rejected":true}}`),
+			})
+
+			assert.Equal(t, "Reject", res.DisplayText)
+		})
+	}
+}
+
+func TestResolveControlResponse_OpenCodeDropsEmptyAnswerValues(t *testing.T) {
+	// Edge case for the shared labeledAnswerLine formatting: an answer whose values are all
+	// empty/whitespace produces NO line (never a dangling "Env: "), and the question is omitted
+	// entirely -- while a sibling question with a real value still renders.
+	res := ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE).ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"type":"question.asked","properties":{"questions":[{"header":"Task"},{"header":"Env"}]}}`),
+		ResponseContent: []byte(`{"result":{"answers":[["Build"],["  ",""]]}}`),
+	})
+
+	assert.Equal(t, "Task: Build", res.DisplayText)
+}
+
+func TestResolveControlResponse_OpenCodeQuestionDispatchIsRegistrationDriven(t *testing.T) {
+	// The OpenCode-protocol `question.asked` answer summary must dispatch through the
+	// registration-time questionAnswersText hook (set only for OpenCode and Kilo in init()), NOT a
+	// provider-enum allowlist in ResolveControlResponse. This is the backend mirror of the frontend's
+	// registerOpenCodeProtocolProvider membership: keeping "who speaks the question protocol" at the
+	// single registration site stops a second source of truth from drifting.
+	//
+	// The fixture deliberately carries BOTH wire shapes at once -- an OpenCode `question.asked`
+	// question/answer AND an ACP permission option/outcome -- so the two dispatch paths yield DISTINCT
+	// display text. A provider WITH the hook renders the question summary ("Task: Build"); a provider
+	// WITHOUT it falls through to the permission summary ("Allow once"). That divergence is what makes
+	// case (b) a real regression guard: it fails if someone re-adds a non-question provider to an enum
+	// allowlist, or wires the hook onto a provider that shouldn't have it -- either way the wrong
+	// provider would render "Task: Build" instead of "Allow once".
+	requestPayload := []byte(`{
+		"type":"question.asked",
+		"properties":{"questions":[{"header":"Task"}]},
+		"params":{"options":[{"optionId":"proceed_once","name":"Allow once"}]}
+	}`)
+	responseContent := []byte(`{"result":{"answers":[["Build"]],"outcome":{"optionId":"proceed_once"}}}`)
+
+	// (a) Both providers registered WITH the hook render the OpenCode question summary.
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
+	} {
+		t.Run(provider.String()+"_uses_question_hook", func(t *testing.T) {
+			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
+				RequestPayload:  requestPayload,
+				ResponseContent: responseContent,
+			})
+			assert.Equal(t, "Task: Build", res.DisplayText)
+		})
+	}
+
+	// (b) An ACP provider registered WITHOUT the hook falls through to the ACP permission summary for
+	// the very same `question.asked` payload -- it never invokes opencodeQuestionAnswersText.
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX,
+	} {
+		t.Run(provider.String()+"_falls_through_to_permission", func(t *testing.T) {
+			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
+				RequestPayload:  requestPayload,
+				ResponseContent: responseContent,
+			})
+			assert.Equal(t, "Allow once", res.DisplayText)
+			assert.NotEqual(t, "Task: Build", res.DisplayText,
+				"a provider without the questionAnswersText hook must not render the OpenCode question summary")
+		})
+	}
+}
+
+func TestResolveControlResponse_ACPPermissionLabels(t *testing.T) {
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX,
+	} {
+		t.Run(provider.String(), func(t *testing.T) {
+			res := acpProvider{provider: provider}.ResolveControlResponse(ControlResponseContext{
+				RequestPayload: []byte(`{
+					"jsonrpc":"2.0",
+					"id":7,
+					"method":"session/request_permission",
+					"params":{"options":[{"optionId":"proceed_once","name":"Allow once"}]}
+				}`),
+				ResponseContent: []byte(`{"jsonrpc":"2.0","id":7,"result":{"outcome":{"optionId":"proceed_once"}}}`),
+			})
+
+			assert.Equal(t, "Allow once", res.DisplayText)
+		})
+	}
+}
+
+func TestResolveControlResponse_PiExtensionUIResponse(t *testing.T) {
+	confirmed := true
+	response, err := json.Marshal(map[string]interface{}{"confirmed": confirmed})
+	require.NoError(t, err)
+
+	res := piProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"method":"confirm"}`),
+		ResponseContent: response,
+	})
+
+	assert.Equal(t, "Approve", res.DisplayText)
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	// Returns the first argument non-empty AFTER trimming, and trims the chosen value --
+	// including a fallback passed with surrounding whitespace (the display-label tidy the
+	// answer summaries rely on).
+	assert.Equal(t, "x", firstNonEmpty("", "  ", "x"))
+	assert.Equal(t, "a", firstNonEmpty("  a  ", "b"), "trims the chosen value")
+	assert.Equal(t, "fallback", firstNonEmpty("   ", "  fallback  "), "trims a whitespace-padded fallback")
+	assert.Equal(t, "", firstNonEmpty(), "no args -> empty")
+	assert.Equal(t, "", firstNonEmpty("", "\t\n "), "all blank -> empty")
+}
+
+func TestWarnUnmarshal(t *testing.T) {
+	var ok struct {
+		Method string `json:"method"`
+	}
+	assert.True(t, warnUnmarshal([]byte(`{"method":"m"}`), &ok, "test"), "valid JSON decodes and returns true")
+	assert.Equal(t, "m", ok.Method)
+
+	var bad struct{}
+	assert.False(t, warnUnmarshal([]byte(`not json`), &bad, "test"), "malformed JSON returns false")
+}
+
+func TestDecodeControlBehavior(t *testing.T) {
+	// A real deny with a typed reason: request id + behavior + message all surface, trimmed.
+	id, behavior, message, ok := DecodeControlBehavior([]byte(
+		`{"response":{"request_id":" req-1 ","response":{"behavior":" deny ","message":" not this way "}}}`))
+	assert.True(t, ok)
+	assert.Equal(t, "req-1", id)
+	assert.Equal(t, ControlBehaviorDeny, behavior)
+	assert.Equal(t, "not this way", message)
+
+	// The ControlRejectedByUserMessage placeholder is collapsed to "" -- a bare rejection carries
+	// no reason, so both the Codex feedback path and the Cursor transform treat it as empty.
+	_, _, message, ok = DecodeControlBehavior([]byte(
+		`{"response":{"request_id":"req-2","response":{"behavior":"deny","message":"Rejected by user."}}}`))
+	assert.True(t, ok)
+	assert.Empty(t, message, "the ControlRejectedByUserMessage placeholder collapses to \"\"")
+
+	// An allow with no message.
+	_, behavior, message, ok = DecodeControlBehavior([]byte(`{"response":{"request_id":"req-3","response":{"behavior":"allow"}}}`))
+	assert.True(t, ok)
+	assert.Equal(t, ControlBehaviorAllow, behavior)
+	assert.Empty(t, message)
+
+	// Malformed JSON: ok is false and every field is empty.
+	id, behavior, message, ok = DecodeControlBehavior([]byte(`not json`))
+	assert.False(t, ok)
+	assert.Empty(t, id)
+	assert.Empty(t, behavior)
+	assert.Empty(t, message)
+}
+
+func TestNormalizeRejectionMessage(t *testing.T) {
+	// A typed reason surfaces trimmed.
+	assert.Equal(t, "not this way", NormalizeRejectionMessage("  not this way  "))
+	// The auto-filled placeholder collapses to "" (no real feedback), including when padded.
+	assert.Empty(t, NormalizeRejectionMessage(ControlRejectedByUserMessage))
+	assert.Empty(t, NormalizeRejectionMessage("  "+ControlRejectedByUserMessage+"  "))
+	// A genuinely empty / whitespace reason is "".
+	assert.Empty(t, NormalizeRejectionMessage(""))
+	assert.Empty(t, NormalizeRejectionMessage("   \n "))
+	// DecodeControlBehavior and NormalizeRejectionMessage apply the SAME rule -- the sentinel
+	// collapse must not drift between the raw-bytes decoder and the shared helper.
+	_, _, decoded, ok := DecodeControlBehavior([]byte(
+		`{"response":{"request_id":"r","response":{"behavior":"deny","message":"  ` + ControlRejectedByUserMessage + `  "}}}`))
+	assert.True(t, ok)
+	assert.Equal(t, NormalizeRejectionMessage("  "+ControlRejectedByUserMessage+"  "), decoded)
+}

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -22,6 +22,14 @@ const (
 	ControlBehaviorDeny  = "deny"
 )
 
+// ControlRejectedByUserMessage is the placeholder reject message the frontend emits when
+// the user declines a control request WITHOUT typing a reason (buildDenyResponse in
+// frontend utils/controlResponse.ts). The backend treats it as "no feedback" -- it is not
+// shown as the user's answer -- so every deny-with-feedback path compares against this one
+// constant instead of re-spelling the literal (which must stay in lockstep with the
+// frontend producer).
+const ControlRejectedByUserMessage = "Rejected by user."
+
 // Tool name constants used in control requests.
 const (
 	ToolNameAskUserQuestion     = "AskUserQuestion"

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -26,6 +26,28 @@ func (c NotificationClassification) Consolidatable() bool {
 	return c.Kind != NotificationKindNone
 }
 
+type PlanModeControlKind int
+
+const (
+	PlanModeControlNone PlanModeControlKind = iota
+	PlanModeControlEnter
+	PlanModeControlExit
+	PlanModeControlPrompt
+)
+
+// PlanApprovalOptions is the provider-specific option settlement the service applies when a
+// plan-mode-prompt control request is APPROVED. Keeping the option ids/values here (rather than
+// hardcoded in the shared service layer) means a provider owns its own plan-approval wire values.
+//   - Base is applied unconditionally on approval (e.g. Codex settling its collaboration axis).
+//   - Bypass is applied only when the approval also switches permission mode (e.g. Codex granting
+//     full network access + no sandbox for the approved mode).
+//
+// Both maps are nil for a provider with no plan-approval options.
+type PlanApprovalOptions struct {
+	Base   map[string]string
+	Bypass map[string]string
+}
+
 // Provider bundles the per-provider wire-format hooks the service
 // layer invokes without holding a running-agent reference. Plugins are
 // stateless and shared across goroutines — a single instance per provider.
@@ -51,6 +73,37 @@ type Provider interface {
 	// mode/approval policy -- the value stamped under the "permissionMode"
 	// option id when the agent carries no explicit selection.
 	DefaultPermissionMode() string
+	// IsSelfDisplayingControlTool reports whether a control response for the
+	// named control request (`toolName` is a Claude tool name; other providers
+	// ignore it) is ALREADY displayed by the provider's own transcript -- e.g.
+	// Claude re-emits AskUserQuestion / ExitPlanMode answers as a user-envelope
+	// tool_result. When true, the scroll rail marks that ingested row directly
+	// and the service layer persists NO separate synthetic display row (which
+	// would double the dot). Every provider except Claude synthesizes the display
+	// row itself (persistSyntheticUserMessage) and so returns false -- confirmed
+	// against the Codex, OpenCode/ACP, and Pi wire protocols, none of which echo a
+	// control answer back into their output stream.
+	IsSelfDisplayingControlTool(toolName string) bool
+	// PlanModeControl classifies a provider-native control request name into
+	// the provider-neutral plan-mode operation the service layer should run.
+	// Unknown or non-plan controls return PlanModeControlNone.
+	PlanModeControl(toolName string) PlanModeControlKind
+	// ResolveControlResponse interprets a frontend control response against the
+	// stored provider-native control request. It is pure: providers may normalize
+	// the response bytes and compute display/plan metadata, but the service owns
+	// persistence, control-request deletion, option changes, and process I/O.
+	ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution
+	// PlanApprovalOptions declares the option changes to settle when a plan-mode-prompt
+	// control request is approved (see PlanApprovalOptions). The service applies them; the
+	// provider owns the ids/values. Empty for providers with no plan-approval options.
+	PlanApprovalOptions() PlanApprovalOptions
+	// NeedsSyntheticInterruptNotice reports whether the service must persist a synthetic
+	// "[Request interrupted by user]" user row when the frontend forwards this provider's
+	// interrupt frame as a raw message (SendAgentRawMessage). True only for providers that
+	// consume the interrupt SILENTLY: Codex resolves turn/interrupt internally and emits no
+	// transcript row for it, so without the synthetic row the interrupt would leave no trace.
+	// A provider whose interrupt already surfaces in its own transcript returns false.
+	NeedsSyntheticInterruptNotice() bool
 }
 
 type noopProvider struct{}
@@ -66,6 +119,23 @@ func (noopProvider) Merge(class NotificationClassification, previous, next json.
 func (noopProvider) IsInterrupt(string) bool { return false }
 
 func (noopProvider) DefaultPermissionMode() string { return "" }
+
+// IsSelfDisplayingControlTool defaults to false: a provider that doesn't echo control
+// answers into its own transcript relies on the service layer's synthetic display row.
+// The ACP-based providers inherit this via their noopProvider embedding.
+func (noopProvider) IsSelfDisplayingControlTool(string) bool { return false }
+
+func (noopProvider) PlanModeControl(string) PlanModeControlKind { return PlanModeControlNone }
+
+// PlanApprovalOptions defaults to none: a provider with no plan-mode-prompt flow settles no
+// options on approval. The ACP-based providers inherit this via their noopProvider embedding.
+func (noopProvider) PlanApprovalOptions() PlanApprovalOptions { return PlanApprovalOptions{} }
+
+// NeedsSyntheticInterruptNotice defaults to false: a provider whose interrupt surfaces in its
+// own transcript (or that is interrupted via the InterruptAgent RPC rather than a raw frame)
+// needs no synthetic notice. The ACP-based providers inherit this via their noopProvider
+// embedding.
+func (noopProvider) NeedsSyntheticInterruptNotice() bool { return false }
 
 var (
 	providerMu       sync.RWMutex
@@ -186,6 +256,35 @@ func (codexProvider) IsInterrupt(content string) bool {
 
 func (codexProvider) DefaultPermissionMode() string { return CodexDefaultApprovalPolicy }
 
+// Codex consumes control responses internally (only a serverRequest/resolved
+// metadata notification returns), so it never self-displays the answer.
+func (codexProvider) IsSelfDisplayingControlTool(string) bool { return false }
+
+func (codexProvider) PlanModeControl(toolName string) PlanModeControlKind {
+	if toolName == ToolNameCodexPlanModePrompt {
+		return PlanModeControlPrompt
+	}
+	return PlanModeControlNone
+}
+
+// PlanApprovalOptions settles Codex on plan approval: Base resets the collaboration axis to its
+// default mode; Bypass (applied only on a permission-mode switch) grants full network access and
+// removes the sandbox for the approved mode.
+func (codexProvider) PlanApprovalOptions() PlanApprovalOptions {
+	return PlanApprovalOptions{
+		Base: map[string]string{CodexOptionCollaborationMode: CodexCollaborationDefault},
+		Bypass: map[string]string{
+			CodexOptionNetworkAccess: CodexNetworkEnabled,
+			CodexOptionSandboxPolicy: CodexSandboxDangerFullAccess,
+		},
+	}
+}
+
+// NeedsSyntheticInterruptNotice: Codex resolves turn/interrupt internally and emits only a
+// serverRequest/resolved metadata notification -- never a transcript row -- so the service
+// persists the synthetic "[Request interrupted by user]" row to record the interrupt.
+func (codexProvider) NeedsSyntheticInterruptNotice() bool { return true }
+
 type claudeProvider struct{}
 
 func (claudeProvider) Classify(raw json.RawMessage) NotificationClassification {
@@ -237,6 +336,33 @@ func (claudeProvider) IsInterrupt(content string) bool {
 
 func (claudeProvider) DefaultPermissionMode() string { return PermissionModeDefault }
 
+// Claude re-emits AskUserQuestion / ExitPlanMode answers as a user-envelope
+// tool_result in its own transcript, so the rail marks that ingested row directly
+// (claudeUserEnvelopeMarkType) and no synthetic display row is persisted for them. The single
+// home for this set, shared by the mark classifier and the synthetic-row skip.
+func (claudeProvider) IsSelfDisplayingControlTool(name string) bool {
+	return name == ToolNameAskUserQuestion || name == ToolNameExitPlanMode
+}
+
+func (claudeProvider) PlanModeControl(toolName string) PlanModeControlKind {
+	switch toolName {
+	case ToolNameEnterPlanMode:
+		return PlanModeControlEnter
+	case ToolNameExitPlanMode:
+		return PlanModeControlExit
+	default:
+		return PlanModeControlNone
+	}
+}
+
+// Claude's plan flow is EnterPlanMode/ExitPlanMode (never PlanModeControlPrompt), so no
+// plan-approval option settlement runs for it.
+func (claudeProvider) PlanApprovalOptions() PlanApprovalOptions { return PlanApprovalOptions{} }
+
+// NeedsSyntheticInterruptNotice: Claude's interrupt surfaces in its own transcript, so no
+// synthetic notice is persisted for a forwarded interrupt frame.
+func (claudeProvider) NeedsSyntheticInterruptNotice() bool { return false }
+
 // piProvider collapses Pi's lifecycle notifications and recognizes
 // Pi's interrupt frame. Pi emits compaction_start/end whenever a turn
 // crosses the compaction threshold; without consolidation, long sessions
@@ -286,6 +412,19 @@ func (piProvider) IsInterrupt(content string) bool {
 
 func (piProvider) DefaultPermissionMode() string { return "" }
 
+// Pi consumes extension_ui_response on stdin without echoing the answer to stdout,
+// so it never self-displays a control answer.
+func (piProvider) IsSelfDisplayingControlTool(string) bool { return false }
+
+func (piProvider) PlanModeControl(string) PlanModeControlKind { return PlanModeControlNone }
+
+// Pi has no plan-mode-prompt flow, so it settles no options on approval.
+func (piProvider) PlanApprovalOptions() PlanApprovalOptions { return PlanApprovalOptions{} }
+
+// NeedsSyntheticInterruptNotice: Pi's abort surfaces in its own transcript, so no synthetic
+// notice is persisted for a forwarded interrupt frame.
+func (piProvider) NeedsSyntheticInterruptNotice() bool { return false }
+
 // acpProvider recognizes ACP's `session/cancel` notification (and
 // the bare `cancel` form retained for legacy producers). Shared across all
 // ACP-based providers (Cursor, Copilot, Kilo, OpenCode, Goose).
@@ -293,7 +432,15 @@ func (piProvider) DefaultPermissionMode() string { return "" }
 // the no-op embedding.
 type acpProvider struct {
 	noopProvider
+	provider              leapmuxv1.AgentProvider
 	defaultPermissionMode string
+	// questionAnswersText renders the display summary for an OpenCode-protocol `question.asked`
+	// answer. Non-nil ONLY for the ACP providers that speak that question protocol (OpenCode,
+	// Kilo); nil for the rest, whose control answers fall through to the ACP permission summary.
+	// Set at registration (init) so the "who uses the OpenCode question shape" membership lives at
+	// one site (mirroring the frontend's registerOpenCodeProtocolProvider) rather than a
+	// provider-enum switch in ResolveControlResponse that would drift.
+	questionAnswersText func(requestPayload, responseContent []byte) string
 }
 
 func (acpProvider) IsInterrupt(content string) bool {
@@ -314,10 +461,10 @@ func init() {
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, codexProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, claudeProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, piProvider{})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{defaultPermissionMode: CursorCLIModeAgent})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{defaultPermissionMode: CopilotCLIModeAgent})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{defaultPermissionMode: GooseCLIModeAuto})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, acpProvider{})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, defaultPermissionMode: CursorCLIModeAgent})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, defaultPermissionMode: CopilotCLIModeAgent})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, questionAnswersText: opencodeQuestionAnswersText})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, questionAnswersText: opencodeQuestionAnswersText})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, defaultPermissionMode: GooseCLIModeAuto})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX})
 }

--- a/backend/internal/worker/agent/provider_test.go
+++ b/backend/internal/worker/agent/provider_test.go
@@ -210,6 +210,30 @@ func TestProviderFor_IsInterruptIsolatedPerProvider(t *testing.T) {
 	}
 }
 
+func TestPlanApprovalOptions_PerProvider(t *testing.T) {
+	// Codex owns its plan-approval option settlement behind the Provider interface: Base
+	// resets the collaboration axis, Bypass (mode-switch only) grants full network + no sandbox.
+	codex := ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX).PlanApprovalOptions()
+	assert.Equal(t, map[string]string{CodexOptionCollaborationMode: CodexCollaborationDefault}, codex.Base)
+	assert.Equal(t, map[string]string{
+		CodexOptionNetworkAccess: CodexNetworkEnabled,
+		CodexOptionSandboxPolicy: CodexSandboxDangerFullAccess,
+	}, codex.Bypass)
+
+	// Every other provider settles no plan-approval options (no plan-mode-prompt flow).
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_PI,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_UNSPECIFIED,
+	} {
+		opts := ProviderFor(provider).PlanApprovalOptions()
+		assert.Empty(t, opts.Base, "provider %v must settle no base plan-approval options", provider)
+		assert.Empty(t, opts.Bypass, "provider %v must settle no bypass plan-approval options", provider)
+	}
+}
+
 func TestIsNotificationThreadable_ClaudeSystemUsesPlugin(t *testing.T) {
 	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"status","status":"idle"}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))
 	assert.True(t, isNotificationThreadable([]byte(`{"type":"system","subtype":"api_retry","attempt":1}`), leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT))

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -56,6 +56,7 @@ type testSinkMessage struct {
 	SpanID          string
 	SpanType        string
 	Closing         bool
+	MarkType        leapmuxv1.MarkType
 	// TurnEnd is set on entries recorded by PersistTurnEnd so tests can
 	// distinguish the turn-end divider from regular AGENT messages
 	// without inspecting the inner content.
@@ -76,7 +77,7 @@ type testSinkSpanOpen struct {
 func (s *testSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messages = append(s.messages, testSinkMessage{Source: source, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing})
+	s.messages = append(s.messages, testSinkMessage{Source: source, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing, MarkType: span.MarkType})
 	return nil
 }
 
@@ -91,6 +92,7 @@ func (s *testSink) PersistTurnEnd(content []byte, span SpanInfo) error {
 		SpanID:          span.SpanID,
 		SpanType:        span.SpanType,
 		Closing:         span.Closing,
+		MarkType:        span.MarkType,
 		TurnEnd:         true,
 	})
 	return nil

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -49,6 +49,9 @@ CREATE TABLE messages (
     span_color          INTEGER NOT NULL DEFAULT 0,
     delivery_error      TEXT NOT NULL DEFAULT '',
     agent_provider      INTEGER NOT NULL DEFAULT 1,
+    -- Scroll-rail jump-mark classifier (0=none, see proto MarkType). Set at write
+    -- time so the rail can list marked seqs without decompressing content.
+    mark_type           INTEGER NOT NULL DEFAULT 0,
     created_at          DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     UNIQUE(agent_id, seq)
 );
@@ -56,6 +59,10 @@ CREATE TABLE messages (
 -- uses to find a tool_result's paired tool_use, so SQLite serves the
 -- ORDER BY seq ASC LIMIT 1 from the index rather than re-sorting matches.
 CREATE INDEX idx_messages_span_id ON messages(agent_id, span_id, source, seq) WHERE span_id <> '';
+-- Covering index for the scroll rail's ListMessageMarksByAgentID: SQLite serves
+-- the (agent_id, ORDER BY seq ASC) scan of marked rows from the index alone.
+-- Partial (only marked rows) so the far-more-numerous unmarked inserts skip it.
+CREATE INDEX idx_messages_mark_type ON messages(agent_id, seq, mark_type) WHERE mark_type <> 0;
 
 -- Advance agents.message_seq_hwm whenever a message is assigned a seq -- a fresh
 -- insert (CreateMessage) or a notification reseq that moves a row to the tail

--- a/backend/internal/worker/db/queries/messages.sql
+++ b/backend/internal/worker/db/queries/messages.sql
@@ -3,7 +3,7 @@
 -- NOT MAX(live seq) + 1, so a deleted tail seq is never reused. The agent row is
 -- guaranteed to exist (messages.agent_id REFERENCES agents); the COALESCE is a
 -- defensive fallback. A trigger advances message_seq_hwm after the insert.
-INSERT INTO messages (id, agent_id, seq, source, content, content_compression, depth, span_id, parent_span_id, span_type, span_lines, span_color, agent_provider, created_at)
+INSERT INTO messages (id, agent_id, seq, source, content, content_compression, depth, span_id, parent_span_id, span_type, span_lines, span_color, agent_provider, mark_type, created_at)
 VALUES (
   sqlc.arg(id),
   sqlc.arg(agent_id),
@@ -18,6 +18,7 @@ VALUES (
   sqlc.arg(span_lines),
   sqlc.arg(span_color),
   sqlc.arg(agent_provider),
+  sqlc.arg(mark_type),
   sqlc.arg(created_at)
 )
 RETURNING seq;
@@ -47,6 +48,12 @@ LIMIT ?;
 
 -- name: GetMessageByAgentAndID :one
 SELECT * FROM messages WHERE id = ? AND agent_id = ?;
+
+-- GetMessageByAgentIDAndSeq fetches a single message by its per-agent seq. Used by
+-- the scroll rail's dot-hover preview (GetAgentMessage RPC). Scoped to agent_id so it
+-- can never read across agents/workspaces even for an authorized caller.
+-- name: GetMessageByAgentIDAndSeq :one
+SELECT * FROM messages WHERE agent_id = ? AND seq = ?;
 
 -- GetAgentMessageBySpanIDAndSource finds the first message that opened the
 -- given span (the tool_use / item-started side). Used by the to-do extractor
@@ -89,3 +96,19 @@ RETURNING seq;
 -- report the authoritative new live-tail seq to windowed watchers. The CAST pins
 -- the result to int64 so sqlc doesn't infer interface{} for COALESCE(MAX(...)).
 SELECT CAST(COALESCE(MAX(seq), 0) AS INTEGER) AS max_seq FROM messages WHERE agent_id = ?;
+
+-- name: GetSeqRangeByAgentID :one
+-- The agent's lowest and highest message seq (each 0 when it has none), using two endpoint
+-- seeks instead of a combined MIN/MAX aggregate scan. Seqs start at 1, but deleting the
+-- leading rows frees those seqs permanently, drifting the true min above 1. The CASTs pin
+-- the results to int64 so sqlc doesn't infer interface{} for COALESCE.
+SELECT
+  CAST(COALESCE((SELECT m.seq FROM messages m WHERE m.agent_id = sqlc.arg(agent_id) ORDER BY m.seq ASC LIMIT 1), 0) AS INTEGER) AS min_seq,
+  CAST(COALESCE((SELECT m.seq FROM messages m WHERE m.agent_id = sqlc.arg(agent_id) ORDER BY m.seq DESC LIMIT 1), 0) AS INTEGER) AS max_seq;
+
+-- name: ListMessageMarksByAgentID :many
+-- Marked seqs (scroll-rail jump targets) for one agent, ascending. Served from the
+-- partial covering index idx_messages_mark_type without touching the table.
+SELECT seq, mark_type FROM messages
+WHERE agent_id = ? AND mark_type <> 0
+ORDER BY seq ASC;

--- a/backend/internal/worker/service/access_control_test.go
+++ b/backend/internal/worker/service/access_control_test.go
@@ -76,6 +76,12 @@ var agentHandlerCases = []agentHandlerCase{
 	{"ListAgentMessages", func(id string) proto.Message {
 		return &leapmuxv1.ListAgentMessagesRequest{AgentId: id}
 	}},
+	{"GetAgentMessage", func(id string) proto.Message {
+		return &leapmuxv1.GetAgentMessageRequest{AgentId: id, Seq: 1}
+	}},
+	{"ListMessageMarks", func(id string) proto.Message {
+		return &leapmuxv1.ListMessageMarksRequest{AgentId: id}
+	}},
 }
 
 // terminalHandlerCases enumerates terminal-ID-scoped handlers gated via

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -353,7 +353,8 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// passthrough vertical bars instead of breaking the column.
 		spanLines := svc.Output.snapshotPassthroughSpanLines(agentID)
 
-		// Persist the user message.
+		// Persist the user message. mark_type=USER_MESSAGE so the scroll rail
+		// draws a jump dot for every message the human actually typed and sent.
 		seq, err := createMessageRow(bgCtx(), svc.Queries, db.CreateMessageParams{
 			ID:                 messageID,
 			AgentID:            agentID,
@@ -366,6 +367,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			SpanLines:          spanLines,
 			SpanColor:          0,
 			AgentProvider:      dbAgent.AgentProvider,
+			MarkType:           leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
 			CreatedAt:          now,
 		})
 		if err != nil {
@@ -388,6 +390,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			CreatedAt:          timefmt.Format(now),
 			Depth:              0,
 			SpanLines:          spanLines,
+			MarkType:           leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
 		}
 
 		// For /clear, broadcast the user message before restarting so live
@@ -473,8 +476,10 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			return
 		}
 		content := r.GetContent()
-		if dbAgent.AgentProvider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX && agent.IsInterruptRequest(dbAgent.AgentProvider, content) {
-			svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, "[Request interrupted by user]")
+		if agent.ProviderFor(dbAgent.AgentProvider).NeedsSyntheticInterruptNotice() && agent.IsInterruptRequest(dbAgent.AgentProvider, content) {
+			// An interrupt notice is not the user's answer to a control request, so it
+			// draws no rail dot.
+			svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, "[Request interrupted by user]", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
 		}
 
 		svc.handleControlRequestMessage(agentID, dbAgent.AgentProvider, content)
@@ -617,15 +622,16 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 
 		// The authoritative live-tail seq, so the --follow CLI can resolve a resume
 		// point even when this page is empty (never inferring a spurious seq 0 from an
-		// empty page on a populated agent). A query error degrades to -1 (the shared
-		// "indeterminate" sentinel), NOT 0: 0 means "the agent genuinely has no
-		// messages" (resume fresh), so a spurious 0 from an error would wrongly tell the
-		// CLI to drain from the start. -1 tells the consumer to fall back to its own
-		// loaded cursor instead. See ListAgentMessagesResponse.latest_seq.
-		latestSeq, maxErr := svc.Queries.GetMaxSeqByAgentID(ctx, agentID)
-		if maxErr != nil {
+		// empty page on a populated agent). A query error leaves it UNSET (indeterminate),
+		// NOT present-0: a present 0 means "the agent genuinely has no messages" (resume
+		// fresh), so a spurious 0 from an error would wrongly tell the CLI to drain from
+		// the start. An unset field tells the consumer to fall back to its own loaded
+		// cursor instead. See ListAgentMessagesResponse.latest_seq.
+		var latestSeq *int64
+		if seq, maxErr := svc.Queries.GetMaxSeqByAgentID(ctx, agentID); maxErr != nil {
 			slog.Warn("failed to read max seq for list response", "agent_id", agentID, "error", maxErr)
-			latestSeq = -1
+		} else {
+			latestSeq = &seq
 		}
 
 		sendProtoResponse(sender, &leapmuxv1.ListAgentMessagesResponse{
@@ -634,6 +640,122 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			Todos:       todoevents.ItemsToProto(todoItems),
 			TodosLoaded: todosLoaded,
 			LatestSeq:   latestSeq,
+		})
+	})
+
+	// GetAgentMessage fetches ONE message by its per-agent seq, for the scroll
+	// rail's dot-hover preview when the marked message is outside the loaded
+	// window. Access control mirrors ListAgentMessages: requireAccessibleAgent
+	// verifies the caller's channel may reach the agent's workspace, and the
+	// query is scoped to agent_id, so an authorized caller can only read a
+	// message belonging to that agent -- never another agent's or workspace's.
+	d.Register("GetAgentMessage", func(ctx context.Context, userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
+		var r leapmuxv1.GetAgentMessageRequest
+		if err := unmarshalRequest(req, &r); err != nil {
+			sendInvalidArgument(sender, "invalid request")
+			return
+		}
+
+		agentID := r.GetAgentId()
+		agentRow, ok := svc.requireAccessibleAgent(sender, agentID)
+		if !ok {
+			return
+		}
+
+		// Return an unset message for closed agents (mirrors ListAgentMessages,
+		// whose empty response leaves the rail without dots to preview anyway).
+		if agentRow.ClosedAt.Valid {
+			sendProtoResponse(sender, &leapmuxv1.GetAgentMessageResponse{})
+			return
+		}
+
+		row, err := svc.Queries.GetMessageByAgentIDAndSeq(ctx, db.GetMessageByAgentIDAndSeqParams{
+			AgentID: agentID,
+			Seq:     r.GetSeq(),
+		})
+		if err != nil {
+			// A mark can outlive its message (deleted / reseq'd since it was recorded):
+			// no row is a normal "no preview available", not an error.
+			if errors.Is(err, sql.ErrNoRows) {
+				sendProtoResponse(sender, &leapmuxv1.GetAgentMessageResponse{})
+				return
+			}
+			slog.Error("failed to get agent message", "agent_id", agentID, "seq", r.GetSeq(), "error", err)
+			sendInternalError(sender, "failed to get message")
+			return
+		}
+
+		sendProtoResponse(sender, &leapmuxv1.GetAgentMessageResponse{Message: messageToProto(&row)})
+	})
+
+	// ListMessageMarks returns the seqs of every marked message (scroll-rail jump
+	// targets) plus the agent's whole-history seq range. Plain indexed SQL -- no
+	// content decompression -- because mark_type is set at write time.
+	d.Register("ListMessageMarks", func(ctx context.Context, userID string, req *leapmuxv1.InnerRpcRequest, sender *channel.Sender) {
+		var r leapmuxv1.ListMessageMarksRequest
+		if err := unmarshalRequest(req, &r); err != nil {
+			sendInvalidArgument(sender, "invalid request")
+			return
+		}
+
+		agentID := r.GetAgentId()
+		agentRow, ok := svc.requireAccessibleAgent(sender, agentID)
+		if !ok {
+			return
+		}
+
+		// Return empty for closed agents (mirrors ListAgentMessages, which serves a closed agent
+		// no history -- so the rail has nothing to show). Report a PRESENT, empty (0) range rather
+		// than leaving min/max unset: an unset range is the DB-error "indeterminate" signal, which
+		// the client cannot tell apart from a closed agent and so retries up to
+		// MAX_MESSAGE_MARK_SEED_RESCHEDULES times (~5 round-trips) on every closed-tab view. A
+		// present-0 range seeds the rail `loaded` (it stays hidden over the empty window) and ends
+		// the retry chain.
+		if agentRow.ClosedAt.Valid {
+			zeroSeq := int64(0)
+			sendProtoResponse(sender, &leapmuxv1.ListMessageMarksResponse{MinSeq: &zeroSeq, MaxSeq: &zeroSeq})
+			return
+		}
+
+		tx, txErr := svc.DB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+		if txErr != nil {
+			slog.Error("failed to start message marks read transaction", "agent_id", agentID, "error", txErr)
+			sendInternalError(sender, "failed to list message marks")
+			return
+		}
+		queries := svc.Queries.WithTx(tx)
+
+		rows, marksErr := queries.ListMessageMarksByAgentID(ctx, agentID)
+		if marksErr != nil {
+			_ = tx.Rollback()
+			slog.Error("failed to list message marks", "agent_id", agentID, "error", marksErr)
+			sendInternalError(sender, "failed to list message marks")
+			return
+		}
+		marks := make([]*leapmuxv1.MessageMark, 0, len(rows))
+		for i := range rows {
+			marks = append(marks, &leapmuxv1.MessageMark{Seq: rows[i].Seq, Type: rows[i].MarkType})
+		}
+
+		// Two endpoint seeks for the whole-history bounds. min/max are left UNSET on error
+		// (both together), matching latest_seq's explicit-presence convention (the client
+		// keeps its current value rather than trusting a bogus 0).
+		var minSeq, maxSeq *int64
+		if seqRange, rangeErr := queries.GetSeqRangeByAgentID(ctx, agentID); rangeErr != nil {
+			slog.Warn("failed to read seq range for marks response", "agent_id", agentID, "error", rangeErr)
+		} else {
+			minSeq, maxSeq = &seqRange.MinSeq, &seqRange.MaxSeq
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			slog.Error("failed to finish message marks read transaction", "agent_id", agentID, "error", commitErr)
+			sendInternalError(sender, "failed to list message marks")
+			return
+		}
+
+		sendProtoResponse(sender, &leapmuxv1.ListMessageMarksResponse{
+			Marks:  marks,
+			MinSeq: minSeq,
+			MaxSeq: maxSeq,
 		})
 	})
 
@@ -743,12 +865,12 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		// The authoritative new live tail AFTER the delete (0 if no rows remain). A
 		// windowed client whose loaded window lags the live tail sets its recorded
 		// live-tail seq to exactly this when the deleted row was that tail -- no
-		// guesswork. On the exceptional query-error path, degrade to the shared "-1"
-		// indeterminate sentinel rather than guessing deletedSeq - 1: the old guess
+		// guesswork. On the exceptional query-error path, leave the field UNSET
+		// (indeterminate) rather than guessing deletedSeq - 1: the old guess
 		// under-reported a non-tail delete's tail and conflated a deleted seq 1 with
-		// "agent empty". -1 tells the client to leave its recorded tail unchanged (see
-		// AgentMessageDeleted.new_latest_seq / removeMessage), which is always safe.
-		newLatestSeq := svc.maxSeqOrIndeterminate(agentID, "failed to read max seq after delete")
+		// "agent empty". An unset field tells the client to leave its recorded tail
+		// unchanged (see AgentMessageDeleted.new_latest_seq / removeMessage), always safe.
+		newLatestSeq := svc.maxSeqOrNil(agentID, "failed to read max seq after delete")
 
 		// Broadcast deletion to all watchers, carrying the deleted row's seq (so a
 		// windowed client can tell whether the deleted row was its recorded tail)
@@ -868,38 +990,30 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		}
 		content := r.GetContent()
 
-		if svc.handleCodexPlanModePromptResponse(agentID, content) {
+		plan := svc.buildControlResponsePlan(agentID, dbAgent, content)
+
+		// Drop the control request before persisting display rows or forwarding the response,
+		// on EVERY path (the plan-prompt branch below and the fall-through both need it). Claude
+		// can emit a follow-up control_request immediately after it reads a denial; if the old
+		// request is still pending client-side, the revised request can hide behind stale dedup
+		// state.
+		svc.deleteControlRequest(agentID, dbAgent.AgentProvider, plan.requestMeta, plan.resolution.SelfDisplayed)
+
+		if plan.resolution.PlanModeControl == agent.PlanModeControlPrompt && plan.hasDecision {
+			svc.handleControlResponsePromptPlan(agentID, dbAgent, plan)
 			sendProtoResponse(sender, &leapmuxv1.SendControlResponseResponse{})
 			return
 		}
 
-		var displayText string
-		content, displayText = svc.normalizeProviderControlResponse(agentID, dbAgent.AgentProvider, content)
-		if displayText == "" {
-			displayText = svc.controlResponseDisplayText(agentID, dbAgent.AgentProvider, content)
-		}
+		svc.persistControlResponseAnswerRows(agentID, dbAgent.AgentProvider, plan)
 
-		// Detect plan mode changes from the control response before
-		// forwarding to the agent. This mirrors the main-branch Hub logic
-		// that updated permission mode based on EnterPlanMode/ExitPlanMode
-		// approval or rejection.
-		skipSend := svc.handleControlResponsePlanMode(agentID, content)
-
-		// Drop the prompt before forwarding the response. Claude can emit the
-		// follow-up control_request immediately after it reads the denial; if
-		// the old request is still pending client-side, the revised request can
-		// be hidden behind stale dedup state.
-		reqID := extractControlResponseRequestID(content)
-		if reqID != "" {
-			sink := svc.Output.NewSink(agentID, dbAgent.AgentProvider)
-			sink.DeleteControlRequest(reqID)
-			sink.BroadcastControlCancel(reqID)
-		}
-
-		svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, displayText)
+		// Detect plan mode changes after the answer row is durable but before forwarding to
+		// the agent. Clear-context plan execution starts asynchronously, so persisting first
+		// keeps the user's answer before plan-execution rows even if the goroutine runs fast.
+		skipSend := svc.applyControlResponsePlanModeEffects(agentID, dbAgent, plan)
 
 		if !skipSend {
-			if err := svc.Agents.SendRawInput(agentID, content); err != nil {
+			if err := svc.Agents.SendRawInput(agentID, plan.resolution.Content); err != nil {
 				slog.Error("failed to send control response to agent",
 					"agent_id", agentID, "error", err)
 				sendNotFoundError(sender, "agent not found or not running")
@@ -1381,10 +1495,10 @@ func (svc *Context) replayAgentCatchUp(
 	// the message replay, so a reconnecting windowed client drops phantom rows
 	// (a tail it loaded before disconnect that was deleted while it was away) up
 	// front, rather than flashing them until CatchUpComplete reconciles at the end.
-	// -1 on a query error tells the client to skip the reconcile (see
+	// An unset field on a query error tells the client to skip the reconcile (see
 	// CatchUpStart.latest_seq). The tail is re-read for CatchUpComplete below so the
 	// final authority reflects any message created mid-replay.
-	replayStartTail := svc.maxSeqOrIndeterminate(agentID, "failed to read max seq for catch-up start")
+	replayStartTail := svc.maxSeqOrNil(agentID, "failed to read max seq for catch-up start")
 	broadcastReplayAgentEvent(sender, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
 		Event: &leapmuxv1.AgentEvent_CatchUpStart{
@@ -1485,11 +1599,7 @@ func (svc *Context) replayAgentCatchUp(
 			broadcastReplayAgentEvent(sender, &leapmuxv1.AgentEvent{
 				AgentId: agentID,
 				Event: &leapmuxv1.AgentEvent_ControlRequest{
-					ControlRequest: &leapmuxv1.AgentControlRequest{
-						AgentId:   agentID,
-						RequestId: cr.RequestID,
-						Payload:   cr.Payload,
-					},
+					ControlRequest: buildAgentControlRequest(agentID, dbAgent.AgentProvider, cr.RequestID, cr.Payload),
 				},
 			})
 		}
@@ -1500,11 +1610,11 @@ func (svc *Context) replayAgentCatchUp(
 	// live-tail seq (highest existing message seq) so a client that missed
 	// deletions while disconnected can drop phantom rows beyond it and clamp
 	// its recorded live-tail (see CatchUpComplete.latest_seq). On a query error
-	// send -1 (NOT 0): the client trims rows strictly above latest_seq, so a
-	// genuine 0 (empty agent) correctly drops a fully-deleted window, while a
-	// spurious 0 would wrongly wipe a populated one -- the negative sentinel
-	// tells the client "couldn't determine, skip reconciliation".
-	catchUpLatestSeq := svc.maxSeqOrIndeterminate(agentID, "failed to read max seq for catch-up complete")
+	// leave it UNSET (NOT 0): the client trims rows strictly above latest_seq, so a
+	// present 0 (empty agent) correctly drops a fully-deleted window, while a
+	// spurious 0 would wrongly wipe a populated one -- an unset field tells the
+	// client "couldn't determine, skip reconciliation".
+	catchUpLatestSeq := svc.maxSeqOrNil(agentID, "failed to read max seq for catch-up complete")
 	broadcastReplayAgentEvent(sender, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
 		Event: &leapmuxv1.AgentEvent_CatchUpComplete{
@@ -2715,7 +2825,12 @@ func (svc *Context) handleControlRequestMessage(agentID string, provider leapmux
 	}
 }
 
-func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmuxv1.AgentProvider, content string) {
+// persistSyntheticUserMessage persists a backend-synthesized `{content}` user row.
+// markType tags it for the scroll rail: CONTROL_RESPONSE for the user's answer to a
+// control request (the display row every provider except Claude relies on, since none
+// echo the answer in their own stream), or UNSPECIFIED for a non-answer marker such as
+// the interrupt notice -- so only genuine control answers draw a rail dot.
+func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmuxv1.AgentProvider, content string, markType leapmuxv1.MarkType) {
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return
@@ -2726,7 +2841,7 @@ func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmux
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{}, nil); err != nil {
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{MarkType: markType}, nil); err != nil {
 		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
 	}
 }
@@ -2853,7 +2968,12 @@ func (svc *Context) setAgentPermissionModeWithAgent(dbAgent db.Agent, mode strin
 // sendSyntheticUserMessage persists and broadcasts a user message, then sends
 // it to the agent process if possible. This is used for local plan-mode flows
 // that originate from a UI prompt rather than a frontend SendAgentMessage RPC.
-func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
+// sendSyntheticUserMessage persists a `{content}` user row AND forwards it to the agent as
+// input. markType tags it for the scroll rail: UNSPECIFIED for a truly synthetic prompt the
+// user did not type (e.g. the auto-injected "Implement the plan."), or CONTROL_RESPONSE for
+// the user's own typed answer to a control request that is delivered as agent input (a Codex
+// plan-mode-prompt denial's feedback) -- so only genuine user answers draw a rail dot.
+func (svc *Context) sendSyntheticUserMessage(agentID, content string, markType leapmuxv1.MarkType) {
 	dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
 	if err != nil {
 		slog.Error("synthetic user message: agent not found", "agent_id", agentID, "error", err)
@@ -2877,6 +2997,9 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 	// passthrough vertical bars instead of breaking the column.
 	spanLines := svc.Output.snapshotPassthroughSpanLines(agentID)
 
+	// mark_type is caller-scoped: UNSPECIFIED for an auto-injected synthetic prompt
+	// (no rail dot), CONTROL_RESPONSE for the user's own typed control answer delivered
+	// as agent input (a rail dot, like every other control-answer path).
 	seq, err := createMessageRow(bgCtx(), svc.Queries, db.CreateMessageParams{
 		ID:                 messageID,
 		AgentID:            agentID,
@@ -2889,6 +3012,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 		SpanLines:          spanLines,
 		SpanColor:          0,
 		AgentProvider:      dbAgent.AgentProvider,
+		MarkType:           markType,
 		CreatedAt:          now,
 	})
 	if err != nil {
@@ -2927,6 +3051,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 		CreatedAt:          timefmt.Format(now),
 		Depth:              0,
 		SpanLines:          spanLines,
+		MarkType:           markType,
 	}
 	svc.Watchers.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
@@ -2946,328 +3071,6 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string) {
 			},
 		})
 	}
-}
-
-// controlResponsePlanModePayload is the decoded shape of a plan-mode control
-// response: the approve/reject envelope ({request_id, response:{behavior, message}})
-// plus the optional permission-mode switch and context-clear the frontend attaches.
-// Shared by the two plan-mode handlers (the Codex prompt-response path and the common
-// control-response path) so the wire shape is defined once and can't drift between them.
-type controlResponsePlanModePayload struct {
-	PermissionMode string `json:"permissionMode"`
-	ClearContext   bool   `json:"clearContext"`
-	Response       struct {
-		RequestID string `json:"request_id"`
-		Response  struct {
-			Behavior string `json:"behavior"`
-			Message  string `json:"message"`
-		} `json:"response"`
-	} `json:"response"`
-}
-
-func (svc *Context) handleCodexPlanModePromptResponse(agentID string, content []byte) bool {
-	var crPayload controlResponsePlanModePayload
-	if err := json.Unmarshal(content, &crPayload); err != nil {
-		return false
-	}
-
-	reqID := crPayload.Response.RequestID
-	if reqID == "" {
-		return false
-	}
-
-	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
-		AgentID:   agentID,
-		RequestID: reqID,
-	})
-	if err != nil {
-		return false
-	}
-
-	var crBody struct {
-		Request struct {
-			ToolName string `json:"tool_name"`
-		} `json:"request"`
-	}
-	if err := json.Unmarshal(cr.Payload, &crBody); err != nil {
-		slog.Warn("codex plan mode prompt unmarshal failed", "agent_id", agentID, "error", err)
-		return false
-	}
-	if crBody.Request.ToolName != agent.ToolNameCodexPlanModePrompt {
-		return false
-	}
-
-	_ = svc.Queries.DeleteControlRequest(bgCtx(), db.DeleteControlRequestParams{
-		AgentID:   agentID,
-		RequestID: reqID,
-	})
-	svc.Watchers.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
-		AgentId: agentID,
-		Event: &leapmuxv1.AgentEvent_ControlCancel{
-			ControlCancel: &leapmuxv1.AgentControlCancelRequest{
-				AgentId:   agentID,
-				RequestId: reqID,
-			},
-		},
-	})
-
-	switch crPayload.Response.Response.Behavior {
-	case agent.ControlBehaviorAllow:
-		dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
-		if err != nil {
-			slog.Error("codex plan mode prompt: agent not found", "agent_id", agentID, "error", err)
-			return false
-		}
-
-		// Settle Codex's collaboration axis back to its default mode (applied live, notify on
-		// first set).
-		dbAgent = svc.applyOptionChanges(dbAgent,
-			map[string]string{agent.CodexOptionCollaborationMode: agent.CodexCollaborationDefault},
-			applyOptionsSpec{live: true, notifyFirstSet: true})
-
-		if crPayload.PermissionMode != "" {
-			dbAgent = svc.setAgentPermissionModeWithAgent(dbAgent, crPayload.PermissionMode)
-			// Grant Codex bypass options for the approved mode: full network access and no
-			// sandbox restrictions (applied live, notify on first set).
-			svc.applyOptionChanges(dbAgent, map[string]string{
-				agent.CodexOptionNetworkAccess: agent.CodexNetworkEnabled,
-				agent.CodexOptionSandboxPolicy: agent.CodexSandboxDangerFullAccess,
-			}, applyOptionsSpec{live: true, notifyFirstSet: true})
-		}
-
-		if crPayload.ClearContext {
-			targetMode := crPayload.PermissionMode
-			if targetMode == "" {
-				targetMode = agent.PermissionModeDefault
-			}
-			go svc.initiatePlanExecution(agentID, targetMode)
-		} else {
-			svc.sendSyntheticUserMessage(agentID, "Implement the plan.")
-		}
-	case agent.ControlBehaviorDeny:
-		if msg := strings.TrimSpace(crPayload.Response.Response.Message); msg != "" && msg != "Rejected by user." {
-			svc.sendSyntheticUserMessage(agentID, msg)
-		}
-	}
-
-	return true
-}
-
-// normalizeProviderControlResponse transforms provider-specific control
-// responses into the wire format expected by the agent process.  It returns
-// the (possibly transformed) content and, when the transform already computed
-// the display text, a non-empty displayText so the caller can skip a second
-// DB lookup in controlResponseDisplayText.
-func (svc *Context) normalizeProviderControlResponse(agentID string, provider leapmuxv1.AgentProvider, content []byte) (normalized []byte, displayText string) {
-	switch provider {
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR:
-		if transformed, text, ok := svc.transformCursorControlResponse(agentID, content); ok {
-			return transformed, text
-		}
-	}
-	return content, ""
-}
-
-func (svc *Context) transformCursorControlResponse(agentID string, content []byte) ([]byte, string, bool) {
-	var crPayload struct {
-		Response struct {
-			RequestID string `json:"request_id"`
-			Response  struct {
-				Behavior string `json:"behavior"`
-				Message  string `json:"message"`
-			} `json:"response"`
-		} `json:"response"`
-	}
-	if err := json.Unmarshal(content, &crPayload); err != nil {
-		return nil, "", false
-	}
-
-	reqID := strings.TrimSpace(crPayload.Response.RequestID)
-	if reqID == "" {
-		return nil, "", false
-	}
-
-	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
-		AgentID:   agentID,
-		RequestID: reqID,
-	})
-	if err != nil {
-		return nil, "", false
-	}
-
-	var req struct {
-		Method string `json:"method"`
-	}
-	if err := json.Unmarshal(cr.Payload, &req); err != nil {
-		slog.Warn("cursor control response unmarshal method failed", "agent_id", agentID, "error", err)
-		return nil, "", false
-	}
-	if req.Method != agent.CursorMethodCreatePlan {
-		return nil, "", false
-	}
-
-	idRaw, _, ok := agent.ExtractJSONRPCID(cr.Payload)
-	if !ok {
-		return nil, "", false
-	}
-
-	outcomeBody := map[string]interface{}{
-		"outcome": "accepted",
-	}
-	if crPayload.Response.Response.Behavior == agent.ControlBehaviorDeny {
-		outcomeBody["outcome"] = "rejected"
-		if reason := strings.TrimSpace(crPayload.Response.Response.Message); reason != "" && reason != "Rejected by user." {
-			outcomeBody["reason"] = reason
-		}
-	}
-
-	encoded, err := json.Marshal(map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      json.RawMessage(idRaw),
-		"result":  map[string]interface{}{"outcome": outcomeBody},
-	})
-	if err != nil {
-		return nil, "", false
-	}
-	return encoded, cursorCreatePlanResponseDisplayText(encoded), true
-}
-
-// extractControlResponseRequestID extracts the control request ID from a
-// control response's raw JSON content.  It supports both Claude Code format
-// (response.request_id) and OpenCode/ACP JSON-RPC format (top-level id).
-func extractControlResponseRequestID(content []byte) string {
-	var parsed struct {
-		// Claude Code format
-		Response struct {
-			RequestID string `json:"request_id"`
-		} `json:"response"`
-		// OpenCode / ACP JSON-RPC format (id can be number or string)
-		ID json.RawMessage `json:"id"`
-	}
-	if err := json.Unmarshal(content, &parsed); err != nil {
-		slog.Warn("extract control response request ID unmarshal failed", "error", err)
-		return ""
-	}
-	if parsed.Response.RequestID != "" {
-		return parsed.Response.RequestID
-	}
-	// Try JSON-RPC id: strip quotes for string, use raw for number.
-	if len(parsed.ID) > 0 && string(parsed.ID) != "null" {
-		var s string
-		if json.Unmarshal(parsed.ID, &s) == nil {
-			return s
-		}
-		return strings.TrimSpace(string(parsed.ID))
-	}
-	return ""
-}
-
-// handleControlResponsePlanMode detects plan mode changes from control
-// responses. When the frontend approves/rejects an EnterPlanMode or
-// ExitPlanMode control request, this updates the permission mode and
-// initiates plan execution as needed. Returns true when the caller
-// should skip sending the response to the agent (clearContext path).
-func (svc *Context) handleControlResponsePlanMode(agentID string, content []byte) bool {
-	var crPayload controlResponsePlanModePayload
-	if err := json.Unmarshal(content, &crPayload); err != nil {
-		return false
-	}
-
-	reqID := crPayload.Response.RequestID
-	if reqID == "" {
-		return false
-	}
-
-	// Look up the original control request to get the tool_name.
-	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
-		AgentID:   agentID,
-		RequestID: reqID,
-	})
-	if err != nil {
-		return false
-	}
-
-	var crBody struct {
-		Request struct {
-			ToolName  string `json:"tool_name"`
-			ToolUseID string `json:"tool_use_id"`
-		} `json:"request"`
-	}
-	if err := json.Unmarshal(cr.Payload, &crBody); err != nil {
-		slog.Warn("control request payload unmarshal failed", "agent_id", agentID, "error", err)
-		return false
-	}
-	toolName := crBody.Request.ToolName
-	toolUseID := crBody.Request.ToolUseID
-
-	// Look up the agent's provider for message persistence.
-	dbAgent, dbErr := svc.Queries.GetAgentByID(bgCtx(), agentID)
-	if dbErr != nil {
-		return false
-	}
-
-	// Persist a display message for the control response.
-	// Skip for AskUserQuestion — the tool_result already shows the user's answers.
-	// Skip for ExitPlanMode — the tool_result already shows approval/feedback.
-	if toolName != agent.ToolNameAskUserQuestion && toolName != agent.ToolNameExitPlanMode {
-		action := "approved"
-		if crPayload.Response.Response.Behavior == agent.ControlBehaviorDeny {
-			action = "rejected"
-		}
-		displayContent := map[string]interface{}{
-			"isSynthetic": true,
-			"controlResponse": map[string]string{
-				"action":  action,
-				"comment": crPayload.Response.Response.Message,
-			},
-		}
-		displayJSON, marshalErr := json.Marshal(displayContent)
-		if marshalErr != nil {
-			slog.Warn("marshal control response notification", "agent_id", agentID, "error", marshalErr)
-		} else if err := svc.Output.persistAndBroadcast(agentID, dbAgent.AgentProvider, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, displayJSON, agent.SpanInfo{}, nil); err != nil {
-			slog.Warn("failed to persist control response notification", "agent_id", agentID, "error", err)
-		}
-	}
-
-	// Detect plan mode changes from control responses (agent-initiated).
-	skipSend := false
-	if crPayload.Response.Response.Behavior == agent.ControlBehaviorAllow {
-		switch toolName {
-		case agent.ToolNameEnterPlanMode:
-			svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModePlan)
-		case agent.ToolNameExitPlanMode:
-			// Determine target permission mode from control_response.
-			targetMode := agent.PermissionModeAcceptEdits
-			if crPayload.PermissionMode != "" {
-				targetMode = crPayload.PermissionMode
-			}
-			svc.setAgentPermissionModeWithAgent(dbAgent, targetMode)
-
-			// Remove the planModeToolUse entry so detectPlanModeFromToolResult
-			// does not override the mode we just set.
-			if toolUseID != "" {
-				svc.Output.planModeToolUse.Delete(toolUseID)
-			}
-
-			if crPayload.ClearContext {
-				// When clearing context, don't send the approval to the
-				// agent — we're about to stop it anyway. This avoids
-				// the race where the agent acts on the approval before
-				// initiatePlanExecution kills it.
-				go svc.initiatePlanExecution(agentID, targetMode)
-				skipSend = true
-			}
-			// When !clearContext, the agent continues in current context.
-		}
-	}
-
-	// Delete the answered control request.
-	_ = svc.Queries.DeleteControlRequest(bgCtx(), db.DeleteControlRequestParams{
-		AgentID:   agentID,
-		RequestID: reqID,
-	})
-
-	return skipSend
 }
 
 // initiatePlanExecution clears the agent's context and sends the plan as a
@@ -3436,6 +3239,15 @@ func broadcastReplayAgentEvent(sender *channel.Sender, event *leapmuxv1.AgentEve
 	})
 }
 
+func buildAgentControlRequest(agentID string, provider leapmuxv1.AgentProvider, requestID string, payload []byte) *leapmuxv1.AgentControlRequest {
+	return &leapmuxv1.AgentControlRequest{
+		AgentId:       agentID,
+		RequestId:     requestID,
+		Payload:       payload,
+		AgentProvider: provider,
+	}
+}
+
 // broadcastWatchEvent sends a WatchEventsResponse as a stream message.
 func broadcastWatchEvent(sender *channel.Sender, resp *leapmuxv1.WatchEventsResponse) {
 	slog.Debug("stream payload", "payload", protojson.Format(resp))
@@ -3505,22 +3317,22 @@ func replayPageAnchor(replay leapmuxv1.WatchReplayMode, cursorSeq int64) leapmux
 	return leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST
 }
 
-// maxSeqOrIndeterminate reads the agent's live-tail seq on a background context,
-// returning the shared -1 "indeterminate" sentinel (after logging logMsg) on a
-// query error. -1 (NOT 0) is deliberate: 0 means the agent is genuinely empty, so a
-// spurious 0 from an error would wrongly wipe a populated window / drain from the
-// start, while -1 tells the consumer to skip reconciliation and keep its own cursor.
-// Shared by the delete, catch-up-start, and catch-up-complete broadcasts so the
-// sentinel rule lives in one place. The synchronous list-response handler does NOT
-// use this -- it reads max seq on the cancellable request ctx and logs an expected
-// cancellation at Warn, not Error.
-func (svc *Context) maxSeqOrIndeterminate(agentID, logMsg string) int64 {
+// maxSeqOrNil reads the agent's live-tail seq on a background context, returning nil
+// (after logging logMsg) on a query error -- the explicit-presence "indeterminate"
+// signal. Leaving the field UNSET (rather than 0) is deliberate: a present 0 means the
+// agent is genuinely empty, so a spurious 0 from an error would wrongly wipe a populated
+// window / drain from the start, while an unset field tells the consumer to skip
+// reconciliation and keep its own cursor. Shared by the delete, catch-up-start, and
+// catch-up-complete broadcasts so the presence rule lives in one place. The synchronous
+// list-response handler does NOT use this -- it reads max seq on the cancellable request
+// ctx and logs an expected cancellation at Warn, not Error.
+func (svc *Context) maxSeqOrNil(agentID, logMsg string) *int64 {
 	seq, err := svc.Queries.GetMaxSeqByAgentID(bgCtx(), agentID)
 	if err != nil {
 		slog.Error(logMsg, "agent_id", agentID, "error", err)
-		return -1
+		return nil
 	}
-	return seq
+	return &seq
 }
 
 // resolveMessagePage maps an anchor + cursor + caller limit to a query plan.
@@ -3599,5 +3411,6 @@ func messageToProto(m *db.Message) *leapmuxv1.AgentChatMessage {
 		SpanType:           m.SpanType,
 		SpanColor:          int32(m.SpanColor),
 		SpanLines:          m.SpanLines,
+		MarkType:           m.MarkType,
 	}
 }

--- a/backend/internal/worker/service/control_response.go
+++ b/backend/internal/worker/service/control_response.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -12,448 +11,379 @@ import (
 )
 
 func controlResponseRequestID(content []byte) string {
-	var rpc struct {
-		ID json.RawMessage `json:"id"`
+	if requestID, _, _, ok := agent.DecodeControlBehavior(content); ok && requestID != "" {
+		return requestID
 	}
-	if err := json.Unmarshal(content, &rpc); err == nil && len(rpc.ID) > 0 && string(rpc.ID) != "null" {
-		var str string
-		if json.Unmarshal(rpc.ID, &str) == nil {
-			return str
-		}
-		return strings.TrimSpace(string(rpc.ID))
+	if _, requestID, ok := agent.ExtractJSONRPCID(content); ok {
+		return requestID
 	}
-
-	var cr struct {
-		Response struct {
-			RequestID string `json:"request_id"`
-		} `json:"response"`
-	}
-	if err := json.Unmarshal(content, &cr); err == nil {
-		return cr.Response.RequestID
-	}
-
 	return ""
 }
 
-func codexUserInputAnswersText(requestPayload, responseContent []byte) string {
-	var req struct {
-		Params struct {
-			Questions []struct {
-				ID     string `json:"id"`
-				Header string `json:"header"`
-			} `json:"questions"`
-		} `json:"params"`
-	}
-	var resp struct {
-		Result struct {
-			Answers map[string]struct {
-				Answers []string `json:"answers"`
-			} `json:"answers"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(requestPayload, &req); err != nil {
-		slog.Warn("codex user input request unmarshal failed", "error", err)
-		return ""
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		slog.Warn("codex user input response unmarshal failed", "error", err)
-		return ""
-	}
-
-	if len(resp.Result.Answers) == 0 {
-		return ""
-	}
-
-	labels := make(map[string]string, len(req.Params.Questions))
-	order := make([]string, 0, len(req.Params.Questions))
-	for _, q := range req.Params.Questions {
-		key := strings.TrimSpace(q.ID)
-		if key == "" {
-			key = strings.TrimSpace(q.Header)
-		}
-		if key == "" {
-			continue
-		}
-		label := strings.TrimSpace(q.Header)
-		if label == "" {
-			label = key
-		}
-		labels[key] = label
-		order = append(order, key)
-	}
-
-	lines := make([]string, 0, len(resp.Result.Answers))
-	seen := make(map[string]bool, len(resp.Result.Answers))
-	appendLine := func(key string) {
-		answer, ok := resp.Result.Answers[key]
-		if !ok || seen[key] {
-			return
-		}
-		parts := make([]string, 0, len(answer.Answers))
-		for _, entry := range answer.Answers {
-			if text := strings.TrimSpace(entry); text != "" {
-				parts = append(parts, text)
-			}
-		}
-		if len(parts) == 0 {
-			return
-		}
-		lines = append(lines, fmt.Sprintf("%s: %s", labels[key], strings.Join(parts, ", ")))
-		seen[key] = true
-	}
-
-	for _, key := range order {
-		appendLine(key)
-	}
-	for key := range resp.Result.Answers {
-		if seen[key] {
-			continue
-		}
-		if _, ok := labels[key]; !ok {
-			labels[key] = key
-		}
-		appendLine(key)
-	}
-
-	return strings.Join(lines, "\n")
+// controlResponsePlanModePayload is the decoded shape of a plan-mode control response: the
+// approve/reject envelope plus the optional permission-mode switch and context-clear the frontend
+// attaches. It EMBEDS agent.ControlBehaviorEnvelope (the single Go home for the
+// {response:{request_id, response:{behavior, message}}} shape) rather than re-declaring it, so the
+// envelope fields (promoted as plan.decision.Response.*) can't drift from DecodeControlBehavior's
+// reading of the same wire bytes. Shared by the two plan-mode handlers (the Codex prompt-response
+// path and the common control-response path).
+type controlResponsePlanModePayload struct {
+	PermissionMode string `json:"permissionMode"`
+	ClearContext   bool   `json:"clearContext"`
+	agent.ControlBehaviorEnvelope
 }
 
-func codexFeedbackMessageText(responseContent []byte) string {
-	var cr struct {
-		Response struct {
-			Response struct {
-				Message string `json:"message"`
-			} `json:"response"`
-		} `json:"response"`
-	}
-	if err := json.Unmarshal(responseContent, &cr); err != nil {
-		return ""
-	}
-	message := strings.TrimSpace(cr.Response.Response.Message)
-	if message == "" || message == "Rejected by user." {
-		return ""
-	}
-	return message
+type controlResponseRequestMetadata struct {
+	RequestID string
+	ToolName  string
+	ToolUseID string
+	Payload   json.RawMessage
+	Loaded    bool
 }
 
-func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string {
-	var req struct {
-		Properties struct {
-			Questions []struct {
-				Header   string `json:"header"`
-				Question string `json:"question"`
-			} `json:"questions"`
-		} `json:"properties"`
-	}
-	var resp struct {
-		Result struct {
-			Answers [][]string `json:"answers"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(requestPayload, &req); err != nil {
-		slog.Warn("opencode question request unmarshal failed", "error", err)
-		return ""
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		slog.Warn("opencode question response unmarshal failed", "error", err)
-		return ""
-	}
-
-	lines := make([]string, 0, len(resp.Result.Answers))
-	for i, answers := range resp.Result.Answers {
-		if len(answers) == 0 {
-			continue
-		}
-		parts := make([]string, 0, len(answers))
-		for _, answer := range answers {
-			if text := strings.TrimSpace(answer); text != "" {
-				parts = append(parts, text)
-			}
-		}
-		if len(parts) == 0 {
-			continue
-		}
-
-		label := fmt.Sprintf("Question %d", i+1)
-		if i < len(req.Properties.Questions) {
-			if header := strings.TrimSpace(req.Properties.Questions[i].Header); header != "" {
-				label = header
-			} else if question := strings.TrimSpace(req.Properties.Questions[i].Question); question != "" {
-				label = question
-			}
-		}
-		lines = append(lines, fmt.Sprintf("%s: %s", label, strings.Join(parts, ", ")))
-	}
-	return strings.Join(lines, "\n")
+type controlResponsePlan struct {
+	requestMeta controlResponseRequestMetadata
+	// resolution is the provider-owned interpretation of the response verbatim, held as ONE field
+	// rather than copied out field-by-field, so a new ControlResponseResolution field can never be
+	// silently dropped by a forgotten copy line -- the plan references the provider's resolution as
+	// the single source of truth for content/display/self-display/plan-mode.
+	resolution  agent.ControlResponseResolution
+	decision    controlResponsePlanModePayload
+	hasDecision bool
 }
 
-func cursorQuestionAnswersText(requestPayload, responseContent []byte) string {
-	var req struct {
-		Params struct {
-			Questions []struct {
-				ID      string `json:"id"`
-				Prompt  string `json:"prompt"`
-				Options []struct {
-					ID    string `json:"id"`
-					Label string `json:"label"`
-				} `json:"options"`
-			} `json:"questions"`
-		} `json:"params"`
-	}
-	var resp struct {
-		Result struct {
-			Outcome struct {
-				Outcome string `json:"outcome"`
-				Reason  string `json:"reason"`
-				Answers []struct {
-					QuestionID        string   `json:"questionId"`
-					SelectedOptionIDs []string `json:"selectedOptionIds"`
-				} `json:"answers"`
-			} `json:"outcome"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(requestPayload, &req); err != nil {
-		slog.Warn("cursor question request unmarshal failed", "error", err)
-		return ""
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		slog.Warn("cursor question response unmarshal failed", "error", err)
-		return ""
-	}
-
-	switch resp.Result.Outcome.Outcome {
-	case "answered":
-		labels := make(map[string]string, len(req.Params.Questions))
-		optionLabels := make(map[string]map[string]string, len(req.Params.Questions))
-		order := make([]string, 0, len(req.Params.Questions))
-		for _, q := range req.Params.Questions {
-			if strings.TrimSpace(q.ID) == "" {
-				continue
-			}
-			labels[q.ID] = strings.TrimSpace(q.Prompt)
-			options := make(map[string]string, len(q.Options))
-			for _, option := range q.Options {
-				if strings.TrimSpace(option.ID) == "" {
-					continue
-				}
-				label := strings.TrimSpace(option.Label)
-				if label == "" {
-					label = option.ID
-				}
-				options[option.ID] = label
-			}
-			optionLabels[q.ID] = options
-			order = append(order, q.ID)
-		}
-
-		answerByQuestion := make(map[string][]string, len(resp.Result.Outcome.Answers))
-		for _, answer := range resp.Result.Outcome.Answers {
-			if strings.TrimSpace(answer.QuestionID) == "" {
-				continue
-			}
-			mapped := make([]string, 0, len(answer.SelectedOptionIDs))
-			for _, optionID := range answer.SelectedOptionIDs {
-				optionID = strings.TrimSpace(optionID)
-				if optionID == "" {
-					continue
-				}
-				label := optionID
-				if options := optionLabels[answer.QuestionID]; options != nil {
-					if mappedLabel := strings.TrimSpace(options[optionID]); mappedLabel != "" {
-						label = mappedLabel
-					}
-				}
-				mapped = append(mapped, label)
-			}
-			if len(mapped) > 0 {
-				answerByQuestion[answer.QuestionID] = mapped
-			}
-		}
-
-		lines := make([]string, 0, len(answerByQuestion))
-		for _, questionID := range order {
-			mapped := answerByQuestion[questionID]
-			if len(mapped) == 0 {
-				continue
-			}
-			label := strings.TrimSpace(labels[questionID])
-			if label == "" {
-				label = questionID
-			}
-			lines = append(lines, fmt.Sprintf("%s: %s", label, strings.Join(mapped, ", ")))
-		}
-		return strings.Join(lines, "\n")
-	case "cancelled", "skipped":
-		return strings.TrimSpace(resp.Result.Outcome.Reason)
-	default:
-		return ""
-	}
-}
-
-func cursorCreatePlanResponseDisplayText(responseContent []byte) string {
-	var resp struct {
-		Result struct {
-			Outcome struct {
-				Outcome string `json:"outcome"`
-				Reason  string `json:"reason"`
-			} `json:"outcome"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		slog.Warn("cursor create plan response unmarshal failed", "error", err)
-		return ""
-	}
-
-	switch resp.Result.Outcome.Outcome {
-	case "accepted":
-		return "Accept"
-	case "rejected":
-		if reason := strings.TrimSpace(resp.Result.Outcome.Reason); reason != "" {
-			return reason
-		}
-		return "Reject"
-	case "cancelled":
-		if reason := strings.TrimSpace(resp.Result.Outcome.Reason); reason != "" {
-			return reason
-		}
-		return "Cancel"
-	default:
-		return ""
-	}
-}
-
-func (svc *Context) controlResponseDisplayText(agentID string, provider leapmuxv1.AgentProvider, content []byte) string {
+func (svc *Context) loadControlResponseRequestMetadata(agentID string, content []byte) controlResponseRequestMetadata {
 	reqID := controlResponseRequestID(content)
 	if reqID == "" {
-		return ""
+		return controlResponseRequestMetadata{}
 	}
-
+	meta := controlResponseRequestMetadata{RequestID: reqID}
 	cr, err := svc.Queries.GetControlRequest(bgCtx(), db.GetControlRequestParams{
 		AgentID:   agentID,
 		RequestID: reqID,
 	})
 	if err != nil {
-		return ""
+		return meta
+	}
+	meta.Payload = json.RawMessage(cr.Payload)
+
+	var crBody struct {
+		Request struct {
+			ToolName  string `json:"tool_name"`
+			ToolUseID string `json:"tool_use_id"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(cr.Payload, &crBody); err != nil {
+		slog.Warn("control request payload unmarshal failed", "agent_id", agentID, "error", err)
+		return meta
+	}
+	meta.ToolName = crBody.Request.ToolName
+	meta.ToolUseID = crBody.Request.ToolUseID
+	meta.Loaded = true
+	return meta
+}
+
+func (svc *Context) buildControlResponsePlan(agentID string, dbAgent db.Agent, content []byte) controlResponsePlan {
+	requestMeta := svc.loadControlResponseRequestMetadata(agentID, content)
+	resolution := agent.ProviderFor(dbAgent.AgentProvider).ResolveControlResponse(agent.ControlResponseContext{
+		RequestID:       requestMeta.RequestID,
+		RequestPayload:  requestMeta.Payload,
+		ResponseContent: content,
+		ToolName:        requestMeta.ToolName,
+		ToolUseID:       requestMeta.ToolUseID,
+	})
+	if resolution.Content == nil {
+		resolution.Content = content
 	}
 
-	var payload struct {
-		Method string `json:"method"`
-		Type   string `json:"type"`
+	plan := controlResponsePlan{
+		requestMeta: requestMeta,
+		resolution:  resolution,
 	}
-	if err := json.Unmarshal(cr.Payload, &payload); err != nil {
-		slog.Warn("control response display text unmarshal failed", "agent_id", agentID, "error", err)
-		return ""
+	// plan.decision is the frontend's approve/reject + permissionMode/clearContext envelope, decoded
+	// from the ORIGINAL `content` -- the raw frontend control response, which ALWAYS carries that
+	// envelope -- NOT from resolution.Content, which a provider may have rewritten for the agent
+	// (e.g. Cursor createPlan's transformCursorControlResponse replaces it with an ACP outcome that
+	// carries no request_id). Reading the frontend-only shape from the frontend bytes keeps plan-mode
+	// handling and the fallback row correct even for a provider that BOTH rewrites Content for the
+	// agent AND needs plan-mode handling; resolution.Content is still what gets forwarded to the
+	// agent. (For every provider except Cursor createPlan resolution.Content == content, so this is
+	// identical to decoding from resolution.Content; for Cursor createPlan it flips hasDecision to
+	// true, which is behavior-neutral -- PlanModeControl==None makes the plan-mode effects a no-op
+	// and the answer stays controlAnswerSynthetic, so no fallback row is added.)
+	//
+	// hasDecision gates the plan-mode / fallback-row handling, and is set ONLY for a recognized
+	// allow/deny behavior. The frontend is the sole producer of control responses and provably
+	// emits nothing else (buildAllowResponse/buildDenyResponse/decodeControlResponseBehavior in
+	// utils/controlResponse.ts), so an empty/unknown behavior is unreachable in practice -- the
+	// narrowing (a plan-prompt whose behavior is neither would otherwise forward its raw envelope
+	// and skip the fallback row) rests on that frontend contract by design rather than a defensive
+	// guard.
+	if err := json.Unmarshal(content, &plan.decision); err == nil && plan.decision.Response.RequestID != "" {
+		switch plan.behavior() {
+		case agent.ControlBehaviorAllow, agent.ControlBehaviorDeny:
+			plan.hasDecision = true
+		}
+	}
+	return plan
+}
+
+// behavior is the approve/reject behavior the frontend attached to this control response, read
+// through one accessor rather than walking plan.decision.Response.Response.Behavior at each site.
+// Trimmed to match agent.DecodeControlBehavior's behavior read: buildControlResponsePlan gates
+// hasDecision on this matching agent.ControlBehaviorAllow/Deny, so surrounding whitespace must not
+// silently drop it to "no decision" here while the trimming decoder accepts it on the other paths.
+func (plan controlResponsePlan) behavior() string {
+	return strings.TrimSpace(plan.decision.Response.Response.Behavior)
+}
+
+// rejectionMessage is the user's typed rejection reason, or "" when they gave none -- an empty
+// message OR the ControlRejectedByUserMessage sentinel (the auto-filled placeholder). Delegates to
+// agent.NormalizeRejectionMessage so this side of the wire and DecodeControlBehavior apply one
+// shared deny-feedback rule that can't drift.
+func (plan controlResponsePlan) rejectionMessage() string {
+	return agent.NormalizeRejectionMessage(plan.decision.Response.Response.Message)
+}
+
+// answerRow is which persisted row carries the single CONTROL_RESPONSE rail mark, derived from the
+// immutable resolution rather than stored -- a method like its sibling derivations (behavior /
+// rejectionMessage / exitPlanClearingContext) so the plan can never be constructed with an
+// answerRow that disagrees with its own resolution.
+func (plan controlResponsePlan) answerRow() controlAnswerRow {
+	return classifyControlAnswerRow(plan.resolution.SelfDisplayed, plan.resolution.DisplayText)
+}
+
+func (svc *Context) deleteControlRequest(agentID string, provider leapmuxv1.AgentProvider, requestMeta controlResponseRequestMetadata, selfDisplayed bool) {
+	if requestMeta.RequestID == "" {
+		return
+	}
+	sink := svc.Output.NewSink(agentID, provider)
+	if requestMeta.ToolUseID != "" && selfDisplayed {
+		sink.SetSpanType(requestMeta.ToolUseID, requestMeta.ToolName)
+	}
+	sink.DeleteControlRequest(requestMeta.RequestID)
+	sink.BroadcastControlCancel(requestMeta.RequestID)
+}
+
+func (svc *Context) persistControlResponseAnswerRows(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
+	if plan.needsFallbackDisplayRow() {
+		svc.persistControlResponseDisplayRow(agentID, provider, plan)
 	}
 
-	switch provider {
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX:
-		if payload.Method == "item/tool/requestUserInput" {
-			return codexUserInputAnswersText(cr.Payload, content)
-		}
-		return codexFeedbackMessageText(content)
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE:
-		if payload.Type == "question.asked" {
-			return opencodeQuestionAnswersText(cr.Payload, content)
-		}
-		return acpPermissionResponseDisplayText(cr.Payload, content)
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
-		leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX:
-		return acpPermissionResponseDisplayText(cr.Payload, content)
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR:
-		switch payload.Method {
-		case agent.CursorMethodAskQuestion:
-			return cursorQuestionAnswersText(cr.Payload, content)
-		case agent.CursorMethodCreatePlan:
-			return cursorCreatePlanResponseDisplayText(content)
-		default:
-			return ""
-		}
-	case leapmuxv1.AgentProvider_AGENT_PROVIDER_PI:
-		return piExtensionUIResponseDisplayText(payload.Method, content)
-	default:
-		return ""
+	// The synthetic {content} answer row belongs ONLY to a provider-resolved answer
+	// (controlAnswerSynthetic). A self-displayed answer already lives in the provider's own
+	// transcript, and a fallback answer is carried by the {controlResponse} row above -- persisting
+	// resolution.DisplayText for either would DUPLICATE the answer row. Today the only
+	// self-displaying provider (Claude) returns no DisplayText, so persistSyntheticUserMessage
+	// early-returns on empty and this is a no-op for it -- but gating on the classifier makes "exactly
+	// one answer row" STRUCTURAL (matching classifyControlAnswerRow's no-double-MARK guarantee) rather
+	// than resting on that emptiness, so a future provider that BOTH self-displays AND returns display
+	// text can't double-render the answer. controlAnswerSynthetic always carries non-empty display
+	// text (the classifier's own rule), so the mark is unconditionally CONTROL_RESPONSE here.
+	if plan.answerRow() == controlAnswerSynthetic {
+		svc.persistSyntheticUserMessage(agentID, provider, plan.resolution.DisplayText, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
 	}
 }
 
-// piExtensionUIResponseDisplayText extracts a human-readable summary of a Pi
-// extension_ui_response so the user's choice shows up as a synthetic message
-// in the transcript.
-func piExtensionUIResponseDisplayText(method string, responseContent []byte) string {
-	var resp struct {
-		Cancelled bool   `json:"cancelled"`
-		Confirmed *bool  `json:"confirmed"`
-		Value     string `json:"value"`
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		return ""
-	}
-
-	if resp.Cancelled {
-		return "Cancelled"
-	}
-
-	switch method {
-	case agent.PiDialogMethodConfirm:
-		if resp.Confirmed != nil && *resp.Confirmed {
-			return "Approve"
-		}
-		return "Deny"
-	case agent.PiDialogMethodSelect, agent.PiDialogMethodInput, agent.PiDialogMethodEditor:
-		return strings.TrimSpace(resp.Value)
-	default:
-		return ""
-	}
+// exitPlanClearingContext reports the one compound condition the fallback-row rule and the
+// plan-mode-effects skipSend both hinge on: an APPROVED ExitPlanMode that ALSO clears context.
+// When it holds, initiatePlanExecution is about to stop the agent, so the self-displayed
+// transcript tool_result never materializes -- which is why the fallback display row must
+// carry the mark instead. Naming the triple once keeps needsFallbackDisplayRow and
+// applyControlResponsePlanModeEffects from silently drifting on it.
+func (plan controlResponsePlan) exitPlanClearingContext() bool {
+	return plan.behavior() == agent.ControlBehaviorAllow &&
+		plan.resolution.PlanModeControl == agent.PlanModeControlExit &&
+		plan.decision.ClearContext
 }
 
-// acpPermissionResponseDisplayText extracts a human-readable display text from
-// an ACP permission response by matching the selected optionId against the
-// original request payload's option list.
-func acpPermissionResponseDisplayText(requestPayload, responseContent []byte) string {
-	var req struct {
-		Params struct {
-			Options []struct {
-				OptionID string `json:"optionId"`
-				Name     string `json:"name"`
-			} `json:"options"`
-		} `json:"params"`
+func (plan controlResponsePlan) needsFallbackDisplayRow() bool {
+	if !plan.requestMeta.Loaded || !plan.hasDecision {
+		return false
 	}
-	var resp struct {
-		Result struct {
-			Outcome struct {
-				OptionID string `json:"optionId"`
-			} `json:"outcome"`
-		} `json:"result"`
+	if plan.answerRow() == controlAnswerFallback {
+		return true
 	}
-	if err := json.Unmarshal(requestPayload, &req); err != nil {
-		slog.Warn("acp permission request unmarshal failed", "error", err)
-		return ""
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		slog.Warn("acp permission response unmarshal failed", "error", err)
-		return ""
+	// A self-displayed answer normally owns the mark on its own transcript row -- unless a
+	// context-clearing plan exit is about to wipe that row, where the fallback row carries it.
+	return plan.answerRow() == controlAnswerSelfDisplayed && plan.exitPlanClearingContext()
+}
+
+func (svc *Context) handleControlResponsePromptPlan(agentID string, dbAgent db.Agent, plan controlResponsePlan) {
+	if !plan.requestMeta.Loaded || !plan.hasDecision {
+		return
 	}
 
-	optionID := strings.TrimSpace(resp.Result.Outcome.OptionID)
-	if optionID == "" {
-		return ""
-	}
-	for _, option := range req.Params.Options {
-		if strings.TrimSpace(option.OptionID) == optionID {
-			if name := strings.TrimSpace(option.Name); name != "" {
-				return name
+	crPayload := plan.decision
+	// The provider owns which options a plan approval settles (the values stay in the plugin);
+	// the service just applies them. Base settles unconditionally; Bypass rides a mode switch.
+	approvalOptions := agent.ProviderFor(dbAgent.AgentProvider).PlanApprovalOptions()
+	switch plan.behavior() {
+	case agent.ControlBehaviorAllow:
+		svc.persistControlResponseDisplayRow(agentID, dbAgent.AgentProvider, plan)
+
+		// Settle the provider's base plan-approval options (applied live, notify on first set).
+		if len(approvalOptions.Base) > 0 {
+			dbAgent = svc.applyOptionChanges(dbAgent, approvalOptions.Base, applyOptionsSpec{live: true, notifyFirstSet: true})
+		}
+
+		if crPayload.PermissionMode != "" {
+			dbAgent = svc.setAgentPermissionModeWithAgent(dbAgent, crPayload.PermissionMode)
+			// Grant the provider's bypass options for the approved mode (applied live, notify on
+			// first set) -- e.g. Codex's full network access + no sandbox.
+			if len(approvalOptions.Bypass) > 0 {
+				svc.applyOptionChanges(dbAgent, approvalOptions.Bypass, applyOptionsSpec{live: true, notifyFirstSet: true})
 			}
-			break
+		}
+
+		if crPayload.ClearContext {
+			go svc.initiatePlanExecution(agentID, resolveTargetMode(crPayload.PermissionMode, agent.PermissionModeDefault))
+		} else {
+			// An auto-injected prompt, not the user's own words: no rail dot.
+			svc.sendSyntheticUserMessage(agentID, "Implement the plan.", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+		}
+	case agent.ControlBehaviorDeny:
+		if msg := plan.rejectionMessage(); msg != "" {
+			// The user's typed rejection reason IS their answer to the plan-mode control
+			// request, so mark it CONTROL_RESPONSE for a rail dot -- consistent with every
+			// other deny-with-feedback path (ExitPlanMode, permission decisions).
+			svc.sendSyntheticUserMessage(agentID, msg, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
+		} else {
+			svc.persistControlResponseDisplayRow(agentID, dbAgent.AgentProvider, plan)
+		}
+	}
+}
+
+// controlAnswerRow identifies which persisted row carries the single CONTROL_RESPONSE rail
+// mark for a user's answer to a control request. The three homes are mutually exclusive, so
+// naming them here lets the two persist sites agree on exactly one -- never both (a double
+// dot), never neither (a real answer with no dot).
+type controlAnswerRow int
+
+const (
+	// controlAnswerSelfDisplayed: the provider re-emits the answer in its OWN transcript
+	// (Claude's AskUserQuestion / ExitPlanMode tool_result), which the Claude user-envelope
+	// classifier marks at ingestion -- so neither synthesized row is marked.
+	controlAnswerSelfDisplayed controlAnswerRow = iota
+	// controlAnswerSynthetic: a provider-resolved answer row (Codex/OpenCode/Pi/Cursor) that
+	// SendControlResponse writes via persistSyntheticUserMessage from displayText -- that row
+	// carries the mark.
+	controlAnswerSynthetic
+	// controlAnswerFallback: no provider display text and not self-displayed (a Claude
+	// permission decision, or a non-Claude approval with no feedback) -- the synthetic
+	// {controlResponse} fallback row in persistControlResponseAnswerRows carries the mark.
+	controlAnswerFallback
+)
+
+// classifyControlAnswerRow is the SINGLE home for the "which row is the control answer"
+// decision, derived from the provider-resolved self-display flag and display text. Both
+// persist sites consult it -- the synthetic answer row and the fallback display row -- so
+// exactly one row draws the rail's jump dot. Because self-display is checked FIRST, a
+// provider that BOTH self-displays AND returns display text can never double-mark: its
+// ingested transcript row owns the mark and the synthesized rows stay unmarked.
+func classifyControlAnswerRow(selfDisplayed bool, displayText string) controlAnswerRow {
+	if selfDisplayed {
+		return controlAnswerSelfDisplayed
+	}
+	if strings.TrimSpace(displayText) != "" {
+		return controlAnswerSynthetic
+	}
+	return controlAnswerFallback
+}
+
+// applyControlResponsePlanModeEffects detects plan mode changes from control responses.
+// When the frontend approves/rejects an EnterPlanMode or ExitPlanMode control request,
+// this updates the permission mode and initiates plan execution as needed. Returns true
+// when the caller should skip sending the response to the agent (clearContext path).
+func (svc *Context) applyControlResponsePlanModeEffects(agentID string, dbAgent db.Agent, plan controlResponsePlan) bool {
+	if !plan.requestMeta.Loaded || !plan.hasDecision {
+		return false
+	}
+
+	crPayload := plan.decision
+	// Trim to match: plan.requestMeta.RequestID came through DecodeControlBehavior (which trims),
+	// so read the response's own request id the same way -- otherwise a whitespace-padded id would
+	// fail this equality and silently skip the plan-mode transition even though hasDecision (which
+	// also trims) accepted it. Keeps the "trim everywhere" rule the rest of this file enforces.
+	reqID := strings.TrimSpace(crPayload.Response.RequestID)
+	if reqID == "" || reqID != plan.requestMeta.RequestID {
+		return false
+	}
+
+	// Detect plan mode changes from control responses (agent-initiated).
+	skipSend := false
+	if plan.behavior() == agent.ControlBehaviorAllow {
+		switch plan.resolution.PlanModeControl {
+		case agent.PlanModeControlEnter:
+			svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModePlan)
+		case agent.PlanModeControlExit:
+			// Determine target permission mode from control_response (default AcceptEdits here,
+			// vs Default on the plan-prompt path -- resolveTargetMode owns that fallback).
+			targetMode := resolveTargetMode(crPayload.PermissionMode, agent.PermissionModeAcceptEdits)
+			svc.setAgentPermissionModeWithAgent(dbAgent, targetMode)
+
+			// Remove the planModeToolUse entry so detectPlanModeFromToolResult
+			// does not override the mode we just set.
+			if plan.requestMeta.ToolUseID != "" {
+				svc.Output.planModeToolUse.Delete(plan.requestMeta.ToolUseID)
+			}
+
+			// Inside the Behavior==Allow branch and the PlanModeControlExit case, this
+			// IS plan.exitPlanClearingContext() -- the same predicate needsFallbackDisplayRow
+			// keys the mark-carrying fallback row off. Call it (rather than re-inlining the
+			// ClearContext read) so the two provably stay in lockstep, as its doc promises.
+			if plan.exitPlanClearingContext() {
+				// When clearing context, don't send the approval to the
+				// agent — we're about to stop it anyway. This avoids
+				// the race where the agent acts on the approval before
+				// initiatePlanExecution kills it.
+				go svc.initiatePlanExecution(agentID, targetMode)
+				skipSend = true
+			}
+			// When !clearContext, the agent continues in current context.
 		}
 	}
 
-	switch optionID {
-	case "once", "proceed_once":
-		return "Allow once"
-	case "always", "proceed_always":
-		return "Always allow"
-	case "reject", "cancel":
-		return "Reject"
-	default:
-		return optionID
+	return skipSend
+}
+
+// resolveTargetMode picks the plan-execution target permission mode: the mode the frontend
+// attached to the control response, or `defaultMode` when it attached none. The two plan-mode
+// entry points differ only in that default (PermissionModeDefault on the plan-prompt path,
+// PermissionModeAcceptEdits on the ExitPlanMode path).
+func resolveTargetMode(permissionMode, defaultMode string) string {
+	if permissionMode != "" {
+		return permissionMode
+	}
+	return defaultMode
+}
+
+// persistControlResponseDisplayRow writes the synthetic {controlResponse} row from the plan's
+// approve/reject behavior and the NORMALIZED comment the frontend attached, reading both off the
+// plan so the deep decision chain lives here once rather than at each call site. The comment runs
+// through plan.rejectionMessage() (not the raw decision message) so the auto-filled
+// ControlRejectedByUserMessage sentinel collapses to "" -- otherwise a bare deny would render the
+// placeholder "Rejected by user." as if it were typed feedback ("Sent feedback: ...") in both the
+// transcript row (controlResponseRenderer) and the rail dot preview (defaultMarkPreview), instead
+// of the intended "Rejected". An approved row ignores comment, so normalizing it is safe there too.
+func (svc *Context) persistControlResponseDisplayRow(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
+	action := "approved"
+	if plan.behavior() == agent.ControlBehaviorDeny {
+		action = "rejected"
+	}
+	displayContent := map[string]interface{}{
+		"isSynthetic": true,
+		"controlResponse": map[string]string{
+			"action":  action,
+			"comment": plan.rejectionMessage(),
+		},
+	}
+	displayJSON, err := json.Marshal(displayContent)
+	if err != nil {
+		slog.Warn("marshal control response notification", "agent_id", agentID, "error", err)
+		return
+	}
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, displayJSON, agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE}, nil); err != nil {
+		slog.Warn("failed to persist control response notification", "agent_id", agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -88,6 +88,7 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Task: Inspect the renderer\nReason: Need parity with Claude Code", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
 func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
@@ -146,6 +147,221 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Please add tests before exiting plan mode.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
+}
+
+// TestSendControlResponse_CodexPlanModePromptDenyFeedbackIsMarked covers the Codex
+// plan-mode-prompt DENY-with-feedback path in the shared control-response planner. The
+// user's typed rejection reason is their own answer to the control request, so it must draw
+// a scroll-rail jump dot (CONTROL_RESPONSE) -- consistent with every other deny-with-
+// feedback path -- rather than staying unmarked like a truly synthetic prompt.
+func TestSendControlResponse_CodexPlanModePromptDenyFeedbackIsMarked(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Options:    map[string]string{agent.OptionIDModel: "opus"},
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"response":{
+				"request_id":"plan-1",
+				"response":{
+					"behavior":"deny",
+					"message":"Not yet -- split the migration first."
+				}
+			}
+		}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	assert.Equal(t, "Not yet -- split the migration first.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType,
+		"a plan-mode-prompt denial's typed feedback is the user's control answer and draws a rail dot")
+}
+
+// TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow covers the deny path
+// when the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage
+// placeholder, which controlResponsePlan.rejectionMessage() (via agent.NormalizeRejectionMessage)
+// collapses to "" -- so the planner persists the synthetic {controlResponse action:"rejected"}
+// display row (LEAPMUX-sourced, still mark-carrying) rather than a USER-sourced feedback row
+// echoing the placeholder as if it were the user's words.
+func TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Options:    map[string]string{agent.OptionIDModel: "opus"},
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// The sentinel has no JSON-special characters, so embedding the constant keeps the wire
+	// value in lockstep with the backend's collapse rule without a fmt import.
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source,
+		"a bare denial (placeholder collapsed to no feedback) persists the synthetic display row, not a user feedback row")
+	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "rejected", action)
+	assert.Empty(t, comment,
+		"a bare denial must NOT leak the ControlRejectedByUserMessage placeholder as feedback -- the row renders \"Rejected\", not \"Sent feedback: Rejected by user.\"")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+func TestSendControlResponse_CodexPlanModePromptAllowPersistsMarkedApproval(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+		Options:       marshalOptions(map[string]string{agent.CodexOptionCollaborationMode: agent.CodexCollaborationDefault}),
+	}))
+
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Options:    map[string]string{agent.OptionIDModel: "opus"},
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"response":{
+				"request_id":"plan-1",
+				"response":{"behavior":"allow"}
+			}
+		}`),
+	}, w)
+
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source)
+	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType,
+		"the user's plan-mode approval must have a scroll-rail control-response dot")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[1].Source)
+	assert.Equal(t, "Implement the plan.", decodeMessageContent(t, rows[1].Content, rows[1].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[1].MarkType,
+		"the auto-injected prompt is not the user's own answer")
+}
+
+func TestBuildControlResponsePlan_MalformedPlanPromptHasNoDecision(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+
+	plan := svc.buildControlResponsePlan("agent-1", dbAgent, []byte(`{"response":{"request_id":"plan-1"},"clearContext":true}`))
+
+	assert.True(t, plan.requestMeta.Loaded)
+	assert.Equal(t, agent.PlanModeControlPrompt, plan.resolution.PlanModeControl)
+	assert.False(t, plan.hasDecision)
+}
+
+func TestBuildControlResponsePlan_WhitespacePaddedBehaviorStillDecides(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+
+	// A behavior string with surrounding whitespace must still resolve to a decision: behavior()
+	// trims to match ControlBehaviorAllow (mirroring agent.DecodeControlBehavior's trimming read),
+	// so hasDecision holds and the plan-mode/answer-row handling is not silently skipped.
+	plan := svc.buildControlResponsePlan("agent-1", dbAgent, []byte(`{"response":{"request_id":"plan-1","response":{"behavior":" allow "}}}`))
+
+	assert.True(t, plan.requestMeta.Loaded)
+	assert.Equal(t, agent.ControlBehaviorAllow, plan.behavior(), "behavior() trims surrounding whitespace")
+	assert.True(t, plan.hasDecision, "a whitespace-padded allow still counts as a decision")
 }
 
 func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T) {
@@ -270,6 +486,7 @@ func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
 	assert.Equal(t, "Task: Build\nEnv: Dev", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
 func TestSendControlResponse_PersistsCopilotPermissionSelectionLabel(t *testing.T) {
@@ -329,36 +546,528 @@ func TestSendControlResponse_PersistsCopilotPermissionSelectionLabel(t *testing.
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, "Allow once", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
-func TestExtractControlResponseRequestID(t *testing.T) {
+// decodeControlResponseAction decompresses a `{controlResponse:{action,comment}}` fallback
+// display row and returns its action.
+func decodeControlResponseAction(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) string {
+	t.Helper()
+	action, _ := decodeControlResponseRow(t, content, compression)
+	return action
+}
+
+// decodeControlResponseRow decompresses a `{controlResponse:{action,comment}}` display row and
+// returns both fields. The comment must have the ControlRejectedByUserMessage placeholder collapsed
+// to "" by persistControlResponseDisplayRow -- a bare deny renders "Rejected", not the placeholder.
+func decodeControlResponseRow(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) (action, comment string) {
+	t.Helper()
+	raw, err := msgcodec.Decompress(content, compression)
+	require.NoError(t, err)
+	var body struct {
+		ControlResponse struct {
+			Action  string `json:"action"`
+			Comment string `json:"comment"`
+		} `json:"controlResponse"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body))
+	return body.ControlResponse.Action, body.ControlResponse.Comment
+}
+
+// TestSendControlResponse_PersistsClaudePermissionFallbackRow covers the Claude permission
+// path: the provider resolver produces no display text for Bash and Bash is not
+// self-displaying, so the planner's fallback `{controlResponse}` row IS the display -- and
+// must carry the CONTROL_RESPONSE mark.
+func TestSendControlResponse_PersistsClaudePermissionFallbackRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source)
+	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the fallback row draws the rail jump dot")
+}
+
+// TestSendControlResponse_ClaudePermissionBareDenyRowHasNoComment covers the fallback-row deny
+// path when the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage
+// placeholder, which persistControlResponseDisplayRow must collapse to "" (via
+// plan.rejectionMessage) so the row renders "Rejected" -- NOT "Sent feedback: Rejected by user."
+// The row previously stored the raw message, leaking the placeholder as if it were typed feedback.
+func TestSendControlResponse_ClaudePermissionBareDenyRowHasNoComment(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "rejected", action)
+	assert.Empty(t, comment,
+		"a bare denial must collapse the ControlRejectedByUserMessage placeholder to \"\" -- the row renders \"Rejected\", not \"Sent feedback: Rejected by user.\"")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestSendControlResponse_ClaudePermissionDenyWithReasonKeepsComment is the counterpart: a REAL
+// typed reason (not the placeholder) must survive into the display row's comment, proving the
+// normalization collapses only the sentinel and never a genuine rejection reason.
+func TestSendControlResponse_ClaudePermissionDenyWithReasonKeepsComment(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"use ripgrep instead"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "rejected", action)
+	assert.Equal(t, "use ripgrep instead", comment, "a genuine typed rejection reason must survive into the display row")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+func TestSendControlResponse_UsesNestedRequestIDWhenTopLevelIDAlsoExists(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{
+			"id":"jsonrpc-req",
+			"type":"control_response",
+			"response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}
+		}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+func TestSendControlResponse_SkipsFallbackRowWithoutStoredControlRequest(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"missing","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Empty(t, rows, "without the stored request, the service cannot classify the answer row")
+}
+
+// TestSendControlResponse_SkipsClaudeSelfDisplayingFallbackRow asserts the fallback row is
+// SKIPPED for a self-displaying tool (ExitPlanMode) -- its own tool_result carries the mark
+// via ingestion, so a second synthetic `{controlResponse}` row would double the rail dot.
+func TestSendControlResponse_SkipsClaudeSelfDisplayingFallbackRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"ExitPlanMode"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// Approve WITHOUT clearContext, so no plan execution / synthetic prompt is persisted.
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	for _, row := range rows {
+		assert.NotEqual(t, "approved", decodeControlResponseAction(t, row.Content, row.ContentCompression),
+			"no synthetic {controlResponse} fallback row for a self-displaying tool")
+	}
+}
+
+func TestSendControlResponse_RestoresClaudeSelfDisplayedToolUseType(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-ask",
+		Payload: []byte(`{"type":"control_request","request_id":"req-ask","request":{"tool_name":"AskUserQuestion","tool_use_id":"toolu-ask"}}`),
+	}))
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	sink.ResetSpans()
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, sink)
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-ask","response":{"behavior":"allow","message":"Yes, continue."}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	assert.Equal(t, agent.ToolNameAskUserQuestion, sink.GetSpanType("toolu-ask"),
+		"the later Claude tool_result relies on this mapping to carry the CONTROL_RESPONSE mark")
+}
+
+func TestSendControlResponse_ClaudeExitPlanModeClearContextMarksFallbackRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"ExitPlanMode","tool_use_id":"toolu-exit"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","clearContext":true,"response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+
+	controlRows := make([]db.Message, 0, len(rows))
+	for _, row := range rows {
+		if decodeControlResponseAction(t, row.Content, row.ContentCompression) != "" {
+			controlRows = append(controlRows, row)
+		}
+	}
+
+	require.Len(t, controlRows, 1)
+	assert.Equal(t, "approved", decodeControlResponseAction(t, controlRows[0].Content, controlRows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, controlRows[0].MarkType,
+		"clear-context skips Claude's self-displayed tool_result, so the fallback row must carry the rail dot")
+}
+
+// TestSendControlResponse_EnterPlanModeAllowTrimsRequestID pins the "trim everywhere" rule for
+// the plan-mode transition: a control response whose request_id carries surrounding whitespace
+// must still switch the agent to plan mode. plan.requestMeta.RequestID is trimmed (it comes
+// through DecodeControlBehavior), so applyControlResponsePlanModeEffects must trim the response's
+// own request_id the same way -- otherwise the untrimmed " req-1 " != "req-1" equality would
+// silently skip the transition even though hasDecision (which trims) accepted it.
+func TestSendControlResponse_EnterPlanModeAllowTrimsRequestID(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"EnterPlanMode","tool_use_id":"toolu-enter"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// The request_id carries surrounding whitespace on the wire.
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"  req-1  ","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	got := loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	assert.Equal(t, agent.PermissionModePlan, got[agent.OptionIDPermissionMode],
+		"a whitespace-padded request_id must still apply the EnterPlanMode transition")
+}
+
+// TestSendControlResponse_CursorCreatePlanPersistsOnlySyntheticAnswerRow covers the Cursor
+// createPlan path, where the provider REWRITES resolution.Content into an ACP outcome that
+// carries no request_id while the ORIGINAL response content still carries the frontend
+// approve/reject envelope. buildControlResponsePlan decodes plan.decision from that original
+// content, so hasDecision is TRUE here -- which makes the fallback-row gate
+// (needsFallbackDisplayRow) actually evaluate for this path rather than short-circuit on
+// !hasDecision. The answer must route to the single synthetic {content} row (marked
+// CONTROL_RESPONSE for a rail dot) and MUST NOT also emit a {controlResponse} fallback row --
+// i.e. exactly one persisted row, never two.
+func TestSendControlResponse_CursorCreatePlanPersistsOnlySyntheticAnswerRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "7",
+		Payload: []byte(`{"jsonrpc":"2.0","id":7,"method":"cursor/create_plan","params":{}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"response":{"request_id":"7","response":{"behavior":"deny","message":"Needs tests."}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1", Seq: 0, Limit: 10,
+	})
+	require.NoError(t, err)
+	// Exactly one row: the synthetic answer. A second row would be the {controlResponse}
+	// fallback double-rendering now that hasDecision is reachable for this path.
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source,
+		"the answer is the synthetic {content} user row, not a LEAPMUX {controlResponse} fallback row")
+	assert.Equal(t, "Needs tests.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType,
+		"a control-response answer draws a scroll-rail jump dot")
+}
+
+// TestSendControlResponse_CursorCreatePlanApprovePersistsOnlySyntheticAnswerRow is the ALLOW
+// sibling of the deny case above. Approving createPlan flips hasDecision true (decoded from the
+// original content), so applyControlResponsePlanModeEffects now runs its `behavior == Allow`
+// branch for this path -- which must be a NO-OP because Cursor's createPlan is PlanModeControlNone
+// (no permission-mode switch, no plan execution) -- while the answer still routes to the single
+// synthetic "Accept" row with no {controlResponse} fallback.
+func TestSendControlResponse_CursorCreatePlanApprovePersistsOnlySyntheticAnswerRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "plan-7",
+		Payload: []byte(`{"jsonrpc":"2.0","id":"plan-7","method":"cursor/create_plan","params":{}}`),
+	}))
+	before, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	_, err = svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"response":{"request_id":"plan-7","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1", Seq: 0, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "exactly the synthetic answer row -- no {controlResponse} fallback double-render")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	assert.Equal(t, "Accept", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+
+	// createPlan is PlanModeControlNone, so the Allow branch must not touch permission mode.
+	after, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, before.Options, after.Options, "approving createPlan must not change agent options/permission mode")
+}
+
+func TestControlResponseRequestID(t *testing.T) {
 	// Claude Code format: response.request_id
-	assert.Equal(t, "req-1", extractControlResponseRequestID(
+	assert.Equal(t, "req-1", controlResponseRequestID(
 		[]byte(`{"response":{"request_id":"req-1","response":{"behavior":"allow"}}}`),
 	))
 
+	// Mixed envelopes still belong to the nested control response. A top-level
+	// JSON-RPC id can be present for provider plumbing, but the pending LeapMux
+	// control_request row is keyed by response.request_id.
+	assert.Equal(t, "req-1", controlResponseRequestID(
+		[]byte(`{"id":"jsonrpc-req","response":{"request_id":"req-1","response":{"behavior":"allow"}}}`),
+	))
+
 	// OpenCode / ACP JSON-RPC format: numeric id
-	assert.Equal(t, "5", extractControlResponseRequestID(
+	assert.Equal(t, "5", controlResponseRequestID(
 		[]byte(`{"jsonrpc":"2.0","id":5,"result":{"outcome":{"outcome":"selected","optionId":"once"}}}`),
 	))
 
 	// OpenCode / ACP JSON-RPC format: string id
-	assert.Equal(t, "abc-123", extractControlResponseRequestID(
+	assert.Equal(t, "abc-123", controlResponseRequestID(
 		[]byte(`{"jsonrpc":"2.0","id":"abc-123","result":{"outcome":{"outcome":"selected","optionId":"reject"}}}`),
 	))
 
 	// No request ID
-	assert.Equal(t, "", extractControlResponseRequestID(
+	assert.Equal(t, "", controlResponseRequestID(
 		[]byte(`{"type":"unknown"}`),
 	))
 
 	// Null id
-	assert.Equal(t, "", extractControlResponseRequestID(
+	assert.Equal(t, "", controlResponseRequestID(
 		[]byte(`{"id":null}`),
 	))
 
 	// Invalid JSON
-	assert.Equal(t, "", extractControlResponseRequestID(
+	assert.Equal(t, "", controlResponseRequestID(
 		[]byte(`not json`),
 	))
+}
+
+// TestClassifyControlAnswerRow pins the single home for the "which row carries the control
+// answer's rail mark" decision that the synthetic-row and fallback-row persist sites share.
+// Exactly one of the three homes owns the mark for any provider-resolved self-display flag
+// and displayText, so the two sites can't both mark (a double dot) or both skip (a real
+// answer with no dot).
+func TestClassifyControlAnswerRow(t *testing.T) {
+	cases := []struct {
+		name          string
+		selfDisplayed bool
+		displayText   string
+		want          controlAnswerRow
+	}{
+		// The future-proofing invariant: self-display is checked FIRST, so a self-displaying
+		// tool classifies as self-displayed even WITH display text -- the synthetic row stays
+		// unmarked and can't double the ingested tool_result's dot. (No provider is in this
+		// state today; this pins the precedence so a new one can't break it.)
+		{"self-display without display text", true, "", controlAnswerSelfDisplayed},
+		{"self-display wins over display text (no double dot)", true, "answered", controlAnswerSelfDisplayed},
+		// A Claude permission decision self-displays nothing and carries no display text: the
+		// fallback {controlResponse} row is its home.
+		{"non-self-displayed empty text -> fallback row", false, "", controlAnswerFallback},
+		// A non-self-displaying tool WITH display text -> the synthetic answer row owns the mark.
+		{"non-self-displayed text -> synthetic row", false, "approved", controlAnswerSynthetic},
+		// A whitespace-only displayText is treated as empty (mirrors persistSyntheticUserMessage's
+		// own TrimSpace guard), so it falls through to the fallback rather than a blank synthetic row.
+		{"whitespace-only display text -> fallback row", false, "   \n\t ", controlAnswerFallback},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyControlAnswerRow(tc.selfDisplayed, tc.displayText))
+		})
+	}
+}
+
+func TestExitPlanClearingContext(t *testing.T) {
+	// The single triple that both needsFallbackDisplayRow and the plan-mode-effects skipSend
+	// key off: an APPROVED ExitPlanMode that ALSO clears context (the transcript row is wiped,
+	// so the fallback display row carries the mark and the approval is not forwarded).
+	mk := func(behavior string, ctrl agent.PlanModeControlKind, clear bool) controlResponsePlan {
+		var plan controlResponsePlan
+		plan.decision.Response.Response.Behavior = behavior
+		plan.decision.ClearContext = clear
+		plan.resolution.PlanModeControl = ctrl
+		return plan
+	}
+	assert.True(t, mk(agent.ControlBehaviorAllow, agent.PlanModeControlExit, true).exitPlanClearingContext())
+	assert.False(t, mk(agent.ControlBehaviorDeny, agent.PlanModeControlExit, true).exitPlanClearingContext(), "deny is not an approval")
+	assert.False(t, mk(agent.ControlBehaviorAllow, agent.PlanModeControlEnter, true).exitPlanClearingContext(), "enter is not exit")
+	assert.False(t, mk(agent.ControlBehaviorAllow, agent.PlanModeControlExit, false).exitPlanClearingContext(), "not clearing context")
+}
+
+func TestResolveTargetMode(t *testing.T) {
+	// The frontend's attached permission mode wins when present.
+	assert.Equal(t, agent.PermissionModePlan, resolveTargetMode(agent.PermissionModePlan, agent.PermissionModeDefault))
+	// Empty falls back to the caller's default -- the ONE thing the plan-prompt path
+	// (PermissionModeDefault) and the ExitPlanMode path (PermissionModeAcceptEdits) differ on.
+	assert.Equal(t, agent.PermissionModeDefault, resolveTargetMode("", agent.PermissionModeDefault))
+	assert.Equal(t, agent.PermissionModeAcceptEdits, resolveTargetMode("", agent.PermissionModeAcceptEdits))
 }

--- a/backend/internal/worker/service/create_message_row_test.go
+++ b/backend/internal/worker/service/create_message_row_test.go
@@ -61,6 +61,36 @@ func TestCreateMessageRow_RejectsUnspecifiedProvider(t *testing.T) {
 	assert.Equal(t, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, msgs[0].AgentProvider)
 }
 
+func TestCreateMessageRow_RejectsUnknownMarkType(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus"}),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	_, err := createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
+		ID:            "msg-bad-mark",
+		AgentID:       "agent-1",
+		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		Content:       []byte(`{"type":"result"}`),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		MarkType:      leapmuxv1.MarkType(999),
+		CreatedAt:     time.Now(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mark_type")
+
+	msgs, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	assert.Empty(t, msgs, "a message with an unknown mark_type must not be persisted")
+}
+
 // createAgentRecord enforces the same real-provider invariant at the point agent
 // rows are born, so a misconfigured caller fails at creation with a clear error
 // rather than later when createMessageRow rejects the agent's first message. The

--- a/backend/internal/worker/service/get_agent_message_test.go
+++ b/backend/internal/worker/service/get_agent_message_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+func getAgentMessage(t *testing.T, d *channel.Dispatcher, agentID string, seq int64) (*leapmuxv1.GetAgentMessageResponse, *testResponseWriter) {
+	t.Helper()
+	w := newTestWriter()
+	dispatch(d, "GetAgentMessage", &leapmuxv1.GetAgentMessageRequest{AgentId: agentID, Seq: seq}, w)
+	if len(w.responses) == 0 {
+		return nil, w
+	}
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.GetAgentMessageResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	return &resp, w
+}
+
+// TestGetAgentMessage_ReturnsMessageBySeq asserts the handler returns the row whose
+// per-agent seq matches, carrying the fields the rail preview needs (content stays
+// compressed for the frontend to decode; mark_type rides along).
+func TestGetAgentMessage_ReturnsMessageBySeq(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+
+	seq, err := createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
+		ID:            "m1",
+		AgentID:       "agent-1",
+		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		Content:       []byte(`{"content":"hello world"}`),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		MarkType:      leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
+		CreatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+	// A second row at a different seq to prove the handler selects by seq, not "first".
+	_, err = createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
+		ID: "m2", AgentID: "agent-1", Source: leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		Content: []byte(`{"content":"other"}`), AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	resp, _ := getAgentMessage(t, d, "agent-1", seq)
+	require.NotNil(t, resp.GetMessage(), "the message at the requested seq must be returned")
+	assert.Equal(t, "m1", resp.GetMessage().GetId())
+	assert.Equal(t, seq, resp.GetMessage().GetSeq())
+	assert.Equal(t, []byte(`{"content":"hello world"}`), resp.GetMessage().GetContent())
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, resp.GetMessage().GetMarkType())
+}
+
+// TestGetAgentMessage_MissingSeq_ReturnsUnset asserts a seq with no row yields an
+// unset message (not an error): a mark can outlive its message after a delete/reseq.
+func TestGetAgentMessage_MissingSeq_ReturnsUnset(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+
+	resp, w := getAgentMessage(t, d, "agent-1", 999)
+	require.Empty(t, w.errors, "a missing seq is a normal empty result, not an error")
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.GetMessage(), "no row at that seq -> unset message")
+}
+
+// TestGetAgentMessage_ClosedAgent_ReturnsUnset mirrors ListAgentMessages: a closed
+// agent yields an unset message rather than an error.
+func TestGetAgentMessage_ClosedAgent_ReturnsUnset(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	seq := seedMark(t, svc, "agent-1", "m1", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+	require.NoError(t, svc.Queries.CloseAgent(ctx, "agent-1"))
+
+	resp, w := getAgentMessage(t, d, "agent-1", seq)
+	require.Empty(t, w.errors)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.GetMessage())
+}
+
+// TestGetAgentMessage_UnknownAgent_Errors asserts an unknown agent id produces an
+// error (not a success response), via requireAccessibleAgent.
+func TestGetAgentMessage_UnknownAgent_Errors(t *testing.T) {
+	_, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	resp, w := getAgentMessage(t, d, "nope", 1)
+	assert.Nil(t, resp, "an unknown agent must not produce a success response")
+	require.NotEmpty(t, w.errors, "an unknown agent must produce an error")
+}
+
+// TestGetAgentMessage_InaccessibleWorkspace_Denied is the security check the RPC
+// exists to satisfy: a caller whose channel was NOT granted the agent's workspace
+// cannot read the message, even though the row exists and the agent id is valid.
+// requireAccessibleAgent must deny before the agent-scoped query ever runs.
+func TestGetAgentMessage_InaccessibleWorkspace_Denied(t *testing.T) {
+	ctx := context.Background()
+	// The caller's channel is granted ws-1 only.
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	// The agent (and its message) live in ws-2, which the caller cannot access.
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "other-agent", WorkspaceID: "ws-2", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	seq := seedMark(t, svc, "other-agent", "m1", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+
+	resp, w := getAgentMessage(t, d, "other-agent", seq)
+	assert.Nil(t, resp, "a cross-workspace read must not return the message")
+	require.NotEmpty(t, w.errors, "a cross-workspace read must be denied")
+}

--- a/backend/internal/worker/service/message_marks_test.go
+++ b/backend/internal/worker/service/message_marks_test.go
@@ -1,0 +1,317 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	"github.com/leapmux/leapmux/internal/worker/channel"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// seedMark persists one message with the given mark type and returns its seq.
+func seedMark(t *testing.T, svc *Context, agentID, id string, mark leapmuxv1.MarkType) int64 {
+	t.Helper()
+	seq, err := createMessageRow(context.Background(), svc.Queries, db.CreateMessageParams{
+		ID:            id,
+		AgentID:       agentID,
+		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		Content:       []byte("hi"),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		MarkType:      mark,
+		CreatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+	return seq
+}
+
+func listMarks(t *testing.T, d *channel.Dispatcher, agentID string) *leapmuxv1.ListMessageMarksResponse {
+	t.Helper()
+	w := newTestWriter()
+	dispatch(d, "ListMessageMarks", &leapmuxv1.ListMessageMarksRequest{AgentId: agentID}, w)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListMessageMarksResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	return &resp
+}
+
+// TestListMessageMarks_ReturnsMarkedSeqsAndRange asserts the handler returns only
+// the marked rows (unmarked ones excluded), ascending, each with its type, and the
+// whole-history min/max seq -- including seqs of unmarked rows in the range.
+func TestListMessageMarks_ReturnsMarkedSeqsAndRange(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+
+	// seq 1: user message (marked), 2: unmarked, 3: control response (marked),
+	// 4: unmarked. Marks are a subset; the range spans all four.
+	seq1 := seedMark(t, svc, "agent-1", "m1", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+	seedMark(t, svc, "agent-1", "m2", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+	seq3 := seedMark(t, svc, "agent-1", "m3", leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
+	seq4 := seedMark(t, svc, "agent-1", "m4", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+
+	resp := listMarks(t, d, "agent-1")
+	require.Len(t, resp.GetMarks(), 2)
+	assert.Equal(t, seq1, resp.GetMarks()[0].GetSeq())
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, resp.GetMarks()[0].GetType())
+	assert.Equal(t, seq3, resp.GetMarks()[1].GetSeq())
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, resp.GetMarks()[1].GetType())
+	assert.Equal(t, seq1, resp.GetMinSeq(), "min spans the whole history, incl. unmarked rows")
+	assert.Equal(t, seq4, resp.GetMaxSeq(), "max spans the whole history, incl. unmarked rows")
+
+	// Deleting the last (unmarked) row lowers max_seq but leaves the marks unchanged.
+	_, err := svc.Queries.DeleteMessageByAgentAndID(ctx, db.DeleteMessageByAgentAndIDParams{AgentID: "agent-1", ID: "m4"})
+	require.NoError(t, err)
+	resp = listMarks(t, d, "agent-1")
+	require.Len(t, resp.GetMarks(), 2)
+	assert.Equal(t, seq3, resp.GetMaxSeq(), "max_seq drops to the new highest live seq after a tail delete")
+
+	// Deleting a marked row removes it from the marks list.
+	_, err = svc.Queries.DeleteMessageByAgentAndID(ctx, db.DeleteMessageByAgentAndIDParams{AgentID: "agent-1", ID: "m3"})
+	require.NoError(t, err)
+	resp = listMarks(t, d, "agent-1")
+	require.Len(t, resp.GetMarks(), 1)
+	assert.Equal(t, seq1, resp.GetMarks()[0].GetSeq())
+}
+
+// TestListMessageMarks_MinSeqAfterLeadingDelete asserts min_seq drifts above 1
+// once the leading rows are deleted -- the exact case the RPC's min_seq exists for
+// (seqs are never reused, so a deleted prefix is gone permanently).
+func TestListMessageMarks_MinSeqAfterLeadingDelete(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	seedMark(t, svc, "agent-1", "m1", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+	seq2 := seedMark(t, svc, "agent-1", "m2", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+
+	_, err := svc.Queries.DeleteMessageByAgentAndID(ctx, db.DeleteMessageByAgentAndIDParams{AgentID: "agent-1", ID: "m1"})
+	require.NoError(t, err)
+
+	resp := listMarks(t, d, "agent-1")
+	assert.Equal(t, seq2, resp.GetMinSeq(), "min_seq follows the surviving oldest row, not 1")
+	require.Len(t, resp.GetMarks(), 1)
+	assert.Equal(t, seq2, resp.GetMarks()[0].GetSeq())
+}
+
+// TestListMessageMarks_EmptyAgent asserts an agent with no messages yields no marks
+// and a 0/0 range (the "genuinely empty" sentinel, distinct from -1 indeterminate).
+func TestListMessageMarks_EmptyAgent(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+
+	resp := listMarks(t, d, "agent-1")
+	assert.Empty(t, resp.GetMarks())
+	require.NotNil(t, resp.MinSeq, "an empty (non-error) agent reports a PRESENT 0 range, not unset")
+	require.NotNil(t, resp.MaxSeq, "an empty (non-error) agent reports a PRESENT 0 range, not unset")
+	assert.Equal(t, int64(0), resp.GetMinSeq())
+	assert.Equal(t, int64(0), resp.GetMaxSeq())
+}
+
+// TestListMessageMarks_ClosedAgent_ReturnsEmptyWithPresentRange mirrors ListAgentMessages
+// (which serves a closed agent no history): the response carries no marks. Critically the
+// seq range is PRESENT and 0 -- NOT left unset -- so the client can tell a closed agent
+// ("no rail") apart from a DB-error indeterminate range ("retry"). An unset range would
+// drive ~5 retry RPCs per closed-tab view; a present-0 range seeds the rail loaded (and it
+// stays hidden over the empty window) and ends the retry chain.
+func TestListMessageMarks_ClosedAgent_ReturnsEmptyWithPresentRange(t *testing.T) {
+	ctx := context.Background()
+	svc, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	seedMark(t, svc, "agent-1", "m1", leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE)
+	require.NoError(t, svc.Queries.CloseAgent(ctx, "agent-1"))
+
+	resp := listMarks(t, d, "agent-1")
+	assert.Empty(t, resp.GetMarks())
+	require.NotNil(t, resp.MinSeq, "closed agent must report a PRESENT range, not the DB-error indeterminate (unset) signal")
+	require.NotNil(t, resp.MaxSeq, "closed agent must report a PRESENT range, not the DB-error indeterminate (unset) signal")
+	assert.Equal(t, int64(0), resp.GetMinSeq())
+	assert.Equal(t, int64(0), resp.GetMaxSeq())
+}
+
+// TestListMessageMarks_UnknownAgent_Errors asserts an inaccessible/unknown agent id
+// produces an error, not a success response, via requireAccessibleAgent.
+func TestListMessageMarks_UnknownAgent_Errors(t *testing.T) {
+	_, d, _ := setupTestService(t, withWorkspaces("ws-1"))
+	w := newTestWriter()
+	dispatch(d, "ListMessageMarks", &leapmuxv1.ListMessageMarksRequest{AgentId: "nope"}, w)
+	assert.Empty(t, w.responses, "an unknown agent must not produce a success response")
+	require.NotEmpty(t, w.errors, "an unknown agent must produce an error")
+}
+
+// TestSendAgentMessage_PersistsUserMessageMark asserts a genuine user send is
+// persisted with mark_type=USER_MESSAGE (so the rail dots it), and that the mark
+// surfaces through ListMessageMarks. The synthetic-prompt path stays unmarked.
+func TestSendAgentMessage_PersistsUserMessageMark(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{AgentId: "agent-1", Content: "hello"}, w)
+	require.Empty(t, w.errors)
+
+	msgs, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, msgs[0].MarkType, "a user send must be marked")
+
+	resp := listMarks(t, d, "agent-1")
+	require.Len(t, resp.GetMarks(), 1)
+	assert.Equal(t, msgs[0].Seq, resp.GetMarks()[0].GetSeq())
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, resp.GetMarks()[0].GetType())
+
+	// A synthetic prompt (auto-continue / plan execution) is byte-identical on the
+	// wire but is NOT a human input, so it must stay unmarked.
+	svc.sendSyntheticUserMessage("agent-1", "please continue", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+	msgs, err = svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, msgs[1].MarkType, "a synthetic prompt must not be marked")
+
+	resp = listMarks(t, d, "agent-1")
+	assert.Len(t, resp.GetMarks(), 1, "the synthetic prompt adds no rail dot")
+}
+
+// TestPersistAndBroadcast_ThreadsMarkType covers the shared persist path used by
+// the Claude transcript ingestion AND the control-response display row: a SpanInfo
+// MarkType must land in both the persisted row and the live broadcast. This is the
+// coverage for the control-response CONTROL_RESPONSE mark, whose write site routes
+// through sink.PersistMessage -> persistAndBroadcast.
+func TestPersistAndBroadcast_ThreadsMarkType(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, withWorkspaces("ws-1"))
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	require.NoError(t, sink.PersistMessage(
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX,
+		[]byte(`{"isSynthetic":true,"controlResponse":{"action":"approved"}}`),
+		agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE},
+	))
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "persisted row must carry the mark")
+
+	// The broadcast must carry the same mark so live watchers dot it without a refetch.
+	var broadcastMark leapmuxv1.MarkType
+	found := false
+	for _, s := range w.streamsSnapshot() {
+		ev := decodeWatchAgentEvent(t, s)
+		if msg := ev.GetAgentMessage(); msg != nil && msg.GetId() == rows[0].ID {
+			broadcastMark = msg.GetMarkType()
+			found = true
+		}
+	}
+	require.True(t, found, "the persisted row must be broadcast")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, broadcastMark, "broadcast must carry the mark")
+}
+
+// TestPersistSyntheticUserMessage_MarkScopedToControlResponse asserts the shared
+// synthetic-user-message writer marks ONLY the caller's requested type: the control-
+// response display row (every non-Claude provider's answer flows through here) is a
+// CONTROL_RESPONSE jump target, while a non-answer notice like the interrupt marker
+// stays UNSPECIFIED so it draws no rail dot.
+func TestPersistSyntheticUserMessage_MarkScopedToControlResponse(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	// A control-response answer -> marked (draws a dot).
+	svc.persistSyntheticUserMessage("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "Task: Build", leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
+	// The interrupt notice -> unmarked (no dot).
+	svc.persistSyntheticUserMessage("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "[Request interrupted by user]", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the control-response answer is marked")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[1].MarkType, "the interrupt notice stays unmarked")
+}
+
+// TestPersistControlResponseAnswerRows_SelfDisplayedWithTextDoesNotDoubleRow pins the structural
+// "exactly one answer row" guarantee for the double-DISPLAY case -- the sibling of
+// classifyControlAnswerRow's no-double-MARK rule. A self-displayed answer that ALSO carries display
+// text, in the context-clearing ExitPlanMode case where the fallback row must carry the mark (the
+// transcript row is about to be wiped), must persist ONLY the mark-carrying {controlResponse}
+// fallback row -- never an extra {content} synthetic row duplicating the provider's own transcript
+// answer. No current provider is in this state (Claude self-displays but returns no display text);
+// this pins the guarantee structurally so a future one can't double-render. Without the classifier
+// gate this persists TWO rows.
+func TestPersistControlResponseAnswerRows_SelfDisplayedWithTextDoesNotDoubleRow(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	var plan controlResponsePlan
+	plan.requestMeta.Loaded = true
+	plan.hasDecision = true
+	plan.decision.Response.Response.Behavior = agent.ControlBehaviorAllow
+	plan.decision.ClearContext = true
+	plan.resolution.PlanModeControl = agent.PlanModeControlExit
+	plan.resolution.SelfDisplayed = true
+	plan.resolution.DisplayText = "Answered: proceed"
+
+	svc.persistControlResponseAnswerRows("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, plan)
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "a self-displayed answer must persist only the {controlResponse} fallback row, not a second {content} echo")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the single persisted row carries the rail mark")
+}
+
+func TestReplayAgentCatchUp_ReplaysControlRequestAgentProvider(t *testing.T) {
+	ctx := context.Background()
+	svc, _, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_PI,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "request-1",
+		Payload:   []byte(`{"type":"permission","id":"request-1"}`),
+	}))
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+
+	svc.replayAgentCatchUp(channel.NewSender(w), &leapmuxv1.WatchAgentEntry{AgentId: "agent-1"}, dbAgent, nil)
+
+	var replayed *leapmuxv1.AgentControlRequest
+	for _, stream := range w.streamsSnapshot() {
+		ev := decodeWatchAgentEvent(t, stream)
+		if cr := ev.GetControlRequest(); cr != nil {
+			replayed = cr
+			break
+		}
+	}
+	require.NotNil(t, replayed, "catch-up replay must include pending control requests")
+	assert.Equal(t, leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, replayed.GetAgentProvider(),
+		"replayed control requests must preserve the provider-specific UI/response policy")
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -911,12 +911,7 @@ func (s *agentOutputSink) BroadcastControlRequest(requestID string, payload []by
 	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
 		AgentId: s.agentID,
 		Event: &leapmuxv1.AgentEvent_ControlRequest{
-			ControlRequest: &leapmuxv1.AgentControlRequest{
-				AgentId:       s.agentID,
-				RequestId:     requestID,
-				Payload:       payload,
-				AgentProvider: s.agentProvider,
-			},
+			ControlRequest: buildAgentControlRequest(s.agentID, s.agentProvider, requestID, payload),
 		},
 	})
 }
@@ -1613,16 +1608,22 @@ func (h *OutputHandler) clearNotifThread(agentID string) {
 	h.lastNotifThread.Delete(agentID)
 }
 
-// createMessageRow persists a chat-message row, refusing an UNSPECIFIED agent
-// provider. Every persisted message must carry a real provider so the client can
-// render it through that provider's renderers; an UNSPECIFIED provider is a
-// persistence bug (the frontend surfaces such a row as `unsupported_provider`).
-// Catch it here at the DB boundary so the malformed row is never written,
-// whichever write path produced it -- the agent open path already defaults an
-// unspecified request to a real provider, so this should never fire in practice.
+// createMessageRow persists a chat-message row, refusing invalid boundary values.
+// Every persisted message must carry a real provider so the client can render it
+// through that provider's renderers; an UNSPECIFIED provider is a persistence bug
+// (the frontend surfaces such a row as `unsupported_provider`). mark_type is also
+// stored as an integer and later rendered as a rail label, so reject unknown enum
+// values before they become misleading clickable dots.
 func createMessageRow(ctx context.Context, q *db.Queries, params db.CreateMessageParams) (int64, error) {
 	if params.AgentProvider == leapmuxv1.AgentProvider_AGENT_PROVIDER_UNSPECIFIED {
 		return 0, fmt.Errorf("refusing to persist message %q for agent %q with UNSPECIFIED agent provider", params.ID, params.AgentID)
+	}
+	switch params.MarkType {
+	case leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED,
+		leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
+		leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE:
+	default:
+		return 0, fmt.Errorf("refusing to persist message %q for agent %q with unknown mark_type %d", params.ID, params.AgentID, params.MarkType)
 	}
 	return q.CreateMessage(ctx, params)
 }
@@ -1663,6 +1664,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 		SpanColor:          int64(spanColor),
 		SpanLines:          spanLines,
 		AgentProvider:      agentProvider,
+		MarkType:           span.MarkType,
 		CreatedAt:          now,
 	})
 	if err != nil {
@@ -1686,6 +1688,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 		SpanType:           span.SpanType,
 		SpanColor:          spanColor,
 		SpanLines:          spanLines,
+		MarkType:           span.MarkType,
 	})
 
 	// Update the provider-neutral to-do list off the just-persisted
@@ -2232,6 +2235,12 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		CreatedAt:          timefmt.Format(parentRow.CreatedAt),
 		Depth:              0,
 		SpanLines:          spanLines,
+		// Carry the row's scroll-rail mark so this MOVE broadcast matches what a
+		// refetch (messageToProto) would report. UpdateNotificationThread leaves
+		// mark_type untouched, so parentRow.MarkType is still authoritative. Today
+		// threaded rows are unmarked (0), but a future marked-and-threaded row would
+		// otherwise show its dot only after a reload.
+		MarkType: parentRow.MarkType,
 		// This broadcast is a MOVE: the consolidated thread row jumped from its old
 		// seq (parentRow.Seq, read before UpdateNotificationThread) to newSeq. Mark it
 		// so consumers reconcile by id instead of treating it as a new message. Only set

--- a/backend/internal/worker/service/output_reseq_broadcast_test.go
+++ b/backend/internal/worker/service/output_reseq_broadcast_test.go
@@ -92,3 +92,47 @@ func TestNotificationReseqBroadcast_CarriesPreviousSeq(t *testing.T) {
 	assert.Greater(t, msgs[1].GetSeq(), firstSeq, "the reseq lands at a new, higher tail seq")
 	assert.Equal(t, firstSeq, msgs[1].GetPreviousSeq(), "previous_seq marks the seq the row moved from")
 }
+
+// TestNotificationReseqBroadcast_CarriesMarkType pins the scroll-rail contract for the
+// move: the MOVE broadcast must carry the persisted row's mark_type, so a live client and
+// a client that later refetches the same row (via messageToProto) agree on whether it has
+// a rail dot. Threaded rows are unmarked today, so we force a mark on the parent row to
+// prove the broadcast reads it from the DB rather than dropping it to UNSPECIFIED.
+func TestNotificationReseqBroadcast_CarriesMarkType(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	mock := &agentMessageCapturingWriter{channelID: "ch-1"}
+	svc.Watchers.WatchAgent("agent-1", &EventWatcher{ChannelID: "ch-1", Sender: channel.NewSender(mock)})
+
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	first, err := json.Marshal(map[string]any{"type": "context_cleared"})
+	require.NoError(t, err)
+	second, err := json.Marshal(map[string]any{"type": "interrupted"})
+	require.NoError(t, err)
+
+	// First notification opens the standalone thread row.
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, first)
+	parentID := mock.snapshot()[0].GetId()
+
+	// Force a mark on the persisted parent row (no production path threads a marked row
+	// yet -- this simulates the future case the proto comment anticipates).
+	_, err = svc.DB.ExecContext(ctx, "UPDATE messages SET mark_type = ? WHERE id = ? AND agent_id = ?",
+		int64(leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE), parentID, "agent-1")
+	require.NoError(t, err)
+
+	// Second adjacent notification consolidates into the thread, reseq'ing it -> MOVE broadcast.
+	persistNotif(t, sink, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, second)
+
+	msgs := mock.snapshot()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, msgs[1].GetMarkType(),
+		"the MOVE broadcast must carry the persisted row's mark_type, not drop it to UNSPECIFIED")
+}

--- a/backend/internal/worker/service/output_user_span_lines_test.go
+++ b/backend/internal/worker/service/output_user_span_lines_test.go
@@ -201,7 +201,7 @@ func TestSendSyntheticUserMessage_PersistsSpanLinesWhileSpanIsOpen(t *testing.T)
 
 	svc.Output.spanTracker("agent-1").OpenSpan("span-A", "")
 
-	svc.sendSyntheticUserMessage("agent-1", "synthetic prompt")
+	svc.sendSyntheticUserMessage("agent-1", "synthetic prompt", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
 		AgentID: "agent-1",

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -304,8 +304,12 @@ func (svc *Context) Init() {
 		panic("service.Context.Init: Send must be set before calling Init")
 	}
 
-	// Wire auto-continue so OutputHandler can send synthetic user messages.
-	svc.Output.SetSendMessageFunc(svc.sendSyntheticUserMessage)
+	// Wire auto-continue so OutputHandler can send synthetic user messages. An
+	// auto-continue injection is not a human-typed input, so it stays UNSPECIFIED
+	// (no scroll-rail jump dot).
+	svc.Output.SetSendMessageFunc(func(agentID, content string) {
+		svc.sendSyntheticUserMessage(agentID, content, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+	})
 	// Let PersistSettingsRefresh detect the startup window so it doesn't clobber
 	// a settings change made mid-startup (see SetAgentStartingFunc).
 	svc.Output.SetAgentStartingFunc(func(agentID string) bool {

--- a/backend/internal/worker/sqlc.yaml
+++ b/backend/internal/worker/sqlc.yaml
@@ -30,3 +30,7 @@ sql:
             go_type:
               import: "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
               type: "AgentProvider"
+          - column: "messages.mark_type"
+            go_type:
+              import: "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+              type: "MarkType"

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -11,10 +11,12 @@ import type { GenMessage } from '@bufbuild/protobuf/codegenv2'
 import type {
   CloseAgentResponse,
   DeleteAgentMessageResponse,
+  GetAgentMessageResponse,
   InterruptAgentResponse,
   ListAgentMessagesResponse,
   ListAgentsResponse,
   ListAvailableProvidersResponse,
+  ListMessageMarksResponse,
   OpenAgentResponse,
   RenameAgentResponse,
   SendAgentMessageResponse,
@@ -77,6 +79,8 @@ import {
   CloseAgentResponseSchema,
   DeleteAgentMessageRequestSchema,
   DeleteAgentMessageResponseSchema,
+  GetAgentMessageRequestSchema,
+  GetAgentMessageResponseSchema,
   InterruptAgentRequestSchema,
   InterruptAgentResponseSchema,
   ListAgentMessagesRequestSchema,
@@ -85,6 +89,8 @@ import {
   ListAgentsResponseSchema,
   ListAvailableProvidersRequestSchema,
   ListAvailableProvidersResponseSchema,
+  ListMessageMarksRequestSchema,
+  ListMessageMarksResponseSchema,
   OpenAgentRequestSchema,
   OpenAgentResponseSchema,
   RenameAgentRequestSchema,
@@ -467,6 +473,14 @@ export function listAgents(workerId: string, req: MessageInitShape<typeof ListAg
 
 export function listAgentMessages(workerId: string, req: MessageInitShape<typeof ListAgentMessagesRequestSchema>): Promise<ListAgentMessagesResponse> {
   return callWorker(workerId, 'ListAgentMessages', ListAgentMessagesRequestSchema, ListAgentMessagesResponseSchema, req)
+}
+
+export function listMessageMarks(workerId: string, req: MessageInitShape<typeof ListMessageMarksRequestSchema>, opts?: { signal?: AbortSignal }): Promise<ListMessageMarksResponse> {
+  return callWorker(workerId, 'ListMessageMarks', ListMessageMarksRequestSchema, ListMessageMarksResponseSchema, req, opts)
+}
+
+export function getAgentMessage(workerId: string, req: MessageInitShape<typeof GetAgentMessageRequestSchema>): Promise<GetAgentMessageResponse> {
+  return callWorker(workerId, 'GetAgentMessage', GetAgentMessageRequestSchema, GetAgentMessageResponseSchema, req)
 }
 
 export function renameAgent(workerId: string, req: MessageInitShape<typeof RenameAgentRequestSchema>): Promise<RenameAgentResponse> {

--- a/frontend/src/components/chat/ChatScrollRail.css.ts
+++ b/frontend/src/components/chat/ChatScrollRail.css.ts
@@ -1,0 +1,190 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+
+// Fixed px here are scrollbar-like dimensions (rail/thumb/dot widths, thumb radius),
+// NOT spacing-scale values -- see CLAUDE.md. The top/bottom insets use the spacing scale.
+
+/**
+ * Max height of the preview popover (px). Exported so ChatScrollRail's vertical clamp (which
+ * keeps a near-edge popover from clipping against the overflow-hidden wrapper) reads the SAME
+ * value the CSS enforces, rather than a hand-synced literal that could drift from this one.
+ */
+export const PREVIEW_POPOVER_MAX_H_PX = 200
+
+/** Width of the rail overlay column (a touch wider than the 8px native scrollbar). */
+const RAIL_WIDTH_PX = 10
+/**
+ * Wider interactive column on COARSE pointers (touch): a finger can't hit a 10px strip, so
+ * the hit area grows to a touch-friendlier size while the thin visuals (track/thumb/dots)
+ * stay their fine-pointer widths, just centred in the wider column. Kept modest so the strip
+ * stays within (or barely past) the list's right padding rather than eating message taps.
+ */
+const RAIL_WIDTH_COARSE_PX = 22
+/** Thumb width, matching the app's 8px native scrollbar thumb. */
+const THUMB_WIDTH_PX = 8
+
+export const rail = style({
+  'position': 'absolute',
+  'top': 'var(--space-2)',
+  'bottom': 'var(--space-2)',
+  'right': '2px',
+  'width': `${RAIL_WIDTH_PX}px`,
+  'zIndex': 10,
+  // Interactive (unlike the pointer-events:none loading pills): track clicks + thumb drag.
+  'cursor': 'pointer',
+  // Never capture text selection while dragging the thumb.
+  'userSelect': 'none',
+  'touchAction': 'none',
+  '@media': {
+    '(pointer: coarse)': {
+      width: `${RAIL_WIDTH_COARSE_PX}px`,
+    },
+  },
+})
+
+/** The muted vertical track line, centered in the rail. Non-interactive (clicks fall to rail). */
+export const track = style({
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  width: '2px',
+  borderRadius: '1px',
+  backgroundColor: 'var(--border)',
+  pointerEvents: 'none',
+})
+
+/** The scrollbar thumb, positioned/sized in seq space. Uses the app's scrollbar tokens. */
+export const thumb = style({
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  width: `${THUMB_WIDTH_PX}px`,
+  borderRadius: '4px',
+  backgroundColor: 'var(--scrollbar-thumb)',
+  zIndex: 1,
+  cursor: 'grab',
+  transition: 'background-color 0.12s ease',
+  selectors: {
+    '&:hover': {
+      backgroundColor: 'var(--scrollbar-thumb-hover)',
+    },
+  },
+})
+
+export const thumbDragging = style({
+  backgroundColor: 'var(--scrollbar-thumb-hover)',
+  cursor: 'grabbing',
+})
+
+/**
+ * A teal jump dot marking a user input / control response, centered on its seq band.
+ * Rendered ABOVE the thumb (higher z-index) so an overlapping thumb never hides it --
+ * the dot is prioritized, per the design.
+ */
+export const dot = style({
+  position: 'absolute',
+  left: '50%',
+  width: '6px',
+  height: '6px',
+  borderRadius: '50%',
+  backgroundColor: 'var(--primary)',
+  // Center the dot on its fraction (top set inline) and horizontally.
+  transform: 'translate(-50%, -50%)',
+  zIndex: 2,
+  cursor: 'pointer',
+  padding: 0,
+  border: 'none',
+  // A thin ring in the panel background separates adjacent/overlapping dots so
+  // a cluster reads as distinct dots rather than one blob. A box-shadow ring
+  // (not a border) keeps the 6px colored fill intact instead of eating into it.
+  boxShadow: '0 0 0 1px var(--background)',
+  transition: 'background-color 0.12s ease',
+  selectors: {
+    // Recolor on hover so the dot the tooltip describes is visually distinct.
+    '&:hover': {
+      backgroundColor: 'var(--accent)',
+    },
+  },
+})
+
+// Coarse-pointer (touch) hit expander: a transparent ~24px circle centred on the 6px dot,
+// so a finger tap within range still hits the button. A pseudo-element leaves the dot's
+// visual fill + ring at 6px (unlike padding, which would enlarge them or the box-shadow).
+globalStyle(`${dot}::before`, {
+  '@media': {
+    '(pointer: coarse)': {
+      content: '',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: '24px',
+      height: '24px',
+      borderRadius: '50%',
+    },
+  },
+})
+
+/**
+ * A dot standing for MULTIPLE marks collapsed to one rail pixel (a cluster). An extra
+ * outer ring in the primary colour distinguishes it from a single-mark dot, so a dense
+ * band reads as "several messages here" rather than one. The inner --background ring
+ * (from `dot`) still separates it from neighbours.
+ */
+export const dotCluster = style({
+  boxShadow: '0 0 0 1px var(--background), 0 0 0 2.5px var(--primary)',
+})
+
+/** Small muted header in a cluster's tooltip: how many messages it stands for. */
+export const dotPreviewCount = style({
+  fontSize: '0.75rem',
+  opacity: 0.7,
+  marginBottom: 'var(--space-1)',
+})
+
+/** Placeholder line shown in the dot tooltip while its preview is being fetched. */
+export const dotPreviewLoading = style({
+  opacity: 0.7,
+  fontStyle: 'italic',
+})
+
+/**
+ * Wraps the markdown-rendered preview inside the dot tooltip. The markdown renderer
+ * emits block elements (paragraphs, blockquotes, lists) with their own vertical
+ * margins; strip the outer ones so the preview sits flush against the tooltip padding.
+ */
+export const dotPreviewMarkdown = style({})
+
+// Child selectors must be globalStyle in vanilla-extract (style() selectors can only
+// target the element itself). The markdown body is rendered by MarkdownText inside this
+// wrapper, so reach its first/last block to drop the outer margins.
+globalStyle(`${dotPreviewMarkdown} > * > :first-child`, { marginTop: 0 })
+globalStyle(`${dotPreviewMarkdown} > * > :last-child`, { marginBottom: 0 })
+
+/**
+ * The single live preview card shown to the LEFT of the rail for the ACTIVE dot -- whether
+ * it's hovered/focused or under the dragging thumb (scrub). One element for both cases, so a
+ * hover and a scrub can never show two popovers at once. Its top is set inline (clamped to
+ * the rail so it never clips against the overflow-hidden wrapper); translateY(-50%) centres
+ * it on that Y. Non-interactive so it never intercepts a drag or a click.
+ */
+export const previewPopover = style({
+  position: 'absolute',
+  right: 'calc(100% + var(--space-2))',
+  transform: 'translateY(-50%)',
+  width: 'max-content',
+  maxWidth: '280px',
+  maxHeight: `${PREVIEW_POPOVER_MAX_H_PX}px`,
+  overflowY: 'auto',
+  padding: 'var(--space-2) var(--space-3)',
+  borderRadius: '6px',
+  backgroundColor: 'var(--background)',
+  border: '1px solid var(--border)',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+  fontSize: '0.8125rem',
+  lineHeight: 1.4,
+  color: 'var(--text)',
+  pointerEvents: 'none',
+  zIndex: 20,
+})

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -1,0 +1,749 @@
+import type { ChatScrollRailProps } from './ChatScrollRail'
+import type { VirtualItem } from './useChatVirtualizer'
+import type { ChatRailData } from '~/stores/chatMessageMarks'
+import { fireEvent, render } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { SCRUB_WARM_DEBOUNCE_MS } from './chatDotPreview'
+import { resolveScrollbarOwner } from './chatRailPolicy'
+import { ChatScrollRail } from './ChatScrollRail'
+import * as styles from './ChatScrollRail.css'
+import { rowStartSeqs } from './chatScrollRailGeometry'
+
+// jsdom does no layout, so clientHeight is 0 everywhere. Force a fixed viewport height
+// for the whole test file so the rail measures a non-zero height and the scroll metrics
+// are meaningful. Restored after each test.
+const VIEWPORT_H = 400
+let clientHeightSpy: PropertyDescriptor | undefined
+
+/** Flush pending microtasks (a macrotask runs after every queued microtask). */
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+/** Run drag pointermove frames synchronously; jsdom has no real frame clock. */
+function installImmediateRaf() {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+}
+
+beforeEach(() => {
+  clientHeightSpy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => VIEWPORT_H })
+})
+afterEach(() => {
+  if (clientHeightSpy)
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightSpy)
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+/** A scroll container with defined scroll geometry (clientHeight comes from the prototype spy). */
+function makeScrollEl(scrollTop = 0, scrollHeight = 500): HTMLDivElement {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true })
+  el.scrollTop = scrollTop
+  return el
+}
+
+// Accepts flat rail-field overrides (loaded/minSeq/maxSeq/marks/window*) for test convenience and
+// assembles them into the single `rail: ChatRailData` prop, so existing `baseProps({ minSeq, maxSeq,
+// marks })` call sites keep working after the prop shape moved to a ChatRailData object.
+type BasePropsOverrides = Partial<Omit<ChatScrollRailProps, 'rail'>> & Partial<ChatRailData>
+
+function baseProps(overrides: BasePropsOverrides = {}): ChatScrollRailProps {
+  const items: VirtualItem[] = [1n, 2n, 3n, 4n, 5n].map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+  const { loaded, minSeq, maxSeq, marks, windowFirstSeq, windowLastSeq, hidden, ...rest } = overrides
+  const rail: ChatRailData = {
+    loaded: loaded ?? true,
+    minSeq: minSeq ?? 1n,
+    maxSeq: maxSeq ?? 5n,
+    marks: marks ?? [
+      { seq: 2n, type: MarkType.USER_MESSAGE },
+      { seq: 4n, type: MarkType.CONTROL_RESPONSE },
+    ],
+    windowFirstSeq: windowFirstSeq ?? 1n,
+    windowLastSeq: windowLastSeq ?? 5n,
+  }
+  const totalHeight = rest.totalHeight ?? 500
+  // `hidden` is now resolved by the host (ChatView), not the rail. Default it here the same way
+  // ChatView does -- one resolveScrollbarOwner call off the flat fields (VIEWPORT_H is the
+  // content-box height the clientHeight spy reports) -- so the pre-existing render/hide tests keep
+  // their intent; a test that drives hiding reactively passes `hidden` explicitly instead.
+  const resolvedHidden = resolveScrollbarOwner({
+    loaded: rail.loaded,
+    itemCount: items.length,
+    rowSeqs: rowStartSeqs(items),
+    range: { minSeq: rail.minSeq, maxSeq: rail.maxSeq },
+    hasMoreOlder: rest.hasMoreOlder ?? false,
+    hasMoreNewer: rest.hasMoreNewer ?? false,
+    totalHeight,
+    viewportHeight: VIEWPORT_H,
+  }) !== 'rail'
+  return {
+    scrollEl: makeScrollEl(),
+    items,
+    offsetOfIndex: i => i * 100, // totalHeight 500, 5 rows of 100px
+    totalHeight: 500,
+    geometryVersion: 0,
+    railRowSeqs: rowStartSeqs(items), // ChatView computes this once and passes it down (see F2)
+    rail,
+    hidden: hidden ?? resolvedHidden,
+    hasMoreOlder: false,
+    hasMoreNewer: false,
+    onJumpToSeq: vi.fn(),
+    previewScrollTo: vi.fn(),
+    ...rest,
+  }
+}
+
+describe('chatscrollrail', () => {
+  it('renders nothing when not loaded', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps({ loaded: false })} />)
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+  })
+
+  it('renders nothing for an empty conversation (maxSeq 0)', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 0n, maxSeq: 0n, marks: [] })} />)
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+  })
+
+  it('disconnects the rail ResizeObserver when the rail hides', async () => {
+    const instances: { disconnect: ReturnType<typeof vi.fn> }[] = []
+    class MockResizeObserver {
+      disconnect = vi.fn()
+      observe = vi.fn()
+
+      constructor() {
+        instances.push(this)
+      }
+    }
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+    const [hidden, setHidden] = createSignal(false)
+    const base = baseProps()
+    const { container } = render(() => <ChatScrollRail {...base} hidden={hidden()} />)
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).not.toBeNull()
+    const disconnectsBeforeHide = instances.reduce((sum, ro) => sum + ro.disconnect.mock.calls.length, 0)
+
+    setHidden(true)
+    await Promise.resolve()
+
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+    const disconnectsAfterHide = instances.reduce((sum, ro) => sum + ro.disconnect.mock.calls.length, 0)
+    expect(disconnectsAfterHide).toBeGreaterThan(disconnectsBeforeHide)
+  })
+
+  it('renders a dot per mark, centered on its seq band, with data attributes', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    expect(dots.length).toBe(2)
+    // Dots sit on the thumb-CENTRE axis: fixed thumb 24px -> centre travels [12, 388].
+    // dotFraction(2)=0.3 -> 12+0.3*376=124.8; dotFraction(4)=0.7 -> 275.2.
+    expect((dots[0] as HTMLElement).style.top).toBe('125px')
+    expect(dots[0].getAttribute('data-seq')).toBe('2')
+    expect(dots[0].getAttribute('data-mark-type')).toBe(String(MarkType.USER_MESSAGE))
+    expect((dots[1] as HTMLElement).style.top).toBe('275px')
+    expect(dots[1].getAttribute('data-seq')).toBe('4')
+    expect(dots[1].getAttribute('data-mark-type')).toBe(String(MarkType.CONTROL_RESPONSE))
+  })
+
+  it('keeps the same dot DOM nodes when maxSeq bumps without moving a dot pixel (no per-row rebuild)', () => {
+    // maxSeq ticks up on every persisted row during a streaming turn. On a long history a
+    // +1 seq bump rounds to the same dot pixels, so the content-compared dots memo must keep
+    // the SAME array reference -- else <For> tears down and rebuilds every dot's Tooltip.
+    const [maxSeq, setMaxSeq] = createSignal(100_000n)
+    const marks = [
+      { seq: 50_000n, type: MarkType.USER_MESSAGE },
+      { seq: 75_000n, type: MarkType.CONTROL_RESPONSE },
+    ]
+    const base = baseProps({ minSeq: 1n, marks, hasMoreOlder: true, hasMoreNewer: true })
+    const { container } = render(() => (
+      <ChatScrollRail {...base} rail={{ ...base.rail, maxSeq: maxSeq() }} />
+    ))
+    const before = Array.from(container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]'))
+    expect(before.length).toBe(2)
+    setMaxSeq(100_001n) // a streamed row bumps the live tail; the dots don't move
+    const after = Array.from(container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]'))
+    expect(after.length).toBe(2)
+    // Same element instances => <For> reused the rows, so the Tooltips were not rebuilt.
+    expect(after[0]).toBe(before[0])
+    expect(after[1]).toBe(before[1])
+  })
+
+  it('clusters marks that round to the same rail pixel into one dot carrying a count', () => {
+    // Three marks a few seqs apart in a huge history collapse to the same pixel -- they
+    // become ONE cluster of count 3 (not dropped), so none of the three is lost.
+    const marks = [
+      { seq: 500n, type: MarkType.USER_MESSAGE },
+      { seq: 501n, type: MarkType.USER_MESSAGE },
+      { seq: 502n, type: MarkType.USER_MESSAGE },
+    ]
+    const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    expect(dots.length).toBe(1)
+    expect(dots[0].getAttribute('data-count')).toBe('3')
+    expect(dots[0].getAttribute('aria-label')).toBe('3 messages')
+    // The cluster gets the extra-ring variant class so it reads as multiple.
+    expect((dots[0] as HTMLElement).className).toContain(styles.dotCluster)
+  })
+
+  it('jumps to the cluster member nearest the pixel centre on click, and warms it', () => {
+    const onJumpToSeq = vi.fn()
+    const warmPreview = vi.fn()
+    // seqs 500..502 in [1, 100000] all round to the same pixel on the thumb-centre axis; of
+    // the three, 502's exact position is nearest that pixel centre -> representative seq 502.
+    const marks = [
+      { seq: 500n, type: MarkType.USER_MESSAGE },
+      { seq: 501n, type: MarkType.USER_MESSAGE },
+      { seq: 502n, type: MarkType.USER_MESSAGE },
+    ]
+    const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks, onJumpToSeq, warmPreview })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    expect(dot.getAttribute('data-seq')).toBe('502')
+    fireEvent.pointerEnter(dot)
+    expect(warmPreview).toHaveBeenCalledWith(502n)
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(502n)
+  })
+
+  it('fires onJumpToSeq with the dot seq on a dot pointerdown', () => {
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(2n)
+  })
+
+  it('jumps to the dot seq on keyboard Enter / Space (keyboard activation), ignoring other keys', () => {
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenLastCalledWith(2n)
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenLastCalledWith(2n)
+    expect(onJumpToSeq).toHaveBeenCalledTimes(2) // exactly one jump per activation, no double
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(2) // an unrelated key does nothing
+  })
+
+  it('renders the thumb from the computed seq-space rect', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb).toBeTruthy()
+    // The seq-space visible span affects top projection, but rendered thumb height is fixed.
+    expect(thumb.style.height).toBe('24px')
+    expect(thumb.style.top).toBe('0px')
+  })
+
+  it('consumes the railRowSeqs prop rather than recomputing it (no thumb when it is null)', () => {
+    // F2: ChatView computes rowStartSeqs ONCE and hands it down. The rail must use that prop, so a
+    // null railRowSeqs (no server anchor) drops the thumb even though rowStartSeqs(items) would be
+    // non-null -- a rail that recomputed from `items` would (wrongly) still render a thumb here.
+    const { container } = render(() => <ChatScrollRail {...baseProps({ railRowSeqs: null })} />)
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).not.toBeNull() // rail still shown
+    expect(container.querySelector('[data-testid="chat-scroll-rail-thumb"]')).toBeNull() // but no thumb
+  })
+
+  it('renders the fixed thumb flush to the bottom at the true bottom edge', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl: makeScrollEl(100, 500) })} />)
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb).toBeTruthy()
+    expect(thumb.style.height).toBe('24px')
+    expect(thumb.style.top).toBe('376px')
+  })
+
+  it('insets the track to the thumb-centre travel range (ends = where the thumb centre reaches)', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    // thumb 24px -> thumbHalf 12, so the track is inset 12px at top AND bottom (its ends
+    // sit where the thumb centre can reach, not at the rail edges).
+    const track = container.querySelector(`.${styles.track}`) as HTMLElement
+    expect(track).toBeTruthy()
+    expect(track.style.top).toBe('12px')
+    expect(track.style.bottom).toBe('12px')
+  })
+
+  it('maps a track click (below the thumb) to a seq via onJumpToSeq', () => {
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    // Give the rail a concrete rect (jsdom returns zeros otherwise).
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // The thumb spans 0..24px, so click at y=360 (track region) maps near the bottom -> seq 5.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360 }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+  })
+
+  it('forwards a wheel over the rail to the chat scroll container (no dead zone)', () => {
+    // scrollEl: scrollTop 0, scrollHeight 500, clientHeight 400 -> max scrollTop 100.
+    const scrollEl = makeScrollEl(0, 500)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 60 }))
+    expect(scrollEl.scrollTop).toBe(60)
+    // A large downward wheel clamps at the max scroll rather than overrunning.
+    rail.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 9999 }))
+    expect(scrollEl.scrollTop).toBe(100)
+  })
+
+  it('forwards wheel intent to the chat scroll container so edge pagination still runs', () => {
+    const scrollEl = makeScrollEl(100, 500)
+    const onScrollWheel = vi.fn()
+    scrollEl.addEventListener('wheel', onScrollWheel)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+
+    rail.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 60 }))
+
+    expect(onScrollWheel).toHaveBeenCalledTimes(1)
+    expect(onScrollWheel.mock.calls[0][0].deltaY).toBe(60)
+  })
+
+  it('normalizes line-mode and page-mode wheel deltas to pixels', () => {
+    // Line mode (deltaMode 1): 3 lines * WHEEL_LINE_PX(16) = 48px.
+    const lineEl = makeScrollEl(0, 500)
+    const { container: c1 } = render(() => <ChatScrollRail {...baseProps({ scrollEl: lineEl })} />)
+    ;(c1.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement)
+      .dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 3, deltaMode: 1 }))
+    expect(lineEl.scrollTop).toBe(48)
+    // Page mode (deltaMode 2): 1 page * clientHeight(400), clamped at max scroll (100).
+    const pageEl = makeScrollEl(0, 500)
+    const { container: c2 } = render(() => <ChatScrollRail {...baseProps({ scrollEl: pageEl })} />)
+    ;(c2.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement)
+      .dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 1, deltaMode: 2 }))
+    expect(pageEl.scrollTop).toBe(100)
+  })
+
+  it('drags the thumb: live-scrolls in-window on grab and seeks the mapped seq on release', () => {
+    // jsdom has no pointer capture; stub it so startDrag doesn't throw.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const previewScrollTo = vi.fn()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ previewScrollTo, onJumpToSeq })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    // Concrete rail rect (top 0, height 400). The fixed thumb spans 0..24px at the top,
+    // so its CENTRE axis is [12, 388].
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    previewScrollTo.mockClear()
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    // Move to the axis midpoint y=200 -> fraction 0.5 -> seqF = 1 + 0.5*4 = 3.
+    // Seq 3 is in the loaded window, so the drag live-scrolls to its content-Y (row 2 top = 200px).
+    expect(previewScrollTo).toHaveBeenCalledWith(200)
+    // Release at the same y -> fractionToSeq(0.5, 1, 5) = 3.
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(3n)
+  })
+
+  it('fires onSeekInterrupt on a thumb grab (abandon a prior seek) but NOT on a track click', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onSeekInterrupt = vi.fn()
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ onSeekInterrupt })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // A track click (below the thumb at 0..24) supersedes any pending seek via its own jump,
+    // so it must NOT also fire onSeekInterrupt.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    expect(onSeekInterrupt).not.toHaveBeenCalled()
+    // A thumb grab (on the thumb at y=12) is manual control: abandon a prior release's
+    // still-fetching out-of-window seek so it can't yank the viewport mid-scrub.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 2 }))
+    expect(onSeekInterrupt).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a second pointerdown on the track while a thumb-drag is live (no rival seek)', () => {
+    // jsdom has no pointer capture; stub it so startDrag doesn't throw.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ onJumpToSeq })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // A first pointer grabs the thumb (spans 0..24) -> a live drag is in progress.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    // A SECOND pointer lands on the TRACK (below the thumb) mid-drag: without the drag guard it
+    // would fire a rival onJumpToSeq that races the drag's live-scroll and its release seek.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 2 }))
+    expect(onJumpToSeq).not.toHaveBeenCalled()
+    // The original drag still releases normally into exactly ONE seek.
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds the thumb through an ambient metrics change while the seek is in flight (no early flash)', async () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    // A pending (out-of-window) seek: it awaits a fetch before the landing scrolls.
+    let landSeek!: (scrolled: boolean) => void
+    const onJumpToSeq = vi.fn(() => new Promise<boolean>((r) => {
+      landSeek = r
+    }))
+    const [geometryVersion, setGeometryVersion] = createSignal(0)
+    // hasMoreOlder/Newer so the thumb isn't a full-height (hidden) thumb, and there's remote
+    // history the drag could target out-of-window (where the flash was worst).
+    const scrollEl = makeScrollEl(0, 500)
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ scrollEl, onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} geometryVersion={geometryVersion()} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Grab the fixed thumb (spans 0..24) and release at a DIFFERENT position.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    // Held after release: the thumb did NOT revert to its metrics-derived (pre-drag) position.
+    expect(thumb.className).toContain(styles.thumbDragging)
+    // The window swaps / streaming commits WHILE the seek's fetch is still in flight -- an
+    // ambient metrics change. The OLD hold cleared on the first such change, flashing the thumb
+    // back before the landing; the fix keeps it pinned until the seek itself resolves.
+    scrollEl.scrollTop = 100
+    setGeometryVersion(1)
+    await Promise.resolve()
+    expect(thumb.className).toContain(styles.thumbDragging) // still held -- no early hand-off
+    // The seek finally resolves (here scrolled=false: the landing had nowhere to scroll), so the
+    // hold clears on the seek's own resolution and the thumb hands off rather than staying stuck.
+    landSeek(false)
+    await tick()
+    expect(thumb.className).not.toContain(styles.thumbDragging)
+  })
+
+  it('clears the held thumb when the release-seek scrolls nowhere (no stuck dragging state)', async () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    // The seek resolves false: the landing produced no scroll (target already at this scrollTop,
+    // or no landable row), so no landing scroll -- and thus no clear frame -- will come. The
+    // hold must clear on the seek's own resolution instead, or the thumb stays stuck dragging.
+    const onJumpToSeq = vi.fn(() => Promise.resolve(false))
+    const scrollEl = makeScrollEl(0, 500)
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ scrollEl, onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    // Held immediately after release (the anti-flash hold is armed)...
+    expect(thumb.className).toContain(styles.thumbDragging)
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    // ...but once the seek resolves with scrolled=false, the fallback clears the hold even
+    // though no metrics change ever fires -- so the thumb can't stay stuck dragging forever.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(thumb.className).not.toContain(styles.thumbDragging)
+  })
+
+  it('ignores a second concurrent grab while a drag is live (no orphaned listener set)', () => {
+    const capture = vi.fn()
+    HTMLElement.prototype.setPointerCapture = capture
+    const { container } = render(() => <ChatScrollRail {...baseProps({ hasMoreOlder: true, hasMoreNewer: true })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // First grab on the fixed thumb (spans 0..24) captures pointer 1.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    expect(capture).toHaveBeenCalledTimes(1)
+    // A second finger lands on the thumb mid-drag: the guard drops it (no rival capture/listeners).
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 14, pointerId: 2 }))
+    expect(capture).toHaveBeenCalledTimes(1)
+    // The first drag releases, freeing the guard; a fresh grab then captures again.
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 14, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 3 }))
+    expect(capture).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels an active thumb drag when the rail hides', async () => {
+    const capture = vi.fn()
+    const release = vi.fn()
+    HTMLElement.prototype.setPointerCapture = capture
+    HTMLElement.prototype.releasePointerCapture = release
+    installImmediateRaf()
+    const [hidden, setHidden] = createSignal(false)
+    const base = baseProps({ hasMoreOlder: true, hasMoreNewer: true })
+    const { container } = render(() => (
+      <ChatScrollRail {...base} hidden={hidden()} />
+    ))
+    let rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    expect(capture).toHaveBeenCalledTimes(1)
+
+    setHidden(true)
+    await Promise.resolve()
+
+    expect(release).toHaveBeenCalledWith(1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+
+    setHidden(false)
+    await Promise.resolve()
+
+    rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 2 }))
+    expect(capture).toHaveBeenCalledTimes(2)
+  })
+
+  it('reveals the preview popover for the dot the thumb passes over while dragging, and warms it after it settles', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    vi.useFakeTimers()
+    installImmediateRaf() // override the faked rAF with a synchronous one for the drag frames
+    const warmPreview = vi.fn()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'scrubbed message two' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview, previewFor })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // No popover until a drag is in progress (and nothing is hovered).
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+    // Grab the fixed thumb, then scrub to the seq-2 dot at y=125.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 125, pointerId: 1 }))
+    const preview = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
+    expect(preview.length).toBe(1) // never two popovers
+    expect(preview[0]).toHaveTextContent('scrubbed message two')
+    // The scrub warm is DEBOUNCED: nothing is fetched until the thumb settles on the dot, so a
+    // fast fly-over doesn't fire a GetAgentMessage RPC per dot crossed.
+    expect(warmPreview).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(SCRUB_WARM_DEBOUNCE_MS)
+    expect(warmPreview).toHaveBeenCalledWith(2n)
+  })
+
+  it('coalesces a fast scrub: only the dot the thumb settles on is warmed, not the ones flown over', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    vi.useFakeTimers()
+    // A DEFERRED rAF (drained by flushRaf) rather than the synchronous installImmediateRaf: the
+    // coalescer resets its rafId inside its dispatch, so back-to-back moves in one synchronous run
+    // need a real frame boundary between them for BOTH to apply (a synchronous rAF leaves rafId
+    // set from its own return value, swallowing the second push).
+    const rafQueue: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => rafQueue.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const flushRaf = () => rafQueue.splice(0).forEach(cb => cb(0))
+    const warmPreview = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Grab the thumb, pass OVER the seq-2 dot (y=125), then move on to seq-4 (y=275) BEFORE the
+    // debounce elapses -- the second move supersedes the first dot's pending warm.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    flushRaf()
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 125, pointerId: 1 }))
+    flushRaf()
+    vi.advanceTimersByTime(SCRUB_WARM_DEBOUNCE_MS - 20) // not yet settled on seq-2
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 275, pointerId: 1 }))
+    flushRaf()
+    vi.advanceTimersByTime(SCRUB_WARM_DEBOUNCE_MS)
+    expect(warmPreview).toHaveBeenCalledTimes(1)
+    expect(warmPreview).toHaveBeenCalledWith(4n) // only the settled dot, never the flown-over seq-2
+  })
+
+  it('shows no preview popover when the dragging thumb is between dots', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // y=200 -> thumb centre 200; dots sit at 125 and 275, both >12px away -> no scrub target.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('shows ONE popover (the scrub target wins) when a dot is hovered while scrubbing', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'scrub target two' : seq === 4n ? 'hovered four' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Scrub over the seq-2 dot (thumb centre 125), then also hover the seq-4 dot.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 125, pointerId: 1 }))
+    const dot4 = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="4"]') as HTMLElement
+    fireEvent.pointerEnter(dot4)
+    const previews = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
+    expect(previews.length).toBe(1) // exactly one popover, no double
+    expect(previews[0]).toHaveTextContent('scrub target two') // scrub wins over the hover
+    expect(previews[0]).not.toHaveTextContent('hovered four')
+  })
+
+  it('warms a mark preview on dot hover, keyed by the dot seq', () => {
+    const warmPreview = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    expect(warmPreview).toHaveBeenCalledWith(2n)
+  })
+
+  it('labels each dot for accessibility by its mark type', () => {
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    expect(dots[0].getAttribute('aria-label')).toBe('Your message')
+    expect(dots[1].getAttribute('aria-label')).toBe('Your response')
+  })
+
+  it('hides the rail when the whole conversation is loaded and fits (thumb would be full)', () => {
+    // clientHeight (400) >= totalHeight requires content that fits; use a short total.
+    const items: VirtualItem[] = [1n, 2n].map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+    const { container } = render(() => (
+      <ChatScrollRail
+        {...baseProps({
+          items,
+          offsetOfIndex: i => i * 100,
+          totalHeight: 200, // < clientHeight (400): no scroll
+          scrollEl: makeScrollEl(0, 400),
+          minSeq: 1n,
+          maxSeq: 2n,
+          windowFirstSeq: 1n,
+          windowLastSeq: 2n,
+          hasMoreOlder: false,
+          hasMoreNewer: false,
+        })}
+      />
+    ))
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+  })
+
+  it('keeps the rail visible when a big seq gap makes the seq-space share ~1 but the content overflows in pixels', () => {
+    // Whole conversation loaded (no more older/newer), only two visible server rows: a tiny
+    // seq-1 row and a huge seq-1000 row (seqs 2..999 deleted/hidden absorb into the gap). The
+    // seq-space visibleFraction rounds to ~1 (the loaded window covers ~the whole seq range),
+    // but the content overflows the viewport in PIXELS (2020px > 400px), so a scrollbar IS
+    // needed. The rail must stay visible -- else, with the native scrollbar hidden by
+    // hideNativeScrollbar, the viewport would have no usable scrollbar at all.
+    const items: VirtualItem[] = [1n, 1000n].map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+    const { container } = render(() => (
+      <ChatScrollRail
+        {...baseProps({
+          items,
+          offsetOfIndex: i => i * 20, // row0 [0,20], row1 [20,2020]
+          totalHeight: 2020, // >> clientHeight (400): overflows in pixels
+          scrollEl: makeScrollEl(0, 2020),
+          minSeq: 1n,
+          maxSeq: 1000n,
+          windowFirstSeq: 1n,
+          windowLastSeq: 1000n,
+          hasMoreOlder: false,
+          hasMoreNewer: false,
+        })}
+      />
+    ))
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).not.toBeNull()
+  })
+
+  it('keeps the rail visible when the loaded content fits but older history remains off-window', () => {
+    // The pixel-fits self-hide is gated on the WHOLE conversation being loaded
+    // (!hasMoreOlder && !hasMoreNewer). Here the loaded window fits the viewport in pixels
+    // (200px < 400px) yet older history exists off-window, so the rail must stay visible --
+    // it is the only way to jump into that unloaded history.
+    const items: VirtualItem[] = [10n, 11n, 12n, 13n, 14n].map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+    const { container } = render(() => (
+      <ChatScrollRail
+        {...baseProps({
+          items,
+          offsetOfIndex: i => i * 40,
+          totalHeight: 200, // < clientHeight (400): the loaded window fits in pixels
+          scrollEl: makeScrollEl(0, 400),
+          minSeq: 1n, // whole-history floor is far below the loaded window
+          maxSeq: 14n,
+          windowFirstSeq: 10n,
+          windowLastSeq: 14n,
+          hasMoreOlder: true,
+          hasMoreNewer: false,
+        })}
+      />
+    ))
+    expect(container.querySelector('[data-testid="chat-scroll-rail"]')).not.toBeNull()
+  })
+})
+
+describe('chatscrollrail dot preview popover', () => {
+  /** Hover the first dot -- the popover opens IMMEDIATELY (no show-delay), and returns it. */
+  function hoverFirstDot(container: HTMLElement): HTMLElement | null {
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    return container.querySelector('[data-testid="chat-scroll-rail-preview"]')
+  }
+
+  it('clamps the popover into the rail so a dot near the top edge does not clip past it', () => {
+    // With the fixed 24px thumb, the seq-1 dot sits at ~12px,
+    // above the popover's clamp floor. The popover top is pinned down to keep the card visible.
+    const marks = [{ seq: 1n, type: MarkType.USER_MESSAGE }]
+    const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    expect(dot.style.top).toBe('12px') // the dot itself is near the top
+    fireEvent.pointerEnter(dot)
+    const popover = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    expect(popover.style.top).toBe('100px') // clamped down from 12 (rail 400, half-height 100)
+  })
+
+  it('opens the popover immediately on hover and renders the resolved preview as markdown', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? '**jump** to this message' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const popover = hoverFirstDot(container)! // no timers advanced -- it's immediate
+    expect(popover).toHaveTextContent('jump to this message')
+    // The markdown is rendered, not shown as raw source: **jump** becomes a bold element.
+    const strong = popover.querySelector('strong, b')
+    expect(strong?.textContent).toBe('jump')
+    expect(popover.textContent).not.toContain('**')
+  })
+
+  it('closes the popover when the pointer leaves the dot', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'hi there' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+    fireEvent.pointerLeave(dot)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('closes the popover when the hovered dot disappears', async () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'stale preview' : undefined)
+    const [marks, setMarks] = createSignal([{ seq: 2n, type: MarkType.USER_MESSAGE }])
+    const { container } = render(() => <ChatScrollRail {...baseProps({ marks: marks(), previewFor })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toHaveTextContent('stale preview')
+
+    setMarks([])
+    await Promise.resolve()
+
+    expect(container.querySelector('[data-testid="chat-scroll-rail-dot"]')).toBeNull()
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('shows a loading line while the preview is unresolved', () => {
+    const previewFor = () => undefined // never resolves within the test
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    expect(hoverFirstDot(container)).toHaveTextContent('Loading preview…')
+  })
+
+  it('falls back to the mark-type label when the preview resolved empty', () => {
+    const previewFor = () => '' // resolved, but no previewable text
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    expect(hoverFirstDot(container)).toHaveTextContent('Your message')
+  })
+
+  it('shows an aggregate "N messages" header plus the representative preview for a cluster', () => {
+    // seqs 500..502 in [1, 100000] collapse to one pixel -> a cluster of 3; on the centre axis
+    // 502 is nearest the pixel centre -> representative 502.
+    const marks = [
+      { seq: 500n, type: MarkType.USER_MESSAGE },
+      { seq: 501n, type: MarkType.USER_MESSAGE },
+      { seq: 502n, type: MarkType.USER_MESSAGE },
+    ]
+    const previewFor = (seq: bigint) => (seq === 502n ? 'the nearest message' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks, previewFor })} />)
+    const popover = hoverFirstDot(container)!
+    expect(popover).toHaveTextContent('3 messages') // the aggregate header
+    expect(popover).toHaveTextContent('the nearest message') // the representative's preview
+  })
+})

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -1,0 +1,427 @@
+import type { DotCluster } from './chatRailPolicy'
+import type { PreparedGeometry } from './chatScrollRailGeometry'
+import type { VirtualItem } from './useChatVirtualizer'
+import type { ChatRailData } from '~/stores/chatMessageMarks'
+import { createEffect, createMemo, createSignal, For, onCleanup, Show } from 'solid-js'
+import { createDotPreview } from './chatDotPreview'
+import { clusterMarks, dotClustersEqual } from './chatRailPolicy'
+import { clampScrollTop } from './chatScrollGeometry'
+import * as styles from './ChatScrollRail.css'
+import { createThumbDrag } from './chatScrollRailDrag'
+import { createDragReleaseHold } from './chatScrollRailDragHold'
+import {
+  computeSeqThumb,
+  dragThumbPx,
+  fixedThumbHeightPx,
+  fractionToSeq,
+  projectThumbPx,
+  railYToSeq,
+} from './chatScrollRailGeometry'
+import { createRailMetrics } from './chatScrollRailMetrics'
+import { dotLabel, DotPreview } from './ChatScrollRailPreview'
+
+// ---------------------------------------------------------------------------
+// Seq-space scroll rail
+//
+// A custom scrollbar drawn over the WHOLE conversation [minSeq..maxSeq] (not just the
+// ~150-message virtualized window), with teal jump dots for marked messages. This component
+// orchestrates the extracted pieces and owns only the wiring + render:
+//   - createRailMetrics      -- samples the scroll container reactively.
+//   - chatScrollRailGeometry -- pure seq<->pixel math, the thumb rect, and dot clustering.
+//   - createThumbDrag        -- the pointer-capture drag lifecycle.
+//   - createDragReleaseHold  -- pins the thumb at its release fraction until the seek settles.
+//   - ChatScrollRailPreview  -- the dot hover/scrub tooltip presentation.
+// ---------------------------------------------------------------------------
+
+/** Wheel-line height (px) used to translate line/page wheel deltas into pixels. */
+const WHEEL_LINE_PX = 16
+
+/** Fixed thumb height so the rail shows position without encoding viewport size. */
+const THUMB_HEIGHT_PX = 24
+
+export interface ChatScrollRailProps {
+  /** The chat scroll container (the element the native scrollbar was hidden on). */
+  scrollEl: HTMLDivElement | undefined
+  /** Visible virtual rows (ascending; trailing optimistic locals carry seq 0n). */
+  items: readonly VirtualItem[]
+  /** Content-Y of the top of row `i`. */
+  offsetOfIndex: (index: number) => number
+  /** Total virtual content height (px). */
+  totalHeight: number
+  /** Bumped by the virtualizer whenever the offset map changes (measurement/prepend/trim). */
+  geometryVersion: number
+  /**
+   * The rows' precomputed rowStartSeqs (null when the window holds no server row). Computed ONCE
+   * by ChatView (which needs it for the scroll-owner resolution) and passed down so the O(n)
+   * row-seq scan isn't repeated here -- see ChatView.railRowSeqs.
+   */
+  railRowSeqs: number[] | null
+  /**
+   * The seq-space rail data (loaded flag, whole-history min/max seq range, marked seqs, and the
+   * loaded window's first/last server seq) as the SINGLE {@link ChatRailData} shape the store's
+   * getRailData produces -- rather than re-flattening those six fields, which the view would then
+   * have to keep in hand-sync (the exact drift ChatRailData exists to prevent).
+   */
+  rail: ChatRailData
+  /**
+   * Whether the rail hides itself, resolved by ChatView (railOwner() !== 'rail') so the ONE
+   * scrollbar-owner decision -- and its single viewport-height source -- drives both this and the
+   * native-scrollbar hide. The rail no longer re-resolves ownership from its own metrics: a second
+   * evaluation against a different (padding-box) height was what could strand a viewport with zero
+   * or two scrollbars. See resolveScrollbarOwner.
+   */
+  hidden: boolean
+  hasMoreOlder: boolean
+  hasMoreNewer: boolean
+  /**
+   * Seek to a seq (dot click, track click, thumb release). May resolve to whether the seek
+   * actually moved the view -- the thumb-drag release awaits this to time its preview
+   * hand-off; the dot/track callers ignore the result.
+   */
+  onJumpToSeq: (seq: bigint) => void | Promise<boolean>
+  /** Guard-marked programmatic scroll write for in-window thumb-drag live-scrolling. */
+  previewScrollTo: (top: number) => void
+  /**
+   * A fresh thumb-drag grab began. Lets the host abandon an in-flight out-of-window seek
+   * (from a PRIOR release) so its late fetch can't yank the viewport mid-scrub -- the
+   * drag's own scroll writes are programmatic and never trip the host's user-scroll
+   * cancellation. Optional; the dot/track jump paths supersede the seek on their own.
+   */
+  onSeekInterrupt?: () => void
+  /**
+   * Reactive read of a marked message's hover-preview text: undefined = not resolved
+   * yet, '' = resolved with no previewable text (show a label), else the snippet.
+   */
+  previewFor?: (seq: bigint) => string | undefined
+  /** Kick off resolving a mark's preview (dot hover). Idempotent + deduped upstream. */
+  warmPreview?: (seq: bigint) => void
+}
+
+export function ChatScrollRail(props: ChatScrollRailProps) {
+  // The rail overlay's own pixel height, for thumb sizing and dot placement.
+  const [railHeight, setRailHeight] = createSignal(0)
+
+  let railEl: HTMLDivElement | undefined
+  let railResizeObserver: ResizeObserver | undefined
+  let dragCleanup: (() => void) | undefined
+
+  // Scroll-container metrics (scrollTop / dist-from-bottom / clientHeight), sampled reactively
+  // via a passive scroll listener + ResizeObserver and re-sampled on a geometry commit.
+  const metrics = createRailMetrics({
+    scrollEl: () => props.scrollEl,
+    totalHeight: () => props.totalHeight,
+    geometryVersion: () => props.geometryVersion,
+  })
+
+  // The drag-release "hold": the preview thumb fraction (null when idle) plus the state machine
+  // that pins it at the release fraction until the post-release seek scrolls the view to match.
+  // It clears one frame after the seek RESOLVES (not on the first ambient metrics change), so an
+  // out-of-window seek's in-flight window swap / streaming churn can't hand off before the landing.
+  const dragHold = createDragReleaseHold()
+  const drag = dragHold.fraction
+
+  // The (n+1)-length row-seq map is computed ONCE in ChatView (railRowSeqs, memoized on the item
+  // list) and handed down as a prop -- the scroll-owner resolution there already needs it, so the
+  // O(n) row-seq scan runs once per item-list change instead of twice. The thin `geo` wrapper still
+  // rebuilds per streaming-height commit (its offsets moved) while reusing that row-seq map
+  // unchanged, so the scan stays off the streaming-commit path exactly as before.
+  const prepared = createMemo<PreparedGeometry>(() => ({
+    geo: { items: props.items, offsetOfIndex: props.offsetOfIndex, totalHeight: props.totalHeight },
+    rowSeqs: props.railRowSeqs,
+  }))
+
+  // The current thumb height in px. Used to inset the thumb-CENTRE axis: dots, the track, and
+  // track-clicks all map onto [thumbHalf, railHeight - thumbHalf] -- the range the thumb centre
+  // can occupy -- so a dot always lines up with the thumb centre. Matches thumbPx's height in
+  // both the resting and drag branches.
+  const thumbHeightNow = createMemo(() => fixedThumbHeightPx(railHeight(), THUMB_HEIGHT_PX))
+
+  // Dots, deduped by rounded rail pixel: many marks in a tall history collapse to the same
+  // pixel, so they CLUSTER (one dot standing for its `count` marks) rather than dropping the
+  // collisions. See clusterMarks. Compared by CONTENT (dotClustersEqual) so an unchanged
+  // layout keeps the SAME array reference: maxSeq ticks up on every persisted row during a
+  // streaming turn, but on a long conversation a +1 seq shift rounds to the same clusters, so
+  // recomputing would otherwise hand <For> a fresh array each frame and tear down + rebuild
+  // every dot's tooltip (3 effects + 5 listeners each) for no visual change.
+  const dots = createMemo<DotCluster[]>(
+    // props.rail is a ChatRailData -- a structural superset of RailRange -- so pass it straight
+    // through as the range rather than re-flattening {minSeq, maxSeq} (which the two would then
+    // have to keep in hand-sync, the drift ChatRailData exists to prevent; see the `rail` prop).
+    () => clusterMarks(props.rail.marks, props.rail, railHeight(), thumbHeightNow()),
+    [],
+    { equals: dotClustersEqual },
+  )
+
+  // The dot-preview state machine (which dot the single popover describes, its placement, and when
+  // to warm its preview) extracted into its own unit alongside createRailMetrics /
+  // createDragReleaseHold / createThumbDrag, so this component owns only the wiring + render.
+  const { activeDot, popoverTopPx, setHoverDot } = createDotPreview({
+    dots,
+    drag,
+    railHeight,
+    thumbHeightPx: thumbHeightNow,
+    warmPreview: seq => props.warmPreview?.(seq),
+  })
+
+  const cancelActiveDrag = () => {
+    const cleanup = dragCleanup
+    dragCleanup = undefined
+    cleanup?.()
+  }
+
+  const disconnectRail = () => {
+    cancelActiveDrag()
+    railResizeObserver?.disconnect()
+    railResizeObserver = undefined
+    railEl = undefined
+    setRailHeight(0)
+    setHoverDot(null)
+  }
+
+  const setRailRef = (el: HTMLDivElement) => {
+    railResizeObserver?.disconnect()
+    railEl = el
+    const ro = new ResizeObserver(() => setRailHeight(el.clientHeight))
+    railResizeObserver = ro
+    ro.observe(el)
+    setRailHeight(el.clientHeight)
+  }
+
+  const thumbRect = createMemo(() => {
+    // While a drag is live the thumb is drawn from the drag fraction (dragThumbPx in
+    // thumbPx), so this resting-thumb geometry is discarded -- bail BEFORE reading metrics
+    // so the drag's per-frame previewScrollTo scroll echoes don't re-run computeSeqThumb's
+    // two seqAtContentY binary searches every rAF for a rect nothing consumes.
+    if (drag() !== null)
+      return null
+    const m = metrics()
+    return computeSeqThumb(prepared(), {
+      scrollTop: m.scrollTop,
+      clientHeight: m.clientHeight,
+      minSeq: props.rail.minSeq,
+      maxSeq: props.rail.maxSeq,
+      hasMoreOlder: props.hasMoreOlder,
+      hasMoreNewer: props.hasMoreNewer,
+      distFromBottomPx: m.dist,
+    })
+  })
+
+  // Hidden unless this rail OWNS scrolling. The decision is resolved ONCE by ChatView
+  // (railOwner) and handed down as `props.hidden`, the exact complement of the native-scrollbar
+  // hide -- so the rail shows precisely when the native bar is hidden. Resolving it here too, from
+  // the rail's own (padding-box) metrics height, is what previously let the two drift and strand
+  // the viewport with zero or two scrollbars; the rail now trusts the single upstream decision.
+  const hidden = () => props.hidden
+
+  createEffect(() => {
+    if (hidden())
+      disconnectRail()
+  })
+
+  const thumbPx = createMemo(() => {
+    const rh = railHeight()
+    if (rh <= 0)
+      return null
+    const dragFraction = drag()
+    if (dragFraction !== null) {
+      // Preview: keep the resting thumb height (thumbHeightNow(), same inputs), positioned so
+      // its CENTRE sits on the same centre axis the dots + track use -- dragThumbPx routes
+      // through centerAxisY, so the "drag thumb lines up with the dots" invariant is one
+      // tested formula rather than an inline re-derivation.
+      return dragThumbPx(dragFraction, rh, thumbHeightNow())
+    }
+    const rect = thumbRect()
+    if (!rect)
+      return null
+    return projectThumbPx(rect, rh, THUMB_HEIGHT_PX)
+  })
+
+  // Land a thumb release: seek to the mapped seq while the hold keeps the thumb pinned at the
+  // release fraction until the seek settles (see createDragReleaseHold.release). The seq and
+  // the jump callback are resolved synchronously here so the seek thunk closes over locals,
+  // not reactive props -- the release runs from a pointer handler, not a tracked scope.
+  const releaseDragAt = (fraction: number) => {
+    const seq = fractionToSeq(fraction, props.rail.minSeq, props.rail.maxSeq)
+    if (seq === null) {
+      dragHold.release(fraction, () => {})
+      return
+    }
+    const jump = props.onJumpToSeq
+    dragHold.release(fraction, () => jump(seq))
+  }
+
+  const startDrag = (event: PointerEvent, rect: DOMRect, thumbTopPx: number) => {
+    const el = railEl
+    // Ignore a second concurrent grab while a drag is live (begin() returns false) -- it would
+    // add a rival listener set and orphan the first's on the rail. begin() also claims the
+    // preview so a prior release's async settle can't clear THIS drag mid-way.
+    if (!el || !dragHold.begin())
+      return
+    // A fresh grab is manual control: abandon a prior release's still-fetching out-of-window
+    // seek so it can't land and yank the viewport while this drag scrubs (the drag scrolls
+    // only programmatically, so the host's user-scroll seek-cancel never fires for it).
+    props.onSeekInterrupt?.()
+    // The drag lifecycle (pointer capture, rAF-throttled move, release/cancel) lives in the
+    // extracted, unit-tested createThumbDrag controller. Accessors hand it the LIVE seq
+    // range/geometry so a mid-drag live-tail advance is picked up on the next move.
+    const handle = createThumbDrag({
+      el,
+      rect,
+      // The thumb's resting top at grab, so the drag holds the pointer's within-thumb offset
+      // (no jump-on-grab) rather than recentering the thumb on the cursor.
+      grabThumbTopPx: thumbTopPx,
+      minSeq: () => props.rail.minSeq,
+      maxSeq: () => props.rail.maxSeq,
+      windowFirstSeq: () => props.rail.windowFirstSeq,
+      windowLastSeq: () => props.rail.windowLastSeq,
+      // `prepared` / `thumbHeightNow` are zero-arg memo accessors -- pass them directly rather
+      // than re-wrapping. (`minSeq` etc. must stay wrapped: they read reactive props lazily.)
+      prepared,
+      thumbHeightPx: thumbHeightNow,
+      setDrag: dragHold.preview,
+      previewScrollTo: top => props.previewScrollTo(top),
+      onRelease: releaseDragAt,
+      // The pointer lifecycle ended (release/cancel/unmount): free the "drag active" guard so
+      // the next grab can start. Fires before onRelease, so the release's preview-hold is intact.
+      onEnd: () => {
+        dragCleanup = undefined
+        dragHold.end()
+      },
+    })
+    // Teardown for an unmount that lands mid-drag (onCleanup below); idempotent, so a
+    // normal release leaving this set is harmless.
+    dragCleanup = () => handle.cancel()
+    handle.start(event.pointerId, event.clientY)
+  }
+
+  // One pointerdown handler for the rail: hit-test the thumb (start a drag) vs the track
+  // (jump to the clicked position). Dots stop propagation so they never reach here.
+  const onRailPointerDown = (event: PointerEvent) => {
+    const el = railEl
+    // Ignore a second pointerdown while a thumb-drag is already live (dragCleanup is set from
+    // startDrag until the pointer lifecycle ends). Without this, a second finger landing on the
+    // TRACK -- the thumb branch is already guarded by dragHold.begin() -- would fire a rival
+    // onJumpToSeq that races the in-progress drag's live-scroll and its eventual release seek.
+    if (!el || hidden() || dragCleanup)
+      return
+    event.preventDefault()
+    const rect = el.getBoundingClientRect()
+    const y = event.clientY - rect.top
+    const tp = thumbPx()
+    // On the thumb -> drag (holding the pointer's within-thumb offset, no jump-on-grab); on the
+    // bare track -> jump to the clicked position.
+    if (tp && y >= tp.topPx && y <= tp.topPx + tp.heightPx) {
+      startDrag(event, rect, tp.topPx)
+    }
+    else {
+      const seq = railYToSeq(y, rect.height, thumbHeightNow(), props.rail)
+      if (seq !== null) {
+        props.onJumpToSeq(seq)
+      }
+    }
+  }
+
+  const onDotPointerDown = (event: PointerEvent, seq: bigint) => {
+    // Prioritize the dot over the thumb/track underneath: jump to its message.
+    event.stopPropagation()
+    event.preventDefault()
+    props.onJumpToSeq(seq)
+  }
+
+  // Keyboard activation of a focused dot. Pointer devices jump on pointerdown (above) and
+  // never fire keydown; the keyboard never fires pointerdown -- so exactly one jump per
+  // activation, and the button's inert native click can't double it. preventDefault stops
+  // Space from also page-scrolling.
+  const onDotKeyDown = (event: KeyboardEvent, seq: bigint) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      props.onJumpToSeq(seq)
+    }
+  }
+
+  // The rail overlays the strip where the native scrollbar used to be, and its ancestors
+  // are overflow:hidden, so a wheel over it would otherwise scroll nothing (a dead zone).
+  // Forward the delta to the chat container as a genuine user scroll -- exactly what
+  // wheeling over the native scrollbar did before it was hidden.
+  const onRailWheel = (event: WheelEvent) => {
+    const el = props.scrollEl
+    if (!el)
+      return
+    el.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: false,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey,
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+      deltaZ: event.deltaZ,
+      deltaMode: event.deltaMode,
+    }))
+    // deltaMode: 0=pixels (trackpads, most mice), 1=lines, 2=pages -- normalize to pixels.
+    const factor = event.deltaMode === 1 ? WHEEL_LINE_PX : event.deltaMode === 2 ? el.clientHeight : 1
+    el.scrollTop = clampScrollTop(el, el.scrollTop + event.deltaY * factor)
+    event.preventDefault()
+  }
+
+  onCleanup(() => {
+    cancelActiveDrag()
+    disconnectRail()
+  })
+
+  return (
+    <Show when={!hidden()}>
+      <div
+        ref={setRailRef}
+        class={styles.rail}
+        data-testid="chat-scroll-rail"
+        onPointerDown={onRailPointerDown}
+        onWheel={onRailWheel}
+      >
+        {/* Inset the track to the thumb-CENTRE travel range so its ends are where the thumb
+            centre can reach (dots live on this same axis), not the thumb's top/bottom edge. */}
+        <div class={styles.track} style={{ top: `${thumbHeightNow() / 2}px`, bottom: `${thumbHeightNow() / 2}px` }} />
+        <Show when={thumbPx()}>
+          {tp => (
+            <div
+              class={`${styles.thumb} ${drag() !== null ? styles.thumbDragging : ''}`}
+              data-testid="chat-scroll-rail-thumb"
+              style={{ top: `${tp().topPx}px`, height: `${tp().heightPx}px` }}
+            />
+          )}
+        </Show>
+        <For each={dots()}>
+          {d => (
+            <button
+              type="button"
+              class={`${styles.dot} ${d.count > 1 ? styles.dotCluster : ''}`}
+              data-testid="chat-scroll-rail-dot"
+              data-seq={d.seq.toString()}
+              data-mark-type={d.type}
+              data-count={d.count}
+              aria-label={dotLabel(d)}
+              style={{ top: `${d.topPx}px` }}
+              // Set/clear the active dot so the shared popover opens immediately on hover AND
+              // keyboard focus (the warm effect on activeDot fills it in).
+              onPointerEnter={() => setHoverDot(d)}
+              onPointerLeave={() => setHoverDot(null)}
+              onFocus={() => setHoverDot(d)}
+              onBlur={() => setHoverDot(null)}
+              onPointerDown={e => onDotPointerDown(e, d.seq)}
+              onKeyDown={e => onDotKeyDown(e, d.seq)}
+            />
+          )}
+        </For>
+        {/* ONE preview popover for the active dot (hover/focus OR scrub) -- never two. */}
+        <Show when={activeDot()}>
+          {d => (
+            <div class={styles.previewPopover} data-testid="chat-scroll-rail-preview" style={{ top: `${popoverTopPx()}px` }}>
+              <DotPreview previewFor={() => props.previewFor?.(d().seq)} markType={d().type} count={d().count} />
+            </div>
+          )}
+        </Show>
+      </div>
+    </Show>
+  )
+}

--- a/frontend/src/components/chat/ChatScrollRailPreview.tsx
+++ b/frontend/src/components/chat/ChatScrollRailPreview.tsx
@@ -1,0 +1,57 @@
+import type { DotCluster } from './chatRailPolicy'
+import { Show } from 'solid-js'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import * as styles from './ChatScrollRail.css'
+import { MarkdownText } from './messageRenderers'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail dot preview presentation
+//
+// The tooltip/label surface for a rail jump dot, split from ChatScrollRail so the component
+// is left to own geometry + interaction. Pure presentation: the "which dot is active" and
+// "warm its preview" wiring stays in the rail.
+// ---------------------------------------------------------------------------
+
+/** Fallback tooltip label for a mark whose content has no previewable text. */
+function markLabel(type: number): string {
+  return type === MarkType.CONTROL_RESPONSE ? 'Your response' : 'Your message'
+}
+
+/** "N messages" wording shared by a cluster dot's aria-label and its tooltip header. */
+function clusterCountLabel(count: number): string {
+  return `${count} messages`
+}
+
+/** Accessible label / tooltip fallback for a dot: a count for a cluster, else the mark type. */
+export function dotLabel(cluster: DotCluster): string {
+  return cluster.count > 1 ? clusterCountLabel(cluster.count) : markLabel(cluster.type)
+}
+
+/**
+ * Tooltip body for a jump dot: an aggregate "N messages" header when the dot is a cluster,
+ * then the representative's preview -- rendered markdown (the marked message's content is
+ * markdown), a mark-type label when there's no previewable text, or a loading line while the
+ * fetch is in flight. Reads `previewFor` reactively so a slow fetch that lands after the
+ * tooltip opens still fills it in. The preview string is already length-bounded upstream
+ * (truncatePreview), so rendered markdown stays small.
+ */
+export function DotPreview(props: { previewFor: () => string | undefined, markType: number, count: number }) {
+  const preview = () => props.previewFor()
+  return (
+    <>
+      <Show when={props.count > 1}>
+        <div class={styles.dotPreviewCount}>{clusterCountLabel(props.count)}</div>
+      </Show>
+      <Show
+        when={preview() !== undefined}
+        fallback={<span class={styles.dotPreviewLoading}>Loading preview…</span>}
+      >
+        <Show when={preview()} fallback={<span>{markLabel(props.markType)}</span>}>
+          <div class={styles.dotPreviewMarkdown}>
+            <MarkdownText text={preview()!} />
+          </div>
+        </Show>
+      </Show>
+    </>
+  )
+}

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { globalStyle, keyframes, style } from '@vanilla-extract/css'
 import { resizeHandleSelectors } from '~/styles/resizeHandle'
 import { breakpoints, motion } from '~/styles/tokens'
 
@@ -65,6 +65,20 @@ export const messageList = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-3)',
+})
+
+/**
+ * Hides the native scrollbar so ONLY the seq-space ChatScrollRail overlay shows (the
+ * browser thumb reflects just the loaded window, not the whole conversation). Applied to
+ * `messageList` only while the rail is actually active (marks seeded); if the marks RPC
+ * fails or lags, the native scrollbar stays visible rather than leaving a long
+ * conversation with no scrollbar at all. Scoped here -- the app-wide thin scrollbar stays.
+ */
+export const messageListRailActive = style({
+  scrollbarWidth: 'none',
+})
+globalStyle(`${messageListRailActive}::-webkit-scrollbar`, {
+  display: 'none',
 })
 
 /**

--- a/frontend/src/components/chat/ChatView.test.tsx
+++ b/frontend/src/components/chat/ChatView.test.tsx
@@ -6,7 +6,7 @@ import { render, waitFor } from '@solidjs/testing-library'
 import { batch, createEffect, createSignal, For } from 'solid-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentChatMessageSchema, AgentProvider, MessageSource } from '~/generated/leapmux/v1/agent_pb'
-import { rowSkeletonClosing } from './ChatView.css'
+import { messageListRailActive, rowSkeletonClosing } from './ChatView.css'
 
 type HiddenPremeasureOnMeasure = (id: string, height: number, heightKey: string | undefined, measureDurationMs: number, settled: boolean) => boolean
 
@@ -746,5 +746,79 @@ describe('chat view virtualized visible slice', () => {
     finally {
       spy.mockRestore()
     }
+  })
+})
+
+describe('chat view native scrollbar hiding', () => {
+  // The seq-space rail replaces the native scrollbar, but ONLY once it is active AND can
+  // draw a thumb, or when there is no scrollable local-only content that needs the native
+  // scrollbar fallback. Otherwise scrollable content would be left with no scrollbar at all.
+  const railBase = {
+    loaded: true,
+    minSeq: 1n,
+    maxSeq: 10n,
+    marks: [],
+    windowFirstSeq: 1n,
+    windowLastSeq: 5n,
+  }
+  const scroller = (container: HTMLElement) => container.querySelector('[data-chat-scroll-container]') as HTMLElement
+
+  it('hides the native scrollbar when the rail is loaded AND has a server row to anchor', () => {
+    const { container } = render(() => (
+      <ChatView messages={[message('m0', 1)]} streamingText="" rail={railBase} />
+    ))
+    expect(scroller(container).className).toContain(messageListRailActive)
+  })
+
+  it('hides the native scrollbar for an empty seeded rail because there is no native overflow to preserve', () => {
+    const { container } = render(() => (
+      <ChatView messages={[]} streamingText="" rail={{ ...railBase, windowFirstSeq: undefined, windowLastSeq: undefined }} />
+    ))
+    expect(scroller(container).className).toContain(messageListRailActive)
+  })
+
+  it('keeps the native scrollbar while the rail is unseeded (marks RPC failed / slow)', () => {
+    const { container } = render(() => (
+      <ChatView messages={[message('m0', 1)]} streamingText="" rail={{ ...railBase, loaded: false }} />
+    ))
+    expect(scroller(container).className).not.toContain(messageListRailActive)
+  })
+
+  it('keeps the native scrollbar for an all-optimistic-local window (no server seq to anchor)', () => {
+    // A window of only optimistic locals (seq 0n) has no server row for the rail to anchor a thumb
+    // to, so the rail hides itself and the native scrollbar must stay or overflowing local content
+    // would have no scrollbar at all. windowFirst/LastSeq are undefined to match (no server seq).
+    const { container } = render(() => (
+      <ChatView messages={[message('m0', 0)]} streamingText="" rail={{ ...railBase, windowFirstSeq: undefined, windowLastSeq: undefined }} />
+    ))
+    expect(scroller(container).className).not.toContain(messageListRailActive)
+  })
+
+  it('keeps the native scrollbar when unsafe seq geometry prevents the rail from rendering', () => {
+    const unsafe = BigInt(Number.MAX_SAFE_INTEGER)
+    const unsafeMessage = create(AgentChatMessageSchema, {
+      id: 'unsafe',
+      source: MessageSource.AGENT,
+      content: new TextEncoder().encode('unsafe seq'),
+      seq: unsafe,
+      createdAt: '2026-06-28T00:00:00.000Z',
+      agentProvider: AgentProvider.CODEX,
+    })
+
+    const { container } = render(() => (
+      <ChatView
+        messages={[unsafeMessage]}
+        streamingText=""
+        rail={{
+          ...railBase,
+          minSeq: unsafe,
+          maxSeq: unsafe,
+          windowFirstSeq: unsafe,
+          windowLastSeq: unsafe,
+        }}
+      />
+    ))
+
+    expect(scroller(container).className).not.toContain(messageListRailActive)
   })
 })

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -5,6 +5,7 @@ import type { ChatScrollState, PaginationCallbacks } from './useChatScroll'
 import type { VirtualItem } from './useChatVirtualizer'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
+import type { ChatRailData } from '~/stores/chatMessageMarks'
 import type { TodoItem } from '~/stores/chatTodos'
 import type { CommandStreamSegment, SpanMessageRevision } from '~/stores/chatTypes'
 
@@ -24,8 +25,11 @@ import { ChatHiddenPremeasure } from './chatHiddenPremeasure'
 import { createMessageUiState } from './chatMessageUiState'
 import { createOrderedTailReveal } from './chatOrderedReveal'
 import { createChatPremeasureBands } from './chatPremeasureBands'
+import { resolveScrollbarOwner } from './chatRailPolicy'
 import { kindScopedLayoutKey } from './chatRowGeometry'
 import { createRowHeightPersistence } from './chatRowHeightPersistence'
+import { ChatScrollRail } from './ChatScrollRail'
+import { rowStartSeqs } from './chatScrollRailGeometry'
 import { createDelayedSet, createFlingSkeletonRegistry, createLingerSet } from './chatSkeletonCrossfade'
 import { createStreamingTail } from './chatStreamingTail'
 import * as styles from './ChatView.css'
@@ -178,6 +182,19 @@ export interface AgentLifecycleProps {
   providerLabel?: string
 }
 
+/**
+ * The scroll-rail data ({@link ChatRailData}) plus the two on-demand preview callbacks the
+ * host wires per agent. Named (rather than an inline `ChatRailData & {...}`) so the store's
+ * `getRailData` producer, this consumer prop, and the memoized `rail` object the host builds
+ * (TileRenderer) all check against ONE shape and can't drift.
+ */
+export interface ChatRailProps extends ChatRailData {
+  /** Reactive read of a mark's hover-preview text (undefined = loading, '' = no text). */
+  previewFor?: (seq: bigint) => string | undefined
+  /** Kick off resolving a mark's preview on dot hover. */
+  warmPreview?: (seq: bigint) => void
+}
+
 interface ChatViewProps {
   /**
    * Stable agent id. Forwarded to ThinkingIndicator so the random
@@ -204,6 +221,11 @@ interface ChatViewProps {
   homeDir?: string
   /** Pagination / windowing state + callbacks (see ChatPaginationProps). */
   pagination?: ChatPaginationProps
+  /**
+   * Seq-space scroll-rail data: the marked seqs (teal jump dots) plus the whole-history
+   * seq range. The rail hides itself when absent / unseeded (see ChatScrollRail).
+   */
+  rail?: ChatRailProps
   /** Saved scroll state for viewport restoration on tab switch. */
   savedViewportScroll?: ChatScrollState
   /** Called when saved scroll state should be cleared after restoration. */
@@ -285,6 +307,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // The scroll container (also handed to scroll.attachListRef below). Read
   // non-reactively by isRowNearViewport at worker-dispatch time.
   let listEl: HTMLElement | undefined
+  // Reactive handle on the same element for the scroll rail (which attaches its own
+  // passive listener + ResizeObserver in a createEffect keyed on it).
+  const [scrollEl, setScrollEl] = createSignal<HTMLDivElement | undefined>()
 
   // Classify + cache the window's messages by id so <For> receives stable object
   // references for unchanged rows. createClassifiedEntryCache owns the cache, the
@@ -433,6 +458,46 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // Point the UI-state cap's protect set at the virtualizer's live mounted rows
   // (a stable Set reference) now that `virt` exists.
   mountedRowIds = virt.mountedIds
+
+  // Resolve which scrollbar owns the viewport ONCE, here -- ChatView holds the single
+  // viewport CONTENT-box height (viewportHeight(), the ResizeObserver's contentRect, the same
+  // coordinate space totalHeight lives in) plus the item list, range, and totalHeight -- and hands
+  // the result to BOTH the native-scrollbar hide below AND the rail (via its `hidden` prop). One
+  // resolution, one height source, is what makes "never zero or two scrollbars" STRUCTURAL: a
+  // shared function called twice with two height sources (the rail formerly read its own
+  // padding-box clientHeight) could hide both bars over content overflowing by the container's
+  // vertical padding. railRowSeqs is memoized on the item list so the O(n) row-seq scan reruns
+  // only when rows change -- not on every scroll frame or streaming-height commit.
+  //
+  // Gate the scan on a STABLE presence boolean, NOT props.rail's object reference: the host
+  // rebuilds the rail prop object on every marks / live-tail / window change (TileRenderer's
+  // railProps memo), so a bare `props.rail ?` here would re-run the O(n) scan on each of those
+  // even when the row list is unchanged. railPresent flips only when the rail appears / disappears,
+  // so the scan reruns solely when virtualItems changes -- exactly as the note above promises.
+  const railPresent = createMemo(() => props.rail !== undefined)
+  const railRowSeqs = createMemo(() => (railPresent() ? rowStartSeqs(virtualItems()) : null))
+  const railOwner = createMemo(() => {
+    const rail = props.rail
+    if (!rail)
+      return null
+    return resolveScrollbarOwner({
+      loaded: rail.loaded,
+      itemCount: virtualItems().length,
+      rowSeqs: railRowSeqs(),
+      range: { minSeq: rail.minSeq, maxSeq: rail.maxSeq },
+      hasMoreOlder: !!props.pagination?.hasOlderMessages,
+      hasMoreNewer: !!props.pagination?.hasNewerMessages,
+      totalHeight: virt.totalHeight(),
+      viewportHeight: viewportHeight(),
+    })
+  })
+  // Hide the native scrollbar whenever the rail owns scrolling OR nothing needs a scrollbar -- i.e.
+  // every owner except 'native'. The exact complement of the rail's `hidden` prop (owner !==
+  // 'rail'), both derived from the SAME railOwner, so exactly one bar is ever shown.
+  const hideNativeScrollbar = createMemo(() => {
+    const owner = railOwner()
+    return owner !== null && owner !== 'native'
+  })
 
   // Reload warm-start: hydrate persisted measured heights (keyed by height-
   // key digest, so content/width changes self-invalidate) and keep the
@@ -715,6 +780,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     onLoadNewerMessages: () => props.pagination?.onLoadNewerMessages?.(),
     onJumpToLatest: () => props.pagination?.onJumpToLatest?.(),
     onJumpToOldest: () => props.pagination?.onJumpToOldest?.(),
+    onJumpToSeq: seq => props.pagination?.onJumpToSeq?.(seq),
     virtualizer: virt,
     savedViewportScroll: () => props.savedViewportScroll,
     onClearSavedViewportScroll: () => props.onClearSavedViewportScroll?.(),
@@ -723,6 +789,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // Now that the scroll hook (and its anchor engine) exists, point the toggle-time row
   // pin at it (see the `let` declaration above and buildMessageHost).
   anchorRowForResize = scroll.anchorRowForResize
+
+  // The rail's seq-space bounds (window-aware min/max) and loaded-window seqs are resolved
+  // once in the store's getRailData (see resolveRailRange), so ChatView passes props.rail
+  // straight through to ChatScrollRail rather than re-deriving the range in the view.
 
   const pauseThen = <Args extends unknown[]>(handler: (...args: Args) => void): ((...args: Args) => void) =>
     (...args: Args) => {
@@ -819,11 +889,15 @@ export const ChatView: Component<ChatViewProps> = (props) => {
         <div
           ref={(el) => {
             listEl = el
+            setScrollEl(el)
             scroll.attachListRef(el)
             viewportSizeObserver.observe(el)
             attachPassiveScrollListeners(el)
           }}
-          class={styles.messageList}
+          // Hide the native scrollbar when the rail is active and either can draw a thumb
+          // from a server anchor, or there is no scrollable local-only overflow that would
+          // need the native scrollbar as a fallback.
+          class={`${styles.messageList} ${hideNativeScrollbar() ? styles.messageListRailActive : ''}`}
           data-chat-scroll-container="true"
           tabIndex={0}
           {...scrollHandlers}
@@ -1090,6 +1164,34 @@ export const ChatView: Component<ChatViewProps> = (props) => {
           >
             <Icon icon={ArrowDown} size="lg" />
           </button>
+        </Show>
+        <Show when={props.rail?.loaded}>
+          <ChatScrollRail
+            scrollEl={scrollEl()}
+            items={virtualItems()}
+            offsetOfIndex={virt.offsetOfIndex}
+            totalHeight={virt.totalHeight()}
+            geometryVersion={virt.geometryVersion()}
+            // The row-seq map the owner resolution above already computes (railRowSeqs), reused by
+            // the rail's geometry so the O(n) scan runs once per item-list change, not twice.
+            railRowSeqs={railRowSeqs()}
+            // ChatRailProps extends ChatRailData, so pass the whole object straight through as the
+            // rail's `rail` prop rather than re-flattening its six fields (which the view would then
+            // have to keep in hand-sync). previewFor/warmPreview are the orthogonal on-demand
+            // callbacks and stay separate.
+            rail={props.rail!}
+            // Whether the rail hides itself, the exact complement of hideNativeScrollbar: both are
+            // derived from ONE railOwner resolution (single viewport-height source), so the rail is
+            // shown exactly when the native bar is hidden -- never zero, never two scrollbars.
+            hidden={railOwner() !== 'rail'}
+            hasMoreOlder={!!props.pagination?.hasOlderMessages}
+            hasMoreNewer={!!props.pagination?.hasNewerMessages}
+            onJumpToSeq={seq => scroll.jumpToSeq(seq)}
+            previewScrollTo={top => scroll.previewScrollTo(top)}
+            onSeekInterrupt={() => scroll.cancelPendingSeek()}
+            previewFor={props.rail!.previewFor}
+            warmPreview={props.rail!.warmPreview}
+          />
         </Show>
       </div>
       <ChatHiddenPremeasure

--- a/frontend/src/components/chat/chatDotPreview.test.ts
+++ b/frontend/src/components/chat/chatDotPreview.test.ts
@@ -1,0 +1,111 @@
+import type { DotCluster } from './chatRailPolicy'
+import { createRoot, createSignal } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { createDotPreview } from './chatDotPreview'
+import * as styles from './ChatScrollRail.css'
+
+// Flush queued Solid effects (the stale-hover re-anchor effect is not a pull-based memo).
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+// activeDot / popoverTopPx are memos (pull-based), so these read synchronously after a signal
+// write -- no effect flush needed. The scrub-warm DEBOUNCE effect (instant-hover vs settled-scrub
+// timing) is exercised end-to-end by ChatScrollRail.test.tsx; here we pin the pure reactive
+// selection + placement the component delegates to this unit.
+
+function dot(seq: bigint, topPx: number, count = 1): DotCluster {
+  return { seq, topPx, type: MarkType.USER_MESSAGE, count }
+}
+
+describe('createdotpreview', () => {
+  it('activeDot is the hovered dot when not dragging', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(5n, 100)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      expect(p.activeDot()).toBeNull()
+      p.setHoverDot(dot(5n, 100))
+      expect(p.activeDot()?.seq).toBe(5n)
+      dispose()
+    }))
+
+  it('a scrub target takes precedence over a hovered dot (one popover, never two)', () =>
+    createRoot((dispose) => {
+      // centerAxisY(0.5, 200, 24) = 12 + 0.5*176 = 100, so the dot at topPx 100 is under the thumb
+      // centre while dragging; hovering a DIFFERENT dot must not open a rival popover.
+      const [dots] = createSignal<DotCluster[]>([dot(5n, 100), dot(9n, 20)])
+      const [drag] = createSignal<number | null>(0.5)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      p.setHoverDot(dot(9n, 20))
+      expect(p.activeDot()?.seq).toBe(5n) // the scrub target wins over the hover
+      dispose()
+    }))
+
+  it('activeDot falls back to the hovered dot when the scrub is between dots', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(9n, 20)]) // topPx 20 is far from the thumb centre (100)
+      const [drag] = createSignal<number | null>(0.5)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      p.setHoverDot(dot(9n, 20))
+      expect(p.activeDot()?.seq).toBe(9n) // no dot within scrub range -> the hover shows
+      dispose()
+    }))
+
+  it('popoverTopPx clamps a top/bottom dot inside the rail so the card is not clipped', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(1n, 0), dot(2n, 200)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      const half = Math.min(styles.PREVIEW_POPOVER_MAX_H_PX / 2, 200 / 2)
+      p.setHoverDot(dot(1n, 0)) // a dot at the very top
+      expect(p.popoverTopPx()).toBe(half)
+      p.setHoverDot(dot(2n, 200)) // a dot at the very bottom
+      expect(p.popoverTopPx()).toBe(200 - half)
+      dispose()
+    }))
+
+  it('re-anchors the hovered popover to the same-seq dot when a streaming turn shifts its topPx', async () => {
+    await createRoot(async (dispose) => {
+      const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      p.setHoverDot(dot(5n, 100))
+      expect(p.activeDot()?.seq).toBe(5n)
+      // maxSeq ticks during a streaming turn: the SAME seq's cluster re-rounds to a new topPx and
+      // <For> hands over a fresh (unequal) object. The popover must FOLLOW the dot, not vanish.
+      setDots([dot(5n, 101)])
+      await tick()
+      expect(p.activeDot()?.seq).toBe(5n)
+      expect(p.activeDot()?.topPx).toBe(101) // re-anchored to the shifted cluster
+      dispose()
+    })
+  })
+
+  it('clears the hovered popover only when its seq is truly gone from the rail', async () => {
+    await createRoot(async (dispose) => {
+      const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      p.setHoverDot(dot(5n, 100))
+      expect(p.activeDot()?.seq).toBe(5n)
+      // The hovered mark's message was deleted/reseq'd -- no dot carries seq 5 anymore, so the
+      // popover clears rather than pointing at a stale cluster.
+      setDots([dot(9n, 100)])
+      await tick()
+      expect(p.activeDot()).toBeNull()
+      dispose()
+    })
+  })
+})

--- a/frontend/src/components/chat/chatDotPreview.ts
+++ b/frontend/src/components/chat/chatDotPreview.ts
@@ -1,0 +1,148 @@
+import type { Accessor, Setter } from 'solid-js'
+import type { DotCluster } from './chatRailPolicy'
+import { createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js'
+import { clamp } from '~/lib/clamp'
+import { dotClusterEqual, nearestDotWithin } from './chatRailPolicy'
+import * as styles from './ChatScrollRail.css'
+import { centerAxisY } from './chatScrollRailGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail dot preview
+//
+// The rail's "which dot the single popover describes + when to warm its preview" state machine:
+// a scrub target (the dot the dragging thumb is over) takes precedence over a hovered/focused
+// dot, the popover is placed on the dot's centre-axis Y (clamped off the rail edges), and the
+// preview is warmed instantly on hover/focus but DEBOUNCED during a scrub -- so dragging across a
+// dense rail doesn't fire a GetAgentMessage per fly-over dot. Extracted from ChatScrollRail (where
+// it was a signal, three memos, an effect, and a debounce timer tangled through the component) so
+// the subtle precedence/debounce/cleanup behaviour is one named, unit-tested unit -- the sibling
+// of createRailMetrics / createDragReleaseHold / createThumbDrag.
+// ---------------------------------------------------------------------------
+
+/** Rail px within which a dragging thumb counts as "over" a dot, revealing its scrub preview. */
+const SCRUB_PREVIEW_RANGE_PX = 12
+
+/**
+ * How long the thumb must settle on a dot mid-scrub before its preview is fetched. A hover/focus
+ * warms instantly; a SCRUB debounces, because dragging across a dense rail passes many dots and
+ * warming each would fire a GetAgentMessage RPC per out-of-window mark crossed. Reset on every
+ * scrub dot change, so only a dot the thumb lingers near is fetched -- the fly-over dots coalesce.
+ */
+export const SCRUB_WARM_DEBOUNCE_MS = 120
+
+export interface DotPreviewDeps {
+  /** The rail's current dot clusters (ascending by topPx). */
+  dots: Accessor<DotCluster[]>
+  /** The live drag fraction (null when not dragging), so a scrub can take popover precedence. */
+  drag: Accessor<number | null>
+  /** The rail's pixel height, for the centre-axis mapping and the popover clamp. */
+  railHeight: Accessor<number>
+  /** The current thumb height (px), for mapping a drag fraction to the thumb-centre rail-Y. */
+  thumbHeightPx: Accessor<number>
+  /** Kick off resolving a mark's preview (dot hover/focus or scrub-settle). Deduped upstream. */
+  warmPreview?: (seq: bigint) => void
+}
+
+// Named ...Controller (not DotPreview) to avoid clashing with the sibling DotPreview presentation
+// component in ChatScrollRailPreview -- this is the state machine that decides WHICH dot that
+// component renders, not the component itself.
+export interface DotPreviewController {
+  /** The dot the single preview popover describes: the scrub target while dragging, else hover/focus. */
+  activeDot: Accessor<DotCluster | null>
+  /** The popover's rail-Y, clamped so a dot near the top/bottom doesn't clip past the wrapper. */
+  popoverTopPx: Accessor<number>
+  /** Set/clear the hovered/focused dot (from a dot's pointer/focus handlers and the rail teardown). */
+  setHoverDot: Setter<DotCluster | null>
+}
+
+/**
+ * Create the rail's dot-preview state machine (see the module header). Must be created within an
+ * owner scope (it wires createEffect + onCleanup); ChatScrollRail creates it once at component top
+ * level, exactly like its createRailMetrics / createDragReleaseHold siblings.
+ */
+export function createDotPreview(deps: DotPreviewDeps): DotPreviewController {
+  // The dot the pointer is hovering / focusing (null when none). The rail shows ONE preview
+  // popover for the "active" dot -- a scrub target takes precedence over this (see activeDot).
+  const [hoverDot, setHoverDot] = createSignal<DotCluster | null>(null)
+
+  // While dragging, the dot the thumb is currently over (nearest within range), so a scrub --
+  // mouse OR touch -- reveals each marked message's preview as the thumb passes it. Null when
+  // not dragging or the thumb is between dots.
+  const scrubDot = createMemo(() => {
+    const f = deps.drag()
+    if (f === null)
+      return null
+    const rh = deps.railHeight()
+    if (rh <= 0)
+      return null
+    const y = centerAxisY(f, rh, deps.thumbHeightPx()) // the thumb centre's rail-Y at this drag fraction
+    return nearestDotWithin(deps.dots(), y, SCRUB_PREVIEW_RANGE_PX)
+  })
+
+  // The dot the single preview popover describes: the scrub target while dragging (it takes
+  // precedence, so hovering a dot mid-scrub can't open a second popover), else the hovered/
+  // focused dot. One source -> one popover, shown immediately (no hover delay).
+  const activeDot = createMemo(() => scrubDot() ?? hoverDot())
+
+  createEffect(() => {
+    const h = hoverDot()
+    if (!h)
+      return
+    const currentDots = deps.dots()
+    // The exact hovered cluster is still present -- leave the popover alone.
+    if (currentDots.some(d => dotClusterEqual(d, h)))
+      return
+    // The hovered cluster changed identity but may still stand for the same seq: a streaming
+    // turn ticks maxSeq and re-rounds its topPx by a pixel, or a fresh mark lands in its pixel
+    // and bumps the count. <For> is reference-keyed, so it tears the hovered button down and
+    // mounts a new one -- and removing the element under the cursor fires no pointerleave, so
+    // hoverDot still holds the STALE cluster. Re-anchor to the current cluster for the same seq
+    // so the popover the reader is looking at FOLLOWS the dot instead of vanishing out from
+    // under them; clear only when that seq is genuinely gone (its message was deleted/reseq'd).
+    setHoverDot(currentDots.find(d => d.seq === h.seq) ?? null)
+  })
+
+  // The popover's rail-Y: centred on the active dot but clamped so a dot near the rail's top
+  // or bottom doesn't push the card past the overflow-hidden wrapper and clip it.
+  const popoverTopPx = createMemo(() => {
+    const d = activeDot()
+    if (!d)
+      return 0
+    const rh = deps.railHeight()
+    const half = Math.min(styles.PREVIEW_POPOVER_MAX_H_PX / 2, rh / 2)
+    return clamp(d.topPx, half, rh - half)
+  })
+
+  // Warm the active dot's preview so the popover fills in. A HOVER/focus warms instantly; a SCRUB
+  // (thumb drag) debounces -- dragging across a dense rail changes activeDot dot-by-dot, and
+  // warming each would fire a GetAgentMessage RPC per out-of-window mark it crosses. The effect
+  // tracks ONLY activeDot (its scrub source, scrubDot, dedups per dot, so it changes when the
+  // thumb reaches a NEW dot, not on every drag pixel); the scrub-vs-hover classification reads
+  // drag() untracked so a fraction change doesn't itself reset the debounce.
+  let scrubWarmTimer: ReturnType<typeof setTimeout> | undefined
+  const clearScrubWarmTimer = () => {
+    if (scrubWarmTimer !== undefined) {
+      clearTimeout(scrubWarmTimer)
+      scrubWarmTimer = undefined
+    }
+  }
+  onCleanup(clearScrubWarmTimer)
+  createEffect(() => {
+    const d = activeDot()
+    // A new active dot supersedes any pending scrub warm (the thumb moved on before it settled).
+    clearScrubWarmTimer()
+    if (!d)
+      return
+    if (untrack(() => deps.drag()) === null) {
+      deps.warmPreview?.(d.seq) // hover/focus: instant
+      return
+    }
+    // Scrub: warm only once the thumb has settled on this dot for the debounce window.
+    scrubWarmTimer = setTimeout(() => {
+      scrubWarmTimer = undefined
+      deps.warmPreview?.(d.seq)
+    }, SCRUB_WARM_DEBOUNCE_MS)
+  })
+
+  return { activeDot, popoverTopPx, setHoverDot }
+}

--- a/frontend/src/components/chat/chatMarkPreview.test.ts
+++ b/frontend/src/components/chat/chatMarkPreview.test.ts
@@ -1,0 +1,261 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { create } from '@bufbuild/protobuf'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { __resetMarkPreviewCacheForTest, forgetMarkPreview, getCachedMarkPreview, messageMarkPreviewText, warmMarkPreview } from './chatMarkPreview'
+import * as registry from './providers/registry'
+// Register provider plugins so messageMarkPreviewText (called inside warm) can resolve one.
+import '~/components/chat/providers'
+
+/** Force the resolved plugin's previewText to throw, to exercise the extraction guard. */
+function withThrowingPlugin(body: () => void): void {
+  const spy = vi.spyOn(registry, 'pluginFor').mockReturnValue({
+    previewText() { throw new Error('boom') },
+  } as unknown as ReturnType<typeof registry.pluginFor>)
+  try {
+    body()
+  }
+  finally {
+    spy.mockRestore()
+  }
+}
+
+function userMessage(seq: bigint, text: string): AgentChatMessage {
+  return create(AgentChatMessageSchema, {
+    id: `m${seq}`,
+    source: MessageSource.USER,
+    content: new TextEncoder().encode(JSON.stringify({ content: text })),
+    contentCompression: ContentCompression.NONE,
+    seq,
+    agentProvider: AgentProvider.CLAUDE_CODE,
+  })
+}
+
+/** A marked message carrying an arbitrary content shape (default provider Claude). */
+function messageOf(content: Record<string, unknown>, agentProvider = AgentProvider.CLAUDE_CODE): AgentChatMessage {
+  return create(AgentChatMessageSchema, {
+    id: 'm1',
+    source: MessageSource.USER,
+    content: new TextEncoder().encode(JSON.stringify(content)),
+    contentCompression: ContentCompression.NONE,
+    seq: 5n,
+    agentProvider,
+  })
+}
+
+afterEach(() => __resetMarkPreviewCacheForTest())
+
+describe('message mark preview text', () => {
+  it('resolves a user message through its provider plugin and the shared default', () => {
+    expect(messageMarkPreviewText(messageOf({ content: 'jump here' }))).toBe('jump here')
+  })
+
+  it('resolves a non-Claude (Codex) control-response answer via its plugin\'s neutral previewText', () => {
+    // Codex marks are the Leapmux-neutral `{content}` synthetic answer row; its plugin's
+    // previewText delegates to the shared default, so this resolves through the plugin.
+    expect(messageMarkPreviewText(messageOf({ content: 'Allow once' }, AgentProvider.CODEX))).toBe('Allow once')
+  })
+
+  it('returns null for a message with no previewable text', () => {
+    expect(messageMarkPreviewText(messageOf({ type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }))).toBeNull()
+  })
+
+  it('degrades to null instead of propagating when a provider plugin previewText throws', () => {
+    // A malformed message a plugin's previewText (or the parse it drives) chokes on must read
+    // as "no preview", not blow up the hover effect / poison the async fetch as transient.
+    withThrowingPlugin(() => {
+      expect(messageMarkPreviewText(messageOf({ content: 'x' }))).toBeNull()
+    })
+  })
+})
+
+describe('warmmarkpreview', () => {
+  it('resolves from the loaded window without fetching', () => {
+    const fetchMessageBySeq = vi.fn()
+    warmMarkPreview('w1', 'a1', 5n, {
+      getLoadedMessageBySeq: () => userMessage(5n, 'in window'),
+      fetchMessageBySeq,
+    })
+    expect(getCachedMarkPreview('a1', 5n)).toBe('in window')
+    expect(fetchMessageBySeq).not.toHaveBeenCalled()
+  })
+
+  it('fetches an out-of-window mark and caches its extracted preview', async () => {
+    const fetchMessageBySeq = vi.fn().mockResolvedValue(userMessage(9n, 'far away'))
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq })
+    // Undefined = still resolving; the tooltip shows a loading line meanwhile.
+    expect(getCachedMarkPreview('a1', 9n)).toBeUndefined()
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('far away'))
+    expect(fetchMessageBySeq).toHaveBeenCalledOnce()
+  })
+
+  it('dedupes concurrent hovers on the same seq to a single fetch', async () => {
+    let resolve!: (m: AgentChatMessage) => void
+    const pending = new Promise<AgentChatMessage>((r) => {
+      resolve = r
+    })
+    const fetchMessageBySeq = vi.fn().mockReturnValue(pending)
+    const deps = { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq }
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    expect(fetchMessageBySeq).toHaveBeenCalledOnce()
+    resolve(userMessage(9n, 'landed'))
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('landed'))
+  })
+
+  it('does not re-fetch a seq already resolved', async () => {
+    const fetchMessageBySeq = vi.fn().mockResolvedValue(userMessage(9n, 'once'))
+    const deps = { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq }
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('once'))
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    expect(fetchMessageBySeq).toHaveBeenCalledOnce()
+  })
+
+  it('bounds the per-agent preview cache across long hover sessions', () => {
+    for (let seq = 1n; seq <= 505n; seq++) {
+      warmMarkPreview('w1', 'a1', seq, {
+        getLoadedMessageBySeq: () => userMessage(seq, `message ${seq}`),
+        fetchMessageBySeq: vi.fn(),
+      })
+    }
+    expect(getCachedMarkPreview('a1', 1n)).toBeUndefined()
+    expect(getCachedMarkPreview('a1', 505n)).toBe('message 505')
+  })
+
+  it('caches "" when the message is gone, so the rail shows a label without re-fetching', async () => {
+    const fetchMessageBySeq = vi.fn().mockResolvedValue(undefined)
+    const deps = { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq }
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe(''))
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    expect(fetchMessageBySeq).toHaveBeenCalledOnce()
+  })
+
+  it('leaves the cache unresolved when the fetch rejects, so a later hover retries', async () => {
+    // A transient RPC failure (reject) must NOT be cached as '' -- that would poison the
+    // dot with a permanent label for the rest of the session. It stays unresolved and a
+    // later hover re-fetches; only a resolved-undefined (definitive absence) caches ''.
+    const fetchMessageBySeq = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(userMessage(9n, 'recovered'))
+    const deps = { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq }
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    // The rejection settles and the in-flight token is dropped, with nothing cached.
+    await vi.waitFor(() => expect(fetchMessageBySeq).toHaveBeenCalledOnce())
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getCachedMarkPreview('a1', 9n)).toBeUndefined()
+    // A later hover re-fetches (the '' poison is gone) and resolves the real preview.
+    warmMarkPreview('w1', 'a1', 9n, deps)
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('recovered'))
+    expect(fetchMessageBySeq).toHaveBeenCalledTimes(2)
+  })
+
+  it('loaded-window extraction throw caches "" synchronously without propagating', () => {
+    // A plugin previewText throw on the SYNC loaded-window path must not escape into the
+    // caller's hover effect; it caches '' (a label), same as any un-previewable message.
+    withThrowingPlugin(() => {
+      const fetchMessageBySeq = vi.fn()
+      expect(() =>
+        warmMarkPreview('w1', 'a1', 4n, { getLoadedMessageBySeq: () => userMessage(4n, 'x'), fetchMessageBySeq }),
+      ).not.toThrow()
+      expect(getCachedMarkPreview('a1', 4n)).toBe('')
+      expect(fetchMessageBySeq).not.toHaveBeenCalled()
+    })
+  })
+
+  it('fetched-message extraction throw caches "" (a real absence), NOT an endless re-fetch', async () => {
+    // The fetch SUCCEEDS but extraction throws: this is a permanent parse failure, so cache
+    // '' once (a label) rather than misreading it as the transient RPC failure the .catch
+    // handles -- which would re-fetch the same dot on every hover for the session. The spy is
+    // held through the await (not withThrowingPlugin, which would restore before the .then).
+    const spy = vi.spyOn(registry, 'pluginFor').mockReturnValue({
+      previewText() { throw new Error('boom') },
+    } as unknown as ReturnType<typeof registry.pluginFor>)
+    try {
+      const fetchMessageBySeq = vi.fn().mockResolvedValue(userMessage(9n, 'far'))
+      const deps = { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq }
+      warmMarkPreview('w1', 'a1', 9n, deps)
+      await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe(''))
+      warmMarkPreview('w1', 'a1', 9n, deps) // a second hover must NOT re-fetch
+      expect(fetchMessageBySeq).toHaveBeenCalledOnce()
+    }
+    finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('ignores optimistic locals (seq 0n)', () => {
+    const fetchMessageBySeq = vi.fn()
+    warmMarkPreview('w1', 'a1', 0n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq })
+    expect(fetchMessageBySeq).not.toHaveBeenCalled()
+    expect(getCachedMarkPreview('a1', 0n)).toBeUndefined()
+  })
+
+  it('forgetMarkPreview drops one agent\'s entries and leaves other agents intact', () => {
+    warmMarkPreview('w1', 'a1', 5n, { getLoadedMessageBySeq: () => userMessage(5n, 'agent one'), fetchMessageBySeq: vi.fn() })
+    warmMarkPreview('w1', 'a2', 5n, { getLoadedMessageBySeq: () => userMessage(5n, 'agent two'), fetchMessageBySeq: vi.fn() })
+    expect(getCachedMarkPreview('a1', 5n)).toBe('agent one')
+    expect(getCachedMarkPreview('a2', 5n)).toBe('agent two')
+
+    forgetMarkPreview('a1')
+    expect(getCachedMarkPreview('a1', 5n)).toBeUndefined() // pruned
+    expect(getCachedMarkPreview('a2', 5n)).toBe('agent two') // untouched
+  })
+
+  it('fences an in-flight fetch when the agent is forgotten mid-flight (no re-leak)', async () => {
+    let resolve!: (m: AgentChatMessage | undefined) => void
+    const pending = new Promise<AgentChatMessage | undefined>((r) => {
+      resolve = r
+    })
+    const fetchMessageBySeq = vi.fn().mockReturnValue(pending)
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq })
+    expect(getCachedMarkPreview('a1', 9n)).toBeUndefined() // still resolving
+
+    // Agent closed while the fetch is in flight: the cache has no entry yet to prune.
+    forgetMarkPreview('a1')
+    // The fetch resolves AFTER forget -- it must NOT write an entry back for the closed agent.
+    resolve(userMessage(9n, 'landed too late'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getCachedMarkPreview('a1', 9n)).toBeUndefined()
+  })
+
+  it('a re-warm after forget supersedes an older in-flight fetch (no stale clobber)', async () => {
+    let resolveOld!: (m: AgentChatMessage) => void
+    const oldPending = new Promise<AgentChatMessage>((r) => {
+      resolveOld = r
+    })
+    const oldFetch = vi.fn().mockReturnValue(oldPending)
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq: oldFetch })
+
+    forgetMarkPreview('a1') // close
+    // Reopen + re-warm: a fresh fetch resolves first with the current value.
+    const newFetch = vi.fn().mockResolvedValue(userMessage(9n, 'fresh'))
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq: newFetch })
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('fresh'))
+
+    // The OLD fetch resolves late; its token was superseded, so it must not clobber 'fresh'.
+    resolveOld(userMessage(9n, 'stale'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getCachedMarkPreview('a1', 9n)).toBe('fresh')
+  })
+
+  it('re-fetches after forget so a stale "" does not survive a close/reopen', async () => {
+    // First warm resolves empty (message transiently gone) and caches ''.
+    const gone = vi.fn().mockResolvedValue(undefined)
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq: gone })
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe(''))
+
+    // Agent closed -> cache pruned. The reopened agent now has the message, and a re-warm
+    // must fetch again rather than short-circuit on the stale ''.
+    forgetMarkPreview('a1')
+    expect(getCachedMarkPreview('a1', 9n)).toBeUndefined()
+    const back = vi.fn().mockResolvedValue(userMessage(9n, 'now available'))
+    warmMarkPreview('w1', 'a1', 9n, { getLoadedMessageBySeq: () => undefined, fetchMessageBySeq: back })
+    await vi.waitFor(() => expect(getCachedMarkPreview('a1', 9n)).toBe('now available'))
+    expect(back).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/chat/chatMarkPreview.ts
+++ b/frontend/src/components/chat/chatMarkPreview.ts
@@ -1,0 +1,198 @@
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { createStore, produce, reconcile } from 'solid-js/store'
+import { parseMessageContent } from '~/lib/messageParser'
+import { defaultMarkPreview } from './markPreviewShared'
+import { classifyAgentMessage } from './messageClassification'
+import { pluginFor } from './providers/registry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail mark preview -- extraction + cache
+//
+// Resolves the short plaintext snippet the rail shows when the user hovers a jump dot, and
+// caches it. Two concerns, one job ("give me the preview for this mark"):
+//   1. messageMarkPreviewText -- pure extraction, routed through the message's own Provider
+//      plugin (`previewText`) since only the renderer layer knows each provider's raw shapes,
+//      with the shared, provider-neutral `defaultMarkPreview` (markPreviewShared.ts, a leaf
+//      to avoid a registry import cycle) as the fallback.
+//   2. the reactive `seq -> preview text` cache + fetch-through below.
+//
+// A marked message is usually OUTSIDE the loaded window (the rail spans the whole
+// conversation), so the preview is resolved on demand: from the loaded window when possible
+// (no fetch), else via a single-message fetch (GetAgentMessage). The cache is module-global
+// (keyed by `${agentId}:${seq}`) so it survives rail remounts (tile split/merge, tab switch)
+// and is shared across every rail instance for the same agent. Store DATA ops (loaded-message
+// lookup, single-message fetch) are injected as deps so this component-layer module never
+// imports the DI'd store.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the hover-preview text for a marked message, routed through the message's own
+ * provider plugin (`Provider.previewText`) so provider-specific shapes are read by the
+ * provider that owns them, with the shared neutral {@link defaultMarkPreview} as the
+ * fallback for providers with no bespoke marked shape. `parseMessageContent` and
+ * `classifyAgentMessage` are both WeakMap-cached on the message reference, so this is
+ * cheap to call repeatedly on hover. Returns null when the content carries no previewable
+ * text (the rail then shows a mark-type label instead).
+ */
+export function messageMarkPreviewText(message: AgentChatMessage): string | null {
+  // Defensive: a provider plugin's previewText (or the parse/classify it drives) throwing
+  // on a malformed message must degrade to "no preview" (null), never propagate. On the
+  // synchronous loaded-window path (warmMarkPreview) an uncaught throw errors the caller's
+  // warmPreview effect on every hover; on the async single-fetch path it lands in the
+  // .catch that is reserved for TRANSIENT RPC failures, which would re-fetch the same dot
+  // forever instead of caching '' once. Catch it here so both paths cache a label.
+  try {
+    const parsed = parseMessageContent(message)
+    const category = classifyAgentMessage(message)
+    const plugin = pluginFor(message.agentProvider)
+    // Route to the plugin's previewText when it defines one, treating its result as
+    // authoritative -- including a deliberate null (no preview). Only a provider WITHOUT
+    // a previewText falls back to the shared neutral extractor. (A `?? defaultMarkPreview`
+    // would both re-run the default a second time -- claude's previewText already falls
+    // back to it internally -- and rob a plugin of the ability to suppress a preview.)
+    const previewText = plugin?.previewText
+    return previewText ? previewText(category, parsed) : defaultMarkPreview(category, parsed)
+  }
+  catch (err) {
+    console.warn('mark preview extraction failed', { id: message.id, err })
+    return null
+  }
+}
+
+// '' is a real cache entry meaning "resolved, but no previewable text" -- distinct
+// from `undefined` ("not resolved yet"), so a resolved-empty preview shows the rail's
+// mark-type label without re-fetching on every hover.
+const MAX_PREVIEW_CACHE_ENTRIES_PER_AGENT = 500
+const [cache, setCache] = createStore<Record<string, string>>({})
+// Key -> a token identifying the CURRENT in-flight fetch, both to dedupe concurrent hovers
+// on the same dot AND to fence a stale resolution: forget (agent close) drops the key, and
+// a re-warm after a close/reopen issues a NEW token, so an older fetch that resolves late
+// finds its token gone/superseded and does not write to the cache.
+const inflight = new Map<string, number>()
+let nextFetchToken = 0
+
+function cacheKey(agentId: string, seq: bigint): string {
+  return `${agentId}:${seq}`
+}
+
+function cachePrefix(agentId: string): string {
+  return `${agentId}:`
+}
+
+function setCachedMarkPreview(agentId: string, seq: bigint, preview: string): void {
+  const k = cacheKey(agentId, seq)
+  const prefix = cachePrefix(agentId)
+  setCache(produce((c) => {
+    if (!(k in c)) {
+      // Evict this agent's oldest previews down to the cap before inserting. ONE Object.keys
+      // pass (insertion-ordered, so the agent-prefixed slice is oldest-first) serves both the
+      // count and the eviction, rather than scanning the whole global cache twice per insert.
+      const agentKeys = Object.keys(c).filter(existing => existing.startsWith(prefix))
+      let excess = agentKeys.length - MAX_PREVIEW_CACHE_ENTRIES_PER_AGENT + 1
+      for (const existing of agentKeys) {
+        if (excess <= 0)
+          break
+        delete c[existing]
+        excess--
+      }
+    }
+    c[k] = preview
+  }))
+}
+
+export interface MarkPreviewDeps {
+  /** The loaded message at this seq, or undefined when it's outside the window. */
+  getLoadedMessageBySeq: (agentId: string, seq: bigint) => AgentChatMessage | undefined
+  /**
+   * Fetch a single message by seq. Resolves `undefined` ONLY for a definitive absence
+   * (no row at that seq -- deleted/reseq'd since the mark was recorded); REJECTS on a
+   * transient RPC failure. The two must stay distinguishable so warmMarkPreview caches
+   * '' for a real absence but retries a transient failure instead of poisoning the dot.
+   */
+  fetchMessageBySeq: (workerId: string, agentId: string, seq: bigint) => Promise<AgentChatMessage | undefined>
+}
+
+/**
+ * Reactive read of a resolved preview: `undefined` until resolved, `''` when resolved
+ * with no previewable text, otherwise the snippet. Tracks the cache so the tooltip
+ * re-renders when a pending fetch lands.
+ */
+export function getCachedMarkPreview(agentId: string, seq: bigint): string | undefined {
+  return cache[cacheKey(agentId, seq)]
+}
+
+/**
+ * Ensure the preview for (agentId, seq) is resolved into the cache. Idempotent and
+ * deduped: a cached key or an in-flight fetch is a no-op. Resolves synchronously from
+ * the loaded window when the message is present (no fetch); otherwise fetches the single
+ * message and caches its extracted preview. A DEFINITIVE miss -- the fetch resolves with
+ * no row (deleted/reseq'd since the mark was recorded) -- caches `''` so the rail falls
+ * back to a label without re-fetching on every hover. A TRANSIENT fetch FAILURE (the RPC
+ * rejects) is deliberately left UNRESOLVED (no cache entry) so a later hover retries,
+ * rather than poisoning the dot with a permanent empty preview for the rest of the session.
+ */
+export function warmMarkPreview(workerId: string, agentId: string, seq: bigint, deps: MarkPreviewDeps): void {
+  if (seq <= 0n)
+    return
+  const k = cacheKey(agentId, seq)
+  if (k in cache || inflight.has(k))
+    return
+
+  const local = deps.getLoadedMessageBySeq(agentId, seq)
+  if (local) {
+    setCachedMarkPreview(agentId, seq, messageMarkPreviewText(local) ?? '')
+    return
+  }
+
+  const token = ++nextFetchToken
+  inflight.set(k, token)
+  // Only the CURRENT fetch for this key may write/clear -- a resolution whose token was
+  // dropped by forget or superseded by a re-warm is a no-op, so it can neither re-leak an
+  // entry for a closed agent nor clobber a fresher fetch's result.
+  const isCurrent = () => inflight.get(k) === token
+  deps.fetchMessageBySeq(workerId, agentId, seq)
+    .then((msg) => {
+      // A resolved-undefined message is a DEFINITIVE absence (no row at this seq) --
+      // cache '' so the rail shows a label without re-fetching. A REJECTION lands in
+      // .catch below and is NOT cached, so a transient failure can be retried.
+      if (isCurrent())
+        setCachedMarkPreview(agentId, seq, msg ? (messageMarkPreviewText(msg) ?? '') : '')
+    })
+    .catch(() => {
+      // Transient fetch failure: leave the key UNRESOLVED (the finally drops the
+      // in-flight token, so the next hover re-fetches) rather than caching '' --
+      // caching here would permanently label the dot until the agent is reopened.
+    })
+    .finally(() => {
+      if (isCurrent())
+        inflight.delete(k)
+    })
+}
+
+/**
+ * Drop every cached preview + in-flight key for an agent. Called from the chat
+ * store's forgetAgent so the module-global cache doesn't accumulate one entry per
+ * (agentId, seq) ever hovered for the life of the tab -- and so a stale `''` (a
+ * fetch that transiently found no row) never survives a close/reopen of the same
+ * agentId to suppress the now-available preview. Dropping the in-flight token also
+ * fences any pending fetch for this agent, so a late resolve can't re-leak an entry.
+ */
+export function forgetMarkPreview(agentId: string): void {
+  const prefix = cachePrefix(agentId)
+  setCache(produce((c) => {
+    for (const k of Object.keys(c)) {
+      if (k.startsWith(prefix))
+        delete c[k]
+    }
+  }))
+  for (const k of inflight.keys()) {
+    if (k.startsWith(prefix))
+      inflight.delete(k)
+  }
+}
+
+/** Test-only: reset the module-global cache + in-flight set between cases. */
+export function __resetMarkPreviewCacheForTest(): void {
+  setCache(reconcile({}))
+  inflight.clear()
+}

--- a/frontend/src/components/chat/chatRailPolicy.test.ts
+++ b/frontend/src/components/chat/chatRailPolicy.test.ts
@@ -1,0 +1,201 @@
+import type { DotCluster } from './chatRailPolicy'
+import type { VirtualItem } from './useChatVirtualizer'
+import { describe, expect, it } from 'vitest'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { canRenderSeqRailThumb, clusterMarks, dotClustersEqual, nearestDotWithin, resolveScrollbarOwner } from './chatRailPolicy'
+import { rowStartSeqs } from './chatScrollRailGeometry'
+
+describe('chatrailpolicy', () => {
+  describe('cluster marks', () => {
+    it('places one dot per spread-out mark, centered on its band on the thumb-centre axis', () => {
+      // rail 400, fixed thumb 24 -> centre travels [12, 388] (travel 376).
+      // dotFraction(2,{1,5})=0.3 -> 12+0.3*376=124.8; dotFraction(4)=0.7 -> 275.2.
+      const dots = clusterMarks(
+        [{ seq: 2n, type: MarkType.USER_MESSAGE }, { seq: 4n, type: MarkType.CONTROL_RESPONSE }],
+        { minSeq: 1n, maxSeq: 5n },
+        400,
+        24,
+      )
+      expect(dots).toEqual([
+        { seq: 2n, topPx: 125, type: MarkType.USER_MESSAGE, count: 1 },
+        { seq: 4n, topPx: 275, type: MarkType.CONTROL_RESPONSE, count: 1 },
+      ])
+    })
+
+    it('collapses marks that round to the same pixel into ONE dot whose rep is nearest the pixel centre', () => {
+      // seqs 500..502 of a huge history all round to px 14 on the [12,388] centre axis; 502's
+      // exact position is nearest that pixel centre, so it is the cluster's representative.
+      const dots = clusterMarks(
+        [
+          { seq: 500n, type: MarkType.USER_MESSAGE },
+          { seq: 501n, type: MarkType.USER_MESSAGE },
+          { seq: 502n, type: MarkType.USER_MESSAGE },
+        ],
+        { minSeq: 1n, maxSeq: 100_000n },
+        400,
+        24,
+      )
+      expect(dots).toEqual([{ seq: 502n, topPx: 14, type: MarkType.USER_MESSAGE, count: 3 }])
+    })
+
+    it('drops marks outside [minSeq, maxSeq]', () => {
+      const dots = clusterMarks(
+        [
+          { seq: 1n, type: MarkType.USER_MESSAGE }, // below range
+          { seq: 3n, type: MarkType.USER_MESSAGE }, // in range
+          { seq: 9n, type: MarkType.USER_MESSAGE }, // above range
+        ],
+        { minSeq: 2n, maxSeq: 5n },
+        400,
+        0,
+      )
+      expect(dots.map(d => d.seq)).toEqual([3n])
+    })
+
+    it('skips marks when the range is unsafe (dotFraction fails closed) instead of piling them at fraction 0', () => {
+      // A whole-range overflow makes every dotFraction null; clusterMarks must produce NO dots
+      // rather than clustering them all at the rail top (fraction 0) -- the fail-closed contract.
+      const tooWide = BigInt(Number.MAX_SAFE_INTEGER) + 2n
+      const dots = clusterMarks(
+        [{ seq: 5n, type: MarkType.USER_MESSAGE }, { seq: 9n, type: MarkType.CONTROL_RESPONSE }],
+        { minSeq: 1n, maxSeq: tooWide },
+        400,
+        24,
+      )
+      expect(dots).toEqual([])
+    })
+
+    it('returns [] for a zero-height rail (nothing to place)', () => {
+      expect(clusterMarks([{ seq: 2n, type: MarkType.USER_MESSAGE }], { minSeq: 1n, maxSeq: 5n }, 0, 0)).toEqual([])
+    })
+
+    it('returns [] for no marks', () => {
+      expect(clusterMarks([], { minSeq: 1n, maxSeq: 5n }, 400, 0)).toEqual([])
+    })
+
+    it('includes marks sitting exactly on the range boundary (minSeq and maxSeq are inclusive)', () => {
+      // thumb 0 -> centerAxisY(f,400,0) = f*400. span = (5-2)+1 = 4.
+      // dotFraction(2)=0.5/4=0.125 -> 50; dotFraction(5)=3.5/4=0.875 -> 350.
+      const dots = clusterMarks(
+        [{ seq: 2n, type: MarkType.USER_MESSAGE }, { seq: 5n, type: MarkType.CONTROL_RESPONSE }],
+        { minSeq: 2n, maxSeq: 5n },
+        400,
+        0,
+      )
+      expect(dots).toEqual([
+        { seq: 2n, topPx: 50, type: MarkType.USER_MESSAGE, count: 1 },
+        { seq: 5n, topPx: 350, type: MarkType.CONTROL_RESPONSE, count: 1 },
+      ])
+    })
+  })
+
+  describe('dot clusters equal', () => {
+    const base: DotCluster[] = [
+      { seq: 2n, topPx: 184, type: MarkType.USER_MESSAGE, count: 1 },
+      { seq: 4n, topPx: 216, type: MarkType.CONTROL_RESPONSE, count: 3 },
+    ]
+    it('is true for content-equal arrays (so a +1 seq bump that keeps every pixel reuses the reference)', () => {
+      expect(dotClustersEqual(base, base.map(d => ({ ...d })))).toBe(true)
+    })
+    it('is false when any dot field or the length differs', () => {
+      expect(dotClustersEqual(base, [{ ...base[0] }, { ...base[1], topPx: 217 }])).toBe(false)
+      expect(dotClustersEqual(base, [{ ...base[0] }, { ...base[1], count: 4 }])).toBe(false)
+      expect(dotClustersEqual(base, [{ ...base[0] }, { ...base[1], seq: 5n }])).toBe(false)
+      expect(dotClustersEqual(base, [base[0]])).toBe(false)
+    })
+  })
+
+  describe('nearest dot within', () => {
+    const dots: DotCluster[] = [
+      { seq: 1n, topPx: 20, type: MarkType.USER_MESSAGE, count: 1 },
+      { seq: 2n, topPx: 60, type: MarkType.USER_MESSAGE, count: 1 },
+      { seq: 3n, topPx: 100, type: MarkType.CONTROL_RESPONSE, count: 2 },
+    ]
+    it('returns the dot within range nearest y (checking the lower-bound dot and its predecessor)', () => {
+      expect(nearestDotWithin(dots, 58, 12)?.seq).toBe(2n) // 2px from the 60 dot
+      expect(nearestDotWithin(dots, 100, 12)?.seq).toBe(3n) // exactly on the 100 dot
+      expect(nearestDotWithin(dots, 12, 12)?.seq).toBe(1n) // 8px from the 20 dot (predecessor of idx 0 is absent)
+    })
+    it('returns null when no dot is within range', () => {
+      expect(nearestDotWithin(dots, 40, 12)).toBeNull() // 20px from either neighbour, range 12
+      expect(nearestDotWithin([], 40, 12)).toBeNull()
+    })
+    it('is inclusive at exactly rangePx and prefers the dot at/after y on a tie', () => {
+      expect(nearestDotWithin(dots, 8, 12)?.seq).toBe(1n) // exactly 12px from the 20 dot
+      // y midway (40) between the 20 and 60 dots: both are 20px away; range 20 admits both,
+      // and the dot at/after y (60) wins the tie (checked second under `<=`).
+      expect(nearestDotWithin(dots, 40, 20)?.seq).toBe(2n)
+    })
+  })
+
+  describe('resolvescrollbarowner', () => {
+    const items = (seqs: bigint[]): VirtualItem[] => seqs.map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+    // The window-shape half of ScrollbarOwnerInputs (itemCount + precomputed rowSeqs), so a test
+    // states a window as its seqs and mirrors how ChatView memoizes rowStartSeqs once per commit.
+    const window = (seqs: bigint[]) => ({ itemCount: seqs.length, rowSeqs: rowStartSeqs(items(seqs)) })
+    const base = {
+      loaded: true,
+      ...window([1n, 2n, 3n]),
+      range: { minSeq: 1n, maxSeq: 3n },
+      hasMoreOlder: false,
+      hasMoreNewer: false,
+      totalHeight: 5000,
+      viewportHeight: 500,
+    }
+
+    it('an unseeded rail leaves the native scrollbar in charge', () => {
+      expect(resolveScrollbarOwner({ ...base, loaded: false })).toBe('native')
+    })
+
+    it('an empty window scrolls with neither bar', () => {
+      expect(resolveScrollbarOwner({ ...base, ...window([]), range: { minSeq: 0n, maxSeq: 0n } })).toBe('none')
+    })
+
+    it('the rail owns scrolling for a multi-seq history that overflows', () => {
+      expect(resolveScrollbarOwner(base)).toBe('rail')
+    })
+
+    it('neither bar shows when the whole history is loaded and fits', () => {
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 400 })).toBe('none')
+    })
+
+    it('the passed viewportHeight is the overflow measure (ChatView passes the content-box height)', () => {
+      // The single caller (ChatView) passes the content-box viewportHeight -- the SAME coordinate
+      // space totalHeight lives in -- so `totalHeight <= viewportHeight + tolerance` is the true
+      // overflow test. Content overflowing it past the tolerance keeps the rail as owner; if a
+      // caller instead passed the padding-box clientHeight (content-box + the container's ~32px
+      // vertical padding), a conversation overflowing by up to that padding would resolve 'none'
+      // and hide the rail over overflowing content -- the zero-scrollbar strand this design
+      // forecloses by resolving ownership ONCE from ChatView's content-box height.
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 502, viewportHeight: 500 })).toBe('rail')
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 532, viewportHeight: 500 })).toBe('rail')
+      // Same overflow (532) but a padding-box-sized height (532) would (wrongly) read as fitting.
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 532, viewportHeight: 532 })).toBe('none')
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 500, viewportHeight: 500 })).toBe('none')
+    })
+
+    it('the rail still owns scrolling when the loaded content fits but more history is off-window', () => {
+      expect(resolveScrollbarOwner({ ...base, totalHeight: 400, hasMoreNewer: true })).toBe('rail')
+    })
+
+    it('hands a single-seq overflowing history back to the NATIVE bar (the strand fix)', () => {
+      // A whole history of one distinct seq collapses the seq-space thumb-drag to a point, so a
+      // lone message taller than the viewport must keep the native scrollbar rather than strand
+      // behind a frozen rail. canRenderSeqRailThumb alone would (wrongly) report the rail usable.
+      expect(canRenderSeqRailThumb(rowStartSeqs(items([7n])), { minSeq: 7n, maxSeq: 7n })).toBe(true)
+      expect(resolveScrollbarOwner({
+        ...base,
+        ...window([7n]),
+        range: { minSeq: 7n, maxSeq: 7n },
+      })).toBe('native')
+    })
+
+    it('hands an all-optimistic-local overflowing window to the native bar (no server anchor)', () => {
+      expect(resolveScrollbarOwner({
+        ...base,
+        ...window([0n, 0n]),
+        range: { minSeq: 1n, maxSeq: 3n },
+      })).toBe('native')
+    })
+  })
+})

--- a/frontend/src/components/chat/chatRailPolicy.ts
+++ b/frontend/src/components/chat/chatRailPolicy.ts
@@ -1,0 +1,250 @@
+import type { RailRange } from './chatScrollRailGeometry'
+import type { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import type { SeqMark } from '~/stores/chatMessageMarks'
+import { lowerBoundBySeq, smallestIndexWhere } from '~/lib/binarySearch'
+import { clamp } from '~/lib/clamp'
+import { SCROLLBAR_OVERFLOW_TOLERANCE_PX } from './chatScrollGeometry'
+import { centerAxisY, safeSeqDeltaNumber, seqSpan } from './chatScrollRailGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail policy
+//
+// The rail DECISIONS layered on top of the pure coordinate math in chatScrollRailGeometry:
+// which scrollbar owns the viewport, whether a seq-space thumb is worth drawing, and how the
+// marked seqs cluster into jump dots (plus the scrub hit-test). Kept apart from the geometry
+// module so that file stays pure seq<->pixel math; everything here reads that math and adds a
+// rail-behaviour judgement on top. The dependency is one-way (policy -> geometry, never back).
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the rail can render a seq-space thumb, over a PRECOMPUTED rowStartSeqs. The caller
+ * memoizes rowStartSeqs (the scroll-owner resolution in ChatView) and reuses it here instead of
+ * re-deriving the O(n) row-seq map on every evaluation -- so the owner decision stays O(1) on a
+ * scroll frame or a streaming-height commit, which leave the item list (and thus rowStartSeqs)
+ * unchanged. `rowSeqs === null` (no server anchor) is the only structural gate beyond the range
+ * guards; single-seq (maxSeq === minSeq) still reports drawable here -- the "can't scrub a point"
+ * rule is resolveScrollbarOwner's, not the geometry's (see its `maxSeq > minSeq` term).
+ */
+export function canRenderSeqRailThumb(rowSeqs: number[] | null, range: RailRange): boolean {
+  if (range.maxSeq <= 0n)
+    return false
+  if (rowSeqs === null)
+    return false
+  // seqSpan folds in the inverted-range (maxSeq < minSeq) and unsafe-seq guards.
+  return seqSpan(range) !== null
+}
+
+/**
+ * Which scrollbar owns the viewport: the native one, the seq-space rail, or neither (content
+ * fits). The SINGLE decision behind both the rail's self-hide (ChatScrollRail.hidden) and the
+ * native-scrollbar hide (ChatView.hideNativeScrollbar). To make the "never zero or two
+ * scrollbars" invariant STRUCTURAL rather than a coincidence, ChatView resolves this ONCE and
+ * hands the rail its result (see ChatView.railOwner): a shared pure function is not enough if the
+ * two consumers feed it inputs from two reactive sources -- notably viewport height, where the
+ * native-hide once read the content-box height and the rail read its own padding-box
+ * clientHeight, so a whole-history conversation overflowing by up to the container's vertical
+ * padding could hide BOTH bars. Rules:
+ *   - not loaded -> native (the rail isn't ready to take over).
+ *   - whole history loaded AND content fits -> none (nothing to scroll; both hide).
+ *   - the rail can scroll every pixel -> rail; otherwise -> native.
+ * "The rail can scroll every pixel" requires a drawable thumb AND a whole-history seq span of
+ * MORE than one seq: a single distinct seq (maxSeq === minSeq) collapses the thumb-drag to a
+ * point, so a lone message taller than the viewport must keep the native scrollbar rather than
+ * strand behind a frozen rail.
+ */
+export type ScrollbarOwner = 'native' | 'rail' | 'none'
+
+export interface ScrollbarOwnerInputs {
+  /** True once the marks RPC has seeded the rail (ChatRailData.loaded). */
+  loaded: boolean
+  /** Count of visible virtual rows; 0 = empty window (nothing to scroll, so neither bar shows). */
+  itemCount: number
+  /**
+   * rowStartSeqs of the visible rows (null when the window holds no server row). Passed in
+   * PRECOMPUTED -- the caller memoizes it on the item list -- so this O(1) resolution never
+   * triggers the O(n) row-seq scan on a scroll frame or a streaming-height commit, both of which
+   * leave the item list (and thus rowStartSeqs) unchanged.
+   */
+  rowSeqs: number[] | null
+  /** The whole-history seq range the rail spans. */
+  range: RailRange
+  /** Whether older/newer messages remain unfetched beyond the loaded window. */
+  hasMoreOlder: boolean
+  hasMoreNewer: boolean
+  /** Total virtual content height (px). */
+  totalHeight: number
+  /**
+   * The viewport CONTENT-box height (px) -- the same coordinate space totalHeight is measured in,
+   * NOT the padding-box `clientHeight`. Content overflows iff totalHeight > content-box (the
+   * scroll container's vertical padding cancels out of `scrollHeight > clientHeight`), so feeding
+   * clientHeight here would over-report the fit by that padding and hide the rail over overflowing
+   * content. ChatView passes its ResizeObserver's contentRect.height (see viewportHeight).
+   */
+  viewportHeight: number
+}
+
+export function resolveScrollbarOwner(inp: ScrollbarOwnerInputs): ScrollbarOwner {
+  if (!inp.loaded)
+    return 'native'
+  // No rows loaded: nothing to scroll, so neither scrollbar is needed. Structural (independent of a
+  // possibly-unmeasured height) so an empty window never flickers a native bar over no content.
+  if (inp.itemCount === 0)
+    return 'none'
+  const contentFits = inp.totalHeight <= inp.viewportHeight + SCROLLBAR_OVERFLOW_TOLERANCE_PX
+  const railCanScroll = inp.range.maxSeq > inp.range.minSeq && canRenderSeqRailThumb(inp.rowSeqs, inp.range)
+  if (railCanScroll) {
+    // The rail scrubs the whole seq-space, so it owns scrolling whenever there is any -- it
+    // self-hides only when the whole history is loaded AND fits (nothing to scroll anywhere).
+    const wholeHistoryLoaded = !inp.hasMoreOlder && !inp.hasMoreNewer
+    return wholeHistoryLoaded && contentFits ? 'none' : 'rail'
+  }
+  // The rail can't scrub (no server row, or a single-seq history): the native bar owns scrolling,
+  // needed only when content actually overflows; otherwise nothing scrolls.
+  return contentFits ? 'none' : 'native'
+}
+
+/**
+ * The rail fraction [0,1] at which to draw the dot for message `seq` (centered on its band), or
+ * null when the range is degenerate / overflows an exact int. Fails CLOSED like the geometry
+ * siblings (safeSeqNumber, computeSeqThumb, fractionToSeq) -- honoring the "fail closed instead of
+ * silently rounding jumps" contract -- so an unsafe range DROPS the dot in clusterMarks rather than
+ * pinning it to the rail top (fraction 0, a valid in-band position that would mis-place the jump).
+ */
+export function dotFraction(seq: bigint, range: RailRange): number | null {
+  const metrics = seqSpan(range)
+  if (metrics === null)
+    return null
+  return dotFractionForSpan(seq, range.minSeq, metrics.span)
+}
+
+// The span-carrying core of dotFraction, so clusterMarks can hoist the range-invariant
+// seqSpan(range) out of its per-mark loop instead of recomputing it (a bigint subtraction +
+// object alloc) once per mark.
+function dotFractionForSpan(seq: bigint, minSeq: bigint, span: number): number | null {
+  const offset = seq >= minSeq ? safeSeqDeltaNumber(seq - minSeq) : null
+  if (offset === null)
+    return null
+  return clamp((offset + 0.5) / span, 0, 1)
+}
+
+/** One rail dot: a pixel that stands for `count` marks (>1 = a cluster). */
+export interface DotCluster {
+  /** The member nearest the pixel centre -- the jump + preview target. */
+  seq: bigint
+  /** Rail-Y (px) of the dot, on the thumb-centre axis. */
+  topPx: number
+  /** The representative member's mark type (drives the label/colour). */
+  type: MarkType
+  /** How many marks collapsed to this pixel. */
+  count: number
+}
+
+/**
+ * Cluster the in-range marks into one dot per rounded rail pixel. Many marks in a tall
+ * history collapse to the same pixel; rather than DROP the collisions (which would make
+ * ~all-but-one message per pixel unreachable on a long history), each pixel becomes ONE
+ * dot that stands for its `count` marks, jumps to the member nearest the pixel centre, and
+ * previews with an aggregate header. This caps the DOM node count at ~rail height while
+ * keeping every marked message reachable.
+ *
+ * Dots are placed on the thumb-CENTRE axis (via {@link centerAxisY}) so a dot lines up with
+ * the thumb centre, not the rail edge. Returns [] for a zero-height rail (nothing to place).
+ * Marks must be ascending by seq (the store keeps them so); since {@link dotFraction} is
+ * monotonic, buckets are inserted in ascending pixel order and Map iteration preserves it,
+ * so the result needs no sort.
+ */
+export function clusterMarks(
+  marks: readonly SeqMark[],
+  range: RailRange,
+  railHeightPx: number,
+  thumbHeightPx: number,
+): DotCluster[] {
+  if (railHeightPx <= 0)
+    return []
+  // seqSpan(range) is invariant across the loop, so resolve it once here rather than per mark
+  // (dotFraction would recompute it M times). A degenerate/overflowing range yields null,
+  // which would drop EVERY mark, so bail to an empty cluster set immediately.
+  const metrics = seqSpan(range)
+  if (metrics === null)
+    return []
+  // Bucket in-range marks by rounded rail pixel; the representative is the member whose
+  // exact (pre-round) position is nearest the pixel centre -- the "jump-to-nearest" target.
+  const byPx = new Map<number, { rep: SeqMark, repDist: number, count: number }>()
+  const start = lowerBoundBySeq(marks, range.minSeq)
+  for (let i = start; i < marks.length; i++) {
+    const mark = marks[i]
+    if (mark.seq > range.maxSeq)
+      break
+    const frac = dotFractionForSpan(mark.seq, range.minSeq, metrics.span)
+    if (frac === null)
+      continue
+    const exact = centerAxisY(frac, railHeightPx, thumbHeightPx)
+    const px = Math.round(exact)
+    const dist = Math.abs(exact - px)
+    const cur = byPx.get(px)
+    if (!cur) {
+      byPx.set(px, { rep: mark, repDist: dist, count: 1 })
+    }
+    else {
+      cur.count += 1
+      if (dist < cur.repDist) {
+        cur.rep = mark
+        cur.repDist = dist
+      }
+    }
+  }
+  const out: DotCluster[] = []
+  for (const [px, c] of byPx)
+    out.push({ seq: c.rep.seq, topPx: px, type: c.rep.type, count: c.count })
+  return out
+}
+
+/**
+ * Whether two dot clusters are identical across EVERY field -- the single "same dot" rule shared by
+ * the `dots` memo's array `equals` ({@link dotClustersEqual}) and the rail's hover-cleanup membership
+ * check, so adding a {@link DotCluster} field can't leave one comparison stale while the other updates.
+ */
+export function dotClusterEqual(a: DotCluster, b: DotCluster): boolean {
+  return a.seq === b.seq && a.topPx === b.topPx && a.type === b.type && a.count === b.count
+}
+
+/**
+ * Content equality for two {@link clusterMarks} results, for a memo's `equals`: an unchanged
+ * layout keeps the SAME array reference so `<For>` doesn't tear down + rebuild every dot's
+ * tooltip. maxSeq ticks up on every persisted row during a streaming turn, but on a long
+ * conversation a +1 seq shift rounds to the same clusters, so recomputing would otherwise
+ * hand `<For>` a fresh array each frame for no visual change.
+ */
+export function dotClustersEqual(a: readonly DotCluster[], b: readonly DotCluster[]): boolean {
+  return a.length === b.length && a.every((d, i) => dotClusterEqual(d, b[i]))
+}
+
+/**
+ * The dot nearest rail-Y `y` within `rangePx`, or null when none is that close -- the
+ * scrub-hover hit-test the rail draws its single preview popover from as the dragging
+ * thumb passes each dot. `dots` are ascending by {@link DotCluster.topPx} (clusterMarks
+ * emits them in pixel order), so a lower-bound search finds the first dot at/after `y` and
+ * the nearer of it and its predecessor wins. On a tie the dot at/after `y` wins (it is
+ * checked second under the inclusive `<=`). Pure + testable here rather than inline in the
+ * component, alongside clusterMarks / resolveScrollbarOwner.
+ */
+export function nearestDotWithin(dots: readonly DotCluster[], y: number, rangePx: number): DotCluster | null {
+  const idx = smallestIndexWhere(dots.length, i => dots[i].topPx >= y, dots.length)
+  let best: DotCluster | null = null
+  let bestDist = rangePx
+  // Check the predecessor first, then the dot at/after y, WITHOUT allocating a candidate array
+  // each call (this runs per rAF frame during a scrub). The at/after dot is checked second so a
+  // tie resolves to it, under the inclusive `<=`.
+  const consider = (d: DotCluster | undefined) => {
+    if (!d)
+      return
+    const dist = Math.abs(d.topPx - y)
+    if (dist <= bestDist) {
+      best = d
+      bestDist = dist
+    }
+  }
+  consider(dots[idx - 1])
+  consider(dots[idx])
+  return best
+}

--- a/frontend/src/components/chat/chatScrollAnchor.test.ts
+++ b/frontend/src/components/chat/chatScrollAnchor.test.ts
@@ -1,6 +1,6 @@
 import type { AnchorOffsetGeometry, AnchorRow } from './chatScrollAnchor'
 import { describe, expect, it } from 'vitest'
-import { anchorAtOffset, resolveAnchorScrollTop, resolveNearestAnchorScrollTop } from './chatScrollAnchor'
+import { anchorAtOffset, nearestServerRowIndexBySeq, resolveAnchorScrollTop, resolveNearestAnchorScrollTop } from './chatScrollAnchor'
 
 /**
  * A fake geometry over uniform rows of `rowHeight` with a constant `gap` below each
@@ -131,7 +131,7 @@ describe('chatscrollanchor', () => {
     })
   })
 
-  describe('resolveNearestAnchorScrollTop (trimmed-row recovery)', () => {
+  describe('resolve nearest anchor scroll top (trimmed-row recovery)', () => {
     it('returns the exact position when the row still resolves', () => {
       const geo = fakeGeo(rows([10, 20, 30]))
       expect(resolveNearestAnchorScrollTop(geo, { id: 'm20', offsetWithinRow: 0, seq: 20n })).toBe(120)
@@ -168,6 +168,28 @@ describe('chatscrollanchor', () => {
       // local lived).
       const geo = fakeGeo(rows([10, 20, 30]))
       expect(resolveNearestAnchorScrollTop(geo, { id: 'gone', offsetWithinRow: 0, seq: 0n })).toBeNull()
+    })
+  })
+
+  describe('nearest server row index by seq (shared scan)', () => {
+    it('picks the row with the smallest absolute seq distance', () => {
+      const r = rows([10, 20, 30])
+      expect(nearestServerRowIndexBySeq(r, 22n)).toBe(1) // 20 is nearest
+      expect(nearestServerRowIndexBySeq(r, 30n)).toBe(2) // exact
+      expect(nearestServerRowIndexBySeq(r, 5n)).toBe(0) // below floor -> oldest
+      expect(nearestServerRowIndexBySeq(r, 999n)).toBe(2) // above ceiling -> newest
+    })
+
+    it('breaks ties toward the first (lower-index) row via the strict < compare', () => {
+      // target 15 is equidistant (5) from 10 and 20; strict `<` keeps the first.
+      expect(nearestServerRowIndexBySeq(rows([10, 20]), 15n)).toBe(0)
+    })
+
+    it('skips optimistic locals (seq 0n) and missing seqs, and returns -1 when none remain', () => {
+      const mixed: { id: string, seq?: bigint }[] = [{ id: 'a', seq: 0n }, { id: 'b', seq: 40n }, { id: 'c' }]
+      expect(nearestServerRowIndexBySeq(mixed, 5n)).toBe(1) // only 'b' is a server row
+      expect(nearestServerRowIndexBySeq([{ seq: 0n }], 5n)).toBe(-1)
+      expect(nearestServerRowIndexBySeq([], 5n)).toBe(-1)
     })
   })
 })

--- a/frontend/src/components/chat/chatScrollAnchor.ts
+++ b/frontend/src/components/chat/chatScrollAnchor.ts
@@ -1,5 +1,6 @@
 import type { ScrollAnchor } from '~/stores/chatTypes'
 import { clamp } from '~/lib/clamp'
+import { isOptimisticLocalSeq } from '~/stores/chatReconcile'
 
 // ---------------------------------------------------------------------------
 // Scroll-anchor math
@@ -121,6 +122,31 @@ export function resolveAnchorScrollTop(geo: AnchorOffsetGeometry, anchor: Scroll
 }
 
 /**
+ * Index of the SERVER row whose seq is nearest `target` by absolute distance, or -1 when
+ * the list holds no server row. Skips rows with no seq / an optimistic-local 0n seq (which
+ * pin to the tail out of seq order). The single home for the "nearest surviving row by seq"
+ * scan shared by the trim-restore recovery ({@link resolveNearestAnchorScrollTop}) and the
+ * scroll rail's out-of-window seek landing (useChatScroll.landOnSeq), so the two can't
+ * drift on the skip rule or the tie-break (strict `<` keeps the first/oldest on a tie).
+ * Linear over a bounded list; callers run it only on a rare restore/seek.
+ */
+export function nearestServerRowIndexBySeq(rows: readonly { seq?: bigint }[], target: bigint): number {
+  let bestIdx = -1
+  let bestDelta = 0n
+  for (let i = 0; i < rows.length; i++) {
+    const s = rows[i].seq
+    if (s == null || isOptimisticLocalSeq(s))
+      continue
+    const delta = s > target ? s - target : target - s
+    if (bestIdx < 0 || delta < bestDelta) {
+      bestIdx = i
+      bestDelta = delta
+    }
+  }
+  return bestIdx
+}
+
+/**
  * Resolve an anchor to a scrollTop, recovering when its row was TRIMMED away (id gone)
  * by landing on the NEAREST surviving row by seq. Returns the exact scrollTopForAnchor
  * when the row still resolves; otherwise, if the anchor carries a seq and the list has a
@@ -139,25 +165,11 @@ export function resolveNearestAnchorScrollTop(geo: AnchorOffsetGeometry, anchor:
   // a reader parked on a tail-pinned local to the top of history once the local
   // reconciles (its id changes, so the exact resolve above fails). Falling back to null
   // lets the caller snap to the tail, which is where a local lived anyway.
-  if (anchor.seq == null || anchor.seq === 0n)
+  if (anchor.seq == null || isOptimisticLocalSeq(anchor.seq))
     return null
-  // Scan the surviving SERVER rows (skip trailing optimistic locals, seq 0n, which pin
-  // to the tail out of seq order) for the one whose seq is closest to the gone anchor's.
   // A trim/replacement drops a contiguous run, so the nearest survivor is normally the
   // list's oldest (anchor older) or newest (anchor newer) row; the general nearest also
-  // handles a mid-list drop. Linear over a bounded list and only on a rare restore.
-  const { list } = geo
-  let bestIdx = -1
-  let bestDelta = 0n
-  for (let i = 0; i < list.length; i++) {
-    const s = list[i].seq
-    if (s == null || s === 0n)
-      continue
-    const delta = s > anchor.seq ? s - anchor.seq : anchor.seq - s
-    if (bestIdx < 0 || delta < bestDelta) {
-      bestIdx = i
-      bestDelta = delta
-    }
-  }
+  // handles a mid-list drop.
+  const bestIdx = nearestServerRowIndexBySeq(geo.list, anchor.seq)
   return bestIdx < 0 ? null : geo.offsetOfIndex(bestIdx)
 }

--- a/frontend/src/components/chat/chatScrollGeometry.ts
+++ b/frontend/src/components/chat/chatScrollGeometry.ts
@@ -34,6 +34,15 @@ export const STICKY_BOTTOM_THRESHOLD_PX = 32
 export const EDGE_INTENT_TOLERANCE_PX = 1
 
 /**
+ * Pixel slack for "does the content fit the viewport, so no scrollbar is needed?" -- a
+ * sub-pixel rounding overflow (fractional DPI / zoom) needs no scrollbar. The SINGLE source
+ * for this bound so the rail's self-hide (ChatScrollRail) and the native-scrollbar hide
+ * (ChatView) agree on what "overflows" means; if they diverged, a viewport could be left with
+ * NO usable scrollbar (both hidden) or two.
+ */
+export const SCROLLBAR_OVERFLOW_TOLERANCE_PX = 1
+
+/**
  * A synchronous scroll-pipeline phase (refreshViewport render cascade, a premeasure row's
  * forced-layout measure, or an offset-map rebuild) that runs longer than this dropped
  * multiple frames and is a main-thread STALL -- the cause of the batched catch-up scroll

--- a/frontend/src/components/chat/chatScrollRailDrag.test.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.test.ts
@@ -1,0 +1,278 @@
+import type { ThumbDragDeps } from './chatScrollRailDrag'
+import type { PreparedGeometry } from './chatScrollRailGeometry'
+import type { VirtualItem } from './useChatVirtualizer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createThumbDrag } from './chatScrollRailDrag'
+import { prepareGeometry } from './chatScrollRailGeometry'
+
+// A hand-driven rAF so moves flush deterministically: requestAnimationFrame queues the
+// callback (returning an id), cancelAnimationFrame drops it by id, flushRaf() runs the rest.
+let rafQueue: { id: number, cb: FrameRequestCallback }[] = []
+let nextRafId = 0
+let rafSpy: ReturnType<typeof vi.fn>
+let cancelSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  rafQueue = []
+  nextRafId = 0
+  rafSpy = vi.fn((cb: FrameRequestCallback) => {
+    const id = ++nextRafId
+    rafQueue.push({ id, cb })
+    return id
+  })
+  cancelSpy = vi.fn((id: number) => {
+    rafQueue = rafQueue.filter(e => e.id !== id)
+  })
+  vi.stubGlobal('requestAnimationFrame', rafSpy)
+  vi.stubGlobal('cancelAnimationFrame', cancelSpy)
+})
+afterEach(() => vi.unstubAllGlobals())
+
+function flushRaf() {
+  const q = rafQueue
+  rafQueue = []
+  q.forEach(e => e.cb(0))
+}
+
+function prepOf(seqs: bigint[], rowPx = 100): PreparedGeometry {
+  const items: VirtualItem[] = seqs.map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+  return prepareGeometry({ items, offsetOfIndex: i => i * rowPx, totalHeight: seqs.length * rowPx })
+}
+
+/** A rail-relative rect: top 0, height 400 (so clientY maps 1:1 to a [0,1] fraction /400). */
+function makeRect(): DOMRect {
+  return { top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+}
+
+function setup() {
+  const el = document.createElement('div')
+  el.setPointerCapture = vi.fn()
+  el.releasePointerCapture = vi.fn()
+  // Loaded window = seqs 1..5 over rows of 100px; whole range also 1..5 for the base case.
+  const state = {
+    minSeq: 1n,
+    maxSeq: 5n,
+    windowFirstSeq: 1n as bigint | undefined,
+    windowLastSeq: 5n as bigint | undefined,
+    prepared: prepOf([1n, 2n, 3n, 4n, 5n]),
+    thumbHeightPx: 0, // 0 -> the centre axis is the full rail, so clientY/rect.height == fraction
+  }
+  // The resting thumb top at grab. The tests grab AT this position (clientY 100 == grabThumbTopPx),
+  // so the within-thumb offset is 0 and the drag maps clientY/400 straight to the fraction -- the
+  // offset-preservation itself is exercised by its own test below (a grab OFF the resting position).
+  const grabThumbTopPx = 100
+  const setDrag = vi.fn()
+  const previewScrollTo = vi.fn()
+  const onRelease = vi.fn()
+  const onEnd = vi.fn()
+  const deps: ThumbDragDeps = {
+    el,
+    rect: makeRect(),
+    grabThumbTopPx,
+    minSeq: () => state.minSeq,
+    maxSeq: () => state.maxSeq,
+    windowFirstSeq: () => state.windowFirstSeq,
+    windowLastSeq: () => state.windowLastSeq,
+    prepared: () => state.prepared,
+    thumbHeightPx: () => state.thumbHeightPx,
+    setDrag,
+    previewScrollTo,
+    onRelease,
+    onEnd,
+  }
+  const handle = createThumbDrag(deps)
+  return { el, handle, state, setDrag, previewScrollTo, onRelease, onEnd }
+}
+
+function move(el: HTMLElement, clientY: number) {
+  el.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY }))
+}
+function up(el: HTMLElement, clientY: number) {
+  el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY }))
+}
+
+describe('createthumbdrag', () => {
+  it('captures the pointer and applies the initial position, live-scrolling in-window', () => {
+    const { el, handle, setDrag, previewScrollTo } = setup()
+    handle.start(7, 100) // clientY 100 of 400 -> fraction 0.25 -> seqF 1 + 0.25*4 = 2 (in window)
+    expect(el.setPointerCapture).toHaveBeenCalledWith(7)
+    expect(setDrag).toHaveBeenLastCalledWith(0.25)
+    // seqF 2 -> contentY = top of row index 1 = 100px.
+    expect(previewScrollTo).toHaveBeenCalledWith(100)
+  })
+
+  it('drops the drag cleanly when pointer capture fails', () => {
+    const { el, handle, setDrag, onEnd } = setup()
+    el.setPointerCapture = vi.fn(() => {
+      throw new DOMException('pointer is no longer active', 'NotFoundError')
+    })
+
+    expect(() => handle.start(7, 100)).not.toThrow()
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(setDrag).toHaveBeenLastCalledWith(null)
+
+    setDrag.mockClear()
+    move(el, 200)
+    flushRaf()
+    expect(setDrag).not.toHaveBeenCalled()
+  })
+
+  it('maps the pointer onto the thumb-CENTRE axis when the thumb is inset', () => {
+    const { el, handle, state, setDrag } = setup()
+    state.thumbHeightPx = 200 // centre axis [100, 300] over the 400px rail (travel 200)
+    handle.start(1, 200) // the axis midpoint -> fraction 0.5 (the thumb centre follows the pointer)
+    expect(setDrag).toHaveBeenLastCalledWith(0.5)
+    move(el, 50) // above the centre travel -> clamped to 0
+    flushRaf()
+    expect(setDrag).toHaveBeenLastCalledWith(0)
+    move(el, 350) // below the centre travel -> clamped to 1
+    flushRaf()
+    expect(setDrag).toHaveBeenLastCalledWith(1)
+  })
+
+  it('holds the within-thumb grab offset -- no jump-on-grab when grabbing off the thumb centre', () => {
+    const { el, handle, state, setDrag } = setup()
+    // Resting thumb spans [100, 300] (grabThumbTopPx 100, height 200) -> resting fraction 0.5.
+    state.thumbHeightPx = 200
+    // Grab near the thumb's TOP edge (clientY 120), well off its centre (200). The OLD absolute
+    // mapping snapped the thumb centre onto the cursor -> fraction 0.1 (a visible jump); the
+    // offset-preserving drag keeps the thumb at its resting fraction and only tracks FROM there.
+    handle.start(1, 120)
+    expect(setDrag).toHaveBeenLastCalledWith(0.5) // no jump-on-grab
+    setDrag.mockClear()
+    // Moving the pointer down 40px moves the thumb 40px of its 200px centre-travel = +0.2.
+    move(el, 160)
+    flushRaf()
+    expect(setDrag).toHaveBeenLastCalledWith(0.7)
+  })
+
+  it('previews the thumb but does NOT live-scroll when the drag maps outside the loaded window', () => {
+    const { handle, state, setDrag, previewScrollTo } = setup()
+    state.windowFirstSeq = 3n // the loaded window now starts above seqF 2
+    handle.start(1, 100)
+    expect(setDrag).toHaveBeenLastCalledWith(0.25)
+    expect(previewScrollTo).not.toHaveBeenCalled()
+  })
+
+  it('previews the thumb but does NOT live-scroll when seq comparisons exceed safe numbers', () => {
+    const { handle, state, setDrag, previewScrollTo } = setup()
+    const unsafeBase = BigInt(Number.MAX_SAFE_INTEGER) + 1n
+    state.minSeq = unsafeBase
+    state.maxSeq = unsafeBase + 4n
+    state.windowFirstSeq = unsafeBase
+    state.windowLastSeq = unsafeBase + 4n
+    state.prepared = prepOf([unsafeBase, unsafeBase + 1n, unsafeBase + 2n, unsafeBase + 3n, unsafeBase + 4n])
+
+    handle.start(1, 100)
+
+    expect(setDrag).toHaveBeenLastCalledWith(0.25)
+    expect(previewScrollTo).not.toHaveBeenCalled()
+  })
+
+  it('coalesces rAF-throttled moves to the latest position', () => {
+    const { el, handle, setDrag, previewScrollTo } = setup()
+    handle.start(1, 100)
+    setDrag.mockClear()
+    previewScrollTo.mockClear()
+    rafSpy.mockClear()
+    move(el, 150)
+    move(el, 200) // two moves before a frame -> a single scheduled rAF
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    expect(setDrag).not.toHaveBeenCalled() // nothing applied until the frame runs
+    flushRaf()
+    expect(setDrag).toHaveBeenCalledTimes(1)
+    expect(setDrag).toHaveBeenLastCalledWith(0.5) // 200/400, the latest Y
+    expect(previewScrollTo).toHaveBeenCalledWith(200) // seqF 3 -> row index 2 top = 200px
+  })
+
+  it('reports the release fraction on pointerup, stops tracking, and leaves the preview to the owner', () => {
+    const { el, handle, setDrag, onRelease } = setup()
+    handle.start(1, 100)
+    setDrag.mockClear()
+    up(el, 100) // fraction 0.25
+    expect(onRelease).toHaveBeenCalledWith(0.25)
+    // The controller does NOT clear the preview on release -- the owner holds it until settle.
+    expect(setDrag).not.toHaveBeenCalled()
+    // Listeners detached: a later move does nothing.
+    move(el, 300)
+    flushRaf()
+    expect(setDrag).not.toHaveBeenCalled()
+  })
+
+  it('reports the fraction of the RELEASE position, not the grab', () => {
+    const { el, handle, onRelease } = setup()
+    handle.start(1, 100) // grabbed at 0.25
+    up(el, 300) // released at 300/400 = 0.75
+    expect(onRelease).toHaveBeenCalledWith(0.75)
+  })
+
+  it('abandons the drag on pointercancel: clears the preview and does not release/seek', () => {
+    const { el, handle, setDrag, onRelease } = setup()
+    handle.start(1, 100)
+    setDrag.mockClear()
+    // A system/edge gesture stole the pointer mid-drag.
+    el.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, clientY: 200 }))
+    expect(onRelease).not.toHaveBeenCalled() // an abort is not a seek
+    expect(setDrag).toHaveBeenLastCalledWith(null) // preview dropped
+    expect(el.releasePointerCapture).toHaveBeenCalledWith(1)
+    // Detached: a later move does nothing.
+    setDrag.mockClear()
+    move(el, 300)
+    flushRaf()
+    expect(setDrag).not.toHaveBeenCalled()
+  })
+
+  it('cancel() clears the preview, releases capture, and stops tracking, cancelling a pending frame', () => {
+    const { el, handle, setDrag, onRelease } = setup()
+    handle.start(1, 100)
+    move(el, 200) // schedules a frame
+    setDrag.mockClear()
+    handle.cancel()
+    expect(cancelSpy).toHaveBeenCalled() // the pending rAF is cancelled
+    expect(setDrag).toHaveBeenLastCalledWith(null)
+    expect(el.releasePointerCapture).toHaveBeenCalledWith(1)
+    expect(onRelease).not.toHaveBeenCalled() // a cancel is not a release
+    // Fully detached: a later move + frame does nothing.
+    setDrag.mockClear()
+    move(el, 300)
+    flushRaf()
+    expect(setDrag).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: cancel() after a completed release is a harmless no-op', () => {
+    const { el, handle, setDrag, onRelease } = setup()
+    handle.start(1, 100)
+    up(el, 100)
+    onRelease.mockClear()
+    setDrag.mockClear()
+    expect(() => handle.cancel()).not.toThrow()
+    expect(onRelease).not.toHaveBeenCalled()
+    // cancel still clears the preview; harmless.
+    expect(setDrag).toHaveBeenCalledWith(null)
+  })
+
+  it('fires onEnd exactly once per drag -- before onRelease on a deliberate release', () => {
+    const { el, handle, onRelease, onEnd } = setup()
+    handle.start(1, 100)
+    expect(onEnd).not.toHaveBeenCalled() // still tracking
+    up(el, 100)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    // onEnd frees the "drag active" guard before onRelease starts the seek.
+    expect(onEnd.mock.invocationCallOrder[0]).toBeLessThan(onRelease.mock.invocationCallOrder[0])
+    // A later cancel() (unmount) must NOT fire onEnd again -- the guard clears only once.
+    handle.cancel()
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onEnd once on pointercancel and on a bare cancel()', () => {
+    const a = setup()
+    a.handle.start(1, 100)
+    a.el.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, clientY: 200 }))
+    expect(a.onEnd).toHaveBeenCalledTimes(1)
+
+    const b = setup()
+    b.handle.start(1, 100)
+    b.handle.cancel()
+    expect(b.onEnd).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/chat/chatScrollRailDrag.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.ts
@@ -1,0 +1,193 @@
+import type { PreparedGeometry } from './chatScrollRailGeometry'
+import { createRafCoalescer } from '~/lib/rafCoalesce'
+import { centerAxisFraction, contentYForSeq, safeSeqNumber, seqNumberAtFraction } from './chatScrollRailGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail thumb-drag controller
+//
+// Owns the pointer-capture + rAF-throttled move + release lifecycle of a rail thumb
+// drag, extracted from ChatScrollRail so it can be unit-tested WITHOUT rendering a rail
+// (the component just wires accessors + sinks and forwards pointerdown). The seq range and
+// geometry are read through accessors -- called FRESH on each move/release -- because a
+// live-tail advance mid-drag grows maxSeq, and the release must land against the same range
+// the last move previewed against.
+// ---------------------------------------------------------------------------
+
+export interface ThumbDragDeps {
+  /** The rail element the pointer was captured on (also the move/up listener target). */
+  el: HTMLElement
+  /** The rail's bounding rect at grab time; drag Y maps against its top/height. */
+  rect: DOMRect
+  /**
+   * The resting thumb's TOP pixel at grab time. The drag holds the pointer's offset WITHIN the
+   * thumb (grabY - grabThumbTopPx) so the thumb tracks the pointer FROM where it was grabbed
+   * rather than snapping its centre onto the cursor -- i.e. no jump-on-grab (conventional
+   * scrollbar feel), which matters most when grabbing near the thumb's edge on a tall history.
+   */
+  grabThumbTopPx: number
+  /** Live whole-history seq range (read each move/release). */
+  minSeq: () => bigint
+  maxSeq: () => bigint
+  /** Live loaded-window first/last SERVER seq; live-scroll only fires while inside it. */
+  windowFirstSeq: () => bigint | undefined
+  windowLastSeq: () => bigint | undefined
+  /** Live prepared geometry for the in-window content-Y mapping. */
+  prepared: () => PreparedGeometry
+  /** Live thumb height (px); the drag maps the pointer onto the thumb-centre axis with it. */
+  thumbHeightPx: () => number
+  /** Set/clear the drag-preview thumb fraction (null clears the preview). */
+  setDrag: (fraction: number | null) => void
+  /** Guard-marked programmatic scroll write for in-window live-scroll. */
+  previewScrollTo: (top: number) => void
+  /**
+   * The pointer was released at rail fraction `fraction`. The controller does NOT clear the
+   * drag preview here -- the owner holds the thumb at this position and clears it once the
+   * seek has scrolled the view to match, so the thumb doesn't flash back to the pre-drag
+   * position while an out-of-window seek fetches + lands.
+   */
+  onRelease: (fraction: number) => void
+  /**
+   * The pointer lifecycle ended (release, cancel, or an explicit cancel() from an unmount):
+   * the controller has torn down its listeners + rAF. Fires at most once per drag, BEFORE
+   * onRelease on a deliberate release, so the owner can free a "drag active" guard without
+   * disturbing the release's preview-hold. Optional. Idempotent teardown means a normal
+   * release followed by cancel() won't fire it twice.
+   */
+  onEnd?: () => void
+}
+
+export interface ThumbDragHandle {
+  /** Begin the drag: capture the pointer, wire listeners, and apply the initial position. */
+  start: (pointerId: number, initialClientY: number) => void
+  /** Stop the rAF/listeners and clear the drag preview (an unmount landing mid-drag). */
+  cancel: () => void
+}
+
+/**
+ * Create a thumb-drag controller for one grab. `start` captures the pointer and begins
+ * tracking; the drag ends on pointerup/pointercancel (seeking the mapped seq) or when the
+ * caller invokes `cancel` (mid-drag unmount). All handlers are idempotent, so `cancel`
+ * after a completed drag is a harmless no-op.
+ */
+export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
+  const { el, rect } = deps
+  let capturedPointerId: number | null = null
+
+  // The thumb height + within-thumb grab offset, both frozen at grab (start) so the
+  // pointer->fraction axis stays internally consistent for the whole drag: the offset is measured
+  // against THIS height, and mixing it with a live re-read (a mid-drag rail resize) would map the
+  // pointer against a different height than the one the offset was anchored to. The RENDERED thumb
+  // still tracks the live height -- the fraction is normalised [0,1], so it projects correctly onto
+  // whatever geometry the render holds. grabOffsetPx = grabY - grabThumbTopPx; holding it is what
+  // makes the thumb track the pointer FROM where it was grabbed rather than recentering on the
+  // cursor (no jump-on-grab).
+  let grabThumbHeightPx = 0
+  let grabOffsetPx = 0
+
+  // Map a rail-relative pointer Y to the drag fraction: place the thumb TOP so the pointer keeps
+  // its within-thumb grab offset, then project the thumb CENTRE onto the centre axis (the same
+  // axis the dots + track are drawn on). Shared by the live move (apply) and the release (finish)
+  // so the two can't drift on the geometry they map the pointer against.
+  const fractionAt = (clientY: number) => {
+    const thumbTop = clientY - rect.top - grabOffsetPx
+    return centerAxisFraction(thumbTop + grabThumbHeightPx / 2, rect.height, grabThumbHeightPx)
+  }
+
+  const releasePointerCapture = () => {
+    if (capturedPointerId === null)
+      return
+    try {
+      el.releasePointerCapture?.(capturedPointerId)
+    }
+    catch {
+      // The browser may have already dropped capture on pointercancel/pointerup.
+    }
+    capturedPointerId = null
+  }
+
+  // Map a rail-relative pointer Y to the drag fraction, preview the thumb, and -- while the
+  // target maps INSIDE the loaded window -- live-scroll the chat so the view tracks the thumb.
+  const apply = (clientY: number) => {
+    // Map the pointer to the drag fraction (offset-preserving; see fractionAt), preview the thumb
+    // there, and -- while the mapped seq is in-window -- live-scroll so the view tracks the thumb.
+    const f = fractionAt(clientY)
+    deps.setDrag(f)
+    // The absolute (fractional) seq under the thumb, via the SAME fail-closed mapping the resting
+    // thumb geometry (fractionToSeq) uses -- so the drag and the rest of the rail agree on the
+    // range->seq travel math. Null on a degenerate/unsafe range: preview the thumb, no live-scroll.
+    const seqF = seqNumberAtFraction(f, deps.minSeq(), deps.maxSeq())
+    if (seqF === null)
+      return
+    const wf = deps.windowFirstSeq()
+    const wl = deps.windowLastSeq()
+    const first = wf === undefined ? null : safeSeqNumber(wf)
+    const last = wl === undefined ? null : safeSeqNumber(wl)
+    if (first !== null && last !== null && seqF >= first && seqF <= last) {
+      const cy = contentYForSeq(deps.prepared(), seqF)
+      if (cy !== null)
+        deps.previewScrollTo(cy)
+    }
+  }
+
+  // rAF-coalesce pointermove through the shared helper: one apply() per frame with the latest
+  // pointer Y, instead of re-hand-rolling the schedule-once + lastY bookkeeping.
+  const moveCoalescer = createRafCoalescer<number>(apply)
+  const onMove = (ev: PointerEvent) => moveCoalescer.push(ev.clientY)
+
+  let ended = false
+  const teardown = () => {
+    moveCoalescer.abort()
+    releasePointerCapture()
+    el.removeEventListener('pointermove', onMove)
+    el.removeEventListener('pointerup', finish)
+    el.removeEventListener('pointercancel', abandon)
+    // Fire onEnd exactly once, even if teardown runs again (a normal release then a later
+    // cancel() from an unmount): the owner's "drag active" guard must clear only once.
+    if (!ended) {
+      ended = true
+      deps.onEnd?.()
+    }
+  }
+
+  // Hoisted function declarations so `teardown` (declared above) can reference them without a
+  // forward-declared `let` -- teardown detaches them and each tears down. Both run as pointer
+  // listeners, so reading deps at call time is correct.
+
+  // pointerup: a deliberate release -> seek. Runs as a pointerup listener.
+  function finish(ev: PointerEvent) {
+    teardown()
+    const f = fractionAt(ev.clientY)
+    deps.onRelease(f) // owner keeps the preview until the seek settles -- see onRelease
+  }
+
+  // pointercancel: the interaction was aborted (a system/edge gesture stole the pointer,
+  // common on touch) -- do NOT seek; just drop the preview and stop tracking, as if the drag
+  // never happened.
+  function abandon() {
+    teardown()
+    deps.setDrag(null)
+  }
+
+  return {
+    start(pointerId, initialClientY) {
+      try {
+        el.setPointerCapture(pointerId)
+        capturedPointerId = pointerId
+      }
+      catch {
+        teardown()
+        deps.setDrag(null)
+        return
+      }
+      // Freeze the grab-time thumb height and anchor the within-thumb grab offset BEFORE the first
+      // apply() so it holds the thumb where it rests (no jump) and then tracks the pointer delta.
+      grabThumbHeightPx = deps.thumbHeightPx()
+      grabOffsetPx = (initialClientY - rect.top) - deps.grabThumbTopPx
+      el.addEventListener('pointermove', onMove)
+      el.addEventListener('pointerup', finish)
+      el.addEventListener('pointercancel', abandon)
+      apply(initialClientY)
+    },
+    cancel: abandon,
+  }
+}

--- a/frontend/src/components/chat/chatScrollRailDragHold.test.ts
+++ b/frontend/src/components/chat/chatScrollRailDragHold.test.ts
@@ -1,0 +1,154 @@
+import { createRoot } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDragReleaseHold } from './chatScrollRailDragHold'
+
+/** Flush pending microtasks (a macrotask runs after every queued microtask). */
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+// Deterministic requestAnimationFrame: the hold schedules its post-landing clear on a frame,
+// so the test drives frames by hand rather than racing a real ~16ms rAF timer. cancelAnimation-
+// Frame genuinely removes the callback, so a superseded clear can be asserted as never firing.
+let rafCallbacks: Map<number, () => void>
+let nextRafId: number
+function runFrame() {
+  const cbs = [...rafCallbacks.values()]
+  rafCallbacks.clear()
+  cbs.forEach(cb => cb())
+}
+beforeEach(() => {
+  rafCallbacks = new Map()
+  nextRafId = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+    const id = ++nextRafId
+    rafCallbacks.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    rafCallbacks.delete(id)
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+/** Run `body` inside a root, rejecting the returned promise on throw so async assertions surface. */
+function inRoot(body: (dispose: () => void) => Promise<void>): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    createRoot(async (dispose) => {
+      try {
+        await body(dispose)
+        dispose()
+        resolve()
+      }
+      catch (e) {
+        dispose()
+        reject(e instanceof Error ? e : new Error(String(e)))
+      }
+    })
+  })
+}
+
+describe('createdragreleasehold', () => {
+  it('begin() claims ownership and rejects a rival concurrent grab until end()', () =>
+    createRoot((dispose) => {
+      const hold = createDragReleaseHold()
+      expect(hold.begin()).toBe(true) // first grab claims
+      expect(hold.begin()).toBe(false) // a rival second-finger grab is dropped
+      hold.end() // the pointer lifecycle ended
+      expect(hold.begin()).toBe(true) // a fresh grab can claim again
+      dispose()
+    }))
+
+  it('preview() sets and clears the live drag fraction', () =>
+    createRoot((dispose) => {
+      const hold = createDragReleaseHold()
+      expect(hold.fraction()).toBeNull()
+      hold.preview(0.42)
+      expect(hold.fraction()).toBe(0.42)
+      hold.preview(null) // an aborted drag drops the preview
+      expect(hold.fraction()).toBeNull()
+      dispose()
+    }))
+
+  it('release() pins the fraction, then clears it ONE FRAME after the seek resolves (scrolled)', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      hold.release(0.7, () => Promise.resolve(true)) // the seek moved the view
+      expect(hold.fraction()).toBe(0.7) // pinned at the release fraction (no flash back to origin)
+      await tick() // the seek resolves; the clear is SCHEDULED for the next frame, not run now
+      expect(hold.fraction()).toBe(0.7) // still pinned until the landing frame
+      runFrame() // the next frame: the metrics-derived thumb has caught up to the landing
+      expect(hold.fraction()).toBeNull() // handed off without a flash
+    }))
+
+  it('an ambient change during the seek\'s async fetch does NOT clear the hold early (out-of-window)', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      // An out-of-window seek awaits a fetch before landOnSeq scrolls. Frames elapse during it --
+      // each would carry an ambient metrics change (window swap / streaming / RO tick). None may
+      // hand off the pin, because the clear is armed off the seek's RESOLUTION, not those changes.
+      let land!: (scrolled: boolean) => void
+      hold.release(0.6, () => new Promise<boolean>((r) => {
+        land = r
+      }))
+      expect(hold.fraction()).toBe(0.6)
+      runFrame()
+      runFrame()
+      expect(hold.fraction()).toBe(0.6) // still pinned through the whole in-flight fetch
+      land(true) // the fetch resolves and the landing scrolled
+      await tick()
+      expect(hold.fraction()).toBe(0.6) // still pinned until the landing frame
+      runFrame()
+      expect(hold.fraction()).toBeNull() // now handed off
+    }))
+
+  it('release() clears immediately when the seek scrolled nowhere (no landing frame will come)', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      hold.release(0.3, () => Promise.resolve(false)) // a landing that scrolls nowhere
+      expect(hold.fraction()).toBe(0.3) // pinned immediately after release
+      await tick()
+      // Cleared on resolution -- no frame wait -- so the thumb never stays stuck dragging.
+      expect(hold.fraction()).toBeNull()
+      expect(rafCallbacks.size).toBe(0) // and no clear frame was scheduled
+    }))
+
+  it('release() clears when the seek throws or rejects (no stuck dragging state)', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      hold.release(0.4, () => Promise.reject(new Error('seek failed')))
+      expect(hold.fraction()).toBe(0.4)
+      await tick()
+      expect(hold.fraction()).toBeNull()
+
+      hold.release(0.6, () => {
+        throw new Error('sync seek failed')
+      })
+      expect(hold.fraction()).toBe(0.6)
+      await tick()
+      expect(hold.fraction()).toBeNull()
+    }))
+
+  it('a fresh grab supersedes a still-pending release: its stale clear frame cannot clear the new preview', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      hold.release(0.3, () => Promise.resolve(true)) // would schedule a clear frame...
+      await tick() // the seek resolves and schedules the clear frame
+      expect(rafCallbacks.size).toBe(1)
+      expect(hold.begin()).toBe(true) // ...but a fresh grab claims ownership, cancelling it
+      expect(rafCallbacks.size).toBe(0) // the pending clear frame was cancelled
+      hold.preview(0.9) // the new drag live-previews
+      runFrame() // no-op: the stale clear frame is gone
+      expect(hold.fraction()).toBe(0.9) // not cleared: begin() cancelled the clear + bumped the epoch
+    }))
+
+  it('a newer release supersedes an older one\'s pending clear (epoch guard)', () =>
+    inRoot(async () => {
+      const hold = createDragReleaseHold()
+      hold.release(0.2, () => Promise.resolve(true))
+      await tick() // older release's clear frame scheduled
+      hold.release(0.8, () => Promise.resolve(true)) // a newer release supersedes it
+      expect(hold.fraction()).toBe(0.8) // pinned at the newer fraction; the older clear was cancelled
+      await tick()
+      runFrame() // only the newer release's clear frame runs
+      expect(hold.fraction()).toBeNull()
+    }))
+})

--- a/frontend/src/components/chat/chatScrollRailDragHold.ts
+++ b/frontend/src/components/chat/chatScrollRailDragHold.ts
@@ -1,0 +1,152 @@
+import type { Accessor } from 'solid-js'
+import { createSignal, onCleanup } from 'solid-js'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail drag-release "hold"
+//
+// Owns the small state machine that pins the rail thumb at its RELEASE fraction until the
+// post-release seek has scrolled the view to match -- the anti-flash hand-off. Extracted
+// from ChatScrollRail (where it was a signal plus three bare `let`s, a deferred effect, and
+// two functions tangled through the component) so the subtle "don't flash back / don't
+// stick" behaviour is one named, unit-tested unit.
+//
+// The lifecycle across one grab:
+//   begin()   -- a fresh grab claims ownership: drop any pending clear and invalidate a prior
+//                release still awaiting its seek, then raise the active guard.
+//   preview() -- the controller live-previews the thumb fraction during the drag.
+//   release() -- the pointer released: pin the fraction, then clear it ONE FRAME after the
+//                post-release seek RESOLVES -- OR immediately if the seek scrolled NOWHERE.
+//   end()     -- the pointer lifecycle ended (release/cancel/unmount): free the active guard.
+//
+// Why clear off the seek's own resolution (+1 animation frame) rather than off "the first
+// metrics change after release": an OUT-OF-WINDOW seek awaits a network fetch, during which
+// the window swap, a streaming-measurement commit, or a ResizeObserver tick each change the
+// scroll metrics BEFORE the landing scroll. Keying the clear off any metrics change would hand
+// off on one of those and flash the thumb back to the pre-landing position -- exactly what this
+// hold exists to prevent. The seek promise resolves only AFTER its landOnSeq has scrolled, so a
+// clear scheduled from its resolution is guaranteed to be after the landing; the extra frame
+// lets the metrics-derived thumb catch up to the landing so the hand-off itself doesn't flash.
+// ---------------------------------------------------------------------------
+
+export interface DragReleaseHold {
+  /** The preview thumb fraction (null when idle). Read by the thumb/dots/scrub geometry. */
+  fraction: Accessor<number | null>
+  /**
+   * Set the live preview fraction during a drag (the controller's `setDrag` sink); `null`
+   * clears the preview on an aborted drag (pointercancel).
+   */
+  preview: (fraction: number | null) => void
+  /**
+   * Claim a fresh grab. Returns `false` when a drag is already active (a rival second-finger
+   * grab, which the caller must drop rather than start a rival listener set); returns `true`
+   * after claiming ownership -- which cancels any still-pending clear AND invalidates a prior
+   * release's async clear so neither can clear THIS drag mid-way.
+   */
+  begin: () => boolean
+  /** The pointer lifecycle ended (release/cancel/unmount): free the active guard. */
+  end: () => void
+  /**
+   * Land a release at rail fraction `fraction`: pin the preview there, then hand off once the
+   * post-release seek resolves. `seek` performs the jump and may resolve to whether it actually
+   * moved the view; when it resolves `true` (the landing scrolled) the pin is cleared on the
+   * NEXT animation frame -- by when the metrics-derived thumb has reached the landing, so the
+   * hand-off is flash-free. When it resolves `false` (a landing that scrolls nowhere -- an
+   * in-window target already at the current scrollTop, or no landable row) the pin is cleared
+   * immediately instead of hanging forever.
+   */
+  release: (fraction: number, seek: () => void | Promise<boolean>) => void
+}
+
+/**
+ * Create the drag-release hold. Clears the held preview one animation frame after the
+ * post-release seek RESOLVES (not on an ambient metrics change), so an out-of-window seek's
+ * in-flight fetch churn can't hand off before the landing.
+ *
+ * Must be created within an owner scope (it wires an `onCleanup`); ChatScrollRail creates it
+ * once at component top level.
+ */
+export function createDragReleaseHold(): DragReleaseHold {
+  const [fraction, setFraction] = createSignal<number | null>(null)
+  // Bumped on every release/grab so a superseded release's async clear is a no-op (a fresh
+  // grab, or a newer release, invalidates an older release still awaiting its seek).
+  let releaseEpoch = 0
+  // True while a drag holds the pointer capture + listeners. Guards against a SECOND
+  // concurrent grab (a second finger on the thumb) starting a rival drag that would orphan
+  // the first's listeners. Cleared by end().
+  let active = false
+  // A pending "clear the hold" animation frame scheduled after a scrolled landing; cancelled
+  // by a fresh grab / a newer release / cleanup so it can never clear a newer drag's preview.
+  let clearRaf: number | null = null
+
+  const cancelClear = () => {
+    if (clearRaf !== null && typeof cancelAnimationFrame === 'function')
+      cancelAnimationFrame(clearRaf)
+    clearRaf = null
+  }
+  onCleanup(cancelClear)
+
+  // Clear the pin on the next frame IF `epoch` is still the current release -- by the next
+  // frame the metrics-derived thumb has caught up to the landing, so the hand-off is flash-
+  // free. Falls back to a synchronous clear where rAF is unavailable (SSR / some test envs).
+  const clearNextFrame = (epoch: number) => {
+    const clear = () => {
+      clearRaf = null
+      if (epoch === releaseEpoch)
+        setFraction(null)
+    }
+    if (typeof requestAnimationFrame === 'function')
+      clearRaf = requestAnimationFrame(clear)
+    else
+      clear()
+  }
+
+  const clearAfterFailedSeek = (epoch: number) => {
+    void Promise.resolve().then(() => {
+      if (epoch === releaseEpoch)
+        setFraction(null)
+    })
+  }
+
+  return {
+    fraction,
+    preview: setFraction,
+    begin() {
+      if (active)
+        return false
+      // A fresh grab owns the preview: invalidate a prior release's async clear (bump the
+      // epoch) AND cancel a still-pending clear frame so neither can clear THIS drag mid-way.
+      releaseEpoch++
+      cancelClear()
+      active = true
+      return true
+    },
+    end() {
+      active = false
+    },
+    release(fraction, seek) {
+      setFraction(fraction)
+      const epoch = ++releaseEpoch
+      // Drop a prior release's still-pending clear frame; this release owns the hand-off now.
+      cancelClear()
+      let seekResult: void | Promise<boolean>
+      try {
+        seekResult = seek()
+      }
+      catch {
+        clearAfterFailedSeek(epoch)
+        return
+      }
+      void Promise.resolve(seekResult).then((scrolled) => {
+        // Superseded by a fresh grab / newer release: leave the current preview alone.
+        if (epoch !== releaseEpoch)
+          return
+        if (scrolled)
+          clearNextFrame(epoch) // hand off one frame after the landing scrolled
+        else
+          setFraction(null) // scrolled nowhere: no landing scroll will come, clear now
+      }).catch(() => {
+        clearAfterFailedSeek(epoch)
+      })
+    },
+  }
+}

--- a/frontend/src/components/chat/chatScrollRailGeometry.test.ts
+++ b/frontend/src/components/chat/chatScrollRailGeometry.test.ts
@@ -1,0 +1,338 @@
+import type { PreparedGeometry, SeqSpaceGeometry } from './chatScrollRailGeometry'
+import type { VirtualItem } from './useChatVirtualizer'
+import { describe, expect, it } from 'vitest'
+// dotFraction lives in chatRailPolicy (rail decision), but it's tested here alongside its
+// geometry siblings fractionToSeq / railYToSeq because they share the seq-range fail-closed
+// contract; the clustering / owner-resolution policy tests live in chatRailPolicy.test.ts.
+import { dotFraction } from './chatRailPolicy'
+import {
+  centerAxisFraction,
+  centerAxisY,
+  computeSeqThumb,
+  contentYForSeq,
+  dragThumbPx,
+  fixedThumbHeightPx,
+  fractionToSeq,
+  prepareGeometry,
+  projectThumbPx,
+  railYToSeq,
+  rowStartSeqs,
+  seqAtContentY,
+  seqNumberAtFraction,
+  seqSpan,
+} from './chatScrollRailGeometry'
+
+/** Build a raw geometry with uniform-height rows for the given seqs (0n = optimistic local). */
+function geoOf(seqs: bigint[], rowPx = 100): SeqSpaceGeometry {
+  const items: VirtualItem[] = seqs.map((seq, i) => ({ id: `m${i}`, hasSpanLines: false, seq }))
+  return {
+    items,
+    offsetOfIndex: i => i * rowPx,
+    totalHeight: seqs.length * rowPx,
+  }
+}
+
+/** A PreparedGeometry (geo + its precomputed rowStartSeqs) for the given seqs. */
+function prepOf(seqs: bigint[], rowPx = 100): PreparedGeometry {
+  return prepareGeometry(geoOf(seqs, rowPx))
+}
+
+describe('chatscrollrailgeometry', () => {
+  describe('seq at content y', () => {
+    it('returns the row seq at a row boundary and interpolates within a row', () => {
+      const prep = prepOf([1n, 2n, 3n, 4n, 5n])
+      expect(seqAtContentY(prep, 0)).toBe(1)
+      expect(seqAtContentY(prep, 100)).toBe(2)
+      expect(seqAtContentY(prep, 150)).toBe(2.5) // halfway through row 1 (seq 2 -> 3)
+      // The very bottom maps to the terminal boundary (maxSeq + 1), i.e. fraction 1 later.
+      expect(seqAtContentY(prep, 500)).toBe(6)
+    })
+
+    it('absorbs seq gaps (deleted/hidden rows) linearly between visible rows', () => {
+      // seqs jump 3 -> 7: the pixel span between them covers seqs [3,7).
+      const prep = prepOf([1n, 3n, 7n])
+      expect(seqAtContentY(prep, 100)).toBe(3)
+      expect(seqAtContentY(prep, 150)).toBe(5) // halfway from seq 3 to seq 7
+      expect(seqAtContentY(prep, 200)).toBe(7)
+    })
+
+    it('maps trailing optimistic locals above the last server seq (never as the oldest)', () => {
+      const prep = prepOf([4n, 5n, 0n]) // a pending local at the tail
+      expect(seqAtContentY(prep, 0)).toBe(4)
+      expect(seqAtContentY(prep, 200)).toBe(6) // local sits one unit above seq 5
+    })
+
+    it('returns null for an all-locals / empty window', () => {
+      expect(seqAtContentY(prepOf([0n, 0n]), 50)).toBeNull()
+      expect(seqAtContentY(prepOf([]), 0)).toBeNull()
+    })
+  })
+
+  describe('content y for seq (inverse)', () => {
+    it('round-trips with seqAtContentY within the loaded window', () => {
+      const prep = prepOf([1n, 2n, 3n, 4n, 5n])
+      for (const y of [0, 50, 150, 250, 399]) {
+        const seqF = seqAtContentY(prep, y)!
+        expect(contentYForSeq(prep, seqF)).toBeCloseTo(y, 5)
+      }
+    })
+
+    it('returns null for a seq outside the loaded window span', () => {
+      const prep = prepOf([10n, 11n, 12n])
+      expect(contentYForSeq(prep, 5)).toBeNull()
+      expect(contentYForSeq(prep, 99)).toBeNull()
+    })
+  })
+
+  describe('compute seq thumb', () => {
+    const base = { hasMoreOlder: false, hasMoreNewer: false, distFromBottomPx: 999 }
+
+    it('computes the viewport share when the whole conversation is loaded', () => {
+      const thumb = computeSeqThumb(prepOf([1n, 2n, 3n, 4n, 5n]), { ...base, scrollTop: 0, clientHeight: 200, minSeq: 1n, maxSeq: 5n })!
+      expect(thumb.topFraction).toBeCloseTo(0, 5)
+      expect(thumb.visibleFraction).toBeCloseTo(0.4, 5) // viewing seqs 1..3 of 5
+    })
+
+    it('reports a smaller visible seq span when the loaded window is a slice of remote history', () => {
+      // Loaded window = seqs 10..12 (fits the viewport), whole conversation = 1..100.
+      const thumb = computeSeqThumb(prepOf([10n, 11n, 12n]), {
+        scrollTop: 0,
+        clientHeight: 500, // >= totalHeight (300): the native scrollbar would show full height
+        minSeq: 1n,
+        maxSeq: 100n,
+        hasMoreOlder: true,
+        hasMoreNewer: true,
+        distFromBottomPx: 999,
+      })!
+      expect(thumb.topFraction).toBeCloseTo(0.09, 5) // window starts ~9% into the history
+      expect(thumb.visibleFraction).toBeCloseTo(0.03, 5) // 3 of 100 seqs
+    })
+
+    it('snaps to the top/bottom edges when the window is at the true start/end', () => {
+      const thumb = computeSeqThumb(prepOf([1n, 2n, 3n, 4n, 5n]), {
+        scrollTop: 0,
+        clientHeight: 500,
+        minSeq: 1n,
+        maxSeq: 5n,
+        hasMoreOlder: false,
+        hasMoreNewer: false,
+        distFromBottomPx: 0, // at the bottom
+      })!
+      expect(thumb.topFraction).toBe(0)
+      expect(thumb.topFraction + thumb.visibleFraction).toBe(1)
+    })
+
+    it('returns null for an empty conversation and a full thumb for a single seq', () => {
+      expect(computeSeqThumb(prepOf([1n]), { ...base, scrollTop: 0, clientHeight: 100, minSeq: 0n, maxSeq: 0n })).toBeNull()
+      const single = computeSeqThumb(prepOf([7n]), { ...base, scrollTop: 0, clientHeight: 100, minSeq: 7n, maxSeq: 7n })!
+      expect(single.topFraction).toBe(0)
+      expect(single.visibleFraction).toBeCloseTo(1, 5)
+    })
+
+    it('returns null (never a NaN thumb) for an inverted range where maxSeq < minSeq', () => {
+      // A stale minSeq stranded above a delete-lowered maxSeq makes span <= 0, which without
+      // the guard yields NaN fractions -> the thumb/track render at `NaNpx`. Hide instead.
+      const thumb = computeSeqThumb(prepOf([3n, 4n]), { ...base, scrollTop: 0, clientHeight: 100, minSeq: 9n, maxSeq: 4n })
+      expect(thumb).toBeNull()
+    })
+  })
+
+  describe('fraction to seq / dot fraction / rail y to seq', () => {
+    it('fractionToSeq maps clamped fractions to the nearest seq', () => {
+      expect(fractionToSeq(0, 1n, 101n)).toBe(1n)
+      expect(fractionToSeq(1, 1n, 101n)).toBe(101n)
+      expect(fractionToSeq(0.5, 1n, 101n)).toBe(51n)
+      expect(fractionToSeq(-1, 1n, 101n)).toBe(1n) // clamped
+      expect(fractionToSeq(0.5, 5n, 5n)).toBe(5n) // degenerate range
+    })
+
+    it('fractionToSeq treats a NaN fraction as the top rather than throwing BigInt(NaN)', () => {
+      // A 0/0 from a degenerate rail/rect height reaches here as NaN; it must not throw.
+      expect(() => fractionToSeq(Number.NaN, 1n, 101n)).not.toThrow()
+      expect(fractionToSeq(Number.NaN, 1n, 101n)).toBe(1n)
+    })
+
+    it('seqNumberAtFraction maps a fraction to the absolute fractional seq, failing closed', () => {
+      // The shared fail-closed core: fractionToSeq rounds it; the thumb-drag maps it to content-Y.
+      expect(seqNumberAtFraction(0, 1n, 101n)).toBe(1)
+      expect(seqNumberAtFraction(1, 1n, 101n)).toBe(101)
+      expect(seqNumberAtFraction(0.5, 1n, 101n)).toBe(51)
+      expect(seqNumberAtFraction(-1, 1n, 101n)).toBe(1) // f clamped to [0,1]
+      expect(seqNumberAtFraction(2, 1n, 101n)).toBe(101) // f clamped to [0,1]
+      expect(seqNumberAtFraction(Number.NaN, 1n, 101n)).toBe(1) // NaN -> 0, never BigInt(NaN) downstream
+      expect(seqNumberAtFraction(0.5, 5n, 5n)).toBe(5) // degenerate single-seq range: span 0
+      expect(seqNumberAtFraction(0.5, 10n, 1n)).toBeNull() // inverted range
+      expect(seqNumberAtFraction(0.5, 1n, BigInt(Number.MAX_SAFE_INTEGER) + 2n)).toBeNull() // unsafe span
+    })
+
+    it('fractionToSeq is seqNumberAtFraction rounded to a bigint (one shared travel core)', () => {
+      for (const f of [0, 0.13, 0.5, 0.87, 1]) {
+        const num = seqNumberAtFraction(f, 1n, 101n)
+        expect(num).not.toBeNull()
+        expect(fractionToSeq(f, 1n, 101n)).toBe(BigInt(Math.round(num!)))
+      }
+    })
+
+    it('dotFraction centers a dot on its message band', () => {
+      // span = (10 - 1) + 1 = 10; seq 1 -> 0.5/10, seq 10 -> 9.5/10
+      expect(dotFraction(1n, { minSeq: 1n, maxSeq: 10n })).toBeCloseTo(0.05, 5)
+      expect(dotFraction(10n, { minSeq: 1n, maxSeq: 10n })).toBeCloseTo(0.95, 5)
+    })
+
+    it('railYToSeq inverts a rail-relative pixel to a seq via the thumb-centre axis', () => {
+      // thumbHeight 0 -> no inset, so the pixel maps over the full rail.
+      expect(railYToSeq(0, 200, 0, { minSeq: 1n, maxSeq: 101n })).toBe(1n)
+      expect(railYToSeq(100, 200, 0, { minSeq: 1n, maxSeq: 101n })).toBe(51n)
+      expect(railYToSeq(200, 200, 0, { minSeq: 1n, maxSeq: 101n })).toBe(101n)
+      // thumbHeight 24 -> the centre axis is [12, 188] over a 200px rail. y below/above it
+      // clamps to the range ends; the midpoint (100) still maps to the middle seq.
+      expect(railYToSeq(12, 200, 24, { minSeq: 1n, maxSeq: 101n })).toBe(1n)
+      expect(railYToSeq(0, 200, 24, { minSeq: 1n, maxSeq: 101n })).toBe(1n) // above the axis -> clamped
+      expect(railYToSeq(100, 200, 24, { minSeq: 1n, maxSeq: 101n })).toBe(51n)
+      expect(railYToSeq(188, 200, 24, { minSeq: 1n, maxSeq: 101n })).toBe(101n)
+      expect(railYToSeq(200, 200, 24, { minSeq: 1n, maxSeq: 101n })).toBe(101n) // below the axis -> clamped
+    })
+
+    it('handles huge bigint seqs by converting only deltas', () => {
+      const big = 9_000_000_000n
+      expect(fractionToSeq(0.5, big, big + 100n)).toBe(big + 50n)
+      expect(dotFraction(big + 50n, { minSeq: big, maxSeq: big + 100n })).toBeCloseTo(0.5, 3)
+    })
+
+    it('fails closed when a fraction maps across an unsafe seq span', () => {
+      const tooWide = BigInt(Number.MAX_SAFE_INTEGER) + 2n
+      expect(fractionToSeq(0.5, 1n, tooWide)).toBeNull()
+      expect(railYToSeq(100, 200, 0, { minSeq: 1n, maxSeq: tooWide })).toBeNull()
+    })
+
+    it('dotFraction fails CLOSED (null) on an unsafe/degenerate range, not fraction 0', () => {
+      // An unsafe span or an inverted range must DROP the dot (null), never pin it to the rail
+      // top (fraction 0, a valid in-band position that would mis-place the jump) -- honoring the
+      // module's fail-closed contract shared with computeSeqThumb / fractionToSeq.
+      const tooWide = BigInt(Number.MAX_SAFE_INTEGER) + 2n
+      expect(dotFraction(5n, { minSeq: 1n, maxSeq: tooWide })).toBeNull()
+      expect(dotFraction(5n, { minSeq: 10n, maxSeq: 1n })).toBeNull() // inverted range
+    })
+  })
+
+  describe('seq span (shared inclusive-range metrics)', () => {
+    it('returns min + inclusive band width, failing closed on degenerate/unsafe ranges', () => {
+      expect(seqSpan({ minSeq: 1n, maxSeq: 10n })).toEqual({ min: 1, span: 10 })
+      expect(seqSpan({ minSeq: 5n, maxSeq: 5n })).toEqual({ min: 5, span: 1 }) // single seq
+      expect(seqSpan({ minSeq: 10n, maxSeq: 1n })).toBeNull() // inverted
+      expect(seqSpan({ minSeq: 1n, maxSeq: BigInt(Number.MAX_SAFE_INTEGER) + 2n })).toBeNull() // unsafe span
+    })
+  })
+
+  describe('center axis y / center axis fraction (thumb-centre axis)', () => {
+    it('maps a fraction onto the thumb-centre travel [thumbHalf, railHeight - thumbHalf]', () => {
+      // rail 400, thumb 24 -> centre travels [12, 388].
+      expect(centerAxisY(0, 400, 24)).toBe(12)
+      expect(centerAxisY(1, 400, 24)).toBe(388)
+      expect(centerAxisY(0.5, 400, 24)).toBe(200)
+      expect(centerAxisY(-1, 400, 24)).toBe(12) // clamped
+    })
+
+    it('degenerates to the rail midpoint when the thumb fills the rail (no travel)', () => {
+      expect(centerAxisY(0, 400, 400)).toBe(200)
+      expect(centerAxisY(1, 400, 400)).toBe(200)
+      expect(centerAxisFraction(123, 400, 400)).toBe(0)
+    })
+
+    it('centerAxisFraction inverts centerAxisY', () => {
+      expect(centerAxisFraction(12, 400, 24)).toBe(0)
+      expect(centerAxisFraction(388, 400, 24)).toBe(1)
+      expect(centerAxisFraction(200, 400, 24)).toBeCloseTo(0.5, 5)
+      // Clamps outside the centre travel.
+      expect(centerAxisFraction(0, 400, 24)).toBe(0)
+      expect(centerAxisFraction(400, 400, 24)).toBe(1)
+      // Round-trips.
+      for (const p of [0, 0.25, 0.5, 0.75, 1])
+        expect(centerAxisFraction(centerAxisY(p, 400, 24), 400, 24)).toBeCloseTo(p, 5)
+    })
+  })
+
+  describe('project thumb px', () => {
+    it('uses a fixed thumb height and projects its top over the full travel', () => {
+      const bottom = projectThumbPx({ topFraction: 0.98, visibleFraction: 0.02 }, 400, 24)
+      expect(bottom.heightPx).toBe(24)
+      // At the very bottom, the fixed thumb still ends flush with the rail.
+      expect(bottom.topPx + bottom.heightPx).toBeCloseTo(400, 3)
+
+      const top = projectThumbPx({ topFraction: 0, visibleFraction: 0.02 }, 400, 24)
+      expect(top.topPx).toBe(0)
+      expect(top.heightPx).toBe(24)
+    })
+
+    it('keeps visible span out of thumb height while using it to project top', () => {
+      const middle = projectThumbPx({ topFraction: 0.25, visibleFraction: 0.5 }, 400, 24)
+      const bottom = projectThumbPx({ topFraction: 0.25, visibleFraction: 0.75 }, 400, 24)
+
+      expect(middle.heightPx).toBe(24)
+      expect(bottom.heightPx).toBe(24)
+      expect(middle.topPx).toBeCloseTo(188, 6) // progress 0.5 over the 376px travel
+      expect(bottom.topPx).toBeCloseTo(376, 6) // topFraction + visibleFraction == 1
+    })
+
+    it('caps the fixed thumb height at the rail height', () => {
+      const full = projectThumbPx({ topFraction: 0, visibleFraction: 1 }, 12, 24)
+      expect(full.heightPx).toBe(12)
+      expect(full.topPx).toBe(0)
+    })
+  })
+
+  describe('drag thumb px', () => {
+    it('keeps the given thumb height and places its CENTRE on the centre axis, per fraction', () => {
+      for (const f of [0, 0.25, 0.5, 0.75, 1]) {
+        const { topPx, heightPx } = dragThumbPx(f, 400, 24)
+        expect(heightPx).toBe(24)
+        // The thumb centre lands exactly where dots at the same fraction are drawn.
+        expect(topPx + heightPx / 2).toBeCloseTo(centerAxisY(f, 400, 24), 6)
+      }
+    })
+
+    it('clamps an out-of-range fraction and never overruns the rail (top>=0, bottom<=rail)', () => {
+      const below = dragThumbPx(-0.5, 400, 24)
+      expect(below.topPx).toBe(0)
+      const above = dragThumbPx(1.5, 400, 24)
+      expect(above.topPx + above.heightPx).toBeCloseTo(400, 6)
+    })
+  })
+
+  describe('fixed thumb height px', () => {
+    it('uses the fixed thumb height and caps it at the rail height', () => {
+      expect(fixedThumbHeightPx(400, 24)).toBe(24)
+      expect(fixedThumbHeightPx(12, 24)).toBe(12)
+    })
+
+    it('is the exact height projectThumbPx uses, so the two cannot drift', () => {
+      expect(projectThumbPx({ topFraction: 0.5, visibleFraction: 0.3 }, 400, 24).heightPx)
+        .toBe(fixedThumbHeightPx(400, 24))
+    })
+  })
+
+  describe('prepare geometry', () => {
+    it('pairs a geometry with its rowStartSeqs, computed once, preserving the geo reference', () => {
+      const geo = geoOf([10n, 11n, 12n])
+      const prep = prepareGeometry(geo)
+      expect(prep.geo).toBe(geo)
+      expect(prep.rowSeqs).toEqual(rowStartSeqs(geo.items))
+    })
+
+    it('carries a null rowSeqs for an all-locals / empty window, so the geometry fns short-circuit', () => {
+      expect(prepareGeometry(geoOf([0n, 0n])).rowSeqs).toBeNull()
+      expect(prepareGeometry(geoOf([])).rowSeqs).toBeNull()
+      // Every consumer then short-circuits on the single null-rowSeqs guard.
+      expect(seqAtContentY(prepOf([0n, 0n]), 50)).toBeNull()
+      expect(contentYForSeq(prepOf([]), 0)).toBeNull()
+      expect(computeSeqThumb(prepOf([0n]), { hasMoreOlder: false, hasMoreNewer: false, distFromBottomPx: 999, scrollTop: 0, clientHeight: 100, minSeq: 1n, maxSeq: 5n })).toBeNull()
+    })
+
+    it('carries a null rowSeqs when server seqs exceed exact number conversion', () => {
+      const unsafe = BigInt(Number.MAX_SAFE_INTEGER) + 1n
+      expect(prepareGeometry(geoOf([unsafe])).rowSeqs).toBeNull()
+      expect(seqAtContentY(prepOf([unsafe]), 0)).toBeNull()
+      expect(prepareGeometry(geoOf([BigInt(Number.MAX_SAFE_INTEGER)])).rowSeqs).toBeNull()
+    })
+  })
+})

--- a/frontend/src/components/chat/chatScrollRailGeometry.ts
+++ b/frontend/src/components/chat/chatScrollRailGeometry.ts
@@ -1,0 +1,345 @@
+import type { VirtualItem } from './useChatVirtualizer'
+import { largestIndexWhere } from '~/lib/binarySearch'
+import { clamp } from '~/lib/clamp'
+import { EDGE_INTENT_TOLERANCE_PX } from './chatScrollGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail geometry
+//
+// Pure math mapping the chat scroll state into SEQ SPACE -- the position within the
+// WHOLE conversation [minSeq..maxSeq], not the loaded window. This is why the rail's
+// thumb is accurate where the native scrollbar (which only knows the ~150-message
+// loaded window) is not. The rail DECISIONS built on this math (which scrollbar owns the
+// viewport, whether a thumb is worth drawing, how marks cluster into jump dots) live in
+// chatRailPolicy, so this file stays pure seq<->pixel coordinate math.
+//
+// Three coordinate spaces:
+//   1. content-Y: pixels within the virtual spacer, [0, totalHeight].
+//   2. seq: bigint message seqs. Each row occupies one seq unit; seq gaps (deletes,
+//      hidden rows excluded from the virtual list) absorb linearly into the pixel
+//      span between adjacent visible rows.
+//   3. fraction: [0,1] over [minSeq..maxSeq], what the rail renders against.
+//
+// bigint -> number conversions cross an explicit exact-integer boundary. Per-agent seqs are
+// expected to stay far below 2^53, but the backend stores int64s; when a future/imported DB
+// violates that assumption, rail geometry fails closed instead of silently rounding jumps.
+// ---------------------------------------------------------------------------
+
+// EDGE_INTENT_TOLERANCE_PX (the 1px "treated as fully at the edge" slack the rail's edge snaps
+// use) is shared with the rest of the scroll pipeline -- imported from chatScrollGeometry so
+// the rail can't drift from the edge slack every other scroll module already agrees on.
+const MAX_SAFE_SEQ_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
+
+/** Convert an absolute seq to a number only when JS can represent it exactly. */
+export function safeSeqNumber(seq: bigint): number | null {
+  if (seq < 0n || seq > MAX_SAFE_SEQ_BIGINT)
+    return null
+  return Number(seq)
+}
+
+/** Convert a seq delta/span to a number only when JS can represent it exactly. */
+export function safeSeqDeltaNumber(delta: bigint): number | null {
+  if (delta < 0n || delta > MAX_SAFE_SEQ_BIGINT)
+    return null
+  return Number(delta)
+}
+
+export interface SeqSpaceGeometry {
+  /** Visible rows, ascending by seq; trailing optimistic locals carry seq 0n. */
+  items: readonly VirtualItem[]
+  /** Content-Y of the top of row `i` (i in [0, items.length]; == totalHeight at the end). */
+  offsetOfIndex: (index: number) => number
+  /** Total virtual content height in px. */
+  totalHeight: number
+}
+
+export interface RailRange {
+  minSeq: bigint
+  maxSeq: bigint
+}
+
+export interface SeqThumb {
+  /** Top of the thumb as a fraction of the rail [0,1]. */
+  topFraction: number
+  /**
+   * Viewport span as a fraction of the whole seq range. The rendered thumb height is fixed;
+   * this span is still needed to project the thumb top over the scrollable travel so a bottom
+   * viewport lands with the fixed thumb flush to the rail bottom.
+   */
+  visibleFraction: number
+}
+
+export interface SeqThumbInputs {
+  /** Logical (clamped) scrollTop of the scroll container. */
+  scrollTop: number
+  clientHeight: number
+  minSeq: bigint
+  maxSeq: bigint
+  hasMoreOlder: boolean
+  hasMoreNewer: boolean
+  /** distFromBottom(el): scrollHeight - scrollTop - clientHeight, for the bottom edge snap. */
+  distFromBottomPx: number
+}
+
+/**
+ * The absolute seq (as a number) at the START of each row's coverage, plus a terminal
+ * boundary. `out[i]` is where row i begins in seq space; `out[n]` = `out[n-1] + 1` so
+ * the last row occupies one seq unit. Trailing optimistic locals (seq 0n) are assigned
+ * one unit above the running server max, so they map ABOVE the last server row (where
+ * they render) rather than scanning as the oldest. Returns null when the window holds no
+ * server row (all-locals / empty), since no seq anchor exists to place a thumb against.
+ *
+ * Derived purely from `items`, and the internal primitive of {@link prepareGeometry} --
+ * callers hold a {@link PreparedGeometry} (which memoizes this once) rather than calling
+ * seqAtContentY / contentYForSeq / computeSeqThumb with a raw geometry, so the (n+1)-length
+ * array is scanned a single time per geometry, not re-derived on every scroll frame.
+ */
+export function rowStartSeqs(items: readonly VirtualItem[]): number[] | null {
+  const n = items.length
+  if (n === 0)
+    return null
+  let hasServer = false
+  let running = 0
+  const out = Array.from<number>({ length: n + 1 })
+  for (let i = 0; i < n; i++) {
+    const s = items[i].seq
+    if (s !== undefined && s !== 0n) {
+      const safe = safeSeqNumber(s)
+      if (safe === null)
+        return null
+      hasServer = true
+      running = safe
+      out[i] = running
+    }
+    else {
+      // Optimistic local: one unit above the running max (pinned at the tail).
+      if (running >= Number.MAX_SAFE_INTEGER)
+        return null
+      running += 1
+      out[i] = running
+    }
+  }
+  if (!hasServer)
+    return null
+  if (out[n - 1] >= Number.MAX_SAFE_INTEGER)
+    return null
+  out[n] = out[n - 1] + 1
+  return out
+}
+
+/**
+ * A {@link SeqSpaceGeometry} paired with its `rowStartSeqs` computed ONCE, handed to
+ * seqAtContentY / contentYForSeq / computeSeqThumb so the (n+1)-length row map is scanned a
+ * single time per geometry rather than re-derived on every call (the rail recomputes the
+ * thumb every scroll frame). `rowSeqs` is null when the window holds no server row
+ * (all-locals / empty), so a single guard on it covers the "no seq anchor" case for every
+ * consumer.
+ *
+ * The rail component builds this INLINE from two separate memos (an `items`-keyed rowSeqs
+ * memo plus a per-commit `geo` wrapper) so a streaming turn -- which bumps totalHeight every
+ * commit while keeping the item reference -- reruns the O(n) row-seq scan only when the item
+ * list actually changes. {@link prepareGeometry} is the one-shot constructor for callers
+ * without that streaming-frequency concern (tests, one-off computations).
+ */
+export interface PreparedGeometry {
+  geo: SeqSpaceGeometry
+  rowSeqs: number[] | null
+}
+
+/**
+ * Pair a geometry with its precomputed row-start-seqs map. The one-shot convenience form of
+ * the "compute once" seam; the rail builds {@link PreparedGeometry} inline instead (see that
+ * type's note) to keep the row-seq scan off the streaming-commit path.
+ */
+export function prepareGeometry(geo: SeqSpaceGeometry): PreparedGeometry {
+  return { geo, rowSeqs: rowStartSeqs(geo.items) }
+}
+
+/**
+ * The inclusive seq-range metrics shared by every range->fraction consumer: `min` is the range
+ * floor as a number and `span` is the count of seqs the band covers (maxSeq - minSeq + 1). Returns
+ * null when either crosses the exact-integer boundary (an unsafe seq), the range is inverted, or the
+ * span is non-positive -- so all consumers fail CLOSED on a degenerate/overflowing range through one
+ * shared guard rather than re-deriving the `+ 1n` band width and its null/zero check at each site.
+ */
+export function seqSpan(range: RailRange): { min: number, span: number } | null {
+  const min = safeSeqNumber(range.minSeq)
+  const span = safeSeqDeltaNumber(range.maxSeq - range.minSeq + 1n)
+  if (min === null || span === null || span <= 0)
+    return null
+  return { min, span }
+}
+
+/**
+ * The fractional seq (absolute, as a number) under content-Y `y`. Interpolates within
+ * the row+gap span so the result is continuous across the whole content height. Returns
+ * null when the window has no server row.
+ */
+export function seqAtContentY(prep: PreparedGeometry, y: number): number | null {
+  const { geo, rowSeqs } = prep
+  if (!rowSeqs)
+    return null
+  const n = geo.items.length
+  const cy = clamp(y, 0, geo.totalHeight)
+  const offAt = (i: number) => (i >= n ? geo.totalHeight : geo.offsetOfIndex(i))
+  const i = largestIndexWhere(n, k => offAt(k) <= cy)
+  const top = offAt(i)
+  const bot = offAt(i + 1)
+  const span = bot - top
+  const t = span > 0 ? clamp((cy - top) / span, 0, 1) : 0
+  return rowSeqs[i] + t * (rowSeqs[i + 1] - rowSeqs[i])
+}
+
+/**
+ * Inverse of seqAtContentY: the content-Y that places fractional seq `seqF` at the
+ * viewport top. Used for in-window thumb-drag live-scrolling. Returns null when the
+ * window has no server row, or `seqF` falls outside the loaded window's seq span.
+ */
+export function contentYForSeq(prep: PreparedGeometry, seqF: number): number | null {
+  const { geo, rowSeqs } = prep
+  if (!rowSeqs)
+    return null
+  const n = geo.items.length
+  if (seqF < rowSeqs[0] || seqF > rowSeqs[n])
+    return null
+  const i = largestIndexWhere(n, k => rowSeqs[k] <= seqF)
+  // `rowSpan`, not `seqSpan`: the module exports a `seqSpan()` function, and a local of
+  // that name would shadow it -- a future `seqSpan(range)` call added here would resolve
+  // to this number and throw "seqSpan is not a function".
+  const rowSpan = rowSeqs[i + 1] - rowSeqs[i]
+  const t = rowSpan > 0 ? clamp((seqF - rowSeqs[i]) / rowSpan, 0, 1) : 0
+  const top = geo.offsetOfIndex(i)
+  const bot = i + 1 >= n ? geo.totalHeight : geo.offsetOfIndex(i + 1)
+  return top + t * (bot - top)
+}
+
+/**
+ * The thumb rect in seq-space fractions, or null when the rail can't/shouldn't render
+ * (empty conversation, or the window has no server row). Handles the case the native
+ * scrollbar gets wrong -- clientHeight >= totalHeight while remote history exists -- by
+ * computing the loaded window's SHARE of [minSeq..maxSeq], positioned by seq.
+ */
+export function computeSeqThumb(prep: PreparedGeometry, inp: SeqThumbInputs): SeqThumb | null {
+  if (inp.maxSeq <= 0n)
+    return null
+  // Guard an inverted range (maxSeq < minSeq): a stale minSeq stranded above a
+  // delete-lowered maxSeq would make `span` (below) <= 0 and every fraction NaN, which
+  // renders the thumb/track at `NaNpx`. Hide the thumb instead until the range heals.
+  if (inp.maxSeq < inp.minSeq)
+    return null
+  const topSeqF = seqAtContentY(prep, inp.scrollTop)
+  if (topSeqF === null)
+    return null
+  const botSeqF = seqAtContentY(prep, inp.scrollTop + inp.clientHeight)
+  if (botSeqF === null)
+    return null
+  const metrics = seqSpan({ minSeq: inp.minSeq, maxSeq: inp.maxSeq })
+  if (metrics === null)
+    return null
+  const { min, span } = metrics
+  let topFraction = clamp((topSeqF - min) / span, 0, 1)
+  let bottomFraction = clamp((botSeqF - min) / span, topFraction, 1)
+  // Edge snaps: kill sub-pixel / container-padding bias exactly where users notice it.
+  if (!inp.hasMoreOlder && inp.scrollTop <= EDGE_INTENT_TOLERANCE_PX)
+    topFraction = 0
+  if (!inp.hasMoreNewer && inp.distFromBottomPx <= EDGE_INTENT_TOLERANCE_PX)
+    bottomFraction = 1
+  return { topFraction, visibleFraction: Math.max(bottomFraction - topFraction, 0) }
+}
+
+/**
+ * Rail-Y of the thumb's CENTRE for position fraction `p` in [0,1]. The thumb centre can only
+ * travel [thumbHalf, railHeight - thumbHalf] (its top/bottom EDGES hit the rail ends at the
+ * extremes), so dots, the track, and track-clicks all map onto THIS inset axis -- then a dot
+ * always lines up with the thumb centre, never falling in the dead zones past the centre's
+ * reach. Degenerates to the rail midpoint when the thumb fills the rail (no travel).
+ */
+export function centerAxisY(p: number, railHeightPx: number, thumbHeightPx: number): number {
+  return thumbHeightPx / 2 + clamp(p, 0, 1) * Math.max(railHeightPx - thumbHeightPx, 0)
+}
+
+/** Inverse of {@link centerAxisY}: the position fraction [0,1] for a rail-Y on the centre axis. */
+export function centerAxisFraction(y: number, railHeightPx: number, thumbHeightPx: number): number {
+  const travel = railHeightPx - thumbHeightPx
+  if (travel <= 0)
+    return 0
+  return clamp((y - thumbHeightPx / 2) / travel, 0, 1)
+}
+
+/**
+ * The absolute (fractional) seq NUMBER at rail fraction `f`, over [minSeq, maxSeq], or null when
+ * the range is inverted (maxSeq < minSeq) or crosses the exact-integer boundary (an unsafe seq).
+ * The shared fail-closed core of the fraction->seq mapping: {@link fractionToSeq} rounds it to a
+ * bigint, and the thumb-drag maps its pointer fraction to an in-window content-Y through it -- so
+ * the safe bigint->number conversion and the `min + f*span` travel math live in ONE tested place
+ * rather than hand-rolled at both sites. A NaN `f` (a 0/0 from a degenerate rail/rect height at a
+ * mid-collapse layout frame) is treated as 0 so it can never reach a BigInt(NaN) downstream.
+ */
+export function seqNumberAtFraction(f: number, minSeq: bigint, maxSeq: bigint): number | null {
+  if (maxSeq < minSeq)
+    return null
+  const min = safeSeqNumber(minSeq)
+  const span = safeSeqDeltaNumber(maxSeq - minSeq)
+  if (min === null || span === null)
+    return null
+  const frac = Number.isFinite(f) ? clamp(f, 0, 1) : 0
+  return min + frac * span
+}
+
+/** The nearest integer seq at rail fraction `f`, clamped to [minSeq, maxSeq]. */
+export function fractionToSeq(f: number, minSeq: bigint, maxSeq: bigint): bigint | null {
+  const seqF = seqNumberAtFraction(f, minSeq, maxSeq)
+  if (seqF === null)
+    return null
+  // seqF - min == frac*span exactly (same float multiply), and minSeq is safe (seqNumberAtFraction
+  // succeeded), so Number(minSeq) is exact -- this rounds the same delta the inline math did.
+  return minSeq + BigInt(Math.round(seqF - Number(minSeq)))
+}
+
+/**
+ * The seq at rail-relative pixel `y` (track click / drag), mapped through the thumb-centre
+ * axis so `y` picks the seq whose thumb centre would sit there -- consistent with where dots
+ * are drawn ({@link centerAxisY}).
+ */
+export function railYToSeq(y: number, railHeightPx: number, thumbHeightPx: number, range: RailRange): bigint | null {
+  return fractionToSeq(centerAxisFraction(y, railHeightPx, thumbHeightPx), range.minSeq, range.maxSeq)
+}
+
+export interface ThumbPx {
+  topPx: number
+  heightPx: number
+}
+
+/**
+ * The thumb's pixel height: fixed at `fixedThumbPx`, capped at the rail height so a collapsed
+ * rail cannot render the thumb outside its own bounds. The single home for the fixed-size rule
+ * shared by `projectThumbPx` (the resting thumb) and the rail's drag-preview branch.
+ */
+export function fixedThumbHeightPx(railHeightPx: number, fixedThumbPx: number): number {
+  return clamp(fixedThumbPx, 0, railHeightPx)
+}
+
+/**
+ * Project a seq-space thumb onto rail pixels with a fixed thumb height. The top is projected
+ * through the classic scrollbar progress formula so a fixed-height thumb still spans the full
+ * rail travel (top at fraction 0, bottom at fraction 1) rather than overrunning the rail.
+ */
+export function projectThumbPx(thumb: SeqThumb, railHeightPx: number, fixedThumbPx: number): ThumbPx {
+  const heightPx = fixedThumbHeightPx(railHeightPx, fixedThumbPx)
+  const travel = railHeightPx - heightPx
+  const denom = 1 - thumb.visibleFraction
+  const progress = denom > 0 ? clamp(thumb.topFraction / denom, 0, 1) : 0
+  return { topPx: travel * progress, heightPx }
+}
+
+/**
+ * The drag-PREVIEW thumb rect: the resting thumb height `thumbHeightPx`, positioned so its
+ * CENTRE sits on the same {@link centerAxisY} axis the dots + track are drawn on, at drag
+ * position `fraction`. `topPx = centerAxisY(fraction) - thumbHeightPx/2` reduces to
+ * `travel * fraction`, but routing through {@link centerAxisY} keeps the "drag thumb lines
+ * up with the dots" invariant structural -- one home for the centre-axis math -- and carries
+ * its `clamp(fraction)` and non-negative-travel guard rather than re-deriving them inline.
+ */
+export function dragThumbPx(fraction: number, railHeightPx: number, thumbHeightPx: number): ThumbPx {
+  return { topPx: centerAxisY(fraction, railHeightPx, thumbHeightPx) - thumbHeightPx / 2, heightPx: thumbHeightPx }
+}

--- a/frontend/src/components/chat/chatScrollRailMetrics.test.ts
+++ b/frontend/src/components/chat/chatScrollRailMetrics.test.ts
@@ -1,0 +1,117 @@
+import { createEffect, createRoot, createSignal, on } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { createRailMetrics } from './chatScrollRailMetrics'
+import { installScrollTestEnv, makeFakeScrollDiv } from './useChatScroll.testkit'
+
+installScrollTestEnv()
+
+/** Flush pending microtasks + Solid effects (setTimeout runs after the effect scheduler + microtask rAF). */
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+function inRoot(body: (dispose: () => void) => Promise<void>): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    createRoot(async (dispose) => {
+      try {
+        await body(dispose)
+        dispose()
+        resolve()
+      }
+      catch (e) {
+        dispose()
+        reject(e instanceof Error ? e : new Error(String(e)))
+      }
+    })
+  })
+}
+
+describe('createrailmetrics', () => {
+  it('samples the scroll container, and re-samples on a scroll event (after the coalescing frame)', () =>
+    inRoot(async () => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(1000)
+      div.setClientHeight(400)
+      div.setScrollTop(0)
+      const [scrollEl] = createSignal<HTMLDivElement | undefined>(div.el)
+      const metrics = createRailMetrics({ scrollEl, totalHeight: () => 1000, geometryVersion: () => 0 })
+      await tick()
+      expect(metrics()).toEqual({ scrollTop: 0, dist: 600, clientHeight: 400 }) // 1000 - 0 - 400
+
+      div.setScrollTop(250)
+      div.el.dispatchEvent(new Event('scroll'))
+      await tick() // the scroll handler coalesces through a rAF (a microtask in the test env)
+      expect(metrics()).toEqual({ scrollTop: 250, dist: 350, clientHeight: 400 })
+    }))
+
+  it('re-samples on a geometry commit that moved the offset map without a scroll event', () =>
+    inRoot(async () => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(1000)
+      div.setClientHeight(400)
+      const [scrollEl] = createSignal<HTMLDivElement | undefined>(div.el)
+      const [geo, setGeo] = createSignal(0)
+      const metrics = createRailMetrics({ scrollEl, totalHeight: () => 1000, geometryVersion: geo })
+      await tick()
+
+      // A prepend/measurement shifts the view without dispatching a scroll event.
+      div.setScrollTop(120)
+      await tick()
+      expect(metrics().scrollTop).toBe(0) // still stale: no scroll event, no geometry commit yet
+      setGeo(1) // the virtualizer bumps geometryVersion on the commit
+      await tick()
+      expect(metrics().scrollTop).toBe(120)
+    }))
+
+  it('defers a geometry-commit re-sample to a coalescing rAF (not a synchronous per-commit layout read)', () =>
+    inRoot(async () => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(1000)
+      div.setClientHeight(400)
+      const [scrollEl] = createSignal<HTMLDivElement | undefined>(div.el)
+      const [geo, setGeo] = createSignal(0)
+      const metrics = createRailMetrics({ scrollEl, totalHeight: () => 1000, geometryVersion: geo })
+      await tick()
+
+      const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+      // A burst of commits before the frame flushes: the re-sample is DEFERRED (scrollTop
+      // stays stale synchronously, not read per commit) and the burst COALESCES to one frame.
+      div.setScrollTop(200)
+      setGeo(1)
+      setGeo(2)
+      expect(metrics().scrollTop).toBe(0) // deferred: no synchronous layout read on the commit
+      await tick()
+      expect(rafSpy).toHaveBeenCalledTimes(1) // one frame for the whole burst
+      expect(metrics().scrollTop).toBe(200) // the single frame sampled the final position
+      rafSpy.mockRestore()
+    }))
+
+  it('stays at the default and does not crash when the scroll element is absent (pre-mount)', () =>
+    inRoot(async () => {
+      // props.scrollEl is undefined until the chat container mounts; sampling must no-op.
+      const metrics = createRailMetrics({ scrollEl: () => undefined, totalHeight: () => 1000, geometryVersion: () => 0 })
+      await tick()
+      expect(metrics()).toEqual({ scrollTop: 0, dist: 0, clientHeight: 0 })
+    }))
+
+  it('does not notify subscribers on an identical re-sample (value equals)', () =>
+    inRoot(async () => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(1000)
+      div.setClientHeight(400)
+      div.setScrollTop(80)
+      const [scrollEl] = createSignal<HTMLDivElement | undefined>(div.el)
+      const [geo, setGeo] = createSignal(0)
+      const metrics = createRailMetrics({ scrollEl, totalHeight: () => 1000, geometryVersion: geo })
+      let notifications = 0
+      createEffect(on(metrics, () => {
+        notifications += 1
+      }))
+      await tick()
+      const baseline = notifications
+
+      // A geometry commit that re-samples the SAME scroll position must not invalidate the
+      // thumb memos downstream -- the value equals keeps the old reference.
+      setGeo(1)
+      await tick()
+      expect(notifications).toBe(baseline)
+    }))
+})

--- a/frontend/src/components/chat/chatScrollRailMetrics.ts
+++ b/frontend/src/components/chat/chatScrollRailMetrics.ts
@@ -1,0 +1,93 @@
+import type { Accessor } from 'solid-js'
+import { createEffect, createSignal, on, onCleanup } from 'solid-js'
+import { createRafCoalescer } from '~/lib/rafCoalesce'
+import { clampScrollTop, distFromBottom } from './chatScrollGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail metrics sampler
+//
+// Reactively samples the chat scroll container's position -- the inputs the rail's thumb
+// geometry is computed from -- via a passive scroll listener + ResizeObserver, re-sampling
+// on a geometry commit that moves the offset map without a scroll event. Extracted from
+// ChatScrollRail so the "metrics sampling" job has a name and a seam, and the component is
+// left to orchestrate geometry rather than manage DOM listeners.
+// ---------------------------------------------------------------------------
+
+export interface RailScrollMetrics {
+  /** Logical (clamped) scrollTop of the scroll container. */
+  scrollTop: number
+  /** distFromBottom(el): scrollHeight - scrollTop - clientHeight, for the bottom-edge snap. */
+  dist: number
+  /** The scroll container's viewport height. */
+  clientHeight: number
+}
+
+export interface RailMetricsInputs {
+  /** The chat scroll container (the element the native scrollbar was hidden on). */
+  scrollEl: Accessor<HTMLDivElement | undefined>
+  /** Total virtual content height (px); a change is a geometry commit to re-sample against. */
+  totalHeight: Accessor<number>
+  /** Bumped by the virtualizer whenever the offset map changes (measurement/prepend/trim). */
+  geometryVersion: Accessor<number>
+}
+
+/**
+ * Sample the scroll container's metrics reactively. The signal uses a VALUE equals so an
+ * identical re-sample (a ResizeObserver tick with unchanged size, or a rAF landing on the
+ * same scrollTop) does NOT invalidate the thumb memos downstream.
+ *
+ * Must be created within an owner scope (it wires effects + onCleanup); ChatScrollRail
+ * creates it once at component top level.
+ */
+export function createRailMetrics(inp: RailMetricsInputs): Accessor<RailScrollMetrics> {
+  const [metrics, setMetrics] = createSignal<RailScrollMetrics>(
+    { scrollTop: 0, dist: 0, clientHeight: 0 },
+    { equals: (a, b) => a.scrollTop === b.scrollTop && a.dist === b.dist && a.clientHeight === b.clientHeight },
+  )
+
+  const sample = () => {
+    const el = inp.scrollEl()
+    if (!el)
+      return
+    setMetrics({ scrollTop: clampScrollTop(el, el.scrollTop), dist: distFromBottom(el), clientHeight: el.clientHeight })
+  }
+
+  // Attach the passive scroll listener + ResizeObserver whenever the scroll element changes.
+  createEffect(on(inp.scrollEl, (el) => {
+    if (!el)
+      return
+    // rAF-coalesce the scroll burst through the shared helper (one sample per frame) rather
+    // than re-hand-rolling the schedule-once + cancel-on-teardown lifecycle.
+    const scrollCoalescer = createRafCoalescer<void>(sample)
+    const onScroll = () => scrollCoalescer.push()
+    el.addEventListener('scroll', onScroll, { passive: true })
+    const ro = new ResizeObserver(() => sample())
+    ro.observe(el)
+    sample()
+    onCleanup(() => {
+      el.removeEventListener('scroll', onScroll)
+      ro.disconnect()
+      scrollCoalescer.abort()
+    })
+  }))
+
+  // A geometry commit (measurement/prepend/trim) can move the offset map without a scroll
+  // event; re-sample so the thumb recomputes against the new mapping. rAF-coalesced (like the
+  // scroll path above) so a streaming turn's burst of commits forces at most ONE layout read
+  // per frame rather than one synchronous read per commit -- the value-equals signal drops the
+  // redundant re-samples, and the thumb lagging a commit by a single frame is imperceptible.
+  // Falls back to a synchronous sample where rAF is unavailable (SSR / some test envs) -- the
+  // shared coalescer schedules unconditionally, so the guard stays here BEFORE push().
+  const geoCoalescer = createRafCoalescer<void>(sample)
+  const sampleAfterGeometryCommit = () => {
+    if (typeof requestAnimationFrame !== 'function') {
+      sample()
+      return
+    }
+    geoCoalescer.push()
+  }
+  createEffect(on(() => [inp.totalHeight(), inp.geometryVersion()], () => sampleAfterGeometryCommit()))
+  onCleanup(() => geoCoalescer.abort())
+
+  return metrics
+}

--- a/frontend/src/components/chat/chatSeek.ts
+++ b/frontend/src/components/chat/chatSeek.ts
@@ -1,0 +1,234 @@
+import type { ScrollContext } from './useChatScroll'
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { SavedViewportScroll, ScrollAnchor } from '~/stores/chatTypes'
+import { firstServerSeq, lastServerSeq } from '~/stores/chatMessageOrder'
+import { nearestServerRowIndexBySeq } from './chatScrollAnchor'
+import { clampScrollTop } from './chatScrollGeometry'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail seek (jumpToSeq / previewScrollTo)
+//
+// The seek machine a scroll-rail dot click / track click / thumb release drives: an
+// in-window aligned landing, or a fetch-around-seq window swap then land. Extracted from
+// useChatScroll so the epoch-guarded pending-seek state and the landing logic have a named
+// home + a test seam (useChatScroll.seek.test.ts), mirroring the sibling rail/scroll units.
+// It owns its own pendingSeek / seekEpoch; the hook's handleScroll cancels an in-flight seek
+// on a genuine user scroll via cancelPendingSeek. Reads the scroll primitives through the
+// shared ScrollContext plus a small `extras` bag for the deps unique to it.
+// ---------------------------------------------------------------------------
+
+export interface ChatSeek {
+  /**
+   * Seek to a message seq (a scroll-rail dot click, track click, or thumb release):
+   * an in-window aligned landing, or a fetch-around-seq window swap then land. Resolves
+   * to whether the seek actually moved the scroll position (so the rail's drag-release
+   * hold knows whether to await the landing's metrics settle or clear the thumb now).
+   */
+  jumpToSeq: (seq: bigint) => Promise<boolean>
+  /**
+   * A guard-marked programmatic scroll write for in-window rail thumb-drag live-scroll.
+   * Marked like the landing writes so the drag's scroll events don't trip velocity
+   * sampling, edge pagination, or the buffer filler.
+   */
+  previewScrollTo: (top: number) => void
+  /**
+   * Abandon any in-flight out-of-window seek so its late-resolving fetch cannot land
+   * (yank the viewport) after the user has taken manual control. The hook's handleScroll
+   * calls this on a genuine user scroll, and the rail calls it (via the hook) when a fresh
+   * thumb grab begins -- a drag scrolls only programmatically, so it never trips the
+   * user-scroll path. Clearing pendingSeek makes an in-flight seek's `.then` short-circuit
+   * (its epoch no longer matches a live pendingSeek).
+   */
+  cancelPendingSeek: () => void
+}
+
+/**
+ * The deps createChatSeek needs beyond the shared {@link ScrollContext}: the live message
+ * list, a handful of hook-private scroll actions (some declared later in the hook and threaded
+ * in as thunks -- e.g. rearmScrollBufferFiller), and the host's window-swap / save-viewport
+ * callbacks.
+ */
+export interface ChatSeekExtras {
+  /** Live loaded messages (server rows + trailing optimistic locals). */
+  messages: () => AgentChatMessage[]
+  /** Clamped logical scrollTop read (Safari rubber-band safe). */
+  readScrollTop: (el: HTMLDivElement) => number
+  /** Stop any running scroll animation before a landing / preview write. */
+  cancelScrollAnimation: () => void
+  /** Cancel AND drop the deferred fling-settle so a landing isn't fought by leftover drift. */
+  cancelFlingSettle: () => void
+  /** Capture the current viewport anchor (leaving follow mode before an out-of-window swap). */
+  captureAnchor: () => void
+  /** Pin a row's top across the post-landing measurement storm; false if it isn't in the offset map. */
+  captureRowTopAnchor: (id: string) => boolean
+  /** Bump the geometry tick so DOM-reading memos (stall indicators) re-evaluate after a landing. */
+  bumpGeomTick: () => void
+  /** Re-take manual scroll control (clear the per-window filler pause / settle / suppress flags). */
+  retakeScrollControl: () => void
+  /** Drop the old window's per-side filler state when a jump replaces the message window. */
+  rearmScrollBufferFiller: () => void
+  /** Refresh atBottom off a fresh DOM read (used when an out-of-window fetch fails). */
+  checkAtBottom: () => void
+  /** Replace the window with a page centered on `seq` (the out-of-window seek). */
+  onJumpToSeq: ((seq: bigint) => Promise<void> | void) | undefined
+  /** Hand a hidden-mid-jump target to the SavedViewportScroll restore path. */
+  onSaveViewportScroll: ((state: SavedViewportScroll) => void) | undefined
+  /** Whether newer messages exist beyond the loaded window (windowed away from tail). */
+  hasNewerMessages: () => boolean
+}
+
+export function createChatSeek(ctx: ScrollContext, extras: ChatSeekExtras): ChatSeek {
+  // Pixels of breathing room left above the target row when landing on a seek.
+  const SEEK_ALIGN_OFFSET_PX = 8
+
+  // The in-flight out-of-window seek, guarded by an epoch so a superseding jump / a genuine
+  // user scroll (which clears it via cancelPendingSeek) makes a late resolve a no-op.
+  let pendingSeek: { seq: bigint, epoch: number } | null = null
+  let seekEpoch = 0
+
+  // The window's first/last SERVER seq (skipping seq-0n optimistic locals) come from the
+  // shared chatMessageOrder helpers -- the same definition the rail's window bounds and the
+  // windowing core use -- so the in-window seek decision can't drift from them.
+
+  /**
+   * The loaded server row nearest `seq` by absolute seq distance, via the same
+   * nearestServerRowIndexBySeq scan the trim-restore anchor recovery uses (scrollTopNearAnchor),
+   * so the seek landing and that recovery can't drift on the skip/tie-break rule.
+   */
+  const nearestRowIdBySeq = (seq: bigint): string | undefined => {
+    const msgs = extras.messages()
+    const idx = nearestServerRowIndexBySeq(msgs, seq)
+    return idx < 0 ? undefined : msgs[idx].id
+  }
+
+  /**
+   * Land the viewport on the loaded row nearest `seq`, pinning it through the
+   * post-landing measurement storm. Instant, not animated: an animation over
+   * mostly-estimated heights would fight the re-pin every frame.
+   *
+   * Returns whether the landing actually MOVED the scroll position (i.e. a scroll event,
+   * and hence a settling metrics change, will follow). It returns false -- no scroll -- when
+   * the container is detached/hidden, no target row resolves, OR the target is already the
+   * current scrollTop; the rail's drag-release hold uses this to know whether to wait for a
+   * metrics settle or clear immediately, so it never sticks when the landing scrolls nowhere.
+   */
+  const landOnSeq = (seq: bigint): boolean => {
+    const el = ctx.getEl()
+    if (!el || el.clientHeight === 0)
+      return false
+    const id = nearestRowIdBySeq(seq)
+    if (!id)
+      return false
+    // Resolve the row's top scrollTop via the anchor resolver (offsetWithinRow 0 pins the
+    // row top to the viewport top). Falls back to the nearest-survivor resolver if the id
+    // isn't in the current offset map. Both are already on the narrowed virtualizer type.
+    const anchor: ScrollAnchor = { id, offsetWithinRow: 0, seq }
+    const resolved = ctx.virt.scrollTopForAnchor(anchor) ?? ctx.virt.scrollTopNearAnchor(anchor)
+    if (resolved == null)
+      return false
+    extras.cancelScrollAnimation()
+    extras.cancelFlingSettle()
+    const target = clampScrollTop(el, resolved - SEEK_ALIGN_OFFSET_PX)
+    // Whether this write will actually move the view (and so emit a scroll event): an equal
+    // target is a no-op write that fires no event, so no metrics settle will come.
+    const scrolled = target !== extras.readScrollTop(el)
+    // Marked programmatic so the echo isn't misread as a user gesture (no velocity
+    // sample, no edge pagination, no buffer fill on the still-echo).
+    ctx.writeScrollTop(target, 'seek-jump')
+    // Pin the TARGET row's top across the measurement commits that follow (the fresh
+    // rows are mostly unmeasured). The hold survives the landing write's own echo and
+    // auto-releases once the row measures; any genuine user gesture releases it too.
+    // Fall back to a viewport anchor if the row isn't in the offset map yet.
+    if (!extras.captureRowTopAnchor(id))
+      ctx.setAnchor(ctx.virt.anchorAt(extras.readScrollTop(el)))
+    ctx.setAtBottom(ctx.isAtBottom())
+    ctx.refreshViewport()
+    extras.bumpGeomTick()
+    return scrolled
+  }
+
+  /**
+   * Seek to a message `seq` (a scroll-rail dot click, track click, or thumb release).
+   * In-window: land immediately. Out-of-window: fetch a page centered on the seq
+   * (onJumpToSeq), then land once the window has swapped. A jump supersedes any prior
+   * in-flight seek via the epoch, and a genuine user scroll cancels it.
+   *
+   * Resolves to whether the seek actually MOVED the scroll position (landOnSeq's result;
+   * false when the container is detached, the tab is hidden, or the fetch fails). The rail's
+   * drag-release hold awaits this to decide whether to wait for the landing's metrics settle
+   * or clear the held thumb immediately -- so the thumb neither flashes back mid-fetch nor
+   * sticks when the landing scrolls nowhere.
+   */
+  const jumpToSeq = (seq: bigint): Promise<boolean> => {
+    const el = ctx.getEl()
+    if (!el)
+      return Promise.resolve(false)
+    const msgs = extras.messages()
+    const firstS = firstServerSeq(msgs)
+    const lastS = lastServerSeq(msgs)
+    // In-window: the seq sits within the loaded server span. Re-take control (clear the
+    // per-window filler pause/settle/suppress flags, same as forceScrollToBottom) and land.
+    if (firstS !== undefined && lastS !== undefined && seq >= firstS && seq <= lastS) {
+      pendingSeek = null
+      extras.retakeScrollControl()
+      return Promise.resolve(landOnSeq(seq))
+    }
+    // Out-of-window: swap the window to a page centered on the seq, then land. The
+    // preamble leaves follow mode and re-takes control so the swap's restick/auto-load
+    // paths stay inert; the centered fetch handles the tail case too (BEFORE seq+1
+    // returns the latest page when seq >= maxSeq).
+    extras.cancelScrollAnimation()
+    extras.cancelFlingSettle()
+    extras.retakeScrollControl()
+    extras.rearmScrollBufferFiller()
+    if (ctx.isFollowing())
+      extras.captureAnchor()
+    ctx.setAtBottom(false)
+    const epoch = ++seekEpoch
+    pendingSeek = { seq, epoch }
+    return Promise.resolve(extras.onJumpToSeq?.(seq))
+      .then(() => {
+        // Superseded by a newer jump, or cancelled by a genuine user scroll.
+        if (pendingSeek?.epoch !== epoch)
+          return false
+        pendingSeek = null
+        const cur = ctx.getEl()
+        if (cur && cur.clientHeight > 0) {
+          // Visible: applyMessages already swapped the window synchronously and the
+          // virtualizer memos are pull-based, so offsetOfId reflects the new window now.
+          return landOnSeq(seq)
+        }
+        // Hidden mid-jump (tab switched away): hand the target to the SavedViewportScroll
+        // restore path so the seek lands when the tab returns, instead of snapping to tail.
+        const id = nearestRowIdBySeq(seq)
+        if (id) {
+          extras.onSaveViewportScroll?.({
+            anchor: { id, offsetWithinRow: 0, seq },
+            atBottom: false,
+            hasMoreNewer: extras.hasNewerMessages(),
+          })
+        }
+        return false
+      })
+      .catch(() => {
+        if (pendingSeek?.epoch === epoch)
+          pendingSeek = null
+        extras.checkAtBottom()
+        return false
+      })
+  }
+
+  const previewScrollTo = (top: number) => {
+    const el = ctx.getEl()
+    if (!el)
+      return
+    extras.cancelScrollAnimation()
+    ctx.writeScrollTop(clampScrollTop(el, top), 'seek-drag')
+  }
+
+  const cancelPendingSeek = () => {
+    pendingSeek = null
+  }
+
+  return { jumpToSeq, previewScrollTo, cancelPendingSeek }
+}

--- a/frontend/src/components/chat/controls/CursorControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CursorControlRequest.tsx
@@ -139,7 +139,9 @@ export const CursorControlActions: Component<ActionsProps> = (props) => {
   const createPlanReject = () => sendResponse(
     props.request.agentId,
     props.onRespond,
-    buildDenyResponse(props.request.requestId, 'Rejected by user.'),
+    // Bare deny (no typed reason): buildDenyResponse fills the shared
+    // CONTROL_REJECTED_BY_USER_MESSAGE placeholder, so don't re-spell the literal here.
+    buildDenyResponse(props.request.requestId),
   )
 
   const userInputOnRespond = async (_agentId: string, content: Uint8Array) => {

--- a/frontend/src/components/chat/markPreviewShared.test.ts
+++ b/frontend/src/components/chat/markPreviewShared.test.ts
@@ -1,0 +1,62 @@
+import type { MessageCategory } from './messageClassification'
+import type { ParsedMessageContent } from '~/lib/messageParser'
+import { describe, expect, it } from 'vitest'
+import { defaultMarkPreview } from './markPreviewShared'
+
+function parsedOf(obj: Record<string, unknown> | undefined): ParsedMessageContent {
+  return { rawText: obj ? JSON.stringify(obj) : '', topLevel: obj ?? null, parentObject: obj, wrapper: null }
+}
+
+const USER: MessageCategory = { kind: 'user_content' }
+const CONTROL: MessageCategory = { kind: 'control_response' }
+
+describe('default mark preview', () => {
+  it('extracts the provider-neutral {content} user shape', () => {
+    expect(defaultMarkPreview(USER, parsedOf({ content: 'hello world' }))).toBe('hello world')
+  })
+
+  it('does NOT extract the Claude {message:{content}} transcript shape (that is the claude plugin\'s job)', () => {
+    // The nested `{message:{content}}` envelope is an Anthropic transcript shape; the shared
+    // neutral default handles only `{content}` / `{controlResponse}`. See claude/plugin.test.ts.
+    expect(defaultMarkPreview({ kind: 'user_text' }, parsedOf({ message: { content: 'typed text' } }))).toBeNull()
+  })
+
+  it('summarizes an approved control response', () => {
+    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'approved' } }))).toBe('Approved')
+  })
+
+  it('summarizes a rejected control response carrying feedback the same way the row renderer does', () => {
+    // Mirror controlResponseRenderer (notificationRenderers), the row the dot jumps to: a
+    // rejection WITH a typed reason renders "Sent feedback:" above the reason, so the preview
+    // must read the same -- NOT the inline ControlResponseTag's "Rejected: <reason>".
+    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'rejected', comment: 'not this way' } })))
+      .toBe('Sent feedback:\nnot this way')
+  })
+
+  it('labels a bare rejection', () => {
+    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'rejected' } }))).toBe('Rejected')
+  })
+
+  it('returns null when there is no previewable text', () => {
+    expect(defaultMarkPreview(USER, parsedOf({ foo: 'bar' }))).toBeNull()
+    expect(defaultMarkPreview(USER, parsedOf(undefined))).toBeNull()
+  })
+
+  it('never mis-picks an assistant content-block array as user text (no neutral string field)', () => {
+    // Assistant messages store content as a block array; the neutral string test must skip
+    // them. The shared default handles ONLY neutral shapes -- Anthropic tool_result blocks
+    // are a Claude-specific shape handled by the claude plugin's previewText, not here.
+    expect(defaultMarkPreview({ kind: 'assistant_text' }, parsedOf({ content: [{ type: 'text', text: 'hi' }] }))).toBeNull()
+    expect(defaultMarkPreview({ kind: 'assistant_text' }, parsedOf({ message: { content: [{ type: 'text', text: 'hi' }] } }))).toBeNull()
+  })
+
+  it('does NOT extract Anthropic tool_result blocks (that is the claude plugin\'s job)', () => {
+    // The shared default is provider-neutral; a bare tool_result array yields no preview
+    // here. The Claude plugin's previewText reads it (see claude/plugin.test.ts).
+    const parsed = parsedOf({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', content: 'answer', tool_use_id: 't1' }] },
+    })
+    expect(defaultMarkPreview({ kind: 'tool_result' }, parsed)).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/markPreviewShared.ts
+++ b/frontend/src/components/chat/markPreviewShared.ts
@@ -1,0 +1,64 @@
+import type { MessageCategory } from './messageClassification'
+import type { ParsedMessageContent } from '~/lib/messageParser'
+import { isObject, pickString } from '~/lib/jsonPick'
+import { truncatePreview } from '~/lib/textTruncate'
+
+// ---------------------------------------------------------------------------
+// Scroll-rail mark preview -- shared, provider-neutral extraction
+//
+// A LEAF module (only pure json/text utils) so every provider plugin can import
+// `defaultMarkPreview` as the fallback for its `Provider.previewText` WITHOUT pulling in
+// the plugin registry / classifier (chatMarkPreview.ts, which orchestrates the plugins) --
+// that would be a module-init cycle. Provider-specific extraction lives in each plugin's
+// `previewText`; this covers only the Leapmux-neutral marked shapes.
+// ---------------------------------------------------------------------------
+
+// The three user-facing labels for a persisted {controlResponse} answer row. Shared by the row's
+// renderer (controlResponseRenderer in notificationRenderers) AND its scroll-rail dot preview
+// (defaultMarkPreview below) so the dot reads IDENTICALLY to the row it jumps to -- the wording
+// lives here once instead of being mirrored by hand across the two surfaces (the drift a comment
+// alone can't prevent). Kept in this leaf so the preview extractor and the renderer can both import
+// them without a module-init cycle.
+/** An approved control request (ExitPlanMode approval, an "allow" permission decision). */
+export const CONTROL_RESPONSE_APPROVED_LABEL = 'Approved'
+/** A declined control request with no typed reason. */
+export const CONTROL_RESPONSE_REJECTED_LABEL = 'Rejected'
+/** Lead-in shown above the user's typed rejection reason (their feedback follows as markdown). */
+export const CONTROL_RESPONSE_FEEDBACK_LEAD = 'Sent feedback:'
+
+/**
+ * Provider-NEUTRAL preview extractor and shared fallback for every provider's
+ * {@link Provider.previewText}. Handles only the Leapmux-neutral marked shapes: the
+ * app persists user sends as `{content:"..."}` and control-request responses as
+ * `{controlResponse:{action,comment}}` regardless of provider. Provider-specific shapes
+ * (e.g. Claude's Anthropic tool_result blocks and its `{message:{content}}` transcript
+ * envelope) are handled by that provider's `previewText` BEFORE it falls back here.
+ */
+export function defaultMarkPreview(_category: MessageCategory, parsed: ParsedMessageContent): string | null {
+  const obj = parsed.parentObject
+  if (!obj)
+    return null
+
+  // User-typed input: the Leapmux-neutral `{content:"..."}` shape (every provider).
+  // Assistant messages store `content` as a block array, so a string test here
+  // never mis-picks them.
+  const content = pickString(obj, 'content', '')
+  if (content)
+    return truncatePreview(content)
+
+  // Control-request response display row -- mirror controlResponseRenderer (notificationRenderers),
+  // the row the dot actually jumps to, so the preview reads the same as that row: an approved row
+  // shows "Approved"; a rejection carrying the user's typed reason shows "Sent feedback:" above the
+  // reason (NOT the inline ControlResponseTag's "Rejected: <reason>", which is a different surface);
+  // a bare rejection shows "Rejected".
+  const cr = isObject(obj.controlResponse) ? obj.controlResponse : undefined
+  if (cr) {
+    const action = pickString(cr, 'action', '')
+    const comment = pickString(cr, 'comment', '')
+    if (action === 'approved')
+      return CONTROL_RESPONSE_APPROVED_LABEL
+    return comment ? truncatePreview(`${CONTROL_RESPONSE_FEEDBACK_LEAD}\n${comment}`) : CONTROL_RESPONSE_REJECTED_LABEL
+  }
+
+  return null
+}

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -12,6 +12,7 @@ import { isCompactBoundary, parseBoundaryMeta, toTokenCount } from '~/lib/messag
 import { NOTIFICATION_TYPE } from '~/lib/notificationTypes'
 import { getCachedSettingsGroupLabel, getCachedSettingsLabel } from '~/lib/settingsLabelCache'
 import { spinner } from '~/styles/animations.css'
+import { CONTROL_RESPONSE_APPROVED_LABEL, CONTROL_RESPONSE_FEEDBACK_LEAD, CONTROL_RESPONSE_REJECTED_LABEL } from './markPreviewShared'
 import { MarkdownText } from './messageRenderers'
 import {
   controlResponseMessage,
@@ -255,21 +256,23 @@ export const controlResponseRenderer: MessageContentRenderer = {
     const action = cr.action as string
     const comment = (cr.comment as string) || ''
 
+    // The three labels are shared with the scroll-rail dot preview (defaultMarkPreview) via the
+    // markPreviewShared constants, so the dot reads identically to this row it jumps to.
     if (action === 'approved')
-      return <div class={controlResponseMessage}>Approved</div>
+      return <div class={controlResponseMessage}>{CONTROL_RESPONSE_APPROVED_LABEL}</div>
 
     if (comment) {
       return (
         <div class={controlResponseMessage}>
           <div>
-            <div>Sent feedback:</div>
+            <div>{CONTROL_RESPONSE_FEEDBACK_LEAD}</div>
             <MarkdownText text={comment} context={context} />
           </div>
         </div>
       )
     }
 
-    return <div class={controlResponseMessage}>Rejected</div>
+    return <div class={controlResponseMessage}>{CONTROL_RESPONSE_REJECTED_LABEL}</div>
   },
 }
 

--- a/frontend/src/components/chat/providers/acp/registerACPProvider.ts
+++ b/frontend/src/components/chat/providers/acp/registerACPProvider.ts
@@ -4,6 +4,7 @@ import type { AttachmentCapabilities, Provider } from '../registry'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { PermissionMode } from '~/utils/controlResponse'
 import { ACPControlActions, ACPControlContent } from '../../controls/ACPControlRequest'
+import { defaultMarkPreview } from '../../markPreviewShared'
 import { buildPlanMode, OPTION_ID_PERMISSION_MODE } from '../../settingsGroups'
 import { registerProvider } from '../registry'
 import { acpBuildControlResponse, acpExtractQuotableText, buildACPInterruptContent, classifyACPMessage } from './classification'
@@ -138,6 +139,12 @@ export function registerACPProvider(opts: ACPProviderOptions): void {
     renderMessage: renderACPMessage,
     resultDivider: acpResultDivider,
     extractQuotableText: acpExtractQuotableText,
+    // ACP-based providers (OpenCode, Cursor, Copilot, ...) mark only user sends and
+    // control-response answers. A control answer is persisted in one of two Leapmux-neutral shapes --
+    // `{content}` (a provider-resolved answer or a deny-with-feedback) or `{controlResponse}` (a bare
+    // approve/deny with no feedback) -- and ACP never echoes the answer as a message. The shared
+    // neutral extractor handles BOTH shapes, so it is the whole preview.
+    previewText: defaultMarkPreview,
     buildInterruptContent: buildACPInterruptContent,
     buildControlResponse: acpBuildControlResponse,
 

--- a/frontend/src/components/chat/providers/claude/extractors/assistantContent.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/assistantContent.ts
@@ -43,6 +43,22 @@ export function extractToolUseInfo(parsed: ParsedMessageContent): { toolName: st
 }
 
 /**
+ * The text body of ONE Claude tool_result block's `content`: a plain string, or the joined text of a
+ * nested Anthropic-style block array (text blocks). Returns null when neither yields text. The single
+ * home for the string-vs-array unwrap -- the fiddly part -- shared by {@link extractToolResultText}
+ * (the FIRST tool_result) and {@link joinToolResultText} (EVERY tool_result), so the two can't drift.
+ */
+function toolResultBlockText(block: ContentBlock): string | null {
+  const inner = block.content
+  if (typeof inner === 'string')
+    return inner || null
+  const nested = asContentArray(inner)
+  if (!nested)
+    return null
+  return joinContentParagraphs(nested, { text: 'text' }) || null
+}
+
+/**
  * Pull the text content out of a Claude `tool_result` block inside a
  * parsed `{message:{content:[...]}}` envelope. Returns null when the
  * envelope carries no tool_result or its content has no text blocks.
@@ -52,11 +68,29 @@ export function extractToolResultText(parsed: Record<string, unknown> | null | u
   if (!content)
     return null
   const tr = content.find(c => isObject(c) && c.type === 'tool_result')
-  if (!tr)
+  return tr ? toolResultBlockText(tr) : null
+}
+
+/**
+ * Join the textual body of EVERY tool_result block in a Claude
+ * `{message:{content:[...]}}` envelope (distinct from {@link extractToolResultText},
+ * which returns only the FIRST). Parallel tool calls join with a blank line. A
+ * tool_result's `content` is either a plain string or a nested Anthropic-style block
+ * array (text/image blocks); both are handled. Used by Claude's scroll-rail `previewText`
+ * to preview a self-displaying control-response answer (AskUserQuestion / ExitPlanMode).
+ * Returns null when there is no tool_result text.
+ */
+export function joinToolResultText(parsed: Record<string, unknown> | null | undefined): string | null {
+  const content = getMessageContentArray(parsed)
+  if (!content)
     return null
-  const inner = tr.content
-  const text = Array.isArray(inner)
-    ? joinContentParagraphs(asContentArray(inner), { text: 'text' })
-    : String(inner || '')
-  return text || null
+  const parts: string[] = []
+  for (const block of content) {
+    if (!isObject(block) || block.type !== 'tool_result')
+      continue
+    const text = toolResultBlockText(block)
+    if (text)
+      parts.push(text)
+  }
+  return parts.length > 0 ? parts.join('\n\n') : null
 }

--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -58,6 +58,62 @@ describe('claude extractQuotableText', () => {
   })
 })
 
+describe('claude preview text (scroll-rail mark preview)', () => {
+  const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
+
+  it('extracts a self-displaying control-response tool_result body (ExitPlanMode / AskUserQuestion answer)', () => {
+    // The user's answer/feedback lives inside a tool_result block; is_error is irrelevant.
+    const parent = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', content: '> **A stored** column: needs a migration.\n\nWe should go with this option.', is_error: true, tool_use_id: 'toolu_1' }],
+      },
+      parent_tool_use_id: null,
+    }
+    // Newlines survive so the tooltip renders the blockquote + paragraph structure.
+    expect(plugin.previewText!({ kind: 'tool_result' }, input(parent)))
+      .toBe('> **A stored** column: needs a migration.\n\nWe should go with this option.')
+  })
+
+  it('extracts a tool_result whose content is itself a block array', () => {
+    const parent = {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', content: [{ type: 'text', text: 'answer text' }] }] },
+    }
+    expect(plugin.previewText!({ kind: 'tool_result' }, input(parent))).toBe('answer text')
+  })
+
+  it('joins multiple tool_result bodies (parallel tool calls) with a blank line', () => {
+    const parent = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', content: 'first', tool_use_id: 'a' },
+          { type: 'tool_result', content: 'second', tool_use_id: 'b' },
+        ],
+      },
+    }
+    expect(plugin.previewText!({ kind: 'tool_result' }, input(parent))).toBe('first\n\nsecond')
+  })
+
+  it('reads the Claude {message:{content}} transcript envelope (a Claude-specific shape, not the shared default)', () => {
+    // A transcript user row nests its text under message.content as a string; this Anthropic
+    // shape is read here, not by the provider-neutral defaultMarkPreview.
+    expect(plugin.previewText!({ kind: 'user_text' }, input({ message: { content: 'typed text' } }))).toBe('typed text')
+  })
+
+  it('falls back to the shared neutral extractor for a plain {content} user send', () => {
+    expect(plugin.previewText!({ kind: 'user_content' }, input({ content: 'hello world' }))).toBe('hello world')
+  })
+
+  it('falls back to the shared neutral extractor for a {controlResponse} row, and null otherwise', () => {
+    expect(plugin.previewText!({ kind: 'control_response' }, input({ controlResponse: { action: 'approved' } }))).toBe('Approved')
+    expect(plugin.previewText!({ kind: 'assistant_text' }, input({ message: { content: [{ type: 'text', text: 'hi' }] } }))).toBeNull()
+  })
+})
+
 describe('claude classify', () => {
   const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
 

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -6,14 +6,16 @@ import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { joinContentParagraphs } from '~/lib/contentBlocks'
 import { randomUUID } from '~/lib/idGenerator'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
+import { truncatePreview } from '~/lib/textTruncate'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import { buildAskAnswers } from '../../controls/AskUserQuestionControl'
 import { ClaudeCodeControlActions, ClaudeCodeControlContent } from '../../controls/ClaudeCodeControlRequest'
+import { defaultMarkPreview } from '../../markPreviewShared'
 import { isNotificationThreadWrapper, isTerminalCompactingStatus } from '../../messageUtils'
 import { buildPlanMode } from '../../settingsGroups'
 import { registerProvider } from '../registry'
-import { getAssistantContent } from './extractors/assistantContent'
+import { getAssistantContent, joinToolResultText } from './extractors/assistantContent'
 import { claudeNotificationThreadEntry } from './notifications'
 import { renderClaudeMessage } from './renderMessage'
 import { claudeResultDivider } from './resultDivider'
@@ -280,6 +282,28 @@ function claudeExtractQuotableText(category: MessageCategory, parsed: ParsedMess
   return null
 }
 
+/**
+ * Scroll-rail preview for a Claude marked message. Two Claude-specific (Anthropic) shapes
+ * only this plugin knows how to read are handled here before the shared fallback: a
+ * self-displaying control response (AskUserQuestion / ExitPlanMode answer) re-emitted as a
+ * `message.content[]` tool_result, and a transcript user row nesting its text under
+ * `{message:{content:"..."}}`. Every other marked shape (`{content}`, `{controlResponse}`)
+ * is Leapmux-neutral and handled by the shared defaultMarkPreview.
+ */
+function claudeMarkPreview(category: MessageCategory, parsed: ParsedMessageContent): string | null {
+  const toolResultText = joinToolResultText(parsed.parentObject)
+  if (toolResultText)
+    return truncatePreview(toolResultText)
+  // Claude transcript user row: `{message:{content:"..."}}` (string content). The
+  // message-array (assistant / tool_result) form is picked up by joinToolResultText above,
+  // so a string here is genuine user text, never a mis-picked block array.
+  const message = pickObject(parsed.parentObject, 'message')
+  const nestedContent = pickString(message, 'content', '')
+  if (nestedContent)
+    return truncatePreview(nestedContent)
+  return defaultMarkPreview(category, parsed)
+}
+
 // Claude reserves ~16.5% of the context window as an autocompact buffer, so the
 // context-usage percentage is measured against the remaining usable capacity.
 const CLAUDE_AUTOCOMPACT_BUFFER_PCT = 16.5
@@ -309,6 +333,7 @@ const claudeCodePlugin: Provider = {
   renderMessage: renderClaudeMessage,
   toolResultMeta: claudeToolResultMeta,
   extractQuotableText: claudeExtractQuotableText,
+  previewText: claudeMarkPreview,
   notificationThreadEntry: claudeNotificationThreadEntry,
   resultDivider: claudeResultDivider,
 

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -13,6 +13,7 @@ import { CODEX_RATE_LIMITS_METHOD, codexRateLimitReachedType, iterCodexRateLimit
 import { CODEX_INTERNAL_TOOL, CODEX_ITEM, CODEX_METHOD, CODEX_STATUS } from '~/types/toolMessages'
 import { getToolName } from '~/utils/controlResponse'
 import { CodexControlActions, CodexControlContent, sendCodexUserInputResponse } from '../../controls/CodexControlRequest'
+import { defaultMarkPreview } from '../../markPreviewShared'
 import { PlanExecutionMessage, UserContentMessage } from '../../messageRenderers'
 import { isNotificationThreadWrapper, isTerminalCompactingStatus } from '../../messageUtils'
 import { acpBuildControlResponse, isJsonRpcResponseObject } from '../acp/classification'
@@ -459,6 +460,12 @@ const codexPlugin: Provider = {
     }
     return null
   },
+
+  // Codex marks only user sends and control-response answers. A control answer is persisted in one
+  // of two Leapmux-neutral shapes -- `{content}` (a provider-resolved answer or a deny-with-feedback)
+  // or `{controlResponse}` (a bare approve/deny with no feedback) -- and Codex never self-displays
+  // one. The shared neutral extractor handles BOTH shapes, so it is the whole preview.
+  previewText: defaultMarkPreview,
 
   notificationThreadEntry: codexNotificationThreadEntry,
 

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -9,6 +9,7 @@ import type { ParsedMessageContent } from '~/lib/messageParser'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
 import { formatUnifiedDiffText } from '../../diff'
+import { defaultMarkPreview } from '../../markPreviewShared'
 import { PlanExecutionMessage, UserContentMessage } from '../../messageRenderers'
 import { isNotificationThreadWrapper } from '../../messageUtils'
 import { COLLAPSED_RESULT_ROWS } from '../../results/collapse'
@@ -317,6 +318,13 @@ const piPlugin: Provider = {
       return obj.content.trim() || null
     return null
   },
+
+  // Pi marks only user sends and control-response answers. A control answer is persisted in one of
+  // two Leapmux-neutral shapes -- `{content}` (a provider-resolved answer or a deny-with-feedback)
+  // or `{controlResponse}` (a bare approve/deny with no feedback) -- and Pi consumes
+  // extension_ui_response on stdin without echoing it. The shared neutral extractor handles BOTH
+  // shapes, so it is the whole preview.
+  previewText: defaultMarkPreview,
 
   buildInterruptContent(): string | null {
     return JSON.stringify({ type: 'abort' })

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -219,6 +219,21 @@ export interface Provider {
   ) => string | null
 
   /**
+   * Short plaintext preview of a MARKED message's content (user inputs, control
+   * responses) for the chat scroll rail's dot-hover tooltip. Sibling of
+   * {@link extractQuotableText}: each provider knows its own wire shapes, so preview
+   * extraction is a per-provider concern. Providers whose marked rows are all in the
+   * Leapmux-neutral shapes (`{content}`, `{controlResponse}`) delegate to the shared
+   * `defaultMarkPreview`; Claude also reads its Anthropic `message.content[]` tool_result
+   * blocks. Return null when there is no previewable text (the rail then shows a
+   * mark-type label). See chatMarkPreview.ts.
+   */
+  previewText?: (
+    category: MessageCategory,
+    parsed: ParsedMessageContent,
+  ) => string | null
+
+  /**
    * Build the wire-format content string to interrupt the agent.
    * Returns null if interrupt is not supported or not applicable.
    */

--- a/frontend/src/components/chat/useChatScroll.seek.test.ts
+++ b/frontend/src/components/chat/useChatScroll.seek.test.ts
@@ -1,0 +1,299 @@
+import type { ChatScrollVirtualizer } from './useChatScroll'
+import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import type { ScrollAnchor } from '~/stores/chatTypes'
+import { createRoot, createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { useChatScroll } from './useChatScroll'
+import { installScrollTestEnv, makeFakeScrollDiv, measurementDeferralNoOps } from './useChatScroll.testkit'
+
+installScrollTestEnv()
+
+function mkMsgs(seqs: number[]): AgentChatMessage[] {
+  return seqs.map(s => ({ id: `m${s}`, seq: BigInt(s), source: MessageSource.USER } as AgentChatMessage))
+}
+
+/** A virtualizer stub that resolves an anchor to `Number(seq) * 200` scrollTop. */
+function seekVirt(): ChatScrollVirtualizer {
+  return {
+    ...measurementDeferralNoOps(),
+    totalHeight: () => 5000,
+    geometryVersion: () => 0,
+    updateViewport: () => {},
+    anchorAt: () => ({ id: 'x', offsetWithinRow: 0 }),
+    scrollTopNearAnchor: () => null,
+    scrollTopForAnchor: (a: ScrollAnchor) => (a.seq !== undefined ? Number(a.seq) * 200 : null),
+  }
+}
+
+describe('usechatscroll jump to seq', () => {
+  it('lands on an in-window seq: writes the resolved row top minus the align offset', () =>
+    createRoot((dispose) => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(5000)
+      div.setClientHeight(500)
+      div.setScrollTop(0)
+      const [messages] = createSignal(mkMsgs([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+      const [streamingText] = createSignal('')
+      const onJumpToSeq = vi.fn()
+      const hook = useChatScroll({
+        virtualizer: seekVirt(),
+        messages,
+        streamingText,
+        hasOlderMessages: () => false,
+        hasNewerMessages: () => false,
+        onJumpToSeq,
+      })
+      hook.attachListRef(div.el)
+
+      hook.jumpToSeq(5n)
+
+      // scrollTopForAnchor(seq 5) = 1000; landing subtracts the 8px align offset.
+      expect(div.getScrollTop()).toBe(992)
+      // In-window: no fetch.
+      expect(onJumpToSeq).not.toHaveBeenCalled()
+      dispose()
+    }))
+
+  it('resolves to whether the landing moved the view (the contract the rail drag-release hold relies on)', async () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(0)
+          const [messages] = createSignal(mkMsgs([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+          const [streamingText] = createSignal('')
+          const hook = useChatScroll({
+            virtualizer: seekVirt(),
+            messages,
+            streamingText,
+            hasOlderMessages: () => false,
+            hasNewerMessages: () => false,
+          })
+          hook.attachListRef(div.el)
+
+          // From scrollTop 0, landing on seq 5 moves the view to 992 -> resolves true.
+          expect(await hook.jumpToSeq(5n)).toBe(true)
+          expect(div.getScrollTop()).toBe(992)
+          // Landing on seq 5 AGAIN targets the same 992 -> no move -> resolves false. This is
+          // the "scrolls nowhere" signal the rail's drag-release fallback keys off to clear the
+          // held thumb instead of waiting forever for a metrics change that never comes.
+          expect(await hook.jumpToSeq(5n)).toBe(false)
+          expect(div.getScrollTop()).toBe(992)
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('fetches around an out-of-window seq, then lands once the window swaps', async () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(2500)
+          // The loaded window is seqs 100..110; the target (5) is far below it.
+          const [messages, setMessages] = createSignal(mkMsgs([100, 101, 102, 103, 104]))
+          const [streamingText] = createSignal('')
+          const onJumpToSeq = vi.fn(async (_seq: bigint) => {
+            // The paginator swaps the window to a page around the target.
+            setMessages(mkMsgs([3, 4, 5, 6, 7]))
+          })
+          const hook = useChatScroll({
+            virtualizer: seekVirt(),
+            messages,
+            streamingText,
+            hasOlderMessages: () => true,
+            hasNewerMessages: () => false,
+            onJumpToSeq,
+          })
+          hook.attachListRef(div.el)
+
+          hook.jumpToSeq(5n)
+          expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+
+          // Let the onJumpToSeq promise resolve, then the landing runs.
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(992) // scrollTopForAnchor(5) = 1000, minus 8
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('cancels the out-of-window landing when the user scrolls while the fetch is in flight', async () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(2500)
+          const [messages, setMessages] = createSignal(mkMsgs([100, 101, 102, 103, 104]))
+          const [streamingText] = createSignal('')
+          let releaseFetch: (() => void) | undefined
+          const onJumpToSeq = vi.fn(() => new Promise<void>((r) => {
+            releaseFetch = r
+          }))
+          const hook = useChatScroll({
+            virtualizer: seekVirt(),
+            messages,
+            streamingText,
+            hasOlderMessages: () => true,
+            hasNewerMessages: () => false,
+            onJumpToSeq,
+          })
+          hook.attachListRef(div.el)
+
+          hook.jumpToSeq(5n)
+          // The reader scrolls (a genuine wheel gesture, not an ambient layout scroll)
+          // while the fetch is pending.
+          hook.handlers.onWheel(new WheelEvent('wheel', { bubbles: true, deltaY: -100 }))
+          div.setScrollTop(1800)
+          hook.handlers.onScroll()
+
+          // The fetch resolves and swaps the window -- but the landing must be cancelled.
+          setMessages(mkMsgs([3, 4, 5, 6, 7]))
+          releaseFetch?.()
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // The reader stays where they scrolled to; no seek-jump write clobbered it.
+          expect(div.getScrollTop()).toBe(1800)
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('does not cancel an out-of-window landing for ambient scroll noise before the fetch resolves', async () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(2500)
+          const [messages, setMessages] = createSignal(mkMsgs([100, 101, 102, 103, 104]))
+          const [streamingText] = createSignal('')
+          let releaseFetch: (() => void) | undefined
+          const onJumpToSeq = vi.fn(() => new Promise<void>((r) => {
+            releaseFetch = r
+          }))
+          const hook = useChatScroll({
+            virtualizer: seekVirt(),
+            messages,
+            streamingText,
+            hasOlderMessages: () => true,
+            hasNewerMessages: () => false,
+            onJumpToSeq,
+          })
+          hook.attachListRef(div.el)
+
+          hook.jumpToSeq(5n)
+          // Browser scroll anchoring/layout can emit a scroll event during the window swap
+          // without a fresh input gesture. That should not clear the pending seek.
+          div.setScrollTop(2450)
+          hook.handlers.onScroll()
+
+          setMessages(mkMsgs([3, 4, 5, 6, 7]))
+          releaseFetch?.()
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(992)
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('cancelPendingSeek (a fresh thumb re-grab) abandons an in-flight out-of-window landing', async () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(2500)
+          const [messages, setMessages] = createSignal(mkMsgs([100, 101, 102, 103, 104]))
+          const [streamingText] = createSignal('')
+          let releaseFetch: (() => void) | undefined
+          const onJumpToSeq = vi.fn(() => new Promise<void>((r) => {
+            releaseFetch = r
+          }))
+          const hook = useChatScroll({
+            virtualizer: seekVirt(),
+            messages,
+            streamingText,
+            hasOlderMessages: () => true,
+            hasNewerMessages: () => false,
+            onJumpToSeq,
+          })
+          hook.attachListRef(div.el)
+
+          hook.jumpToSeq(5n)
+          // A fresh thumb-drag grab takes manual control while the fetch is still pending.
+          // The drag scrolls only programmatically, so it never trips the user-scroll seek
+          // cancel -- the rail calls cancelPendingSeek explicitly on grab.
+          hook.cancelPendingSeek()
+
+          // The fetch resolves and swaps the window, but the abandoned seek must NOT land.
+          setMessages(mkMsgs([3, 4, 5, 6, 7]))
+          releaseFetch?.()
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // No seek-jump write clobbered the viewport; it is left for the live drag to drive.
+          expect(div.getScrollTop()).toBe(2500)
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('previewScrollTo writes a clamped programmatic scroll for in-window drag', () =>
+    createRoot((dispose) => {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(5000)
+      div.setClientHeight(500)
+      div.setScrollTop(0)
+      const [messages] = createSignal(mkMsgs([1, 2, 3]))
+      const [streamingText] = createSignal('')
+      const hook = useChatScroll({ virtualizer: seekVirt(), messages, streamingText })
+      hook.attachListRef(div.el)
+
+      hook.previewScrollTo(1200)
+      expect(div.getScrollTop()).toBe(1200)
+      // Clamped to the max scroll (scrollHeight - clientHeight = 4500).
+      hook.previewScrollTo(99999)
+      expect(div.getScrollTop()).toBe(4500)
+      dispose()
+    }))
+})

--- a/frontend/src/components/chat/useChatScroll.ts
+++ b/frontend/src/components/chat/useChatScroll.ts
@@ -19,6 +19,7 @@ import { createStaleNativeScrollTranslator } from './chatScrollStaleNative'
 import { createStickyBottom } from './chatScrollSticky'
 import { createScrollVelocity } from './chatScrollVelocity'
 import { createViewportRestore } from './chatScrollViewportRestore'
+import { createChatSeek } from './chatSeek'
 
 /** Saved/queried scroll position — anchored to a message, see SavedViewportScroll. */
 export type ChatScrollState = SavedViewportScroll
@@ -278,6 +279,11 @@ export interface PaginationCallbacks {
   /** Re-fetch the earliest page and snap to the first message (Home). */
   onJumpToOldest?: () => Promise<void> | void
   /**
+   * Replace the window with a page centered on `seq` (the scroll rail's out-of-window
+   * seek). Resolves once the window has been swapped, so the hook can land on the row.
+   */
+  onJumpToSeq?: (seq: bigint) => Promise<void> | void
+  /**
    * Cap the in-memory window on a live-tail append. `minKeepNewest` is the count of
    * newest messages the trim must retain to leave a scrolled-up reader's viewport
    * intact (the anchored row down to the tail); 0 while following the bottom. The
@@ -352,6 +358,24 @@ export interface UseChatScrollResult {
   /** Synchronous jump to bottom (used by the inline "show more" button). */
   jumpToBottom: () => void
   /**
+   * Seek to a message seq (a scroll-rail dot click, track click, or thumb release):
+   * an in-window aligned landing, or a fetch-around-seq window swap then land. Resolves
+   * to whether the seek actually moved the scroll position (so the rail's drag-release
+   * hold knows whether to await the landing's metrics settle or clear the thumb now).
+   */
+  jumpToSeq: (seq: bigint) => Promise<boolean>
+  /**
+   * A guard-marked programmatic scroll write for in-window rail thumb-drag live-scroll.
+   * Marked like the landing writes so the drag's scroll events don't trip velocity
+   * sampling, edge pagination, or the buffer filler.
+   */
+  previewScrollTo: (top: number) => void
+  /**
+   * Abandon any in-flight out-of-window seek (rail thumb re-grab): its late fetch must
+   * not yank the viewport after the user has taken manual control of the thumb.
+   */
+  cancelPendingSeek: () => void
+  /**
    * Re-stick to the bottom if we were pinned there and content below the
    * viewport just grew. For tail content that is NOT a virtualizer row -- the
    * streaming-markdown block and the thinking indicator, rendered as siblings of
@@ -416,6 +440,11 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
   let preserveBrowsingPosition = false
   let scrollAnimationId: number | null = null
   let suppressAutoLoadOlderAfterRestore = false
+  // The scroll-rail seek unit (createChatSeek), assigned below where its deps are all in
+  // scope. It owns the in-flight out-of-window seek + epoch; a forward `let` (read only at
+  // call time) lets handleScroll cancel a live seek on a genuine user scroll before the unit
+  // is created. See the wiring at the assignment site.
+  let chatSeek!: ReturnType<typeof createChatSeek>
   let autoScrollFirstSeq: bigint | undefined
   let autoScrollLastSeq: bigint | undefined
   let lastAutoScrollSig: unknown[] = []
@@ -1172,6 +1201,13 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
     )
     // Defer the re-pin as fling drift only for a momentum scroll.
     userScrolling = isMomentumScroll
+    // Only a user-directed scroll cancels an in-flight out-of-window seek: ambient layout
+    // shifts/window swaps can emit real scroll events while the fetch is pending, but they
+    // are not the reader taking control and must not strand the seek before it can land.
+    const userDirectedScroll = !programmaticEcho
+      && (discretePage || isScrollInputActive() || hasRecentMomentumInput() || hasRecentKeyboardScroll())
+    if (userDirectedScroll)
+      chatSeek.cancelPendingSeek()
     // Render-ahead overscan for this scroll (undefined for echoes and idle), read
     // BEFORE refreshViewport / checkAtBottom can move scrollTop.
     const viewportLead = scrollTopAtStart !== undefined
@@ -1382,19 +1418,23 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
     }
   }
 
-  const forceScrollToBottom = () => {
-    cancelScrollAnimation()
-    // A deliberate jump-to-bottom is the user re-taking control of position, exactly
-    // like a genuine scroll: resume the pre-fetch a prior forced-stop tap paused. It
-    // otherwise clears only on a non-echo scroll, and a jump emits only programmatic
-    // echoes -- so without this a stop-then-jump leaves the buffer fill wedged off.
+  /**
+   * Clear the per-window "buffer filler paused / suppressed" flags -- a deliberate jump
+   * (to bottom, or to a rail seq) is the user re-taking control of position, exactly like
+   * a genuine scroll, but a jump emits only programmatic echoes that never clear them.
+   * Resumes a pre-fetch a prior forced-stop tap paused, drops the settle gate, and
+   * abandons any near-top restore's older-load suppression. Callers that REPLACE the
+   * window additionally rearmScrollBufferFiller() for the fresh window's per-window state.
+   */
+  const retakeScrollControl = () => {
     bufferFillPaused = false
     bufferFillSettling = false
-    // A jump-to-bottom also abandons any near-top restore landing, so its older-load
-    // suppression no longer applies -- clear it (a window REPLACE on the hasNewer path
-    // below invalidates it outright; even a same-window stick is a deliberate move off
-    // the protected top). Mirrors the rearmScrollBufferFiller() below for per-window state.
     suppressAutoLoadOlderAfterRestore = false
+  }
+
+  const forceScrollToBottom = () => {
+    cancelScrollAnimation()
+    retakeScrollControl()
     // Scrolled away from the live tail: re-fetch the latest page first, then
     // snap. jumpToLatest replaces the window; the totalHeight re-pin effect and
     // the sticky auto-scroll then land us at the true bottom.
@@ -1453,6 +1493,30 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
     }
     stickToBottom()
   }
+
+  // ---- Scroll-rail seek (jumpToSeq / previewScrollTo / cancelPendingSeek) -------------
+  // The seek machine (dot/track/thumb -> land, or fetch-around-seq then land) lives in its
+  // own tested unit, createChatSeek; wired here where all its deps are in scope. It owns the
+  // pendingSeek/epoch state. rearmScrollBufferFiller is threaded as a thunk because the
+  // buffer filler is created LATER than this seam; the rest are already defined above.
+  chatSeek = createChatSeek(scrollCtx, {
+    messages: opts.messages,
+    readScrollTop: readLogicalScrollTop,
+    cancelScrollAnimation,
+    cancelFlingSettle: () => {
+      flingSettle.cancel()
+      flingSettle.reset()
+    },
+    captureAnchor,
+    captureRowTopAnchor,
+    bumpGeomTick: () => bumpGeomTick(t => t + 1),
+    retakeScrollControl,
+    rearmScrollBufferFiller: () => rearmScrollBufferFiller(),
+    checkAtBottom,
+    onJumpToSeq: opts.onJumpToSeq,
+    onSaveViewportScroll: opts.onSaveViewportScroll,
+    hasNewerMessages: () => !!opts.hasNewerMessages?.(),
+  })
 
   // The keyboard / wheel input layer (createScrollInput). Owns no scroll state -- the
   // shared `lastScrollDir` / `discretePageTarget` stay here (handleScroll reads them)
@@ -1892,6 +1956,9 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
     scrollToBottomAnimated,
     scrollToBottom,
     jumpToBottom,
+    jumpToSeq: seq => chatSeek.jumpToSeq(seq),
+    previewScrollTo: top => chatSeek.previewScrollTo(top),
+    cancelPendingSeek: () => chatSeek.cancelPendingSeek(),
     restickIfAtBottom,
     getScrollState,
     forceScrollToBottom,

--- a/frontend/src/components/chat/useChatVirtualizer.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.ts
@@ -2,6 +2,7 @@ import type { Accessor } from 'solid-js'
 import type { AnchorOffsetGeometry } from './chatScrollAnchor'
 import type { ScrollAnchor } from '~/stores/chatTypes'
 import { batch, createMemo, createSignal, onCleanup } from 'solid-js'
+import { largestIndexWhere, smallestIndexWhere } from '~/lib/binarySearch'
 import { clamp } from '~/lib/clamp'
 import { capMapInsertionOrder } from '~/lib/mapLru'
 import { monotonicNow } from '~/lib/monotonicNow'
@@ -236,46 +237,6 @@ function resolve(v: Accessor<number> | number | undefined, fallback: number): nu
  */
 function isUsableHeight(n: number): boolean {
   return n > 0 && Number.isFinite(n)
-}
-
-// Largest index in [0, n-1] for which `pred(mid)` holds, or 0 when none does.
-// Lower-bound scan: each satisfied probe raises the floor. Module-level and pure
-// (state passed in), so it isn't re-allocated per useChatVirtualizer instance and
-// can be unit-tested directly.
-function largestIndexWhere(n: number, pred: (mid: number) => boolean): number {
-  let lo = 0
-  let hi = n - 1
-  let ans = 0
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1
-    if (pred(mid)) {
-      ans = mid
-      lo = mid + 1
-    }
-    else {
-      hi = mid - 1
-    }
-  }
-  return ans
-}
-
-// Smallest index in [0, n-1] for which `pred(mid)` holds, or `fallback` when none
-// does. Upper-bound scan: each satisfied probe lowers the ceiling.
-function smallestIndexWhere(n: number, pred: (mid: number) => boolean, fallback: number): number {
-  let lo = 0
-  let hi = n - 1
-  let ans = fallback
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1
-    if (pred(mid)) {
-      ans = mid
-      hi = mid - 1
-    }
-    else {
-      lo = mid + 1
-    }
-  }
-  return ans
 }
 
 export interface UseChatVirtualizerResult {

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -5,7 +5,7 @@ import type { TileActions, TilePopAction } from './TileActionsMenu'
 import type { useAgentOperations } from './useAgentOperations'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { FileAttachment } from '~/components/chat/attachments'
-import type { ChatMessageLookups } from '~/components/chat/ChatView'
+import type { ChatMessageLookups, ChatRailProps } from '~/components/chat/ChatView'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ToggleDialogState } from '~/hooks/createDialogState'
 import type { createLoadingSignal } from '~/hooks/createLoadingSignal'
@@ -24,6 +24,7 @@ import { create } from '@bufbuild/protobuf'
 import { createEffect, createMemo, For, mapArray, onCleanup, Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { AgentEditorPanel } from '~/components/chat/AgentEditorPanel'
+import { getCachedMarkPreview, warmMarkPreview } from '~/components/chat/chatMarkPreview'
 import { ChatView } from '~/components/chat/ChatView'
 import { agentProviderLabel } from '~/components/common/AgentProviderIcon'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
@@ -598,6 +599,28 @@ export function createTileRenderer(opts: TileRendererOpts) {
               getMessageContentVersion: id => chatStore.getMessageContentVersion(id),
               getTodoById: taskId => chatStore.todos.getById(agentId, taskId),
             }
+            // The scroll-rail prop object, memoized like `lookups` above: getRailData does
+            // firstServerSeq/lastServerSeq scans and the rail's per-frame memos read
+            // props.rail.{minSeq,maxSeq,marks} several times per scroll frame -- a fresh
+            // `{...getRailData(), previewFor, warmPreview}` per access would re-run those scans
+            // and allocate an object + two closures each time. Memoizing recomputes only when
+            // getRailData's reactive deps change (marks / window / live tail), and the preview
+            // callbacks are built ONCE (stable references) rather than per read.
+            const railPreviewFor = (seq: bigint) => getCachedMarkPreview(agentId, seq)
+            const railWarmPreview = (seq: bigint) => {
+              const workerId = agent()?.workerId
+              if (!workerId)
+                return
+              warmMarkPreview(workerId, agentId, seq, {
+                getLoadedMessageBySeq: chatStore.getLoadedMessageBySeq,
+                fetchMessageBySeq: chatStore.fetchMessageBySeq,
+              })
+            }
+            const railProps = createMemo<ChatRailProps>(() => ({
+              ...chatStore.getRailData(agentId),
+              previewFor: railPreviewFor,
+              warmPreview: railWarmPreview,
+            }))
             onCleanup(() => {
               agentScrollStates.delete(agentId)
               agentScrollToBottoms.delete(agentId)
@@ -633,7 +656,9 @@ export function createTileRenderer(opts: TileRendererOpts) {
                       onLoadNewerMessages: () => chatStore.loadNewerPage(agent()?.workerId ?? '', agentId),
                       onJumpToLatest: () => chatStore.jumpToLatestMessages(agent()?.workerId ?? '', agentId),
                       onJumpToOldest: () => chatStore.jumpToOldestMessages(agent()?.workerId ?? '', agentId),
+                      onJumpToSeq: seq => chatStore.jumpToMessagesAroundSeq(agent()?.workerId ?? '', agentId, seq),
                     }}
+                    rail={railProps()}
                     savedViewportScroll={chatStore.viewportScroll.get(agentId)}
                     onClearSavedViewportScroll={() => chatStore.viewportScroll.clear(agentId)}
                     // Unmount save (tile split/merge, workspace switch): keep the

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -1023,8 +1023,8 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // Pre-trim BEFORE the message replay renders: the worker ships the
         // authoritative live tail up front so a reconnecting client drops phantom rows
         // (a tail it loaded before disconnect that was deleted while away) immediately,
-        // rather than flashing them until catchUpComplete reconciles at the end. A
-        // negative latest_seq (worker couldn't determine the tail) is skipped by the store.
+        // rather than flashing them until catchUpComplete reconciles at the end. An
+        // unset latest_seq (worker couldn't determine the tail) is skipped by the store.
         //
         // At catch-up START, latest_seq IS the start tail, so a phantom and a live
         // message that raced in are indistinguishable by seq alone -- both sit above
@@ -1047,11 +1047,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // reconnecting client never received the AgentMessageDeleted for rows deleted
         // while it was disconnected, so it drops phantom rows beyond latest_seq and
         // clamps its recorded live-tail -- otherwise its "new messages below"
-        // affordance can stay stuck past a now-shorter history. A negative latest_seq
+        // affordance can stay stuck past a now-shorter history. An unset latest_seq
         // (worker couldn't determine the tail) is skipped for the reap, but PROBED (see
         // probeIndeterminate below). start_tail_seq (the tail when replay began) bounds
         // the reap so a live message that raced in DURING catch-up -- seq above it --
-        // isn't reaped as a phantom. When start_tail_seq is indeterminate (-1, a failed
+        // isn't reaped as a phantom. When start_tail_seq is indeterminate (unset, a failed
         // worker readback), fall back to the resume cursor (the loaded tail this subscribe
         // sent) as the ceiling -- the SAME bound catchUpStart uses -- so a live arrival
         // above it is still exempted instead of reaping everything beyond latest_seq and
@@ -1063,18 +1063,22 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // whenever the loaded tail lags it -- so a windowed-away reader keeps their
         // position + affordance, and a following reader's gap closes without hinging on
         // this frame. The ONE exception folded into the reconcile is an INDETERMINATE
-        // (-1) tail: liveTail can't be raised, so probeIndeterminate=true nudges it one
+        // (unset) tail: liveTail can't be raised, so probeIndeterminate=true nudges it one
         // past the loaded tail to make the continuous reconcile probe (it would otherwise
         // read the partial replay as caught up). This keeps ALL forward-fill in the
         // continuous reconcile -- there is no one-shot fill in this handler.
         chatStore.reconcileAuthoritativeTail(
           agentId,
           inner.value.latestSeq,
-          inner.value.startTailSeq < 0n
+          inner.value.startTailSeq === undefined
             ? resumeTails.get(agentId)
             : inner.value.startTailSeq,
           true,
         )
+        // Re-seed the scroll-rail marks so any user sends / deletes that happened while
+        // disconnected are reflected (live add/remove already heals the connected case). Tied
+        // to this subscription's signal so a resubscribe/teardown cancels it (see loadMessageMarks).
+        void chatStore.loadMessageMarks(tabStore.getAgentTab(agentId)?.workerId ?? '', agentId, eventStreamAbort?.signal)
         // Reclaim any command stream orphaned DURING catch-up: a mid-stream
         // delete (or beyond-window reseq) recorded an orphan, but its turn-end
         // divider replayed while the phase was still 'catchingUp', so the
@@ -1226,6 +1230,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           try {
             const wid = tabStore.getAgentTab(entry.agentId)?.workerId ?? ''
             await chatStore.loadInitialMessages(wid, entry.agentId)
+            // Seed the scroll-rail marks alongside history (not awaited: a failure
+            // must not block or fail the history load -- the rail just stays hidden). Tied to
+            // this subscription's signal so a resubscribe/teardown cancels it.
+            void chatStore.loadMessageMarks(wid, entry.agentId, eventStreamAbort?.signal)
           }
           catch (err) {
             showWarnToast('Failed to load chat history', err)
@@ -1497,6 +1505,9 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     chatStore.loadInitialMessages(agent.workerId, tabId).catch((err) => {
       showWarnToast('Failed to load chat history', err)
     })
+    // Seed the scroll-rail marks for the newly-opened agent (fire-and-forget). Tied to the
+    // current subscription's signal so a resubscribe/teardown cancels it (see loadMessageMarks).
+    void chatStore.loadMessageMarks(agent.workerId, tabId, eventStreamAbort?.signal)
   })
 
   // Continuous tail reconcile: whenever a loaded window lags its recorded live tail

--- a/frontend/src/lib/binarySearch.test.ts
+++ b/frontend/src/lib/binarySearch.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { largestIndexWhere, lowerBoundBySeq, smallestIndexWhere } from './binarySearch'
+
+describe('binarysearch', () => {
+  describe('largestindexwhere', () => {
+    // Non-decreasing array; find the largest index with arr[i] <= target.
+    const arr = [0, 10, 20, 30, 40]
+    it('finds the largest index whose value is <= target', () => {
+      expect(largestIndexWhere(arr.length, i => arr[i] <= 25)).toBe(2) // 20
+      expect(largestIndexWhere(arr.length, i => arr[i] <= 30)).toBe(3) // exact boundary
+      expect(largestIndexWhere(arr.length, i => arr[i] <= 999)).toBe(4) // last
+    })
+
+    it('returns 0 when the predicate holds for nothing (below the floor)', () => {
+      expect(largestIndexWhere(arr.length, i => arr[i] <= -1)).toBe(0)
+    })
+
+    it('handles a single-element and matches a linear scan across the range', () => {
+      expect(largestIndexWhere(1, () => true)).toBe(0)
+      for (let target = -5; target <= 45; target += 3) {
+        const pred = (i: number) => arr[i] <= target
+        let expected = 0
+        for (let i = 0; i < arr.length; i++) {
+          if (pred(i))
+            expected = i
+        }
+        expect(largestIndexWhere(arr.length, pred)).toBe(expected)
+      }
+    })
+  })
+
+  describe('smallestindexwhere', () => {
+    const arr = [0, 10, 20, 30, 40]
+    it('finds the smallest index whose value is >= target', () => {
+      expect(smallestIndexWhere(arr.length, i => arr[i] >= 15, arr.length - 1)).toBe(2) // 20
+      expect(smallestIndexWhere(arr.length, i => arr[i] >= 20, arr.length - 1)).toBe(2) // exact
+      expect(smallestIndexWhere(arr.length, i => arr[i] >= 0, arr.length - 1)).toBe(0) // first
+    })
+
+    it('returns the fallback when the predicate holds for nothing', () => {
+      expect(smallestIndexWhere(arr.length, i => arr[i] >= 999, 42)).toBe(42)
+    })
+  })
+
+  describe('lowerboundbyseq', () => {
+    const items = [{ seq: 2n }, { seq: 5n }, { seq: 5n }, { seq: 9n }] as const
+
+    it('finds the first index whose seq is >= target (membership + gap)', () => {
+      expect(lowerBoundBySeq(items, 5n)).toBe(1) // first of the duplicate 5s
+      expect(lowerBoundBySeq(items, 2n)).toBe(0) // first
+      expect(lowerBoundBySeq(items, 9n)).toBe(3) // last
+      expect(lowerBoundBySeq(items, 6n)).toBe(3) // gap -> next-higher (insertion point)
+      expect(lowerBoundBySeq(items, 1n)).toBe(0) // below the floor
+    })
+
+    it('returns the length (insertion point) when every seq is smaller', () => {
+      expect(lowerBoundBySeq(items, 10n)).toBe(items.length)
+    })
+
+    it('handles the empty list', () => {
+      expect(lowerBoundBySeq([], 5n)).toBe(0)
+    })
+
+    it('restricts the search to the [0, hi) prefix, ignoring trailing rows', () => {
+      // The prefix bound excludes indices >= hi entirely, so a target present only in the
+      // excluded suffix lands at hi (the insertion point), never scanning the trailing rows --
+      // this is the "server region, excluding trailing optimistic locals" call shape.
+      const withTail = [{ seq: 2n }, { seq: 5n }, { seq: 0n }, { seq: 0n }] as const
+      expect(lowerBoundBySeq(withTail, 5n, 2)).toBe(1)
+      expect(lowerBoundBySeq(withTail, 9n, 2)).toBe(2) // hi, not the array length
+    })
+
+    it('matches a linear lower-bound scan across the range', () => {
+      const asc: { seq: bigint }[] = [{ seq: 0n }, { seq: 3n }, { seq: 3n }, { seq: 8n }, { seq: 100n }]
+      for (let t = -2n; t <= 102n; t += 1n) {
+        let expected = asc.length
+        for (let i = 0; i < asc.length; i++) {
+          if (asc[i].seq >= t) {
+            expected = i
+            break
+          }
+        }
+        expect(lowerBoundBySeq(asc, t)).toBe(expected)
+      }
+    })
+  })
+})

--- a/frontend/src/lib/binarySearch.ts
+++ b/frontend/src/lib/binarySearch.ts
@@ -1,0 +1,66 @@
+/**
+ * Monotonic-predicate binary searches over an index range [0, n-1].
+ *
+ * Both assume `pred` is monotonic across the range (all-true then all-false for
+ * `largestIndexWhere`; all-false then all-true for `smallestIndexWhere`) -- the shape
+ * every offset/seq lookup in the chat virtualizer + scroll rail produces. Kept in one
+ * leaf so the virtualizer's offset scans and the rail geometry's row lookup share a
+ * single tested implementation instead of each hand-rolling the off-by-one.
+ */
+
+/**
+ * Largest index in [0, n-1] for which `pred(mid)` holds, or 0 when none does.
+ * Lower-bound scan: each satisfied probe raises the floor. `pred` must be
+ * true-then-false across the range.
+ */
+export function largestIndexWhere(n: number, pred: (mid: number) => boolean): number {
+  let lo = 0
+  let hi = n - 1
+  let ans = 0
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (pred(mid)) {
+      ans = mid
+      lo = mid + 1
+    }
+    else {
+      hi = mid - 1
+    }
+  }
+  return ans
+}
+
+/**
+ * Smallest index in [0, n-1] for which `pred(mid)` holds, or `fallback` when none
+ * does. Upper-bound scan: each satisfied probe lowers the ceiling. `pred` must be
+ * false-then-true across the range.
+ */
+export function smallestIndexWhere(n: number, pred: (mid: number) => boolean, fallback: number): number {
+  let lo = 0
+  let hi = n - 1
+  let ans = fallback
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (pred(mid)) {
+      ans = mid
+      hi = mid - 1
+    }
+    else {
+      lo = mid + 1
+    }
+  }
+  return ans
+}
+
+/**
+ * Lower bound by seq: the first index in `[0, hi)` whose `seq` is `>= target`, or `hi` when every
+ * seq is smaller (the insertion point) -- so `items[idx]?.seq === target` tests membership. The one
+ * home for the ascending-by-seq lower-bound lookup the chat window, the marks store, and the rail
+ * all repeat, backed by {@link smallestIndexWhere} so the `seq >= target` predicate + off-by-one
+ * live in a single tested place. `hi` defaults to the full length; pass a smaller bound to restrict
+ * the search to a prefix -- e.g. the ascending server-row region, excluding trailing optimistic
+ * locals (seq 0n) that pin to the tail out of seq order.
+ */
+export function lowerBoundBySeq(items: readonly { seq: bigint }[], target: bigint, hi: number = items.length): number {
+  return smallestIndexWhere(hi, mid => items[mid].seq >= target, hi)
+}

--- a/frontend/src/lib/textTruncate.test.ts
+++ b/frontend/src/lib/textTruncate.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { __setGraphemeSegmenterForTest, truncatePreview } from './textTruncate'
+
+describe('truncate preview', () => {
+  it('tidies horizontal whitespace but preserves newlines (for markdown structure)', () => {
+    expect(truncatePreview('  a\n\n  b\t c  ')).toBe('a\n\nb c')
+    expect(truncatePreview('one\n\n\n\ntwo')).toBe('one\n\ntwo') // blank-line runs cap at one
+  })
+
+  it('preserves bare \\r (classic-Mac) and \\r\\n line endings as newlines, not spaces', () => {
+    expect(truncatePreview('a\rb')).toBe('a\nb') // a bare CR is a line break, not a space
+    expect(truncatePreview('a\r\nb')).toBe('a\nb') // a CRLF grapheme is one newline
+  })
+
+  it('coalesces CRLF to a single newline on the no-Intl.Segmenter fallback path (not a paragraph break)', () => {
+    // Force the code-point fallback (older engines / SSR). Without CRLF coalescing there, the
+    // '\r' and '\n' each hit the newline branch and one CRLF double-counts into a paragraph
+    // break, diverging from the Segmenter path asserted above.
+    __setGraphemeSegmenterForTest(null)
+    try {
+      expect(truncatePreview('a\r\nb')).toBe('a\nb')
+      expect(truncatePreview('a\rb')).toBe('a\nb') // a bare CR still one newline on the fallback
+    }
+    finally {
+      __setGraphemeSegmenterForTest(undefined) // re-resolve the real segmenter for later tests
+    }
+  })
+
+  it('bounds the graphemes scanned on a whitespace-dominated input (does not segment the whole prefix)', () => {
+    // Whitespace graphemes never append, so the content cap can't stop the loop; the scan cap
+    // must. A counting segmenter proves the loop stops near MAX_PREVIEW_SCAN, not at 1_000_004.
+    let pulled = 0
+    __setGraphemeSegmenterForTest({
+      segment: (input: string) => ({
+        * [Symbol.iterator]() {
+          for (const ch of input) {
+            pulled++
+            yield { segment: ch }
+          }
+        },
+      }),
+    })
+    try {
+      truncatePreview(`${' '.repeat(1_000_000)}tail`)
+      expect(pulled).toBeLessThan(5000) // ~MAX_PREVIEW_SCAN (4000), not the full 1_000_004
+    }
+    finally {
+      __setGraphemeSegmenterForTest(undefined)
+    }
+  })
+
+  it('preserves content that follows a whitespace run within the scan bound', () => {
+    // Guards the scan bound against over-truncation: a moderate leading-whitespace run must not
+    // drop the content that follows it.
+    expect(truncatePreview(`${' '.repeat(50)}hello`)).toBe('hello')
+  })
+
+  it('marks the result truncated (trailing ellipsis) when the scan cap drops trailing content', () => {
+    // Content, then a huge whitespace run that exhausts the scan cap BEFORE the trailing "world"
+    // is reached -- so "world" is dropped. The result must carry the ellipsis affordance, not
+    // silently render "hello" as if it were the whole message.
+    expect(truncatePreview(`hello${' '.repeat(5000)}world`)).toBe('hello…')
+  })
+
+  it('returns null for empty / whitespace-only / nullish input', () => {
+    expect(truncatePreview('')).toBeNull()
+    expect(truncatePreview('   \n ')).toBeNull()
+    expect(truncatePreview(undefined)).toBeNull()
+    expect(truncatePreview(null)).toBeNull()
+  })
+
+  it('caps overlong text at the limit with a trailing ellipsis', () => {
+    const out = truncatePreview('x'.repeat(500))!
+    expect(out.endsWith('…')).toBe(true)
+    expect(out.length).toBe(201) // 200 kept + the ellipsis
+  })
+
+  it('does not split a surrogate pair at the truncation boundary', () => {
+    expect(truncatePreview(`${'x'.repeat(199)}😀tail`)).toBe(`${'x'.repeat(199)}😀…`)
+  })
+
+  it('does not split a combining-character grapheme at the truncation boundary', () => {
+    expect(truncatePreview(`${'x'.repeat(199)}e\u0301tail`)).toBe(`${'x'.repeat(199)}e\u0301…`)
+  })
+})

--- a/frontend/src/lib/textTruncate.ts
+++ b/frontend/src/lib/textTruncate.ts
@@ -1,0 +1,162 @@
+// ---------------------------------------------------------------------------
+// General grapheme-aware snippet truncator
+//
+// Tidies an arbitrary text body into a bounded, single-snippet preview: collapse
+// horizontal whitespace, cap blank-line runs, and truncate at a grapheme boundary
+// with a trailing ellipsis. Provider- and feature-neutral (no mark-preview / message
+// concerns), so any surface that needs a short snippet of a longer body can reuse it.
+//
+// Extracted from `~/components/chat/markPreviewShared` -- the scroll-rail mark preview
+// was its first caller, which is why the exported names keep the `preview` prefix.
+// ---------------------------------------------------------------------------
+
+/** Longest preview kept; longer content is truncated with an ellipsis. */
+const MAX_PREVIEW_LEN = 200
+const PREVIEW_ELLIPSIS = '…'
+// Hard cap on graphemes SCANNED (not just appended). The MAX_PREVIEW_LEN break bounds appended
+// CONTENT, but whitespace / post-cap blank-line graphemes append nothing while the loop keeps
+// segmenting, so a whitespace-dominated input (a huge leading/embedded run in a pasted body or a
+// large tool_result) would segment its whole prefix on the main thread. 20x the output cap -- far
+// more than any content-dense input needs to reach MAX_PREVIEW_LEN -- so it never truncates normal
+// content, only bounds the pathological run.
+const MAX_PREVIEW_SCAN = MAX_PREVIEW_LEN * 20
+
+interface GraphemeSegment {
+  segment: string
+}
+
+interface GraphemeSegmenter {
+  segment: (input: string) => Iterable<GraphemeSegment>
+}
+
+interface GraphemeSegmenterConstructor {
+  new (
+    locales?: string | string[],
+    options?: { granularity: 'grapheme' },
+  ): GraphemeSegmenter
+}
+
+// A single grapheme segmenter reused across previews: constructing an Intl.Segmenter is not
+// free, and `segment()` is stateless per call, so one instance serves every truncatePreview.
+// `undefined` = not yet resolved; `null` = the runtime has no Intl.Segmenter (SSR / older
+// engines), where we fall back to code-unit iteration.
+let graphemeSegmenter: GraphemeSegmenter | null | undefined
+
+function resolveGraphemeSegmenter(): GraphemeSegmenter | null {
+  if (graphemeSegmenter !== undefined)
+    return graphemeSegmenter
+  const Segmenter = (Intl as typeof Intl & { Segmenter?: GraphemeSegmenterConstructor }).Segmenter
+  graphemeSegmenter = Segmenter ? new Segmenter(undefined, { granularity: 'grapheme' }) : null
+  return graphemeSegmenter
+}
+
+/**
+ * Test-only: override the memoized grapheme segmenter. Pass `null` to exercise the
+ * code-point fallback path (the runtime has no Intl.Segmenter), or `undefined` to clear the
+ * override so the next call re-resolves the real one.
+ */
+export function __setGraphemeSegmenterForTest(value: GraphemeSegmenter | null | undefined): void {
+  graphemeSegmenter = value
+}
+
+function* previewSegments(text: string): Iterable<string> {
+  const segmenter = resolveGraphemeSegmenter()
+  if (segmenter) {
+    for (const part of segmenter.segment(text))
+      yield part.segment
+    return
+  }
+  // Fallback (no Intl.Segmenter -- SSR / older engines): iterate code points, but emit a
+  // '\r\n' pair as ONE segment so a CRLF line ending matches the Segmenter's single grapheme.
+  // Without this, the '\r' and the '\n' each hit truncatePreview's newline branch and one CRLF
+  // double-counts into a paragraph break, diverging from the Segmenter path. Kept lazy (a
+  // one-code-point lookahead) so truncatePreview's early break still bounds the iteration.
+  const it = text[Symbol.iterator]()
+  let cur = it.next()
+  while (!cur.done) {
+    const ch = cur.value
+    cur = it.next()
+    if (ch === '\r' && !cur.done && cur.value === '\n') {
+      yield '\r\n'
+      cur = it.next()
+    }
+    else {
+      yield ch
+    }
+  }
+}
+
+/**
+ * Tidy a message body into a bounded snippet for the tooltip. Horizontal whitespace
+ * runs collapse to a single space and blank-line runs cap at one, but NEWLINES ARE
+ * PRESERVED so the tooltip's markdown renderer keeps paragraph / blockquote / list
+ * structure. The result is capped at MAX_PREVIEW_LEN with a trailing ellipsis. Returns
+ * null for empty input so callers fall back to a mark-type label.
+ */
+export function truncatePreview(text: string | null | undefined): string | null {
+  if (!text)
+    return null
+  const out: string[] = []
+  let seenContent = false
+  let pendingSpace = false
+  let newlineRun = 0
+  let truncated = false
+  let scanned = 0
+
+  const append = (part: string) => {
+    out.push(part)
+    if (out.length > MAX_PREVIEW_LEN) {
+      truncated = true
+      return false
+    }
+    return true
+  }
+
+  for (const ch of previewSegments(text)) {
+    // Stop after MAX_PREVIEW_SCAN graphemes even if none appended: content-dense input hits the
+    // append cap (out.length > MAX_PREVIEW_LEN) at scanned ~= MAX_PREVIEW_LEN, far below this, so
+    // normal previews are unaffected -- this only bounds a whitespace-dominated run that would
+    // otherwise segment the whole (possibly huge) input. Both segmenter paths are generators, so
+    // breaking stops pulling, structurally bounding the work.
+    if (++scanned > MAX_PREVIEW_SCAN) {
+      // Stopped scanning before consuming all input, so any content past this whitespace-dominated
+      // run is dropped -- mark truncated so the trailing ellipsis signals it (the append cap already
+      // sets `truncated` for content-dense input; this covers the scan-cap path, which otherwise
+      // returned a silently-cut snippet with no `…`).
+      truncated = true
+      break
+    }
+    // A bare '\r' (classic-Mac line ending) is its own grapheme, distinct from the '\r\n'
+    // cluster; treat it as a newline too rather than letting it fall through to the
+    // horizontal-whitespace branch below (which would collapse the line break to a space).
+    if (ch === '\n' || ch === '\r\n' || ch === '\r') {
+      pendingSpace = false
+      if (!seenContent)
+        continue
+      if (newlineRun < 2 && !append('\n'))
+        break
+      newlineRun = Math.min(newlineRun + 1, 2)
+      continue
+    }
+
+    if (/\s/u.test(ch)) {
+      if (seenContent)
+        pendingSpace = true
+      continue
+    }
+
+    if (pendingSpace && newlineRun === 0 && !append(' '))
+      break
+    pendingSpace = false
+    if (!append(ch))
+      break
+    seenContent = true
+    newlineRun = 0
+  }
+
+  while (out.length > 0 && /\s/u.test(out[out.length - 1]))
+    out.pop()
+  if (out.length === 0)
+    return null
+  return truncated ? `${out.slice(0, MAX_PREVIEW_LEN).join('')}${PREVIEW_ELLIPSIS}` : out.join('')
+}

--- a/frontend/src/stores/chat.store.test.ts
+++ b/frontend/src/stores/chat.store.test.ts
@@ -1,8 +1,14 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { create } from '@bufbuild/protobuf'
-import { describe, expect, it } from 'vitest'
-import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { listMessageMarks } from '~/api/workerRpc'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MarkType, MessageMarkSchema, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { createChatStore } from './chat.store'
+
+vi.mock('~/api/workerRpc', () => ({
+  getAgentMessage: vi.fn(),
+  listMessageMarks: vi.fn(),
+}))
 
 function jsonContent(value: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(value))
@@ -43,6 +49,36 @@ function claudeToolResult(id: string, seq: bigint, spanId: string, content: stri
     spanId,
   })
 }
+
+function markedMessage(id: string, seq: bigint, markType = MarkType.USER_MESSAGE): AgentChatMessage {
+  return create(AgentChatMessageSchema, {
+    id,
+    source: MessageSource.USER,
+    content: jsonContent({ content: id }),
+    contentCompression: ContentCompression.NONE,
+    seq,
+    agentProvider: AgentProvider.CLAUDE_CODE,
+    markType,
+  })
+}
+
+function messageMark(seq: bigint, type: MarkType) {
+  return create(MessageMarkSchema, { seq, type })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  vi.mocked(listMessageMarks).mockReset()
+})
 
 describe('chatstore span content versions', () => {
   it('exposes same-seq tool_result content-version bumps by span id', () => {
@@ -97,5 +133,568 @@ describe('chatstore span content versions', () => {
 
     expect(store.getToolResultParsedBySpanId(agentId, spanId)).toBeUndefined()
     expect(store.getToolResultContentVersionBySpanId(agentId, spanId)).toBe(0)
+  })
+})
+
+describe('chatstore get loaded message by seq', () => {
+  it('finds a loaded message by seq, skipping gaps, optimistic locals, and unknown agents', () => {
+    const store = createChatStore()
+    const agentId = 'agent-1'
+    store.setMessages(agentId, [
+      claudeToolUse('m1', 3n, 'span-1'),
+      claudeToolResult('m2', 5n, 'span-1', 'result'),
+    ])
+
+    expect(store.getLoadedMessageBySeq(agentId, 3n)?.id).toBe('m1')
+    expect(store.getLoadedMessageBySeq(agentId, 5n)?.id).toBe('m2')
+    // A seq that is not loaded (a gap between the two rows) resolves to undefined.
+    expect(store.getLoadedMessageBySeq(agentId, 4n)).toBeUndefined()
+    // Optimistic locals carry seq 0n; the guard must never return one for a "0" mark.
+    expect(store.getLoadedMessageBySeq(agentId, 0n)).toBeUndefined()
+    // An agent with no loaded window resolves to undefined rather than throwing.
+    expect(store.getLoadedMessageBySeq('other-agent', 5n)).toBeUndefined()
+  })
+
+  it('finds a server row even when optimistic locals trail the window', () => {
+    const store = createChatStore()
+    const agentId = 'agent-1'
+    const local = create(AgentChatMessageSchema, {
+      id: 'local-1',
+      source: MessageSource.USER,
+      content: jsonContent({ content: 'unsent' }),
+      contentCompression: ContentCompression.NONE,
+      seq: 0n,
+      agentProvider: AgentProvider.CLAUDE_CODE,
+    })
+    // Server rows [3n, 5n] ascending, then a trailing optimistic local (seq 0n). The
+    // binary search must bound itself to the server region (serverMessageEnd) and still
+    // resolve a server seq -- never wander into or trip over the trailing local.
+    store.setMessages(agentId, [
+      claudeToolUse('m1', 3n, 'span-1'),
+      claudeToolResult('m2', 5n, 'span-1', 'result'),
+      local,
+    ])
+
+    expect(store.getLoadedMessageBySeq(agentId, 3n)?.id).toBe('m1')
+    expect(store.getLoadedMessageBySeq(agentId, 5n)?.id).toBe('m2')
+    expect(store.getLoadedMessageBySeq(agentId, 4n)).toBeUndefined()
+    expect(store.getLoadedMessageBySeq(agentId, 0n)).toBeUndefined()
+  })
+})
+
+describe('chatstore loadmessagemarks', () => {
+  it('does not request marks before the worker id is available', async () => {
+    const store = createChatStore()
+
+    await store.loadMessageMarks('', 'agent-1')
+
+    expect(listMessageMarks).not.toHaveBeenCalled()
+    expect(store.getRailData('agent-1').loaded).toBe(false)
+  })
+
+  it('ignores an older overlapping response that resolves after a newer seed', async () => {
+    const store = createChatStore()
+    const older = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    const newer = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    vi.mocked(listMessageMarks)
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+
+    const firstLoad = store.loadMessageMarks('worker-1', 'agent-1')
+    const secondLoad = store.loadMessageMarks('worker-1', 'agent-1')
+
+    newer.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(9n, MarkType.USER_MESSAGE)],
+      minSeq: 1n,
+      maxSeq: 9n,
+    })
+    await secondLoad
+
+    older.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+      minSeq: 1n,
+      maxSeq: 2n,
+    })
+    await firstLoad
+
+    expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([9n])
+  })
+
+  it('fences a pre-close seed still in flight across a close/reopen of the same agent', async () => {
+    const store = createChatStore()
+    const stale = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    const fresh = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    vi.mocked(listMessageMarks)
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise)
+
+    // Open the agent: its seed RPC goes in flight, then the tab closes (forgetAgent) before it
+    // lands. A per-agent epoch counter would restart at 0 here; the reopen below would mint the
+    // SAME epoch this stale seed holds, so its late resolve would slip past the cancel guard.
+    const firstLoad = store.loadMessageMarks('worker-1', 'agent-1')
+    store.forgetAgent('agent-1')
+
+    // Reopen the same agent and seed it freshly.
+    const secondLoad = store.loadMessageMarks('worker-1', 'agent-1')
+    fresh.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(9n, MarkType.USER_MESSAGE)],
+      minSeq: 9n,
+      maxSeq: 9n,
+    })
+    await secondLoad
+    expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([9n])
+
+    // The pre-close seed resolves LATE with stale marks: the monotonic epoch must fence it so it
+    // can't clobber the reopened window.
+    stale.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(2n, MarkType.USER_MESSAGE), messageMark(3n, MarkType.USER_MESSAGE)],
+      minSeq: 2n,
+      maxSeq: 3n,
+    })
+    await firstLoad
+
+    const rail = store.getRailData('agent-1')
+    expect(rail.marks.map(m => m.seq)).toEqual([9n])
+    expect(rail.maxSeq).toBe(9n)
+  })
+
+  it('does not let an in-flight seed resurrect a mark deleted by a live event', async () => {
+    const store = createChatStore()
+    store.addMessage('agent-1', markedMessage('m2', 2n))
+    expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([2n])
+
+    const stale = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    vi.mocked(listMessageMarks)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [],
+        minSeq: 0n,
+        maxSeq: 0n,
+      })
+    const load = store.loadMessageMarks('worker-1', 'agent-1')
+
+    store.removeMessage('agent-1', 'm2', 2n, 0n)
+    stale.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+      minSeq: 1n,
+      maxSeq: 2n,
+    })
+    await load
+
+    expect(listMessageMarks).toHaveBeenCalledTimes(2)
+    expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([])
+    expect(store.getRailData('agent-1').loaded).toBe(true)
+  })
+
+  it('retries a stale seed so a live mark during startup still reveals the rail', async () => {
+    const store = createChatStore()
+    const stale = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    vi.mocked(listMessageMarks)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+        minSeq: 2n,
+        maxSeq: 2n,
+      })
+
+    const load = store.loadMessageMarks('worker-1', 'agent-1')
+    store.addMessage('agent-1', markedMessage('m2', 2n))
+    stale.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [],
+      minSeq: 0n,
+      maxSeq: 0n,
+    })
+    await load
+
+    const rail = store.getRailData('agent-1')
+    expect(listMessageMarks).toHaveBeenCalledTimes(2)
+    expect(rail.loaded).toBe(true)
+    expect(rail.marks.map(m => m.seq)).toEqual([2n])
+  })
+
+  it('schedules another marks seed when every immediate response races live mark changes', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      const first = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      const second = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      const third = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      vi.mocked(listMessageMarks)
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise)
+        .mockReturnValueOnce(third.promise)
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [
+            messageMark(1n, MarkType.USER_MESSAGE),
+            messageMark(2n, MarkType.USER_MESSAGE),
+            messageMark(3n, MarkType.USER_MESSAGE),
+            messageMark(99n, MarkType.USER_MESSAGE),
+          ],
+          minSeq: 1n,
+          maxSeq: 99n,
+        })
+
+      const load = store.loadMessageMarks('worker-1', 'agent-1')
+
+      store.addMessage('agent-1', markedMessage('m1', 1n))
+      first.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [],
+        minSeq: 0n,
+        maxSeq: 0n,
+      })
+      await Promise.resolve()
+
+      store.addMessage('agent-1', markedMessage('m2', 2n))
+      second.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [messageMark(1n, MarkType.USER_MESSAGE)],
+        minSeq: 1n,
+        maxSeq: 1n,
+      })
+      await Promise.resolve()
+
+      store.addMessage('agent-1', markedMessage('m3', 3n))
+      third.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+        minSeq: 2n,
+        maxSeq: 2n,
+      })
+      await load
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(3)
+      expect(store.getRailData('agent-1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('message marks seed retry scheduled', {
+        agentId: 'agent-1',
+        reason: 'live updates kept racing the seed',
+        rescheduleDepth: 0,
+      })
+
+      await vi.runOnlyPendingTimersAsync()
+      await Promise.resolve()
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(4)
+      const rail = store.getRailData('agent-1')
+      expect(rail.loaded).toBe(true)
+      expect(rail.marks.map(m => m.seq)).toEqual([1n, 2n, 3n, 99n])
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a FIRST seed whose range came back indeterminate, so a transient DB error does not hide the rail all session', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      // First seed: marks present but the worker's seq-range subquery errored (-1/-1). The
+      // rail must stay hidden (loaded=false) yet schedule a retry -- the live add/remove path
+      // can never reveal a never-seeded rail, so without the retry it hides for the session.
+      vi.mocked(listMessageMarks)
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(3n, MarkType.USER_MESSAGE)],
+          minSeq: undefined, // indeterminate: the worker left the range unset (a DB error)
+          maxSeq: undefined,
+        })
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(3n, MarkType.USER_MESSAGE)],
+          minSeq: 1n,
+          maxSeq: 8n,
+        })
+
+      await store.loadMessageMarks('worker-1', 'agent-1')
+      expect(store.getRailData('agent-1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('message marks seed retry scheduled', {
+        agentId: 'agent-1',
+        reason: 'first seed range indeterminate',
+        rescheduleDepth: 0,
+      })
+
+      await vi.runOnlyPendingTimersAsync()
+      await Promise.resolve()
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(2)
+      const rail = store.getRailData('agent-1')
+      expect(rail.loaded).toBe(true)
+      expect(rail.minSeq).toBe(1n)
+      expect(rail.marks.map(m => m.seq)).toEqual([3n])
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a pending marks seed retry when reseeded without a worker', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      const first = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      const second = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      const third = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      vi.mocked(listMessageMarks)
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise)
+        .mockReturnValueOnce(third.promise)
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(99n, MarkType.USER_MESSAGE)],
+          minSeq: 99n,
+          maxSeq: 99n,
+        })
+
+      const load = store.loadMessageMarks('worker-1', 'agent-1')
+
+      store.addMessage('agent-1', markedMessage('m1', 1n))
+      first.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [],
+        minSeq: 0n,
+        maxSeq: 0n,
+      })
+      await Promise.resolve()
+      store.addMessage('agent-1', markedMessage('m2', 2n))
+      second.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [],
+        minSeq: 0n,
+        maxSeq: 0n,
+      })
+      await Promise.resolve()
+      store.addMessage('agent-1', markedMessage('m3', 3n))
+      third.resolve({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [],
+        minSeq: 0n,
+        maxSeq: 0n,
+      })
+      await load
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(3)
+
+      await store.loadMessageMarks('', 'agent-1')
+      await vi.runOnlyPendingTimersAsync()
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(3)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops reseeding after a bounded number of retries when the range stays indeterminate, instead of polling forever', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      // The worker's seq-range subquery is PERSISTENTLY broken: every response carries marks but
+      // an indeterminate (-1) range, so seed() keeps loaded=false. Without a cap this reschedules
+      // a fetch every retry-delay for the whole session -- an infinite RPC poll.
+      vi.mocked(listMessageMarks).mockResolvedValue({
+        $typeName: 'leapmux.v1.ListMessageMarksResponse',
+        marks: [messageMark(3n, MarkType.USER_MESSAGE)],
+        minSeq: undefined, // indeterminate: the worker left the range unset (a DB error)
+        maxSeq: undefined,
+      })
+
+      await store.loadMessageMarks('worker-1', 'agent-1')
+      // Drive far more reschedule ticks than the cap allows; the chain must terminate.
+      for (let i = 0; i < 20; i++) {
+        await vi.runOnlyPendingTimersAsync()
+        await Promise.resolve()
+      }
+
+      // Bounded to MAX_MESSAGE_MARK_SEED_RESCHEDULES fetches total, then it gives up.
+      expect(listMessageMarks).toHaveBeenCalledTimes(5)
+      expect(store.getRailData('agent-1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('message marks seed gave up after retries', expect.objectContaining({
+        agentId: 'agent-1',
+        reason: 'first seed range indeterminate',
+      }))
+      // No pending timer remains -- the poll has genuinely stopped, not just paused.
+      expect(vi.getTimerCount()).toBe(0)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('reseeds a loaded agent whose reseed range came back indeterminate, healing a dropped beyond-horizon mark', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      vi.mocked(listMessageMarks)
+        // 1) First seed: good range reveals the rail with mark 2n.
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+          minSeq: 1n,
+          maxSeq: 5n,
+        })
+        // 2) Reseed: seq-range subquery errored (-1/-1) AND its snapshot missed the live 9n mark
+        //    noted below, so seed() drops 9n (horizon unknown) while staying loaded.
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+          minSeq: undefined, // indeterminate: the worker left the range unset (a DB error)
+          maxSeq: undefined,
+        })
+        // 3) Retry: horizon healed and now includes 9n -- restores the dropped dot.
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(2n, MarkType.USER_MESSAGE), messageMark(9n, MarkType.USER_MESSAGE)],
+          minSeq: 1n,
+          maxSeq: 9n,
+        })
+
+      await store.loadMessageMarks('worker-1', 'agent-1')
+      expect(store.getRailData('agent-1').loaded).toBe(true)
+
+      // A live send lands beyond the seeded horizon.
+      store.addMessage('agent-1', markedMessage('m9', 9n))
+      expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([2n, 9n])
+
+      // The indeterminate reseed drops 9n transiently but MUST schedule a retry to heal it.
+      await store.loadMessageMarks('worker-1', 'agent-1')
+      expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([2n])
+      expect(warn).toHaveBeenCalledWith('message marks seed retry scheduled', {
+        agentId: 'agent-1',
+        reason: 'reseed range indeterminate',
+        rescheduleDepth: 0,
+      })
+
+      await vi.runOnlyPendingTimersAsync()
+      await Promise.resolve()
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(3)
+      expect(store.getRailData('agent-1').marks.map(m => m.seq)).toEqual([2n, 9n])
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a transient rpc rejection so a one-off failure does not hide the rail all session', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const store = createChatStore()
+      // The initial seed RPC rejects once (a network blip). An outright rejection never reaches
+      // seed(), so the indeterminate-range retry can't cover it; without a retry here the rail
+      // stays hidden for the whole session (loaded never flips, and the live add/remove path
+      // can't reveal a never-seeded rail). A bounded retry heals it.
+      vi.mocked(listMessageMarks)
+        .mockRejectedValueOnce(new Error('worker busy'))
+        .mockResolvedValueOnce({
+          $typeName: 'leapmux.v1.ListMessageMarksResponse',
+          marks: [messageMark(3n, MarkType.USER_MESSAGE)],
+          minSeq: 1n,
+          maxSeq: 8n,
+        })
+
+      await store.loadMessageMarks('worker-1', 'agent-1')
+      expect(store.getRailData('agent-1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('failed to load message marks', expect.objectContaining({ agentId: 'agent-1' }))
+      expect(warn).toHaveBeenCalledWith('message marks seed retry scheduled', {
+        agentId: 'agent-1',
+        reason: 'list message marks rpc failed',
+        rescheduleDepth: 0,
+      })
+
+      await vi.runOnlyPendingTimersAsync()
+      await Promise.resolve()
+
+      expect(listMessageMarks).toHaveBeenCalledTimes(2)
+      const rail = store.getRailData('agent-1')
+      expect(rail.loaded).toBe(true)
+      expect(rail.marks.map(m => m.seq)).toEqual([3n])
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the seed entirely when the subscription signal is already aborted', async () => {
+    const store = createChatStore()
+    const controller = new AbortController()
+    controller.abort()
+
+    await store.loadMessageMarks('worker-1', 'agent-1', controller.signal)
+
+    expect(listMessageMarks).not.toHaveBeenCalled()
+    expect(store.getRailData('agent-1').loaded).toBe(false)
+  })
+
+  it('ties the RPC to the subscription signal and drops a response that lands after teardown', async () => {
+    const store = createChatStore()
+    const controller = new AbortController()
+    const inflight = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    vi.mocked(listMessageMarks).mockReturnValueOnce(inflight.promise)
+
+    const load = store.loadMessageMarks('worker-1', 'agent-1', controller.signal)
+    // The RPC carries the subscription's signal, so a teardown aborts it mid-flight.
+    expect(listMessageMarks).toHaveBeenCalledWith('worker-1', { agentId: 'agent-1' }, { signal: controller.signal })
+
+    // The subscription tears down (workspace switch / reconnect) before the response lands.
+    controller.abort()
+    inflight.resolve({
+      $typeName: 'leapmux.v1.ListMessageMarksResponse',
+      marks: [messageMark(2n, MarkType.USER_MESSAGE)],
+      minSeq: 1n,
+      maxSeq: 2n,
+    })
+    await load
+
+    // The late response is dropped: no seed against a worker the reader navigated away from.
+    expect(store.getRailData('agent-1').loaded).toBe(false)
+    expect(store.getRailData('agent-1').marks).toEqual([])
+  })
+
+  it('does not log or retry when a torn-down subscription aborts the in-flight RPC', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const store = createChatStore()
+      const controller = new AbortController()
+      const inflight = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+      vi.mocked(listMessageMarks).mockReturnValueOnce(inflight.promise)
+
+      const load = store.loadMessageMarks('worker-1', 'agent-1', controller.signal)
+      // Teardown aborts the RPC, which rejects (AbortError) -- a deliberate cancellation, NOT a
+      // transient failure, so it must neither warn nor schedule a retry (unlike a network blip).
+      controller.abort()
+      inflight.reject(new DOMException('aborted', 'AbortError'))
+      await load
+
+      expect(warn).not.toHaveBeenCalledWith('failed to load message marks', expect.anything())
+      expect(warn).not.toHaveBeenCalledWith('message marks seed retry scheduled', expect.anything())
+      expect(listMessageMarks).toHaveBeenCalledTimes(1)
+      expect(store.getRailData('agent-1').loaded).toBe(false)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -1,11 +1,15 @@
+import type { ChatRailData } from './chatMessageMarks'
 import type { PendingOutboundMessage } from './chatPendingOutbound'
 import type { CommandStreamSegment, SavedViewportScroll, SpanMessageRevision } from './chatTypes'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import { toBinary } from '@bufbuild/protobuf'
 import { createStore, produce, unwrap } from 'solid-js/store'
+import { getAgentMessage } from '~/api/workerRpc'
+import { forgetMarkPreview } from '~/components/chat/chatMarkPreview'
 import { invalidateMessageClassificationCache } from '~/components/chat/messageClassification'
-import { AgentChatMessageSchema, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, MarkType, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+import { lowerBoundBySeq } from '~/lib/binarySearch'
 import { invalidateMessageParseCache } from '~/lib/messageParser'
 import { createCommandStreamStore } from './chatCommandStreams'
 import { createContentVersionStore } from './chatContentVersions'
@@ -13,10 +17,12 @@ import { createHistoryPaginator, linkWatchSignal, MESSAGE_PAGE_SIZE } from './ch
 import { createLiveTailTracker } from './chatLiveTail'
 import { getPersistedLocalMessages, hydrateLocalMessage, persistLocalMessage, removePersistedLocalMessage } from './chatLocalMessages'
 import { createMessageAnnotationStore } from './chatMessageAnnotations'
+import { createMessageMarksStore, resolveRailRange } from './chatMessageMarks'
+import { createMessageMarkSeeder } from './chatMessageMarkSeeder'
 import { applyFreshMessage, firstServerSeq, insertServerBySeq, isReapablePhantom, lastServerSeq, mergeWindow, prunableDroppedSpanIds, serverMessageEnd, withTrailingLocals } from './chatMessageOrder'
 import { createPendingOutboundStore } from './chatPendingOutbound'
 import { createPerAgentStore } from './chatPerAgentStore'
-import { isOptimisticLocal, isReconcilableLocal, priorServerIds, reconcileEchoedLocals, userMessageSignature } from './chatReconcile'
+import { isOptimisticLocal, isOptimisticLocalSeq, isReconcilableLocal, priorServerIds, reconcileEchoedLocals, userMessageSignature } from './chatReconcile'
 import { createSpanIndex } from './chatSpanIndex'
 import { createStreamingTextStore } from './chatStreamingText'
 import { createTodoStore } from './chatTodoStore'
@@ -90,7 +96,7 @@ export interface ChatStoreState {
    * Whether a reconnect catch-up is in flight for this agent (per agent): set when the
    * client (re)subscribes via WatchEvents, cleared at CatchUpComplete. During catch-up
    * the recorded live tail tracks the LOADED tail (the bounded replay's own bumps), not
-   * the true server tail -- and an indeterminate (-1) tail never raises it -- so the
+   * the true server tail -- and an indeterminate (unset) tail never raises it -- so the
    * live-append guard falls back to seq-CONTIGUITY while this is set (a non-contiguous
    * frame is a live arrival past the unfilled replay gap; a contiguous one is the next
    * in-order replay page). See beyondUnloadedNewerTail.
@@ -136,6 +142,16 @@ export function createChatStore() {
   // The "true tail + caught-up" invariant: highest server seq observed (incl. messages
   // dropped while scrolled away), with the bump/settle/delete rules in one tested unit.
   const liveTail = createLiveTailTracker()
+  // Scroll-rail jump marks: the seqs of notable messages (user inputs, control
+  // responses) + whole-history seq range. Seeded from ListMessageMarks, kept current
+  // from live add/delete. Recorded even for messages dropped beyond the window.
+  const messageMarks = createMessageMarksStore()
+  // The seed-race machine that drives ListMessageMarks into `messageMarks`: epoch fencing,
+  // the immediate-retry loop, and the bounded delayed-reschedule chain that heal a seed that
+  // didn't stick. Its own tested unit (createMessageMarkSeeder), the sibling of the marks DATA
+  // above; the store keeps the public loadMessageMarks entry (delegating to markSeeder.load)
+  // and forgetAgent (calling markSeeder.forget).
+  const markSeeder = createMessageMarkSeeder({ marks: messageMarks })
 
   /**
    * Non-reactive index linking each tool span's opener (tool_use) and result
@@ -342,6 +358,12 @@ export function createChatStore() {
     }))
     // Drop the agent's entry in each composed per-agent sub-store.
     liveTail.forget(agentId)
+    messageMarks.forget(agentId)
+    markSeeder.forget(agentId)
+    // The rail's hover-preview cache is module-global (survives rail remounts), so it
+    // must be pruned explicitly here or it leaks -- and a stale entry would outlive a
+    // close/reopen of the same agentId. See chatMarkPreview.forgetMarkPreview.
+    forgetMarkPreview(agentId)
     streaming.remove(agentId)
     todos.remove(agentId)
     pendingOutbound.remove(agentId)
@@ -365,6 +387,18 @@ export function createChatStore() {
     const survivors = prev.filter(m => !isReapablePhantom(m.seq, latestSeq, reapCeilingSeq))
     if (survivors.length === prev.length)
       return // nothing loaded in the phantom band -- window already consistent
+    // Drop the scroll-rail marks of the reaped rows -- rows the client held but the
+    // worker deleted while we were disconnected. Without this, a reaped marked row
+    // (a USER_MESSAGE / CONTROL_RESPONSE) strands its dot: the mark's seq now exceeds
+    // the lowered maxSeq, so the reseed's beyond-horizon preserve (seed's
+    // freshBeyondSnapshot) keeps it -- indistinguishable from a live send racing the
+    // reseed -- and it resurfaces as a ghost dot the moment a later append raises maxSeq
+    // past it. Mirrors the removeMessage / reseq-MOVE mark drop for the online case. remove()
+    // bumps the marks store's own seed-race revision on each real drop.
+    for (const m of prev) {
+      if (!isOptimisticLocalSeq(m.seq) && isReapablePhantom(m.seq, latestSeq, reapCeilingSeq))
+        messageMarks.remove(agentId, m.seq)
+    }
     reclaimDroppedRows(agentId, prev, survivors)
     spanIdx.reindex(agentId, survivors)
     setState('messagesByAgent', agentId, survivors)
@@ -383,9 +417,9 @@ export function createChatStore() {
    * received the AgentMessageDeleted for rows deleted meanwhile, so it drops any loaded
    * SERVER row whose seq exceeds `latestSeq` (a deletion it missed) and clamps its
    * recorded live-tail -- so the "new messages below" affordance can't stay stuck past a
-   * now-shorter history. A NEGATIVE `latestSeq` means the worker couldn't determine the
-   * tail (query error); skip rather than trim against a value we don't trust. Optimistic
-   * locals (seq 0n) are never above a non-negative tail, so they're preserved.
+   * now-shorter history. An UNSET (`undefined`) `latestSeq` means the worker couldn't
+   * determine the tail (query error); skip rather than trim against a value we don't trust.
+   * Optimistic locals (seq 0n) are never above a present tail, so they're preserved.
    *
    * `reapCeilingSeq` (CatchUpComplete.start_tail_seq -- the tail when replay BEGAN)
    * exempts live arrivals from the reap: a row ABOVE it was broadcast DURING catch-up
@@ -397,7 +431,7 @@ export function createChatStore() {
    * phantom.
    *
    * `probeIndeterminate` (true only at CatchUpComplete, when the bounded replay is DONE)
-   * handles an indeterminate (-1) tail: the worker couldn't read its max seq, so liveTail
+   * handles an indeterminate (unset) tail: the worker couldn't read its max seq, so liveTail
    * was never raised and the continuous reconcile would read the loaded tail as caught up
    * even though a bounded replay may have stopped short. Nudge the recorded live tail one
    * past the loaded tail so the reconcile PROBES (caughtUpToLiveTail reads false) and
@@ -405,8 +439,8 @@ export function createChatStore() {
    * nothing's there. Skipped at CatchUpStart (the replay hasn't run, so a probe would
    * race it).
    */
-  function reconcileAuthoritativeTail(agentId: string, latestSeq: bigint, reapCeilingSeq?: bigint, probeIndeterminate = false) {
-    if (latestSeq < 0n) {
+  function reconcileAuthoritativeTail(agentId: string, latestSeq: bigint | undefined, reapCeilingSeq?: bigint, probeIndeterminate = false) {
+    if (latestSeq === undefined) {
       if (probeIndeterminate) {
         const windowTail = lastServerSeq(state.messagesByAgent[agentId] ?? []) ?? 0n
         if (windowTail > 0n)
@@ -771,7 +805,7 @@ export function createChatStore() {
      *    the continuous reconcile forward-fill (lastSeq, seq] contiguously rather than
      *    splice a hole; a CONTIGUOUS frame is the next in-order replay page, kept. This
      *    branch is what makes catch-up robust when the worker can't report its tail
-     *    (latest_seq = -1, a DB error): liveTail then only tracks the LOADED tail, so the
+     *    (latest_seq unset, a DB error): liveTail then only tracks the LOADED tail, so the
      *    live-tail comparison below can't see a beyond-tail live frame.
      *  - in the LIVE phase: the loaded tail provably lags a KNOWN higher live tail
      *    (lastSeq < recordedLiveTail) and `seq` is beyond it (seq > recordedLiveTail).
@@ -954,6 +988,21 @@ export function createChatStore() {
       // jumpToLatestMessages knows where the true tail is.
       liveTail.bump(agentId, message.seq)
 
+      // Record the scroll-rail mark BEFORE any beyond-window drop, so a message the
+      // reader scrolled away from still gets its jump dot. The mark rides the proto
+      // (set at write time by the worker); optimistic locals (seq 0n) are excluded.
+      // A reseq MOVE (previousSeq set) carries the mark to its new seq, so drop the
+      // stale mark at the vacated old seq first, or it strands a ghost dot. (Threaded
+      // rows are unmarked today, so this is latent -- but the worker now carries
+      // mark_type on the MOVE broadcast, so keep the two ends symmetric.) noteMark/remove
+      // bump the marks store's own seed-race revision only on a real change: an unmarked
+      // reseq MOVE (remove of a never-marked seq) or a re-broadcast of an already-noted
+      // mark are no-ops that must not perturb a concurrent loadMessageMarks.
+      if (message.previousSeq !== 0n)
+        messageMarks.remove(agentId, message.previousSeq)
+      if (message.markType !== MarkType.UNSPECIFIED)
+        messageMarks.noteMark(agentId, message.seq, message.markType)
+
       // Notification thread update: LEAPMUX notification messages can be updated
       // in-place when consolidating. Check if a message with this ID exists.
       const messages = state.messagesByAgent[agentId] ?? []
@@ -1085,6 +1134,13 @@ export function createChatStore() {
         newLatestSeq,
         windowTail: this.getLastSeq(agentId),
       })
+      // Drop the deleted row's scroll-rail mark. The seq comes from the loaded row when
+      // present, else the broadcast-carried seq for an unloaded beyond-window delete.
+      // remove() bumps the marks store's own seed-race revision only on a real drop (an
+      // unmarked row's delete is a no-op and must not perturb a concurrent seed).
+      const goneSeq = removed?.seq ?? deletedSeq
+      if (goneSeq !== undefined && goneSeq !== 0n)
+        messageMarks.remove(agentId, goneSeq)
       // Only rebuild when the removed row actually carried a span (the common
       // case -- a user/local message -- has none, so this is usually skipped).
       if (removedSpanId) {
@@ -1433,10 +1489,84 @@ export function createChatStore() {
     forgetAgent,
     reconcileAuthoritativeTail,
     liveTail,
+    messageMarks,
     todos,
     streamingText: streaming,
     pendingOutbound,
     viewportScroll,
+    /**
+     * Reactive scroll-rail data for an agent: the marked seqs, the window-aware whole-history
+     * seq range, and the loaded window's bounds. The range rule (seed vs live tail vs window
+     * head/tail) lives in the pure {@link resolveRailRange} so it is testable and can't drift
+     * from a second copy -- this selector just wires the reactive reads to it. Read inside a
+     * memo/JSX for reactivity (it tracks the marks store, the live tail, and the window).
+     */
+    getRailData(agentId: string): ChatRailData {
+      const marks = messageMarks.get(agentId)
+      const messages = state.messagesByAgent[agentId] ?? []
+      const windowFirstSeq = firstServerSeq(messages)
+      const windowLastSeq = lastServerSeq(messages)
+      const { minSeq, maxSeq } = resolveRailRange({
+        seededMinSeq: marks.minSeq,
+        seedMaxSeq: marks.seedMaxSeq,
+        liveMaxSeq: liveTail.get(agentId),
+        windowFirstSeq,
+        windowLastSeq,
+        hasOlderMessages: state.hasMoreOlder[agentId] ?? false,
+      })
+      return { loaded: marks.loaded, minSeq, maxSeq, marks: marks.marks, windowFirstSeq, windowLastSeq }
+    },
+    /**
+     * Seed (or re-seed) an agent's scroll-rail marks from the worker. The public entry to
+     * the seed-race machine, which lives in its own tested unit (createMessageMarkSeeder);
+     * this just delegates. `watchSignal` ties the seed to the current WatchEvents
+     * subscription -- see markSeeder.load for the full fire-and-forget / retry / fencing
+     * contract. Kept as a method name here because the connection hook and the store tests
+     * drive the seed through `store.loadMessageMarks`.
+     */
+    loadMessageMarks: markSeeder.load,
+    /**
+     * The loaded message at `seq`, or undefined when it isn't in the current window.
+     * Used by the scroll rail's hover preview to extract a mark's preview WITHOUT a
+     * fetch when the marked message is already loaded. Optimistic locals (seq 0n) are
+     * skipped -- a real mark's seq never matches them. Non-reactive: called imperatively
+     * on hover, not inside a tracking scope.
+     */
+    getLoadedMessageBySeq(agentId: string, seq: bigint): AgentChatMessage | undefined {
+      if (isOptimisticLocalSeq(seq))
+        return undefined
+      const messages = state.messagesByAgent[agentId]
+      if (!messages)
+        return undefined
+      // Server rows occupy [0, serverMessageEnd) ascending by unique seq (optimistic locals,
+      // seq 0n, trail after and are excluded by the guard above), so binary-search that region
+      // instead of a linear .find: a marked message is usually OUTSIDE the loaded window, so the
+      // old scan traversed the whole ~1200-row window fruitlessly for every hovered/scrubbed dot.
+      const end = serverMessageEnd(messages)
+      const idx = lowerBoundBySeq(messages, seq, end)
+      const hit = messages[idx]
+      return hit?.seq === seq ? hit : undefined
+    },
+    /**
+     * Fetch a SINGLE message by its per-agent seq for the scroll rail's hover preview
+     * of a mark outside the loaded window. Resolves undefined ONLY for a definitive
+     * absence -- the agent has no message at that seq (deleted/reseq'd since the mark
+     * was recorded), which the worker returns as an unset message. A transient RPC
+     * failure RETHROWS (rather than collapsing to undefined) so the caller can tell a
+     * real absence -- cache '' and stop -- from a blip it should retry, instead of
+     * poisoning the dot's preview for the rest of the session. Does NOT touch the
+     * loaded window; it's a read-only lookup for preview text only.
+     */
+    async fetchMessageBySeq(workerId: string, agentId: string, seq: bigint): Promise<AgentChatMessage | undefined> {
+      try {
+        const resp = await getAgentMessage(workerId, { agentId, seq })
+        return resp.message
+      }
+      catch (err) {
+        console.warn('failed to fetch message for preview', { agentId, seq, err })
+        throw err
+      }
+    },
     /**
      * Persist an agent's viewport scroll for the NEXT mount of the same chat window (a
      * tile split/merge or workspace switch recreates ChatView over the still-live store

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -8,8 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { listAgentMessages } = vi.hoisted(() => ({ listAgentMessages: vi.fn() }))
 vi.mock('~/api/workerRpc', () => ({ listAgentMessages }))
 
-const { createHistoryPaginator, linkWatchSignal } = await import('./chatHistoryPaginator')
-const { MessageSource } = await import('~/generated/leapmux/v1/agent_pb')
+const { createHistoryPaginator, linkWatchSignal, MESSAGE_PAGE_SIZE } = await import('./chatHistoryPaginator')
+const { MessagePageAnchor, MessageSource } = await import('~/generated/leapmux/v1/agent_pb')
 
 // The harness's cap/ceiling, distinct so an assertion can prove WHICH was used. The
 // production wiring passes MAX_LOADED_CHAT_MESSAGES / MAX_LOADED_CHAT_MESSAGES_CEILING.
@@ -195,6 +195,90 @@ describe('chathistorypaginator', () => {
     })
   })
 
+  describe('jumptomessagesaroundseq centers the window on a seq', () => {
+    // Route the two parallel fetches by anchor so a test can return distinct
+    // before/after pages and assert the cursor values.
+    function routeByAnchor(before: ReturnType<typeof page>, after: ReturnType<typeof page>) {
+      listAgentMessages.mockImplementation(async (_w: string, req: { anchor: number }) =>
+        req.anchor === MessagePageAnchor.BEFORE ? before : after)
+    }
+
+    it('fetches BEFORE seq+1 and AFTER seq, applies the concatenated window, and sets flags', async () => {
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      routeByAnchor(
+        page([makeMsg(4n), makeMsg(5n)], true), // more older history exists
+        page([makeMsg(6n), makeMsg(7n)], false),
+      )
+
+      await h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n)
+
+      // Cursor values: BEFORE is exclusive at seq+1 (includes the target), AFTER at seq.
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.BEFORE, cursorSeq: 6n }))
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.AFTER, cursorSeq: 5n }))
+      // One window swap with the disjoint, ascending concatenation; hasMoreOlder from before.
+      expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(4n), makeMsg(5n), makeMsg(6n), makeMsg(7n)], true)
+      // after.hasMore=false and caughtUp -> no newer.
+      expect(h.state.hasMoreNewer.a).toBe(false)
+    })
+
+    it('does not overflow the BEFORE cursor when seeking the maximum int64 seq', async () => {
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      const maxInt64Seq = 9223372036854775807n
+      listAgentMessages.mockImplementation(async (_w: string, req: { anchor: number }) =>
+        req.anchor === MessagePageAnchor.LATEST
+          ? page([makeMsg(maxInt64Seq)], true)
+          : page([], false))
+
+      await h.paginator.jumpToMessagesAroundSeq('w', 'a', maxInt64Seq)
+
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
+        anchor: MessagePageAnchor.LATEST,
+        limit: MESSAGE_PAGE_SIZE,
+      }))
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
+        anchor: MessagePageAnchor.AFTER,
+        cursorSeq: maxInt64Seq,
+        limit: MESSAGE_PAGE_SIZE,
+      }))
+      expect(listAgentMessages).not.toHaveBeenCalledWith('w', expect.objectContaining({
+        cursorSeq: maxInt64Seq + 1n,
+      }))
+      expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(maxInt64Seq)], true)
+      expect(h.state.hasMoreNewer.a).toBe(false)
+    })
+
+    it('keeps hasMoreNewer set when a live message bumped the tail during the fetch (!caughtUp)', async () => {
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => false })
+      routeByAnchor(page([makeMsg(5n)], false), page([makeMsg(6n)], false))
+
+      await h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n)
+
+      // after.hasMore=false, but !caughtUpToLiveTail forces hasMoreNewer true.
+      expect(h.state.hasMoreNewer.a).toBe(true)
+    })
+
+    it('lands on the surviving newest rows when the target seq is in a deleted prefix', async () => {
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      // BEFORE empty (nothing at-or-below the deleted target), AFTER has survivors.
+      routeByAnchor(page([], false), page([makeMsg(8n), makeMsg(9n)], false))
+
+      await h.paginator.jumpToMessagesAroundSeq('w', 'a', 3n)
+
+      // hasMoreOlder from before.hasMore=false (nothing older survives).
+      expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(8n), makeMsg(9n)], false)
+    })
+
+    it('empties the window and resets a stale tail when the history vanished around the seq', async () => {
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      routeByAnchor(page([], false), page([], false))
+
+      await h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n)
+
+      expect(h.applyMessages).toHaveBeenCalledWith('a', [], false)
+      expect(h.resetToEmptyIfStale).toHaveBeenCalledWith('a', expect.anything())
+    })
+  })
+
   describe('catchuptotail is idempotent under the continuous reconcile effect', () => {
     it('skips a re-kick while a catch-up is already draining the agent (no RPC thrash)', async () => {
       const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false })
@@ -303,6 +387,39 @@ describe('chathistorypaginator', () => {
       expect(listAgentMessages).toHaveBeenCalledTimes(2) // would be 1 if the slot were still held
       resolveFirst(page([], false))
       await first
+    })
+
+    it('an aborted loop resuming late does NOT clobber a superseding loop\'s single-flight slot', async () => {
+      // The abort listener frees the slot INSTANTLY on abort, so a re-kick can start a new
+      // (superseding) loop while the aborted one is still suspended on its signal-less RPC.
+      // When that aborted loop finally resumes into its `finally`, it must NOT delete the
+      // superseding loop's slot -- else the next reconcile tick passes the single-flight guard,
+      // starts a THIRD loop, and aborts the superseding loop's in-flight page (RPC thrash).
+      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false, caughtUp: () => false, liveGet: () => 9n })
+      const watch = new AbortController()
+      let resolveFirst: (v: ReturnType<typeof page>) => void = () => {}
+      let resolveSecond: (v: ReturnType<typeof page>) => void = () => {}
+      listAgentMessages
+        .mockReturnValueOnce(new Promise((r) => { resolveFirst = r })) // loop 1 hangs
+        .mockReturnValueOnce(new Promise((r) => { resolveSecond = r })) // loop 2 (superseding) hangs
+
+      const first = h.paginator.catchUpToTail('w', 'a', 1n, watch.signal)
+      await Promise.resolve()
+      watch.abort() // aborts loop 1; the abort listener frees the slot immediately
+      const second = h.paginator.catchUpToTail('w', 'a', 1n) // superseding loop 2 claims the freed slot
+      await Promise.resolve()
+      expect(listAgentMessages).toHaveBeenCalledTimes(2)
+
+      // Loop 1's aborted RPC resolves LATE; its finally must leave loop 2's slot intact.
+      resolveFirst(page([], false))
+      await first
+
+      // A reconcile re-kick while loop 2 is still draining: guarded OFF iff its slot survived.
+      await h.paginator.catchUpToTail('w', 'a', 1n)
+      expect(listAgentMessages).toHaveBeenCalledTimes(2) // 3 if loop 1 clobbered loop 2's slot
+
+      resolveSecond(page([], false))
+      await second
     })
   })
 })

--- a/frontend/src/stores/chatHistoryPaginator.ts
+++ b/frontend/src/stores/chatHistoryPaginator.ts
@@ -12,6 +12,7 @@ export const MESSAGE_PAGE_SIZE = 50
  * genuinely-vanished live seq stops the loop instead of spinning.
  */
 const MAX_FORWARD_FILL_ATTEMPTS = 4
+const MAX_INT64_SEQ = 9223372036854775807n
 
 /**
  * Abort `controller` when the WatchEvents `watchSignal` fires, so a reconcile-driven
@@ -279,10 +280,19 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
     }
     finally {
       cleanupWatchSignal()
-      catchingUp.delete(agentId)
-      // Release the slot, but only if a superseding loop hasn't replaced the controller.
-      if (deps.catchUpAbort.get(agentId) === controller)
+      // Release the single-flight slot AND the controller together, but only if a superseding
+      // loop hasn't already replaced this controller. On an abort-driven supersession the abort
+      // listener above frees the `catchingUp` slot INSTANTLY (so a reconcile re-kick fired in that
+      // window isn't dropped), and a newer loop may already own the slot by the time this aborted
+      // body resumes into the finally. Deleting `catchingUp` unconditionally here would clobber
+      // that newer loop's slot -- the next reconcile tick then passes the `catchingUp.has` guard,
+      // starts a THIRD loop, and aborts the newer loop's in-flight page: exactly the abort-and-
+      // re-issue RPC thrash the single-flight guard exists to prevent. Gating the slot release on
+      // still owning the controller keeps the two in lock-step.
+      if (deps.catchUpAbort.get(agentId) === controller) {
+        catchingUp.delete(agentId)
         deps.catchUpAbort.delete(agentId)
+      }
     }
   }
 
@@ -664,6 +674,55 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
     })
   }
 
+  /**
+   * Replace the window with a page CENTERED on `seq` -- the scroll-rail's seek/jump
+   * target. Two disjoint anchored fetches run in parallel: BEFORE cursor=seq+1n (rows
+   * with seq <= seq, INCLUDING the target when it exists -- the bound is exclusive;
+   * LATEST is used instead at int64 max because seq+1 is not a valid backend cursor) and
+   * AFTER cursor=seq (rows with seq > seq). Both come back ascending, so their
+   * concatenation is one contiguous ascending window with the target ~mid-window and
+   * ~50 rows of padding on each side (under the 150 cap), so the buffer filler's first
+   * pass fetches BACKGROUND pages rather than tripping the hard-edge stall indicators.
+   *
+   * A deleted target seq lands on the nearest survivors (BEFORE returns the highest
+   * seq <= target); the scroll hook's nearest-row-by-seq landing does the rest. When
+   * `seq` falls into a deleted prefix/suffix, one page is empty and the window snaps to
+   * the surviving oldest/newest rows. Both empty means the history genuinely vanished
+   * (mirrors jumpToLatestMessages' authoritative-empty reset).
+   */
+  async function jumpToMessagesAroundSeq(workerId: string, agentId: string, seq: bigint): Promise<void> {
+    await deps.runHistoryFetch(agentId, 'fetchingNewer', async (signal) => {
+      // Snapshot the recorded live tail before the swap: a message broadcast DURING the
+      // fetch raises it past this, and hasMoreNewer/resetToEmptyIfStale must respect that.
+      const liveSeqAtEntry = deps.liveTail.get(agentId)
+      const beforeRequest = seq >= MAX_INT64_SEQ
+        ? { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_SIZE }
+        : { agentId, anchor: MessagePageAnchor.BEFORE, cursorSeq: seq + 1n, limit: MESSAGE_PAGE_SIZE }
+      const [before, after] = await Promise.all([
+        listAgentMessages(workerId, beforeRequest),
+        listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.AFTER, cursorSeq: seq, limit: MESSAGE_PAGE_SIZE }),
+      ])
+      if (signal.aborted)
+        return
+      const rows = [...before.messages, ...after.messages]
+      if (rows.length === 0) {
+        // No rows on either side: the history around (and beyond) the target is gone.
+        // Empty the window and clear a stale recorded tail (skipped if a mid-fetch
+        // broadcast raised a genuinely-reachable seq -- forward-fill will pull it).
+        deps.applyMessages(agentId, [], false)
+        deps.liveTail.resetToEmptyIfStale(agentId, liveSeqAtEntry)
+        return
+      }
+      // One window swap. applyMessages sets hasMoreOlder from before.hasMore (more
+      // history exists below the loaded page) and defaults hasMoreNewer=false.
+      deps.applyMessages(agentId, rows, before.hasMore)
+      // Override hasMoreNewer: after.hasMore covers server rows past the page; the
+      // !caughtUpToLiveTail term (mirroring loadNewerPage) covers a live message that
+      // bumped the recorded tail during the fetch, so the window can't claim the tail.
+      setState('hasMoreNewer', agentId, after.hasMore || !deps.caughtUpToLiveTail(agentId))
+    })
+  }
+
   return {
     loadInitialMessages,
     loadOlderMessages,
@@ -673,5 +732,6 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
     resumeDeferredTailFill,
     jumpToLatestMessages,
     jumpToOldestMessages,
+    jumpToMessagesAroundSeq,
   }
 }

--- a/frontend/src/stores/chatLiveTail.ts
+++ b/frontend/src/stores/chatLiveTail.ts
@@ -100,11 +100,12 @@ export function createLiveTailTracker() {
       // must NEVER claim a tail BELOW a row still loaded in the window (that would make
       // caughtUp falsely true). The one home for the floor both delete branches apply.
       const clampAtWindowFloor = (seq: bigint): bigint => (seq > windowTail ? seq : windowTail)
-      // Normalize the indeterminate sentinel: the broadcast carries new_latest_seq = -1
-      // when the worker couldn't read the tail (a DB error), which is NOT a real seq.
-      // Treat it like "no authoritative tail carried" so we never lower the recorded
-      // tail toward a bogus value (see AgentMessageDeleted.new_latest_seq).
-      const newLatestSeq = opts.newLatestSeq !== undefined && opts.newLatestSeq >= 0n ? opts.newLatestSeq : undefined
+      // new_latest_seq is UNSET (undefined here) when the worker couldn't read the tail (a
+      // DB error) or for a local optimistic delete that carries none; a present value is
+      // always a real post-delete MAX(seq). Treat undefined as "no authoritative tail
+      // carried" so we never lower the recorded tail toward a bogus value (see
+      // AgentMessageDeleted.new_latest_seq).
+      const newLatestSeq = opts.newLatestSeq
       const recordedTail = get(agentId)
       if (removedSeq !== undefined && removedSeq !== 0n && removedSeq === recordedTail) {
         // Loaded tail deleted. Prefer the authoritative new tail; a local optimistic
@@ -115,9 +116,9 @@ export function createLiveTailTracker() {
       }
       else if (removedSeq === undefined && deletedSeq !== undefined && deletedSeq !== 0n && deletedSeq === recordedTail) {
         // The deleted row was an UNLOADED beyond-window tail. With an authoritative new
-        // tail, set it exactly; otherwise -- an INDETERMINATE -1 broadcast (a failed
-        // worker MAX(seq) readback, normalized to undefined above) or no new_latest_seq
-        // field at all -- fall back to deletedSeq - 1n. That is the PROVABLE ceiling of
+        // tail, set it exactly; otherwise -- an INDETERMINATE (unset) broadcast (a failed
+        // worker MAX(seq) readback) or no new_latest_seq field at all -- fall back to
+        // deletedSeq - 1n. That is the PROVABLE ceiling of
         // the new tail, NOT a guess: we are in this branch only because deletedSeq ===
         // recordedTail, the highest seq the client has observed, and ordered broadcasts
         // rule out a higher UNobserved one (a later create/reseq would have bumped

--- a/frontend/src/stores/chatMessageMarkSeeder.ts
+++ b/frontend/src/stores/chatMessageMarkSeeder.ts
@@ -1,0 +1,182 @@
+import type { MessageMarksStore } from './chatMessageMarks'
+import { listMessageMarks as listMessageMarksRpc } from '~/api/workerRpc'
+
+// ---------------------------------------------------------------------------
+// Message-mark seeder (the seed-race machine)
+//
+// Owns the per-agent machine that SEEDS an agent's scroll-rail marks from the
+// backend ListMessageMarks RPC and keeps re-seeding until the snapshot "sticks".
+// The race-fencing sibling of createMessageMarksStore, which owns the marks DATA:
+// the data store holds the reactive marks + the live-mutation revision; THIS holds
+// the epoch fencing, the retry timers, and the bounded reschedule chain that drive a
+// seed to completion against the three ways it can fail to stick -- a live mark racing
+// the snapshot, an indeterminate range, and a transient RPC rejection (see `load`).
+//
+// Split out of the windowed chat store so the seed-race invariants -- a single global
+// monotonic epoch that never reissues a live value, an immediate-retry loop plus a
+// bounded delayed-reschedule chain, and a watchSignal teardown that cancels the chain
+// -- live in one tested unit, mirroring how createMessageMarksStore (the marks data)
+// and createLiveTailTracker (the true tail) each own their own slice. The store keeps
+// the PUBLIC entry points: `loadMessageMarks` delegates to `load`, and forgetAgent
+// calls `forget`.
+// ---------------------------------------------------------------------------
+
+export const MAX_MESSAGE_MARK_SEED_ATTEMPTS = 3
+export const MESSAGE_MARK_SEED_RETRY_DELAY_MS = 250
+// Cap on delayed reseeds chained from one fresh trigger, so a PERSISTENT failure (a worker
+// whose seq-range query keeps erroring, or an RPC that keeps rejecting) self-limits to a short
+// burst instead of polling every MESSAGE_MARK_SEED_RETRY_DELAY_MS for the whole session. A
+// genuinely fresh trigger (initial load / reconnect catch-up / open) starts a new chain at 0.
+export const MAX_MESSAGE_MARK_SEED_RESCHEDULES = 5
+
+/** Dependencies the seeder needs from the store: the marks data store, and an optional RPC override. */
+export interface MessageMarkSeederDeps {
+  /** The marks DATA store this seeder seeds/reseeds (createMessageMarksStore). */
+  marks: MessageMarksStore
+  /**
+   * The ListMessageMarks RPC. Optional: defaults to the real RPC, and is resolved LAZILY inside
+   * `load` (never at construction) so building the store stays free of the RPC surface -- matching
+   * the codebase's I/O-free store construction. Tests inject a fake here to drive the seed-race.
+   */
+  listMessageMarks?: typeof listMessageMarksRpc
+}
+
+/**
+ * The scroll-rail mark seeder: the seed-race state machine behind the store's public
+ * `loadMessageMarks`. See the module header for how it splits from the marks DATA.
+ */
+export function createMessageMarkSeeder(deps: MessageMarkSeederDeps) {
+  const { marks } = deps
+
+  // The epoch a loadMessageMarks call fences its late resolves against. Drawn from a single
+  // monotonic counter (NOT a per-agent `+ 1`): forgetAgent deletes an agent's entry, so a
+  // per-agent counter would restart at 0 and a close->reopen could mint the SAME epoch a
+  // still-in-flight pre-close seed holds, defeating the cancel guard and letting the stale
+  // RPC clobber the fresh window. A global counter never reissues a live epoch.
+  const markSeedEpoch = new Map<string, number>()
+  let markSeedEpochSeq = 0
+  const markSeedRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const clearMarkSeedRetry = (agentId: string) => {
+    const timer = markSeedRetryTimers.get(agentId)
+    if (timer === undefined)
+      return
+    clearTimeout(timer)
+    markSeedRetryTimers.delete(agentId)
+  }
+
+  /**
+   * Seed (or re-seed) an agent's scroll-rail marks from the worker. Fire-and-forget:
+   * a failure leaves the rail hidden/stale rather than blocking history load. Called
+   * on initial load and again at catch-up complete to heal marks that changed (user
+   * sends, deletes) while disconnected.
+   *
+   * `watchSignal` ties the seed to the CURRENT WatchEvents subscription (the same seam the
+   * history fetches use, see beginHistoryFetch/linkWatchSignal): when a workspace switch /
+   * worker reconnect tears the stream down, its abort cancels the in-flight ListMessageMarks
+   * RPC and stops the retry chain from re-issuing against a worker the reader navigated away
+   * from -- rather than polling it for up to MAX_MESSAGE_MARK_SEED_RESCHEDULES rounds. The
+   * epoch guard still handles supersession by a fresh seed on the SAME subscription; the
+   * signal handles the subscription itself going away.
+   */
+  async function load(workerId: string, agentId: string, watchSignal?: AbortSignal, rescheduleDepth = 0) {
+    // Resolve the RPC HERE (not at construction) so building the store touches no RPC binding: the
+    // injected fake if a test supplied one, else the real ListMessageMarks. See MessageMarkSeederDeps.
+    const listMessageMarks = deps.listMessageMarks ?? listMessageMarksRpc
+    // Clear any pending retry FIRST, then bail on an empty workerId or a torn-down subscription:
+    // an empty workerId means the agent's worker/tab is gone (getAgentTab returned undefined), so a
+    // reseed against it can't happen and the retry chain must STOP rather than keep polling a
+    // worker the reader can no longer reach (see chat.store.test.ts "cancels a pending marks seed
+    // retry when reseeded without a worker").
+    clearMarkSeedRetry(agentId)
+    if (!workerId || watchSignal?.aborted)
+      return
+    const epoch = ++markSeedEpochSeq
+    markSeedEpoch.set(agentId, epoch)
+    let revision = marks.liveRevision(agentId)
+    // Re-arm the delayed reseed for THIS epoch (cancelled by a fresh call / forget via the
+    // epoch guard, or a torn-down subscription via watchSignal), BOUNDED by
+    // MAX_MESSAGE_MARK_SEED_RESCHEDULES so a persistent failure gives up instead of polling
+    // forever. Reused by the three "seed didn't stick" cases: live updates kept racing the
+    // snapshot, a first seed whose range came back indeterminate, and a transient RPC rejection.
+    // `rescheduleDepth` counts the chain length from the fresh trigger; each reschedule
+    // increments it, and a fresh external call starts a new chain at 0.
+    const scheduleRetry = (reason: string) => {
+      if (markSeedEpoch.get(agentId) !== epoch || watchSignal?.aborted)
+        return
+      if (rescheduleDepth + 1 >= MAX_MESSAGE_MARK_SEED_RESCHEDULES) {
+        console.warn('message marks seed gave up after retries', { agentId, reason, rescheduleDepth })
+        return
+      }
+      console.warn('message marks seed retry scheduled', { agentId, reason, rescheduleDepth })
+      const timer = setTimeout(() => {
+        markSeedRetryTimers.delete(agentId)
+        if (markSeedEpoch.get(agentId) === epoch && !watchSignal?.aborted)
+          void load(workerId, agentId, watchSignal, rescheduleDepth + 1)
+      }, MESSAGE_MARK_SEED_RETRY_DELAY_MS)
+      markSeedRetryTimers.set(agentId, timer)
+    }
+    try {
+      for (let attempt = 0; attempt < MAX_MESSAGE_MARK_SEED_ATTEMPTS; attempt++) {
+        const resp = await listMessageMarks(workerId, { agentId }, { signal: watchSignal })
+        if (markSeedEpoch.get(agentId) !== epoch || watchSignal?.aborted)
+          return
+        const currentRevision = marks.liveRevision(agentId)
+        if (currentRevision !== revision) {
+          revision = currentRevision
+          continue
+        }
+        marks.seed(
+          agentId,
+          resp.marks.map(m => ({ seq: m.seq, type: m.type })),
+          resp.minSeq,
+          resp.maxSeq,
+        )
+        // A FIRST seed whose range came back indeterminate (min/max unset: the worker's
+        // seq-range subquery errored) leaves the rail hidden (seed keeps loaded=false), and the
+        // live add/remove path can never reveal a never-seeded rail. Retry so a transient range
+        // error self-heals instead of hiding the rail for the whole session.
+        if (!marks.get(agentId).loaded) {
+          scheduleRetry('first seed range indeterminate')
+        }
+        // An ALREADY-loaded agent reseeded with an indeterminate range stays loaded, but seed()
+        // can no longer tell a beyond-horizon live mark (noteMark'd during the reseed race) from
+        // a stale one, so it trusts the snapshot wholesale and drops that mark -- and nothing
+        // re-notes it until the next reconnect reseed. Retry so a good horizon returns and seed()
+        // heals the dropped dot promptly instead of leaving it missing for the session.
+        else if (resp.minSeq === undefined || resp.maxSeq === undefined) {
+          scheduleRetry('reseed range indeterminate')
+        }
+        return
+      }
+      scheduleRetry('live updates kept racing the seed')
+    }
+    catch (err) {
+      // A subscription teardown aborts the in-flight RPC (watchSignal); that is a deliberate
+      // cancellation, not a transient failure, so swallow it without logging or retrying -- the
+      // fresh subscription's own seed takes over.
+      if (watchSignal?.aborted)
+        return
+      // A transient RPC failure (a network blip / the worker briefly busy) must not hide the
+      // rail for the whole session: retry, bounded like the other "seed didn't stick" cases,
+      // so a one-off rejection self-heals but a persistent one stops instead of never revealing
+      // the rail. (The indeterminate-range retry only covers a SUCCESSFUL response with a bad
+      // range; an outright rejection never reaches the seed at all.)
+      console.warn('failed to load message marks', { agentId, err })
+      scheduleRetry('list message marks rpc failed')
+    }
+  }
+
+  /**
+   * Drop an agent's seed-race state when the agent is closed: cancel any pending retry
+   * timer and delete its epoch entry (so a still-in-flight pre-close seed's late resolve
+   * stays fenced -- see the global-counter note above). Called from the store's forgetAgent.
+   */
+  function forget(agentId: string) {
+    clearMarkSeedRetry(agentId)
+    markSeedEpoch.delete(agentId)
+  }
+
+  return { load, forget }
+}
+
+export type MessageMarkSeeder = ReturnType<typeof createMessageMarkSeeder>

--- a/frontend/src/stores/chatMessageMarks.ts
+++ b/frontend/src/stores/chatMessageMarks.ts
@@ -1,0 +1,248 @@
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { lowerBoundBySeq } from '~/lib/binarySearch'
+import { createPerAgentStore } from './chatPerAgentStore'
+import { isOptimisticLocalSeq } from './chatReconcile'
+
+// ---------------------------------------------------------------------------
+// Message-marks tracker
+//
+// Owns the per-agent set of "scroll-rail marks": the seqs of notable messages
+// (user-typed inputs, control-request responses) the rail draws teal jump dots
+// for, plus the agent's whole-history seq range. The frontend never holds the
+// full conversation (a ~150-message sliding window), so these seqs -- and the
+// min/max range -- come from the backend ListMessageMarks RPC (seed) and are then
+// kept current incrementally from live events (noteMark / remove), exactly as
+// chatLiveTail keeps the true tail. A dropped-beyond-window live message still
+// records its mark, because addMessage calls noteMark BEFORE the window drop.
+//
+// Mirrors chatLiveTail's shape: layers domain reconcilers on a createPerAgentStore
+// leaf. The leaf is a whole MessageMarks object replaced on every write (never
+// mutated in place -- the empty value is shared across unseeded agents).
+// ---------------------------------------------------------------------------
+
+export interface SeqMark {
+  seq: bigint
+  type: MarkType
+}
+
+/**
+ * The reactive scroll-rail data an agent exposes to the chat view: the marked seqs, the
+ * effective whole-history seq range the rail's track spans, and the loaded window's bounds.
+ * One named shape shared by the store's `getRailData` return and `ChatViewProps.rail`, so
+ * the two can't drift. The range (minSeq/maxSeq) is already window-aware -- the store
+ * resolves it via {@link resolveRailRange}, so the view passes it straight through.
+ */
+export interface ChatRailData {
+  /** True once the marks RPC has seeded this agent (reveals the rail). */
+  loaded: boolean
+  /** Whole-history lowest seq the rail's seq-space track starts at (window-aware). */
+  minSeq: bigint
+  /** Whole-history highest seq the rail's seq-space track ends at (window-aware). */
+  maxSeq: bigint
+  /** The marked seqs (teal jump dots). */
+  marks: readonly SeqMark[]
+  /**
+   * The loaded window's first/last SERVER seq (skipping optimistic locals), or undefined
+   * when the window holds no server row. The rail's thumb-drag uses these to gate in-window
+   * live-scrolling; a drag mapping outside them only previews.
+   */
+  windowFirstSeq: bigint | undefined
+  windowLastSeq: bigint | undefined
+}
+
+/** Inputs to {@link resolveRailRange}: the seeded range, the live tail, and the loaded window. */
+export interface RailRangeInputs {
+  /** RPC-seeded whole-history lowest seq (`MessageMarks.minSeq`, lowered live by noteMark). */
+  seededMinSeq: bigint
+  /** RPC-seeded whole-history highest seq at seed time (`MessageMarks.seedMaxSeq`). */
+  seedMaxSeq: bigint
+  /** liveTail's observed max (0n before liveTail has seen a message). */
+  liveMaxSeq: bigint
+  /** The loaded window's first/last SERVER seq (undefined for an all-locals / empty window). */
+  windowFirstSeq: bigint | undefined
+  windowLastSeq: bigint | undefined
+  /** Whether older messages remain unfetched below the loaded window. */
+  hasOlderMessages: boolean
+}
+
+/**
+ * Resolve the rail's effective whole-history seq range from the seeded range, the live tail,
+ * and the loaded window. The SINGLE home for the window-aware min/max rule (previously split
+ * across the store's getRailData and two ChatView memos, which could silently drift):
+ *
+ *  - min: when the oldest page is loaded, the window HEAD is the exact whole-history min, so
+ *    the rail's floor tracks a delete of the oldest without waiting for a reseed; otherwise
+ *    the RPC-seeded min (older history exists off-window).
+ *  - max: liveTail is authoritative once populated -- it rises as the stream grows past the
+ *    loaded window AND falls when the tail is deleted -- with the seed max as the pre-liveTail
+ *    fallback (max(liveMax, seedMax) would instead pin a deleted tail's phantom slot at the
+ *    stale seed max). But the window TAIL wins when it has outrun both, so the thumb keeps
+ *    shrinking as rows persist past the window before liveTail catches up.
+ */
+export function resolveRailRange(inp: RailRangeInputs): { minSeq: bigint, maxSeq: bigint } {
+  const seededOrLiveMax = inp.liveMaxSeq > 0n ? inp.liveMaxSeq : inp.seedMaxSeq
+  return {
+    minSeq: !inp.hasOlderMessages ? (inp.windowFirstSeq ?? inp.seededMinSeq) : inp.seededMinSeq,
+    maxSeq: inp.windowLastSeq !== undefined && inp.windowLastSeq > seededOrLiveMax
+      ? inp.windowLastSeq
+      : seededOrLiveMax,
+  }
+}
+
+export interface MessageMarks {
+  /** True once the seed RPC has populated this agent at least once. */
+  loaded: boolean
+  /** Whole-history lowest seq (0n = empty / unseeded). */
+  minSeq: bigint
+  /** Whole-history highest seq at seed time (chatLiveTail supersedes it live). */
+  seedMaxSeq: bigint
+  /** Marked seqs, ascending, deduped. */
+  marks: readonly SeqMark[]
+}
+
+const EMPTY_MARKS: MessageMarks = { loaded: false, minSeq: 0n, seedMaxSeq: 0n, marks: [] }
+
+/**
+ * Insert `{seq, type}` keeping `marks` ascending by seq. Returns the SAME array
+ * reference when `seq` is already present (idempotent re-note of a re-broadcast
+ * message), so callers can skip a no-op reactive write.
+ */
+export function insertMarkSorted(marks: readonly SeqMark[], seq: bigint, type: MarkType): readonly SeqMark[] {
+  const idx = lowerBoundBySeq(marks, seq)
+  if (idx < marks.length && marks[idx].seq === seq)
+    return marks
+  const next = marks.slice()
+  next.splice(idx, 0, { seq, type })
+  return next
+}
+
+/**
+ * Remove the mark at `seq`. Returns the SAME array reference when `seq` is absent,
+ * so callers can skip a no-op reactive write.
+ */
+export function removeMarkAt(marks: readonly SeqMark[], seq: bigint): readonly SeqMark[] {
+  const idx = lowerBoundBySeq(marks, seq)
+  if (idx >= marks.length || marks[idx].seq !== seq)
+    return marks
+  const next = marks.slice()
+  next.splice(idx, 1)
+  return next
+}
+
+/** Ascending, deduped copy of a seeded marks list (defensive against a mis-ordered RPC). */
+function normalizeSeed(marks: readonly SeqMark[]): SeqMark[] {
+  let alreadySorted = true
+  for (let i = 1; i < marks.length; i++) {
+    if (marks[i - 1].seq > marks[i].seq) {
+      alreadySorted = false
+      break
+    }
+  }
+  const sorted = alreadySorted ? marks : [...marks].sort((a, b) => (a.seq < b.seq ? -1 : a.seq > b.seq ? 1 : 0))
+  const out: SeqMark[] = []
+  for (const m of sorted) {
+    if (out.length > 0 && out[out.length - 1].seq === m.seq)
+      continue
+    out.push({ seq: m.seq, type: m.type })
+  }
+  return out
+}
+
+export function createMessageMarksStore() {
+  const base = createPerAgentStore<MessageMarks>(EMPTY_MARKS)
+  // Per-agent "live mutation revision", bumped by noteMark/remove on every REAL change (never a
+  // no-op) so a concurrent loadMessageMarks can detect a mark change that raced its in-flight seed
+  // RPC. Owning it HERE -- rather than the caller bumping after a returned bool -- makes it
+  // mechanically impossible for a mark mutation to skip the bump. seed() deliberately does NOT
+  // bump: it is the snapshot being raced against, not a live change.
+  const liveRevisions = new Map<string, number>()
+  const bump = (agentId: string) => {
+    liveRevisions.set(agentId, (liveRevisions.get(agentId) ?? 0) + 1)
+  }
+
+  return {
+    /** The reactive id -> MessageMarks map (read by id for reactivity). */
+    get byAgent() {
+      return base.byAgent
+    },
+    /** The marks state for an agent (EMPTY_MARKS when unseeded; treat as read-only). */
+    get: base.get,
+    /**
+     * The per-agent live-mutation revision: a monotonically-increasing count bumped by every real
+     * noteMark/remove. loadMessageMarks reads it before and after its seed RPC to detect a mark
+     * change that raced the fetch (see the seed-race retry there). 0 for an agent never mutated.
+     */
+    liveRevision(agentId: string): number {
+      return liveRevisions.get(agentId) ?? 0
+    },
+    /**
+     * Replace an agent's marks from a ListMessageMarks response. An INDETERMINATE range
+     * (min/max unset -- the worker couldn't read the seq range on a DB error) keeps the
+     * prior value rather than trusting a bogus 0.
+     */
+    seed(agentId: string, marks: readonly SeqMark[], minSeq: bigint | undefined, maxSeq: bigint | undefined) {
+      const cur = base.get(agentId)
+      // Preserve any already-noted mark BEYOND this snapshot's horizon (seq > maxSeq): a
+      // live message can be noteMark'd from a broadcast in the window between the worker
+      // reading ListMessageMarks and this response applying (e.g. a send landing during a
+      // reconnect reseed). Since maxSeq is the snapshot's MAX(seq), such a mark is provably
+      // newer than the snapshot and absent from `marks`; a wholesale replace would drop its
+      // dot until the next reseed. Marks at/below maxSeq stay the snapshot's authority, so a
+      // delete that happened while disconnected is still healed. When maxSeq is indeterminate
+      // (unset) the horizon is unknown, so the preserve is skipped and the fresh snapshot is
+      // trusted wholesale (a beyond-horizon race mark is dropped); loadMessageMarks schedules a
+      // retry to heal it once a good horizon returns.
+      const freshBeyondSnapshot = maxSeq !== undefined ? cur.marks.filter(m => m.seq > maxSeq) : []
+      base.set(agentId, {
+        // `loaded` is what reveals the rail. Claim it only once we hold a usable range:
+        // a FIRST seed whose min/max came back indeterminate (unset, a worker DB error) would
+        // otherwise install real marks against the bogus 0n floor kept below and
+        // mis-position every dot. Stay hidden until a good reseed heals it; once loaded, a
+        // later indeterminate reseed keeps the prior range and stays loaded.
+        loaded: cur.loaded || (minSeq !== undefined && maxSeq !== undefined),
+        minSeq: minSeq !== undefined ? minSeq : cur.minSeq,
+        seedMaxSeq: maxSeq !== undefined ? maxSeq : cur.seedMaxSeq,
+        marks: normalizeSeed([...marks, ...freshBeyondSnapshot]),
+      })
+    },
+    /**
+     * Record a live message's mark. Ignores optimistic locals (seq 0n) and unmarked
+     * rows. Idempotent for a re-broadcast seq. Lowers minSeq when the agent was empty
+     * (0n) or the seq precedes the recorded min, so the rail range always covers it.
+     * Bumps the live-mutation revision ONLY on a real change -- a no-op re-note (a
+     * re-broadcast seq, an optimistic local, an unmarked row) must not perturb the
+     * concurrent-seed race detector.
+     */
+    noteMark(agentId: string, seq: bigint, type: MarkType): void {
+      if (isOptimisticLocalSeq(seq) || type === MarkType.UNSPECIFIED)
+        return
+      const cur = base.get(agentId)
+      const nextMarks = insertMarkSorted(cur.marks, seq, type)
+      const nextMin = cur.minSeq === 0n || seq < cur.minSeq ? seq : cur.minSeq
+      if (nextMarks === cur.marks && nextMin === cur.minSeq)
+        return
+      base.set(agentId, { ...cur, minSeq: nextMin, marks: nextMarks })
+      bump(agentId)
+    },
+    /**
+     * Drop the mark at `seq` (no-op when absent). Called on message delete / phantom
+     * reap. Bumps the live-mutation revision only on a real removal -- an unmarked seq
+     * is a no-op and must not perturb the concurrent-seed race detector.
+     */
+    remove(agentId: string, seq: bigint): void {
+      const cur = base.get(agentId)
+      const nextMarks = removeMarkAt(cur.marks, seq)
+      if (nextMarks === cur.marks)
+        return
+      base.set(agentId, { ...cur, marks: nextMarks })
+      bump(agentId)
+    },
+    /** Drop an agent's marks (and its live-revision counter) entirely when the agent is closed. */
+    forget(agentId: string) {
+      base.remove(agentId)
+      liveRevisions.delete(agentId)
+    },
+  }
+}
+
+export type MessageMarksStore = ReturnType<typeof createMessageMarksStore>

--- a/frontend/src/stores/chatMessageOrder.ts
+++ b/frontend/src/stores/chatMessageOrder.ts
@@ -1,4 +1,5 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
+import { lowerBoundBySeq } from '~/lib/binarySearch'
 import { isOptimisticLocal } from './chatReconcile'
 
 /**
@@ -87,16 +88,9 @@ export function insertServerBySeq(list: AgentChatMessage[], message: AgentChatMe
   // Fast path: newer than the last server message.
   if (end === 0 || message.seq > list[end - 1].seq)
     return [...list.slice(0, end), message, ...list.slice(end)]
-  // Slow path: binary-insert among server messages [0, end).
-  let lo = 0
-  let hi = end
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1
-    if (list[mid].seq < message.seq)
-      lo = mid + 1
-    else
-      hi = mid
-  }
+  // Slow path: binary-insert among server messages [0, end) at the lower bound (the first index
+  // whose seq >= message.seq), via the shared tested search rather than a hand-rolled off-by-one.
+  const lo = lowerBoundBySeq(list, message.seq, end)
   return [...list.slice(0, lo), message, ...list.slice(lo)]
 }
 
@@ -175,12 +169,14 @@ export function applyFreshMessage(
   if (isOptimisticLocal(message))
     return { next: [...base, message], inserted: true }
 
-  // Dedup: skip if a server message with this exact seq already exists.
+  // Dedup: skip if a server message with this exact seq already exists. The server region
+  // [0, serverEnd) is unique and ascending by seq (insertServerBySeq maintains that), so a
+  // binary lower-bound probe replaces the O(n) backward scan -- the same lowerBoundBySeq
+  // insertServerBySeq itself runs on the next line, kept off this per-message-commit hot path.
   const serverEnd = serverMessageEnd(base)
-  for (let i = serverEnd - 1; i >= 0; i--) {
-    if (base[i].seq === message.seq)
-      return { next: base, inserted: false }
-  }
+  const dupIdx = lowerBoundBySeq(base, message.seq, serverEnd)
+  if (dupIdx < serverEnd && base[dupIdx].seq === message.seq)
+    return { next: base, inserted: false }
 
   return { next: insertServerBySeq(base, message), inserted: true }
 }
@@ -193,10 +189,10 @@ export function applyFreshMessage(
  * Locals never appear in a fetched page, but seq 0n is ignored defensively.
  */
 function olderRowsPrecedeWindowHead(older: AgentChatMessage[], base: AgentChatMessage[]): boolean {
-  const headSeq = base.find(m => m.seq !== 0n)?.seq
+  const headSeq = base.find(m => !isOptimisticLocal(m))?.seq
   if (headSeq === undefined)
     return true
-  return older.every(m => m.seq === 0n || m.seq < headSeq)
+  return older.every(m => isOptimisticLocal(m) || m.seq < headSeq)
 }
 
 /**
@@ -235,8 +231,8 @@ export function mergeWindow(
   // stay pinned to the tail. On the 'older' side this drop is inert: an older page's
   // seqs are all below the window head, so they never collide with a loaded row.
   const newIds = new Set(newMsgs.map(m => m.id))
-  const newSeqs = new Set(newMsgs.filter(m => m.seq !== 0n).map(m => m.seq))
-  const collidesNewSeq = (m: AgentChatMessage) => m.seq !== 0n && newSeqs.has(m.seq) && !newIds.has(m.id)
+  const newSeqs = new Set(newMsgs.filter(m => !isOptimisticLocal(m)).map(m => m.seq))
+  const collidesNewSeq = (m: AgentChatMessage) => !isOptimisticLocal(m) && newSeqs.has(m.seq) && !newIds.has(m.id)
   const dropsExisting = reconciledLocalIds.size > 0
     || prev.some(m => newIds.has(m.id) || collidesNewSeq(m))
   const base = dropsExisting

--- a/frontend/src/stores/chatReconcile.ts
+++ b/frontend/src/stores/chatReconcile.ts
@@ -90,14 +90,25 @@ export function userMessageSignature(message: AgentChatMessage): string | null {
 }
 
 /**
+ * True when `seq` is the optimistic-local sentinel: a freshly-sent bubble is assigned
+ * seq 0n and pinned to the tail until its server echo arrives, and server-persisted rows
+ * always carry seq > 0n -- so a 0n seq unambiguously marks an unassigned local. The
+ * seq-level companion to {@link isOptimisticLocal} for sites that hold only a seq (a marks
+ * entry, a rail lookup) rather than the whole message, so the "pinned local" rule has one
+ * named home instead of a bare `seq === 0n` scattered across the slices.
+ */
+export function isOptimisticLocalSeq(seq: bigint): boolean {
+  return seq === 0n
+}
+
+/**
  * True for an optimistic local message: a freshly-sent bubble assigned seq 0n
  * and pinned to the tail until its server echo arrives. The seq-0n marker is the
  * single load-bearing signal the windowing core, both trims, and the reconcile
- * path all key the "pinned local" rule off -- so it gets one named home here
- * rather than a bare `seq === 0n` scattered across the slices.
+ * path all key the "pinned local" rule off.
  */
 export function isOptimisticLocal(m: AgentChatMessage): boolean {
-  return m.seq === 0n
+  return isOptimisticLocalSeq(m.seq)
 }
 
 /**

--- a/frontend/src/utils/controlResponse.test.ts
+++ b/frontend/src/utils/controlResponse.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildDenyResponse, CONTROL_REJECTED_BY_USER_MESSAGE } from './controlResponse'
+
+// Reach the deny reason nested in the control_response envelope:
+// { response: { response: { behavior, message } } }.
+function denyEnvelope(resp: Record<string, unknown>): { requestId: string, behavior: string, message: string } {
+  const outer = resp.response as { request_id: string, response: { behavior: string, message: string } }
+  return { requestId: outer.request_id, behavior: outer.response.behavior, message: outer.response.message }
+}
+
+describe('builddenyresponse', () => {
+  it('fills the shared rejected-by-user placeholder for a bare deny (omitted or empty reason)', () => {
+    // The Claude Code SDK converts a deny into a tool_result with is_error=true, and the Anthropic
+    // API rejects empty content, so the message must never be empty -- a bare deny falls back to
+    // the shared constant, which the backend's NormalizeRejectionMessage then collapses to "".
+    expect(denyEnvelope(buildDenyResponse('req-1')).message).toBe(CONTROL_REJECTED_BY_USER_MESSAGE)
+    expect(denyEnvelope(buildDenyResponse('req-1', '')).message).toBe(CONTROL_REJECTED_BY_USER_MESSAGE)
+  })
+
+  it('passes a typed rejection reason through unchanged', () => {
+    expect(denyEnvelope(buildDenyResponse('req-1', 'looks unsafe')).message).toBe('looks unsafe')
+  })
+
+  it('carries the request id and deny behavior in the control_response envelope', () => {
+    const r = buildDenyResponse('req-42')
+    expect(r.type).toBe('control_response')
+    const env = denyEnvelope(r)
+    expect(env.requestId).toBe('req-42')
+    expect(env.behavior).toBe('deny')
+  })
+
+  it('pins the placeholder byte-identical to the backend ControlRejectedByUserMessage', () => {
+    // This literal MUST match backend/internal/worker/agent/factory.go's ControlRejectedByUserMessage
+    // -- if it drifts, the backend can no longer collapse a bare deny and the "Rejected by user."
+    // placeholder leaks into the transcript/rail as if it were typed feedback.
+    expect(CONTROL_REJECTED_BY_USER_MESSAGE).toBe('Rejected by user.')
+  })
+})

--- a/frontend/src/utils/controlResponse.ts
+++ b/frontend/src/utils/controlResponse.ts
@@ -34,11 +34,22 @@ export function buildAllowResponse(
 }
 
 /**
- * Builds a control_response JSON object that denies a tool use.
+ * The placeholder reject message emitted when the user declines a control request WITHOUT
+ * typing a reason. Must stay byte-identical to the backend's `ControlRejectedByUserMessage`
+ * (backend/internal/worker/agent/factory.go), whose `NormalizeRejectionMessage` collapses it
+ * to "" so a bare deny renders "Rejected" rather than leaking this placeholder as if it were
+ * typed feedback. Kept as ONE frontend constant so the producer sites (buildDenyResponse's
+ * default and any caller wanting a bare deny) can't drift from each other.
+ */
+export const CONTROL_REJECTED_BY_USER_MESSAGE = 'Rejected by user.'
+
+/**
+ * Builds a control_response JSON object that denies a tool use. Omit `message` for a bare
+ * deny with no typed reason (it falls back to CONTROL_REJECTED_BY_USER_MESSAGE).
  */
 export function buildDenyResponse(
   requestId: string,
-  message: string,
+  message?: string,
 ): Record<string, unknown> {
   return {
     type: 'control_response',
@@ -50,7 +61,7 @@ export function buildDenyResponse(
         // Ensure the message is never empty — Claude Code SDK converts deny
         // responses into tool_result with is_error=true, and the Anthropic API
         // rejects empty content when is_error is set.
-        message: message || 'Rejected by user.',
+        message: message || CONTROL_REJECTED_BY_USER_MESSAGE,
       },
     },
   }

--- a/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
+++ b/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
@@ -1,0 +1,94 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { waitForAgentIdle } from './helpers/ui'
+
+/**
+ * Smoke test for the seq-space chat scroll rail. The geometry math, the marks store,
+ * the seek/jump wiring, and the paginator's fetch-around-seq are exhaustively unit
+ * tested (chatScrollRailGeometry.test.ts, chatMessageMarks.test.ts, chat.store.test.ts,
+ * chatHistoryPaginator.test.ts, useChatScroll.seek.test.ts, ChatScrollRail.test.tsx).
+ * This covers the bits that need a real browser: the native scrollbar being hidden, a
+ * teal dot rendering for each of the user's own messages, and clicking a dot jumping to
+ * that message.
+ */
+
+// A deliberately long message so each user bubble is tall enough that two of them
+// overflow the short viewport below -- otherwise the rail correctly hides itself.
+const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the quick brown fox jumps over the lazy dog. '.repeat(12)}`
+
+async function sendMessage(page: Page, message: string) {
+  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  await expect(editor).toBeVisible()
+  await editor.click()
+  await page.keyboard.type(message)
+  await page.keyboard.press('Meta+Enter')
+  await expect(editor).toHaveText('')
+}
+
+/** The virtual row wrapper (carries data-seq) for the Nth user message bubble. */
+function userRow(page: Page, nth: number) {
+  return page
+    .locator('[data-seq]')
+    .filter({ has: page.locator('[data-testid="message-bubble"][data-role="user"]') })
+    .nth(nth)
+}
+
+test.describe('chat scroll rail', () => {
+  test('hides the native scrollbar, dots each user message, and jumps on a dot click', async ({ page, authenticatedWorkspace }) => {
+    // A short viewport so a couple of tall user bubbles overflow and the rail appears.
+    await page.setViewportSize({ width: 720, height: 380 })
+
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await expect(editor).toBeVisible()
+    // Let the agent finish starting so the send takes the fast path (see 010).
+    await expect(page.getByText(/^Starting /)).not.toBeVisible()
+
+    // The native scrollbar is hidden on the chat container -- the rail replaces it. This
+    // holds regardless of conversation length, so assert it up front.
+    const scroller = page.locator('[data-chat-scroll-container="true"]')
+    await expect(scroller).toBeVisible()
+    expect(await scroller.evaluate(el => getComputedStyle(el).scrollbarWidth)).toBe('none')
+
+    // Send two messages, waiting for each turn to finish.
+    await sendMessage(page, LONG_MESSAGE)
+    await waitForAgentIdle(page)
+    await sendMessage(page, LONG_MESSAGE)
+    await waitForAgentIdle(page)
+
+    // Two user messages landed (their server echoes carry real seqs).
+    const userBubbles = page.locator('[data-testid="message-bubble"][data-role="user"]')
+    await expect(userBubbles).toHaveCount(2)
+
+    // The tall bubbles overflow the short viewport, so the rail shows with a thumb.
+    const rail = page.locator('[data-testid="chat-scroll-rail"]')
+    await expect(rail).toBeVisible()
+    const thumb = page.locator('[data-testid="chat-scroll-rail-thumb"]')
+    await expect(thumb).toBeVisible()
+
+    // Each user message has a teal jump dot at its seq (there may be additional dots for
+    // any control responses, so assert per-user-message rather than an exact total).
+    const firstUserSeq = await userRow(page, 0).getAttribute('data-seq')
+    const secondUserSeq = await userRow(page, 1).getAttribute('data-seq')
+    expect(firstUserSeq).not.toBeNull()
+    expect(secondUserSeq).not.toBeNull()
+    await expect(page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${firstUserSeq}"]`)).toHaveCount(1)
+    await expect(page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${secondUserSeq}"]`)).toHaveCount(1)
+
+    // Hovering a dot previews that message's content in a popover (shown immediately). The
+    // message text begins with a fixed phrase, so the preview (extracted + truncated on the
+    // client) must contain it.
+    await page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${firstUserSeq}"]`).hover()
+    await expect(page.locator('[data-testid="chat-scroll-rail-preview"]')).toContainText('Please just reply with "ok"')
+
+    // The thumb is sized to the viewport's share of the conversation, not the whole rail.
+    const railBox = await rail.boundingBox()
+    const thumbBox = await thumb.boundingBox()
+    expect(railBox).not.toBeNull()
+    expect(thumbBox).not.toBeNull()
+    expect(thumbBox!.height).toBeLessThan(railBox!.height)
+
+    // Clicking the FIRST user message's dot jumps the view (scrolled to the tail) up to it.
+    await page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${firstUserSeq}"]`).click()
+    await expect(userRow(page, 0)).toBeInViewport()
+  })
+})

--- a/frontend/tests/unit/stores/chat.store.test.ts
+++ b/frontend/tests/unit/stores/chat.store.test.ts
@@ -3,14 +3,18 @@ import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createClassifiedEntryCache } from '~/components/chat/chatEntryCache'
-import { AgentChatMessageSchema, AgentProvider, ContentCompression, MessagePageAnchor, MessageSource, TodoItemSchema, TodoStatus } from '~/generated/leapmux/v1/agent_pb'
+import { AgentChatMessageSchema, AgentProvider, ContentCompression, MarkType, MessagePageAnchor, MessageSource, TodoItemSchema, TodoStatus } from '~/generated/leapmux/v1/agent_pb'
 import { createChatStore, MAX_LOADED_CHAT_MESSAGES, MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
 import { MESSAGE_PAGE_SIZE } from '~/stores/chatHistoryPaginator'
 
 // Mock workerRpc for loadInitialMessages / loadOlderMessages / loadNewerPage / catchUpToTail
 const mockListAgentMessages = vi.fn()
+const mockListMessageMarks = vi.fn()
+const mockGetAgentMessage = vi.fn()
 vi.mock('~/api/workerRpc', () => ({
   listAgentMessages: (...args: unknown[]) => mockListAgentMessages(...args),
+  listMessageMarks: (...args: unknown[]) => mockListMessageMarks(...args),
+  getAgentMessage: (...args: unknown[]) => mockGetAgentMessage(...args),
 }))
 
 function makeMessage(id: string, seq: bigint, deliveryError = '') {
@@ -20,6 +24,17 @@ function makeMessage(id: string, seq: bigint, deliveryError = '') {
     content: new TextEncoder().encode(`{"content":"test"}`),
     seq,
     deliveryError,
+  })
+}
+
+/** A message carrying a scroll-rail mark_type, to exercise the marks hooks. */
+function makeMarkedMessage(id: string, seq: bigint, markType: MarkType) {
+  return create(AgentChatMessageSchema, {
+    id,
+    source: MessageSource.USER,
+    content: new TextEncoder().encode(`{"content":"test"}`),
+    seq,
+    markType,
   })
 }
 
@@ -147,6 +162,8 @@ describe('createChatStore', () => {
   // per-call expectations after this.
   beforeEach(() => {
     mockListAgentMessages.mockReset()
+    mockListMessageMarks.mockReset()
+    mockGetAgentMessage.mockReset()
   })
 
   it('should initialize with empty state', () => {
@@ -575,12 +592,12 @@ describe('createChatStore', () => {
     })
   })
 
-  it('reconcileAuthoritativeTail skips a negative latest_seq (worker could not determine the tail)', () => {
+  it('reconcileAuthoritativeTail skips an unset (indeterminate) latest_seq (worker could not determine the tail)', () => {
     createRoot((dispose) => {
       const store = createChatStore()
       store.setMessages('a1', [makeMessage('m1', 1n), makeMessage('m2', 2n)], false)
       store.liveTail.bump('a1', 2n)
-      store.reconcileAuthoritativeTail('a1', -1n)
+      store.reconcileAuthoritativeTail('a1', undefined)
       // Nothing trimmed, tail untouched -- we don't act on a value we can't trust.
       expect(store.getMessages('a1').map(m => m.id)).toEqual(['m1', 'm2'])
       expect(store.liveTail.get('a1')).toBe(2n)
@@ -594,12 +611,12 @@ describe('createChatStore', () => {
       store.setMessages('a1', [makeMessage('m1', 1n), makeMessage('m2', 2n)], false)
       store.liveTail.bump('a1', 2n)
       expect(store.caughtUpToLiveTail('a1')).toBe(true)
-      // CatchUpComplete with an indeterminate (-1) tail + probeIndeterminate=true: the
+      // CatchUpComplete with an indeterminate (unset) tail + probeIndeterminate=true: the
       // worker couldn't read its tail, so liveTail can't be raised authoritatively. Nudge
       // it one past the loaded tail so the continuous reconcile probes (catchUpToTail)
       // instead of trusting a possibly-partial replay as the tail; settleToWindow clamps
       // the nudge back down if nothing's actually there.
-      store.reconcileAuthoritativeTail('a1', -1n, undefined, true)
+      store.reconcileAuthoritativeTail('a1', undefined, undefined, true)
       expect(store.liveTail.get('a1')).toBe(3n) // windowTail (2) + 1
       expect(store.caughtUpToLiveTail('a1')).toBe(false) // now lagging -> reconcile probes
       // Nothing is trimmed (no authoritative tail to reap against).
@@ -615,7 +632,7 @@ describe('createChatStore', () => {
       store.liveTail.bump('a1', 2n)
       // CatchUpStart path (probeIndeterminate defaults false): the replay hasn't run yet,
       // so a probe would race it. Leave liveTail untouched -- catchUpComplete probes.
-      store.reconcileAuthoritativeTail('a1', -1n)
+      store.reconcileAuthoritativeTail('a1', undefined)
       expect(store.liveTail.get('a1')).toBe(2n)
       expect(store.caughtUpToLiveTail('a1')).toBe(true)
       dispose()
@@ -3909,6 +3926,204 @@ describe('createChatStore', () => {
 
         expect(store.getMessageVersion('a1')).toBe(2)
         expect(store.getMessageVersion('a2')).toBe(1)
+        dispose()
+      })
+    })
+  })
+
+  describe('scroll-rail marks', () => {
+    it('addMessage records a mark for a marked message, keeping the mark type', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        store.addMessage('a1', makeMarkedMessage('m2', 2n, MarkType.CONTROL_RESPONSE))
+        store.addMessage('a1', makeMessage('m3', 3n)) // unmarked
+        expect(store.messageMarks.get('a1').marks).toEqual([
+          { seq: 1n, type: MarkType.USER_MESSAGE },
+          { seq: 2n, type: MarkType.CONTROL_RESPONSE },
+        ])
+        dispose()
+      })
+    })
+
+    it('records the mark even when the message is dropped beyond the loaded window', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        // Window holds [m2, m3] with older history unloaded (hasMoreOlder=true).
+        store.setMessages('a1', [makeMessage('m2', 2n), makeMessage('m3', 3n)], true)
+        // A marked message for seq 1 (< firstSeq) belongs to the unloaded older region,
+        // so the live-append guard DROPS it -- but the mark is recorded first.
+        const dropped = store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        expect(dropped).toBe(false) // not loaded into the window
+        expect(store.getMessages('a1').map(m => m.id)).toEqual(['m2', 'm3'])
+        expect(store.messageMarks.get('a1').marks).toEqual([{ seq: 1n, type: MarkType.USER_MESSAGE }])
+        dispose()
+      })
+    })
+
+    it('does not record a mark for optimistic locals (seq 0n)', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMarkedMessage('local-1', 0n, MarkType.USER_MESSAGE))
+        expect(store.messageMarks.get('a1').marks).toEqual([])
+        dispose()
+      })
+    })
+
+    it('removeMessage drops the mark for a loaded row', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        store.addMessage('a1', makeMarkedMessage('m2', 2n, MarkType.USER_MESSAGE))
+        store.removeMessage('a1', 'm1')
+        expect(store.messageMarks.get('a1').marks).toEqual([{ seq: 2n, type: MarkType.USER_MESSAGE }])
+        dispose()
+      })
+    })
+
+    it('removeMessage drops the mark for an unloaded beyond-window delete (seq from the broadcast)', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        // Record a mark for a beyond-window seq (dropped, but marked -- see above).
+        store.setMessages('a1', [makeMessage('m2', 2n)], true)
+        store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        expect(store.messageMarks.get('a1').marks.map(m => m.seq)).toEqual([1n])
+        // The row isn't loaded, so removeMessage learns its seq from the broadcast arg.
+        store.removeMessage('a1', 'm1', 1n)
+        expect(store.messageMarks.get('a1').marks).toEqual([])
+        dispose()
+      })
+    })
+
+    it('moves a mark on a reseq (previousSeq) instead of stranding a ghost dot at the old seq', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMarkedMessage('m1', 3n, MarkType.CONTROL_RESPONSE))
+        expect(store.messageMarks.get('a1').marks).toEqual([{ seq: 3n, type: MarkType.CONTROL_RESPONSE }])
+        // A reseq MOVE re-emits the same id at a higher seq, carrying its mark.
+        const moved = create(AgentChatMessageSchema, {
+          id: 'm1',
+          source: MessageSource.USER,
+          content: new TextEncoder().encode(`{"content":"test"}`),
+          seq: 8n,
+          previousSeq: 3n,
+          markType: MarkType.CONTROL_RESPONSE,
+        })
+        store.addMessage('a1', moved)
+        // The mark follows to seq 8 with no ghost left behind at seq 3.
+        expect(store.messageMarks.get('a1').marks).toEqual([{ seq: 8n, type: MarkType.CONTROL_RESPONSE }])
+        dispose()
+      })
+    })
+
+    it('reconcileAuthoritativeTail drops the marks of reaped phantom rows (no ghost dot after a disconnected delete)', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        // Two marked rows in the window; m2 was deleted server-side while the client was
+        // disconnected, so the worker reports the authoritative tail is 1.
+        store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        store.addMessage('a1', makeMarkedMessage('m2', 2n, MarkType.CONTROL_RESPONSE))
+        store.liveTail.bump('a1', 2n)
+        expect(store.messageMarks.get('a1').marks.map(m => m.seq)).toEqual([1n, 2n])
+
+        store.reconcileAuthoritativeTail('a1', 1n)
+
+        // The reaped row m2 leaves the window AND its mark is dropped -- otherwise the stale
+        // seq-2 mark survives the next reseed (its seq exceeds the lowered maxSeq, so the
+        // beyond-horizon preserve keeps it) and resurfaces as a ghost dot once a later
+        // append raises maxSeq past it.
+        expect(store.getMessages('a1').map(m => m.id)).toEqual(['m1'])
+        expect(store.messageMarks.get('a1').marks.map(m => m.seq)).toEqual([1n])
+        dispose()
+      })
+    })
+
+    it('forgetAgent clears an agent\'s marks', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.addMessage('a1', makeMarkedMessage('m1', 1n, MarkType.USER_MESSAGE))
+        store.forgetAgent('a1')
+        expect(store.messageMarks.get('a1').loaded).toBe(false)
+        expect(store.messageMarks.get('a1').marks).toEqual([])
+        dispose()
+      })
+    })
+
+    it('getRailData takes the live-tail high-water over the seeded max', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.messageMarks.seed('a1', [{ seq: 2n, type: MarkType.USER_MESSAGE }], 1n, 5n)
+        // A beyond-window live message bumps liveTail past the seed's max.
+        store.setMessages('a1', [makeMessage('m2', 2n)], true)
+        store.addMessage('a1', makeMessage('m9', 9n)) // dropped beyond window, bumps liveTail
+        const rail = store.getRailData('a1')
+        expect(rail.loaded).toBe(true)
+        expect(rail.minSeq).toBe(1n)
+        expect(rail.maxSeq).toBe(9n) // liveTail (9) > seedMax (5)
+        dispose()
+      })
+    })
+
+    it('getRailData drops a deleted tail seq from the range instead of pinning the stale seed max', () => {
+      createRoot((dispose) => {
+        const store = createChatStore()
+        store.messageMarks.seed('a1', [{ seq: 5n, type: MarkType.USER_MESSAGE }], 1n, 10n)
+        store.liveTail.bump('a1', 10n)
+        expect(store.getRailData('a1').maxSeq).toBe(10n)
+        // Delete the tail row (seq 10); the window's new last seq is 9. liveTail lowers.
+        store.liveTail.onDelete('a1', { removedSeq: 10n, windowTail: 9n })
+        // Must follow the live tail down, NOT stay pinned at the stale seed max (10).
+        expect(store.getRailData('a1').maxSeq).toBe(9n)
+        dispose()
+      })
+    })
+
+    it('loadMessageMarks seeds from the RPC and survives an RPC failure', async () => {
+      mockListMessageMarks.mockResolvedValueOnce({
+        marks: [{ seq: 3n, type: MarkType.USER_MESSAGE }, { seq: 7n, type: MarkType.CONTROL_RESPONSE }],
+        minSeq: 1n,
+        maxSeq: 10n,
+      })
+      await createRoot(async (dispose) => {
+        const store = createChatStore()
+        await store.loadMessageMarks('w1', 'a1')
+        const rail = store.getRailData('a1')
+        expect(rail.marks.map(m => m.seq)).toEqual([3n, 7n])
+        expect(rail.minSeq).toBe(1n)
+        expect(rail.maxSeq).toBe(10n)
+
+        // A failing RPC leaves the prior state intact (rail stays as-is, no throw).
+        mockListMessageMarks.mockRejectedValueOnce(new Error('offline'))
+        await store.loadMessageMarks('w1', 'a1')
+        expect(store.getRailData('a1').marks.map(m => m.seq)).toEqual([3n, 7n])
+        dispose()
+      })
+    })
+
+    it('fetchMessageBySeq returns the fetched message on success', async () => {
+      mockGetAgentMessage.mockResolvedValueOnce({ message: makeMessage('m9', 9n) })
+      await createRoot(async (dispose) => {
+        const store = createChatStore()
+        const got = await store.fetchMessageBySeq('w1', 'a1', 9n)
+        expect(got?.id).toBe('m9')
+        expect(mockGetAgentMessage).toHaveBeenCalledWith('w1', { agentId: 'a1', seq: 9n })
+        dispose()
+      })
+    })
+
+    it('fetchMessageBySeq resolves undefined for an unset message but RETHROWS a failed RPC', async () => {
+      await createRoot(async (dispose) => {
+        const store = createChatStore()
+        // Unset message: the mark outlived its row (deleted / reseq'd) -> definitive absence,
+        // resolves undefined so the rail caches '' and shows a label without re-fetching.
+        mockGetAgentMessage.mockResolvedValueOnce({ message: undefined })
+        expect(await store.fetchMessageBySeq('w1', 'a1', 9n)).toBeUndefined()
+        // An RPC failure RETHROWS (rather than collapsing to undefined) so the caller can tell
+        // a transient blip from a real absence and retry instead of poisoning the preview.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mockGetAgentMessage.mockRejectedValueOnce(new Error('offline'))
+        await expect(store.fetchMessageBySeq('w1', 'a1', 9n)).rejects.toThrow('offline')
+        warn.mockRestore()
         dispose()
       })
     })

--- a/frontend/tests/unit/stores/chatLiveTail.test.ts
+++ b/frontend/tests/unit/stores/chatLiveTail.test.ts
@@ -124,12 +124,12 @@ describe('chatlivetail', () => {
     it('lowers to deletedSeq-1 for an unloaded beyond-window delete with an indeterminate (-1) tail', () => {
       withTracker((t) => {
         t.bump('a1', 60n)
-        // The worker degraded new_latest_seq to -1 (couldn't read the tail), but deletedSeq
+        // The worker left new_latest_seq unset (couldn't read the tail), but deletedSeq
         // (60) === the recorded tail, so it is the highest observed seq and the new tail is
         // provably <= 59. Lower to it rather than leaving the recorded tail pointing at the
         // now-deleted 60 (which would keep the "new messages below" affordance falsely lit
         // forever, since 60 can never load again).
-        t.onDelete('a1', { deletedSeq: 60n, newLatestSeq: -1n, windowTail: 30n })
+        t.onDelete('a1', { deletedSeq: 60n, newLatestSeq: undefined, windowTail: 30n })
         expect(t.get('a1')).toBe(59n)
       })
     })
@@ -137,21 +137,21 @@ describe('chatlivetail', () => {
     it('clears the caught-up gap when the window had loaded right up to the deleted unloaded tail', () => {
       withTracker((t) => {
         t.bump('a1', 31n) // the unloaded tail was 31; the window loaded up to 30
-        // 31 is deleted with an indeterminate (-1) tail. deletedSeq-1 = 30 == windowTail,
+        // 31 is deleted with an indeterminate (unset) tail. deletedSeq-1 = 30 == windowTail,
         // so the reader has now loaded everything that still exists: caughtUp must resolve
         // (recorded clamps to 30), not stay wedged at the deleted 31.
-        t.onDelete('a1', { deletedSeq: 31n, newLatestSeq: -1n, windowTail: 30n })
+        t.onDelete('a1', { deletedSeq: 31n, newLatestSeq: undefined, windowTail: 30n })
         expect(t.get('a1')).toBe(30n)
         expect(t.caughtUp('a1', 30n)).toBe(true)
       })
     })
 
-    it('uses the loaded window tail for a LOADED-tail delete with an indeterminate (-1) tail', () => {
+    it('uses the loaded window tail for a LOADED-tail delete with an indeterminate (unset) tail', () => {
       withTracker((t) => {
         t.bump('a1', 3n)
         // A loaded-tail delete can see the new last loaded row (windowTail), so an
-        // indeterminate broadcast falls back to it rather than the bogus -1.
-        t.onDelete('a1', { removedSeq: 3n, newLatestSeq: -1n, windowTail: 2n })
+        // indeterminate broadcast falls back to it rather than a missing tail.
+        t.onDelete('a1', { removedSeq: 3n, newLatestSeq: undefined, windowTail: 2n })
         expect(t.get('a1')).toBe(2n)
       })
     })

--- a/frontend/tests/unit/stores/chatMessageMarkSeeder.test.ts
+++ b/frontend/tests/unit/stores/chatMessageMarkSeeder.test.ts
@@ -1,0 +1,183 @@
+import type { listMessageMarks } from '~/api/workerRpc'
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it, vi } from 'vitest'
+import { ListMessageMarksResponseSchema, MarkType, MessageMarkSchema } from '~/generated/leapmux/v1/agent_pb'
+import { createMessageMarksStore } from '~/stores/chatMessageMarks'
+import { createMessageMarkSeeder, MAX_MESSAGE_MARK_SEED_RESCHEDULES } from '~/stores/chatMessageMarkSeeder'
+
+// Unit tests for the seed-race machine itself, driven directly against a FAKE
+// ListMessageMarks RPC + a REAL createMessageMarksStore (no mocked module, no whole
+// chat store). The store's chat.store.test.ts seed tests exercise the SAME machine
+// end-to-end through the delegating store.loadMessageMarks; these pin its retry /
+// revision-race / cancellation edges close to the source.
+
+/** A ListMessageMarks response; pass `undefined` min/max for an indeterminate seq range. */
+function marksResponse(seqs: bigint[], minSeq: bigint | undefined, maxSeq: bigint | undefined) {
+  return create(ListMessageMarksResponseSchema, {
+    marks: seqs.map(seq => create(MessageMarkSchema, { seq, type: MarkType.USER_MESSAGE })),
+    minSeq,
+    maxSeq,
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/** A fresh seeder over a real marks store with the RPC replaced by a controllable fake. */
+function harness() {
+  const rpc = vi.fn<typeof listMessageMarks>()
+  const marks = createMessageMarksStore()
+  const seeder = createMessageMarkSeeder({ listMessageMarks: rpc, marks })
+  return { rpc, marks, seeder }
+}
+
+describe('chatmessagemarkseeder', () => {
+  it('retries a first seed whose range stays indeterminate, then gives up after the bounded reschedules', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const { rpc, marks, seeder } = harness()
+      // Every response carries marks but an indeterminate (unset) seq range, so seed() keeps
+      // loaded=false. Without a cap this would reschedule a fetch every retry-delay forever.
+      rpc.mockResolvedValue(marksResponse([3n], undefined, undefined))
+
+      await seeder.load('w1', 'a1')
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(marks.get('a1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('message marks seed retry scheduled', {
+        agentId: 'a1',
+        reason: 'first seed range indeterminate',
+        rescheduleDepth: 0,
+      })
+
+      // Drive far more reschedule ticks than the cap allows; the chain must terminate.
+      for (let i = 0; i < 20; i++) {
+        await vi.runOnlyPendingTimersAsync()
+        await Promise.resolve()
+      }
+
+      // Bounded to MAX_MESSAGE_MARK_SEED_RESCHEDULES fetches total, then it gives up.
+      expect(rpc).toHaveBeenCalledTimes(MAX_MESSAGE_MARK_SEED_RESCHEDULES)
+      expect(marks.get('a1').loaded).toBe(false)
+      expect(warn).toHaveBeenCalledWith('message marks seed gave up after retries', expect.objectContaining({
+        agentId: 'a1',
+        reason: 'first seed range indeterminate',
+      }))
+      // No pending timer remains -- the poll has genuinely stopped, not just paused.
+      expect(vi.getTimerCount()).toBe(0)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-fetches when a live mark change races the in-flight seed instead of seeding the stale snapshot', async () => {
+    const { rpc, marks, seeder } = harness()
+    const inflight = deferred<Awaited<ReturnType<typeof listMessageMarks>>>()
+    rpc
+      .mockReturnValueOnce(inflight.promise)
+      .mockResolvedValueOnce(marksResponse([2n], 2n, 2n))
+
+    const load = seeder.load('w1', 'a1')
+    // A live mark lands while the FIRST snapshot is in flight, bumping the marks store's
+    // live-mutation revision. The seeder must discard the (now-stale) snapshot and re-fetch
+    // rather than seed the empty pre-mark response and drop the dot.
+    marks.noteMark('a1', 2n, MarkType.USER_MESSAGE)
+    inflight.resolve(marksResponse([], 0n, 0n))
+    await load
+
+    expect(rpc).toHaveBeenCalledTimes(2)
+    const data = marks.get('a1')
+    expect(data.loaded).toBe(true)
+    expect(data.marks.map(m => m.seq)).toEqual([2n])
+  })
+
+  it('stops the retry chain when the watch signal is aborted after a retry was scheduled', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const { rpc, marks, seeder } = harness()
+      const controller = new AbortController()
+      // An indeterminate first seed schedules a retry timer.
+      rpc.mockResolvedValue(marksResponse([3n], undefined, undefined))
+
+      await seeder.load('w1', 'a1', controller.signal)
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(1)
+
+      // The subscription tears down before the retry fires: the scheduled timer's callback
+      // must bail (its watchSignal guard) rather than re-issue the seed against a worker the
+      // reader navigated away from -- and no fresh timer is armed.
+      controller.abort()
+      await vi.runOnlyPendingTimersAsync()
+
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(marks.get('a1').loaded).toBe(false)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('a reseed with an empty workerId stops the pending retry chain (the worker is gone)', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const { rpc, seeder } = harness()
+      // A VALID first seed comes back indeterminate and arms a retry timer.
+      rpc.mockResolvedValue(marksResponse([3n], undefined, undefined))
+      await seeder.load('w1', 'a1')
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(1)
+
+      // A reseed with an EMPTY workerId means the agent's worker/tab is gone (getAgentTab returned
+      // undefined). That is the deliberate signal to STOP retrying -- the retry chain is cancelled
+      // and nothing is rescheduled, so the seeder never polls a worker the reader can't reach.
+      await seeder.load('', 'a1')
+      expect(vi.getTimerCount()).toBe(0) // the pending retry was cancelled
+      await vi.runOnlyPendingTimersAsync()
+      expect(rpc).toHaveBeenCalledTimes(1) // ...and never re-issued
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a pending retry timer when the agent is forgotten', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const { rpc, marks, seeder } = harness()
+      // An indeterminate first seed schedules a retry timer.
+      rpc.mockResolvedValue(marksResponse([3n], undefined, undefined))
+
+      await seeder.load('w1', 'a1')
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(1)
+
+      // Closing the agent cancels the pending retry outright (clearTimeout), not merely
+      // guarding it -- so the timer is gone immediately and never re-issues the seed.
+      seeder.forget('a1')
+      expect(vi.getTimerCount()).toBe(0)
+
+      await vi.runOnlyPendingTimersAsync()
+      expect(rpc).toHaveBeenCalledTimes(1)
+      expect(marks.get('a1').loaded).toBe(false)
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/tests/unit/stores/chatMessageMarks.test.ts
+++ b/frontend/tests/unit/stores/chatMessageMarks.test.ts
@@ -1,0 +1,227 @@
+import type { RailRangeInputs } from '~/stores/chatMessageMarks'
+import { createRoot } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { createMessageMarksStore, insertMarkSorted, removeMarkAt, resolveRailRange } from '~/stores/chatMessageMarks'
+
+/** Run a body with a fresh store inside a reactive root (its store needs an owner). */
+function withStore(body: (s: ReturnType<typeof createMessageMarksStore>) => void) {
+  createRoot((dispose) => {
+    body(createMessageMarksStore())
+    dispose()
+  })
+}
+
+const U = MarkType.USER_MESSAGE
+const C = MarkType.CONTROL_RESPONSE
+
+describe('chatmessagemarks', () => {
+  describe('pure helpers', () => {
+    it('insertMarkSorted keeps ascending order and is idempotent on a duplicate seq', () => {
+      let marks = insertMarkSorted([], 5n, U)
+      marks = insertMarkSorted(marks, 2n, U)
+      marks = insertMarkSorted(marks, 8n, C)
+      marks = insertMarkSorted(marks, 5n, U) // duplicate seq
+      expect(marks.map(m => m.seq)).toEqual([2n, 5n, 8n])
+      expect(marks.map(m => m.type)).toEqual([U, U, C])
+    })
+
+    it('insertMarkSorted returns the SAME reference when the seq is already present', () => {
+      const marks = insertMarkSorted([], 3n, U)
+      expect(insertMarkSorted(marks, 3n, U)).toBe(marks)
+    })
+
+    it('removeMarkAt drops the seq and returns the same reference when absent', () => {
+      const marks = insertMarkSorted(insertMarkSorted([], 1n, U), 2n, C)
+      expect(removeMarkAt(marks, 1n).map(m => m.seq)).toEqual([2n])
+      expect(removeMarkAt(marks, 99n)).toBe(marks)
+    })
+  })
+
+  describe('seed', () => {
+    it('replaces marks, sorts/dedupes, and records the range', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 8n, type: C }, { seq: 2n, type: U }, { seq: 8n, type: C }], 1n, 10n)
+        const st = s.get('a1')
+        expect(st.loaded).toBe(true)
+        expect(st.marks.map(m => m.seq)).toEqual([2n, 8n])
+        expect(st.minSeq).toBe(1n)
+        expect(st.seedMaxSeq).toBe(10n)
+      })
+    })
+
+    it('ignores an UNSET (indeterminate) range for min/max, keeping the prior values', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 3n, type: U }], 2n, 20n)
+        s.seed('a1', [{ seq: 3n, type: U }, { seq: 5n, type: U }], undefined, undefined)
+        const st = s.get('a1')
+        expect(st.minSeq).toBe(2n)
+        expect(st.seedMaxSeq).toBe(20n)
+        expect(st.marks.map(m => m.seq)).toEqual([3n, 5n])
+      })
+    })
+
+    it('stays unloaded when the FIRST seed has an indeterminate (unset) range, then loads on a good reseed', () => {
+      withStore((s) => {
+        // Worker DB error: marks came back but the min/max range is unset. Installing marks
+        // against the bogus 0n floor would mis-position every dot, so keep hidden.
+        s.seed('a1', [{ seq: 5n, type: U }], undefined, undefined)
+        expect(s.get('a1').loaded).toBe(false)
+        // A later good reseed heals it and reveals the rail.
+        s.seed('a1', [{ seq: 5n, type: U }], 4n, 8n)
+        expect(s.get('a1').loaded).toBe(true)
+        expect(s.get('a1').minSeq).toBe(4n)
+      })
+    })
+
+    it('preserves a live mark noted BEYOND the snapshot horizon across a reseed (reconnect race)', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 2n, type: U }], 1n, 5n)
+        // A send lands live (broadcast) AFTER the worker snapshotted ListMessageMarks but
+        // before its response applies -- noteMark records seq 9n, past the snapshot's max.
+        s.noteMark('a1', 9n, U)
+        // The slightly-stale reseed (max=5n, no 9n) must NOT drop the freshly-noted 9n dot.
+        s.seed('a1', [{ seq: 2n, type: U }], 1n, 5n)
+        expect(s.get('a1').marks.map(m => m.seq)).toEqual([2n, 9n])
+      })
+    })
+
+    it('a reseed still heals a delete WITHIN the snapshot horizon (wholesale replace at/below max)', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 2n, type: U }, { seq: 4n, type: U }], 1n, 5n)
+        // While disconnected, seq 4n's message was deleted. The reseed (which read the DB
+        // fresh, so 4n <= max is gone) drops it -- only marks BEYOND max are preserved.
+        s.seed('a1', [{ seq: 2n, type: U }], 1n, 5n)
+        expect(s.get('a1').marks.map(m => m.seq)).toEqual([2n])
+      })
+    })
+  })
+
+  describe('note mark', () => {
+    it('inserts a mark and preserves its type', () => {
+      withStore((s) => {
+        s.seed('a1', [], 1n, 5n)
+        s.noteMark('a1', 3n, C)
+        expect(s.get('a1').marks).toEqual([{ seq: 3n, type: C }])
+      })
+    })
+
+    it('rejects optimistic locals (seq 0n) and unmarked rows', () => {
+      withStore((s) => {
+        s.seed('a1', [], 1n, 5n)
+        s.noteMark('a1', 0n, U)
+        s.noteMark('a1', 4n, MarkType.UNSPECIFIED)
+        expect(s.get('a1').marks).toEqual([])
+      })
+    })
+
+    it('lowers minSeq when the agent was empty (first message of an empty agent)', () => {
+      withStore((s) => {
+        s.seed('a1', [], 0n, 0n) // empty agent
+        s.noteMark('a1', 7n, U)
+        expect(s.get('a1').minSeq).toBe(7n)
+      })
+    })
+
+    it('does not raise minSeq for a later seq', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 2n, type: U }], 2n, 5n)
+        s.noteMark('a1', 9n, U)
+        expect(s.get('a1').minSeq).toBe(2n)
+      })
+    })
+
+    it('bumps the live revision on a real insert but not on any no-op re-note, so a concurrent seed is not perturbed', () => {
+      withStore((s) => {
+        s.seed('a1', [], 1n, 5n)
+        const r0 = s.liveRevision('a1')
+        s.noteMark('a1', 3n, C) // a real insert
+        const r1 = s.liveRevision('a1')
+        expect(r1).toBeGreaterThan(r0)
+        s.noteMark('a1', 3n, C) // idempotent re-note of the same seq
+        s.noteMark('a1', 0n, U) // optimistic local, ignored
+        s.noteMark('a1', 4n, MarkType.UNSPECIFIED) // unmarked row, ignored
+        expect(s.liveRevision('a1')).toBe(r1) // none of the no-ops bumped the revision
+      })
+    })
+  })
+
+  describe('remove / forget', () => {
+    it('remove drops a mark; forget clears the agent (and its live-revision counter) entirely', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 2n, type: U }, { seq: 4n, type: C }], 1n, 5n)
+        s.remove('a1', 2n)
+        expect(s.get('a1').marks.map(m => m.seq)).toEqual([4n])
+        expect(s.liveRevision('a1')).toBeGreaterThan(0)
+        s.forget('a1')
+        // Back to the shared empty value (unseeded), and the live revision resets.
+        expect(s.get('a1').loaded).toBe(false)
+        expect(s.get('a1').marks).toEqual([])
+        expect(s.liveRevision('a1')).toBe(0)
+      })
+    })
+
+    it('bumps the live revision only when remove actually drops a mark, so an unmarked-row delete is not counted', () => {
+      withStore((s) => {
+        s.seed('a1', [{ seq: 2n, type: U }], 1n, 5n)
+        const r0 = s.liveRevision('a1')
+        s.remove('a1', 2n) // present -> dropped
+        const r1 = s.liveRevision('a1')
+        expect(r1).toBeGreaterThan(r0)
+        s.remove('a1', 2n) // already gone
+        s.remove('a1', 99n) // never marked
+        expect(s.liveRevision('a1')).toBe(r1) // neither no-op bumped the revision
+      })
+    })
+  })
+
+  describe('resolve rail range', () => {
+    /** resolveRailRange inputs with sensible defaults; override the field a case exercises. */
+    function inputs(overrides: Partial<RailRangeInputs> = {}): RailRangeInputs {
+      return {
+        seededMinSeq: 10n,
+        seedMaxSeq: 100n,
+        liveMaxSeq: 0n,
+        windowFirstSeq: undefined,
+        windowLastSeq: undefined,
+        hasOlderMessages: false,
+        ...overrides,
+      }
+    }
+
+    describe('min', () => {
+      it('uses the loaded window head as the exact whole-history min when the oldest page is loaded', () => {
+        expect(resolveRailRange(inputs({ hasOlderMessages: false, windowFirstSeq: 20n })).minSeq).toBe(20n)
+      })
+
+      it('falls back to the seeded min when the oldest is loaded but the window holds no server row', () => {
+        expect(resolveRailRange(inputs({ hasOlderMessages: false, windowFirstSeq: undefined })).minSeq).toBe(10n)
+      })
+
+      it('uses the seeded min (ignoring the window head) while older history remains off-window', () => {
+        expect(resolveRailRange(inputs({ hasOlderMessages: true, windowFirstSeq: 20n })).minSeq).toBe(10n)
+      })
+    })
+
+    describe('max', () => {
+      it('uses liveTail once populated (it rises past the window and falls on a tail delete)', () => {
+        expect(resolveRailRange(inputs({ liveMaxSeq: 150n, windowLastSeq: 140n })).maxSeq).toBe(150n)
+      })
+
+      it('falls back to the seed max before liveTail is populated', () => {
+        expect(resolveRailRange(inputs({ liveMaxSeq: 0n, seedMaxSeq: 100n, windowLastSeq: undefined })).maxSeq).toBe(100n)
+      })
+
+      it('lets the window tail win when rows persisted past the window before liveTail caught up', () => {
+        expect(resolveRailRange(inputs({ liveMaxSeq: 0n, seedMaxSeq: 100n, windowLastSeq: 120n })).maxSeq).toBe(120n)
+        // Even over a populated liveTail: the window tail is the freshest known max.
+        expect(resolveRailRange(inputs({ liveMaxSeq: 150n, windowLastSeq: 200n })).maxSeq).toBe(200n)
+      })
+
+      it('ignores a window tail at or below the seeded/live max (undefined or smaller)', () => {
+        expect(resolveRailRange(inputs({ liveMaxSeq: 150n, windowLastSeq: undefined })).maxSeq).toBe(150n)
+        expect(resolveRailRange(inputs({ liveMaxSeq: 150n, windowLastSeq: 150n })).maxSeq).toBe(150n)
+      })
+    })
+  })
+})

--- a/frontend/tests/unit/stores/chatMessageOrder.test.ts
+++ b/frontend/tests/unit/stores/chatMessageOrder.test.ts
@@ -186,6 +186,30 @@ describe('chatMessageOrder', () => {
       expect(next).toBe(prev)
     })
 
+    it('discards a duplicate seq in the MIDDLE of the window (binary-search dedup, not just the tail)', () => {
+      // The lower-bound probe must find a non-terminal duplicate, not only the last server row.
+      const prev = [msg('a', 1n), msg('b', 2n), msg('c', 3n)]
+      const { next, inserted } = applyFreshMessage(prev, msg('b-dup', 2n), undefined)
+      expect(inserted).toBe(false)
+      expect(next).toBe(prev)
+    })
+
+    it('discards a duplicate server seq while optimistic locals trail (dedup bounded to the server region)', () => {
+      // The dedup search is bounded to [0, serverEnd); a trailing seq-0n local must not be
+      // scanned as a server row nor let the duplicate slip through.
+      const prev = [msg('a', 1n), msg('b', 2n), msg('local-x', 0n)]
+      const { next, inserted } = applyFreshMessage(prev, msg('b-dup', 2n), undefined)
+      expect(inserted).toBe(false)
+      expect(next).toBe(prev)
+    })
+
+    it('inserts a fresh server message below the window head (lower-bound at index 0, no false dedup)', () => {
+      const prev = [msg('b', 2n), msg('c', 3n)]
+      const { next, inserted } = applyFreshMessage(prev, msg('a', 1n), undefined)
+      expect(inserted).toBe(true)
+      expect(ids(next)).toEqual(['a', 'b', 'c'])
+    })
+
     it('drops the reconciled local first, then lands the echo among server messages (not at the local index)', () => {
       // An earlier send (local-1) is still pending when a LATER send (local-2)
       // echoes first: substituting in place would strand local-1 mid-list. The

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -64,6 +64,19 @@ enum MessageSource {
   MESSAGE_SOURCE_LEAPMUX = 3;
 }
 
+// MarkType classifies a message as a notable jump target for the chat scroll
+// rail (teal dots the user clicks to jump). Set at write time by the worker so
+// the rail can enumerate marked seqs without decompressing message content.
+// Deliberately NOT user-scoped: future values may mark non-user messages worth
+// jumping to (e.g. errors, turn dividers).
+enum MarkType {
+  MARK_TYPE_UNSPECIFIED = 0;      // Not a jump mark.
+  MARK_TYPE_USER_MESSAGE = 1;     // A message the user typed and sent.
+  MARK_TYPE_CONTROL_RESPONSE = 2; // The user's answer to a control request
+                                  // (AskUserQuestion answers, ExitPlanMode
+                                  // approval, permission decisions).
+}
+
 // ContentCompression identifies the compression algorithm used for message content.
 enum ContentCompression {
   CONTENT_COMPRESSION_UNSPECIFIED = 0;
@@ -254,6 +267,9 @@ message AgentChatMessage {
   // Lets every consumer recognize a move EXPLICITLY instead of inferring it (the CLI
   // follower has no id memory; the frontend no longer has to guess from a seq change).
   int64 previous_seq = 15;
+  // Scroll-rail jump-mark classifier, set at write time. MARK_TYPE_UNSPECIFIED for
+  // ordinary rows. Carried on persisted rows, ListAgentMessages pages, and replays.
+  MarkType mark_type = 16;
 }
 
 message AgentStreamChunk {
@@ -377,12 +393,56 @@ message ListAgentMessagesResponse {
   // the `--follow` CLI resolve a resume point WITHOUT inferring it from the page's
   // content: when page 1 comes back empty it resumes after latest_seq instead of seq 0,
   // so a transient empty page on a populated agent can no longer collapse to the
-  // "drain the entire history from OLDEST" path. Sentinel (shared with
-  // CatchUpStart/Complete.latest_seq and AgentMessageDeleted.new_latest_seq): -1 = the
-  // worker couldn't determine it (a DB error) and the consumer skips reconciliation /
-  // falls back to its loaded cursor; 0 = the agent genuinely has no messages; >0 = the
-  // authoritative MAX(seq).
-  int64 latest_seq = 5;
+  // "drain the entire history from OLDEST" path. Explicit presence (the shared convention
+  // with CatchUpStart/Complete.latest_seq and AgentMessageDeleted.new_latest_seq): UNSET =
+  // the worker couldn't determine it (a DB error) and the consumer skips reconciliation /
+  // falls back to its loaded cursor; present 0 = the agent genuinely has no messages;
+  // present >0 = the authoritative MAX(seq).
+  optional int64 latest_seq = 5;
+}
+
+// GetAgentMessage fetches a SINGLE message by its per-agent seq. Used by the
+// chat scroll rail to preview a marked message on dot-hover when that message
+// is outside the loaded window (the rail spans the whole conversation, so the
+// hovered mark is usually not loaded). The seq is agent-scoped; the worker
+// verifies the caller may access the agent's workspace before reading, and the
+// lookup is scoped to agent_id, so no cross-agent/cross-workspace read is
+// possible.
+message GetAgentMessageRequest {
+  string agent_id = 1;
+  int64 seq = 2;
+}
+
+message GetAgentMessageResponse {
+  // The message at the requested seq, or unset when the agent has no message
+  // with that seq (deleted/reseq'd since the mark was recorded, or a closed
+  // agent). The client treats an unset message as "no preview available".
+  AgentChatMessage message = 1;
+}
+
+// ListMessageMarks returns the seqs of every marked message (scroll-rail jump
+// targets) plus the agent's whole-history seq range. Drives the chat scroll
+// rail: dot positions (marked seqs) and the seq-space track extent
+// (min_seq..max_seq). The frontend keeps the set updated incrementally from
+// live events; this seeds it and heals it after a reconnect.
+message ListMessageMarksRequest {
+  string agent_id = 1;
+}
+
+message MessageMark {
+  int64 seq = 1;
+  MarkType type = 2;
+}
+
+message ListMessageMarksResponse {
+  repeated MessageMark marks = 1; // Ascending by seq. May be empty.
+  // Lowest / highest live message seq. Explicit presence, the shared convention with
+  // ListAgentMessagesResponse.latest_seq: UNSET = the worker couldn't determine the
+  // range (a DB error; the client keeps its current value), present 0 = the agent
+  // genuinely has no messages, present >0 = the authoritative MIN/MAX(seq). Both are
+  // set or unset together (they come from one seq-range query).
+  optional int64 min_seq = 2;
+  optional int64 max_seq = 3;
 }
 
 // TodoItem is the provider-neutral to-do row used by the sidebar list and
@@ -455,11 +515,11 @@ message AgentMessageDeleted {
   // the recorded live tail, a windowed client sets its live-tail seq to exactly this
   // value instead of guessing seq - 1 -- so a delete of an unloaded beyond-window tail
   // can't strand the recorded tail above the true server max, and the next forward-fill
-  // resolves against the real tail rather than a conservative under-estimate. Sentinel
-  // (shared with latest_seq): -1 = the worker couldn't determine it (a DB error) and
-  // the client leaves its recorded tail unchanged; 0 = no messages remain; >0 = the
-  // authoritative MAX(seq).
-  int64 new_latest_seq = 4;
+  // resolves against the real tail rather than a conservative under-estimate. Explicit
+  // presence (shared with latest_seq): UNSET = the worker couldn't determine it (a DB
+  // error) and the client leaves its recorded tail unchanged; present 0 = no messages
+  // remain; present >0 = the authoritative MAX(seq).
+  optional int64 new_latest_seq = 4;
 }
 
 message DeleteAgentMessageRequest {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -249,11 +249,11 @@ message AgentEvent {
 // flashing until CatchUpComplete. CatchUpComplete repeats the reconcile as the final
 // authority after the burst.
 message CatchUpStart {
-  // The agent's authoritative live-tail seq at the moment replay began. Sentinel:
-  // -1 = the worker couldn't determine it (a DB error) and the client skips
-  // reconciliation; 0 = the agent genuinely has no messages; >0 = the authoritative
-  // MAX(seq).
-  int64 latest_seq = 1;
+  // The agent's authoritative live-tail seq at the moment replay began. Explicit
+  // presence: UNSET = the worker couldn't determine it (a DB error) and the client skips
+  // reconciliation; present 0 = the agent genuinely has no messages; present >0 = the
+  // authoritative MAX(seq).
+  optional int64 latest_seq = 1;
 }
 
 message CatchUpComplete {
@@ -262,10 +262,10 @@ message CatchUpComplete {
   // deleted meanwhile, so it reconciles here: it drops any loaded row whose seq exceeds
   // latest_seq (a tail deletion it missed) and clamps its recorded live-tail to this
   // value, so its "new messages below" affordance can't stay stuck past a now-shorter
-  // history. Sentinel: -1 = the worker couldn't determine it (a DB error) and the
-  // client skips reconciliation; 0 = the agent genuinely has no messages; >0 = the
-  // authoritative MAX(seq).
-  int64 latest_seq = 1;
+  // history. Explicit presence: UNSET = the worker couldn't determine it (a DB error) and
+  // the client skips reconciliation; present 0 = the agent genuinely has no messages;
+  // present >0 = the authoritative MAX(seq).
+  optional int64 latest_seq = 1;
   // The live-tail seq at the moment replay BEGAN (== CatchUpStart.latest_seq), repeated
   // here so the reconcile can tell a deleted-during-replay phantom from a live arrival.
   // The worker registers the watcher BEFORE reading latest_seq, so a message created and
@@ -274,9 +274,9 @@ message CatchUpComplete {
   // deleted-during-replay phantom sits at-or-below it. So the client reaps only the
   // (latest_seq, start_tail_seq] band and EXEMPTS rows above start_tail_seq (genuine live
   // arrivals), instead of reaping everything above latest_seq (which would wrongly drop
-  // them). Same -1/0/>0 sentinel as latest_seq; -1 disables the band exemption (the
+  // them). Same explicit presence as latest_seq; UNSET disables the band exemption (the
   // client falls back to reaping above latest_seq, matching the pre-field behavior).
-  int64 start_tail_seq = 2;
+  optional int64 start_tail_seq = 2;
 }
 
 message TerminalEvent {


### PR DESCRIPTION
## Motivation
The chat view's virtualized window only renders ~150 messages at a time, so the native browser scrollbar's thumb size/position is meaningless relative to the whole conversation — users have no way to see where their own messages or agent control-response prompts sit across a long history, or to jump to one that's scrolled out of the loaded window.

Separately, control-response handling had grown organically inside `service/control_response.go`: provider-specific wire-format knowledge for Codex/OpenCode/Cursor/Pi/ACP was baked into shared functions (`handleCodexPlanModePromptResponse`, `transformCursorControlResponse`, `normalizeProviderControlResponse`, ...), which is exactly the anti-pattern this codebase's provider-isolation convention exists to prevent. It also produced real bugs: the control request wasn't deleted consistently on every response path (a revised `control_request` could hide behind stale client-side dedup state), and plan-mode decisions were decoded from provider-rewritten forwarded bytes instead of the original envelope, breaking content-rewriting providers like Cursor's `createPlan`.

Finally, several proto fields used `-1` as a sentinel for "unknown/indeterminate," which is ambiguous with a genuine value of `0` (e.g. an empty history vs. a DB error) and made catch-up/live-tail/reconcile logic error-prone.

## Modifications

**Scroll rail (all new, frontend):**
- `ChatScrollRail.tsx` orchestrates a whole-conversation `[minSeq..maxSeq]` custom scrollbar with clustered teal jump dots, backed by `chatScrollRailGeometry.ts` (pure seq↔pixel math) and `chatRailPolicy.ts` (scrollbar-ownership, drawable-thumb gating, dot clustering, scrub hit-testing), with a one-way policy → geometry dependency.
- Extracted interaction units: `createThumbDrag`, `createDragReleaseHold`, `createRailMetrics`, `createDotPreview`, plus a `chatSeek.ts` seek machine (`jumpToSeq` / `previewScrollTo` / `cancelPendingSeek`).
- `resolveScrollbarOwner` is computed once in `ChatView` off a single content-box height, so the native scrollbar and the rail are structurally mutually exclusive (never zero, never two).
- All bigint → number conversions in geometry/policy fail closed (drop the dot / hide the thumb) at the `MAX_SAFE_INTEGER` boundary rather than silently rounding.

**Control responses (backend + frontend):**
- New `Provider` interface methods (`ResolveControlResponse`, `PlanApprovalOptions`, `IsSelfDisplayingControlTool`, `PlanModeControl`, `NeedsSyntheticInterruptNotice`) move all per-provider wire-format/normalization logic out of shared service code into `agent/control_response.go`, per the project's provider-isolation convention.
- Service flow rewritten around an explicit `controlResponsePlan` (`buildControlResponsePlan`) with a `classifyControlAnswerRow` classifier that guarantees exactly one row carries the `CONTROL_RESPONSE` rail mark (self-displayed, synthetic, or fallback) — never doubled, never missing.
- The control request is now deleted on every response path before persisting/forwarding (previously plan-prompt and fall-through diverged).
- The plan-mode decision is decoded from the original frontend content, not provider-rewritten forwarded bytes, so it stays correct for content-rewriting providers.
- `ControlBehaviorEnvelope`/`DecodeControlBehavior`/`NormalizeRejectionMessage` centralize the `{response:{request_id, response:{behavior, message}}}` wire shape and the `"Rejected by user."` placeholder rule; a matching `CONTROL_REJECTED_BY_USER_MESSAGE` frontend constant lets `buildDenyResponse`'s message param become optional, and Cursor's plan-reject path stops re-spelling the literal.

**Marks store & seed race (backend + frontend):**
- New `MarkType` enum (`UNSPECIFIED`/`USER_MESSAGE`/`CONTROL_RESPONSE`) persisted via a new `messages.mark_type` column and a partial covering index `idx_messages_mark_type`, with the value set at write time so the rail enumerates marks without decompressing content.
- New `GetAgentMessage` and `ListMessageMarks` RPCs (new sqlc queries `GetMessageByAgentIDAndSeq`, `ListMessageMarksByAgentID`, `GetSeqRangeByAgentID`) for dot-hover preview and whole-history mark enumeration.
- `createMessageMarksStore` (per-agent marked seqs + seq range) and `createMessageMarkSeeder` (a single global monotonic epoch fencing seed races against close/reopen, tied to `WatchEvents`' watch signal, with bounded retry/reschedule).
- Mark-preview extraction (`chatMarkPreview.ts`) routes through each message's own provider via a new `Provider.previewText` plugin hook (sibling of `extractQuotableText`), with a shared `defaultMarkPreview` fallback (`markPreviewShared.ts`) and a 500-entry-per-agent eviction cache.

**Explicit-presence seq ranges (proto):**
- `-1`-sentinel fields (`ListAgentMessagesResponse.latest_seq`, `AgentMessageDeleted.new_latest_seq`, `CatchUpStart`/`CatchUpComplete.latest_seq` + `start_tail_seq`) migrated to `optional int64` explicit presence; new `ListMessageMarksResponse.min_seq`/`max_seq` follow the same convention. Unset now unambiguously means "indeterminate (DB error)"; present-zero means "genuinely empty." `maxSeqOrIndeterminate` (returning `-1`) became `maxSeqOrNil` (`*int64`); CLI `resumeCursorFor` now takes `*int64`.
- This is a pre-release project with no external consumers, so the proto field changes and the new DB column/index are not treated as breaking changes.

**Shared helpers:**
- `frontend/src/lib/binarySearch.ts` (`largestIndexWhere`, `smallestIndexWhere`, `lowerBoundBySeq`) replaces hand-rolled off-by-one scans in `insertServerBySeq` and `applyFreshMessage` dedup, and backs the marks store and rail lookups.
- Grapheme-aware `textTruncate` extracted to `lib/` for reuse between the transcript row and rail dot preview.
- New `jumpToMessagesAroundSeq` paginator runs two disjoint anchored fetches (`BEFORE`/`AFTER`/`LATEST`) in parallel and concatenates them into one contiguous window centered on a target seq.

## Result
- The chat view now shows an accurate, whole-conversation scrollbar with clustered jump dots for your own messages and agent control-response prompts, and lets you jump straight to any of them — including ones outside the currently loaded window — via hover preview and click.
- A control-response answer is recorded exactly once on the rail; a revised `control_request` from the agent can no longer hide behind stale client-side dedup state, and plan-mode effects are ordered after the answer is durably persisted.
- A bare Cursor plan-reject no longer leaks the literal `"Rejected by user."` placeholder as typed feedback.
- Catch-up, live-tail, and marks-range code can now distinguish "we don't know yet" from "genuinely zero," removing a class of latent misinterpretation bugs around DB errors vs. empty history.
- Message dedup/insert on the sliding chat window moved from O(n) linear scans to binary search, and the single-flight catch-up slot is no longer clobbered by an aborted `finally`, preventing redundant catch-up loops.
