### PR TITLE
fix(store): Rebuild keyset pagination on store-owned composite cursors

### DIFF
--- a/backend/cmd/leapmux/admin.go
+++ b/backend/cmd/leapmux/admin.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
@@ -258,37 +257,6 @@ func adminConfig(dataDir string) *config.Config {
 	return cfg
 }
 
-// adminAllUsersLimit caps how many users `collectAcrossUsers` will
-// scan when --user is unset on a list-style admin command. Hub
-// deployments large enough to bump against this should pass --user
-// to narrow the query; we surface the cap here so changes are
-// reviewed in one place.
-const adminAllUsersLimit = 1000
-
-// collectAcrossUsers runs `fetch` once per user in the store when
-// `userID` is empty, otherwise just once for the named user. The
-// per-user results are concatenated in user-listing order. Shared by
-// `api-token list` and `delegation-token list` which both walk every
-// user when --user is unset.
-func collectAcrossUsers[T any](ctx context.Context, st store.Store, userID string, fetch func(uid string) ([]T, error)) ([]T, error) {
-	if userID != "" {
-		return fetch(userID)
-	}
-	users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: adminAllUsersLimit})
-	if err != nil {
-		return nil, err
-	}
-	var rows []T
-	for _, u := range users {
-		batch, err := fetch(u.ID)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, batch...)
-	}
-	return rows, nil
-}
-
 // withAdminConfig creates a flag set with --data-dir, parses args, and
 // calls fn with the resolved config. Use this for commands that need
 // the config but not a database connection.
@@ -332,6 +300,44 @@ func resolveUser(ctx context.Context, st store.Store, userID, username string) (
 		return nil, fmt.Errorf("get user by username: %w", err)
 	}
 	return user, nil
+}
+
+// resolveUserFilter resolves an optional --user-id/--username flag pair into a
+// user-id list filter for the admin listings. Unlike resolveUser (which serves
+// user-mutation commands and therefore sees only live users), the ID path
+// resolves via GetByIDIncludeDeleted: the admin listings deliberately surface
+// soft-deleted owners' still-live rows for audit, so an operator must be able
+// to scope a listing to a soft-deleted user's id (e.g. to enumerate and revoke
+// a compromised account's outstanding tokens). A username resolves among live
+// users only -- usernames are freed for re-registration on soft-delete, so a
+// name is not a stable handle for a deleted account; use the id instead.
+// Returns nil (no filter) when both flags are empty; a nonexistent id or
+// username fails loudly rather than printing an empty table.
+func resolveUserFilter(ctx context.Context, st store.Store, userID, username string) (*string, error) {
+	if userID == "" && username == "" {
+		return nil, nil
+	}
+	if userID != "" && username != "" {
+		return nil, fmt.Errorf("--user-id and --username are mutually exclusive")
+	}
+	if userID != "" {
+		user, err := st.Users().GetByIDIncludeDeleted(ctx, userID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, fmt.Errorf("user not found: %s", userID)
+			}
+			return nil, fmt.Errorf("get user by ID: %w", err)
+		}
+		return &user.ID, nil
+	}
+	user, err := st.Users().GetByUsername(ctx, username)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("user not found: %s", username)
+		}
+		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+	return &user.ID, nil
 }
 
 // friendlyConstraintError translates uniqueness constraint violations
@@ -402,12 +408,69 @@ func printJSON(v any) error {
 	return enc.Encode(v)
 }
 
-// maybePrintNextCursor prints a cursor hint for the next page if the result
-// set is exactly limit items (indicating more pages may exist).
-func maybePrintNextCursor[T any](items []T, limit int64, getTime func(T) time.Time) {
-	if n := int64(len(items)); n > 0 && n == limit {
-		fmt.Printf("\nNext page: --cursor %s\n", getTime(items[n-1]).UTC().Format(time.RFC3339Nano))
+// cursorFlagUsage is the shared --cursor help text for the admin list
+// subcommands; the value is the opaque keyset cursor emitted by
+// maybePrintNextCursor.
+const cursorFlagUsage = "cursor for pagination (opaque; copy from the previous page's output)"
+
+// addListFlags registers the shared --limit/--cursor flag pair every admin
+// list subcommand takes, so a new listing cannot register a divergent default
+// or usage string. validateListLimit still runs per command: it needs the
+// parsed value, which exists only after flag parsing inside the run callback.
+func addListFlags(fs *flag.FlagSet) (limit *int64, cursor *string) {
+	limit = fs.Int64("limit", 50, "maximum number of results")
+	cursor = fs.String("cursor", "", cursorFlagUsage)
+	return limit, cursor
+}
+
+// maybePrintNextCursor prints the cursor hint for the next page when the
+// store reports one. The store owns both the has-more probe and the cursor
+// encoding (see store.NewPage), so the CLI cannot mispair the cursor column
+// or hint at a page that turns out empty. The hint goes to stderr so it never
+// pollutes piped output: stdout stays pure tabular data for `| awk`-style
+// consumers, while an interactive operator still sees the hint.
+func maybePrintNextCursor[T store.PageCursorer](page store.Page[T]) {
+	if page.HasMore() {
+		fmt.Fprintf(os.Stderr, "\nNext page: --cursor %s\n", page.NextCursor)
 	}
+}
+
+// classifyListError maps a store list error to a CLI-friendly message. A
+// malformed or stale --cursor is bad operator input (the store surfaces it
+// wrapped in store.ErrInvalidCursor), not a server fault: return an
+// actionable hint so the operator knows to re-copy the cursor or omit it,
+// rather than an opaque wrapped error that reads like a hub failure. Mirrors
+// the ListWorkers RPC's errors.Is(err, store.ErrInvalidCursor) -> connect.Code
+// InvalidArgument classification in worker_mgmt_service.go.
+func classifyListError(cmd string, err error) error {
+	if errors.Is(err, store.ErrInvalidCursor) {
+		return fmt.Errorf("%s: invalid cursor (pass the --cursor value printed at the end of the previous page, or omit --cursor to start from the first page): %w", cmd, err)
+	}
+	return fmt.Errorf("%s: %w", cmd, err)
+}
+
+// ownerLabel renders a JOINed owner/creator username for the admin listings; a
+// soft-deleted owner surfaces as "(deleted)". The store returns the raw
+// (username, deleted) state -- the placeholder is a presentation decision made
+// here, not in SQL.
+func ownerLabel(username string, deleted bool) string {
+	if deleted {
+		return "(deleted)"
+	}
+	return username
+}
+
+// validateListLimit rejects a non-positive --limit. A paginated store listing
+// treats a limit of 0 (and, after clamping, any negative) as "return no rows"
+// (store.FetchLimit / store.ClampListLimit), so a stray `--limit 0` or
+// `--limit -5` would print an empty listing an operator cannot distinguish
+// from a genuinely empty result. Reject it at the CLI boundary so bad input
+// fails loudly instead of masquerading as "none found".
+func validateListLimit(limit int64) error {
+	if limit <= 0 {
+		return fmt.Errorf("--limit must be a positive number (got %d)", limit)
+	}
+	return nil
 }
 
 // truncate shortens a string to maxLen runes, appending "..." if truncated.

--- a/backend/cmd/leapmux/admin_api_token.go
+++ b/backend/cmd/leapmux/admin_api_token.go
@@ -16,42 +16,68 @@ import (
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
 
-// runAPITokenList prints all api_tokens for a user (or all users when
-// --user is empty).
+// runAPITokenList prints api_tokens through the single keyset-paginated
+// store-level ListAll (a JOINed query carrying each row's owner username).
+// --user-id/--username narrows it to one user via the ByUser query twin, with
+// identical --limit/--cursor behavior on both paths.
 func runAPITokenList(cmd adminCmdCtx, args []string) error {
-	var userID string
+	var userID, username string
 	var clientType string
+	var includeRevoked bool
+	var limit *int64
+	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
-		fs.StringVar(&userID, "user", "", "user id (empty = all users)")
+		fs.StringVar(&userID, "user-id", "", "filter by user ID (soft-deleted users included; empty = all users)")
+		fs.StringVar(&username, "username", "", "filter by username")
 		fs.StringVar(&clientType, "client-type", "", "filter by client type (empty = all)")
+		fs.BoolVar(&includeRevoked, "include-revoked", false, "include revoked tokens (forensics; default lists live tokens only)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		rows, err := collectAcrossUsers(ctx, st, userID, func(uid string) ([]store.APIToken, error) {
-			return st.APITokens().ListByUser(ctx, store.ListAPITokensByUserParams{
-				UserID:     uid,
-				ClientType: clientType,
-			})
-		})
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		userFilter, err := resolveUserFilter(ctx, st, userID, username)
 		if err != nil {
 			return err
 		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "ID\tUSER\tTYPE\tNAME\tCREATED\tLAST USED\tEXPIRES")
-		for _, r := range rows {
-			lastUsed := "-"
-			if r.LastUsedAt != nil {
-				lastUsed = timefmt.Format(*r.LastUsedAt)
-			}
-			expires := "-"
-			if r.ExpiresAt != nil {
-				expires = timefmt.Format(*r.ExpiresAt)
-			}
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				r.ID, r.UserID, r.ClientType, r.ClientName,
-				timefmt.Format(r.CreatedAt), lastUsed, expires)
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{
+			UserID:         userFilter,
+			ClientType:     clientType,
+			PageParams:     store.PageParams{Cursor: *cursor, Limit: *limit},
+			IncludeRevoked: includeRevoked,
+		})
+		if err != nil {
+			return classifyListError("list api tokens", err)
 		}
-		return w.Flush()
+		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "ID\tUSER\tTYPE\tNAME\tCREATED\tLAST USED\tEXPIRES\tREVOKED")
+		for _, t := range page.Rows {
+			writeAPITokenRow(w, t.APIToken, ownerLabel(t.OwnerUsername, t.OwnerDeleted))
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		maybePrintNextCursor(page)
+		return nil
 	})
+}
+
+func writeAPITokenRow(w *tabwriter.Writer, t store.APIToken, userLabel string) {
+	lastUsed := "-"
+	if t.LastUsedAt != nil {
+		lastUsed = timefmt.Format(*t.LastUsedAt)
+	}
+	expires := "-"
+	if t.ExpiresAt != nil {
+		expires = timefmt.Format(*t.ExpiresAt)
+	}
+	revoked := "-"
+	if t.RevokedAt != nil {
+		revoked = timefmt.Format(*t.RevokedAt)
+	}
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		t.ID, userLabel, t.ClientType, t.ClientName,
+		timefmt.Format(t.CreatedAt), lastUsed, expires, revoked)
 }
 
 // runAPITokenIssue mints a new token for the named user. This is the

--- a/backend/cmd/leapmux/admin_delegation_token.go
+++ b/backend/cmd/leapmux/admin_delegation_token.go
@@ -13,28 +13,58 @@ import (
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
 
+// runDelegationTokenList prints delegation tokens through the single
+// keyset-paginated store-level ListAll (a JOINed query carrying each row's
+// owner username). --user-id/--username narrows it to one user via the ByUser
+// query twin, with identical --limit/--cursor behavior on both paths.
 func runDelegationTokenList(cmd adminCmdCtx, args []string) error {
-	var userID string
+	var userID, username string
+	var includeRevoked bool
+	var limit *int64
+	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
-		fs.StringVar(&userID, "user", "", "user id (empty = all users)")
+		fs.StringVar(&userID, "user-id", "", "filter by user ID (soft-deleted users included; empty = all users)")
+		fs.StringVar(&username, "username", "", "filter by username")
+		fs.BoolVar(&includeRevoked, "include-revoked", false, "include revoked tokens (forensics; default lists live tokens only)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		rows, err := collectAcrossUsers(ctx, st, userID, func(uid string) ([]store.DelegationToken, error) {
-			return st.DelegationTokens().ListByUser(ctx, uid)
-		})
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		userFilter, err := resolveUserFilter(ctx, st, userID, username)
 		if err != nil {
 			return err
 		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "ID\tUSER\tWORKER\tWORKSPACE\tAGENT\tTERMINAL\tCREATED\tEXPIRES")
-		for _, r := range rows {
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				r.ID, r.UserID, r.WorkerID, r.WorkspaceID,
-				cmp.Or(r.AgentID, "-"), cmp.Or(r.TerminalID, "-"),
-				timefmt.Format(r.CreatedAt), timefmt.Format(r.ExpiresAt))
+		page, err := st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{
+			UserID:         userFilter,
+			PageParams:     store.PageParams{Cursor: *cursor, Limit: *limit},
+			IncludeRevoked: includeRevoked,
+		})
+		if err != nil {
+			return classifyListError("list delegation tokens", err)
 		}
-		return w.Flush()
+		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "ID\tUSER\tWORKER\tWORKSPACE\tAGENT\tTERMINAL\tCREATED\tEXPIRES\tREVOKED")
+		for _, t := range page.Rows {
+			writeDelegationTokenRow(w, t.DelegationToken, ownerLabel(t.OwnerUsername, t.OwnerDeleted))
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		maybePrintNextCursor(page)
+		return nil
 	})
+}
+
+func writeDelegationTokenRow(w *tabwriter.Writer, t store.DelegationToken, userLabel string) {
+	revoked := "-"
+	if t.RevokedAt != nil {
+		revoked = timefmt.Format(*t.RevokedAt)
+	}
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		t.ID, userLabel, t.WorkerID, t.WorkspaceID,
+		cmp.Or(t.AgentID, "-"), cmp.Or(t.TerminalID, "-"),
+		timefmt.Format(t.CreatedAt), timefmt.Format(t.ExpiresAt), revoked)
 }
 
 // runDelegationTokenRevoke marks a delegation_tokens row revoked.

--- a/backend/cmd/leapmux/admin_session.go
+++ b/backend/cmd/leapmux/admin_session.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 
-	"time"
-
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -17,31 +15,32 @@ func runSessionList(cmd adminCmdCtx, args []string) error {
 	var limit *int64
 	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
-		limit = fs.Int64("limit", 50, "maximum number of results")
-		cursor = fs.String("cursor", "", "pagination cursor (last_active_at from previous page)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Cursor: *cursor,
-			Limit:  *limit,
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Cursor: *cursor, Limit: *limit},
 		})
 		if err != nil {
-			return fmt.Errorf("list sessions: %w", err)
+			return classifyListError("list sessions", err)
 		}
 
-		if len(sessions) == 0 {
+		if len(page.Rows) == 0 {
 			fmt.Println("No active sessions.")
 			return nil
 		}
 
 		fmt.Printf("%-48s %-48s %-20s %-24s %-24s %-16s %s\n", "ID", "USER_ID", "USERNAME", "LAST_ACTIVE", "EXPIRES", "IP", "USER_AGENT")
-		for _, s := range sessions {
+		for _, s := range page.Rows {
 			fmt.Printf("%-48s %-48s %-20s %-24s %-24s %-16s %s\n",
-				s.ID, s.UserID, s.Username,
+				s.ID, s.UserID, ownerLabel(s.Username, s.UserDeleted),
 				timefmt.Format(s.LastActiveAt), timefmt.Format(s.ExpiresAt),
 				s.IPAddress, truncate(s.UserAgent, 60))
 		}
 
-		maybePrintNextCursor(sessions, *limit, func(s store.ActiveSession) time.Time { return s.LastActiveAt })
+		maybePrintNextCursor(page)
 		return nil
 	})
 }

--- a/backend/cmd/leapmux/admin_test.go
+++ b/backend/cmd/leapmux/admin_test.go
@@ -55,6 +55,16 @@ func openTestDB(t *testing.T, dir string) (*sql.DB, *gendb.Queries) {
 	return sqlDB, gendb.New(sqlDB)
 }
 
+// listSessions returns every live session row for userID via the paginated
+// generated query, using one oversized page: these CLI tests assert only on
+// membership, not paging behavior.
+func listSessions(t *testing.T, q *gendb.Queries, userID string) []gendb.UserSession {
+	t.Helper()
+	sessions, err := q.ListUserSessionsByUserID(context.Background(), gendb.ListUserSessionsByUserIDParams{UserID: userID, Limit: 1000})
+	require.NoError(t, err)
+	return sessions
+}
+
 // createTestUser creates a user via runUserCreate and returns the user from DB.
 // Uses a fixed password "TestPassword1!" to minimize Argon2id hashing calls.
 func createTestUser(t *testing.T, dir, username string) gendb.User {
@@ -552,11 +562,14 @@ func TestCLI_UserList_WithQuery(t *testing.T) {
 	createTestUser(t, dir, "bob")
 	createTestUser(t, dir, "alicia")
 
-	// Search for "ali" should match alice and alicia.
+	// Search for "ali" should match alice and alicia. The generated query
+	// takes the COMPLETE LIKE pattern (store.SearchLikePattern builds it:
+	// fold + metachar escape + trailing '%'), so build it the same way here.
 	_, q := openTestDB(t, dir)
 
+	term := "ali"
 	users, err := q.SearchUsers(context.Background(), gendb.SearchUsersParams{
-		Query: sql.NullString{String: "ali", Valid: true},
+		Query: sql.NullString{String: *store.SearchLikePattern(&term), Valid: true},
 		Limit: 50,
 	})
 	require.NoError(t, err)
@@ -583,12 +596,13 @@ func TestCLI_UserList_WithLimitAndCursor(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, users, 2)
 
-	// Verify cursor-based pagination works.
-	// The cursor must be passed in the same string format SQLite stores it in.
-	cursor := users[len(users)-1].CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+	// Verify cursor-based pagination works. The generated params take the
+	// cursor timestamp in SQLite's storage format plus the id tiebreaker.
+	last := users[len(users)-1]
 	users2, err := q.ListAllUsers(context.Background(), gendb.ListAllUsersParams{
-		Cursor: cursor,
-		Limit:  10,
+		CursorTime: last.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		CursorID:   sql.NullString{String: last.ID, Valid: true},
+		Limit:      10,
 	})
 	require.NoError(t, err)
 	assert.Len(t, users2, 3)
@@ -755,8 +769,7 @@ func TestCLI_UserResetPassword(t *testing.T) {
 	assert.NotEqual(t, original.PasswordHash, updated.PasswordHash)
 
 	// Verify sessions deleted.
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	assert.Empty(t, sessions)
 }
 
@@ -781,8 +794,7 @@ func TestCLI_UserResetPassword_PreservesOtherUserSessions(t *testing.T) {
 	// Verify bob's session is still there.
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), bob.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, bob.ID)
 	require.Len(t, sessions, 1)
 	assert.Equal(t, bobSessionID, sessions[0].ID)
 }
@@ -1103,6 +1115,182 @@ func TestCLI_SessionList(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestCLI_APITokenList_UserScopedPagination pins the unified token-listing
+// path: --user-id composes with --limit/--cursor through the same
+// keyset-paginated ListAll (ByUser query twin). The old two-branch shape
+// silently ignored both flags under the user filter, so the malformed-cursor
+// assertion below failed against that code; and an unknown --user-id fails
+// loudly instead of printing an empty table.
+func TestCLI_APITokenList_UserScopedPagination(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+
+	require.NoError(t, runAPITokenIssue(testAdminCtx, []string{
+		"--user", alice.ID, "--client-name", "t1", "--data-dir", dir}))
+	require.NoError(t, runAPITokenIssue(testAdminCtx, []string{
+		"--user", alice.ID, "--client-name", "t2", "--data-dir", dir}))
+
+	// --user-id + --limit are both honored on the unified path.
+	require.NoError(t, runAPITokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--limit", "1", "--data-dir", dir}))
+
+	// A malformed --cursor classifies as operator input error on the --user-id
+	// path too — proving the cursor is parsed there, not silently dropped.
+	err := runAPITokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--cursor", "not-a-cursor", "--data-dir", dir})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrInvalidCursor)
+
+	// Unknown user id fails loudly (the fail-loud contract shared with
+	// `user get` / `user delete`), not empty-table-exit-0.
+	err = runAPITokenList(testAdminCtx, []string{
+		"--user-id", "no-such-user", "--data-dir", dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+
+	// --username resolves the same filter; --user-id and --username together
+	// are rejected as ambiguous.
+	require.NoError(t, runAPITokenList(testAdminCtx, []string{
+		"--username", "alice", "--data-dir", dir}))
+	err = runAPITokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--username", "alice", "--data-dir", dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestCLI_DelegationTokenList_UserScopedCursorHonored is the delegation twin
+// of the malformed-cursor pin above: --cursor must be parsed on the --user
+// path (the old branch ignored it and returned success).
+func TestCLI_DelegationTokenList_UserScopedCursorHonored(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+
+	err := runDelegationTokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--cursor", "not-a-cursor", "--data-dir", dir})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrInvalidCursor)
+}
+
+// TestCLI_TokenList_SoftDeletedUserScope pins the audit path the token
+// listings' LEFT JOIN exists for: scoping a listing to a SOFT-DELETED user's
+// id must succeed (an operator enumerating a compromised account's still-live
+// tokens), not fail "user not found" — the list filter resolves via
+// GetByIDIncludeDeleted, unlike the user-mutation commands' live-only lookup.
+func TestCLI_TokenList_SoftDeletedUserScope(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+
+	require.NoError(t, runAPITokenIssue(testAdminCtx, []string{
+		"--user", alice.ID, "--client-name", "t1", "--data-dir", dir}))
+	require.NoError(t, runUserDelete(testAdminCtx, []string{
+		"--username", "alice", "--data-dir", dir}))
+
+	require.NoError(t, runAPITokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--data-dir", dir}))
+	require.NoError(t, runDelegationTokenList(testAdminCtx, []string{
+		"--user-id", alice.ID, "--data-dir", dir}))
+
+	// The freed username no longer resolves — a username is not a stable
+	// handle for a deleted account (it can be re-registered); the id is.
+	err := runAPITokenList(testAdminCtx, []string{
+		"--username", "alice", "--data-dir", dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+// TestCLI_APITokenList_IncludeRevoked pins the forensics opt-in: after a
+// revoke, --include-revoked lists without error, alone and composed with
+// --user-id (exercising both IncludingRevoked query twins of the 2x2
+// dispatch).
+func TestCLI_APITokenList_IncludeRevoked(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+
+	require.NoError(t, runAPITokenIssue(testAdminCtx, []string{
+		"--user", alice.ID, "--client-name", "t1", "--data-dir", dir}))
+
+	// The mint prints the bearer once and never again; recover the row id
+	// from the DB to drive the revoke.
+	_, q := openTestDB(t, dir)
+	tokens, err := q.ListAPITokensByUser(context.Background(), gendb.ListAPITokensByUserParams{
+		UserID:     alice.ID,
+		ClientType: "",
+	})
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+
+	require.NoError(t, runAPITokenRevoke(testAdminCtx, []string{
+		"--id", tokens[0].ID, "--data-dir", dir}))
+
+	// The forensics listing succeeds on the all-users path...
+	require.NoError(t, runAPITokenList(testAdminCtx, []string{
+		"--include-revoked", "--data-dir", dir}))
+	// ...and composed with --user-id (the ByUserIncludingRevoked twin).
+	require.NoError(t, runAPITokenList(testAdminCtx, []string{
+		"--include-revoked", "--user-id", alice.ID, "--data-dir", dir}))
+}
+
+// TestCLI_DelegationTokenList_IncludeRevoked pins the delegation twin's
+// --include-revoked flag wiring through both IncludingRevoked query paths.
+// Delegation tokens are worker-minted, so no CLI issue path exists to seed a
+// revoked row here; the row-level forensics semantics are pinned cross-dialect
+// by the storetest include-revoked subtests. This exercises the flag, the 2x2
+// dispatch, and the generated queries end-to-end.
+func TestCLI_DelegationTokenList_IncludeRevoked(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+
+	require.NoError(t, runDelegationTokenList(testAdminCtx, []string{
+		"--include-revoked", "--data-dir", dir}))
+	require.NoError(t, runDelegationTokenList(testAdminCtx, []string{
+		"--include-revoked", "--user-id", alice.ID, "--data-dir", dir}))
+}
+
+// TestOwnerLabel pins the presentation-layer placeholder decision: the store
+// returns raw (username, deleted) state and the CLI alone renders
+// "(deleted)".
+func TestOwnerLabel(t *testing.T) {
+	assert.Equal(t, "alice", ownerLabel("alice", false))
+	assert.Equal(t, "(deleted)", ownerLabel("", true))
+}
+
+// TestCLI_ListCommands_RejectNonPositiveLimit pins the validateListLimit
+// boundary guard: the store's documented `LIMIT 0 -> no rows` semantics mean a
+// stray `--limit 0` / negative limit would print an empty listing
+// indistinguishable from a genuinely empty result, so the CLI must reject it
+// loudly. Two commands cover the shared-helper wiring at distinct call sites.
+func TestCLI_ListCommands_RejectNonPositiveLimit(t *testing.T) {
+	dir := setupTestDataDir(t)
+	for _, lim := range []string{"0", "-5"} {
+		err := runSessionList(testAdminCtx, []string{"--limit", lim, "--data-dir", dir})
+		require.Error(t, err, "session list --limit %s must be rejected", lim)
+		assert.Contains(t, err.Error(), "--limit")
+
+		err = runWorkerList(testAdminCtx, []string{"--limit", lim, "--data-dir", dir})
+		require.Error(t, err, "worker list --limit %s must be rejected", lim)
+		assert.Contains(t, err.Error(), "--limit")
+	}
+}
+
+func TestCLI_SessionList_MalformedCursorIsFriendlyError(t *testing.T) {
+	dir := setupTestDataDir(t)
+	alice := createTestUser(t, dir, "alice")
+	_, q := openTestDB(t, dir)
+	createTestSession(t, q, alice.ID, time.Now().UTC().Add(24*time.Hour))
+
+	// A stale / truncated / hand-edited --cursor is bad operator input, not a
+	// server fault: the store surfaces it wrapped in store.ErrInvalidCursor and
+	// classifyListError turns that into an actionable hint. Assert both the
+	// classification (ErrInvalidCursor reaches the CLI) and the human-readable
+	// hint so the operator-facing message cannot silently regress to an opaque
+	// "list sessions: ..." wrap.
+	err := runSessionList(testAdminCtx, []string{"--cursor", "not-a-valid-cursor", "--data-dir", dir})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrInvalidCursor)
+	assert.Contains(t, err.Error(), "invalid cursor")
+	assert.Contains(t, err.Error(), "--cursor")
+}
+
 func TestCLI_SessionRevoke(t *testing.T) {
 	dir := setupTestDataDir(t)
 	user := createTestUser(t, dir, "alice")
@@ -1115,8 +1303,7 @@ func TestCLI_SessionRevoke(t *testing.T) {
 	// Verify session is gone.
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	assert.Empty(t, sessions)
 }
 
@@ -1132,8 +1319,7 @@ func TestCLI_SessionRevokeUser_ByID(t *testing.T) {
 
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	assert.Empty(t, sessions)
 }
 
@@ -1148,8 +1334,7 @@ func TestCLI_SessionRevokeUser_ByUsername(t *testing.T) {
 
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	assert.Empty(t, sessions)
 }
 
@@ -1169,13 +1354,11 @@ func TestCLI_SessionRevokeUser_PreservesOtherUsers(t *testing.T) {
 	_, q = openTestDB(t, dir)
 
 	// Alice's sessions should be gone.
-	aliceSessions, err := q.ListUserSessionsByUserID(context.Background(), alice.ID)
-	require.NoError(t, err)
+	aliceSessions := listSessions(t, q, alice.ID)
 	assert.Empty(t, aliceSessions)
 
 	// Bob's session should remain.
-	bobSessions, err := q.ListUserSessionsByUserID(context.Background(), bob.ID)
-	require.NoError(t, err)
+	bobSessions := listSessions(t, q, bob.ID)
 	require.Len(t, bobSessions, 1)
 	assert.Equal(t, bobSessionID, bobSessions[0].ID)
 }
@@ -1195,8 +1378,7 @@ func TestCLI_SessionPurgeExpired(t *testing.T) {
 	// Only the active session should remain.
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	require.Len(t, sessions, 1)
 	assert.Equal(t, activeID, sessions[0].ID)
 }
@@ -1233,8 +1415,7 @@ func TestCLI_SessionPurgeExpired_NoneExpired(t *testing.T) {
 	// Session should still be there.
 	_, q = openTestDB(t, dir)
 
-	sessions, err := q.ListUserSessionsByUserID(context.Background(), user.ID)
-	require.NoError(t, err)
+	sessions := listSessions(t, q, user.ID)
 	assert.Len(t, sessions, 1)
 }
 

--- a/backend/cmd/leapmux/admin_user.go
+++ b/backend/cmd/leapmux/admin_user.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/config"
@@ -23,40 +22,40 @@ func runUserList(cmd adminCmdCtx, args []string) error {
 	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
 		query = fs.String("query", "", "search query (matches username, display name, email)")
-		limit = fs.Int64("limit", 50, "maximum number of results")
-		cursor = fs.String("cursor", "", "cursor for pagination (created_at in RFC3339Nano)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		var users []store.User
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		var page store.Page[store.User]
 		var err error
 
 		if *query != "" {
-			users, err = st.Users().Search(ctx, store.SearchUsersParams{
-				Query:  query,
-				Limit:  *limit,
-				Cursor: *cursor,
+			page, err = st.Users().Search(ctx, store.SearchUsersParams{
+				Query:      query,
+				PageParams: store.PageParams{Cursor: *cursor, Limit: *limit},
 			})
 		} else {
-			users, err = st.Users().ListAll(ctx, store.ListAllUsersParams{
-				Limit:  *limit,
-				Cursor: *cursor,
+			page, err = st.Users().ListAll(ctx, store.ListAllUsersParams{
+				PageParams: store.PageParams{Cursor: *cursor, Limit: *limit},
 			})
 		}
 		if err != nil {
-			return fmt.Errorf("list users: %w", err)
+			return classifyListError("list users", err)
 		}
 
-		if len(users) == 0 {
+		if len(page.Rows) == 0 {
 			fmt.Println("No users found.")
 			return nil
 		}
 
 		fmt.Printf("%-48s %-20s %-24s %-30s %-8s %-8s\n", "ID", "USERNAME", "DISPLAY_NAME", "EMAIL", "ADMIN", "CREATED")
-		for _, u := range users {
+		for _, u := range page.Rows {
 			fmt.Printf("%-48s %-20s %-24s %-30s %-8s %-8s\n",
 				u.ID, u.Username, u.DisplayName, u.Email, yesNo(u.IsAdmin), timefmt.Format(u.CreatedAt))
 		}
 
-		maybePrintNextCursor(users, *limit, func(u store.User) time.Time { return u.CreatedAt })
+		maybePrintNextCursor(page)
 		return nil
 	})
 }
@@ -409,31 +408,42 @@ func runUserSetAdmin(cmd adminCmdCtx, args []string, admin bool) error {
 func runUserListSessions(cmd adminCmdCtx, args []string) error {
 	var userID *string
 	var username *string
+	var limit *int64
+	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
 		userID = fs.String("id", "", "user ID")
 		username = fs.String("username", "", "username")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
 		user, err := resolveUser(ctx, st, *userID, *username)
 		if err != nil {
 			return err
 		}
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
+		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
+			UserID:     user.ID,
+			PageParams: store.PageParams{Cursor: *cursor, Limit: *limit},
+		})
 		if err != nil {
-			return fmt.Errorf("list sessions: %w", err)
+			return classifyListError("list sessions", err)
 		}
 
-		if len(sessions) == 0 {
+		if len(page.Rows) == 0 {
 			fmt.Printf("No active sessions for user %q.\n", user.Username)
 			return nil
 		}
 
 		fmt.Printf("%-48s %-24s %-24s %-24s %-16s %s\n", "ID", "CREATED", "LAST_ACTIVE", "EXPIRES", "IP", "USER_AGENT")
-		for _, s := range sessions {
+		for _, s := range page.Rows {
 			fmt.Printf("%-48s %-24s %-24s %-24s %-16s %s\n",
 				s.ID, timefmt.Format(s.CreatedAt), timefmt.Format(s.LastActiveAt),
 				timefmt.Format(s.ExpiresAt), s.IPAddress, truncate(s.UserAgent, 60))
 		}
+
+		maybePrintNextCursor(page)
 		return nil
 	})
 }

--- a/backend/cmd/leapmux/admin_worker.go
+++ b/backend/cmd/leapmux/admin_worker.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"strings"
-	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/config"
@@ -23,22 +22,15 @@ func runWorkerList(cmd adminCmdCtx, args []string) error {
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
 		userID = fs.String("user-id", "", "filter by user ID")
 		username = fs.String("username", "", "filter by username")
-		status = fs.String("status", "active", "filter by status (active, deregistering, deleted, all)")
-		limit = fs.Int64("limit", 50, "maximum number of results")
-		cursor = fs.String("cursor", "", "cursor for pagination (created_at in RFC3339Nano)")
+		status = fs.String("status", "active", "filter by status (active, deregistering, deleted, all); \"all\" lists non-deleted workers of any status (pass --status deleted to surface soft-deleted workers)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		var resolvedUserID *string
-		if *userID != "" {
-			resolvedUserID = userID
-		} else if *username != "" {
-			user, err := st.Users().GetByUsername(ctx, *username)
-			if err != nil {
-				if errors.Is(err, store.ErrNotFound) {
-					return fmt.Errorf("user not found: %s", *username)
-				}
-				return fmt.Errorf("get user: %w", err)
-			}
-			resolvedUserID = &user.ID
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		resolvedUserID, err := resolveUserFilter(ctx, st, *userID, *username)
+		if err != nil {
+			return err
 		}
 
 		allStatuses := *status == "all"
@@ -51,32 +43,31 @@ func runWorkerList(cmd adminCmdCtx, args []string) error {
 			statusVal = &s
 		}
 
-		rows, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			UserID: resolvedUserID,
-			Status: statusVal,
-			Cursor: *cursor,
-			Limit:  *limit,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			UserID:     resolvedUserID,
+			Status:     statusVal,
+			PageParams: store.PageParams{Cursor: *cursor, Limit: *limit},
 		})
 		if err != nil {
-			return fmt.Errorf("list workers: %w", err)
+			return classifyListError("list workers", err)
 		}
 
-		if len(rows) == 0 {
+		if len(page.Rows) == 0 {
 			fmt.Println("No workers found.")
 			return nil
 		}
 
 		fmt.Printf("%-48s %-20s %-16s %-6s %-24s %-24s\n", "ID", "OWNER", "STATUS", "AUTO", "CREATED", "LAST_SEEN")
-		for _, w := range rows {
+		for _, w := range page.Rows {
 			lastSeen := "-"
 			if w.LastSeenAt != nil {
 				lastSeen = timefmt.Format(*w.LastSeenAt)
 			}
 			fmt.Printf("%-48s %-20s %-16s %-6s %-24s %-24s\n",
-				w.ID, w.OwnerUsername, workerStatusString(w.Status), yesNo(w.AutoRegistered), timefmt.Format(w.CreatedAt), lastSeen)
+				w.ID, ownerLabel(w.OwnerUsername, w.OwnerDeleted), workerStatusString(w.Status), yesNo(w.AutoRegistered), timefmt.Format(w.CreatedAt), lastSeen)
 		}
 
-		maybePrintNextCursor(rows, *limit, func(w store.WorkerWithOwner) time.Time { return w.CreatedAt })
+		maybePrintNextCursor(page)
 		return nil
 	})
 }

--- a/backend/cmd/leapmux/admin_worker_regkey.go
+++ b/backend/cmd/leapmux/admin_worker_regkey.go
@@ -17,30 +17,31 @@ func runWorkerRegKeyList(cmd adminCmdCtx, args []string) error {
 	var cursor *string
 	return withAdminStore(cmd, args, func(fs *flag.FlagSet) {
 		includeExpired = fs.Bool("include-expired", false, "include revoked or expired keys (forensics; default shows only live keys)")
-		limit = fs.Int64("limit", 50, "maximum number of results")
-		cursor = fs.String("cursor", "", "cursor for pagination (created_at in RFC3339Nano)")
+		limit, cursor = addListFlags(fs)
 	}, func(ctx context.Context, _ *config.Config, st store.Store) error {
-		rows, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
-			Cursor:         *cursor,
-			Limit:          *limit,
+		if err := validateListLimit(*limit); err != nil {
+			return err
+		}
+		page, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
+			PageParams:     store.PageParams{Cursor: *cursor, Limit: *limit},
 			IncludeExpired: *includeExpired,
 		})
 		if err != nil {
-			return fmt.Errorf("list registration keys: %w", err)
+			return classifyListError("list registration keys", err)
 		}
 
-		if len(rows) == 0 {
+		if len(page.Rows) == 0 {
 			fmt.Println("No registration keys.")
 			return nil
 		}
 
 		fmt.Printf("%-32s %-20s %-24s %-24s\n", "ID", "CREATED_BY", "CREATED", "EXPIRES")
-		for _, r := range rows {
+		for _, r := range page.Rows {
 			fmt.Printf("%-32s %-20s %-24s %-24s\n",
-				r.ID, r.CreatorUsername, timefmt.Format(r.CreatedAt), timefmt.Format(r.ExpiresAt))
+				r.ID, ownerLabel(r.CreatorUsername, r.CreatorDeleted), timefmt.Format(r.CreatedAt), timefmt.Format(r.ExpiresAt))
 		}
 
-		maybePrintNextCursor(rows, *limit, func(r store.WorkerRegistrationKeyWithCreator) time.Time { return r.CreatedAt })
+		maybePrintNextCursor(page)
 		return nil
 	})
 }

--- a/backend/internal/hub/auth/auth_test.go
+++ b/backend/internal/hub/auth/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
@@ -337,8 +338,7 @@ func TestLogin_RejectsOldPasswordRotatedAtTransactionBoundary(t *testing.T) {
 	_, _, _, err = auth.Login(ctx, hooked, "testuser", "password123")
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
-	sessions, listErr := st.Sessions().ListByUserID(ctx, userID)
-	require.NoError(t, listErr)
+	sessions := storetest.ListAllSessions(t, st, userID)
 	assert.Empty(t, sessions)
 }
 
@@ -369,8 +369,7 @@ func TestLogin_AcceptsNewPasswordRotatedAtTransactionBoundary(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, sessionID)
 	assert.Equal(t, userID, user.ID)
-	sessions, listErr := st.Sessions().ListByUserID(ctx, userID)
-	require.NoError(t, listErr)
+	sessions := storetest.ListAllSessions(t, st, userID)
 	require.Len(t, sessions, 1)
 }
 

--- a/backend/internal/hub/bootstrap/bootstrap_test.go
+++ b/backend/internal/hub/bootstrap/bootstrap_test.go
@@ -61,7 +61,7 @@ func TestRun_Idempotent(t *testing.T) {
 	err = bootstrap.Run(ctx, st, true)
 	require.NoError(t, err)
 
-	users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: 100})
+	page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 100}})
 	require.NoError(t, err)
-	assert.Len(t, users, 1)
+	assert.Len(t, page.Rows, 1)
 }

--- a/backend/internal/hub/service/worker_mgmt_service.go
+++ b/backend/internal/hub/service/worker_mgmt_service.go
@@ -265,35 +265,31 @@ func (s *WorkerManagementService) ListWorkers(
 		}
 	}
 
-	workers, err := s.store.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+	page, err := s.store.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 		RegisteredBy: user.ID,
-		Cursor:       cursor,
-		Limit:        limit,
+		PageParams:   store.PageParams{Cursor: cursor, Limit: limit},
 	})
 	if err != nil {
+		// A malformed or stale opaque cursor is bad client input, not a server
+		// fault: the store's cursor decode wraps store.ErrInvalidCursor before
+		// any query runs, and it must surface as 400 InvalidArgument rather
+		// than the 500 Internal that genuine store failures map to.
+		if errors.Is(err, store.ErrInvalidCursor) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	protoWorkers := make([]*leapmuxv1.Worker, len(workers))
-	for i := range workers {
-		protoWorkers[i] = s.workerToProto(&workers[i], user.OrgID)
-	}
-
-	hasMore := int64(len(workers)) == limit
-	var nextCursor string
-	if hasMore {
-		// This single-column created_at cursor can skip rows sharing the last
-		// page's millisecond (the worker list queries lack a unique tiebreaker); a
-		// composite (created_at, id) cursor across the keyset-paginated queries is
-		// tracked in https://github.com/leapmux/leapmux/issues/287.
-		nextCursor = workers[len(workers)-1].CreatedAt.UTC().Format(time.RFC3339Nano)
+	protoWorkers := make([]*leapmuxv1.Worker, len(page.Rows))
+	for i := range page.Rows {
+		protoWorkers[i] = s.workerToProto(&page.Rows[i], user.OrgID)
 	}
 
 	return connect.NewResponse(&leapmuxv1.ListWorkersResponse{
 		Workers: protoWorkers,
 		Page: &leapmuxv1.PageResponse{
-			NextCursor: nextCursor,
-			HasMore:    hasMore,
+			NextCursor: page.NextCursor,
+			HasMore:    page.HasMore(),
 		},
 	}), nil
 }

--- a/backend/internal/hub/service/worker_mgmt_service_test.go
+++ b/backend/internal/hub/service/worker_mgmt_service_test.go
@@ -1,0 +1,48 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/mail"
+	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/testutil"
+)
+
+// TestListWorkers_RejectsMalformedCursor pins the API-boundary contract: a
+// stale (pre-composite-format) or garbled opaque cursor is bad client input
+// and must surface as InvalidArgument (400), not the Internal (500) that
+// genuine store failures map to. The store's cursor decode wraps
+// store.ErrInvalidCursor before any query runs, and ListWorkers classifies
+// the store call's error via errors.Is instead of re-parsing the cursor.
+func TestListWorkers_RejectsMalformedCursor(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	svc := service.NewWorkerManagementService(st, nil, nil, nil, nil, mail.Renderer{}, &config.Config{}, nil)
+	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: "u1", OrgID: "o1"})
+
+	// Missing "_" delimiter -> store.ErrInvalidCursor -> InvalidArgument.
+	_, err := svc.ListWorkers(ctx, connect.NewRequest(&leapmuxv1.ListWorkersRequest{
+		Page: &leapmuxv1.PageRequest{Cursor: "no-underscore-timestamp"},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// An unparseable timestamp half is also bad client input, not a server fault.
+	_, err = svc.ListWorkers(ctx, connect.NewRequest(&leapmuxv1.ListWorkersRequest{
+		Page: &leapmuxv1.PageRequest{Cursor: "not-a-time_abc"},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// The empty first-page cursor stays valid: no error, an empty page, and no
+	// next cursor for a user with no workers.
+	resp, err := svc.ListWorkers(ctx, connect.NewRequest(&leapmuxv1.ListWorkersRequest{}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.GetWorkers())
+	assert.False(t, resp.Msg.GetPage().GetHasMore())
+}

--- a/backend/internal/hub/store/mysql/api_tokens.go
+++ b/backend/internal/hub/store/mysql/api_tokens.go
@@ -72,6 +72,62 @@ func (s *apiTokenStore) ListByUser(ctx context.Context, p store.ListAPITokensByU
 	return store.MapSlice(rows, fromDBAPIToken), nil
 }
 
+// apiTokenWithOwner assembles the JOINed listing row shared by the ListAll and
+// ListAllByUser query twins (mirroring workerWithOwner), so a field addition
+// to APITokenWithOwner edits one site instead of one closure per query.
+func apiTokenWithOwner(t gendb.ApiToken, ownerUsername string, ownerDeleted bool) store.APITokenWithOwner {
+	return store.APITokenWithOwner{APIToken: fromDBAPIToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *apiTokenStore) ListAll(ctx context.Context, p store.ListAllAPITokensParams) (store.Page[store.APITokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see api_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+				return listAllAPITokensByUserIncludingRevokedParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUserIncludingRevoked,
+			func(r gendb.ListAllAPITokensByUserIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserParams, error) {
+				return listAllAPITokensByUserParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUser,
+			func(r gendb.ListAllAPITokensByUserRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+				return listAllAPITokensIncludingRevokedParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensIncludingRevoked,
+			func(r gendb.ListAllAPITokensIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensParams, error) {
+				return listAllAPITokensParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokens,
+			func(r gendb.ListAllAPITokensRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	}
+}
+
 func (s *apiTokenStore) Touch(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.TouchAPIToken(ctx, id))
 }

--- a/backend/internal/hub/store/mysql/convert.go
+++ b/backend/internal/hub/store/mysql/convert.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -37,125 +38,187 @@ func rowsAffected(result sql.Result, err error) (int64, error) {
 	return sqlutil.RowsAffected(result, err, mapErr)
 }
 
-// parseMySQLCursor parses the opaque cursor string into the two positional
-// parameters needed by MySQL queries that use "(? IS NULL OR <col> < ?)".
-// The first return is nil for the first page (making the IS NULL branch true),
-// or the parsed time for subsequent pages. The second return is the same time
-// value for binding to the "<col> < ?" parameter. The cursor column varies
-// by query (created_at, last_active_at, etc.) — it is the caller's
-// responsibility to bind the returns to the correct query parameters.
-func parseMySQLCursor(cursor string) (any, time.Time, error) {
-	t, ok, err := store.ParseCursorTime(cursor)
+// decodeCursorParams decodes the composite list cursor into the two nullable sqlc
+// parameters MySQL's keyset queries bind: the cursor timestamp (truncated to
+// the DATETIME(3) columns' millisecond precision) and the id tiebreaker. An
+// empty cursor (first page) returns the zero values so the queries'
+// "cursor_time IS NULL" branch selects every row. The id comparison collates
+// byte-wise via the table-level COLLATE=utf8mb4_bin declared in the migration.
+//
+// The timestamp is truncated (not rounded) to milliseconds to match the
+// DATETIME(3) columns: the driver serializes a time.Time param with full
+// sub-millisecond digits, and a hand-crafted cursor carrying any would make
+// the "=" tiebreak branch unsatisfiable while "<" still matched the boundary
+// row, re-returning the previous page's tail as duplicates. EncodeCursor
+// produces cursors from DB-scanned rows (already millisecond-quantized), so
+// this is a no-op for real cursors.
+func decodeCursorParams(cursor string) (sql.NullTime, sql.NullString, error) {
+	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return nil, time.Time{}, err
+		return sql.NullTime{}, sql.NullString{}, err
 	}
-	if !ok {
-		return nil, time.Time{}, nil
+	if c == nil {
+		return sql.NullTime{}, sql.NullString{}, nil
 	}
-	return t, t, nil
+	ms := c.Time.Truncate(time.Millisecond)
+	return sql.NullTime{Time: ms, Valid: true}, sql.NullString{String: c.ID, Valid: true}, nil
+}
+
+// withCursor decodes the composite list cursor and applies the dialect's
+// fetch-limit clamp, then hands the decoded values to fill, which assembles
+// the dialect-specific sqlc params struct. Centralizing decodeCursorParams + the
+// error short-circuit + store.FetchLimit (with the int32 cast the MySQL LIMIT
+// column requires) here means a change to the cursor decode, the clamp rule, or
+// the probe-row accounting edits ONE site instead of being copy-pasted across
+// every list builder.
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime sql.NullTime, cursorID sql.NullString, fetchLimit int32) T) (T, error) {
+	cursorTime, cursorID, err := decodeCursorParams(cursor)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return fill(cursorTime, cursorID, int32(store.FetchLimit(limit))), nil
+}
+
+// queryPage forwards to store.QueryPage with this dialect's mapErr bound:
+// every listing in the package routes through it, so the shared
+// build -> query -> NewPage skeleton (and its error wrapping and probe-row
+// accounting) lives once in store instead of drifting per dialect.
+func queryPage[P any, R any, I store.PageCursorer](
+	ctx context.Context,
+	limit int64,
+	build func() (P, error),
+	query func(context.Context, P) ([]R, error),
+	mapRow func(R) I,
+) (store.Page[I], error) {
+	return store.QueryPage(ctx, limit, build, query, mapRow, mapErr)
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	column1, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListAllUsersParams{}, err
-	}
-	return gendb.ListAllUsersParams{
-		Column1:   column1,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllUsersParams {
+		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	column5, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.SearchUsersParams{}, err
-	}
-	return gendb.SearchUsersParams{
-		// Fold the search term the same way the write path folds display_name_folded,
-		// so the plain-LIKE match is case-insensitive (and cross-dialect consistent) for
-		// non-ASCII names. A nil query stays nil (SearchUsers reads it as "no filter").
-		Query:     ptrconv.PtrToNullString(store.FoldSearchQuery(query)),
-		Column5:   column5,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.SearchUsersParams {
+		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
+		// '%') at the one shared site, so the match is case-insensitive and literal
+		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
+		return gendb.SearchUsersParams{
+			Query:      ptrconv.PtrToNullString(store.SearchLikePattern(query)),
+			CursorTime: ct,
+			CursorID:   cid,
+			Limit:      fl,
+		}
+	})
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	column2, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListWorkersByUserIDParams{}, err
-	}
-	return gendb.ListWorkersByUserIDParams{
-		RegisteredBy: registeredBy,
-		Column2:      column2,
-		CreatedAt:    createdAt,
-		Limit:        int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersByUserIDParams {
+		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminAllParams(cursor string, limit int64) (gendb.ListWorkersAdminAllParams, error) {
-	column1, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminAllParams{}, err
-	}
-	return gendb.ListWorkersAdminAllParams{
-		Column1:   column1,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
+// listWorkersAdminParams builds the status=nil, user_id=nil query
+// (ListWorkersAdmin): deleted_at IS NULL, no user filter.
+func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminParams {
+		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
+// listWorkersAdminByUserParams builds the status=nil, user_id=set query
+// (ListWorkersAdminByUser): deleted_at IS NULL + required registered_by.
+func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserParams {
+		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listWorkersAdminByStatusParams builds the status=set, user_id=nil query
+// (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
+// soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	column2, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByStatusParams{
-		Status:    status,
-		Column2:   column2,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByStatusParams {
+		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminByUserParams(userID, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	column2, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserParams{
-		UserID:    userID,
-		Column2:   column2,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
-}
-
-func listWorkersAdminByUserAndStatusParams(userID string, status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	column3, createdAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserAndStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserAndStatusParams{
-		UserID:    userID,
-		Status:    status,
-		Column3:   column3,
-		CreatedAt: createdAt,
-		Limit:     int32(store.ClampListLimit(limit)),
-	}, nil
+// listWorkersAdminByUserAndStatusParams builds the status=set, user_id=set
+// query (ListWorkersAdminByUserAndStatus): required registered_by + status.
+func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
+		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	column1, lastActiveAt, err := parseMySQLCursor(cursor)
-	if err != nil {
-		return gendb.ListAllActiveSessionsParams{}, err
-	}
-	return gendb.ListAllActiveSessionsParams{
-		Column1:      column1,
-		LastActiveAt: lastActiveAt,
-		Limit:        int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllActiveSessionsParams {
+		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListUserSessionsByUserIDParams {
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensParams {
+		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserParams {
+		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
+		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensParams {
+		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserParams {
+		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listRegistrationKeysAdminParams mirrors the other list builders so the
+// registration-key admin listing shares the cursor decode and limit clamp.
+// now is the caller-computed expiry probe (zero NullTime when expired rows are
+// included), passed in so the builder stays a pure function of its arguments.
+func listRegistrationKeysAdminParams(cursor string, limit int64, now sql.NullTime) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListRegistrationKeysAdminParams {
+		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }

--- a/backend/internal/hub/store/mysql/convert_test.go
+++ b/backend/internal/hub/store/mysql/convert_test.go
@@ -1,0 +1,40 @@
+package mysql
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// TestParseCursorTruncatesToMillisecond pins the DATETIME(3) precision
+// contract: the driver serializes a bound time.Time with full sub-millisecond
+// digits, so a hand-crafted cursor carrying any would make the composite
+// predicate's "col = ?" tiebreak branch unsatisfiable (the stored value is
+// millisecond-quantized) while "col < ?" still matched the boundary row --
+// re-returning the previous page's tail as duplicates. decodeCursorParams must
+// therefore quantize the cursor timestamp to the column's precision.
+func TestParseCursorTruncatesToMillisecond(t *testing.T) {
+	sub := time.Date(2026, 7, 20, 12, 34, 56, 123_456_789, time.UTC)
+	want := time.Date(2026, 7, 20, 12, 34, 56, 123_000_000, time.UTC)
+
+	ct, cid, err := decodeCursorParams(store.EncodeCursor(sub, "abc"))
+	require.NoError(t, err)
+	assert.True(t, ct.Valid, "cursor_time must be Valid for a non-empty cursor")
+	assert.True(t, ct.Time.Equal(want), "cursor_time = %v, want %v", ct.Time, want)
+	assert.Equal(t, sql.NullString{String: "abc", Valid: true}, cid)
+}
+
+// TestParseCursorFirstPage pins the empty-cursor contract the queries'
+// "(narg IS NULL OR ...)" first branch relies on: invalid (NULL) cursor fields
+// select every row.
+func TestParseCursorFirstPage(t *testing.T) {
+	ct, cid, err := decodeCursorParams("")
+	require.NoError(t, err)
+	assert.False(t, ct.Valid)
+	assert.False(t, cid.Valid)
+}

--- a/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
@@ -1,7 +1,26 @@
 -- +goose Up
 
--- Use binary collation for case-sensitive string comparison.
--- Username and email case-insensitivity is handled at the application layer.
+-- Binary collation is declared per-table (COLLATE=utf8mb4_bin) so every string
+-- column -- ids and FK columns alike -- collates byte-wise (case-sensitive),
+-- keeping cross-table FK collations consistent. SET NAMES alone cannot do this:
+-- it sets the *session* collation, not the column collation the tables inherit.
+-- Every CREATE TABLE here and in future migrations MUST carry
+-- COLLATE=utf8mb4_bin: a table without it silently inherits the server or
+-- database default (typically case-INsensitive), breaking the byte-wise id
+-- tiebreak ordering and FK collation consistency. This convention is
+-- enforced only by this comment today; a schema test that fails any
+-- CREATE TABLE lacking the suffix is tracked in
+-- https://github.com/leapmux/leapmux/issues/300. The database-level default
+-- is intentionally left to the operator (the app connects to a pre-created
+-- database and owns only its tables).
+-- Username/email/display-name case-insensitivity is handled at the application
+-- layer (NormalizeUsername/NormalizeEmail lowercases on write and lookup).
+--
+-- TEXT/BLOB columns intentionally carry NO DEFAULT, unlike their sqlite/
+-- postgres twins: MySQL only allows the expression form -- DEFAULT ('') --
+-- on TEXT/BLOB, and TiDB (which runs this same migration) rejects that
+-- form outright. Every INSERT must therefore supply these columns
+-- explicitly.
 SET NAMES utf8mb4 COLLATE utf8mb4_bin;
 
 -- Personal organizations: exactly one per user, created with the account,
@@ -13,10 +32,9 @@ CREATE TABLE orgs (
     deleted_at  DATETIME(3),
     -- Generated column for partial unique index emulation
     active_name VARCHAR(255) GENERATED ALWAYS AS (CASE WHEN deleted_at IS NULL THEN name ELSE NULL END) STORED
-);
+) COLLATE=utf8mb4_bin;
 CREATE UNIQUE INDEX idx_orgs_active_name ON orgs(active_name);
 CREATE INDEX idx_orgs_deleted_at ON orgs(deleted_at);
-CREATE INDEX idx_orgs_created_at ON orgs(created_at DESC);
 
 -- Users
 CREATE TABLE users (
@@ -60,19 +78,21 @@ CREATE TABLE users (
     active_username VARCHAR(255) GENERATED ALWAYS AS (CASE WHEN deleted_at IS NULL THEN username ELSE NULL END) STORED,
     active_email    VARCHAR(255) GENERATED ALWAYS AS (CASE WHEN deleted_at IS NULL AND email != '' THEN email ELSE NULL END) STORED,
     FOREIGN KEY (org_id) REFERENCES orgs(id)
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_users_org_id ON users(org_id);
 CREATE UNIQUE INDEX idx_users_active_username ON users(active_username);
 CREATE UNIQUE INDEX idx_users_active_email ON users(active_email);
 CREATE INDEX idx_users_deleted_at ON users(deleted_at);
-CREATE INDEX idx_users_tokens_revoked_at ON users(tokens_revoked_at);
-CREATE INDEX idx_users_created_at ON users(created_at DESC);
+CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC);
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at);
 -- GetFirstAdmin scans for the earliest non-deleted admin (bootstrap path).
--- MySQL has no partial indexes; the composite covers the filter and sort.
-CREATE INDEX idx_users_is_admin ON users(is_admin, created_at);
+-- MySQL has no partial indexes; the composite indexes deleted_at as a key
+-- part (IS NULL is a ref-able key part in MySQL), so the ORDER BY created_at
+-- + LIMIT 1 lands on the first live admin directly instead of walking past
+-- soft-deleted admins as a residual filter.
+CREATE INDEX idx_users_is_admin ON users(is_admin, deleted_at, created_at);
 
 -- Auth sessions
 CREATE TABLE user_sessions (
@@ -85,9 +105,18 @@ CREATE TABLE user_sessions (
     user_agent      TEXT NOT NULL,
     ip_address      VARCHAR(255) NOT NULL DEFAULT '',
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-CREATE INDEX idx_user_sessions_user_id ON user_sessions(user_id);
+) COLLATE=utf8mb4_bin;
+-- Serves the plain user_id lookups (prefix) AND the per-user keyset listing
+-- ListUserSessionsByUserID (user_id =, ORDER BY last_active_at DESC, id DESC),
+-- so that query both seeks and rides the index instead of sorting.
+CREATE INDEX idx_user_sessions_user_last_active ON user_sessions(user_id, last_active_at DESC, id DESC);
 CREATE INDEX idx_user_sessions_expires_at_last_active ON user_sessions(expires_at, last_active_at);
+-- The active-session listing orders by (last_active_at DESC, id DESC) while
+-- filtering expires_at with a range predicate. A range on the leading
+-- expires_at column means the index above can never provide that order (the
+-- engine would top-N sort every page), so the ORDER BY gets its own index and
+-- the expiry check runs as a residual filter during the ordered scan.
+CREATE INDEX idx_user_sessions_last_active ON user_sessions(last_active_at DESC, id DESC);
 
 -- Registered workers
 CREATE TABLE workers (
@@ -106,17 +135,24 @@ CREATE TABLE workers (
     -- accidentally tear down the bundled desktop worker -- it would just
     -- re-register on next launch and the running process would noisily
     -- exit with "invalid auth token" in between.
-    auto_registered TINYINT(1) NOT NULL DEFAULT 0,
+    auto_registered BOOLEAN NOT NULL DEFAULT FALSE,
     deleted_at    DATETIME(3),
     FOREIGN KEY (registered_by) REFERENCES users(id)
-);
-CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC);
+) COLLATE=utf8mb4_bin;
+CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC, id DESC);
 -- Admin status-only listing (ListWorkersAdminByStatus) cannot use the
 -- (registered_by, status, created_at) index because registered_by is the
 -- leading column.
-CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC);
+CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC, id DESC);
+-- Admin per-user listing (ListWorkersAdminByUser: registered_by=?, deleted_at IS
+-- NULL, no status filter). The (registered_by, status, created_at, id) composite
+-- above can't serve this query's ORDER BY because status sits between the
+-- registered_by equality and the created_at sort key. MySQL has no partial
+-- indexes, so deleted_at IS NULL is a residual filter rather than an index
+-- predicate (mirrors idx_workers_created_at below).
+CREATE INDEX idx_workers_registered_by_created ON workers(registered_by, created_at DESC, id DESC);
 CREATE INDEX idx_workers_deleted_at ON workers(deleted_at);
-CREATE INDEX idx_workers_created_at ON workers(created_at DESC);
+CREATE INDEX idx_workers_created_at ON workers(created_at DESC, id DESC);
 
 -- Worker notifications (persistent queue for reliable delivery)
 CREATE TABLE worker_notifications (
@@ -130,7 +166,7 @@ CREATE TABLE worker_notifications (
     created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     delivered_at DATETIME(3),
     FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_worker_notifications_worker_status ON worker_notifications(worker_id, status);
 
 -- Active worker registration keys.
@@ -149,26 +185,10 @@ CREATE TABLE worker_registration_keys (
     created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     expires_at  DATETIME(3) NOT NULL,
     FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_worker_registration_keys_expires_at ON worker_registration_keys(expires_at);
 CREATE INDEX idx_worker_registration_keys_created_by ON worker_registration_keys(created_by);
-CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at);
-
--- Workspaces (hub-owned registry)
-CREATE TABLE workspaces (
-    id            VARCHAR(255) PRIMARY KEY,
-    org_id        VARCHAR(255) NOT NULL,
-    owner_user_id VARCHAR(255) NOT NULL,
-    title         TEXT NOT NULL,
-    is_deleted    BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-    deleted_at    DATETIME(3),
-    FOREIGN KEY (org_id) REFERENCES orgs(id),
-    FOREIGN KEY (owner_user_id) REFERENCES users(id)
-);
-CREATE INDEX idx_workspaces_org_owner ON workspaces(org_id, owner_user_id);
-CREATE INDEX idx_workspaces_owner_user_id ON workspaces(owner_user_id);
-CREATE INDEX idx_workspaces_deleted_at ON workspaces(deleted_at);
+CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at DESC, id DESC);
 
 -- Sidebar sections (per-user organization of sidebar panels)
 CREATE TABLE workspace_sections (
@@ -180,8 +200,24 @@ CREATE TABLE workspace_sections (
     sidebar      INT NOT NULL DEFAULT 1,
     created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_workspace_sections_user_id ON workspace_sections(user_id);
+
+-- Workspaces (hub-owned registry) -- must come before workspace_section_items
+CREATE TABLE workspaces (
+    id            VARCHAR(255) PRIMARY KEY,
+    org_id        VARCHAR(255) NOT NULL,
+    owner_user_id VARCHAR(255) NOT NULL,
+    title         TEXT NOT NULL,
+    is_deleted    BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    deleted_at    DATETIME(3),
+    FOREIGN KEY (org_id) REFERENCES orgs(id),
+    FOREIGN KEY (owner_user_id) REFERENCES users(id)
+) COLLATE=utf8mb4_bin;
+CREATE INDEX idx_workspaces_org_owner ON workspaces(org_id, owner_user_id);
+CREATE INDEX idx_workspaces_owner_user_id ON workspaces(owner_user_id);
+CREATE INDEX idx_workspaces_deleted_at ON workspaces(deleted_at);
 
 -- Workspace-to-section assignments (per-user)
 CREATE TABLE workspace_section_items (
@@ -193,7 +229,7 @@ CREATE TABLE workspace_section_items (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
     FOREIGN KEY (section_id) REFERENCES workspace_sections(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(section_id);
 
 -- See sqlite migration for full rationale on the CRDT schema.
@@ -212,7 +248,7 @@ CREATE TABLE org_op_batches (
     committed_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     PRIMARY KEY (org_id, physical_ms, logical, origin_client),
     FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE UNIQUE INDEX idx_org_op_batches_dedup ON org_op_batches(org_id, batch_id);
 
 CREATE TABLE org_state (
@@ -223,7 +259,7 @@ CREATE TABLE org_state (
     updated_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     PRIMARY KEY (org_id),
     FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 
 CREATE TABLE workspace_tab_owned (
     org_id       VARCHAR(255) NOT NULL,
@@ -235,7 +271,7 @@ CREATE TABLE workspace_tab_owned (
     position     TEXT NOT NULL,
     PRIMARY KEY (org_id, tab_id),
     FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_workspace_tab_owned_worker    ON workspace_tab_owned(worker_id);
 CREATE INDEX idx_workspace_tab_owned_workspace ON workspace_tab_owned(workspace_id);
 
@@ -249,7 +285,7 @@ CREATE TABLE workspace_tab_rendered (
     position     TEXT NOT NULL,
     PRIMARY KEY (org_id, tab_id),
     FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_workspace_tab_rendered_workspace ON workspace_tab_rendered(workspace_id);
 -- LocateAccessibleRenderedTab filters on tab_id alone; the PK has tab_id
 -- as the trailing column so it is not seekable.
@@ -268,7 +304,7 @@ CREATE TABLE org_recent_batch_ids (
     expires_at            DATETIME(6) NOT NULL,
     PRIMARY KEY (org_id, batch_id),
     FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_org_recent_batch_ids_expires ON org_recent_batch_ids(expires_at);
 
 CREATE TABLE lifecycle_outbox (
@@ -279,7 +315,7 @@ CREATE TABLE lifecycle_outbox (
     enqueued_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     consumed_at DATETIME(6),
     FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_lifecycle_outbox_pending ON lifecycle_outbox(org_id, id);
 
 CREATE TABLE revocation_events (
@@ -292,15 +328,15 @@ CREATE TABLE revocation_events (
     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     seq BIGINT UNIQUE CHECK (seq IS NULL OR seq > 0),
     published_at DATETIME(6),
-    CHECK ((seq IS NULL AND published_at IS NULL) OR (seq IS NOT NULL AND published_at IS NOT NULL))
-);
+    CHECK ((seq IS NULL) = (published_at IS NULL))
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_revocation_events_pending ON revocation_events(seq, created_at, id);
 CREATE INDEX idx_revocation_events_published ON revocation_events(published_at, seq);
 
 CREATE TABLE revocation_event_sequence (
     id       INT PRIMARY KEY CHECK (id = 1),
     last_seq BIGINT NOT NULL CHECK (last_seq >= 0)
-);
+) COLLATE=utf8mb4_bin;
 INSERT INTO revocation_event_sequence (id, last_seq) VALUES (1, 0);
 
 CREATE TABLE hub_runtime_lease (
@@ -308,7 +344,7 @@ CREATE TABLE hub_runtime_lease (
     holder_id        VARCHAR(64) NOT NULL CHECK (holder_id <> ''),
     cursor_seq       BIGINT NOT NULL CHECK (cursor_seq >= 0),
     lease_expires_at DATETIME(6) NOT NULL
-);
+) COLLATE=utf8mb4_bin;
 
 -- See sqlite migration for full rationale on api_tokens.
 CREATE TABLE api_tokens (
@@ -329,10 +365,19 @@ CREATE TABLE api_tokens (
     refresh_expires_at            DATETIME(3),
     revoked_at                    DATETIME(3),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-CREATE INDEX idx_api_tokens_user ON api_tokens(user_id, client_type);
-CREATE INDEX idx_api_tokens_expires_at ON api_tokens(expires_at);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_api_tokens_revoked_at ON api_tokens(revoked_at);
+-- Keyset index for the admin ListAllAPITokens listing. MySQL has no partial
+-- indexes, so revoked_at IS NULL stays a residual filter; the (created_at DESC,
+-- id DESC) shape still lets the composite ORDER BY ride the index.
+CREATE INDEX idx_api_tokens_created_at ON api_tokens(created_at DESC, id DESC);
+-- Keyset index for the admin ListAllAPITokensByUser listing (the --user-id
+-- path): the leading user_id equality seeks, and (created_at DESC, id DESC)
+-- rides the composite ORDER BY. Plain (no partial indexes in MySQL);
+-- revoked_at IS NULL stays a residual filter. Mirrors
+-- idx_workers_registered_by_created. Its leftmost user_id prefix also
+-- enforces the user_id FK (no separate user_id index).
+CREATE INDEX idx_api_tokens_user_created ON api_tokens(user_id, created_at DESC, id DESC);
 
 CREATE TABLE delegation_tokens (
     id                            VARCHAR(255) PRIMARY KEY,
@@ -354,25 +399,35 @@ CREATE TABLE delegation_tokens (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (worker_id) REFERENCES workers(id) ON DELETE CASCADE,
     FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
-);
-CREATE INDEX idx_delegation_tokens_user ON delegation_tokens(user_id);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_delegation_tokens_worker_agent ON delegation_tokens(worker_id, agent_id);
 CREATE INDEX idx_delegation_tokens_workspace ON delegation_tokens(workspace_id);
 CREATE INDEX idx_delegation_tokens_revoked_at ON delegation_tokens(revoked_at);
+-- Keyset index for the admin ListAllDelegationTokens listing (see
+-- idx_api_tokens_created_at for the rationale).
+CREATE INDEX idx_delegation_tokens_created_at ON delegation_tokens(created_at DESC, id DESC);
+-- Per-user keyset twin (see idx_api_tokens_user_created). Its leftmost
+-- user_id prefix also enforces the user_id FK (no separate user_id index).
+CREATE INDEX idx_delegation_tokens_user_created ON delegation_tokens(user_id, created_at DESC, id DESC);
+-- Serves the hourly DeleteExpiredDelegationTokensBefore sweep of this
+-- high-churn table: seek the expired live rows instead of scanning every
+-- live token. Plain (no partial indexes in MySQL); revoked_at IS NULL is a
+-- residual filter.
+CREATE INDEX idx_delegation_tokens_expires_at ON delegation_tokens(expires_at);
 
 CREATE TABLE device_authorizations (
     device_code           VARCHAR(255) PRIMARY KEY,
     user_code             VARCHAR(64) NOT NULL UNIQUE,
     device_name           VARCHAR(255) NOT NULL DEFAULT '',
     user_id               VARCHAR(255),
-    approved              INT NOT NULL DEFAULT 0,
+    approved              INT NOT NULL DEFAULT 0,        -- 0 pending, 1 approved, 2 denied
     last_polled_at        DATETIME(3),
     interval_seconds      INT NOT NULL DEFAULT 5,
     created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     expires_at            DATETIME(3) NOT NULL,
     consumed_at           DATETIME(3),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_device_authorizations_expires_at ON device_authorizations(expires_at);
 
 CREATE TABLE cli_authorization_codes (
@@ -384,7 +439,7 @@ CREATE TABLE cli_authorization_codes (
     expires_at            DATETIME(3) NOT NULL,
     consumed_at           DATETIME(3),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_cli_authorization_codes_expires_at ON cli_authorization_codes(expires_at);
 
 -- OAuth identity providers (admin-configured)
@@ -399,7 +454,7 @@ CREATE TABLE oauth_providers (
     trust_email     BOOLEAN NOT NULL DEFAULT TRUE,
     enabled         BOOLEAN NOT NULL DEFAULT TRUE,
     created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
-);
+) COLLATE=utf8mb4_bin;
 
 -- Links between local users and OAuth provider identities
 CREATE TABLE oauth_user_links (
@@ -410,7 +465,7 @@ CREATE TABLE oauth_user_links (
     PRIMARY KEY (user_id, provider_id),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (provider_id) REFERENCES oauth_providers(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE UNIQUE INDEX idx_oauth_user_links_provider_subject ON oauth_user_links(provider_id, provider_subject);
 
 -- Encrypted OAuth tokens per user per provider
@@ -426,7 +481,7 @@ CREATE TABLE oauth_tokens (
     PRIMARY KEY (user_id, provider_id),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (provider_id) REFERENCES oauth_providers(id) ON DELETE CASCADE
-);
+) COLLATE=utf8mb4_bin;
 CREATE INDEX idx_oauth_tokens_provider_id ON oauth_tokens(provider_id);
 CREATE INDEX idx_oauth_tokens_expires_at ON oauth_tokens(expires_at);
 CREATE INDEX idx_oauth_tokens_key_version ON oauth_tokens(key_version);
@@ -440,7 +495,7 @@ CREATE TABLE oauth_states (
     expires_at      DATETIME(3) NOT NULL,
     created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     FOREIGN KEY (provider_id) REFERENCES oauth_providers(id)
-);
+) COLLATE=utf8mb4_bin;
 
 -- Pending OAuth signups (new users choosing their username)
 CREATE TABLE pending_oauth_signups (
@@ -458,7 +513,7 @@ CREATE TABLE pending_oauth_signups (
     expires_at       DATETIME(3) NOT NULL,
     created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     FOREIGN KEY (provider_id) REFERENCES oauth_providers(id)
-);
+) COLLATE=utf8mb4_bin;
 
 -- +goose Down
 DROP TABLE IF EXISTS cli_authorization_codes;

--- a/backend/internal/hub/store/mysql/db/queries/api_tokens.sql
+++ b/backend/internal/hub/store/mysql/db/queries/api_tokens.sql
@@ -25,6 +25,56 @@ WHERE user_id = ?
   AND revoked_at IS NULL
 ORDER BY created_at DESC;
 
+-- name: ListAllAPITokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllAPITokensIncludingRevoked :many
+-- Forensics variant of ListAllAPITokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllAPITokensByUser :many
+-- Per-user variant of ListAllAPITokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllAPITokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllAPITokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllAPITokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
 -- name: TouchAPIToken :exec
 UPDATE api_tokens
 SET last_used_at = NOW(3)

--- a/backend/internal/hub/store/mysql/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/mysql/db/queries/delegation_tokens.sql
@@ -22,10 +22,51 @@ INSERT INTO delegation_tokens (
 -- name: GetDelegationTokenByID :one
 SELECT * FROM delegation_tokens WHERE id = ?;
 
--- name: ListDelegationTokensByUser :many
-SELECT * FROM delegation_tokens
-WHERE user_id = ? AND revoked_at IS NULL
-ORDER BY created_at DESC;
+-- name: ListAllDelegationTokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllDelegationTokensIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllDelegationTokensByUser :many
+-- Per-user variant of ListAllDelegationTokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
+
+-- name: ListAllDelegationTokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllDelegationTokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL OR t.created_at < sqlc.narg(cursor_time) OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT ?;
 
 -- name: ListActiveDelegationTokensByUser :many
 SELECT * FROM delegation_tokens

--- a/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
@@ -53,15 +53,16 @@ DELETE FROM user_sessions WHERE user_id = ? AND id != ?;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = ? AND expires_at > NOW(3)
-ORDER BY last_active_at DESC
-LIMIT 1000;
+WHERE user_id = sqlc.arg(user_id) AND expires_at > NOW(3)
+  AND (sqlc.narg(cursor_time) IS NULL OR last_active_at < sqlc.narg(cursor_time) OR (last_active_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY last_active_at DESC, id DESC
+LIMIT ?;
 
 -- name: ListAllActiveSessions :many
-SELECT s.id, s.user_id, u.username, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
+SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, (u.id IS NULL) AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
-JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
+LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
 WHERE s.expires_at > NOW(3)
-  AND (? IS NULL OR s.last_active_at < ?)
-ORDER BY s.last_active_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL OR s.last_active_at < sqlc.narg(cursor_time) OR (s.last_active_at = sqlc.narg(cursor_time) AND s.id < sqlc.narg(cursor_id)))
+ORDER BY s.last_active_at DESC, s.id DESC
 LIMIT ?;

--- a/backend/internal/hub/store/mysql/db/queries/users.sql
+++ b/backend/internal/hub/store/mysql/db/queries/users.sql
@@ -47,8 +47,8 @@ SELECT EXISTS(
 
 -- name: ListAllUsers :many
 SELECT * FROM users WHERE deleted_at IS NULL
-  AND (? IS NULL OR created_at < ?)
-ORDER BY created_at DESC LIMIT ?;
+  AND (sqlc.narg(cursor_time) IS NULL OR created_at < sqlc.narg(cursor_time) OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC LIMIT ?;
 
 -- The query arg is pre-folded (store.FoldSearchText) by the Go glue, and username
 -- and email are already stored lowercased, so a plain LIKE against the pre-folded
@@ -57,12 +57,16 @@ ORDER BY created_at DESC LIMIT ?;
 -- name: SearchUsers :many
 SELECT * FROM users
 WHERE deleted_at IS NULL
+-- The query arg arrives as a complete LIKE prefix pattern built by
+-- store.SearchLikePattern (folded + backslash-escaped + trailing '%');
+-- backslash is MySQL's default LIKE escape character, so the escaped
+-- metacharacters match literally without an ESCAPE clause.
   AND (sqlc.narg(query) IS NULL
-   OR username LIKE CONCAT(sqlc.narg(query), '%')
-   OR display_name_folded LIKE CONCAT(sqlc.narg(query), '%')
-   OR email LIKE CONCAT(sqlc.narg(query), '%'))
-  AND (? IS NULL OR created_at < ?)
-ORDER BY created_at DESC
+   OR username LIKE sqlc.narg(query)
+   OR display_name_folded LIKE sqlc.narg(query)
+   OR email LIKE sqlc.narg(query))
+  AND (sqlc.narg(cursor_time) IS NULL OR created_at < sqlc.narg(cursor_time) OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT ?;
 
 -- name: UpdateUserPassword :exec

--- a/backend/internal/hub/store/mysql/db/queries/worker_registration_keys.sql
+++ b/backend/internal/hub/store/mysql/db/queries/worker_registration_keys.sql
@@ -50,17 +50,20 @@ DELETE FROM worker_registration_keys WHERE id IN (
     ) inner_q
 );
 
--- The first placeholder in each `(? IS NULL OR ...)` pair lets callers opt
--- out of the active-only / cursor filter (mirrors ListWorkersAdmin*; sqlc's
--- MySQL engine rejects narg, hence the doubled positional placeholders).
+-- Both opt-in filters (active-only via `now`, cursor via cursor_time/cursor_id)
+-- use sqlc.narg so a NULL bind selects the "no filter" branch. A repeated narg
+-- reference still compiles to one `?` per occurrence, but sqlc collapses them
+-- onto a single typed Go param field (bound once per placeholder by the
+-- generated code) -- unlike the old hand-doubled `?` pairs, which surfaced as
+-- opaque ColumnN fields the caller had to fill twice.
 -- name: ListRegistrationKeysAdmin :many
 SELECT k.id, k.created_by, k.created_at, k.expires_at,
-       COALESCE(u.username, '(deleted)') AS creator_username
+       COALESCE(u.username, '') AS creator_username, (u.id IS NULL) AS creator_deleted
 FROM worker_registration_keys k
 LEFT JOIN users u ON k.created_by = u.id AND u.deleted_at IS NULL
-WHERE (? IS NULL OR k.expires_at > ?)
-  AND (? IS NULL OR k.created_at < ?)
-ORDER BY k.created_at DESC
+WHERE (sqlc.narg(now) IS NULL OR k.expires_at > sqlc.narg(now))
+  AND (sqlc.narg(cursor_time) IS NULL OR k.created_at < sqlc.narg(cursor_time) OR (k.created_at = sqlc.narg(cursor_time) AND k.id < sqlc.narg(cursor_id)))
+ORDER BY k.created_at DESC, k.id DESC
 LIMIT ?;
 
 -- name: AdminSoftDeleteRegistrationKey :execresult

--- a/backend/internal/hub/store/mysql/db/queries/workers.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workers.sql
@@ -14,8 +14,8 @@ SELECT * FROM workers WHERE auth_token = ? AND status != 3;
 -- name: ListWorkersByUserID :many
 SELECT * FROM workers
 WHERE registered_by = sqlc.arg(registered_by) AND status = 1
-  AND (? IS NULL OR created_at < ?)
-ORDER BY created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL OR created_at < sqlc.narg(cursor_time) OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT ?;
 
 -- name: GetOwnedWorker :one
@@ -48,40 +48,69 @@ UPDATE workers SET public_key = ?, mlkem_public_key = ?, slhdsa_public_key = ? W
 -- name: GetWorkerPublicKey :one
 SELECT public_key, mlkem_public_key, slhdsa_public_key FROM workers WHERE id = ? AND deleted_at IS NULL;
 
--- name: ListWorkersAdminAll :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+-- The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+-- nil/set), implemented as FOUR separate queries. The user_id dimension cannot
+-- be an opt-in `(? IS NULL OR registered_by = ?)` probe: the doubled
+-- placeholders produced opaque ColumnN param names and required binding the
+-- user_id twice. Splitting user_id into its own REQUIRED-equality query
+-- (sqlc.arg) yields a single typed param per query. The status dimension stays
+-- split: status=nil keeps `deleted_at IS NULL`; status=set drops it so status=3
+-- can surface soft-deleted rows. MySQL has no partial indexes, so deleted_at IS
+-- NULL is a residual either way, but the split lets each half ride its
+-- leading-column index (created_at vs status). sqlc's MySQL engine supports
+-- sqlc.narg: a repeated narg reference still compiles to one `?` per
+-- occurrence, but all of them are fed from a single typed Go param field by
+-- the generated code, so the cursor predicate uses narg rather than the old
+-- hand-doubled `?` pairs with their opaque ColumnN fields.
+
+-- ListWorkersAdmin: status=nil, user_id=nil.
+-- name: ListWorkersAdmin :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.deleted_at IS NULL
-  AND (? IS NULL OR w.created_at < ?)
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT ?;
 
+-- ListWorkersAdminByUser: status=nil, user_id=set.
+-- name: ListWorkersAdminByUser :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
+FROM workers w
+LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
+WHERE w.deleted_at IS NULL
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
+LIMIT ?;
+
+-- ListWorkersAdminByStatus: status=set, user_id=nil.
 -- name: ListWorkersAdminByStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.status = sqlc.arg(status)
-  AND (? IS NULL OR w.created_at < ?)
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT ?;
 
--- name: ListWorkersAdminByUser :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
-FROM workers w
-LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.deleted_at IS NULL
-  AND (? IS NULL OR w.created_at < ?)
-ORDER BY w.created_at DESC
-LIMIT ?;
-
+-- ListWorkersAdminByUserAndStatus: status=set, user_id=set.
 -- name: ListWorkersAdminByUserAndStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.status = sqlc.arg(status)
-  AND (? IS NULL OR w.created_at < ?)
-ORDER BY w.created_at DESC
+WHERE w.status = sqlc.arg(status)
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT ?;
 
 -- name: HardDeleteWorkersBefore :execresult

--- a/backend/internal/hub/store/mysql/db/queries/workspace_section_items.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workspace_section_items.sql
@@ -21,18 +21,17 @@ WHERE user_id = ? AND workspace_id = ?;
 -- Without the workspace_id tiebreaker the planner flips their
 -- relative order across refreshes.
 --
--- BINARY cast pins the tiebreaker to byte-wise (case-sensitive)
--- ordering. MySQL's default `utf8mb4_general_ci` collation is
--- case-INsensitive, so two workspace_ids that differ only in case
--- (e.g. "Foo..." vs "foo...") would sort non-deterministically
--- across runs -- different planner picks land on different orderings,
--- and the storetest tiebreaker-stability test catches it. SQLite and
--- PostgreSQL already collate case-sensitively by default, so they
--- don't need an explicit cast.
+-- The workspace_id tiebreaker is byte-wise (case-sensitive) because every
+-- table is created COLLATE=utf8mb4_bin, so no explicit cast is needed.
+-- MySQL's session default `utf8mb4_general_ci` is case-INsensitive; the
+-- table-level binary collation ensures two workspace_ids differing only in
+-- case still sort deterministically (the storetest tiebreaker-stability
+-- test catches any regression). SQLite and PostgreSQL already collate
+-- case-sensitively by default.
 SELECT wsi.* FROM workspace_section_items wsi
 JOIN workspace_sections ws ON wsi.section_id = ws.id
 WHERE wsi.user_id = ?
-ORDER BY ws.position, wsi.position, BINARY wsi.workspace_id;
+ORDER BY ws.position, wsi.position, wsi.workspace_id;
 
 -- name: DeleteWorkspaceSectionItem :exec
 DELETE FROM workspace_section_items

--- a/backend/internal/hub/store/mysql/db/queries/workspaces.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workspaces.sql
@@ -20,16 +20,17 @@ WHERE id IN (sqlc.slice('workspace_ids'))
 -- refresh -- most reproducibly for fresh accounts whose seed
 -- workspaces land in a batch.
 --
--- BINARY cast on the id tiebreaker pins byte-wise (case-sensitive)
--- ordering. MySQL's default `utf8mb4_general_ci` collation is
--- case-INsensitive, so two ids differing only in case (e.g. "Foo..."
--- vs "foo...") would sort non-deterministically across runs. SQLite
--- and PostgreSQL already collate case-sensitively by default.
+-- The id tiebreaker is byte-wise (case-sensitive) because every table is
+-- created COLLATE=utf8mb4_bin, so no explicit cast is needed. MySQL's
+-- session default `utf8mb4_general_ci` is case-INsensitive; the
+-- table-level binary collation ensures two ids differing only in case
+-- (e.g. "Foo..." vs "foo...") still sort deterministically. SQLite and
+-- PostgreSQL already collate case-sensitively by default.
 SELECT w.* FROM workspaces w
 WHERE w.is_deleted = 0
   AND w.org_id = sqlc.arg(org_id)
   AND w.owner_user_id = sqlc.arg(user_id)
-ORDER BY w.created_at DESC, BINARY w.id DESC;
+ORDER BY w.created_at DESC, w.id DESC;
 
 -- name: RenameWorkspace :execresult
 UPDATE workspaces SET title = ? WHERE id = ? AND owner_user_id = ?;

--- a/backend/internal/hub/store/mysql/delegation_tokens.go
+++ b/backend/internal/hub/store/mysql/delegation_tokens.go
@@ -64,12 +64,61 @@ func (s *delegationTokenStore) GetByID(ctx context.Context, id string) (*store.D
 	return &out, nil
 }
 
-func (s *delegationTokenStore) ListByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {
-	rows, err := s.conn.q.ListDelegationTokensByUser(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
+// delegationTokenWithOwner assembles the JOINed listing row shared by the
+// ListAll and ListAllByUser query twins (mirroring workerWithOwner), so a
+// field addition to DelegationTokenWithOwner edits one site instead of one
+// closure per query.
+func delegationTokenWithOwner(t gendb.DelegationToken, ownerUsername string, ownerDeleted bool) store.DelegationTokenWithOwner {
+	return store.DelegationTokenWithOwner{DelegationToken: fromDBDelegationToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDelegationTokensParams) (store.Page[store.DelegationTokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see delegation_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+				return listAllDelegationTokensByUserIncludingRevokedParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUserIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensByUserIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserParams, error) {
+				return listAllDelegationTokensByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUser,
+			func(r gendb.ListAllDelegationTokensByUserRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+				return listAllDelegationTokensIncludingRevokedParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensParams, error) {
+				return listAllDelegationTokensParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokens,
+			func(r gendb.ListAllDelegationTokensRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
 	}
-	return store.MapSlice(rows, fromDBDelegationToken), nil
 }
 
 func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {

--- a/backend/internal/hub/store/mysql/mysql_test.go
+++ b/backend/internal/hub/store/mysql/mysql_test.go
@@ -4,10 +4,13 @@ package mysql_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -19,16 +22,13 @@ import (
 	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
-func TestMySQLStore(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
+// startMySQLContainer boots a disposable MySQL 8 container and returns its
+// DSN. Shared by the store conformance suite and the live schema assertions.
+func startMySQLContainer(t *testing.T) string {
+	t.Helper()
 	testutil.ConfigureDockerHost(t)
 
 	ctx := context.Background()
-
-	// Start a MySQL container.
 	req := testcontainers.ContainerRequest{
 		Image:        "mysql:8",
 		ExposedPorts: []string{"3306/tcp"},
@@ -54,7 +54,16 @@ func TestMySQLStore(t *testing.T) {
 	port, err := container.MappedPort(ctx, "3306")
 	require.NoError(t, err)
 
-	dsn := fmt.Sprintf("test:test@tcp(%s:%s)/leapmux_test?parseTime=true", host, port.Port())
+	return fmt.Sprintf("test:test@tcp(%s:%s)/leapmux_test?parseTime=true", host, port.Port())
+}
+
+func TestMySQLStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dsn := startMySQLContainer(t)
 
 	// Create ONE store and run migrations once.
 	st, err := mysqlstore.OpenTestable(config.MySQLConfig{DSN: dsn})
@@ -76,4 +85,55 @@ func TestMySQLStore(t *testing.T) {
 		},
 	}
 	suite.Run(t)
+}
+
+// TestMySQLBinaryCollationLive pins the binary-collation invariant against the
+// ACTUAL migrated schema: every application table must carry the utf8mb4_bin
+// collation so id/FK columns collate byte-wise (case-sensitive) and the
+// composite cursor's `id < ?` tiebreak stays deterministic for mixed-case ids.
+// This is the live twin of the static source scan in schema_internal_test.go
+// (TestEveryCreateTableDeclaresBinaryCollation): the static scan runs without
+// Docker but reads only 00001_initial.sql, while this one is
+// migration-count-agnostic and also catches a column-level collation override
+// the source scan cannot see.
+func TestMySQLBinaryCollationLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dsn := startMySQLContainer(t)
+
+	st, err := mysqlstore.OpenTestable(config.MySQLConfig{DSN: dsn})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(ctx))
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.QueryContext(ctx, `SHOW TABLES`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var tables []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		tables = append(tables, name)
+	}
+	require.NoError(t, rows.Err())
+	require.Greater(t, len(tables), 20, "expected the migrated schema to carry many tables; got %v", tables)
+
+	for _, table := range tables {
+		if table == "goose_db_version" {
+			// The migration tool's bookkeeping table is not ours; it inherits
+			// the database default collation and takes part in no cursor.
+			continue
+		}
+		var name, ddl string
+		require.NoError(t, db.QueryRowContext(ctx, "SHOW CREATE TABLE `"+table+"`").Scan(&name, &ddl))
+		assert.Contains(t, strings.ToLower(ddl), "utf8mb4_bin",
+			"table %s must carry the utf8mb4_bin collation; the cursor id tiebreak relies on byte-wise collation", table)
+	}
 }

--- a/backend/internal/hub/store/mysql/registration_keys.go
+++ b/backend/internal/hub/store/mysql/registration_keys.go
@@ -108,33 +108,21 @@ func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (
 	}))
 }
 
-func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) ([]store.WorkerRegistrationKeyWithCreator, error) {
-	// MySQL has no narg, so each `(? IS NULL OR <col> ?)` pair takes a
-	// presence probe and a column-typed value. parseMySQLCursor returns
-	// that pair for created_at; we mirror its shape for `now` (zero-value
-	// time when including expired rows is fine because the IS NULL probe
-	// short-circuits the comparison).
-	var nowProbe any
-	var nowCompare time.Time
+func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
+	// now is the expiry probe: a real instant when active-only (IncludeExpired=false)
+	// so the `(narg(now) IS NULL OR expires_at > narg(now))` predicate's second
+	// branch filters live rows; a zero (invalid) NullTime when IncludeExpired=true
+	// so the IS NULL branch surfaces every row.
+	var now sql.NullTime
 	if !p.IncludeExpired {
-		nowCompare = time.Now().UTC()
-		nowProbe = nowCompare
+		now = sql.NullTime{Time: time.Now().UTC(), Valid: true}
 	}
-	cursorProbe, cursorCompare, err := parseMySQLCursor(p.Cursor)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListRegistrationKeysAdmin(ctx, gendb.ListRegistrationKeysAdminParams{
-		Column1:   nowProbe,
-		ExpiresAt: nowCompare,
-		Column3:   cursorProbe,
-		CreatedAt: cursorCompare,
-		Limit:     int32(p.Limit),
-	})
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return store.MapSlice(rows, fromDBListRegistrationKeysAdminRow), nil
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListRegistrationKeysAdminParams, error) {
+			return listRegistrationKeysAdminParams(p.Cursor, p.Limit, now)
+		},
+		s.conn.q.ListRegistrationKeysAdmin,
+		fromDBListRegistrationKeysAdminRow)
 }
 
 func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) store.WorkerRegistrationKeyWithCreator {
@@ -146,5 +134,6 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 			ExpiresAt: r.ExpiresAt,
 		},
 		CreatorUsername: r.CreatorUsername,
+		CreatorDeleted:  r.CreatorDeleted,
 	}
 }

--- a/backend/internal/hub/store/mysql/schema_internal_test.go
+++ b/backend/internal/hub/store/mysql/schema_internal_test.go
@@ -1,0 +1,70 @@
+package mysql
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryCreateTableDeclaresBinaryCollation pins the migration convention that
+// every MySQL CREATE TABLE must carry COLLATE=utf8mb4_bin so id and FK columns
+// collate byte-wise (case-sensitive), matching SQLite's BINARY default and
+// keeping the composite cursor's `id < ?` tiebreak deterministic for mixed-case
+// ids. The per-query BINARY casts were dropped from workspaces.sql and
+// workspace_section_items.sql in the keyset-pagination rebuild, so the
+// table-level collation is now the sole guarantee -- a table added without the
+// suffix silently inherits the database default (typically case-insensitive) and
+// the cursor id tiebreak nondeterministically re-returns or skips rows. Closes
+// https://github.com/leapmux/leapmux/issues/300.
+//
+// This is a static check of the migration source, so it runs without Docker.
+// Its live twin, TestMySQLBinaryCollationLive (mysql_test.go, -tags
+// integration), asserts the same invariant against the actual migrated schema
+// and is migration-count-agnostic.
+func TestEveryCreateTableDeclaresBinaryCollation(t *testing.T) {
+	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	require.NoError(t, err)
+	// Strip line comments (-- to end of line) so a ';' inside a prose comment
+	// (e.g. "...issued; force-expires...") doesn't split a CREATE TABLE body.
+	sql := strings.ToUpper(stripLineComments(string(sqlBytes)))
+
+	const create = "CREATE TABLE"
+	idx := 0
+	count := 0
+	for {
+		i := strings.Index(sql[idx:], create)
+		if i < 0 {
+			break
+		}
+		i += idx
+		semi := strings.Index(sql[i:], ";")
+		require.GreaterOrEqual(t, semi, 0, "CREATE TABLE at offset %d missing terminating ;", i)
+		stmt := sql[i : i+semi]
+		assert.Contains(t, stmt, "COLLATE=UTF8MB4_BIN",
+			"CREATE TABLE at offset %d must declare COLLATE=utf8mb4_bin so id/FK columns collate byte-wise; the dropped per-query BINARY casts rely on it", i)
+		idx = i + semi
+		count++
+	}
+	require.GreaterOrEqual(t, count, 1, "found no CREATE TABLE statements in the migration")
+	// Sanity: the migration is non-trivial -- a healthy schema has many tables.
+	assert.Greater(t, count, 20, "expected many CREATE TABLE statements; got %d (is the migration readable?)", count)
+}
+
+// stripLineComments removes a SQL line comment (-- to end of line) from each
+// line. The migration uses only line comments (no /* */ block comments, no
+// string literals containing --), so this is a faithful comment strip for the
+// static COLLATE scan.
+func stripLineComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/backend/internal/hub/store/mysql/sessions.go
+++ b/backend/internal/hub/store/mysql/sessions.go
@@ -28,8 +28,18 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	}
 }
 
-func fromDBSessions(rows []gendb.UserSession) []store.UserSession {
-	return store.MapSlice(rows, fromDBSession)
+func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSession {
+	return store.ActiveSession{
+		ID:           r.ID,
+		UserID:       r.UserID,
+		Username:     r.Username,
+		UserDeleted:  r.UserDeleted,
+		CreatedAt:    r.CreatedAt,
+		LastActiveAt: r.LastActiveAt,
+		ExpiresAt:    r.ExpiresAt,
+		IPAddress:    r.IpAddress,
+		UserAgent:    r.UserAgent,
+	}
 }
 
 func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) error {
@@ -108,37 +118,20 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	}))
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, userID string) ([]store.UserSession, error) {
-	rows, err := s.conn.q.ListUserSessionsByUserID(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBSessions(rows), nil
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListUserSessionsByUserIDParams, error) {
+			return listUserSessionsParams(p.UserID, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) ([]store.ActiveSession, error) {
-	params, err := listAllActiveSessionsParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllActiveSessions(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	out := make([]store.ActiveSession, len(rows))
-	for i, r := range rows {
-		out[i] = store.ActiveSession{
-			ID:           r.ID,
-			UserID:       r.UserID,
-			Username:     r.Username,
-			CreatedAt:    r.CreatedAt,
-			LastActiveAt: r.LastActiveAt,
-			ExpiresAt:    r.ExpiresAt,
-			IPAddress:    r.IpAddress,
-			UserAgent:    r.UserAgent,
-		}
-	}
-	return out, nil
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllActiveSessionsParams, error) {
+			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+		},
+		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
 func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {

--- a/backend/internal/hub/store/mysql/testhelper.go
+++ b/backend/internal/hub/store/mysql/testhelper.go
@@ -49,6 +49,10 @@ func (h *mysqlTestHelper) SetCreatedAt(ctx context.Context, entity store.TestEnt
 	return sqlutil.SetCreatedAt(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, id, createdAt)
 }
 
+func (h *mysqlTestHelper) SetLastActiveAt(ctx context.Context, id string, lastActiveAt time.Time) error {
+	return sqlutil.SetLastActiveAt(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, id, lastActiveAt)
+}
+
 func (h *mysqlTestHelper) SetRevocationEventRevokedAt(ctx context.Context, id string, revokedAt time.Time) error {
 	return h.setTimestamp(ctx, sqlutil.TimestampColumnRevocationEventRevokedAt, id, revokedAt)
 }

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -42,10 +42,6 @@ func fromDBUser(u gendb.User) store.User {
 	}
 }
 
-func fromDBUsers(rows []gendb.User) []store.User {
-	return store.MapSlice(rows, fromDBUser)
-}
-
 func (s *userStore) Create(ctx context.Context, p store.CreateUserParams) error {
 	if err := p.Validate(); err != nil {
 		return err
@@ -174,28 +170,16 @@ func (s *userStore) Count(ctx context.Context) (int64, error) {
 	return n, mapErr(err)
 }
 
-func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) ([]store.User, error) {
-	params, err := listAllUsersParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllUsersParams, error) { return listAllUsersParams(p.Cursor, p.Limit) },
+		s.conn.q.ListAllUsers, fromDBUser)
 }
 
-func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) ([]store.User, error) {
-	params, err := searchUsersParams(p.Query, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.SearchUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.SearchUsersParams, error) { return searchUsersParams(p.Query, p.Cursor, p.Limit) },
+		s.conn.q.SearchUsers, fromDBUser)
 }
 
 // loadUserInfoCacheFields reads the current cached-UserInfo projection for id.

--- a/backend/internal/hub/store/mysql/workers.go
+++ b/backend/internal/hub/store/mysql/workers.go
@@ -65,63 +65,52 @@ func (s *workerStore) GetOwned(ctx context.Context, p store.GetOwnedWorkerParams
 	return store.GetOwnedWorker(ctx, p, s.GetByID)
 }
 
-func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) ([]store.Worker, error) {
-	params, err := listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListWorkersByUserID(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBWorkers(rows), nil
+func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) (store.Page[store.Worker], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListWorkersByUserIDParams, error) {
+			return listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListWorkersByUserID,
+		func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
 }
 
-func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) ([]store.WorkerWithOwner, error) {
+func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) (store.Page[store.WorkerWithOwner], error) {
+	// The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+	// nil/set), dispatched to four generated queries. The user_id dimension is a
+	// required-equality query rather than an opt-in `(? IS NULL OR registered_by
+	// = ?)` probe: that probe required binding user_id twice and produced opaque
+	// ColumnN param names. MySQL has no partial indexes, so deleted_at IS NULL is
+	// a residual either way, but the status split lets each half ride its
+	// leading-column index (created_at vs status). See workers.sql.
 	switch {
-	case p.UserID == nil && p.Status == nil:
-		params, err := listWorkersAdminAllParams(p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminAll(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminAllRow), nil
-
-	case p.UserID == nil && p.Status != nil:
-		params, err := listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByStatusRow), nil
-
-	case p.UserID != nil && p.Status == nil:
-		params, err := listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUser(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserRow), nil
-
-	default: // both non-nil
-		params, err := listWorkersAdminByUserAndStatusParams(*p.UserID, *p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUserAndStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserAndStatusRow), nil
+	case p.Status != nil && p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+				return listWorkersAdminByUserAndStatusParams(*p.Status, *p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUserAndStatus,
+			fromDBListWorkersAdminByUserAndStatusRow)
+	case p.Status != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByStatusParams, error) {
+				return listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByStatus,
+			fromDBListWorkersAdminByStatusRow)
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserParams, error) {
+				return listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUser,
+			fromDBListWorkersAdminByUserRow)
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminParams, error) {
+				return listWorkersAdminParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdmin,
+			fromDBListWorkersAdminRow)
 	}
 }
 
@@ -180,82 +169,25 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 	}
 }
 
-func fromDBWorkers(rows []gendb.Worker) []store.Worker {
-	return store.MapSlice(rows, func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
+// workerWithOwner is the shared body of the four admin-worker Row mappers. The
+// queries select sqlc.embed(w) so every admin Row is {Worker, OwnerUsername};
+// this helper keeps the gendb.Worker -> store.Worker mapping in one site.
+func workerWithOwner(w gendb.Worker, ownerUsername string, ownerDeleted bool) store.WorkerWithOwner {
+	return store.WorkerWithOwner{Worker: *fromDBWorker(w), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
 }
 
-func fromDBListWorkersAdminAllRow(r gendb.ListWorkersAdminAllRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
-}
-
-func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+func fromDBListWorkersAdminRow(r gendb.ListWorkersAdminRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserRow(r gendb.ListWorkersAdminByUserRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
+}
+
+func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserAndStatusRow(r gendb.ListWorkersAdminByUserAndStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }

--- a/backend/internal/hub/store/pagination.go
+++ b/backend/internal/hub/store/pagination.go
@@ -1,10 +1,10 @@
 package store
 
 import (
-	"cmp"
+	"context"
+	"errors"
 	"fmt"
 	"math"
-	"slices"
 	"strings"
 	"time"
 )
@@ -24,6 +24,155 @@ const (
 	SearchMaxExamine = 10000
 )
 
+// cursorDelimiter separates the timestamp and id components of an opaque list
+// cursor (see EncodeCursor / ParseCursor). The choice is constrained on three
+// sides: it must never appear in a time.RFC3339Nano string (that layout is
+// fixed to digits, '-', 'T', ':', '.', 'Z'); it must be shell-safe so an
+// operator can paste a cursor into a --cursor flag without quoting; and it
+// must be absent from the project's id alphabet (the nanoid generator in
+// internal/util/id uses pure [A-Za-z0-9]) so the first occurrence is
+// unambiguously the split point. Underscore satisfies all three.
+const cursorDelimiter = "_"
+
+// ErrInvalidCursor wraps every ParseCursor failure so an API boundary can
+// classify a malformed opaque cursor as bad client input (errors.Is on the
+// store call's error -> InvalidArgument) without re-parsing the cursor itself,
+// while genuine store failures keep mapping to Internal.
+var ErrInvalidCursor = errors.New("invalid cursor")
+
+// Cursor is a decoded composite list cursor: the keyset position of the last
+// row of the previous page -- the timestamp column the query orders by plus
+// the unique id tiebreaker.
+type Cursor struct {
+	Time time.Time
+	ID   string
+}
+
+// EncodeCursor builds the opaque cursor that continues a keyset page after the
+// row identified by (t, id). The composite form is required because the listed
+// tables order by a millisecond-precision timestamp DESC with a unique id
+// tiebreaker; a timestamp-only cursor silently drops rows that share the last
+// page's millisecond (https://github.com/leapmux/leapmux/issues/287).
+//
+// Adding a new keyset-paginated query? Match all four pieces or paging breaks:
+//  1. WHERE (t < cursor_time OR (t = cursor_time AND id < cursor_id)).
+//  2. ORDER BY the same columns: t DESC, id DESC.
+//  3. A composite index on (t DESC, id DESC), scoped by any equality filter,
+//     or the scan degrades to a full sort every page.
+//  4. The column passed here as t MUST be the query's ORDER BY column
+//     (created_at for most tables, last_active_at for sessions); a mismatch
+//     silently corrupts paging.
+func EncodeCursor(t time.Time, id string) string {
+	return t.UTC().Format(time.RFC3339Nano) + cursorDelimiter + id
+}
+
+// ParseCursor decodes a cursor produced by EncodeCursor. An empty cursor
+// indicates the first page and returns (nil, nil). A non-empty cursor must
+// carry both a timestamp and an id joined by cursorDelimiter; anything else is
+// an error wrapping ErrInvalidCursor rather than silently treated as "start
+// from the beginning", so a stale or truncated cursor surfaces loudly.
+func ParseCursor(cursor string) (*Cursor, error) {
+	if cursor == "" {
+		return nil, nil
+	}
+	timeStr, id, found := strings.Cut(cursor, cursorDelimiter)
+	if !found {
+		return nil, fmt.Errorf("%w: missing %q delimiter", ErrInvalidCursor, cursorDelimiter)
+	}
+	t, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: bad timestamp: %w", ErrInvalidCursor, err)
+	}
+	if id == "" {
+		return nil, fmt.Errorf("%w: missing id", ErrInvalidCursor)
+	}
+	return &Cursor{Time: t, ID: id}, nil
+}
+
+// PageCursorer is implemented by every row type a keyset-paginated listing
+// returns. PageCursor yields the row's keyset position -- the timestamp
+// column the listing's ORDER BY sorts on plus the unique id tiebreaker --
+// which NewPage encodes into the page's next cursor. The implementation MUST
+// match the ORDER BY of every keyset query returning the type; a mismatch
+// silently corrupts paging (checklist item 4 on EncodeCursor).
+type PageCursorer interface {
+	PageCursor() (time.Time, string)
+}
+
+// Page is one keyset page of a paginated listing. The store assembles it via
+// NewPage so the next cursor is always encoded from the query's own ORDER BY
+// column (callers cannot mispair the timestamp column) and the has-more signal
+// comes from an extra-row probe rather than the len(rows)==limit heuristic,
+// which false-positives when the total row count is an exact multiple of the
+// page size and sends the client one guaranteed-empty extra request.
+type Page[T PageCursorer] struct {
+	Rows []T
+	// NextCursor continues the listing after the last row of this page.
+	// Empty on the final page.
+	NextCursor string
+}
+
+// HasMore reports whether a further page exists: exactly when NewPage's
+// extra-row probe produced a next cursor. Deriving it from NextCursor makes it
+// mechanically impossible for the has-more flag and the cursor to contradict
+// each other -- a page cannot claim more rows without saying where they start.
+func (p Page[T]) HasMore() bool { return p.NextCursor != "" }
+
+// FetchLimit returns the LIMIT a keyset list query should request for a
+// caller-facing page limit: one row beyond the clamped limit, so NewPage can
+// detect a further page without a second query. The result stays within
+// [0, math.MaxInt32], keeping the dialects' int32 LIMIT casts safe -- the
+// clamp ceiling is math.MaxInt32-1 (see ClampListLimit), so even the largest
+// page's probe row fits and HasMore stays exact at every limit. A zero clamped
+// limit stays zero (such a page is terminal; see NewPage).
+func FetchLimit(limit int64) int64 {
+	clamped := ClampListLimit(limit)
+	if clamped == 0 {
+		return clamped
+	}
+	return clamped + 1
+}
+
+// NewPage assembles a keyset page from rows fetched with FetchLimit(limit):
+// an extra row beyond the clamped limit proves a further page exists; it is
+// sliced off and the next cursor is encoded from the last returned row's
+// PageCursor.
+func NewPage[T PageCursorer](rows []T, limit int64) Page[T] {
+	clamped := ClampListLimit(limit)
+	if clamped == 0 || int64(len(rows)) <= clamped {
+		return Page[T]{Rows: rows}
+	}
+	rows = rows[:clamped]
+	t, id := rows[len(rows)-1].PageCursor()
+	return Page[T]{Rows: rows, NextCursor: EncodeCursor(t, id)}
+}
+
+// QueryPage runs one keyset-paginated listing: build the dialect's sqlc
+// params, execute the generated query, wrap any query error via the dialect's
+// mapErr, and assemble the page. Every dialect's thin queryPage forwarder
+// binds its package-level mapErr here, so the build -> query -> NewPage
+// skeleton shared by all listings lives at this ONE site -- an edit to the
+// error wrapping or the probe-row accounting cannot silently reach only some
+// dialects or only some listings.
+func QueryPage[P any, R any, I PageCursorer](
+	ctx context.Context,
+	limit int64,
+	build func() (P, error),
+	query func(context.Context, P) ([]R, error),
+	mapRow func(R) I,
+	mapErr func(error) error,
+) (Page[I], error) {
+	params, err := build()
+	if err != nil {
+		return Page[I]{}, err
+	}
+	rows, err := query(ctx, params)
+	if err != nil {
+		return Page[I]{}, mapErr(err)
+	}
+	return NewPage(MapSlice(rows, mapRow), limit), nil
+}
+
 // MapSlice converts a slice of type In to a slice of type Out using fn.
 func MapSlice[In, Out any](in []In, fn func(In) Out) []Out {
 	out := make([]Out, len(in))
@@ -33,91 +182,30 @@ func MapSlice[In, Out any](in []In, fn func(In) Out) []Out {
 	return out
 }
 
+// maxListLimit is the clamp ceiling for caller-supplied page limits: one below
+// math.MaxInt32 so FetchLimit's +1 probe row still fits the dialects' int32
+// LIMIT casts. Capping at MaxInt32 itself would force a probe-less fetch at
+// exactly that limit, silently degrading HasMore to false there -- lowering
+// the ceiling by one dissolves that special case instead of documenting it.
+const maxListLimit = math.MaxInt32 - 1
+
 // ClampListLimit normalizes a caller-supplied page limit into the range every
 // dialect can carry. The Postgres and MySQL LIMIT columns are int32, so an
 // unclamped int64 (an admin passing --limit 3000000000 or 4294967297) would
 // truncate on the int32 cast -- wrapping to a negative LIMIT (a DB error) or a
 // tiny positive one (4294967297 -> 1 silent under-fetch) -- while SQLite's int64
 // LIMIT would return a wildly different set for the same flag. Clamping to
-// [0, math.MaxInt32] here makes the int32 conversion always safe and the three
-// dialects agree: a value past int32 caps at the max, a negative floors at 0.
-// A limit of 0 is preserved (the paginated queries treat it as "no rows"); this
-// only rewrites values a page limit could never legitimately hold.
+// [0, maxListLimit] makes the int32 conversion always safe (probe row
+// included; see maxListLimit) and the three dialects agree: a value past the
+// ceiling caps there, a negative floors at 0. A limit of 0 is preserved (the
+// paginated queries treat it as "no rows"); this only rewrites values a page
+// limit could never legitimately hold.
 func ClampListLimit(limit int64) int64 {
 	if limit < 0 {
 		return 0
 	}
-	if limit > math.MaxInt32 {
-		return math.MaxInt32
+	if limit > maxListLimit {
+		return maxListLimit
 	}
 	return limit
-}
-
-// ParseCursorTime parses an RFC3339Nano cursor string into a time.Time.
-// Returns zero time and false for an empty cursor (first page).
-func ParseCursorTime(cursor string) (time.Time, bool, error) {
-	if cursor == "" {
-		return time.Time{}, false, nil
-	}
-	t, err := time.Parse(time.RFC3339Nano, cursor)
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("invalid cursor: %w", err)
-	}
-	return t, true, nil
-}
-
-// SortFilterLimit sorts items by timeVal descending, applies cursor-based
-// filtering, and limits results. Generic helper for paginated listings.
-func SortFilterLimit[T any](items []T, timeVal func(T) time.Time, cursor string, limit int64) ([]T, error) {
-	descCmp := func(a, b T) int {
-		return cmp.Compare(timeVal(b).UnixNano(), timeVal(a).UnixNano())
-	}
-	if !slices.IsSortedFunc(items, descCmp) {
-		slices.SortFunc(items, descCmp)
-	}
-	if cursor != "" {
-		cursorTime, ok, err := ParseCursorTime(cursor)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			var filtered []T
-			for _, item := range items {
-				if timeVal(item).Before(cursorTime) {
-					filtered = append(filtered, item)
-				}
-			}
-			items = filtered
-		}
-	}
-	return ApplyOffsetLimit(items, 0, limit), nil
-}
-
-// PrefixMatchUser returns true if the lowered query is a prefix of the
-// user's username, display name, or email (case-insensitive).
-// The caller must pass a pre-lowercased query.
-func PrefixMatchUser(u User, loweredQuery string) bool {
-	return strings.HasPrefix(strings.ToLower(u.Username), loweredQuery) ||
-		strings.HasPrefix(strings.ToLower(u.DisplayName), loweredQuery) ||
-		strings.HasPrefix(strings.ToLower(u.Email), loweredQuery)
-}
-
-// PrefixMatchOrg returns true if the lowered query is a prefix of the
-// org's name (case-insensitive).
-// The caller must pass a pre-lowercased query.
-func PrefixMatchOrg(o Org, loweredQuery string) bool {
-	return strings.HasPrefix(strings.ToLower(o.Name), loweredQuery)
-}
-
-// ApplyOffsetLimit returns the slice all[offset:offset+limit], clamped to bounds.
-// It always returns a non-nil slice.
-func ApplyOffsetLimit[T any](all []T, offset, limit int64) []T {
-	if offset >= int64(len(all)) {
-		return []T{}
-	}
-	end := offset + limit
-	if end > int64(len(all)) {
-		end = int64(len(all))
-	}
-	return all[offset:end]
 }

--- a/backend/internal/hub/store/pagination_test.go
+++ b/backend/internal/hub/store/pagination_test.go
@@ -1,0 +1,278 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeCursor_UsesUnderscoreDelimiter(t *testing.T) {
+	got := EncodeCursor(time.Date(2026, 7, 20, 12, 34, 56, 789_000_000, time.UTC), "V1StGXR8")
+	// The delimiter is an underscore and the timestamp half is RFC3339Nano;
+	// splitting on the first underscore must recover the id verbatim.
+	ts, id, ok := strings.Cut(got, "_")
+	require.True(t, ok, "cursor missing underscore delimiter: %q", got)
+	_, err := time.Parse(time.RFC3339Nano, ts)
+	require.NoError(t, err, "timestamp half not RFC3339Nano")
+	assert.Equal(t, "V1StGXR8", id)
+}
+
+func TestParseCursor_RoundTrip(t *testing.T) {
+	want := time.Date(2026, 7, 20, 12, 34, 56, 789_000_000, time.UTC)
+	const wantID = "abc123"
+	c, err := ParseCursor(EncodeCursor(want, wantID))
+	require.NoError(t, err)
+	require.NotNil(t, c, "non-empty cursor must not decode as first page")
+	assert.True(t, c.Time.Equal(want), "time = %v, want %v", c.Time, want)
+	assert.Equal(t, wantID, c.ID)
+}
+
+func TestParseCursor_RoundTripWholeSecond(t *testing.T) {
+	// A whole-second timestamp encodes without a fractional component (RFC3339Nano
+	// drops it) and must still round-trip exactly.
+	want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	c, err := ParseCursor(EncodeCursor(want, "id"))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.True(t, c.Time.Equal(want), "time = %v, want %v", c.Time, want)
+}
+
+func TestParseCursor_EmptyIsFirstPage(t *testing.T) {
+	c, err := ParseCursor("")
+	require.NoError(t, err)
+	assert.Nil(t, c, "empty cursor should decode as first page (nil cursor)")
+}
+
+func TestParseCursor_IDContainingUnderscore(t *testing.T) {
+	// The id alphabet today is pure [A-Za-z0-9], but the parser splits on only
+	// the FIRST underscore, so a future id format that embeds one survives in
+	// the id half rather than being mistaken for the delimiter.
+	const wantID = "a_b"
+	c, err := ParseCursor(EncodeCursor(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), wantID))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, wantID, c.ID)
+}
+
+func TestParseCursor_Errors(t *testing.T) {
+	cases := map[string]string{
+		"missing delimiter": "2026-07-20T12:34:56.789Z",
+		"empty id":          "2026-07-20T12:34:56.789Z_",
+		"bad timestamp":     "not-a-time_abc",
+		"bare value":        "not-a-time",
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			cur, err := ParseCursor(c)
+			require.Error(t, err, "ParseCursor(%q)", c)
+			// Every parse failure must wrap ErrInvalidCursor so API boundaries
+			// can classify a malformed cursor as bad client input via errors.Is.
+			assert.ErrorIs(t, err, ErrInvalidCursor)
+			assert.Nil(t, cur)
+		})
+	}
+}
+
+func TestFetchLimit(t *testing.T) {
+	cases := map[string]struct {
+		limit int64
+		want  int64
+	}{
+		"normal limit gains the probe row": {limit: 50, want: 51},
+		"limit of one":                     {limit: 1, want: 2},
+		"zero stays terminal":              {limit: 0, want: 0},
+		"negative clamps to zero":          {limit: -5, want: 0},
+		"max int32 caps probe-safe":        {limit: math.MaxInt32, want: math.MaxInt32},
+		"beyond int32 clamps to max":       {limit: math.MaxInt32 + 10, want: math.MaxInt32},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.want, FetchLimit(c.limit))
+		})
+	}
+}
+
+func TestNewPage_TerminalWhenNoProbeRowCameBack(t *testing.T) {
+	// Fewer rows than the limit: the probe row did not materialize, so the
+	// page is terminal with every fetched row kept.
+	rows := []User{{ID: "a"}, {ID: "b"}}
+	page := NewPage(rows, 5)
+	assert.Equal(t, rows, page.Rows)
+	assert.False(t, page.HasMore())
+	assert.Empty(t, page.NextCursor)
+}
+
+func TestNewPage_ExactlyLimitRowsIsTerminal(t *testing.T) {
+	// The limit+1 fetch returned exactly limit rows: total is an exact
+	// multiple of the page size, and unlike the old len(rows)==limit
+	// heuristic the page must NOT claim a further page.
+	page := NewPage([]User{{ID: "a"}, {ID: "b"}}, 2)
+	assert.Len(t, page.Rows, 2)
+	assert.False(t, page.HasMore())
+	assert.Empty(t, page.NextCursor)
+}
+
+func TestNewPage_SlicesProbeRowAndEncodesLastKeptRow(t *testing.T) {
+	newest := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	rows := []User{
+		{ID: "a", CreatedAt: newest},
+		{ID: "b", CreatedAt: newest.Add(-time.Second)},
+		{ID: "c", CreatedAt: newest.Add(-2 * time.Second)}, // the probe row
+	}
+	page := NewPage(rows, 2)
+	require.Len(t, page.Rows, 2)
+	assert.True(t, page.HasMore())
+	// The cursor continues after the last KEPT row ("b"), not the probe row.
+	assert.Equal(t, EncodeCursor(rows[1].CreatedAt, "b"), page.NextCursor)
+}
+
+func TestNewPage_EncodesOrderByColumnViaPageCursor(t *testing.T) {
+	// ActiveSession pages on last_active_at, not created_at; NewPage must
+	// pick the column up from the row type's PageCursor so no caller can
+	// mispair the timestamp column.
+	created := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	active := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	rows := []ActiveSession{
+		{ID: "s1", CreatedAt: created, LastActiveAt: active},
+		{ID: "s2", CreatedAt: created, LastActiveAt: active.Add(-time.Second)},
+		{ID: "s3", CreatedAt: created, LastActiveAt: active.Add(-2 * time.Second)},
+	}
+	page := NewPage(rows, 2)
+	require.True(t, page.HasMore())
+	assert.Equal(t, EncodeCursor(rows[1].LastActiveAt, "s2"), page.NextCursor)
+}
+
+func TestNewPage_EmptyRows(t *testing.T) {
+	page := NewPage([]User{}, 5)
+	assert.Empty(t, page.Rows)
+	assert.False(t, page.HasMore())
+	assert.Empty(t, page.NextCursor)
+}
+
+func TestNewPage_ZeroLimitIsTerminal(t *testing.T) {
+	// Guard for the FetchLimit(0)=0 contract: even if a caller violates it
+	// and hands rows in with a zero limit, the page must not panic slicing
+	// or mint a cursor pointing nowhere.
+	page := NewPage([]User{{ID: "a"}}, 0)
+	assert.False(t, page.HasMore())
+	assert.Empty(t, page.NextCursor)
+}
+
+// TestQueryPage pins the shared listing skeleton every dialect's queryPage
+// forwarder routes through: a params-build error short-circuits UNWRAPPED
+// (cursor errors must stay errors.Is-able as ErrInvalidCursor at API
+// boundaries) without running the query, a query error comes back through the
+// dialect's mapErr, and a success maps rows and applies the probe-row
+// accounting via NewPage.
+func TestQueryPage(t *testing.T) {
+	ctx := context.Background()
+	mapErr := func(err error) error { return fmt.Errorf("mapped: %w", err) }
+	identity := func(u User) User { return u }
+
+	t.Run("build error short-circuits unwrapped", func(t *testing.T) {
+		buildErr := fmt.Errorf("%w: bad cursor", ErrInvalidCursor)
+		queryRan := false
+		page, err := QueryPage(ctx, 5,
+			func() (struct{}, error) { return struct{}{}, buildErr },
+			func(context.Context, struct{}) ([]User, error) { queryRan = true; return nil, nil },
+			identity, mapErr)
+		require.ErrorIs(t, err, ErrInvalidCursor,
+			"a cursor decode error must surface errors.Is-able, not mapped")
+		assert.NotContains(t, err.Error(), "mapped:", "build errors bypass mapErr")
+		assert.False(t, queryRan, "the query must not run after a build error")
+		assert.Empty(t, page.Rows)
+	})
+
+	t.Run("query error routes through mapErr", func(t *testing.T) {
+		queryErr := errors.New("boom")
+		_, err := QueryPage(ctx, 5,
+			func() (struct{}, error) { return struct{}{}, nil },
+			func(context.Context, struct{}) ([]User, error) { return nil, queryErr },
+			identity, mapErr)
+		require.ErrorIs(t, err, queryErr)
+		assert.Contains(t, err.Error(), "mapped:", "query errors must pass through the dialect's mapErr")
+	})
+
+	t.Run("success maps rows and slices the probe row", func(t *testing.T) {
+		newest := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		rows := []User{
+			{ID: "a", CreatedAt: newest},
+			{ID: "b", CreatedAt: newest.Add(-time.Second)},
+			{ID: "c", CreatedAt: newest.Add(-2 * time.Second)}, // the probe row
+		}
+		page, err := QueryPage(ctx, 2,
+			func() (struct{}, error) { return struct{}{}, nil },
+			func(context.Context, struct{}) ([]User, error) { return rows, nil },
+			identity, mapErr)
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.True(t, page.HasMore())
+		assert.Equal(t, EncodeCursor(rows[1].CreatedAt, "b"), page.NextCursor)
+	})
+}
+
+func TestEncodeCursor_NormalizesTimezone(t *testing.T) {
+	// A caller may hand EncodeCursor a non-UTC time; it must encode the UTC
+	// instant so the cursor compares against the UTC-stored column. The same
+	// wall-clock instant in two zones must produce the same cursor.
+	utc := time.Date(2026, 7, 20, 12, 34, 56, 789_000_000, time.UTC)
+	pst := time.Date(2026, 7, 20, 4, 34, 56, 789_000_000, time.FixedZone("PST", -8*3600))
+	assert.Equal(t, EncodeCursor(utc, "id"), EncodeCursor(pst, "id"),
+		"EncodeCursor must be timezone-normalized")
+	// And the encoded timestamp half must carry a trailing Z (UTC), not an offset.
+	ts, _, ok := strings.Cut(EncodeCursor(utc, "id"), "_")
+	require.True(t, ok)
+	assert.True(t, strings.HasSuffix(ts, "Z"), "EncodeCursor did not normalize to UTC (Z suffix): %q", ts)
+}
+
+// TestPageCursorReturnsListingOrderByColumn pins the contract that each row
+// type's PageCursor returns the SAME column its listing's ORDER BY sorts on.
+// A mismatch silently corrupts paging (EncodeCursor checklist item #4): the
+// cursor encodes one column's value while the predicate + ORDER BY use another,
+// so the next page skips or repeats rows. The zero distractor field is what
+// makes the test bite -- if a PageCursor implementation flips to the distractor
+// (e.g. User.PageCursor returning UpdatedAt instead of CreatedAt), the zero
+// fails the assertion. Covers all seven PageCursorer implementations; the SQL
+// ORDER BY side is pinned per-dialect by the keyset contract (see EncodeCursor's
+// doc comment) and by the sqlite indexes_internal_test.go index-shape pins.
+func TestPageCursorReturnsListingOrderByColumn(t *testing.T) {
+	sentinel := time.Unix(1_750_000_000, 0).UTC()
+	cases := []struct {
+		name string
+		row  PageCursorer
+		want time.Time
+	}{
+		// users ListAll/Search order by (created_at DESC, id DESC).
+		{"User_orders_by_created_at", User{CreatedAt: sentinel, UpdatedAt: time.Time{}}, sentinel},
+		// workers ListByUserID/ListAdmin order by (created_at DESC, id DESC).
+		{"Worker_orders_by_created_at", Worker{CreatedAt: sentinel}, sentinel},
+		// registration keys ListAdmin orders by (created_at DESC, id DESC);
+		// ExpiresAt is the distractor a flip might land on.
+		{"WorkerRegistrationKey_orders_by_created_at", WorkerRegistrationKey{CreatedAt: sentinel, ExpiresAt: time.Time{}}, sentinel},
+		// active sessions order by (last_active_at DESC, id DESC); CreatedAt is
+		// the distractor.
+		{"ActiveSession_orders_by_last_active_at", ActiveSession{CreatedAt: time.Time{}, LastActiveAt: sentinel}, sentinel},
+		// per-user sessions (ListByUserID) order by (last_active_at DESC, id
+		// DESC); CreatedAt and ExpiresAt are the distractors.
+		{"UserSession_orders_by_last_active_at", UserSession{CreatedAt: time.Time{}, ExpiresAt: time.Time{}, LastActiveAt: sentinel}, sentinel},
+		// admin api-token listing (ListAllAPITokens) orders by
+		// (created_at DESC, id DESC).
+		{"APITokenWithOwner_orders_by_created_at", APITokenWithOwner{APIToken: APIToken{CreatedAt: sentinel}}, sentinel},
+		// admin delegation-token listing (ListAllDelegationTokens) orders by
+		// (created_at DESC, id DESC); ExpiresAt is the distractor.
+		{"DelegationTokenWithOwner_orders_by_created_at", DelegationTokenWithOwner{DelegationToken: DelegationToken{CreatedAt: sentinel, ExpiresAt: time.Time{}}}, sentinel},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := c.row.PageCursor()
+			require.Equal(t, c.want, got, "PageCursor must return the column the listing ORDER BYs; a mismatch silently corrupts paging")
+		})
+	}
+}

--- a/backend/internal/hub/store/postgres/api_tokens.go
+++ b/backend/internal/hub/store/postgres/api_tokens.go
@@ -70,6 +70,62 @@ func (s *apiTokenStore) ListByUser(ctx context.Context, p store.ListAPITokensByU
 	return store.MapSlice(rows, fromDBAPIToken), nil
 }
 
+// apiTokenWithOwner assembles the JOINed listing row shared by the ListAll and
+// ListAllByUser query twins (mirroring workerWithOwner), so a field addition
+// to APITokenWithOwner edits one site instead of one closure per query.
+func apiTokenWithOwner(t gendb.ApiToken, ownerUsername string, ownerDeleted bool) store.APITokenWithOwner {
+	return store.APITokenWithOwner{APIToken: fromDBAPIToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *apiTokenStore) ListAll(ctx context.Context, p store.ListAllAPITokensParams) (store.Page[store.APITokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see api_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+				return listAllAPITokensByUserIncludingRevokedParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUserIncludingRevoked,
+			func(r gendb.ListAllAPITokensByUserIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserParams, error) {
+				return listAllAPITokensByUserParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUser,
+			func(r gendb.ListAllAPITokensByUserRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+				return listAllAPITokensIncludingRevokedParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensIncludingRevoked,
+			func(r gendb.ListAllAPITokensIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensParams, error) {
+				return listAllAPITokensParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokens,
+			func(r gendb.ListAllAPITokensRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	}
+}
+
 func (s *apiTokenStore) Touch(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.TouchAPIToken(ctx, id))
 }

--- a/backend/internal/hub/store/postgres/convert.go
+++ b/backend/internal/hub/store/postgres/convert.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -50,115 +51,194 @@ func ptrToText(s *string) pgtype.Text {
 	return pgtype.Text{}
 }
 
-// parseCursorToTs parses the opaque cursor string into a pgtype.Timestamptz.
-// An empty cursor returns the zero value (no cursor). A non-empty cursor must
-// be an RFC3339Nano-formatted timestamp.
-func parseCursorToTs(cursor string) (pgtype.Timestamptz, error) {
-	t, ok, err := store.ParseCursorTime(cursor)
+// decodeCursorParams decodes the composite list cursor into the two nullable sqlc
+// parameters the keyset queries bind: the cursor timestamp and the id
+// tiebreaker. An empty cursor (first page) returns the zero values so the
+// queries' "cursor_time IS NULL" branch selects every row.
+//
+// The timestamp is truncated to microsecond precision to match the timestamptz
+// columns: pgx sends pgtype.Timestamptz over the binary protocol floored to
+// microseconds, but a hand-crafted cursor parsed from text could carry
+// sub-microsecond digits, and a future switch to text binding would let the
+// `::timestamptz` cast round (half-to-even) at the .5us boundary -- making the
+// `=` tiebreak branch unsatisfiable and re-returning the previous page's tail
+// as duplicates. Truncating in Go mirrors MySQL's defensive
+// Truncate(time.Millisecond) and makes the "=" branch mechanically satisfiable
+// regardless of how the value is transported. EncodeCursor produces cursors
+// from DB-scanned rows (already microsecond-quantized), so this is a no-op for
+// real cursors.
+func decodeCursorParams(cursor string) (pgtype.Timestamptz, pgtype.Text, error) {
+	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return pgtype.Timestamptz{}, err
+		return pgtype.Timestamptz{}, pgtype.Text{}, err
 	}
-	if !ok {
-		return pgtype.Timestamptz{}, nil
+	if c == nil {
+		return pgtype.Timestamptz{}, pgtype.Text{}, nil
 	}
-	return pgtype.Timestamptz{Time: t, Valid: true}, nil
+	return pgtype.Timestamptz{Time: c.Time.Truncate(time.Microsecond), Valid: true}, pgtype.Text{String: c.ID, Valid: true}, nil
+}
+
+// withCursor decodes the composite list cursor and applies the dialect's
+// fetch-limit clamp, then hands the decoded values to fill, which assembles
+// the dialect-specific sqlc params struct. Centralizing decodeCursorParams + the
+// error short-circuit + store.FetchLimit (with the int32 cast the Postgres
+// LIMIT column requires) here means a change to the cursor decode, the clamp
+// rule, or the probe-row accounting edits ONE site per dialect instead of
+// being copy-pasted across every list builder.
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime pgtype.Timestamptz, cursorID pgtype.Text, fetchLimit int32) T) (T, error) {
+	cursorTime, cursorID, err := decodeCursorParams(cursor)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return fill(cursorTime, cursorID, int32(store.FetchLimit(limit))), nil
+}
+
+// queryPage forwards to store.QueryPage with this dialect's mapErr bound:
+// every listing in the package routes through it, so the shared
+// build -> query -> NewPage skeleton (and its error wrapping and probe-row
+// accounting) lives once in store instead of drifting per dialect.
+func queryPage[P any, R any, I store.PageCursorer](
+	ctx context.Context,
+	limit int64,
+	build func() (P, error),
+	query func(context.Context, P) ([]R, error),
+	mapRow func(R) I,
+) (store.Page[I], error) {
+	return store.QueryPage(ctx, limit, build, query, mapRow, mapErr)
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListAllUsersParams{}, err
-	}
-	return gendb.ListAllUsersParams{
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllUsersParams {
+		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.SearchUsersParams{}, err
-	}
-	return gendb.SearchUsersParams{
-		// Fold the search term the same way the write path folds display_name_folded,
-		// so the plain-LIKE match is case-insensitive (and cross-dialect consistent) for
-		// non-ASCII names. A nil query stays nil (SearchUsers reads it as "no filter").
-		Query:  ptrToText(store.FoldSearchQuery(query)),
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.SearchUsersParams {
+		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
+		// '%') at the one shared site, so the match is case-insensitive and literal
+		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
+		return gendb.SearchUsersParams{
+			Query:      ptrToText(store.SearchLikePattern(query)),
+			CursorTime: ct,
+			CursorID:   cid,
+			Limit:      fl,
+		}
+	})
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListWorkersByUserIDParams{}, err
-	}
-	return gendb.ListWorkersByUserIDParams{
-		RegisteredBy: registeredBy,
-		Cursor:       parsedCursor,
-		Limit:        int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersByUserIDParams {
+		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminAllParams(cursor string, limit int64) (gendb.ListWorkersAdminAllParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminAllParams{}, err
-	}
-	return gendb.ListWorkersAdminAllParams{
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+// listWorkersAdminParams builds the status=nil, user_id=nil query
+// (ListWorkersAdmin): deleted_at IS NULL, no user filter.
+func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminParams {
+		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
+// listWorkersAdminByUserParams builds the status=nil, user_id=set query
+// (ListWorkersAdminByUser): deleted_at IS NULL + required registered_by. The
+// user_id dimension is its own query rather than an opt-in `(narg IS NULL OR
+// registered_by = narg)` probe: that probe made sqlc emit UserID as an untyped
+// interface{}, and binding NULL raised SQLSTATE 42P08 (YugabyteDB inherits the
+// break via this store). See workers.sql for the full 2x2 matrix rationale.
+func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserParams {
+		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listWorkersAdminByStatusParams builds the status=set, user_id=nil query
+// (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
+// soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByStatusParams{
-		Status: status,
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByStatusParams {
+		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminByUserParams(userID, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserParams{
-		UserID: userID,
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
-}
-
-func listWorkersAdminByUserAndStatusParams(userID string, status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserAndStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserAndStatusParams{
-		UserID: userID,
-		Status: status,
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+// listWorkersAdminByUserAndStatusParams builds the status=set, user_id=set
+// query (ListWorkersAdminByUserAndStatus): required registered_by + status.
+func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
+		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	parsedCursor, err := parseCursorToTs(cursor)
-	if err != nil {
-		return gendb.ListAllActiveSessionsParams{}, err
-	}
-	return gendb.ListAllActiveSessionsParams{
-		Cursor: parsedCursor,
-		Limit:  int32(store.ClampListLimit(limit)),
-	}, nil
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllActiveSessionsParams {
+		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListUserSessionsByUserIDParams {
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensParams {
+		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserParams {
+		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
+		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensParams {
+		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserParams {
+		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listRegistrationKeysAdminParams mirrors the other list builders so the
+// registration-key admin listing shares the cursor decode and limit clamp.
+// now is the caller-computed expiry probe (Valid=false when expired rows are
+// included), passed in so the builder stays a pure function of its arguments.
+func listRegistrationKeysAdminParams(cursor string, limit int64, now pgtype.Timestamptz) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListRegistrationKeysAdminParams {
+		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func mapErr(err error) error {

--- a/backend/internal/hub/store/postgres/convert_test.go
+++ b/backend/internal/hub/store/postgres/convert_test.go
@@ -1,0 +1,41 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// TestParseCursorTruncatesToMicrosecond pins the timestamptz precision contract:
+// pgx sends pgtype.Timestamptz over the binary protocol floored to microseconds,
+// so a hand-crafted cursor carrying sub-microsecond digits would make the
+// composite predicate's "col = $cursor" tiebreak branch unsatisfiable (the
+// stored value is microsecond-quantized) while "col < $cursor" still matched the
+// boundary row -- re-returning the previous page's tail as duplicates. decodeCursorParams
+// must therefore quantize the cursor timestamp to the column's precision. Mirrors
+// mysql/convert_test.go::TestParseCursorTruncatesToMillisecond.
+func TestParseCursorTruncatesToMicrosecond(t *testing.T) {
+	sub := time.Date(2026, 7, 20, 12, 34, 56, 123_456_789, time.UTC)  // 123.456_789 us
+	want := time.Date(2026, 7, 20, 12, 34, 56, 123_456_000, time.UTC) // truncated to 123.456 us
+
+	ct, cid, err := decodeCursorParams(store.EncodeCursor(sub, "abc"))
+	require.NoError(t, err)
+	assert.True(t, ct.Valid, "cursor_time must be Valid for a non-empty cursor")
+	assert.True(t, ct.Time.Equal(want), "cursor_time = %v, want %v", ct.Time, want)
+	assert.Equal(t, pgtype.Text{String: "abc", Valid: true}, cid)
+}
+
+// TestParseCursorFirstPage pins the empty-cursor contract the queries'
+// "(narg IS NULL OR ...)" first branch relies on: invalid (NULL) cursor fields
+// select every row.
+func TestParseCursorFirstPage(t *testing.T) {
+	ct, cid, err := decodeCursorParams("")
+	require.NoError(t, err)
+	assert.False(t, ct.Valid)
+	assert.False(t, cid.Valid)
+}

--- a/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
@@ -3,19 +3,18 @@
 -- Personal organizations: exactly one per user, created with the account,
 -- soft-deleted with it. name mirrors the username (renamed together).
 CREATE TABLE orgs (
-    id          TEXT PRIMARY KEY,
+    id          TEXT COLLATE "C" PRIMARY KEY,
     name        TEXT NOT NULL,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     deleted_at  TIMESTAMPTZ
 );
 CREATE UNIQUE INDEX idx_orgs_name ON orgs(name) WHERE deleted_at IS NULL;
 CREATE INDEX idx_orgs_deleted_at ON orgs(deleted_at) WHERE deleted_at IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_orgs_created_at ON orgs(created_at DESC) WHERE deleted_at IS NULL;
 
 -- Users
 CREATE TABLE users (
-    id             TEXT PRIMARY KEY,
-    org_id         TEXT NOT NULL REFERENCES orgs(id),
+    id             TEXT COLLATE "C" PRIMARY KEY,
+    org_id         TEXT COLLATE "C" NOT NULL REFERENCES orgs(id),
     username       TEXT NOT NULL,
     password_hash  TEXT NOT NULL,
     display_name   TEXT NOT NULL DEFAULT '',
@@ -55,8 +54,7 @@ CREATE INDEX idx_users_org_id ON users(org_id);
 CREATE UNIQUE INDEX idx_users_username ON users(username) WHERE deleted_at IS NULL;
 CREATE UNIQUE INDEX idx_users_email ON users(email) WHERE email != '' AND deleted_at IS NULL;
 CREATE INDEX idx_users_deleted_at ON users(deleted_at) WHERE deleted_at IS NOT NULL;
-CREATE INDEX idx_users_tokens_revoked_at ON users(tokens_revoked_at) WHERE tokens_revoked_at IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC) WHERE deleted_at IS NULL;
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at) WHERE pending_email_expires_at IS NOT NULL;
@@ -67,8 +65,8 @@ CREATE INDEX idx_users_is_admin ON users(created_at) WHERE is_admin AND deleted_
 
 -- Auth sessions
 CREATE TABLE user_sessions (
-    id              TEXT PRIMARY KEY,
-    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    id              TEXT COLLATE "C" PRIMARY KEY,
+    user_id         TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     expires_at      TIMESTAMPTZ NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_active_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -76,14 +74,23 @@ CREATE TABLE user_sessions (
     user_agent      TEXT NOT NULL DEFAULT '',
     ip_address      TEXT NOT NULL DEFAULT ''
 );
-CREATE INDEX idx_user_sessions_user_id ON user_sessions(user_id);
+-- Serves the plain user_id lookups (prefix) AND the per-user keyset listing
+-- ListUserSessionsByUserID (user_id =, ORDER BY last_active_at DESC, id DESC),
+-- so that query both seeks and rides the index instead of sorting.
+CREATE INDEX idx_user_sessions_user_last_active ON user_sessions(user_id, last_active_at DESC, id DESC);
 CREATE INDEX idx_user_sessions_expires_at_last_active ON user_sessions(expires_at, last_active_at);
+-- The active-session listing orders by (last_active_at DESC, id DESC) while
+-- filtering expires_at with a range predicate. A range on the leading
+-- expires_at column means the index above can never provide that order (the
+-- engine would top-N sort every page), so the ORDER BY gets its own index and
+-- the expiry check runs as a residual filter during the ordered scan.
+CREATE INDEX idx_user_sessions_last_active ON user_sessions(last_active_at DESC, id DESC);
 
 -- Registered workers
 CREATE TABLE workers (
-    id            TEXT PRIMARY KEY,
-    auth_token    TEXT NOT NULL UNIQUE,
-    registered_by TEXT NOT NULL REFERENCES users(id),
+    id            TEXT COLLATE "C" PRIMARY KEY,
+    auth_token    TEXT COLLATE "C" NOT NULL UNIQUE,
+    registered_by TEXT COLLATE "C" NOT NULL REFERENCES users(id),
     status        INTEGER NOT NULL DEFAULT 1,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_seen_at  TIMESTAMPTZ,
@@ -99,22 +106,34 @@ CREATE TABLE workers (
     auto_registered BOOLEAN NOT NULL DEFAULT FALSE,
     deleted_at    TIMESTAMPTZ
 );
-CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC) WHERE deleted_at IS NULL;
--- Full (non-partial) registered_by index for the cleanup FK gate:
--- HardDeleteUsersBefore probes NOT EXISTS a worker (INCLUDING soft-deleted rows)
--- referencing the user, which the partial index above (deleted_at IS NULL) cannot serve.
-CREATE INDEX idx_workers_registered_by ON workers(registered_by);
+-- Non-partial on purpose (matches MySQL): ListWorkersByUserID and
+-- ListWorkersAdminByUserAndStatus filter on registered_by + status with NO
+-- deleted_at predicate, so a WHERE deleted_at IS NULL partial index would be
+-- ineligible and every page would fall back to a full table scan plus sort.
+-- The leading registered_by column also serves HardDeleteUsersBefore's
+-- NOT EXISTS (workers.registered_by = users.id) point probe over ALL rows
+-- (including soft-deleted), so no separate registered_by-only index is needed.
+CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC, id DESC);
 -- Admin status-only listing (ListWorkersAdminByStatus) cannot use the
 -- (registered_by, status, created_at) index because registered_by is the
--- leading column.
-CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC) WHERE deleted_at IS NULL;
+-- leading column. Non-partial on purpose: the query carries no deleted_at
+-- filter (status=3 lists soft-deleted workers), so a WHERE deleted_at IS NULL
+-- partial index would be ineligible and every page would fall back to a full
+-- table scan plus sort.
+CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC, id DESC);
+-- Admin per-user listing (ListWorkersAdminByUser): see the sqlite migration for
+-- the full rationale. Partial on deleted_at IS NULL because the query filters
+-- it; the (registered_by, status, created_at, id) composite above can't serve
+-- this query's ORDER BY (status breaks the created_at order within a
+-- registered_by prefix).
+CREATE INDEX idx_workers_registered_by_created ON workers(registered_by, created_at DESC, id DESC) WHERE deleted_at IS NULL;
 CREATE INDEX idx_workers_deleted_at ON workers(deleted_at) WHERE deleted_at IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_workers_created_at ON workers(created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX idx_workers_created_at ON workers(created_at DESC, id DESC) WHERE deleted_at IS NULL;
 
 -- Worker notifications (persistent queue for reliable delivery)
 CREATE TABLE worker_notifications (
-    id           TEXT PRIMARY KEY,
-    worker_id    TEXT NOT NULL REFERENCES workers(id) ON DELETE CASCADE,
+    id           TEXT COLLATE "C" PRIMARY KEY,
+    worker_id    TEXT COLLATE "C" NOT NULL REFERENCES workers(id) ON DELETE CASCADE,
     type         INTEGER NOT NULL,
     payload      TEXT NOT NULL DEFAULT '{}',
     status       INTEGER NOT NULL DEFAULT 1,
@@ -136,22 +155,23 @@ CREATE INDEX idx_worker_notifications_worker_status ON worker_notifications(work
 -- The cleanup loop hard-deletes rows whose expires_at is older than the
 -- retention cutoff.
 CREATE TABLE worker_registration_keys (
-    id          TEXT PRIMARY KEY,
-    created_by  TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    id          TEXT COLLATE "C" PRIMARY KEY,
+    created_by  TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     expires_at  TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX idx_worker_registration_keys_expires_at ON worker_registration_keys(expires_at);
 CREATE INDEX idx_worker_registration_keys_created_by ON worker_registration_keys(created_by);
-CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at);
+CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at DESC, id DESC);
 
 
 -- Sidebar sections (per-user organization of sidebar panels)
 CREATE TABLE workspace_sections (
-    id           TEXT PRIMARY KEY,
-    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    id           TEXT COLLATE "C" PRIMARY KEY,
+    user_id      TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     name         TEXT NOT NULL,
-    position     TEXT NOT NULL,
+    -- COLLATE "C" on every position column: ORDER BY position must sort byte-wise to match the Go/TS lexorank comparator regardless of alphabet.
+    position     TEXT COLLATE "C" NOT NULL,
     section_type INTEGER NOT NULL DEFAULT 1,
     sidebar      INTEGER NOT NULL DEFAULT 1,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -160,9 +180,9 @@ CREATE INDEX idx_workspace_sections_user_id ON workspace_sections(user_id);
 
 -- Workspaces (hub-owned registry) -- must come before workspace_section_items
 CREATE TABLE workspaces (
-    id            TEXT PRIMARY KEY,
-    org_id        TEXT NOT NULL REFERENCES orgs(id),
-    owner_user_id TEXT NOT NULL REFERENCES users(id),
+    id            TEXT COLLATE "C" PRIMARY KEY,
+    org_id        TEXT COLLATE "C" NOT NULL REFERENCES orgs(id),
+    owner_user_id TEXT COLLATE "C" NOT NULL REFERENCES users(id),
     title         TEXT NOT NULL DEFAULT '',
     is_deleted    BOOLEAN NOT NULL DEFAULT FALSE,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -174,10 +194,10 @@ CREATE INDEX idx_workspaces_deleted_at ON workspaces(deleted_at) WHERE deleted_a
 
 -- Workspace-to-section assignments (per-user)
 CREATE TABLE workspace_section_items (
-    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    section_id   TEXT NOT NULL REFERENCES workspace_sections(id) ON DELETE CASCADE,
-    position     TEXT NOT NULL,
+    user_id      TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    workspace_id TEXT COLLATE "C" NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    section_id   TEXT COLLATE "C" NOT NULL REFERENCES workspace_sections(id) ON DELETE CASCADE,
+    position     TEXT COLLATE "C" NOT NULL,
     PRIMARY KEY (user_id, workspace_id)
 );
 CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(section_id);
@@ -186,13 +206,13 @@ CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(sect
 -- journal, materialized state blob, derived tab views, dedup table,
 -- and lifecycle outbox).
 CREATE TABLE org_op_batches (
-    org_id        TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+    org_id        TEXT COLLATE "C" NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
     physical_ms   BIGINT NOT NULL,
     logical       BIGINT NOT NULL,
     last_logical  BIGINT NOT NULL,
-    origin_client TEXT NOT NULL,
-    principal_id  TEXT NOT NULL,
-    batch_id      TEXT NOT NULL,
+    origin_client TEXT COLLATE "C" NOT NULL,
+    principal_id  TEXT COLLATE "C" NOT NULL,
+    batch_id      TEXT COLLATE "C" NOT NULL,
     body_hash     BYTEA NOT NULL,
     batch_payload BYTEA NOT NULL,
     op_count      INTEGER NOT NULL CHECK (op_count > 0),
@@ -203,7 +223,7 @@ CREATE TABLE org_op_batches (
 CREATE UNIQUE INDEX idx_org_op_batches_dedup ON org_op_batches(org_id, batch_id);
 
 CREATE TABLE org_state (
-    org_id           TEXT PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
+    org_id           TEXT COLLATE "C" PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
     state_payload    BYTEA NOT NULL,
     current_epoch    BIGINT NOT NULL DEFAULT 1,
     epoch_started_at TIMESTAMPTZ NOT NULL,
@@ -211,26 +231,26 @@ CREATE TABLE org_state (
 );
 
 CREATE TABLE workspace_tab_owned (
-    org_id       TEXT NOT NULL,
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    org_id       TEXT COLLATE "C" NOT NULL,
+    workspace_id TEXT COLLATE "C" NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
     tab_type     INTEGER NOT NULL,
-    tab_id       TEXT NOT NULL,
-    worker_id    TEXT NOT NULL,
-    tile_id      TEXT NOT NULL,
-    position     TEXT NOT NULL,
+    tab_id       TEXT COLLATE "C" NOT NULL,
+    worker_id    TEXT COLLATE "C" NOT NULL,
+    tile_id      TEXT COLLATE "C" NOT NULL,
+    position     TEXT COLLATE "C" NOT NULL,
     PRIMARY KEY (org_id, tab_id)
 );
 CREATE INDEX idx_workspace_tab_owned_worker    ON workspace_tab_owned(worker_id);
 CREATE INDEX idx_workspace_tab_owned_workspace ON workspace_tab_owned(workspace_id);
 
 CREATE TABLE workspace_tab_rendered (
-    org_id       TEXT NOT NULL,
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    org_id       TEXT COLLATE "C" NOT NULL,
+    workspace_id TEXT COLLATE "C" NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
     tab_type     INTEGER NOT NULL,
-    tab_id       TEXT NOT NULL,
-    worker_id    TEXT NOT NULL,
-    tile_id      TEXT NOT NULL,
-    position     TEXT NOT NULL,
+    tab_id       TEXT COLLATE "C" NOT NULL,
+    worker_id    TEXT COLLATE "C" NOT NULL,
+    tile_id      TEXT COLLATE "C" NOT NULL,
+    position     TEXT COLLATE "C" NOT NULL,
     PRIMARY KEY (org_id, tab_id)
 );
 CREATE INDEX idx_workspace_tab_rendered_workspace ON workspace_tab_rendered(workspace_id);
@@ -239,13 +259,13 @@ CREATE INDEX idx_workspace_tab_rendered_workspace ON workspace_tab_rendered(work
 CREATE INDEX idx_workspace_tab_rendered_tab_id ON workspace_tab_rendered(tab_id);
 
 CREATE TABLE org_recent_batch_ids (
-    org_id                TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
-    batch_id              TEXT NOT NULL,
+    org_id                TEXT COLLATE "C" NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+    batch_id              TEXT COLLATE "C" NOT NULL,
     body_hash             BYTEA NOT NULL,
-    principal_id          TEXT NOT NULL,
+    principal_id          TEXT COLLATE "C" NOT NULL,
     canonical_physical_ms BIGINT NOT NULL,
     canonical_logical     BIGINT NOT NULL,
-    canonical_client      TEXT NOT NULL,
+    canonical_client      TEXT COLLATE "C" NOT NULL,
     op_count              INTEGER NOT NULL CHECK (op_count > 0),
     epoch                 BIGINT NOT NULL,
     expires_at            TIMESTAMPTZ NOT NULL,
@@ -255,7 +275,7 @@ CREATE INDEX idx_org_recent_batch_ids_expires ON org_recent_batch_ids(expires_at
 
 CREATE TABLE lifecycle_outbox (
     id          BIGSERIAL PRIMARY KEY,
-    org_id      TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+    org_id      TEXT COLLATE "C" NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
     op_type     TEXT NOT NULL,
     payload     BYTEA NOT NULL,
     enqueued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -264,10 +284,10 @@ CREATE TABLE lifecycle_outbox (
 CREATE INDEX idx_lifecycle_outbox_pending ON lifecycle_outbox(org_id, id) WHERE consumed_at IS NULL;
 
 CREATE TABLE revocation_events (
-    id         TEXT PRIMARY KEY,
+    id         TEXT COLLATE "C" PRIMARY KEY,
     kind       TEXT NOT NULL CHECK (kind IN ('session', 'api_token', 'api_token_rotation', 'delegation_token', 'user_tokens', 'user_info')),
-    subject_id TEXT NOT NULL,
-    user_id    TEXT NOT NULL,
+    subject_id TEXT COLLATE "C" NOT NULL,
+    user_id    TEXT COLLATE "C" NOT NULL,
     revoked_at TIMESTAMPTZ NOT NULL,
     user_auth_generation BIGINT NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -286,15 +306,15 @@ INSERT INTO revocation_event_sequence (id, last_seq) VALUES (1, 0);
 
 CREATE TABLE hub_runtime_lease (
     singleton_id     SMALLINT PRIMARY KEY CHECK (singleton_id = 1),
-    holder_id        TEXT NOT NULL CHECK (holder_id <> ''),
+    holder_id        TEXT COLLATE "C" NOT NULL CHECK (holder_id <> ''),
     cursor_seq       BIGINT NOT NULL CHECK (cursor_seq >= 0),
     lease_expires_at TIMESTAMPTZ NOT NULL
 );
 
 -- See sqlite migration for full rationale on api_tokens.
 CREATE TABLE api_tokens (
-    id                            TEXT PRIMARY KEY,
-    user_id                       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    id                            TEXT COLLATE "C" PRIMARY KEY,
+    user_id                       TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     client_type                   TEXT NOT NULL,
     client_name                   TEXT NOT NULL,
     secret_hash                   BYTEA NOT NULL,
@@ -310,18 +330,29 @@ CREATE TABLE api_tokens (
     refresh_expires_at            TIMESTAMPTZ,
     revoked_at                    TIMESTAMPTZ
 );
-CREATE INDEX idx_api_tokens_user ON api_tokens(user_id, client_type);
-CREATE INDEX idx_api_tokens_expires_at ON api_tokens(expires_at);
+-- user_id only: the client_type filters are the optional OR-form and never
+-- seek; the remaining job is the user_id seek for the ByUserIncludingRevoked
+-- listing, which the partial idx_api_tokens_user_created cannot serve.
+CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX idx_api_tokens_revoked_at ON api_tokens(revoked_at) WHERE revoked_at IS NOT NULL;
+-- Keyset index for the admin ListAllAPITokens listing: partial on
+-- revoked_at IS NULL to match the query's live-token filter, with the trailing
+-- id DESC so the composite ORDER BY rides the index instead of top-N sorting.
+CREATE INDEX idx_api_tokens_created_at ON api_tokens(created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Keyset index for the admin ListAllAPITokensByUser listing (the --user-id
+-- path): the leading user_id equality seeks, and (created_at DESC, id DESC)
+-- rides the composite ORDER BY -- without it the per-user page pays a seek on
+-- idx_api_tokens_user plus a sort. Mirrors idx_workers_registered_by_created.
+CREATE INDEX idx_api_tokens_user_created ON api_tokens(user_id, created_at DESC, id DESC) WHERE revoked_at IS NULL;
 
 CREATE TABLE delegation_tokens (
-    id                            TEXT PRIMARY KEY,
-    user_id                       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    worker_id                     TEXT NOT NULL REFERENCES workers(id) ON DELETE CASCADE,
-    workspace_id                  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    agent_id                      TEXT NOT NULL DEFAULT '',
-    terminal_id                   TEXT NOT NULL DEFAULT '',
-    issued_for_tab_id             TEXT NOT NULL DEFAULT '',
+    id                            TEXT COLLATE "C" PRIMARY KEY,
+    user_id                       TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    worker_id                     TEXT COLLATE "C" NOT NULL REFERENCES workers(id) ON DELETE CASCADE,
+    workspace_id                  TEXT COLLATE "C" NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    agent_id                      TEXT COLLATE "C" NOT NULL DEFAULT '',
+    terminal_id                   TEXT COLLATE "C" NOT NULL DEFAULT '',
+    issued_for_tab_id             TEXT COLLATE "C" NOT NULL DEFAULT '',
     issued_for_tab_type           INTEGER NOT NULL DEFAULT 0,
     secret_hash                   BYTEA NOT NULL,
     refresh_hash                  BYTEA,
@@ -336,13 +367,22 @@ CREATE INDEX idx_delegation_tokens_user ON delegation_tokens(user_id);
 CREATE INDEX idx_delegation_tokens_worker_agent ON delegation_tokens(worker_id, agent_id);
 CREATE INDEX idx_delegation_tokens_workspace ON delegation_tokens(workspace_id);
 CREATE INDEX idx_delegation_tokens_revoked_at ON delegation_tokens(revoked_at) WHERE revoked_at IS NOT NULL;
+-- Keyset index for the admin ListAllDelegationTokens listing (see
+-- idx_api_tokens_created_at for the rationale).
+CREATE INDEX idx_delegation_tokens_created_at ON delegation_tokens(created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Per-user keyset twin (see idx_api_tokens_user_created).
+CREATE INDEX idx_delegation_tokens_user_created ON delegation_tokens(user_id, created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Serves the hourly DeleteExpiredDelegationTokensBefore sweep of this
+-- high-churn table: seek the expired live rows instead of scanning every
+-- live token. Partial on revoked_at IS NULL to match the sweep's filter.
+CREATE INDEX idx_delegation_tokens_expires_at ON delegation_tokens(expires_at) WHERE revoked_at IS NULL;
 
 CREATE TABLE device_authorizations (
-    device_code           TEXT PRIMARY KEY,
-    user_code             TEXT NOT NULL UNIQUE,
+    device_code           TEXT COLLATE "C" PRIMARY KEY,
+    user_code             TEXT COLLATE "C" NOT NULL UNIQUE,
     device_name           TEXT NOT NULL DEFAULT '',
-    user_id               TEXT REFERENCES users(id) ON DELETE CASCADE,
-    approved              INTEGER NOT NULL DEFAULT 0,
+    user_id               TEXT COLLATE "C" REFERENCES users(id) ON DELETE CASCADE,
+    approved              INTEGER NOT NULL DEFAULT 0,        -- 0 pending, 1 approved, 2 denied
     last_polled_at        TIMESTAMPTZ,
     interval_seconds      INTEGER NOT NULL DEFAULT 5,
     created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -352,8 +392,8 @@ CREATE TABLE device_authorizations (
 CREATE INDEX idx_device_authorizations_expires_at ON device_authorizations(expires_at);
 
 CREATE TABLE cli_authorization_codes (
-    code                  TEXT PRIMARY KEY,
-    user_id               TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code                  TEXT COLLATE "C" PRIMARY KEY,
+    user_id               TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     code_challenge        TEXT NOT NULL,
     device_name           TEXT NOT NULL DEFAULT '',
     created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -364,11 +404,11 @@ CREATE INDEX idx_cli_authorization_codes_expires_at ON cli_authorization_codes(e
 
 -- OAuth identity providers (admin-configured)
 CREATE TABLE oauth_providers (
-    id              TEXT PRIMARY KEY,
+    id              TEXT COLLATE "C" PRIMARY KEY,
     provider_type   TEXT NOT NULL,
     name            TEXT NOT NULL,
     issuer_url      TEXT NOT NULL DEFAULT '',
-    client_id       TEXT NOT NULL,
+    client_id       TEXT COLLATE "C" NOT NULL,
     client_secret   BYTEA NOT NULL,
     scopes          TEXT NOT NULL DEFAULT 'openid profile email',
     trust_email     BOOLEAN NOT NULL DEFAULT TRUE,
@@ -378,9 +418,9 @@ CREATE TABLE oauth_providers (
 
 -- Links between local users and OAuth provider identities
 CREATE TABLE oauth_user_links (
-    user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    provider_id      TEXT NOT NULL REFERENCES oauth_providers(id) ON DELETE CASCADE,
-    provider_subject TEXT NOT NULL,
+    user_id          TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id      TEXT COLLATE "C" NOT NULL REFERENCES oauth_providers(id) ON DELETE CASCADE,
+    provider_subject TEXT COLLATE "C" NOT NULL,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (user_id, provider_id)
 );
@@ -388,13 +428,13 @@ CREATE UNIQUE INDEX idx_oauth_user_links_provider_subject ON oauth_user_links(pr
 
 -- Encrypted OAuth tokens per user per provider
 CREATE TABLE oauth_tokens (
-    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    provider_id     TEXT NOT NULL REFERENCES oauth_providers(id) ON DELETE CASCADE,
+    user_id         TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id     TEXT COLLATE "C" NOT NULL REFERENCES oauth_providers(id) ON DELETE CASCADE,
     access_token    BYTEA NOT NULL,
     refresh_token   BYTEA NOT NULL,
     token_type      TEXT NOT NULL DEFAULT 'Bearer',
     expires_at      TIMESTAMPTZ NOT NULL,
-    key_version     INTEGER NOT NULL DEFAULT 1,
+    key_version     BIGINT NOT NULL DEFAULT 1,
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (user_id, provider_id)
 );
@@ -404,8 +444,8 @@ CREATE INDEX idx_oauth_tokens_key_version ON oauth_tokens(key_version);
 
 -- Short-lived OAuth state for CSRF + PKCE during auth flow
 CREATE TABLE oauth_states (
-    state           TEXT PRIMARY KEY,
-    provider_id     TEXT NOT NULL REFERENCES oauth_providers(id),
+    state           TEXT COLLATE "C" PRIMARY KEY,
+    provider_id     TEXT COLLATE "C" NOT NULL REFERENCES oauth_providers(id),
     pkce_verifier   TEXT NOT NULL,
     redirect_uri    TEXT NOT NULL DEFAULT '',
     expires_at      TIMESTAMPTZ NOT NULL,
@@ -414,16 +454,16 @@ CREATE TABLE oauth_states (
 
 -- Pending OAuth signups (new users choosing their username)
 CREATE TABLE pending_oauth_signups (
-    token            TEXT PRIMARY KEY,
-    provider_id      TEXT NOT NULL REFERENCES oauth_providers(id),
-    provider_subject TEXT NOT NULL,
+    token            TEXT COLLATE "C" PRIMARY KEY,
+    provider_id      TEXT COLLATE "C" NOT NULL REFERENCES oauth_providers(id),
+    provider_subject TEXT COLLATE "C" NOT NULL,
     email            TEXT NOT NULL DEFAULT '',
     display_name     TEXT NOT NULL DEFAULT '',
     access_token     BYTEA NOT NULL,
     refresh_token    BYTEA NOT NULL,
     token_type       TEXT NOT NULL DEFAULT 'Bearer',
     token_expires_at TIMESTAMPTZ NOT NULL,
-    key_version      INTEGER NOT NULL DEFAULT 1,
+    key_version      BIGINT NOT NULL DEFAULT 1,
     redirect_uri     TEXT NOT NULL DEFAULT '',
     expires_at       TIMESTAMPTZ NOT NULL,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/backend/internal/hub/store/postgres/db/queries/api_tokens.sql
+++ b/backend/internal/hub/store/postgres/db/queries/api_tokens.sql
@@ -25,6 +25,64 @@ WHERE user_id = $1
   AND revoked_at IS NULL
 ORDER BY created_at DESC;
 
+-- name: ListAllAPITokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.arg(client_type)::text = '' OR t.client_type = sqlc.arg(client_type)::text)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllAPITokensIncludingRevoked :many
+-- Forensics variant of ListAllAPITokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.arg(client_type)::text = '' OR t.client_type = sqlc.arg(client_type)::text)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllAPITokensByUser :many
+-- Per-user variant of ListAllAPITokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type)::text = '' OR t.client_type = sqlc.arg(client_type)::text)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllAPITokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllAPITokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllAPITokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type)::text = '' OR t.client_type = sqlc.arg(client_type)::text)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
 -- name: TouchAPIToken :exec
 UPDATE api_tokens
 SET last_used_at = NOW()

--- a/backend/internal/hub/store/postgres/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/postgres/db/queries/delegation_tokens.sql
@@ -22,10 +22,59 @@ INSERT INTO delegation_tokens (
 -- name: GetDelegationTokenByID :one
 SELECT * FROM delegation_tokens WHERE id = $1;
 
--- name: ListDelegationTokensByUser :many
-SELECT * FROM delegation_tokens
-WHERE user_id = $1 AND revoked_at IS NULL
-ORDER BY created_at DESC;
+-- name: ListAllDelegationTokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllDelegationTokensIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllDelegationTokensByUser :many
+-- Per-user variant of ListAllDelegationTokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
+
+-- name: ListAllDelegationTokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllDelegationTokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (t.created_at = sqlc.narg(cursor_time)::timestamptz AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg('limit');
 
 -- name: ListActiveDelegationTokensByUser :many
 SELECT * FROM delegation_tokens

--- a/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
@@ -51,15 +51,20 @@ DELETE FROM user_sessions WHERE user_id = $1 AND id != $2;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = $1 AND expires_at > NOW()
-ORDER BY last_active_at DESC
-LIMIT 1000;
+WHERE user_id = sqlc.arg(user_id) AND expires_at > NOW()
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR last_active_at < sqlc.narg(cursor_time)::timestamptz
+       OR (last_active_at = sqlc.narg(cursor_time)::timestamptz AND id < sqlc.narg(cursor_id)))
+ORDER BY last_active_at DESC, id DESC
+LIMIT sqlc.arg('limit');
 
 -- name: ListAllActiveSessions :many
-SELECT s.id, s.user_id, u.username, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
+SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, (u.id IS NULL)::boolean AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
-JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
+LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
 WHERE s.expires_at > NOW()
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR s.last_active_at < sqlc.narg(cursor))
-ORDER BY s.last_active_at DESC
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR s.last_active_at < sqlc.narg(cursor_time)::timestamptz
+       OR (s.last_active_at = sqlc.narg(cursor_time)::timestamptz AND s.id < sqlc.narg(cursor_id)))
+ORDER BY s.last_active_at DESC, s.id DESC
 LIMIT sqlc.arg('limit');

--- a/backend/internal/hub/store/postgres/db/queries/users.sql
+++ b/backend/internal/hub/store/postgres/db/queries/users.sql
@@ -47,8 +47,10 @@ SELECT EXISTS(
 
 -- name: ListAllUsers :many
 SELECT * FROM users WHERE deleted_at IS NULL
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC LIMIT sqlc.arg('limit');
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (created_at = sqlc.narg(cursor_time)::timestamptz AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC LIMIT sqlc.arg('limit');
 
 -- The query arg is pre-folded (store.FoldSearchText) by the Go glue, and username
 -- and email are already stored lowercased, so a plain LIKE (not ILIKE) against the
@@ -57,12 +59,18 @@ ORDER BY created_at DESC LIMIT sqlc.arg('limit');
 -- name: SearchUsers :many
 SELECT * FROM users
 WHERE deleted_at IS NULL
+-- The query arg arrives as a complete LIKE prefix pattern built by
+-- store.SearchLikePattern (folded + backslash-escaped + trailing '%');
+-- backslash is Postgres's default LIKE escape character, so the escaped
+-- metacharacters match literally without an ESCAPE clause.
   AND (sqlc.narg(query)::text IS NULL
-   OR username LIKE sqlc.narg(query) || '%'
-   OR display_name_folded LIKE sqlc.narg(query) || '%'
-   OR email LIKE sqlc.narg(query) || '%')
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC
+   OR username LIKE sqlc.narg(query)
+   OR display_name_folded LIKE sqlc.narg(query)
+   OR email LIKE sqlc.narg(query))
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (created_at = sqlc.narg(cursor_time)::timestamptz AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: UpdateUserPassword :exec

--- a/backend/internal/hub/store/postgres/db/queries/worker_registration_keys.sql
+++ b/backend/internal/hub/store/postgres/db/queries/worker_registration_keys.sql
@@ -48,12 +48,14 @@ DELETE FROM worker_registration_keys WHERE id IN (SELECT id FROM to_delete);
 -- pass NULL to surface expired rows for forensics.
 -- name: ListRegistrationKeysAdmin :many
 SELECT k.id, k.created_by, k.created_at, k.expires_at,
-       COALESCE(u.username, '(deleted)') AS creator_username
+       COALESCE(u.username, '') AS creator_username, (u.id IS NULL)::boolean AS creator_deleted
 FROM worker_registration_keys k
 LEFT JOIN users u ON k.created_by = u.id AND u.deleted_at IS NULL
 WHERE (sqlc.narg(now)::timestamptz IS NULL OR k.expires_at > sqlc.narg(now))
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR k.created_at < sqlc.narg(cursor))
-ORDER BY k.created_at DESC
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR k.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (k.created_at = sqlc.narg(cursor_time)::timestamptz AND k.id < sqlc.narg(cursor_id)))
+ORDER BY k.created_at DESC, k.id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: AdminSoftDeleteRegistrationKey :execresult

--- a/backend/internal/hub/store/postgres/db/queries/workers.sql
+++ b/backend/internal/hub/store/postgres/db/queries/workers.sql
@@ -14,8 +14,10 @@ SELECT * FROM workers WHERE auth_token = $1 AND status != 3;
 -- name: ListWorkersByUserID :many
 SELECT * FROM workers
 WHERE registered_by = sqlc.arg(registered_by) AND status = 1
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (created_at = sqlc.narg(cursor_time)::timestamptz AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: GetOwnedWorker :one
@@ -48,40 +50,67 @@ UPDATE workers SET public_key = $1, mlkem_public_key = $2, slhdsa_public_key = $
 -- name: GetWorkerPublicKey :one
 SELECT public_key, mlkem_public_key, slhdsa_public_key FROM workers WHERE id = $1 AND deleted_at IS NULL;
 
--- name: ListWorkersAdminAll :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+-- The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+-- nil/set), implemented as FOUR separate queries. The user_id dimension CANNOT
+-- be an opt-in `(narg(user_id) IS NULL OR registered_by = narg(user_id))` probe:
+-- sqlc emits the IS-NULL-probed narg as an untyped interface{}, and binding NULL
+-- for it raises SQLSTATE 42P08 "could not determine data type of parameter"
+-- (verified: TestPostgresStore/workers/list_admin_filter_by_user_and_status
+-- fails on this commit's two-query collapse; YugabyteDB inherits the break via
+-- this store). Splitting user_id into its own REQUIRED-equality query
+-- (sqlc.arg, not narg) yields a typed `string` param and restores the index
+-- seek. The status dimension stays split for partial-index eligibility:
+-- status=nil keeps `deleted_at IS NULL`; status=set drops it so status=3 can
+-- surface soft-deleted rows.
+
+-- ListWorkersAdmin: status=nil, user_id=nil.
+-- name: ListWorkersAdmin :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.deleted_at IS NULL
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (w.created_at = sqlc.narg(cursor_time)::timestamptz AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg('limit');
 
+-- ListWorkersAdminByUser: status=nil, user_id=set.
+-- name: ListWorkersAdminByUser :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
+FROM workers w
+LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
+WHERE w.deleted_at IS NULL
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (w.created_at = sqlc.narg(cursor_time)::timestamptz AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
+LIMIT sqlc.arg('limit');
+
+-- ListWorkersAdminByStatus: status=set, user_id=nil.
 -- name: ListWorkersAdminByStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.status = sqlc.arg(status)
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (w.created_at = sqlc.narg(cursor_time)::timestamptz AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg('limit');
 
--- name: ListWorkersAdminByUser :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
-FROM workers w
-LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.deleted_at IS NULL
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
-LIMIT sqlc.arg('limit');
-
+-- ListWorkersAdminByUserAndStatus: status=set, user_id=set.
 -- name: ListWorkersAdminByUserAndStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, (u.id IS NULL)::boolean AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.status = sqlc.arg(status)
-  AND (sqlc.narg(cursor)::timestamptz IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+WHERE w.status = sqlc.arg(status)
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time)::timestamptz IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)::timestamptz
+       OR (w.created_at = sqlc.narg(cursor_time)::timestamptz AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: HardDeleteWorkersBefore :execresult

--- a/backend/internal/hub/store/postgres/delegation_tokens.go
+++ b/backend/internal/hub/store/postgres/delegation_tokens.go
@@ -60,12 +60,61 @@ func (s *delegationTokenStore) GetByID(ctx context.Context, id string) (*store.D
 	return &out, nil
 }
 
-func (s *delegationTokenStore) ListByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {
-	rows, err := s.conn.q.ListDelegationTokensByUser(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
+// delegationTokenWithOwner assembles the JOINed listing row shared by the
+// ListAll and ListAllByUser query twins (mirroring workerWithOwner), so a
+// field addition to DelegationTokenWithOwner edits one site instead of one
+// closure per query.
+func delegationTokenWithOwner(t gendb.DelegationToken, ownerUsername string, ownerDeleted bool) store.DelegationTokenWithOwner {
+	return store.DelegationTokenWithOwner{DelegationToken: fromDBDelegationToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDelegationTokensParams) (store.Page[store.DelegationTokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see delegation_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+				return listAllDelegationTokensByUserIncludingRevokedParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUserIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensByUserIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserParams, error) {
+				return listAllDelegationTokensByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUser,
+			func(r gendb.ListAllDelegationTokensByUserRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+				return listAllDelegationTokensIncludingRevokedParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensParams, error) {
+				return listAllDelegationTokensParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokens,
+			func(r gendb.ListAllDelegationTokensRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
 	}
-	return store.MapSlice(rows, fromDBDelegationToken), nil
 }
 
 func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {

--- a/backend/internal/hub/store/postgres/migrate.go
+++ b/backend/internal/hub/store/postgres/migrate.go
@@ -1,9 +1,13 @@
 package postgres
 
 import (
+	"bytes"
 	"database/sql"
 	"embed"
+	"fmt"
+	"io"
 	"io/fs"
+	"strings"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
@@ -15,5 +19,107 @@ var migrations embed.FS
 
 func newMigrator(db *sql.DB) (store.Migrator, error) {
 	sub, _ := fs.Sub(migrations, "db/migrations")
+	crdb, err := isCockroachDB(db)
+	if err != nil {
+		return nil, fmt.Errorf("detect backend flavor: %w", err)
+	}
+	if crdb {
+		// CockroachDB parses collation names as BCP-47 language tags and
+		// rejects the C locale outright ("invalid locale C"). Stripping the
+		// clause is semantics-preserving there: CRDB compares STRING values
+		// byte-wise by default, which is exactly the ordering COLLATE "C"
+		// pins on PostgreSQL for the keyset cursor id tiebreaks and FK joins.
+		// YugabyteDB accepts COLLATE "C" natively and takes the plain path.
+		sub = transformFS{inner: sub, transform: stripCollateC}
+	}
 	return sqlutil.NewGooseMigrator(goose.DialectPostgres, db, sub)
 }
+
+// isCockroachDB reports whether the connected backend is CockroachDB
+// masquerading behind the PostgreSQL wire protocol.
+func isCockroachDB(db *sql.DB) (bool, error) {
+	var version string
+	if err := db.QueryRow(`SELECT version()`).Scan(&version); err != nil {
+		return false, err
+	}
+	return strings.Contains(version, "CockroachDB"), nil
+}
+
+func stripCollateC(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte(` COLLATE "C"`), nil)
+}
+
+// transformFS serves the inner FS with transform applied to every regular
+// file's contents. Directories pass through untouched (goose only lists
+// them). Read-only; sufficient for handing goose a rewritten copy of the
+// embedded migrations.
+type transformFS struct {
+	inner     fs.FS
+	transform func([]byte) []byte
+}
+
+func (t transformFS) Open(name string) (fs.File, error) {
+	f, err := t.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		return f, nil
+	}
+	data, err := io.ReadAll(f)
+	closeErr := f.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	content := t.transform(data)
+	return &memFile{
+		info: memFileInfo{FileInfo: info, size: int64(len(content))},
+		r:    bytes.NewReader(content),
+	}, nil
+}
+
+// ReadDir delegates listing to the inner FS so goose's migration discovery
+// sees the same file set.
+func (t transformFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return fs.ReadDir(t.inner, name)
+}
+
+// ReadFile implements fs.ReadFileFS through the transform, so a consumer that
+// type-asserts the fs.ReadFile fast path (rather than falling back to Open)
+// can never observe the untransformed bytes.
+func (t transformFS) ReadFile(name string) ([]byte, error) {
+	data, err := fs.ReadFile(t.inner, name)
+	if err != nil {
+		return nil, err
+	}
+	return t.transform(data), nil
+}
+
+// memFile is a read-only fs.File over transformed in-memory contents.
+type memFile struct {
+	info fs.FileInfo
+	r    *bytes.Reader
+}
+
+func (f *memFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+func (f *memFile) Read(p []byte) (int, error) { return f.r.Read(p) }
+func (f *memFile) Close() error               { return nil }
+
+// memFileInfo wraps the inner file's metadata, overriding Size to the
+// TRANSFORMED length: Stat must never report a size different from what Read
+// serves, or a consumer sizing a read from Stat (io.CopyN, buffer prealloc)
+// gets a truncated or over-long view of the migration.
+type memFileInfo struct {
+	fs.FileInfo
+	size int64
+}
+
+func (i memFileInfo) Size() int64 { return i.size }

--- a/backend/internal/hub/store/postgres/migrate_internal_test.go
+++ b/backend/internal/hub/store/postgres/migrate_internal_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"io"
+	"io/fs"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStripCollateCLeavesNoCollation guards the CockroachDB migration path
+// against a silent strip miss: stripCollateC matches ONE exact byte sequence
+// (` COLLATE "C"`), so a future column hand-typed as `collate "C"`, with
+// different spacing, or line-leading would escape the strip and fail the CRDB
+// migration at startup ("invalid locale C") -- an outage no Postgres-only test
+// can catch, because the strip only runs on the CRDB detection path. This test
+// runs the real transform over the real embedded migrations and asserts no
+// COLLATE survives in any spelling, so the invisible "hand-type exactly this
+// byte sequence" rule becomes a mechanically checked one.
+func TestStripCollateCLeavesNoCollation(t *testing.T) {
+	sub, err := fs.Sub(migrations, "db/migrations")
+	require.NoError(t, err)
+
+	entries, err := fs.ReadDir(sub, ".")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "embedded migrations must not be empty")
+
+	anyCollate := regexp.MustCompile(`(?i)collate`)
+	strippedTotal := 0
+	for _, e := range entries {
+		raw, err := fs.ReadFile(sub, e.Name())
+		require.NoError(t, err)
+		stripped := stripCollateC(raw)
+		strippedTotal += len(raw) - len(stripped)
+		assert.NotRegexp(t, anyCollate, string(stripped),
+			"%s: a COLLATE clause survived stripCollateC -- its spelling does not match the exact ' COLLATE \"C\"' byte sequence the strip removes, and CockroachDB will reject the migration at startup",
+			e.Name())
+	}
+	// The strip must actually have removed something: a zero delta means the
+	// embed path or the strip literal broke and the assertion above passed
+	// vacuously.
+	assert.Positive(t, strippedTotal, "stripCollateC removed nothing from the embedded migrations")
+}
+
+// TestTransformFSServesTransformedContentConsistently pins the transformFS
+// wrapper contract on the real embedded migrations: the Open path and the
+// fs.ReadFile fast path (fs.ReadFileFS) must serve the SAME transformed bytes,
+// and Stat().Size() must equal what Read serves -- the inner (pre-transform)
+// FileInfo would over-report, and a consumer sizing a read from Stat would
+// read a wrong-length view of the migration.
+func TestTransformFSServesTransformedContentConsistently(t *testing.T) {
+	sub, err := fs.Sub(migrations, "db/migrations")
+	require.NoError(t, err)
+	tfs := transformFS{inner: sub, transform: stripCollateC}
+
+	entries, err := fs.ReadDir(tfs, ".")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, e := range entries {
+		viaReadFile, err := fs.ReadFile(tfs, e.Name())
+		require.NoError(t, err)
+
+		f, err := tfs.Open(e.Name())
+		require.NoError(t, err)
+		viaOpen, err := io.ReadAll(f)
+		require.NoError(t, err)
+		info, err := f.Stat()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		assert.Equal(t, viaOpen, viaReadFile,
+			"%s: the ReadFile fast path and the Open path must serve identical transformed bytes", e.Name())
+		assert.Equal(t, int64(len(viaOpen)), info.Size(),
+			"%s: Stat().Size() must report the transformed length Read serves, not the inner file's", e.Name())
+
+		raw, err := fs.ReadFile(sub, e.Name())
+		require.NoError(t, err)
+		assert.NotEqual(t, raw, viaOpen,
+			"%s: the transform must have been applied on both paths", e.Name())
+	}
+}

--- a/backend/internal/hub/store/postgres/oauth_tokens.go
+++ b/backend/internal/hub/store/postgres/oauth_tokens.go
@@ -21,7 +21,7 @@ func fromDBOAuthToken(t gendb.OauthToken) store.OAuthToken {
 		RefreshToken: t.RefreshToken,
 		TokenType:    t.TokenType,
 		ExpiresAt:    tsToTime(t.ExpiresAt),
-		KeyVersion:   int64(t.KeyVersion),
+		KeyVersion:   t.KeyVersion,
 		UpdatedAt:    tsToTime(t.UpdatedAt),
 	}
 }
@@ -38,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
 		ExpiresAt:    timeToTs(p.ExpiresAt.UTC()),
-		KeyVersion:   int32(p.KeyVersion),
+		KeyVersion:   p.KeyVersion,
 	}))
 }
 
@@ -63,7 +63,7 @@ func (s *oauthTokenStore) ListExpiring(ctx context.Context) ([]store.OAuthToken,
 }
 
 func (s *oauthTokenStore) ListByKeyVersion(ctx context.Context, keyVersion int64) ([]store.OAuthToken, error) {
-	rows, err := s.conn.q.ListOAuthTokensByKeyVersion(ctx, int32(keyVersion))
+	rows, err := s.conn.q.ListOAuthTokensByKeyVersion(ctx, keyVersion)
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -71,7 +71,7 @@ func (s *oauthTokenStore) ListByKeyVersion(ctx context.Context, keyVersion int64
 }
 
 func (s *oauthTokenStore) CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error) {
-	count, err := s.conn.q.CountOAuthTokensByKeyVersion(ctx, int32(keyVersion))
+	count, err := s.conn.q.CountOAuthTokensByKeyVersion(ctx, keyVersion)
 	if err != nil {
 		return 0, mapErr(err)
 	}

--- a/backend/internal/hub/store/postgres/pending_oauth_signups.go
+++ b/backend/internal/hub/store/postgres/pending_oauth_signups.go
@@ -24,7 +24,7 @@ func fromDBPendingOAuthSignup(p gendb.PendingOauthSignup) *store.PendingOAuthSig
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
 		TokenExpiresAt:  tsToTime(p.TokenExpiresAt),
-		KeyVersion:      int64(p.KeyVersion),
+		KeyVersion:      p.KeyVersion,
 		RedirectURI:     p.RedirectUri,
 		ExpiresAt:       tsToTime(p.ExpiresAt),
 		CreatedAt:       tsToTime(p.CreatedAt),
@@ -42,7 +42,7 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
 		TokenExpiresAt:  timeToTs(p.TokenExpiresAt),
-		KeyVersion:      int32(p.KeyVersion),
+		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
 		ExpiresAt:       timeToTs(p.ExpiresAt),
 	}))

--- a/backend/internal/hub/store/postgres/postgres_test.go
+++ b/backend/internal/hub/store/postgres/postgres_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -19,16 +20,14 @@ import (
 	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
-func TestPostgresStore(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
+// startPostgresContainer boots a disposable PostgreSQL 17 container and
+// returns its connection string. Shared by the store conformance suite and the
+// live schema assertions.
+func startPostgresContainer(t *testing.T) string {
+	t.Helper()
 	testutil.ConfigureDockerHost(t)
 
 	ctx := context.Background()
-
-	// Start a PostgreSQL container.
 	req := testcontainers.ContainerRequest{
 		Image:        "postgres:17-alpine",
 		ExposedPorts: []string{"5432/tcp"},
@@ -53,7 +52,16 @@ func TestPostgresStore(t *testing.T) {
 	port, err := pgContainer.MappedPort(ctx, "5432")
 	require.NoError(t, err)
 
-	connStr := "postgres://test:test@" + host + ":" + port.Port() + "/leapmux_test?sslmode=disable"
+	return "postgres://test:test@" + host + ":" + port.Port() + "/leapmux_test?sslmode=disable"
+}
+
+func TestPostgresStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	connStr := startPostgresContainer(t)
 
 	// Create ONE pool and store, run migrations once.
 	pool, err := pgxpool.New(ctx, connStr)
@@ -80,4 +88,77 @@ func TestPostgresStore(t *testing.T) {
 		},
 	}
 	suite.Run(t)
+}
+
+// TestPostgresBinaryCollationLive pins the byte-wise-collation invariant
+// against the ACTUAL migrated schema: every TEXT column that serves as a
+// keyset id tiebreaker or an FK to one -- named "id", "*_id", or in the
+// FK-author set (registered_by, created_by) -- must carry an explicit
+// COLLATE "C", so `id < $cursor_id` compares byte-wise on every deployment
+// instead of inheriting the database's locale collation. Unlike MySQL's
+// table-level suffix, Postgres applies the clause per column, so a new table's
+// id column can silently omit it; information_schema reports collation_name
+// only when it differs from the database default, so asserting the literal
+// 'C' catches an omitted clause even in a C-locale test database.
+// Point-lookup secrets that never tiebreak a cursor (device_code, user_code,
+// code, state, token, auth_token, provider_subject) also carry COLLATE "C"
+// for byte-wise equality, but fall outside the name shape and are not
+// enumerated here.
+// Live twin of mysql's TestMySQLBinaryCollationLive; sqlite needs no
+// counterpart because its TEXT comparison is BINARY unless a collation is
+// declared. YugabyteDB inherits this pin via the shared migration.
+func TestPostgresBinaryCollationLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	connStr := startPostgresContainer(t)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	sqlDB := stdlib.OpenDBFromPool(pool)
+	st, err := postgres.NewTestableFromPool(pool, sqlDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(ctx))
+
+	// Beyond the id name shape, enumerate the columns whose byte-wise ORDERING
+	// is behaviorally load-bearing despite falling outside it: the CRDT
+	// journal's origin_client tiebreak and compaction watermark must order
+	// exactly like Go's plain string compare (crdt/op.go), and the four
+	// lexorank position columns must order exactly like the Go/TS comparators
+	// for ANY future alphabet -- a dropped COLLATE "C" on these regresses
+	// silently under a linguistic database locale.
+	rows, err := pool.Query(ctx, `
+		SELECT table_name, column_name, COALESCE(collation_name, '<database default>')
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND data_type = 'text'
+		  AND table_name <> 'goose_db_version'
+		  AND (column_name = 'id' OR column_name LIKE '%\_id' OR column_name IN ('registered_by', 'created_by')
+		       OR (table_name, column_name) IN (
+		           ('org_op_batches', 'origin_client'),
+		           ('org_recent_batch_ids', 'canonical_client'),
+		           ('workspace_sections', 'position'),
+		           ('workspace_section_items', 'position'),
+		           ('workspace_tab_owned', 'position'),
+		           ('workspace_tab_rendered', 'position')))
+		ORDER BY table_name, column_name`)
+	require.NoError(t, err)
+	defer rows.Close()
+	checked := 0
+	for rows.Next() {
+		var table, column, collation string
+		require.NoError(t, rows.Scan(&table, &column, &collation))
+		checked++
+		assert.Equalf(t, "C", collation,
+			"%s.%s must carry an explicit COLLATE \"C\" so the cursor id tiebreak and FK joins compare byte-wise on every deployment", table, column)
+	}
+	require.NoError(t, rows.Err())
+	// The migration declares 74 COLLATE "C" columns; a collapse of this count
+	// means the name heuristic (or the schema) broke, not that fewer pins are
+	// needed.
+	assert.Greater(t, checked, 40, "expected many id/FK TEXT columns; the name heuristic may have broken (got %d)", checked)
 }

--- a/backend/internal/hub/store/postgres/registration_keys.go
+++ b/backend/internal/hub/store/postgres/registration_keys.go
@@ -88,7 +88,7 @@ func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (
 	}))
 }
 
-func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) ([]store.WorkerRegistrationKeyWithCreator, error) {
+func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
 	// Leave Valid=false on the pgtype.Timestamptz values so the
 	// `($N::timestamptz IS NULL OR …)` short-circuits keep every row /
 	// start from the head.
@@ -96,19 +96,12 @@ func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegist
 	if !p.IncludeExpired {
 		nowTs = timeToTs(time.Now().UTC())
 	}
-	cursorTs, err := parseCursorToTs(p.Cursor)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListRegistrationKeysAdmin(ctx, gendb.ListRegistrationKeysAdminParams{
-		Now:    nowTs,
-		Cursor: cursorTs,
-		Limit:  int32(p.Limit),
-	})
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return store.MapSlice(rows, fromDBListRegistrationKeysAdminRow), nil
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListRegistrationKeysAdminParams, error) {
+			return listRegistrationKeysAdminParams(p.Cursor, p.Limit, nowTs)
+		},
+		s.conn.q.ListRegistrationKeysAdmin,
+		fromDBListRegistrationKeysAdminRow)
 }
 
 func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) store.WorkerRegistrationKeyWithCreator {
@@ -120,5 +113,6 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 			ExpiresAt: tsToTime(r.ExpiresAt),
 		},
 		CreatorUsername: r.CreatorUsername,
+		CreatorDeleted:  r.CreatorDeleted,
 	}
 }

--- a/backend/internal/hub/store/postgres/sessions.go
+++ b/backend/internal/hub/store/postgres/sessions.go
@@ -26,8 +26,18 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	}
 }
 
-func fromDBSessions(rows []gendb.UserSession) []store.UserSession {
-	return store.MapSlice(rows, fromDBSession)
+func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSession {
+	return store.ActiveSession{
+		ID:           r.ID,
+		UserID:       r.UserID,
+		Username:     r.Username,
+		UserDeleted:  r.UserDeleted,
+		CreatedAt:    tsToTime(r.CreatedAt),
+		LastActiveAt: tsToTime(r.LastActiveAt),
+		ExpiresAt:    tsToTime(r.ExpiresAt),
+		IPAddress:    r.IpAddress,
+		UserAgent:    r.UserAgent,
+	}
 }
 
 func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) error {
@@ -96,37 +106,20 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	return n, mapErr(err)
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, userID string) ([]store.UserSession, error) {
-	rows, err := s.conn.q.ListUserSessionsByUserID(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBSessions(rows), nil
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListUserSessionsByUserIDParams, error) {
+			return listUserSessionsParams(p.UserID, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) ([]store.ActiveSession, error) {
-	params, err := listAllActiveSessionsParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllActiveSessions(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	out := make([]store.ActiveSession, len(rows))
-	for i, r := range rows {
-		out[i] = store.ActiveSession{
-			ID:           r.ID,
-			UserID:       r.UserID,
-			Username:     r.Username,
-			CreatedAt:    tsToTime(r.CreatedAt),
-			LastActiveAt: tsToTime(r.LastActiveAt),
-			ExpiresAt:    tsToTime(r.ExpiresAt),
-			IPAddress:    r.IpAddress,
-			UserAgent:    r.UserAgent,
-		}
-	}
-	return out, nil
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllActiveSessionsParams, error) {
+			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+		},
+		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
 func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {

--- a/backend/internal/hub/store/postgres/testhelper.go
+++ b/backend/internal/hub/store/postgres/testhelper.go
@@ -58,6 +58,10 @@ func (h *pgTestHelper) SetCreatedAt(ctx context.Context, entity store.TestEntity
 	return sqlutil.SetCreatedAt(ctx, h.exec, sqlutil.ParameterStyleDollar, entity, id, createdAt)
 }
 
+func (h *pgTestHelper) SetLastActiveAt(ctx context.Context, id string, lastActiveAt time.Time) error {
+	return sqlutil.SetLastActiveAt(ctx, h.exec, sqlutil.ParameterStyleDollar, id, lastActiveAt)
+}
+
 func (h *pgTestHelper) SetRevocationEventRevokedAt(ctx context.Context, id string, revokedAt time.Time) error {
 	return h.setTimestamp(ctx, sqlutil.TimestampColumnRevocationEventRevokedAt, id, revokedAt)
 }

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -40,10 +40,6 @@ func fromDBUser(u gendb.User) store.User {
 	}
 }
 
-func fromDBUsers(rows []gendb.User) []store.User {
-	return store.MapSlice(rows, fromDBUser)
-}
-
 func (s *userStore) Create(ctx context.Context, p store.CreateUserParams) error {
 	if err := p.Validate(); err != nil {
 		return err
@@ -153,28 +149,16 @@ func (s *userStore) Count(ctx context.Context) (int64, error) {
 	return n, mapErr(err)
 }
 
-func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) ([]store.User, error) {
-	params, err := listAllUsersParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllUsersParams, error) { return listAllUsersParams(p.Cursor, p.Limit) },
+		s.conn.q.ListAllUsers, fromDBUser)
 }
 
-func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) ([]store.User, error) {
-	params, err := searchUsersParams(p.Query, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.SearchUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.SearchUsersParams, error) { return searchUsersParams(p.Query, p.Cursor, p.Limit) },
+		s.conn.q.SearchUsers, fromDBUser)
 }
 
 // loadUserInfoCacheFields reads the current cached-UserInfo projection for id.

--- a/backend/internal/hub/store/postgres/workers.go
+++ b/backend/internal/hub/store/postgres/workers.go
@@ -64,63 +64,53 @@ func (s *workerStore) GetOwned(ctx context.Context, p store.GetOwnedWorkerParams
 	return store.GetOwnedWorker(ctx, p, s.GetByID)
 }
 
-func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) ([]store.Worker, error) {
-	params, err := listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListWorkersByUserID(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBWorkers(rows), nil
+func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) (store.Page[store.Worker], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListWorkersByUserIDParams, error) {
+			return listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListWorkersByUserID,
+		func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
 }
 
-func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) ([]store.WorkerWithOwner, error) {
+func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) (store.Page[store.WorkerWithOwner], error) {
+	// The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+	// nil/set), dispatched to four generated queries. The user_id dimension is a
+	// required-equality query rather than an opt-in `(narg IS NULL OR registered_by
+	// = narg)` probe: that probe made sqlc emit UserID as an untyped interface{},
+	// and binding NULL raised SQLSTATE 42P08 "could not determine data type of
+	// parameter" (YugabyteDB inherits the break via this store). Splitting
+	// user_id into its own query yields a typed `string` param and restores the
+	// index seek. See workers.sql for the per-query index rationale.
 	switch {
-	case p.UserID == nil && p.Status == nil:
-		params, err := listWorkersAdminAllParams(p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminAll(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminAllRow), nil
-
-	case p.UserID == nil && p.Status != nil:
-		params, err := listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByStatusRow), nil
-
-	case p.UserID != nil && p.Status == nil:
-		params, err := listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUser(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserRow), nil
-
-	default: // both non-nil
-		params, err := listWorkersAdminByUserAndStatusParams(*p.UserID, *p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUserAndStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserAndStatusRow), nil
+	case p.Status != nil && p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+				return listWorkersAdminByUserAndStatusParams(*p.Status, *p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUserAndStatus,
+			fromDBListWorkersAdminByUserAndStatusRow)
+	case p.Status != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByStatusParams, error) {
+				return listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByStatus,
+			fromDBListWorkersAdminByStatusRow)
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserParams, error) {
+				return listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUser,
+			fromDBListWorkersAdminByUserRow)
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminParams, error) {
+				return listWorkersAdminParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdmin,
+			fromDBListWorkersAdminRow)
 	}
 }
 
@@ -179,82 +169,25 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 	}
 }
 
-func fromDBWorkers(rows []gendb.Worker) []store.Worker {
-	return store.MapSlice(rows, func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
+// workerWithOwner is the shared body of the four admin-worker Row mappers. The
+// queries select sqlc.embed(w) so every admin Row is {Worker, OwnerUsername};
+// this helper keeps the gendb.Worker -> store.Worker mapping in one site.
+func workerWithOwner(w gendb.Worker, ownerUsername string, ownerDeleted bool) store.WorkerWithOwner {
+	return store.WorkerWithOwner{Worker: *fromDBWorker(w), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
 }
 
-func fromDBListWorkersAdminAllRow(r gendb.ListWorkersAdminAllRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       tsToTime(r.CreatedAt),
-			LastSeenAt:      tsToTimePtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       tsToTimePtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
-}
-
-func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       tsToTime(r.CreatedAt),
-			LastSeenAt:      tsToTimePtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       tsToTimePtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+func fromDBListWorkersAdminRow(r gendb.ListWorkersAdminRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserRow(r gendb.ListWorkersAdminByUserRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       tsToTime(r.CreatedAt),
-			LastSeenAt:      tsToTimePtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       tsToTimePtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
+}
+
+func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserAndStatusRow(r gendb.ListWorkersAdminByUserAndStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       tsToTime(r.CreatedAt),
-			LastSeenAt:      tsToTimePtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  r.AutoRegistered,
-			DeletedAt:       tsToTimePtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }

--- a/backend/internal/hub/store/sqlite/api_tokens.go
+++ b/backend/internal/hub/store/sqlite/api_tokens.go
@@ -70,6 +70,62 @@ func (s *apiTokenStore) ListByUser(ctx context.Context, p store.ListAPITokensByU
 	return store.MapSlice(rows, fromDBAPIToken), nil
 }
 
+// apiTokenWithOwner assembles the JOINed listing row shared by the ListAll and
+// ListAllByUser query twins (mirroring workerWithOwner), so a field addition
+// to APITokenWithOwner edits one site instead of one closure per query.
+func apiTokenWithOwner(t gendb.ApiToken, ownerUsername string, ownerDeleted bool) store.APITokenWithOwner {
+	return store.APITokenWithOwner{APIToken: fromDBAPIToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *apiTokenStore) ListAll(ctx context.Context, p store.ListAllAPITokensParams) (store.Page[store.APITokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see api_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+				return listAllAPITokensByUserIncludingRevokedParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUserIncludingRevoked,
+			func(r gendb.ListAllAPITokensByUserIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensByUserParams, error) {
+				return listAllAPITokensByUserParams(*p.UserID, p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensByUser,
+			func(r gendb.ListAllAPITokensByUserRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+				return listAllAPITokensIncludingRevokedParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokensIncludingRevoked,
+			func(r gendb.ListAllAPITokensIncludingRevokedRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllAPITokensParams, error) {
+				return listAllAPITokensParams(p.ClientType, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllAPITokens,
+			func(r gendb.ListAllAPITokensRow) store.APITokenWithOwner {
+				return apiTokenWithOwner(r.ApiToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	}
+}
+
 func (s *apiTokenStore) Touch(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.TouchAPIToken(ctx, id))
 }

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -19,27 +18,27 @@ func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, er
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, cutoff))
+	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteOrgsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
@@ -59,11 +58,11 @@ func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, c
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sql.NullTime{Time: cutoff.UTC(), Valid: true}))
+	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sql.NullTime{Time: cutoff.UTC(), Valid: true}))
+	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/backend/internal/hub/store/sqlite/convert.go
+++ b/backend/internal/hub/store/sqlite/convert.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -16,8 +17,20 @@ import (
 	sqlitelib "modernc.org/sqlite/lib"
 )
 
-// sqliteTimeFormat is the ISO 8601 format matching SQLite's
-// strftime('%Y-%m-%dT%H:%M:%fZ', 'now') output.
+// sqliteTimeFormat is the ISO 8601 layout SQLite writes via
+// strftime('%Y-%m-%dT%H:%M:%fZ', ...): fixed 3-digit fractional seconds, the
+// same instant grid as this Go layout's ".000". Every SQL-side write path
+// (column DEFAULTs, the Create/Touch strftime wraps, SoftDelete's
+// strftime('now')) stores canonical 24-char values ON DISK, so the raw-string
+// keyset predicates and cleanup cutoff compares -- which run SQL-side against
+// the stored bytes -- are byte-exact against formatSQLiteTime-formatted
+// params, including at trailing-zero milliseconds (pinned by
+// TestKeysetCursorTrailingZeroMillisecondTie in sessions_internal_test.go).
+// CAUTION for tests and tooling: modernc TRIMS trailing fractional zeros when
+// a DATETIME column is scanned into a Go string (a stored ".130Z" arrives as
+// ".13Z") -- a driver presentation artifact only; production reads scan into
+// time.Time and are unaffected. Do not mistake a short scanned string for
+// on-disk variability.
 const sqliteTimeFormat = timefmt.ISO8601
 
 func formatSQLiteTime(t time.Time) string {
@@ -41,115 +54,186 @@ func mapErr(err error) error {
 	return err
 }
 
-// parseCursorToSQLiteTime converts an RFC3339Nano cursor string to the
-// ISO 8601 format that SQLite stores via strftime('%Y-%m-%dT%H:%M:%fZ', 'now').
-// Returns nil when cursor is empty (first page).
-func parseCursorToSQLiteTime(cursor string) (any, error) {
-	t, ok, err := store.ParseCursorTime(cursor)
+// decodeCursorParams decodes the composite list cursor into the two nullable sqlc
+// parameters SQLite's keyset queries bind: the cursor timestamp, formatted as
+// the ISO 8601 string SQLite stores via strftime('%Y-%m-%dT%H:%M:%fZ'), and the
+// id tiebreaker. An empty cursor (first page) returns the zero values so the
+// queries' "cursor_time IS NULL" branch selects every row.
+func decodeCursorParams(cursor string) (cursorTime any, cursorID sql.NullString, err error) {
+	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return nil, err
+		return nil, sql.NullString{}, err
 	}
-	if !ok {
-		return nil, nil
+	if c == nil {
+		return nil, sql.NullString{}, nil
 	}
-	return t.UTC().Format(sqliteTimeFormat), nil
+	return formatSQLiteTime(c.Time), sql.NullString{String: c.ID, Valid: true}, nil
+}
+
+// withCursor decodes the composite list cursor and applies the dialect's
+// fetch-limit clamp, then hands the decoded values to fill, which assembles
+// the dialect-specific sqlc params struct. Centralizing decodeCursorParams + the
+// error short-circuit + store.FetchLimit here means a change to the cursor
+// decode, the clamp rule, or the probe-row accounting edits ONE site per
+// dialect instead of being copy-pasted across every list builder -- the prior
+// shape let ListRegistrationKeysAdmin silently bypass ClampListLimit until this
+// commit's pagination rebuild caught it.
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime any, cursorID sql.NullString, fetchLimit int64) T) (T, error) {
+	cursorTime, cursorID, err := decodeCursorParams(cursor)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return fill(cursorTime, cursorID, store.FetchLimit(limit)), nil
+}
+
+// queryPage forwards to store.QueryPage with this dialect's mapErr bound:
+// every listing in the package routes through it, so the shared
+// build -> query -> NewPage skeleton (and its error wrapping and probe-row
+// accounting) lives once in store instead of drifting per dialect.
+func queryPage[P any, R any, I store.PageCursorer](
+	ctx context.Context,
+	limit int64,
+	build func() (P, error),
+	query func(context.Context, P) ([]R, error),
+	mapRow func(R) I,
+) (store.Page[I], error) {
+	return store.QueryPage(ctx, limit, build, query, mapRow, mapErr)
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListAllUsersParams{}, err
-	}
-	return gendb.ListAllUsersParams{
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllUsersParams {
+		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.SearchUsersParams{}, err
-	}
-	return gendb.SearchUsersParams{
-		// Fold the search term the same way the write path folds display_name_folded,
-		// so the plain-LIKE match is case-insensitive (and cross-dialect consistent) for
-		// non-ASCII names. A nil query stays nil (SearchUsers reads it as "no filter").
-		Query:  ptrconv.PtrToNullString(store.FoldSearchQuery(query)),
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.SearchUsersParams {
+		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
+		// '%') at the one shared site, so the match is case-insensitive and literal
+		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
+		return gendb.SearchUsersParams{
+			Query:      ptrconv.PtrToNullString(store.SearchLikePattern(query)),
+			CursorTime: ct,
+			CursorID:   cid,
+			Limit:      fl,
+		}
+	})
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListWorkersByUserIDParams{}, err
-	}
-	return gendb.ListWorkersByUserIDParams{
-		RegisteredBy: registeredBy,
-		Cursor:       parsedCursor,
-		Limit:        store.ClampListLimit(limit),
-	}, nil
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersByUserIDParams {
+		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminAllParams(cursor string, limit int64) (gendb.ListWorkersAdminAllParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminAllParams{}, err
-	}
-	return gendb.ListWorkersAdminAllParams{
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+// listWorkersAdminParams builds the status=nil, user_id=nil query
+// (ListWorkersAdmin): deleted_at IS NULL, no user filter.
+func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminParams {
+		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
+// listWorkersAdminByUserParams builds the status=nil, user_id=set query
+// (ListWorkersAdminByUser): deleted_at IS NULL + required registered_by. The
+// user_id dimension is its own query rather than an opt-in `(narg IS NULL OR
+// registered_by = narg)` probe: that probe defeats SQLite's index seek for the
+// user_id-set case (EXPLAIN: full partial-index scan + sort) and emits an
+// untyped interface{} param that breaks Postgres (SQLSTATE 42P08). See
+// workers.sql for the full 2x2 matrix rationale.
+func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserParams {
+		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listWorkersAdminByStatusParams builds the status=set, user_id=nil query
+// (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
+// soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByStatusParams{
-		Status: status,
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByStatusParams {
+		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
-func listWorkersAdminByUserParams(userID, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserParams{
-		UserID: userID,
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
-}
-
-func listWorkersAdminByUserAndStatusParams(userID string, status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListWorkersAdminByUserAndStatusParams{}, err
-	}
-	return gendb.ListWorkersAdminByUserAndStatusParams{
-		UserID: userID,
-		Status: status,
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+// listWorkersAdminByUserAndStatusParams builds the status=set, user_id=set
+// query (ListWorkersAdminByUserAndStatus): required registered_by + status,
+// riding the (registered_by, status, created_at, id) composite seek.
+func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserAndStatusParams {
+		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	parsedCursor, err := parseCursorToSQLiteTime(cursor)
-	if err != nil {
-		return gendb.ListAllActiveSessionsParams{}, err
-	}
-	return gendb.ListAllActiveSessionsParams{
-		Cursor: parsedCursor,
-		Limit:  store.ClampListLimit(limit),
-	}, nil
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllActiveSessionsParams {
+		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListUserSessionsByUserIDParams {
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensParams {
+		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserParams {
+		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensIncludingRevokedParams {
+		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensParams {
+		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserParams {
+		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
+}
+
+// listRegistrationKeysAdminParams mirrors the other list builders so the
+// registration-key admin listing shares the cursor decode and limit clamp.
+// now is the caller-computed expiry probe (nil when expired rows are
+// included), passed in so the builder stays a pure function of its arguments.
+func listRegistrationKeysAdminParams(cursor string, limit int64, now any) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListRegistrationKeysAdminParams {
+		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
+	})
 }
 
 func rowsAffected(result sql.Result, err error) (int64, error) {

--- a/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
@@ -51,21 +51,24 @@ CREATE TABLE users (
     -- value when issued; user-wide revocation increments it so stale
     -- credentials fail without depending on timestamp precision or
     -- cross-host clock agreement.
-    auth_generation          INTEGER NOT NULL DEFAULT 0,
+    auth_generation          BIGINT NOT NULL DEFAULT 0,
     deleted_at     DATETIME
 );
 CREATE INDEX idx_users_org_id ON users(org_id);
 CREATE UNIQUE INDEX idx_users_username ON users(username) WHERE deleted_at IS NULL;
 CREATE UNIQUE INDEX idx_users_email ON users(email) WHERE email != '' AND deleted_at IS NULL;
 CREATE INDEX idx_users_deleted_at ON users(deleted_at) WHERE deleted_at IS NOT NULL;
-CREATE INDEX idx_users_tokens_revoked_at ON users(tokens_revoked_at) WHERE tokens_revoked_at IS NOT NULL;
+CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC) WHERE deleted_at IS NULL;
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at) WHERE pending_email_expires_at IS NOT NULL;
 -- GetFirstAdmin scans for the earliest non-deleted admin (bootstrap path).
 -- Partial on (is_admin, deleted_at) keeps the index tiny; indexing on
 -- created_at lets the ORDER BY + LIMIT 1 hit the first leaf directly.
-CREATE INDEX idx_users_is_admin ON users(created_at) WHERE is_admin AND deleted_at IS NULL;
+-- The predicate MUST be spelled `is_admin = 1` -- SQLite's partial-index
+-- matcher is syntactic, so a bare `is_admin` predicate never matches
+-- GetFirstAdmin's `is_admin = 1` term and the index goes unused.
+CREATE INDEX idx_users_is_admin ON users(created_at) WHERE is_admin = 1 AND deleted_at IS NULL;
 
 -- Auth sessions
 CREATE TABLE user_sessions (
@@ -74,12 +77,21 @@ CREATE TABLE user_sessions (
     expires_at      DATETIME NOT NULL,
     created_at      DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_active_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    auth_generation INTEGER NOT NULL DEFAULT 0,
+    auth_generation BIGINT NOT NULL DEFAULT 0,
     user_agent      TEXT NOT NULL DEFAULT '',
     ip_address      TEXT NOT NULL DEFAULT ''
 );
-CREATE INDEX idx_user_sessions_user_id ON user_sessions(user_id);
+-- Serves the plain user_id lookups (prefix) AND the per-user keyset listing
+-- ListUserSessionsByUserID (user_id =, ORDER BY last_active_at DESC, id DESC),
+-- so that query both seeks and rides the index instead of TEMP-sorting.
+CREATE INDEX idx_user_sessions_user_last_active ON user_sessions(user_id, last_active_at DESC, id DESC);
 CREATE INDEX idx_user_sessions_expires_at_last_active ON user_sessions(expires_at, last_active_at);
+-- The active-session listing orders by (last_active_at DESC, id DESC) while
+-- filtering expires_at with a range predicate. A range on the leading
+-- expires_at column means the index above can never provide that order (the
+-- engine would top-N sort every page), so the ORDER BY gets its own index and
+-- the expiry check runs as a residual filter during the ordered scan.
+CREATE INDEX idx_user_sessions_last_active ON user_sessions(last_active_at DESC, id DESC);
 
 -- Registered workers
 CREATE TABLE workers (
@@ -101,16 +113,33 @@ CREATE TABLE workers (
     auto_registered INTEGER NOT NULL DEFAULT 0,
     deleted_at    DATETIME
 );
-CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC) WHERE deleted_at IS NULL;
--- Full (non-partial) registered_by index for the cleanup FK gate:
--- HardDeleteUsersBefore probes NOT EXISTS a worker (INCLUDING soft-deleted rows)
--- referencing the user, which the partial index above (deleted_at IS NULL) cannot serve.
-CREATE INDEX idx_workers_registered_by ON workers(registered_by);
+-- Non-partial on purpose (matches MySQL): ListWorkersByUserID and
+-- ListWorkersAdminByUserAndStatus filter on registered_by + status with NO
+-- deleted_at predicate, so a WHERE deleted_at IS NULL partial index would be
+-- ineligible and every page would fall back to a full table scan plus sort.
+-- The leading registered_by column also serves HardDeleteUsersBefore's
+-- NOT EXISTS (workers.registered_by = users.id) point probe over ALL rows
+-- (including soft-deleted), so no separate registered_by-only index is needed.
+CREATE INDEX idx_workers_registered_by_status_created ON workers(registered_by, status, created_at DESC, id DESC);
 -- Admin status-only listing (ListWorkersAdminByStatus) cannot use the
 -- (registered_by, status, created_at) index because registered_by is the
--- leading column.
-CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC) WHERE deleted_at IS NULL;
+-- leading column. Non-partial on purpose: the query carries no deleted_at
+-- filter (status=3 lists soft-deleted workers), so a WHERE deleted_at IS NULL
+-- partial index would be ineligible and every page would fall back to a full
+-- table scan plus sort.
+CREATE INDEX idx_workers_status_created ON workers(status, created_at DESC, id DESC);
+-- Admin per-user listing (ListWorkersAdminByUser: registered_by=?, deleted_at IS
+-- NULL, no status filter). The (registered_by, status, created_at, id) composite
+-- above can't serve this query's ORDER BY because status sits between the
+-- registered_by equality and the created_at sort key -- within a registered_by
+-- prefix rows are grouped by status, not ordered by created_at, so every page
+-- would top-N sort. This partial index closes that gap and completes the
+-- 'composite ORDER BY rides an index' invariant for all five worker keyset
+-- families. (ListWorkersByUserID is still served by the composite above: it
+-- filters registered_by + status=1, so the composite's prefix matches exactly.)
+CREATE INDEX idx_workers_registered_by_created ON workers(registered_by, created_at DESC, id DESC) WHERE deleted_at IS NULL;
 CREATE INDEX idx_workers_deleted_at ON workers(deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_workers_created_at ON workers(created_at DESC, id DESC) WHERE deleted_at IS NULL;
 
 -- Worker notifications (persistent queue for reliable delivery)
 CREATE TABLE worker_notifications (
@@ -144,7 +173,7 @@ CREATE TABLE worker_registration_keys (
 );
 CREATE INDEX idx_worker_registration_keys_expires_at ON worker_registration_keys(expires_at);
 CREATE INDEX idx_worker_registration_keys_created_by ON worker_registration_keys(created_by);
-CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at);
+CREATE INDEX idx_worker_registration_keys_created_at ON worker_registration_keys(created_at DESC, id DESC);
 
 
 -- Sidebar sections (per-user organization of sidebar panels)
@@ -159,17 +188,7 @@ CREATE TABLE workspace_sections (
 );
 CREATE INDEX idx_workspace_sections_user_id ON workspace_sections(user_id);
 
--- Workspace-to-section assignments (per-user)
-CREATE TABLE workspace_section_items (
-    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    section_id   TEXT NOT NULL REFERENCES workspace_sections(id) ON DELETE CASCADE,
-    position     TEXT NOT NULL,
-    PRIMARY KEY (user_id, workspace_id)
-);
-CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(section_id);
-
--- Workspaces (hub-owned registry)
+-- Workspaces (hub-owned registry) -- must come before workspace_section_items
 CREATE TABLE workspaces (
     id            TEXT PRIMARY KEY,
     org_id        TEXT NOT NULL REFERENCES orgs(id),
@@ -182,6 +201,16 @@ CREATE TABLE workspaces (
 CREATE INDEX idx_workspaces_org_owner ON workspaces(org_id, owner_user_id) WHERE is_deleted = 0;
 CREATE INDEX idx_workspaces_owner_user_id ON workspaces(owner_user_id);
 CREATE INDEX idx_workspaces_deleted_at ON workspaces(deleted_at) WHERE deleted_at IS NOT NULL;
+
+-- Workspace-to-section assignments (per-user)
+CREATE TABLE workspace_section_items (
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    section_id   TEXT NOT NULL REFERENCES workspace_sections(id) ON DELETE CASCADE,
+    position     TEXT NOT NULL,
+    PRIMARY KEY (user_id, workspace_id)
+);
+CREATE INDEX idx_workspace_section_items_section ON workspace_section_items(section_id);
 
 -- CRDT op-batch journal. The per-org CRDT manager appends every committed
 -- batch here in the same transaction that updates the in-memory state and
@@ -305,9 +334,9 @@ CREATE TABLE revocation_events (
     subject_id TEXT NOT NULL,
     user_id    TEXT NOT NULL,
     revoked_at DATETIME NOT NULL,
-    user_auth_generation INTEGER NOT NULL DEFAULT 0,
+    user_auth_generation BIGINT NOT NULL DEFAULT 0,
     created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    seq INTEGER UNIQUE CHECK (seq IS NULL OR seq > 0),
+    seq BIGINT UNIQUE CHECK (seq IS NULL OR seq > 0),
     published_at DATETIME,
     CHECK ((seq IS NULL) = (published_at IS NULL))
 );
@@ -316,14 +345,14 @@ CREATE INDEX idx_revocation_events_published ON revocation_events(published_at, 
 
 CREATE TABLE revocation_event_sequence (
     id       INTEGER PRIMARY KEY CHECK (id = 1),
-    last_seq INTEGER NOT NULL CHECK (last_seq >= 0)
+    last_seq BIGINT NOT NULL CHECK (last_seq >= 0)
 );
 INSERT INTO revocation_event_sequence (id, last_seq) VALUES (1, 0);
 
 CREATE TABLE hub_runtime_lease (
     singleton_id     INTEGER PRIMARY KEY CHECK (singleton_id = 1),
     holder_id        TEXT NOT NULL CHECK (holder_id <> ''),
-    cursor_seq       INTEGER NOT NULL CHECK (cursor_seq >= 0),
+    cursor_seq       BIGINT NOT NULL CHECK (cursor_seq >= 0),
     lease_expires_at DATETIME NOT NULL
 );
 
@@ -349,16 +378,28 @@ CREATE TABLE api_tokens (
     previous_refresh_expires_at   DATETIME,
     scope                         TEXT NOT NULL DEFAULT 'remote:*',
     created_at                    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    auth_generation               INTEGER NOT NULL DEFAULT 0,
+    auth_generation               BIGINT NOT NULL DEFAULT 0,
     last_used_at                  DATETIME,
     last_rotated_at               DATETIME,
     expires_at                    DATETIME,
     refresh_expires_at            DATETIME,
     revoked_at                    DATETIME
 );
-CREATE INDEX idx_api_tokens_user ON api_tokens(user_id, client_type);
-CREATE INDEX idx_api_tokens_expires_at ON api_tokens(expires_at);
+-- user_id only: the client_type filters are the optional OR-form and never
+-- seek; the remaining job is the user_id seek for the ByUserIncludingRevoked
+-- listing, which the partial idx_api_tokens_user_created cannot serve.
+CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX idx_api_tokens_revoked_at ON api_tokens(revoked_at) WHERE revoked_at IS NOT NULL;
+-- Keyset index for the admin ListAllAPITokens listing: partial on
+-- revoked_at IS NULL to match the query's live-token filter, with the trailing
+-- id DESC so the composite ORDER BY rides the index instead of top-N sorting.
+CREATE INDEX idx_api_tokens_created_at ON api_tokens(created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Keyset index for the admin ListAllAPITokensByUser listing (the --user-id
+-- path): the leading user_id equality seeks, and (created_at DESC, id DESC)
+-- rides the composite ORDER BY -- without it the per-user page pays a seek on
+-- idx_api_tokens_user plus a TEMP B-TREE sort. Mirrors
+-- idx_workers_registered_by_created.
+CREATE INDEX idx_api_tokens_user_created ON api_tokens(user_id, created_at DESC, id DESC) WHERE revoked_at IS NULL;
 
 -- Ephemeral, high-churn delegation tokens minted by workers when a
 -- spawned agent (or opt-in terminal) calls into the hub or a sibling
@@ -378,7 +419,7 @@ CREATE TABLE delegation_tokens (
     secret_hash                   BLOB NOT NULL,
     refresh_hash                  BLOB,
     created_at                    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    auth_generation               INTEGER NOT NULL DEFAULT 0,
+    auth_generation               BIGINT NOT NULL DEFAULT 0,
     last_used_at                  DATETIME,
     expires_at                    DATETIME NOT NULL,
     refresh_expires_at            DATETIME,
@@ -388,6 +429,15 @@ CREATE INDEX idx_delegation_tokens_user ON delegation_tokens(user_id);
 CREATE INDEX idx_delegation_tokens_worker_agent ON delegation_tokens(worker_id, agent_id);
 CREATE INDEX idx_delegation_tokens_workspace ON delegation_tokens(workspace_id);
 CREATE INDEX idx_delegation_tokens_revoked_at ON delegation_tokens(revoked_at) WHERE revoked_at IS NOT NULL;
+-- Keyset index for the admin ListAllDelegationTokens listing (see
+-- idx_api_tokens_created_at for the rationale).
+CREATE INDEX idx_delegation_tokens_created_at ON delegation_tokens(created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Per-user keyset twin (see idx_api_tokens_user_created).
+CREATE INDEX idx_delegation_tokens_user_created ON delegation_tokens(user_id, created_at DESC, id DESC) WHERE revoked_at IS NULL;
+-- Serves the hourly DeleteExpiredDelegationTokensBefore sweep of this
+-- high-churn table: seek the expired live rows instead of scanning every
+-- live token. Partial on revoked_at IS NULL to match the sweep's filter.
+CREATE INDEX idx_delegation_tokens_expires_at ON delegation_tokens(expires_at) WHERE revoked_at IS NULL;
 
 -- RFC 8628 device authorizations. The CLI starts the flow on a headless
 -- machine, the user activates the user_code from any browser, then the
@@ -486,10 +536,6 @@ CREATE TABLE pending_oauth_signups (
     expires_at       DATETIME NOT NULL,
     created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
-
-CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at DESC) WHERE deleted_at IS NULL;
-CREATE INDEX IF NOT EXISTS idx_workers_created_at ON workers(created_at DESC) WHERE deleted_at IS NULL;
-CREATE INDEX IF NOT EXISTS idx_orgs_created_at ON orgs(created_at DESC) WHERE deleted_at IS NULL;
 
 -- +goose Down
 DROP TABLE IF EXISTS cli_authorization_codes;

--- a/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
@@ -25,6 +25,65 @@ WHERE user_id = ?
   AND revoked_at IS NULL
 ORDER BY created_at DESC;
 
+-- name: ListAllAPITokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username so the
+-- CLI does not fan out per user). Keyset on (created_at DESC, id DESC).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllAPITokensIncludingRevoked :many
+-- Forensics variant of ListAllAPITokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllAPITokensByUser :many
+-- Per-user variant of ListAllAPITokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllAPITokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllAPITokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllAPITokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM api_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.arg(client_type) = '' OR t.client_type = sqlc.arg(client_type))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
 -- name: TouchAPIToken :exec
 UPDATE api_tokens
 SET last_used_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
@@ -62,8 +121,8 @@ SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE user_id = ? AND revoked_at IS NULL;
 
 -- name: DeleteRevokedAPITokensBefore :execresult
--- See the matching delegation_tokens query for the rationale: wrap
--- both sides in datetime() so format mismatches between the strftime
--- write path and Go's bound time.Time don't silently skip rows.
+-- See the matching delegation_tokens query for the rationale: revoked_at is
+-- written canonical on every path, so the raw compare against the canonical
+-- CAST AS TEXT cutoff is byte-exact and sargable for idx_api_tokens_revoked_at.
 DELETE FROM api_tokens
-WHERE revoked_at IS NOT NULL AND datetime(revoked_at) < datetime(?);
+WHERE revoked_at IS NOT NULL AND revoked_at < CAST(sqlc.arg(cutoff) AS TEXT);

--- a/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
@@ -22,10 +22,60 @@ INSERT INTO delegation_tokens (
 -- name: GetDelegationTokenByID :one
 SELECT * FROM delegation_tokens WHERE id = ?;
 
--- name: ListDelegationTokensByUser :many
-SELECT * FROM delegation_tokens
-WHERE user_id = ? AND revoked_at IS NULL
-ORDER BY created_at DESC;
+-- name: ListAllDelegationTokens :many
+-- Admin listing across all users (LEFT JOIN users for the owner username so the
+-- CLI does not fan out per user). Keyset on (created_at DESC, id DESC).
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllDelegationTokensIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokens: includes revoked rows
+-- (--include-revoked). No matching partial index serves this shape -- an
+-- occasional admin forensics page may top-N sort, which is deliberate; the
+-- live listings keep their partial-index seeks.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllDelegationTokensByUser :many
+-- Per-user variant of ListAllDelegationTokens (the admin --user path): required
+-- user_id equality on top of the same keyset + owner join.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.revoked_at IS NULL
+  AND t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
+
+-- name: ListAllDelegationTokensByUserIncludingRevoked :many
+-- Forensics variant of ListAllDelegationTokensByUser: includes revoked rows
+-- (--include-revoked); see ListAllDelegationTokensIncludingRevoked for the
+-- no-matching-index note.
+SELECT sqlc.embed(t), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM delegation_tokens t
+LEFT JOIN users u ON t.user_id = u.id AND u.deleted_at IS NULL
+WHERE t.user_id = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR t.created_at < sqlc.narg(cursor_time)
+       OR (t.created_at = sqlc.narg(cursor_time) AND t.id < sqlc.narg(cursor_id)))
+ORDER BY t.created_at DESC, t.id DESC
+LIMIT sqlc.arg(limit);
 
 -- name: ListActiveDelegationTokensByUser :many
 -- Returns rows that are still usable: not revoked AND not yet expired.
@@ -54,15 +104,16 @@ WHERE id = ? AND revoked_at IS NULL
 RETURNING id, user_id, revoked_at;
 
 -- name: DeleteRevokedDelegationTokensBefore :execresult
--- Both revoked_at and the bound cutoff go through datetime() so the
--- comparison is tolerant of format differences: revoked_at is stored
--- as ISO-8601 with 'T'/'Z' via strftime, while Go's database/sql
--- binds time.Time in a driver-native form. Without the datetime()
--- wrap the < comparison falls back to a lexicographic test that
--- silently fails on legitimate cutoffs (the 'T' separator on the
--- stored side sorts after the ' ' separator on the bound side).
+-- Raw compare: every revoked_at write path stores the canonical strftime
+-- layout (RevokeDelegationToken and RevokeDelegationTokensByUserFast both SET
+-- strftime('%Y-%m-%dT%H:%M:%fZ','now')), and the Go side binds a
+-- formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param), so the
+-- lexicographic < is byte-exact. Unlike the previous datetime() wrap on the
+-- column, this is sargable: the partial idx_delegation_tokens_revoked_at
+-- serves an upper-bounded SEARCH of just the cutoff-eligible rows instead of
+-- reading every revoked row on each hourly sweep of this high-churn table.
 DELETE FROM delegation_tokens
-WHERE revoked_at IS NOT NULL AND datetime(revoked_at) < datetime(?);
+WHERE revoked_at IS NOT NULL AND revoked_at < CAST(sqlc.arg(cutoff) AS TEXT);
 
 -- name: DeleteExpiredDelegationTokensBefore :execresult
 DELETE FROM delegation_tokens

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
@@ -1,6 +1,19 @@
 -- name: UpsertOAuthTokens :exec
+-- expires_at is stored in the canonical strftime layout (the wrap converts the
+-- driver-bound instant) so ListExpiringOAuthTokens can compare it raw --
+-- sargable for idx_oauth_tokens_expires_at -- instead of wrapping the column
+-- in datetime() and scanning every row. The DO UPDATE reuses the transformed
+-- excluded value, so both insert and update paths store the same layout.
 INSERT INTO oauth_tokens (user_id, provider_id, access_token, refresh_token, token_type, expires_at, key_version)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+VALUES (
+    sqlc.arg(user_id),
+    sqlc.arg(provider_id),
+    sqlc.arg(access_token),
+    sqlc.arg(refresh_token),
+    sqlc.arg(token_type),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
+    sqlc.arg(key_version)
+)
 ON CONFLICT (user_id, provider_id) DO UPDATE SET
     access_token = excluded.access_token,
     refresh_token = excluded.refresh_token,
@@ -14,8 +27,12 @@ SELECT * FROM oauth_tokens
 WHERE user_id = ? AND provider_id = ?;
 
 -- name: ListExpiringOAuthTokens :many
+-- Raw compare: expires_at is stored canonical (UpsertOAuthTokens wraps the
+-- bound instant in strftime), so comparing it raw against the same canonical
+-- RHS layout is byte-exact and sargable -- idx_oauth_tokens_expires_at serves
+-- an upper-bounded SEARCH instead of a full scan under a datetime() wrap.
 SELECT * FROM oauth_tokens
-WHERE datetime(expires_at) <= datetime('now', '+5 minutes');
+WHERE expires_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+5 minutes');
 
 -- name: DeleteOAuthTokensByProvider :exec
 DELETE FROM oauth_tokens WHERE provider_id = ?;

--- a/backend/internal/hub/store/sqlite/db/queries/orgs.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/orgs.sql
@@ -24,7 +24,9 @@ UPDATE orgs SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?;
 -- idx_users_org_id makes the NOT EXISTS lookup an indexed point probe.
 DELETE FROM orgs WHERE rowid IN (
     SELECT o.rowid FROM orgs o
-    WHERE o.deleted_at IS NOT NULL AND o.deleted_at < ?
+    -- Raw compare: deleted_at (strftime-written) against the canonical cutoff
+    -- string (CAST AS TEXT -> string param; see HardDeleteWorkersBefore).
+    WHERE o.deleted_at IS NOT NULL AND o.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT)
       AND NOT EXISTS (SELECT 1 FROM users u WHERE u.org_id = o.id)
     LIMIT 1000
 );

--- a/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
@@ -59,17 +59,20 @@ DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND holder_id = sqlc.arg(ho
 DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND julianday(lease_expires_at) <= julianday('now');
 
 -- name: DeleteCompactablePublishedRevocationEvents :execresult
--- Normalize both sides to the same fixed-width ISO8601 millis format via
--- strftime %f before comparing, so the compare keeps full stored (millisecond)
--- precision. A bare datetime() wrap on both sides truncates to whole seconds and
--- retains sub-second-younger events that postgres/mysql compact -- a
--- cross-dialect divergence. strftime also tolerates whatever time format the
--- driver binds the cutoff in (the reason the datetime() wrap existed).
+-- Raw compare: published_at is written canonical on its only write path (the
+-- publish UPDATE sets strftime('%Y-%m-%dT%H:%M:%fZ','now')), and the Go side
+-- binds a formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param),
+-- so the lexicographic < is byte-exact at full millisecond precision --
+-- matching what postgres/mysql compact, with no strftime re-normalization per
+-- row. Unlike a function wrap on the column, this is sargable: the partial
+-- idx_revocation_events_published(published_at, seq) serves an upper-bounded
+-- SEARCH (the `ev.seq <= ...` term implies seq IS NOT NULL, satisfying the
+-- partial predicate).
 DELETE FROM revocation_events
 WHERE id IN (
     SELECT ev.id
     FROM revocation_events AS ev
-    WHERE strftime('%Y-%m-%dT%H:%M:%fZ', ev.published_at) < strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(cutoff))
+    WHERE ev.published_at < CAST(sqlc.arg(cutoff) AS TEXT)
       AND ev.seq <= COALESCE(
           (SELECT cursor_seq FROM hub_runtime_lease WHERE singleton_id = 1),
           (SELECT last_seq FROM revocation_event_sequence WHERE id = 1)

--- a/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
@@ -4,16 +4,17 @@ INSERT INTO user_sessions (
 ) VALUES (
     sqlc.arg(id),
     sqlc.arg(user_id),
-    sqlc.arg(expires_at),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
     sqlc.arg(user_agent),
     sqlc.arg(ip_address),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
 );
 
 -- name: GetUserSessionByID :one
--- julianday() normalizes modernc's bound time format and SQLite's strftime
--- format without discarding the fractional second at the expiry boundary.
-SELECT * FROM user_sessions WHERE id = ? AND julianday(expires_at) > julianday('now');
+-- expires_at is stored in the canonical strftime('%Y-%m-%dT%H:%M:%fZ') layout
+-- (CreateUserSession wraps the bound instant), so the liveness filter compares
+-- it raw against the same layout -- millisecond-exact at the expiry boundary.
+SELECT * FROM user_sessions WHERE id = ? AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: DeleteUserSession :one
 DELETE FROM user_sessions WHERE id = ? RETURNING id, user_id;
@@ -23,7 +24,7 @@ SELECT u.id, u.org_id, u.username, u.is_admin, u.email_verified, u.email, s.crea
 FROM user_sessions s
 JOIN users u ON s.user_id = u.id
 WHERE s.id = ?
-  AND julianday(s.expires_at) > julianday('now')
+  AND s.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
   AND u.deleted_at IS NULL
   AND s.auth_generation >= u.auth_generation;
 
@@ -41,7 +42,12 @@ WHERE user_sessions.id = sqlc.arg(session_id)
   );
 
 -- name: DeleteExpiredUserSessions :execresult
-DELETE FROM user_sessions WHERE julianday(expires_at) < julianday('now');
+-- expires_at is stored canonical (CreateUserSession + Touch both wrap the bound
+-- instant in strftime), so comparing it raw against the same canonical RHS is
+-- sargable for idx_user_sessions_expires_at_last_active (SEARCH expires_at<?,
+-- not a SCAN-with-residual under julianday()) -- the index was orphaned under
+-- the julianday wrap. RHS is strftime('now'), evaluated once, no binding.
+DELETE FROM user_sessions WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: DeleteUserSessionsByUser :exec
 DELETE FROM user_sessions WHERE user_id = ?;
@@ -51,15 +57,33 @@ DELETE FROM user_sessions WHERE user_id = ? AND id != ?;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = ? AND julianday(expires_at) > julianday('now')
-ORDER BY last_active_at DESC
-LIMIT 1000;
+WHERE user_id = sqlc.arg(user_id) AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR last_active_at < sqlc.narg(cursor_time)
+       OR (last_active_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY last_active_at DESC, id DESC
+LIMIT sqlc.arg(limit);
 
 -- name: ListAllActiveSessions :many
-SELECT s.id, s.user_id, u.username, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
+-- Both timestamp filters compare the raw canonical strftime('%Y-%m-%dT%H:%M:%fZ')
+-- column against the same layout. expires_at is stored canonical because BOTH
+-- write paths canonicalize it: CreateUserSession wraps the bound instant in
+-- strftime, and Touch (the inline UPDATE in sqlite/sessions.go) binds a
+-- formatSQLiteTime-pre-formatted string. last_active_at is written SQL-side by
+-- the column DEFAULT and Touch. A future session write path MUST keep this
+-- invariant -- binding a raw time.Time stores modernc's driver layout
+-- ("... ...+00:00", space at byte 10) and silently breaks every raw-string
+-- liveness filter below; see TestTouchStoresExpiresAtCanonical.
+-- last_active_at also carries the keyset cursor (decodeCursorParams formats it
+-- identically), so the predicate is a byte-exact raw-string compare -- exact
+-- equality for the id tiebreak, consistent with the raw-column ORDER BY, and
+-- sargable for the index.
+SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, CAST(u.id IS NULL AS BOOLEAN) AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
-JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
-WHERE julianday(s.expires_at) > julianday('now')
-  AND (sqlc.narg(cursor) IS NULL OR julianday(s.last_active_at) < julianday(sqlc.narg(cursor)))
-ORDER BY s.last_active_at DESC
+LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
+WHERE s.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR s.last_active_at < sqlc.narg(cursor_time)
+       OR (s.last_active_at = sqlc.narg(cursor_time) AND s.id < sqlc.narg(cursor_id)))
+ORDER BY s.last_active_at DESC, s.id DESC
 LIMIT sqlc.arg(limit);

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -50,23 +50,33 @@ SELECT EXISTS(
 
 -- name: ListAllUsers :many
 SELECT * FROM users WHERE deleted_at IS NULL
-  AND (sqlc.narg(cursor) IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC LIMIT sqlc.arg(limit);
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR created_at < sqlc.narg(cursor_time)
+       OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC LIMIT sqlc.arg(limit);
 
--- The query arg is pre-folded (store.FoldSearchText) by the Go glue, and username
--- and email are already stored lowercased, so a plain LIKE against the pre-folded
--- display_name_folded column matches case-insensitively for non-ASCII names -- and
--- identically to Postgres/MySQL, which fold the same way. (A bare LIKE on the raw
--- display_name would fold only ASCII on SQLite; see FoldSearchText.)
+-- The query arg arrives as a complete LIKE prefix pattern built by
+-- store.SearchLikePattern: pre-folded (so the match against the pre-folded
+-- display_name_folded column and the lowercased username/email columns is
+-- case-insensitive for non-ASCII names, identically to Postgres/MySQL),
+-- backslash-escaped (so an operator's literal '%'/'_' cannot act as a
+-- wildcard), with the trailing match-anything '%' already appended. (A bare
+-- LIKE on the raw display_name would fold only ASCII on SQLite; see
+-- FoldSearchText.) like(pattern, col, '\') is the LIKE operator's function
+-- form with an explicit escape character: a bare `col LIKE ?` has NO escape
+-- char on SQLite (unlike Postgres/MySQL, whose default is backslash), and
+-- sqlc's SQLite grammar cannot parse the `LIKE ? ESCAPE '\'` clause form.
 -- name: SearchUsers :many
 SELECT * FROM users
 WHERE deleted_at IS NULL
   AND (sqlc.narg(query) IS NULL
-   OR username LIKE sqlc.narg(query) || '%'
-   OR display_name_folded LIKE sqlc.narg(query) || '%'
-   OR email LIKE sqlc.narg(query) || '%')
-  AND (sqlc.narg(cursor) IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC
+   OR like(sqlc.narg(query), username, '\')
+   OR like(sqlc.narg(query), display_name_folded, '\')
+   OR like(sqlc.narg(query), email, '\'))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR created_at < sqlc.narg(cursor_time)
+       OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg(limit);
 
 -- name: UpdateUserPassword :exec
@@ -136,10 +146,13 @@ WHERE orgs.id = (SELECT users.org_id FROM users WHERE users.id = sqlc.arg(user_i
 -- Gating keeps the workspaces/workers -> users delete order correct under bulk
 -- deletes; the user is reaped on a later pass once its stragglers drain. Mirrors
 -- the NOT EXISTS users gate on HardDeleteOrgsBefore. idx_workspaces_owner_user_id
--- and idx_workers_registered_by make each NOT EXISTS an indexed point probe.
+-- and the leading column of idx_workers_registered_by_status_created make each
+-- NOT EXISTS an indexed point probe.
 DELETE FROM users WHERE rowid IN (
     SELECT u.rowid FROM users u
-    WHERE u.deleted_at IS NOT NULL AND u.deleted_at < ?
+    -- Raw compare: deleted_at (strftime-written) against the canonical cutoff
+    -- string (CAST AS TEXT -> string param; see HardDeleteWorkersBefore).
+    WHERE u.deleted_at IS NOT NULL AND u.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT)
       AND NOT EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_user_id = u.id)
       AND NOT EXISTS (SELECT 1 FROM workers wk WHERE wk.registered_by = u.id)
     LIMIT 1000
@@ -159,8 +172,15 @@ SELECT count(*) FROM users WHERE deleted_at IS NULL;
 SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1);
 
 -- name: SetPendingEmail :exec
-UPDATE users SET pending_email = ?, pending_email_token = ?, pending_email_expires_at = ?, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE id = ?;
+-- pending_email_expires_at MUST land in the canonical strftime layout, so the
+-- bound instant is wrapped rather than stored in the modernc driver layout a
+-- raw time.Time bind would produce: ConsumeVerificationAttempt's lockout branch
+-- writes the same column via strftime('now'), and ClearStalePendingEmails
+-- compares it raw against a canonical cutoff -- mixing layouts breaks that
+-- lexicographic compare at the ' ' vs 'T' separator byte (byte 10). strftime
+-- passes a NULL bind through as NULL.
+UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(pending_email_expires_at)), pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = sqlc.arg(id);
 
 -- name: ClearPendingEmail :exec
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
@@ -186,8 +206,12 @@ UPDATE users SET pending_email = '', pending_email_token = '', pending_email_exp
 WHERE pending_email = ? AND id != ?;
 
 -- name: ClearStalePendingEmails :execresult
+-- Raw compare: pending_email_expires_at is stored canonical on every write path
+-- (SetPendingEmail wraps the bound instant in strftime; ConsumeVerificationAttempt's
+-- lockout branch writes strftime('now')), so comparing it raw against the canonical
+-- cutoff string (CAST AS TEXT -> string param) is byte-exact; see HardDeleteUsersBefore.
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < ?;
+WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < CAST(sqlc.arg(cutoff) AS TEXT);
 
 -- name: BumpUserTokensRevokedAt :one
 -- Bumps the user-wide revocation timestamp and credential epoch, then

--- a/backend/internal/hub/store/sqlite/db/queries/worker_registration_keys.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/worker_registration_keys.sql
@@ -1,5 +1,6 @@
 -- name: CreateRegistrationKey :exec
-INSERT INTO worker_registration_keys (id, created_by, expires_at) VALUES (?, ?, ?);
+INSERT INTO worker_registration_keys (id, created_by, expires_at)
+VALUES (sqlc.arg(id), sqlc.arg(created_by), strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)));
 
 -- name: GetRegistrationKeyByID :one
 SELECT * FROM worker_registration_keys WHERE id = ?;
@@ -14,10 +15,10 @@ SELECT * FROM worker_registration_keys WHERE id = ? AND created_by = ?;
 -- not revive the dead row.
 -- name: ExtendRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = sqlc.arg(new_expires_at)
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_expires_at))
 WHERE id = sqlc.arg(id)
   AND created_by = sqlc.arg(created_by)
-  AND expires_at > sqlc.arg(now);
+  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(now));
 
 -- SoftDeleteRegistrationKey is the user-initiated path; ownership lives
 -- in the WHERE clause so a single roundtrip both authorizes and acts.
@@ -25,7 +26,7 @@ WHERE id = sqlc.arg(id)
 -- matches by id+owner only); the service layer maps 0 rows to NotFound.
 -- name: SoftDeleteRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = sqlc.arg(expires_at)
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
 WHERE id = sqlc.arg(id) AND created_by = sqlc.arg(created_by);
 
 -- ConsumeRegistrationKey atomically marks a live key as consumed and
@@ -33,16 +34,18 @@ WHERE id = sqlc.arg(id) AND created_by = sqlc.arg(created_by);
 -- (March 2021) and is used by all of our prod targets.
 -- name: ConsumeRegistrationKey :one
 UPDATE worker_registration_keys
-SET expires_at = sqlc.arg(soft_deleted_at)
-WHERE id = sqlc.arg(id) AND expires_at > sqlc.arg(now)
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(soft_deleted_at))
+WHERE id = sqlc.arg(id) AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(now))
 RETURNING *;
 
 -- name: HardDeleteExpiredRegistrationKeysBefore :execresult
+-- Raw compare: expires_at (strftime-written) against the canonical cutoff string
+-- (CAST AS TEXT -> string param). Sargable for idx_worker_registration_keys_expires_at.
 DELETE FROM worker_registration_keys
 WHERE rowid IN (
     SELECT k.rowid
     FROM worker_registration_keys k
-    WHERE k.expires_at < sqlc.arg(cutoff)
+    WHERE k.expires_at < CAST(sqlc.arg(cutoff) AS TEXT)
     LIMIT 1000
 );
 
@@ -50,15 +53,17 @@ WHERE rowid IN (
 -- pass NULL to surface expired rows for forensics.
 -- name: ListRegistrationKeysAdmin :many
 SELECT k.id, k.created_by, k.created_at, k.expires_at,
-       COALESCE(u.username, '(deleted)') AS creator_username
+       COALESCE(u.username, '') AS creator_username, CAST(u.id IS NULL AS BOOLEAN) AS creator_deleted
 FROM worker_registration_keys k
 LEFT JOIN users u ON k.created_by = u.id AND u.deleted_at IS NULL
-WHERE (sqlc.narg(now) IS NULL OR k.expires_at > sqlc.narg(now))
-  AND (sqlc.narg(cursor) IS NULL OR k.created_at < sqlc.narg(cursor))
-ORDER BY k.created_at DESC
+WHERE (sqlc.narg(now) IS NULL OR k.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.narg(now)))
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR k.created_at < sqlc.narg(cursor_time)
+       OR (k.created_at = sqlc.narg(cursor_time) AND k.id < sqlc.narg(cursor_id)))
+ORDER BY k.created_at DESC, k.id DESC
 LIMIT sqlc.arg(limit);
 
 -- name: AdminSoftDeleteRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = sqlc.arg(expires_at)
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
 WHERE id = sqlc.arg(id);

--- a/backend/internal/hub/store/sqlite/db/queries/workers.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workers.sql
@@ -14,8 +14,10 @@ SELECT * FROM workers WHERE auth_token = ? AND status != 3;
 -- name: ListWorkersByUserID :many
 SELECT * FROM workers
 WHERE registered_by = sqlc.arg(registered_by) AND status = 1
-  AND (sqlc.narg(cursor) IS NULL OR created_at < sqlc.narg(cursor))
-ORDER BY created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR created_at < sqlc.narg(cursor_time)
+       OR (created_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
+ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg(limit);
 
 -- name: GetOwnedWorker :one
@@ -48,41 +50,78 @@ UPDATE workers SET public_key = ?, mlkem_public_key = ?, slhdsa_public_key = ? W
 -- name: GetWorkerPublicKey :one
 SELECT public_key, mlkem_public_key, slhdsa_public_key FROM workers WHERE id = ? AND deleted_at IS NULL;
 
--- name: ListWorkersAdminAll :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+-- The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+-- nil/set), implemented as FOUR separate queries. Two reasons it cannot collapse
+-- to two queries with an opt-in `(narg(user_id) IS NULL OR registered_by =
+-- narg(user_id))` probe:
+--   1. SQLite's OR-optimization falls back to a full partial-index scan +
+--      TEMP B-TREE sort for the user_id-set cases (verified via EXPLAIN),
+--      defeating both the seek and the ORDER-BY-rides-index invariant.
+--   2. sqlc emits the IS-NULL-probed narg as an untyped interface{}; on Postgres
+--      binding NULL raises SQLSTATE 42P08 "could not determine data type of
+--      parameter" and breaks the listing entirely (YugabyteDB inherits the
+--      break via the postgres store). Splitting user_id into its own
+--      REQUIRED-equality query (sqlc.arg, not narg) yields a typed param and
+--      restores the index seek.
+-- The status dimension stays split for partial-index eligibility: status=nil
+-- keeps `deleted_at IS NULL` (partial-index-eligible); status=set drops it so
+-- status=3 (WORKER_STATUS_DELETED) can surface soft-deleted rows. See the
+-- migration for the per-query index rationale.
+
+-- ListWorkersAdmin: status=nil, user_id=nil (all live workers).
+-- name: ListWorkersAdmin :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.deleted_at IS NULL
-  AND (sqlc.narg(cursor) IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg(limit);
 
+-- ListWorkersAdminByUser: status=nil, user_id=set.
+-- name: ListWorkersAdminByUser :many
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
+FROM workers w
+LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
+WHERE w.deleted_at IS NULL
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
+LIMIT sqlc.arg(limit);
+
+-- ListWorkersAdminByStatus: status=set, user_id=nil (all workers in a status).
 -- name: ListWorkersAdminByStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
 WHERE w.status = sqlc.arg(status)
-  AND (sqlc.narg(cursor) IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg(limit);
 
--- name: ListWorkersAdminByUser :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
-FROM workers w
-LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.deleted_at IS NULL
-  AND (sqlc.narg(cursor) IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
-LIMIT sqlc.arg(limit);
-
+-- ListWorkersAdminByUserAndStatus: status=set, user_id=set.
 -- name: ListWorkersAdminByUserAndStatus :many
-SELECT w.*, COALESCE(u.username, '(deleted)') AS owner_username
+SELECT sqlc.embed(w), COALESCE(u.username, '') AS owner_username, CAST(u.id IS NULL AS BOOLEAN) AS owner_deleted
 FROM workers w
 LEFT JOIN users u ON w.registered_by = u.id AND u.deleted_at IS NULL
-WHERE w.registered_by = sqlc.arg(user_id) AND w.status = sqlc.arg(status)
-  AND (sqlc.narg(cursor) IS NULL OR w.created_at < sqlc.narg(cursor))
-ORDER BY w.created_at DESC
+WHERE w.status = sqlc.arg(status)
+  AND w.registered_by = sqlc.arg(user_id)
+  AND (sqlc.narg(cursor_time) IS NULL
+       OR w.created_at < sqlc.narg(cursor_time)
+       OR (w.created_at = sqlc.narg(cursor_time) AND w.id < sqlc.narg(cursor_id)))
+ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg(limit);
 
 -- name: HardDeleteWorkersBefore :execresult
-DELETE FROM workers WHERE rowid IN (SELECT w.rowid FROM workers w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < ? LIMIT 1000);
+-- Raw compare: deleted_at (strftime-written) against the canonical cutoff string
+-- (CAST AS TEXT so sqlc emits a string param the Go layer fills with
+-- formatSQLiteTime(cutoff), not a time.Time the driver would serialize in its
+-- own layout). Sargable for idx_workers_deleted_at (SEARCH deleted_at<?, not a
+-- SCAN-with-residual under datetime()).
+DELETE FROM workers WHERE rowid IN (SELECT w.rowid FROM workers w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);

--- a/backend/internal/hub/store/sqlite/db/queries/workspaces.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workspaces.sql
@@ -40,4 +40,7 @@ UPDATE workspaces SET is_deleted = 1, deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ'
 UPDATE workspaces SET is_deleted = 1, deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE owner_user_id = ? AND is_deleted = 0;
 
 -- name: HardDeleteWorkspacesBefore :execresult
-DELETE FROM workspaces WHERE rowid IN (SELECT w.rowid FROM workspaces w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < ? LIMIT 1000);
+-- Raw compare: deleted_at (strftime-written) against the canonical cutoff string
+-- bound by the Go layer (formatSQLiteTime). Sargable for idx_workspaces_deleted_at
+-- (SEARCH deleted_at<?, not SCAN-with-residual under datetime()).
+DELETE FROM workspaces WHERE rowid IN (SELECT w.rowid FROM workspaces w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);

--- a/backend/internal/hub/store/sqlite/delegation_tokens.go
+++ b/backend/internal/hub/store/sqlite/delegation_tokens.go
@@ -61,12 +61,61 @@ func (s *delegationTokenStore) GetByID(ctx context.Context, id string) (*store.D
 	return &out, nil
 }
 
-func (s *delegationTokenStore) ListByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {
-	rows, err := s.conn.q.ListDelegationTokensByUser(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
+// delegationTokenWithOwner assembles the JOINed listing row shared by the
+// ListAll and ListAllByUser query twins (mirroring workerWithOwner), so a
+// field addition to DelegationTokenWithOwner edits one site instead of one
+// closure per query.
+func delegationTokenWithOwner(t gendb.DelegationToken, ownerUsername string, ownerDeleted bool) store.DelegationTokenWithOwner {
+	return store.DelegationTokenWithOwner{DelegationToken: fromDBDelegationToken(t), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
+}
+
+func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDelegationTokensParams) (store.Page[store.DelegationTokenWithOwner], error) {
+	// The admin token listing is a 2x2 matrix over (user_id nil/set) x
+	// (include_revoked false/true), dispatched to four generated queries
+	// (mirroring workers.go ListAdmin). The revoked dimension is split rather
+	// than an `(narg IS NULL OR revoked_at IS NULL)` probe because the live
+	// listings' partial keyset indexes are only planner-eligible when the query
+	// textually filters `revoked_at IS NULL`; the probe would deoptimize the
+	// COMMON live path. The IncludingRevoked forensics variants intentionally
+	// have no matching index -- see delegation_tokens.sql.
+	switch {
+	case p.UserID != nil && p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
+				return listAllDelegationTokensByUserIncludingRevokedParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUserIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensByUserIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensByUserParams, error) {
+				return listAllDelegationTokensByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensByUser,
+			func(r gendb.ListAllDelegationTokensByUserRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	case p.IncludeRevoked:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
+				return listAllDelegationTokensIncludingRevokedParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokensIncludingRevoked,
+			func(r gendb.ListAllDelegationTokensIncludingRevokedRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListAllDelegationTokensParams, error) {
+				return listAllDelegationTokensParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListAllDelegationTokens,
+			func(r gendb.ListAllDelegationTokensRow) store.DelegationTokenWithOwner {
+				return delegationTokenWithOwner(r.DelegationToken, r.OwnerUsername, r.OwnerDeleted)
+			})
 	}
-	return store.MapSlice(rows, fromDBDelegationToken), nil
 }
 
 func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID string) ([]store.DelegationToken, error) {

--- a/backend/internal/hub/store/sqlite/format_internal_test.go
+++ b/backend/internal/hub/store/sqlite/format_internal_test.go
@@ -1,0 +1,69 @@
+package sqlite
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// canonicalStrftimePattern is the ONE strftime layout every SQL-side timestamp
+// write and compare in this dialect must use. It is the strftime spelling of
+// the Go-side sqliteTimeFormat (timefmt.ISO8601, "2006-01-02T15:04:05.000Z"):
+// %Y-%m-%d = 2006-01-02, T literal, %H:%M = 15:04, %f = seconds with fixed
+// 3-digit millis (05.000), Z literal.
+const canonicalStrftimePattern = `'%Y-%m-%dT%H:%M:%fZ'`
+
+// TestStrftimeLiteralsAreCanonical is the Docker-less static source scan (twin
+// of the mysql/postgres collation scans) that collapses the ~75 hand-typed
+// strftime literals across this dialect's SQL into ONE pinned fact: every
+// strftime( call in the migrations and queries uses exactly
+// canonicalStrftimePattern. Without this, each literal is an independent
+// opportunity for a one-character drift (a missing T, %f -> %S, a stray
+// space) that silently breaks the raw-string keyset/liveness compares while
+// every result-level test stays green -- the "cannot drift" claim in
+// sqliteTimeFormat's doc comment held only for the single Go constant until
+// this scan made it true SQL-side too.
+func TestStrftimeLiteralsAreCanonical(t *testing.T) {
+	// Sanity-pin the Go side of the pairing first, so a change to
+	// timefmt.ISO8601 cannot silently diverge from the SQL pattern this test
+	// enforces.
+	require.Equal(t, "2006-01-02T15:04:05.000Z", sqliteTimeFormat,
+		"sqliteTimeFormat changed: update canonicalStrftimePattern (and every SQL literal) in lockstep")
+
+	var files []string
+	for _, glob := range []string{"db/migrations/*.sql", "db/queries/*.sql"} {
+		matches, err := filepath.Glob(glob)
+		require.NoError(t, err)
+		files = append(files, matches...)
+	}
+	require.NotEmpty(t, files, "no SQL files found; the scan is vacuous")
+
+	strftimeCall := regexp.MustCompile(`strftime\(\s*('[^']*')`)
+	total := 0
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		for i, line := range strings.Split(string(data), "\n") {
+			// Strip -- comments: prose ("...writes strftime('now')") is not an
+			// invariant-bearing call site. The canonical pattern itself never
+			// contains a double hyphen, so this cannot truncate a real literal.
+			if idx := strings.Index(line, "--"); idx >= 0 {
+				line = line[:idx]
+			}
+			for _, m := range strftimeCall.FindAllStringSubmatch(line, -1) {
+				total++
+				assert.Equal(t, canonicalStrftimePattern, m[1],
+					"%s:%d: strftime format literal deviates from the canonical layout; a drifted literal silently breaks the raw-string keyset/liveness compares", path, i+1)
+			}
+		}
+	}
+	// The scan must have matched a substantial number of call sites: a near-zero
+	// count means the glob or regex broke and the assertions above passed
+	// vacuously.
+	assert.Greater(t, total, 50, "strftime scan matched too few literals; scan is likely broken")
+}

--- a/backend/internal/hub/store/sqlite/indexes_internal_test.go
+++ b/backend/internal/hub/store/sqlite/indexes_internal_test.go
@@ -1,0 +1,376 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkersIndexesServeCompositeKeyset pins the index shape that makes the
+// two hottest worker keyset queries index-backed rather than full-scan-plus-sort:
+// ListWorkersByUserID (registered_by=? AND status=1) and
+// ListWorkersAdminByUserAndStatus (registered_by=? AND status=?) carry NO
+// deleted_at filter, so a partial `WHERE deleted_at IS NULL` predicate on the
+// composite index makes it ineligible on SQLite and every page falls back to a
+// sort. The index must therefore be non-partial. The composite's leading
+// registered_by column also serves HardDeleteUsersBefore's
+// NOT EXISTS (workers.registered_by = users.id) point probe, so no separate
+// registered_by-only index is kept. This is a plan-level concern: a regression
+// (re-adding the partial predicate) leaves the result rows identical and would
+// slip through every result-based storetest, so it needs a schema assertion.
+func TestWorkersIndexesServeCompositeKeyset(t *testing.T) {
+	_, db := newSessionTestStore(t)
+
+	type idx struct{ name, sql string }
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='workers' AND name LIKE 'idx_workers_%'`)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rows.Close()) })
+
+	got := map[string]string{}
+	for rows.Next() {
+		var ix idx
+		require.NoError(t, rows.Scan(&ix.name, &ix.sql))
+		got[ix.name] = ix.sql
+	}
+	require.NoError(t, rows.Err())
+
+	// The composite keyset index must exist and be non-partial (no WHERE clause)
+	// so the no-deleted_at-filter worker queries stay eligible for it.
+	composite, ok := got["idx_workers_registered_by_status_created"]
+	require.True(t, ok, "composite workers index missing; got %v", got)
+	assert.NotContains(t, strings.ToUpper(composite), "WHERE",
+		"composite index must be non-partial: a WHERE deleted_at IS NULL predicate makes it ineligible for ListWorkersByUserID / ListWorkersAdminByUserAndStatus (no deleted_at filter), regressing every page to a full scan plus sort")
+
+	// No separate registered_by-only index: the composite's leading column
+	// serves the HardDeleteUsersBefore FK-gate point probe (over all rows,
+	// including soft-deleted), so a narrow duplicate is dead write-amplification.
+	assert.NotContains(t, got, "idx_workers_registered_by",
+		"a separate registered_by-only index is redundant with the composite's leading column; got %v", got)
+}
+
+// indexSQL returns the CREATE INDEX statement for the named index, failing the
+// test if it is absent. Pinning index presence + shape via sqlite_master catches
+// regressions that result-level storetests cannot: a partial-vs-non-partial flip
+// or a dropped `id DESC` tiebreaker leaves result rows identical while regressing
+// every keyset page to a full scan plus sort.
+func indexSQL(t *testing.T, db *sql.DB, table, indexName string) string {
+	t.Helper()
+	var sqlText string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND name=?`, table, indexName,
+	).Scan(&sqlText)
+	require.NoError(t, err, "index %s on %s missing", indexName, table)
+	return sqlText
+}
+
+// assertCompositeKeysetIndex pins that a keyset-serving index carries the exact
+// column list the composite ORDER BY (col DESC, id DESC) needs -- so a leading-
+// column flip (e.g. last_active_at -> created_at) regresses to a sort, not just a
+// dropped trailing id -- plus the right partial-ness: wantPartial is the exact
+// partial predicate (e.g. "WHERE deleted_at IS NULL") when the index's query
+// carries the matching filter (so the planner can match the partial index), or
+// empty when it does not (so a WHERE clause cannot make the index ineligible).
+func assertCompositeKeysetIndex(t *testing.T, db *sql.DB, table, indexName, wantColumns, wantPartial string) {
+	t.Helper()
+	sqlText := strings.ToUpper(indexSQL(t, db, table, indexName))
+	assert.Contains(t, sqlText, strings.ToUpper(wantColumns),
+		"%s must carry the column list %s so the composite ORDER BY rides the index; a leading-column change silently regresses every page to a sort while result-level tests stay green", indexName, wantColumns)
+	if wantPartial != "" {
+		assert.Contains(t, sqlText, strings.ToUpper(wantPartial),
+			"%s must be partial `%s`: its query carries the matching filter, and a non-partial match is impossible to guarantee once the planner considers OR-probes", indexName, wantPartial)
+	} else {
+		assert.NotContains(t, sqlText, "WHERE",
+			"%s must be non-partial: its query carries no matching filter, and a WHERE clause would make it ineligible", indexName)
+	}
+}
+
+// TestWorkersRegisteredByCreatedIndex pins the index added for
+// ListWorkersAdminByUser (registered_by=?, deleted_at IS NULL, no status). It
+// must be partial on deleted_at (the query filters it) and carry the trailing
+// id DESC; without it the admin per-user listing falls back to the
+// (registered_by, status, created_at, id) composite, where status breaks the
+// created_at order and every page top-N sorts.
+func TestWorkersRegisteredByCreatedIndex(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "workers", "idx_workers_registered_by_created", "registered_by, created_at DESC, id DESC", "WHERE deleted_at IS NULL")
+}
+
+// TestUsersKeysetIndexShape pins idx_users_created_at: ListAllUsers and
+// SearchUsers filter `deleted_at IS NULL`, so the index must be partial on it
+// (matching the query exactly) and carry the trailing id DESC.
+func TestUsersKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "users", "idx_users_created_at", "created_at DESC, id DESC", "WHERE deleted_at IS NULL")
+}
+
+// TestRegistrationKeysKeysetIndexShape pins idx_worker_registration_keys_created_at:
+// ListRegistrationKeysAdmin filters `expires_at > now` (not deleted_at --
+// worker_registration_keys has no deleted_at column), so the index must be
+// non-partial and carry the trailing id DESC.
+func TestRegistrationKeysKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "worker_registration_keys", "idx_worker_registration_keys_created_at", "created_at DESC, id DESC", "")
+}
+
+// TestSessionsKeysetIndexShape pins idx_user_sessions_last_active:
+// ListAllActiveSessions filters `expires_at > now` (user_sessions has no
+// deleted_at column) and orders by (last_active_at DESC, id DESC), so the index
+// must be non-partial and carry the trailing id DESC.
+func TestSessionsKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "user_sessions", "idx_user_sessions_last_active", "last_active_at DESC, id DESC", "")
+}
+
+// TestSessionsUserKeysetIndexShape pins idx_user_sessions_user_last_active: the
+// per-user session listing ListUserSessionsByUserID (user_id =, expires_at
+// residual, ORDER BY last_active_at DESC, id DESC) both seeks the leading
+// user_id column and rides the trailing (last_active_at DESC, id DESC) order;
+// the same index serves the plain user_id lookups (DeleteUserSessionsByUser,
+// DeleteOtherUserSessions) via its prefix, so no separate user_id-only index
+// exists. Non-partial: user_sessions has no deleted_at column.
+func TestSessionsUserKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "user_sessions", "idx_user_sessions_user_last_active", "user_id, last_active_at DESC, id DESC", "")
+}
+
+// TestWorkersStatusCreatedIndex pins idx_workers_status_created: the
+// ListWorkersAdminByStatus query (status=?, no deleted_at filter, no user
+// filter) rides this index, and it MUST be non-partial -- status=3
+// (WORKER_STATUS_DELETED) must surface soft-deleted rows, so a
+// `WHERE deleted_at IS NULL` partial predicate would make the index ineligible
+// and regress every status-filtered admin page to a full scan plus sort. The
+// regression is plan-level only (result rows stay identical), so it needs a
+// schema assertion.
+func TestWorkersStatusCreatedIndex(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "workers", "idx_workers_status_created", "status, created_at DESC, id DESC", "")
+}
+
+// TestWorkersCreatedAtIndex pins idx_workers_created_at: the no-filter admin
+// listing (ListWorkersAdmin: status=nil, user_id=nil) filters `deleted_at IS
+// NULL`, so the index must be partial on it (matching the query exactly so the
+// planner can use it) and carry the trailing id DESC.
+func TestWorkersCreatedAtIndex(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "workers", "idx_workers_created_at", "created_at DESC, id DESC", "WHERE deleted_at IS NULL")
+}
+
+// TestAPITokensKeysetIndexShape pins idx_api_tokens_created_at: the admin
+// ListAllAPITokens listing filters `revoked_at IS NULL`, so the index must be
+// partial on it (matching the query exactly so the planner can use it) and
+// carry the trailing id DESC.
+func TestAPITokensKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "api_tokens", "idx_api_tokens_created_at", "created_at DESC, id DESC", "WHERE revoked_at IS NULL")
+}
+
+// TestDelegationTokensKeysetIndexShape pins idx_delegation_tokens_created_at:
+// the admin ListAllDelegationTokens listing filters `revoked_at IS NULL`, so
+// the index must be partial on it and carry the trailing id DESC.
+func TestDelegationTokensKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "delegation_tokens", "idx_delegation_tokens_created_at", "created_at DESC, id DESC", "WHERE revoked_at IS NULL")
+}
+
+// TestAPITokensUserKeysetIndexShape pins idx_api_tokens_user_created: the
+// admin ListAllAPITokensByUser listing (the --user-id path) seeks the leading
+// user_id equality and rides (created_at DESC, id DESC); without this index
+// the per-user page seeks idx_api_tokens_user and pays a TEMP B-TREE sort.
+// Partial on revoked_at IS NULL, matching the query's live-token filter.
+func TestAPITokensUserKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "api_tokens", "idx_api_tokens_user_created", "user_id, created_at DESC, id DESC", "WHERE revoked_at IS NULL")
+}
+
+// TestDelegationTokensUserKeysetIndexShape is the delegation twin of
+// TestAPITokensUserKeysetIndexShape.
+func TestDelegationTokensUserKeysetIndexShape(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	assertCompositeKeysetIndex(t, db, "delegation_tokens", "idx_delegation_tokens_user_created", "user_id, created_at DESC, id DESC", "WHERE revoked_at IS NULL")
+}
+
+// loadQuerySQL extracts one named query from a db/queries file and rewrites
+// it to plain executable SQL: the block runs from the `-- name:` marker to the
+// next marker (comment lines are stripped BEFORE cutting at the terminating
+// semicolon, since comment prose may legally contain one), `sqlc.embed(x)`
+// becomes `x.*`, and every sqlc.arg/sqlc.narg becomes a bare `?`. Reading the
+// REAL query text keeps these plan pins incapable of drifting from the SQL
+// sqlc compiles.
+func loadQuerySQL(t *testing.T, file, name string) string {
+	t.Helper()
+	data, err := os.ReadFile("db/queries/" + file)
+	require.NoError(t, err)
+	src := string(data)
+	loc := regexp.MustCompile(`-- name: ` + name + ` :\w+\n`).FindStringIndex(src)
+	require.NotNil(t, loc, "query %s not found in %s", name, file)
+	block := src[loc[1]:]
+	if next := strings.Index(block, "\n-- name: "); next >= 0 {
+		block = block[:next]
+	}
+	block = regexp.MustCompile(`(?m)^--[^\n]*\n?`).ReplaceAllString(block, "")
+	sql, _, found := strings.Cut(block, ";")
+	require.True(t, found, "query %s in %s has no terminating semicolon", name, file)
+	sql = regexp.MustCompile(`sqlc\.embed\((\w+)\)`).ReplaceAllString(sql, "$1.*")
+	sql = regexp.MustCompile(`sqlc\.n?arg\('?\w+'?\)`).ReplaceAllString(sql, "?")
+	return sql
+}
+
+// TestPaginatedListingsRideTheirKeysetIndexes pins the query PLAN of every
+// keyset-paginated listing: each must read its expected index (a SEARCH seek
+// for the equality-prefixed queries, an ordered SCAN for the full listings)
+// with NO `USE TEMP B-TREE FOR ORDER BY`. This closes the failure mode the
+// DDL-shape pins above cannot see: a QUERY-side edit that leaves the index
+// intact but makes it ineligible -- a re-added residual filter that breaks
+// partial-index matching, a function wrapped around the ORDER BY column, a
+// predicate rewrite the planner cannot push into the seek -- regresses every
+// page to scan-plus-sort while result rows (and every result-level test) stay
+// identical. The four IncludingRevoked forensics variants are deliberately
+// absent: they have no matching partial index and may top-N sort by design
+// (see their query comments).
+func TestPaginatedListingsRideTheirKeysetIndexes(t *testing.T) {
+	_, db := newSessionTestStore(t)
+
+	cases := []struct{ file, query, index string }{
+		{"users.sql", "ListAllUsers", "idx_users_created_at"},
+		{"users.sql", "SearchUsers", "idx_users_created_at"},
+		{"workers.sql", "ListWorkersByUserID", "idx_workers_registered_by_status_created"},
+		{"workers.sql", "ListWorkersAdmin", "idx_workers_created_at"},
+		{"workers.sql", "ListWorkersAdminByUser", "idx_workers_registered_by_created"},
+		{"workers.sql", "ListWorkersAdminByStatus", "idx_workers_status_created"},
+		{"workers.sql", "ListWorkersAdminByUserAndStatus", "idx_workers_registered_by_status_created"},
+		{"worker_registration_keys.sql", "ListRegistrationKeysAdmin", "idx_worker_registration_keys_created_at"},
+		{"user_sessions.sql", "ListUserSessionsByUserID", "idx_user_sessions_user_last_active"},
+		{"user_sessions.sql", "ListAllActiveSessions", "idx_user_sessions_last_active"},
+		{"api_tokens.sql", "ListAllAPITokens", "idx_api_tokens_created_at"},
+		{"api_tokens.sql", "ListAllAPITokensByUser", "idx_api_tokens_user_created"},
+		{"delegation_tokens.sql", "ListAllDelegationTokens", "idx_delegation_tokens_created_at"},
+		{"delegation_tokens.sql", "ListAllDelegationTokensByUser", "idx_delegation_tokens_user_created"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			details := explainPlan(t, db, loadQuerySQL(t, tc.file, tc.query))
+			// "USING INDEX" or "USING COVERING INDEX"; the LEFT JOIN users leg
+			// contributes its own row, so match any row.
+			assert.Condition(t, func() bool {
+				for _, d := range details {
+					if strings.Contains(d, "INDEX "+tc.index) {
+						return true
+					}
+				}
+				return false
+			}, "%s must read %s; plan: %v", tc.query, tc.index, details)
+			for _, d := range details {
+				assert.NotContains(t, d, "USE TEMP B-TREE FOR ORDER BY",
+					"%s must ride its index order, not sort every page; plan: %v", tc.query, details)
+			}
+		})
+	}
+}
+
+// explainPlan returns the detail column of EXPLAIN QUERY PLAN for sqlText,
+// binding NULL for every placeholder: SQLite chooses the plan at prepare
+// time, so parameter values cannot change it.
+func explainPlan(t *testing.T, db *sql.DB, sqlText string) []string {
+	t.Helper()
+	args := make([]any, strings.Count(sqlText, "?"))
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+sqlText, args...)
+	require.NoError(t, err)
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, details)
+	return details
+}
+
+// TestRetentionAndBootstrapScansAreSargable pins the plans of the schema's
+// remaining tuned index consumers (the keyset listings and revoked-token
+// sweeps have their own pins above):
+//
+//   - GetFirstAdmin must read idx_users_is_admin. This pins the partial
+//     predicate's SPELLING: SQLite's partial-index matcher is syntactic, so
+//     rewriting the migration's `WHERE is_admin = 1` back to bare
+//     `WHERE is_admin` silently orphans the index and this fails.
+//   - ListExpiringOAuthTokens and DeleteExpiredDelegationTokensBefore must
+//     seek their expires_at indexes with an upper bound -- the former
+//     regressed to a full scan under its old datetime() wrap.
+//   - The revocation-events compaction subquery must be a BOUNDED search.
+//     Both sqlite_autoindex(seq) and idx_revocation_events_published are
+//     eligible now that published_at compares raw (sargable); which wins is
+//     a stats-dependent cost choice, so only boundedness is pinned.
+func TestRetentionAndBootstrapScansAreSargable(t *testing.T) {
+	_, db := newSessionTestStore(t)
+
+	admin := explainPlan(t, db, loadQuerySQL(t, "users.sql", "GetFirstAdmin"))
+	assert.Contains(t, admin[0], "INDEX idx_users_is_admin",
+		"GetFirstAdmin must ride the partial admin index; plan: %v", admin)
+
+	oauth := explainPlan(t, db, loadQuerySQL(t, "oauth_tokens.sql", "ListExpiringOAuthTokens"))
+	assert.Contains(t, oauth[0], "INDEX idx_oauth_tokens_expires_at", "plan: %v", oauth)
+	assert.Contains(t, oauth[0], "expires_at<",
+		"the expiring-token scan must carry its upper bound into the seek; plan: %v", oauth)
+
+	expiry := explainPlan(t, db, loadQuerySQL(t, "delegation_tokens.sql", "DeleteExpiredDelegationTokensBefore"))
+	assert.Contains(t, expiry[0], "INDEX idx_delegation_tokens_expires_at", "plan: %v", expiry)
+	assert.Contains(t, expiry[0], "expires_at<", "plan: %v", expiry)
+
+	compact := explainPlan(t, db, loadQuerySQL(t, "revocation_events.sql", "DeleteCompactablePublishedRevocationEvents"))
+	var bounded bool
+	for _, d := range compact {
+		require.NotContains(t, d, "SCAN ev",
+			"the compaction subquery must not full-scan published events; plan: %v", compact)
+		if strings.Contains(d, "SEARCH ev USING") {
+			bounded = true
+		}
+	}
+	assert.True(t, bounded, "the compaction subquery must be a bounded index search; plan: %v", compact)
+}
+
+// TestRevokedTokenSweepsAreSargable pins the query PLAN of the two hourly
+// revoked-token retention sweeps: the raw-string `revoked_at < CAST(? AS
+// TEXT)` compare must seek idx_*_revoked_at with an UPPER bound, touching only
+// the cutoff-eligible rows. The prior `datetime(revoked_at) < datetime(?)`
+// shape wrapped the indexed column in a function, so the planner emitted a
+// lower-bound-only SEARCH (`revoked_at>?` -- the partial index's IS NOT NULL
+// floor) and evaluated datetime() per revoked row on every sweep; the
+// regression is plan-level only (deleted rows stay identical), so it needs an
+// EXPLAIN assertion.
+func TestRevokedTokenSweepsAreSargable(t *testing.T) {
+	_, db := newSessionTestStore(t)
+	for _, tc := range []struct{ table, index string }{
+		{"api_tokens", "idx_api_tokens_revoked_at"},
+		{"delegation_tokens", "idx_delegation_tokens_revoked_at"},
+	} {
+		rows, err := db.QueryContext(context.Background(),
+			`EXPLAIN QUERY PLAN DELETE FROM `+tc.table+` WHERE revoked_at IS NOT NULL AND revoked_at < CAST(? AS TEXT)`,
+			"2026-01-01T00:00:00.000Z")
+		require.NoError(t, err)
+		var details []string
+		for rows.Next() {
+			var id, parent, notUsed int
+			var detail string
+			require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+			details = append(details, detail)
+		}
+		require.NoError(t, rows.Close())
+		require.NoError(t, rows.Err())
+		require.Len(t, details, 1, "%s sweep plan: %v", tc.table, details)
+		// "USING INDEX" or "USING COVERING INDEX", depending on planner choice.
+		assert.Contains(t, details[0], "INDEX "+tc.index,
+			"%s sweep must seek its partial revoked_at index", tc.table)
+		assert.Contains(t, details[0], "revoked_at<",
+			"%s sweep must carry the UPPER bound into the index seek (the datetime() wrap loses it and scans every revoked row)", tc.table)
+	}
+}

--- a/backend/internal/hub/store/sqlite/registration_keys.go
+++ b/backend/internal/hub/store/sqlite/registration_keys.go
@@ -87,28 +87,26 @@ func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (
 	}))
 }
 
-func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) ([]store.WorkerRegistrationKeyWithCreator, error) {
-	// `now` is compared against expires_at (driver-serialized time.Time);
-	// `cursor` is compared against created_at (set via SQL DEFAULT strftime
-	// to ms precision), so the cursor must use parseCursorToSQLiteTime to
-	// match that format.
+func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
+	// `now` is bound as a time.Time and compared against expires_at through a
+	// strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.narg(now)) wrap in the SQL itself (see
+	// worker_registration_keys.sql ListRegistrationKeysAdmin), so the comparison
+	// is canonical-layout against canonical-layout -- expires_at is written
+	// canonical by every Create/Extend/SoftDelete/Consume/AdminSoftDelete path.
+	// The cursor timestamp is compared against created_at (set via SQL DEFAULT
+	// strftime to ms precision), so the cursor must be formatted via decodeCursorParams
+	// to match that format. The id half of the composite cursor is the
+	// deterministic tiebreaker for rows sharing a millisecond.
 	var nowArg any
 	if !p.IncludeExpired {
 		nowArg = time.Now().UTC()
 	}
-	cursorArg, err := parseCursorToSQLiteTime(p.Cursor)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListRegistrationKeysAdmin(ctx, gendb.ListRegistrationKeysAdminParams{
-		Now:    nowArg,
-		Cursor: cursorArg,
-		Limit:  p.Limit,
-	})
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return store.MapSlice(rows, fromDBListRegistrationKeysAdminRow), nil
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListRegistrationKeysAdminParams, error) {
+			return listRegistrationKeysAdminParams(p.Cursor, p.Limit, nowArg)
+		},
+		s.conn.q.ListRegistrationKeysAdmin,
+		fromDBListRegistrationKeysAdminRow)
 }
 
 func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) store.WorkerRegistrationKeyWithCreator {
@@ -120,5 +118,6 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 			ExpiresAt: r.ExpiresAt,
 		},
 		CreatorUsername: r.CreatorUsername,
+		CreatorDeleted:  r.CreatorDeleted,
 	}
 }

--- a/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
+++ b/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
@@ -1,0 +1,40 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateRegistrationKeyStoresExpiresAtCanonical pins the canonical-strftime
+// storage contract for the registration-key write path, mirroring
+// TestCreateUserSessionStoresExpiresAtCanonical. ListRegistrationKeysAdmin
+// compares expires_at raw against strftime('%Y-%m-%dT%H:%M:%fZ', now), so a
+// revert of the Create wrap to a direct time.Time bind would silently
+// mis-compare the active/expired filter (and the liveness guards in
+// Extend/Consume). The result-level storetest writes expires_at through the
+// store but does not assert the on-disk layout, so the contract needs a direct
+// storage read.
+func TestCreateRegistrationKeyStoresExpiresAtCanonical(t *testing.T) {
+	st, db := newSessionTestStore(t)
+	orgID := storetest.SeedOrg(t, st, "canonical-regkey-org")
+	user := storetest.SeedUser(t, st, orgID, "canonical-regkey-user")
+	expiresAt := time.Date(2026, 7, 20, 12, 34, 56, 789_456_789, time.UTC)
+	keyID := id.Generate()
+	require.NoError(t, st.RegistrationKeys().Create(context.Background(), store.CreateRegistrationKeyParams{
+		ID:        keyID,
+		CreatedBy: user.ID,
+		ExpiresAt: expiresAt,
+	}))
+
+	var stored string
+	require.NoError(t, db.QueryRow(`SELECT expires_at FROM worker_registration_keys WHERE id = ?`, keyID).Scan(&stored))
+	assert.Equal(t, formatSQLiteTime(expiresAt), stored,
+		"expires_at must be stored in the canonical strftime layout the raw-string filters assume; got %q", stored)
+}

--- a/backend/internal/hub/store/sqlite/revocation_events.go
+++ b/backend/internal/hub/store/sqlite/revocation_events.go
@@ -117,7 +117,7 @@ func newRevocationEventStore(conn *sqliteConn) *revocationEventStore {
 				return mapErr(err)
 			},
 			CompactPublished: func(ctx context.Context, conn *sqliteConn, cutoff time.Time) (int64, error) {
-				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, cutoff))
+				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, formatSQLiteTime(cutoff)))
 			},
 			InsertLease: func(ctx context.Context, conn *sqliteConn, lease store.RevocationLease) error {
 				return mapErr(conn.q.InsertHubRuntimeLease(ctx, gendb.InsertHubRuntimeLeaseParams{

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -28,8 +28,18 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	}
 }
 
-func fromDBSessions(rows []gendb.UserSession) []store.UserSession {
-	return store.MapSlice(rows, fromDBSession)
+func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSession {
+	return store.ActiveSession{
+		ID:           r.ID,
+		UserID:       r.UserID,
+		Username:     r.Username,
+		UserDeleted:  r.UserDeleted,
+		CreatedAt:    r.CreatedAt,
+		LastActiveAt: r.LastActiveAt,
+		ExpiresAt:    r.ExpiresAt,
+		IPAddress:    r.IpAddress,
+		UserAgent:    r.UserAgent,
+	}
 }
 
 func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) error {
@@ -55,16 +65,20 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	// sqlite Touch is an inline query rather than a generated one (unlike
-	// postgres/mysql): the WHERE compares the bound timestamp against the stored
-	// last_active_at as strings, so LastActiveAt is formatted in the same ISO 8601
-	// layout as strftime('%Y-%m-%dT%H:%M:%fZ', 'now') to keep the string
-	// comparison correct. A generated query would bind modernc's default time
-	// layout, which does not match.
+	// postgres/mysql). Both timestamp columns it writes MUST land in the canonical
+	// strftime layout because the read-side liveness/cursor filters in
+	// user_sessions.sql compare them as raw strings; see the ListAllActiveSessions
+	// comment there for the full storage invariant and the modernc driver-layout
+	// hazard that makes binding a raw time.Time unsafe. The SET clause wraps both
+	// values in strftime; the WHERE clause compares against a formatSQLiteTime-
+	// pre-formatted string -- byte-exact, because the on-disk strftime values
+	// carry fixed 3-digit fractional seconds exactly like sqliteTimeFormat (see
+	// its doc in convert.go, including the Go-string-scan caution).
 	lastActiveStr := p.LastActiveAt.UTC().Format(sqliteTimeFormat)
 	res, err := s.conn.exec.ExecContext(ctx,
 		`UPDATE user_sessions
 		 SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-		     expires_at = ?
+		     expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', ?)
 		 WHERE id = ? AND last_active_at < ?`,
 		p.ExpiresAt.UTC(), p.ID, lastActiveStr,
 	)
@@ -106,37 +120,20 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	}))
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, userID string) ([]store.UserSession, error) {
-	rows, err := s.conn.q.ListUserSessionsByUserID(ctx, userID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBSessions(rows), nil
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListUserSessionsByUserIDParams, error) {
+			return listUserSessionsParams(p.UserID, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) ([]store.ActiveSession, error) {
-	params, err := listAllActiveSessionsParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllActiveSessions(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	out := make([]store.ActiveSession, len(rows))
-	for i, r := range rows {
-		out[i] = store.ActiveSession{
-			ID:           r.ID,
-			UserID:       r.UserID,
-			Username:     r.Username,
-			CreatedAt:    r.CreatedAt,
-			LastActiveAt: r.LastActiveAt,
-			ExpiresAt:    r.ExpiresAt,
-			IPAddress:    r.IpAddress,
-			UserAgent:    r.UserAgent,
-		}
-	}
-	return out, nil
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllActiveSessionsParams, error) {
+			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+		},
+		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
 func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {

--- a/backend/internal/hub/store/sqlite/sessions_internal_test.go
+++ b/backend/internal/hub/store/sqlite/sessions_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,12 +64,13 @@ func TestSessionExpiryPredicatesPreserveFractionalPrecision(t *testing.T) {
 		require.NoError(t, err)
 		_, err = st.Sessions().ValidateWithUser(context.Background(), sessionID)
 		require.NoError(t, err)
-		byUser, err := st.Sessions().ListByUserID(context.Background(), userID)
+		byUserPage, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{UserID: userID, PageParams: store.PageParams{Limit: 1000}})
 		require.NoError(t, err)
+		byUser := byUserPage.Rows
 		assert.Len(t, byUser, 1)
-		all, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{Limit: 10})
+		page, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{PageParams: store.PageParams{Limit: 10}})
 		require.NoError(t, err)
-		assert.Len(t, all, 1)
+		assert.Len(t, page.Rows, 1)
 	})
 
 	t.Run("expired session is deleted within its expiry second", func(t *testing.T) {
@@ -84,19 +86,236 @@ func TestSessionExpiryPredicatesPreserveFractionalPrecision(t *testing.T) {
 	})
 }
 
+// TestListAllActiveSessionsPreservesFractionalCursorPrecision pins the
+// invariant the keyset predicate relies on: last_active_at is stored in the
+// fixed strftime('%Y-%m-%dT%H:%M:%fZ') layout (the column DEFAULT and Touch
+// both write it SQL-side) and decodeCursorParams formats the cursor identically, so
+// the raw string comparison is byte-exact -- sub-second distinctions survive
+// (400ms < 600ms), and a row TIED with the cursor instant is included or
+// excluded purely by the (= AND id <) tiebreak. If the stored layout and the
+// cursor layout ever diverge, the equality branch stops matching and the tied
+// row below the cursor id silently disappears, failing this test.
 func TestListAllActiveSessionsPreservesFractionalCursorPrecision(t *testing.T) {
 	st, db := newSessionTestStore(t)
-	sessionID, _ := seedFractionalSession(t, st, time.Now().Add(time.Hour))
-	base := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
-	lastActive := base.Add(400 * time.Millisecond)
-	_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, lastActive, sessionID)
-	require.NoError(t, err)
+	beforeID, userID := seedFractionalSession(t, st, time.Now().Add(time.Hour))
+	// Two more sessions for the same user, pinned exactly at the cursor
+	// instant, with hand-picked ids on both sides of the cursor id.
+	const tieBelowID, tieCursorID = "tie-a", "tie-b"
+	for _, sessID := range []string{tieBelowID, tieCursorID} {
+		require.NoError(t, st.Sessions().Create(context.Background(), store.CreateSessionParams{
+			ID:        sessID,
+			UserID:    userID,
+			ExpiresAt: time.Now().Add(time.Hour),
+		}))
+	}
 
-	rows, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{
-		Cursor: base.Add(600 * time.Millisecond).Format(time.RFC3339Nano),
-		Limit:  10,
+	base := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	cursorTime := base.Add(600 * time.Millisecond)
+	// Backdate all three rows in the production strftime layout (fixed three
+	// fractional digits), exactly as the column DEFAULT and Touch would.
+	for sessID, lastActive := range map[string]time.Time{
+		beforeID:    base.Add(400 * time.Millisecond),
+		tieBelowID:  cursorTime,
+		tieCursorID: cursorTime,
+	} {
+		_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, formatSQLiteTime(lastActive), sessID)
+		require.NoError(t, err)
+	}
+
+	page, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{
+		PageParams: store.PageParams{Cursor: store.EncodeCursor(cursorTime, tieCursorID), Limit: 10},
 	})
 	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	assert.Equal(t, sessionID, rows[0].ID)
+	// The cursor row itself is excluded (id not < itself); the tied row with
+	// the smaller id survives via the equality branch; the 400ms row survives
+	// via the strict < branch. DESC order puts the tied row first.
+	require.Len(t, page.Rows, 2)
+	assert.Equal(t, tieBelowID, page.Rows[0].ID)
+	assert.Equal(t, beforeID, page.Rows[1].ID)
+}
+
+// TestCreateUserSessionStoresExpiresAtCanonical pins the storage contract the
+// raw-string expiry/cursor filters rely on: CreateUserSession wraps the bound
+// ExpiresAt in strftime('%Y-%m-%dT%H:%M:%fZ'), so the column holds the canonical
+// layout. A revert to binding time.Time directly (the driver's layout) would
+// make expires_at > strftime(...,'now') silently mis-compare while the
+// result-level tests still passed (they write expires_at via db.Exec), so the
+// contract needs a direct storage assertion. The sub-millisecond digits also
+// prove the wrap quantizes to the canonical millisecond layout.
+func TestCreateUserSessionStoresExpiresAtCanonical(t *testing.T) {
+	st, db := newSessionTestStore(t)
+	orgID := storetest.SeedOrg(t, st, "canonical-expiry-org")
+	user := storetest.SeedUser(t, st, orgID, "canonical-expiry-user")
+	expiresAt := time.Date(2026, 7, 20, 12, 34, 56, 789_456_789, time.UTC)
+	sessionID := id.Generate()
+	require.NoError(t, st.Sessions().Create(context.Background(), store.CreateSessionParams{
+		ID:        sessionID,
+		UserID:    user.ID,
+		ExpiresAt: expiresAt,
+	}))
+
+	var expiresAtStored, createdAtStored, lastActiveAtStored string
+	require.NoError(t, db.QueryRow(
+		`SELECT expires_at, created_at, last_active_at FROM user_sessions WHERE id = ?`,
+		sessionID,
+	).Scan(&expiresAtStored, &createdAtStored, &lastActiveAtStored))
+	// expires_at is the caller-supplied instant, wrapped canonical by CreateUserSession.
+	assert.Equal(t, formatSQLiteTime(expiresAt), expiresAtStored,
+		"expires_at must be stored in the canonical strftime layout the raw-string filters assume; got %q", expiresAtStored)
+	// created_at + last_active_at are written by the column DEFAULT
+	// (strftime('%Y-%m-%dT%H:%M:%fZ','now')), NOT by an explicit Go-bound wrap,
+	// so a migration change to the DEFAULT is the one path the explicit-wrap
+	// tests cannot catch. Pin their layout: a canonical value parses cleanly
+	// under sqliteTimeFormat; a non-canonical one (e.g. modernc's driver layout
+	// with a space at byte 10) does not.
+	for _, col := range []struct{ name, val string }{
+		{"created_at", createdAtStored},
+		{"last_active_at", lastActiveAtStored},
+	} {
+		// The column DEFAULT writes strftime('%Y-%m-%dT%H:%M:%fZ','now'), which
+		// stores fixed 3-digit fractional seconds ON DISK -- but scanning a
+		// DATETIME column into a Go string goes through modernc's presentation
+		// layer, which trims trailing fractional zeros (a stored ".130Z" arrives
+		// as ".13Z"), so the scanned digit count varies here and a strict ".000"
+		// parse would be over-tight. What IS load-bearing is the canonical
+		// *shape* -- 'T' at byte 10 and a 'Z' suffix -- because modernc's driver
+		// layout ("YYYY-MM-DD HH:MM:SS+00:00", space at byte 10) sorts BEFORE
+		// the canonical 'T'-prefixed RHS and silently breaks every raw-string
+		// liveness/cursor filter. Pin the shape so a future write path that
+		// binds a raw time.Time fails loudly here.
+		require.GreaterOrEqual(t, len(col.val), 20, "%s too short to be canonical; got %q", col.name, col.val)
+		assert.Equal(t, "T", string(col.val[10]), "%s byte 10 must be 'T' (canonical), not a space (driver layout); got %q", col.name, col.val)
+		assert.True(t, strings.HasSuffix(col.val, "Z"), "%s must end in 'Z' (canonical UTC), not an offset; got %q", col.name, col.val)
+	}
+}
+
+// TestTouchStoresExpiresAtCanonical pins the SAME storage contract as
+// TestCreateUserSessionStoresExpiresAtCanonical, but for the Touch write path.
+// Touch is the only other session write path, and it is an inline query rather
+// than a generated one -- a prior version bound `expires_at = ?` raw, modernc
+// serialized it as "2026-07-20 12:34:56.123+00:00" (space + offset), and every
+// raw-string liveness filter (GetByID, ValidateWithUser, ListAllActive,
+// ListByUserID) then deemed the touched session expired -- logging the user
+// out on the request following each Touch. The result-level touch tests used a
+// 48h expiry whose different UTC day masked the byte-10 mismatch, so the
+// regression shipped green. This test touches with a same-day sub-millisecond
+// expiry and asserts both the on-disk layout AND that GetByID still finds the
+// row, so neither the storage drift nor its user-visible consequence can
+// silently return.
+func TestTouchStoresExpiresAtCanonical(t *testing.T) {
+	st, db := newSessionTestStore(t)
+	orgID := storetest.SeedOrg(t, st, "touch-canonical-org")
+	user := storetest.SeedUser(t, st, orgID, "touch-canonical-user")
+	sessionID := storetest.SeedSession(t, st, user.ID).ID
+
+	// Pin last_active_at to a known-old canonical instant so Touch's
+	// `last_active_at < ?` guard provably matches and the UPDATE fires.
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, formatSQLiteTime(old), sessionID)
+	require.NoError(t, err)
+
+	// Same UTC day as "now", with sub-millisecond precision -- the exact shape
+	// that exposed the raw-bind bug.
+	newExpiry := time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	n, err := st.Sessions().Touch(context.Background(), store.TouchSessionParams{
+		ID:           sessionID,
+		ExpiresAt:    newExpiry,
+		LastActiveAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n, "Touch must fire against the backdated row")
+
+	// Direct contract: the raw-string liveness filter GetUserSessionByID uses
+	// must see the touched row as live. Reading the column back through Scan
+	// is not a reliable witness here -- modernc reformats a DATETIME value on
+	// scan, so it hides a non-canonical on-disk layout. The filter result and
+	// GetByID below exercise the exact SQL path that broke.
+	var live bool
+	require.NoError(t, db.QueryRow(
+		`SELECT expires_at > strftime('%Y-%m-%dT%H:%M:%fZ','now') FROM user_sessions WHERE id = ?`,
+		sessionID,
+	).Scan(&live))
+	assert.True(t, live,
+		"touched session's expires_at must compare live under the raw-string "+
+			"strftime filter (the path that returned false pre-fix and logged users out)")
+
+	// Direct layout pin: Touch's SET wraps expires_at in strftime, so the
+	// on-disk value must equal formatSQLiteTime(newExpiry) exactly. A future
+	// Touch refactor that binds expires_at raw would store modernc's driver
+	// layout here and this assertion fails before the liveness filter regresses.
+	var expiresAtStored string
+	require.NoError(t, db.QueryRow(`SELECT expires_at FROM user_sessions WHERE id = ?`, sessionID).Scan(&expiresAtStored))
+	assert.Equal(t, formatSQLiteTime(newExpiry), expiresAtStored,
+		"Touch must store expires_at in the canonical strftime layout; got %q", expiresAtStored)
+
+	// The user-visible consequence: GetByID uses that same raw-string filter,
+	// so a non-canonical stored value returns ErrNotFound on the request after
+	// each Touch.
+	_, err = st.Sessions().GetByID(context.Background(), sessionID)
+	require.NoError(t, err, "touched session must remain visible to GetByID")
+}
+
+// TestKeysetCursorTrailingZeroMillisecondTie pins that the SQL-side strftime
+// write paths store canonical fixed 3-digit fractional seconds ON DISK, so the
+// keyset predicate's "=" tiebreak branch byte-matches a formatSQLiteTime-decoded
+// cursor even when the boundary millisecond ends in a trailing zero. (modernc
+// trims trailing zeros only when a DATETIME column is scanned into a Go string
+// -- a driver presentation artifact; production reads scan time.Time and the
+// comparisons run SQL-side on the stored bytes.) A prior review round misread
+// that scan artifact as on-disk variability and documented a same-ms tied-row
+// drop here; this test is the deterministic counterexample, and it guards
+// against a future driver regression that would make the drop real.
+func TestKeysetCursorTrailingZeroMillisecondTie(t *testing.T) {
+	st, db := newSessionTestStore(t)
+	orgID := storetest.SeedOrg(t, st, "tie-org")
+	user := storetest.SeedUser(t, st, orgID, "tie-user")
+
+	mk := func() string {
+		sessionID := id.Generate()
+		require.NoError(t, st.Sessions().Create(context.Background(), store.CreateSessionParams{
+			ID:        sessionID,
+			UserID:    user.ID,
+			ExpiresAt: time.Now().Add(time.Hour),
+		}))
+		return sessionID
+	}
+	below, tie1, tie2 := mk(), mk(), mk()
+
+	// Rewrite last_active_at through SQLite's own strftime -- the same
+	// formatting layer the production write paths use -- at a millisecond whose
+	// final digit is zero (.130), with two rows tied at the boundary instant.
+	tieInstant := time.Date(2026, 1, 2, 3, 4, 5, 130_000_000, time.UTC)
+	set := func(sessionID string, at time.Time) {
+		_, err := db.Exec(`UPDATE user_sessions SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', ?) WHERE id = ?`,
+			formatSQLiteTime(at), sessionID)
+		require.NoError(t, err)
+	}
+	set(below, tieInstant.Add(-time.Millisecond))
+	set(tie1, tieInstant)
+	set(tie2, tieInstant)
+
+	// The on-disk invariant the byte-exact compare rests on: strftime kept all
+	// three fractional digits, trailing zero included. length() runs SQL-side
+	// on the stored bytes, before any driver string conversion.
+	var short int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM user_sessions WHERE length(last_active_at) != 24`).Scan(&short))
+	require.Zero(t, short, "on-disk strftime values must keep fixed 3-digit fractional seconds")
+
+	// Page boundary ON the tie: cursor at (tieInstant, larger tie id). The "="
+	// tiebreak branch must admit the smaller-id tied row; the "<" branch the
+	// earlier row. Under the misread bug neither branch would have matched and
+	// both rows would silently vanish from the next page.
+	boundary, expectTied := tie1, tie2
+	if boundary < expectTied {
+		boundary, expectTied = expectTied, boundary
+	}
+	page, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{
+		UserID:     user.ID,
+		PageParams: store.PageParams{Cursor: store.EncodeCursor(tieInstant, boundary), Limit: 10},
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Rows, 2, "the tied smaller-id row and the earlier row must both survive the boundary")
+	assert.Equal(t, expectTied, page.Rows[0].ID)
+	assert.Equal(t, below, page.Rows[1].ID)
+	assert.False(t, page.HasMore())
 }

--- a/backend/internal/hub/store/sqlite/sqlite_test.go
+++ b/backend/internal/hub/store/sqlite/sqlite_test.go
@@ -24,6 +24,14 @@ func TestSQLiteStore(t *testing.T) {
 			require.NoError(t, err)
 			err = st.TestHelper().TruncateAll(context.Background())
 			require.NoError(t, err)
+			// After the subtest's writes (cleanup runs before the next
+			// NewStore truncates), walk every raw-string-compared timestamp
+			// column and assert the canonical on-disk layout -- so ANY store
+			// write path the suite exercises that forgets its strftime wrap
+			// fails here, not as a silent row drop in production.
+			t.Cleanup(func() {
+				require.NoError(t, sqlite.CheckCanonicalTimestamps(context.Background(), st))
+			})
 			return st
 		},
 	}

--- a/backend/internal/hub/store/sqlite/testhelper.go
+++ b/backend/internal/hub/store/sqlite/testhelper.go
@@ -44,11 +44,37 @@ func (h *sqliteTestHelper) exec(ctx context.Context, query string, args ...any) 
 }
 
 func (h *sqliteTestHelper) SetDeletedAt(ctx context.Context, entity store.TestEntity, id string, deletedAt time.Time) error {
-	return sqlutil.SetDeletedAt(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, id, deletedAt)
+	return h.setEntityTime(ctx, entity, "deleted_at", id, deletedAt)
 }
 
 func (h *sqliteTestHelper) SetCreatedAt(ctx context.Context, entity store.TestEntity, id string, createdAt time.Time) error {
-	return sqlutil.SetCreatedAt(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, id, createdAt)
+	return h.setEntityTime(ctx, entity, "created_at", id, createdAt)
+}
+
+func (h *sqliteTestHelper) SetLastActiveAt(ctx context.Context, id string, lastActiveAt time.Time) error {
+	return h.setEntityTime(ctx, store.EntitySessions, "last_active_at", id, lastActiveAt)
+}
+
+// setEntityTime formats t in the canonical fixed-".000" layout and writes it
+// to a fixed column on a validated entity table. This matches every production
+// write path byte-for-byte: Go-bound writes use the same formatSQLiteTime, and
+// the SQL-side strftime writes (column DEFAULTs, SoftDelete's strftime('now'))
+// also store fixed 3-digit fractional seconds on disk -- see sqliteTimeFormat's
+// doc in convert.go, including the caution that modernc trims zeros only when a
+// DATETIME column is scanned into a Go string.
+func (h *sqliteTestHelper) setEntityTime(ctx context.Context, entity store.TestEntity, column, id string, t time.Time) error {
+	return h.setEntityColumn(ctx, entity, column, id, formatSQLiteTime(t))
+}
+
+// setEntityColumn writes a pre-formatted timestamp string to a fixed column on
+// a validated entity table. SQLite stores timestamps as TEXT via strftime
+// ('%Y-%m-%dT%H:%M:%fZ'), so the value is formatted with formatSQLiteTime to
+// match production rows exactly -- a bound time.Time would serialize in the
+// driver's own layout and break byte-sensitive comparisons (the created_at =
+// cursor tiebreaker, the datetime()-normalized deleted_at cleanup cutoffs).
+// The column is a hardcoded literal, never caller input.
+func (h *sqliteTestHelper) setEntityColumn(ctx context.Context, entity store.TestEntity, column, id, value string) error {
+	return sqlutil.SetEntityColumnValue(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, column, id, value)
 }
 
 func (h *sqliteTestHelper) SetRevocationEventRevokedAt(ctx context.Context, id string, revokedAt time.Time) error {
@@ -57,6 +83,75 @@ func (h *sqliteTestHelper) SetRevocationEventRevokedAt(ctx context.Context, id s
 
 func (h *sqliteTestHelper) setTimestamp(ctx context.Context, column sqlutil.TimestampColumn, id string, at any) error {
 	return sqlutil.SetTimestampColumn(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, column, id, at)
+}
+
+// canonicalTimestampColumns lists every column the SQLite dialect compares as
+// a RAW string (keyset ORDER BY columns, liveness filters, cleanup cutoffs).
+// Each one's every write path MUST store the canonical
+// strftime('%Y-%m-%dT%H:%M:%fZ') layout: a single raw time.Time bind stores
+// modernc's driver layout (space at byte 10) and silently corrupts the
+// raw-string compares. CheckCanonicalTimestamps walks this list after each
+// storetest subtest, so a NEW write path that forgets the strftime wrap (or a
+// new raw-compared column added here) fails the suite instead of shipping a
+// #287-shaped silent-row-drop. Columns compared only under datetime() wraps
+// (e.g. delegation_tokens.expires_at) are deliberately absent: their binds are
+// driver-layout by design.
+var canonicalTimestampColumns = map[string][]string{
+	"users":                    {"created_at", "deleted_at", "pending_email_expires_at"},
+	"user_sessions":            {"last_active_at", "expires_at"},
+	"workers":                  {"created_at", "deleted_at"},
+	"workspaces":               {"deleted_at"},
+	"orgs":                     {"deleted_at"},
+	"worker_registration_keys": {"created_at", "expires_at"},
+	"api_tokens":               {"created_at", "revoked_at"},
+	"delegation_tokens":        {"created_at", "revoked_at"},
+	"oauth_tokens":             {"expires_at"},
+	"revocation_events":        {"published_at"},
+}
+
+// CheckCanonicalTimestamps asserts every raw-string-compared timestamp column
+// currently holds only canonical 24-char 'T'-separated values on disk. The
+// probe runs SQL-side (length/substr over the stored TEXT) because modernc
+// reformats DATETIME values on scan, which would hide a non-canonical layout.
+// Intended to run as a test cleanup after store writes; see
+// canonicalTimestampColumns for the invariant.
+func CheckCanonicalTimestamps(ctx context.Context, st store.TestableStore) error {
+	ts, ok := st.(*testableSQLiteStore)
+	if !ok {
+		return fmt.Errorf("CheckCanonicalTimestamps: not a sqlite testable store: %T", st)
+	}
+	db := ts.conn.shared.db
+	for table, columns := range canonicalTimestampColumns {
+		// A migrator test may have rolled the schema back below this table;
+		// nothing to check then.
+		var exists bool
+		if err := db.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)`, table,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("canonical-timestamp walk %s: %w", table, err)
+		}
+		if !exists {
+			continue
+		}
+		for _, col := range columns {
+			var count int
+			var sample sql.NullString
+			// The column is a hardcoded literal from the map above, never caller input.
+			err := db.QueryRowContext(ctx,
+				`SELECT COUNT(*), MIN(CAST(`+col+` AS TEXT)) FROM `+table+
+					` WHERE `+col+` IS NOT NULL AND (length(CAST(`+col+` AS TEXT)) != 24 OR substr(CAST(`+col+` AS TEXT), 11, 1) != 'T')`,
+			).Scan(&count, &sample)
+			if err != nil {
+				return fmt.Errorf("canonical-timestamp walk %s.%s: %w", table, col, err)
+			}
+			if count > 0 {
+				return fmt.Errorf(
+					"%s.%s holds %d non-canonical timestamp value(s) on disk (e.g. %q): a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap, which silently corrupts this column's raw-string compares",
+					table, col, count, sample.String)
+			}
+		}
+	}
+	return nil
 }
 
 func (h *sqliteTestHelper) TruncateAll(ctx context.Context) error {

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -42,10 +42,6 @@ func fromDBUser(u gendb.User) store.User {
 	}
 }
 
-func fromDBUsers(rows []gendb.User) []store.User {
-	return store.MapSlice(rows, fromDBUser)
-}
-
 func (s *userStore) Create(ctx context.Context, p store.CreateUserParams) error {
 	if err := p.Validate(); err != nil {
 		return err
@@ -155,28 +151,16 @@ func (s *userStore) Count(ctx context.Context) (int64, error) {
 	return n, mapErr(err)
 }
 
-func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) ([]store.User, error) {
-	params, err := listAllUsersParams(p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListAllUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) ListAll(ctx context.Context, p store.ListAllUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListAllUsersParams, error) { return listAllUsersParams(p.Cursor, p.Limit) },
+		s.conn.q.ListAllUsers, fromDBUser)
 }
 
-func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) ([]store.User, error) {
-	params, err := searchUsersParams(p.Query, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.SearchUsers(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBUsers(rows), nil
+func (s *userStore) Search(ctx context.Context, p store.SearchUsersParams) (store.Page[store.User], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.SearchUsersParams, error) { return searchUsersParams(p.Query, p.Cursor, p.Limit) },
+		s.conn.q.SearchUsers, fromDBUser)
 }
 
 // loadUserInfoCacheFields reads the current cached-UserInfo projection for id.

--- a/backend/internal/hub/store/sqlite/users_internal_test.go
+++ b/backend/internal/hub/store/sqlite/users_internal_test.go
@@ -1,0 +1,91 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
+)
+
+// TestSetPendingEmailStoresCanonicalFormat pins the storage contract of the
+// third mixed-format-hazard column this package canonicalizes:
+// users.pending_email_expires_at. SetPendingEmail wraps its bound instant in
+// strftime (like CreateUserSession/Touch do for expires_at) because
+// ConsumeVerificationAttempt's lockout branch writes the SAME column via
+// strftime('now') -- a prior version bound the SetPendingEmail value raw, so
+// the column held a mix of modernc's driver layout (space at byte 10) and the
+// canonical layout ('T' at byte 10), and ClearStalePendingEmails' raw-string
+// cutoff compare silently misjudged rows whose stored value and cutoff shared
+// a UTC calendar day.
+func TestSetPendingEmailStoresCanonicalFormat(t *testing.T) {
+	st, db := newSessionTestStore(t)
+	ctx := context.Background()
+	orgID := storetest.SeedOrg(t, st, "pending-canonical-org")
+	user := storetest.SeedUser(t, st, orgID, "pending-canonical-user")
+
+	// Millisecond-aligned, same UTC day as "now" (matching the session
+	// canonical-layout pins): strftime ROUNDS sub-millisecond digits while
+	// formatSQLiteTime truncates, so a ms-aligned instant isolates the layout
+	// assertion from that sub-ms rounding difference.
+	expiry := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Millisecond)
+	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		ID:                    user.ID,
+		PendingEmail:          "new@example.com",
+		PendingEmailToken:     "tok-1",
+		PendingEmailExpiresAt: &expiry,
+	}))
+
+	// Direct layout pin: the on-disk value must equal formatSQLiteTime(expiry)
+	// byte-for-byte. Comparing SQL-side (raw = CAST) avoids modernc's
+	// scan-time reformatting, which would hide a non-canonical layout.
+	var canonical bool
+	require.NoError(t, db.QueryRow(
+		`SELECT pending_email_expires_at = CAST(? AS TEXT) FROM users WHERE id = ?`,
+		formatSQLiteTime(expiry), user.ID,
+	).Scan(&canonical))
+	assert.True(t, canonical,
+		"SetPendingEmail must store the canonical strftime layout, not the raw driver layout")
+}
+
+// TestClearStalePendingEmailsSweepsLockoutRowSameDay reproduces the exact
+// pre-fix failure: a pending_email_expires_at written by the
+// ConsumeVerificationAttempt LOCKOUT branch (SQL-side strftime('now'),
+// canonical 'T' at byte 10) compared against a cutoff bound from Go. The old
+// code bound the cutoff raw (driver layout, ' ' at byte 10): on any run where
+// the stored value and the cutoff shared a UTC calendar day, ' ' < 'T' made
+// `stored < cutoff` false and the sweep silently skipped the row until the
+// dates diverged. The fixed code binds formatSQLiteTime(cutoff), so a cutoff
+// one minute in the future must clear the just-locked-out row.
+func TestClearStalePendingEmailsSweepsLockoutRowSameDay(t *testing.T) {
+	st, _ := newSessionTestStore(t)
+	ctx := context.Background()
+	orgID := storetest.SeedOrg(t, st, "lockout-sweep-org")
+	user := storetest.SeedUser(t, st, orgID, "lockout-sweep-user")
+
+	expiry := time.Now().UTC().Add(24 * time.Hour)
+	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		ID:                    user.ID,
+		PendingEmail:          "locked@example.com",
+		PendingEmailToken:     "tok-lock",
+		PendingEmailExpiresAt: &expiry,
+	}))
+
+	// Exceed the attempt budget so the lockout branch rewrites
+	// pending_email_expires_at to strftime('now').
+	for range 6 {
+		_, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID)
+		require.NoError(t, err)
+	}
+
+	// A cutoff barely in the future, on the same UTC day as the lockout
+	// write. Pre-fix this cleared 0 rows; it must clear exactly this one.
+	n, err := st.Cleanup().ClearStalePendingEmails(ctx, time.Now().UTC().Add(time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n,
+		"the same-day sweep must clear the lockout-expired pending email")
+}

--- a/backend/internal/hub/store/sqlite/workers.go
+++ b/backend/internal/hub/store/sqlite/workers.go
@@ -65,63 +65,52 @@ func (s *workerStore) GetOwned(ctx context.Context, p store.GetOwnedWorkerParams
 	return store.GetOwnedWorker(ctx, p, s.GetByID)
 }
 
-func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) ([]store.Worker, error) {
-	params, err := listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.conn.q.ListWorkersByUserID(ctx, params)
-	if err != nil {
-		return nil, mapErr(err)
-	}
-	return fromDBWorkers(rows), nil
+func (s *workerStore) ListByUserID(ctx context.Context, p store.ListWorkersByUserIDParams) (store.Page[store.Worker], error) {
+	return queryPage(ctx, p.Limit,
+		func() (gendb.ListWorkersByUserIDParams, error) {
+			return listWorkersByUserIDParams(p.RegisteredBy, p.Cursor, p.Limit)
+		},
+		s.conn.q.ListWorkersByUserID,
+		func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
 }
 
-func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) ([]store.WorkerWithOwner, error) {
+func (s *workerStore) ListAdmin(ctx context.Context, p store.ListWorkersAdminParams) (store.Page[store.WorkerWithOwner], error) {
+	// The admin worker listing is a 2x2 matrix over (status nil/set) x (user_id
+	// nil/set), dispatched to four generated queries. The user_id dimension is a
+	// required-equality query rather than an opt-in OR-probe: that probe defeated
+	// SQLite's index seek for the user_id-set case (EXPLAIN: full partial-index
+	// scan + TEMP B-TREE sort) and emitted an untyped interface{} param that
+	// broke Postgres (SQLSTATE 42P08). See workers.sql for the per-query index
+	// rationale.
 	switch {
-	case p.UserID == nil && p.Status == nil:
-		params, err := listWorkersAdminAllParams(p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminAll(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminAllRow), nil
-
-	case p.UserID == nil && p.Status != nil:
-		params, err := listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByStatusRow), nil
-
-	case p.UserID != nil && p.Status == nil:
-		params, err := listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUser(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserRow), nil
-
-	default: // both non-nil
-		params, err := listWorkersAdminByUserAndStatusParams(*p.UserID, *p.Status, p.Cursor, p.Limit)
-		if err != nil {
-			return nil, err
-		}
-		rows, err := s.conn.q.ListWorkersAdminByUserAndStatus(ctx, params)
-		if err != nil {
-			return nil, mapErr(err)
-		}
-		return store.MapSlice(rows, fromDBListWorkersAdminByUserAndStatusRow), nil
+	case p.Status != nil && p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserAndStatusParams, error) {
+				return listWorkersAdminByUserAndStatusParams(*p.Status, *p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUserAndStatus,
+			fromDBListWorkersAdminByUserAndStatusRow)
+	case p.Status != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByStatusParams, error) {
+				return listWorkersAdminByStatusParams(*p.Status, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByStatus,
+			fromDBListWorkersAdminByStatusRow)
+	case p.UserID != nil:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminByUserParams, error) {
+				return listWorkersAdminByUserParams(*p.UserID, p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdminByUser,
+			fromDBListWorkersAdminByUserRow)
+	default:
+		return queryPage(ctx, p.Limit,
+			func() (gendb.ListWorkersAdminParams, error) {
+				return listWorkersAdminParams(p.Cursor, p.Limit)
+			},
+			s.conn.q.ListWorkersAdmin,
+			fromDBListWorkersAdminRow)
 	}
 }
 
@@ -180,82 +169,26 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 	}
 }
 
-func fromDBWorkers(rows []gendb.Worker) []store.Worker {
-	return store.MapSlice(rows, func(r gendb.Worker) store.Worker { return *fromDBWorker(r) })
+// workerWithOwner is the shared body of the four admin-worker Row mappers. The
+// queries select sqlc.embed(w) so every admin Row is {Worker, OwnerUsername};
+// this helper keeps the gendb.Worker -> store.Worker mapping in one site, so a
+// new workers column edits one place, not four.
+func workerWithOwner(w gendb.Worker, ownerUsername string, ownerDeleted bool) store.WorkerWithOwner {
+	return store.WorkerWithOwner{Worker: *fromDBWorker(w), OwnerUsername: ownerUsername, OwnerDeleted: ownerDeleted}
 }
 
-func fromDBListWorkersAdminAllRow(r gendb.ListWorkersAdminAllRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  ptrconv.Int64ToBool(r.AutoRegistered),
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
-}
-
-func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  ptrconv.Int64ToBool(r.AutoRegistered),
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+func fromDBListWorkersAdminRow(r gendb.ListWorkersAdminRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserRow(r gendb.ListWorkersAdminByUserRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  ptrconv.Int64ToBool(r.AutoRegistered),
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
+}
+
+func fromDBListWorkersAdminByStatusRow(r gendb.ListWorkersAdminByStatusRow) store.WorkerWithOwner {
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }
 
 func fromDBListWorkersAdminByUserAndStatusRow(r gendb.ListWorkersAdminByUserAndStatusRow) store.WorkerWithOwner {
-	return store.WorkerWithOwner{
-		Worker: store.Worker{
-			ID:              r.ID,
-			AuthToken:       r.AuthToken,
-			RegisteredBy:    r.RegisteredBy,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt,
-			LastSeenAt:      ptrconv.NullTimeToPtr(r.LastSeenAt),
-			PublicKey:       r.PublicKey,
-			MlkemPublicKey:  r.MlkemPublicKey,
-			SlhdsaPublicKey: r.SlhdsaPublicKey,
-			AutoRegistered:  ptrconv.Int64ToBool(r.AutoRegistered),
-			DeletedAt:       ptrconv.NullTimeToPtr(r.DeletedAt),
-		},
-		OwnerUsername: r.OwnerUsername,
-	}
+	return workerWithOwner(r.Worker, r.OwnerUsername, r.OwnerDeleted)
 }

--- a/backend/internal/hub/store/sqlutil/testhelper.go
+++ b/backend/internal/hub/store/sqlutil/testhelper.go
@@ -12,29 +12,73 @@ import (
 // closure and parameter style let every dialect delegate here rather than
 // hand-rolling the UPDATE with its own placeholder convention (`?` vs `$n`).
 func SetDeletedAt(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, entity store.TestEntity, id string, deletedAt time.Time) error {
-	return setEntityTimestamp(ctx, exec, style, entity, "deleted_at", id, deletedAt)
+	return SetEntityColumnValue(ctx, exec, style, entity, "deleted_at", id, deletedAt)
 }
 
 // SetCreatedAt backdates the created_at timestamp for a record. See SetDeletedAt
 // for the exec/style contract.
 func SetCreatedAt(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, entity store.TestEntity, id string, createdAt time.Time) error {
-	return setEntityTimestamp(ctx, exec, style, entity, "created_at", id, createdAt)
+	return SetEntityColumnValue(ctx, exec, style, entity, "created_at", id, createdAt)
 }
 
-// setEntityTimestamp backdates one fixed column (deleted_at/created_at -- a
-// literal, never caller input) on a validated entity table. The entity is
-// checked against the allowlist so this cannot become an arbitrary-SQL escape
-// hatch.
-func setEntityTimestamp(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, entity store.TestEntity, column, id string, at time.Time) error {
+// SetLastActiveAt writes an exact last_active_at timestamp for a session row.
+// Only the user_sessions table carries this column, so the table is pinned
+// here rather than caller-supplied -- passing a table without the column
+// would only fail at the database with an obscure "no such column" error.
+// See SetDeletedAt for the exec/style contract.
+func SetLastActiveAt(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, id string, lastActiveAt time.Time) error {
+	return SetEntityColumnValue(ctx, exec, style, store.EntitySessions, "last_active_at", id, lastActiveAt)
+}
+
+// SetEntityColumnValue backdates one fixed column (deleted_at/created_at/
+// last_active_at -- a literal, never caller input) on a validated entity
+// table. BOTH the entity and the column are checked against closed allowlists
+// so this cannot become an arbitrary-SQL escape hatch -- a future typed wrapper
+// that passes an unvalidated column fails loudly here rather than interpolating
+// caller input into the UPDATE. value is `any` (mirroring SetTimestampColumn)
+// so SQLite can pass a pre-formatted strftime string that byte-matches
+// production rows while the driver-serialized dialects pass a time.Time; the
+// exported typed wrappers above keep every call site's value strongly typed.
+func SetEntityColumnValue(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, entity store.TestEntity, column, id string, value any) error {
 	if err := store.ValidateEntity(entity); err != nil {
 		return err
 	}
+	if err := validateEntityColumn(column); err != nil {
+		return err
+	}
+	return execColumnUpdate(ctx, exec, style, string(entity), column, id, value)
+}
+
+// execColumnUpdate is the shared UPDATE tail of SetEntityColumnValue and
+// SetTimestampColumn: resolve the parameter placeholders, format the
+// single-column UPDATE, and execute it. Both callers validate (table, column)
+// against their own closed allowlist BEFORE calling; table and column here are
+// therefore always known literals, never caller input.
+func execColumnUpdate(ctx context.Context, exec func(context.Context, string, ...any) error, style ParameterStyle, table, column, id string, value any) error {
 	first, second, err := placeholders(style)
 	if err != nil {
 		return err
 	}
-	query := fmt.Sprintf("UPDATE %s SET %s = %s WHERE id = %s", entity, column, first, second)
-	return exec(ctx, query, at, id)
+	query := fmt.Sprintf("UPDATE %s SET %s = %s WHERE id = %s", table, column, first, second)
+	return exec(ctx, query, value, id)
+}
+
+// allowedEntityColumns is the closed set of literal column names
+// SetEntityColumnValue may interpolate. Mirroring the entity allowlist on the
+// column side makes the SQL-injection surface mechanically impossible to
+// widen: a column outside this set is rejected before the sprintf, so the
+// interpolation only ever receives a known literal.
+var allowedEntityColumns = map[string]bool{
+	"deleted_at":     true,
+	"created_at":     true,
+	"last_active_at": true,
+}
+
+func validateEntityColumn(column string) error {
+	if !allowedEntityColumns[column] {
+		return fmt.Errorf("unknown entity column %q", column)
+	}
+	return nil
 }
 
 // TimestampColumn is a closed set of timestamp columns exposed through the
@@ -66,12 +110,7 @@ func SetTimestampColumn(
 	if err != nil {
 		return err
 	}
-	first, second, err := placeholders(style)
-	if err != nil {
-		return err
-	}
-	query := fmt.Sprintf("UPDATE %s SET %s = %s WHERE id = %s", table, name, first, second)
-	return exec(ctx, query, at, id)
+	return execColumnUpdate(ctx, exec, style, table, name, id, at)
 }
 
 func timestampColumnNames(column TimestampColumn) (string, string, error) {

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -114,8 +114,8 @@ type UserStore interface {
 	GetPrefs(ctx context.Context, id string) (string, error)
 	HasAny(ctx context.Context) (bool, error)
 	Count(ctx context.Context) (int64, error)
-	ListAll(ctx context.Context, p ListAllUsersParams) ([]User, error)
-	Search(ctx context.Context, p SearchUsersParams) ([]User, error)
+	ListAll(ctx context.Context, p ListAllUsersParams) (Page[User], error)
+	Search(ctx context.Context, p SearchUsersParams) (Page[User], error)
 	UpdateProfile(ctx context.Context, p UpdateUserProfileParams) error
 	UpdatePassword(ctx context.Context, p UpdateUserPasswordParams) error
 	UpdateEmail(ctx context.Context, p UpdateUserEmailParams) error
@@ -166,8 +166,8 @@ type SessionStore interface {
 	// user's latest auth_generation after a password change. Other
 	// sessions remain deleted or stale.
 	RefreshAuthGeneration(ctx context.Context, p RefreshSessionAuthGenerationParams) (int64, error)
-	ListByUserID(ctx context.Context, userID string) ([]UserSession, error)
-	ListAllActive(ctx context.Context, p ListAllActiveSessionsParams) ([]ActiveSession, error)
+	ListByUserID(ctx context.Context, p ListUserSessionsParams) (Page[UserSession], error)
+	ListAllActive(ctx context.Context, p ListAllActiveSessionsParams) (Page[ActiveSession], error)
 	ValidateWithUser(ctx context.Context, id string) (*SessionWithUser, error)
 }
 
@@ -181,8 +181,8 @@ type WorkerStore interface {
 	GetByAuthToken(ctx context.Context, token string) (*Worker, error)
 	GetPublicKey(ctx context.Context, id string) (*WorkerPublicKeys, error)
 	GetOwned(ctx context.Context, p GetOwnedWorkerParams) (*Worker, error)
-	ListByUserID(ctx context.Context, p ListWorkersByUserIDParams) ([]Worker, error)
-	ListAdmin(ctx context.Context, p ListWorkersAdminParams) ([]WorkerWithOwner, error)
+	ListByUserID(ctx context.Context, p ListWorkersByUserIDParams) (Page[Worker], error)
+	ListAdmin(ctx context.Context, p ListWorkersAdminParams) (Page[WorkerWithOwner], error)
 	SetStatus(ctx context.Context, p SetWorkerStatusParams) error
 	UpdateLastSeen(ctx context.Context, id string) error
 	UpdatePublicKey(ctx context.Context, p UpdateWorkerPublicKeyParams) error
@@ -241,7 +241,7 @@ type RegistrationKeyStore interface {
 	// IncludeExpired=false is the default and hides revoked/expired rows;
 	// IncludeExpired=true surfaces the full table for forensics within the
 	// cleanup retention window.
-	ListAdmin(ctx context.Context, p ListRegistrationKeysAdminParams) ([]WorkerRegistrationKeyWithCreator, error)
+	ListAdmin(ctx context.Context, p ListRegistrationKeysAdminParams) (Page[WorkerRegistrationKeyWithCreator], error)
 }
 
 type WorkspaceStore interface {
@@ -368,6 +368,10 @@ type APITokenStore interface {
 	Create(ctx context.Context, p CreateAPITokenParams) error
 	GetByID(ctx context.Context, id string) (*APIToken, error)
 	ListByUser(ctx context.Context, p ListAPITokensByUserParams) ([]APIToken, error)
+	// ListAll pages every live api_token across users with the owner username
+	// (LEFT JOIN users), replacing the admin CLI's per-user fanout. Keyset on
+	// created_at.
+	ListAll(ctx context.Context, p ListAllAPITokensParams) (Page[APITokenWithOwner], error)
 	Touch(ctx context.Context, id string) error
 	// RotateRefresh atomically replaces the access/refresh secrets and emits a
 	// cache-only rotation event when its compare-and-swap succeeds.
@@ -387,7 +391,10 @@ type APITokenStore interface {
 type DelegationTokenStore interface {
 	Create(ctx context.Context, p CreateDelegationTokenParams) error
 	GetByID(ctx context.Context, id string) (*DelegationToken, error)
-	ListByUser(ctx context.Context, userID string) ([]DelegationToken, error)
+	// ListAll pages every delegation token across users with the owner username
+	// (LEFT JOIN users), replacing the admin CLI's per-user fanout. Keyset on
+	// created_at.
+	ListAll(ctx context.Context, p ListAllDelegationTokensParams) (Page[DelegationTokenWithOwner], error)
 	ListActiveByUser(ctx context.Context, userID string) ([]DelegationToken, error)
 	Touch(ctx context.Context, id string) error
 	Revoke(ctx context.Context, id string) (int64, error)
@@ -594,6 +601,8 @@ const (
 	EntityWorkers                TestEntity = "workers"
 	EntityWorkerRegistrationKeys TestEntity = "worker_registration_keys"
 	EntityWorkspaces             TestEntity = "workspaces"
+	EntityAPITokens              TestEntity = "api_tokens"
+	EntityDelegationTokens       TestEntity = "delegation_tokens"
 )
 
 // validEntities is the set of known TestEntity values, used by
@@ -605,6 +614,8 @@ var validEntities = map[TestEntity]bool{
 	EntityWorkers:                true,
 	EntityWorkerRegistrationKeys: true,
 	EntityWorkspaces:             true,
+	EntityAPITokens:              true,
+	EntityDelegationTokens:       true,
 }
 
 // ValidateEntity returns an error if entity is not a known TestEntity value.
@@ -624,6 +635,12 @@ type TestHelper interface {
 
 	// SetCreatedAt backdates the created_at timestamp for a record.
 	SetCreatedAt(ctx context.Context, entity TestEntity, id string, createdAt time.Time) error
+
+	// SetLastActiveAt writes an exact last_active_at timestamp for a session
+	// row. Only the user_sessions table carries this column, so the table is
+	// pinned in the implementations rather than caller-supplied -- a
+	// wrong-entity call is inexpressible.
+	SetLastActiveAt(ctx context.Context, id string, lastActiveAt time.Time) error
 
 	// SetRevocationEventRevokedAt writes an exact revocation_events.revoked_at timestamp.
 	SetRevocationEventRevokedAt(ctx context.Context, id string, revokedAt time.Time) error

--- a/backend/internal/hub/store/storetest/helpers.go
+++ b/backend/internal/hub/store/storetest/helpers.go
@@ -24,6 +24,58 @@ func RequireConflict(t *testing.T, err error) {
 
 var ctx = context.Background()
 
+// ListAllSessions returns every live session for userID via the paginated
+// ListByUserID, using one oversized page: for tests that assert on the full
+// membership rather than paging behavior.
+func ListAllSessions(t *testing.T, st store.Store, userID string) []store.UserSession {
+	t.Helper()
+	page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userID, PageParams: store.PageParams{Limit: 1000}})
+	require.NoError(t, err)
+	return page.Rows
+}
+
+// pageThroughByOne pages through a keyset-paginated listing one row at a
+// time using the store-produced next cursor, and returns the row ids in
+// visit order. Used by the same-millisecond tie tests: paging with limit=1
+// forces every row onto a page boundary, so a broken tiebreaker shows up as
+// a skipped or duplicated id. The loop follows HasMore, which the store
+// derives from a limit+1 probe row -- so it also asserts the final page
+// reports HasMore=false instead of handing out a dead extra cursor.
+//
+// The cap is a safety net for a paging bug that re-returns rows forever, NOT
+// the expected termination path: a correct keyset walk ends via the empty-page
+// or !HasMore break. It sits well above any real test's row count (currently
+// <=3), and the loop fails loudly if it ever reaches the cap -- otherwise a
+// runaway pager would exit silently and only the caller's ElementsMatch (which
+// a future author could weaken or omit) would catch the missing rows.
+func pageThroughByOne[T store.PageCursorer](t *testing.T, fetch func(cursor string) (store.Page[T], error)) []string {
+	t.Helper()
+	var seen []string
+	cursor := ""
+	const safetyCap = 100
+	for i := 0; i < safetyCap; i++ {
+		page, err := fetch(cursor)
+		require.NoError(t, err)
+		if len(page.Rows) == 0 {
+			require.False(t, page.HasMore(), "empty page must not report more rows")
+			break
+		}
+		require.Len(t, page.Rows, 1)
+		_, id := page.Rows[0].PageCursor()
+		seen = append(seen, id)
+		if !page.HasMore() {
+			require.Empty(t, page.NextCursor, "terminal page must not carry a cursor")
+			break
+		}
+		require.NotEmpty(t, page.NextCursor)
+		cursor = page.NextCursor
+		if i == safetyCap-1 {
+			require.Failf(t, "paging did not terminate", "walked %d pages without reaching a terminal page (cursor re-returning rows forever?)", safetyCap)
+		}
+	}
+	return seen
+}
+
 // SeedOrg creates an org and returns its ID.
 func SeedOrg(t *testing.T, st store.Store, name string) string {
 	t.Helper()

--- a/backend/internal/hub/store/storetest/suite.go
+++ b/backend/internal/hub/store/storetest/suite.go
@@ -41,6 +41,7 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("transactions", s.testTransactions)
 	t.Run("cleanup", s.testCleanup)
 	t.Run("token_revocation", s.testTokenRevocation)
+	t.Run("token_listing", s.testTokenListing)
 	// `migrator` runs last because its `migrate to zero` subtest leaves
 	// the schema partially dropped, and the suite's per-test re-migrate
 	// trampoline can't always recover the dropped state cleanly. Any

--- a/backend/internal/hub/store/storetest/test_registrations.go
+++ b/backend/internal/hub/store/storetest/test_registrations.go
@@ -1,6 +1,7 @@
 package storetest
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -174,10 +175,10 @@ func (s *Suite) testRegistrations(t *testing.T) {
 		live := SeedRegistrationKey(t, st, owner.ID, time.Now().Add(5*time.Minute).UTC())
 		_ = SeedRegistrationKey(t, st, owner.ID, time.Now().Add(-1*time.Minute).UTC())
 
-		rows, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{Limit: 50})
+		page, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{PageParams: store.PageParams{Limit: 50}})
 		require.NoError(t, err)
 
-		ownerRows := filterRowsByCreator(rows, owner.ID)
+		ownerRows := filterRowsByCreator(page.Rows, owner.ID)
 		require.Len(t, ownerRows, 1)
 		assert.Equal(t, live, ownerRows[0].ID)
 		assert.Equal(t, owner.Username, ownerRows[0].CreatorUsername)
@@ -190,13 +191,13 @@ func (s *Suite) testRegistrations(t *testing.T) {
 		live := SeedRegistrationKey(t, st, owner.ID, time.Now().Add(5*time.Minute).UTC())
 		dead := SeedRegistrationKey(t, st, owner.ID, time.Now().Add(-1*time.Minute).UTC())
 
-		rows, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
-			Limit:          50,
+		page, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
+			PageParams:     store.PageParams{Limit: 50},
 			IncludeExpired: true,
 		})
 		require.NoError(t, err)
 
-		ownerRows := filterRowsByCreator(rows, owner.ID)
+		ownerRows := filterRowsByCreator(page.Rows, owner.ID)
 		ids := make([]string, 0, len(ownerRows))
 		for _, r := range ownerRows {
 			ids = append(ids, r.ID)
@@ -220,24 +221,77 @@ func (s *Suite) testRegistrations(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 		idNew := SeedRegistrationKey(t, st, owner.ID, expires)
 
-		full, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{Limit: 100})
+		full, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{PageParams: store.PageParams{Limit: 100}})
 		require.NoError(t, err)
 
-		ownerRows := filterRowsByCreator(full, owner.ID)
+		ownerRows := filterRowsByCreator(full.Rows, owner.ID)
 		require.Len(t, ownerRows, 3, "all three seeded keys should be visible without a cursor")
 		assert.Equal(t, []string{idNew, idMid, idOld}, []string{ownerRows[0].ID, ownerRows[1].ID, ownerRows[2].ID},
 			"DESC order should put newest-created first")
 
-		cursor := ownerRows[1].CreatedAt.UTC().Format(time.RFC3339Nano)
+		cursor := store.EncodeCursor(ownerRows[1].CreatedAt, ownerRows[1].ID)
 		next, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
-			Cursor: cursor,
-			Limit:  100,
+			PageParams: store.PageParams{Cursor: cursor, Limit: 100},
 		})
 		require.NoError(t, err)
 
-		afterCursor := filterRowsByCreator(next, owner.ID)
+		afterCursor := filterRowsByCreator(next.Rows, owner.ID)
 		require.Len(t, afterCursor, 1)
 		assert.Equal(t, idOld, afterCursor[0].ID, "second page should contain only the oldest key")
+	})
+
+	t.Run("list admin cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "regkey-tie-org")
+		owner := SeedUser(t, st, orgID, "regkey-tie-user")
+		expires := time.Now().Add(5 * time.Minute).UTC()
+
+		// Three keys: two share an identical created_at millisecond and the
+		// third is strictly older. The store is fresh, so every row belongs to
+		// this owner and limit=1 pages walk exactly the seeded set.
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedRegistrationKey(t, st, owner.ID, expires)
+		tiedA := SeedRegistrationKey(t, st, owner.ID, expires)
+		tiedB := SeedRegistrationKey(t, st, owner.ID, expires)
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkerRegistrationKeys, older, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkerRegistrationKeys, tiedA, tie))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkerRegistrationKeys, tiedB, tie))
+
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
+			return st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{
+				PageParams: store.PageParams{Cursor: cursor, Limit: 1},
+			})
+		})
+		assert.ElementsMatch(t, []string{older, tiedA, tiedB}, seen,
+			"same-millisecond registration keys must not be skipped across page boundaries")
+	})
+
+	t.Run("list admin clamps out-of-range limits", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "regkey-clamp-org")
+		owner := SeedUser(t, st, orgID, "regkey-clamp-user")
+		expires := time.Now().Add(5 * time.Minute).UTC()
+		keyA := SeedRegistrationKey(t, st, owner.ID, expires)
+		keyB := SeedRegistrationKey(t, st, owner.ID, expires)
+
+		// A negative limit clamps to 0 ("no rows") on every dialect, instead
+		// of SQLite's LIMIT -1 semantics (unlimited -- the full-table dump) or
+		// a Postgres/MySQL negative-LIMIT error. A zero-limit page is terminal:
+		// it must not claim a further page it can never advance past.
+		page, err := st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{PageParams: store.PageParams{Limit: -1}})
+		require.NoError(t, err)
+		assert.Empty(t, page.Rows)
+		assert.False(t, page.HasMore())
+
+		// A limit past int32 range clamps to MaxInt32 instead of truncating on
+		// the int32 cast (2^32+1 would silently become LIMIT 1). Both rows fit,
+		// so the page is terminal: no HasMore and no dangling cursor.
+		page, err = st.RegistrationKeys().ListAdmin(ctx, store.ListRegistrationKeysAdminParams{PageParams: store.PageParams{Limit: int64(math.MaxInt32) + 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.ElementsMatch(t, []string{keyA, keyB}, []string{page.Rows[0].ID, page.Rows[1].ID})
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
 	})
 }
 

--- a/backend/internal/hub/store/storetest/test_sessions.go
+++ b/backend/internal/hub/store/storetest/test_sessions.go
@@ -111,8 +111,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		err := st.Sessions().DeleteByUser(ctx, user.ID)
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
-		require.NoError(t, err)
+		sessions := ListAllSessions(t, st, user.ID)
 		require.NotNil(t, sessions)
 		assert.Empty(t, sessions)
 	})
@@ -131,8 +130,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
-		require.NoError(t, err)
+		sessions := ListAllSessions(t, st, user.ID)
 		require.Len(t, sessions, 1)
 		assert.Equal(t, keep.ID, sessions[0].ID)
 	})
@@ -144,8 +142,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		SeedSession(t, st, user.ID)
 		SeedSession(t, st, user.ID)
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
-		require.NoError(t, err)
+		sessions := ListAllSessions(t, st, user.ID)
 		assert.Len(t, sessions, 2)
 	})
 
@@ -238,10 +235,11 @@ func (s *Suite) testSessions(t *testing.T) {
 		SeedSession(t, st, user1.ID)
 		SeedSession(t, st, user2.ID)
 
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 100,
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
+		sessions := page.Rows
 		assert.GreaterOrEqual(t, len(sessions), 2)
 
 		// Verify fields are populated.
@@ -365,8 +363,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
-		require.NoError(t, err)
+		sessions := ListAllSessions(t, st, user.ID)
 		require.Len(t, sessions, 1)
 		assert.Equal(t, sess.ID, sessions[0].ID)
 	})
@@ -374,12 +371,12 @@ func (s *Suite) testSessions(t *testing.T) {
 	t.Run("list all active empty", func(t *testing.T) {
 		st := s.NewStore(t)
 
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 100,
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, sessions)
-		assert.Empty(t, sessions)
+		require.NotNil(t, page.Rows)
+		assert.Empty(t, page.Rows)
 	})
 
 	t.Run("list all active excludes expired", func(t *testing.T) {
@@ -401,13 +398,13 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 100,
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
 		// Only the valid session should appear.
-		require.Len(t, sessions, 1)
-		assert.Equal(t, user.ID, sessions[0].UserID)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, user.ID, page.Rows[0].UserID)
 	})
 
 	t.Run("list all active with limit", func(t *testing.T) {
@@ -418,11 +415,11 @@ func (s *Suite) testSessions(t *testing.T) {
 		SeedSession(t, st, user.ID)
 		SeedSession(t, st, user.ID)
 
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 2,
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 2},
 		})
 		require.NoError(t, err)
-		assert.Len(t, sessions, 2)
+		assert.Len(t, page.Rows, 2)
 	})
 
 	t.Run("validate deleted user", func(t *testing.T) {
@@ -440,7 +437,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
-	t.Run("list all active excludes sessions of deleted users", func(t *testing.T) {
+	t.Run("list all active surfaces sessions of soft-deleted users", func(t *testing.T) {
 		st := s.NewStore(t)
 		orgID := SeedOrg(t, st, "sess-org")
 		alive := SeedUser(t, st, orgID, "active-alive-user")
@@ -451,13 +448,26 @@ func (s *Suite) testSessions(t *testing.T) {
 		err := st.Users().Delete(ctx, dead.ID)
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 100,
+		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
-		for _, s := range sessions {
-			assert.NotEqual(t, dead.ID, s.UserID, "should not include sessions of deleted users")
+		// The soft-deleted user's still-live session must surface for operator audit
+		// (LEFT JOIN with u.deleted_at IS NULL in the join condition, NOT an INNER
+		// JOIN that drops the row), with UserDeleted set and an empty username
+		// since the soft-deleted user row no longer satisfies the join -- the
+		// presentation layer decides the placeholder. This is the audit surface
+		// for "every active session"; hiding soft-deleted owners' sessions
+		// would let a just-deleted user's sessions linger invisibly until expiry.
+		var sawDead bool
+		for _, s := range page.Rows {
+			if s.UserID == dead.ID {
+				sawDead = true
+				assert.True(t, s.UserDeleted, "soft-deleted owner's session must surface with UserDeleted set")
+				assert.Empty(t, s.Username, "soft-deleted owner must surface with an empty username")
+			}
 		}
+		assert.True(t, sawDead, "soft-deleted user's live session must be listed for audit (LEFT JOIN)")
 	})
 
 	t.Run("list by user excludes expired sessions", func(t *testing.T) {
@@ -477,9 +487,43 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		sessions, err := st.Sessions().ListByUserID(ctx, user.ID)
-		require.NoError(t, err)
+		sessions := ListAllSessions(t, st, user.ID)
 		assert.Len(t, sessions, 1)
+	})
+
+	t.Run("list by user pages by last_active_at", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "sess-org")
+		user := SeedUser(t, st, orgID, "sess-page-user")
+		other := SeedUser(t, st, orgID, "sess-page-other")
+		s1 := SeedSession(t, st, user.ID)
+		s2 := SeedSession(t, st, user.ID)
+		s3 := SeedSession(t, st, user.ID)
+		// The other user's session is the most recent overall; it must not
+		// leak into user's pages even across a cursor boundary.
+		leak := SeedSession(t, st, other.ID)
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, s1.ID, base.Add(1*time.Second)))
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, s2.ID, base.Add(2*time.Second)))
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, s3.ID, base.Add(3*time.Second)))
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, leak.ID, base.Add(10*time.Second)))
+
+		// ListByUserID pages on (last_active_at DESC, id DESC) -- NOT
+		// created_at; a wrong PageCursor column or ORDER BY would misorder or
+		// drop rows across this boundary.
+		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: user.ID, PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.Equal(t, s3.ID, page.Rows[0].ID)
+		assert.Equal(t, s2.ID, page.Rows[1].ID)
+		require.True(t, page.HasMore())
+
+		page, err = st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: user.ID, PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, s1.ID, page.Rows[0].ID)
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
 	})
 
 	t.Run("list all active with cursor returns next page", func(t *testing.T) {
@@ -495,24 +539,51 @@ func (s *Suite) testSessions(t *testing.T) {
 		}
 
 		// First page.
-		page1, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Limit: 2,
+		res1, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 2},
 		})
 		require.NoError(t, err)
+		assert.True(t, res1.HasMore())
+		page1 := res1.Rows
 		require.Len(t, page1, 2)
 
-		// Second page using last item's LastActiveAt as cursor (RFC3339Nano).
-		cursor := page1[len(page1)-1].LastActiveAt.UTC().Format(time.RFC3339Nano)
-		page2, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
-			Cursor: cursor,
-			Limit:  2,
+		// Second page using last item's composite (last_active_at, id) cursor.
+		cursor := store.EncodeCursor(page1[len(page1)-1].LastActiveAt, page1[len(page1)-1].ID)
+		res2, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Cursor: cursor, Limit: 2},
 		})
 		require.NoError(t, err)
+		page2 := res2.Rows
 		require.Len(t, page2, 1)
 
 		// No overlap between pages.
 		page1IDs := map[string]bool{page1[0].ID: true, page1[1].ID: true}
 		assert.False(t, page1IDs[page2[0].ID], "page2 should not overlap with page1")
+	})
+
+	t.Run("list all active cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "sess-tie-org")
+		user := SeedUser(t, st, orgID, "sess-tie-user")
+
+		// Three sessions: two share an identical last_active_at millisecond and
+		// the third is strictly older. The cursor orders on last_active_at, so
+		// the tie is forced on that column.
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedSession(t, st, user.ID)
+		tiedA := SeedSession(t, st, user.ID)
+		tiedB := SeedSession(t, st, user.ID)
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, older.ID, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, tiedA.ID, tie))
+		require.NoError(t, st.TestHelper().SetLastActiveAt(ctx, tiedB.ID, tie))
+
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.ActiveSession], error) {
+			return st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+				PageParams: store.PageParams{Cursor: cursor, Limit: 1},
+			})
+		})
+		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
+			"same-millisecond sessions must not be skipped across page boundaries")
 	})
 
 	t.Run("duplicate session id returns conflict", func(t *testing.T) {
@@ -527,5 +598,33 @@ func (s *Suite) testSessions(t *testing.T) {
 			UserAgent: "test", IPAddress: "127.0.0.1",
 		})
 		assert.ErrorIs(t, err, store.ErrConflict)
+	})
+
+	t.Run("list all active rejects malformed cursor with ErrInvalidCursor", func(t *testing.T) {
+		// Pins the store-level cursor-decode contract for a non-ListWorkers
+		// method: a stale, truncated, or hand-edited --cursor must surface as
+		// store.ErrInvalidCursor (not a generic store fault and not a silent
+		// restart from page one) so the RPC and CLI layers can classify it as
+		// bad client input. worker_mgmt_service_test.go covers the ListWorkers
+		// RPC's InvalidArgument mapping; this covers the five sibling list
+		// methods' shared decode path through store.ParseCursor.
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "cursor-err-org")
+		SeedUser(t, st, orgID, "cursor-err-user")
+
+		cases := map[string]string{
+			"missing delimiter": "2026-07-20T12:34:56.789Z",
+			"empty id":          "2026-07-20T12:34:56.789Z_",
+			"bad timestamp":     "not-a-time_abc",
+		}
+		for name, bad := range cases {
+			t.Run(name, func(t *testing.T) {
+				_, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+					PageParams: store.PageParams{Cursor: bad, Limit: 10},
+				})
+				assert.ErrorIs(t, err, store.ErrInvalidCursor,
+					"cursor %q must surface as ErrInvalidCursor, not a generic store fault", bad)
+			})
+		}
 	})
 }

--- a/backend/internal/hub/store/storetest/test_token_listing.go
+++ b/backend/internal/hub/store/storetest/test_token_listing.go
@@ -1,0 +1,421 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedAPITokenForList inserts a live api_token row with minimal fields for the
+// listing tests (the admin listing does not surface the secrets).
+func seedAPITokenForList(t *testing.T, st store.Store, userID, clientType, clientName string) string {
+	t.Helper()
+	tokenID := id.Generate()
+	require.NoError(t, st.APITokens().Create(context.Background(), store.CreateAPITokenParams{
+		ID:          tokenID,
+		UserID:      userID,
+		ClientType:  clientType,
+		ClientName:  clientName,
+		SecretHash:  []byte("hash"),
+		RefreshHash: []byte("refresh"),
+		Scope:       "remote:*",
+	}))
+	return tokenID
+}
+
+func seedDelegationTokenForList(t *testing.T, st store.Store, userID, workspaceID string) string {
+	t.Helper()
+	worker := SeedWorker(t, st, userID)
+	tokenID := id.Generate()
+	require.NoError(t, st.DelegationTokens().Create(context.Background(), store.CreateDelegationTokenParams{
+		ID:          tokenID,
+		UserID:      userID,
+		WorkerID:    worker.ID,
+		WorkspaceID: workspaceID,
+		SecretHash:  []byte("hash"),
+		RefreshHash: []byte("refresh"),
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}))
+	return tokenID
+}
+
+// pinTokenCreatedAt backdates a token row's created_at to a distinct pinned
+// instant so paging tests can assert exact (created_at DESC, id DESC) page
+// contents instead of racing the insert timestamps.
+func pinTokenCreatedAt(t *testing.T, st store.TestableStore, entity store.TestEntity, tokenID string, at time.Time) {
+	t.Helper()
+	require.NoError(t, st.TestHelper().SetCreatedAt(context.Background(), entity, tokenID, at))
+}
+
+func (s *Suite) testTokenListing(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("api tokens list all joins owner and pages through", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "alice")
+		bob := SeedUser(t, st, orgID, "bob")
+		t1 := seedAPITokenForList(t, st, alice.ID, "cli", "alice-cli")
+		t2 := seedAPITokenForList(t, st, bob.ID, "cli", "bob-cli")
+		t3 := seedAPITokenForList(t, st, bob.ID, "integration", "bot")
+		// Pin distinct created_at instants so each page's exact contents and
+		// order are assertable, not just the union's membership.
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		pinTokenCreatedAt(t, st, store.EntityAPITokens, t1, base.Add(1*time.Second))
+		pinTokenCreatedAt(t, st, store.EntityAPITokens, t2, base.Add(2*time.Second))
+		pinTokenCreatedAt(t, st, store.EntityAPITokens, t3, base.Add(3*time.Second))
+
+		// First page: the two newest by (created_at DESC, id DESC), owners
+		// carried by the LEFT JOIN (proving the per-user fanout is gone).
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.Equal(t, t3, page.Rows[0].ID)
+		assert.Equal(t, t2, page.Rows[1].ID)
+		assert.Equal(t, "bob", page.Rows[0].OwnerUsername)
+		assert.Equal(t, "bob", page.Rows[1].OwnerUsername)
+		require.True(t, page.HasMore())
+
+		// Second page: the remaining row, then clean termination -- no
+		// HasMore, no dangling cursor.
+		page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, t1, page.Rows[0].ID)
+		assert.Equal(t, "alice", page.Rows[0].OwnerUsername)
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
+	})
+
+	t.Run("api tokens list all client_type filter", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		user := SeedUser(t, st, orgID, "filter-user")
+		seedAPITokenForList(t, st, user.ID, "cli", "a")
+		seedAPITokenForList(t, st, user.ID, "integration", "b")
+
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{ClientType: "cli", PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, "cli", page.Rows[0].ClientType)
+	})
+
+	t.Run("api tokens list all client_type filter composes with pagination", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		user := SeedUser(t, st, orgID, "filter-page-user")
+		c1 := seedAPITokenForList(t, st, user.ID, "cli", "c1")
+		i1 := seedAPITokenForList(t, st, user.ID, "integration", "i1")
+		c2 := seedAPITokenForList(t, st, user.ID, "cli", "c2")
+		i2 := seedAPITokenForList(t, st, user.ID, "integration", "i2")
+		c3 := seedAPITokenForList(t, st, user.ID, "cli", "c3")
+		// Interleave the two client types in time so the cursor from page one
+		// (at c2) straddles integration rows on both sides: i2 is newer and i1
+		// is older than the cursor, and neither may leak into a "cli" page --
+		// the filter conjunct and the keyset conjunct must compose.
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		for i, tok := range []string{c1, i1, c2, i2, c3} {
+			pinTokenCreatedAt(t, st, store.EntityAPITokens, tok, base.Add(time.Duration(i+1)*time.Second))
+		}
+
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{ClientType: "cli", PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.Equal(t, c3, page.Rows[0].ID)
+		assert.Equal(t, c2, page.Rows[1].ID)
+		require.True(t, page.HasMore())
+
+		page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{ClientType: "cli", PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, c1, page.Rows[0].ID)
+		assert.False(t, page.HasMore())
+	})
+
+	t.Run("api tokens list all filters by user and paginates", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "byuser-alice")
+		bob := SeedUser(t, st, orgID, "byuser-bob")
+		a1 := seedAPITokenForList(t, st, alice.ID, "cli", "a1")
+		b1 := seedAPITokenForList(t, st, bob.ID, "cli", "b1")
+		a2 := seedAPITokenForList(t, st, alice.ID, "cli", "a2")
+		a3 := seedAPITokenForList(t, st, alice.ID, "cli", "a3")
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		for i, tok := range []string{a1, b1, a2, a3} {
+			pinTokenCreatedAt(t, st, store.EntityAPITokens, tok, base.Add(time.Duration(i+1)*time.Second))
+		}
+
+		// The UserID filter dispatches to the ByUser query twin; bob's token is
+		// newer than a2 and must not leak into alice's pages, even across the
+		// cursor boundary.
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{UserID: &alice.ID, PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.Equal(t, a3, page.Rows[0].ID)
+		assert.Equal(t, a2, page.Rows[1].ID)
+		assert.Equal(t, "byuser-alice", page.Rows[0].OwnerUsername)
+		require.True(t, page.HasMore())
+
+		page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{UserID: &alice.ID, PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, a1, page.Rows[0].ID)
+		assert.False(t, page.HasMore())
+	})
+
+	t.Run("delegation tokens list all filters by user", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "del-byuser-alice")
+		bob := SeedUser(t, st, orgID, "del-byuser-bob")
+		ws := SeedWorkspace(t, st, orgID, alice.ID, "ws")
+		d1 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		_ = seedDelegationTokenForList(t, st, bob.ID, ws)
+		d3 := seedDelegationTokenForList(t, st, alice.ID, ws)
+
+		page, err := st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{UserID: &alice.ID, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2, "only alice's delegation tokens must be listed")
+		ids := []string{page.Rows[0].ID, page.Rows[1].ID}
+		assert.ElementsMatch(t, []string{d1, d3}, ids)
+		for _, r := range page.Rows {
+			assert.Equal(t, "del-byuser-alice", r.OwnerUsername)
+		}
+	})
+
+	t.Run("api tokens list all surfaces soft-deleted owner as (deleted)", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		dead := SeedUser(t, st, orgID, "dead-owner")
+		token := seedAPITokenForList(t, st, dead.ID, "cli", "dead-cli")
+
+		// Soft-delete the owner; the token row survives (no ON DELETE CASCADE
+		// on a soft-delete). The LEFT JOIN ... AND u.deleted_at IS NULL no
+		// longer matches, so the row surfaces with OwnerDeleted set and an
+		// empty username -- the presentation layer decides the placeholder.
+		require.NoError(t, st.Users().Delete(ctx, dead.ID))
+
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		var found bool
+		for _, r := range page.Rows {
+			if r.ID == token {
+				found = true
+				assert.True(t, r.OwnerDeleted, "soft-deleted owner's token must surface with OwnerDeleted set")
+				assert.Empty(t, r.OwnerUsername, "soft-deleted owner must surface with an empty username")
+			}
+		}
+		require.True(t, found, "soft-deleted owner's live token must still be listed for audit")
+	})
+
+	t.Run("delegation tokens list all joins owner", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "del-alice")
+		bob := SeedUser(t, st, orgID, "del-bob")
+		ws := SeedWorkspace(t, st, orgID, alice.ID, "ws")
+		d1 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		d2 := seedDelegationTokenForList(t, st, bob.ID, ws)
+
+		page, err := st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		owners := map[string]string{}
+		for _, r := range page.Rows {
+			owners[r.ID] = r.OwnerUsername
+		}
+		assert.Equal(t, "del-alice", owners[d1])
+		assert.Equal(t, "del-bob", owners[d2])
+	})
+
+	t.Run("delegation tokens list all pages through and surfaces (deleted) owner", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "del-page-alice")
+		bob := SeedUser(t, st, orgID, "del-page-bob")
+		ws := SeedWorkspace(t, st, orgID, alice.ID, "ws")
+		d1 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		d2 := seedDelegationTokenForList(t, st, bob.ID, ws)
+		d3 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		pinTokenCreatedAt(t, st, store.EntityDelegationTokens, d1, base.Add(1*time.Second))
+		pinTokenCreatedAt(t, st, store.EntityDelegationTokens, d2, base.Add(2*time.Second))
+		pinTokenCreatedAt(t, st, store.EntityDelegationTokens, d3, base.Add(3*time.Second))
+
+		// Soft-delete bob: the still-live token must keep surfacing (audit),
+		// with OwnerDeleted set mid-walk (the presentation layer decides the
+		// placeholder).
+		require.NoError(t, st.Users().Delete(ctx, bob.ID))
+
+		page, err := st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.Equal(t, d3, page.Rows[0].ID)
+		assert.Equal(t, "del-page-alice", page.Rows[0].OwnerUsername)
+		assert.False(t, page.Rows[0].OwnerDeleted)
+		assert.Equal(t, d2, page.Rows[1].ID)
+		assert.True(t, page.Rows[1].OwnerDeleted,
+			"soft-deleted owner's delegation token must surface with OwnerDeleted set")
+		assert.Empty(t, page.Rows[1].OwnerUsername)
+		require.True(t, page.HasMore())
+
+		page, err = st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, d1, page.Rows[0].ID)
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
+	})
+
+	t.Run("api tokens list all include revoked forensics opt-in", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "rev-alice")
+		bob := SeedUser(t, st, orgID, "rev-bob")
+		a1 := seedAPITokenForList(t, st, alice.ID, "cli", "a1")
+		a2 := seedAPITokenForList(t, st, alice.ID, "cli", "a2")
+		b1 := seedAPITokenForList(t, st, bob.ID, "cli", "b1")
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		for i, tok := range []string{a1, a2, b1} {
+			pinTokenCreatedAt(t, st, store.EntityAPITokens, tok, base.Add(time.Duration(i+1)*time.Second))
+		}
+
+		n, err := st.APITokens().Revoke(ctx, a2)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+
+		// (a) The default listing stays live-only: the revoked row vanishes.
+		page, err := st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		liveIDs := make([]string, 0, len(page.Rows))
+		for _, r := range page.Rows {
+			liveIDs = append(liveIDs, r.ID)
+		}
+		assert.ElementsMatch(t, []string{a1, b1}, liveIDs,
+			"default ListAll must omit the revoked row")
+
+		// (b) IncludeRevoked surfaces the revoked row with its RevokedAt set and
+		// the owner username still riding the JOIN.
+		page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{IncludeRevoked: true, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 3)
+		byID := map[string]store.APITokenWithOwner{}
+		for _, r := range page.Rows {
+			byID[r.ID] = r
+		}
+		require.Contains(t, byID, a2, "IncludeRevoked must list the revoked row")
+		require.NotNil(t, byID[a2].RevokedAt, "revoked row must carry its RevokedAt")
+		assert.Equal(t, "rev-alice", byID[a2].OwnerUsername)
+		require.Contains(t, byID, a1)
+		assert.Nil(t, byID[a1].RevokedAt, "live row must not carry a RevokedAt")
+
+		// (c) IncludeRevoked composes with the UserID filter: only alice's rows,
+		// revoked one included.
+		page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{UserID: &alice.ID, IncludeRevoked: true, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		userIDs := make([]string, 0, len(page.Rows))
+		for _, r := range page.Rows {
+			userIDs = append(userIDs, r.ID)
+			assert.Equal(t, alice.ID, r.UserID)
+		}
+		assert.ElementsMatch(t, []string{a1, a2}, userIDs)
+
+		// (d) IncludeRevoked composes with the keyset cursor: a Limit-1 walk
+		// visits every row exactly once, in (created_at DESC, id DESC) order.
+		var visited []string
+		cursor := ""
+		for i := 0; ; i++ {
+			require.Less(t, i, 10, "cursor walk did not terminate")
+			page, err = st.APITokens().ListAll(ctx, store.ListAllAPITokensParams{IncludeRevoked: true, PageParams: store.PageParams{Cursor: cursor, Limit: 1}})
+			require.NoError(t, err)
+			for _, r := range page.Rows {
+				visited = append(visited, r.ID)
+			}
+			if !page.HasMore() {
+				break
+			}
+			cursor = page.NextCursor
+		}
+		assert.Equal(t, []string{b1, a2, a1}, visited,
+			"Limit-1 cursor walk must visit every row exactly once")
+	})
+
+	t.Run("delegation tokens list all include revoked forensics opt-in", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "tok-org")
+		alice := SeedUser(t, st, orgID, "del-rev-alice")
+		bob := SeedUser(t, st, orgID, "del-rev-bob")
+		ws := SeedWorkspace(t, st, orgID, alice.ID, "ws")
+		d1 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		d2 := seedDelegationTokenForList(t, st, alice.ID, ws)
+		d3 := seedDelegationTokenForList(t, st, bob.ID, ws)
+		base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		for i, tok := range []string{d1, d2, d3} {
+			pinTokenCreatedAt(t, st, store.EntityDelegationTokens, tok, base.Add(time.Duration(i+1)*time.Second))
+		}
+
+		n, err := st.DelegationTokens().Revoke(ctx, d2)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+
+		// (a) The default listing stays live-only: the revoked row vanishes.
+		page, err := st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		liveIDs := make([]string, 0, len(page.Rows))
+		for _, r := range page.Rows {
+			liveIDs = append(liveIDs, r.ID)
+		}
+		assert.ElementsMatch(t, []string{d1, d3}, liveIDs,
+			"default ListAll must omit the revoked row")
+
+		// (b) IncludeRevoked surfaces the revoked row with its RevokedAt set and
+		// the owner username still riding the JOIN.
+		page, err = st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{IncludeRevoked: true, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 3)
+		byID := map[string]store.DelegationTokenWithOwner{}
+		for _, r := range page.Rows {
+			byID[r.ID] = r
+		}
+		require.Contains(t, byID, d2, "IncludeRevoked must list the revoked row")
+		require.NotNil(t, byID[d2].RevokedAt, "revoked row must carry its RevokedAt")
+		assert.Equal(t, "del-rev-alice", byID[d2].OwnerUsername)
+		require.Contains(t, byID, d1)
+		assert.Nil(t, byID[d1].RevokedAt, "live row must not carry a RevokedAt")
+
+		// (c) IncludeRevoked composes with the UserID filter: only alice's rows,
+		// revoked one included.
+		page, err = st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{UserID: &alice.ID, IncludeRevoked: true, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		userIDs := make([]string, 0, len(page.Rows))
+		for _, r := range page.Rows {
+			userIDs = append(userIDs, r.ID)
+			assert.Equal(t, alice.ID, r.UserID)
+		}
+		assert.ElementsMatch(t, []string{d1, d2}, userIDs)
+
+		// (d) IncludeRevoked composes with the keyset cursor: a Limit-1 walk
+		// visits every row exactly once, in (created_at DESC, id DESC) order.
+		var visited []string
+		cursor := ""
+		for i := 0; ; i++ {
+			require.Less(t, i, 10, "cursor walk did not terminate")
+			page, err = st.DelegationTokens().ListAll(ctx, store.ListAllDelegationTokensParams{IncludeRevoked: true, PageParams: store.PageParams{Cursor: cursor, Limit: 1}})
+			require.NoError(t, err)
+			for _, r := range page.Rows {
+				visited = append(visited, r.ID)
+			}
+			if !page.HasMore() {
+				break
+			}
+			cursor = page.NextCursor
+		}
+		assert.Equal(t, []string{d3, d2, d1}, visited,
+			"Limit-1 cursor walk must visit every row exactly once")
+	})
+}

--- a/backend/internal/hub/store/storetest/test_transactions.go
+++ b/backend/internal/hub/store/storetest/test_transactions.go
@@ -55,10 +55,10 @@ func (s *Suite) testTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Both org and user should be visible.
-		users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: 10})
+		page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 10}})
 		require.NoError(t, err)
-		assert.Len(t, users, 1)
-		assert.Equal(t, "tx-multi-user", users[0].Username)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, "tx-multi-user", page.Rows[0].Username)
 	})
 
 	t.Run("nested reads within transaction", func(t *testing.T) {

--- a/backend/internal/hub/store/storetest/test_users.go
+++ b/backend/internal/hub/store/storetest/test_users.go
@@ -180,15 +180,16 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "u3")
 
 		// First page: limit 2.
-		users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: 2})
+		page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 2}})
 		require.NoError(t, err)
-		assert.Len(t, users, 2)
+		assert.Len(t, page.Rows, 2)
 
 		// Second page: use cursor from last item of first page.
-		cursor := users[len(users)-1].CreatedAt.Format(time.RFC3339Nano)
-		users, err = st.Users().ListAll(ctx, store.ListAllUsersParams{Cursor: cursor, Limit: 10})
+		last := page.Rows[len(page.Rows)-1]
+		cursor := store.EncodeCursor(last.CreatedAt, last.ID)
+		page, err = st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Cursor: cursor, Limit: 10}})
 		require.NoError(t, err)
-		assert.Len(t, users, 1)
+		assert.Len(t, page.Rows, 1)
 	})
 
 	t.Run("search", func(t *testing.T) {
@@ -200,12 +201,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "other-carol")
 
 		q := "searchable"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q,
-			Limit: 10,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, users, 2)
+		assert.Len(t, page.Rows, 2)
 	})
 
 	t.Run("search folds non-ASCII display names case-insensitively", func(t *testing.T) {
@@ -228,17 +229,48 @@ func (s *Suite) testUsers(t *testing.T) {
 		// while the pre-folded column + Go-folded query match identically on every backend.
 		for _, query := range []string{"öl", "ÖL", "Öl", "ölaf", "ÖLAF"} {
 			q := query
-			users, err := st.Users().Search(ctx, store.SearchUsersParams{Query: &q, Limit: 10})
+			page, err := st.Users().Search(ctx, store.SearchUsersParams{Query: &q, PageParams: store.PageParams{Limit: 10}})
 			require.NoError(t, err, "query %q", query)
-			require.Len(t, users, 1, "query %q must match the non-ASCII display name case-insensitively", query)
-			assert.Equal(t, "Ölaf Müller", users[0].DisplayName, "the ORIGINAL (unfolded) display name is returned")
+			require.Len(t, page.Rows, 1, "query %q must match the non-ASCII display name case-insensitively", query)
+			assert.Equal(t, "Ölaf Müller", page.Rows[0].DisplayName, "the ORIGINAL (unfolded) display name is returned")
 		}
 
 		// A non-matching prefix still misses.
 		miss := "xyz"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{Query: &miss, Limit: 10})
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{Query: &miss, PageParams: store.PageParams{Limit: 10}})
 		require.NoError(t, err)
-		assert.Empty(t, users)
+		assert.Empty(t, page.Rows)
+	})
+
+	t.Run("search matches LIKE metacharacters literally", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "like-org")
+
+		// Two users whose emails differ only at the character a bare `_`
+		// wildcard would blur; `_` is legal in an email local part.
+		require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+			ID: id.Generate(), OrgID: orgID, Username: "underscore-user",
+			Email: "a_b@example.com", PasswordSet: true,
+		}))
+		require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+			ID: id.Generate(), OrgID: orgID, Username: "literal-x-user",
+			Email: "axb@example.com", PasswordSet: true,
+		}))
+
+		// `a_b` must match only the literal-underscore email: an unescaped
+		// LIKE would treat `_` as a one-char wildcard and return both rows.
+		q := "a_b"
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{Query: &q, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1, "`_` must match literally, not as a one-char wildcard")
+		assert.Equal(t, "a_b@example.com", page.Rows[0].Email)
+
+		// `%` must prefix-match a literal percent sign (no user has one), not
+		// act as match-anything and dump every user.
+		pct := "%"
+		page, err = st.Users().Search(ctx, store.SearchUsersParams{Query: &pct, PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		assert.Empty(t, page.Rows, "a literal %-search must not act as a wildcard dump")
 	})
 
 	t.Run("update profile", func(t *testing.T) {
@@ -653,10 +685,10 @@ func (s *Suite) testUsers(t *testing.T) {
 		err := st.Users().Delete(ctx, dead.ID)
 		require.NoError(t, err)
 
-		users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: 100})
+		page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 100}})
 		require.NoError(t, err)
-		require.Len(t, users, 1)
-		assert.Equal(t, "alive-all-user", users[0].Username)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, "alive-all-user", page.Rows[0].Username)
 	})
 
 	t.Run("deleted user excluded from search", func(t *testing.T) {
@@ -669,13 +701,13 @@ func (s *Suite) testUsers(t *testing.T) {
 		require.NoError(t, err)
 
 		q := "searchdel"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q,
-			Limit: 100,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
-		require.Len(t, users, 1)
-		assert.Equal(t, "searchdel-alive", users[0].Username)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, "searchdel-alive", page.Rows[0].Username)
 	})
 
 	t.Run("duplicate email returns conflict", func(t *testing.T) {
@@ -702,12 +734,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "sqall-b")
 
 		q := ""
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q,
-			Limit: 100,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
-		assert.Len(t, users, 2)
+		assert.Len(t, page.Rows, 2)
 	})
 
 	t.Run("list all pagination", func(t *testing.T) {
@@ -721,15 +753,48 @@ func (s *Suite) testUsers(t *testing.T) {
 		}
 
 		// First page: limit 2.
-		page1, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Limit: 2})
+		page1, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 2}})
 		require.NoError(t, err)
-		assert.Len(t, page1, 2)
+		assert.Len(t, page1.Rows, 2)
+		assert.True(t, page1.HasMore())
 
 		// Second page using cursor from last item.
-		cursor := page1[len(page1)-1].CreatedAt.Format(time.RFC3339Nano)
-		page2, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Cursor: cursor, Limit: 2})
+		last := page1.Rows[len(page1.Rows)-1]
+		cursor := store.EncodeCursor(last.CreatedAt, last.ID)
+		page2, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Cursor: cursor, Limit: 2}})
 		require.NoError(t, err)
-		assert.Len(t, page2, 2)
+		assert.Len(t, page2.Rows, 2)
+	})
+
+	t.Run("list all has-more is exact at page boundaries", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "user-org")
+		SeedUser(t, st, orgID, "exact-a")
+		SeedUser(t, st, orgID, "exact-b")
+		SeedUser(t, st, orgID, "exact-c")
+
+		// Limit == total: the limit+1 probe proves no further page exists, so
+		// HasMore must be false and no cursor is handed out (the old
+		// len(rows)==limit heuristic would have claimed more).
+		page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 3}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 3)
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
+
+		// Limit < total: a further page exists and the store encodes its cursor.
+		page, err = st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 2)
+		assert.True(t, page.HasMore())
+		require.NotEmpty(t, page.NextCursor)
+
+		// Following the store-produced cursor drains the remaining row.
+		page, err = st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.False(t, page.HasMore())
+		assert.Empty(t, page.NextCursor)
 	})
 
 	t.Run("list all cursor beyond total", func(t *testing.T) {
@@ -738,11 +803,29 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "beyond-user")
 
 		// Use a cursor far in the past to get no results.
-		cursor := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
-		users, err := st.Users().ListAll(ctx, store.ListAllUsersParams{Cursor: cursor, Limit: 10})
+		cursor := store.EncodeCursor(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "beyond")
+		page, err := st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Cursor: cursor, Limit: 10}})
 		require.NoError(t, err)
-		require.NotNil(t, users)
-		assert.Empty(t, users)
+		require.NotNil(t, page.Rows)
+		assert.Empty(t, page.Rows)
+	})
+
+	t.Run("list all cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "user-tie-org")
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedUser(t, st, orgID, "tie-older")
+		tiedA := SeedUser(t, st, orgID, "tie-a")
+		tiedB := SeedUser(t, st, orgID, "tie-b")
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, older.ID, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, tiedA.ID, tie))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, tiedB.ID, tie))
+
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.User], error) {
+			return st.Users().ListAll(ctx, store.ListAllUsersParams{PageParams: store.PageParams{Cursor: cursor, Limit: 1}})
+		})
+		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
+			"same-millisecond users must not be skipped across page boundaries")
 	})
 
 	t.Run("has any after delete", func(t *testing.T) {
@@ -865,11 +948,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "searchable-user")
 
 		q := "searchable-user"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Limit: 10,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, users, 1)
+		assert.Len(t, page.Rows, 1)
 	})
 
 	t.Run("delete already deleted user is no-op", func(t *testing.T) {
@@ -891,11 +975,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "nilq-user1")
 		SeedUser(t, st, orgID, "nilq-user2")
 
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: nil, Limit: 100,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      nil,
+			PageParams: store.PageParams{Limit: 100},
 		})
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, len(users), 2)
+		assert.GreaterOrEqual(t, len(page.Rows), 2)
 	})
 
 	t.Run("update profile preserves email", func(t *testing.T) {
@@ -943,18 +1028,41 @@ func (s *Suite) testUsers(t *testing.T) {
 		q := "pagesearch"
 		// First page.
 		page1, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Limit: 2,
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 2},
 		})
 		require.NoError(t, err)
-		assert.Len(t, page1, 2)
+		assert.Len(t, page1.Rows, 2)
+		assert.True(t, page1.HasMore())
 
 		// Second page using cursor.
-		cursor := page1[len(page1)-1].CreatedAt.Format(time.RFC3339Nano)
+		last := page1.Rows[len(page1.Rows)-1]
+		cursor := store.EncodeCursor(last.CreatedAt, last.ID)
 		page2, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Cursor: cursor, Limit: 2,
+			Query:      &q,
+			PageParams: store.PageParams{Cursor: cursor, Limit: 2},
 		})
 		require.NoError(t, err)
-		assert.Len(t, page2, 2)
+		assert.Len(t, page2.Rows, 2)
+	})
+
+	t.Run("search cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "search-tie-org")
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedUser(t, st, orgID, "srtie-older")
+		tiedA := SeedUser(t, st, orgID, "srtie-a")
+		tiedB := SeedUser(t, st, orgID, "srtie-b")
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, older.ID, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, tiedA.ID, tie))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityUsers, tiedB.ID, tie))
+
+		q := "srtie"
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.User], error) {
+			return st.Users().Search(ctx, store.SearchUsersParams{Query: &q, PageParams: store.PageParams{Cursor: cursor, Limit: 1}})
+		})
+		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
+			"same-millisecond search results must not be skipped across page boundaries")
 	})
 
 	t.Run("search is case insensitive", func(t *testing.T) {
@@ -963,11 +1071,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		SeedUser(t, st, orgID, "MixedCaseSearchUser")
 
 		q := "mixedcasesearchuser"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Limit: 10,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, users, 1)
+		assert.Len(t, page.Rows, 1)
 	})
 
 	t.Run("search is prefix not substring", func(t *testing.T) {
@@ -978,12 +1087,13 @@ func (s *Suite) testUsers(t *testing.T) {
 
 		// "alice" is a prefix of "alice" but NOT "superalice".
 		q := "alice"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Limit: 10,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, users, 1)
-		assert.Equal(t, "alice", users[0].Username)
+		assert.Len(t, page.Rows, 1)
+		assert.Equal(t, "alice", page.Rows[0].Username)
 	})
 
 	t.Run("username and email are case-normalized on create", func(t *testing.T) {
@@ -1054,11 +1164,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		}
 
 		q := "del-search"
-		users, err := st.Users().Search(ctx, store.SearchUsersParams{
-			Query: &q, Limit: 10,
+		page, err := st.Users().Search(ctx, store.SearchUsersParams{
+			Query:      &q,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Empty(t, users)
+		assert.Empty(t, page.Rows)
 	})
 
 	t.Run("update profile conflict preserves original fields", func(t *testing.T) {

--- a/backend/internal/hub/store/storetest/test_workers.go
+++ b/backend/internal/hub/store/storetest/test_workers.go
@@ -106,11 +106,12 @@ func (s *Suite) testWorkers(t *testing.T) {
 
 		// ListByUserID is scoped strictly to registered_by: a user sees their own
 		// workers and nothing else, even for co-members of the same org.
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 			RegisteredBy: other.ID,
-			Limit:        10,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
+		workers := page.Rows
 		require.Len(t, workers, 1)
 		assert.Equal(t, ownWorker.ID, workers[0].ID)
 
@@ -131,12 +132,12 @@ func (s *Suite) testWorkers(t *testing.T) {
 		err := st.Workers().MarkDeleted(ctx, dead.ID)
 		require.NoError(t, err)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Limit: 10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.Len(t, workers, 1)
-		assert.Equal(t, alive.ID, workers[0].ID)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, alive.ID, page.Rows[0].ID)
 	})
 
 	t.Run("list admin filter by user id", func(t *testing.T) {
@@ -147,13 +148,13 @@ func (s *Suite) testWorkers(t *testing.T) {
 		w1 := SeedWorker(t, st, user1.ID)
 		SeedWorker(t, st, user2.ID)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			UserID: &user1.ID,
-			Limit:  10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			UserID:     &user1.ID,
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.Len(t, workers, 1)
-		assert.Equal(t, w1.ID, workers[0].ID)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, w1.ID, page.Rows[0].ID)
 	})
 
 	t.Run("get by auth token excluded after mark deleted", func(t *testing.T) {
@@ -176,12 +177,12 @@ func (s *Suite) testWorkers(t *testing.T) {
 		SeedWorker(t, st, user.ID)
 		SeedWorker(t, st, user.ID)
 
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 			RegisteredBy: user.ID,
-			Limit:        10,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, workers, 2)
+		assert.Len(t, page.Rows, 2)
 	})
 
 	t.Run("list admin", func(t *testing.T) {
@@ -190,12 +191,12 @@ func (s *Suite) testWorkers(t *testing.T) {
 		user := SeedUser(t, st, orgID, "admin-list-user")
 		SeedWorker(t, st, user.ID)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Limit: 10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.Len(t, workers, 1)
-		assert.Equal(t, "admin-list-user", workers[0].OwnerUsername)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, "admin-list-user", page.Rows[0].OwnerUsername)
 	})
 
 	t.Run("list admin filter by status", func(t *testing.T) {
@@ -210,20 +211,50 @@ func (s *Suite) testWorkers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Status: ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_ACTIVE),
-			Limit:  10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			Status:     ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_ACTIVE),
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, workers, 1)
+		assert.Len(t, page.Rows, 1)
 
-		workers, err = st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Status: ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_DEREGISTERING),
-			Limit:  10,
+		page, err = st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			Status:     ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_DEREGISTERING),
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, workers)
-		assert.Empty(t, workers)
+		require.NotNil(t, page.Rows)
+		assert.Empty(t, page.Rows)
+	})
+
+	t.Run("list admin status=deleted surfaces soft-deleted workers", func(t *testing.T) {
+		// Pins the deleted_at-split that the two-query ListAdmin collapse relies
+		// on: the status=nil half filters `deleted_at IS NULL` (hides deleted); the
+		// status-set half drops deleted_at entirely so WORKER_STATUS_DELETED can
+		// surface soft-deleted rows. A regression that applied deleted_at IS NULL
+		// to the status=DELETED case would silently return zero rows here while
+		// every other status-filter test still passed.
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "worker-org")
+		user := SeedUser(t, st, orgID, "deleted-status-user")
+		alive := SeedWorker(t, st, user.ID)
+		dead := SeedWorker(t, st, user.ID)
+		require.NoError(t, st.Workers().MarkDeleted(ctx, dead.ID))
+
+		// No status filter: deleted workers are hidden (the status=nil half).
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{PageParams: store.PageParams{Limit: 10}})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, alive.ID, page.Rows[0].ID)
+
+		// status=DELETED: the status-set half surfaces the soft-deleted row.
+		page, err = st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			Status:     ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_DELETED),
+			PageParams: store.PageParams{Limit: 10},
+		})
+		require.NoError(t, err)
+		require.Len(t, page.Rows, 1, "status=DELETED must surface soft-deleted workers (no deleted_at filter)")
+		assert.Equal(t, dead.ID, page.Rows[0].ID)
 	})
 
 	t.Run("set status", func(t *testing.T) {
@@ -345,12 +376,12 @@ func (s *Suite) testWorkers(t *testing.T) {
 		err := st.Workers().MarkAllDeletedByUser(ctx, user.ID)
 		require.NoError(t, err)
 
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 			RegisteredBy: user.ID,
-			Limit:        10,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		for _, w := range workers {
+		for _, w := range page.Rows {
 			assert.NotNil(t, w.DeletedAt)
 		}
 	})
@@ -408,24 +439,24 @@ func (s *Suite) testWorkers(t *testing.T) {
 		orgID := SeedOrg(t, st, "worker-org")
 		user := SeedUser(t, st, orgID, "no-workers-user")
 
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 			RegisteredBy: user.ID,
-			Limit:        10,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, workers)
-		assert.Empty(t, workers)
+		require.NotNil(t, page.Rows)
+		assert.Empty(t, page.Rows)
 	})
 
 	t.Run("list admin empty", func(t *testing.T) {
 		st := s.NewStore(t)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Limit: 10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, workers)
-		assert.Empty(t, workers)
+		require.NotNil(t, page.Rows)
+		assert.Empty(t, page.Rows)
 	})
 
 	t.Run("mark deleted excludes from list by user", func(t *testing.T) {
@@ -438,13 +469,13 @@ func (s *Suite) testWorkers(t *testing.T) {
 		err := st.Workers().MarkDeleted(ctx, dead.ID)
 		require.NoError(t, err)
 
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
 			RegisteredBy: user.ID,
-			Limit:        10,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.Len(t, workers, 1)
-		assert.Equal(t, alive.ID, workers[0].ID)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, alive.ID, page.Rows[0].ID)
 	})
 
 	t.Run("mark all deleted by user empty", func(t *testing.T) {
@@ -540,21 +571,21 @@ func (s *Suite) testWorkers(t *testing.T) {
 		require.NoError(t, err)
 
 		// ListAdmin with status=DEREGISTERING should find it.
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Status: ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_DEREGISTERING),
-			Limit:  10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			Status:     ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_DEREGISTERING),
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, workers, 1)
-		assert.Equal(t, w.ID, workers[0].ID)
+		assert.Len(t, page.Rows, 1)
+		assert.Equal(t, w.ID, page.Rows[0].ID)
 
 		// ListAdmin with no status filter should also include it.
-		workers, err = st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Limit: 10,
+		page, err = st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
 		found := false
-		for _, wo := range workers {
+		for _, wo := range page.Rows {
 			if wo.ID == w.ID {
 				found = true
 				break
@@ -578,12 +609,13 @@ func (s *Suite) testWorkers(t *testing.T) {
 		require.NoError(t, err)
 
 		// ListByUserID filters on status = 1, so only the active worker comes back.
-		workers, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
-			RegisteredBy: user.ID, Limit: 10,
+		page, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+			RegisteredBy: user.ID,
+			PageParams:   store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		assert.Len(t, workers, 1)
-		assert.Equal(t, active.ID, workers[0].ID)
+		assert.Len(t, page.Rows, 1)
+		assert.Equal(t, active.ID, page.Rows[0].ID)
 	})
 
 	t.Run("list admin filter by user and status", func(t *testing.T) {
@@ -603,14 +635,14 @@ func (s *Suite) testWorkers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		workers, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			UserID: &user.ID,
-			Status: ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_ACTIVE),
-			Limit:  10,
+		page, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
+			UserID:     &user.ID,
+			Status:     ptrconv.Ptr(leapmuxv1.WorkerStatus_WORKER_STATUS_ACTIVE),
+			PageParams: store.PageParams{Limit: 10},
 		})
 		require.NoError(t, err)
-		require.Len(t, workers, 1)
-		assert.Equal(t, w1.ID, workers[0].ID)
+		require.Len(t, page.Rows, 1)
+		assert.Equal(t, w1.ID, page.Rows[0].ID)
 	})
 
 	t.Run("set status on deleted worker is no-op", func(t *testing.T) {
@@ -668,10 +700,13 @@ func (s *Suite) testWorkers(t *testing.T) {
 		}
 
 		// First page: newest first (ORDER BY created_at DESC).
-		page1, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
-			RegisteredBy: user.ID, Limit: 3,
+		res1, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+			RegisteredBy: user.ID,
+			PageParams:   store.PageParams{Limit: 3},
 		})
 		require.NoError(t, err)
+		assert.True(t, res1.HasMore())
+		page1 := res1.Rows
 		require.Len(t, page1, 3)
 		for i := 1; i < len(page1); i++ {
 			assert.False(t, page1[i].CreatedAt.After(page1[i-1].CreatedAt),
@@ -680,11 +715,13 @@ func (s *Suite) testWorkers(t *testing.T) {
 
 		// Second page using the cursor from the last item of page 1. The cursor
 		// is exclusive (created_at < cursor), so the remaining 2 come back.
-		cursor := page1[len(page1)-1].CreatedAt.UTC().Format(time.RFC3339Nano)
-		page2, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
-			RegisteredBy: user.ID, Cursor: cursor, Limit: 3,
+		cursor := store.EncodeCursor(page1[len(page1)-1].CreatedAt, page1[len(page1)-1].ID)
+		res2, err := st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+			RegisteredBy: user.ID,
+			PageParams:   store.PageParams{Cursor: cursor, Limit: 3},
 		})
 		require.NoError(t, err)
+		page2 := res2.Rows
 		assert.Len(t, page2, 2, "remaining 2 workers should be on page 2")
 
 		// No overlap between pages, and page 2 is strictly older than the cursor.
@@ -697,6 +734,34 @@ func (s *Suite) testWorkers(t *testing.T) {
 			assert.True(t, w.CreatedAt.Before(page1[len(page1)-1].CreatedAt),
 				"page 2 rows must be strictly older than the cursor")
 		}
+	})
+
+	t.Run("list by user id cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "worker-tie-org")
+		user := SeedUser(t, st, orgID, "tie-user")
+
+		// Three workers: two share an identical created_at millisecond and the
+		// third is strictly older. A single-column created_at cursor drops one of
+		// the tied rows when it lands on a page boundary; the composite
+		// (created_at, id) cursor must surface all three.
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedWorker(t, st, user.ID)
+		tiedA := SeedWorker(t, st, user.ID)
+		tiedB := SeedWorker(t, st, user.ID)
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, older.ID, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, tiedA.ID, tie))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, tiedB.ID, tie))
+
+		// Page through one row at a time; the union must cover all three with no dupes.
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.Worker], error) {
+			return st.Workers().ListByUserID(ctx, store.ListWorkersByUserIDParams{
+				RegisteredBy: user.ID,
+				PageParams:   store.PageParams{Cursor: cursor, Limit: 1},
+			})
+		})
+		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
+			"same-millisecond workers must not be skipped across page boundaries")
 	})
 
 	t.Run("update public key reflected in get by id", func(t *testing.T) {
@@ -789,17 +854,38 @@ func (s *Suite) testWorkers(t *testing.T) {
 
 		// First page.
 		page1, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Limit: 2,
+			PageParams: store.PageParams{Limit: 2},
 		})
 		require.NoError(t, err)
-		assert.Len(t, page1, 2)
+		assert.Len(t, page1.Rows, 2)
+		assert.True(t, page1.HasMore())
 
 		// Second page using cursor.
-		cursor := page1[len(page1)-1].CreatedAt.Format(time.RFC3339Nano)
+		last := page1.Rows[len(page1.Rows)-1]
+		cursor := store.EncodeCursor(last.CreatedAt, last.ID)
 		page2, err := st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{
-			Cursor: cursor, Limit: 2,
+			PageParams: store.PageParams{Cursor: cursor, Limit: 2},
 		})
 		require.NoError(t, err)
-		assert.Len(t, page2, 2)
+		assert.Len(t, page2.Rows, 2)
+	})
+
+	t.Run("list admin cursor survives same-millisecond tie", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "worker-admin-tie-org")
+		user := SeedUser(t, st, orgID, "admin-tie-user")
+		tie := time.Now().UTC().Truncate(time.Millisecond)
+		older := SeedWorker(t, st, user.ID)
+		tiedA := SeedWorker(t, st, user.ID)
+		tiedB := SeedWorker(t, st, user.ID)
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, older.ID, tie.Add(-time.Second)))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, tiedA.ID, tie))
+		require.NoError(t, st.TestHelper().SetCreatedAt(ctx, store.EntityWorkers, tiedB.ID, tie))
+
+		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.WorkerWithOwner], error) {
+			return st.Workers().ListAdmin(ctx, store.ListWorkersAdminParams{PageParams: store.PageParams{Cursor: cursor, Limit: 1}})
+		})
+		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
+			"same-millisecond admin-listed workers must not be skipped across page boundaries")
 	})
 }

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -25,16 +25,30 @@ func NormalizeEmail(s string) string { return strings.ToLower(s) }
 // way, so both sides share this one rule and cannot drift.
 func FoldSearchText(s string) string { return strings.ToLower(s) }
 
-// FoldSearchQuery returns a folded copy of an optional admin-search term, preserving
-// nil (which SearchUsers reads as "no filter -> return all rows"). Folding via
-// FoldSearchText so the term matches the pre-folded display_name_folded column and
-// the lowercased username/email columns consistently across every dialect.
-func FoldSearchQuery(query *string) *string {
+// likeEscaper backslash-escapes the LIKE metacharacters so a search term
+// matches literally: \ itself first, then % (match-any) and _ (match-one).
+// The dialects' SearchUsers queries declare ESCAPE '\' to match.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// SearchLikePattern builds the complete LIKE prefix pattern for an optional
+// admin-search term, preserving nil (which SearchUsers reads as "no filter ->
+// return all rows"). The term is case-folded via FoldSearchText (so it matches
+// the pre-folded display_name_folded column and the lowercased username/email
+// columns consistently across every dialect), its LIKE metacharacters are
+// backslash-escaped so an operator's query matches literally -- `--query '%'`
+// prefix-matches a literal percent sign instead of dumping every user, and a
+// literal `_` in an email (legal in the local part) matches exactly rather
+// than as a single-char wildcard -- and the match-anything `%` suffix is
+// appended here, so the whole pattern is built at this one site and the SQL
+// binds it directly (sqlc's SQLite grammar cannot parse `LIKE x || y ESCAPE`).
+// Escaping lives here -- NOT in FoldSearchText, which the write path uses to
+// store display_name_folded unescaped.
+func SearchLikePattern(query *string) *string {
 	if query == nil {
 		return nil
 	}
-	folded := FoldSearchText(*query)
-	return &folded
+	pattern := likeEscaper.Replace(FoldSearchText(*query)) + "%"
+	return &pattern
 }
 
 // --- Domain model types (backend-agnostic) ---
@@ -70,6 +84,10 @@ type User struct {
 	DeletedAt             *time.Time
 }
 
+// PageCursor returns the keyset position for user listings (ListAll/Search),
+// which order by (created_at DESC, id DESC).
+func (u User) PageCursor() (time.Time, string) { return u.CreatedAt, u.ID }
+
 // UserSession represents an authenticated session.
 type UserSession struct {
 	ID             string
@@ -81,6 +99,11 @@ type UserSession struct {
 	UserAgent      string
 	IPAddress      string
 }
+
+// PageCursor returns the keyset position for the per-user session listing
+// (ListByUserID), which orders by (last_active_at DESC, id DESC) -- not
+// created_at.
+func (s UserSession) PageCursor() (time.Time, string) { return s.LastActiveAt, s.ID }
 
 // SessionWithUser is the result of ValidateSessionWithUser (JOIN).
 type SessionWithUser struct {
@@ -97,15 +120,23 @@ type SessionWithUser struct {
 
 // ActiveSession is a session with the owning username (for admin listing).
 type ActiveSession struct {
-	ID           string
-	UserID       string
+	ID     string
+	UserID string
+	// Username is the owner's username, or "" when the owner is soft-deleted
+	// (UserDeleted true). The store returns the raw state; presentation layers
+	// decide how to render a deleted owner.
 	Username     string
+	UserDeleted  bool
 	CreatedAt    time.Time
 	LastActiveAt time.Time
 	ExpiresAt    time.Time
 	IPAddress    string
 	UserAgent    string
 }
+
+// PageCursor returns the keyset position for the active-session listing,
+// which orders by (last_active_at DESC, id DESC) -- not created_at.
+func (s ActiveSession) PageCursor() (time.Time, string) { return s.LastActiveAt, s.ID }
 
 // Worker represents a registered worker node.
 type Worker struct {
@@ -126,6 +157,11 @@ type Worker struct {
 	DeletedAt      *time.Time
 }
 
+// PageCursor returns the keyset position for worker listings (ListByUserID
+// and, via the WorkerWithOwner embedding, ListAdmin), which order by
+// (created_at DESC, id DESC).
+func (w Worker) PageCursor() (time.Time, string) { return w.CreatedAt, w.ID }
+
 // WorkerPublicKeys holds a worker's public key material.
 type WorkerPublicKeys struct {
 	PublicKey       []byte
@@ -136,7 +172,10 @@ type WorkerPublicKeys struct {
 // WorkerWithOwner is the result of admin worker listing (JOIN with users).
 type WorkerWithOwner struct {
 	Worker
+	// OwnerUsername is "" when the owner is soft-deleted (OwnerDeleted true);
+	// presentation layers decide how to render a deleted owner.
 	OwnerUsername string
+	OwnerDeleted  bool
 }
 
 // WorkerNotification represents a queued notification for a worker.
@@ -167,12 +206,19 @@ type WorkerRegistrationKey struct {
 	ExpiresAt time.Time
 }
 
+// PageCursor returns the keyset position for the admin registration-key
+// listing (via the WorkerRegistrationKeyWithCreator embedding), which orders
+// by (created_at DESC, id DESC).
+func (k WorkerRegistrationKey) PageCursor() (time.Time, string) { return k.CreatedAt, k.ID }
+
 // WorkerRegistrationKeyWithCreator augments WorkerRegistrationKey with the
-// creator's username (JOINed on users). Soft-deleted creators surface as
-// "(deleted)" so admin listings remain readable after a user is purged.
+// creator's username (LEFT JOINed on users) for the admin listing.
 type WorkerRegistrationKeyWithCreator struct {
 	WorkerRegistrationKey
+	// CreatorUsername is "" when the creator is soft-deleted (CreatorDeleted
+	// true); presentation layers decide how to render a deleted creator.
 	CreatorUsername string
+	CreatorDeleted  bool
 }
 
 // Workspace represents a hub-owned workspace.
@@ -439,15 +485,25 @@ type ClearCompetingPendingEmailsParams struct {
 	ExcludeID    string
 }
 
-type SearchUsersParams struct {
-	Query  *string
-	Cursor string // RFC3339Nano of created_at; empty = first page
+// PageParams is the shared keyset-pagination input embedded in every list
+// param struct: the opaque composite cursor (empty = first page; produced by
+// EncodeCursor / maybePrintNextCursor, validated by ParseCursor) and the page
+// limit (normalized via ClampListLimit; 0 = no rows). Each embedding struct
+// notes which ORDER BY tiebreak column its listing pages on -- created_at for
+// most listings, last_active_at for the session listings -- since the cursor
+// must be encoded from that column.
+type PageParams struct {
+	Cursor string
 	Limit  int64
 }
 
+type SearchUsersParams struct {
+	Query      *string
+	PageParams // Keyset on (created_at DESC, id DESC).
+}
+
 type ListAllUsersParams struct {
-	Cursor string // RFC3339Nano of created_at; empty = first page
-	Limit  int64
+	PageParams // Keyset on (created_at DESC, id DESC).
 }
 
 type CreateSessionParams struct {
@@ -475,8 +531,14 @@ type RefreshSessionAuthGenerationParams struct {
 }
 
 type ListAllActiveSessionsParams struct {
-	Cursor string
-	Limit  int64
+	PageParams // Keyset on (last_active_at DESC, id DESC).
+}
+
+// ListUserSessionsParams pages a per-user session listing (ListByUserID),
+// ordered by (last_active_at DESC, id DESC).
+type ListUserSessionsParams struct {
+	UserID     string
+	PageParams // Keyset on (last_active_at DESC, id DESC).
 }
 
 type CreateWorkerParams struct {
@@ -511,8 +573,7 @@ type DeregisterWorkerParams struct {
 
 type ListWorkersByUserIDParams struct {
 	RegisteredBy string
-	Cursor       string // RFC3339Nano of created_at; empty = first page
-	Limit        int64
+	PageParams   // Keyset on (created_at DESC, id DESC).
 }
 
 type GetOwnedWorkerParams struct {
@@ -521,10 +582,9 @@ type GetOwnedWorkerParams struct {
 }
 
 type ListWorkersAdminParams struct {
-	UserID *string
-	Status *leapmuxv1.WorkerStatus
-	Cursor string // RFC3339Nano of created_at; empty = first page
-	Limit  int64
+	UserID     *string
+	Status     *leapmuxv1.WorkerStatus
+	PageParams // Keyset on (created_at DESC, id DESC).
 }
 
 type CreateWorkerNotificationParams struct {
@@ -552,8 +612,7 @@ type SoftDeleteRegistrationKeyParams struct {
 }
 
 type ListRegistrationKeysAdminParams struct {
-	Cursor         string // RFC3339Nano of created_at; empty = first page
-	Limit          int64
+	PageParams          // Keyset on (created_at DESC, id DESC).
 	IncludeExpired bool // true to surface revoked/expired rows for forensics
 }
 
@@ -847,6 +906,20 @@ type APIToken struct {
 	RevokedAt                *time.Time
 }
 
+// APITokenWithOwner augments APIToken with the owner's username (LEFT JOINed
+// on users) for the admin listing. A soft-deleted owner surfaces as
+// OwnerUsername "" + OwnerDeleted true; presentation layers decide how to
+// render a deleted owner.
+type APITokenWithOwner struct {
+	APIToken
+	OwnerUsername string
+	OwnerDeleted  bool
+}
+
+// PageCursor returns the keyset position for the admin api-token listing
+// (ListAllAPITokens), which orders by (created_at DESC, id DESC).
+func (t APITokenWithOwner) PageCursor() (time.Time, string) { return t.CreatedAt, t.ID }
+
 // DelegationToken is a short-lived bearer minted by a worker so a
 // spawned agent (or opt-in terminal) can act for the user against the
 // hub or a sibling worker. Scope is (UserID, WorkspaceID); IssuedFor*
@@ -869,6 +942,19 @@ type DelegationToken struct {
 	RefreshExpiresAt *time.Time
 	RevokedAt        *time.Time
 }
+
+// DelegationTokenWithOwner augments DelegationToken with the owner's username
+// for the admin listing. A soft-deleted owner surfaces as OwnerUsername "" +
+// OwnerDeleted true; presentation layers decide how to render a deleted owner.
+type DelegationTokenWithOwner struct {
+	DelegationToken
+	OwnerUsername string
+	OwnerDeleted  bool
+}
+
+// PageCursor returns the keyset position for the admin delegation-token listing
+// (ListAllDelegationTokens), which orders by (created_at DESC, id DESC).
+func (t DelegationTokenWithOwner) PageCursor() (time.Time, string) { return t.CreatedAt, t.ID }
 
 // DeviceAuthorization is an in-flight RFC 8628 device-code grant.
 type DeviceAuthorization struct {
@@ -921,6 +1007,28 @@ type RotateAPITokenRefreshParams struct {
 type ListAPITokensByUserParams struct {
 	UserID     string
 	ClientType string // empty = all
+}
+
+// ListAllAPITokensParams pages the admin api-token listing (ListAllAPITokens),
+// ordered by (created_at DESC, id DESC) and LEFT JOINed with users so the owner
+// username rides each row (no per-user fanout).
+type ListAllAPITokensParams struct {
+	UserID     *string // nil = all users; non-nil dispatches to the ByUser query twin
+	ClientType string  // empty = all
+	PageParams         // Keyset on (created_at DESC, id DESC).
+	// IncludeRevoked adds revoked rows to the listing (forensics); the default
+	// lists live tokens only and rides the partial keyset indexes.
+	IncludeRevoked bool
+}
+
+// ListAllDelegationTokensParams pages the admin delegation-token listing
+// (ListAllDelegationTokens), ordered by (created_at DESC, id DESC).
+type ListAllDelegationTokensParams struct {
+	UserID     *string // nil = all users; non-nil dispatches to the ByUser query twin
+	PageParams         // Keyset on (created_at DESC, id DESC).
+	// IncludeRevoked adds revoked rows to the listing (forensics); the default
+	// lists live tokens only and rides the partial keyset indexes.
+	IncludeRevoked bool
 }
 
 type CreateDelegationTokenParams struct {

--- a/backend/internal/hub/store/types_test.go
+++ b/backend/internal/hub/store/types_test.go
@@ -71,22 +71,30 @@ func TestCreateUserParams_Validate(t *testing.T) {
 	}
 }
 
-// TestFoldSearchQuery pins the case-fold helper that keeps the admin user search
-// consistent across dialects: it Unicode-lowercases a term so it matches the
-// pre-folded display_name_folded column, and preserves nil (which SearchUsers reads
-// as "no filter -> all rows") so an absent query is never turned into an empty match.
-func TestFoldSearchQuery(t *testing.T) {
-	assert.Nil(t, FoldSearchQuery(nil), "a nil query stays nil (no filter), not an empty-string match")
+// TestSearchLikePattern pins the one site that builds the admin-search LIKE
+// pattern: it Unicode-lowercases a term so it matches the pre-folded
+// display_name_folded column, backslash-escapes the LIKE metacharacters so an
+// operator's literal '%'/'_' cannot act as a wildcard (paired with the queries'
+// ESCAPE '\'), appends the prefix-match '%', and preserves nil (which
+// SearchUsers reads as "no filter -> all rows").
+func TestSearchLikePattern(t *testing.T) {
+	assert.Nil(t, SearchLikePattern(nil), "a nil query stays nil (no filter), not an empty-string match")
 
-	empty := ""
-	require.NotNil(t, FoldSearchQuery(&empty))
-	assert.Equal(t, "", *FoldSearchQuery(&empty), "an empty query folds to empty, not nil")
-
-	mixed := "ÖLaf"
-	require.NotNil(t, FoldSearchQuery(&mixed))
-	assert.Equal(t, "ölaf", *FoldSearchQuery(&mixed), "a non-ASCII mixed-case term folds to lowercase")
+	pattern := func(s string) string {
+		p := SearchLikePattern(&s)
+		require.NotNil(t, p)
+		return *p
+	}
+	assert.Equal(t, "%", pattern(""), "an empty query becomes the match-all prefix pattern")
+	assert.Equal(t, "ölaf%", pattern("ÖLaf"), "a non-ASCII mixed-case term folds to lowercase")
 	// The direct folder agrees, so the write path and the query fold identically.
 	assert.Equal(t, "ölaf", FoldSearchText("ÖLaf"))
+
+	// LIKE metacharacters in the operator's term are escaped, so they match
+	// literally instead of widening the search.
+	assert.Equal(t, `\%%`, pattern("%"), "a literal %-search cannot dump every user")
+	assert.Equal(t, `a\_b%`, pattern("a_b"), "a literal _ (legal in email local parts) is not a one-char wildcard")
+	assert.Equal(t, `a\\b%`, pattern(`a\b`), "a backslash is escaped before the metachars it could mask")
 }
 
 // TestGetOwnedWorker_EmptyUserIDDenied pins the empty-identity fail-close on the
@@ -121,13 +129,16 @@ func TestClampListLimit(t *testing.T) {
 	assert.Equal(t, int64(50), ClampListLimit(50), "an ordinary limit passes through")
 	assert.Equal(t, int64(0), ClampListLimit(0), "zero is preserved (paginated queries treat it as no rows)")
 	assert.Equal(t, int64(0), ClampListLimit(-1), "a negative limit floors at 0 rather than wrapping negative")
-	assert.Equal(t, int64(math.MaxInt32), ClampListLimit(math.MaxInt32), "the int32 max passes through unchanged")
-	assert.Equal(t, int64(math.MaxInt32), ClampListLimit(math.MaxInt32+1), "a value past int32 caps at the max, not wraps")
+	// The ceiling is MaxInt32-1, not MaxInt32: FetchLimit adds a probe row, and
+	// the +1 must still fit the dialects' int32 LIMIT casts -- so HasMore stays
+	// exact even at the largest permitted limit instead of silently degrading.
+	assert.Equal(t, int64(math.MaxInt32-1), ClampListLimit(math.MaxInt32), "the int32 max caps at the probe-safe ceiling")
+	assert.Equal(t, int64(math.MaxInt32-1), ClampListLimit(math.MaxInt32+1), "a value past int32 caps at the ceiling, not wraps")
 	// The two concrete wrap cases the fix targets: 4294967297 would truncate to 1
 	// (a silent under-fetch) and 3000000000 to a negative int32 (a DB error).
-	assert.Equal(t, int64(math.MaxInt32), ClampListLimit(4294967297), "2^32+1 caps instead of truncating to 1")
-	assert.Equal(t, int64(math.MaxInt32), ClampListLimit(3000000000), "3e9 caps instead of wrapping negative on int32")
-	// The clamped value is always a safe int32 conversion.
-	assert.LessOrEqual(t, ClampListLimit(math.MaxInt64), int64(math.MaxInt32))
+	assert.Equal(t, int64(math.MaxInt32-1), ClampListLimit(4294967297), "2^32+1 caps instead of truncating to 1")
+	assert.Equal(t, int64(math.MaxInt32-1), ClampListLimit(3000000000), "3e9 caps instead of wrapping negative on int32")
+	// The clamped value +1 (the probe row) is always a safe int32 conversion.
+	assert.LessOrEqual(t, ClampListLimit(math.MaxInt64)+1, int64(math.MaxInt32))
 	assert.GreaterOrEqual(t, ClampListLimit(math.MinInt64), int64(0))
 }


### PR DESCRIPTION
## Motivation

The keyset-paginated list queries ordered rows by a millisecond-precision timestamp `DESC` with a strict `col < cursor` predicate and no unique tiebreaker. Whenever two rows shared a timestamp across a page boundary, both were excluded from the results — silently dropping live rows from admin listings (#287).

The surrounding pagination contract shared the same caller-trusting shape: every call site hand-picked its own cursor column, built its own `WHERE`/`ORDER BY`, and guessed "has more" from `len(rows) == limit`, which is also wrong at exact page-size multiples. This logic was duplicated across the admin CLI, the store layer, and all three SQL dialects (SQLite, Postgres, MySQL), so the same class of bug could recur independently in any of them.

## Modifications

- Replaced the shared pagination helpers (`SortFilterLimit`, `ApplyOffsetLimit`, `ParseCursorTime`) with a keyset-pagination framework the store owns end-to-end: composite `Cursor` (timestamp + id tiebreaker), opaque `EncodeCursor`/`ParseCursor` (`ErrInvalidCursor` on malformed input), a `PageCursorer` interface per row type, and a generic `Page[T]`/`NewPage`/`FetchLimit`/`QueryPage` skeleton shared by every list query. A limit+1 probe row drives `HasMore()`/`NextCursor` instead of the `len(rows)==limit` heuristic.
- Every store list method now returns `Page[T]` instead of a slice (`UserStore.ListAll/Search`, `SessionStore.ListByUserID/ListAllActive`, `WorkerStore.ListByUserID/ListAdmin`, `RegistrationKeyStore.ListAdmin`), and moved every admin listing (workers, users, registration keys, sessions, API tokens, delegation tokens) onto this one path.
- Added store-level `APITokenStore.ListAll` / `DelegationTokenStore.ListAll` with an owner `LEFT JOIN`, replacing the per-user `ListByUser` fanout (previously looped across up to 1000 users via `collectAcrossUsers`/`adminAllUsersLimit`, which the CLI has now removed). Soft-deleted owners surface via explicit boolean flags (`OwnerDeleted`/`CreatorDeleted`/`UserDeleted`) instead of a `"(deleted)"` string sentinel baked into SQL, so their sessions/tokens stay visible for audit instead of being hidden.
- Per-dialect composite predicate + `ORDER BY col DESC, id DESC`: MySQL tables now declare `COLLATE=utf8mb4_bin`; Postgres adds `COLLATE "C"` to ~74 TEXT id/FK/ordering columns, with a new CockroachDB-detecting migrator that strips `COLLATE "C"` on the fly (CRDB rejects the clause but already compares byte-wise) via a transforming `fs.FS`; SQLite standardizes on a canonical `strftime` timestamp layout and sargable raw-string comparisons so cleanup sweeps keep using their indexes. Rebuilt the admin worker listing in all three dialects as a 2x2 matrix of required-equality queries — the old `(narg IS NULL OR col = narg)` probe defeated SQLite's partial index (full scan + TEMP B-TREE sort) and emitted an untyped param that broke on Postgres.
- Renamed `FoldSearchQuery` to `SearchLikePattern`, which now backslash-escapes LIKE metacharacters (`--query '%'` no longer dumps every row).
- `WorkerManagementService.ListWorkers` now maps `store.ErrInvalidCursor` to `connect.CodeInvalidArgument` (400) instead of `CodeInternal` (500).
- **CLI breaking changes:** `--user` renamed to `--user-id`/`--username` (mutually exclusive) on token listings; `--cursor` is now an opaque store-emitted keyset token rather than a raw RFC3339Nano timestamp; the next-page hint now prints to stderr instead of stdout so piped tabular output stays clean; `--limit 0` or negative is now a hard error instead of returning an empty listing.
- Extensive new coverage: cross-dialect `storetest` suites for same-millisecond ties, cursor round-trips, exact-multiple `HasMore` boundaries, include-revoked forensics, and LIKE-literality; SQLite `EXPLAIN`-plan pins confirming every listing rides its keyset index with no TEMP B-TREE sort; Postgres/MySQL live schema pins confirming collation declarations; admin CLI and worker-management-service tests for the new error mapping and flag behavior.

## Result

- Closes #287
- You no longer lose rows when paging through admin listings (workers, users, registration keys, sessions, API tokens, delegation tokens) that contain rows sharing the same millisecond timestamp.
- Admin token listings (`api-token list`, `delegation-token list`) run as a single JOINed query instead of fanning out per-user, and now support forensic scoping to a soft-deleted account:
  ```
  leapmux admin api-token list --user-id <deleted-account-id> --include-revoked
  ```
- `--cursor` values are now opaque and must come from the previous page's hint (printed on stderr); a malformed or hand-crafted cursor now fails with an actionable "invalid cursor" error instead of being silently ignored or surfacing as an opaque server fault.
- `--limit 0` or a negative limit now fails immediately with a clear error instead of printing an empty listing indistinguishable from a genuinely empty result.
