### PR TITLE
fix(store): Floor time binds and canonicalize DATETIME storage

### DIFF
--- a/backend/internal/hub/store/mysql/api_tokens.go
+++ b/backend/internal/hub/store/mysql/api_tokens.go
@@ -46,8 +46,8 @@ func (s *apiTokenStore) Create(ctx context.Context, p store.CreateAPITokenParams
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
 			Scope:            p.Scope,
-			ExpiresAt:        sqlutil.ToNullTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.ToNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqlutil.BindNullTime(p.ExpiresAt),
+			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -137,11 +137,11 @@ func (s *apiTokenStore) RotateRefresh(ctx context.Context, p store.RotateAPIToke
 		n, err := rowsAffected(conn.q.RotateAPITokenRefresh(ctx, gendb.RotateAPITokenRefreshParams{
 			ID:                   p.ID,
 			NewSecretHash:        p.NewSecretHash,
-			NewExpiresAt:         sqlutil.ToNullTime(p.NewExpiresAt),
+			NewExpiresAt:         sqlutil.BindNullTime(p.NewExpiresAt),
 			NewRefreshHash:       p.NewRefreshHash,
-			NewRefreshExpiresAt:  sqlutil.ToNullTime(p.NewRefreshExpiresAt),
+			NewRefreshExpiresAt:  sqlutil.BindNullTime(p.NewRefreshExpiresAt),
 			PrevRefreshHash:      p.PreviousRefreshHash,
-			PrevRefreshExpiresAt: sqlutil.ToNullTime(p.PreviousRefreshExpiresAt),
+			PrevRefreshExpiresAt: sqlutil.BindNullTime(p.PreviousRefreshExpiresAt),
 		}))
 		if err != nil || n == 0 {
 			return nil, err

--- a/backend/internal/hub/store/mysql/cleanup.go
+++ b/backend/internal/hub/store/mysql/cleanup.go
@@ -2,10 +2,10 @@ package mysql
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type cleanupStore struct {
@@ -19,27 +19,27 @@ func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, er
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, cutoff))
+	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, sqlutil.BindTime(cutoff)))
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteOrgsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
@@ -51,23 +51,23 @@ func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (in
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqlutil.BindTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqlutil.BindTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sql.NullTime{Time: cutoff.UTC(), Valid: true}))
+	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sql.NullTime{Time: cutoff.UTC(), Valid: true}))
+	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqlutil.BindTimeValid(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqlutil.BindTime(cutoff)))
 }
 
 func (s *cleanupStore) CompactPublishedRevocationEvents(

--- a/backend/internal/hub/store/mysql/cli_authorization_codes.go
+++ b/backend/internal/hub/store/mysql/cli_authorization_codes.go
@@ -30,7 +30,7 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 		UserID:        p.UserID,
 		CodeChallenge: p.CodeChallenge,
 		DeviceName:    p.DeviceName,
-		ExpiresAt:     p.ExpiresAt.UTC(),
+		ExpiresAt:     sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/delegation_tokens.go
+++ b/backend/internal/hub/store/mysql/delegation_tokens.go
@@ -49,8 +49,8 @@ func (s *delegationTokenStore) Create(ctx context.Context, p store.CreateDelegat
 			IssuedForTabType: p.IssuedForTabType,
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
-			ExpiresAt:        p.ExpiresAt.UTC(),
-			RefreshExpiresAt: sqlutil.ToNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqlutil.BindTime(p.ExpiresAt),
+			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }

--- a/backend/internal/hub/store/mysql/device_authorizations.go
+++ b/backend/internal/hub/store/mysql/device_authorizations.go
@@ -34,7 +34,7 @@ func (s *deviceAuthorizationStore) Create(ctx context.Context, p store.CreateDev
 		UserCode:        p.UserCode,
 		DeviceName:      p.DeviceName,
 		IntervalSeconds: int32(p.IntervalSeconds),
-		ExpiresAt:       p.ExpiresAt.UTC(),
+		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/lifecycle_outbox.go
+++ b/backend/internal/hub/store/mysql/lifecycle_outbox.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -49,10 +48,10 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 func (s *lifecycleOutboxStore) MarkConsumed(ctx context.Context, p store.MarkLifecycleOutboxConsumedParams) error {
 	return mapErr(s.conn.q.MarkLifecycleOutboxConsumed(ctx, gendb.MarkLifecycleOutboxConsumedParams{
 		ID:         p.ID,
-		ConsumedAt: sql.NullTime{Time: p.ConsumedAt, Valid: true},
+		ConsumedAt: sqlutil.BindTimeValid(p.ConsumedAt),
 	}))
 }
 
 func (s *lifecycleOutboxStore) DeleteConsumedBefore(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sql.NullTime{Time: before, Valid: true}))
+	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sqlutil.BindTimeValid(before)))
 }

--- a/backend/internal/hub/store/mysql/oauth_states.go
+++ b/backend/internal/hub/store/mysql/oauth_states.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type oauthStateStore struct {
@@ -30,7 +31,7 @@ func (s *oauthStateStore) Create(ctx context.Context, p store.CreateOAuthStatePa
 		ProviderID:   p.ProviderID,
 		PkceVerifier: p.PkceVerifier,
 		RedirectUri:  p.RedirectURI,
-		ExpiresAt:    p.ExpiresAt,
+		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/oauth_tokens.go
+++ b/backend/internal/hub/store/mysql/oauth_tokens.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type oauthTokenStore struct {
@@ -37,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
-		ExpiresAt:    p.ExpiresAt.UTC(),
+		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
 		KeyVersion:   p.KeyVersion,
 	}))
 }

--- a/backend/internal/hub/store/mysql/org_recent_batch_ids.go
+++ b/backend/internal/hub/store/mysql/org_recent_batch_ids.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgRecentBatchIDStore struct {
@@ -49,10 +50,10 @@ func (s *orgRecentBatchIDStore) Insert(ctx context.Context, p store.InsertOrgRec
 		CanonicalClient:     p.CanonicalClient,
 		OpCount:             int32(p.OpCount),
 		Epoch:               p.Epoch,
-		ExpiresAt:           p.ExpiresAt,
+		ExpiresAt:           sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 
 func (s *orgRecentBatchIDStore) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, before))
+	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, sqlutil.BindTime(before)))
 }

--- a/backend/internal/hub/store/mysql/org_state.go
+++ b/backend/internal/hub/store/mysql/org_state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStateStore struct {
@@ -37,8 +38,8 @@ func (s *orgStateStore) Upsert(ctx context.Context, p store.UpsertOrgStateParams
 		OrgID:          p.OrgID,
 		StatePayload:   p.StatePayload,
 		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: p.EpochStartedAt,
-		UpdatedAt:      p.UpdatedAt,
+		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
+		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
 	}))
 }
 
@@ -46,7 +47,7 @@ func (s *orgStateStore) AdvanceEpoch(ctx context.Context, p store.AdvanceOrgEpoc
 	return mapErr(s.conn.q.AdvanceOrgEpoch(ctx, gendb.AdvanceOrgEpochParams{
 		OrgID:          p.OrgID,
 		Epoch:          p.Epoch,
-		EpochStartedAt: p.EpochStartedAt,
-		UpdatedAt:      p.UpdatedAt,
+		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
+		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
 	}))
 }

