### PR TITLE
feat(chat): Persist control responses with instance-scoped dedup

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -2986,8 +2986,8 @@ func (b *acpBase) handleRequestPermission(id string, content []byte) {
 		slog.Warn("acp requestPermission missing id", "agent_id", b.agentID)
 		return
 	}
-	b.sink.PersistControlRequest(id, content)
-	b.sink.BroadcastControlRequest(id, content)
+	claimToken := b.sink.PersistControlRequest(id, content)
+	b.sink.BroadcastControlRequest(id, content, claimToken)
 }
 
 // handleOutput dispatches a single parsed output line using the provider's

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -82,9 +82,16 @@ type OutputSink interface {
 	ReserveSpanColor(spanID, parentSpanID string) int32
 	BroadcastStreamChunk(content []byte, spanID string, method string)
 	BroadcastStreamEnd(spanID string)
-	PersistControlRequest(requestID string, payload []byte)
+	// PersistControlRequest stores the pending control request and returns the fresh per-instance
+	// claim_token it minted for it. The caller threads that token straight into the paired
+	// BroadcastControlRequest so the live broadcast carries the SAME token that was persisted --
+	// without a second DB round-trip to read it back (and without the readback-failure window that
+	// would broadcast an empty token). Empty only when the sink mints none (test fakes).
+	PersistControlRequest(requestID string, payload []byte) (claimToken string)
 	DeleteControlRequest(requestID string)
-	BroadcastControlRequest(requestID string, payload []byte)
+	// BroadcastControlRequest fans the control request out to live windows, carrying the claim_token
+	// PersistControlRequest returned so the frontend can echo it in its answer (AgentControlRequest.claim_token).
+	BroadcastControlRequest(requestID string, payload []byte, claimToken string)
 	BroadcastControlCancel(requestID string)
 	UpdateSessionID(sessionID string)
 	UpdatePermissionMode(mode string)

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -610,8 +610,8 @@ func (a *ClaudeCodeAgent) claudeCodeHandleControlRequest(content []byte) {
 		slog.Warn("invalid control_request JSON", "agent_id", a.agentID, "error", err)
 		return
 	}
-	a.sink.PersistControlRequest(cr.RequestID, content)
-	a.sink.BroadcastControlRequest(cr.RequestID, content)
+	claimToken := a.sink.PersistControlRequest(cr.RequestID, content)
+	a.sink.BroadcastControlRequest(cr.RequestID, content, claimToken)
 }
 
 // claudeCodeHandleControlCancel persists and broadcasts a control_cancel_request.

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -519,8 +519,8 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 				},
 			})
 			if err == nil {
-				a.sink.PersistControlRequest(requestID, payload)
-				a.sink.BroadcastControlRequest(requestID, payload)
+				claimToken := a.sink.PersistControlRequest(requestID, payload)
+				a.sink.BroadcastControlRequest(requestID, payload, claimToken)
 			}
 		}
 	}
@@ -602,8 +602,8 @@ func (a *CodexAgent) handleApprovalRequest(id string, content []byte) {
 		slog.Warn("codex approval request missing id", "agent_id", a.agentID)
 		return
 	}
-	a.sink.PersistControlRequest(id, content)
-	a.sink.BroadcastControlRequest(id, content)
+	claimToken := a.sink.PersistControlRequest(id, content)
+	a.sink.BroadcastControlRequest(id, content, claimToken)
 }
 
 // handleServerRequestResolved processes serverRequest/resolved notifications.

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -81,6 +81,13 @@ func TestHandleCodexOutput_RequestUserInput(t *testing.T) {
 	rec := sink.LastPersistedControl()
 	assert.Equal(t, "42", rec.RequestID)
 
+	// The claim token PersistControlRequest returns is threaded straight into the paired
+	// BroadcastControlRequest (no readback), so the live broadcast carries the SAME token that was
+	// persisted -- the token the frontend echoes in its idempotency claim.
+	bcast := sink.LastBroadcastControl()
+	assert.NotEmpty(t, rec.ClaimToken, "persist mints a claim token")
+	assert.Equal(t, rec.ClaimToken, bcast.ClaimToken, "the broadcast carries the token persist returned")
+
 	// Verify payload is the original content.
 	var parsed struct {
 		Method string `json:"method"`

--- a/backend/internal/worker/agent/control_response.go
+++ b/backend/internal/worker/agent/control_response.go
@@ -2,9 +2,7 @@ package agent
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -14,19 +12,24 @@ import (
 // control response. The service loads the stored control request once, extracts the
 // shared metadata, and passes both payloads here; providers must not perform I/O.
 type ControlResponseContext struct {
-	RequestID       string
 	RequestPayload  json.RawMessage
 	ResponseContent []byte
 	ToolName        string
-	ToolUseID       string
 }
 
 // ControlResponseResolution is the provider-owned interpretation of a control
-// response. The service executes side effects from this plan: it persists display
-// rows, deletes control requests, mutates plan-mode settings, and forwards Content.
+// response. The service executes side effects from this plan: it persists the
+// structured control-response row, deletes control requests, mutates plan-mode
+// settings, and forwards Content.
 type ControlResponseResolution struct {
-	Content         []byte
-	DisplayText     string
+	Content []byte
+	// RequestContext is the provider-pruned minimal request context persisted alongside the
+	// native response so the frontend can render the answer AFTER the pending control request is
+	// deleted (permission option names, question headers, the request method, ...). Provider code
+	// owns the pruning -- what each wire shape keeps stays in that provider's resolver, never in
+	// shared service code. Nil when the stored request is unavailable or unrecognized, in which
+	// case the row persists with `request` omitted and the frontend degrades gracefully.
+	RequestContext  json.RawMessage
 	SelfDisplayed   bool
 	PlanModeControl PlanModeControlKind
 }
@@ -45,22 +48,7 @@ func (p codexProvider) ResolveControlResponse(ctx ControlResponseContext) Contro
 		return res
 	}
 	res.PlanModeControl = p.PlanModeControl(ctx.ToolName)
-
-	var req struct {
-		Method string `json:"method"`
-	}
-	if !warnUnmarshal(ctx.RequestPayload, &req, "codex control response request") {
-		return res
-	}
-	if req.Method == "item/tool/requestUserInput" {
-		res.DisplayText = codexUserInputAnswersText(ctx.RequestPayload, ctx.ResponseContent)
-		return res
-	}
-	if text := codexFeedbackMessageText(ctx.ResponseContent); text != "" {
-		res.DisplayText = text
-		return res
-	}
-	res.DisplayText = codexDecisionDisplayText(ctx.ResponseContent)
+	res.RequestContext = codexControlRequestContext(ctx.RequestPayload)
 	return res
 }
 
@@ -68,6 +56,9 @@ func (p claudeProvider) ResolveControlResponse(ctx ControlResponseContext) Contr
 	res := defaultControlResponseResolution(ctx)
 	res.SelfDisplayed = p.IsSelfDisplayingControlTool(ctx.ToolName)
 	res.PlanModeControl = p.PlanModeControl(ctx.ToolName)
+	// The tool name is all the frontend needs to render Claude's approve/reject/feedback answer;
+	// the behavior itself lives in the native response payload.
+	res.RequestContext = toolNameRequestContext(ctx.ToolName)
 	return res
 }
 
@@ -82,7 +73,7 @@ func (p piProvider) ResolveControlResponse(ctx ControlResponseContext) ControlRe
 	if !warnUnmarshal(ctx.RequestPayload, &req, "pi control response request") {
 		return res
 	}
-	res.DisplayText = piExtensionUIResponseDisplayText(req.Method, ctx.ResponseContent)
+	res.RequestContext = methodRequestContext(req.Method)
 	return res
 }
 
@@ -106,27 +97,29 @@ func (p acpProvider) ResolveControlResponse(ctx ControlResponseContext) ControlR
 	if p.provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR {
 		switch req.Method {
 		case CursorMethodAskQuestion:
-			res.DisplayText = cursorQuestionAnswersText(ctx.RequestPayload, ctx.ResponseContent)
+			res.RequestContext = cursorQuestionRequestContext(ctx.RequestPayload)
 			return res
 		case CursorMethodCreatePlan:
-			if transformed, text, ok := transformCursorControlResponse(ctx.RequestPayload, ctx.ResponseContent); ok {
+			if transformed, ok := transformCursorControlResponse(ctx.RequestPayload, ctx.ResponseContent); ok {
+				// Persist the TRANSFORMED outcome that was forwarded to the agent -- the frontend
+				// renders the plan decision (Accept / Reject / Cancel) from result.outcome alone.
 				res.Content = transformed
-				res.DisplayText = text
+				res.RequestContext = methodRequestContext(req.Method)
 				return res
 			}
 		}
 	}
 
-	// The OpenCode-protocol `question.asked` answer summary dispatches through a registration-time
+	// The OpenCode-protocol `question.asked` request context dispatches through a registration-time
 	// hook (set only for the providers that speak that protocol, see init()) rather than a provider
 	// enum allowlist -- so the membership lives at the single registration site, mirroring the
 	// frontend's registerOpenCodeProtocolProvider, not a second source of truth that drifts.
-	if p.questionAnswersText != nil && req.Type == "question.asked" {
-		res.DisplayText = p.questionAnswersText(ctx.RequestPayload, ctx.ResponseContent)
+	if p.questionRequestContext != nil && req.Type == "question.asked" {
+		res.RequestContext = p.questionRequestContext(ctx.RequestPayload)
 		return res
 	}
 
-	res.DisplayText = acpPermissionResponseDisplayText(ctx.RequestPayload, ctx.ResponseContent)
+	res.RequestContext = acpPermissionRequestContext(ctx.RequestPayload)
 	return res
 }
 
@@ -141,111 +134,99 @@ func warnUnmarshal(data []byte, v any, label string) bool {
 	return true
 }
 
-// firstNonEmpty returns the first argument that is non-empty after trimming surrounding
-// whitespace, or "" when all are blank. Centralizes the "prefer this label, else fall back to
-// that one" idiom the answer summaries repeat -- and, because it trims the fallback too, a
-// display label chosen from a fallback never renders with stray whitespace.
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if t := strings.TrimSpace(v); t != "" {
-			return t
-		}
+// marshalControlRequestContext encodes a provider-pruned request-context projection into the
+// bytes persisted under the synthetic row's `request` field, returning nil (which omits `request`)
+// when the value can't be encoded. The single home for the marshal-and-warn tail every context
+// builder shares.
+func marshalControlRequestContext(v any) json.RawMessage {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		slog.Warn("marshal control request context failed", "error", err)
+		return nil
 	}
-	return ""
+	return encoded
 }
 
-// labeledAnswerLine formats one "label: v1, v2" answer line, trimming each value and dropping the
-// empties; ok is false when no value survives (the caller skips the line). The single home for the
-// per-line answer formatting the codex / opencode / cursor answer summaries all repeat, so a change
-// to the separator or the empty-value rule happens once.
-func labeledAnswerLine(label string, values []string) (string, bool) {
-	parts := make([]string, 0, len(values))
-	for _, v := range values {
-		if t := strings.TrimSpace(v); t != "" {
-			parts = append(parts, t)
-		}
+// projectRequestContext decodes a stored control request into the pruned projection dst (a pointer to
+// a projection struct), then re-marshals dst as the persisted request context -- the
+// decode->warn->remarshal glue the per-provider question pruners share, so each caller's struct
+// declaration stays the single spec of what survives. Nil when the payload doesn't parse
+// (warnUnmarshal logs the reason).
+func projectRequestContext(requestPayload []byte, dst any, label string) json.RawMessage {
+	if !warnUnmarshal(requestPayload, dst, label) {
+		return nil
 	}
-	if len(parts) == 0 {
-		return "", false
-	}
-	return fmt.Sprintf("%s: %s", label, strings.Join(parts, ", ")), true
+	return marshalControlRequestContext(dst)
 }
 
-func codexUserInputAnswersText(requestPayload, responseContent []byte) string {
+// methodRequestContext is the pruned request context for a request whose only render-relevant
+// field is its method (Codex approvals, Pi extension UI, Cursor create-plan): {"method": ...}.
+// Nil when the method is blank.
+func methodRequestContext(method string) json.RawMessage {
+	if strings.TrimSpace(method) == "" {
+		return nil
+	}
+	return marshalControlRequestContext(struct {
+		Method string `json:"method"`
+	}{Method: method})
+}
+
+// toolNameRequestContext is the pruned request context for a Claude-style control request (Claude
+// permission tools, the synthesized Codex plan-mode prompt): {"request": {"tool_name": ...}}, which
+// is all the frontend needs to render Approved / Rejected / feedback. Nil when the tool name is
+// blank.
+func toolNameRequestContext(toolName string) json.RawMessage {
+	if strings.TrimSpace(toolName) == "" {
+		return nil
+	}
+	var ctx struct {
+		Request struct {
+			ToolName string `json:"tool_name"`
+		} `json:"request"`
+	}
+	ctx.Request.ToolName = toolName
+	return marshalControlRequestContext(ctx)
+}
+
+// codexControlRequestContext prunes a stored Codex control request to the minimal context the
+// frontend needs to render the answer: the question definitions for requestUserInput, the tool
+// name for the synthesized plan-mode prompt, or just the method for a command-approval request.
+// Nil when nothing render-relevant survives.
+func codexControlRequestContext(requestPayload []byte) json.RawMessage {
 	var req struct {
+		Method  string `json:"method"`
+		Request struct {
+			ToolName string `json:"tool_name"`
+		} `json:"request"`
+	}
+	if !warnUnmarshal(requestPayload, &req, "codex control request context") {
+		return nil
+	}
+	if req.Method == "item/tool/requestUserInput" {
+		return codexUserInputRequestContext(requestPayload)
+	}
+	if req.Method != "" {
+		return methodRequestContext(req.Method)
+	}
+	// The plan-mode prompt is a synthesized Claude-style frame with no top-level method; its
+	// request.tool_name (CodexPlanModePrompt) is what the frontend keys the plan answer off.
+	return toolNameRequestContext(req.Request.ToolName)
+}
+
+// codexUserInputRequestContext keeps the requestUserInput question definitions (id + header) the
+// frontend maps its answer values onto. It unmarshals the stored request into the projection shape
+// and re-marshals it, so the struct declaration is the single spec of what survives.
+func codexUserInputRequestContext(requestPayload []byte) json.RawMessage {
+	var req struct {
+		Method string `json:"method"`
 		Params struct {
 			Questions []struct {
-				ID     string `json:"id"`
-				Header string `json:"header"`
+				ID     string `json:"id,omitempty"`
+				Header string `json:"header,omitempty"`
 			} `json:"questions"`
 		} `json:"params"`
 	}
-	var resp struct {
-		Result struct {
-			Answers map[string]struct {
-				Answers []string `json:"answers"`
-			} `json:"answers"`
-		} `json:"result"`
-	}
-	if !warnUnmarshal(requestPayload, &req, "codex user input request") {
-		return ""
-	}
-	if !warnUnmarshal(responseContent, &resp, "codex user input response") {
-		return ""
-	}
-
-	if len(resp.Result.Answers) == 0 {
-		return ""
-	}
-
-	labels := make(map[string]string, len(req.Params.Questions))
-	order := make([]string, 0, len(req.Params.Questions))
-	for _, q := range req.Params.Questions {
-		key := firstNonEmpty(q.ID, q.Header)
-		if key == "" {
-			continue
-		}
-		labels[key] = firstNonEmpty(q.Header, key)
-		order = append(order, key)
-	}
-
-	lines := make([]string, 0, len(resp.Result.Answers))
-	seen := make(map[string]bool, len(resp.Result.Answers))
-	appendLine := func(key string) {
-		answer, ok := resp.Result.Answers[key]
-		if !ok || seen[key] {
-			return
-		}
-		// seen is set ONLY when a non-empty line is emitted, so the empty-filter and the dedup
-		// stay entangled -- an all-empty answer neither renders nor marks the key seen.
-		if line, ok := labeledAnswerLine(labels[key], answer.Answers); ok {
-			lines = append(lines, line)
-			seen[key] = true
-		}
-	}
-
-	for _, key := range order {
-		appendLine(key)
-	}
-	// Any answer whose key wasn't in the request's questions is absent from `order`. Append
-	// these in a STABLE (sorted) order rather than Go's randomized map-iteration order, so the
-	// same control response always renders the same lines (a map range would reorder them
-	// nondeterministically between renders).
-	extraKeys := make([]string, 0, len(resp.Result.Answers))
-	for key := range resp.Result.Answers {
-		if !seen[key] {
-			extraKeys = append(extraKeys, key)
-		}
-	}
-	sort.Strings(extraKeys)
-	for _, key := range extraKeys {
-		if _, ok := labels[key]; !ok {
-			labels[key] = key
-		}
-		appendLine(key)
-	}
-
-	return strings.Join(lines, "\n")
+	return projectRequestContext(requestPayload, &req, "codex user input request context")
 }
 
 // ControlBehaviorEnvelope is the frontend's neutral approve/reject control-response envelope --
@@ -294,232 +275,91 @@ func NormalizeRejectionMessage(message string) string {
 	return message
 }
 
-func codexFeedbackMessageText(responseContent []byte) string {
-	_, _, message, _ := DecodeControlBehavior(responseContent)
-	return message
-}
-
-func codexDecisionDisplayText(responseContent []byte) string {
-	var resp struct {
-		Result struct {
-			Decision json.RawMessage `json:"decision"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil || len(resp.Result.Decision) == 0 || string(resp.Result.Decision) == "null" {
-		return ""
-	}
-
-	var decision string
-	if err := json.Unmarshal(resp.Result.Decision, &decision); err == nil {
-		switch strings.TrimSpace(decision) {
-		case "accept":
-			return "Allow"
-		case "acceptForSession":
-			return "Allow for Session"
-		case "decline":
-			return "Reject"
-		case "cancel":
-			return "Cancel"
-		default:
-			return strings.TrimSpace(decision)
-		}
-	}
-
-	var objectDecision map[string]json.RawMessage
-	if err := json.Unmarshal(resp.Result.Decision, &objectDecision); err != nil {
-		return ""
-	}
-	if _, ok := objectDecision["acceptWithExecpolicyAmendment"]; ok {
-		return "Allow & Remember"
-	}
-	if _, ok := objectDecision["applyNetworkPolicyAmendment"]; ok {
-		return "Apply Network Policy"
-	}
-	if len(objectDecision) > 0 {
-		return "Allow"
-	}
-	return ""
-}
-
-func opencodeQuestionAnswersText(requestPayload, responseContent []byte) string {
+// opencodeQuestionRequestContext keeps the OpenCode-protocol `question.asked` question definitions
+// (header + question) the frontend labels its answer values with. Registered as the ACP
+// questionRequestContext hook for the providers that speak that protocol (OpenCode, Kilo).
+func opencodeQuestionRequestContext(requestPayload []byte) json.RawMessage {
 	var req struct {
+		Type       string `json:"type"`
 		Properties struct {
 			Questions []struct {
-				Header   string `json:"header"`
-				Question string `json:"question"`
+				Header   string `json:"header,omitempty"`
+				Question string `json:"question,omitempty"`
 			} `json:"questions"`
 		} `json:"properties"`
 	}
-	var resp struct {
-		Result struct {
-			Rejected bool       `json:"rejected"`
-			Answers  [][]string `json:"answers"`
-		} `json:"result"`
-	}
-	if !warnUnmarshal(requestPayload, &req, "opencode question request") {
-		return ""
-	}
-	if !warnUnmarshal(responseContent, &resp, "opencode question response") {
-		return ""
-	}
-	if resp.Result.Rejected {
-		return "Reject"
-	}
-
-	lines := make([]string, 0, len(resp.Result.Answers))
-	for i, answers := range resp.Result.Answers {
-		label := fmt.Sprintf("Question %d", i+1)
-		if i < len(req.Properties.Questions) {
-			q := req.Properties.Questions[i]
-			if v := firstNonEmpty(q.Header, q.Question); v != "" {
-				label = v
-			}
-		}
-		if line, ok := labeledAnswerLine(label, answers); ok {
-			lines = append(lines, line)
-		}
-	}
-	return strings.Join(lines, "\n")
+	return projectRequestContext(requestPayload, &req, "opencode question request context")
 }
 
-func cursorQuestionAnswersText(requestPayload, responseContent []byte) string {
+// cursorQuestionRequestContext keeps the Cursor ask_question definitions (id + prompt + the option
+// id/label map) the frontend needs to render selected options as their labels.
+func cursorQuestionRequestContext(requestPayload []byte) json.RawMessage {
 	var req struct {
+		Method string `json:"method"`
 		Params struct {
 			Questions []struct {
-				ID      string `json:"id"`
-				Prompt  string `json:"prompt"`
+				ID      string `json:"id,omitempty"`
+				Prompt  string `json:"prompt,omitempty"`
 				Options []struct {
-					ID    string `json:"id"`
-					Label string `json:"label"`
-				} `json:"options"`
+					ID    string `json:"id,omitempty"`
+					Label string `json:"label,omitempty"`
+				} `json:"options,omitempty"`
 			} `json:"questions"`
 		} `json:"params"`
 	}
-	var resp struct {
-		Result struct {
-			Outcome struct {
-				Outcome string `json:"outcome"`
-				Reason  string `json:"reason"`
-				Answers []struct {
-					QuestionID        string   `json:"questionId"`
-					SelectedOptionIDs []string `json:"selectedOptionIds"`
-				} `json:"answers"`
-			} `json:"outcome"`
-		} `json:"result"`
-	}
-	if !warnUnmarshal(requestPayload, &req, "cursor question request") {
-		return ""
-	}
-	if !warnUnmarshal(responseContent, &resp, "cursor question response") {
-		return ""
-	}
-
-	switch resp.Result.Outcome.Outcome {
-	case "answered":
-		labels := make(map[string]string, len(req.Params.Questions))
-		optionLabels := make(map[string]map[string]string, len(req.Params.Questions))
-		order := make([]string, 0, len(req.Params.Questions))
-		for _, q := range req.Params.Questions {
-			if strings.TrimSpace(q.ID) == "" {
-				continue
-			}
-			labels[q.ID] = strings.TrimSpace(q.Prompt)
-			options := make(map[string]string, len(q.Options))
-			for _, option := range q.Options {
-				if strings.TrimSpace(option.ID) == "" {
-					continue
-				}
-				options[option.ID] = firstNonEmpty(option.Label, option.ID)
-			}
-			optionLabels[q.ID] = options
-			order = append(order, q.ID)
-		}
-
-		answerByQuestion := make(map[string][]string, len(resp.Result.Outcome.Answers))
-		for _, answer := range resp.Result.Outcome.Answers {
-			if strings.TrimSpace(answer.QuestionID) == "" {
-				continue
-			}
-			mapped := make([]string, 0, len(answer.SelectedOptionIDs))
-			for _, optionID := range answer.SelectedOptionIDs {
-				optionID = strings.TrimSpace(optionID)
-				if optionID == "" {
-					continue
-				}
-				label := optionID
-				if options := optionLabels[answer.QuestionID]; options != nil {
-					if mappedLabel := strings.TrimSpace(options[optionID]); mappedLabel != "" {
-						label = mappedLabel
-					}
-				}
-				mapped = append(mapped, label)
-			}
-			if len(mapped) > 0 {
-				answerByQuestion[answer.QuestionID] = mapped
-			}
-		}
-
-		lines := make([]string, 0, len(answerByQuestion))
-		for _, questionID := range order {
-			mapped := answerByQuestion[questionID]
-			if len(mapped) == 0 {
-				continue
-			}
-			label := firstNonEmpty(labels[questionID], questionID)
-			if line, ok := labeledAnswerLine(label, mapped); ok {
-				lines = append(lines, line)
-			}
-		}
-		return strings.Join(lines, "\n")
-	case "cancelled", "skipped":
-		return strings.TrimSpace(resp.Result.Outcome.Reason)
-	default:
-		return ""
-	}
+	return projectRequestContext(requestPayload, &req, "cursor question request context")
 }
 
-func cursorCreatePlanDisplayText(outcome, reason string) string {
-	switch outcome {
-	case "accepted":
-		return "Accept"
-	case "rejected":
-		if reason := strings.TrimSpace(reason); reason != "" {
-			return reason
-		}
-		return "Reject"
-	case "cancelled":
-		if reason := strings.TrimSpace(reason); reason != "" {
-			return reason
-		}
-		return "Cancel"
-	default:
-		return ""
+// acpPermissionRequestContext keeps the ACP permission options (optionId + name) the frontend
+// matches the selected optionId against to render its label. When the request carries no options
+// (e.g. a create-plan request that failed the Cursor transform and fell through here), it degrades
+// to method-only context, or nil when even the method is absent.
+func acpPermissionRequestContext(requestPayload []byte) json.RawMessage {
+	var req struct {
+		Method string `json:"method"`
+		Params struct {
+			Options []struct {
+				OptionID string `json:"optionId"`
+				Name     string `json:"name,omitempty"`
+			} `json:"options"`
+		} `json:"params"`
 	}
+	if !warnUnmarshal(requestPayload, &req, "acp permission request context") {
+		return nil
+	}
+	if len(req.Params.Options) == 0 {
+		return methodRequestContext(req.Method)
+	}
+	return marshalControlRequestContext(req)
 }
 
-func transformCursorControlResponse(requestPayload, responseContent []byte) ([]byte, string, bool) {
+// transformCursorControlResponse rewrites the frontend's neutral approve/reject envelope for a
+// Cursor create-plan control request into the ACP outcome Cursor expects on its stdin, returning
+// ok=false (and the caller forwards the response unchanged) when the bytes aren't a create-plan
+// decision that matches the stored request id.
+func transformCursorControlResponse(requestPayload, responseContent []byte) ([]byte, bool) {
 	var req struct {
 		Method string `json:"method"`
 	}
 	if !warnUnmarshal(requestPayload, &req, "cursor control response method") {
-		return nil, "", false
+		return nil, false
 	}
 	if req.Method != CursorMethodCreatePlan {
-		return nil, "", false
+		return nil, false
 	}
 
 	respRequestID, behavior, message, ok := DecodeControlBehavior(responseContent)
 	if !ok {
-		return nil, "", false
+		return nil, false
 	}
 
 	idRaw, requestID, ok := ExtractJSONRPCID(requestPayload)
 	if !ok {
-		return nil, "", false
+		return nil, false
 	}
 
 	if respRequestID == "" || respRequestID != requestID {
-		return nil, "", false
+		return nil, false
 	}
 
 	outcome := "accepted"
@@ -532,7 +372,7 @@ func transformCursorControlResponse(requestPayload, responseContent []byte) ([]b
 		// to "" by DecodeControlBehavior, so a bare rejection carries no reason.
 		reason = message
 	default:
-		return nil, "", false
+		return nil, false
 	}
 
 	outcomeBody := map[string]interface{}{
@@ -548,88 +388,7 @@ func transformCursorControlResponse(requestPayload, responseContent []byte) ([]b
 		"result":  map[string]interface{}{"outcome": outcomeBody},
 	})
 	if err != nil {
-		return nil, "", false
+		return nil, false
 	}
-	return encoded, cursorCreatePlanDisplayText(outcome, reason), true
-}
-
-// piExtensionUIResponseDisplayText extracts a human-readable summary of a Pi
-// extension_ui_response so the user's choice shows up as a synthetic message
-// in the transcript.
-func piExtensionUIResponseDisplayText(method string, responseContent []byte) string {
-	var resp struct {
-		Cancelled bool   `json:"cancelled"`
-		Confirmed *bool  `json:"confirmed"`
-		Value     string `json:"value"`
-	}
-	if err := json.Unmarshal(responseContent, &resp); err != nil {
-		return ""
-	}
-
-	if resp.Cancelled {
-		return "Cancelled"
-	}
-
-	switch method {
-	case PiDialogMethodConfirm:
-		if resp.Confirmed != nil && *resp.Confirmed {
-			return "Approve"
-		}
-		return "Deny"
-	case PiDialogMethodSelect, PiDialogMethodInput, PiDialogMethodEditor:
-		return strings.TrimSpace(resp.Value)
-	default:
-		return ""
-	}
-}
-
-// acpPermissionResponseDisplayText extracts a human-readable display text from
-// an ACP permission response by matching the selected optionId against the
-// original request payload's option list.
-func acpPermissionResponseDisplayText(requestPayload, responseContent []byte) string {
-	var req struct {
-		Params struct {
-			Options []struct {
-				OptionID string `json:"optionId"`
-				Name     string `json:"name"`
-			} `json:"options"`
-		} `json:"params"`
-	}
-	var resp struct {
-		Result struct {
-			Outcome struct {
-				OptionID string `json:"optionId"`
-			} `json:"outcome"`
-		} `json:"result"`
-	}
-	if !warnUnmarshal(requestPayload, &req, "acp permission request") {
-		return ""
-	}
-	if !warnUnmarshal(responseContent, &resp, "acp permission response") {
-		return ""
-	}
-
-	optionID := strings.TrimSpace(resp.Result.Outcome.OptionID)
-	if optionID == "" {
-		return ""
-	}
-	for _, option := range req.Params.Options {
-		if strings.TrimSpace(option.OptionID) == optionID {
-			if name := strings.TrimSpace(option.Name); name != "" {
-				return name
-			}
-			break
-		}
-	}
-
-	switch optionID {
-	case "once", "proceed_once":
-		return "Allow once"
-	case "always", "proceed_always":
-		return "Always allow"
-	case "reject", "cancel":
-		return "Reject"
-	default:
-		return optionID
-	}
+	return encoded, true
 }

--- a/backend/internal/worker/agent/control_response_test.go
+++ b/backend/internal/worker/agent/control_response_test.go
@@ -15,12 +15,27 @@ func TestResolveControlResponse_NoopKeepsRawResponse(t *testing.T) {
 	res := noopProvider{}.ResolveControlResponse(ControlResponseContext{ResponseContent: content})
 
 	assert.Equal(t, content, res.Content)
-	assert.Empty(t, res.DisplayText)
+	assert.Nil(t, res.RequestContext)
 	assert.False(t, res.SelfDisplayed)
 	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
 }
 
-func TestResolveControlResponse_CodexUserInputAnswer(t *testing.T) {
+func TestResolveControlResponse_CodexApprovalRequestContext(t *testing.T) {
+	// A Codex command-approval decision: the native response is forwarded verbatim, and the pruned
+	// request context is just the method -- the frontend maps result.decision to a label itself.
+	content := []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`)
+	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"jsonrpc":"2.0","id":7,"method":"item/commandExecution/requestApproval","params":{}}`),
+		ResponseContent: content,
+	})
+
+	assert.Equal(t, content, res.Content)
+	assert.JSONEq(t, `{"method":"item/commandExecution/requestApproval"}`, string(res.RequestContext))
+	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
+}
+
+func TestResolveControlResponse_CodexUserInputRequestContext(t *testing.T) {
+	// requestUserInput keeps the question id + header the frontend labels its answer values with.
 	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
 		RequestPayload: []byte(`{
 			"jsonrpc":"2.0",
@@ -35,36 +50,16 @@ func TestResolveControlResponse_CodexUserInputAnswer(t *testing.T) {
 		}`),
 	})
 
-	assert.Equal(t, "Task: Inspect\nReason: Parity", res.DisplayText)
+	assert.JSONEq(t, `{
+		"method":"item/tool/requestUserInput",
+		"params":{"questions":[{"id":"task","header":"Task"},{"id":"reason","header":"Reason"}]}
+	}`, string(res.RequestContext))
 	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
 }
 
-func TestResolveControlResponse_CodexUserInputAnswerStableExtraOrdering(t *testing.T) {
-	// The response carries answer keys NOT present in the request's questions ("alpha", "mango",
-	// "zebra"). Those are absent from the request-derived order, so they must render in a STABLE
-	// (sorted) order rather than Go's randomized map-iteration order -- otherwise the same control
-	// response would render its trailing lines differently across renders.
-	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
-		RequestPayload: []byte(`{
-			"jsonrpc":"2.0","id":7,"method":"item/tool/requestUserInput",
-			"params":{"questions":[{"header":"Task","id":"task"}]}
-		}`),
-		ResponseContent: []byte(`{
-			"jsonrpc":"2.0","id":7,
-			"result":{"answers":{
-				"task":{"answers":["Inspect"]},
-				"zebra":{"answers":["Z"]},
-				"alpha":{"answers":["A"]},
-				"mango":{"answers":["M"]}
-			}}
-		}`),
-	})
-
-	// The request-ordered question first, then the extra keys alphabetically.
-	assert.Equal(t, "Task: Inspect\nalpha: A\nmango: M\nzebra: Z", res.DisplayText)
-}
-
 func TestResolveControlResponse_CodexPlanModePrompt(t *testing.T) {
+	// The synthesized plan-mode prompt frame carries no top-level method; its request.tool_name is
+	// the pruned context, and the neutral allow/deny envelope is forwarded verbatim.
 	content := []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`)
 	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
 		RequestPayload:  []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
@@ -73,60 +68,8 @@ func TestResolveControlResponse_CodexPlanModePrompt(t *testing.T) {
 	})
 
 	assert.Equal(t, content, res.Content)
-	assert.Empty(t, res.DisplayText)
+	assert.JSONEq(t, `{"request":{"tool_name":"CodexPlanModePrompt"}}`, string(res.RequestContext))
 	assert.Equal(t, PlanModeControlPrompt, res.PlanModeControl)
-}
-
-func TestResolveControlResponse_CodexFeedbackMessage(t *testing.T) {
-	content := []byte(`{"response":{"response":{"behavior":"deny","message":"Add tests first."}}}`)
-	res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
-		RequestPayload:  []byte(`{"method":"item/commandExecution/requestApproval"}`),
-		ResponseContent: content,
-	})
-
-	assert.Equal(t, content, res.Content)
-	assert.Equal(t, "Add tests first.", res.DisplayText)
-	assert.Equal(t, PlanModeControlNone, res.PlanModeControl)
-}
-
-func TestResolveControlResponse_CodexDecisionDisplayText(t *testing.T) {
-	tests := []struct {
-		name    string
-		content []byte
-		want    string
-	}{
-		{
-			name:    "accept",
-			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`),
-			want:    "Allow",
-		},
-		{
-			name:    "decline",
-			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"decline"}}`),
-			want:    "Reject",
-		},
-		{
-			name:    "exec policy amendment",
-			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":{"acceptWithExecpolicyAmendment":{"match":"npm test"}}}}`),
-			want:    "Allow & Remember",
-		},
-		{
-			name:    "network policy amendment",
-			content: []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":{"applyNetworkPolicyAmendment":true}}}`),
-			want:    "Apply Network Policy",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			res := codexProvider{}.ResolveControlResponse(ControlResponseContext{
-				RequestPayload:  []byte(`{"method":"item/commandExecution/requestApproval"}`),
-				ResponseContent: tt.content,
-			})
-
-			assert.Equal(t, tt.want, res.DisplayText)
-		})
-	}
 }
 
 func TestResolveControlResponse_ClaudeSelfDisplayAndPlanMode(t *testing.T) {
@@ -137,6 +80,8 @@ func TestResolveControlResponse_ClaudeSelfDisplayAndPlanMode(t *testing.T) {
 
 	assert.True(t, res.SelfDisplayed)
 	assert.Equal(t, PlanModeControlExit, res.PlanModeControl)
+	// The tool name is all the frontend needs to render Claude's Approved / Rejected / feedback.
+	assert.JSONEq(t, `{"request":{"tool_name":"ExitPlanMode"}}`, string(res.RequestContext))
 }
 
 func TestResolveControlResponse_CursorCreatePlanTransformsResponse(t *testing.T) {
@@ -155,7 +100,9 @@ func TestResolveControlResponse_CursorCreatePlanTransformsResponse(t *testing.T)
 		}`),
 	})
 
-	require.Equal(t, "Needs tests.", res.DisplayText)
+	// The plan decision renders from the transformed outcome alone, so the pruned context is
+	// method-only.
+	assert.JSONEq(t, `{"method":"cursor/create_plan"}`, string(res.RequestContext))
 	var normalized struct {
 		ID     int `json:"id"`
 		Result struct {
@@ -187,7 +134,7 @@ func TestResolveControlResponse_CursorCreatePlanAcceptsResponse(t *testing.T) {
 		}`),
 	})
 
-	require.Equal(t, "Accept", res.DisplayText)
+	assert.JSONEq(t, `{"method":"cursor/create_plan"}`, string(res.RequestContext))
 	var normalized struct {
 		ID     string `json:"id"`
 		Result struct {
@@ -219,7 +166,7 @@ func TestResolveControlResponse_CursorCreatePlanRejectsDefaultMessageAsReject(t 
 		}`),
 	})
 
-	require.Equal(t, "Reject", res.DisplayText)
+	assert.JSONEq(t, `{"method":"cursor/create_plan"}`, string(res.RequestContext))
 	var normalized struct {
 		Result struct {
 			Outcome struct {
@@ -234,6 +181,9 @@ func TestResolveControlResponse_CursorCreatePlanRejectsDefaultMessageAsReject(t 
 }
 
 func TestResolveControlResponse_CursorCreatePlanIgnoresMalformedEnvelope(t *testing.T) {
+	// The response isn't the neutral envelope, so the transform bails and the create-plan request
+	// falls through to the ACP permission context -- which has no options, so it degrades to
+	// method-only. The raw response is forwarded unchanged.
 	content := []byte(`{"jsonrpc":"2.0","id":7,"result":{"outcome":{"outcome":"rejected","reason":"No"}}}`)
 	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
 		RequestPayload: []byte(`{
@@ -246,13 +196,12 @@ func TestResolveControlResponse_CursorCreatePlanIgnoresMalformedEnvelope(t *test
 	})
 
 	assert.Equal(t, content, res.Content)
-	assert.Empty(t, res.DisplayText)
+	assert.JSONEq(t, `{"method":"cursor/create_plan"}`, string(res.RequestContext))
 }
 
-func TestResolveControlResponse_CursorQuestionAnsweredMapsOptionLabels(t *testing.T) {
-	// Cursor AskQuestion "answered": each selected optionId maps to its option LABEL, formatted as
-	// "prompt: label1, label2" per question in request order. This exercises cursorQuestionAnswersText's
-	// answered path (option-label mapping + labeled-line formatting), which had no direct coverage.
+func TestResolveControlResponse_CursorQuestionRequestContext(t *testing.T) {
+	// Cursor AskQuestion keeps the question prompts and the option id->label map the frontend needs
+	// to render selected option ids as their labels.
 	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR}.ResolveControlResponse(ControlResponseContext{
 		RequestPayload: []byte(`{
 			"jsonrpc":"2.0","id":7,"method":"` + CursorMethodAskQuestion + `",
@@ -270,18 +219,24 @@ func TestResolveControlResponse_CursorQuestionAnsweredMapsOptionLabels(t *testin
 		}`),
 	})
 
-	assert.Equal(t, "Pick a color: Red, Blue\nPick a size: Large", res.DisplayText)
+	assert.JSONEq(t, `{
+		"method":"cursor/ask_question",
+		"params":{"questions":[
+			{"id":"q1","prompt":"Pick a color","options":[{"id":"o1","label":"Red"},{"id":"o2","label":"Blue"}]},
+			{"id":"q2","prompt":"Pick a size","options":[{"id":"s1","label":"Large"}]}
+		]}
+	}`, string(res.RequestContext))
 }
 
-func TestResolveControlResponse_OpenCodeStyleQuestionAnswer(t *testing.T) {
+func TestResolveControlResponse_OpenCodeQuestionRequestContext(t *testing.T) {
+	// The OpenCode/Kilo question context keeps the question headers the frontend labels its answer
+	// values with. Resolve through ProviderFor (not an inline literal) so the test exercises the
+	// real registration: the question hook is set only for OpenCode/Kilo in init().
 	for _, provider := range []leapmuxv1.AgentProvider{
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
 	} {
 		t.Run(provider.String(), func(t *testing.T) {
-			// Resolve through ProviderFor (not an inline acpProvider literal) so the test exercises
-			// the real registration: the OpenCode question summary now dispatches through the
-			// questionAnswersText hook that init() sets only for OpenCode/Kilo.
 			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
 				RequestPayload: []byte(`{
 					"type":"question.asked",
@@ -290,64 +245,39 @@ func TestResolveControlResponse_OpenCodeStyleQuestionAnswer(t *testing.T) {
 				ResponseContent: []byte(`{"jsonrpc":"2.0","id":"q1","result":{"answers":[["Build"],["Dev"]]}}`),
 			})
 
-			assert.Equal(t, "Task: Build\nEnv: Dev", res.DisplayText)
+			assert.JSONEq(t, `{
+				"type":"question.asked",
+				"properties":{"questions":[{"header":"Task"},{"header":"Env"}]}
+			}`, string(res.RequestContext))
 		})
 	}
-}
-
-func TestResolveControlResponse_OpenCodeStyleQuestionReject(t *testing.T) {
-	for _, provider := range []leapmuxv1.AgentProvider{
-		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
-		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
-	} {
-		t.Run(provider.String(), func(t *testing.T) {
-			res := ProviderFor(provider).ResolveControlResponse(ControlResponseContext{
-				RequestPayload: []byte(`{
-					"type":"question.asked",
-					"properties":{"questions":[{"header":"Task"}]}
-				}`),
-				ResponseContent: []byte(`{"jsonrpc":"2.0","id":"q1","result":{"rejected":true}}`),
-			})
-
-			assert.Equal(t, "Reject", res.DisplayText)
-		})
-	}
-}
-
-func TestResolveControlResponse_OpenCodeDropsEmptyAnswerValues(t *testing.T) {
-	// Edge case for the shared labeledAnswerLine formatting: an answer whose values are all
-	// empty/whitespace produces NO line (never a dangling "Env: "), and the question is omitted
-	// entirely -- while a sibling question with a real value still renders.
-	res := ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE).ResolveControlResponse(ControlResponseContext{
-		RequestPayload:  []byte(`{"type":"question.asked","properties":{"questions":[{"header":"Task"},{"header":"Env"}]}}`),
-		ResponseContent: []byte(`{"result":{"answers":[["Build"],["  ",""]]}}`),
-	})
-
-	assert.Equal(t, "Task: Build", res.DisplayText)
 }
 
 func TestResolveControlResponse_OpenCodeQuestionDispatchIsRegistrationDriven(t *testing.T) {
-	// The OpenCode-protocol `question.asked` answer summary must dispatch through the
-	// registration-time questionAnswersText hook (set only for OpenCode and Kilo in init()), NOT a
+	// The OpenCode-protocol `question.asked` request context must dispatch through the
+	// registration-time questionRequestContext hook (set only for OpenCode and Kilo in init()), NOT a
 	// provider-enum allowlist in ResolveControlResponse. This is the backend mirror of the frontend's
 	// registerOpenCodeProtocolProvider membership: keeping "who speaks the question protocol" at the
 	// single registration site stops a second source of truth from drifting.
 	//
 	// The fixture deliberately carries BOTH wire shapes at once -- an OpenCode `question.asked`
-	// question/answer AND an ACP permission option/outcome -- so the two dispatch paths yield DISTINCT
-	// display text. A provider WITH the hook renders the question summary ("Task: Build"); a provider
-	// WITHOUT it falls through to the permission summary ("Allow once"). That divergence is what makes
-	// case (b) a real regression guard: it fails if someone re-adds a non-question provider to an enum
-	// allowlist, or wires the hook onto a provider that shouldn't have it -- either way the wrong
-	// provider would render "Task: Build" instead of "Allow once".
+	// question AND an ACP permission method/options -- so the two dispatch paths yield DISTINCT
+	// request context. A provider WITH the hook prunes the question context; a provider WITHOUT it
+	// falls through to the permission context. That divergence is what makes case (b) a real
+	// regression guard: it fails if someone re-adds a non-question provider to an enum allowlist, or
+	// wires the hook onto a provider that shouldn't have it.
 	requestPayload := []byte(`{
 		"type":"question.asked",
 		"properties":{"questions":[{"header":"Task"}]},
+		"method":"session/request_permission",
 		"params":{"options":[{"optionId":"proceed_once","name":"Allow once"}]}
 	}`)
 	responseContent := []byte(`{"result":{"answers":[["Build"]],"outcome":{"optionId":"proceed_once"}}}`)
 
-	// (a) Both providers registered WITH the hook render the OpenCode question summary.
+	questionContext := `{"type":"question.asked","properties":{"questions":[{"header":"Task"}]}}`
+	permissionContext := `{"method":"session/request_permission","params":{"options":[{"optionId":"proceed_once","name":"Allow once"}]}}`
+
+	// (a) Both providers registered WITH the hook prune the OpenCode question context.
 	for _, provider := range []leapmuxv1.AgentProvider{
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO,
@@ -357,12 +287,12 @@ func TestResolveControlResponse_OpenCodeQuestionDispatchIsRegistrationDriven(t *
 				RequestPayload:  requestPayload,
 				ResponseContent: responseContent,
 			})
-			assert.Equal(t, "Task: Build", res.DisplayText)
+			assert.JSONEq(t, questionContext, string(res.RequestContext))
 		})
 	}
 
-	// (b) An ACP provider registered WITHOUT the hook falls through to the ACP permission summary for
-	// the very same `question.asked` payload -- it never invokes opencodeQuestionAnswersText.
+	// (b) An ACP provider registered WITHOUT the hook falls through to the ACP permission context for
+	// the very same `question.asked` payload -- it never invokes opencodeQuestionRequestContext.
 	for _, provider := range []leapmuxv1.AgentProvider{
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX,
@@ -372,14 +302,12 @@ func TestResolveControlResponse_OpenCodeQuestionDispatchIsRegistrationDriven(t *
 				RequestPayload:  requestPayload,
 				ResponseContent: responseContent,
 			})
-			assert.Equal(t, "Allow once", res.DisplayText)
-			assert.NotEqual(t, "Task: Build", res.DisplayText,
-				"a provider without the questionAnswersText hook must not render the OpenCode question summary")
+			assert.JSONEq(t, permissionContext, string(res.RequestContext))
 		})
 	}
 }
 
-func TestResolveControlResponse_ACPPermissionLabels(t *testing.T) {
+func TestResolveControlResponse_ACPPermissionRequestContext(t *testing.T) {
 	for _, provider := range []leapmuxv1.AgentProvider{
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 		leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR,
@@ -394,17 +322,40 @@ func TestResolveControlResponse_ACPPermissionLabels(t *testing.T) {
 					"jsonrpc":"2.0",
 					"id":7,
 					"method":"session/request_permission",
-					"params":{"options":[{"optionId":"proceed_once","name":"Allow once"}]}
+					"params":{"options":[
+						{"optionId":"proceed_once","name":"Allow once","kind":"allow_once"},
+						{"optionId":"reject","name":"Reject","kind":"reject_once"}
+					]}
 				}`),
 				ResponseContent: []byte(`{"jsonrpc":"2.0","id":7,"result":{"outcome":{"optionId":"proceed_once"}}}`),
 			})
 
-			assert.Equal(t, "Allow once", res.DisplayText)
+			// Options keep optionId + name -- the minimal context the frontend matches the selected
+			// id against to render its label; the selected optionId itself lives in the native
+			// response. The request's `kind` is intentionally pruned away (the frontend never reads it).
+			assert.JSONEq(t, `{
+				"method":"session/request_permission",
+				"params":{"options":[
+					{"optionId":"proceed_once","name":"Allow once"},
+					{"optionId":"reject","name":"Reject"}
+				]}
+			}`, string(res.RequestContext))
 		})
 	}
 }
 
-func TestResolveControlResponse_PiExtensionUIResponse(t *testing.T) {
+func TestResolveControlResponse_ACPPermissionRequestContextWithoutOptions(t *testing.T) {
+	// A permission request that carries no options (e.g. a Cursor create-plan request that fell
+	// through the transform) degrades to method-only context rather than an empty options list.
+	res := acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE}.ResolveControlResponse(ControlResponseContext{
+		RequestPayload:  []byte(`{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{}}`),
+		ResponseContent: []byte(`{"jsonrpc":"2.0","id":7,"result":{"outcome":{"optionId":"proceed_once"}}}`),
+	})
+
+	assert.JSONEq(t, `{"method":"session/request_permission"}`, string(res.RequestContext))
+}
+
+func TestResolveControlResponse_PiRequestContext(t *testing.T) {
 	confirmed := true
 	response, err := json.Marshal(map[string]interface{}{"confirmed": confirmed})
 	require.NoError(t, err)
@@ -414,18 +365,47 @@ func TestResolveControlResponse_PiExtensionUIResponse(t *testing.T) {
 		ResponseContent: response,
 	})
 
-	assert.Equal(t, "Approve", res.DisplayText)
+	assert.Equal(t, response, res.Content)
+	assert.JSONEq(t, `{"method":"confirm"}`, string(res.RequestContext))
 }
 
-func TestFirstNonEmpty(t *testing.T) {
-	// Returns the first argument non-empty AFTER trimming, and trims the chosen value --
-	// including a fallback passed with surrounding whitespace (the display-label tidy the
-	// answer summaries rely on).
-	assert.Equal(t, "x", firstNonEmpty("", "  ", "x"))
-	assert.Equal(t, "a", firstNonEmpty("  a  ", "b"), "trims the chosen value")
-	assert.Equal(t, "fallback", firstNonEmpty("   ", "  fallback  "), "trims a whitespace-padded fallback")
-	assert.Equal(t, "", firstNonEmpty(), "no args -> empty")
-	assert.Equal(t, "", firstNonEmpty("", "\t\n "), "all blank -> empty")
+func TestResolveControlResponse_EmptyRequestPayloadYieldsNilContext(t *testing.T) {
+	// Every resolver returns nil RequestContext when it has no stored request to prune (the request
+	// row was already deleted, or never captured) -- the row then persists with `request` omitted.
+	content := []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`)
+	cases := map[string]Provider{
+		"codex":  codexProvider{},
+		"pi":     piProvider{},
+		"acp":    acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE},
+		"claude": claudeProvider{}, // Claude keys context off ToolName, empty here
+	}
+	for name, provider := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := provider.ResolveControlResponse(ControlResponseContext{ResponseContent: content})
+			assert.Nil(t, res.RequestContext)
+			assert.Equal(t, content, res.Content)
+		})
+	}
+}
+
+func TestResolveControlResponse_MalformedRequestPayloadYieldsNilContext(t *testing.T) {
+	// A stored request that doesn't parse as JSON leaves RequestContext nil (warnUnmarshal fails)
+	// without dropping the forwarded response.
+	content := []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`)
+	for name, provider := range map[string]Provider{
+		"codex": codexProvider{},
+		"pi":    piProvider{},
+		"acp":   acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := provider.ResolveControlResponse(ControlResponseContext{
+				RequestPayload:  []byte(`not json`),
+				ResponseContent: content,
+			})
+			assert.Nil(t, res.RequestContext)
+			assert.Equal(t, content, res.Content)
+		})
+	}
 }
 
 func TestWarnUnmarshal(t *testing.T) {

--- a/backend/internal/worker/agent/cursor_output.go
+++ b/backend/internal/worker/agent/cursor_output.go
@@ -49,8 +49,8 @@ func (a *CursorCLIAgent) handleAskQuestionRequest(raw []byte, requestID string) 
 	if !ok {
 		return
 	}
-	a.sink.PersistControlRequest(requestID, payload)
-	a.sink.BroadcastControlRequest(requestID, payload)
+	claimToken := a.sink.PersistControlRequest(requestID, payload)
+	a.sink.BroadcastControlRequest(requestID, payload, claimToken)
 }
 
 func (a *CursorCLIAgent) buildAskQuestionPayload(raw []byte) ([]byte, bool) {
@@ -130,6 +130,6 @@ func (a *CursorCLIAgent) handleCreatePlanRequest(raw []byte, requestID string) {
 		return
 	}
 
-	a.sink.PersistControlRequest(requestID, encoded)
-	a.sink.BroadcastControlRequest(requestID, encoded)
+	claimToken := a.sink.PersistControlRequest(requestID, encoded)
+	a.sink.BroadcastControlRequest(requestID, encoded, claimToken)
 }

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -343,8 +343,8 @@ func (a *PiAgent) handlePiExtensionUIRequest(raw []byte) {
 				"agent_id", a.agentID, "method", head.Method)
 			return
 		}
-		a.sink.PersistControlRequest(head.ID, raw)
-		a.sink.BroadcastControlRequest(head.ID, raw)
+		claimToken := a.sink.PersistControlRequest(head.ID, raw)
+		a.sink.BroadcastControlRequest(head.ID, raw, claimToken)
 		return
 	}
 

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -78,11 +78,11 @@ type Provider interface {
 	// ignore it) is ALREADY displayed by the provider's own transcript -- e.g.
 	// Claude re-emits AskUserQuestion / ExitPlanMode answers as a user-envelope
 	// tool_result. When true, the scroll rail marks that ingested row directly
-	// and the service layer persists NO separate synthetic display row (which
-	// would double the dot). Every provider except Claude synthesizes the display
-	// row itself (persistSyntheticUserMessage) and so returns false -- confirmed
-	// against the Codex, OpenCode/ACP, and Pi wire protocols, none of which echo a
-	// control answer back into their output stream.
+	// and the service layer persists NO separate structured control-response row
+	// (which would double the dot). Every provider except Claude has the service
+	// synthesize the structured row and so returns false -- confirmed against the
+	// Codex, OpenCode/ACP, and Pi wire protocols, none of which echo a control
+	// answer back into their output stream.
 	IsSelfDisplayingControlTool(toolName string) bool
 	// PlanModeControl classifies a provider-native control request name into
 	// the provider-neutral plan-mode operation the service layer should run.
@@ -90,7 +90,8 @@ type Provider interface {
 	PlanModeControl(toolName string) PlanModeControlKind
 	// ResolveControlResponse interprets a frontend control response against the
 	// stored provider-native control request. It is pure: providers may normalize
-	// the response bytes and compute display/plan metadata, but the service owns
+	// the response bytes and prune the request into the minimal render context
+	// persisted alongside it (plus plan-mode metadata), but the service owns
 	// persistence, control-request deletion, option changes, and process I/O.
 	ResolveControlResponse(ctx ControlResponseContext) ControlResponseResolution
 	// PlanApprovalOptions declares the option changes to settle when a plan-mode-prompt
@@ -434,13 +435,14 @@ type acpProvider struct {
 	noopProvider
 	provider              leapmuxv1.AgentProvider
 	defaultPermissionMode string
-	// questionAnswersText renders the display summary for an OpenCode-protocol `question.asked`
-	// answer. Non-nil ONLY for the ACP providers that speak that question protocol (OpenCode,
-	// Kilo); nil for the rest, whose control answers fall through to the ACP permission summary.
+	// questionRequestContext prunes an OpenCode-protocol `question.asked` request to the minimal
+	// context persisted alongside the native answer (the question headers the frontend labels its
+	// values with). Non-nil ONLY for the ACP providers that speak that question protocol (OpenCode,
+	// Kilo); nil for the rest, whose control answers fall through to the ACP permission context.
 	// Set at registration (init) so the "who uses the OpenCode question shape" membership lives at
 	// one site (mirroring the frontend's registerOpenCodeProtocolProvider) rather than a
 	// provider-enum switch in ResolveControlResponse that would drift.
-	questionAnswersText func(requestPayload, responseContent []byte) string
+	questionRequestContext func(requestPayload []byte) json.RawMessage
 }
 
 func (acpProvider) IsInterrupt(content string) bool {
@@ -463,8 +465,8 @@ func init() {
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, piProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, defaultPermissionMode: CursorCLIModeAgent})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, defaultPermissionMode: CopilotCLIModeAgent})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, questionAnswersText: opencodeQuestionAnswersText})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, questionAnswersText: opencodeQuestionAnswersText})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, questionRequestContext: opencodeQuestionRequestContext})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, questionRequestContext: opencodeQuestionRequestContext})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, defaultPermissionMode: GooseCLIModeAuto})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX})
 }

--- a/backend/internal/worker/agent/recording_sink_test.go
+++ b/backend/internal/worker/agent/recording_sink_test.go
@@ -4,13 +4,17 @@ import (
 	"sync"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/id"
 )
 
 // controlRequestRecord captures a single PersistControlRequest /
-// BroadcastControlRequest call.
+// BroadcastControlRequest call. ClaimToken is the per-instance token the
+// sink minted (persist) or was handed (broadcast), so a test can assert the
+// broadcast carries the SAME token PersistControlRequest returned.
 type controlRequestRecord struct {
-	RequestID string
-	Payload   []byte
+	RequestID  string
+	Payload    []byte
+	ClaimToken string
 }
 
 // planUpdateRecord captures a single UpdatePlan call.
@@ -34,21 +38,25 @@ type recordingControlSink struct {
 	notifications     []map[string]interface{}
 }
 
-func (s *recordingControlSink) PersistControlRequest(requestID string, payload []byte) {
+func (s *recordingControlSink) PersistControlRequest(requestID string, payload []byte) string {
 	s.crMu.Lock()
 	defer s.crMu.Unlock()
+	claimToken := id.Generate()
 	s.persistedControls = append(s.persistedControls, controlRequestRecord{
-		RequestID: requestID,
-		Payload:   append([]byte(nil), payload...),
+		RequestID:  requestID,
+		Payload:    append([]byte(nil), payload...),
+		ClaimToken: claimToken,
 	})
+	return claimToken
 }
 
-func (s *recordingControlSink) BroadcastControlRequest(requestID string, payload []byte) {
+func (s *recordingControlSink) BroadcastControlRequest(requestID string, payload []byte, claimToken string) {
 	s.crMu.Lock()
 	defer s.crMu.Unlock()
 	s.broadcastControls = append(s.broadcastControls, controlRequestRecord{
-		RequestID: requestID,
-		Payload:   append([]byte(nil), payload...),
+		RequestID:  requestID,
+		Payload:    append([]byte(nil), payload...),
+		ClaimToken: claimToken,
 	})
 }
 

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -153,10 +153,10 @@ func (s *testSink) BroadcastStreamEnd(spanID string) {
 	s.streamEnds = append(s.streamEnds, spanID)
 }
 
-func (s *testSink) PersistControlRequest(string, []byte)   {}
-func (s *testSink) DeleteControlRequest(string)            {}
-func (s *testSink) BroadcastControlRequest(string, []byte) {}
-func (s *testSink) BroadcastControlCancel(string)          {}
+func (s *testSink) PersistControlRequest(string, []byte) string    { return "" }
+func (s *testSink) DeleteControlRequest(string)                    {}
+func (s *testSink) BroadcastControlRequest(string, []byte, string) {}
+func (s *testSink) BroadcastControlCancel(string)                  {}
 func (s *testSink) UpdateSessionID(sessionID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -438,9 +438,9 @@ func (noopSink) GetSpanType(string) string                                      
 func (noopSink) ReserveSpanColor(string, string) int32                             { return 0 }
 func (noopSink) BroadcastStreamChunk([]byte, string, string)                       {}
 func (noopSink) BroadcastStreamEnd(string)                                         {}
-func (noopSink) PersistControlRequest(string, []byte)                              {}
+func (noopSink) PersistControlRequest(string, []byte) string                       { return "" }
 func (noopSink) DeleteControlRequest(string)                                       {}
-func (noopSink) BroadcastControlRequest(string, []byte)                            {}
+func (noopSink) BroadcastControlRequest(string, []byte, string)                    {}
 func (noopSink) BroadcastControlCancel(string)                                     {}
 func (noopSink) UpdateSessionID(string)                                            {}
 func (noopSink) UpdatePermissionMode(string)                                       {}

--- a/backend/internal/worker/agent/thinking_tokens.go
+++ b/backend/internal/worker/agent/thinking_tokens.go
@@ -227,7 +227,7 @@ func (s *thinkingResetSink) PersistTurnEnd(content []byte, span SpanInfo) error 
 	return s.OutputSink.PersistTurnEnd(content, span)
 }
 
-func (s *thinkingResetSink) BroadcastControlRequest(requestID string, payload []byte) {
+func (s *thinkingResetSink) BroadcastControlRequest(requestID string, payload []byte, claimToken string) {
 	s.est.reset()
-	s.OutputSink.BroadcastControlRequest(requestID, payload)
+	s.OutputSink.BroadcastControlRequest(requestID, payload, claimToken)
 }

--- a/backend/internal/worker/agent/thinking_tokens_test.go
+++ b/backend/internal/worker/agent/thinking_tokens_test.go
@@ -155,7 +155,7 @@ func TestThinkingResetSink_ResetsOnFrontendClearBoundariesOnly(t *testing.T) {
 		// clears -- the estimate must not reset either.
 		{name: "AGENT notification (collapsed, no broadcast) does NOT reset", suppress: true, call: func(s OutputSink) { _, _ = s.PersistNotification(agent, nil) }, reset: false},
 		{name: "turn-end divider resets", call: func(s OutputSink) { _ = s.PersistTurnEnd(nil, SpanInfo{}) }, reset: true},
-		{name: "control request resets", call: func(s OutputSink) { s.BroadcastControlRequest("id", nil) }, reset: true},
+		{name: "control request resets", call: func(s OutputSink) { s.BroadcastControlRequest("id", nil, "") }, reset: true},
 		{name: "USER message does NOT reset", call: func(s OutputSink) { _ = s.PersistMessage(user, nil, SpanInfo{}) }, reset: false},
 		{name: "LEAPMUX notification does NOT reset", call: func(s OutputSink) { _, _ = s.PersistNotification(leapmux, nil) }, reset: false},
 		{name: "stream chunk does NOT reset", call: func(s OutputSink) { s.BroadcastStreamChunk(nil, "", "m") }, reset: false},

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -85,11 +85,36 @@ END;
 
 -- Pending control requests
 CREATE TABLE control_requests (
-    agent_id   TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    request_id TEXT NOT NULL,
-    payload    BLOB NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    request_id  TEXT NOT NULL,
+    payload     BLOB NOT NULL,
+    -- claim_token identifies this REQUEST INSTANCE. The worker mints a fresh token per
+    -- PersistControlRequest (id.Generate nanoid), broadcasts it in AgentControlRequest, and the frontend
+    -- echoes it in the answer so control_response_answers can dedup per instance rather than per
+    -- reused request_id. '' for a row stored before the token existed (degrades to id-only dedup).
+    claim_token TEXT NOT NULL DEFAULT '',
+    created_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     PRIMARY KEY (agent_id, request_id)
+);
+
+-- Idempotency claims for control-response answers (#258). A control answer is deduped by an atomic
+-- INSERT here (ClaimControlResponseAnswer): the first answer for a (agent_id, request_id, claim_token)
+-- wins the primary key, and a duplicate -- an RPC retry, or a second window answering the SAME request
+-- instance (same echoed claim_token) -- loses. Being a durable row rather than in-memory state, the
+-- claim survives BOTH a subprocess restart and a worker-PROCESS restart, so a duplicate straddling
+-- either is still deduped instead of re-persisting a second answer row + scroll-rail dot.
+--
+-- claim_token is what makes the dedup INSTANCE-scoped: when a request_id is REUSED (a Codex/ACP
+-- JSON-RPC counter that reset across a plan-exec restart, or a Claude follow-up), the new instance
+-- carries a FRESH claim_token, so its genuine answer claims a distinct key and is never rejected as a
+-- duplicate of the prior instance's -- while a stale duplicate of the PRIOR instance (carrying the old
+-- token) still loses. No release-on-reissue is needed; rows are cleaned up in bulk with the agent via
+-- ON DELETE CASCADE. '' claim_token (a pre-token or lookup-miss answer) degrades to id-only dedup.
+CREATE TABLE control_response_answers (
+    agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    request_id  TEXT NOT NULL,
+    claim_token TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (agent_id, request_id, claim_token)
 );
 
 -- Scheduled synthetic auto-continue messages
@@ -231,6 +256,7 @@ DROP VIEW IF EXISTS worktree_tab_liveness;
 DROP TABLE IF EXISTS worktree_tabs;
 DROP TABLE IF EXISTS worktrees;
 DROP TABLE IF EXISTS auto_continue_schedules;
+DROP TABLE IF EXISTS control_response_answers;
 DROP TABLE IF EXISTS control_requests;
 DROP TRIGGER IF EXISTS trg_messages_seq_hwm_update;
 DROP TRIGGER IF EXISTS trg_messages_seq_hwm_insert;

--- a/backend/internal/worker/db/queries/control_requests.sql
+++ b/backend/internal/worker/db/queries/control_requests.sql
@@ -1,6 +1,9 @@
 -- name: CreateControlRequest :exec
-INSERT INTO control_requests (agent_id, request_id, payload) VALUES (?, ?, ?)
-ON CONFLICT (agent_id, request_id) DO UPDATE SET payload = excluded.payload;
+-- A re-store of an existing (agent_id, request_id) row refreshes BOTH the payload and the claim_token
+-- (a re-issued id is a NEW instance and must mint a fresh token), so a stale duplicate of the prior
+-- instance can no longer match the current instance's answer claim.
+INSERT INTO control_requests (agent_id, request_id, payload, claim_token) VALUES (?, ?, ?, ?)
+ON CONFLICT (agent_id, request_id) DO UPDATE SET payload = excluded.payload, claim_token = excluded.claim_token;
 
 -- name: DeleteControlRequest :exec
 DELETE FROM control_requests WHERE agent_id = ? AND request_id = ?;

--- a/backend/internal/worker/db/queries/control_response_answers.sql
+++ b/backend/internal/worker/db/queries/control_response_answers.sql
@@ -1,0 +1,13 @@
+-- name: ClaimControlResponseAnswer :execrows
+-- Atomically record that (agent_id, request_id, claim_token) is being answered and report whether THIS
+-- call won: 1 rows affected means the INSERT succeeded (the first/only answer for this request
+-- INSTANCE), 0 means a row already existed (a duplicate -- an RPC retry, or a second window answering
+-- the same instance, both echoing the SAME claim_token). Being a durable row, the claim survives a
+-- worker-process restart, so a duplicate straddling one is still deduped (#258).
+--
+-- claim_token makes the dedup INSTANCE-scoped: a REUSED request_id gets a fresh token per instance, so
+-- the new instance's genuine answer claims a distinct key and is never rejected as a duplicate of the
+-- prior instance's -- while a stale duplicate of the prior instance (old token) still loses. No
+-- release-on-reissue is needed; rows are cleaned up in bulk with the agent via ON DELETE CASCADE.
+INSERT INTO control_response_answers (agent_id, request_id, claim_token) VALUES (?, ?, ?)
+ON CONFLICT (agent_id, request_id, claim_token) DO NOTHING;

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -479,7 +479,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		if agent.ProviderFor(dbAgent.AgentProvider).NeedsSyntheticInterruptNotice() && agent.IsInterruptRequest(dbAgent.AgentProvider, content) {
 			// An interrupt notice is not the user's answer to a control request, so it
 			// draws no rail dot.
-			svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, "[Request interrupted by user]", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+			svc.persistSyntheticUserMessage(agentID, dbAgent.AgentProvider, "[Request interrupted by user]")
 		}
 
 		svc.handleControlRequestMessage(agentID, dbAgent.AgentProvider, content)
@@ -988,32 +988,13 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		if !ok {
 			return
 		}
-		content := r.GetContent()
 
-		plan := svc.buildControlResponsePlan(agentID, dbAgent, content)
-
-		// Drop the control request before persisting display rows or forwarding the response,
-		// on EVERY path (the plan-prompt branch below and the fall-through both need it). Claude
-		// can emit a follow-up control_request immediately after it reads a denial; if the old
-		// request is still pending client-side, the revised request can hide behind stale dedup
-		// state.
-		svc.deleteControlRequest(agentID, dbAgent.AgentProvider, plan.requestMeta, plan.resolution.SelfDisplayed)
-
-		if plan.resolution.PlanModeControl == agent.PlanModeControlPrompt && plan.hasDecision {
-			svc.handleControlResponsePromptPlan(agentID, dbAgent, plan)
-			sendProtoResponse(sender, &leapmuxv1.SendControlResponseResponse{})
-			return
-		}
-
-		svc.persistControlResponseAnswerRows(agentID, dbAgent.AgentProvider, plan)
-
-		// Detect plan mode changes after the answer row is durable but before forwarding to
-		// the agent. Clear-context plan execution starts asynchronously, so persisting first
-		// keeps the user's answer before plan-execution rows even if the goroutine runs fast.
-		skipSend := svc.applyControlResponsePlanModeEffects(agentID, dbAgent, plan)
-
-		if !skipSend {
-			if err := svc.Agents.SendRawInput(agentID, plan.resolution.Content); err != nil {
+		// The claim/dedup/plan-mode/forward orchestration lives in processControlResponse (dispatcher-
+		// free, unit-testable); the handler is just transport. It reports the bytes to forward, or
+		// forward=false for a deduped duplicate / server-side plan-prompt / withheld restart approval.
+		// claimToken is the per-instance token the frontend echoed from the answered AgentControlRequest.
+		if forwardBytes, forward := svc.processControlResponse(agentID, dbAgent, r.GetContent(), r.GetClaimToken()); forward {
+			if err := svc.Agents.SendRawInput(agentID, forwardBytes); err != nil {
 				slog.Error("failed to send control response to agent",
 					"agent_id", agentID, "error", err)
 				sendNotFoundError(sender, "agent not found or not running")
@@ -1599,7 +1580,7 @@ func (svc *Context) replayAgentCatchUp(
 			broadcastReplayAgentEvent(sender, &leapmuxv1.AgentEvent{
 				AgentId: agentID,
 				Event: &leapmuxv1.AgentEvent_ControlRequest{
-					ControlRequest: buildAgentControlRequest(agentID, dbAgent.AgentProvider, cr.RequestID, cr.Payload),
+					ControlRequest: buildAgentControlRequest(agentID, dbAgent.AgentProvider, cr.RequestID, cr.Payload, cr.ClaimToken),
 				},
 			})
 		}
@@ -2825,12 +2806,11 @@ func (svc *Context) handleControlRequestMessage(agentID string, provider leapmux
 	}
 }
 
-// persistSyntheticUserMessage persists a backend-synthesized `{content}` user row.
-// markType tags it for the scroll rail: CONTROL_RESPONSE for the user's answer to a
-// control request (the display row every provider except Claude relies on, since none
-// echo the answer in their own stream), or UNSPECIFIED for a non-answer marker such as
-// the interrupt notice -- so only genuine control answers draw a rail dot.
-func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmuxv1.AgentProvider, content string, markType leapmuxv1.MarkType) {
+// persistSyntheticUserMessage persists a backend-synthesized `{content}` user row that is NOT the
+// user's answer to a control request -- the interrupt notice ("[Request interrupted by user]").
+// It is left UNMARKED (MARK_TYPE_UNSPECIFIED) so it draws no scroll-rail dot; genuine control
+// answers persist through persistControlResponseRow, which owns the CONTROL_RESPONSE mark.
+func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmuxv1.AgentProvider, content string) {
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return
@@ -2841,7 +2821,7 @@ func (svc *Context) persistSyntheticUserMessage(agentID string, provider leapmux
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{MarkType: markType}, nil); err != nil {
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, innerJSON, agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED}, nil); err != nil {
 		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
 	}
 }
@@ -2965,12 +2945,10 @@ func (svc *Context) setAgentPermissionModeWithAgent(dbAgent db.Agent, mode strin
 		applyOptionsSpec{live: false, notifyFirstSet: false})
 }
 
-// sendSyntheticUserMessage persists and broadcasts a user message, then sends
-// it to the agent process if possible. This is used for local plan-mode flows
-// that originate from a UI prompt rather than a frontend SendAgentMessage RPC.
-// sendSyntheticUserMessage persists a `{content}` user row AND forwards it to the agent as
-// input. markType tags it for the scroll rail: UNSPECIFIED for a truly synthetic prompt the
-// user did not type (e.g. the auto-injected "Implement the plan."), or CONTROL_RESPONSE for
+// sendSyntheticUserMessage persists a `{content}` user row AND forwards it to the agent as input --
+// used for local plan-mode flows that originate from a UI prompt rather than a frontend
+// SendAgentMessage RPC. markType tags it for the scroll rail: UNSPECIFIED for a truly synthetic
+// prompt the user did not type (e.g. the auto-injected "Implement the plan."), or CONTROL_RESPONSE for
 // the user's own typed answer to a control request that is delivered as agent input (a Codex
 // plan-mode-prompt denial's feedback) -- so only genuine user answers draw a rail dot.
 func (svc *Context) sendSyntheticUserMessage(agentID, content string, markType leapmuxv1.MarkType) {
@@ -3239,12 +3217,15 @@ func broadcastReplayAgentEvent(sender *channel.Sender, event *leapmuxv1.AgentEve
 	})
 }
 
-func buildAgentControlRequest(agentID string, provider leapmuxv1.AgentProvider, requestID string, payload []byte) *leapmuxv1.AgentControlRequest {
+func buildAgentControlRequest(agentID string, provider leapmuxv1.AgentProvider, requestID string, payload []byte, claimToken string) *leapmuxv1.AgentControlRequest {
 	return &leapmuxv1.AgentControlRequest{
 		AgentId:       agentID,
 		RequestId:     requestID,
 		Payload:       payload,
 		AgentProvider: provider,
+		// The per-instance token the frontend echoes in its answer so the idempotency claim can dedup
+		// a reused request_id per INSTANCE (see AgentControlRequest.claim_token).
+		ClaimToken: claimToken,
 	}
 }
 

--- a/backend/internal/worker/service/control_response.go
+++ b/backend/internal/worker/service/control_response.go
@@ -86,13 +86,15 @@ func (svc *Context) loadControlResponseRequestMetadata(agentID string, content [
 func (svc *Context) buildControlResponsePlan(agentID string, dbAgent db.Agent, content []byte) controlResponsePlan {
 	requestMeta := svc.loadControlResponseRequestMetadata(agentID, content)
 	resolution := agent.ProviderFor(dbAgent.AgentProvider).ResolveControlResponse(agent.ControlResponseContext{
-		RequestID:       requestMeta.RequestID,
 		RequestPayload:  requestMeta.Payload,
 		ResponseContent: content,
 		ToolName:        requestMeta.ToolName,
-		ToolUseID:       requestMeta.ToolUseID,
 	})
-	if resolution.Content == nil {
+	// Backfill on len==0, not just ==nil: a provider that returned an empty-but-non-nil Content would
+	// otherwise reach persistControlResponseRow, where json.RawMessage of empty bytes makes
+	// json.Marshal fail ("unexpected end of JSON input") and silently drop the user's answer row.
+	// Falling back to the raw response bytes keeps the forwarded payload as the persisted response.
+	if len(resolution.Content) == 0 {
 		resolution.Content = content
 	}
 
@@ -105,24 +107,37 @@ func (svc *Context) buildControlResponsePlan(agentID string, dbAgent db.Agent, c
 	// envelope -- NOT from resolution.Content, which a provider may have rewritten for the agent
 	// (e.g. Cursor createPlan's transformCursorControlResponse replaces it with an ACP outcome that
 	// carries no request_id). Reading the frontend-only shape from the frontend bytes keeps plan-mode
-	// handling and the fallback row correct even for a provider that BOTH rewrites Content for the
-	// agent AND needs plan-mode handling; resolution.Content is still what gets forwarded to the
-	// agent. (For every provider except Cursor createPlan resolution.Content == content, so this is
-	// identical to decoding from resolution.Content; for Cursor createPlan it flips hasDecision to
-	// true, which is behavior-neutral -- PlanModeControl==None makes the plan-mode effects a no-op
-	// and the answer stays controlAnswerSynthetic, so no fallback row is added.)
+	// handling correct even for a provider that BOTH rewrites Content for the agent AND needs
+	// plan-mode handling; resolution.Content is still what gets forwarded to the agent. (For every
+	// provider except Cursor createPlan resolution.Content == content, so this is identical to
+	// decoding from resolution.Content; for Cursor createPlan it flips hasDecision to true, which is
+	// behavior-neutral -- PlanModeControl==None makes the plan-mode effects a no-op, and the single
+	// structured row is unaffected by hasDecision.)
 	//
-	// hasDecision gates the plan-mode / fallback-row handling, and is set ONLY for a recognized
+	// hasDecision gates the plan-mode handling, and is set ONLY for a recognized
 	// allow/deny behavior. The frontend is the sole producer of control responses and provably
 	// emits nothing else (buildAllowResponse/buildDenyResponse/decodeControlResponseBehavior in
 	// utils/controlResponse.ts), so an empty/unknown behavior is unreachable in practice -- the
 	// narrowing (a plan-prompt whose behavior is neither would otherwise forward its raw envelope
-	// and skip the fallback row) rests on that frontend contract by design rather than a defensive
-	// guard.
-	if err := json.Unmarshal(content, &plan.decision); err == nil && plan.decision.Response.RequestID != "" {
-		switch plan.behavior() {
-		case agent.ControlBehaviorAllow, agent.ControlBehaviorDeny:
-			plan.hasDecision = true
+	// and skip the plan-mode branch) rests on that frontend contract by design rather than a
+	// defensive guard.
+	//
+	// Normalize the decoded envelope ONCE here -- trim request_id and behavior, collapse the
+	// ControlRejectedByUserMessage placeholder to "" -- exactly as agent.DecodeControlBehavior reads
+	// the same wire bytes on the other paths. Every downstream reader (behavior(), rejectionMessage(),
+	// the plan-mode request-id match) is then a plain field read, so the "trim everywhere to match"
+	// hazard becomes mechanically impossible instead of comment-enforced at each site. In particular
+	// the hasDecision gate and the applyControlResponsePlanModeMutations request-id match now read the
+	// SAME normalized request_id, so a whitespace-padded id can't make one accept while the other skips.
+	if err := json.Unmarshal(content, &plan.decision); err == nil {
+		plan.decision.Response.RequestID = strings.TrimSpace(plan.decision.Response.RequestID)
+		plan.decision.Response.Response.Behavior = strings.TrimSpace(plan.decision.Response.Response.Behavior)
+		plan.decision.Response.Response.Message = agent.NormalizeRejectionMessage(plan.decision.Response.Response.Message)
+		if plan.decision.Response.RequestID != "" {
+			switch plan.decision.Response.Response.Behavior {
+			case agent.ControlBehaviorAllow, agent.ControlBehaviorDeny:
+				plan.hasDecision = true
+			}
 		}
 	}
 	return plan
@@ -130,27 +145,106 @@ func (svc *Context) buildControlResponsePlan(agentID string, dbAgent db.Agent, c
 
 // behavior is the approve/reject behavior the frontend attached to this control response, read
 // through one accessor rather than walking plan.decision.Response.Response.Behavior at each site.
-// Trimmed to match agent.DecodeControlBehavior's behavior read: buildControlResponsePlan gates
-// hasDecision on this matching agent.ControlBehaviorAllow/Deny, so surrounding whitespace must not
-// silently drop it to "no decision" here while the trimming decoder accepts it on the other paths.
+// Already trimmed at construction (buildControlResponsePlan), so this is a plain field read.
 func (plan controlResponsePlan) behavior() string {
-	return strings.TrimSpace(plan.decision.Response.Response.Behavior)
+	return plan.decision.Response.Response.Behavior
 }
 
 // rejectionMessage is the user's typed rejection reason, or "" when they gave none -- an empty
-// message OR the ControlRejectedByUserMessage sentinel (the auto-filled placeholder). Delegates to
-// agent.NormalizeRejectionMessage so this side of the wire and DecodeControlBehavior apply one
-// shared deny-feedback rule that can't drift.
+// message OR the ControlRejectedByUserMessage sentinel (the auto-filled placeholder). Already
+// normalized (via agent.NormalizeRejectionMessage) at construction, so this names the deeply-nested
+// field for the one caller rather than re-applying the rule.
 func (plan controlResponsePlan) rejectionMessage() string {
-	return agent.NormalizeRejectionMessage(plan.decision.Response.Response.Message)
+	return plan.decision.Response.Response.Message
 }
 
-// answerRow is which persisted row carries the single CONTROL_RESPONSE rail mark, derived from the
-// immutable resolution rather than stored -- a method like its sibling derivations (behavior /
-// rejectionMessage / exitPlanClearingContext) so the plan can never be constructed with an
-// answerRow that disagrees with its own resolution.
-func (plan controlResponsePlan) answerRow() controlAnswerRow {
-	return classifyControlAnswerRow(plan.resolution.SelfDisplayed, plan.resolution.DisplayText)
+// isPlanPrompt reports whether this answer is a plan-mode PROMPT decision (the Codex plan-mode
+// prompt), which handleControlResponsePromptPlan handles entirely server-side and NEVER forwards to
+// the agent. Derived from the immutable resolution + hasDecision -- a method like its sibling
+// predicates (behavior / withholdsForward / exitPlanClearingContext) so the winner-work dispatch and
+// the forward gate can never be constructed to disagree on it.
+func (plan controlResponsePlan) isPlanPrompt() bool {
+	return plan.resolution.PlanModeControl == agent.PlanModeControlPrompt && plan.hasDecision
+}
+
+// applyWinningControlResponse runs the once-only work the idempotency-claim WINNER performs for a
+// control answer: delete the pending control request (broadcasting its cancel to every window and
+// marking the self-displayed span), then either handle a plan-mode prompt entirely server-side or
+// persist the structured answer row and apply the plan-mode side effects. SendControlResponse calls
+// it for the claim winner only -- a duplicate must not re-delete, re-persist, or re-restart.
+//
+// Deleting the request here (for the winner alone) is also what keeps the winner's earlier read
+// while-present: a loser that deleted could tear the request out from under a concurrent winner's
+// not-yet-run read. Claude can emit a follow-up control_request right after it reads a denial; the
+// winner's delete + cancel clears the stale one from every window. The row is persisted here BEFORE
+// the caller forwards, so the user's answer precedes any async plan-execution rows.
+func (svc *Context) applyWinningControlResponse(agentID string, dbAgent db.Agent, plan controlResponsePlan) {
+	svc.deleteControlRequest(agentID, dbAgent.AgentProvider, plan.requestMeta, plan.resolution.SelfDisplayed)
+	if plan.isPlanPrompt() {
+		svc.handleControlResponsePromptPlan(agentID, dbAgent, plan)
+	} else {
+		svc.persistControlResponseAnswerRow(agentID, dbAgent.AgentProvider, plan)
+		svc.applyControlResponsePlanModeMutations(agentID, dbAgent, plan)
+	}
+}
+
+// processControlResponse runs the control-response orchestration for one SendControlResponse call:
+// build the plan, claim the answer for idempotency, run the once-only WINNER work, and report the
+// bytes (if any) the RPC handler should forward to the agent. It is dispatcher-free -- the transport
+// (unmarshal, access check, sender replies) stays in the handler -- so the winner/duplicate/forward
+// decision is unit-testable without a channel sender. Returns forward=false (nil bytes) for a
+// duplicate (deduped no-op), a plan-mode prompt (handled entirely server-side), or a context-clearing
+// plan approval (withheld so it can't race the restart it kicked off).
+func (svc *Context) processControlResponse(agentID string, dbAgent db.Agent, content []byte, claimToken string) (forwardBytes []byte, forward bool) {
+	// Build the plan (which reads the pending control request and decodes the request id ONCE),
+	// then CLAIM the answer for idempotency. The claim is the concurrency serialization point:
+	// handlers run concurrently (DispatchAsync, no per-agent lock), and an atomic INSERT on
+	// (agent_id, request_id, claim_token) picks exactly ONE winner. A duplicate -- an RPC retry, or a
+	// second window answering the same request instance before it received the cancel broadcast, both
+	// echoing the SAME claim_token -- loses. The claim is a DURABLE row (see claimControlResponseAnswer),
+	// so a duplicate straddling even a worker-PROCESS restart is deduped, and a REUSED request_id is
+	// deduped per instance by its distinct claim_token. An unattributable answer (no request id) is
+	// nobody's duplicate, so it needs no claim.
+	//
+	// Claiming AFTER buildControlResponsePlan is safe and lets the request id be decoded once: only
+	// the winner deletes the request (in applyWinningControlResponse below), and only AFTER its own
+	// claim, which is after its own read -- so the winner always reads the FULL render context (and
+	// the true SelfDisplayed flag) while the request is present, and a loser (which does nothing) may
+	// read it gone. The claim must precede the persist/delete, though: claiming only after a
+	// successful persist would let two answers both persist before either claims -- the double-row
+	// this prevents.
+	plan := svc.buildControlResponsePlan(agentID, dbAgent, content)
+
+	firstAnswer := true
+	if plan.requestMeta.RequestID != "" {
+		firstAnswer = svc.Output.claimControlResponseAnswer(agentID, plan.requestMeta.RequestID, claimToken)
+	}
+
+	// A duplicate does NOTHING: the winner already deleted the request, persisted the answer row,
+	// applied the plan-mode side effects, AND forwarded its own response. A duplicate must not
+	// re-do any of it -- and in particular must NOT re-forward. Because a duplicate read the request
+	// gone, its resolution.Content diverges from the winner's: a Codex plan-mode prompt approval
+	// would forward an envelope the winner (via applyWinningControlResponse) handles server-side and
+	// never sends, and a Cursor create_plan answer whose ACP transform needs the now-deleted request
+	// would forward the untransformed envelope. Re-forwarding either injects a stray/malformed frame
+	// onto the agent's stdin, so only the winner forwards.
+	if !firstAnswer {
+		return nil, false
+	}
+
+	// The once-only winner work: delete the request, then persist the answer row and apply the
+	// plan-mode side effects (or handle a plan-mode prompt entirely server-side). It runs BEFORE the
+	// forward so the user's answer row precedes any async plan-execution rows.
+	svc.applyWinningControlResponse(agentID, dbAgent, plan)
+
+	// Forward the winner's response to the agent unless it withholds its forward. A plan-prompt is
+	// handled server-side and never forwarded (plan.isPlanPrompt()); a context-clearing plan
+	// approval must not race the restart applyWinningControlResponse just kicked off
+	// (withholdsForward keys off the response's clearContext).
+	if plan.isPlanPrompt() || plan.withholdsForward() {
+		return nil, false
+	}
+	return plan.resolution.Content, true
 }
 
 func (svc *Context) deleteControlRequest(agentID string, provider leapmuxv1.AgentProvider, requestMeta controlResponseRequestMetadata, selfDisplayed bool) {
@@ -165,48 +259,59 @@ func (svc *Context) deleteControlRequest(agentID string, provider leapmuxv1.Agen
 	sink.BroadcastControlCancel(requestMeta.RequestID)
 }
 
-func (svc *Context) persistControlResponseAnswerRows(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
-	if plan.needsFallbackDisplayRow() {
-		svc.persistControlResponseDisplayRow(agentID, provider, plan)
-	}
-
-	// The synthetic {content} answer row belongs ONLY to a provider-resolved answer
-	// (controlAnswerSynthetic). A self-displayed answer already lives in the provider's own
-	// transcript, and a fallback answer is carried by the {controlResponse} row above -- persisting
-	// resolution.DisplayText for either would DUPLICATE the answer row. Today the only
-	// self-displaying provider (Claude) returns no DisplayText, so persistSyntheticUserMessage
-	// early-returns on empty and this is a no-op for it -- but gating on the classifier makes "exactly
-	// one answer row" STRUCTURAL (matching classifyControlAnswerRow's no-double-MARK guarantee) rather
-	// than resting on that emptiness, so a future provider that BOTH self-displays AND returns display
-	// text can't double-render the answer. controlAnswerSynthetic always carries non-empty display
-	// text (the classifier's own rule), so the mark is unconditionally CONTROL_RESPONSE here.
-	if plan.answerRow() == controlAnswerSynthetic {
-		svc.persistSyntheticUserMessage(agentID, provider, plan.resolution.DisplayText, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
+// persistControlResponseAnswerRow persists the single synthetic control-response row that carries
+// the user's answer -- and the rail's CONTROL_RESPONSE mark -- for every provider whose answer is
+// not already shown in its own transcript. needsStructuredRow decides whether THIS answer needs the
+// row, so a self-displayed answer (Claude's echoed tool_result) draws its dot on the ingested
+// provider row instead of here. Duplicate answers for the same request are gated out one layer up
+// (SendControlResponse's idempotency claim) before reaching here, so the row is never double-marked.
+func (svc *Context) persistControlResponseAnswerRow(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
+	if plan.needsStructuredRow() {
+		svc.persistControlResponseRow(agentID, provider, plan)
 	}
 }
 
-// exitPlanClearingContext reports the one compound condition the fallback-row rule and the
-// plan-mode-effects skipSend both hinge on: an APPROVED ExitPlanMode that ALSO clears context.
-// When it holds, initiatePlanExecution is about to stop the agent, so the self-displayed
-// transcript tool_result never materializes -- which is why the fallback display row must
-// carry the mark instead. Naming the triple once keeps needsFallbackDisplayRow and
-// applyControlResponsePlanModeEffects from silently drifting on it.
+// approvedClearContext reports an APPROVED decision that clears context: behavior()==Allow with the
+// frontend's clearContext flag set. clearContext is attached ONLY by the two restart-causing plan
+// approvals (ExitPlanMode, the Codex plan-mode prompt), so this is the shared core of the two
+// predicates below -- withholdsForward (the request-independent forward gate) narrows it with
+// hasDecision, exitPlanClearingContext (the loaded-answer mark rule) narrows it with
+// PlanModeControl==Exit. Named once so the two can't drift on what "approved + clears context" means.
+func (plan controlResponsePlan) approvedClearContext() bool {
+	return plan.behavior() == agent.ControlBehaviorAllow && plan.decision.ClearContext
+}
+
+// exitPlanClearingContext reports the one compound condition the structured-row rule hinges on: an
+// APPROVED ExitPlanMode that ALSO clears context. When it holds, initiatePlanExecution is about to
+// stop the agent, so the self-displayed transcript tool_result never materializes -- which is why the
+// synthetic structured row must carry the mark instead. It is the LOADED-answer equivalent of
+// withholdsForward (which is request-independent); naming the triple once keeps needsStructuredRow and
+// applyControlResponsePlanModeMutations from silently drifting on it.
 func (plan controlResponsePlan) exitPlanClearingContext() bool {
-	return plan.behavior() == agent.ControlBehaviorAllow &&
-		plan.resolution.PlanModeControl == agent.PlanModeControlExit &&
-		plan.decision.ClearContext
+	return plan.approvedClearContext() && plan.resolution.PlanModeControl == agent.PlanModeControlExit
 }
 
-func (plan controlResponsePlan) needsFallbackDisplayRow() bool {
-	if !plan.requestMeta.Loaded || !plan.hasDecision {
+// needsStructuredRow reports whether SendControlResponse should synthesize the structured
+// control-response row for this answer. A resolvable request id is required (an unattributable
+// response draws no row, as before).
+//
+// A genuinely self-displayed answer (Claude's echoed tool_result carries the mark) gets NO structured
+// row, EXCEPT when a context-clearing plan exit is about to wipe that echoed row, where the
+// structured row carries the mark instead.
+//
+// Otherwise the answer gets the row -- even when the pending request was already deleted or the
+// decision was unrecognized, so the user's answer is never lost (#258). The "answered twice" concern
+// (a request-gone duplicate whose first answer's Claude tool_result already carries the mark) is
+// handled ONE layer up by SendControlResponse's per-request idempotency claim, which lets only the
+// first answer reach this row -- so needsStructuredRow no longer needs a provider-capability guard.
+func (plan controlResponsePlan) needsStructuredRow() bool {
+	if plan.requestMeta.RequestID == "" {
 		return false
 	}
-	if plan.answerRow() == controlAnswerFallback {
-		return true
+	if plan.resolution.SelfDisplayed {
+		return plan.exitPlanClearingContext()
 	}
-	// A self-displayed answer normally owns the mark on its own transcript row -- unless a
-	// context-clearing plan exit is about to wipe that row, where the fallback row carries it.
-	return plan.answerRow() == controlAnswerSelfDisplayed && plan.exitPlanClearingContext()
+	return true
 }
 
 func (svc *Context) handleControlResponsePromptPlan(agentID string, dbAgent db.Agent, plan controlResponsePlan) {
@@ -220,7 +325,7 @@ func (svc *Context) handleControlResponsePromptPlan(agentID string, dbAgent db.A
 	approvalOptions := agent.ProviderFor(dbAgent.AgentProvider).PlanApprovalOptions()
 	switch plan.behavior() {
 	case agent.ControlBehaviorAllow:
-		svc.persistControlResponseDisplayRow(agentID, dbAgent.AgentProvider, plan)
+		svc.persistControlResponseRow(agentID, dbAgent.AgentProvider, plan)
 
 		// Settle the provider's base plan-approval options (applied live, notify on first set).
 		if len(approvalOptions.Base) > 0 {
@@ -249,102 +354,80 @@ func (svc *Context) handleControlResponsePromptPlan(agentID string, dbAgent db.A
 			// other deny-with-feedback path (ExitPlanMode, permission decisions).
 			svc.sendSyntheticUserMessage(agentID, msg, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
 		} else {
-			svc.persistControlResponseDisplayRow(agentID, dbAgent.AgentProvider, plan)
+			svc.persistControlResponseRow(agentID, dbAgent.AgentProvider, plan)
 		}
 	}
 }
 
-// controlAnswerRow identifies which persisted row carries the single CONTROL_RESPONSE rail
-// mark for a user's answer to a control request. The three homes are mutually exclusive, so
-// naming them here lets the two persist sites agree on exactly one -- never both (a double
-// dot), never neither (a real answer with no dot).
-type controlAnswerRow int
-
-const (
-	// controlAnswerSelfDisplayed: the provider re-emits the answer in its OWN transcript
-	// (Claude's AskUserQuestion / ExitPlanMode tool_result), which the Claude user-envelope
-	// classifier marks at ingestion -- so neither synthesized row is marked.
-	controlAnswerSelfDisplayed controlAnswerRow = iota
-	// controlAnswerSynthetic: a provider-resolved answer row (Codex/OpenCode/Pi/Cursor) that
-	// SendControlResponse writes via persistSyntheticUserMessage from displayText -- that row
-	// carries the mark.
-	controlAnswerSynthetic
-	// controlAnswerFallback: no provider display text and not self-displayed (a Claude
-	// permission decision, or a non-Claude approval with no feedback) -- the synthetic
-	// {controlResponse} fallback row in persistControlResponseAnswerRows carries the mark.
-	controlAnswerFallback
-)
-
-// classifyControlAnswerRow is the SINGLE home for the "which row is the control answer"
-// decision, derived from the provider-resolved self-display flag and display text. Both
-// persist sites consult it -- the synthetic answer row and the fallback display row -- so
-// exactly one row draws the rail's jump dot. Because self-display is checked FIRST, a
-// provider that BOTH self-displays AND returns display text can never double-mark: its
-// ingested transcript row owns the mark and the synthesized rows stay unmarked.
-func classifyControlAnswerRow(selfDisplayed bool, displayText string) controlAnswerRow {
-	if selfDisplayed {
-		return controlAnswerSelfDisplayed
-	}
-	if strings.TrimSpace(displayText) != "" {
-		return controlAnswerSynthetic
-	}
-	return controlAnswerFallback
+// withholdsForward reports whether this answer's response must NOT be forwarded to the agent: an
+// APPROVED context-clearing plan approval (ExitPlanMode, or the Codex plan-mode prompt), which is
+// about to restart the agent via initiatePlanExecution -- forwarding it would race the restart. Only
+// the claim WINNER ever reaches this predicate: a duplicate returns at SendControlResponse's
+// !firstAnswer gate before the forward decision. It is read from the RESPONSE envelope
+// (content-derived, request-independent), so a request-gone winner -- a genuine orphan whose pending
+// request was already cleared (a teardown, or never stored), which therefore can't resolve
+// PlanModeControlExit -- still withholds rather than forwarding a stale restart-approval onto a
+// subprocess that is already being torn down. clearContext is set ONLY by the two restart-causing plan
+// approvals, never an ordinary permission or EnterPlanMode, so it is a reliable proxy for "this answer
+// restarts the agent."
+//
+// On a LOADED ExitPlanMode answer this equals exitPlanClearingContext() -- the predicate
+// needsStructuredRow keys its mark-carrying row off -- because such an answer resolves
+// PlanModeControl==Exit; the two are named separately only so the mark rule can require
+// PlanModeControl==Exit while the forward rule stays request-independent for the request-gone case.
+// The one loaded answer where they DIVERGE is the Codex plan-mode PROMPT: it also carries
+// clearContext+Allow (so withholdsForward is true) but resolves PlanModeControl==Prompt, not Exit (so
+// exitPlanClearingContext is false). That divergence is harmless: the handler catches a plan prompt on
+// its isPlanPrompt gate and runs it server-side (handleControlResponsePromptPlan) BEFORE the forward,
+// so withholdsForward is never consulted for it.
+func (plan controlResponsePlan) withholdsForward() bool {
+	return plan.hasDecision && plan.approvedClearContext()
 }
 
-// applyControlResponsePlanModeEffects detects plan mode changes from control responses.
-// When the frontend approves/rejects an EnterPlanMode or ExitPlanMode control request,
-// this updates the permission mode and initiates plan execution as needed. Returns true
-// when the caller should skip sending the response to the agent (clearContext path).
-func (svc *Context) applyControlResponsePlanModeEffects(agentID string, dbAgent db.Agent, plan controlResponsePlan) bool {
-	if !plan.requestMeta.Loaded || !plan.hasDecision {
-		return false
+// applyControlResponsePlanModeMutations applies the once-only plan-mode side effects of an
+// EnterPlanMode / ExitPlanMode approval: the permission-mode switch, the planModeToolUse cleanup, and
+// (for a context-clearing exit) kicking off initiatePlanExecution. The caller runs it for the WINNER
+// only -- a duplicate must not re-run the switch or re-restart the agent -- so unlike withholdsForward
+// (a pure content-derived predicate, correct for any answer but reached only by the winner), these
+// mutations are side effects the caller gates externally to the winner, not internally.
+// A request-gone or decision-less answer touches nothing (the mutations need the loaded request).
+func (svc *Context) applyControlResponsePlanModeMutations(agentID string, dbAgent db.Agent, plan controlResponsePlan) {
+	if !plan.requestMeta.Loaded || !plan.hasDecision || plan.behavior() != agent.ControlBehaviorAllow {
+		return
 	}
 
 	crPayload := plan.decision
-	// Trim to match: plan.requestMeta.RequestID came through DecodeControlBehavior (which trims),
-	// so read the response's own request id the same way -- otherwise a whitespace-padded id would
-	// fail this equality and silently skip the plan-mode transition even though hasDecision (which
-	// also trims) accepted it. Keeps the "trim everywhere" rule the rest of this file enforces.
-	reqID := strings.TrimSpace(crPayload.Response.RequestID)
+	// crPayload.Response.RequestID is already trimmed at construction (buildControlResponsePlan),
+	// matching plan.requestMeta.RequestID (which came through DecodeControlBehavior's trimming read),
+	// so this equality can never be a trimmed-vs-untrimmed mismatch -- and it agrees with the
+	// hasDecision gate, which reads the same normalized id.
+	reqID := crPayload.Response.RequestID
 	if reqID == "" || reqID != plan.requestMeta.RequestID {
-		return false
+		return
 	}
 
-	// Detect plan mode changes from control responses (agent-initiated).
-	skipSend := false
-	if plan.behavior() == agent.ControlBehaviorAllow {
-		switch plan.resolution.PlanModeControl {
-		case agent.PlanModeControlEnter:
-			svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModePlan)
-		case agent.PlanModeControlExit:
-			// Determine target permission mode from control_response (default AcceptEdits here,
-			// vs Default on the plan-prompt path -- resolveTargetMode owns that fallback).
-			targetMode := resolveTargetMode(crPayload.PermissionMode, agent.PermissionModeAcceptEdits)
-			svc.setAgentPermissionModeWithAgent(dbAgent, targetMode)
+	switch plan.resolution.PlanModeControl {
+	case agent.PlanModeControlEnter:
+		svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModePlan)
+	case agent.PlanModeControlExit:
+		// Determine target permission mode from control_response (default AcceptEdits here,
+		// vs Default on the plan-prompt path -- resolveTargetMode owns that fallback).
+		targetMode := resolveTargetMode(crPayload.PermissionMode, agent.PermissionModeAcceptEdits)
+		svc.setAgentPermissionModeWithAgent(dbAgent, targetMode)
 
-			// Remove the planModeToolUse entry so detectPlanModeFromToolResult
-			// does not override the mode we just set.
-			if plan.requestMeta.ToolUseID != "" {
-				svc.Output.planModeToolUse.Delete(plan.requestMeta.ToolUseID)
-			}
+		// Remove the planModeToolUse entry so detectPlanModeFromToolResult
+		// does not override the mode we just set.
+		if plan.requestMeta.ToolUseID != "" {
+			svc.Output.planModeToolUse.Delete(plan.requestMeta.ToolUseID)
+		}
 
-			// Inside the Behavior==Allow branch and the PlanModeControlExit case, this
-			// IS plan.exitPlanClearingContext() -- the same predicate needsFallbackDisplayRow
-			// keys the mark-carrying fallback row off. Call it (rather than re-inlining the
-			// ClearContext read) so the two provably stay in lockstep, as its doc promises.
-			if plan.exitPlanClearingContext() {
-				// When clearing context, don't send the approval to the
-				// agent — we're about to stop it anyway. This avoids
-				// the race where the agent acts on the approval before
-				// initiatePlanExecution kills it.
-				go svc.initiatePlanExecution(agentID, targetMode)
-				skipSend = true
-			}
-			// When !clearContext, the agent continues in current context.
+		// When clearing context, kick off the restart -- once. The forward itself is withheld for
+		// every answer by withholdsForward (== exitPlanClearingContext on this loaded path), so we only
+		// start the restart here; we don't re-decide the withhold.
+		if plan.exitPlanClearingContext() {
+			go svc.initiatePlanExecution(agentID, targetMode)
 		}
 	}
-
-	return skipSend
 }
 
 // resolveTargetMode picks the plan-execution target permission mode: the mode the frontend
@@ -358,32 +441,82 @@ func resolveTargetMode(permissionMode, defaultMode string) string {
 	return defaultMode
 }
 
-// persistControlResponseDisplayRow writes the synthetic {controlResponse} row from the plan's
-// approve/reject behavior and the NORMALIZED comment the frontend attached, reading both off the
-// plan so the deep decision chain lives here once rather than at each call site. The comment runs
-// through plan.rejectionMessage() (not the raw decision message) so the auto-filled
-// ControlRejectedByUserMessage sentinel collapses to "" -- otherwise a bare deny would render the
-// placeholder "Rejected by user." as if it were typed feedback ("Sent feedback: ...") in both the
-// transcript row (controlResponseRenderer) and the rail dot preview (defaultMarkPreview), instead
-// of the intended "Rejected". An approved row ignores comment, so normalizing it is safe there too.
-func (svc *Context) persistControlResponseDisplayRow(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
-	action := "approved"
-	if plan.behavior() == agent.ControlBehaviorDeny {
-		action = "rejected"
+// persistedControlResponse is the structured control-response payload persisted inside the
+// synthetic transcript row (issue #258). It keeps the provider-native response as sent to the
+// agent plus the minimal provider-pruned request context, so the frontend can render human-facing
+// labels AFTER the pending control request is deleted -- the backend no longer duplicates the
+// frontend's label text.
+type persistedControlResponse struct {
+	// Provider is the AgentProvider enum name minus its AGENT_PROVIDER_ prefix (CODEX, OPENCODE,
+	// CLAUDE_CODE, ...), matching how protobuf-es names the TS enum members. It durably records
+	// which provider produced this answer; the frontend resolves the rendering plugin from the
+	// message's own agentProvider, NOT this field, so it is an audit/debug token rather than a
+	// dispatch key.
+	Provider string `json:"provider"`
+	// RequestID is the id of the control request this answers, omitted only when unknown.
+	RequestID string `json:"requestId,omitempty"`
+	// Request is the provider-pruned minimal render context (agent.ControlResponseResolution's
+	// RequestContext), omitted when the stored request was unavailable or unrecognized.
+	Request json.RawMessage `json:"request,omitempty"`
+	// Response is the provider-native response payload forwarded to the agent (resolution.Content,
+	// e.g. Cursor's transformed outcome), the source of truth the frontend renders the answer from.
+	Response json.RawMessage `json:"response"`
+}
+
+// syntheticControlResponseRow is the transcript-row content envelope wrapping a
+// persistedControlResponse. isSynthetic (NOT the message source) is what makes the frontend
+// classify it as a control_response: the row is USER-sourced (a control answer is the user's own
+// response), so without this flag it would render as a plain user-send content bubble.
+type syntheticControlResponseRow struct {
+	IsSynthetic     bool                     `json:"isSynthetic"`
+	ControlResponse persistedControlResponse `json:"controlResponse"`
+}
+
+// controlResponseProviderName renders an AgentProvider as the bare token the persisted control
+// response records -- the proto enum name with its AGENT_PROVIDER_ prefix stripped, matching how
+// protobuf-es names the TS enum members (AGENT_PROVIDER_CODEX -> "CODEX"). It is recorded for
+// audit/debug; the frontend dispatches on the message's agentProvider, not this token.
+func controlResponseProviderName(p leapmuxv1.AgentProvider) string {
+	return strings.TrimPrefix(p.String(), "AGENT_PROVIDER_")
+}
+
+// persistControlResponseRow writes the durable synthetic control-response transcript row: the
+// provider-native response payload forwarded to the agent, plus the provider-pruned request
+// context the frontend renders human-facing labels from (issue #258). It is sourced from USER --
+// a control answer is the user's own response to the agent, so like a typed message it counts
+// toward HasUserMessages/resolveResumeSessionID (answering alone can make a session resumable) and
+// its bubble exposes data-role="user". This matches how every non-Claude provider-resolved answer
+// was persisted on the pre-#258 path (a USER {content} row); the isSynthetic flag -- not the source
+// -- is what routes it to the control_response renderer. It carries the CONTROL_RESPONSE rail mark.
+// The frontend owns all label text; the backend no longer duplicates it.
+func (svc *Context) persistControlResponseRow(agentID string, provider leapmuxv1.AgentProvider, plan controlResponsePlan) {
+	// Coalesce empty-OR-invalid bytes to nil so the Response field marshals as `null` rather than
+	// making the WHOLE row marshal fail (which would silently drop the user's answer row): a
+	// json.RawMessage marshals only when it holds valid JSON -- empty-but-non-nil bytes error with
+	// "unexpected end of JSON input", and non-empty non-JSON bytes error with "invalid character
+	// ...". buildControlResponsePlan already backfills empty Content with the raw response, so this is
+	// the marshal-boundary backstop that keeps "a resolvable answer always persists a row" true
+	// regardless of the resolution's Content -- empty or malformed. json.Valid also treats nil/empty
+	// as invalid, so this one check subsumes the empty case.
+	response := json.RawMessage(plan.resolution.Content)
+	if !json.Valid(response) {
+		response = nil
 	}
-	displayContent := map[string]interface{}{
-		"isSynthetic": true,
-		"controlResponse": map[string]string{
-			"action":  action,
-			"comment": plan.rejectionMessage(),
+	row := syntheticControlResponseRow{
+		IsSynthetic: true,
+		ControlResponse: persistedControlResponse{
+			Provider:  controlResponseProviderName(provider),
+			RequestID: plan.requestMeta.RequestID,
+			Request:   plan.resolution.RequestContext,
+			Response:  response,
 		},
 	}
-	displayJSON, err := json.Marshal(displayContent)
+	rowJSON, err := json.Marshal(row)
 	if err != nil {
-		slog.Warn("marshal control response notification", "agent_id", agentID, "error", err)
+		slog.Warn("marshal control response row", "agent_id", agentID, "error", err)
 		return
 	}
-	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, displayJSON, agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE}, nil); err != nil {
-		slog.Warn("failed to persist control response notification", "agent_id", agentID, "error", err)
+	if err := svc.Output.persistAndBroadcast(agentID, provider, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rowJSON, agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE}, nil); err != nil {
+		slog.Warn("failed to persist control response row", "agent_id", agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -27,7 +27,45 @@ func decodeMessageContent(t *testing.T, content []byte, compression leapmuxv1.Co
 	return body.Content
 }
 
-func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
+// decodedControlResponse is the structured `{isSynthetic, controlResponse:{provider, requestId,
+// request, response}}` row (issue #258): the provider-native response as sent to the agent plus the
+// pruned request context the frontend renders labels from. `request` is nil when the row omitted it
+// (the stored request was unavailable or unrecognized). Its json tags INDEPENDENTLY spell the
+// persisted wire field names -- the backend->DB->frontend contract -- so a production tag rename is
+// caught here rather than silently round-tripping through the shared struct that wrote the row.
+type decodedControlResponse struct {
+	Provider  string          `json:"provider"`
+	RequestID string          `json:"requestId"`
+	Request   json.RawMessage `json:"request"`
+	Response  json.RawMessage `json:"response"`
+}
+
+func decodeStructuredControlResponse(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) decodedControlResponse {
+	t.Helper()
+	raw, err := msgcodec.Decompress(content, compression)
+	require.NoError(t, err)
+	var body struct {
+		IsSynthetic     bool                   `json:"isSynthetic"`
+		ControlResponse decodedControlResponse `json:"controlResponse"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body))
+	require.True(t, body.IsSynthetic, "a structured control-response row must be marked isSynthetic")
+	return body.ControlResponse
+}
+
+// controlResponseRows returns the CONTROL_RESPONSE-marked rows, isolating the single structured
+// answer row from any async plan-execution rows a clear-context path may append.
+func controlResponseRows(rows []db.Message) []db.Message {
+	marked := make([]db.Message, 0, len(rows))
+	for _, row := range rows {
+		if row.MarkType == leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE {
+			marked = append(marked, row)
+		}
+	}
+	return marked
+}
+
+func TestSendControlResponse_PersistsCodexUserInputRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 
@@ -63,18 +101,19 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{
+		"jsonrpc":"2.0",
+		"id":7,
+		"result":{
+			"answers":{
+				"task":{"answers":["Inspect the renderer"]},
+				"reason":{"answers":["Need parity with Claude Code"]}
+			}
+		}
+	}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{
-			"jsonrpc":"2.0",
-			"id":7,
-			"result":{
-				"answers":{
-					"task":{"answers":["Inspect the renderer"]},
-					"reason":{"answers":["Need parity with Claude Code"]}
-				}
-			}
-		}`),
+		Content: response,
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -87,11 +126,18 @@ func TestSendControlResponse_PersistsCodexUserInputAnswer(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
-	assert.Equal(t, "Task: Inspect the renderer\nReason: Need parity with Claude Code", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CODEX", cr.Provider)
+	assert.Equal(t, "7", cr.RequestID)
+	assert.JSONEq(t, `{
+		"method":"item/tool/requestUserInput",
+		"params":{"questions":[{"id":"task","header":"Task"},{"id":"reason","header":"Reason"}]}
+	}`, string(cr.Request), "the pruned question context lets the frontend label the answers")
+	assert.JSONEq(t, string(response), string(cr.Response), "the native answer payload is retained verbatim")
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
-func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
+func TestSendControlResponse_PersistsCodexDenyFeedbackRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 
@@ -121,19 +167,20 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{
+		"type":"control_response",
+		"response":{
+			"subtype":"success",
+			"request_id":"req-1",
+			"response":{
+				"behavior":"deny",
+				"message":"Please add tests before exiting plan mode."
+			}
+		}
+	}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{
-			"type":"control_response",
-			"response":{
-				"subtype":"success",
-				"request_id":"req-1",
-				"response":{
-					"behavior":"deny",
-					"message":"Please add tests before exiting plan mode."
-				}
-			}
-		}`),
+		Content: response,
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -146,15 +193,18 @@ func TestSendControlResponse_PersistsCodexFeedbackMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
-	assert.Equal(t, "Please add tests before exiting plan mode.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CODEX", cr.Provider)
+	assert.Equal(t, "req-1", cr.RequestID)
+	// The typed feedback lives inside the native response; the frontend extracts and renders it.
+	assert.JSONEq(t, string(response), string(cr.Response))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
 // TestSendControlResponse_CodexPlanModePromptDenyFeedbackIsMarked covers the Codex
-// plan-mode-prompt DENY-with-feedback path in the shared control-response planner. The
-// user's typed rejection reason is their own answer to the control request, so it must draw
-// a scroll-rail jump dot (CONTROL_RESPONSE) -- consistent with every other deny-with-
-// feedback path -- rather than staying unmarked like a truly synthetic prompt.
+// plan-mode-prompt DENY-with-feedback path. The user's typed rejection reason is their own answer,
+// forwarded to the agent as a real user message that draws a scroll-rail jump dot -- it stays the
+// plain {content} shape, not the structured control-response row.
 func TestSendControlResponse_CodexPlanModePromptDenyFeedbackIsMarked(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
@@ -205,13 +255,12 @@ func TestSendControlResponse_CodexPlanModePromptDenyFeedbackIsMarked(t *testing.
 		"a plan-mode-prompt denial's typed feedback is the user's control answer and draws a rail dot")
 }
 
-// TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow covers the deny path
-// when the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage
-// placeholder, which controlResponsePlan.rejectionMessage() (via agent.NormalizeRejectionMessage)
-// collapses to "" -- so the planner persists the synthetic {controlResponse action:"rejected"}
-// display row (LEAPMUX-sourced, still mark-carrying) rather than a USER-sourced feedback row
-// echoing the placeholder as if it were the user's words.
-func TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow(t *testing.T) {
+// TestSendControlResponse_CodexPlanModePromptBareDenyPersistsStructuredRow covers the plan-prompt
+// deny path when the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage
+// placeholder, so there is no typed feedback to forward as a user message. The planner persists the
+// structured control-response row instead, retaining the native response verbatim (the frontend --
+// not the backend -- collapses the placeholder when rendering).
+func TestSendControlResponse_CodexPlanModePromptBareDenyPersistsStructuredRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 
@@ -237,10 +286,11 @@ func TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow(t *t
 	defer svc.Agents.StopAgent("agent-1")
 
 	// The sentinel has no JSON-special characters, so embedding the constant keeps the wire
-	// value in lockstep with the backend's collapse rule without a fmt import.
+	// value in lockstep with the backend's rule without a fmt import.
+	response := []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`),
+		Content: response,
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -248,12 +298,14 @@ func TestSendControlResponse_CodexPlanModePromptBareDenyPersistsRejectedRow(t *t
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source,
-		"a bare denial (placeholder collapsed to no feedback) persists the synthetic display row, not a user feedback row")
-	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
-	assert.Equal(t, "rejected", action)
-	assert.Empty(t, comment,
-		"a bare denial must NOT leak the ControlRejectedByUserMessage placeholder as feedback -- the row renders \"Rejected\", not \"Sent feedback: Rejected by user.\"")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source,
+		"a bare denial persists the structured control-response row (USER-sourced), identified by its {controlResponse} shape rather than a forwarded {content} feedback row")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CODEX", cr.Provider)
+	assert.JSONEq(t, `{"request":{"tool_name":"CodexPlanModePrompt"}}`, string(cr.Request))
+	// The native response is retained verbatim -- the placeholder is not collapsed backend-side;
+	// the frontend collapses it to render "Rejected".
+	assert.JSONEq(t, string(response), string(cr.Response))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 }
 
@@ -299,14 +351,61 @@ func TestSendControlResponse_CodexPlanModePromptAllowPersistsMarkedApproval(t *t
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
-	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source)
-	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CODEX", cr.Provider)
+	assert.JSONEq(t, `{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`, string(cr.Response))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType,
 		"the user's plan-mode approval must have a scroll-rail control-response dot")
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[1].Source)
 	assert.Equal(t, "Implement the plan.", decodeMessageContent(t, rows[1].Content, rows[1].ContentCompression))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[1].MarkType,
 		"the auto-injected prompt is not the user's own answer")
+}
+
+// TestSendControlResponse_CodexPlanModePromptDuplicateAnswerAppliesOnce pins the plan-prompt side of
+// the idempotency claim: a plan-prompt answer processed twice -- with the request re-stored so BOTH
+// answers resolve as a LOADED plan-prompt, mirroring a true concurrent retry rather than the
+// request-gone path -- runs handleControlResponsePromptPlan (which persists the structured row AND
+// applies plan-mode side effects like the "Implement the plan." prompt) exactly ONCE, not per retry.
+func TestSendControlResponse_CodexPlanModePromptDuplicateAnswerAppliesOnce(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+		Options:       marshalOptions(map[string]string{agent.CodexOptionCollaborationMode: agent.CodexCollaborationDefault}),
+	}))
+	storeRequest := func() {
+		require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+			AgentID: "agent-1", RequestID: "plan-1",
+			Payload: []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+		}))
+	}
+	storeRequest()
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	answer := &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`),
+	}
+	dispatch(d, "SendControlResponse", answer, w)
+	// The first answer deleted the request; re-store it so the duplicate ALSO resolves as a loaded
+	// plan-prompt. The idempotency claim -- not a request-gone short-circuit -- must stop the reapply.
+	storeRequest()
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2,
+		"the plan-prompt approval applies once: one structured row + one 'Implement the plan.' prompt, not doubled")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+	assert.Equal(t, "Implement the plan.", decodeMessageContent(t, rows[1].Content, rows[1].ContentCompression))
 }
 
 func TestBuildControlResponsePlan_MalformedPlanPromptHasNoDecision(t *testing.T) {
@@ -354,14 +453,52 @@ func TestBuildControlResponsePlan_WhitespacePaddedBehaviorStillDecides(t *testin
 	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
 
-	// A behavior string with surrounding whitespace must still resolve to a decision: behavior()
-	// trims to match ControlBehaviorAllow (mirroring agent.DecodeControlBehavior's trimming read),
-	// so hasDecision holds and the plan-mode/answer-row handling is not silently skipped.
+	// A behavior string with surrounding whitespace must still resolve to a decision: the envelope is
+	// normalized at construction (mirroring agent.DecodeControlBehavior's trimming read), so behavior()
+	// reads the trimmed value, hasDecision holds, and the plan-mode handling is not silently skipped.
 	plan := svc.buildControlResponsePlan("agent-1", dbAgent, []byte(`{"response":{"request_id":"plan-1","response":{"behavior":" allow "}}}`))
 
 	assert.True(t, plan.requestMeta.Loaded)
-	assert.Equal(t, agent.ControlBehaviorAllow, plan.behavior(), "behavior() trims surrounding whitespace")
+	assert.Equal(t, agent.ControlBehaviorAllow, plan.behavior(), "behavior() reads the value trimmed at construction")
 	assert.True(t, plan.hasDecision, "a whitespace-padded allow still counts as a decision")
+}
+
+// TestBuildControlResponsePlan_RequestIDNormalizedConsistently pins that the response envelope's
+// request_id is trimmed ONCE at construction, so the hasDecision gate and the plan-mode mutation
+// request-id match read the SAME normalized value and can never disagree. A padded-but-nonempty id
+// trims and still decides (matching the trimmed requestMeta id); an all-whitespace id normalizes to
+// "" and is treated as no-decision on BOTH gates (previously hasDecision read it untrimmed as
+// non-empty while the mutation gate trimmed it to "" and skipped -- the inconsistency this closes).
+func TestBuildControlResponsePlan_RequestIDNormalizedConsistently(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID:   "agent-1",
+		RequestID: "plan-1",
+		Payload:   []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+
+	// A padded-but-nonempty request_id trims to the loaded id, so it decides and its plan-mode
+	// mutation gate would match (both read "plan-1").
+	padded := svc.buildControlResponsePlan("agent-1", dbAgent, []byte(`{"response":{"request_id":" plan-1 ","response":{"behavior":"allow"}}}`))
+	assert.Equal(t, "plan-1", padded.decision.Response.RequestID, "request_id is trimmed at construction")
+	assert.True(t, padded.hasDecision, "a padded-nonempty request_id still counts as a decision")
+
+	// An all-whitespace request_id normalizes to "" -> no decision, consistently on both gates (the
+	// hasDecision gate no longer reads it untrimmed-nonempty while the mutation gate trims it to "").
+	blank := svc.buildControlResponsePlan("agent-1", dbAgent, []byte(`{"response":{"request_id":"   ","response":{"behavior":"allow"}}}`))
+	assert.Equal(t, "", blank.decision.Response.RequestID, "an all-whitespace request_id normalizes to empty")
+	assert.False(t, blank.hasDecision, "an all-whitespace request_id is no decision on the hasDecision gate too")
 }
 
 func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T) {
@@ -430,7 +567,7 @@ func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T
 	assert.Equal(t, []string{"cancel", "message"}, kinds[:2])
 }
 
-func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
+func TestSendControlResponse_PersistsOpenCodeQuestionRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 
@@ -464,15 +601,16 @@ func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{
+		"jsonrpc":"2.0",
+		"id":"que-1",
+		"result":{
+			"answers":[["Build"],["Dev"]]
+		}
+	}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{
-			"jsonrpc":"2.0",
-			"id":"que-1",
-			"result":{
-				"answers":[["Build"],["Dev"]]
-			}
-		}`),
+		Content: response,
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -485,11 +623,18 @@ func TestSendControlResponse_PersistsOpenCodeQuestionAnswer(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
-	assert.Equal(t, "Task: Build\nEnv: Dev", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "OPENCODE", cr.Provider)
+	assert.Equal(t, "que-1", cr.RequestID)
+	assert.JSONEq(t, `{
+		"type":"question.asked",
+		"properties":{"questions":[{"header":"Task","question":"Pick a task"},{"header":"Env","question":"Pick an environment"}]}
+	}`, string(cr.Request), "the question headers let the frontend label the structured answers")
+	assert.JSONEq(t, string(response), string(cr.Response))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
-func TestSendControlResponse_PersistsCopilotPermissionSelectionLabel(t *testing.T) {
+func TestSendControlResponse_PersistsCopilotPermissionSelectionRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 
@@ -525,15 +670,16 @@ func TestSendControlResponse_PersistsCopilotPermissionSelectionLabel(t *testing.
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{
+		"jsonrpc":"2.0",
+		"id":7,
+		"result":{
+			"outcome":{"outcome":"selected","optionId":"proceed_once"}
+		}
+	}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{
-			"jsonrpc":"2.0",
-			"id":7,
-			"result":{
-				"outcome":{"outcome":"selected","optionId":"proceed_once"}
-			}
-		}`),
+		Content: response,
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -545,40 +691,24 @@ func TestSendControlResponse_PersistsCopilotPermissionSelectionLabel(t *testing.
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "Allow once", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "GITHUB_COPILOT", cr.Provider)
+	assert.JSONEq(t, `{
+		"method":"requestPermission",
+		"params":{"options":[
+			{"optionId":"proceed_once","name":"Allow once"},
+			{"optionId":"cancel","name":"Deny"}
+		]}
+	}`, string(cr.Request), "the option names let the frontend resolve the selected optionId to a label (kind is pruned)")
+	assert.JSONEq(t, string(response), string(cr.Response))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "a control-response answer draws a scroll-rail jump dot")
 }
 
-// decodeControlResponseAction decompresses a `{controlResponse:{action,comment}}` fallback
-// display row and returns its action.
-func decodeControlResponseAction(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) string {
-	t.Helper()
-	action, _ := decodeControlResponseRow(t, content, compression)
-	return action
-}
-
-// decodeControlResponseRow decompresses a `{controlResponse:{action,comment}}` display row and
-// returns both fields. The comment must have the ControlRejectedByUserMessage placeholder collapsed
-// to "" by persistControlResponseDisplayRow -- a bare deny renders "Rejected", not the placeholder.
-func decodeControlResponseRow(t *testing.T, content []byte, compression leapmuxv1.ContentCompression) (action, comment string) {
-	t.Helper()
-	raw, err := msgcodec.Decompress(content, compression)
-	require.NoError(t, err)
-	var body struct {
-		ControlResponse struct {
-			Action  string `json:"action"`
-			Comment string `json:"comment"`
-		} `json:"controlResponse"`
-	}
-	require.NoError(t, json.Unmarshal(raw, &body))
-	return body.ControlResponse.Action, body.ControlResponse.Comment
-}
-
-// TestSendControlResponse_PersistsClaudePermissionFallbackRow covers the Claude permission
-// path: the provider resolver produces no display text for Bash and Bash is not
-// self-displaying, so the planner's fallback `{controlResponse}` row IS the display -- and
-// must carry the CONTROL_RESPONSE mark.
-func TestSendControlResponse_PersistsClaudePermissionFallbackRow(t *testing.T) {
+// TestSendControlResponse_PersistsClaudePermissionRow covers the Claude permission path: Bash is
+// not self-displaying, so the planner's structured control-response row IS the answer and must
+// carry the CONTROL_RESPONSE mark.
+func TestSendControlResponse_PersistsClaudePermissionRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -595,26 +725,30 @@ func TestSendControlResponse_PersistsClaudePermissionFallbackRow(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+		Content: response,
 	}, w)
 	require.Empty(t, w.errors)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX, rows[0].Source)
-	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
-	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the fallback row draws the rail jump dot")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CLAUDE_CODE", cr.Provider)
+	assert.Equal(t, "req-1", cr.RequestID)
+	assert.JSONEq(t, `{"request":{"tool_name":"Bash"}}`, string(cr.Request))
+	assert.JSONEq(t, string(response), string(cr.Response))
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the structured row draws the rail jump dot")
 }
 
-// TestSendControlResponse_ClaudePermissionBareDenyRowHasNoComment covers the fallback-row deny
-// path when the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage
-// placeholder, which persistControlResponseDisplayRow must collapse to "" (via
-// plan.rejectionMessage) so the row renders "Rejected" -- NOT "Sent feedback: Rejected by user."
-// The row previously stored the raw message, leaking the placeholder as if it were typed feedback.
-func TestSendControlResponse_ClaudePermissionBareDenyRowHasNoComment(t *testing.T) {
+// TestSendControlResponse_ClaudePermissionBareDenyRetainsNativeResponse covers the deny path when
+// the user gave NO reason: the frontend auto-fills the ControlRejectedByUserMessage placeholder,
+// which is now RETAINED verbatim inside the native response (the frontend collapses it to render
+// "Rejected"). The backend no longer derives or normalizes label text.
+func TestSendControlResponse_ClaudePermissionBareDenyRetainsNativeResponse(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -631,26 +765,25 @@ func TestSendControlResponse_ClaudePermissionBareDenyRowHasNoComment(t *testing.
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"` + agent.ControlRejectedByUserMessage + `"}}}`),
+		Content: response,
 	}, w)
 	require.Empty(t, w.errors)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
-	assert.Equal(t, "rejected", action)
-	assert.Empty(t, comment,
-		"a bare denial must collapse the ControlRejectedByUserMessage placeholder to \"\" -- the row renders \"Rejected\", not \"Sent feedback: Rejected by user.\"")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.JSONEq(t, string(response), string(cr.Response),
+		"the backend retains the native deny response verbatim; the frontend collapses the placeholder")
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 }
 
-// TestSendControlResponse_ClaudePermissionDenyWithReasonKeepsComment is the counterpart: a REAL
-// typed reason (not the placeholder) must survive into the display row's comment, proving the
-// normalization collapses only the sentinel and never a genuine rejection reason.
-func TestSendControlResponse_ClaudePermissionDenyWithReasonKeepsComment(t *testing.T) {
+// TestSendControlResponse_ClaudePermissionDenyWithReasonRetainsMessage is the counterpart: a REAL
+// typed reason survives verbatim into the native response for the frontend to render as feedback.
+func TestSendControlResponse_ClaudePermissionDenyWithReasonRetainsMessage(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -667,18 +800,18 @@ func TestSendControlResponse_ClaudePermissionDenyWithReasonKeepsComment(t *testi
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
+	response := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"use ripgrep instead"}}}`)
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
-		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"deny","message":"use ripgrep instead"}}}`),
+		Content: response,
 	}, w)
 	require.Empty(t, w.errors)
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	action, comment := decodeControlResponseRow(t, rows[0].Content, rows[0].ContentCompression)
-	assert.Equal(t, "rejected", action)
-	assert.Equal(t, "use ripgrep instead", comment, "a genuine typed rejection reason must survive into the display row")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.JSONEq(t, string(response), string(cr.Response), "a genuine typed rejection reason survives verbatim into the native response")
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 }
 
@@ -712,11 +845,50 @@ func TestSendControlResponse_UsesNestedRequestIDWhenTopLevelIDAlsoExists(t *test
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "approved", decodeControlResponseAction(t, rows[0].Content, rows[0].ContentCompression))
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "req-1", cr.RequestID, "the nested control-response request_id keys the row, not the top-level JSON-RPC id")
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 }
 
-func TestSendControlResponse_SkipsFallbackRowWithoutStoredControlRequest(t *testing.T) {
+// TestSendControlResponse_PersistsRowWithRequestOmittedWhenRequestUnknown covers the #258
+// improvement: even when the pending control request row is gone (already deleted, or never stored),
+// the user's answer is NOT lost -- the structured row persists with `request` omitted and a
+// resolvable request id, and the frontend degrades gracefully. (A DUPLICATE answer for the same
+// request draws no second row -- see TestSendControlResponse_WithholdsDuplicateAnswerRow below.)
+func TestSendControlResponse_PersistsRowWithRequestOmittedWhenRequestUnknown(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"missing","response":{"behavior":"allow"}}}`),
+	}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the answer persists even without the stored request")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "missing", cr.RequestID)
+	assert.Nil(t, cr.Request, "request context is omitted when the stored request is unavailable")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestSendControlResponse_PersistsRequestGoneClaudeOrphanRow pins that the #258 request-gone
+// persistence now extends to Claude too: a SINGLE request-gone Claude answer (a genuine orphan --
+// the request was deleted before this first answer, so no tool_result was ever marked for it) is NOT
+// lost, it persists the structured row. Deduping a "same request answered twice" case is the
+// idempotency claim's job (see the duplicate test below), not a blanket provider-capability withhold.
+func TestSendControlResponse_PersistsRequestGoneClaudeOrphanRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -733,17 +905,172 @@ func TestSendControlResponse_SkipsFallbackRowWithoutStoredControlRequest(t *test
 		AgentId: "agent-1",
 		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"missing","response":{"behavior":"allow"}}}`),
 	}, w)
-	require.Empty(t, w.errors)
+	require.Empty(t, w.errors, "the response is still forwarded to the agent")
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
-	require.Empty(t, rows, "without the stored request, the service cannot classify the answer row")
+	require.Len(t, rows, 1, "a genuine request-gone Claude orphan answer persists (#258), not withheld")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "missing", cr.RequestID)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 }
 
-// TestSendControlResponse_SkipsClaudeSelfDisplayingFallbackRow asserts the fallback row is
-// SKIPPED for a self-displaying tool (ExitPlanMode) -- its own tool_result carries the mark
-// via ingestion, so a second synthetic `{controlResponse}` row would double the rail dot.
-func TestSendControlResponse_SkipsClaudeSelfDisplayingFallbackRow(t *testing.T) {
+// TestSendControlResponse_WithholdsDuplicateAnswerRow pins the idempotency claim: the SAME control
+// request answered twice -- an RPC retry, or a second window answering before it received the cancel
+// broadcast -- persists exactly ONE structured row + one scroll-rail dot, never two. The first
+// answer claims the request id and does all the work; the duplicate (whose request row was deleted by
+// the first) is a deduped no-op -- it draws no second row and is NOT re-forwarded to the agent.
+func TestSendControlResponse_WithholdsDuplicateAnswerRow(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	answer := &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+	}
+	dispatch(d, "SendControlResponse", answer, w)
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors, "neither answer errors -- the winner forwards, the duplicate is a deduped no-op")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "answering the same request twice draws exactly one row, not two")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestSendControlResponse_DuplicateAnswerDeletesRequestOnce pins the delete-gating half of the
+// idempotency claim: deleteControlRequest is gated on firstAnswer, so ONLY the claim winner deletes
+// the pending request and broadcasts its cancel. A duplicate answer (an RPC retry / a second window)
+// therefore draws exactly ONE ControlCancel and one row -- never a second delete. Gating the delete
+// on the winner is also what keeps the winner's request read while-present, so a concurrent duplicate
+// can't tear the request out from under it and force a context-less / double-marked row.
+func TestSendControlResponse_DuplicateAnswerDeletesRequestOnce(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	svc.Watchers.WatchAgent("agent-1", &EventWatcher{ChannelID: "test-ch", Sender: channel.NewSender(w)})
+
+	answer := &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+	}
+	dispatch(d, "SendControlResponse", answer, w)
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors, "neither answer errors -- the winner forwards, the duplicate is a deduped no-op")
+
+	cancels := 0
+	for _, stream := range w.streamsSnapshot() {
+		if _, ok := decodeWatchAgentEvent(t, stream).GetEvent().(*leapmuxv1.AgentEvent_ControlCancel); ok {
+			cancels++
+		}
+	}
+	assert.Equal(t, 1, cancels, "only the claim winner deletes the request, so the duplicate re-broadcasts no second cancel")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the duplicate draws no second row")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestSendControlResponse_DuplicateDoesNotForward pins winner-only forwarding: a duplicate answer
+// (RPC retry / second window) must NOT forward its response to the agent. A request-gone duplicate's
+// resolution diverges from the winner's -- here a Codex plan-mode PROMPT approval, which the winner
+// handles entirely server-side and never forwards, but whose duplicate resolves PlanModeControl==None
+// (request-gone) and, before the fix, forwarded the stray approval envelope onto the agent's stdin.
+// The forward is observed via a STOPPED agent: a duplicate that ATTEMPTED to forward would hit
+// SendRawInput -> "agent not running" and surface an error; winner-only forward draws none.
+func TestSendControlResponse_DuplicateDoesNotForward(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+		Options:       marshalOptions(map[string]string{agent.CodexOptionCollaborationMode: agent.CodexCollaborationDefault}),
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "plan-1",
+		Payload: []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+
+	// A plan-mode prompt approval with the DEFAULT clearContext=false. The winner handles it
+	// server-side (never forwarded) and deletes the request, so the duplicate below reads request-gone
+	// -- the exact case where withholdsForward is false and the old code re-forwarded the stray frame.
+	answer := &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`),
+	}
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors)
+
+	// Stop the agent so any forward the duplicate ATTEMPTS surfaces as an "agent not running" error.
+	svc.Agents.StopAgent("agent-1")
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors,
+		"a request-gone duplicate must not forward its diverged response -- winner-only forward draws no error even to a stopped agent")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2,
+		"the duplicate is a no-op: only the winner's one structured row + 'Implement the plan.' prompt, undoubled")
+}
+
+// TestSendControlResponse_GarbageContentPersistsNothing covers a response with no extractable
+// request id: it draws no structured row (there is nothing to attribute the answer to) but is still
+// forwarded to the agent.
+func TestSendControlResponse_GarbageContentPersistsNothing(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
+		AgentId: "agent-1",
+		Content: []byte(`{"foo":"bar"}`),
+	}, w)
+	require.Empty(t, w.errors, "the response is still forwarded to the agent")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Empty(t, rows, "an unattributable answer (no request id) persists no row")
+}
+
+// TestSendControlResponse_SkipsStructuredRowForSelfDisplayingTool asserts NO structured row is
+// persisted for a self-displaying tool (ExitPlanMode) that is NOT clearing context -- its own
+// ingested tool_result carries the mark, so a second synthetic row would double the rail dot.
+func TestSendControlResponse_SkipsStructuredRowForSelfDisplayingTool(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -769,10 +1096,7 @@ func TestSendControlResponse_SkipsClaudeSelfDisplayingFallbackRow(t *testing.T) 
 
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
-	for _, row := range rows {
-		assert.NotEqual(t, "approved", decodeControlResponseAction(t, row.Content, row.ContentCompression),
-			"no synthetic {controlResponse} fallback row for a self-displaying tool")
-	}
+	require.Empty(t, rows, "a self-displaying tool's answer lives on its ingested tool_result, not a synthetic row")
 }
 
 func TestSendControlResponse_RestoresClaudeSelfDisplayedToolUseType(t *testing.T) {
@@ -804,7 +1128,7 @@ func TestSendControlResponse_RestoresClaudeSelfDisplayedToolUseType(t *testing.T
 		"the later Claude tool_result relies on this mapping to carry the CONTROL_RESPONSE mark")
 }
 
-func TestSendControlResponse_ClaudeExitPlanModeClearContextMarksFallbackRow(t *testing.T) {
+func TestSendControlResponse_ClaudeExitPlanModeClearContextMarksStructuredRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -830,25 +1154,21 @@ func TestSendControlResponse_ClaudeExitPlanModeClearContextMarksFallbackRow(t *t
 	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
 	require.NoError(t, err)
 
-	controlRows := make([]db.Message, 0, len(rows))
-	for _, row := range rows {
-		if decodeControlResponseAction(t, row.Content, row.ContentCompression) != "" {
-			controlRows = append(controlRows, row)
-		}
-	}
-
+	// A context-clearing plan exit wipes Claude's own tool_result, so the structured row carries the
+	// mark instead. Filter to CONTROL_RESPONSE rows to isolate it from any async plan-execution rows.
+	controlRows := controlResponseRows(rows)
 	require.Len(t, controlRows, 1)
-	assert.Equal(t, "approved", decodeControlResponseAction(t, controlRows[0].Content, controlRows[0].ContentCompression))
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, controlRows[0].Source)
+	cr := decodeStructuredControlResponse(t, controlRows[0].Content, controlRows[0].ContentCompression)
+	assert.Equal(t, "CLAUDE_CODE", cr.Provider)
+	assert.JSONEq(t, `{"request":{"tool_name":"ExitPlanMode"}}`, string(cr.Request))
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, controlRows[0].MarkType,
-		"clear-context skips Claude's self-displayed tool_result, so the fallback row must carry the rail dot")
+		"clear-context skips Claude's self-displayed tool_result, so the structured row must carry the rail dot")
 }
 
 // TestSendControlResponse_EnterPlanModeAllowTrimsRequestID pins the "trim everywhere" rule for
 // the plan-mode transition: a control response whose request_id carries surrounding whitespace
-// must still switch the agent to plan mode. plan.requestMeta.RequestID is trimmed (it comes
-// through DecodeControlBehavior), so applyControlResponsePlanModeEffects must trim the response's
-// own request_id the same way -- otherwise the untrimmed " req-1 " != "req-1" equality would
-// silently skip the transition even though hasDecision (which trims) accepted it.
+// must still switch the agent to plan mode.
 func TestSendControlResponse_EnterPlanModeAllowTrimsRequestID(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
@@ -880,16 +1200,187 @@ func TestSendControlResponse_EnterPlanModeAllowTrimsRequestID(t *testing.T) {
 		"a whitespace-padded request_id must still apply the EnterPlanMode transition")
 }
 
-// TestSendControlResponse_CursorCreatePlanPersistsOnlySyntheticAnswerRow covers the Cursor
-// createPlan path, where the provider REWRITES resolution.Content into an ACP outcome that
-// carries no request_id while the ORIGINAL response content still carries the frontend
-// approve/reject envelope. buildControlResponsePlan decodes plan.decision from that original
-// content, so hasDecision is TRUE here -- which makes the fallback-row gate
-// (needsFallbackDisplayRow) actually evaluate for this path rather than short-circuit on
-// !hasDecision. The answer must route to the single synthetic {content} row (marked
-// CONTROL_RESPONSE for a rail dot) and MUST NOT also emit a {controlResponse} fallback row --
-// i.e. exactly one persisted row, never two.
-func TestSendControlResponse_CursorCreatePlanPersistsOnlySyntheticAnswerRow(t *testing.T) {
+// TestControlResponsePlan_WithholdsForward pins the forward-withhold predicate the handler applies to
+// BOTH the winner and a duplicate: ONLY an APPROVED context-clearing plan approval withholds (the
+// agent is about to be restarted via initiatePlanExecution, so forwarding would race the restart). It
+// is content-derived, so it never depends on whether the stored request is still loaded -- a duplicate
+// that raced past the winner's delete (request-gone) withholds identically. It is the one pure
+// predicate the handler's forward decision keys off for winner and duplicate alike (loaded /
+// request-gone clear-context withhold, request-gone non-clearing forwards).
+func TestControlResponsePlan_WithholdsForward(t *testing.T) {
+	mk := func(behavior string, clear bool) controlResponsePlan {
+		var plan controlResponsePlan
+		plan.hasDecision = behavior == agent.ControlBehaviorAllow || behavior == agent.ControlBehaviorDeny
+		plan.decision.Response.Response.Behavior = behavior
+		plan.decision.ClearContext = clear
+		return plan
+	}
+
+	assert.True(t, mk(agent.ControlBehaviorAllow, true).withholdsForward(),
+		"an approved context-clearing plan approval withholds its forward")
+	assert.False(t, mk(agent.ControlBehaviorAllow, false).withholdsForward(),
+		"an ordinary approval (no clearContext) forwards -- only restart answers withhold")
+	assert.False(t, mk(agent.ControlBehaviorDeny, true).withholdsForward(),
+		"a denial never withholds, even with clearContext -- a rejection doesn't restart the agent")
+
+	// No recognized decision -> no withhold (an empty/unknown behavior is not a decision).
+	var noDecision controlResponsePlan
+	noDecision.decision.ClearContext = true
+	assert.False(t, noDecision.withholdsForward(), "no decision -> no withhold")
+
+	// The predicate reads ONLY the response envelope, never requestMeta, so it is identical whether the
+	// stored request is loaded or gone -- the property that lets a request-gone duplicate withhold like
+	// the winner. Prove it by flipping Loaded and asserting the decision is unchanged.
+	clearExit := mk(agent.ControlBehaviorAllow, true)
+	clearExit.requestMeta.Loaded = true
+	assert.True(t, clearExit.withholdsForward())
+	clearExit.requestMeta.Loaded = false
+	assert.True(t, clearExit.withholdsForward(), "withholdsForward is request-independent (holds request-gone)")
+}
+
+// TestApplyControlResponsePlanModeMutations pins the once-only plan-mode side effects the WINNER
+// applies (the handler calls this inside `if firstAnswer`, so a duplicate never reaches it): an
+// approved EnterPlanMode switches the agent into plan mode, while a request-gone answer -- which
+// cannot resolve the transition -- touches nothing.
+func TestApplyControlResponsePlanModeMutations(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: "agent-1", RequestID: "req-1",
+		Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"EnterPlanMode","tool_use_id":"toolu-enter"}}`),
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	content := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`)
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	plan := svc.buildControlResponsePlan("agent-1", dbAgent, content)
+	require.True(t, plan.requestMeta.Loaded)
+	require.Equal(t, agent.PlanModeControlEnter, plan.resolution.PlanModeControl)
+
+	before := loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode]
+	require.NotEqual(t, agent.PermissionModePlan, before, "sanity: the agent is not already in plan mode")
+
+	svc.applyControlResponsePlanModeMutations("agent-1", dbAgent, plan)
+	dbAgent, err = svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, agent.PermissionModePlan, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
+		"an approved EnterPlanMode applies the plan-mode switch")
+
+	// A request-gone answer (no stored request to resolve the transition) mutates nothing.
+	svc.Output.ClearPendingControlRequests("agent-1")
+	gonePlan := svc.buildControlResponsePlan("agent-1", dbAgent, content)
+	require.False(t, gonePlan.requestMeta.Loaded, "sanity: the request is gone")
+	// Reset to Default so a no-op is distinguishable from a re-applied Enter transition (which sets Plan).
+	dbAgent = svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModeDefault)
+	svc.applyControlResponsePlanModeMutations("agent-1", dbAgent, gonePlan)
+	dbAgent, err = svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, agent.PermissionModeDefault, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
+		"a request-gone answer resolves no transition, so it mutates nothing")
+}
+
+// TestSendControlResponse_DuplicateStraddlingRestartStillDeduped is the #258 regression guard for
+// the clear-context path: the approved answer's OWN restart (e.g. a clear-context ExitPlanMode) runs
+// ClearAgentRuntimeState, which tears down every in-memory tracker -- but the idempotency claim is a
+// DURABLE row, keyed by (agent, request, claim_token), so it survives that teardown. A DUPLICATE of the
+// answer (an RPC retry, or a second window) echoing the SAME claim_token and arriving AFTER the restart
+// is still deduped, drawing exactly ONE row, not two. Because the claim is durable rather than
+// in-memory, this also holds across a full worker-PROCESS restart. Contrast
+// TestSendControlResponse_ReusedRequestIDAfterRelaunchPersists, where the new subprocess re-issues the
+// id with a FRESH claim_token, so a genuine post-relaunch answer persists.
+func TestSendControlResponse_DuplicateStraddlingRestartStillDeduped(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	// Both answers echo the SAME instance token (a genuine duplicate -- an RPC retry / a second window
+	// on the same instance), so the claim dedups on (agent, req, token).
+	answer := &leapmuxv1.SendControlResponseRequest{
+		AgentId:    "agent-1",
+		Content:    []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`),
+		ClaimToken: "instA",
+	}
+	dispatch(d, "SendControlResponse", answer, w)
+	// The full restart the clear-context plan exit triggers (initiatePlanExecutionRestart ->
+	// ClearAgentRuntimeState = ClearPendingControlRequests + CleanupAgent). Neither touches the durable
+	// answer claim, so the claim survives and the duplicate below (same token) is deduped.
+	svc.Output.ClearAgentRuntimeState("agent-1")
+	dispatch(d, "SendControlResponse", answer, w)
+	require.Empty(t, w.errors, "neither answer errors -- the winner forwards, the straddling duplicate is a deduped no-op")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "a duplicate straddling the restart is deduped -- the surviving claim draws exactly one row")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestSendControlResponse_ReusedRequestIDAfterRelaunchPersists is the counterpart: after a relaunch,
+// the new subprocess re-issues a request that REUSES the id (its JSON-RPC counter restarted from
+// scratch). PersistControlRequest mints a FRESH claim_token for that new instance, which the frontend
+// echoes back, so the genuine post-relaunch answer claims a distinct key and persists its OWN row --
+// while a stale duplicate of the PRE-relaunch instance (old token) is still deduped, so the reuse
+// window stays closed. The distinct claim_token -- not a release step -- is what tells the two apart.
+func TestSendControlResponse_ReusedRequestIDAfterRelaunchPersists(t *testing.T) {
+	ctx := context.Background()
+	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: "agent-1", Options: map[string]string{agent.OptionIDModel: "opus"}, WorkingDir: t.TempDir(),
+	}, sink)
+	require.NoError(t, err)
+	defer svc.Agents.StopAgent("agent-1")
+
+	content := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`)
+	// Instance A answers with its echoed token.
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{AgentId: "agent-1", Content: content, ClaimToken: "instA"}, w)
+
+	// Relaunch, then the new subprocess re-issues a request that reuses id "req-1" -- PersistControlRequest
+	// mints a fresh token, which the frontend would echo. Read it back (as the frontend does via the
+	// broadcast) and answer with it: this genuine post-relaunch answer claims a distinct key and persists.
+	svc.Output.ClearPendingControlRequests("agent-1")
+	sink.PersistControlRequest("req-1", []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`))
+	reissued, err := svc.Queries.GetControlRequest(ctx, db.GetControlRequestParams{AgentID: "agent-1", RequestID: "req-1"})
+	require.NoError(t, err)
+	require.NotEqual(t, "instA", reissued.ClaimToken, "the reissued instance minted a distinct token")
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{AgentId: "agent-1", Content: content, ClaimToken: reissued.ClaimToken}, w)
+
+	// A stale duplicate of the PRE-relaunch instance (old token) is still deduped -- the reuse window is closed.
+	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{AgentId: "agent-1", Content: content, ClaimToken: "instA"}, w)
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "the two distinct instances persist their own rows; instance A's stale duplicate draws none")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[1].MarkType)
+}
+
+// TestSendControlResponse_CursorCreatePlanPersistsOnlyStructuredRow covers the Cursor createPlan
+// path, where the provider REWRITES resolution.Content into an ACP outcome. The answer must route
+// to exactly ONE structured row (marked CONTROL_RESPONSE) whose response is the transformed outcome
+// forwarded to the agent -- never two rows.
+func TestSendControlResponse_CursorCreatePlanPersistsOnlyStructuredRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -916,23 +1407,31 @@ func TestSendControlResponse_CursorCreatePlanPersistsOnlySyntheticAnswerRow(t *t
 		AgentID: "agent-1", Seq: 0, Limit: 10,
 	})
 	require.NoError(t, err)
-	// Exactly one row: the synthetic answer. A second row would be the {controlResponse}
-	// fallback double-rendering now that hasDecision is reachable for this path.
-	require.Len(t, rows, 1)
-	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source,
-		"the answer is the synthetic {content} user row, not a LEAPMUX {controlResponse} fallback row")
-	assert.Equal(t, "Needs tests.", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	require.Len(t, rows, 1, "exactly the structured answer row -- no double-render")
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "CURSOR", cr.Provider)
+	assert.JSONEq(t, `{"method":"cursor/create_plan"}`, string(cr.Request))
+	// The response is the TRANSFORMED ACP outcome that was forwarded to Cursor, not the raw envelope.
+	var outcome struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+				Reason  string `json:"reason"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(cr.Response, &outcome))
+	assert.Equal(t, "rejected", outcome.Result.Outcome.Outcome)
+	assert.Equal(t, "Needs tests.", outcome.Result.Outcome.Reason)
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType,
 		"a control-response answer draws a scroll-rail jump dot")
 }
 
-// TestSendControlResponse_CursorCreatePlanApprovePersistsOnlySyntheticAnswerRow is the ALLOW
-// sibling of the deny case above. Approving createPlan flips hasDecision true (decoded from the
-// original content), so applyControlResponsePlanModeEffects now runs its `behavior == Allow`
-// branch for this path -- which must be a NO-OP because Cursor's createPlan is PlanModeControlNone
-// (no permission-mode switch, no plan execution) -- while the answer still routes to the single
-// synthetic "Accept" row with no {controlResponse} fallback.
-func TestSendControlResponse_CursorCreatePlanApprovePersistsOnlySyntheticAnswerRow(t *testing.T) {
+// TestSendControlResponse_CursorCreatePlanApprovePersistsOnlyStructuredRow is the ALLOW sibling:
+// createPlan is PlanModeControlNone, so the Allow branch must be a NO-OP (no permission-mode
+// switch) while the answer still routes to the single structured "accepted" row.
+func TestSendControlResponse_CursorCreatePlanApprovePersistsOnlyStructuredRow(t *testing.T) {
 	ctx := context.Background()
 	svc, d, w := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -961,9 +1460,18 @@ func TestSendControlResponse_CursorCreatePlanApprovePersistsOnlySyntheticAnswerR
 		AgentID: "agent-1", Seq: 0, Limit: 10,
 	})
 	require.NoError(t, err)
-	require.Len(t, rows, 1, "exactly the synthetic answer row -- no {controlResponse} fallback double-render")
+	require.Len(t, rows, 1, "exactly the structured answer row -- no double-render")
 	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
-	assert.Equal(t, "Accept", decodeMessageContent(t, rows[0].Content, rows[0].ContentCompression))
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	var outcome struct {
+		Result struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(cr.Response, &outcome))
+	assert.Equal(t, "accepted", outcome.Result.Outcome.Outcome)
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
 
 	// createPlan is PlanModeControlNone, so the Allow branch must not touch permission mode.
@@ -1011,45 +1519,56 @@ func TestControlResponseRequestID(t *testing.T) {
 	))
 }
 
-// TestClassifyControlAnswerRow pins the single home for the "which row carries the control
-// answer's rail mark" decision that the synthetic-row and fallback-row persist sites share.
-// Exactly one of the three homes owns the mark for any provider-resolved self-display flag
-// and displayText, so the two sites can't both mark (a double dot) or both skip (a real
-// answer with no dot).
-func TestClassifyControlAnswerRow(t *testing.T) {
-	cases := []struct {
-		name          string
-		selfDisplayed bool
-		displayText   string
-		want          controlAnswerRow
-	}{
-		// The future-proofing invariant: self-display is checked FIRST, so a self-displaying
-		// tool classifies as self-displayed even WITH display text -- the synthetic row stays
-		// unmarked and can't double the ingested tool_result's dot. (No provider is in this
-		// state today; this pins the precedence so a new one can't break it.)
-		{"self-display without display text", true, "", controlAnswerSelfDisplayed},
-		{"self-display wins over display text (no double dot)", true, "answered", controlAnswerSelfDisplayed},
-		// A Claude permission decision self-displays nothing and carries no display text: the
-		// fallback {controlResponse} row is its home.
-		{"non-self-displayed empty text -> fallback row", false, "", controlAnswerFallback},
-		// A non-self-displaying tool WITH display text -> the synthetic answer row owns the mark.
-		{"non-self-displayed text -> synthetic row", false, "approved", controlAnswerSynthetic},
-		// A whitespace-only displayText is treated as empty (mirrors persistSyntheticUserMessage's
-		// own TrimSpace guard), so it falls through to the fallback rather than a blank synthetic row.
-		{"whitespace-only display text -> fallback row", false, "   \n\t ", controlAnswerFallback},
+// TestNeedsStructuredRow pins the single "does this answer get a synthetic structured row" rule.
+// A resolvable request id is required. A genuinely self-displayed answer draws no row except when a
+// context-clearing plan exit wipes its echoed tool_result. Otherwise the answer gets the row -- for
+// EVERY provider, and even when the stored request is gone (#258, a genuine orphan): there is no
+// provider-capability guard here. The "answered twice" duplicate (whose first answer's tool_result
+// already carries the mark) is deduped one layer up by SendControlResponse's idempotency claim, so it
+// never reaches this decision a second time -- the withhold guard the old SelfDisplaysControlAnswers
+// capability provided is subsumed by that claim and intentionally gone.
+func TestNeedsStructuredRow(t *testing.T) {
+	// mk sets only the fields needsStructuredRow reads: the resolvable request id and the resolved
+	// self-display flag. requestMeta.Loaded no longer participates -- the "answered twice" duplicate
+	// is deduped one layer up by SendControlResponse's idempotency claim, not here.
+	mk := func(requestID string, selfDisplayed bool) controlResponsePlan {
+		var plan controlResponsePlan
+		plan.requestMeta.RequestID = requestID
+		plan.resolution.SelfDisplayed = selfDisplayed
+		return plan
+	}
+	// selfDisplayedExit builds a genuinely self-displayed plan for the exitPlanClearingContext branch.
+	selfDisplayedExit := func(clear bool) controlResponsePlan {
+		plan := mk("req-1", true)
+		plan.decision.Response.Response.Behavior = agent.ControlBehaviorAllow
+		plan.resolution.PlanModeControl = agent.PlanModeControlExit
+		plan.decision.ClearContext = clear
+		return plan
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, classifyControlAnswerRow(tc.selfDisplayed, tc.displayText))
-		})
-	}
+	assert.False(t, mk("", false).needsStructuredRow(),
+		"no request id -> the answer is unattributable and draws no row")
+
+	// Not self-displayed: the answer gets the row for EVERY provider -- Claude permission answers
+	// included, and even when the stored request is gone (#258, a genuine orphan). No
+	// provider-capability guard here: a request-gone duplicate whose first answer already carries
+	// the mark is stopped earlier by the idempotency claim, so it never reaches this decision twice.
+	assert.True(t, mk("req-1", false).needsStructuredRow(),
+		"not self-displayed -> structured row")
+
+	// A genuinely self-displayed answer: its own tool_result owns the mark, except a context-clearing
+	// plan exit wipes that row, where the structured row carries it instead.
+	assert.False(t, selfDisplayedExit(false).needsStructuredRow(),
+		"self-displayed, not clearing context -> tool_result owns the mark, no structured row")
+	assert.True(t, selfDisplayedExit(true).needsStructuredRow(),
+		"self-displayed, context-clearing plan exit wipes the tool_result -> structured row carries the mark")
 }
 
 func TestExitPlanClearingContext(t *testing.T) {
-	// The single triple that both needsFallbackDisplayRow and the plan-mode-effects skipSend
-	// key off: an APPROVED ExitPlanMode that ALSO clears context (the transcript row is wiped,
-	// so the fallback display row carries the mark and the approval is not forwarded).
+	// The single triple that needsStructuredRow keys the mark-carrying row off (and that gates the
+	// once-only initiatePlanExecution): an APPROVED ExitPlanMode that ALSO clears context (the
+	// transcript row is wiped, so the structured row carries the mark and the approval is not
+	// forwarded). It is the loaded-answer equivalent of the request-independent withholdsForward.
 	mk := func(behavior string, ctrl agent.PlanModeControlKind, clear bool) controlResponsePlan {
 		var plan controlResponsePlan
 		plan.decision.Response.Response.Behavior = behavior
@@ -1070,4 +1589,221 @@ func TestResolveTargetMode(t *testing.T) {
 	// (PermissionModeDefault) and the ExitPlanMode path (PermissionModeAcceptEdits) differ on.
 	assert.Equal(t, agent.PermissionModeDefault, resolveTargetMode("", agent.PermissionModeDefault))
 	assert.Equal(t, agent.PermissionModeAcceptEdits, resolveTargetMode("", agent.PermissionModeAcceptEdits))
+}
+
+// TestPersistControlResponseRow_EmptyContentPersistsRowNotDropped pins the marshal-boundary
+// backstop: a plan whose resolution.Content is empty-but-non-nil ([]byte{}) must NOT silently drop
+// the user's answer row. json.RawMessage of empty bytes makes json.Marshal(row) fail ("unexpected
+// end of JSON input"), so persistControlResponseRow coalesces empty Content to nil -- the response
+// marshals as `null` and the row (with its CONTROL_RESPONSE rail mark) still persists. Without the
+// coalesce this persists ZERO rows.
+func TestPersistControlResponseRow_EmptyContentPersistsRowNotDropped(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	var plan controlResponsePlan
+	plan.requestMeta.RequestID = "req-1"
+	plan.resolution.Content = []byte{} // empty, non-nil -- the json.RawMessage marshal footgun
+
+	svc.persistControlResponseRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, plan)
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "an empty-but-non-nil Content must not silently drop the answer row")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "req-1", cr.RequestID)
+	assert.JSONEq(t, "null", string(cr.Response), "empty Content coalesces to a null response, not a dropped row")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestPersistControlResponseRow_InvalidJSONContentPersistsRowNotDropped pins the same marshal-boundary
+// backstop for the OTHER way json.RawMessage marshaling fails: a resolution.Content that is non-empty
+// but NOT valid JSON. A json.RawMessage marshals only valid JSON -- malformed bytes error with
+// "invalid character ...", which (without the json.Valid coalesce) makes json.Marshal(row) fail and
+// silently drops the user's answer row. No current provider forwards non-JSON control bytes, so this
+// guards the documented "a resolvable answer always persists a row" invariant against a future one.
+// Without the coalesce this persists ZERO rows.
+func TestPersistControlResponseRow_InvalidJSONContentPersistsRowNotDropped(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	var plan controlResponsePlan
+	plan.requestMeta.RequestID = "req-1"
+	plan.resolution.Content = []byte("not json at all") // non-empty but invalid JSON -- the other marshal footgun
+
+	svc.persistControlResponseRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, plan)
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "a non-empty but invalid-JSON Content must not silently drop the answer row")
+	cr := decodeStructuredControlResponse(t, rows[0].Content, rows[0].ContentCompression)
+	assert.Equal(t, "req-1", cr.RequestID)
+	assert.JSONEq(t, "null", string(cr.Response), "invalid Content coalesces to a null response, not a dropped row")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+}
+
+// TestPersistControlResponseRow_IsUserSourcedCountsAsUserMessage pins that the structured
+// control-response row is USER-sourced (not LEAPMUX). A control answer is the user's own response to
+// the agent, so -- matching how every non-Claude provider-resolved answer was persisted on the
+// pre-#258 path (a USER {content} row) -- it counts toward HasUserMessages (the resume-decision
+// predicate in resolveResumeSessionID: answering a control request alone can make a session
+// resumable) and its bubble exposes data-role="user". The isSynthetic flag, NOT the source, routes it
+// to the control_response renderer, so USER source does not make it render as a plain user bubble. The
+// row seq (1) is above the default session_start_seq (0), so HasUserMessages returning true is due to
+// the USER source, not the seq gate.
+func TestPersistControlResponseRow_IsUserSourcedCountsAsUserMessage(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+
+	var plan controlResponsePlan
+	plan.requestMeta.RequestID = "req-1"
+	plan.resolution.Content = []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`)
+	svc.persistControlResponseRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, plan)
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source,
+		"a control-response answer is the user's own response, persisted as a USER row")
+	assert.Greater(t, rows[0].Seq, int64(0), "sanity: the row is above the default session_start_seq, so only the source decides HasUserMessages")
+
+	hasUser, err := svc.Queries.HasUserMessages(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.True(t, hasUser,
+		"a control-response answer counts as a user message for resolveResumeSessionID -- answering alone can make a session resumable")
+}
+
+// TestPersistControlResponseRow_MakesSessionResumable pins the USER-source decision at the actual
+// resume DECISION point (resolveResumeSessionID), not just its HasUserMessages building block: a
+// non-resumed agent whose ONLY interaction is answering a control request -- no typed prompt -- goes
+// from not-resumable to resumable once the answer row is persisted, because that row is now a USER
+// message. This is the auto-started / control-answer-only session the pre-uniform-USER LEAPMUX source
+// excluded from resume; uniform USER includes it. The seq of the answer row is above the
+// session_start_seq recorded at UpdateAgentSessionID, so the flip is due to the source, not the seq gate.
+func TestPersistControlResponseRow_MakesSessionResumable(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	// Agent startup assigns a session ID (and records session_start_seq). resumed==0, so resumability
+	// hinges entirely on whether a USER message exists past session_start_seq.
+	require.NoError(t, svc.Queries.UpdateAgentSessionID(ctx, db.UpdateAgentSessionIDParams{
+		AgentSessionID: "session-A", ID: "agent-1",
+	}))
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Empty(t, svc.resolveResumeSessionID("agent-1", dbAgent.AgentSessionID, dbAgent.Resumed),
+		"before any answer, a never-typed-into session is not resumable")
+
+	var plan controlResponsePlan
+	plan.requestMeta.RequestID = "req-1"
+	plan.resolution.Content = []byte(`{"jsonrpc":"2.0","id":7,"result":{"decision":"accept"}}`)
+	svc.persistControlResponseRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, plan)
+
+	dbAgent, err = svc.Queries.GetAgentByID(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, "session-A",
+		svc.resolveResumeSessionID("agent-1", dbAgent.AgentSessionID, dbAgent.Resumed),
+		"answering a control request alone makes the session resumable -- the answer is a USER row")
+}
+
+// TestProcessControlResponse pins the dispatcher-free forward decision the RPC handler keys off: the
+// extracted processControlResponse reports the bytes to forward for a plain answer, and forward=false
+// for a deduped duplicate and a server-side plan-mode prompt. Exercising the tuple directly (no
+// channel sender) is exactly the testability seam the extraction bought.
+func TestProcessControlResponse(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("forwards a plain permission answer, then dedups its duplicate", func(t *testing.T) {
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+			AgentID: "agent-1", RequestID: "req-1",
+			Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+		}))
+		dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+		require.NoError(t, err)
+		content := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`)
+
+		bytes, forward := svc.processControlResponse("agent-1", dbAgent, content, "tok-1")
+		require.True(t, forward, "a plain permission answer is forwarded to the agent")
+		assert.Equal(t, content, bytes, "the forwarded bytes are the (unrewritten) response content")
+
+		// The duplicate echoes the SAME instance token, so it lost the idempotency claim taken by the
+		// first call and forwards nothing.
+		bytes, forward = svc.processControlResponse("agent-1", dbAgent, content, "tok-1")
+		assert.False(t, forward, "a duplicate answer (same claim token) is a deduped no-op and is not re-forwarded")
+		assert.Nil(t, bytes)
+	})
+
+	t.Run("a reissued instance's answer (fresh claim token) forwards despite the reused request_id", func(t *testing.T) {
+		// The id-reuse closure at the processControlResponse level: a stale duplicate of a prior instance
+		// (old token) is deduped, but the genuine answer to a reissued request whose new instance minted a
+		// FRESH token is forwarded, not withheld as a duplicate of the reused id.
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+			AgentID: "agent-1", RequestID: "req-1",
+			Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+		}))
+		dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+		require.NoError(t, err)
+		content := []byte(`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"behavior":"allow"}}}`)
+
+		_, forward := svc.processControlResponse("agent-1", dbAgent, content, "instA")
+		require.True(t, forward, "instance A's answer forwards")
+
+		// Re-store req-1 (the reissued instance) and answer with a DIFFERENT token.
+		require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+			AgentID: "agent-1", RequestID: "req-1",
+			Payload: []byte(`{"type":"control_request","request_id":"req-1","request":{"tool_name":"Bash"}}`),
+		}))
+		_, forward = svc.processControlResponse("agent-1", dbAgent, content, "instB")
+		assert.True(t, forward, "the reissued instance's answer (fresh token) forwards -- not withheld as a duplicate of the reused id")
+
+		// A stale duplicate of instance A (old token) is STILL deduped.
+		_, forward = svc.processControlResponse("agent-1", dbAgent, content, "instA")
+		assert.False(t, forward, "instance A's stale duplicate stays deduped even after instance B answered")
+	})
+
+	t.Run("does not forward a plan-mode prompt (handled server-side)", func(t *testing.T) {
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+			Options:       marshalOptions(map[string]string{agent.CodexOptionCollaborationMode: agent.CodexCollaborationDefault}),
+		}))
+		require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+			AgentID: "agent-1", RequestID: "plan-1",
+			Payload: []byte(`{"request":{"tool_name":"CodexPlanModePrompt"}}`),
+		}))
+		dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
+		require.NoError(t, err)
+
+		bytes, forward := svc.processControlResponse("agent-1", dbAgent,
+			[]byte(`{"response":{"request_id":"plan-1","response":{"behavior":"allow"}}}`), "plan-tok")
+		assert.False(t, forward, "a plan-mode prompt is handled server-side, never forwarded")
+		assert.Nil(t, bytes)
+	})
 }

--- a/backend/internal/worker/service/message_marks_test.go
+++ b/backend/internal/worker/service/message_marks_test.go
@@ -190,7 +190,7 @@ func TestSendAgentMessage_PersistsUserMessageMark(t *testing.T) {
 }
 
 // TestPersistAndBroadcast_ThreadsMarkType covers the shared persist path used by
-// the Claude transcript ingestion AND the control-response display row: a SpanInfo
+// the Claude transcript ingestion AND the structured control-response row: a SpanInfo
 // MarkType must land in both the persisted row and the live broadcast. This is the
 // coverage for the control-response CONTROL_RESPONSE mark, whose write site routes
 // through sink.PersistMessage -> persistAndBroadcast.
@@ -200,8 +200,8 @@ func TestPersistAndBroadcast_ThreadsMarkType(t *testing.T) {
 	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 
 	require.NoError(t, sink.PersistMessage(
-		leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX,
-		[]byte(`{"isSynthetic":true,"controlResponse":{"action":"approved"}}`),
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"isSynthetic":true,"controlResponse":{"provider":"CLAUDE_CODE","requestId":"r","response":{"behavior":"allow"}}}`),
 		agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE},
 	))
 
@@ -224,12 +224,10 @@ func TestPersistAndBroadcast_ThreadsMarkType(t *testing.T) {
 	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, broadcastMark, "broadcast must carry the mark")
 }
 
-// TestPersistSyntheticUserMessage_MarkScopedToControlResponse asserts the shared
-// synthetic-user-message writer marks ONLY the caller's requested type: the control-
-// response display row (every non-Claude provider's answer flows through here) is a
-// CONTROL_RESPONSE jump target, while a non-answer notice like the interrupt marker
-// stays UNSPECIFIED so it draws no rail dot.
-func TestPersistSyntheticUserMessage_MarkScopedToControlResponse(t *testing.T) {
+// TestPersistSyntheticUserMessage_LeavesInterruptNoticeUnmarked asserts the synthetic-user-message
+// writer -- now used ONLY for the interrupt notice, since genuine control answers persist through
+// persistControlResponseRow -- writes an UNSPECIFIED-mark row so the interrupt draws no rail dot.
+func TestPersistSyntheticUserMessage_LeavesInterruptNoticeUnmarked(t *testing.T) {
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -237,50 +235,73 @@ func TestPersistSyntheticUserMessage_MarkScopedToControlResponse(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
 	}))
 
-	// A control-response answer -> marked (draws a dot).
-	svc.persistSyntheticUserMessage("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "Task: Build", leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE)
-	// The interrupt notice -> unmarked (no dot).
-	svc.persistSyntheticUserMessage("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "[Request interrupted by user]", leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED)
+	svc.persistSyntheticUserMessage("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "[Request interrupted by user]")
 
 	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
 	require.NoError(t, err)
-	require.Len(t, rows, 2)
-	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the control-response answer is marked")
-	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[1].MarkType, "the interrupt notice stays unmarked")
+	require.Len(t, rows, 1)
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, rows[0].Source)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[0].MarkType, "the interrupt notice stays unmarked")
 }
 
-// TestPersistControlResponseAnswerRows_SelfDisplayedWithTextDoesNotDoubleRow pins the structural
-// "exactly one answer row" guarantee for the double-DISPLAY case -- the sibling of
-// classifyControlAnswerRow's no-double-MARK rule. A self-displayed answer that ALSO carries display
-// text, in the context-clearing ExitPlanMode case where the fallback row must carry the mark (the
-// transcript row is about to be wiped), must persist ONLY the mark-carrying {controlResponse}
-// fallback row -- never an extra {content} synthetic row duplicating the provider's own transcript
-// answer. No current provider is in this state (Claude self-displays but returns no display text);
-// this pins the guarantee structurally so a future one can't double-render. Without the classifier
-// gate this persists TWO rows.
-func TestPersistControlResponseAnswerRows_SelfDisplayedWithTextDoesNotDoubleRow(t *testing.T) {
+// TestPersistControlResponseAnswerRows_SingleStructuredRow pins the structural "exactly one answer
+// row" guarantee. A non-self-displayed provider gets exactly one marked structured row; a
+// self-displayed answer in the context-clearing ExitPlanMode case (its own tool_result is about to
+// be wiped) gets exactly one marked structured row too -- never a second echo; a self-displayed
+// answer NOT clearing context gets none (its ingested tool_result owns the mark).
+func TestPersistControlResponseAnswerRows_SingleStructuredRow(t *testing.T) {
 	ctx := context.Background()
-	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
-	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
-		ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
-		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-	}))
 
-	var plan controlResponsePlan
-	plan.requestMeta.Loaded = true
-	plan.hasDecision = true
-	plan.decision.Response.Response.Behavior = agent.ControlBehaviorAllow
-	plan.decision.ClearContext = true
-	plan.resolution.PlanModeControl = agent.PlanModeControlExit
-	plan.resolution.SelfDisplayed = true
-	plan.resolution.DisplayText = "Answered: proceed"
+	mk := func(selfDisplayed, clear bool) controlResponsePlan {
+		var plan controlResponsePlan
+		plan.requestMeta.RequestID = "req-1"
+		plan.requestMeta.Loaded = true
+		plan.hasDecision = true
+		plan.decision.Response.Response.Behavior = agent.ControlBehaviorAllow
+		plan.decision.ClearContext = clear
+		plan.resolution.PlanModeControl = agent.PlanModeControlExit
+		plan.resolution.SelfDisplayed = selfDisplayed
+		plan.resolution.Content = []byte(`{"response":{"request_id":"req-1","response":{"behavior":"allow"}}}`)
+		return plan
+	}
 
-	svc.persistControlResponseAnswerRows("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, plan)
+	t.Run("non-self-displayed persists one marked structured row", func(t *testing.T) {
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		svc.persistControlResponseAnswerRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, mk(false, false))
+		rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+	})
 
-	rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
-	require.NoError(t, err)
-	require.Len(t, rows, 1, "a self-displayed answer must persist only the {controlResponse} fallback row, not a second {content} echo")
-	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType, "the single persisted row carries the rail mark")
+	t.Run("self-displayed clear-context persists exactly one marked structured row", func(t *testing.T) {
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		svc.persistControlResponseAnswerRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, mk(true, true))
+		rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "the wiped tool_result's mark moves to the single structured row, never a second echo")
+		assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_CONTROL_RESPONSE, rows[0].MarkType)
+	})
+
+	t.Run("self-displayed without clear-context persists no row", func(t *testing.T) {
+		svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: "agent-1", WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		svc.persistControlResponseAnswerRow("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, mk(true, false))
+		rows, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: "agent-1", Seq: 0})
+		require.NoError(t, err)
+		require.Empty(t, rows, "the ingested tool_result owns the mark; no synthetic row")
+	})
 }
 
 func TestReplayAgentCatchUp_ReplaysControlRequestAgentProvider(t *testing.T) {
@@ -294,9 +315,10 @@ func TestReplayAgentCatchUp_ReplaysControlRequestAgentProvider(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_PI,
 	}))
 	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
-		AgentID:   "agent-1",
-		RequestID: "request-1",
-		Payload:   []byte(`{"type":"permission","id":"request-1"}`),
+		AgentID:    "agent-1",
+		RequestID:  "request-1",
+		Payload:    []byte(`{"type":"permission","id":"request-1"}`),
+		ClaimToken: "instance-token-1",
 	}))
 	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
@@ -314,4 +336,8 @@ func TestReplayAgentCatchUp_ReplaysControlRequestAgentProvider(t *testing.T) {
 	require.NotNil(t, replayed, "catch-up replay must include pending control requests")
 	assert.Equal(t, leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, replayed.GetAgentProvider(),
 		"replayed control requests must preserve the provider-specific UI/response policy")
+	// The replay must carry the stored per-instance claim_token so a reconnecting window echoes it back
+	// on its answer and the worker's idempotency claim stays instance-scoped across the reconnect.
+	assert.Equal(t, "instance-token-1", replayed.GetClaimToken(),
+		"replayed control requests must carry the per-instance claim token the frontend echoes back")
 }

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -676,6 +676,47 @@ func (h *OutputHandler) CleanupAgent(agentID string) {
 	h.spanTrackers.Delete(agentID)
 	h.todos.Delete(agentID)
 	h.cleanupAutoContinue(agentID)
+	// The control-response answer claims are DURABLE rows (control_response_answers), not in-memory
+	// state, so there is nothing to reclaim here -- a reused request_id is deduped per INSTANCE by its
+	// claim_token (no release needed) and rows are cleaned up in bulk with the agent via ON DELETE CASCADE.
+}
+
+// claimControlResponseAnswer atomically records that (agentID, requestID, claimToken)'s answer is being
+// persisted and reports whether THIS call is the first to claim it. A later duplicate answer for the
+// same request INSTANCE -- an RPC retry, or a second window answering before it received the cancel
+// broadcast, BOTH echoing the same claim_token -- gets false, so the caller skips persisting a second
+// answer row and its scroll-rail dot. Handlers run concurrently (DispatchAsync, no per-agent lock), so
+// the claim -- a single INSERT serialized by the (agent_id, request_id, claim_token) primary key -- is
+// also what decides who deletes the pending request and applies the once-only plan-mode effects.
+//
+// claimToken (minted per PersistControlRequest, echoed by the frontend from the AgentControlRequest it
+// answers) is what makes the dedup INSTANCE-scoped: a REUSED request_id -- a Codex/ACP JSON-RPC counter
+// that reset across a plan-exec restart, or a Claude follow-up -- carries a FRESH token per instance, so
+// the new instance's genuine answer claims a distinct key while a stale duplicate of the PRIOR instance
+// (old token) still loses. No release-on-reissue is needed. An empty claimToken (a pre-token answer, or a
+// frontend lookup miss) degrades to request_id-only dedup for that answer.
+//
+// The claim is a DURABLE row (control_response_answers) cleaned up in bulk with its agent via ON DELETE
+// CASCADE. Because nothing else clears it, it survives BOTH a subprocess restart AND a worker-PROCESS
+// restart, so a duplicate straddling either is still deduped instead of re-persisting (#258) -- no
+// in-memory tracker to lose. On a query error it fails OPEN (returns true): dropping the user's answer
+// on a transient DB error is the worse outcome. The fail-open cost is NOT merely a duplicate row -- a
+// fail-open winner runs the FULL winner path (persist AND re-forward / re-restart). It bites when a
+// genuine DUPLICATE's claim query errors (the first answer already claimed cleanly, so only the
+// duplicate's INSERT need fail): fail-open then treats that duplicate as a fresh winner. That is rare by
+// construction -- SQLite writes are serialized under a 60s busy_timeout (see sqlitedb.Open), so a claim
+// error means a genuine DB failure, not routine write contention -- and the lesser evil accepts it.
+func (h *OutputHandler) claimControlResponseAnswer(agentID, requestID, claimToken string) bool {
+	rows, err := h.queries.ClaimControlResponseAnswer(bgCtx(), db.ClaimControlResponseAnswerParams{
+		AgentID:    agentID,
+		RequestID:  requestID,
+		ClaimToken: claimToken,
+	})
+	if err != nil {
+		slog.Warn("claim control response answer", "agent_id", agentID, "request_id", requestID, "error", err)
+		return true
+	}
+	return rows > 0
 }
 
 // TrackedAgentIDs returns the set of agent ids that currently hold any in-memory
@@ -724,10 +765,12 @@ func (h *OutputHandler) broadcastControlCancel(agentID, requestID string) {
 // (this handler included) has fully finished BEFORE registering the new provider, so a
 // relaunch's old-process onExit can only ever clear requests that genuinely belong to the
 // process that just went away -- never the freshly-restarted one's. It deliberately does NOT
-// touch the in-memory per-agent trackers (CleanupAgent): those carry timeline state (the open
-// notification thread, the to-do list, span hierarchy) that must SURVIVE a relaunch, or two
-// settings-change notifications bracketing a model/effort switch land in separate threads and
-// can no longer consolidate/cancel.
+// touch the TIMELINE per-agent trackers (CleanupAgent): the open notification thread, the to-do
+// list, and the span hierarchy must SURVIVE a relaunch, or two settings-change notifications
+// bracketing a model/effort switch land in separate threads and can no longer consolidate/cancel.
+// The durable control-response answer claims are likewise untouched here -- a duplicate straddling the
+// restart stays deduped because its claim survives, and a genuinely reissued request_id is disambiguated
+// per instance by its fresh claim_token rather than by clearing the prior claim.
 func (h *OutputHandler) ClearPendingControlRequests(agentID string) {
 	deletedIDs, err := h.queries.DeleteControlRequestsByAgentID(bgCtx(), agentID)
 	if err != nil {
@@ -738,9 +781,12 @@ func (h *OutputHandler) ClearPendingControlRequests(agentID string) {
 	}
 }
 
-// ClearAgentRuntimeState removes every piece of state tied to a dying agent:
-// pending control_requests in the DB plus the in-memory trackers cleared by
-// CleanupAgent. Call it only when the agent is PERMANENTLY gone (close, context
+// ClearAgentRuntimeState tears down the state tied to a dying SUBPROCESS: pending
+// control_requests in the DB plus the in-memory trackers cleared by CleanupAgent.
+// It leaves the durable control-response answer claims intact, so a duplicate answer
+// straddling a transient restart stays deduped.
+//
+// Call it when the current subprocess instance is being torn down (close, context
 // clear, plan-exec restart) -- NOT from the per-exit onExit handler, which a
 // relaunch also triggers and which must keep the in-memory timeline state (see
 // ClearPendingControlRequests).
@@ -890,14 +936,25 @@ func (s *agentOutputSink) BroadcastStreamEnd(spanID string) {
 	})
 }
 
-func (s *agentOutputSink) PersistControlRequest(requestID string, payload []byte) {
+func (s *agentOutputSink) PersistControlRequest(requestID string, payload []byte) string {
+	// Mint a fresh per-INSTANCE claim token. A reused request_id (a Codex/ACP counter that reset
+	// across a plan-exec restart, or a Claude follow-up) gets a distinct token here, so the answer's
+	// idempotency claim is scoped to THIS instance -- the genuine answer to the new instance claims a
+	// fresh key while a stale duplicate of the prior instance (old token) still loses. The token is
+	// stored on the row so the replay to a reconnecting window (ListControlRequestsByAgentID) carries
+	// it, AND returned to the caller so the paired live BroadcastControlRequest carries the SAME token
+	// the frontend echoes back -- without a second GetControlRequest to read back what we just wrote
+	// (and without the readback-failure window that would broadcast an empty token).
+	claimToken := id.Generate()
 	if err := s.h.queries.CreateControlRequest(bgCtx(), db.CreateControlRequestParams{
-		AgentID:   s.agentID,
-		RequestID: requestID,
-		Payload:   payload,
+		AgentID:    s.agentID,
+		RequestID:  requestID,
+		Payload:    payload,
+		ClaimToken: claimToken,
 	}); err != nil {
 		slog.Error("persist control request", "agent_id", s.agentID, "request_id", requestID, "error", err)
 	}
+	return claimToken
 }
 
 func (s *agentOutputSink) DeleteControlRequest(requestID string) {
@@ -907,11 +964,14 @@ func (s *agentOutputSink) DeleteControlRequest(requestID string) {
 	})
 }
 
-func (s *agentOutputSink) BroadcastControlRequest(requestID string, payload []byte) {
+func (s *agentOutputSink) BroadcastControlRequest(requestID string, payload []byte, claimToken string) {
+	// claimToken is the per-instance token PersistControlRequest just minted and returned, threaded
+	// straight through by the paired caller so the frontend can echo it in its answer (see
+	// AgentControlRequest.claim_token) -- no readback of the row we just wrote.
 	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
 		AgentId: s.agentID,
 		Event: &leapmuxv1.AgentEvent_ControlRequest{
-			ControlRequest: buildAgentControlRequest(s.agentID, s.agentProvider, requestID, payload),
+			ControlRequest: buildAgentControlRequest(s.agentID, s.agentProvider, requestID, payload, claimToken),
 		},
 	})
 }

--- a/backend/internal/worker/service/output_control_answer_claim_test.go
+++ b/backend/internal/worker/service/output_control_answer_claim_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// createClaimTestAgent creates a minimal agent row so the durable answer claim (a control_response_answers
+// row FK-referencing agents) can be inserted.
+func createClaimTestAgent(t *testing.T, svc *Context, id string) {
+	t.Helper()
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID: id, WorkspaceID: "ws-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+}
+
+// TestClaimControlResponseAnswer pins the per-INSTANCE idempotency claim SendControlResponse uses to
+// dedup a duplicate answer (an RPC retry or a second window echoing the SAME claim_token): the first
+// claim for a (agent, request, token) triple wins and a repeat loses, claims are isolated per request,
+// per agent, and per token, a DIFFERENT token for the same request id claims fresh (the reused-instance
+// case), and CleanupAgent (which also runs on a transient restart) does NOT clear the durable claim.
+func TestClaimControlResponseAnswer(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	createClaimTestAgent(t, svc, "agent-1")
+	createClaimTestAgent(t, svc, "agent-2")
+
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "req-1", "tokA"), "the first claim wins")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "req-1", "tokA"),
+		"a repeat claim with the SAME token loses -- the duplicate answer draws no second row")
+
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "req-2", "tokA"),
+		"a different request on the same agent is independent")
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-2", "req-1", "tokA"),
+		"the same request id on a different agent is independent")
+
+	// A REUSED request id whose NEW instance carries a DIFFERENT token claims fresh, while the prior
+	// instance's token stays claimed -- so a stale duplicate of the prior instance (tokA) still loses.
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "req-1", "tokB"),
+		"the reissued instance's fresh token claims a distinct key")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "req-1", "tokA"),
+		"a stale duplicate of the PRIOR instance (old token) still loses")
+
+	// An empty token (a pre-token answer, or a frontend lookup miss) degrades to request_id-only dedup.
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "req-3", ""), "empty-token first claim wins")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "req-3", ""),
+		"a repeat empty-token claim for the same request loses (id-only dedup fallback)")
+
+	// CleanupAgent runs on a transient context reset and does NOT touch the durable claim rows.
+	svc.Output.CleanupAgent("agent-1")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "req-2", "tokA"),
+		"the durable claim survives CleanupAgent (a transient restart), so the duplicate still loses")
+}
+
+// TestClaimControlResponseAnswer_ConcurrentClaimsExactlyOneWins pins the atomicity the dedup rests on:
+// N simultaneous claims for the SAME (agent, request, token) -- the concurrent two-window case the
+// claim exists to serialize -- must yield exactly ONE winner, never two persisting rows. The
+// (agent_id, request_id, claim_token) primary key is the serialization point. Run with -race to also
+// exercise the shared *sql.DB.
+func TestClaimControlResponseAnswer_ConcurrentClaimsExactlyOneWins(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	createClaimTestAgent(t, svc, "agent-1")
+
+	const n = 64
+	var wins int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all goroutines at once to maximize contention
+			if svc.Output.claimControlResponseAnswer("agent-1", "req-1", "tokA") {
+				atomic.AddInt32(&wins, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), wins, "exactly one concurrent claim wins; the rest are deduped duplicates")
+}
+
+// TestClaimControlResponseAnswer_FailsOpenOnError pins the fail-OPEN guard on the durable claim: if
+// the INSERT errors -- here a foreign-key violation because no agent row exists (in production
+// requireAccessibleAgent guarantees one does) -- the claim returns true (treat as first) rather than
+// false, so a transient DB error never silently drops the user's answer. A rare duplicate row is the
+// deliberate lesser evil.
+func TestClaimControlResponseAnswer_FailsOpenOnError(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	// No agent created -> the control_response_answers -> agents(id) foreign key rejects the INSERT.
+	assert.True(t, svc.Output.claimControlResponseAnswer("ghost-agent", "req-1", "tokA"),
+		"a claim whose INSERT errors fails open (true) so the answer is never dropped")
+}
+
+// TestClaimControlResponseAnswer_ReusedRequestIDDistinctTokenClaimsFresh is the id-reuse closure guard.
+// A subprocess relaunch (the per-exit ClearPendingControlRequests path) does NOT clear the durable
+// claims -- so a DUPLICATE of a pre-relaunch answer straddling the restart (carrying the PRIOR
+// instance's token) is still deduped, closing the double-persist window. Yet the genuine post-relaunch
+// answer -- to a re-issued request whose new instance minted a FRESH token -- claims a distinct key and
+// is NOT rejected as a duplicate. No release-on-reissue is involved; the two are told apart purely by
+// their echoed claim_token. Contrast the OLD release-based design, where a reused id reopened the dedup
+// window for the prior instance's lagging duplicate.
+func TestClaimControlResponseAnswer_ReusedRequestIDDistinctTokenClaimsFresh(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	createClaimTestAgent(t, svc, "agent-1")
+
+	// The pre-relaunch subprocess answered Codex/ACP-style request id "2" (instance A, token "instA").
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "2", "instA"), "instance A's answer wins")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "2", "instA"),
+		"a same-instance duplicate (same token) still loses")
+
+	// The subprocess exits/relaunches: ClearPendingControlRequests deletes DB requests but does NOT
+	// drop the durable claims.
+	svc.Output.ClearPendingControlRequests("agent-1")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "2", "instA"),
+		"a duplicate of instance A straddling the relaunch (old token) is still deduped")
+
+	// The NEW subprocess re-issues request id "2" -- a fresh INSTANCE minting a distinct token. Its
+	// genuine answer (token "instB") claims a distinct key and persists, without any release step.
+	assert.True(t, svc.Output.claimControlResponseAnswer("agent-1", "2", "instB"),
+		"the reissued instance's fresh token claims fresh -- the genuine post-relaunch answer is not withheld")
+	assert.False(t, svc.Output.claimControlResponseAnswer("agent-1", "2", "instA"),
+		"instance A's stale duplicate STILL loses even after instance B claimed -- the reuse window stays closed")
+}
+
+// TestPersistControlRequest_MintsFreshClaimTokenPerInstance pins that PersistControlRequest stamps a
+// distinct claim_token on each store of a (reused) request id, so the token the frontend echoes back
+// distinguishes instances. This is the store-side half of the id-reuse closure. It ALSO pins the
+// thread-through guarantee the live broadcast relies on: the token PersistControlRequest RETURNS is
+// exactly the one it stored, so the paired BroadcastControlRequest can carry it without a second
+// GetControlRequest readback (and without the readback-failure window that broadcast an empty token).
+func TestPersistControlRequest_MintsFreshClaimTokenPerInstance(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	createClaimTestAgent(t, svc, "agent-1")
+	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+
+	returned1 := sink.PersistControlRequest("2", []byte(`{"jsonrpc":"2.0","id":2,"method":"session/request_permission","params":{}}`))
+	first, err := svc.Queries.GetControlRequest(ctx, db.GetControlRequestParams{AgentID: "agent-1", RequestID: "2"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, first.ClaimToken, "a stored control request carries a claim token the frontend echoes back")
+	assert.Equal(t, first.ClaimToken, returned1,
+		"PersistControlRequest returns the SAME token it stored, so the paired broadcast carries it without a readback")
+
+	// Re-store the same id (a reissued instance). The token must be a DIFFERENT one so the two
+	// instances' answers claim distinct keys.
+	returned2 := sink.PersistControlRequest("2", []byte(`{"jsonrpc":"2.0","id":2,"method":"session/request_permission","params":{}}`))
+	second, err := svc.Queries.GetControlRequest(ctx, db.GetControlRequestParams{AgentID: "agent-1", RequestID: "2"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, second.ClaimToken)
+	assert.Equal(t, second.ClaimToken, returned2, "the re-store returns the fresh token it stored")
+	assert.NotEqual(t, first.ClaimToken, second.ClaimToken,
+		"re-issuing a request id mints a fresh token so a stale duplicate of the prior instance can't re-win")
+}

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -46,7 +46,7 @@ export interface AgentEditorPanelProps {
   onSendMessage: (content: string, attachments?: FileAttachment[]) => void
   focusRef?: (focus: () => void) => void
   controlRequests?: ControlRequest[]
-  onControlResponse?: (agentId: string, content: Uint8Array) => Promise<void>
+  onControlResponse?: (agentId: string, content: Uint8Array, claimToken?: string) => Promise<void>
   /** Single dispatcher for all settings panel changes (model/effort/permissionMode/optionGroup). */
   onSettingChange?: (change: ProviderSettingChange) => void
   /**
@@ -377,11 +377,14 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                     askState={askState}
                     agentProvider={props.agent?.agentProvider}
                     onRespond={(agentId, content) => {
-                      const reqId = ctrl.activeControlRequest()?.requestId
-                      if (reqId)
-                        ctrl.cleanupControlRequestDrafts(reqId)
+                      // Capture the per-instance claim token from the request being answered NOW,
+                      // before removeRequest can drop it, so the worker's idempotency claim keys on
+                      // the answered instance even in a double-submit / answer-after-cancel race.
+                      const active = ctrl.activeControlRequest()
+                      if (active?.requestId)
+                        ctrl.cleanupControlRequestDrafts(active.requestId)
                       editorHeight.resetEditorHeight()
-                      return props.onControlResponse?.(agentId, content) ?? Promise.resolve()
+                      return props.onControlResponse?.(agentId, content, active?.claimToken) ?? Promise.resolve()
                     }}
                     hasEditorContent={hasContent()}
                     onTriggerSend={() => triggerSend?.()}

--- a/frontend/src/components/chat/chatMarkPreview.test.ts
+++ b/frontend/src/components/chat/chatMarkPreview.test.ts
@@ -50,10 +50,41 @@ describe('message mark preview text', () => {
     expect(messageMarkPreviewText(messageOf({ content: 'jump here' }))).toBe('jump here')
   })
 
-  it('resolves a non-Claude (Codex) control-response answer via its plugin\'s neutral previewText', () => {
-    // Codex marks are the Leapmux-neutral `{content}` synthetic answer row; its plugin's
-    // previewText delegates to the shared default, so this resolves through the plugin.
-    expect(messageMarkPreviewText(messageOf({ content: 'Allow once' }, AgentProvider.CODEX))).toBe('Allow once')
+  it('resolves a persisted Codex control-response row to its decision label', () => {
+    // A structured {isSynthetic, controlResponse} row resolves through the plugin's
+    // controlResponseDisplay -- Codex maps result.decision "accept" to "Allow".
+    const row = messageOf({
+      isSynthetic: true,
+      controlResponse: {
+        provider: 'CODEX',
+        requestId: '7',
+        request: { method: 'item/commandExecution/requestApproval' },
+        response: { jsonrpc: '2.0', id: 7, result: { decision: 'accept' } },
+      },
+    }, AgentProvider.CODEX)
+    expect(messageMarkPreviewText(row)).toBe('Allow')
+  })
+
+  it('resolves a Claude deny-with-feedback row to the "Sent feedback:" preview', () => {
+    const row = messageOf({
+      isSynthetic: true,
+      controlResponse: {
+        provider: 'CLAUDE_CODE',
+        requestId: 'r',
+        request: { request: { tool_name: 'Bash' } },
+        response: { type: 'control_response', response: { request_id: 'r', response: { behavior: 'deny', message: 'use ripgrep instead' } } },
+      },
+    })
+    expect(messageMarkPreviewText(row)).toBe('Sent feedback:\nuse ripgrep instead')
+  })
+
+  it('degrades a malformed control-response row to the generic label', () => {
+    // Neither a recognizable decision nor a behavior envelope -> the fallback ladder's terminal.
+    const row = messageOf({
+      isSynthetic: true,
+      controlResponse: { provider: 'CODEX', response: {} },
+    }, AgentProvider.CODEX)
+    expect(messageMarkPreviewText(row)).toBe('Responded')
   })
 
   it('returns null for a message with no previewable text', () => {

--- a/frontend/src/components/chat/chatMarkPreview.ts
+++ b/frontend/src/components/chat/chatMarkPreview.ts
@@ -1,8 +1,10 @@
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { createStore, produce, reconcile } from 'solid-js/store'
 import { parseMessageContent } from '~/lib/messageParser'
+import { truncatePreview } from '~/lib/textTruncate'
 import { defaultMarkPreview } from './markPreviewShared'
 import { classifyAgentMessage } from './messageClassification'
+import { controlResponsePreviewText, parsePersistedControlResponse, resolveControlResponseDisplay } from './persistedControlResponse'
 import { pluginFor } from './providers/registry'
 
 // ---------------------------------------------------------------------------
@@ -45,6 +47,16 @@ export function messageMarkPreviewText(message: AgentChatMessage): string | null
     const parsed = parseMessageContent(message)
     const category = classifyAgentMessage(message)
     const plugin = pluginFor(message.agentProvider)
+    // A persisted control-response row resolves its preview through the SAME per-provider
+    // derivation the transcript row uses (plugin.controlResponseDisplay), so the dot reads
+    // identically to the row it jumps to. Degrades to the neutral behavior/generic fallback.
+    if (category.kind === 'control_response') {
+      const cr = parsePersistedControlResponse(parsed.parentObject)
+      if (cr) {
+        const display = resolveControlResponseDisplay(cr, plugin?.controlResponseDisplay)
+        return truncatePreview(controlResponsePreviewText(display))
+      }
+    }
     // Route to the plugin's previewText when it defines one, treating its result as
     // authoritative -- including a deliberate null (no preview). Only a provider WITHOUT
     // a previewText falls back to the shared neutral extractor. (A `?? defaultMarkPreview`

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -234,6 +234,28 @@ describe('handleControlSend', () => {
     })
   })
 
+  it('threads the active request\'s per-instance claimToken to onControlResponse', () => {
+    createRoot((dispose) => {
+      const onControlResponse = vi.fn().mockResolvedValue(undefined)
+      const props: ControlResponseHandlingProps = {
+        agentId: 'test-agent',
+        agent: { agentProvider: AgentProvider.CLAUDE_CODE },
+        controlRequests: [{ requestId: 'req-1', agentId: 'test-agent', payload: { request: { tool_name: 'Bash', tool_input: {} } }, claimToken: 'instance-token-7' }],
+        onControlResponse,
+        onSendMessage: vi.fn(),
+      }
+      const result = useControlResponseHandling(props, createMinimalAskState(), () => undefined, vi.fn())
+
+      result.handleControlSend('please stop')
+
+      // The 3rd arg is the answered instance's claim token, captured from the active request so the
+      // worker's idempotency claim keys on THIS instance (not a store re-derivation that can miss).
+      expect(onControlResponse).toHaveBeenCalledOnce()
+      expect(onControlResponse.mock.calls[0][2]).toBe('instance-token-7')
+      dispose()
+    })
+  })
+
   it('does not pass attachments to control responses', () => {
     const onControlResponse = vi.fn().mockResolvedValue(undefined)
     const attachments = [makeAttachment()]

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -17,7 +17,7 @@ export interface ControlResponseHandlingProps {
   agentId: string
   agent?: { optionValues?: Record<string, string>, agentProvider?: AgentProvider }
   controlRequests?: ControlRequest[]
-  onControlResponse?: (agentId: string, content: Uint8Array) => Promise<void>
+  onControlResponse?: (agentId: string, content: Uint8Array, claimToken?: string) => Promise<void>
   onSettingChange?: (change: ProviderSettingChange) => void
   onSendMessage: (content: string, attachments?: FileAttachment[]) => void
   settingsLoading?: boolean
@@ -133,9 +133,12 @@ export function useControlResponseHandling(
     })
   })
 
-  // Handles editor text for control requests.
+  // Handles editor text for control requests. Threads the per-instance claim token of the request
+  // being answered (the active one) so the worker's idempotency claim keys on THIS instance even
+  // after the request leaves the store -- the typed-feedback / ask-question sibling of the footer
+  // action path in AgentEditorPanel.
   const sendControlResponse = (agentId: string, bytes: Uint8Array): Promise<void> => {
-    return props.onControlResponse?.(agentId, bytes) ?? Promise.resolve()
+    return props.onControlResponse?.(agentId, bytes, activeControlRequest()?.claimToken) ?? Promise.resolve()
   }
 
   const cleanupControlRequestDrafts = (requestId: string) => {

--- a/frontend/src/components/chat/controlResponseRow.test.tsx
+++ b/frontend/src/components/chat/controlResponseRow.test.tsx
@@ -1,0 +1,93 @@
+import type { ControlResponseDisplay, PersistedControlResponse } from './persistedControlResponse'
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { renderControlResponseRow, renderMessageContent } from './messageRenderers'
+// Register provider plugins so renderMessageContent can resolve a plugin's controlResponseDisplay.
+import '~/components/chat/providers'
+
+function row(parsed: unknown, display?: (cr: PersistedControlResponse) => ControlResponseDisplay | null) {
+  return render(() => <>{renderControlResponseRow(parsed, undefined, display)}</>)
+}
+
+const ENVELOPE = { isSynthetic: true, controlResponse: { provider: 'CODEX', response: {} } }
+
+describe('rendercontrolresponserow', () => {
+  it('renders a label as line-broken plain text', () => {
+    const { container } = row(ENVELOPE, () => ({ kind: 'label', text: 'Task: Build\nEnv: Dev' }))
+    expect(container.textContent).toBe('Task: Build\nEnv: Dev')
+  })
+
+  it('renders feedback under the "Sent feedback:" lead as markdown', () => {
+    const { container } = row(ENVELOPE, () => ({ kind: 'feedback', message: 'use ripgrep instead' }))
+    expect(container.textContent).toContain('Sent feedback:')
+    expect(container.textContent).toContain('use ripgrep instead')
+  })
+
+  it('degrades to the neutral/generic fallback when the deriver returns null', () => {
+    // No plugin display + an unrecognized response -> the generic terminal label.
+    const { container } = row(ENVELOPE, () => null)
+    expect(container.textContent).toBe('Responded')
+  })
+
+  it('degrades to the fallback when the deriver THROWS, never leaking raw JSON', () => {
+    // A derivation that throws on a malformed payload must NOT propagate to renderMessageContent's
+    // raw-JSON safety net (which would dump the {controlResponse:...} envelope at the user) -- it
+    // degrades to the same neutral fallback as a null return.
+    const throwing = (): never => {
+      throw new Error('bad payload')
+    }
+    const { container } = row(ENVELOPE, throwing)
+    expect(container.textContent).toBe('Responded')
+  })
+
+  it('uses the coarse behavior envelope as the fallback when no deriver is given', () => {
+    const parsed = { isSynthetic: true, controlResponse: { provider: 'CLAUDE_CODE', response: { response: { response: { behavior: 'allow' } } } } }
+    const { container } = row(parsed, undefined)
+    expect(container.textContent).toBe('Approved')
+  })
+
+  it('returns null (no row) for a non-control-response object', () => {
+    const { container } = row({ content: 'hello' }, () => ({ kind: 'label', text: 'x' }))
+    expect(container.textContent).toBe('')
+  })
+})
+
+describe('rendermessagecontent control_response dispatch', () => {
+  // The transcript-side counterpart to chatMarkPreview's rail-side end-to-end test: a
+  // control_response category dispatches through renderMessageContent's shared branch to the
+  // resolved plugin's controlResponseDisplay -- no per-plugin renderMessage case needed.
+  function renderRow(parsed: unknown, provider: AgentProvider) {
+    return render(() => <>{renderMessageContent(parsed, undefined, { kind: 'control_response' }, provider)}</>)
+  }
+
+  it('renders a Codex decision label through the codex plugin', () => {
+    const parsed = {
+      isSynthetic: true,
+      controlResponse: {
+        provider: 'CODEX',
+        request: { method: 'item/commandExecution/requestApproval' },
+        response: { result: { decision: 'accept' } },
+      },
+    }
+    expect(renderRow(parsed, AgentProvider.CODEX).container.textContent).toBe('Allow')
+  })
+
+  it('renders a Claude deny-with-feedback through the claude plugin', () => {
+    const parsed = {
+      isSynthetic: true,
+      controlResponse: {
+        provider: 'CLAUDE_CODE',
+        response: { type: 'control_response', response: { request_id: 'r', response: { behavior: 'deny', message: 'add tests' } } },
+      },
+    }
+    const text = renderRow(parsed, AgentProvider.CLAUDE_CODE).container.textContent ?? ''
+    expect(text).toContain('Sent feedback:')
+    expect(text).toContain('add tests')
+  })
+
+  it('degrades an unrecognized payload to the generic label', () => {
+    const parsed = { isSynthetic: true, controlResponse: { provider: 'CODEX', response: {} } }
+    expect(renderRow(parsed, AgentProvider.CODEX).container.textContent).toBe('Responded')
+  })
+})

--- a/frontend/src/components/chat/controls/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/controls/CodexControlRequest.tsx
@@ -1,12 +1,14 @@
 import type { Component } from 'solid-js'
-import type { ActionsProps, AskQuestionState, ContentProps, Question } from './types'
+import type { CodexDecision } from '../providers/codex/controlResponse'
 
+import type { ActionsProps, AskQuestionState, ContentProps, Question } from './types'
 import { For, Match, Show, Switch } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { Tooltip } from '~/components/common/Tooltip'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
+import { codexDecisionKey, codexDecisionLabel } from '../providers/codex/controlResponse'
 import { AskUserQuestionActions, AskUserQuestionContent } from './AskUserQuestionControl'
 import { CollapsibleText } from './CollapsibleText'
 import { createPlanApprovalState, PlanApprovalCheckboxes } from './PlanApprovalCheckboxes'
@@ -16,8 +18,6 @@ import { sendResponse } from './types'
 function getCodexParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
   return payload.params as Record<string, unknown> | undefined
 }
-
-type CodexDecision = string | Record<string, unknown>
 
 /** Convert a string request ID to a numeric JSON-RPC id when possible. */
 export function toRpcId(requestId: string): number | string {
@@ -113,24 +113,6 @@ function wrapAsAskUserQuestion(payload: Record<string, unknown>): Record<string,
       input: { questions: params?.questions ?? [] },
     },
   }
-}
-
-/** Label for a Codex decision. */
-function decisionLabel(decision: CodexDecision): string {
-  if (typeof decision === 'string') {
-    switch (decision) {
-      case 'accept': return 'Allow'
-      case 'acceptForSession': return 'Allow for Session'
-      case 'decline': return 'Reject'
-      case 'cancel': return 'Cancel'
-      default: return decision
-    }
-  }
-  if ('acceptWithExecpolicyAmendment' in decision)
-    return 'Allow & Remember'
-  if ('applyNetworkPolicyAmendment' in decision)
-    return 'Apply Network Policy'
-  return 'Allow'
 }
 
 /** Whether a decision is a cancel/decline type (rendered as outline button). */
@@ -311,9 +293,9 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                       <button
                         class={isNegativeDecision(decision) ? 'outline' : undefined}
                         onClick={() => handleDecision(decision)}
-                        data-testid={`control-decision-${typeof decision === 'string' ? decision : Object.keys(decision)[0]}`}
+                        data-testid={`control-decision-${codexDecisionKey(decision)}`}
                       >
-                        {decisionLabel(decision)}
+                        {codexDecisionLabel(decision)}
                       </button>
                     )}
                   </For>

--- a/frontend/src/components/chat/markPreviewShared.test.ts
+++ b/frontend/src/components/chat/markPreviewShared.test.ts
@@ -8,7 +8,6 @@ function parsedOf(obj: Record<string, unknown> | undefined): ParsedMessageConten
 }
 
 const USER: MessageCategory = { kind: 'user_content' }
-const CONTROL: MessageCategory = { kind: 'control_response' }
 
 describe('default mark preview', () => {
   it('extracts the provider-neutral {content} user shape', () => {
@@ -17,24 +16,17 @@ describe('default mark preview', () => {
 
   it('does NOT extract the Claude {message:{content}} transcript shape (that is the claude plugin\'s job)', () => {
     // The nested `{message:{content}}` envelope is an Anthropic transcript shape; the shared
-    // neutral default handles only `{content}` / `{controlResponse}`. See claude/plugin.test.ts.
+    // neutral default handles only `{content}`. See claude/plugin.test.ts.
     expect(defaultMarkPreview({ kind: 'user_text' }, parsedOf({ message: { content: 'typed text' } }))).toBeNull()
   })
 
-  it('summarizes an approved control response', () => {
-    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'approved' } }))).toBe('Approved')
-  })
-
-  it('summarizes a rejected control response carrying feedback the same way the row renderer does', () => {
-    // Mirror controlResponseRenderer (notificationRenderers), the row the dot jumps to: a
-    // rejection WITH a typed reason renders "Sent feedback:" above the reason, so the preview
-    // must read the same -- NOT the inline ControlResponseTag's "Rejected: <reason>".
-    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'rejected', comment: 'not this way' } })))
-      .toBe('Sent feedback:\nnot this way')
-  })
-
-  it('labels a bare rejection', () => {
-    expect(defaultMarkPreview(CONTROL, parsedOf({ controlResponse: { action: 'rejected' } }))).toBe('Rejected')
+  it('does NOT handle persisted control-response rows (they resolve through controlResponseDisplay)', () => {
+    // A control-response row classifies as `control_response` and the rail resolves its preview
+    // through the plugin's controlResponseDisplay (chatMarkPreview.ts), NOT this neutral default.
+    expect(defaultMarkPreview(
+      { kind: 'control_response' },
+      parsedOf({ isSynthetic: true, controlResponse: { provider: 'CODEX', response: { result: { decision: 'accept' } } } }),
+    )).toBeNull()
   })
 
   it('returns null when there is no previewable text', () => {

--- a/frontend/src/components/chat/markPreviewShared.ts
+++ b/frontend/src/components/chat/markPreviewShared.ts
@@ -1,6 +1,6 @@
 import type { MessageCategory } from './messageClassification'
 import type { ParsedMessageContent } from '~/lib/messageParser'
-import { isObject, pickString } from '~/lib/jsonPick'
+import { pickString } from '~/lib/jsonPick'
 import { truncatePreview } from '~/lib/textTruncate'
 
 // ---------------------------------------------------------------------------
@@ -13,26 +13,19 @@ import { truncatePreview } from '~/lib/textTruncate'
 // `previewText`; this covers only the Leapmux-neutral marked shapes.
 // ---------------------------------------------------------------------------
 
-// The three user-facing labels for a persisted {controlResponse} answer row. Shared by the row's
-// renderer (controlResponseRenderer in notificationRenderers) AND its scroll-rail dot preview
-// (defaultMarkPreview below) so the dot reads IDENTICALLY to the row it jumps to -- the wording
-// lives here once instead of being mirrored by hand across the two surfaces (the drift a comment
-// alone can't prevent). Kept in this leaf so the preview extractor and the renderer can both import
-// them without a module-init cycle.
-/** An approved control request (ExitPlanMode approval, an "allow" permission decision). */
-export const CONTROL_RESPONSE_APPROVED_LABEL = 'Approved'
-/** A declined control request with no typed reason. */
-export const CONTROL_RESPONSE_REJECTED_LABEL = 'Rejected'
-/** Lead-in shown above the user's typed rejection reason (their feedback follows as markdown). */
-export const CONTROL_RESPONSE_FEEDBACK_LEAD = 'Sent feedback:'
+// The control-response display labels moved to persistedControlResponse.ts (the leaf that owns
+// control-response display); this "preview" module no longer references them, and persisted
+// control-response rows resolve their preview through the plugin's controlResponseDisplay in
+// chatMarkPreview.ts, never here.
 
 /**
  * Provider-NEUTRAL preview extractor and shared fallback for every provider's
- * {@link Provider.previewText}. Handles only the Leapmux-neutral marked shapes: the
- * app persists user sends as `{content:"..."}` and control-request responses as
- * `{controlResponse:{action,comment}}` regardless of provider. Provider-specific shapes
- * (e.g. Claude's Anthropic tool_result blocks and its `{message:{content}}` transcript
- * envelope) are handled by that provider's `previewText` BEFORE it falls back here.
+ * {@link Provider.previewText}. Handles only the Leapmux-neutral user-send shape: the app persists
+ * user sends (and forwarded plan-prompt feedback) as `{content:"..."}` regardless of provider.
+ * Provider-specific shapes (e.g. Claude's Anthropic tool_result blocks and its `{message:{content}}`
+ * transcript envelope) are handled by that provider's `previewText` BEFORE it falls back here.
+ * Persisted control-response rows are NOT handled here -- they classify as `control_response` and
+ * the rail resolves their preview through the plugin's `controlResponseDisplay` (chatMarkPreview.ts).
  */
 export function defaultMarkPreview(_category: MessageCategory, parsed: ParsedMessageContent): string | null {
   const obj = parsed.parentObject
@@ -45,20 +38,6 @@ export function defaultMarkPreview(_category: MessageCategory, parsed: ParsedMes
   const content = pickString(obj, 'content', '')
   if (content)
     return truncatePreview(content)
-
-  // Control-request response display row -- mirror controlResponseRenderer (notificationRenderers),
-  // the row the dot actually jumps to, so the preview reads the same as that row: an approved row
-  // shows "Approved"; a rejection carrying the user's typed reason shows "Sent feedback:" above the
-  // reason (NOT the inline ControlResponseTag's "Rejected: <reason>", which is a different surface);
-  // a bare rejection shows "Rejected".
-  const cr = isObject(obj.controlResponse) ? obj.controlResponse : undefined
-  if (cr) {
-    const action = pickString(cr, 'action', '')
-    const comment = pickString(cr, 'comment', '')
-    if (action === 'approved')
-      return CONTROL_RESPONSE_APPROVED_LABEL
-    return comment ? truncatePreview(`${CONTROL_RESPONSE_FEEDBACK_LEAD}\n${comment}`) : CONTROL_RESPONSE_REJECTED_LABEL
-  }
 
   return null
 }

--- a/frontend/src/components/chat/messageClassification.test.ts
+++ b/frontend/src/components/chat/messageClassification.test.ts
@@ -233,13 +233,34 @@ describe('classifyMessage', () => {
 
   // -- control_response -----------------------------------------------------
 
-  it('classifies synthetic message with controlResponse', () => {
-    const result = classifyMessage(input({ isSynthetic: true, controlResponse: { action: 'approve' } }))
-    expect(result.kind).toBe('control_response')
+  it('classifies a persisted control-response row as control_response for EVERY provider (before plugin dispatch)', () => {
+    // The {isSynthetic, controlResponse} row is a Leapmux-neutral synthetic shape classified once in
+    // classifyMessage -- not per plugin -- so it resolves identically for every provider and a new
+    // plugin can't forget it. Exercise a spread of provider plugins (Claude / Codex / an ACP question
+    // provider / Pi / Cursor) through the real dispatch.
+    for (const provider of [
+      AgentProvider.CLAUDE_CODE,
+      AgentProvider.CODEX,
+      AgentProvider.OPENCODE,
+      AgentProvider.PI,
+      AgentProvider.CURSOR,
+    ]) {
+      const row = { isSynthetic: true, controlResponse: { provider: 'X', requestId: 'r', response: { response: { behavior: 'allow' } } } }
+      expect(classifyMessage(input(row, null, provider)).kind).toBe('control_response')
+    }
+  })
+
+  it('does NOT short-circuit a control-response-shaped row that sits inside a notification thread', () => {
+    // The row is persisted standalone, never inside a thread, so the shared classifier guards on
+    // !wrapper to preserve each plugin's wrapper-first precedence: a thread whose first message
+    // happens to look synthetic still classifies as its plugin's kind, not control_response.
+    const row = { isSynthetic: true, controlResponse: { provider: 'X', response: {} } }
+    const wrapped = input(row, { old_seqs: [], messages: [row] }, AgentProvider.CLAUDE_CODE)
+    expect(classifyMessage(wrapped).kind).not.toBe('control_response')
   })
 
   it('does not classify non-synthetic with controlResponse', () => {
-    const result = classifyMessage(input({ controlResponse: { action: 'approve' } }))
+    const result = classifyMessage(input({ controlResponse: { provider: 'CLAUDE_CODE', response: {} } }))
     expect(result.kind).not.toBe('control_response')
   })
 

--- a/frontend/src/components/chat/messageClassification.ts
+++ b/frontend/src/components/chat/messageClassification.ts
@@ -4,6 +4,7 @@ import type { ParsedMessageContent } from '~/lib/messageParser'
 import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { parseMessageContent } from '~/lib/messageParser'
 import * as chatStyles from './messageStyles.css'
+import { isPersistedControlResponse } from './persistedControlResponse'
 import { pluginFor } from './providers/registry'
 import './providers'
 
@@ -75,9 +76,19 @@ export function classifyMessage(
   context?: ClassificationContext,
 ): MessageCategory {
   const plugin = pluginFor(input.agentProvider)
-  if (plugin)
-    return plugin.classify(input, context)
-  return { kind: 'unsupported_provider' }
+  if (!plugin)
+    return { kind: 'unsupported_provider' }
+
+  // A persisted control-response row ({isSynthetic, controlResponse}) is a Leapmux-NEUTRAL synthetic
+  // shape, not a provider wire format, so its classification lives here once instead of being
+  // re-hardcoded in every plugin's classify (where a new provider plugin could forget it and render
+  // the row as raw JSON). It is persisted as a standalone row, never inside a notification thread, so
+  // guard on !input.wrapper to preserve the plugins' wrapper-first precedence: a notification thread
+  // whose first message somehow looks synthetic still classifies as a notification, not this.
+  if (!input.wrapper && isPersistedControlResponse(input.parentObject))
+    return { kind: 'control_response' }
+
+  return plugin.classify(input, context)
 }
 
 /** Classify a message, returning both the parsed content and category. */

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'solid-js'
 import type { MessageCategory } from './messageClassification'
 import type { MessageRenderCache } from './messageRenderCache'
 import type { MessageUiKey } from './messageUiKeys'
+import type { ControlResponseDeriver } from './persistedControlResponse'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
@@ -23,8 +24,9 @@ import { getCachedMarkdownHtml, renderMarkdown, renderMarkdownCachedOrPlain, ren
 import { inlineFlex } from '~/styles/shared.css'
 import { markdownContent } from './markdownEditor/markdownContent.css'
 import { cachedRenderValueForString, getCachedRenderValueForString, setCachedRenderValueForString } from './messageRenderCache'
-import { attachmentItem, attachmentList, thinkingChevron, thinkingChevronExpanded, thinkingContent, thinkingHeader } from './messageStyles.css'
+import { attachmentItem, attachmentList, controlResponseLabel, controlResponseMessage, thinkingChevron, thinkingChevronExpanded, thinkingContent, thinkingHeader } from './messageStyles.css'
 import { MESSAGE_UI_KEY, messageUiDefault } from './messageUiKeys'
+import { CONTROL_RESPONSE_FEEDBACK_LEAD, parsePersistedControlResponse, resolveControlResponseDisplay } from './persistedControlResponse'
 import { pluginFor } from './providers/registry'
 import {
   toolInputText,
@@ -343,6 +345,37 @@ export function UserContentMessage(props: { parsed: unknown, context?: RenderCon
 }
 
 /**
+ * Render a persisted control-response row (issue #258). The provider plugin's
+ * `controlResponseDisplay` owns the native-payload -> label/feedback derivation (one source of
+ * truth with the scroll-rail preview); this is the shared markup for the two display kinds. A
+ * feedback block renders the user's typed reason as markdown under the "Sent feedback:" lead; a
+ * label renders line-broken plain text (a multi-question answer joins its lines with `\n`). Returns
+ * null when `parsed` isn't a control-response envelope, so `renderMessageContent` falls through to
+ * its raw-JSON safety net.
+ */
+export function renderControlResponseRow(
+  parsed: unknown,
+  context: RenderContext | undefined,
+  display: ControlResponseDeriver | undefined,
+): JSX.Element | null {
+  const cr = parsePersistedControlResponse(parsed)
+  if (!cr)
+    return null
+  const d = resolveControlResponseDisplay(cr, display)
+  if (d.kind === 'feedback') {
+    return (
+      <div class={controlResponseMessage}>
+        <div>
+          <div>{CONTROL_RESPONSE_FEEDBACK_LEAD}</div>
+          <MarkdownText text={d.message} context={context} />
+        </div>
+      </div>
+    )
+  }
+  return <div class={`${controlResponseMessage} ${controlResponseLabel}`}>{d.text}</div>
+}
+
+/**
  * Render a message's content.
  *
  * All rendering goes through the message's own provider plugin's `renderMessage`.
@@ -375,6 +408,16 @@ export function renderMessageContent(
     const result = plugin?.renderMessage?.(category ?? { kind: 'unknown' }, parsed, context) ?? null
     if (result !== null)
       return result
+
+    // A persisted control-response row is provider-neutral in the renderer layer: every plugin's
+    // classify maps it to `control_response`, and the plugin's controlResponseDisplay (when set)
+    // supplies the per-provider label. Dispatched here -- once -- rather than in each plugin's
+    // renderMessage, so a plugin only implements the derivation, not the markup.
+    if (category?.kind === 'control_response') {
+      const row = renderControlResponseRow(parsed, context, plugin?.controlResponseDisplay)
+      if (row !== null)
+        return row
+    }
   }
   catch (err) { logger.warn('Failed to render message content:', err) }
   return <span>{typeof parsedOrRawJson === 'string' ? parsedOrRawJson : JSON.stringify(parsedOrRawJson)}</span>

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -167,6 +167,13 @@ export const controlResponseMessage = style({
   alignSelf: 'stretch',
 })
 
+// A control-response LABEL row (Allow / Approved / "Task: Build\nEnv: Dev"). `pre-line` preserves
+// the `\n` line breaks a multi-question answer joins its lines with, so they render one per line
+// instead of collapsing to a single run.
+export const controlResponseLabel = style({
+  whiteSpace: 'pre-line',
+})
+
 // Base styles for message row layout
 const messageRowBase = {
   display: 'flex',

--- a/frontend/src/components/chat/notificationRenderers.tsx
+++ b/frontend/src/components/chat/notificationRenderers.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable solid/components-return-once -- render methods are not Solid components */
 import type { JSXElement } from 'solid-js'
-import type { MessageContentRenderer } from './messageRenderers'
 import type { NotificationThreadEntry } from './providers/registry'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { CompactionDetail } from '~/lib/messageParser'
@@ -12,8 +10,6 @@ import { isCompactBoundary, parseBoundaryMeta, toTokenCount } from '~/lib/messag
 import { NOTIFICATION_TYPE } from '~/lib/notificationTypes'
 import { getCachedSettingsGroupLabel, getCachedSettingsLabel } from '~/lib/settingsLabelCache'
 import { spinner } from '~/styles/animations.css'
-import { CONTROL_RESPONSE_APPROVED_LABEL, CONTROL_RESPONSE_FEEDBACK_LEAD, CONTROL_RESPONSE_REJECTED_LABEL } from './markPreviewShared'
-import { MarkdownText } from './messageRenderers'
 import {
   controlResponseMessage,
   resultDivider,
@@ -246,35 +242,10 @@ function isMicrocompactBoundary(m: Record<string, unknown>): boolean {
   return m.type === 'system' && m.subtype === 'microcompact_boundary'
 }
 
-/** Handles control response messages: {"isSynthetic":true,"controlResponse":{"action":"approved"|"rejected","comment":"..."}} */
-export const controlResponseRenderer: MessageContentRenderer = {
-  render(parsed, context) {
-    if (!isObject(parsed) || !isObject(parsed.controlResponse))
-      return null
-
-    const cr = parsed.controlResponse as Record<string, unknown>
-    const action = cr.action as string
-    const comment = (cr.comment as string) || ''
-
-    // The three labels are shared with the scroll-rail dot preview (defaultMarkPreview) via the
-    // markPreviewShared constants, so the dot reads identically to this row it jumps to.
-    if (action === 'approved')
-      return <div class={controlResponseMessage}>{CONTROL_RESPONSE_APPROVED_LABEL}</div>
-
-    if (comment) {
-      return (
-        <div class={controlResponseMessage}>
-          <div>
-            <div>{CONTROL_RESPONSE_FEEDBACK_LEAD}</div>
-            <MarkdownText text={comment} context={context} />
-          </div>
-        </div>
-      )
-    }
-
-    return <div class={controlResponseMessage}>{CONTROL_RESPONSE_REJECTED_LABEL}</div>
-  },
-}
+// Persisted control-response rows (issue #258) are rendered by renderControlResponseRow
+// (messageRenderers), dispatched from renderMessageContent's shared `control_response` branch via
+// the provider plugin's controlResponseDisplay -- the frontend owns the label text there, so this
+// module no longer carries a control-response renderer.
 
 // ---------------------------------------------------------------------------
 // Aggregate notification thread renderer

--- a/frontend/src/components/chat/persistedControlResponse.test.ts
+++ b/frontend/src/components/chat/persistedControlResponse.test.ts
@@ -1,0 +1,210 @@
+import type { PersistedControlResponse } from './persistedControlResponse'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  controlBehaviorDisplay,
+  controlResponsePreviewText,
+  fallbackControlResponseDisplay,
+  feedback,
+  feedbackOrLabel,
+  firstNonEmpty,
+  isPersistedControlResponse,
+  joinAnswerLines,
+  label,
+  labeledAnswerLine,
+  labelOrNull,
+  parsePersistedControlResponse,
+  resolveControlResponseDisplay,
+} from './persistedControlResponse'
+
+function crWith(response: Record<string, unknown> | undefined): PersistedControlResponse {
+  return { provider: 'CODEX', requestId: '', request: undefined, response }
+}
+
+describe('ispersistedcontrolresponse', () => {
+  it('accepts a synthetic row whose controlResponse is an object', () => {
+    expect(isPersistedControlResponse({ isSynthetic: true, controlResponse: { provider: 'CODEX' } })).toBe(true)
+  })
+
+  it('rejects non-synthetic rows and non-object controlResponse', () => {
+    expect(isPersistedControlResponse({ controlResponse: { provider: 'CODEX' } })).toBe(false)
+    expect(isPersistedControlResponse({ isSynthetic: true, controlResponse: 'x' })).toBe(false)
+    expect(isPersistedControlResponse(null)).toBe(false)
+    expect(isPersistedControlResponse(undefined)).toBe(false)
+  })
+})
+
+describe('parsepersistedcontrolresponse', () => {
+  it('parses the full envelope', () => {
+    const parsed = parsePersistedControlResponse({
+      isSynthetic: true,
+      controlResponse: {
+        provider: 'OPENCODE',
+        requestId: '7',
+        request: { method: 'session/request_permission' },
+        response: { result: { outcome: { optionId: 'proceed_once' } } },
+      },
+    })
+    expect(parsed).toEqual({
+      provider: 'OPENCODE',
+      requestId: '7',
+      request: { method: 'session/request_permission' },
+      response: { result: { outcome: { optionId: 'proceed_once' } } },
+    })
+  })
+
+  it('defaults missing fields and tolerates an omitted request/response', () => {
+    const parsed = parsePersistedControlResponse({ isSynthetic: true, controlResponse: {} })
+    expect(parsed).toEqual({ provider: '', requestId: '', request: undefined, response: undefined })
+  })
+
+  it('returns null when the shape is not a persisted control response', () => {
+    expect(parsePersistedControlResponse({ content: 'hi' })).toBeNull()
+    expect(parsePersistedControlResponse(null)).toBeNull()
+  })
+})
+
+describe('controlbehaviordisplay', () => {
+  it('maps allow to Approved', () => {
+    expect(controlBehaviorDisplay({ response: { response: { behavior: 'allow' } } })).toEqual({ kind: 'label', text: 'Approved' })
+  })
+
+  it('maps deny with a typed reason to feedback', () => {
+    expect(controlBehaviorDisplay({ response: { response: { behavior: 'deny', message: 'nope' } } })).toEqual({ kind: 'feedback', message: 'nope' })
+  })
+
+  it('maps a bare deny (sentinel-only message) to Rejected', () => {
+    expect(controlBehaviorDisplay({ response: { response: { behavior: 'deny', message: 'Rejected by user.' } } })).toEqual({ kind: 'label', text: 'Rejected' })
+  })
+
+  it('returns null for a non-behavior response', () => {
+    expect(controlBehaviorDisplay({ result: { decision: 'accept' } })).toBeNull()
+  })
+})
+
+describe('fallbackcontrolresponsedisplay', () => {
+  it('uses the behavior envelope when present', () => {
+    expect(fallbackControlResponseDisplay({ provider: 'X', requestId: '', request: undefined, response: { response: { response: { behavior: 'allow' } } } }))
+      .toEqual({ kind: 'label', text: 'Approved' })
+  })
+
+  it('falls back to the generic label as the terminal', () => {
+    expect(fallbackControlResponseDisplay({ provider: 'X', requestId: '', request: undefined, response: { anything: 1 } }))
+      .toEqual({ kind: 'label', text: 'Responded' })
+    expect(fallbackControlResponseDisplay({ provider: 'X', requestId: '', request: undefined, response: undefined }))
+      .toEqual({ kind: 'label', text: 'Responded' })
+  })
+})
+
+describe('label', () => {
+  it('wraps plain text as a label display (including empty)', () => {
+    expect(label('Allow')).toEqual({ kind: 'label', text: 'Allow' })
+    expect(label('')).toEqual({ kind: 'label', text: '' })
+  })
+})
+
+describe('labelornull', () => {
+  it('lifts a non-empty string to a label, and maps null OR empty to null', () => {
+    expect(labelOrNull('Allow')).toEqual({ kind: 'label', text: 'Allow' })
+    expect(labelOrNull(null)).toBeNull()
+    // An empty string degrades to null (not a blank label), so the caller falls back to the
+    // neutral behavior/generic label instead of rendering an empty control-response row.
+    expect(labelOrNull('')).toBeNull()
+  })
+})
+
+describe('feedback', () => {
+  it('wraps a typed reason as a feedback display', () => {
+    expect(feedback('use ripgrep instead')).toEqual({ kind: 'feedback', message: 'use ripgrep instead' })
+  })
+})
+
+describe('feedbackorlabel', () => {
+  it('renders a non-empty reason as feedback and a blank reason as the fallback label', () => {
+    expect(feedbackOrLabel('too risky', 'Rejected')).toEqual({ kind: 'feedback', message: 'too risky' })
+    expect(feedbackOrLabel('', 'Rejected')).toEqual({ kind: 'label', text: 'Rejected' })
+    expect(feedbackOrLabel('', 'Cancel')).toEqual({ kind: 'label', text: 'Cancel' })
+  })
+})
+
+describe('resolvecontrolresponsedisplay', () => {
+  it('returns the plugin derivation when it yields one', () => {
+    expect(resolveControlResponseDisplay(crWith({ anything: 1 }), () => ({ kind: 'label', text: 'X' })))
+      .toEqual({ kind: 'label', text: 'X' })
+  })
+
+  it('degrades to the neutral fallback when the derivation returns null', () => {
+    expect(resolveControlResponseDisplay(crWith({ response: { response: { behavior: 'allow' } } }), () => null))
+      .toEqual({ kind: 'label', text: 'Approved' })
+    expect(resolveControlResponseDisplay(crWith({ anything: 1 }), () => null))
+      .toEqual({ kind: 'label', text: 'Responded' })
+  })
+
+  it('degrades when no derivation is provided', () => {
+    expect(resolveControlResponseDisplay(crWith({ anything: 1 }), undefined))
+      .toEqual({ kind: 'label', text: 'Responded' })
+  })
+
+  it('catches a derivation that THROWS and degrades to the fallback, never leaking', () => {
+    // A malformed payload that makes a plugin derivation throw must NOT propagate (which would dump
+    // raw wire bytes in the transcript) -- it degrades to the same neutral fallback as a null return.
+    const boom = (): never => {
+      throw new Error('bad payload')
+    }
+    expect(resolveControlResponseDisplay(crWith({ anything: 1 }), boom))
+      .toEqual({ kind: 'label', text: 'Responded' })
+    expect(resolveControlResponseDisplay(crWith({ response: { response: { behavior: 'allow' } } }), boom))
+      .toEqual({ kind: 'label', text: 'Approved' })
+  })
+
+  it('logs a warning when the derivation throws, so a real derivation bug is diagnosable', () => {
+    // The catch degrades SILENTLY without the log, so a throwing derivation renders the generic
+    // fallback forever with no trace. Pin that the throw is surfaced (a total derivation never
+    // throws, so a throw is a real bug -- not malformed data -- and must be visible).
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const boom = (): never => {
+        throw new Error('bad payload')
+      }
+      resolveControlResponseDisplay(crWith({ anything: 1 }), boom)
+      expect(warn).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+})
+
+describe('controlresponsepreviewtext', () => {
+  it('renders a label verbatim and feedback under the lead', () => {
+    expect(controlResponsePreviewText({ kind: 'label', text: 'Allow' })).toBe('Allow')
+    expect(controlResponsePreviewText({ kind: 'feedback', message: 'do X' })).toBe('Sent feedback:\ndo X')
+  })
+})
+
+describe('labeledanswerline', () => {
+  it('joins trimmed non-empty values under the label', () => {
+    expect(labeledAnswerLine('Task', ['  Build ', 'Test'])).toBe('Task: Build, Test')
+  })
+
+  it('drops empty values and returns null when none survive', () => {
+    expect(labeledAnswerLine('Env', ['Dev', '  ', ''])).toBe('Env: Dev')
+    expect(labeledAnswerLine('Env', ['  ', ''])).toBeNull()
+    expect(labeledAnswerLine('Env', 'not-an-array')).toBeNull()
+  })
+})
+
+describe('firstnonempty', () => {
+  it('returns the first non-empty trimmed value', () => {
+    expect(firstNonEmpty('', '  ', ' x ')).toBe('x')
+    expect(firstNonEmpty(undefined, 'header')).toBe('header')
+    expect(firstNonEmpty('', '   ')).toBe('')
+  })
+})
+
+describe('joinanswerlines', () => {
+  it('newline-joins the lines, or null when there are none', () => {
+    expect(joinAnswerLines(['Task: Build', 'Env: Dev'])).toBe('Task: Build\nEnv: Dev')
+    expect(joinAnswerLines(['Task: Build'])).toBe('Task: Build')
+    expect(joinAnswerLines([])).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/persistedControlResponse.ts
+++ b/frontend/src/components/chat/persistedControlResponse.ts
@@ -1,0 +1,239 @@
+import { isObject, pickString, stringArray } from '~/lib/jsonPick'
+import { decodeControlBehaviorEnvelope } from '~/utils/controlResponse'
+
+// ---------------------------------------------------------------------------
+// Persisted control-response row -- shared parsing + neutral fallback (issue #258)
+//
+// A LEAF module (only pure json/text utils + the label constants) so provider plugins, the
+// transcript renderer (messageRenderers), and the scroll-rail preview (chatMarkPreview) can all
+// import it without pulling in the plugin registry -- that would be a module-init cycle.
+//
+// The backend persists every non-self-displayed control answer as
+//   {isSynthetic:true, controlResponse:{provider, requestId, request, response}}
+// where `response` is the provider-native payload sent to the agent and `request` is the minimal
+// render context the backend snapshotted before deleting the pending request. This module parses
+// that envelope and provides the provider-NEUTRAL fallback derivation; each provider plugin's
+// `controlResponseDisplay` owns its own native wire shapes and degrades to `fallback*` here.
+// ---------------------------------------------------------------------------
+
+// The user-facing labels for a persisted control-response answer, derived by the frontend from the
+// native response payload (issue #258). They live in THIS leaf -- the module that owns
+// control-response display -- shared by the transcript row renderer (renderControlResponseRow in
+// messageRenderers, which imports CONTROL_RESPONSE_FEEDBACK_LEAD) AND the scroll-rail dot preview
+// (controlResponsePreviewText below), so the dot reads IDENTICALLY to the row it jumps to and the
+// wording lives in one place instead of being mirrored by hand across the two surfaces.
+/** An approved control request (ExitPlanMode approval, an "allow" permission decision). */
+const CONTROL_RESPONSE_APPROVED_LABEL = 'Approved'
+/** A declined control request with no typed reason. */
+const CONTROL_RESPONSE_REJECTED_LABEL = 'Rejected'
+/** Lead-in shown above the user's typed rejection reason (their feedback follows as markdown). */
+export const CONTROL_RESPONSE_FEEDBACK_LEAD = 'Sent feedback:'
+/**
+ * Last-resort label when a plugin can't derive one from the native response and the coarse
+ * behavior envelope isn't decodable either (an unknown provider string, a malformed payload).
+ */
+const CONTROL_RESPONSE_GENERIC_LABEL = 'Responded'
+
+/**
+ * The parsed neutral envelope of a persisted synthetic control-response row. Fields are
+ * tolerant-optional: a malformed or legacy row still parses so the caller can degrade via
+ * {@link fallbackControlResponseDisplay} rather than throwing.
+ */
+export interface PersistedControlResponse {
+  /** AgentProvider enum name minus its `AGENT_PROVIDER_` prefix (CODEX, OPENCODE, ...); '' when absent. */
+  provider: string
+  /** Id of the control request this answers; '' when absent. */
+  requestId: string
+  /** Minimal provider-pruned request context, or undefined when the row omitted it. */
+  request: Record<string, unknown> | undefined
+  /** The provider-native response payload as sent to the agent, or undefined when malformed. */
+  response: Record<string, unknown> | undefined
+}
+
+/**
+ * What a provider derives from a persisted control response.
+ * - `label`: short plain text, possibly multi-line (`\n`-joined answer lines). The row renders it
+ *   with line breaks preserved; the rail truncates it verbatim.
+ * - `feedback`: the user's typed deny reason. The row renders it as markdown under
+ *   {@link CONTROL_RESPONSE_FEEDBACK_LEAD}; the rail shows the lead + reason.
+ */
+export type ControlResponseDisplay
+  = | { kind: 'label', text: string }
+    | { kind: 'feedback', message: string }
+
+/**
+ * A provider's persisted-control-response derivation: native payload -> display, or null when the
+ * payload isn't recognizable (the caller then degrades via {@link fallbackControlResponseDisplay}).
+ * Named once in this leaf so the registry interface, the transcript renderer, and the
+ * {@link resolveControlResponseDisplay} chokepoint reference ONE spelling instead of re-typing the
+ * signature -- a change to the contract lands in one place. (registerACPProvider reaches for
+ * `Provider['controlResponseDisplay']` instead, since it can import the plugin type without a cycle.)
+ */
+export type ControlResponseDeriver = (cr: PersistedControlResponse) => ControlResponseDisplay | null
+
+/**
+ * Build a `label` display from plain text -- the factory for the tagged union's `{ kind: 'label' }`
+ * variant, so that shape is spelled once here instead of inline at every derivation's return
+ * (Codex answer lines, Cursor "Accept", Pi confirm/value, the neutral Approved/Rejected/Responded).
+ */
+export function label(text: string): ControlResponseDisplay {
+  return { kind: 'label', text }
+}
+
+/**
+ * Lift a plain-text label into a `ControlResponseDisplay`, or null when there is no meaningful
+ * label. The provider derivations each produce a `string | null` answer and share this one wrap: a
+ * null answer maps to null, and so does an EMPTY string -- an empty label would render a blank row
+ * (and a blank rail-dot preview), so it degrades to null and the caller falls back to the neutral
+ * behavior/generic label instead. No current derivation returns '' (they return null or a non-empty
+ * line via joinAnswerLines / a guarded optionId), so this only guards a future one.
+ */
+export function labelOrNull(text: string | null): ControlResponseDisplay | null {
+  return text ? label(text) : null
+}
+
+/**
+ * Build a `feedback` display from the user's typed reason -- the sibling factory to
+ * {@link label} for the other variant of the tagged union, so the `{ kind: 'feedback' }`
+ * shape is spelled once instead of inline at every deny-with-reason site (Claude/Codex behavior
+ * envelope, Cursor question/plan rejections).
+ */
+export function feedback(message: string): ControlResponseDisplay {
+  return { kind: 'feedback', message }
+}
+
+/**
+ * A typed reason renders as `feedback` (shown under {@link CONTROL_RESPONSE_FEEDBACK_LEAD}), else the
+ * bare `fallbackLabel`. The single home for the "reason -> feedback, else label" rule the neutral
+ * behavior envelope (bare deny -> "Rejected") and the Cursor question-cancel / plan reject-cancel
+ * outcomes all share, so the deny-with-feedback wording can't drift between them.
+ */
+export function feedbackOrLabel(reason: string, fallbackLabel: string): ControlResponseDisplay {
+  return reason ? feedback(reason) : label(fallbackLabel)
+}
+
+/**
+ * Envelope predicate shared by every provider's classify: a synthetic row whose `controlResponse`
+ * is an object (the shape persistControlResponseRow writes). Keeping it here means each plugin's
+ * classify delegates to one definition rather than re-hardcoding the shape.
+ */
+export function isPersistedControlResponse(
+  obj: unknown,
+): obj is { isSynthetic: true, controlResponse: Record<string, unknown> } {
+  return isObject(obj) && obj.isSynthetic === true && isObject(obj.controlResponse)
+}
+
+/** Parse the envelope; null when the shape isn't a persisted control response. */
+export function parsePersistedControlResponse(
+  obj: unknown,
+): PersistedControlResponse | null {
+  if (!isPersistedControlResponse(obj))
+    return null
+  const cr = obj.controlResponse
+  return {
+    provider: pickString(cr, 'provider', ''),
+    requestId: pickString(cr, 'requestId', ''),
+    request: isObject(cr.request) ? cr.request : undefined,
+    response: isObject(cr.response) ? cr.response : undefined,
+  }
+}
+
+/**
+ * Coarse display from the neutral behavior envelope (`{response:{response:{behavior, message}}}`):
+ * allow -> "Approved"; deny with typed feedback -> that feedback; bare deny -> "Rejected". Null when
+ * `response` isn't that envelope (e.g. a JSON-RPC decision a provider plugin reads instead). This is
+ * ALSO Claude's whole derivation -- its native response IS this envelope.
+ */
+export function controlBehaviorDisplay(response: unknown): ControlResponseDisplay | null {
+  const env = decodeControlBehaviorEnvelope(response)
+  if (!env)
+    return null
+  if (env.behavior === 'allow')
+    return label(CONTROL_RESPONSE_APPROVED_LABEL)
+  return feedbackOrLabel(env.message, CONTROL_RESPONSE_REJECTED_LABEL)
+}
+
+/**
+ * Graceful degradation when a plugin can't derive a label from its native response: fall back to the
+ * coarse behavior envelope, else the generic {@link CONTROL_RESPONSE_GENERIC_LABEL}. Never null, so
+ * a control-response row always renders SOMETHING.
+ */
+export function fallbackControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay {
+  return controlBehaviorDisplay(cr.response) ?? label(CONTROL_RESPONSE_GENERIC_LABEL)
+}
+
+/**
+ * Resolve a persisted control response to its never-null display -- the SINGLE chokepoint both
+ * surfaces that render the row go through (the transcript renderer and the scroll-rail dot preview),
+ * so they can't drift or forget the fallback. Runs the provider's derivation, degrades to
+ * {@link fallbackControlResponseDisplay} when it returns null, AND catches a derivation that THROWS
+ * on a malformed payload -- so neither surface can leak raw wire bytes or render nothing.
+ */
+export function resolveControlResponseDisplay(
+  cr: PersistedControlResponse,
+  display: ControlResponseDeriver | undefined,
+): ControlResponseDisplay {
+  // ONLY the provider derivation is untrusted, so it is the only thing inside the try. The
+  // fallback runs OUTSIDE it -- once, on both the returned-null and the threw paths -- so a
+  // future non-total fallback can never double-throw and escape this never-null chokepoint.
+  try {
+    const derived = display?.(cr)
+    if (derived)
+      return derived
+  }
+  catch (err) {
+    // A total derivation should never throw (they are built from the tolerant pick*/isObject
+    // helpers), so a throw here is a real derivation bug, not malformed data. Log it -- otherwise
+    // the answer silently renders the generic fallback forever with no trace to the cause -- then
+    // fall through to the same degrade below so neither surface leaks raw wire bytes.
+    console.warn('control-response display derivation threw; degrading to fallback', { provider: cr.provider, err })
+  }
+  return fallbackControlResponseDisplay(cr)
+}
+
+/**
+ * Plaintext projection shared by the rail preview: a label renders verbatim; feedback renders the
+ * lead + the reason on the next line (the rail then truncates the whole thing).
+ */
+export function controlResponsePreviewText(display: ControlResponseDisplay): string {
+  return display.kind === 'feedback'
+    ? `${CONTROL_RESPONSE_FEEDBACK_LEAD}\n${display.message}`
+    : display.text
+}
+
+/**
+ * The first argument non-empty after trimming (and the chosen value is trimmed), or '' when all are
+ * blank. The per-provider answer derivations use it to pick a label (`header` else `id`, `prompt`
+ * else `id`, ...).
+ */
+export function firstNonEmpty(...vals: Array<string | undefined>): string {
+  for (const v of vals) {
+    const t = (v ?? '').trim()
+    if (t)
+      return t
+  }
+  return ''
+}
+
+/**
+ * Format one "label: v1, v2" line, trimming each value and dropping the empties; null when no value
+ * survives (the caller skips the line). Non-string entries are ignored, matching the string-typed
+ * answer arrays every provider produces.
+ */
+export function labeledAnswerLine(labelText: string, values: unknown): string | null {
+  const parts = stringArray(values)
+    .map(v => v.trim())
+    .filter(v => v !== '')
+  if (parts.length === 0)
+    return null
+  return `${labelText}: ${parts.join(', ')}`
+}
+
+/**
+ * Join collected answer lines into the multi-question label text, or null when none survived -- the
+ * shared "empty -> null, else newline-join" tail every provider's answer-line builder (Codex,
+ * OpenCode, Cursor) ends with, so the join separator lives in one place instead of three.
+ */
+export function joinAnswerLines(lines: string[]): string | null {
+  return lines.length > 0 ? lines.join('\n') : null
+}

--- a/frontend/src/components/chat/providers/acp/classification.ts
+++ b/frontend/src/components/chat/providers/acp/classification.ts
@@ -129,6 +129,10 @@ export function classifyACPMessage(config: ACPClassifyConfig = {}): (input: Clas
     if (!parent)
       return { kind: 'unknown' }
 
+    // (The synthetic {isSynthetic, controlResponse} row -> control_response is classified upstream in
+    // classifyMessage, before any plugin.classify runs, since it is a Leapmux-neutral shape covering
+    // every ACP-based provider -- OpenCode/Kilo/Goose/Copilot/Reasonix/Cursor -- at one site.)
+
     const sessionUpdate = parent.sessionUpdate as string | undefined
     const type = parent.type as string | undefined
 

--- a/frontend/src/components/chat/providers/acp/controlResponse.test.ts
+++ b/frontend/src/components/chat/providers/acp/controlResponse.test.ts
@@ -1,0 +1,50 @@
+import type { PersistedControlResponse } from '../../persistedControlResponse'
+import { describe, expect, it } from 'vitest'
+import { acpControlResponseDisplay, acpPermissionResponseText } from './controlResponse'
+
+// Mirrors what the backend actually persists as the pruned request context: optionId + name only
+// (the ACP option `kind` is pruned away, so the fixture omits it too).
+const REQUEST = {
+  method: 'session/request_permission',
+  params: {
+    options: [
+      { optionId: 'proceed_once', name: 'Allow once' },
+      { optionId: 'reject', name: 'Reject' },
+    ],
+  },
+}
+
+function selected(optionId: string): Record<string, unknown> {
+  return { result: { outcome: { outcome: 'selected', optionId } } }
+}
+
+describe('acppermissionresponsetext', () => {
+  it('resolves the selected optionId to its request option name', () => {
+    expect(acpPermissionResponseText(REQUEST, selected('proceed_once'))).toBe('Allow once')
+    expect(acpPermissionResponseText(REQUEST, selected('reject'))).toBe('Reject')
+  })
+
+  it('falls back to the well-known-kind map when the option is not in the request', () => {
+    expect(acpPermissionResponseText({ params: { options: [] } }, selected('proceed_once'))).toBe('Allow once')
+    expect(acpPermissionResponseText({ params: { options: [] } }, selected('always'))).toBe('Always allow')
+    expect(acpPermissionResponseText({ params: { options: [] } }, selected('cancel'))).toBe('Reject')
+  })
+
+  it('passes an unknown optionId through and returns null when none was selected', () => {
+    expect(acpPermissionResponseText({}, selected('mystery_opt'))).toBe('mystery_opt')
+    expect(acpPermissionResponseText(REQUEST, { result: { outcome: {} } })).toBeNull()
+    expect(acpPermissionResponseText(REQUEST, {})).toBeNull()
+  })
+})
+
+describe('acpcontrolresponsedisplay', () => {
+  it('wraps the permission text as a label', () => {
+    const cr: PersistedControlResponse = { provider: 'GOOSE', requestId: '7', request: REQUEST, response: selected('proceed_once') }
+    expect(acpControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Allow once' })
+  })
+
+  it('returns null when no optionId was selected (caller degrades)', () => {
+    const cr: PersistedControlResponse = { provider: 'GOOSE', requestId: '7', request: REQUEST, response: {} }
+    expect(acpControlResponseDisplay(cr)).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/providers/acp/controlResponse.ts
+++ b/frontend/src/components/chat/providers/acp/controlResponse.ts
@@ -1,0 +1,55 @@
+import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import { isObject, pickObject, pickString } from '~/lib/jsonPick'
+import { labelOrNull } from '../../persistedControlResponse'
+
+/**
+ * Resolve the selected `optionId` (from `result.outcome.optionId`) to its option `name` in the
+ * request's option list, falling back to the well-known-kind map (once/always/reject/cancel) and
+ * finally the raw optionId. Null when no optionId was selected.
+ */
+export function acpPermissionResponseText(
+  request: Record<string, unknown> | undefined,
+  response: Record<string, unknown> | undefined,
+): string | null {
+  const result = pickObject(response, 'result', undefined)
+  const outcome = pickObject(result, 'outcome', undefined)
+  const optionId = pickString(outcome, 'optionId', '').trim()
+  if (!optionId)
+    return null
+
+  const params = pickObject(request, 'params', undefined)
+  const options = Array.isArray(params?.options) ? params.options : []
+  for (const option of options) {
+    if (!isObject(option))
+      continue
+    if (pickString(option, 'optionId', '').trim() === optionId) {
+      const name = pickString(option, 'name', '').trim()
+      if (name)
+        return name
+      break
+    }
+  }
+
+  switch (optionId) {
+    case 'once':
+    case 'proceed_once':
+      return 'Allow once'
+    case 'always':
+    case 'proceed_always':
+      return 'Always allow'
+    case 'reject':
+    case 'cancel':
+      return 'Reject'
+    default:
+      return optionId
+  }
+}
+
+/**
+ * The default ACP control-response derivation (the permission-selection path). Providers that also
+ * speak a question protocol (OpenCode/Kilo) or a bespoke flow (Cursor) wrap this with their own
+ * dispatch and delegate here for the permission case.
+ */
+export function acpControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay | null {
+  return labelOrNull(acpPermissionResponseText(cr.request, cr.response))
+}

--- a/frontend/src/components/chat/providers/acp/registerACPProvider.ts
+++ b/frontend/src/components/chat/providers/acp/registerACPProvider.ts
@@ -8,6 +8,7 @@ import { defaultMarkPreview } from '../../markPreviewShared'
 import { buildPlanMode, OPTION_ID_PERMISSION_MODE } from '../../settingsGroups'
 import { registerProvider } from '../registry'
 import { acpBuildControlResponse, acpExtractQuotableText, buildACPInterruptContent, classifyACPMessage } from './classification'
+import { acpControlResponseDisplay } from './controlResponse'
 import { acpResultDivider } from './renderers'
 import { renderACPMessage } from './rendering'
 
@@ -75,6 +76,12 @@ export interface ACPProviderOptions {
   bypassPermissionMode?: PermissionMode
   /** Question-handling hooks for providers that override the default ACP path. */
   questionHandling?: ACPQuestionHandling
+  /**
+   * Persisted control-response -> display derivation. Defaults to {@link acpControlResponseDisplay}
+   * (the permission-selection path); OpenCode/Kilo and Cursor pass their own, which dispatch on the
+   * request shape and delegate back to the ACP default for the permission case.
+   */
+  controlResponseDisplay?: Provider['controlResponseDisplay']
   /** Extra `session/update` types that should be hidden from the chat. */
   extraHiddenSessionUpdates?: Set<string>
   /**
@@ -139,12 +146,12 @@ export function registerACPProvider(opts: ACPProviderOptions): void {
     renderMessage: renderACPMessage,
     resultDivider: acpResultDivider,
     extractQuotableText: acpExtractQuotableText,
-    // ACP-based providers (OpenCode, Cursor, Copilot, ...) mark only user sends and
-    // control-response answers. A control answer is persisted in one of two Leapmux-neutral shapes --
-    // `{content}` (a provider-resolved answer or a deny-with-feedback) or `{controlResponse}` (a bare
-    // approve/deny with no feedback) -- and ACP never echoes the answer as a message. The shared
-    // neutral extractor handles BOTH shapes, so it is the whole preview.
+    // ACP-based providers (OpenCode, Cursor, Copilot, ...) mark only user sends and control-response
+    // answers. A user send is the Leapmux-neutral `{content}` shape the shared extractor handles; a
+    // control answer is the structured `{controlResponse}` row, which classifies as
+    // `control_response` and resolves through controlResponseDisplay (below), not here.
     previewText: defaultMarkPreview,
+    controlResponseDisplay: opts.controlResponseDisplay ?? acpControlResponseDisplay,
     buildInterruptContent: buildACPInterruptContent,
     buildControlResponse: acpBuildControlResponse,
 

--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -108,9 +108,19 @@ describe('claude preview text (scroll-rail mark preview)', () => {
     expect(plugin.previewText!({ kind: 'user_content' }, input({ content: 'hello world' }))).toBe('hello world')
   })
 
-  it('falls back to the shared neutral extractor for a {controlResponse} row, and null otherwise', () => {
-    expect(plugin.previewText!({ kind: 'control_response' }, input({ controlResponse: { action: 'approved' } }))).toBe('Approved')
+  it('returns null for an assistant content-block array (no neutral string field)', () => {
     expect(plugin.previewText!({ kind: 'assistant_text' }, input({ message: { content: [{ type: 'text', text: 'hi' }] } }))).toBeNull()
+  })
+
+  it('derives the control-response display from the native response envelope (not previewText)', () => {
+    // Control-response rows resolve through controlResponseDisplay, not previewText -- Claude's
+    // derivation IS the neutral behavior envelope: allow -> Approved, deny+message -> feedback.
+    const allow = { type: 'control_response', response: { request_id: 'r', response: { behavior: 'allow' } } }
+    expect(plugin.controlResponseDisplay!({ provider: 'CLAUDE_CODE', requestId: 'r', request: undefined, response: allow }))
+      .toEqual({ kind: 'label', text: 'Approved' })
+    const deny = { type: 'control_response', response: { request_id: 'r', response: { behavior: 'deny', message: 'use ripgrep' } } }
+    expect(plugin.controlResponseDisplay!({ provider: 'CLAUDE_CODE', requestId: 'r', request: undefined, response: deny }))
+      .toEqual({ kind: 'feedback', message: 'use ripgrep' })
   })
 })
 

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -13,6 +13,7 @@ import { buildAskAnswers } from '../../controls/AskUserQuestionControl'
 import { ClaudeCodeControlActions, ClaudeCodeControlContent } from '../../controls/ClaudeCodeControlRequest'
 import { defaultMarkPreview } from '../../markPreviewShared'
 import { isNotificationThreadWrapper, isTerminalCompactingStatus } from '../../messageUtils'
+import { controlBehaviorDisplay } from '../../persistedControlResponse'
 import { buildPlanMode } from '../../settingsGroups'
 import { registerProvider } from '../registry'
 import { getAssistantContent, joinToolResultText } from './extractors/assistantContent'
@@ -234,9 +235,8 @@ function classifyClaudeCodeMessage(
   if (parentObject.isCompactSummary === true)
     return { kind: 'compact_summary' }
 
-  // Synthetic control response (also preempts content-shaped types).
-  if (parentObject.isSynthetic === true && isObject(parentObject.controlResponse))
-    return { kind: 'control_response' }
+  // (The synthetic {isSynthetic, controlResponse} row -> control_response is classified upstream in
+  // classifyMessage, before any plugin.classify runs, since it is a Leapmux-neutral shape.)
 
   // Content-shaped types (assistant / user).
   if (type) {
@@ -287,8 +287,10 @@ function claudeExtractQuotableText(category: MessageCategory, parsed: ParsedMess
  * only this plugin knows how to read are handled here before the shared fallback: a
  * self-displaying control response (AskUserQuestion / ExitPlanMode answer) re-emitted as a
  * `message.content[]` tool_result, and a transcript user row nesting its text under
- * `{message:{content:"..."}}`. Every other marked shape (`{content}`, `{controlResponse}`)
- * is Leapmux-neutral and handled by the shared defaultMarkPreview.
+ * `{message:{content:"..."}}`. The Leapmux-neutral `{content}` user send falls back to the shared
+ * defaultMarkPreview. A persisted `{controlResponse}` row never reaches here -- it classifies as
+ * `control_response` and the rail resolves its preview through the plugin's controlResponseDisplay
+ * (chatMarkPreview.ts), before previewText runs.
  */
 function claudeMarkPreview(category: MessageCategory, parsed: ParsedMessageContent): string | null {
   const toolResultText = joinToolResultText(parsed.parentObject)
@@ -334,6 +336,9 @@ const claudeCodePlugin: Provider = {
   toolResultMeta: claudeToolResultMeta,
   extractQuotableText: claudeExtractQuotableText,
   previewText: claudeMarkPreview,
+  // Claude's native control response IS the neutral behavior envelope, so its derivation is the
+  // shared reader: allow -> "Approved", deny+message -> feedback, bare deny -> "Rejected".
+  controlResponseDisplay: cr => controlBehaviorDisplay(cr.response),
   notificationThreadEntry: claudeNotificationThreadEntry,
   resultDivider: claudeResultDivider,
 

--- a/frontend/src/components/chat/providers/claude/renderMessage.tsx
+++ b/frontend/src/components/chat/providers/claude/renderMessage.tsx
@@ -8,7 +8,6 @@ import { cachedInnerHtml } from '~/lib/htmlFragmentCache'
 import { isObject } from '~/lib/jsonPick'
 import { renderMarkdownForContext, useSharedExpandedState } from '../../messageRenderers'
 import { MESSAGE_UI_KEY } from '../../messageUiKeys'
-import { controlResponseRenderer } from '../../notificationRenderers'
 import { COLLAPSED_RESULT_ROWS, hasMoreLinesThan } from '../../results/collapse'
 import { taskNotificationRenderer } from '../../taskRenderers'
 import {
@@ -54,11 +53,11 @@ export function renderClaudeMessage(
       return planExecutionRenderer.render(parsed, context)
     case 'task_notification':
       return taskNotificationRenderer.render(parsed, context)
-    case 'control_response':
-      return controlResponseRenderer.render(parsed, context)
     case 'compact_summary':
     case 'hidden':
       return <span />
+    // 'control_response' is dispatched by renderMessageContent's shared branch (via the plugin's
+    // controlResponseDisplay), so it falls through to the default here.
     case 'unknown':
       return tryClaudeUnknownKindRenderers(parsed, context)
     default:

--- a/frontend/src/components/chat/providers/codex/controlResponse.test.ts
+++ b/frontend/src/components/chat/providers/codex/controlResponse.test.ts
@@ -1,0 +1,133 @@
+import type { PersistedControlResponse } from '../../persistedControlResponse'
+import type { CodexDecision } from './controlResponse'
+import { describe, expect, it } from 'vitest'
+import { codexControlResponseDisplay, codexDecisionKey, codexDecisionLabel } from './controlResponse'
+
+function cr(request: Record<string, unknown> | undefined, response: Record<string, unknown> | undefined): PersistedControlResponse {
+  return { provider: 'CODEX', requestId: '7', request, response }
+}
+
+const APPROVAL_REQUEST = { method: 'item/commandExecution/requestApproval' }
+
+function decision(d: unknown): Record<string, unknown> {
+  return { jsonrpc: '2.0', id: 7, result: { decision: d } }
+}
+
+describe('codexdecisionlabel', () => {
+  it('maps the known string decisions', () => {
+    expect(codexDecisionLabel('accept')).toBe('Allow')
+    expect(codexDecisionLabel('acceptForSession')).toBe('Allow for Session')
+    expect(codexDecisionLabel('decline')).toBe('Reject')
+    expect(codexDecisionLabel('cancel')).toBe('Cancel')
+  })
+
+  it('passes an unknown string through and maps amendment objects', () => {
+    expect(codexDecisionLabel('somethingElse')).toBe('somethingElse')
+    expect(codexDecisionLabel({ acceptWithExecpolicyAmendment: { match: 'npm test' } })).toBe('Allow & Remember')
+    expect(codexDecisionLabel({ applyNetworkPolicyAmendment: true })).toBe('Apply Network Policy')
+    expect(codexDecisionLabel({ other: 1 })).toBe('Allow')
+  })
+
+  it('is total: a malformed non-string, non-object decision degrades to "Allow" without throwing', () => {
+    // The live-button path (CodexControlRequest) casts params.availableDecisions straight from wire
+    // bytes, so a malformed entry (null / a number) must NOT make the `in` reads throw a TypeError
+    // and crash the control banner -- the isObject guard degrades it to the neutral "Allow".
+    expect(() => codexDecisionLabel(null as unknown as CodexDecision)).not.toThrow()
+    expect(codexDecisionLabel(null as unknown as CodexDecision)).toBe('Allow')
+    expect(codexDecisionLabel(3 as unknown as CodexDecision)).toBe('Allow')
+  })
+})
+
+describe('codexdecisionkey', () => {
+  it('returns the string decision or the first key of an amendment object', () => {
+    expect(codexDecisionKey('accept')).toBe('accept')
+    expect(codexDecisionKey('decline')).toBe('decline')
+    expect(codexDecisionKey({ acceptWithExecpolicyAmendment: { match: 'npm test' } })).toBe('acceptWithExecpolicyAmendment')
+  })
+
+  it('is total: a malformed non-string, non-object (or empty-object) decision degrades to "unknown" without throwing', () => {
+    // Sibling of codexDecisionLabel's totality: the data-testid interpolation used to call
+    // Object.keys(decision)[0] directly, which throws TypeError on a null/number entry cast straight
+    // from wire bytes (params.availableDecisions) and crashes the whole control-banner <For> render.
+    expect(() => codexDecisionKey(null as unknown as CodexDecision)).not.toThrow()
+    expect(codexDecisionKey(null as unknown as CodexDecision)).toBe('unknown')
+    expect(codexDecisionKey(3 as unknown as CodexDecision)).toBe('unknown')
+    expect(codexDecisionKey({})).toBe('unknown')
+  })
+})
+
+describe('codexcontrolresponsedisplay', () => {
+  it('labels string decisions', () => {
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision('accept')))).toEqual({ kind: 'label', text: 'Allow' })
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision('decline')))).toEqual({ kind: 'label', text: 'Reject' })
+  })
+
+  it('labels amendment-object decisions', () => {
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision({ acceptWithExecpolicyAmendment: { match: 'touch' } }))))
+      .toEqual({ kind: 'label', text: 'Allow & Remember' })
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision({ applyNetworkPolicyAmendment: true }))))
+      .toEqual({ kind: 'label', text: 'Apply Network Policy' })
+  })
+
+  it('returns null for a missing/empty decision (caller degrades)', () => {
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision(null)))).toBeNull()
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, decision({})))).toBeNull()
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, { result: {} }))).toBeNull()
+  })
+
+  it('renders a deny-with-feedback as a feedback block, collapsing the sentinel', () => {
+    const deny = { type: 'control_response', response: { request_id: '7', response: { behavior: 'deny', message: 'Add tests first.' } } }
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, deny))).toEqual({ kind: 'feedback', message: 'Add tests first.' })
+    const bare = { response: { response: { behavior: 'deny', message: 'Rejected by user.' } } }
+    // Sentinel collapses to no feedback -> the decision path yields nothing -> null (fallback -> Rejected).
+    expect(codexControlResponseDisplay(cr(APPROVAL_REQUEST, bare))).toBeNull()
+  })
+
+  describe('requestuserinput answers', () => {
+    const request = {
+      method: 'item/tool/requestUserInput',
+      params: { questions: [{ id: 'task', header: 'Task' }, { id: 'reason', header: 'Reason' }] },
+    }
+
+    it('renders request-ordered header-labeled answer lines', () => {
+      const response = { result: { answers: { task: { answers: ['Inspect'] }, reason: { answers: ['Parity'] } } } }
+      expect(codexControlResponseDisplay(cr(request, response))).toEqual({ kind: 'label', text: 'Task: Inspect\nReason: Parity' })
+    })
+
+    it('drops all-empty answers and joins multiple values', () => {
+      const response = { result: { answers: { task: { answers: ['A', ' ', 'B'] }, reason: { answers: ['', '  '] } } } }
+      expect(codexControlResponseDisplay(cr(request, response))).toEqual({ kind: 'label', text: 'Task: A, B' })
+    })
+
+    it('appends answer keys not in the request in sorted order', () => {
+      const req = { method: 'item/tool/requestUserInput', params: { questions: [{ id: 'task', header: 'Task' }] } }
+      const response = { result: { answers: { task: { answers: ['T'] }, zebra: { answers: ['Z'] }, alpha: { answers: ['A'] } } } }
+      expect(codexControlResponseDisplay(cr(req, response))).toEqual({ kind: 'label', text: 'Task: T\nalpha: A\nzebra: Z' })
+    })
+
+    it('returns null when there are no answers', () => {
+      expect(codexControlResponseDisplay(cr(request, { result: { answers: {} } }))).toBeNull()
+    })
+
+    it('falls through to the decision label when a requestUserInput is declined', () => {
+      // A denied/stopped requestUserInput arrives as a JSON-RPC decision ({result:{decision:'decline'}})
+      // while the request method is still requestUserInput. It must read "Reject", NOT degrade to the
+      // generic "Responded" label -- the answers branch returning null falls through to the decision path.
+      expect(codexControlResponseDisplay(cr(request, decision('decline')))).toEqual({ kind: 'label', text: 'Reject' })
+      expect(codexControlResponseDisplay(cr(request, decision('cancel')))).toEqual({ kind: 'label', text: 'Cancel' })
+    })
+
+    it('renders a requestUserInput deny-with-feedback as a feedback block on fall-through', () => {
+      const deny = { type: 'control_response', response: { request_id: '7', response: { behavior: 'deny', message: 'Need more detail.' } } }
+      expect(codexControlResponseDisplay(cr(request, deny))).toEqual({ kind: 'feedback', message: 'Need more detail.' })
+    })
+
+    it('renders request-gone answers from the response alone, labeled by key', () => {
+      // The pruned request is absent (request-gone), but the answer VALUES live entirely in the
+      // response, so they still render -- labeled by the answer key (sorted, no request order) rather
+      // than the missing question header, instead of degrading to the generic "Responded" label.
+      const response = { result: { answers: { task: { answers: ['Inspect'] }, reason: { answers: ['Parity'] } } } }
+      expect(codexControlResponseDisplay(cr(undefined, response))).toEqual({ kind: 'label', text: 'reason: Parity\ntask: Inspect' })
+    })
+  })
+})

--- a/frontend/src/components/chat/providers/codex/controlResponse.ts
+++ b/frontend/src/components/chat/providers/codex/controlResponse.ts
@@ -1,0 +1,140 @@
+import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import { isObject, pickObject, pickString } from '~/lib/jsonPick'
+import { decodeControlBehaviorEnvelope } from '~/utils/controlResponse'
+import { feedback, firstNonEmpty, joinAnswerLines, label, labeledAnswerLine, labelOrNull } from '../../persistedControlResponse'
+
+/** A Codex approval decision: a bare string (`accept`, `decline`, ...) or an amendment object. */
+export type CodexDecision = string | Record<string, unknown>
+
+/**
+ * The human label for a Codex decision. The SINGLE source of truth for these labels: the live
+ * approval buttons (CodexControlRequest) and the persisted-row derivation
+ * ({@link codexControlResponseDisplay}) both call it, so a rendered answer reads identically to the
+ * button the user clicked.
+ */
+export function codexDecisionLabel(decision: CodexDecision): string {
+  if (typeof decision === 'string') {
+    switch (decision) {
+      case 'accept': return 'Allow'
+      case 'acceptForSession': return 'Allow for Session'
+      case 'decline': return 'Reject'
+      case 'cancel': return 'Cancel'
+      default: return decision
+    }
+  }
+  // Guard the `in` reads with isObject: `decision` is typed string | object, but the live-button
+  // path casts it straight from wire bytes (`params.availableDecisions as CodexDecision[]`), so a
+  // malformed entry (null / a number) would make `'x' in decision` throw a TypeError and crash the
+  // control banner render. Any non-string, non-amendment value falls through to the neutral "Allow".
+  if (isObject(decision)) {
+    if ('acceptWithExecpolicyAmendment' in decision)
+      return 'Allow & Remember'
+    if ('applyNetworkPolicyAmendment' in decision)
+      return 'Apply Network Policy'
+  }
+  return 'Allow'
+}
+
+/**
+ * The stable `data-testid` key for a Codex decision button: the decision string, or the first key of
+ * an amendment object. Total like {@link codexDecisionLabel} -- the live-button path casts
+ * `decision` straight from wire bytes (`params.availableDecisions as CodexDecision[]`), so a
+ * malformed entry (null / a number / an empty object) must degrade to 'unknown' rather than throw a
+ * TypeError on `Object.keys(null)` and crash the control-banner render.
+ */
+export function codexDecisionKey(decision: CodexDecision): string {
+  if (typeof decision === 'string')
+    return decision
+  if (isObject(decision))
+    return Object.keys(decision)[0] ?? 'unknown'
+  return 'unknown'
+}
+
+/**
+ * Render a requestUserInput answer as "Header: v1, v2" lines, in request-question order, then any
+ * answer keys not in the request in a STABLE (sorted) order. Empty answer values are dropped (and
+ * their key isn't marked seen), so an all-empty answer produces no line. Null when nothing renders.
+ */
+function codexUserInputAnswers(
+  request: Record<string, unknown> | undefined,
+  response: Record<string, unknown> | undefined,
+): string | null {
+  const result = pickObject(response, 'result', undefined)
+  const answers = pickObject(result, 'answers', undefined)
+  if (!answers || Object.keys(answers).length === 0)
+    return null
+
+  const params = pickObject(request, 'params', undefined)
+  const questions = Array.isArray(params?.questions) ? params.questions : []
+
+  const labels = new Map<string, string>()
+  const order: string[] = []
+  for (const q of questions) {
+    if (!isObject(q))
+      continue
+    const key = firstNonEmpty(pickString(q, 'id', ''), pickString(q, 'header', ''))
+    if (!key)
+      continue
+    labels.set(key, firstNonEmpty(pickString(q, 'header', ''), key))
+    order.push(key)
+  }
+
+  const lines: string[] = []
+  const seen = new Set<string>()
+  const appendLine = (key: string): void => {
+    const entry = answers[key]
+    if (!isObject(entry) || seen.has(key))
+      return
+    // seen is set ONLY when a non-empty line is emitted, so the empty-filter and the dedup stay
+    // entangled -- an all-empty answer neither renders nor marks the key seen.
+    const line = labeledAnswerLine(labels.get(key) ?? key, entry.answers)
+    if (line !== null) {
+      lines.push(line)
+      seen.add(key)
+    }
+  }
+
+  for (const key of order)
+    appendLine(key)
+  // Answer keys absent from the request's questions render after them, sorted for stable output.
+  for (const key of Object.keys(answers).filter(k => !seen.has(k)).sort())
+    appendLine(key)
+
+  return joinAnswerLines(lines)
+}
+
+/**
+ * Read `result.decision` and map it to a label (the frontend now owns this; the backend persists
+ * the native decision without deriving a label). Null for a missing/null/empty decision so the
+ * caller degrades gracefully.
+ */
+function codexDecisionText(response: Record<string, unknown> | undefined): string | null {
+  const result = pickObject(response, 'result', undefined)
+  const decision = result?.decision
+  if (typeof decision === 'string') {
+    const trimmed = decision.trim()
+    return trimmed ? codexDecisionLabel(trimmed) : null
+  }
+  if (isObject(decision))
+    return Object.keys(decision).length > 0 ? codexDecisionLabel(decision) : null
+  return null
+}
+
+/**
+ * Derive the display for a persisted Codex control response, dispatching on the RESPONSE shape (not
+ * the pruned request) so a request-gone answer still renders: requestUserInput answers live entirely
+ * in `result.answers`, so `codexUserInputAnswers` recognizes them regardless of whether the pruned
+ * request survived (it labels by question header when the request is present, else by the answer
+ * key). A declined/stopped requestUserInput carries no answers -- it arrives as a JSON-RPC decision
+ * ({result:{decision:'decline'}}) -- so it falls through to the deny-with-feedback / decision-label
+ * derivation. Null when none applies (the caller falls back to the neutral behavior/generic label).
+ */
+export function codexControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay | null {
+  const answers = codexUserInputAnswers(cr.request, cr.response)
+  if (answers !== null)
+    return label(answers)
+  const env = decodeControlBehaviorEnvelope(cr.response)
+  if (env?.message)
+    return feedback(env.message)
+  return labelOrNull(codexDecisionText(cr.response))
+}

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -24,6 +24,7 @@ import {
   CODEX_OPTION_SANDBOX_POLICY,
   DEFAULT_CODEX_COLLABORATION_MODE,
 } from './constants'
+import { codexControlResponseDisplay } from './controlResponse'
 import { CODEX_RENDERERS } from './defineRenderer'
 import { codexNotificationThreadEntry } from './notifications'
 // The named imports below are the renderers dispatched explicitly (not via
@@ -338,6 +339,9 @@ const codexPlugin: Provider = {
     if (!parent)
       return { kind: 'unknown' }
 
+    // (The synthetic {isSynthetic, controlResponse} row -> control_response is classified upstream in
+    // classifyMessage, before any plugin.classify runs, since it is a Leapmux-neutral shape.)
+
     if (isCodexJsonRpcResponse(parent) || codexAssistantInterruptEcho(parent))
       return { kind: 'hidden' }
 
@@ -461,11 +465,12 @@ const codexPlugin: Provider = {
     return null
   },
 
-  // Codex marks only user sends and control-response answers. A control answer is persisted in one
-  // of two Leapmux-neutral shapes -- `{content}` (a provider-resolved answer or a deny-with-feedback)
-  // or `{controlResponse}` (a bare approve/deny with no feedback) -- and Codex never self-displays
-  // one. The shared neutral extractor handles BOTH shapes, so it is the whole preview.
+  // Codex marks only user sends and control-response answers. A user send is the Leapmux-neutral
+  // `{content}` shape the shared extractor handles; a control answer is the structured
+  // `{controlResponse}` row, which classifies as `control_response` and resolves its preview
+  // through controlResponseDisplay (chatMarkPreview), not here.
   previewText: defaultMarkPreview,
+  controlResponseDisplay: codexControlResponseDisplay,
 
   notificationThreadEntry: codexNotificationThreadEntry,
 

--- a/frontend/src/components/chat/providers/opencode/plugin.test.ts
+++ b/frontend/src/components/chat/providers/opencode/plugin.test.ts
@@ -57,6 +57,24 @@ describe('opencode classify', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'assistant_text' })
   })
 
+  // The neutral {isSynthetic, controlResponse} row -> control_response classification is provider-
+  // agnostic and lives in classifyMessage (see messageClassification.test.ts); this plugin test
+  // covers only OpenCode's own controlResponseDisplay derivation.
+  it('wires controlResponseDisplay: question answers, else the ACP permission path', () => {
+    expect(plugin.controlResponseDisplay!({
+      provider: 'OPENCODE',
+      requestId: 'q1',
+      request: { type: 'question.asked', properties: { questions: [{ header: 'Task' }] } },
+      response: { result: { answers: [['Build']] } },
+    })).toEqual({ kind: 'label', text: 'Task: Build' })
+    expect(plugin.controlResponseDisplay!({
+      provider: 'OPENCODE',
+      requestId: '7',
+      request: { method: 'session/request_permission', params: { options: [{ optionId: 'proceed_once', name: 'Allow once' }] } },
+      response: { result: { outcome: { optionId: 'proceed_once' } } },
+    })).toEqual({ kind: 'label', text: 'Allow once' })
+  })
+
   it('classifies agent_thought_chunk as assistant_thinking', () => {
     const parent = {
       sessionUpdate: 'agent_thought_chunk',

--- a/frontend/src/components/chat/providers/opencode/questionAnswers.test.ts
+++ b/frontend/src/components/chat/providers/opencode/questionAnswers.test.ts
@@ -1,0 +1,71 @@
+import type { PersistedControlResponse } from '../../persistedControlResponse'
+import { describe, expect, it } from 'vitest'
+import { opencodeControlResponseDisplay, opencodeQuestionAnswersText } from './questionAnswers'
+
+const QUESTION_REQUEST = {
+  type: 'question.asked',
+  properties: { questions: [{ header: 'Task', question: 'Pick a task' }, { header: 'Env', question: 'Pick an environment' }] },
+}
+
+describe('opencodequestionanswerstext', () => {
+  it('renders header-labeled answer lines', () => {
+    expect(opencodeQuestionAnswersText(QUESTION_REQUEST, { result: { answers: [['Build'], ['Dev']] } }))
+      .toBe('Task: Build\nEnv: Dev')
+  })
+
+  it('labels a rejected answer as Reject', () => {
+    expect(opencodeQuestionAnswersText(QUESTION_REQUEST, { result: { rejected: true } })).toBe('Reject')
+  })
+
+  it('falls back to question text then a positional label', () => {
+    const request = { type: 'question.asked', properties: { questions: [{ question: 'Pick a task' }, {}] } }
+    expect(opencodeQuestionAnswersText(request, { result: { answers: [['Build'], ['Dev']] } }))
+      .toBe('Pick a task: Build\nQuestion 2: Dev')
+  })
+
+  it('drops answer groups whose values are all empty', () => {
+    expect(opencodeQuestionAnswersText(QUESTION_REQUEST, { result: { answers: [['Build'], ['  ', '']] } }))
+      .toBe('Task: Build')
+  })
+
+  it('returns null when nothing renders', () => {
+    expect(opencodeQuestionAnswersText(QUESTION_REQUEST, { result: { answers: [] } })).toBeNull()
+  })
+})
+
+describe('opencodecontrolresponsedisplay', () => {
+  it('renders question answers for a question.asked request', () => {
+    const cr: PersistedControlResponse = { provider: 'OPENCODE', requestId: 'q1', request: QUESTION_REQUEST, response: { result: { answers: [['Build']] } } }
+    expect(opencodeControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Task: Build' })
+  })
+
+  it('delegates to the ACP permission path for a non-question request', () => {
+    const cr: PersistedControlResponse = {
+      provider: 'OPENCODE',
+      requestId: '7',
+      request: { method: 'session/request_permission', params: { options: [{ optionId: 'proceed_once', name: 'Allow once' }] } },
+      response: { result: { outcome: { optionId: 'proceed_once' } } },
+    }
+    expect(opencodeControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Allow once' })
+  })
+
+  describe('request-gone (pruned request absent)', () => {
+    // The pruned request type is absent, but a question answer is recognizable from the response
+    // shape (answers array / rejected flag), so it renders -- labeled by position, not the missing
+    // question headers -- instead of degrading to the generic label.
+    it('recovers question answers from the response, labeled by position', () => {
+      const cr: PersistedControlResponse = { provider: 'OPENCODE', requestId: 'q1', request: undefined, response: { result: { answers: [['Build'], ['Dev']] } } }
+      expect(opencodeControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Question 1: Build\nQuestion 2: Dev' })
+    })
+
+    it('recovers a rejected question from the response', () => {
+      const cr: PersistedControlResponse = { provider: 'OPENCODE', requestId: 'q1', request: undefined, response: { result: { rejected: true } } }
+      expect(opencodeControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Reject' })
+    })
+
+    it('still resolves a request-gone permission via the response-based ACP path', () => {
+      const cr: PersistedControlResponse = { provider: 'OPENCODE', requestId: '7', request: undefined, response: { result: { outcome: { optionId: 'proceed_once' } } } }
+      expect(opencodeControlResponseDisplay(cr)).toEqual({ kind: 'label', text: 'Allow once' })
+    })
+  })
+})

--- a/frontend/src/components/chat/providers/opencode/questionAnswers.ts
+++ b/frontend/src/components/chat/providers/opencode/questionAnswers.ts
@@ -1,0 +1,61 @@
+import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import { isObject, pickObject, pickString } from '~/lib/jsonPick'
+import { firstNonEmpty, joinAnswerLines, labeledAnswerLine, labelOrNull } from '../../persistedControlResponse'
+import { acpControlResponseDisplay } from '../acp/controlResponse'
+
+const OPENCODE_QUESTION_TYPE = 'question.asked'
+
+/**
+ * Render an OpenCode/Kilo `question.asked` answer. A rejected answer is "Reject"; otherwise each
+ * answer group renders as a "Header: v1, v2" line labeled by its request question (header else
+ * question, else "Question N"), with empty answer values dropped. Null when nothing renders.
+ */
+export function opencodeQuestionAnswersText(
+  request: Record<string, unknown> | undefined,
+  response: Record<string, unknown> | undefined,
+): string | null {
+  const result = pickObject(response, 'result', undefined)
+  if (result?.rejected === true)
+    return 'Reject'
+
+  const answers = Array.isArray(result?.answers) ? result.answers : []
+  const properties = pickObject(request, 'properties', undefined)
+  const questions = Array.isArray(properties?.questions) ? properties.questions : []
+
+  const lines: string[] = []
+  for (let i = 0; i < answers.length; i++) {
+    let label = `Question ${i + 1}`
+    const q = questions[i]
+    if (isObject(q)) {
+      const named = firstNonEmpty(pickString(q, 'header', ''), pickString(q, 'question', ''))
+      if (named)
+        label = named
+    }
+    const line = labeledAnswerLine(label, answers[i])
+    if (line !== null)
+      lines.push(line)
+  }
+  return joinAnswerLines(lines)
+}
+
+/**
+ * True when the response alone identifies an OpenCode/Kilo `question.asked` answer -- a rejection
+ * flag or an `answers` array (a permission selection has neither; it carries `result.outcome`). Lets
+ * a request-gone question answer still render its lines (positionally labeled) instead of degrading.
+ */
+function isOpencodeQuestionResponse(response: Record<string, unknown> | undefined): boolean {
+  const result = pickObject(response, 'result', undefined)
+  return result?.rejected === true || Array.isArray(result?.answers)
+}
+
+/**
+ * OpenCode/Kilo control-response derivation: a `question.asked` answer renders its question lines;
+ * anything else (a permission selection) delegates to the shared ACP path. When the pruned request
+ * type is gone, the response shape still identifies a question answer, so it is recovered there --
+ * labeled by position rather than the missing question headers.
+ */
+export function opencodeControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay | null {
+  if (pickString(cr.request, 'type', '') === OPENCODE_QUESTION_TYPE || isOpencodeQuestionResponse(cr.response))
+    return labelOrNull(opencodeQuestionAnswersText(cr.request, cr.response))
+  return acpControlResponseDisplay(cr)
+}

--- a/frontend/src/components/chat/providers/pi/controlResponse.test.ts
+++ b/frontend/src/components/chat/providers/pi/controlResponse.test.ts
@@ -1,10 +1,16 @@
+import type { PersistedControlResponse } from '../../persistedControlResponse'
 import { describe, expect, it } from 'vitest'
 import {
   piCancelResponse,
   piConfirmResponse,
+  piControlResponseDisplay,
   piValueResponse,
   sendPiExtensionResponse,
 } from './controlResponse'
+
+function cr(method: string, response: Record<string, unknown> | undefined): PersistedControlResponse {
+  return { provider: 'PI', requestId: 'r', request: { method }, response }
+}
 
 describe('pi controlResponse helpers', () => {
   it('builds value responses for select / input / editor', () => {
@@ -49,5 +55,40 @@ describe('pi controlResponse helpers', () => {
     const text = new TextDecoder().decode(captured!)
     const parsed = JSON.parse(text)
     expect(parsed).toEqual({ type: 'extension_ui_response', id: 'req-1', value: 'Allow' })
+  })
+})
+
+describe('picontrolresponsedisplay', () => {
+  it('labels a cancellation regardless of method', () => {
+    expect(piControlResponseDisplay(cr('confirm', { cancelled: true }))).toEqual({ kind: 'label', text: 'Cancelled' })
+  })
+
+  it('maps a confirm dialog to Approve / Deny', () => {
+    expect(piControlResponseDisplay(cr('confirm', { confirmed: true }))).toEqual({ kind: 'label', text: 'Approve' })
+    expect(piControlResponseDisplay(cr('confirm', { confirmed: false }))).toEqual({ kind: 'label', text: 'Deny' })
+  })
+
+  it('shows the typed value for select / input / editor dialogs', () => {
+    expect(piControlResponseDisplay(cr('select', { value: '  Blue  ' }))).toEqual({ kind: 'label', text: 'Blue' })
+    expect(piControlResponseDisplay(cr('input', { value: 'note' }))).toEqual({ kind: 'label', text: 'note' })
+    expect(piControlResponseDisplay(cr('editor', { value: 'body' }))).toEqual({ kind: 'label', text: 'body' })
+  })
+
+  it('returns null for an empty value or an unknown method (caller degrades)', () => {
+    expect(piControlResponseDisplay(cr('select', { value: '   ' }))).toBeNull()
+    expect(piControlResponseDisplay(cr('mystery', { value: 'x' }))).toBeNull()
+    expect(piControlResponseDisplay(cr('confirm', undefined))).toBeNull()
+  })
+
+  it('recovers the dialog from the response shape when the request is gone', () => {
+    // Request-gone: the pruned request (and its method) is absent, but the response shape still
+    // identifies the dialog -- a `confirmed` boolean is a confirm, a non-empty `value` is a text
+    // dialog -- so the answer renders instead of degrading to the generic label.
+    const gone = (response: Record<string, unknown>): PersistedControlResponse => ({ provider: 'PI', requestId: 'r', request: undefined, response })
+    expect(piControlResponseDisplay(gone({ confirmed: true }))).toEqual({ kind: 'label', text: 'Approve' })
+    expect(piControlResponseDisplay(gone({ confirmed: false }))).toEqual({ kind: 'label', text: 'Deny' })
+    expect(piControlResponseDisplay(gone({ value: 'note' }))).toEqual({ kind: 'label', text: 'note' })
+    expect(piControlResponseDisplay(gone({ cancelled: true }))).toEqual({ kind: 'label', text: 'Cancelled' })
+    expect(piControlResponseDisplay(gone({}))).toBeNull()
   })
 })

--- a/frontend/src/components/chat/providers/pi/controlResponse.ts
+++ b/frontend/src/components/chat/providers/pi/controlResponse.ts
@@ -15,8 +15,11 @@
  */
 
 import type { AskQuestionState } from '../../controls/types'
+import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import { pickString } from '~/lib/jsonPick'
 import { sendResponse } from '../../controls/types'
-import { PI_EVENT } from './protocol'
+import { label } from '../../persistedControlResponse'
+import { PI_DIALOG_METHOD, PI_EVENT } from './protocol'
 
 const RESPONSE_TYPE = PI_EVENT.ExtensionUIResponse
 
@@ -74,4 +77,35 @@ export function sendPiExtensionResponse(
   response: PiExtensionResponse,
 ): Promise<void> {
   return sendResponse(agentId, onRespond, response)
+}
+
+/**
+ * Derive the display for a persisted Pi extension-UI response. A cancel is "Cancelled"; a confirm
+ * dialog maps to "Approve"/"Deny"; a select/input/editor dialog shows the typed value. The pruned
+ * request method disambiguates confirm-vs-value precisely, but when it is absent (a request-gone
+ * answer) the response shape recovers it: a `confirmed` boolean is a confirm dialog, a non-empty
+ * `value` is a text dialog. Null for an empty value or an unrecognized known method (the caller then
+ * degrades to the generic label).
+ */
+export function piControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay | null {
+  const response = cr.response
+  if (!response)
+    return null
+  if (response.cancelled === true)
+    return label('Cancelled')
+
+  const method = pickString(cr.request, 'method', '')
+  if (method === PI_DIALOG_METHOD.Confirm || (method === '' && typeof response.confirmed === 'boolean'))
+    return label(response.confirmed === true ? 'Approve' : 'Deny')
+  switch (method) {
+    case PI_DIALOG_METHOD.Select:
+    case PI_DIALOG_METHOD.Input:
+    case PI_DIALOG_METHOD.Editor:
+    case '': {
+      const value = pickString(response, 'value', '').trim()
+      return value ? label(value) : null
+    }
+    default:
+      return null
+  }
 }

--- a/frontend/src/components/chat/providers/pi/plugin.test.ts
+++ b/frontend/src/components/chat/providers/pi/plugin.test.ts
@@ -95,6 +95,9 @@ describe('pi classify', () => {
     expect(plugin.classify(input(parent))).toEqual({ kind: 'assistant_thinking' })
   })
 
+  // The neutral {isSynthetic, controlResponse} row -> control_response classification is provider-
+  // agnostic and lives in classifyMessage (see messageClassification.test.ts), not this plugin.
+
   it('hides signature-only thinking blocks so tool-call message_end rows do not render empty thinking bubbles', () => {
     const parent = {
       type: 'message_end',

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -21,6 +21,7 @@ import {
   piAskAnswerValue,
   piCancelResponse,
   piConfirmResponse,
+  piControlResponseDisplay,
   piValueResponse,
   sendPiExtensionResponse,
 } from './controlResponse'
@@ -223,6 +224,9 @@ const piPlugin: Provider = {
     if (!parent)
       return { kind: 'unknown' }
 
+    // (The synthetic {isSynthetic, controlResponse} row -> control_response is classified upstream in
+    // classifyMessage, before any plugin.classify runs, since it is a Leapmux-neutral shape.)
+
     const type = pickString(parent, 'type')
 
     // User messages persisted by the Leapmux service layer are stored as
@@ -319,12 +323,12 @@ const piPlugin: Provider = {
     return null
   },
 
-  // Pi marks only user sends and control-response answers. A control answer is persisted in one of
-  // two Leapmux-neutral shapes -- `{content}` (a provider-resolved answer or a deny-with-feedback)
-  // or `{controlResponse}` (a bare approve/deny with no feedback) -- and Pi consumes
-  // extension_ui_response on stdin without echoing it. The shared neutral extractor handles BOTH
-  // shapes, so it is the whole preview.
+  // Pi marks only user sends and control-response answers. A user send is the Leapmux-neutral
+  // `{content}` shape the shared extractor handles; a control answer is the structured
+  // `{controlResponse}` row, which classifies as `control_response` and resolves through
+  // controlResponseDisplay (chatMarkPreview), not here.
   previewText: defaultMarkPreview,
+  controlResponseDisplay: piControlResponseDisplay,
 
   buildInterruptContent(): string | null {
     return JSON.stringify({ type: 'abort' })

--- a/frontend/src/components/chat/providers/registerOpenCodeProtocolProvider.ts
+++ b/frontend/src/components/chat/providers/registerOpenCodeProtocolProvider.ts
@@ -1,6 +1,7 @@
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { extractOpenCodeQuestions, OpenCodeControlActions, OpenCodeControlContent, sendOpenCodeQuestionResponse } from '../controls/OpenCodeControlRequest'
 import { registerACPProvider } from './acp/registerACPProvider'
+import { opencodeControlResponseDisplay } from './opencode/questionAnswers'
 
 interface OpenCodeProtocolOptions {
   provider: AgentProvider
@@ -27,6 +28,9 @@ export function registerOpenCodeProtocolProvider(opts: OpenCodeProtocolOptions):
     ControlContent: OpenCodeControlContent,
     ControlActions: OpenCodeControlActions,
     planValue: PLAN_PRIMARY_AGENT,
+    // OpenCode and Kilo share the question-answer derivation from this single registration site
+    // (mirroring the backend's questionRequestContext hook), so it can't drift per provider.
+    controlResponseDisplay: opencodeControlResponseDisplay,
     questionHandling: {
       isAskUserQuestion: payload => payload?.type === 'question.asked',
       extractAskUserQuestions: extractOpenCodeQuestions,

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -11,6 +11,7 @@ import type { Component, JSX } from 'solid-js'
 import type { ActionsProps, AskQuestionState, ContentProps, Question } from '../controls/types'
 import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
+import type { ControlResponseDeriver } from '../persistedControlResponse'
 import type { AgentInfo, AgentProvider, AvailableOptionGroup } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentSessionInfo } from '~/stores/agentSession.store'
@@ -219,19 +220,35 @@ export interface Provider {
   ) => string | null
 
   /**
-   * Short plaintext preview of a MARKED message's content (user inputs, control
-   * responses) for the chat scroll rail's dot-hover tooltip. Sibling of
-   * {@link extractQuotableText}: each provider knows its own wire shapes, so preview
-   * extraction is a per-provider concern. Providers whose marked rows are all in the
-   * Leapmux-neutral shapes (`{content}`, `{controlResponse}`) delegate to the shared
-   * `defaultMarkPreview`; Claude also reads its Anthropic `message.content[]` tool_result
-   * blocks. Return null when there is no previewable text (the rail then shows a
-   * mark-type label). See chatMarkPreview.ts.
+   * Short plaintext preview of a MARKED user-send row for the chat scroll rail's dot-hover
+   * tooltip. Sibling of {@link extractQuotableText}: each provider knows its own wire shapes, so
+   * preview extraction is a per-provider concern. Providers whose marked user sends are the
+   * Leapmux-neutral `{content}` shape delegate to the shared `defaultMarkPreview`; Claude also
+   * reads its Anthropic `message.content[]` tool_result blocks. Persisted control-response rows
+   * are NOT previewed here -- they classify as `control_response` and the rail resolves their
+   * preview through {@link controlResponseDisplay} (see chatMarkPreview.ts). Return null when
+   * there is no previewable text (the rail then shows a mark-type label).
    */
   previewText?: (
     category: MessageCategory,
     parsed: ParsedMessageContent,
   ) => string | null
+
+  /**
+   * Derive the human-facing display for a persisted control-response row
+   * (`{isSynthetic, controlResponse:{provider, requestId, request, response}}` -- see
+   * persistedControlResponse.ts). Each provider knows its own native request/response wire shapes
+   * (Codex JSON-RPC decisions, ACP permission options, OpenCode question answers, Pi extension-UI
+   * responses, ...) and turns them into a label or a feedback block.
+   *
+   * The SINGLE label source for BOTH surfaces that show the row: the transcript renderer
+   * (renderControlResponseRow, dispatched from renderMessageContent's shared `control_response`
+   * branch) and the scroll rail's dot preview (messageMarkPreviewText), so the two cannot drift.
+   * Return null when the payload isn't recognizable -- the caller then degrades via
+   * {@link fallbackControlResponseDisplay} (coarse Approved/Rejected from the neutral behavior
+   * envelope, else the generic "Responded" label).
+   */
+  controlResponseDisplay?: ControlResponseDeriver
 
   /**
    * Build the wire-format content string to interrupt the agent.

--- a/frontend/src/components/chat/providers/stubs/cursor.test.ts
+++ b/frontend/src/components/chat/providers/stubs/cursor.test.ts
@@ -36,4 +36,16 @@ describe('cursor provider', () => {
   it('renders the permissionMode group as the trigger mode segment', () => {
     expect(plugin.triggerModeGroupKey).toBe('permissionMode')
   })
+
+  // The neutral {isSynthetic, controlResponse} row -> control_response classification is provider-
+  // agnostic and lives in classifyMessage (see messageClassification.test.ts); this covers only
+  // Cursor's own controlResponseDisplay derivation.
+  it('derives Cursor-specific control-response labels', () => {
+    expect(plugin.controlResponseDisplay!({
+      provider: 'CURSOR',
+      requestId: '7',
+      request: { method: 'cursor/create_plan' },
+      response: { result: { outcome: { outcome: 'accepted' } } },
+    })).toEqual({ kind: 'label', text: 'Accept' })
+  })
 })

--- a/frontend/src/components/chat/providers/stubs/cursor.tsx
+++ b/frontend/src/components/chat/providers/stubs/cursor.tsx
@@ -4,10 +4,12 @@ import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { ACPControlActions, ACPControlContent } from '../../controls/ACPControlRequest'
 import { CursorControlActions, CursorControlContent, getCursorQuestions, isCursorAskQuestionPayload, isCursorControlPayload, sendCursorQuestionResponse } from '../../controls/CursorControlRequest'
 import { registerACPProvider } from '../acp/registerACPProvider'
+import { cursorControlResponseDisplay } from './cursorControlResponse'
 
 registerACPProvider({
   provider: AgentProvider.CURSOR,
   defaultPermissionMode: 'agent' as PermissionMode,
+  controlResponseDisplay: cursorControlResponseDisplay,
   // Cursor's ask-question payload is shaped differently from generic ACP, so
   // dispatch on payload type and fall through to the shared ACP UI when not.
   ControlContent: (props) => {

--- a/frontend/src/components/chat/providers/stubs/cursorControlResponse.test.ts
+++ b/frontend/src/components/chat/providers/stubs/cursorControlResponse.test.ts
@@ -1,0 +1,96 @@
+import type { PersistedControlResponse } from '../../persistedControlResponse'
+import { describe, expect, it } from 'vitest'
+import { cursorControlResponseDisplay } from './cursorControlResponse'
+
+function cr(request: Record<string, unknown> | undefined, response: Record<string, unknown> | undefined): PersistedControlResponse {
+  return { provider: 'CURSOR', requestId: '7', request, response }
+}
+
+const QUESTION_REQUEST = {
+  method: 'cursor/ask_question',
+  params: {
+    questions: [
+      { id: 'q1', prompt: 'Pick a color', options: [{ id: 'o1', label: 'Red' }, { id: 'o2', label: 'Blue' }] },
+      { id: 'q2', prompt: 'Pick a size', options: [{ id: 's1', label: 'Large' }] },
+    ],
+  },
+}
+
+function questionOutcome(outcome: Record<string, unknown>): Record<string, unknown> {
+  return { result: { outcome } }
+}
+
+describe('cursorcontrolresponsedisplay', () => {
+  describe('ask_question', () => {
+    it('maps selected option ids to labels in request order', () => {
+      const response = questionOutcome({
+        outcome: 'answered',
+        answers: [
+          { questionId: 'q1', selectedOptionIds: ['o1', 'o2'] },
+          { questionId: 'q2', selectedOptionIds: ['s1'] },
+        ],
+      })
+      expect(cursorControlResponseDisplay(cr(QUESTION_REQUEST, response)))
+        .toEqual({ kind: 'label', text: 'Pick a color: Red, Blue\nPick a size: Large' })
+    })
+
+    it('passes unknown option ids through and drops empty selections', () => {
+      const response = questionOutcome({
+        outcome: 'answered',
+        answers: [
+          { questionId: 'q1', selectedOptionIds: ['o1', 'unknown'] },
+          { questionId: 'q2', selectedOptionIds: [] },
+        ],
+      })
+      expect(cursorControlResponseDisplay(cr(QUESTION_REQUEST, response)))
+        .toEqual({ kind: 'label', text: 'Pick a color: Red, unknown' })
+    })
+
+    it('renders a cancellation reason as feedback, else the Cancel label', () => {
+      expect(cursorControlResponseDisplay(cr(QUESTION_REQUEST, questionOutcome({ outcome: 'cancelled', reason: 'changed mind' }))))
+        .toEqual({ kind: 'feedback', message: 'changed mind' })
+      expect(cursorControlResponseDisplay(cr(QUESTION_REQUEST, questionOutcome({ outcome: 'skipped' }))))
+        .toEqual({ kind: 'label', text: 'Cancel' })
+    })
+  })
+
+  describe('create_plan', () => {
+    const request = { method: 'cursor/create_plan' }
+
+    it('labels an accepted plan', () => {
+      expect(cursorControlResponseDisplay(cr(request, questionOutcome({ outcome: 'accepted' }))))
+        .toEqual({ kind: 'label', text: 'Accept' })
+    })
+
+    it('renders a rejection reason as feedback, else Reject', () => {
+      expect(cursorControlResponseDisplay(cr(request, questionOutcome({ outcome: 'rejected', reason: 'Needs tests.' }))))
+        .toEqual({ kind: 'feedback', message: 'Needs tests.' })
+      expect(cursorControlResponseDisplay(cr(request, questionOutcome({ outcome: 'rejected' }))))
+        .toEqual({ kind: 'label', text: 'Reject' })
+    })
+  })
+
+  it('delegates to the ACP permission path for a plain permission selection', () => {
+    const request = { method: 'session/request_permission', params: { options: [{ optionId: 'proceed_once', name: 'Allow once' }] } }
+    const response = { result: { outcome: { optionId: 'proceed_once' } } }
+    expect(cursorControlResponseDisplay(cr(request, response))).toEqual({ kind: 'label', text: 'Allow once' })
+  })
+
+  describe('request-gone (pruned request absent)', () => {
+    // The pruned request (and its method) is absent, but a create_plan / permission outcome is
+    // recoverable from result.outcome alone, so it renders instead of degrading to "Responded".
+    it('recovers a create_plan decision from the response', () => {
+      expect(cursorControlResponseDisplay(cr(undefined, questionOutcome({ outcome: 'accepted' }))))
+        .toEqual({ kind: 'label', text: 'Accept' })
+      expect(cursorControlResponseDisplay(cr(undefined, questionOutcome({ outcome: 'rejected', reason: 'Needs tests.' }))))
+        .toEqual({ kind: 'feedback', message: 'Needs tests.' })
+      expect(cursorControlResponseDisplay(cr(undefined, questionOutcome({ outcome: 'cancelled', reason: 'changed mind' }))))
+        .toEqual({ kind: 'feedback', message: 'changed mind' })
+    })
+
+    it('still resolves a permission selection via the response-based ACP path', () => {
+      expect(cursorControlResponseDisplay(cr(undefined, { result: { outcome: { optionId: 'proceed_once' } } })))
+        .toEqual({ kind: 'label', text: 'Allow once' })
+    })
+  })
+})

--- a/frontend/src/components/chat/providers/stubs/cursorControlResponse.ts
+++ b/frontend/src/components/chat/providers/stubs/cursorControlResponse.ts
@@ -1,0 +1,147 @@
+import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import { isObject, pickObject, pickString, stringArray } from '~/lib/jsonPick'
+import { feedbackOrLabel, firstNonEmpty, joinAnswerLines, label, labeledAnswerLine, labelOrNull } from '../../persistedControlResponse'
+import { acpControlResponseDisplay } from '../acp/controlResponse'
+
+const CURSOR_METHOD_ASK_QUESTION = 'cursor/ask_question'
+const CURSOR_METHOD_CREATE_PLAN = 'cursor/create_plan'
+
+/** The transformed/native outcome object at `result.outcome`, or undefined when absent. */
+function cursorOutcome(response: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return pickObject(pickObject(response, 'result', undefined), 'outcome', undefined)
+}
+
+/**
+ * The answered branch of the Cursor ask_question derivation: map each selected optionId to its
+ * option LABEL (unknown ids pass through) and render "prompt: label1, label2" lines in
+ * request-question order, dropping questions with no surviving selection. Null when nothing renders.
+ */
+function cursorAnswerLines(
+  request: Record<string, unknown> | undefined,
+  outcome: Record<string, unknown>,
+): string | null {
+  const params = pickObject(request, 'params', undefined)
+  const questions = Array.isArray(params?.questions) ? params.questions : []
+
+  const promptById = new Map<string, string>()
+  const optionLabelById = new Map<string, Map<string, string>>()
+  const order: string[] = []
+  for (const q of questions) {
+    if (!isObject(q))
+      continue
+    const id = pickString(q, 'id', '').trim()
+    if (!id)
+      continue
+    promptById.set(id, pickString(q, 'prompt', '').trim())
+    const optionLabels = new Map<string, string>()
+    const options = Array.isArray(q.options) ? q.options : []
+    for (const opt of options) {
+      if (!isObject(opt))
+        continue
+      const optId = pickString(opt, 'id', '').trim()
+      if (!optId)
+        continue
+      optionLabels.set(optId, firstNonEmpty(pickString(opt, 'label', ''), optId))
+    }
+    optionLabelById.set(id, optionLabels)
+    order.push(id)
+  }
+
+  const answers = Array.isArray(outcome.answers) ? outcome.answers : []
+  const answerByQuestion = new Map<string, string[]>()
+  for (const answer of answers) {
+    if (!isObject(answer))
+      continue
+    const questionId = pickString(answer, 'questionId', '').trim()
+    if (!questionId)
+      continue
+    const mapped: string[] = []
+    for (const raw of stringArray(answer.selectedOptionIds)) {
+      const optId = raw.trim()
+      if (!optId)
+        continue
+      const optionLabel = optionLabelById.get(questionId)?.get(optId)
+      mapped.push(optionLabel && optionLabel.trim() ? optionLabel.trim() : optId)
+    }
+    if (mapped.length > 0)
+      answerByQuestion.set(questionId, mapped)
+  }
+
+  const lines: string[] = []
+  for (const questionId of order) {
+    const mapped = answerByQuestion.get(questionId)
+    if (!mapped || mapped.length === 0)
+      continue
+    const line = labeledAnswerLine(firstNonEmpty(promptById.get(questionId), questionId), mapped)
+    if (line !== null)
+      lines.push(line)
+  }
+  return joinAnswerLines(lines)
+}
+
+/** Derive the display for a Cursor ask_question answer (answered lines, or a cancellation reason). */
+function cursorQuestionDisplay(
+  request: Record<string, unknown> | undefined,
+  response: Record<string, unknown> | undefined,
+): ControlResponseDisplay | null {
+  const outcome = cursorOutcome(response)
+  if (!outcome)
+    return null
+  switch (pickString(outcome, 'outcome', '')) {
+    case 'answered':
+      return labelOrNull(cursorAnswerLines(request, outcome))
+    case 'cancelled':
+    case 'skipped':
+      return feedbackOrLabel(pickString(outcome, 'reason', '').trim(), 'Cancel')
+    default:
+      return null
+  }
+}
+
+/**
+ * Derive the plan decision from the TRANSFORMED outcome the agent was sent
+ * (`result.outcome.{outcome, reason}`): accepted -> "Accept"; rejected/cancelled -> the reason as
+ * feedback, or "Reject"/"Cancel" when bare.
+ */
+function cursorCreatePlanDisplay(response: Record<string, unknown> | undefined): ControlResponseDisplay | null {
+  const outcome = cursorOutcome(response)
+  if (!outcome)
+    return null
+  const reason = pickString(outcome, 'reason', '').trim()
+  switch (pickString(outcome, 'outcome', '')) {
+    case 'accepted':
+      return label('Accept')
+    case 'rejected':
+      return feedbackOrLabel(reason, 'Reject')
+    case 'cancelled':
+      return feedbackOrLabel(reason, 'Cancel')
+    default:
+      return null
+  }
+}
+
+/**
+ * Cursor control-response derivation: dispatch on the request method (ask_question / create_plan),
+ * falling back to the shared ACP permission path for a plain permission selection. When the pruned
+ * request is gone (method absent), a create_plan decision and a permission selection are still fully
+ * recoverable from `result.outcome` alone (the plan verdict / the selected optionId live in the
+ * response), so both are tried before the generic fallback. An ask_question ANSWERED outcome is the
+ * one shape NOT fully recoverable request-gone: the selected option ids are in the response but their
+ * human labels and the question prompts live only in the pruned request, so cursorAnswerLines yields
+ * nothing and the row degrades to the neutral "Responded" -- an accepted limitation (the raw option
+ * ids would be opaque tokens), not a recovery we can complete here.
+ */
+export function cursorControlResponseDisplay(cr: PersistedControlResponse): ControlResponseDisplay | null {
+  switch (pickString(cr.request, 'method', '')) {
+    case CURSOR_METHOD_ASK_QUESTION:
+      return cursorQuestionDisplay(cr.request, cr.response)
+    case CURSOR_METHOD_CREATE_PLAN:
+      return cursorCreatePlanDisplay(cr.response)
+    case '':
+      return cursorCreatePlanDisplay(cr.response)
+        ?? cursorQuestionDisplay(cr.request, cr.response)
+        ?? acpControlResponseDisplay(cr)
+    default:
+      return acpControlResponseDisplay(cr)
+  }
+}

--- a/frontend/src/components/chat/providers/stubs/goose.test.ts
+++ b/frontend/src/components/chat/providers/stubs/goose.test.ts
@@ -27,4 +27,14 @@ describe('goose provider', () => {
     // (permissionMode) without a plan toggle, so it still declares triggerModeGroupKey.
     expect(plugin.triggerModeGroupKey).toBe('permissionMode')
   })
+
+  it('derives a control-response label via the default ACP permission path (no question hook)', () => {
+    // Goose has no question protocol, so it gets the shared acpControlResponseDisplay default.
+    expect(plugin.controlResponseDisplay!({
+      provider: 'GOOSE',
+      requestId: '7',
+      request: { method: 'session/request_permission', params: { options: [{ optionId: 'proceed_once', name: 'Allow once' }] } },
+      response: { result: { outcome: { optionId: 'proceed_once' } } },
+    })).toEqual({ kind: 'label', text: 'Allow once' })
+  })
 })

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -32,7 +32,6 @@ import { FileEditDiffBody, fileEditHasDiff } from './results/fileEditDiff'
 import { parseReadContent, ReadResultView } from './results/ReadResultView'
 import { useCollapsedLines } from './results/useCollapsedLines'
 import {
-  controlResponseTag,
   toolBodyBorder,
   toolBodyContent,
   toolHeaderActions,
@@ -48,22 +47,6 @@ import {
 import { useAsyncCodeTokens } from './useAsyncCodeTokens'
 import { spanColorKey } from './widgets/SpanLines'
 import { spanLineColors } from './widgets/SpanLines.css'
-
-/** Inline control response tag (Approved / Rejected) for tool headers. */
-export function ControlResponseTag(props: { response?: { action: string, comment: string } }): JSX.Element {
-  return (
-    <Show when={props.response}>
-      {cr => (
-        <Tooltip text={cr().comment || undefined}>
-          <span class={controlResponseTag}>
-            {'\u00B7 '}
-            {cr().action === 'approved' ? 'Approved' : cr().comment ? `Rejected: ${cr().comment}` : 'Rejected'}
-          </span>
-        </Tooltip>
-      )}
-    </Show>
-  )
-}
 
 /** Renders a "To-do list cleared" placeholder for empty todo/plan tool_use messages. */
 export function EmptyTodoLayout(props: { toolName: string, context?: RenderContext }): JSX.Element {

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -221,13 +221,6 @@ globalStyle(`${toolUseHeader} .${toolHeaderActions}`, {
   marginLeft: 'auto',
 })
 
-// Inline control response tag in tool header (approved/rejected indicator)
-export const controlResponseTag = style({
-  color: 'var(--muted-foreground)',
-  fontSize: 'var(--text-7)',
-  flexShrink: 0,
-})
-
 // Body content indent for tool_use renderers. The transparent border-
 // left reserves the slot so adding `toolBodyBorder` doesn't shift the
 // content horizontally. Padding compensates for the 1px gap between

--- a/frontend/src/components/shell/useAgentOperations.test.ts
+++ b/frontend/src/components/shell/useAgentOperations.test.ts
@@ -4,6 +4,7 @@ import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as workerRpc from '~/api/workerRpc'
 import { useAgentOperations } from '~/components/shell/useAgentOperations'
 import { AgentInfoSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
@@ -602,6 +603,94 @@ describe('useAgentOperations', () => {
           ops.handleAgentClose('nonexistent')
 
           expect(mockCloseAgent).not.toHaveBeenCalled()
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+  })
+
+  describe('handleControlResponse claim-token echo', () => {
+    const answer = (requestId: string) =>
+      new TextEncoder().encode(JSON.stringify({ response: { request_id: requestId, response: { behavior: 'allow' } } }))
+
+    it('echoes the pending request\'s per-instance claimToken so the worker dedups per instance', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { ops, controlStore } = setup()
+          vi.mocked(workerRpc.sendControlResponse).mockClear()
+          controlStore.addRequest('a1', { requestId: 'r1', agentId: 'a1', payload: { request: { tool_name: 'Bash' } }, claimToken: 'instance-token-1' })
+
+          await ops.handleControlResponse('a1', answer('r1'))
+
+          expect(workerRpc.sendControlResponse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ agentId: 'a1', claimToken: 'instance-token-1' }),
+          )
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('echoes an empty claimToken when the request is not in the store AND none is threaded (degrades to id-only dedup)', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { ops } = setup()
+          vi.mocked(workerRpc.sendControlResponse).mockClear()
+
+          // No control request in the store for r-missing and no threaded token -> the echoed token is ''.
+          await ops.handleControlResponse('a1', answer('r-missing'))
+
+          expect(workerRpc.sendControlResponse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ agentId: 'a1', claimToken: '' }),
+          )
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('uses the threaded (answer-site) claimToken even when the request has already left the store', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { ops } = setup()
+          vi.mocked(workerRpc.sendControlResponse).mockClear()
+
+          // The request is NOT in the store (a prior answer / cancel already removed it), so the store
+          // lookup would miss and fall back to ''. The token captured at the answer site is threaded in
+          // and is authoritative, so the worker still claims on the answered INSTANCE rather than dropping
+          // to an empty-token key (which could double-win or drop the answer).
+          await ops.handleControlResponse('a1', answer('r-gone'), 'threaded-token-9')
+
+          expect(workerRpc.sendControlResponse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ agentId: 'a1', claimToken: 'threaded-token-9' }),
+          )
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    it('the threaded claimToken takes precedence over the store entry', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { ops, controlStore } = setup()
+          vi.mocked(workerRpc.sendControlResponse).mockClear()
+          controlStore.addRequest('a1', { requestId: 'r1', agentId: 'a1', payload: { request: { tool_name: 'Bash' } }, claimToken: 'stale-store-token' })
+
+          await ops.handleControlResponse('a1', answer('r1'), 'fresh-answer-token')
+
+          expect(workerRpc.sendControlResponse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ agentId: 'a1', claimToken: 'fresh-answer-token' }),
+          )
         }
         finally {
           dispose()

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -175,8 +175,11 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
   }
 
-  // Handle control responses (permission grant/deny) for agent prompts
-  const handleControlResponse = async (agentId: string, content: Uint8Array) => {
+  // Handle control responses (permission grant/deny) for agent prompts. answeredClaimToken is the
+  // per-instance token captured from the ACTIVE control request at the answer site (AgentEditorPanel /
+  // controlResponseHandling), threaded through so it is always the answered instance's token -- even
+  // once the request has left the store (a double-submit / answer-after-cancel race).
+  const handleControlResponse = async (agentId: string, content: Uint8Array, answeredClaimToken?: string) => {
     props.forceScrollToBottom?.()
     try {
       const workerId = getAgentWorkerId(agentId)
@@ -184,9 +187,19 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
       const requestId = parsed?.response?.request_id
         ?? (parsed?.id != null ? String(parsed.id) : undefined)
 
+      // Echo the per-instance claimToken the worker minted for THIS request so its idempotency claim
+      // dedups per instance -- a reused request_id gets a fresh token (see AgentControlRequest.claim_token).
+      // Prefer the token threaded from the answer site (authoritative even after the request left the
+      // store); fall back to a store lookup for any caller that doesn't thread one, then to '' (which
+      // degrades to request_id-only dedup on the worker rather than dropping the answer).
+      const claimToken = answeredClaimToken
+        ?? (requestId ? props.controlStore.getRequest(agentId, requestId)?.claimToken : undefined)
+        ?? ''
+
       await workerRpc.sendControlResponse(workerId, {
         agentId,
         content,
+        claimToken,
       })
 
       if (requestId)

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -76,7 +76,7 @@ describe('controlRequest guard for inactive agents', () => {
   }
 
   function makeRequest(requestId: string, agentId: string) {
-    return { requestId, agentId, payload: { method: 'item/commandExecution/requestApproval' } }
+    return { requestId, agentId, payload: { method: 'item/commandExecution/requestApproval' }, claimToken: `tok-${requestId}` }
   }
 
   it('should not add catch-up control request when agent is INACTIVE', () => {
@@ -934,7 +934,7 @@ describe('handleAgentInactive', () => {
     const tabStore = createTabStore()
     tabStore.addTab({ type: TabType.AGENT, id: 'agent-1', agentStatus: AgentStatus.INACTIVE } as unknown as Parameters<typeof tabStore.addTab>[0])
     const controlStore = createControlStore()
-    controlStore.addRequest('agent-1', { requestId: 'r1', agentId: 'agent-1', payload: {} })
+    controlStore.addRequest('agent-1', { requestId: 'r1', agentId: 'agent-1', payload: {}, claimToken: 'tok-r1' })
     return { controlStore, agentSessionStore: createAgentSessionStore(), chatStore: createChatStore(), tabStore }
   }
 
@@ -1608,6 +1608,24 @@ describe('extracted handleAgentEvent arm handlers', () => {
         dispose()
       })
     })
+
+    it('threads the wire claim_token into the stored request so the answer can echo it back', () => {
+      createRoot((dispose) => {
+        const s = argStores()
+        s.tabStore.addTab({ type: TabType.AGENT, id: 'a1', agentStatus: AgentStatus.ACTIVE } as AgentTab)
+        const withToken = {
+          requestId: 'r1',
+          agentId: 'a1',
+          payload: enc(JSON.stringify({ method: 'item/commandExecution/requestApproval' })),
+          claimToken: 'instance-token-1',
+        } as unknown as AgentControlRequest
+        handleControlRequest('a1', withToken, 'live', s, undefined)
+        // The per-instance token from AgentControlRequest.claim_token must reach the store, since the
+        // answer (handleControlResponse) echoes it back so the worker dedups the answer per instance.
+        expect(s.controlStore.getRequest('a1', 'r1')?.claimToken).toBe('instance-token-1')
+        dispose()
+      })
+    })
   })
 
   describe('handleAgentStatusChange', () => {
@@ -1641,7 +1659,7 @@ describe('extracted handleAgentEvent arm handlers', () => {
       createRoot((dispose) => {
         const s = argStores()
         s.tabStore.addTab({ type: TabType.AGENT, id: 'a1', agentStatus: AgentStatus.ACTIVE } as AgentTab)
-        s.controlStore.addRequest('a1', { requestId: 'r1', agentId: 'a1', payload: { method: 'x' } })
+        s.controlStore.addRequest('a1', { requestId: 'r1', agentId: 'a1', payload: { method: 'x' }, claimToken: 'tok-r1' })
         const sc = { agentId: 'a1', status: AgentStatus.INACTIVE, workerOnline: true, optionGroups: [], startupError: '', startupMessage: '' } as unknown as AgentStatusChange
         handleAgentStatusChange('a1', sc, 'live', s, createLoadingSignal(), () => {}, undefined)
         expect(s.controlStore.getRequests('a1')).toHaveLength(0)

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -722,7 +722,7 @@ export function handleControlRequest(
     log.warn('Ignoring malformed control request payload', { agentId: cr.agentId, requestId: cr.requestId, err })
     return
   }
-  controlStore.addRequest(cr.agentId, { requestId: cr.requestId, agentId: cr.agentId, payload })
+  controlStore.addRequest(cr.agentId, { requestId: cr.requestId, agentId: cr.agentId, payload, claimToken: cr.claimToken })
   if (catchUpPhase === 'live') {
     // Light up the tab badge so a user looking at a sibling tab knows the background
     // agent is now waiting on them.

--- a/frontend/src/stores/control.store.test.ts
+++ b/frontend/src/stores/control.store.test.ts
@@ -3,8 +3,10 @@ import { createRoot } from 'solid-js'
 import { describe, expect, it } from 'vitest'
 import { createControlStore } from '~/stores/control.store'
 
-function makeRequest(requestId: string, agentId: string, payload: Record<string, unknown> = { data: requestId }): ControlRequest {
-  return { requestId, agentId, payload }
+// claimToken defaults to a per-requestId token (so a re-add of the SAME id models a reconnect replay of
+// the SAME instance); pass an explicit token to model a REISSUED instance that reused the request_id.
+function makeRequest(requestId: string, agentId: string, payload: Record<string, unknown> = { data: requestId }, claimToken: string = `tok-${requestId}`): ControlRequest {
+  return { requestId, agentId, payload, claimToken }
 }
 
 describe('createControlStore', () => {
@@ -65,6 +67,19 @@ describe('createControlStore', () => {
       store.addRequest('agent-1', makeRequest('r1', 'agent-1'))
       expect(() => store.removeRequest('agent-1', 'nonexistent')).not.toThrow()
       expect(store.getRequests('agent-1')).toHaveLength(1)
+      dispose()
+    })
+  })
+
+  it('should return the matching request (with its claimToken) on getRequest, else undefined', () => {
+    createRoot((dispose) => {
+      const store = createControlStore()
+      store.addRequest('agent-1', makeRequest('r1', 'agent-1'))
+      store.addRequest('agent-1', makeRequest('r2', 'agent-1'))
+      // getRequest recovers the per-instance claimToken the answer echoes back to the worker.
+      expect(store.getRequest('agent-1', 'r2')?.claimToken).toBe('tok-r2')
+      expect(store.getRequest('agent-1', 'missing')).toBeUndefined()
+      expect(store.getRequest('no-agent', 'r1')).toBeUndefined()
       dispose()
     })
   })
@@ -141,23 +156,66 @@ describe('createControlStore', () => {
   })
 
   // Claude Code can reuse request_id for a revised ExitPlanMode prompt after
-  // the user rejects a plan with feedback. That is not a stale replay: the
-  // payload changed and the next banner must be shown.
+  // the user rejects a plan with feedback. That is not a stale replay: it is a
+  // REISSUED instance carrying a fresh claimToken, so the next banner must be shown.
   it('does not suppress a revised request that reuses requestId within the same agent', () => {
     createRoot((dispose) => {
       const store = createControlStore()
       store.addRequest('agent-1', makeRequest('r1', 'agent-1', {
         request: { tool_name: 'ExitPlanMode', input: { plan: 'first plan' } },
-      }))
+      }, 'tok-r1-first'))
       store.removeRequest('agent-1', 'r1')
 
+      // The reissued prompt carries a fresh claimToken (a new PersistControlRequest instance).
       store.addRequest('agent-1', makeRequest('r1', 'agent-1', {
         request: { tool_name: 'ExitPlanMode', input: { plan: 'revised plan' } },
-      }))
+      }, 'tok-r1-revised'))
       expect(store.getRequests('agent-1')).toHaveLength(1)
       expect(store.getRequests('agent-1')[0].payload).toEqual({
         request: { tool_name: 'ExitPlanMode', input: { plan: 'revised plan' } },
       })
+      dispose()
+    })
+  })
+
+  // The regression this closes (the UI half of the backend claim_token fix): after the user answers a
+  // request, an IDENTICAL re-ask (same request_id AND same payload) that carries a FRESH claimToken --
+  // a genuinely new instance, e.g. the agent restarted and its JSON-RPC counter reset -- must be SHOWN,
+  // not swallowed as a duplicate. The payload fingerprint alone would suppress it (same payload); the
+  // per-instance claimToken is what tells the new instance apart.
+  it('shows an identical re-ask (same payload) that carries a fresh claimToken after a prior answer', () => {
+    createRoot((dispose) => {
+      const store = createControlStore()
+      const payload = { request: { tool_name: 'Bash', input: { command: 'ls' } } }
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', payload, 'instA'))
+      store.removeRequest('agent-1', '1')
+
+      // A reconnect replay of the SAME instance (same token) stays suppressed.
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', payload, 'instA'))
+      expect(store.getRequests('agent-1')).toHaveLength(0)
+
+      // A genuine re-ask by a NEW instance (fresh token, identical payload) is shown.
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', payload, 'instB'))
+      expect(store.getRequests('agent-1')).toHaveLength(1)
+      expect(store.getRequests('agent-1')[0].claimToken).toBe('instB')
+      dispose()
+    })
+  })
+
+  // Tokenless fallback: a synthetic / pre-token row (no claimToken) still dedups by the payload
+  // fingerprint, so an identical replay is suppressed while a differing payload is shown.
+  it('falls back to the payload fingerprint when a request carries no claimToken', () => {
+    createRoot((dispose) => {
+      const store = createControlStore()
+      const p1 = { request: { tool_name: 'Bash', input: { command: 'ls' } } }
+      const p2 = { request: { tool_name: 'Bash', input: { command: 'rm -rf /' } } }
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', p1, ''))
+      store.removeRequest('agent-1', '1')
+
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', p1, '')) // identical -> suppressed
+      expect(store.getRequests('agent-1')).toHaveLength(0)
+      store.addRequest('agent-1', makeRequest('1', 'agent-1', p2, '')) // different payload -> shown
+      expect(store.getRequests('agent-1')).toHaveLength(1)
       dispose()
     })
   })

--- a/frontend/src/stores/control.store.ts
+++ b/frontend/src/stores/control.store.ts
@@ -4,6 +4,11 @@ export interface ControlRequest {
   requestId: string
   agentId: string
   payload: Record<string, unknown>
+  // Per-instance token minted by the worker (AgentControlRequest.claim_token). The answer echoes it
+  // in SendControlResponseRequest so the worker's idempotency claim dedups a reused request_id per
+  // INSTANCE. The real ingestion always sets it (from the event); optional so synthetic fixtures and a
+  // pre-token worker can omit it, in which case the answer degrades to request_id-only dedup.
+  claimToken?: string
 }
 
 interface ControlStoreState {
@@ -31,16 +36,27 @@ export function createControlStore() {
   })
 
   // Track recently-responded-to requests so a post-response reconnect cannot
-  // re-add a request the user already handled. Include a payload fingerprint:
-  // request_id alone is not globally unique, and Claude can reuse one within
-  // the same agent for a revised ExitPlanMode prompt after feedback.
-  // Insertion order drives LRU eviction. Non-reactive and intentionally
-  // survives clearAgent / clearAll.
+  // re-add a request the user already handled. request_id alone is NOT globally
+  // unique -- the agent reuses one across a restart (a JSON-RPC / plan-mode counter
+  // that resets) and Claude reuses one for a revised ExitPlanMode prompt after
+  // feedback -- so the key is scoped to the request INSTANCE by its claimToken
+  // (the same per-instance token the worker keys its answer claim on). A genuine
+  // re-ask of the SAME request_id carries a FRESH claimToken, so it is shown rather
+  // than suppressed as a duplicate of the answered prior instance; a reconnect
+  // replay of the SAME instance carries the SAME token and is still suppressed.
+  // Only a pre-token / synthetic row (no claimToken) falls back to the payload
+  // fingerprint, preserving the old "a revised prompt differs by payload" behavior.
+  // Insertion order drives LRU eviction. Non-reactive and intentionally survives
+  // clearAgent / clearAll.
   const respondedKeys = new Set<string>()
   const MAX_RESPONDED = 100
 
-  function respondedKey(agentId: string, requestId: string, payloadFp: string): string {
-    return `${agentId}:${requestId}:${payloadFp}`
+  function respondedKey(agentId: string, requestId: string, claimToken: string | undefined, payloadFp: string): string {
+    // The `t:` / `p:` discriminator keeps a token-keyed entry from ever colliding with a
+    // fingerprint-keyed one for the same (agent, request_id).
+    return claimToken
+      ? `${agentId}:${requestId}:t:${claimToken}`
+      : `${agentId}:${requestId}:p:${payloadFp}`
   }
 
   function rememberResponded(key: string) {
@@ -61,7 +77,7 @@ export function createControlStore() {
 
     addRequest(agentId: string, request: ControlRequest) {
       const fp = canonicalJSON(request.payload)
-      if (respondedKeys.has(respondedKey(agentId, request.requestId, fp)))
+      if (respondedKeys.has(respondedKey(agentId, request.requestId, request.claimToken, fp)))
         return
       setState(produce((s) => {
         const list = s.pendingByAgent[agentId] ??= []
@@ -84,11 +100,17 @@ export function createControlStore() {
         list.splice(idx, 1)
       }))
       if (removed)
-        rememberResponded(respondedKey(agentId, requestId, canonicalJSON(removed.payload)))
+        rememberResponded(respondedKey(agentId, requestId, removed.claimToken, canonicalJSON(removed.payload)))
     },
 
     getRequests(agentId: string): ControlRequest[] {
       return state.pendingByAgent[agentId] ?? []
+    },
+
+    // The pending request for (agentId, requestId), or undefined. Used at answer time to recover the
+    // per-instance claimToken to echo back to the worker.
+    getRequest(agentId: string, requestId: string): ControlRequest | undefined {
+      return state.pendingByAgent[agentId]?.find(r => r.requestId === requestId)
     },
 
     clearAgent(agentId: string) {

--- a/frontend/src/utils/controlResponse.test.ts
+++ b/frontend/src/utils/controlResponse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildDenyResponse, CONTROL_REJECTED_BY_USER_MESSAGE } from './controlResponse'
+import { buildDenyResponse, CONTROL_REJECTED_BY_USER_MESSAGE, decodeControlBehaviorEnvelope, decodeControlResponseBehavior, normalizeRejectionMessage } from './controlResponse'
 
 // Reach the deny reason nested in the control_response envelope:
 // { response: { response: { behavior, message } } }.
@@ -34,5 +34,43 @@ describe('builddenyresponse', () => {
     // -- if it drifts, the backend can no longer collapse a bare deny and the "Rejected by user."
     // placeholder leaks into the transcript/rail as if it were typed feedback.
     expect(CONTROL_REJECTED_BY_USER_MESSAGE).toBe('Rejected by user.')
+  })
+})
+
+describe('normalizerejectionmessage', () => {
+  it('trims a typed reason and collapses the sentinel to ""', () => {
+    expect(normalizeRejectionMessage('  looks unsafe  ')).toBe('looks unsafe')
+    expect(normalizeRejectionMessage(CONTROL_REJECTED_BY_USER_MESSAGE)).toBe('')
+    expect(normalizeRejectionMessage(`  ${CONTROL_REJECTED_BY_USER_MESSAGE}  `)).toBe('')
+    expect(normalizeRejectionMessage('   ')).toBe('')
+  })
+})
+
+describe('decodecontrolbehaviorenvelope', () => {
+  it('decodes an allow envelope with the request id', () => {
+    expect(decodeControlBehaviorEnvelope({ response: { request_id: ' r ', response: { behavior: ' allow ' } } }))
+      .toEqual({ requestId: 'r', behavior: 'allow', message: '' })
+  })
+
+  it('decodes a deny envelope with a typed reason', () => {
+    expect(decodeControlBehaviorEnvelope({ response: { request_id: 'r', response: { behavior: 'deny', message: '  not this way  ' } } }))
+      .toEqual({ requestId: 'r', behavior: 'deny', message: 'not this way' })
+  })
+
+  it('collapses the sentinel message of a bare deny', () => {
+    expect(decodeControlBehaviorEnvelope({ response: { response: { behavior: 'deny', message: CONTROL_REJECTED_BY_USER_MESSAGE } } }))
+      .toEqual({ requestId: '', behavior: 'deny', message: '' })
+  })
+
+  it('returns null for a non-envelope (e.g. a JSON-RPC decision) or an unrecognized behavior', () => {
+    expect(decodeControlBehaviorEnvelope({ result: { decision: 'accept' } })).toBeNull()
+    expect(decodeControlBehaviorEnvelope({ response: { response: { behavior: 'maybe' } } })).toBeNull()
+    expect(decodeControlBehaviorEnvelope('nope')).toBeNull()
+  })
+
+  it('is the shared reader behind the byte-oriented decodeControlResponseBehavior', () => {
+    const bytes = new TextEncoder().encode(JSON.stringify({ response: { request_id: 'r', response: { behavior: 'deny', message: 'x' } } }))
+    expect(decodeControlResponseBehavior(bytes)).toBe('deny')
+    expect(decodeControlResponseBehavior(new TextEncoder().encode('not json'))).toBeNull()
   })
 })

--- a/frontend/src/utils/controlResponse.ts
+++ b/frontend/src/utils/controlResponse.ts
@@ -1,3 +1,5 @@
+import { isObject, pickString } from '~/lib/jsonPick'
+
 /** Extract the tool_name from a control_request payload */
 export function getToolName(payload: Record<string, unknown>): string {
   const request = payload.request as Record<string, unknown> | undefined
@@ -68,6 +70,44 @@ export function buildDenyResponse(
 }
 
 /**
+ * Trim a control-response reject reason and collapse the
+ * {@link CONTROL_REJECTED_BY_USER_MESSAGE} placeholder (the auto-filled "declined without a
+ * reason" text) to "". Mirrors the backend's `NormalizeRejectionMessage` so a bare deny reads
+ * as "Rejected" on both sides instead of leaking the placeholder as typed feedback.
+ */
+export function normalizeRejectionMessage(message: string): string {
+  const trimmed = message.trim()
+  return trimmed === CONTROL_REJECTED_BY_USER_MESSAGE ? '' : trimmed
+}
+
+/**
+ * Decode the neutral approve/reject control-response envelope
+ * (`{response:{request_id, response:{behavior, message}}}`) from an already-parsed OBJECT, the
+ * shape `buildAllowResponse` / `buildDenyResponse` produce and the Claude/Codex-envelope native
+ * response persists. Returns the trimmed request id, behavior, and rejection message (with the
+ * {@link CONTROL_REJECTED_BY_USER_MESSAGE} sentinel collapsed to ""), or null when the object
+ * doesn't carry a recognizable allow/deny behavior. The single home for reading this shape,
+ * shared by the byte-oriented {@link decodeControlResponseBehavior} and the persisted-row
+ * renderer (persistedControlResponse.ts).
+ */
+export function decodeControlBehaviorEnvelope(
+  obj: unknown,
+): { requestId: string, behavior: 'allow' | 'deny', message: string } | null {
+  if (!isObject(obj))
+    return null
+  const outer = isObject(obj.response) ? obj.response : undefined
+  const inner = isObject(outer?.response) ? outer.response as Record<string, unknown> : undefined
+  const behavior = pickString(inner, 'behavior', '').trim()
+  if (behavior !== 'allow' && behavior !== 'deny')
+    return null
+  return {
+    requestId: pickString(outer, 'request_id', '').trim(),
+    behavior,
+    message: normalizeRejectionMessage(pickString(inner, 'message', '')),
+  }
+}
+
+/**
  * Decode the inverse of `buildAllowResponse` / `buildDenyResponse`: a
  * `control_response` envelope's serialized bytes back into its `behavior`.
  * Returns null on any decode failure or when the envelope doesn't carry a
@@ -79,19 +119,14 @@ export function buildDenyResponse(
  * `response.response` themselves.
  */
 export function decodeControlResponseBehavior(content: Uint8Array): 'allow' | 'deny' | null {
-  let parsed: Record<string, unknown>
+  let parsed: unknown
   try {
-    parsed = JSON.parse(new TextDecoder().decode(content)) as Record<string, unknown>
+    parsed = JSON.parse(new TextDecoder().decode(content))
   }
   catch {
     return null
   }
-  const outer = parsed.response as Record<string, unknown> | undefined
-  const inner = outer?.response as Record<string, unknown> | undefined
-  const behavior = inner?.behavior
-  if (behavior === 'allow' || behavior === 'deny')
-    return behavior
-  return null
+  return decodeControlBehaviorEnvelope(parsed)?.behavior ?? null
 }
 
 /**

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -480,6 +480,12 @@ message AgentControlRequest {
   string request_id = 2;
   bytes payload = 3;  // Full JSON of the control_request (verbatim)
   AgentProvider agent_provider = 4; // Provider for this agent
+  // claim_token identifies this REQUEST INSTANCE. The worker mints a fresh token per
+  // PersistControlRequest; the frontend echoes it in SendControlResponseRequest so a stale
+  // duplicate answer to a PRIOR instance of a reused request_id (e.g. a Codex/ACP JSON-RPC
+  // counter that reset across a plan-exec restart) cannot re-win the idempotency claim of the
+  // current instance. Empty when the row predates the token (degrades to request_id-only dedup).
+  string claim_token = 5;
 }
 
 // AgentControlCancelRequest is sent when Claude Code cancels a pending control request.
@@ -492,6 +498,11 @@ message AgentControlCancelRequest {
 message SendControlResponseRequest {
   string agent_id = 1;
   bytes content = 2;  // Raw JSON control_response for Claude Code stdin
+  // claim_token is the per-instance token the frontend echoes from the AgentControlRequest it is
+  // answering (see AgentControlRequest.claim_token). The worker keys the idempotency claim on it so
+  // a stale duplicate of a prior instance of a reused request_id cannot re-win. Empty falls back to
+  // request_id-only dedup.
+  string claim_token = 3;
 }
 
 message SendControlResponseResponse {}


### PR DESCRIPTION
## Motivation
Answering a native control request (a permission/decision/question prompt from Claude, Codex, Cursor, OpenCode, Pi, or an ACP-based provider) had two failure modes:

- If the backing `control_requests` row was already gone by the time the answer arrived (resolved elsewhere, cleared on restart, or the request pruned), the answer was dropped instead of persisted.
- There was no idempotency guard on `SendControlResponse`, so an RPC retry or a duplicate client submission could re-persist and re-forward the same answer, and the frontend's recently-responded dedup was keyed on payload fingerprint rather than the specific request instance — so a genuinely new instance re-asking an identical-looking question (same `request_id`, reused after a restart) was silently swallowed as a duplicate.

Separately, control-response label text ("Approved", "Rejected", answer summaries, etc.) was computed server-side per provider (`codexDecisionDisplayText`, `opencodeQuestionAnswersText`, `cursorQuestionAnswersText`, `piExtensionUIResponseDisplayText`, `acpPermissionResponseDisplayText`, and friends). This duplicated each provider's wire format in backend Go, drifted from the frontend's own rendering, and violated the project's `frontend-owns-message-extraction` convention.

Closes #258.

## Modifications
**Backend idempotency and persistence**
- Added a durable `control_response_answers` table keyed on `(agent_id, request_id, claim_token)`. `processControlResponse` (extracted from `SendControlResponse`, now thin RPC transport) does an atomic INSERT that picks exactly one winner; a duplicate answer is a deduped no-op — no re-persist, no re-forward, no re-restart. The claim survives subprocess/worker-process restarts and fails **open** on a DB error (a dropped answer is worse than an occasional duplicate).
- `OutputSink.PersistControlRequest` now mints and returns a per-instance `claim_token`; `BroadcastControlRequest` takes that same token so the persisted row and the live broadcast never disagree. The token round-trips through proto (`AgentControlRequest.claim_token = 5`, `SendControlResponseRequest.claim_token = 3`) so the frontend can echo back the exact instance it answered.
- `buildControlResponsePlan` normalizes the frontend's control-response envelope once at construction, so behavior/rejection-message reads and the plan-mode request-id match can no longer disagree.

**Backend label removal**
- `ControlResponseResolution.DisplayText` is replaced by a provider-pruned `RequestContext json.RawMessage` snapshot (permission option names, question headers/ids, method, tool name) captured before the pending request row is deleted. All per-provider label-formatting helpers are deleted; label text is no longer computed in Go.
- Persistence is unified into a single structured synthetic transcript row (`{isSynthetic, controlResponse:{provider, requestId, request, response}}`) for every non-self-displayed answer, replacing the old two-path persistence. It is `MESSAGE_SOURCE_USER` (a control answer is the user's own response), so it counts toward `HasUserMessages`/resume-session resolution — a session whose only interaction is answering a control request is resumable — and the `isSynthetic` flag, not the source, routes it to the `control_response` renderer.

**Frontend**
- New `persistedControlResponse.ts` defines the `ControlResponseDisplay` union and a never-null `resolveControlResponseDisplay` chokepoint that both the transcript row renderer and the scroll-rail dot preview resolve through, so the dot always reads identically to the row it jumps to.
- `classifyMessage` now classifies `control_response` centrally, once, instead of per plugin; the old `controlResponseRenderer`, the `ControlResponseTag` component, and its CSS are deleted.
- New per-provider `controlResponseDisplay` derivers (Codex JSON-RPC decisions + `requestUserInput` answers, ACP permission options, OpenCode/Kilo questions, Cursor questions/plans, Pi extension-UI responses) derive labels from the always-present native response, so an answer to a since-deleted request still renders correctly.
- `control.store`'s recently-responded dedup is now scoped to the request instance by `claim_token` (falling back to payload fingerprint only when tokenless). `useAgentOperations`/`AgentEditorPanel`/`controlResponseHandling` capture the answered instance's token and thread it through `SendControlResponse`.

Breaking changes: None — this is all internal/pre-release surface (backend `Provider`/`OutputSink` interfaces, DB schema edited in place, no new migration).

## Result
- Closes #258.
- Answering a control request whose backing request row is already gone no longer loses the answer — it is persisted and rendered with a correct label.
- Answering the same request twice (e.g. an RPC retry) now produces exactly one persisted row and forwards exactly once.
- A genuinely new instance re-asking an identical-looking question (same `request_id`, new `claim_token`, e.g. after a restart) is shown instead of being silently deduped away.
- Control-response transcript rows and the scroll-rail dot preview render identical, frontend-owned labels for every provider, ending the backend/frontend label drift that previously half-served non-Claude providers.
- Roughly half of the diff is new or updated co-located unit tests (`persistedControlResponse`, per-provider `controlResponseDisplay` derivers, `control.store` instance-scoped dedup, the durable claim's concurrency/fail-open/restart behavior, and USER-source resume-counting); all backend worker tests and `golangci-lint` pass.

Relevant files: `backend/internal/worker/agent/control_response.go`, `backend/internal/worker/service/control_response.go`, `backend/internal/worker/service/output.go`, `backend/internal/worker/service/agent.go`, `backend/internal/worker/db/migrations/00001_initial.sql`, `backend/internal/worker/db/queries/control_response_answers.sql`, `proto/leapmux/v1/agent.proto`, `frontend/src/components/chat/persistedControlResponse.ts`, `frontend/src/components/chat/providers/{codex,acp,opencode,cursor,pi}/`, `frontend/src/stores/control.store.ts`, `frontend/src/components/shell/useAgentOperations.ts`, `frontend/src/utils/controlResponse.ts`.