--- a/backend/internal/hub/store/mysql/orgs.go
+++ b/backend/internal/hub/store/mysql/orgs.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStore struct {
@@ -19,7 +19,7 @@ func fromDBOrg(o gendb.Org) store.Org {
 		ID:        o.ID,
 		Name:      o.Name,
 		CreatedAt: o.CreatedAt,
-		DeletedAt: ptrconv.NullTimeToPtr(o.DeletedAt),
+		DeletedAt: sqlutil.NullTimePtr(o.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/mysql/pending_oauth_signups.go
+++ b/backend/internal/hub/store/mysql/pending_oauth_signups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type pendingOAuthSignupStore struct {
@@ -41,10 +42,10 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  p.TokenExpiresAt,
+		TokenExpiresAt:  sqlutil.BindTime(p.TokenExpiresAt),
 		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
-		ExpiresAt:       p.ExpiresAt,
+		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/registration_keys.go
+++ b/backend/internal/hub/store/mysql/registration_keys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type registrationKeyStore struct {
@@ -29,7 +30,7 @@ func (s *registrationKeyStore) Create(ctx context.Context, p store.CreateRegistr
 	return mapErr(s.conn.q.CreateRegistrationKey(ctx, gendb.CreateRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: p.ExpiresAt.UTC(),
+		ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 
@@ -56,8 +57,8 @@ func (s *registrationKeyStore) Extend(ctx context.Context, p store.ExtendRegistr
 	return rowsAffected(s.conn.q.ExtendRegistrationKey(ctx, gendb.ExtendRegistrationKeyParams{
 		ID:           p.ID,
 		CreatedBy:    p.CreatedBy,
-		NewExpiresAt: p.ExpiresAt.UTC(),
-		Now:          time.Now().UTC(),
+		NewExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+		Now:          sqlutil.BindTime(time.Now()),
 	}))
 }
 
@@ -65,7 +66,7 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 	return rowsAffected(s.conn.q.SoftDeleteRegistrationKey(ctx, gendb.SoftDeleteRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset),
+		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
@@ -75,7 +76,7 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.WorkerRegistrationKey, error) {
 	var consumed *store.WorkerRegistrationKey
 	err := s.conn.withTransaction(ctx, func(conn *mysqlConn) error {
-		now := time.Now().UTC()
+		now := sqlutil.BindTime(time.Now())
 		r, err := conn.q.GetActiveRegistrationKeyForUpdate(ctx, gendb.GetActiveRegistrationKeyForUpdateParams{
 			ID:        id,
 			ExpiresAt: now,
@@ -104,7 +105,7 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (int64, error) {
 	return rowsAffected(s.conn.q.AdminSoftDeleteRegistrationKey(ctx, gendb.AdminSoftDeleteRegistrationKeyParams{
 		ID:        id,
-		ExpiresAt: time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset),
+		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
@@ -115,7 +116,7 @@ func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegist
 	// so the IS NULL branch surfaces every row.
 	var now sql.NullTime
 	if !p.IncludeExpired {
-		now = sql.NullTime{Time: time.Now().UTC(), Valid: true}
+		now = sqlutil.BindTimeValid(time.Now())
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListRegistrationKeysAdminParams, error) {

--- a/backend/internal/hub/store/mysql/revocation_events.go
+++ b/backend/internal/hub/store/mysql/revocation_events.go
@@ -52,7 +52,7 @@ func insertRevocationEvent(
 		Kind:               kind,
 		SubjectID:          subjectID,
 		UserID:             userID,
-		RevokedAt:          revokedAt.UTC(),
+		RevokedAt:          sqlutil.BindTime(revokedAt),
 		UserAuthGeneration: userAuthGeneration,
 	}))
 }
@@ -88,7 +88,7 @@ func newRevocationEventStore(conn *mysqlConn) *revocationEventStore {
 				return mapErr(err)
 			},
 			CompactPublished: func(ctx context.Context, conn *mysqlConn, cutoff time.Time) (int64, error) {
-				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, sql.NullTime{Time: cutoff, Valid: true}))
+				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, sqlutil.BindTimeValid(cutoff)))
 			},
 			InsertLease: func(ctx context.Context, conn *mysqlConn, lease store.RevocationLease) error {
 				return mapErr(conn.q.InsertHubRuntimeLease(ctx, gendb.InsertHubRuntimeLeaseParams{
@@ -154,6 +154,11 @@ func (s *revocationEventStore) MaxPublishedSeq(ctx context.Context) (int64, erro
 	return seq, mapErr(err)
 }
 
+// mysqlRevocationNow reads the transaction's clock via SELECT NOW(3). The
+// result is already on the millisecond grid, so revoke paths that bind it
+// back into DATETIME(3) columns (revoked_at, tokens_revoked_at, updated_at)
+// round-trip exactly and deliberately skip the sqlutil.BindTime floor that
+// Go-minted instants require.
 func mysqlRevocationNow(ctx context.Context, conn *mysqlConn) (time.Time, error) {
 	now, err := conn.q.RevocationNow(ctx)
 	if err != nil {

--- a/backend/internal/hub/store/mysql/sessions.go
+++ b/backend/internal/hub/store/mysql/sessions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type sessionStore struct{ conn *mysqlConn }
@@ -47,7 +48,7 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 		return mapErr(tx.(*mysqlStore).conn.q.CreateUserSession(ctx, gendb.CreateUserSessionParams{
 			ID:        p.ID,
 			UserID:    p.UserID,
-			ExpiresAt: p.ExpiresAt,
+			ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
 			UserAgent: p.UserAgent,
 			IpAddress: p.IPAddress,
 		}))
@@ -65,9 +66,9 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
-		ExpiresAt:    p.ExpiresAt,
+		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
 		ID:           p.ID,
-		LastActiveAt: p.LastActiveAt,
+		LastActiveAt: sqlutil.BindTime(p.LastActiveAt),
 	})
 	return n, mapErr(err)
 }

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type userStore struct {
@@ -29,16 +29,16 @@ func fromDBUser(u gendb.User) store.User {
 		EmailVerified:         u.EmailVerified,
 		PendingEmail:          u.PendingEmail,
 		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: ptrconv.NullTimeToPtr(u.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqlutil.NullTimePtr(u.PendingEmailExpiresAt),
 		PendingEmailAttempts:  int64(u.PendingEmailAttempts),
 		PasswordSet:           u.PasswordSet,
 		IsAdmin:               u.IsAdmin,
 		Prefs:                 u.Prefs,
 		CreatedAt:             u.CreatedAt,
 		UpdatedAt:             u.UpdatedAt,
-		TokensRevokedAt:       ptrconv.NullTimeToPtr(u.TokensRevokedAt),
+		TokensRevokedAt:       sqlutil.NullTimePtr(u.TokensRevokedAt),
 		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             ptrconv.NullTimeToPtr(u.DeletedAt),
+		DeletedAt:             sqlutil.NullTimePtr(u.DeletedAt),
 	}
 }
 
@@ -353,7 +353,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
-		PendingEmailExpiresAt: ptrconv.PtrToNullTime(p.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqlutil.BindNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
 	}))
 }

--- a/backend/internal/hub/store/mysql/worker_notifications.go
+++ b/backend/internal/hub/store/mysql/worker_notifications.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerNotificationStore implements store.WorkerNotificationStore backed by MySQL.
@@ -52,6 +52,6 @@ func fromDBWorkerNotification(n gendb.WorkerNotification) store.WorkerNotificati
 		Attempts:    int64(n.Attempts),
 		MaxAttempts: int64(n.MaxAttempts),
 		CreatedAt:   n.CreatedAt,
-		DeliveredAt: ptrconv.NullTimeToPtr(n.DeliveredAt),
+		DeliveredAt: sqlutil.NullTimePtr(n.DeliveredAt),
 	}
 }

--- a/backend/internal/hub/store/mysql/workers.go
+++ b/backend/internal/hub/store/mysql/workers.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerStore implements store.WorkerStore backed by MySQL.
@@ -160,12 +160,12 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 		RegisteredBy:    w.RegisteredBy,
 		Status:          w.Status,
 		CreatedAt:       w.CreatedAt,
-		LastSeenAt:      ptrconv.NullTimeToPtr(w.LastSeenAt),
+		LastSeenAt:      sqlutil.NullTimePtr(w.LastSeenAt),
 		PublicKey:       w.PublicKey,
 		MlkemPublicKey:  w.MlkemPublicKey,
 		SlhdsaPublicKey: w.SlhdsaPublicKey,
 		AutoRegistered:  w.AutoRegistered,
-		DeletedAt:       ptrconv.NullTimeToPtr(w.DeletedAt),
+		DeletedAt:       sqlutil.NullTimePtr(w.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/mysql/workspaces.go
+++ b/backend/internal/hub/store/mysql/workspaces.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type workspaceStore struct {
@@ -22,7 +22,7 @@ func fromDBWorkspace(w gendb.Workspace) *store.Workspace {
 		Title:       w.Title,
 		IsDeleted:   w.IsDeleted,
 		CreatedAt:   w.CreatedAt,
-		DeletedAt:   ptrconv.NullTimeToPtr(w.DeletedAt),
+		DeletedAt:   sqlutil.NullTimePtr(w.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/api_tokens.go
+++ b/backend/internal/hub/store/sqlite/api_tokens.go
@@ -44,8 +44,8 @@ func (s *apiTokenStore) Create(ctx context.Context, p store.CreateAPITokenParams
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
 			Scope:            p.Scope,
-			ExpiresAt:        sqlutil.ToNullTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.ToNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqlutil.BindNullTime(p.ExpiresAt),
+			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -135,11 +135,11 @@ func (s *apiTokenStore) RotateRefresh(ctx context.Context, p store.RotateAPIToke
 		n, err := rowsAffected(conn.q.RotateAPITokenRefresh(ctx, gendb.RotateAPITokenRefreshParams{
 			ID:                   p.ID,
 			NewSecretHash:        p.NewSecretHash,
-			NewExpiresAt:         sqlutil.ToNullTime(p.NewExpiresAt),
+			NewExpiresAt:         sqlutil.BindNullTime(p.NewExpiresAt),
 			NewRefreshHash:       p.NewRefreshHash,
-			NewRefreshExpiresAt:  sqlutil.ToNullTime(p.NewRefreshExpiresAt),
+			NewRefreshExpiresAt:  sqlutil.BindNullTime(p.NewRefreshExpiresAt),
 			PrevRefreshHash:      p.PreviousRefreshHash,
-			PrevRefreshExpiresAt: sqlutil.ToNullTime(p.PreviousRefreshExpiresAt),
+			PrevRefreshExpiresAt: sqlutil.BindNullTime(p.PreviousRefreshExpiresAt),
 		}))
 		if err != nil || n == 0 {
 			return nil, err

--- a/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
+++ b/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
@@ -1,0 +1,207 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllDatetimeColumnsStoreCanonicalLayout drives every write path that
+// binds a Go-side time into a DATETIME column and then asserts -- via the
+// schema-discovered CheckCanonicalTimestamps walk -- that every stored value
+// is the canonical 24-char strftime('%Y-%m-%dT%H:%M:%fZ') layout. Binds use a
+// deliberately non-UTC fixed zone: a raw time.Time bind would store modernc's
+// driver layout with the zone's offset (space at byte 11, '+09:00' suffix),
+// so any write path missing its SQL-side strftime wrap (or Go-side
+// formatSQLiteTime pre-formatting) fails here instead of silently splitting
+// the store into two timestamp layouts whose raw-string compares diverge as
+// soon as the offsets differ.
+func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
+	ctx := context.Background()
+	testable, err := OpenTestable(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testable.Close()) })
+	st := store.Store(testable)
+
+	// Non-UTC on purpose; see the doc comment.
+	zone := time.FixedZone("UTC+9", 9*60*60)
+	now := time.Now().In(zone)
+	future := now.Add(time.Hour)
+	farFuture := now.Add(2 * time.Hour)
+	ptr := func(v time.Time) *time.Time { return &v }
+
+	orgID := storetest.SeedOrg(t, st, "canon-org")
+	user := storetest.SeedUser(t, st, orgID, "canon-user")
+	worker := storetest.SeedWorker(t, st, user.ID)
+	workspaceID := storetest.SeedWorkspace(t, st, orgID, user.ID, "canon-ws")
+	provider := storetest.SeedOAuthProvider(t, st, "canon-provider")
+
+	// delegation_tokens: expires_at + refresh_expires_at.
+	require.NoError(t, st.DelegationTokens().Create(ctx, store.CreateDelegationTokenParams{
+		ID:               id.Generate(),
+		UserID:           user.ID,
+		WorkerID:         worker.ID,
+		WorkspaceID:      workspaceID,
+		SecretHash:       []byte("dt-secret"),
+		RefreshHash:      []byte("dt-refresh"),
+		ExpiresAt:        future,
+		RefreshExpiresAt: ptr(farFuture),
+	}))
+
+	// api_tokens: expires_at + refresh_expires_at on Create, the New*/Prev*
+	// triplet on RotateRefresh, and revocation_events.revoked_at via Revoke.
+	rotatedID := id.Generate()
+	require.NoError(t, st.APITokens().Create(ctx, store.CreateAPITokenParams{
+		ID:               rotatedID,
+		UserID:           user.ID,
+		ClientType:       "cli",
+		ClientName:       "canon-client",
+		SecretHash:       []byte("at-secret"),
+		RefreshHash:      []byte("at-refresh"),
+		Scope:            "remote:*",
+		ExpiresAt:        ptr(future),
+		RefreshExpiresAt: ptr(farFuture),
+	}))
+	rotated, err := st.APITokens().RotateRefresh(ctx, store.RotateAPITokenRefreshParams{
+		ID:                       rotatedID,
+		NewSecretHash:            []byte("at-secret-2"),
+		NewExpiresAt:             ptr(future.Add(time.Minute)),
+		NewRefreshHash:           []byte("at-refresh-2"),
+		NewRefreshExpiresAt:      ptr(farFuture.Add(time.Minute)),
+		PreviousRefreshHash:      []byte("at-refresh"),
+		PreviousRefreshExpiresAt: ptr(future),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rotated)
+	revokedID := id.Generate()
+	require.NoError(t, st.APITokens().Create(ctx, store.CreateAPITokenParams{
+		ID:         revokedID,
+		UserID:     user.ID,
+		ClientType: "cli",
+		ClientName: "canon-client-revoked",
+		SecretHash: []byte("at-secret-3"),
+		Scope:      "remote:*",
+		ExpiresAt:  ptr(future),
+	}))
+	revoked, err := st.APITokens().Revoke(ctx, revokedID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, revoked)
+
+	// oauth_states.expires_at.
+	require.NoError(t, st.OAuthStates().Create(ctx, store.CreateOAuthStateParams{
+		State:        "canon-state",
+		ProviderID:   provider.ID,
+		PkceVerifier: "verifier",
+		ExpiresAt:    future,
+	}))
+
+	// oauth_tokens: expires_at on insert, then the ON CONFLICT branch, which
+	// rewrites updated_at.
+	upsert := store.UpsertOAuthTokensParams{
+		UserID:       user.ID,
+		ProviderID:   provider.ID,
+		AccessToken:  []byte("access"),
+		RefreshToken: []byte("refresh"),
+		TokenType:    "Bearer",
+		ExpiresAt:    future,
+		KeyVersion:   1,
+	}
+	require.NoError(t, st.OAuthTokens().Upsert(ctx, upsert))
+	upsert.ExpiresAt = farFuture
+	require.NoError(t, st.OAuthTokens().Upsert(ctx, upsert))
+
+	// pending_oauth_signups: token_expires_at + expires_at.
+	require.NoError(t, st.PendingOAuthSignups().Create(ctx, store.CreatePendingOAuthSignupParams{
+		Token:           "canon-signup",
+		ProviderID:      provider.ID,
+		ProviderSubject: "subject",
+		AccessToken:     []byte("access"),
+		RefreshToken:    []byte("refresh"),
+		TokenType:       "Bearer",
+		TokenExpiresAt:  future,
+		KeyVersion:      1,
+		ExpiresAt:       farFuture,
+	}))
+
+	// cli_authorization_codes: expires_at on Create, consumed_at on Consume.
+	require.NoError(t, st.CLIAuthorizationCodes().Create(ctx, store.CreateCLIAuthorizationCodeParams{
+		Code:          "canon-code",
+		UserID:        user.ID,
+		CodeChallenge: "challenge",
+		ExpiresAt:     future,
+	}))
+	_, err = st.CLIAuthorizationCodes().Consume(ctx, "canon-code")
+	require.NoError(t, err)
+
+	// device_authorizations: expires_at on Create, last_polled_at on
+	// TouchPoll, consumed_at on Consume.
+	require.NoError(t, st.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
+		DeviceCode:      "canon-device-code",
+		UserCode:        "CANON-USER-CODE",
+		IntervalSeconds: 5,
+		ExpiresAt:       future,
+	}))
+	require.NoError(t, st.DeviceAuthorizations().TouchPoll(ctx, "canon-device-code"))
+	approved, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{
+		DeviceCode: "canon-device-code",
+		UserID:     user.ID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, approved)
+	consumed, err := st.DeviceAuthorizations().Consume(ctx, "canon-device-code")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, consumed)
+
+	// lifecycle_outbox.consumed_at.
+	require.NoError(t, st.LifecycleOutbox().Insert(ctx, store.InsertLifecycleOutboxParams{
+		OrgID:   orgID,
+		OpType:  "create",
+		Payload: []byte("payload"),
+	}))
+	pending, err := st.LifecycleOutbox().ListPending(ctx, store.ListPendingLifecycleOutboxParams{
+		OrgID: orgID,
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.NoError(t, st.LifecycleOutbox().MarkConsumed(ctx, store.MarkLifecycleOutboxConsumedParams{
+		ID:         pending[0].ID,
+		ConsumedAt: now,
+	}))
+
+	// org_recent_batch_ids.expires_at.
+	require.NoError(t, st.OrgRecentBatchIDs().Insert(ctx, store.InsertOrgRecentBatchIDParams{
+		OrgID:               orgID,
+		BatchID:             "canon-batch",
+		BodyHash:            []byte("hash"),
+		PrincipalID:         user.ID,
+		CanonicalPhysicalMs: 1,
+		CanonicalLogical:    1,
+		CanonicalClient:     "client",
+		OpCount:             1,
+		Epoch:               1,
+		ExpiresAt:           future,
+	}))
+
+	// org_state: epoch_started_at + updated_at on Upsert AND AdvanceEpoch.
+	require.NoError(t, st.OrgState().Upsert(ctx, store.UpsertOrgStateParams{
+		OrgID:          orgID,
+		StatePayload:   []byte("state"),
+		CurrentEpoch:   1,
+		EpochStartedAt: now,
+		UpdatedAt:      now,
+	}))
+	require.NoError(t, st.OrgState().AdvanceEpoch(ctx, store.AdvanceOrgEpochParams{
+		OrgID:          orgID,
+		Epoch:          2,
+		EpochStartedAt: future,
+		UpdatedAt:      future,
+	}))
+
+	require.NoError(t, CheckCanonicalTimestamps(ctx, testable))
+}

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -50,11 +50,11 @@ func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (in
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -66,7 +66,7 @@ func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, 
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, cutoff.UTC()))
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, formatSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) CompactPublishedRevocationEvents(

--- a/backend/internal/hub/store/sqlite/cli_authorization_codes.go
+++ b/backend/internal/hub/store/sqlite/cli_authorization_codes.go
@@ -30,7 +30,7 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 		UserID:        p.UserID,
 		CodeChallenge: p.CodeChallenge,
 		DeviceName:    p.DeviceName,
-		ExpiresAt:     p.ExpiresAt.UTC(),
+		ExpiresAt:     sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/convert.go
+++ b/backend/internal/hub/store/sqlite/convert.go
@@ -21,7 +21,9 @@ import (
 // strftime('%Y-%m-%dT%H:%M:%fZ', ...): fixed 3-digit fractional seconds, the
 // same instant grid as this Go layout's ".000". Every SQL-side write path
 // (column DEFAULTs, the Create/Touch strftime wraps, SoftDelete's
-// strftime('now')) stores canonical 24-char values ON DISK, so the raw-string
+// strftime('now')) stores canonical 24-char values ON DISK -- for EVERY
+// DATETIME column of every table, enforced mechanically by
+// CheckCanonicalTimestamps in testhelper.go -- so the raw-string
 // keyset predicates and cleanup cutoff compares -- which run SQL-side against
 // the stored bytes -- are byte-exact against formatSQLiteTime-formatted
 // params, including at trailing-zero milliseconds (pinned by

--- a/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
@@ -10,8 +10,8 @@ INSERT INTO api_tokens (
     sqlc.arg(secret_hash),
     sqlc.arg(refresh_hash),
     sqlc.arg(scope),
-    sqlc.arg(expires_at),
-    sqlc.arg(refresh_expires_at),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(refresh_expires_at)),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
 );
 
@@ -99,11 +99,11 @@ WHERE id = ?;
 -- and deterministically derive the same replacement pair.
 UPDATE api_tokens
 SET secret_hash = sqlc.arg(new_secret_hash),
-    expires_at = sqlc.arg(new_expires_at),
+    expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_expires_at)),
     refresh_hash = sqlc.arg(new_refresh_hash),
-    refresh_expires_at = sqlc.arg(new_refresh_expires_at),
+    refresh_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_refresh_expires_at)),
     previous_refresh_hash = sqlc.arg(prev_refresh_hash),
-    previous_refresh_expires_at = sqlc.arg(prev_refresh_expires_at),
+    previous_refresh_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(prev_refresh_expires_at)),
     last_rotated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = sqlc.arg(id)
   AND revoked_at IS NULL

--- a/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
@@ -1,20 +1,29 @@
 -- name: CreateCLIAuthorizationCode :exec
 INSERT INTO cli_authorization_codes (
     code, user_id, code_challenge, device_name, expires_at
-) VALUES (?, ?, ?, ?, ?);
+) VALUES (
+    sqlc.arg(code),
+    sqlc.arg(user_id),
+    sqlc.arg(code_challenge),
+    sqlc.arg(device_name),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+);
 
 -- name: GetActiveCLIAuthorizationCode :one
+-- Raw compare: expires_at is stored canonical (CreateCLIAuthorizationCode
+-- wraps the bound instant in strftime), so the liveness guard is
+-- millisecond-exact against the same canonical RHS layout.
 SELECT * FROM cli_authorization_codes
-WHERE code = ? AND consumed_at IS NULL AND julianday(expires_at) > julianday('now');
+WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: ConsumeCLIAuthorizationCode :one
--- julianday() normalizes timezone representations without discarding the
--- fractional seconds needed at the exact expiry boundary.
 UPDATE cli_authorization_codes
-SET consumed_at = datetime('now')
-WHERE code = ? AND consumed_at IS NULL AND julianday(expires_at) > julianday('now')
+SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 RETURNING *;
 
 -- name: DeleteExpiredCLIAuthorizationCodes :execresult
+-- Raw compare against a formatSQLiteTime-formatted cutoff (CAST AS TEXT ->
+-- string param); see DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM cli_authorization_codes
-WHERE expires_at < ?;
+WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT);

--- a/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
@@ -14,8 +14,8 @@ INSERT INTO delegation_tokens (
     sqlc.arg(issued_for_tab_type),
     sqlc.arg(secret_hash),
     sqlc.arg(refresh_hash),
-    sqlc.arg(expires_at),
-    sqlc.arg(refresh_expires_at),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(refresh_expires_at)),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
 );
 
@@ -81,10 +81,13 @@ LIMIT sqlc.arg(limit);
 -- Returns rows that are still usable: not revoked AND not yet expired.
 -- Used by lifecycle hooks (logout, password change, account deactivation)
 -- that want to enumerate live tokens before bulk-revoking them.
+-- Raw compare: expires_at is stored canonical (CreateDelegationToken wraps the
+-- bound instant in strftime), so the liveness filter is millisecond-exact
+-- against the same canonical RHS layout.
 SELECT * FROM delegation_tokens
 WHERE user_id = ?
   AND revoked_at IS NULL
-  AND datetime(expires_at) > datetime('now')
+  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 ORDER BY created_at DESC;
 
 -- name: RevokeDelegationTokensByUserFast :execresult
@@ -116,5 +119,10 @@ DELETE FROM delegation_tokens
 WHERE revoked_at IS NOT NULL AND revoked_at < CAST(sqlc.arg(cutoff) AS TEXT);
 
 -- name: DeleteExpiredDelegationTokensBefore :execresult
+-- Raw compare: expires_at is stored canonical (CreateDelegationToken wraps the
+-- bound instant in strftime), and the Go side binds a formatSQLiteTime-
+-- formatted cutoff (CAST AS TEXT -> string param), so the lexicographic < is
+-- byte-exact and sargable for the partial idx_delegation_tokens_expires_at --
+-- the hourly sweep of this high-churn table seeks just the expired live rows.
 DELETE FROM delegation_tokens
-WHERE expires_at < ? AND revoked_at IS NULL;
+WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT) AND revoked_at IS NULL;

--- a/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
@@ -1,7 +1,13 @@
 -- name: CreateDeviceAuthorization :exec
 INSERT INTO device_authorizations (
     device_code, user_code, device_name, interval_seconds, expires_at
-) VALUES (?, ?, ?, ?, ?);
+) VALUES (
+    sqlc.arg(device_code),
+    sqlc.arg(user_code),
+    sqlc.arg(device_name),
+    sqlc.arg(interval_seconds),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+);
 
 -- name: GetDeviceAuthorization :one
 SELECT * FROM device_authorizations WHERE device_code = ?;
@@ -10,16 +16,17 @@ SELECT * FROM device_authorizations WHERE device_code = ?;
 SELECT * FROM device_authorizations WHERE user_code = ?;
 
 -- name: ApproveDeviceAuthorization :execresult
--- julianday() normalizes timezone representations while preserving
--- fractional seconds at the expiry boundary.
+-- Raw compare: expires_at is stored canonical (CreateDeviceAuthorization
+-- wraps the bound instant in strftime), so the liveness guard is
+-- millisecond-exact against the same canonical RHS layout.
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE device_code = ? AND consumed_at IS NULL AND julianday(expires_at) > julianday('now');
+WHERE device_code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: ApproveDeviceAuthorizationByUserCode :execresult
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE user_code = ? AND consumed_at IS NULL AND julianday(expires_at) > julianday('now');
+WHERE user_code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: DenyDeviceAuthorization :execresult
 UPDATE device_authorizations
@@ -28,15 +35,17 @@ WHERE device_code = ? AND consumed_at IS NULL;
 
 -- name: ConsumeDeviceAuthorization :execresult
 UPDATE device_authorizations
-SET consumed_at = datetime('now')
+SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE device_code = ? AND approved = 1 AND consumed_at IS NULL
-  AND julianday(expires_at) > julianday('now');
+  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: TouchDeviceAuthorizationPoll :exec
 UPDATE device_authorizations
-SET last_polled_at = datetime('now')
+SET last_polled_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE device_code = ?;
 
 -- name: DeleteExpiredDeviceAuthorizations :execresult
+-- Raw compare against a formatSQLiteTime-formatted cutoff (CAST AS TEXT ->
+-- string param); see DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM device_authorizations
-WHERE expires_at < ?;
+WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT);

--- a/backend/internal/hub/store/sqlite/db/queries/lifecycle_outbox.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/lifecycle_outbox.sql
@@ -12,7 +12,13 @@ ORDER BY id
 LIMIT ?;
 
 -- name: MarkLifecycleOutboxConsumed :exec
-UPDATE lifecycle_outbox SET consumed_at = ? WHERE id = ?;
+UPDATE lifecycle_outbox
+SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(consumed_at))
+WHERE id = sqlc.arg(id);
 
 -- name: DeleteConsumedLifecycleOutboxBefore :execresult
-DELETE FROM lifecycle_outbox WHERE consumed_at IS NOT NULL AND consumed_at < ?;
+-- Raw compare: consumed_at is stored canonical (MarkLifecycleOutboxConsumed
+-- wraps the bound instant in strftime), and the Go side binds a
+-- formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param), so the
+-- lexicographic < is byte-exact.
+DELETE FROM lifecycle_outbox WHERE consumed_at IS NOT NULL AND consumed_at < CAST(sqlc.arg(before) AS TEXT);

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
@@ -1,6 +1,12 @@
 -- name: CreateOAuthState :exec
 INSERT INTO oauth_states (state, provider_id, pkce_verifier, redirect_uri, expires_at)
-VALUES (?, ?, ?, ?, ?);
+VALUES (
+    sqlc.arg(state),
+    sqlc.arg(provider_id),
+    sqlc.arg(pkce_verifier),
+    sqlc.arg(redirect_uri),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+);
 
 -- name: GetOAuthState :one
 SELECT * FROM oauth_states WHERE state = ?;
@@ -9,4 +15,7 @@ SELECT * FROM oauth_states WHERE state = ?;
 DELETE FROM oauth_states WHERE state = ?;
 
 -- name: DeleteExpiredOAuthStates :execresult
-DELETE FROM oauth_states WHERE datetime(expires_at) < datetime('now');
+-- Raw compare: expires_at is stored canonical (CreateOAuthState wraps the
+-- bound instant in strftime), so the sweep is millisecond-exact against the
+-- same canonical RHS layout.
+DELETE FROM oauth_states WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
@@ -20,7 +20,7 @@ ON CONFLICT (user_id, provider_id) DO UPDATE SET
     token_type = excluded.token_type,
     expires_at = excluded.expires_at,
     key_version = excluded.key_version,
-    updated_at = datetime('now');
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: GetOAuthTokens :one
 SELECT * FROM oauth_tokens

--- a/backend/internal/hub/store/sqlite/db/queries/org_recent_batch_ids.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/org_recent_batch_ids.sql
@@ -6,7 +6,22 @@ INSERT INTO org_recent_batch_ids (
     org_id, batch_id, body_hash, principal_id,
     canonical_physical_ms, canonical_logical, canonical_client,
     op_count, epoch, expires_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+) VALUES (
+    sqlc.arg(org_id),
+    sqlc.arg(batch_id),
+    sqlc.arg(body_hash),
+    sqlc.arg(principal_id),
+    sqlc.arg(canonical_physical_ms),
+    sqlc.arg(canonical_logical),
+    sqlc.arg(canonical_client),
+    sqlc.arg(op_count),
+    sqlc.arg(epoch),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+);
 
 -- name: DeleteExpiredRecentBatchIDs :execresult
-DELETE FROM org_recent_batch_ids WHERE expires_at < ?;
+-- Raw compare: expires_at is stored canonical (InsertRecentBatchID wraps the
+-- bound instant in strftime), and the Go side binds a formatSQLiteTime-
+-- formatted cutoff (CAST AS TEXT -> string param), so the lexicographic < is
+-- byte-exact and sargable for idx_org_recent_batch_ids_expires.
+DELETE FROM org_recent_batch_ids WHERE expires_at < CAST(sqlc.arg(before) AS TEXT);

--- a/backend/internal/hub/store/sqlite/db/queries/org_state.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/org_state.sql
@@ -2,8 +2,16 @@
 SELECT * FROM org_state WHERE org_id = ?;
 
 -- name: UpsertOrgState :exec
+-- The DO UPDATE reuses the strftime-transformed excluded values, so both the
+-- insert and update paths store the canonical layout.
 INSERT INTO org_state (org_id, state_payload, current_epoch, epoch_started_at, updated_at)
-VALUES (?, ?, ?, ?, ?)
+VALUES (
+    sqlc.arg(org_id),
+    sqlc.arg(state_payload),
+    sqlc.arg(current_epoch),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(epoch_started_at)),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(updated_at))
+)
 ON CONFLICT (org_id) DO UPDATE SET
     state_payload    = excluded.state_payload,
     current_epoch    = excluded.current_epoch,
@@ -13,8 +21,12 @@ ON CONFLICT (org_id) DO UPDATE SET
 -- name: AdvanceOrgEpoch :exec
 -- Bumps current_epoch + epoch_started_at without rewriting the (multi-MB)
 -- state_payload. Called by the manager's epoch-rotation timer every 14d.
+-- Every parameter must be named with sqlc.arg(): the previous bare `?` in the
+-- WHERE clause alongside sqlc.arg() SET params made sqlc emit numbered
+-- placeholders (?2..?4) plus an un-numbered trailing `?`, which modernc counts
+-- as index 5 -- every call failed with "missing argument with index 5".
 UPDATE org_state
 SET current_epoch    = sqlc.arg(epoch),
-    epoch_started_at = sqlc.arg(epoch_started_at),
-    updated_at       = sqlc.arg(updated_at)
-WHERE org_id = ?;
+    epoch_started_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(epoch_started_at)),
+    updated_at       = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(updated_at))
+WHERE org_id = sqlc.arg(org_id);

--- a/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
@@ -1,6 +1,19 @@
 -- name: CreatePendingOAuthSignup :exec
 INSERT INTO pending_oauth_signups (token, provider_id, provider_subject, email, display_name, access_token, refresh_token, token_type, token_expires_at, key_version, redirect_uri, expires_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (
+    sqlc.arg(token),
+    sqlc.arg(provider_id),
+    sqlc.arg(provider_subject),
+    sqlc.arg(email),
+    sqlc.arg(display_name),
+    sqlc.arg(access_token),
+    sqlc.arg(refresh_token),
+    sqlc.arg(token_type),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(token_expires_at)),
+    sqlc.arg(key_version),
+    sqlc.arg(redirect_uri),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+);
 
 -- name: GetPendingOAuthSignup :one
 SELECT * FROM pending_oauth_signups WHERE token = ?;
@@ -9,4 +22,7 @@ SELECT * FROM pending_oauth_signups WHERE token = ?;
 DELETE FROM pending_oauth_signups WHERE token = ?;
 
 -- name: DeleteExpiredPendingOAuthSignups :execresult
-DELETE FROM pending_oauth_signups WHERE datetime(expires_at) < datetime('now');
+-- Raw compare: expires_at is stored canonical (CreatePendingOAuthSignup wraps
+-- the bound instant in strftime), so the sweep is millisecond-exact against
+-- the same canonical RHS layout.
+DELETE FROM pending_oauth_signups WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
@@ -1,7 +1,14 @@
 -- name: InsertRevocationEvent :exec
 INSERT INTO revocation_events (
     id, kind, subject_id, user_id, revoked_at, user_auth_generation
-) VALUES (?, ?, ?, ?, ?, ?);
+) VALUES (
+    sqlc.arg(id),
+    sqlc.arg(kind),
+    sqlc.arg(subject_id),
+    sqlc.arg(user_id),
+    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(revoked_at)),
+    sqlc.arg(user_auth_generation)
+);
 
 -- name: LockRevocationEventSequence :one
 UPDATE revocation_event_sequence
@@ -47,7 +54,10 @@ SET cursor_seq = sqlc.arg(cursor_seq),
     lease_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('+%f seconds', CAST(sqlc.arg(lease_millis) AS REAL) / 1000.0))
 WHERE singleton_id = 1
   AND holder_id = sqlc.arg(holder_id)
-  AND julianday(lease_expires_at) > julianday('now')
+  -- Raw compare: lease_expires_at is written canonical on both write paths
+  -- (Insert/Renew both SET strftime('%Y-%m-%dT%H:%M:%fZ', ...)), so the
+  -- liveness guard is millisecond-exact against the same canonical layout.
+  AND lease_expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
   AND cursor_seq <= sqlc.arg(cursor_seq)
   AND sqlc.arg(cursor_seq) <= (SELECT last_seq FROM revocation_event_sequence WHERE id = 1)
   AND CAST(sqlc.arg(lease_millis) AS INTEGER) > 0;
@@ -56,7 +66,7 @@ WHERE singleton_id = 1
 DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND holder_id = sqlc.arg(holder_id);
 
 -- name: DeleteExpiredHubRuntimeLease :execresult
-DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND julianday(lease_expires_at) <= julianday('now');
+DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND lease_expires_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: DeleteCompactablePublishedRevocationEvents :execresult
 -- Raw compare: published_at is written canonical on its only write path (the

--- a/backend/internal/hub/store/sqlite/delegation_tokens.go
+++ b/backend/internal/hub/store/sqlite/delegation_tokens.go
@@ -46,8 +46,8 @@ func (s *delegationTokenStore) Create(ctx context.Context, p store.CreateDelegat
 			IssuedForTabType: int64(p.IssuedForTabType),
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
-			ExpiresAt:        p.ExpiresAt.UTC(),
-			RefreshExpiresAt: sqlutil.ToNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqlutil.BindTime(p.ExpiresAt),
+			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }

--- a/backend/internal/hub/store/sqlite/device_authorizations.go
+++ b/backend/internal/hub/store/sqlite/device_authorizations.go
@@ -34,7 +34,7 @@ func (s *deviceAuthorizationStore) Create(ctx context.Context, p store.CreateDev
 		UserCode:        p.UserCode,
 		DeviceName:      p.DeviceName,
 		IntervalSeconds: p.IntervalSeconds,
-		ExpiresAt:       p.ExpiresAt.UTC(),
+		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/lifecycle_outbox.go
+++ b/backend/internal/hub/store/sqlite/lifecycle_outbox.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -49,10 +48,10 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 func (s *lifecycleOutboxStore) MarkConsumed(ctx context.Context, p store.MarkLifecycleOutboxConsumedParams) error {
 	return mapErr(s.conn.q.MarkLifecycleOutboxConsumed(ctx, gendb.MarkLifecycleOutboxConsumedParams{
 		ID:         p.ID,
-		ConsumedAt: sql.NullTime{Time: p.ConsumedAt, Valid: true},
+		ConsumedAt: sqlutil.BindTime(p.ConsumedAt),
 	}))
 }
 
 func (s *lifecycleOutboxStore) DeleteConsumedBefore(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sql.NullTime{Time: before, Valid: true}))
+	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, formatSQLiteTime(before)))
 }

--- a/backend/internal/hub/store/sqlite/oauth_states.go
+++ b/backend/internal/hub/store/sqlite/oauth_states.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type oauthStateStore struct {
@@ -30,7 +31,7 @@ func (s *oauthStateStore) Create(ctx context.Context, p store.CreateOAuthStatePa
 		ProviderID:   p.ProviderID,
 		PkceVerifier: p.PkceVerifier,
 		RedirectUri:  p.RedirectURI,
-		ExpiresAt:    p.ExpiresAt.UTC(),
+		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/oauth_tokens.go
+++ b/backend/internal/hub/store/sqlite/oauth_tokens.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type oauthTokenStore struct {
@@ -37,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
-		ExpiresAt:    p.ExpiresAt.UTC(),
+		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
 		KeyVersion:   p.KeyVersion,
 	}))
 }

--- a/backend/internal/hub/store/sqlite/org_recent_batch_ids.go
+++ b/backend/internal/hub/store/sqlite/org_recent_batch_ids.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgRecentBatchIDStore struct {
@@ -49,10 +50,10 @@ func (s *orgRecentBatchIDStore) Insert(ctx context.Context, p store.InsertOrgRec
 		CanonicalClient:     p.CanonicalClient,
 		OpCount:             p.OpCount,
 		Epoch:               p.Epoch,
-		ExpiresAt:           p.ExpiresAt,
+		ExpiresAt:           sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 
 func (s *orgRecentBatchIDStore) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, before))
+	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, formatSQLiteTime(before)))
 }

--- a/backend/internal/hub/store/sqlite/org_state.go
+++ b/backend/internal/hub/store/sqlite/org_state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStateStore struct {
@@ -37,8 +38,8 @@ func (s *orgStateStore) Upsert(ctx context.Context, p store.UpsertOrgStateParams
 		OrgID:          p.OrgID,
 		StatePayload:   p.StatePayload,
 		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: p.EpochStartedAt,
-		UpdatedAt:      p.UpdatedAt,
+		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
+		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
 	}))
 }
 
@@ -46,7 +47,7 @@ func (s *orgStateStore) AdvanceEpoch(ctx context.Context, p store.AdvanceOrgEpoc
 	return mapErr(s.conn.q.AdvanceOrgEpoch(ctx, gendb.AdvanceOrgEpochParams{
 		OrgID:          p.OrgID,
 		Epoch:          p.Epoch,
-		EpochStartedAt: p.EpochStartedAt,
-		UpdatedAt:      p.UpdatedAt,
+		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
+		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
 	}))
 }

--- a/backend/internal/hub/store/sqlite/orgs.go
+++ b/backend/internal/hub/store/sqlite/orgs.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStore struct {
@@ -19,7 +19,7 @@ func fromDBOrg(o gendb.Org) store.Org {
 		ID:        o.ID,
 		Name:      o.Name,
 		CreatedAt: o.CreatedAt,
-		DeletedAt: ptrconv.NullTimeToPtr(o.DeletedAt),
+		DeletedAt: sqlutil.NullTimePtr(o.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/pending_oauth_signups.go
+++ b/backend/internal/hub/store/sqlite/pending_oauth_signups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type pendingOAuthSignupStore struct {
@@ -41,10 +42,10 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  p.TokenExpiresAt.UTC(),
+		TokenExpiresAt:  sqlutil.BindTime(p.TokenExpiresAt),
 		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
-		ExpiresAt:       p.ExpiresAt.UTC(),
+		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/registration_keys.go
+++ b/backend/internal/hub/store/sqlite/registration_keys.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type registrationKeyStore struct {
@@ -27,7 +28,7 @@ func (s *registrationKeyStore) Create(ctx context.Context, p store.CreateRegistr
 	return mapErr(s.conn.q.CreateRegistrationKey(ctx, gendb.CreateRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: p.ExpiresAt.UTC(),
+		ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
 	}))
 }
 
@@ -54,8 +55,8 @@ func (s *registrationKeyStore) Extend(ctx context.Context, p store.ExtendRegistr
 	return rowsAffected(s.conn.q.ExtendRegistrationKey(ctx, gendb.ExtendRegistrationKeyParams{
 		ID:           p.ID,
 		CreatedBy:    p.CreatedBy,
-		NewExpiresAt: p.ExpiresAt.UTC(),
-		Now:          time.Now().UTC(),
+		NewExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+		Now:          sqlutil.BindTime(time.Now()),
 	}))
 }
 
@@ -63,12 +64,12 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 	return rowsAffected(s.conn.q.SoftDeleteRegistrationKey(ctx, gendb.SoftDeleteRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset),
+		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
 func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.WorkerRegistrationKey, error) {
-	now := time.Now().UTC()
+	now := sqlutil.BindTime(time.Now())
 	r, err := s.conn.q.ConsumeRegistrationKey(ctx, gendb.ConsumeRegistrationKeyParams{
 		ID:            id,
 		Now:           now,
@@ -83,7 +84,7 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (int64, error) {
 	return rowsAffected(s.conn.q.AdminSoftDeleteRegistrationKey(ctx, gendb.AdminSoftDeleteRegistrationKeyParams{
 		ID:        id,
-		ExpiresAt: time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset),
+		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
@@ -99,7 +100,7 @@ func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegist
 	// deterministic tiebreaker for rows sharing a millisecond.
 	var nowArg any
 	if !p.IncludeExpired {
-		nowArg = time.Now().UTC()
+		nowArg = sqlutil.BindTime(time.Now())
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListRegistrationKeysAdminParams, error) {

--- a/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
+++ b/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
@@ -33,8 +33,10 @@ func TestCreateRegistrationKeyStoresExpiresAtCanonical(t *testing.T) {
 		ExpiresAt: expiresAt,
 	}))
 
+	// CAST strips the DATETIME decltype so modernc returns the stored bytes
+	// verbatim instead of trimming trailing fractional zeros on scan.
 	var stored string
-	require.NoError(t, db.QueryRow(`SELECT expires_at FROM worker_registration_keys WHERE id = ?`, keyID).Scan(&stored))
+	require.NoError(t, db.QueryRow(`SELECT CAST(expires_at AS TEXT) FROM worker_registration_keys WHERE id = ?`, keyID).Scan(&stored))
 	assert.Equal(t, formatSQLiteTime(expiresAt), stored,
 		"expires_at must be stored in the canonical strftime layout the raw-string filters assume; got %q", stored)
 }

--- a/backend/internal/hub/store/sqlite/revocation_events.go
+++ b/backend/internal/hub/store/sqlite/revocation_events.go
@@ -57,7 +57,7 @@ func insertRevocationEvent(
 		Kind:               kind,
 		SubjectID:          subjectID,
 		UserID:             userID,
-		RevokedAt:          revokedAt.UTC(),
+		RevokedAt:          sqlutil.BindTime(revokedAt),
 		UserAuthGeneration: userAuthGeneration,
 	}))
 }

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -47,7 +48,7 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 		return mapErr(tx.(*sqliteStore).conn.q.CreateUserSession(ctx, gendb.CreateUserSessionParams{
 			ID:        p.ID,
 			UserID:    p.UserID,
-			ExpiresAt: p.ExpiresAt.UTC(),
+			ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
 			UserAgent: p.UserAgent,
 			IpAddress: p.IPAddress,
 		}))
@@ -74,13 +75,13 @@ func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (i
 	// pre-formatted string -- byte-exact, because the on-disk strftime values
 	// carry fixed 3-digit fractional seconds exactly like sqliteTimeFormat (see
 	// its doc in convert.go, including the Go-string-scan caution).
-	lastActiveStr := p.LastActiveAt.UTC().Format(sqliteTimeFormat)
+	lastActiveStr := formatSQLiteTime(p.LastActiveAt)
 	res, err := s.conn.exec.ExecContext(ctx,
 		`UPDATE user_sessions
 		 SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
 		     expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', ?)
 		 WHERE id = ? AND last_active_at < ?`,
-		p.ExpiresAt.UTC(), p.ID, lastActiveStr,
+		sqlutil.BindTime(p.ExpiresAt), p.ID, lastActiveStr,
 	)
 	if err != nil {
 		return 0, mapErr(err)

--- a/backend/internal/hub/store/sqlite/sessions_internal_test.go
+++ b/backend/internal/hub/store/sqlite/sessions_internal_test.go
@@ -154,9 +154,14 @@ func TestCreateUserSessionStoresExpiresAtCanonical(t *testing.T) {
 		ExpiresAt: expiresAt,
 	}))
 
+	// CAST strips the DATETIME decltype so modernc returns expires_at's stored
+	// bytes verbatim for the exact-equality pin below (a bare scan trims
+	// trailing fractional zeros). created_at/last_active_at stay bare on
+	// purpose: their shape-only assertions tolerate the trim, and the comment
+	// below documents the scanned-digit variability they must absorb.
 	var expiresAtStored, createdAtStored, lastActiveAtStored string
 	require.NoError(t, db.QueryRow(
-		`SELECT expires_at, created_at, last_active_at FROM user_sessions WHERE id = ?`,
+		`SELECT CAST(expires_at AS TEXT), created_at, last_active_at FROM user_sessions WHERE id = ?`,
 		sessionID,
 	).Scan(&expiresAtStored, &createdAtStored, &lastActiveAtStored))
 	// expires_at is the caller-supplied instant, wrapped canonical by CreateUserSession.
@@ -243,8 +248,11 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 	// on-disk value must equal formatSQLiteTime(newExpiry) exactly. A future
 	// Touch refactor that binds expires_at raw would store modernc's driver
 	// layout here and this assertion fails before the liveness filter regresses.
+	// CAST strips the column's DATETIME decltype so modernc returns the stored
+	// bytes verbatim -- a bare scan trims trailing fractional zeros (".720Z"
+	// arrives as ".72Z") and fails this pin on every ms-ends-in-zero instant.
 	var expiresAtStored string
-	require.NoError(t, db.QueryRow(`SELECT expires_at FROM user_sessions WHERE id = ?`, sessionID).Scan(&expiresAtStored))
+	require.NoError(t, db.QueryRow(`SELECT CAST(expires_at AS TEXT) FROM user_sessions WHERE id = ?`, sessionID).Scan(&expiresAtStored))
 	assert.Equal(t, formatSQLiteTime(newExpiry), expiresAtStored,
 		"Touch must store expires_at in the canonical strftime layout; got %q", expiresAtStored)
 

--- a/backend/internal/hub/store/sqlite/sqlite_test.go
+++ b/backend/internal/hub/store/sqlite/sqlite_test.go
@@ -25,10 +25,10 @@ func TestSQLiteStore(t *testing.T) {
 			err = st.TestHelper().TruncateAll(context.Background())
 			require.NoError(t, err)
 			// After the subtest's writes (cleanup runs before the next
-			// NewStore truncates), walk every raw-string-compared timestamp
-			// column and assert the canonical on-disk layout -- so ANY store
-			// write path the suite exercises that forgets its strftime wrap
-			// fails here, not as a silent row drop in production.
+			// NewStore truncates), walk every DATETIME column of every table
+			// and assert the canonical on-disk layout -- so ANY store write
+			// path the suite exercises that forgets its strftime wrap fails
+			// here, not as a silent row drop in production.
 			t.Cleanup(func() {
 				require.NoError(t, sqlite.CheckCanonicalTimestamps(context.Background(), st))
 			})

--- a/backend/internal/hub/store/sqlite/testhelper.go
+++ b/backend/internal/hub/store/sqlite/testhelper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -71,7 +72,7 @@ func (h *sqliteTestHelper) setEntityTime(ctx context.Context, entity store.TestE
 // ('%Y-%m-%dT%H:%M:%fZ'), so the value is formatted with formatSQLiteTime to
 // match production rows exactly -- a bound time.Time would serialize in the
 // driver's own layout and break byte-sensitive comparisons (the created_at =
-// cursor tiebreaker, the datetime()-normalized deleted_at cleanup cutoffs).
+// cursor tiebreaker, the raw-string deleted_at cleanup cutoffs).
 // The column is a hardcoded literal, never caller input.
 func (h *sqliteTestHelper) setEntityColumn(ctx context.Context, entity store.TestEntity, column, id, value string) error {
 	return sqlutil.SetEntityColumnValue(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, column, id, value)
@@ -85,71 +86,45 @@ func (h *sqliteTestHelper) setTimestamp(ctx context.Context, column sqlutil.Time
 	return sqlutil.SetTimestampColumn(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, column, id, at)
 }
 
-// canonicalTimestampColumns lists every column the SQLite dialect compares as
-// a RAW string (keyset ORDER BY columns, liveness filters, cleanup cutoffs).
-// Each one's every write path MUST store the canonical
-// strftime('%Y-%m-%dT%H:%M:%fZ') layout: a single raw time.Time bind stores
-// modernc's driver layout (space at byte 10) and silently corrupts the
-// raw-string compares. CheckCanonicalTimestamps walks this list after each
-// storetest subtest, so a NEW write path that forgets the strftime wrap (or a
-// new raw-compared column added here) fails the suite instead of shipping a
-// #287-shaped silent-row-drop. Columns compared only under datetime() wraps
-// (e.g. delegation_tokens.expires_at) are deliberately absent: their binds are
-// driver-layout by design.
-var canonicalTimestampColumns = map[string][]string{
-	"users":                    {"created_at", "deleted_at", "pending_email_expires_at"},
-	"user_sessions":            {"last_active_at", "expires_at"},
-	"workers":                  {"created_at", "deleted_at"},
-	"workspaces":               {"deleted_at"},
-	"orgs":                     {"deleted_at"},
-	"worker_registration_keys": {"created_at", "expires_at"},
-	"api_tokens":               {"created_at", "revoked_at"},
-	"delegation_tokens":        {"created_at", "revoked_at"},
-	"oauth_tokens":             {"expires_at"},
-	"revocation_events":        {"published_at"},
-}
-
-// CheckCanonicalTimestamps asserts every raw-string-compared timestamp column
-// currently holds only canonical 24-char 'T'-separated values on disk. The
-// probe runs SQL-side (length/substr over the stored TEXT) because modernc
-// reformats DATETIME values on scan, which would hide a non-canonical layout.
-// Intended to run as a test cleanup after store writes; see
-// canonicalTimestampColumns for the invariant.
+// CheckCanonicalTimestamps asserts every DATETIME column of every table
+// currently holds only canonical 24-char 'T'-separated values on disk
+// (see sqlitedb.FindNonCanonicalDatetimes for the discovery and probe
+// mechanics). Intended to run as a test cleanup after store writes; it walks
+// after each storetest subtest, so a NEW write path that forgets the strftime
+// wrap fails the suite instead of shipping a #287-shaped silent-row-drop. All
+// offending columns are reported at once.
 func CheckCanonicalTimestamps(ctx context.Context, st store.TestableStore) error {
 	ts, ok := st.(*testableSQLiteStore)
 	if !ok {
 		return fmt.Errorf("CheckCanonicalTimestamps: not a sqlite testable store: %T", st)
 	}
 	db := ts.conn.shared.db
-	for table, columns := range canonicalTimestampColumns {
-		// A migrator test may have rolled the schema back below this table;
-		// nothing to check then.
-		var exists bool
+	// goose_db_version is goose's own bookkeeping table (TIMESTAMP via
+	// datetime('now')), not part of the store's canonical-layout contract.
+	offenders, walked, err := sqlitedb.FindNonCanonicalDatetimes(ctx, db, "goose_db_version")
+	if err != nil {
+		return err
+	}
+	if walked == 0 {
+		// A migrator test may have rolled the schema back to zero; with no
+		// application tables there is legitimately nothing to walk. With
+		// tables present, zero DATETIME columns means the discovery query
+		// broke and the walk would pass vacuously.
+		var tables int
 		if err := db.QueryRowContext(ctx,
-			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)`, table,
-		).Scan(&exists); err != nil {
-			return fmt.Errorf("canonical-timestamp walk %s: %w", table, err)
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != 'goose_db_version'`,
+		).Scan(&tables); err != nil {
+			return fmt.Errorf("canonical-timestamp table count: %w", err)
 		}
-		if !exists {
-			continue
+		if tables == 0 {
+			return nil
 		}
-		for _, col := range columns {
-			var count int
-			var sample sql.NullString
-			// The column is a hardcoded literal from the map above, never caller input.
-			err := db.QueryRowContext(ctx,
-				`SELECT COUNT(*), MIN(CAST(`+col+` AS TEXT)) FROM `+table+
-					` WHERE `+col+` IS NOT NULL AND (length(CAST(`+col+` AS TEXT)) != 24 OR substr(CAST(`+col+` AS TEXT), 11, 1) != 'T')`,
-			).Scan(&count, &sample)
-			if err != nil {
-				return fmt.Errorf("canonical-timestamp walk %s.%s: %w", table, col, err)
-			}
-			if count > 0 {
-				return fmt.Errorf(
-					"%s.%s holds %d non-canonical timestamp value(s) on disk (e.g. %q): a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap, which silently corrupts this column's raw-string compares",
-					table, col, count, sample.String)
-			}
-		}
+		return fmt.Errorf("canonical-timestamp walk found no DATETIME columns across %d table(s); the discovery query is broken", tables)
+	}
+	if len(offenders) > 0 {
+		return fmt.Errorf(
+			"non-canonical timestamp value(s) on disk -- a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap, which silently corrupts raw-string compares:\n  %s",
+			strings.Join(offenders, "\n  "))
 	}
 	return nil
 }

--- a/backend/internal/hub/store/sqlite/truncate_tables_internal_test.go
+++ b/backend/internal/hub/store/sqlite/truncate_tables_internal_test.go
@@ -1,0 +1,86 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruncateTableOrderCoversEverySchemaTable pins
+// sqlutil.SQLTruncateTableOrder against the live schema: every application
+// table must appear in the list exactly once, or TestHelper.TruncateAll
+// silently skips it and rows leak across suite subtests (device_authorizations
+// was missing and leaked expired grants into unrelated sweep tests,
+// intermittently, because the leak only bit once the leftover rows' short
+// expiries lapsed). All dialects share one schema shape, so pinning against
+// SQLite covers them all.
+func TestTruncateTableOrderCoversEverySchemaTable(t *testing.T) {
+	testable, err := OpenTestable(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testable.Close()) })
+	db := testable.(*testableSQLiteStore).conn.shared.db
+
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != 'goose_db_version' ORDER BY name`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var schemaTables []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		schemaTables = append(schemaTables, name)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, schemaTables)
+
+	assert.ElementsMatch(t, schemaTables, sqlutil.SQLTruncateTableOrder,
+		"SQLTruncateTableOrder must list every application table exactly once (FK-ordered, children before parents)")
+}
+
+// TestTruncateTableOrderRespectsForeignKeys pins the ORDER of
+// sqlutil.SQLTruncateTableOrder, not just its membership: every FK child must
+// precede its parent. The order is load-bearing for Postgres-family dialects,
+// whose TruncateAll issues plain DELETEs in list order with FK constraints
+// enforced (sqlite and mysql disable FK checks during truncation), so a bad
+// reorder would otherwise surface only in the gated -tags integration suites.
+// FK edges are discovered from the live schema (pragma_foreign_key_list), so
+// a new FK can never be forgotten here.
+func TestTruncateTableOrderRespectsForeignKeys(t *testing.T) {
+	testable, err := OpenTestable(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testable.Close()) })
+	db := testable.(*testableSQLiteStore).conn.shared.db
+
+	pos := make(map[string]int, len(sqlutil.SQLTruncateTableOrder))
+	for i, name := range sqlutil.SQLTruncateTableOrder {
+		pos[name] = i
+	}
+
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT m.name, fk."table"
+		FROM sqlite_master m, pragma_foreign_key_list(m.name) fk
+		WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' AND m.name != 'goose_db_version'`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	edges := 0
+	for rows.Next() {
+		var child, parent string
+		require.NoError(t, rows.Scan(&child, &parent))
+		if child == parent {
+			// A self-reference imposes no cross-table delete ordering.
+			continue
+		}
+		edges++
+		childPos, ok := pos[child]
+		require.True(t, ok, "FK child table %q missing from SQLTruncateTableOrder", child)
+		parentPos, ok := pos[parent]
+		require.True(t, ok, "FK parent table %q missing from SQLTruncateTableOrder", parent)
+		assert.Less(t, childPos, parentPos,
+			"SQLTruncateTableOrder must delete FK child %q before its parent %q -- Postgres TruncateAll deletes in list order with constraints enforced", child, parent)
+	}
+	require.NoError(t, rows.Err())
+	require.NotZero(t, edges, "schema FK discovery returned no edges -- the pragma_foreign_key_list join is broken")
+}

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -29,16 +29,16 @@ func fromDBUser(u gendb.User) store.User {
 		EmailVerified:         ptrconv.Int64ToBool(u.EmailVerified),
 		PendingEmail:          u.PendingEmail,
 		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: ptrconv.NullTimeToPtr(u.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqlutil.NullTimePtr(u.PendingEmailExpiresAt),
 		PendingEmailAttempts:  u.PendingEmailAttempts,
 		PasswordSet:           ptrconv.Int64ToBool(u.PasswordSet),
 		IsAdmin:               ptrconv.Int64ToBool(u.IsAdmin),
 		Prefs:                 u.Prefs,
 		CreatedAt:             u.CreatedAt,
 		UpdatedAt:             u.UpdatedAt,
-		TokensRevokedAt:       ptrconv.NullTimeToPtr(u.TokensRevokedAt),
+		TokensRevokedAt:       sqlutil.NullTimePtr(u.TokensRevokedAt),
 		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             ptrconv.NullTimeToPtr(u.DeletedAt),
+		DeletedAt:             sqlutil.NullTimePtr(u.DeletedAt),
 	}
 }
 
@@ -312,7 +312,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
-		PendingEmailExpiresAt: ptrconv.PtrToNullTime(p.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqlutil.BindNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
 	}))
 }

--- a/backend/internal/hub/store/sqlite/worker_notifications.go
+++ b/backend/internal/hub/store/sqlite/worker_notifications.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerNotificationStore implements store.WorkerNotificationStore backed by SQLite.
@@ -52,6 +52,6 @@ func fromDBWorkerNotification(n gendb.WorkerNotification) store.WorkerNotificati
 		Attempts:    n.Attempts,
 		MaxAttempts: n.MaxAttempts,
 		CreatedAt:   n.CreatedAt,
-		DeliveredAt: ptrconv.NullTimeToPtr(n.DeliveredAt),
+		DeliveredAt: sqlutil.NullTimePtr(n.DeliveredAt),
 	}
 }

--- a/backend/internal/hub/store/sqlite/workers.go
+++ b/backend/internal/hub/store/sqlite/workers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -160,12 +161,12 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 		RegisteredBy:    w.RegisteredBy,
 		Status:          w.Status,
 		CreatedAt:       w.CreatedAt,
-		LastSeenAt:      ptrconv.NullTimeToPtr(w.LastSeenAt),
+		LastSeenAt:      sqlutil.NullTimePtr(w.LastSeenAt),
 		PublicKey:       w.PublicKey,
 		MlkemPublicKey:  w.MlkemPublicKey,
 		SlhdsaPublicKey: w.SlhdsaPublicKey,
 		AutoRegistered:  ptrconv.Int64ToBool(w.AutoRegistered),
-		DeletedAt:       ptrconv.NullTimeToPtr(w.DeletedAt),
+		DeletedAt:       sqlutil.NullTimePtr(w.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/workspaces.go
+++ b/backend/internal/hub/store/sqlite/workspaces.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -22,7 +23,7 @@ func fromDBWorkspace(w gendb.Workspace) *store.Workspace {
 		Title:       w.Title,
 		IsDeleted:   ptrconv.Int64ToBool(w.IsDeleted),
 		CreatedAt:   w.CreatedAt,
-		DeletedAt:   ptrconv.NullTimeToPtr(w.DeletedAt),
+		DeletedAt:   sqlutil.NullTimePtr(w.DeletedAt),
 	}
 }
 

--- a/backend/internal/hub/store/sqlutil/convert.go
+++ b/backend/internal/hub/store/sqlutil/convert.go
@@ -29,14 +29,41 @@ func NullTimePtr(t sql.NullTime) *time.Time {
 	return &v
 }
 
-// ToNullTime converts a *time.Time to sql.NullTime, normalizing the
-// instant to UTC for stable storage. nil yields an invalid NullTime
-// (NULL on the wire).
-func ToNullTime(t *time.Time) sql.NullTime {
+// BindTime floors a Go instant to the millisecond grid (UTC) before it is
+// handed to a database driver. The dialects that store millisecond columns
+// ROUND sub-millisecond fractions instead of truncating them -- SQLite's
+// strftime('%f') and MySQL/TiDB's DATETIME(3) both round half up -- so an
+// un-floored bind could store an instant up to half a millisecond LATER than
+// the one the caller supplied. That is enough to overclaim a credential
+// deadline by a whole second once a ceil-to-seconds lifetime report is
+// derived from the roundtripped value (pinned by
+// TestAPIAuth_Refresh_CASRecoveryReportsWinnerRemainingLifetime and, per
+// dialect, by the storetest time_floor group). Flooring Go-side keeps every
+// stored instant on the millisecond grid, so stored <= bound always holds.
+// Postgres-family dialects don't need it (pgx floors nanoseconds to
+// timestamptz microseconds natively) but tolerate it.
+//
+// Enforcement is per call site by convention; replacing that with a
+// mechanical choke point (a driver.Valuer time type applied via sqlc db_type
+// overrides) is tracked in https://github.com/leapmux/leapmux/issues/303.
+func BindTime(t time.Time) time.Time { return t.UTC().Truncate(time.Millisecond) }
+
+// BindNullTime is BindTime for optional instants: nil yields an invalid
+// NullTime (NULL on the wire), non-nil is floored to the millisecond grid.
+func BindNullTime(t *time.Time) sql.NullTime {
 	if t == nil {
 		return sql.NullTime{}
 	}
-	return sql.NullTime{Time: t.UTC(), Valid: true}
+	return sql.NullTime{Time: BindTime(*t), Valid: true}
+}
+
+// BindTimeValid is BindTime for required instants bound through a nullable
+// column type: the value is floored to the millisecond grid and always
+// marked valid. Callers with an optional *time.Time use BindNullTime
+// instead; hand-assembling sql.NullTime around BindTime at call sites is
+// exactly the pattern this helper exists to remove.
+func BindTimeValid(t time.Time) sql.NullTime {
+	return sql.NullTime{Time: BindTime(t), Valid: true}
 }
 
 // RequireInt64 unwraps a nullable database integer that the schema requires.

--- a/backend/internal/hub/store/sqlutil/convert_test.go
+++ b/backend/internal/hub/store/sqlutil/convert_test.go
@@ -1,6 +1,7 @@
 package sqlutil
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -42,6 +43,53 @@ func TestRowsAffectedReturnsCount(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), n)
+}
+
+func TestNullTimePtr(t *testing.T) {
+	assert.Nil(t, NullTimePtr(sql.NullTime{}), "invalid (NULL) must map to nil")
+
+	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	nt := sql.NullTime{Time: instant, Valid: true}
+	ptr := NullTimePtr(nt)
+	require.NotNil(t, ptr)
+	assert.True(t, ptr.Equal(instant))
+	assert.NotSame(t, &nt.Time, ptr, "must return a copy, not an alias into the NullTime")
+}
+
+func TestBindTimeFloorsToMillisecondGridInUTC(t *testing.T) {
+	// 750us + 999ns of sub-ms residue: a round-half-up conversion would land
+	// on the NEXT millisecond; BindTime must floor to the current one.
+	local := time.Date(2025, 1, 2, 12, 0, 0, 123_750_999, time.FixedZone("test", 9*60*60))
+
+	bound := BindTime(local)
+
+	assert.Equal(t, time.UTC, bound.Location())
+	assert.Equal(t, local.UTC().Truncate(time.Millisecond), bound)
+	assert.Equal(t, 123_000_000, bound.Nanosecond())
+	assert.False(t, bound.After(local), "bound instant must never postdate its input")
+}
+
+func TestBindTimeWholeMillisecondIsIdentity(t *testing.T) {
+	exact := time.Date(2025, 1, 2, 12, 0, 0, 123_000_000, time.UTC)
+	assert.True(t, BindTime(exact).Equal(exact))
+}
+
+func TestBindNullTime(t *testing.T) {
+	assert.False(t, BindNullTime(nil).Valid, "nil must stay NULL on the wire")
+
+	local := time.Date(2025, 1, 2, 12, 0, 0, 999_999_999, time.FixedZone("test", 9*60*60))
+	bound := BindNullTime(&local)
+	require.True(t, bound.Valid)
+	assert.Equal(t, BindTime(local), bound.Time)
+}
+
+func TestBindTimeValid(t *testing.T) {
+	local := time.Date(2025, 1, 2, 12, 0, 0, 999_999_999, time.FixedZone("test", 9*60*60))
+
+	bound := BindTimeValid(local)
+
+	require.True(t, bound.Valid, "a required instant must never bind NULL")
+	assert.Equal(t, BindTime(local), bound.Time)
 }
 
 func TestRequireInt64(t *testing.T) {

--- a/backend/internal/hub/store/sqlutil/tables.go
+++ b/backend/internal/hub/store/sqlutil/tables.go
@@ -4,6 +4,7 @@ package sqlutil
 // Tables are ordered so that foreign key constraints are satisfied
 // (children before parents).
 var SQLTruncateTableOrder = []string{
+	"cli_authorization_codes", "device_authorizations",
 	"pending_oauth_signups", "oauth_states", "oauth_tokens", "oauth_user_links", "oauth_providers",
 	"hub_runtime_lease", "revocation_events", "revocation_event_sequence",
 	"lifecycle_outbox", "org_recent_batch_ids", "workspace_tab_rendered", "workspace_tab_owned",

--- a/backend/internal/hub/store/storetest/suite.go
+++ b/backend/internal/hub/store/storetest/suite.go
@@ -40,6 +40,8 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("cli_authorizations", s.testCLIAuthorizations)
 	t.Run("transactions", s.testTransactions)
 	t.Run("cleanup", s.testCleanup)
+	t.Run("cleanup_boundaries", s.testCleanupBoundaries)
+	t.Run("time_floor", s.testTimeFloor)
 	t.Run("token_revocation", s.testTokenRevocation)
 	t.Run("token_listing", s.testTokenListing)
 	// `migrator` runs last because its `migrate to zero` subtest leaves

--- a/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
+++ b/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
@@ -1,0 +1,365 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boundaryZone keeps every bound instant in this group deliberately non-UTC:
+// each dialect must normalize the offset itself (SQLite via its strftime
+// wraps, Postgres/MySQL via the driver's typed conversion), so a write path
+// that started storing local wall time would shift every boundary by the
+// offset and fail these pins loudly.
+var boundaryZone = time.FixedZone("UTC+9", 9*60*60)
+
+// boundaryCutoff returns a whole-millisecond "now" in boundaryZone. All three
+// dialects store millisecond-or-finer precision (SQLite canonical strftime
+// ms, MySQL DATETIME(3) ms with rounding, Postgres timestamptz us), so
+// ms-aligned instants survive storage exactly and the strict-< semantics
+// below are unambiguous.
+func boundaryCutoff() time.Time {
+	return time.Now().Truncate(time.Millisecond).In(boundaryZone)
+}
+
+// assertBoundarySweep pins the shared strict-< contract of a cutoff sweep:
+// with rows planted at cutoff-1ms / cutoff / cutoff+1ms, the exact-cutoff
+// sweep removes only the strictly-older row, and a far-future sweep then
+// removes the two same-instant survivors -- proving the first sweep kept
+// them, for tables with no unfiltered enumeration to inspect directly.
+func assertBoundarySweep(t *testing.T, cutoff time.Time, sweep func(time.Time) (int64, error)) {
+	t.Helper()
+	swept, err := sweep(cutoff)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, swept, "only the row strictly before the cutoff may fall at the exact-cutoff sweep")
+	swept, err = sweep(cutoff.Add(time.Hour))
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, swept, "both same-instant survivors must still exist for the far-future sweep")
+}
+
+// testCleanupBoundaries pins the millisecond-exact boundary semantics of the
+// cutoff-driven sweeps across every dialect: `col < cutoff` deletes the
+// strictly-older row, keeps the exact-cutoff row, and keeps newer rows, even
+// when all of them share the same second. The coarse multi-day gaps in
+// testCleanup are exactly the shape that let a mixed-layout cutoff bind (which
+// missed every same-day row on SQLite) ship green. Sweeps whose compared
+// operand is not caller-controllable through the store API (the users/orgs
+// hard-deletes, whose FK gating testCleanup covers) share the same compare
+// shape and are represented here by the workspace/worker twins.
+//
+// Where a table has no unfiltered GetByID to enumerate survivors, a second
+// sweep with a far-future cutoff pins the survivor count instead: it must
+// delete exactly the rows the first sweep correctly kept.
+func (s *Suite) testCleanupBoundaries(t *testing.T) {
+	t.Run("delegation token expiry sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		worker := SeedWorker(t, st, user.ID)
+		wsID := SeedWorkspace(t, st, orgID, user.ID, "boundary-ws")
+		cutoff := boundaryCutoff()
+
+		create := func(expiresAt time.Time) string {
+			tokenID := id.Generate()
+			require.NoError(t, st.DelegationTokens().Create(ctx, store.CreateDelegationTokenParams{
+				ID:          tokenID,
+				UserID:      user.ID,
+				WorkerID:    worker.ID,
+				WorkspaceID: wsID,
+				SecretHash:  []byte("secret"),
+				ExpiresAt:   expiresAt,
+			}))
+			return tokenID
+		}
+		expiredID := create(cutoff.Add(-time.Millisecond))
+		atCutoffID := create(cutoff)
+		liveID := create(cutoff.Add(time.Millisecond))
+		// Revoked rows are out of scope for the expiry sweep (revoked_at IS
+		// NULL filter): the revoked-token sweep owns them, so revoking must
+		// shield an otherwise-expired row.
+		revokedID := create(cutoff.Add(-time.Millisecond))
+		n, err := st.DelegationTokens().Revoke(ctx, revokedID)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+
+		deleted, err := st.Cleanup().DeleteExpiredDelegationTokensBefore(ctx, cutoff)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, deleted)
+
+		_, err = st.DelegationTokens().GetByID(ctx, expiredID)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		for _, keep := range []string{atCutoffID, liveID, revokedID} {
+			_, err := st.DelegationTokens().GetByID(ctx, keep)
+			assert.NoError(t, err)
+		}
+	})
+
+	t.Run("revoked token sweeps are strict at the stored revoke instant", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		worker := SeedWorker(t, st, user.ID)
+		wsID := SeedWorkspace(t, st, orgID, user.ID, "boundary-ws")
+
+		// revoked_at is written DB-side (NOW/strftime), so read the stored
+		// instant back and place cutoffs exactly on and just past it: the
+		// sweep must be a strict < against the value the revoke path stored,
+		// whatever the dialect's precision.
+		apiID := id.Generate()
+		require.NoError(t, st.APITokens().Create(ctx, store.CreateAPITokenParams{
+			ID:         apiID,
+			UserID:     user.ID,
+			ClientType: "cli",
+			ClientName: "boundary-client",
+			SecretHash: []byte("secret"),
+			Scope:      "remote:*",
+		}))
+		n, err := st.APITokens().Revoke(ctx, apiID)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+		apiTok, err := st.APITokens().GetByID(ctx, apiID)
+		require.NoError(t, err)
+		require.NotNil(t, apiTok.RevokedAt)
+
+		deleted, err := st.Cleanup().DeleteRevokedAPITokensBefore(ctx, *apiTok.RevokedAt)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, deleted, "exact-cutoff revoked api token must survive the strict <")
+		deleted, err = st.Cleanup().DeleteRevokedAPITokensBefore(ctx, apiTok.RevokedAt.Add(time.Millisecond))
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, deleted)
+
+		delID := id.Generate()
+		require.NoError(t, st.DelegationTokens().Create(ctx, store.CreateDelegationTokenParams{
+			ID:          delID,
+			UserID:      user.ID,
+			WorkerID:    worker.ID,
+			WorkspaceID: wsID,
+			SecretHash:  []byte("secret"),
+			ExpiresAt:   boundaryCutoff().Add(time.Hour),
+		}))
+		n, err = st.DelegationTokens().Revoke(ctx, delID)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+		delTok, err := st.DelegationTokens().GetByID(ctx, delID)
+		require.NoError(t, err)
+		require.NotNil(t, delTok.RevokedAt)
+
+		deleted, err = st.Cleanup().DeleteRevokedDelegationTokensBefore(ctx, *delTok.RevokedAt)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, deleted, "exact-cutoff revoked delegation token must survive the strict <")
+		deleted, err = st.Cleanup().DeleteRevokedDelegationTokensBefore(ctx, delTok.RevokedAt.Add(time.Millisecond))
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, deleted)
+	})
+
+	t.Run("cli authorization code expiry sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		cutoff := boundaryCutoff()
+
+		for _, c := range []struct {
+			code      string
+			expiresAt time.Time
+		}{
+			{"code-expired", cutoff.Add(-time.Millisecond)},
+			{"code-at-cutoff", cutoff},
+			{"code-live", cutoff.Add(time.Millisecond)},
+		} {
+			require.NoError(t, st.CLIAuthorizationCodes().Create(ctx, store.CreateCLIAuthorizationCodeParams{
+				Code:          c.code,
+				UserID:        user.ID,
+				CodeChallenge: "challenge",
+				ExpiresAt:     c.expiresAt,
+			}))
+		}
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().DeleteExpiredCLIAuthorizationCodes(ctx, c)
+		})
+	})
+
+	t.Run("device authorization expiry sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		cutoff := boundaryCutoff()
+
+		for _, d := range []struct {
+			suffix    string
+			expiresAt time.Time
+		}{
+			{"expired", cutoff.Add(-time.Millisecond)},
+			{"at-cutoff", cutoff},
+			{"live", cutoff.Add(time.Millisecond)},
+		} {
+			require.NoError(t, st.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
+				DeviceCode:      "device-" + d.suffix,
+				UserCode:        "USER-" + d.suffix,
+				IntervalSeconds: 5,
+				ExpiresAt:       d.expiresAt,
+			}))
+		}
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().DeleteExpiredDeviceAuthorizations(ctx, c)
+		})
+	})
+
+	t.Run("registration key expiry sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		cutoff := boundaryCutoff()
+
+		SeedRegistrationKey(t, st, user.ID, cutoff.Add(-time.Millisecond))
+		SeedRegistrationKey(t, st, user.ID, cutoff)
+		SeedRegistrationKey(t, st, user.ID, cutoff.Add(time.Millisecond))
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().HardDeleteExpiredRegistrationKeysBefore(ctx, c)
+		})
+	})
+
+	t.Run("workspace soft-delete sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		cutoff := boundaryCutoff()
+
+		for i, deletedAt := range []time.Time{
+			cutoff.Add(-time.Millisecond), cutoff, cutoff.Add(time.Millisecond),
+		} {
+			wsID := SeedWorkspace(t, st, orgID, user.ID, "boundary-ws")
+			_, err := st.Workspaces().SoftDelete(ctx, store.SoftDeleteWorkspaceParams{
+				ID:          wsID,
+				OwnerUserID: user.ID,
+			})
+			require.NoError(t, err, "workspace %d", i)
+			require.NoError(t, st.TestHelper().SetDeletedAt(ctx, store.EntityWorkspaces, wsID, deletedAt))
+		}
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().HardDeleteWorkspacesBefore(ctx, c)
+		})
+	})
+
+	t.Run("worker soft-delete sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		cutoff := boundaryCutoff()
+
+		for _, deletedAt := range []time.Time{
+			cutoff.Add(-time.Millisecond), cutoff, cutoff.Add(time.Millisecond),
+		} {
+			worker := SeedWorker(t, st, user.ID)
+			require.NoError(t, st.Workers().MarkDeleted(ctx, worker.ID))
+			require.NoError(t, st.TestHelper().SetDeletedAt(ctx, store.EntityWorkers, worker.ID, deletedAt))
+		}
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().HardDeleteWorkersBefore(ctx, c)
+		})
+	})
+
+	t.Run("stale pending email sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		cutoff := boundaryCutoff()
+
+		for i, expiresAt := range []time.Time{
+			cutoff.Add(-time.Millisecond), cutoff, cutoff.Add(time.Millisecond),
+		} {
+			user := SeedUser(t, st, orgID, "boundary-email-user-"+string(rune('a'+i)))
+			expiry := expiresAt
+			require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+				ID:                    user.ID,
+				PendingEmail:          user.Username + "@example.com",
+				PendingEmailToken:     "TOKEN1",
+				PendingEmailExpiresAt: &expiry,
+			}))
+		}
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.Cleanup().ClearStalePendingEmails(ctx, c)
+		})
+	})
+
+	t.Run("lifecycle outbox consumed-before sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		cutoff := boundaryCutoff()
+
+		insert := func() int64 {
+			require.NoError(t, st.LifecycleOutbox().Insert(ctx, store.InsertLifecycleOutboxParams{
+				OrgID:   orgID,
+				OpType:  "create",
+				Payload: []byte("payload"),
+			}))
+			pending, err := st.LifecycleOutbox().ListPending(ctx, store.ListPendingLifecycleOutboxParams{
+				OrgID: orgID,
+				Limit: 100,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, pending)
+			return pending[len(pending)-1].ID
+		}
+		for _, consumedAt := range []time.Time{
+			cutoff.Add(-time.Millisecond), cutoff, cutoff.Add(time.Millisecond),
+		} {
+			require.NoError(t, st.LifecycleOutbox().MarkConsumed(ctx, store.MarkLifecycleOutboxConsumedParams{
+				ID:         insert(),
+				ConsumedAt: consumedAt,
+			}))
+		}
+		// Unconsumed rows must survive any cutoff (consumed_at IS NOT NULL filter).
+		unconsumedID := insert()
+
+		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {
+			return st.LifecycleOutbox().DeleteConsumedBefore(ctx, c)
+		})
+		pending, err := st.LifecycleOutbox().ListPending(ctx, store.ListPendingLifecycleOutboxParams{OrgID: orgID, Limit: 100})
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Equal(t, unconsumedID, pending[0].ID)
+	})
+
+	t.Run("recent batch id expiry sweep is millisecond-exact", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "boundary-org")
+		user := SeedUser(t, st, orgID, "boundary-user")
+		cutoff := boundaryCutoff()
+
+		insert := func(batchID string, expiresAt time.Time) {
+			require.NoError(t, st.OrgRecentBatchIDs().Insert(ctx, store.InsertOrgRecentBatchIDParams{
+				OrgID:               orgID,
+				BatchID:             batchID,
+				BodyHash:            []byte("hash"),
+				PrincipalID:         user.ID,
+				CanonicalPhysicalMs: 1,
+				CanonicalLogical:    1,
+				CanonicalClient:     "client",
+				OpCount:             1,
+				Epoch:               1,
+				ExpiresAt:           expiresAt,
+			}))
+		}
+		insert("batch-expired", cutoff.Add(-time.Millisecond))
+		insert("batch-at-cutoff", cutoff)
+		insert("batch-live", cutoff.Add(time.Millisecond))
+
+		deleted, err := st.OrgRecentBatchIDs().DeleteExpired(ctx, cutoff)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, deleted)
+
+		_, err = st.OrgRecentBatchIDs().Get(ctx, orgID, "batch-expired")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		for _, keep := range []string{"batch-at-cutoff", "batch-live"} {
+			_, err := st.OrgRecentBatchIDs().Get(ctx, orgID, keep)
+			assert.NoError(t, err)
+		}
+	})
+}

--- a/backend/internal/hub/store/storetest/test_time_floor.go
+++ b/backend/internal/hub/store/storetest/test_time_floor.go
@@ -1,0 +1,341 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// floorProbeResidue is the sub-millisecond tail carried by every bound instant
+// in this group. The 750us half is deliberately >= 500us: a dialect that
+// ROUNDS sub-millisecond fractions to its column precision (MySQL/TiDB
+// DATETIME(3) round half up; SQLite's strftime '%f' does too before its
+// Go-side floor) would store the NEXT millisecond and fail the "never after
+// the bound" pin. The 999ns tail additionally exercises the nanosecond ->
+// microsecond conversion on dialects that keep microsecond precision
+// (pgx floors it for Postgres-family timestamptz columns).
+const floorProbeResidue = 750*time.Microsecond + 999*time.Nanosecond
+
+// floorProbe returns a future instant i whole milliseconds past a common
+// base, carrying floorProbeResidue and expressed in boundaryZone (non-UTC, so
+// offset normalization stays pinned too). Future-dated so liveness-guarded
+// readbacks (GetActive, Extend) see the row as live.
+func floorProbe(base time.Time, i int) time.Time {
+	return base.Add(time.Duration(i)*time.Millisecond + floorProbeResidue).In(boundaryZone)
+}
+
+func floorProbeBase() time.Time {
+	return time.Now().Add(time.Hour).Truncate(time.Millisecond)
+}
+
+// assertStoredInstant pins the round-trip contract for a Go-bound instant:
+// the stored value must land inside [bound floored to ms, bound]. "Never
+// after the bound" is the load-bearing half -- a stored deadline that
+// postdates the minted one overclaims remaining lifetime (a ceil-to-seconds
+// report gains a whole second, see the api-token refresh CAS test). "Never
+// below the ms floor" rejects coarser truncation (e.g. to whole seconds).
+func assertStoredInstant(t *testing.T, label string, bound, stored time.Time) {
+	t.Helper()
+	floor := bound.Truncate(time.Millisecond)
+	assert.False(t, stored.After(bound),
+		"%s: stored %s postdates its bound %s -- the sub-ms fraction was rounded up",
+		label, stored.UTC().Format(time.RFC3339Nano), bound.UTC().Format(time.RFC3339Nano))
+	assert.False(t, stored.Before(floor),
+		"%s: stored %s predates the bound's ms floor %s -- precision coarser than a millisecond",
+		label, stored.UTC().Format(time.RFC3339Nano), floor.UTC().Format(time.RFC3339Nano))
+}
+
+// testTimeFloor pins that every dialect FLOORS Go-bound instants to its
+// column precision instead of rounding: reading a just-written deadline back
+// must never yield a later instant than the one the caller minted. SQLite
+// enforces this Go-side (sqlutil.BindTime/BindNullTime, because strftime
+// '%f' rounds), MySQL/TiDB likewise Go-side (the server rounds DATETIME(3)
+// inserts half-up), and Postgres-family dialects natively (pgx floors
+// nanoseconds to timestamptz microseconds). Each subtest drives a
+// deadline-bearing write path through the store API with sub-millisecond
+// probes and pins the readback.
+func (s *Suite) testTimeFloor(t *testing.T) {
+	t.Run("delegation token create floors bound expiries", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+		worker := SeedWorker(t, st, user.ID)
+		wsID := SeedWorkspace(t, st, orgID, user.ID, "floor-ws")
+		base := floorProbeBase()
+
+		tokenID := id.Generate()
+		expiresAt := floorProbe(base, 0)
+		refreshExpiresAt := floorProbe(base, 1)
+		require.NoError(t, st.DelegationTokens().Create(ctx, store.CreateDelegationTokenParams{
+			ID:               tokenID,
+			UserID:           user.ID,
+			WorkerID:         worker.ID,
+			WorkspaceID:      wsID,
+			SecretHash:       []byte("secret"),
+			ExpiresAt:        expiresAt,
+			RefreshExpiresAt: &refreshExpiresAt,
+		}))
+
+		tok, err := st.DelegationTokens().GetByID(ctx, tokenID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, tok.ExpiresAt)
+		require.NotNil(t, tok.RefreshExpiresAt)
+		assertStoredInstant(t, "refresh_expires_at", refreshExpiresAt, *tok.RefreshExpiresAt)
+	})
+
+	t.Run("api token create floors bound expiries", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+		base := floorProbeBase()
+
+		tokenID := id.Generate()
+		expiresAt := floorProbe(base, 0)
+		refreshExpiresAt := floorProbe(base, 1)
+		require.NoError(t, st.APITokens().Create(ctx, store.CreateAPITokenParams{
+			ID:               tokenID,
+			UserID:           user.ID,
+			ClientType:       "cli",
+			ClientName:       "floor-client",
+			SecretHash:       []byte("secret"),
+			Scope:            "remote:*",
+			ExpiresAt:        &expiresAt,
+			RefreshExpiresAt: &refreshExpiresAt,
+		}))
+
+		tok, err := st.APITokens().GetByID(ctx, tokenID)
+		require.NoError(t, err)
+		require.NotNil(t, tok.ExpiresAt)
+		assertStoredInstant(t, "expires_at", expiresAt, *tok.ExpiresAt)
+		require.NotNil(t, tok.RefreshExpiresAt)
+		assertStoredInstant(t, "refresh_expires_at", refreshExpiresAt, *tok.RefreshExpiresAt)
+	})
+
+	t.Run("session create and touch floor bound instants", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+		base := floorProbeBase()
+
+		sessionID := id.Generate()
+		expiresAt := floorProbe(base, 0)
+		require.NoError(t, st.Sessions().Create(ctx, store.CreateSessionParams{
+			ID:        sessionID,
+			UserID:    user.ID,
+			ExpiresAt: expiresAt,
+		}))
+		sess, err := st.Sessions().GetByID(ctx, sessionID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, sess.ExpiresAt)
+
+		// Touch stamps last_active_at DB-side (NOW); the LastActiveAt param is
+		// only the throttle threshold in the WHERE, so expires_at is the one
+		// caller-bound instant that round-trips. A future threshold guarantees
+		// the conditional update matches the just-created row.
+		touchedExpiresAt := floorProbe(base, 2)
+		n, err := st.Sessions().Touch(ctx, store.TouchSessionParams{
+			ID:           sessionID,
+			ExpiresAt:    touchedExpiresAt,
+			LastActiveAt: floorProbe(base, 1),
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+		sess, err = st.Sessions().GetByID(ctx, sessionID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "touched expires_at", touchedExpiresAt, sess.ExpiresAt)
+	})
+
+	t.Run("registration key create and extend floor bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+		base := floorProbeBase()
+
+		expiresAt := floorProbe(base, 0)
+		regID := SeedRegistrationKey(t, st, user.ID, expiresAt)
+		key, err := st.RegistrationKeys().GetByID(ctx, regID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, key.ExpiresAt)
+
+		extendedExpiresAt := floorProbe(base, 1)
+		n, err := st.RegistrationKeys().Extend(ctx, store.ExtendRegistrationKeyParams{
+			ID:        regID,
+			CreatedBy: user.ID,
+			ExpiresAt: extendedExpiresAt,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+		key, err = st.RegistrationKeys().GetByID(ctx, regID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "extended expires_at", extendedExpiresAt, key.ExpiresAt)
+	})
+
+	t.Run("cli authorization code create floors bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.CLIAuthorizationCodes().Create(ctx, store.CreateCLIAuthorizationCodeParams{
+			Code:          "floor-code",
+			UserID:        user.ID,
+			CodeChallenge: "challenge",
+			ExpiresAt:     expiresAt,
+		}))
+
+		code, err := st.CLIAuthorizationCodes().GetActive(ctx, "floor-code")
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, code.ExpiresAt)
+	})
+
+	t.Run("device authorization create floors bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
+			DeviceCode:      "floor-device",
+			UserCode:        "FLOOR-USER",
+			IntervalSeconds: 5,
+			ExpiresAt:       expiresAt,
+		}))
+
+		auth, err := st.DeviceAuthorizations().Get(ctx, "floor-device")
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, auth.ExpiresAt)
+	})
+
+	t.Run("org state upsert floors bound instants", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		base := floorProbeBase()
+
+		epochStartedAt := floorProbe(base, 0)
+		updatedAt := floorProbe(base, 1)
+		require.NoError(t, st.OrgState().Upsert(ctx, store.UpsertOrgStateParams{
+			OrgID:          orgID,
+			StatePayload:   []byte("payload"),
+			CurrentEpoch:   1,
+			EpochStartedAt: epochStartedAt,
+			UpdatedAt:      updatedAt,
+		}))
+
+		row, err := st.OrgState().Get(ctx, orgID)
+		require.NoError(t, err)
+		assertStoredInstant(t, "epoch_started_at", epochStartedAt, row.EpochStartedAt)
+		assertStoredInstant(t, "updated_at", updatedAt, row.UpdatedAt)
+	})
+
+	t.Run("pending email expiry floors bound instant", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "floor@example.com",
+			PendingEmailToken:     "TOKEN1",
+			PendingEmailExpiresAt: &expiresAt,
+		}))
+
+		got, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.PendingEmailExpiresAt)
+		assertStoredInstant(t, "pending_email_expires_at", expiresAt, *got.PendingEmailExpiresAt)
+	})
+
+	t.Run("org recent batch id insert floors bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.OrgRecentBatchIDs().Insert(ctx, store.InsertOrgRecentBatchIDParams{
+			OrgID:               orgID,
+			BatchID:             "floor-batch",
+			BodyHash:            []byte("hash"),
+			PrincipalID:         user.ID,
+			CanonicalPhysicalMs: 1,
+			CanonicalLogical:    0,
+			CanonicalClient:     "floor-client",
+			OpCount:             1,
+			Epoch:               1,
+			ExpiresAt:           expiresAt,
+		}))
+
+		row, err := st.OrgRecentBatchIDs().Get(ctx, orgID, "floor-batch")
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, row.ExpiresAt)
+	})
+
+	t.Run("oauth state create floors bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+		prov := SeedOAuthProvider(t, st, "floor-provider")
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.OAuthStates().Create(ctx, store.CreateOAuthStateParams{
+			State:        "floor-state",
+			ProviderID:   prov.ID,
+			PkceVerifier: "verifier",
+			ExpiresAt:    expiresAt,
+		}))
+
+		state, err := st.OAuthStates().Get(ctx, "floor-state")
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, state.ExpiresAt)
+	})
+
+	t.Run("oauth tokens upsert floors bound expiry", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "floor-org")
+		user := SeedUser(t, st, orgID, "floor-user")
+		prov := SeedOAuthProvider(t, st, "floor-provider")
+
+		expiresAt := floorProbe(floorProbeBase(), 0)
+		require.NoError(t, st.OAuthTokens().Upsert(ctx, store.UpsertOAuthTokensParams{
+			UserID:       user.ID,
+			ProviderID:   prov.ID,
+			AccessToken:  []byte("access"),
+			RefreshToken: []byte("refresh"),
+			TokenType:    "Bearer",
+			ExpiresAt:    expiresAt,
+			KeyVersion:   1,
+		}))
+
+		tok, err := st.OAuthTokens().Get(ctx, store.GetOAuthTokensParams{
+			UserID:     user.ID,
+			ProviderID: prov.ID,
+		})
+		require.NoError(t, err)
+		assertStoredInstant(t, "expires_at", expiresAt, tok.ExpiresAt)
+	})
+
+	t.Run("pending oauth signup create floors bound expiries", func(t *testing.T) {
+		st := s.NewStore(t)
+		prov := SeedOAuthProvider(t, st, "floor-provider")
+		base := floorProbeBase()
+
+		tokenExpiresAt := floorProbe(base, 0)
+		expiresAt := floorProbe(base, 1)
+		require.NoError(t, st.PendingOAuthSignups().Create(ctx, store.CreatePendingOAuthSignupParams{
+			Token:           "floor-signup",
+			ProviderID:      prov.ID,
+			ProviderSubject: "subject",
+			AccessToken:     []byte("access"),
+			RefreshToken:    []byte("refresh"),
+			TokenType:       "Bearer",
+			TokenExpiresAt:  tokenExpiresAt,
+			KeyVersion:      1,
+			ExpiresAt:       expiresAt,
+		}))
+
+		signup, err := st.PendingOAuthSignups().Get(ctx, "floor-signup")
+		require.NoError(t, err)
+		assertStoredInstant(t, "token_expires_at", tokenExpiresAt, signup.TokenExpiresAt)
+		assertStoredInstant(t, "expires_at", expiresAt, signup.ExpiresAt)
+	})
+}

--- a/backend/internal/util/ptrconv/ptrconv.go
+++ b/backend/internal/util/ptrconv/ptrconv.go
@@ -80,22 +80,6 @@ func OrEmpty(b []byte) []byte {
 	return b
 }
 
-// NullTimeToPtr converts a sql.NullTime to a *time.Time.
-func NullTimeToPtr(nt sql.NullTime) *time.Time {
-	if nt.Valid {
-		return &nt.Time
-	}
-	return nil
-}
-
-// PtrToNullTime converts a *time.Time to a sql.NullTime.
-func PtrToNullTime(t *time.Time) sql.NullTime {
-	if t != nil {
-		return sql.NullTime{Time: *t, Valid: true}
-	}
-	return sql.NullTime{}
-}
-
 // NullStringToPtr converts a sql.NullString to a *string.
 func NullStringToPtr(ns sql.NullString) *string {
 	if ns.Valid {

--- a/backend/internal/util/sqlitedb/canonical.go
+++ b/backend/internal/util/sqlitedb/canonical.go
@@ -1,0 +1,137 @@
+package sqlitedb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// FindNonCanonicalDatetimes walks every DATETIME column of every table in the
+// connected SQLite database (excluding sqlite_* internals and the tables named
+// in exclude, typically goose's version table) and reports stored values that
+// deviate from the canonical 24-char strftime('%Y-%m-%dT%H:%M:%fZ') layout
+// (timefmt.ISO8601). Columns are discovered mechanically from the live schema
+// (sqlite_master x pragma_table_info), so a new table or column can never be
+// forgotten the way a hand-curated allowlist could. The probe runs SQL-side
+// (length/substr over the stored TEXT) because modernc reformats DATETIME
+// values on scan, which would hide a non-canonical layout -- a single raw
+// time.Time bind stores the driver's own layout (space at byte 11, offset
+// suffix) and silently corrupts raw-string compares (keyset ORDER BY columns,
+// liveness filters, cleanup cutoffs).
+//
+// It returns one human-readable line per offending column and the number of
+// (table, column) pairs walked; walked == 0 means the schema holds no DATETIME
+// columns (e.g. a migrator test rolled it back), which callers should judge
+// for themselves.
+//
+// The walk's coverage is keyed on the DATETIME decltype, so a timestamp column
+// declared with any other type would silently escape it. To make that drift
+// loud instead of silent, the walk also reports every timestamp-named column
+// (name ending in `_at`) whose decltype is not DATETIME as an offender: a
+// future migration must either declare the column DATETIME (bringing it under
+// the walk) or exclude its table deliberately.
+func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...string) (offenders []string, walked int, err error) {
+	// UPPER: SQLite decltypes are case-insensitive, so a migration that
+	// declares a column as lowercase `datetime` must still be walked.
+	rows, err := db.QueryContext(ctx, `
+		SELECT m.name, ti.name
+		FROM sqlite_master m, pragma_table_info(m.name) ti
+		WHERE m.type = 'table'
+		  AND m.name NOT LIKE 'sqlite_%'
+		  AND UPPER(ti.type) = 'DATETIME'
+		ORDER BY m.name, ti.cid`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type tableColumn struct{ table, col string }
+	var columns []tableColumn
+	for rows.Next() {
+		var tc tableColumn
+		if err := rows.Scan(&tc.table, &tc.col); err != nil {
+			return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+		}
+		if slices.Contains(exclude, tc.table) {
+			continue
+		}
+		columns = append(columns, tc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+	}
+	// Schema-shape guard: a timestamp-named column that is not DATETIME sits
+	// outside the value walk below, so report the declaration itself.
+	declRows, err := db.QueryContext(ctx, `
+		SELECT m.name, ti.name, ti.type
+		FROM sqlite_master m, pragma_table_info(m.name) ti
+		WHERE m.type = 'table'
+		  AND m.name NOT LIKE 'sqlite_%'
+		  AND ti.name LIKE '%\_at' ESCAPE '\'
+		  AND UPPER(ti.type) != 'DATETIME'
+		ORDER BY m.name, ti.cid`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+	}
+	defer func() { _ = declRows.Close() }()
+	for declRows.Next() {
+		var table, col, decltype string
+		if err := declRows.Scan(&table, &col, &decltype); err != nil {
+			return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+		}
+		if slices.Contains(exclude, table) {
+			continue
+		}
+		offenders = append(offenders,
+			fmt.Sprintf("%s.%s: declared %s, want DATETIME (timestamp-named column outside the canonical walk)", table, col, decltype))
+	}
+	if err := declRows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+	}
+	if len(columns) > 0 {
+		// One compound probe instead of a round trip per column: the walk runs
+		// after every storetest subtest, so ~58 sequential QueryRow calls per
+		// invocation add up across a suite. Table and column names come from
+		// the live schema, never caller input. SQLite caps compound SELECTs at
+		// 500 arms by default; a schema anywhere near that many DATETIME
+		// columns fails this query loudly, not silently.
+		var probe strings.Builder
+		for i, tc := range columns {
+			if i > 0 {
+				probe.WriteString(" UNION ALL ")
+			}
+			fmt.Fprintf(&probe,
+				"SELECT %d, COUNT(*), MIN(CAST(%s AS TEXT)) FROM %s WHERE %s IS NOT NULL AND (length(CAST(%s AS TEXT)) != 24 OR substr(CAST(%s AS TEXT), 11, 1) != 'T')",
+				i, tc.col, tc.table, tc.col, tc.col, tc.col)
+		}
+		probeRows, err := db.QueryContext(ctx, probe.String())
+		if err != nil {
+			return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
+		}
+		defer func() { _ = probeRows.Close() }()
+		counts := make([]int, len(columns))
+		samples := make([]sql.NullString, len(columns))
+		for probeRows.Next() {
+			var idx, count int
+			var sample sql.NullString
+			if err := probeRows.Scan(&idx, &count, &sample); err != nil {
+				return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
+			}
+			if idx < 0 || idx >= len(columns) {
+				return nil, 0, fmt.Errorf("canonical-timestamp walk: probe returned out-of-range column index %d", idx)
+			}
+			counts[idx], samples[idx] = count, sample
+		}
+		if err := probeRows.Err(); err != nil {
+			return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
+		}
+		for i, tc := range columns {
+			if counts[i] > 0 {
+				offenders = append(offenders,
+					fmt.Sprintf("%s.%s: %d value(s), e.g. %q", tc.table, tc.col, counts[i], samples[i].String))
+			}
+		}
+	}
+	return offenders, len(columns), nil
+}

--- a/backend/internal/util/sqlitedb/canonical_test.go
+++ b/backend/internal/util/sqlitedb/canonical_test.go
@@ -1,0 +1,138 @@
+package sqlitedb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The higher-level canonical-storage tests (hub sqlite store, worker service)
+// only ever assert the EMPTY offender case, which would pass vacuously if the
+// probe stopped matching anything. The tests here pin the detection itself:
+// a known-bad value must be reported, with the right count and sample.
+
+const canonicalValue = "2025-01-02T12:00:00.000Z"
+
+// driverLayoutValue is what a raw time.Time bind stores through modernc with
+// _time_format=sqlite: space separator, zone offset suffix -- the exact
+// corruption shape FindNonCanonicalDatetimes exists to catch.
+const driverLayoutValue = "2025-01-02 21:00:00.000+09:00"
+
+// secondPrecisionValue is canonical-shaped but truncated to whole seconds
+// (20 chars), as datetime('now') would store: same instant grid drift, caught
+// by the length probe rather than the separator probe.
+const secondPrecisionValue = "2025-01-02T12:00:00Z"
+
+func openCanonicalTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := Open(":memory:", Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	// The lowercase `datetime` decltype on bravo.updated_at pins that
+	// discovery is decltype-case-insensitive; junk in the TEXT and TIMESTAMP
+	// columns pins that only DATETIME columns are value-walked. The
+	// non-DATETIME columns deliberately avoid the `_at` suffix so they stay
+	// clear of the timestamp-named decltype guard (pinned separately below).
+	_, err = db.Exec(`
+		CREATE TABLE alpha (
+			id INTEGER PRIMARY KEY,
+			created_at DATETIME,
+			note TEXT
+		);
+		CREATE TABLE bravo (
+			id INTEGER PRIMARY KEY,
+			expires_at DATETIME,
+			updated_at datetime,
+			recorded TIMESTAMP
+		);`)
+	require.NoError(t, err)
+	return db
+}
+
+func TestFindNonCanonicalDatetimes_CleanSchema(t *testing.T) {
+	db := openCanonicalTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO alpha (created_at, note) VALUES (?, ?), (NULL, ?)`,
+		canonicalValue, "not a timestamp at all", "also not one")
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO bravo (expires_at, updated_at, recorded) VALUES (?, ?, ?)`,
+		canonicalValue, canonicalValue, driverLayoutValue)
+	require.NoError(t, err)
+
+	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "canonical values, NULLs, and non-DATETIME columns must not be reported")
+	assert.Equal(t, 3, walked,
+		"must walk exactly the DATETIME columns (alpha.created_at, bravo.expires_at, bravo.updated_at), regardless of decltype case")
+}
+
+func TestFindNonCanonicalDatetimes_ReportsEveryOffendingColumn(t *testing.T) {
+	db := openCanonicalTestDB(t)
+
+	// alpha.created_at: two distinct corruption shapes plus one clean row --
+	// the count must include only the bad rows, the sample is the MIN value.
+	_, err := db.Exec(`INSERT INTO alpha (created_at) VALUES (?), (?), (?)`,
+		driverLayoutValue, secondPrecisionValue, canonicalValue)
+	require.NoError(t, err)
+	// bravo: one bad row in the lowercase-decltype column, clean elsewhere.
+	_, err = db.Exec(`INSERT INTO bravo (expires_at, updated_at) VALUES (?, ?)`,
+		canonicalValue, driverLayoutValue)
+	require.NoError(t, err)
+
+	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, 3, walked)
+	assert.Equal(t, []string{
+		`alpha.created_at: 2 value(s), e.g. "` + driverLayoutValue + `"`,
+		`bravo.updated_at: 1 value(s), e.g. "` + driverLayoutValue + `"`,
+	}, offenders)
+}
+
+func TestFindNonCanonicalDatetimes_ReportsTimestampNamedColumnWithWrongDecltype(t *testing.T) {
+	db := openCanonicalTestDB(t)
+
+	// The guard fires on the declaration alone -- no rows needed. A column
+	// named like a timestamp but not declared DATETIME sits outside the value
+	// walk, which is exactly the drift the guard exists to make loud.
+	_, err := db.Exec(`CREATE TABLE charlie (id INTEGER PRIMARY KEY, seen_at TEXT, logged_at TIMESTAMP)`)
+	require.NoError(t, err)
+
+	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"charlie.seen_at: declared TEXT, want DATETIME (timestamp-named column outside the canonical walk)",
+		"charlie.logged_at: declared TIMESTAMP, want DATETIME (timestamp-named column outside the canonical walk)",
+	}, offenders)
+	assert.Equal(t, 3, walked, "the guard must not add non-DATETIME columns to the value walk")
+
+	// Excluding the table silences the decltype guard along with the walk.
+	offenders, _, err = FindNonCanonicalDatetimes(context.Background(), db, "charlie")
+	require.NoError(t, err)
+	assert.Empty(t, offenders)
+}
+
+func TestFindNonCanonicalDatetimes_ExcludeSkipsTable(t *testing.T) {
+	db := openCanonicalTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO bravo (expires_at) VALUES (?)`, driverLayoutValue)
+	require.NoError(t, err)
+
+	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db, "bravo")
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "an excluded table's values must not be probed")
+	assert.Equal(t, 1, walked, "excluded tables must not count toward the walked total")
+}
+
+func TestFindNonCanonicalDatetimes_EmptySchemaWalksNothing(t *testing.T) {
+	db, err := Open(":memory:", Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, offenders)
+	assert.Zero(t, walked, "an empty schema must report walked == 0 so callers can judge vacuity")
+}

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -145,7 +145,9 @@ UPDATE agents SET workspace_id = ? WHERE id = ?;
 SELECT * FROM agents WHERE id IN (sqlc.slice('ids')) AND closed_at IS NULL;
 
 -- name: DeleteClosedAgentsBefore :execresult
-DELETE FROM agents WHERE rowid IN (SELECT a.rowid FROM agents a WHERE a.closed_at < ? LIMIT 1000);
+-- Raw compare against a timefmt.Format cutoff (CAST AS TEXT -> string param);
+-- see DeleteClosedTerminalsBefore for the rationale.
+DELETE FROM agents WHERE rowid IN (SELECT a.rowid FROM agents a WHERE a.closed_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
 
 -- ListAgentIDsWithPlanInDir returns the IDs of agents whose plan_file_path
 -- begins with the provided literal byte sequence. Used by the plan-archive

--- a/backend/internal/worker/db/queries/auto_continue_schedules.sql
+++ b/backend/internal/worker/db/queries/auto_continue_schedules.sql
@@ -12,7 +12,11 @@ INSERT INTO auto_continue_schedules (
   sqlc.arg(agent_id),
   sqlc.arg(reason),
   sqlc.arg(content),
-  sqlc.arg(due_at),
+  -- Canonical layout, millisecond precision. The Go builders truncate due_at
+  -- to the millisecond BEFORE binding so fireAutoContinue's DueAt.Equal guard
+  -- (in-memory armed instant vs the DB roundtrip of this value) still holds.
+  -- The DO UPDATE below reuses the transformed excluded value.
+  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(due_at)),
   sqlc.arg(jitter_ms),
   sqlc.arg(next_backoff_ms),
   'active',

--- a/backend/internal/worker/db/queries/messages.sql
+++ b/backend/internal/worker/db/queries/messages.sql
@@ -19,7 +19,7 @@ VALUES (
   sqlc.arg(span_color),
   sqlc.arg(agent_provider),
   sqlc.arg(mark_type),
-  sqlc.arg(created_at)
+  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(created_at))
 )
 RETURNING seq;
 

--- a/backend/internal/worker/db/queries/terminals.sql
+++ b/backend/internal/worker/db/queries/terminals.sql
@@ -5,7 +5,24 @@
 -- exit/restart upserts pass whatever value (commonly empty) and the
 -- existing column survives unchanged.
 INSERT INTO terminals (id, workspace_id, working_dir, home_dir, shell_start_dir, shell, title, cols, rows, screen, exit_code, closed_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (
+  sqlc.arg(id),
+  sqlc.arg(workspace_id),
+  sqlc.arg(working_dir),
+  sqlc.arg(home_dir),
+  sqlc.arg(shell_start_dir),
+  sqlc.arg(shell),
+  sqlc.arg(title),
+  sqlc.arg(cols),
+  sqlc.arg(rows),
+  sqlc.arg(screen),
+  sqlc.arg(exit_code),
+  -- The title-update path re-binds a DB-roundtripped closed_at; without this
+  -- wrap that rewrite stores the driver's own layout and splits the column
+  -- into two layouts under the raw-string cleanup sweep. The DO UPDATE below
+  -- reuses the transformed excluded value.
+  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(closed_at))
+)
 ON CONFLICT (id) DO UPDATE SET
   workspace_id    = excluded.workspace_id,
   working_dir     = excluded.working_dir,
@@ -60,7 +77,13 @@ SELECT * FROM terminals WHERE workspace_id = ? AND closed_at IS NULL;
 SELECT * FROM terminals WHERE id IN (sqlc.slice('ids')) AND closed_at IS NULL;
 
 -- name: DeleteClosedTerminalsBefore :execresult
-DELETE FROM terminals WHERE rowid IN (SELECT t.rowid FROM terminals t WHERE t.closed_at < ? LIMIT 1000);
+-- Raw compare: closed_at is stored canonical on every write path
+-- (CloseTerminal/CloseOpenTerminalsByWorkspace SET strftime, UpsertTerminal
+-- wraps its bound value), and the Go side binds a timefmt.Format cutoff
+-- (CAST AS TEXT -> string param), so the lexicographic < is byte-exact. A raw
+-- time.Time bind here would compare in the driver's own layout and skip every
+-- same-day row until the date rolled over.
+DELETE FROM terminals WHERE rowid IN (SELECT t.rowid FROM terminals t WHERE t.closed_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
 
 -- name: GetTerminalWorkspaceID :one
 SELECT workspace_id FROM terminals WHERE id = ?;

--- a/backend/internal/worker/db/queries/worktrees.sql
+++ b/backend/internal/worker/db/queries/worktrees.sql
@@ -14,7 +14,9 @@ UPDATE worktrees SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id
 UPDATE worktrees SET branch_name = ? WHERE id = ?;
 
 -- name: HardDeleteWorktreesBefore :execresult
-DELETE FROM worktrees WHERE rowid IN (SELECT w.rowid FROM worktrees w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < ? LIMIT 1000);
+-- Raw compare against a timefmt.Format cutoff (CAST AS TEXT -> string param);
+-- see DeleteClosedTerminalsBefore for the rationale.
+DELETE FROM worktrees WHERE rowid IN (SELECT w.rowid FROM worktrees w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
 
 -- name: AddWorktreeTab :exec
 -- org_id is set only for FILE links (it scopes the worktree_tab_liveness join

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -10,7 +10,6 @@ import (
 	"maps"
 	"os"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -317,7 +316,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 		}
 
 		messageID := id.Generate()
-		now := time.Now().UTC()
+		now := nowMillis()
 
 		// Store user content as a plain JSON object with a "content" field,
 		// which the frontend classifies as user_content and renders as markdown.
@@ -2963,7 +2962,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string, markType l
 	resumeSessionID := svc.resolveResumeSessionID(agentID, dbAgent.AgentSessionID, dbAgent.Resumed)
 
 	messageID := id.Generate()
-	now := time.Now().UTC()
+	now := nowMillis()
 	innerJSON, err := json.Marshal(map[string]string{"content": content})
 	if err != nil {
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)

--- a/backend/internal/worker/service/auto_continue.go
+++ b/backend/internal/worker/service/auto_continue.go
@@ -56,7 +56,7 @@ func (h *OutputHandler) restoreAutoContinueSchedules() {
 func (h *OutputHandler) scheduleAutoContinue(agentID string, schedule agent.AutoContinueSchedule) {
 	now := time.Now().UTC()
 
-	record, err := h.buildAutoContinueRecord(agentID, schedule, now)
+	record, dueAt, err := h.buildAutoContinueRecord(agentID, schedule, now)
 	if err != nil {
 		slog.Error("auto-continue schedule build failed", "agent_id", agentID, "reason", schedule.Reason, "error", err)
 		return
@@ -68,7 +68,7 @@ func (h *OutputHandler) scheduleAutoContinue(agentID string, schedule agent.Auto
 	}
 
 	key := autoContinueKey{AgentID: agentID, Reason: schedule.Reason}
-	h.armAutoContinueTimer(key, record.DueAt)
+	h.armAutoContinueTimer(key, dueAt)
 }
 
 func (h *OutputHandler) cancelAutoContinue(agentID string, reason agent.AutoContinueReason) {
@@ -93,18 +93,27 @@ func (h *OutputHandler) cleanupAutoContinue(agentID string) {
 	}
 }
 
-func (h *OutputHandler) buildAutoContinueRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, error) {
+// buildAutoContinueRecord returns the upsert params plus the typed due
+// instant the caller arms its timer with. The params' DueAt field is an
+// interface{} (its bind is strftime-wrapped SQL-side), so the builders hand
+// back the time.Time separately instead of making callers type-assert it out.
+// Converging this and the other strftime-wrapped worker write binds
+// (messages.created_at, terminals.closed_at) on typed CAST(... AS TEXT)
+// string params is tracked in
+// https://github.com/leapmux/leapmux/issues/303.
+func (h *OutputHandler) buildAutoContinueRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, time.Time, error) {
 	switch schedule.Reason {
 	case agent.AutoContinueReasonAPIError:
 		return h.buildAPIErrorScheduleRecord(agentID, schedule, now)
 	case agent.AutoContinueReasonRateLimit:
-		return h.buildRateLimitScheduleRecord(agentID, schedule, now), nil
+		record, dueAt := h.buildRateLimitScheduleRecord(agentID, schedule, now)
+		return record, dueAt, nil
 	default:
-		return db.UpsertAutoContinueScheduleParams{}, errors.New("unknown auto-continue reason")
+		return db.UpsertAutoContinueScheduleParams{}, time.Time{}, errors.New("unknown auto-continue reason")
 	}
 }
 
-func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, error) {
+func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, time.Time, error) {
 	delay := autoContinueInitialDelay
 	nextBackoff := time.Duration(float64(autoContinueInitialDelay) * autoContinueMultiplier)
 
@@ -113,7 +122,7 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 		Reason:  string(schedule.Reason),
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return db.UpsertAutoContinueScheduleParams{}, err
+		return db.UpsertAutoContinueScheduleParams{}, time.Time{}, err
 	}
 	if err == nil && existing.State == autoContinueStateActive && existing.NextBackoffMs > 0 {
 		delay = time.Duration(existing.NextBackoffMs) * time.Millisecond
@@ -128,7 +137,11 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 	}
 
 	jitter := symmetricJitter(delay, autoContinueJitterFrac)
-	dueAt := now.Add(delay + jitter)
+	// Millisecond-truncated because the upsert stores due_at in the
+	// millisecond-precision canonical strftime layout: the armed in-memory
+	// instant must survive the DB roundtrip byte-exactly, or
+	// fireAutoContinue's DueAt.Equal guard would reject every firing.
+	dueAt := now.Add(delay + jitter).Truncate(time.Millisecond)
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
@@ -137,12 +150,14 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: nextBackoff.Milliseconds(),
 		SourcePayload: cloneOrEmpty(schedule.SourcePayload),
-	}, nil
+	}, dueAt, nil
 }
 
-func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) db.UpsertAutoContinueScheduleParams {
+func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, time.Time) {
 	jitter := positiveRateLimitJitter(schedule.DueAt.Sub(now))
-	dueAt := schedule.DueAt.UTC().Add(jitter)
+	// Millisecond-truncated for the same DueAt.Equal roundtrip reason as
+	// buildAPIErrorScheduleRecord above.
+	dueAt := schedule.DueAt.UTC().Add(jitter).Truncate(time.Millisecond)
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
@@ -151,7 +166,7 @@ func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule ag
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: 0,
 		SourcePayload: cloneOrEmpty(schedule.SourcePayload),
-	}
+	}, dueAt
 }
 
 func (h *OutputHandler) armAutoContinueTimer(key autoContinueKey, dueAt time.Time) {

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -131,6 +131,50 @@ func TestAutoContinueSchedule_CancelOneReasonLeavesOtherIntact(t *testing.T) {
 	assert.Equal(t, autoContinueStateCancelled, apiRow.State)
 }
 
+// TestAutoContinueSchedule_ArmedDueAtSurvivesDBRoundtrip pins the contract
+// between the schedule builders and fireAutoContinue's DueAt.Equal guard: the
+// dueAt a builder hands back for arming the in-memory timer must equal the DB
+// roundtrip of the record it built. due_at is stored at millisecond precision
+// (the upsert's strftime wrap), so the builders truncate to the millisecond
+// before binding; without that, every live-armed dueAt carries sub-millisecond
+// residue the storage floors away, the Equal guard rejects every firing, and
+// auto-continue silently never fires on the live path. The restore-path tests
+// above can't catch this: they arm from a DB readback, which is already on the
+// millisecond grid.
+func TestAutoContinueSchedule_ArmedDueAtSurvivesDBRoundtrip(t *testing.T) {
+	_, queries := setupTestDB(t)
+	createAutoContinueTestAgent(t, queries, "agent-1")
+	h := NewOutputHandler(nil, queries, nil, nil, nil)
+
+	// Sub-millisecond residue plus a non-UTC zone: the shape every live
+	// scheduling call has (time.Now() carries nanosecond resolution).
+	zone := time.FixedZone("UTC+9", 9*60*60)
+	now := time.Now().In(zone).Truncate(time.Millisecond).Add(123_456 * time.Nanosecond)
+
+	for _, reason := range []agent.AutoContinueReason{
+		agent.AutoContinueReasonAPIError,
+		agent.AutoContinueReasonRateLimit,
+	} {
+		record, dueAt, err := h.buildAutoContinueRecord("agent-1", agent.AutoContinueSchedule{
+			Reason: reason,
+			DueAt:  now.Add(time.Hour),
+		}, now)
+		require.NoError(t, err, reason)
+		assert.True(t, dueAt.Equal(dueAt.Truncate(time.Millisecond)),
+			"%s: armed dueAt %s carries sub-millisecond residue the storage would floor away", reason, dueAt)
+
+		require.NoError(t, queries.UpsertAutoContinueSchedule(bgCtx(), record))
+		row, err := queries.GetAutoContinueSchedule(bgCtx(), db.GetAutoContinueScheduleParams{
+			AgentID: "agent-1",
+			Reason:  string(reason),
+		})
+		require.NoError(t, err)
+		assert.True(t, row.DueAt.Equal(dueAt),
+			"%s: stored due_at %s != armed dueAt %s -- fireAutoContinue's DueAt.Equal guard would reject the firing",
+			reason, row.DueAt, dueAt)
+	}
+}
+
 func TestAutoContinueSchedule_FiresOnceAndDoesNotRefireAfterRestart(t *testing.T) {
 	_, queries := setupTestDB(t)
 	createAutoContinueTestAgent(t, queries, "agent-1")

--- a/backend/internal/worker/service/canonical_storage_test.go
+++ b/backend/internal/worker/service/canonical_storage_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	gendb "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// TestAllDatetimeColumnsStoreCanonicalLayout drives every worker-DB write path
+// that binds a Go-side time into a DATETIME column and asserts -- via the
+// schema-discovered sqlitedb.FindNonCanonicalDatetimes walk -- that every
+// stored value is the canonical 24-char strftime('%Y-%m-%dT%H:%M:%fZ') layout.
+// Binds use a deliberately non-UTC fixed zone: a raw time.Time bind would
+// store modernc's driver layout with the zone's offset (space at byte 11,
+// '+09:00' suffix), splitting a column into two layouts whose raw-string
+// compares (the closed_at/deleted_at cleanup sweeps) silently diverge.
+func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
+	sqlDB, queries := setupTestDB(t)
+	ctx := context.Background()
+
+	// Non-UTC on purpose; see the doc comment.
+	zone := time.FixedZone("UTC+9", 9*60*60)
+	now := time.Now().In(zone)
+
+	// agents: created_at DEFAULT + closed_at via CloseAgent's strftime.
+	require.NoError(t, queries.CreateAgent(ctx, gendb.CreateAgentParams{
+		ID:            "agent-1",
+		WorkspaceID:   "ws-1",
+		WorkingDir:    "/tmp",
+		HomeDir:       "/home",
+		Title:         "agent",
+		Options:       "{}",
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, queries.CloseAgent(ctx, "agent-1"))
+
+	// messages.created_at is Go-bound on every persisted chat message.
+	_, err := queries.CreateMessage(ctx, gendb.CreateMessageParams{
+		ID:                 "msg-1",
+		AgentID:            "agent-1",
+		Source:             leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		Content:            []byte("hello"),
+		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
+		SpanLines:          "[]",
+		AgentProvider:      leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		CreatedAt:          now,
+	})
+	require.NoError(t, err)
+
+	// terminals: UpsertTerminal binds closed_at directly -- the title-update
+	// path re-binds a roundtripped non-NULL value, so exercise that shape on
+	// term-1 and leave it untouched (a subsequent CloseTerminal would
+	// overwrite the bound value and hide the layout it stored). term-2 covers
+	// the CloseTerminal strftime path.
+	require.NoError(t, queries.UpsertTerminal(ctx, gendb.UpsertTerminalParams{
+		ID:          "term-1",
+		WorkspaceID: "ws-1",
+		WorkingDir:  "/tmp",
+		HomeDir:     "/home",
+		Shell:       "/bin/zsh",
+		Title:       "terminal",
+		Cols:        80,
+		Rows:        24,
+		Screen:      []byte{},
+		ClosedAt:    sql.NullTime{Time: now, Valid: true},
+	}))
+	require.NoError(t, queries.UpsertTerminal(ctx, gendb.UpsertTerminalParams{
+		ID:          "term-2",
+		WorkspaceID: "ws-1",
+		WorkingDir:  "/tmp",
+		HomeDir:     "/home",
+		Shell:       "/bin/zsh",
+		Title:       "terminal-2",
+		Cols:        80,
+		Rows:        24,
+		Screen:      []byte{},
+	}))
+	require.NoError(t, queries.CloseTerminal(ctx, "term-2"))
+
+	// worktrees: deleted_at via DeleteWorktree's strftime.
+	require.NoError(t, queries.CreateWorktree(ctx, gendb.CreateWorktreeParams{
+		ID:           "wt-1",
+		WorktreePath: "/tmp/wt1",
+		RepoRoot:     "/repo",
+		BranchName:   "main",
+	}))
+	require.NoError(t, queries.DeleteWorktree(ctx, "wt-1"))
+
+	// auto_continue_schedules.due_at is Go-bound on every upsert.
+	require.NoError(t, queries.UpsertAutoContinueSchedule(ctx, gendb.UpsertAutoContinueScheduleParams{
+		AgentID:       "agent-1",
+		Reason:        "rate_limit",
+		Content:       "continue",
+		DueAt:         now.Add(time.Hour),
+		SourcePayload: []byte("{}"),
+	}))
+
+	// agent_todos.updated_at via UpsertAgentTodo's strftime.
+	require.NoError(t, queries.UpsertAgentTodo(ctx, gendb.UpsertAgentTodoParams{
+		AgentID: "agent-1",
+		RowKey:  "todo-1",
+		Seq:     1,
+		TaskID:  "task-1",
+		Content: "do the thing",
+		Status:  "pending",
+	}))
+
+	offenders, walked, err := sqlitedb.FindNonCanonicalDatetimes(ctx, sqlDB, "goose_db_version")
+	require.NoError(t, err)
+	require.Positive(t, walked, "walk discovered no DATETIME columns; the discovery query is broken")
+	assert.Empty(t, offenders,
+		"non-canonical timestamp value(s) on disk -- a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap:\n  %s",
+		strings.Join(offenders, "\n  "))
+}

--- a/backend/internal/worker/service/cleanup.go
+++ b/backend/internal/worker/service/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/util/periodic"
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -74,10 +75,11 @@ func (svc *Context) SweepOrphanedAgentState() {
 }
 
 func runCleanup(ctx context.Context, queries *db.Queries) {
-	cutoff := sql.NullTime{
-		Time:  time.Now().UTC().Add(-cleanupRetention),
-		Valid: true,
-	}
+	// Pre-formatted in the canonical strftime layout: the sweeps compare
+	// closed_at/deleted_at as raw strings, so the cutoff must be byte-exact
+	// against the stored bytes (a raw time.Time bind would serialize in the
+	// driver's own layout and skip every same-day row).
+	cutoff := timefmt.Format(time.Now().Add(-cleanupRetention))
 
 	cleanupStep(ctx, "agents", func() (sql.Result, error) { return queries.DeleteClosedAgentsBefore(ctx, cutoff) })
 	cleanupStep(ctx, "terminals", func() (sql.Result, error) { return queries.DeleteClosedTerminalsBefore(ctx, cutoff) })

--- a/backend/internal/worker/service/cleanup_test.go
+++ b/backend/internal/worker/service/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/leapmux/leapmux/internal/worker/db"
 	gendb "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -77,10 +78,7 @@ func TestCleanup_HardDeleteWorktreesBefore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete worktrees older than 7 days.
-	cutoff := sql.NullTime{
-		Time:  time.Now().UTC().Add(-7 * 24 * time.Hour),
-		Valid: true,
-	}
+	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -110,10 +108,7 @@ func TestCleanup_HardDeleteWorktreesBefore_RetainsRecent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete worktrees older than 7 days. The recent one should survive.
-	cutoff := sql.NullTime{
-		Time:  time.Now().UTC().Add(-7 * 24 * time.Hour),
-		Valid: true,
-	}
+	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -163,10 +158,7 @@ func TestCleanup_WorktreeTabsCascadeOnHardDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete.
-	cutoff := sql.NullTime{
-		Time:  time.Now().UTC().Add(-7 * 24 * time.Hour),
-		Valid: true,
-	}
+	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -183,4 +175,75 @@ func TestCleanup_WorktreeTabsCascadeOnHardDelete(t *testing.T) {
 	err = sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM worktree_tabs WHERE worktree_id = ?", "wt-cascade").Scan(&tabCount)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), tabCount, "expected tab references to be cascade-deleted")
+}
+
+// TestCleanup_SweepsSameInstantBoundaries pins the millisecond-exact boundary
+// behavior of the three retention sweeps: stored timestamps and cutoffs are
+// both canonical (strftime wrap on write, timefmt.Format on the bound cutoff),
+// so `col < cutoff` must delete strictly-older rows and keep the exact-cutoff
+// and newer rows even when everything shares the same second. The existing
+// retention tests use multi-day gaps, which is exactly how the prior
+// driver-layout cutoff bind (which missed every same-day row) shipped green.
+func TestCleanup_SweepsSameInstantBoundaries(t *testing.T) {
+	sqlDB, queries := setupTestDB(t)
+	ctx := context.Background()
+	cutoffTime := time.Now().UTC().Truncate(time.Millisecond)
+	cutoff := timefmt.Format(cutoffTime)
+
+	seedAgent := func(id string, closedAt time.Time) {
+		require.NoError(t, queries.CreateAgent(ctx, gendb.CreateAgentParams{
+			ID: id, WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/home", Title: id, Options: "{}",
+		}))
+		_, err := sqlDB.ExecContext(ctx, "UPDATE agents SET closed_at = ? WHERE id = ?", timefmt.Format(closedAt), id)
+		require.NoError(t, err)
+	}
+	seedAgent("agent-expired", cutoffTime.Add(-time.Millisecond))
+	seedAgent("agent-at-cutoff", cutoffTime)
+	seedAgent("agent-live", cutoffTime.Add(time.Millisecond))
+
+	res, err := queries.DeleteClosedAgentsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	n, err := res.RowsAffected()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "agents sweep must delete exactly the strictly-older same-second row")
+	_, err = queries.GetAgentByID(ctx, "agent-expired")
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+	for _, keep := range []string{"agent-at-cutoff", "agent-live"} {
+		_, err := queries.GetAgentByID(ctx, keep)
+		assert.NoError(t, err)
+	}
+
+	seedTerminal := func(id string, closedAt time.Time) {
+		require.NoError(t, queries.UpsertTerminal(ctx, gendb.UpsertTerminalParams{
+			ID: id, WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/home", Shell: "/bin/zsh",
+			Title: id, Cols: 80, Rows: 24, Screen: []byte{},
+			ClosedAt: sql.NullTime{Time: closedAt, Valid: true},
+		}))
+	}
+	seedTerminal("term-expired", cutoffTime.Add(-time.Millisecond))
+	seedTerminal("term-at-cutoff", cutoffTime)
+	seedTerminal("term-live", cutoffTime.Add(time.Millisecond))
+
+	res, err = queries.DeleteClosedTerminalsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	n, err = res.RowsAffected()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "terminals sweep must delete exactly the strictly-older same-second row")
+
+	seedWorktree := func(id string, deletedAt time.Time) {
+		require.NoError(t, queries.CreateWorktree(ctx, gendb.CreateWorktreeParams{
+			ID: id, WorktreePath: "/tmp/" + id, RepoRoot: "/repo", BranchName: id,
+		}))
+		_, err := sqlDB.ExecContext(ctx, "UPDATE worktrees SET deleted_at = ? WHERE id = ?", timefmt.Format(deletedAt), id)
+		require.NoError(t, err)
+	}
+	seedWorktree("wt-expired", cutoffTime.Add(-time.Millisecond))
+	seedWorktree("wt-at-cutoff", cutoffTime)
+	seedWorktree("wt-live", cutoffTime.Add(time.Millisecond))
+
+	res, err = queries.HardDeleteWorktreesBefore(ctx, cutoff)
+	require.NoError(t, err)
+	n, err = res.RowsAffected()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "worktrees sweep must delete exactly the strictly-older same-second row")
 }

--- a/backend/internal/worker/service/now.go
+++ b/backend/internal/worker/service/now.go
@@ -1,0 +1,14 @@
+package service
+
+import "time"
+
+// nowMillis returns the current instant floored to the millisecond, in UTC.
+// Message and notification stamps must be minted this way so the
+// live-streamed value is byte-identical to the persisted row: created_at is
+// stored at ms precision (the strftime wrap in the queries) and the proto
+// echo formats via timefmt (ms truncation). A raw time.Now() would carry
+// sub-millisecond residue the storage floors away, making the streamed and
+// persisted stamps drift apart.
+func nowMillis() time.Time {
+	return time.Now().UTC().Truncate(time.Millisecond)
+}

--- a/backend/internal/worker/service/now_test.go
+++ b/backend/internal/worker/service/now_test.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNowMillisIsUTCOnMillisecondGrid(t *testing.T) {
+	got := nowMillis()
+
+	assert.Equal(t, time.UTC, got.Location())
+	assert.Zero(t, got.Nanosecond()%int(time.Millisecond),
+		"stamp must sit on the millisecond grid or the persisted row drifts from the streamed one")
+	assert.False(t, got.After(time.Now()),
+		"a floored stamp must never postdate the clock")
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -1709,7 +1709,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 
 	msgID := id.Generate()
 	compressed, compressionType := msgcodec.Compress(contentJSON)
-	now := time.Now()
+	now := nowMillis()
 
 	seq, err := createMessageRow(bgCtx(), h.queries, db.CreateMessageParams{
 		ID:                 msgID,
@@ -2317,7 +2317,7 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 	msgID := id.Generate()
 	wrapped := wrapNotifContent(contentJSON)
 	compressed, compressionType := msgcodec.Compress(wrapped)
-	now := time.Now()
+	now := nowMillis()
 
 	// Capture currently-active spans so the notification renders with
 	// passthrough vertical bars instead of breaking the column.


### PR DESCRIPTION
## Motivation
MySQL/TiDB `DATETIME(3)` and SQLite both round sub-millisecond fractions
half-up. Because every write path bound Go `time.Time` values without
flooring them first, a bind could be persisted up to 0.5ms **later** than
the instant supplied by the caller. For deadline-bearing rows (API/delegation
token expiry, session lifetimes, etc.) this is enough to overclaim a
credential's remaining lifetime by a whole second once a caller derives a
ceil-to-seconds lifetime from the stored value — a real security-relevant
bug, pinned by `TestAPIAuth_Refresh_CASRecoveryReportsWinnerRemainingLifetime`.

On SQLite, the on-disk DATETIME layout was also inconsistent: a raw
`time.Time` bind stores the `modernc` driver's own layout (space separator,
zone offset) rather than a canonical string, which silently corrupts
raw-string keyset/liveness/cleanup comparisons (the "#287-shaped" row-drop).
Retention cleanup in the worker DB had the same class of bug: comparing a
raw-string cutoff against a driver-serialized column failed to match
same-day rows, so sweeps effectively skipped deletions until the date
rolled over.

Two smaller, unrelated correctness bugs surfaced while auditing every
timestamp write/compare path: `AdvanceOrgEpoch` mixed a bare `?` placeholder
with named `sqlc.arg()` parameters, causing every call to fail with
"missing argument with index 5"; and `SQLTruncateTableOrder` was missing
`device_authorizations` and `cli_authorization_codes`, so `TruncateAll`
silently skipped them and leaked expired grants across test suite subtests.

## Modifications
- Added centralized bind helpers in `sqlutil`: `BindTime`, `BindNullTime`,
  `BindTimeValid`, each flooring the Go instant to whole milliseconds UTC
  before binding (invariant: stored value <= bound value). Removed
  `sqlutil.ToNullTime` and `ptrconv.NullTimeToPtr`/`PtrToNullTime`,
  consolidating read-side conversion into `sqlutil.NullTimePtr`. These are
  internal-package changes with no exported store-interface impact.
- Routed every timestamp bind in the MySQL and SQLite hub stores, and in
  the worker DB (agents, messages, terminals, worktrees,
  auto_continue_schedules), through these helpers or, on SQLite, through
  `strftime('%Y-%m-%dT%H:%M:%fZ', ...)` to enforce one canonical 24-char
  T-separated ms-UTC on-disk layout on every INSERT/UPDATE/UPSERT.
- Switched SQLite liveness guards and cleanup cutoffs from
  `julianday()`/`datetime()` normalization to raw lexicographic string
  compares against a canonical RHS — byte-exact, ms-precise, and sargable
  for partial expiry indexes.
- Rewrote `CheckCanonicalTimestamps` from a hand-maintained column map into
  a schema-discovered walk (new `sqlitedb.FindNonCanonicalDatetimes`, which
  also flags `*_at`-named columns whose decltype isn't DATETIME).
- Worker retention cleanup cutoffs are now pre-formatted via
  `timefmt.Format` and bound through `CAST(... AS TEXT)` instead of a raw
  driver-serialized value.
- Added `nowMillis()` (UTC, ms-floored) for message/notification
  `created_at` stamps so live-streamed values match persisted precision
  exactly; auto-continue schedule builders now return the typed due
  instant alongside upsert params and ms-truncate it so the
  `DueAt.Equal` guard in `fireAutoContinue` survives a DB roundtrip.
- Fixed `AdvanceOrgEpoch`'s mixed positional/named parameter bug and added
  `device_authorizations`/`cli_authorization_codes` to
  `SQLTruncateTableOrder`.
- Added extensive test coverage: `canonical_storage_internal_test.go` and
  `truncate_tables_internal_test.go` for the SQLite store,
  `canonical_storage_test.go`/`cleanup_test.go` additions for the worker
  DB, unit tests for the new sqlutil/sqlitedb helpers, and two new
  storetest groups (`cleanup_boundaries`, `time_floor`) run across all six
  supported dialects (sqlite, postgres, mysql, tidb, cockroachdb,
  yugabytedb).
- Filed #303 to track converging the remaining per-call-site flooring and
  the worker's strftime-wrapped binds onto a mechanical `driver.Valuer`
  choke point.

## Result
- You no longer see a refreshed token's remaining lifetime overclaimed by
  up to a second due to sub-millisecond rounding on write.
- Worker retention sweeps for agents, terminals, and worktrees correctly
  delete expired same-day rows instead of silently deferring deletion
  until the calendar date rolls over.
- Auto-continue schedules reliably fire on the live path; previously a
  `DueAt` mismatch introduced by the DB roundtrip could cause a scheduled
  auto-continue to silently never fire.
- `AdvanceOrgEpoch` no longer fails with "missing argument with index 5".
- `TruncateAll` now clears `device_authorizations` and
  `cli_authorization_codes`, so expired grants no longer leak across test
  suite subtests.
- Follow-up work to fully mechanize the flooring/formatting choke points is
  tracked in #303.
