### PR TITLE
Enforce DATETIME/timestamptz flooring and canonicalization via types

### DIFF
--- a/backend/cmd/leapmux/admin_test.go
+++ b/backend/cmd/leapmux/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/storeopen"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 // testAdminCtx is the dummy adminCmdCtx tests pass to leaf functions. The Path
@@ -93,7 +94,7 @@ func createTestSession(t *testing.T, q *gendb.Queries, userID string, expiresAt 
 	err := q.CreateUserSession(context.Background(), gendb.CreateUserSessionParams{
 		ID:        sessionID,
 		UserID:    userID,
-		ExpiresAt: expiresAt.Truncate(time.Millisecond),
+		ExpiresAt: sqltime.NewSQLiteTime(expiresAt),
 		UserAgent: "test",
 		IpAddress: "127.0.0.1",
 	})
@@ -1518,7 +1519,7 @@ func createTestRegKey(t *testing.T, q *gendb.Queries, createdBy string, expiresA
 	err := q.CreateRegistrationKey(context.Background(), gendb.CreateRegistrationKeyParams{
 		ID:        regID,
 		CreatedBy: createdBy,
-		ExpiresAt: expiresAt.UTC().Truncate(time.Millisecond),
+		ExpiresAt: sqltime.NewSQLiteTime(expiresAt),
 	})
 	require.NoError(t, err)
 	return regID
@@ -1544,7 +1545,7 @@ func TestCLI_WorkerRegKeyList_HidesExpiredByDefault(t *testing.T) {
 
 	_, q = openTestDB(t, dir)
 	got, err := q.ListRegistrationKeysAdmin(context.Background(), gendb.ListRegistrationKeysAdminParams{
-		Now:   time.Now().UTC(),
+		Now:   sqltime.NewSQLiteTime(time.Now().UTC()),
 		Limit: 50,
 	})
 	require.NoError(t, err)
@@ -1638,7 +1639,7 @@ func TestCLI_UserUpdate_ClearPendingEmail(t *testing.T) {
 		ID:                    user.ID,
 		PendingEmail:          "alice-new@example.com",
 		PendingEmailToken:     "ABC123",
-		PendingEmailExpiresAt: sql.NullTime{Time: expires, Valid: true},
+		PendingEmailExpiresAt: sqltime.SQLiteNullTimeOf(expires),
 	}))
 
 	// PendingEmail and PendingEmailToken are plain strings in the

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	golang.org/x/tools v0.45.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.52.0
@@ -319,7 +320,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/backend/internal/hub/store/generated_params_internal_test.go
+++ b/backend/internal/hub/store/generated_params_internal_test.go
@@ -1,0 +1,385 @@
+package store
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+// Import paths of the four sqlc-generated packages (the three hub dialects
+// plus the worker) whose param/result structs the guards below inspect.
+const (
+	sqliteGenPkg   = "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	mysqlGenPkg    = "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	postgresGenPkg = "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	workerGenPkg   = "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// TestGeneratedInterfaceParamsAreAllowlisted type-checks every sqlc-generated
+// package (the three hub dialects plus the worker) via go/packages and fails
+// if a generated struct carries an interface{} field that is not on the
+// explicit allowlist below.
+//
+// Why: the sqltime/pgtime db_type overrides retype every DATETIME/timestamptz
+// param and result column mechanically, so a raw time.Time bind is a compile
+// error -- EXCEPT where sqlc emits interface{} (narg-in-OR-chain keyset
+// params, decltype-losing expressions). Those fields fall outside the
+// compile-time guarantee and are safe only because their fill sites bind
+// valuer types by convention. This scan pins the set of such holes: a new
+// query whose param or result lands as interface{} (a new cursor OR-chain, an
+// aggregate or CASE expression that lost its decltype) fails here and forces
+// a conscious decision -- type it (db_type/column override, CAST, or a typed
+// builder like the dialects' withCursor closures) or extend the allowlist
+// with a comment saying why it cannot be typed.
+func TestGeneratedInterfaceParamsAreAllowlisted(t *testing.T) {
+	// Field names that are interface{} today, per generated package, each with
+	// a reason it cannot be typed by the overrides:
+	allowlist := map[string]map[string]string{
+		sqliteGenPkg: {
+			"CursorTime": "keyset narg IS NULL OR-chain; fed sqltime.SQLiteNullTime by the typed withCursor closure",
+			"Now":        "registration-key expiry narg OR-chain; fed sqltime.SQLiteNullTime by the typed builder",
+			"Query":      "search LIKE narg OR-chain; fed a *string-derived pattern",
+			"ClientType": "narg OR-chain over a text column",
+			"TabType":    "narg OR-chain over a text column",
+		},
+		mysqlGenPkg: {
+			"LeaseMillis": "arithmetic expression param; not a timestamp",
+		},
+		postgresGenPkg: {},
+		workerGenPkg:   {},
+	}
+
+	patterns := make([]string, 0, len(allowlist))
+	for pkgPath := range allowlist {
+		patterns = append(patterns, pkgPath)
+	}
+	sort.Strings(patterns)
+
+	// Types only: the scan reads package-scope struct fields, not syntax.
+	pkgs := loadPackages(t, &packages.Config{Mode: packages.NeedName | packages.NeedTypes}, patterns...)
+	require.Len(t, pkgs, len(allowlist),
+		"expected one loaded package per generated import path %v -- run `task generate-sqlc` if a generated dir is missing", patterns)
+
+	for _, pkg := range pkgs {
+		allowed, ok := allowlist[pkg.PkgPath]
+		require.True(t, ok, "packages.Load returned unexpected package %s", pkg.PkgPath)
+		seen := map[string]bool{}
+		scope := pkg.Types.Scope()
+		for _, typeName := range scope.Names() {
+			tn, ok := scope.Lookup(typeName).(*types.TypeName)
+			if !ok {
+				continue
+			}
+			st, ok := types.Unalias(tn.Type()).Underlying().(*types.Struct)
+			if !ok {
+				continue
+			}
+			for i := 0; i < st.NumFields(); i++ {
+				field := st.Field(i)
+				if !isEmptyInterface(field.Type()) {
+					continue
+				}
+				seen[field.Name()] = true
+				if _, ok := allowed[field.Name()]; !ok {
+					assert.Fail(t, "untyped generated field",
+						"%s: field %s.%s is interface{} -- it escapes the sqltime/pgtime compile-time guarantee; type it (db_type/column override, CAST, typed builder) or allowlist it with a reason (see %s)",
+						pkg.PkgPath, typeName, field.Name(), pkg.Fset.Position(field.Pos()))
+				}
+			}
+		}
+		// Keep the allowlist honest: a fixed hole that got typed should be
+		// removed here so the list never overstates the exceptions.
+		for name := range allowed {
+			assert.True(t, seen[name],
+				"%s: allowlisted field %s no longer exists as interface{} -- remove the stale entry", pkg.PkgPath, name)
+		}
+	}
+}
+
+// TestNoRawTimeBindsIntoInterfaceParams type-checks all non-generated store
+// and worker code and fails on any raw time.Time, *time.Time, or
+// database/sql.NullTime value (matched by static type) headed into an untyped
+// bind: a struct composite literal filling an empty-interface field, an
+// assignment whose target is an empty interface (a generated interface{}
+// param field, a map[...]any entry), a `var x any = ...` declaration, an
+// append into a []any slice, or any argument of an
+// Exec/Query/QueryRow(Context) call (the raw-SQL write paths, e.g.
+// sqlutil.BulkUpsertTabs, that bypass sqlc-generated params entirely).
+//
+// Why: the interface{} params pinned by
+// TestGeneratedInterfaceParamsAreAllowlisted (the keyset CursorTime, the
+// registration-key Now) and the hand-assembled ExecContext arg slices sit
+// outside the sqltime/pgtime compile-time guarantee: `CursorTime: ct.Time`
+// or `args = append(args, r.SomeAt)` compiles fine but hands the driver a raw
+// time.Time, which binds the driver's default layout instead of the canonical
+// storage form and silently corrupts the raw-string keyset compares.
+// sql.NullTime is equally wrong -- its Value() emits the inner raw time.Time.
+// Only driver-valuer types (sqltime.SQLiteNullTime, pgtime.*, etc.; see
+// internal/util/sqltime) may cross these binds.
+//
+// Coverage is stated precisely: the scan matches by STATIC type at the sites
+// go/types can see. A raw time already laundered through an intermediate
+// empty interface (a helper returning any, a multi-value assignment from a
+// function call) is invisible to any static scan -- at that point the
+// expression's type is interface{}, indistinguishable from a legitimate
+// value. The allowlist test above pins WHICH generated fields are untyped;
+// this scan closes every syntactic path a statically-typed raw time can take
+// into an untyped bind.
+//
+// Test files are scanned too (Tests: true): a fixture binding a raw time.Time
+// into an interface{} param would mask the same corruption in whatever the
+// test asserts. Keyed and positional literals are both covered; the scan is
+// deliberately not limited to generated param structs, since binding a raw
+// time into ANY empty-interface sink in these trees is the same layout
+// hazard.
+func TestNoRawTimeBindsIntoInterfaceParams(t *testing.T) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedTypes | packages.NeedSyntax |
+			packages.NeedTypesInfo | packages.NeedDeps,
+		Tests: true,
+	}
+	pkgs := loadPackages(t, cfg,
+		"github.com/leapmux/leapmux/internal/hub/store/...",
+		"github.com/leapmux/leapmux/internal/worker/...",
+	)
+
+	// With Tests: true a source file is type-checked twice when its package
+	// has internal tests (once as the plain package, once as the test
+	// variant), so violations are keyed by position to dedupe the reports.
+	violations := map[string]string{}
+	for _, pkg := range pkgs {
+		// Generated packages only DECLARE the interface{} fields (pinned by the
+		// allowlist test above); the fill sites live in hand-written code. The
+		// synthesized ".test" main packages contain no hand-written binds.
+		if strings.Contains(pkg.PkgPath, "/generated/") || strings.HasSuffix(pkg.PkgPath, ".test") {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.CompositeLit:
+					st := structUnder(pkg.TypesInfo.TypeOf(node))
+					if st == nil {
+						return true
+					}
+					for i, elt := range node.Elts {
+						field, value := literalField(pkg.TypesInfo, st, i, elt)
+						if field == nil || !isEmptyInterface(field.Type()) {
+							continue
+						}
+						flagRawTime(pkg, violations, value, "interface{} field "+field.Name())
+					}
+				case *ast.AssignStmt:
+					// Pairwise x = y only. A multi-value assignment from a
+					// function call carries the callee's typed results; a raw
+					// time can only reach an interface{} target there via a
+					// helper that already returns any, which no static scan
+					// can see (documented limitation above).
+					if len(node.Lhs) != len(node.Rhs) {
+						return true
+					}
+					for i, lhs := range node.Lhs {
+						if t := pkg.TypesInfo.TypeOf(lhs); t == nil || !isEmptyInterface(t) {
+							continue
+						}
+						flagRawTime(pkg, violations, node.Rhs[i], "interface{} assignment target")
+					}
+				case *ast.ValueSpec:
+					// var x any = rawTime -- the laundering declaration itself.
+					// An untyped `var x = rawTime` keeps the value's own type
+					// and needs no check here.
+					if node.Type == nil {
+						return true
+					}
+					if t := pkg.TypesInfo.TypeOf(node.Type); t == nil || !isEmptyInterface(t) {
+						return true
+					}
+					for _, v := range node.Values {
+						flagRawTime(pkg, violations, v, "interface{} variable declaration")
+					}
+				case *ast.CallExpr:
+					switch fun := node.Fun.(type) {
+					case *ast.Ident:
+						// Builtin append into a []any (the hand-assembled
+						// ExecContext arg slices). append(a, b...) is safe:
+						// the spread arg is a slice, never a raw time.
+						if obj, ok := pkg.TypesInfo.Uses[fun].(*types.Builtin); !ok || obj.Name() != "append" || len(node.Args) < 2 {
+							return true
+						}
+						t := pkg.TypesInfo.TypeOf(node.Args[0])
+						if t == nil {
+							return true
+						}
+						sl, ok := types.Unalias(t).Underlying().(*types.Slice)
+						if !ok || !isEmptyInterface(sl.Elem()) {
+							return true
+						}
+						for _, arg := range node.Args[1:] {
+							flagRawTime(pkg, violations, arg, "append into []any")
+						}
+					case *ast.SelectorExpr:
+						// Variadic driver binds passed directly to a query
+						// method. Matching by method name is deliberately
+						// broad: a raw time argument to ANY method with these
+						// names in the store/worker trees is the same layout
+						// hazard, and false positives are impossible for
+						// legitimate code (a raw time has no valid use there).
+						if !rawBindMethods[fun.Sel.Name] {
+							return true
+						}
+						for _, arg := range node.Args {
+							flagRawTime(pkg, violations, arg, fun.Sel.Name+" argument")
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	keys := make([]string, 0, len(violations))
+	for key := range violations {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		assert.Fail(t, "raw time bind into interface{} param", "%s", violations[key])
+	}
+}
+
+// rawBindMethods are the database/sql-shaped query methods whose variadic
+// args reach a driver bind directly, bypassing sqlc-generated params (the
+// sqlutil.BulkUpsertTabs / sessions Touch raw-SQL paths).
+var rawBindMethods = map[string]bool{
+	"Exec": true, "ExecContext": true,
+	"Query": true, "QueryContext": true,
+	"QueryRow": true, "QueryRowContext": true,
+}
+
+// flagRawTime records a violation when the expression's static type is one of
+// the raw-time shapes (see rawTimeTypeName); sink names where the value was
+// headed, and the position key dedupes the Tests:true double type-check.
+func flagRawTime(pkg *packages.Package, violations map[string]string, value ast.Expr, sink string) {
+	badType, ok := rawTimeTypeName(pkg.TypesInfo.TypeOf(value))
+	if !ok {
+		return
+	}
+	pos := pkg.Fset.Position(value.Pos())
+	violations[fmt.Sprintf("%s:%d:%d %s", pos.Filename, pos.Line, pos.Column, sink)] = fmt.Sprintf(
+		"%s: %s bound into %s -- this sink requires a driver-valuer type (sqltime.SQLiteNullTime etc.; see internal/util/sqltime), never a raw time value: a raw bind uses the driver's default layout and silently breaks the canonical-storage keyset compares",
+		pos, badType, sink)
+}
+
+// loadPackages runs packages.Load and fails the test loudly on any load,
+// parse, or type error anywhere in the returned graph: a broken load must
+// never let a guard pass vacuously.
+func loadPackages(t *testing.T, cfg *packages.Config, patterns ...string) []*packages.Package {
+	t.Helper()
+	pkgs, err := packages.Load(cfg, patterns...)
+	require.NoError(t, err, "packages.Load %v", patterns)
+	var loadErrs []string
+	packages.Visit(pkgs, nil, func(pkg *packages.Package) {
+		for _, e := range pkg.Errors {
+			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", pkg.PkgPath, e))
+		}
+	})
+	require.Empty(t, loadErrs,
+		"packages.Load %v reported errors (if a generated package is missing, run `task generate-sqlc` first)", patterns)
+	return pkgs
+}
+
+// structUnder resolves a composite literal's type down to its struct shape,
+// unwrapping aliases, one level of pointer (elided &T-element literals), and
+// named types. Returns nil when the literal is not a struct (slice, map,
+// array literals).
+func structUnder(t types.Type) *types.Struct {
+	if t == nil {
+		return nil
+	}
+	t = types.Unalias(t)
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+	}
+	st, ok := t.Underlying().(*types.Struct)
+	if !ok {
+		return nil
+	}
+	return st
+}
+
+// literalField resolves which struct field the i-th composite-literal element
+// fills -- keyed literals via the type-checker's field object for the key,
+// positional literals via field order -- and returns it with the value
+// expression being bound. Returns nils for elements that resolve to no field
+// (which the type checker rejects anyway).
+func literalField(info *types.Info, st *types.Struct, i int, elt ast.Expr) (*types.Var, ast.Expr) {
+	if kv, ok := elt.(*ast.KeyValueExpr); ok {
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			return nil, nil
+		}
+		if field, ok := info.Uses[key].(*types.Var); ok {
+			return field, kv.Value
+		}
+		// Fallback if the type checker recorded no object for the key:
+		// match the field by name.
+		for j := 0; j < st.NumFields(); j++ {
+			if st.Field(j).Name() == key.Name {
+				return st.Field(j), kv.Value
+			}
+		}
+		return nil, nil
+	}
+	if i < st.NumFields() {
+		return st.Field(i), elt
+	}
+	return nil, nil
+}
+
+// rawTimeTypeName reports whether t is one of the raw-time shapes that must
+// never cross an interface{} bind -- time.Time, *time.Time, or
+// database/sql.NullTime (pointer or value; its Value() emits the inner raw
+// time.Time). Matching is by defining package path + type name, never by
+// string suffix, so a local type that happens to be named Time cannot be
+// confused with time.Time.
+func rawTimeTypeName(t types.Type) (string, bool) {
+	if t == nil {
+		return "", false
+	}
+	t = types.Unalias(t)
+	prefix := ""
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+		prefix = "*"
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return "", false
+	}
+	obj := named.Obj()
+	if obj.Pkg() == nil {
+		return "", false
+	}
+	switch path, name := obj.Pkg().Path(), obj.Name(); {
+	case path == "time" && name == "Time":
+		return prefix + "time.Time", true
+	case path == "database/sql" && name == "NullTime":
+		return prefix + "sql.NullTime", true
+	}
+	return "", false
+}
+
+// isEmptyInterface reports whether t is the empty interface (interface{} or
+// its alias any, or a defined type whose underlying is the empty interface)
+// -- the shape sqlc emits when it cannot resolve a param or column type.
+func isEmptyInterface(t types.Type) bool {
+	iface, ok := types.Unalias(t).Underlying().(*types.Interface)
+	return ok && iface.Empty()
+}

--- a/backend/internal/hub/store/mysql/api_tokens.go
+++ b/backend/internal/hub/store/mysql/api_tokens.go
@@ -9,6 +9,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type apiTokenStore struct{ conn *mysqlConn }
@@ -24,15 +25,15 @@ func fromDBAPIToken(t gendb.ApiToken) store.APIToken {
 		SecretHash:               t.SecretHash,
 		RefreshHash:              t.RefreshHash,
 		PreviousRefreshHash:      t.PreviousRefreshHash,
-		PreviousRefreshExpiresAt: sqlutil.NullTimePtr(t.PreviousRefreshExpiresAt),
+		PreviousRefreshExpiresAt: t.PreviousRefreshExpiresAt.Ptr(),
 		Scope:                    t.Scope,
-		CreatedAt:                t.CreatedAt,
+		CreatedAt:                t.CreatedAt.Time,
 		AuthGeneration:           t.AuthGeneration,
-		LastUsedAt:               sqlutil.NullTimePtr(t.LastUsedAt),
-		LastRotatedAt:            sqlutil.NullTimePtr(t.LastRotatedAt),
-		ExpiresAt:                sqlutil.NullTimePtr(t.ExpiresAt),
-		RefreshExpiresAt:         sqlutil.NullTimePtr(t.RefreshExpiresAt),
-		RevokedAt:                sqlutil.NullTimePtr(t.RevokedAt),
+		LastUsedAt:               t.LastUsedAt.Ptr(),
+		LastRotatedAt:            t.LastRotatedAt.Ptr(),
+		ExpiresAt:                t.ExpiresAt.Ptr(),
+		RefreshExpiresAt:         t.RefreshExpiresAt.Ptr(),
+		RevokedAt:                t.RevokedAt.Ptr(),
 	}
 }
 
@@ -46,8 +47,8 @@ func (s *apiTokenStore) Create(ctx context.Context, p store.CreateAPITokenParams
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
 			Scope:            p.Scope,
-			ExpiresAt:        sqlutil.BindNullTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqltime.NewMySQLNullTime(p.ExpiresAt),
+			RefreshExpiresAt: sqltime.NewMySQLNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -137,11 +138,11 @@ func (s *apiTokenStore) RotateRefresh(ctx context.Context, p store.RotateAPIToke
 		n, err := rowsAffected(conn.q.RotateAPITokenRefresh(ctx, gendb.RotateAPITokenRefreshParams{
 			ID:                   p.ID,
 			NewSecretHash:        p.NewSecretHash,
-			NewExpiresAt:         sqlutil.BindNullTime(p.NewExpiresAt),
+			NewExpiresAt:         sqltime.NewMySQLNullTime(p.NewExpiresAt),
 			NewRefreshHash:       p.NewRefreshHash,
-			NewRefreshExpiresAt:  sqlutil.BindNullTime(p.NewRefreshExpiresAt),
+			NewRefreshExpiresAt:  sqltime.NewMySQLNullTime(p.NewRefreshExpiresAt),
 			PrevRefreshHash:      p.PreviousRefreshHash,
-			PrevRefreshExpiresAt: sqlutil.BindNullTime(p.PreviousRefreshExpiresAt),
+			PrevRefreshExpiresAt: sqltime.NewMySQLNullTime(p.PreviousRefreshExpiresAt),
 		}))
 		if err != nil || n == 0 {
 			return nil, err
@@ -176,7 +177,7 @@ func (s *apiTokenStore) Revoke(ctx context.Context, id string) (int64, error) {
 		}
 		n, err := rowsAffected(conn.q.RevokeAPITokenAt(ctx, gendb.RevokeAPITokenAtParams{
 			ID:        row.ID,
-			RevokedAt: sql.NullTime{Time: revokedAt, Valid: true},
+			RevokedAt: sqltime.MySQLNullTimeOf(revokedAt),
 		}))
 		if err != nil {
 			return nil, err

--- a/backend/internal/hub/store/mysql/cleanup.go
+++ b/backend/internal/hub/store/mysql/cleanup.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type cleanupStore struct {
@@ -19,27 +19,27 @@ func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, er
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, sqlutil.BindTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, sqltime.NewMySQLTime(cutoff)))
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteOrgsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
@@ -51,23 +51,23 @@ func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (in
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqlutil.BindTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewMySQLTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqlutil.BindTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewMySQLTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqlutil.BindTimeValid(cutoff)))
+	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqlutil.BindTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewMySQLTime(cutoff)))
 }
 
 func (s *cleanupStore) CompactPublishedRevocationEvents(

--- a/backend/internal/hub/store/mysql/cli_authorization_codes.go
+++ b/backend/internal/hub/store/mysql/cli_authorization_codes.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type cliAuthorizationCodeStore struct{ conn *mysqlConn }
@@ -18,9 +18,9 @@ func fromDBCLIAuthorizationCode(c gendb.CliAuthorizationCode) store.CLIAuthoriza
 		UserID:        c.UserID,
 		CodeChallenge: c.CodeChallenge,
 		DeviceName:    c.DeviceName,
-		CreatedAt:     c.CreatedAt,
-		ExpiresAt:     c.ExpiresAt,
-		ConsumedAt:    sqlutil.NullTimePtr(c.ConsumedAt),
+		CreatedAt:     c.CreatedAt.Time,
+		ExpiresAt:     c.ExpiresAt.Time,
+		ConsumedAt:    c.ConsumedAt.Ptr(),
 	}
 }
 
@@ -30,7 +30,7 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 		UserID:        p.UserID,
 		CodeChallenge: p.CodeChallenge,
 		DeviceName:    p.DeviceName,
-		ExpiresAt:     sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:     sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/convert.go
+++ b/backend/internal/hub/store/mysql/convert.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -13,6 +12,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 // mysqlErrDupEntry is the MySQL error number for duplicate-key violations.
@@ -39,29 +39,28 @@ func rowsAffected(result sql.Result, err error) (int64, error) {
 }
 
 // decodeCursorParams decodes the composite list cursor into the two nullable sqlc
-// parameters MySQL's keyset queries bind: the cursor timestamp (truncated to
-// the DATETIME(3) columns' millisecond precision) and the id tiebreaker. An
-// empty cursor (first page) returns the zero values so the queries'
-// "cursor_time IS NULL" branch selects every row. The id comparison collates
-// byte-wise via the table-level COLLATE=utf8mb4_bin declared in the migration.
+// parameters MySQL's keyset queries bind: the cursor timestamp and the id
+// tiebreaker. An empty cursor (first page) returns the zero values so the
+// queries' "cursor_time IS NULL" branch selects every row (an invalid
+// MySQLNullTime binds NULL). The id comparison collates byte-wise via the
+// table-level COLLATE=utf8mb4_bin declared in the migration.
 //
-// The timestamp is truncated (not rounded) to milliseconds to match the
-// DATETIME(3) columns: the driver serializes a time.Time param with full
-// sub-millisecond digits, and a hand-crafted cursor carrying any would make
-// the "=" tiebreak branch unsatisfiable while "<" still matched the boundary
-// row, re-returning the previous page's tail as duplicates. EncodeCursor
-// produces cursors from DB-scanned rows (already millisecond-quantized), so
-// this is a no-op for real cursors.
-func decodeCursorParams(cursor string) (sql.NullTime, sql.NullString, error) {
+// The timestamp is a MySQLNullTime, whose Value() floors (not rounds) to
+// milliseconds to match the DATETIME(3) columns: a hand-crafted cursor carrying
+// sub-millisecond digits would otherwise make the "=" tiebreak branch
+// unsatisfiable while "<" still matched the boundary row, re-returning the
+// previous page's tail as duplicates. EncodeCursor produces cursors from
+// DB-scanned rows (already millisecond-quantized), so this is a no-op for real
+// cursors.
+func decodeCursorParams(cursor string) (sqltime.MySQLNullTime, sql.NullString, error) {
 	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return sql.NullTime{}, sql.NullString{}, err
+		return sqltime.MySQLNullTime{}, sql.NullString{}, err
 	}
 	if c == nil {
-		return sql.NullTime{}, sql.NullString{}, nil
+		return sqltime.MySQLNullTime{}, sql.NullString{}, nil
 	}
-	ms := c.Time.Truncate(time.Millisecond)
-	return sql.NullTime{Time: ms, Valid: true}, sql.NullString{String: c.ID, Valid: true}, nil
+	return sqltime.MySQLNullTimeOf(c.Time), sql.NullString{String: c.ID, Valid: true}, nil
 }
 
 // withCursor decodes the composite list cursor and applies the dialect's
@@ -71,7 +70,7 @@ func decodeCursorParams(cursor string) (sql.NullTime, sql.NullString, error) {
 // column requires) here means a change to the cursor decode, the clamp rule, or
 // the probe-row accounting edits ONE site instead of being copy-pasted across
 // every list builder.
-func withCursor[T any](cursor string, limit int64, fill func(cursorTime sql.NullTime, cursorID sql.NullString, fetchLimit int32) T) (T, error) {
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime sqltime.MySQLNullTime, cursorID sql.NullString, fetchLimit int32) T) (T, error) {
 	cursorTime, cursorID, err := decodeCursorParams(cursor)
 	if err != nil {
 		var zero T
@@ -95,13 +94,13 @@ func queryPage[P any, R any, I store.PageCursorer](
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllUsersParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllUsersParams {
 		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.SearchUsersParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.SearchUsersParams {
 		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
 		// '%') at the one shared site, so the match is case-insensitive and literal
 		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
@@ -115,7 +114,7 @@ func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchU
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersByUserIDParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListWorkersByUserIDParams {
 		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -123,7 +122,7 @@ func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.
 // listWorkersAdminParams builds the status=nil, user_id=nil query
 // (ListWorkersAdmin): deleted_at IS NULL, no user filter.
 func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminParams {
 		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -131,7 +130,7 @@ func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminP
 // listWorkersAdminByUserParams builds the status=nil, user_id=set query
 // (ListWorkersAdminByUser): deleted_at IS NULL + required registered_by.
 func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserParams {
 		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -140,7 +139,7 @@ func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (ge
 // (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
 // soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByStatusParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByStatusParams {
 		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -148,77 +147,77 @@ func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string
 // listWorkersAdminByUserAndStatusParams builds the status=set, user_id=set
 // query (ListWorkersAdminByUserAndStatus): required registered_by + status.
 func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
 		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllActiveSessionsParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllActiveSessionsParams {
 		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListUserSessionsByUserIDParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListUserSessionsByUserIDParams {
 		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensParams {
 		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserParams {
 		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
 		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
 		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensParams {
 		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserParams {
 		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 // listRegistrationKeysAdminParams mirrors the other list builders so the
 // registration-key admin listing shares the cursor decode and limit clamp.
-// now is the caller-computed expiry probe (zero NullTime when expired rows are
-// included), passed in so the builder stays a pure function of its arguments.
-func listRegistrationKeysAdminParams(cursor string, limit int64, now sql.NullTime) (gendb.ListRegistrationKeysAdminParams, error) {
-	return withCursor(cursor, limit, func(ct sql.NullTime, cid sql.NullString, fl int32) gendb.ListRegistrationKeysAdminParams {
+// now is the caller-computed expiry probe (invalid MySQLNullTime when expired
+// rows are included), passed in so the builder stays a pure function of its arguments.
+func listRegistrationKeysAdminParams(cursor string, limit int64, now sqltime.MySQLNullTime) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListRegistrationKeysAdminParams {
 		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/mysql/delegation_tokens.go
+++ b/backend/internal/hub/store/mysql/delegation_tokens.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type delegationTokenStore struct{ conn *mysqlConn }
@@ -27,12 +27,12 @@ func fromDBDelegationToken(t gendb.DelegationToken) store.DelegationToken {
 		IssuedForTabType: t.IssuedForTabType,
 		SecretHash:       t.SecretHash,
 		RefreshHash:      t.RefreshHash,
-		CreatedAt:        t.CreatedAt,
+		CreatedAt:        t.CreatedAt.Time,
 		AuthGeneration:   t.AuthGeneration,
-		LastUsedAt:       sqlutil.NullTimePtr(t.LastUsedAt),
-		ExpiresAt:        t.ExpiresAt,
-		RefreshExpiresAt: sqlutil.NullTimePtr(t.RefreshExpiresAt),
-		RevokedAt:        sqlutil.NullTimePtr(t.RevokedAt),
+		LastUsedAt:       t.LastUsedAt.Ptr(),
+		ExpiresAt:        t.ExpiresAt.Time,
+		RefreshExpiresAt: t.RefreshExpiresAt.Ptr(),
+		RevokedAt:        t.RevokedAt.Ptr(),
 	}
 }
 
@@ -49,8 +49,8 @@ func (s *delegationTokenStore) Create(ctx context.Context, p store.CreateDelegat
 			IssuedForTabType: p.IssuedForTabType,
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
-			ExpiresAt:        sqlutil.BindTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqltime.NewMySQLTime(p.ExpiresAt),
+			RefreshExpiresAt: sqltime.NewMySQLNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -148,7 +148,7 @@ func (s *delegationTokenStore) Revoke(ctx context.Context, id string) (int64, er
 		}
 		n, err := rowsAffected(conn.q.RevokeDelegationTokenAt(ctx, gendb.RevokeDelegationTokenAtParams{
 			ID:        row.ID,
-			RevokedAt: sql.NullTime{Time: revokedAt, Valid: true},
+			RevokedAt: sqltime.MySQLNullTimeOf(revokedAt),
 		}))
 		if err != nil {
 			return nil, err

--- a/backend/internal/hub/store/mysql/device_authorizations.go
+++ b/backend/internal/hub/store/mysql/device_authorizations.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type deviceAuthorizationStore struct{ conn *mysqlConn }
@@ -20,11 +20,11 @@ func fromDBDeviceAuthorization(d gendb.DeviceAuthorization) store.DeviceAuthoriz
 		DeviceName:      d.DeviceName,
 		UserID:          d.UserID.String,
 		Approved:        int64(d.Approved),
-		LastPolledAt:    sqlutil.NullTimePtr(d.LastPolledAt),
+		LastPolledAt:    d.LastPolledAt.Ptr(),
 		IntervalSeconds: int64(d.IntervalSeconds),
-		CreatedAt:       d.CreatedAt,
-		ExpiresAt:       d.ExpiresAt,
-		ConsumedAt:      sqlutil.NullTimePtr(d.ConsumedAt),
+		CreatedAt:       d.CreatedAt.Time,
+		ExpiresAt:       d.ExpiresAt.Time,
+		ConsumedAt:      d.ConsumedAt.Ptr(),
 	}
 }
 
@@ -34,7 +34,7 @@ func (s *deviceAuthorizationStore) Create(ctx context.Context, p store.CreateDev
 		UserCode:        p.UserCode,
 		DeviceName:      p.DeviceName,
 		IntervalSeconds: int32(p.IntervalSeconds),
-		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:       sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/lifecycle_outbox.go
+++ b/backend/internal/hub/store/mysql/lifecycle_outbox.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type lifecycleOutboxStore struct {
@@ -38,8 +38,8 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 			OrgID:      r.OrgID,
 			OpType:     r.OpType,
 			Payload:    r.Payload,
-			EnqueuedAt: r.EnqueuedAt,
-			ConsumedAt: sqlutil.NullTimePtr(r.ConsumedAt),
+			EnqueuedAt: r.EnqueuedAt.Time,
+			ConsumedAt: r.ConsumedAt.Ptr(),
 		}
 	}
 	return out, nil
@@ -48,10 +48,10 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 func (s *lifecycleOutboxStore) MarkConsumed(ctx context.Context, p store.MarkLifecycleOutboxConsumedParams) error {
 	return mapErr(s.conn.q.MarkLifecycleOutboxConsumed(ctx, gendb.MarkLifecycleOutboxConsumedParams{
 		ID:         p.ID,
-		ConsumedAt: sqlutil.BindTimeValid(p.ConsumedAt),
+		ConsumedAt: sqltime.MySQLNullTimeOf(p.ConsumedAt),
 	}))
 }
 
 func (s *lifecycleOutboxStore) DeleteConsumedBefore(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sqlutil.BindTimeValid(before)))
+	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sqltime.MySQLNullTimeOf(before)))
 }

--- a/backend/internal/hub/store/mysql/mysql_test.go
+++ b/backend/internal/hub/store/mysql/mysql_test.go
@@ -137,3 +137,62 @@ func TestMySQLBinaryCollationLive(t *testing.T) {
 			"table %s must carry the utf8mb4_bin collation; the cursor id tiebreak relies on byte-wise collation", table)
 	}
 }
+
+// TestMySQLDatetimeColumnsLive asserts, against information_schema of the
+// actual migrated database, that every `_at` column resolves to DATETIME with
+// precision 3..6 and that no column of any name resolves to DATETIME or
+// TIMESTAMP without being `_at`-named (TIMESTAMP is banned outright for its
+// session-timezone semantics). This is the live twin of the static source scan
+// in schema_internal_test.go (TestEveryTimestampColumnDeclaresDatetime): the
+// static scan runs without Docker but reads only 00001_initial.sql with a
+// line-shape-sensitive text parse, while this one is migration-count-agnostic
+// and reads the server's resolved column types. Precision below 3 matters
+// because MySQL ROUNDS a fractional second exceeding the column precision, so
+// a DATETIME(0..2) column could store an instant after the ms-floored bound
+// the sqltime valuers guarantee.
+func TestMySQLDatetimeColumnsLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	dsn := startMySQLContainer(t)
+
+	st, err := mysqlstore.OpenTestable(config.MySQLConfig{DSN: dsn})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(ctx))
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, column_name, data_type, COALESCE(datetime_precision, 0)
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE()
+		  AND table_name <> 'goose_db_version'
+		  AND (column_name LIKE '%\_at' OR data_type IN ('datetime', 'timestamp'))
+		ORDER BY table_name, ordinal_position`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	atColumns := 0
+	for rows.Next() {
+		var table, column, dataType string
+		var precision int
+		require.NoError(t, rows.Scan(&table, &column, &dataType, &precision))
+		if strings.HasSuffix(column, "_at") {
+			atColumns++
+			assert.Equalf(t, "datetime", dataType,
+				"%s.%s resolved to %s; `_at` columns must be DATETIME so the sqlc db_type override retypes them to the flooring valuer", table, column, dataType)
+			assert.Truef(t, precision >= 3 && precision <= 6,
+				"%s.%s resolved to DATETIME(%d); precision must be 3..6 so the column can hold the ms-floored instant (below 3, MySQL ROUNDS past the floor)", table, column, precision)
+		} else {
+			assert.Failf(t, "misnamed time column",
+				"%s.%s resolved to %s; time columns must be named *_at (and TIMESTAMP is banned outright)", table, column, dataType)
+		}
+	}
+	require.NoError(t, rows.Err())
+	assert.Greater(t, atColumns, 20, "expected many _at columns in the migrated schema; got %d", atColumns)
+}

--- a/backend/internal/hub/store/mysql/oauth_providers.go
+++ b/backend/internal/hub/store/mysql/oauth_providers.go
@@ -24,7 +24,7 @@ func fromDBOAuthProvider(p gendb.OauthProvider) *store.OAuthProvider {
 			Scopes:       p.Scopes,
 			TrustEmail:   p.TrustEmail,
 			Enabled:      p.Enabled,
-			CreatedAt:    p.CreatedAt,
+			CreatedAt:    p.CreatedAt.Time,
 		},
 		ClientSecret: p.ClientSecret,
 	}
@@ -44,7 +44,7 @@ func fromDBListEnabledOAuthProvidersRow(r gendb.ListEnabledOAuthProvidersRow) st
 		Scopes:       r.Scopes,
 		TrustEmail:   r.TrustEmail,
 		Enabled:      r.Enabled,
-		CreatedAt:    r.CreatedAt,
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 
@@ -58,7 +58,7 @@ func fromDBListAllOAuthProvidersRow(r gendb.ListAllOAuthProvidersRow) store.OAut
 		Scopes:       r.Scopes,
 		TrustEmail:   r.TrustEmail,
 		Enabled:      r.Enabled,
-		CreatedAt:    r.CreatedAt,
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/mysql/oauth_states.go
+++ b/backend/internal/hub/store/mysql/oauth_states.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type oauthStateStore struct {
@@ -20,8 +20,8 @@ func fromDBOAuthState(s gendb.OauthState) *store.OAuthState {
 		ProviderID:   s.ProviderID,
 		PkceVerifier: s.PkceVerifier,
 		RedirectURI:  s.RedirectUri,
-		ExpiresAt:    s.ExpiresAt,
-		CreatedAt:    s.CreatedAt,
+		ExpiresAt:    s.ExpiresAt.Time,
+		CreatedAt:    s.CreatedAt.Time,
 	}
 }
 
@@ -31,7 +31,7 @@ func (s *oauthStateStore) Create(ctx context.Context, p store.CreateOAuthStatePa
 		ProviderID:   p.ProviderID,
 		PkceVerifier: p.PkceVerifier,
 		RedirectUri:  p.RedirectURI,
-		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:    sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/oauth_tokens.go
+++ b/backend/internal/hub/store/mysql/oauth_tokens.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type oauthTokenStore struct {
@@ -21,9 +21,9 @@ func fromDBOAuthToken(t gendb.OauthToken) store.OAuthToken {
 		AccessToken:  t.AccessToken,
 		RefreshToken: t.RefreshToken,
 		TokenType:    t.TokenType,
-		ExpiresAt:    t.ExpiresAt,
+		ExpiresAt:    t.ExpiresAt.Time,
 		KeyVersion:   t.KeyVersion,
-		UpdatedAt:    t.UpdatedAt,
+		UpdatedAt:    t.UpdatedAt.Time,
 	}
 }
 
@@ -38,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
-		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:    sqltime.NewMySQLTime(p.ExpiresAt),
 		KeyVersion:   p.KeyVersion,
 	}))
 }

--- a/backend/internal/hub/store/mysql/oauth_user_links.go
+++ b/backend/internal/hub/store/mysql/oauth_user_links.go
@@ -18,7 +18,7 @@ func fromDBOAuthUserLink(l gendb.OauthUserLink) store.OAuthUserLink {
 		UserID:          l.UserID,
 		ProviderID:      l.ProviderID,
 		ProviderSubject: l.ProviderSubject,
-		CreatedAt:       l.CreatedAt,
+		CreatedAt:       l.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/mysql/org_op_batches.go
+++ b/backend/internal/hub/store/mysql/org_op_batches.go
@@ -60,7 +60,7 @@ func toOrgOpBatchRow(r gendb.OrgOpBatch) store.OrgOpBatchRow {
 		BatchPayload: r.BatchPayload,
 		OpCount:      int64(r.OpCount),
 		Epoch:        r.Epoch,
-		CommittedAt:  r.CommittedAt,
+		CommittedAt:  r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/mysql/org_recent_batch_ids.go
+++ b/backend/internal/hub/store/mysql/org_recent_batch_ids.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type orgRecentBatchIDStore struct {
@@ -35,7 +35,7 @@ func (s *orgRecentBatchIDStore) Get(ctx context.Context, orgID, batchID string) 
 		CanonicalClient:     row.CanonicalClient,
 		OpCount:             int64(row.OpCount),
 		Epoch:               row.Epoch,
-		ExpiresAt:           row.ExpiresAt,
+		ExpiresAt:           row.ExpiresAt.Time,
 	}, nil
 }
 
@@ -50,10 +50,10 @@ func (s *orgRecentBatchIDStore) Insert(ctx context.Context, p store.InsertOrgRec
 		CanonicalClient:     p.CanonicalClient,
 		OpCount:             int32(p.OpCount),
 		Epoch:               p.Epoch,
-		ExpiresAt:           sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:           sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 
 func (s *orgRecentBatchIDStore) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, sqlutil.BindTime(before)))
+	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, sqltime.NewMySQLTime(before)))
 }

--- a/backend/internal/hub/store/mysql/org_state.go
+++ b/backend/internal/hub/store/mysql/org_state.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type orgStateStore struct {
@@ -28,8 +28,8 @@ func (s *orgStateStore) Get(ctx context.Context, orgID string) (*store.OrgStateR
 		OrgID:          row.OrgID,
 		StatePayload:   row.StatePayload,
 		CurrentEpoch:   row.CurrentEpoch,
-		EpochStartedAt: row.EpochStartedAt,
-		UpdatedAt:      row.UpdatedAt,
+		EpochStartedAt: row.EpochStartedAt.Time,
+		UpdatedAt:      row.UpdatedAt.Time,
 	}, nil
 }
 
@@ -38,8 +38,8 @@ func (s *orgStateStore) Upsert(ctx context.Context, p store.UpsertOrgStateParams
 		OrgID:          p.OrgID,
 		StatePayload:   p.StatePayload,
 		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
-		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
+		EpochStartedAt: sqltime.NewMySQLTime(p.EpochStartedAt),
+		UpdatedAt:      sqltime.NewMySQLTime(p.UpdatedAt),
 	}))
 }
 
@@ -47,7 +47,7 @@ func (s *orgStateStore) AdvanceEpoch(ctx context.Context, p store.AdvanceOrgEpoc
 	return mapErr(s.conn.q.AdvanceOrgEpoch(ctx, gendb.AdvanceOrgEpochParams{
 		OrgID:          p.OrgID,
 		Epoch:          p.Epoch,
-		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
-		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
+		EpochStartedAt: sqltime.NewMySQLTime(p.EpochStartedAt),
+		UpdatedAt:      sqltime.NewMySQLTime(p.UpdatedAt),
 	}))
 }

--- a/backend/internal/hub/store/mysql/orgs.go
+++ b/backend/internal/hub/store/mysql/orgs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStore struct {
@@ -18,8 +17,8 @@ func fromDBOrg(o gendb.Org) store.Org {
 	return store.Org{
 		ID:        o.ID,
 		Name:      o.Name,
-		CreatedAt: o.CreatedAt,
-		DeletedAt: sqlutil.NullTimePtr(o.DeletedAt),
+		CreatedAt: o.CreatedAt.Time,
+		DeletedAt: o.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/mysql/pending_oauth_signups.go
+++ b/backend/internal/hub/store/mysql/pending_oauth_signups.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type pendingOAuthSignupStore struct {
@@ -24,11 +24,11 @@ func fromDBPendingOAuthSignup(p gendb.PendingOauthSignup) *store.PendingOAuthSig
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  p.TokenExpiresAt,
+		TokenExpiresAt:  p.TokenExpiresAt.Time,
 		KeyVersion:      p.KeyVersion,
 		RedirectURI:     p.RedirectUri,
-		ExpiresAt:       p.ExpiresAt,
-		CreatedAt:       p.CreatedAt,
+		ExpiresAt:       p.ExpiresAt.Time,
+		CreatedAt:       p.CreatedAt.Time,
 	}
 }
 
@@ -42,10 +42,10 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  sqlutil.BindTime(p.TokenExpiresAt),
+		TokenExpiresAt:  sqltime.NewMySQLTime(p.TokenExpiresAt),
 		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
-		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:       sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/registration_keys.go
+++ b/backend/internal/hub/store/mysql/registration_keys.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type registrationKeyStore struct {
@@ -21,8 +21,8 @@ func fromDBRegistrationKey(r gendb.WorkerRegistrationKey) *store.WorkerRegistrat
 	return &store.WorkerRegistrationKey{
 		ID:        r.ID,
 		CreatedBy: r.CreatedBy,
-		CreatedAt: r.CreatedAt,
-		ExpiresAt: r.ExpiresAt,
+		CreatedAt: r.CreatedAt.Time,
+		ExpiresAt: r.ExpiresAt.Time,
 	}
 }
 
@@ -30,7 +30,7 @@ func (s *registrationKeyStore) Create(ctx context.Context, p store.CreateRegistr
 	return mapErr(s.conn.q.CreateRegistrationKey(ctx, gendb.CreateRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt: sqltime.NewMySQLTime(p.ExpiresAt),
 	}))
 }
 
@@ -57,8 +57,8 @@ func (s *registrationKeyStore) Extend(ctx context.Context, p store.ExtendRegistr
 	return rowsAffected(s.conn.q.ExtendRegistrationKey(ctx, gendb.ExtendRegistrationKeyParams{
 		ID:           p.ID,
 		CreatedBy:    p.CreatedBy,
-		NewExpiresAt: sqlutil.BindTime(p.ExpiresAt),
-		Now:          sqlutil.BindTime(time.Now()),
+		NewExpiresAt: sqltime.NewMySQLTime(p.ExpiresAt),
+		Now:          sqltime.NewMySQLTime(time.Now()),
 	}))
 }
 
@@ -66,7 +66,7 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 	return rowsAffected(s.conn.q.SoftDeleteRegistrationKey(ctx, gendb.SoftDeleteRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: sqltime.NewMySQLTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
@@ -76,7 +76,7 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.WorkerRegistrationKey, error) {
 	var consumed *store.WorkerRegistrationKey
 	err := s.conn.withTransaction(ctx, func(conn *mysqlConn) error {
-		now := sqlutil.BindTime(time.Now())
+		now := sqltime.NewMySQLTime(time.Now())
 		r, err := conn.q.GetActiveRegistrationKeyForUpdate(ctx, gendb.GetActiveRegistrationKeyForUpdateParams{
 			ID:        id,
 			ExpiresAt: now,
@@ -92,7 +92,7 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 		// user-facing SoftDelete query carries.
 		if err := conn.q.ConsumeSoftDeleteRegistrationKey(ctx, gendb.ConsumeSoftDeleteRegistrationKeyParams{
 			ID:        id,
-			ExpiresAt: now.Add(store.RegistrationKeySoftDeleteOffset),
+			ExpiresAt: sqltime.NewMySQLTime(now.Add(store.RegistrationKeySoftDeleteOffset)),
 		}); err != nil {
 			return mapErr(err)
 		}
@@ -105,7 +105,7 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (int64, error) {
 	return rowsAffected(s.conn.q.AdminSoftDeleteRegistrationKey(ctx, gendb.AdminSoftDeleteRegistrationKeyParams{
 		ID:        id,
-		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: sqltime.NewMySQLTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
@@ -114,9 +114,9 @@ func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegist
 	// so the `(narg(now) IS NULL OR expires_at > narg(now))` predicate's second
 	// branch filters live rows; a zero (invalid) NullTime when IncludeExpired=true
 	// so the IS NULL branch surfaces every row.
-	var now sql.NullTime
+	var now sqltime.MySQLNullTime
 	if !p.IncludeExpired {
-		now = sqlutil.BindTimeValid(time.Now())
+		now = sqltime.MySQLNullTimeOf(time.Now())
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListRegistrationKeysAdminParams, error) {
@@ -131,8 +131,8 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 		WorkerRegistrationKey: store.WorkerRegistrationKey{
 			ID:        r.ID,
 			CreatedBy: r.CreatedBy,
-			CreatedAt: r.CreatedAt,
-			ExpiresAt: r.ExpiresAt,
+			CreatedAt: r.CreatedAt.Time,
+			ExpiresAt: r.ExpiresAt.Time,
 		},
 		CreatorUsername: r.CreatorUsername,
 		CreatorDeleted:  r.CreatorDeleted,

--- a/backend/internal/hub/store/mysql/revocation_events.go
+++ b/backend/internal/hub/store/mysql/revocation_events.go
@@ -9,6 +9,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 // revocationEventStore embeds the shared RevocationCore, which promotes
@@ -52,7 +53,7 @@ func insertRevocationEvent(
 		Kind:               kind,
 		SubjectID:          subjectID,
 		UserID:             userID,
-		RevokedAt:          sqlutil.BindTime(revokedAt),
+		RevokedAt:          sqltime.NewMySQLTime(revokedAt),
 		UserAuthGeneration: userAuthGeneration,
 	}))
 }
@@ -88,7 +89,7 @@ func newRevocationEventStore(conn *mysqlConn) *revocationEventStore {
 				return mapErr(err)
 			},
 			CompactPublished: func(ctx context.Context, conn *mysqlConn, cutoff time.Time) (int64, error) {
-				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, sqlutil.BindTimeValid(cutoff)))
+				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 			},
 			InsertLease: func(ctx context.Context, conn *mysqlConn, lease store.RevocationLease) error {
 				return mapErr(conn.q.InsertHubRuntimeLease(ctx, gendb.InsertHubRuntimeLeaseParams{
@@ -155,10 +156,10 @@ func (s *revocationEventStore) MaxPublishedSeq(ctx context.Context) (int64, erro
 }
 
 // mysqlRevocationNow reads the transaction's clock via SELECT NOW(3). The
-// result is already on the millisecond grid, so revoke paths that bind it
-// back into DATETIME(3) columns (revoked_at, tokens_revoked_at, updated_at)
-// round-trip exactly and deliberately skip the sqlutil.BindTime floor that
-// Go-minted instants require.
+// result is already on the millisecond grid, so binding it back into
+// DATETIME(3) columns (revoked_at, tokens_revoked_at, updated_at) through the
+// sqltime.MySQLTime/MySQLNullTime valuers round-trips exactly: their
+// unconditional millisecond floor is a no-op on an already-floored NOW(3).
 func mysqlRevocationNow(ctx context.Context, conn *mysqlConn) (time.Time, error) {
 	now, err := conn.q.RevocationNow(ctx)
 	if err != nil {

--- a/backend/internal/hub/store/mysql/schema_internal_test.go
+++ b/backend/internal/hub/store/mysql/schema_internal_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 )
 
 // TestEveryCreateTableDeclaresBinaryCollation pins the migration convention that
@@ -29,7 +31,7 @@ func TestEveryCreateTableDeclaresBinaryCollation(t *testing.T) {
 	require.NoError(t, err)
 	// Strip line comments (-- to end of line) so a ';' inside a prose comment
 	// (e.g. "...issued; force-expires...") doesn't split a CREATE TABLE body.
-	sql := strings.ToUpper(stripLineComments(string(sqlBytes)))
+	sql := strings.ToUpper(storetest.StripSQLLineComments(string(sqlBytes)))
 
 	const create = "CREATE TABLE"
 	idx := 0
@@ -53,18 +55,42 @@ func TestEveryCreateTableDeclaresBinaryCollation(t *testing.T) {
 	assert.Greater(t, count, 20, "expected many CREATE TABLE statements; got %d (is the migration readable?)", count)
 }
 
-// stripLineComments removes a SQL line comment (-- to end of line) from each
-// line. The migration uses only line comments (no /* */ block comments, no
-// string literals containing --), so this is a faithful comment strip for the
-// static COLLATE scan.
-func stripLineComments(s string) string {
-	var b strings.Builder
-	for _, line := range strings.Split(s, "\n") {
-		if i := strings.Index(line, "--"); i >= 0 {
-			line = line[:i]
+// TestEveryTimestampColumnDeclaresDatetime pins the decltype spelling the sqlc
+// type-keyed override (sqlc.yaml `db_type: "datetime"`) matches: every `_at`
+// column must be declared DATETIME(n) with n >= 3 so sqlc retypes its params
+// and result fields to the ms-flooring sqltime.MySQLTime/MySQLNullTime valuers
+// AND the column can actually hold the floored millisecond -- MySQL ROUNDS a
+// fractional second that exceeds the column precision, so a DATETIME(0..2)
+// column could store an instant AFTER the ms-floored bound, violating the
+// "stored instant never postdates the bound" invariant while still matching
+// the db_type override. sqlc silently ignores an override that matches
+// nothing, so a column declared with another time type (e.g. TIMESTAMP) would
+// fall through to a raw, unfloored time.Time bind with no red flag anywhere --
+// this scan turns that drift into a static test failure at migration time.
+// TIMESTAMP is also rejected outright for any column: besides evading the
+// override, it carries session-timezone conversion semantics DATETIME
+// deliberately avoids.
+//
+// This is a static check of the migration source, so it runs without Docker.
+// Its live twin, TestMySQLDatetimeColumnsLive (mysql_test.go, -tags
+// integration), asserts the same invariant against information_schema of the
+// actual migrated database and is immune to the text parse's line-shape
+// assumptions (see storetest.WalkCreateTableColumns).
+func TestEveryTimestampColumnDeclaresDatetime(t *testing.T) {
+	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	require.NoError(t, err)
+
+	atColumns := 0
+	storetest.WalkCreateTableColumns(string(sqlBytes), func(name, typeTok string) {
+		if strings.HasSuffix(name, "_at") {
+			atColumns++
+			assert.Regexp(t, `^DATETIME\([3-6]\)$`, typeTok,
+				"column %s is declared %s; `_at` columns must be DATETIME(3..6) so the sqlc db_type override retypes them to the flooring valuer and the stored precision can hold the floored millisecond (below 3, MySQL ROUNDS past the floor)", name, typeTok)
+		} else {
+			assert.False(t, strings.HasPrefix(typeTok, "DATETIME") || strings.HasPrefix(typeTok, "TIMESTAMP"),
+				"column %s is declared %s; time columns must be named *_at (and TIMESTAMP is banned outright)", name, typeTok)
 		}
-		b.WriteString(line)
-		b.WriteByte('\n')
-	}
-	return b.String()
+	})
+	// Sanity: the scan actually saw the schema's many timestamp columns.
+	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (is the migration readable?)", atColumns)
 }

--- a/backend/internal/hub/store/mysql/sessions.go
+++ b/backend/internal/hub/store/mysql/sessions.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type sessionStore struct{ conn *mysqlConn }
@@ -20,9 +20,9 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	return store.UserSession{
 		ID:             s.ID,
 		UserID:         s.UserID,
-		ExpiresAt:      s.ExpiresAt,
-		CreatedAt:      s.CreatedAt,
-		LastActiveAt:   s.LastActiveAt,
+		ExpiresAt:      s.ExpiresAt.Time,
+		CreatedAt:      s.CreatedAt.Time,
+		LastActiveAt:   s.LastActiveAt.Time,
 		AuthGeneration: s.AuthGeneration,
 		UserAgent:      s.UserAgent,
 		IPAddress:      s.IpAddress,
@@ -35,9 +35,9 @@ func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSessio
 		UserID:       r.UserID,
 		Username:     r.Username,
 		UserDeleted:  r.UserDeleted,
-		CreatedAt:    r.CreatedAt,
-		LastActiveAt: r.LastActiveAt,
-		ExpiresAt:    r.ExpiresAt,
+		CreatedAt:    r.CreatedAt.Time,
+		LastActiveAt: r.LastActiveAt.Time,
+		ExpiresAt:    r.ExpiresAt.Time,
 		IPAddress:    r.IpAddress,
 		UserAgent:    r.UserAgent,
 	}
@@ -48,7 +48,7 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 		return mapErr(tx.(*mysqlStore).conn.q.CreateUserSession(ctx, gendb.CreateUserSessionParams{
 			ID:        p.ID,
 			UserID:    p.UserID,
-			ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+			ExpiresAt: sqltime.NewMySQLTime(p.ExpiresAt),
 			UserAgent: p.UserAgent,
 			IpAddress: p.IPAddress,
 		}))
@@ -66,9 +66,9 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
-		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:    sqltime.NewMySQLTime(p.ExpiresAt),
 		ID:           p.ID,
-		LastActiveAt: sqlutil.BindTime(p.LastActiveAt),
+		LastActiveAt: sqltime.NewMySQLTime(p.LastActiveAt),
 	})
 	return n, mapErr(err)
 }

--- a/backend/internal/hub/store/mysql/sqlc.yaml
+++ b/backend/internal/hub/store/mysql/sqlc.yaml
@@ -10,6 +10,22 @@ sql:
         emit_json_tags: true
         emit_empty_slices: true
         overrides:
+          # Millisecond-floored DATETIME types (#303). Type-keyed: retypes every
+          # DATETIME param and result column. mysql strips the precision suffix,
+          # so "datetime" covers both DATETIME(3) and DATETIME(6) columns. The
+          # column-keyed overrides below take precedence where they apply.
+          # sqlc silently ignores an override that matches nothing, so the
+          # decltype spelling this key relies on is pinned statically by
+          # TestEveryTimestampColumnDeclaresDatetime (schema_internal_test.go).
+          - db_type: "datetime"
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "MySQLTime"
+          - db_type: "datetime"
+            nullable: true
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "MySQLNullTime"
           # Worker enums
           - column: "workers.status"
             go_type:

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type userStore struct {
@@ -29,16 +29,16 @@ func fromDBUser(u gendb.User) store.User {
 		EmailVerified:         u.EmailVerified,
 		PendingEmail:          u.PendingEmail,
 		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: sqlutil.NullTimePtr(u.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
 		PendingEmailAttempts:  int64(u.PendingEmailAttempts),
 		PasswordSet:           u.PasswordSet,
 		IsAdmin:               u.IsAdmin,
 		Prefs:                 u.Prefs,
-		CreatedAt:             u.CreatedAt,
-		UpdatedAt:             u.UpdatedAt,
-		TokensRevokedAt:       sqlutil.NullTimePtr(u.TokensRevokedAt),
+		CreatedAt:             u.CreatedAt.Time,
+		UpdatedAt:             u.UpdatedAt.Time,
+		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
 		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             sqlutil.NullTimePtr(u.DeletedAt),
+		DeletedAt:             u.DeletedAt.Ptr(),
 	}
 }
 
@@ -270,7 +270,7 @@ func (s *userStore) UpdateProfile(ctx context.Context, p store.UpdateUserProfile
 			Username:          store.NormalizeUsername(p.Username),
 			DisplayName:       p.DisplayName,
 			DisplayNameFolded: store.FoldSearchText(p.DisplayName),
-			UpdatedAt:         updatedAt,
+			UpdatedAt:         sqltime.NewMySQLTime(updatedAt),
 			ID:                p.ID,
 		}))
 		if ok, err := requireSingleRowUpdate(n, err, "update user profile", p.ID); !ok || err != nil {
@@ -306,7 +306,7 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 		n, err := rowsAffected(conn.q.UpdateUserEmail(ctx, gendb.UpdateUserEmailParams{
 			Email:         store.NormalizeEmail(p.Email),
 			EmailVerified: p.EmailVerified,
-			UpdatedAt:     updatedAt,
+			UpdatedAt:     sqltime.NewMySQLTime(updatedAt),
 			ID:            p.ID,
 		}))
 		return requireSingleRowUpdate(n, err, "update user email", p.ID)
@@ -321,7 +321,7 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.UpdateUserEmailVerified(ctx, gendb.UpdateUserEmailVerifiedParams{
 			EmailVerified: p.EmailVerified,
-			UpdatedAt:     updatedAt,
+			UpdatedAt:     sqltime.NewMySQLTime(updatedAt),
 			ID:            p.ID,
 		}))
 		return requireSingleRowUpdate(n, err, "update user email verified", p.ID)
@@ -335,7 +335,7 @@ func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminPara
 	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.UpdateUserAdmin(ctx, gendb.UpdateUserAdminParams{
 			IsAdmin:   p.IsAdmin,
-			UpdatedAt: updatedAt,
+			UpdatedAt: sqltime.NewMySQLTime(updatedAt),
 			ID:        p.ID,
 		}))
 		return requireSingleRowUpdate(n, err, "update user admin", p.ID)
@@ -353,7 +353,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
-		PendingEmailExpiresAt: sqlutil.BindNullTime(p.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqltime.NewMySQLNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
 	}))
 }
@@ -366,7 +366,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.PromotePendingEmail(ctx, gendb.PromotePendingEmailParams{
-			UpdatedAt: updatedAt,
+			UpdatedAt: sqltime.NewMySQLTime(updatedAt),
 			ID:        id,
 		}))
 		if err != nil {
@@ -419,9 +419,9 @@ func (s *userStore) RevokeUserTokens(ctx context.Context, userID string) (int64,
 		nextGeneration := row.AuthGeneration + 1
 		n, err := rowsAffected(conn.q.SetUserTokensRevokedAt(ctx, gendb.SetUserTokensRevokedAtParams{
 			ID:              row.ID,
-			TokensRevokedAt: sql.NullTime{Time: revokedAt, Valid: true},
+			TokensRevokedAt: sqltime.MySQLNullTimeOf(revokedAt),
 			AuthGeneration:  nextGeneration,
-			UpdatedAt:       updatedAt,
+			UpdatedAt:       sqltime.NewMySQLTime(updatedAt),
 		}))
 		if err != nil {
 			return nil, err

--- a/backend/internal/hub/store/mysql/worker_notifications.go
+++ b/backend/internal/hub/store/mysql/worker_notifications.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerNotificationStore implements store.WorkerNotificationStore backed by MySQL.
@@ -51,7 +50,7 @@ func fromDBWorkerNotification(n gendb.WorkerNotification) store.WorkerNotificati
 		Status:      n.Status,
 		Attempts:    int64(n.Attempts),
 		MaxAttempts: int64(n.MaxAttempts),
-		CreatedAt:   n.CreatedAt,
-		DeliveredAt: sqlutil.NullTimePtr(n.DeliveredAt),
+		CreatedAt:   n.CreatedAt.Time,
+		DeliveredAt: n.DeliveredAt.Ptr(),
 	}
 }

--- a/backend/internal/hub/store/mysql/workers.go
+++ b/backend/internal/hub/store/mysql/workers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerStore implements store.WorkerStore backed by MySQL.
@@ -159,13 +158,13 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 		AuthToken:       w.AuthToken,
 		RegisteredBy:    w.RegisteredBy,
 		Status:          w.Status,
-		CreatedAt:       w.CreatedAt,
-		LastSeenAt:      sqlutil.NullTimePtr(w.LastSeenAt),
+		CreatedAt:       w.CreatedAt.Time,
+		LastSeenAt:      w.LastSeenAt.Ptr(),
 		PublicKey:       w.PublicKey,
 		MlkemPublicKey:  w.MlkemPublicKey,
 		SlhdsaPublicKey: w.SlhdsaPublicKey,
 		AutoRegistered:  w.AutoRegistered,
-		DeletedAt:       sqlutil.NullTimePtr(w.DeletedAt),
+		DeletedAt:       w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/mysql/workspace_sections.go
+++ b/backend/internal/hub/store/mysql/workspace_sections.go
@@ -21,7 +21,7 @@ func fromDBWorkspaceSection(s gendb.WorkspaceSection) *store.WorkspaceSection {
 		Position:    s.Position,
 		SectionType: s.SectionType,
 		Sidebar:     s.Sidebar,
-		CreatedAt:   s.CreatedAt,
+		CreatedAt:   s.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/mysql/workspaces.go
+++ b/backend/internal/hub/store/mysql/workspaces.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type workspaceStore struct {
@@ -21,8 +20,8 @@ func fromDBWorkspace(w gendb.Workspace) *store.Workspace {
 		OwnerUserID: w.OwnerUserID,
 		Title:       w.Title,
 		IsDeleted:   w.IsDeleted,
-		CreatedAt:   w.CreatedAt,
-		DeletedAt:   sqlutil.NullTimePtr(w.DeletedAt),
+		CreatedAt:   w.CreatedAt.Time,
+		DeletedAt:   w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/postgres/api_tokens.go
+++ b/backend/internal/hub/store/postgres/api_tokens.go
@@ -7,6 +7,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type apiTokenStore struct{ conn *pgConn }
@@ -22,15 +23,15 @@ func fromDBAPIToken(t gendb.ApiToken) store.APIToken {
 		SecretHash:               t.SecretHash,
 		RefreshHash:              t.RefreshHash,
 		PreviousRefreshHash:      t.PreviousRefreshHash,
-		PreviousRefreshExpiresAt: tsToTimePtr(t.PreviousRefreshExpiresAt),
+		PreviousRefreshExpiresAt: t.PreviousRefreshExpiresAt.Ptr(),
 		Scope:                    t.Scope,
-		CreatedAt:                tsToTime(t.CreatedAt),
+		CreatedAt:                t.CreatedAt.Time,
 		AuthGeneration:           t.AuthGeneration,
-		LastUsedAt:               tsToTimePtr(t.LastUsedAt),
-		LastRotatedAt:            tsToTimePtr(t.LastRotatedAt),
-		ExpiresAt:                tsToTimePtr(t.ExpiresAt),
-		RefreshExpiresAt:         tsToTimePtr(t.RefreshExpiresAt),
-		RevokedAt:                tsToTimePtr(t.RevokedAt),
+		LastUsedAt:               t.LastUsedAt.Ptr(),
+		LastRotatedAt:            t.LastRotatedAt.Ptr(),
+		ExpiresAt:                t.ExpiresAt.Ptr(),
+		RefreshExpiresAt:         t.RefreshExpiresAt.Ptr(),
+		RevokedAt:                t.RevokedAt.Ptr(),
 	}
 }
 
@@ -44,8 +45,8 @@ func (s *apiTokenStore) Create(ctx context.Context, p store.CreateAPITokenParams
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
 			Scope:            p.Scope,
-			ExpiresAt:        timePtrToTs(p.ExpiresAt),
-			RefreshExpiresAt: timePtrToTs(p.RefreshExpiresAt),
+			ExpiresAt:        pgtime.NewNull(p.ExpiresAt),
+			RefreshExpiresAt: pgtime.NewNull(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -135,11 +136,11 @@ func (s *apiTokenStore) RotateRefresh(ctx context.Context, p store.RotateAPIToke
 		n, err := conn.q.RotateAPITokenRefresh(ctx, gendb.RotateAPITokenRefreshParams{
 			ID:                   p.ID,
 			NewSecretHash:        p.NewSecretHash,
-			NewExpiresAt:         timePtrToTs(p.NewExpiresAt),
+			NewExpiresAt:         pgtime.NewNull(p.NewExpiresAt),
 			NewRefreshHash:       p.NewRefreshHash,
-			NewRefreshExpiresAt:  timePtrToTs(p.NewRefreshExpiresAt),
+			NewRefreshExpiresAt:  pgtime.NewNull(p.NewRefreshExpiresAt),
 			PrevRefreshHash:      p.PreviousRefreshHash,
-			PrevRefreshExpiresAt: timePtrToTs(p.PreviousRefreshExpiresAt),
+			PrevRefreshExpiresAt: pgtime.NewNull(p.PreviousRefreshExpiresAt),
 		})
 		if err != nil || n == 0 {
 			return nil, mapErr(err)

--- a/backend/internal/hub/store/postgres/cleanup.go
+++ b/backend/internal/hub/store/postgres/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type cleanupStore struct {
@@ -18,27 +19,27 @@ func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, er
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, pgtime.NullOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, pgtime.NullOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, pgtime.New(cutoff)))
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, pgtime.NullOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, pgtime.NullOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteOrgsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, timeToTs(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, pgtime.NullOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
@@ -50,23 +51,23 @@ func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (in
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, timeToTs(cutoff))
+	return s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, pgtime.New(cutoff))
 }
 
 func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, timeToTs(cutoff))
+	return s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, pgtime.New(cutoff))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteRevokedAPITokensBefore(ctx, timeToTs(cutoff))
+	return s.conn.q.DeleteRevokedAPITokensBefore(ctx, pgtime.NullOf(cutoff))
 }
 
 func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, timeToTs(cutoff))
+	return s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, pgtime.NullOf(cutoff))
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, timeToTs(cutoff))
+	return s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, pgtime.New(cutoff))
 }
 
 func (s *cleanupStore) CompactPublishedRevocationEvents(

--- a/backend/internal/hub/store/postgres/cli_authorization_codes.go
+++ b/backend/internal/hub/store/postgres/cli_authorization_codes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type cliAuthorizationCodeStore struct{ conn *pgConn }
@@ -17,9 +18,9 @@ func fromDBCLIAuthorizationCode(c gendb.CliAuthorizationCode) store.CLIAuthoriza
 		UserID:        c.UserID,
 		CodeChallenge: c.CodeChallenge,
 		DeviceName:    c.DeviceName,
-		CreatedAt:     tsToTime(c.CreatedAt),
-		ExpiresAt:     tsToTime(c.ExpiresAt),
-		ConsumedAt:    tsToTimePtr(c.ConsumedAt),
+		CreatedAt:     c.CreatedAt.Time,
+		ExpiresAt:     c.ExpiresAt.Time,
+		ConsumedAt:    c.ConsumedAt.Ptr(),
 	}
 }
 
@@ -29,7 +30,7 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 		UserID:        p.UserID,
 		CodeChallenge: p.CodeChallenge,
 		DeviceName:    p.DeviceName,
-		ExpiresAt:     timeToTs(p.ExpiresAt),
+		ExpiresAt:     pgtime.New(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/postgres/convert.go
+++ b/backend/internal/hub/store/postgres/convert.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -13,29 +12,8 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
-
-func tsToTime(ts pgtype.Timestamptz) time.Time {
-	return ts.Time
-}
-
-func tsToTimePtr(ts pgtype.Timestamptz) *time.Time {
-	if ts.Valid {
-		return &ts.Time
-	}
-	return nil
-}
-
-func timeToTs(t time.Time) pgtype.Timestamptz {
-	return pgtype.Timestamptz{Time: t, Valid: true}
-}
-
-func timePtrToTs(t *time.Time) pgtype.Timestamptz {
-	if t != nil {
-		return pgtype.Timestamptz{Time: *t, Valid: true}
-	}
-	return pgtype.Timestamptz{}
-}
 
 func textToPtr(t pgtype.Text) *string {
 	if t.Valid {
@@ -56,26 +34,25 @@ func ptrToText(s *string) pgtype.Text {
 // tiebreaker. An empty cursor (first page) returns the zero values so the
 // queries' "cursor_time IS NULL" branch selects every row.
 //
-// The timestamp is truncated to microsecond precision to match the timestamptz
-// columns: pgx sends pgtype.Timestamptz over the binary protocol floored to
-// microseconds, but a hand-crafted cursor parsed from text could carry
+// The timestamp is floored to microsecond precision (via pgtime.NullOf) to match
+// the timestamptz columns: pgx sends pgtype.Timestamptz over the binary protocol
+// floored to microseconds, but a hand-crafted cursor parsed from text could carry
 // sub-microsecond digits, and a future switch to text binding would let the
 // `::timestamptz` cast round (half-to-even) at the .5us boundary -- making the
 // `=` tiebreak branch unsatisfiable and re-returning the previous page's tail
-// as duplicates. Truncating in Go mirrors MySQL's defensive
-// Truncate(time.Millisecond) and makes the "=" branch mechanically satisfiable
-// regardless of how the value is transported. EncodeCursor produces cursors
-// from DB-scanned rows (already microsecond-quantized), so this is a no-op for
-// real cursors.
-func decodeCursorParams(cursor string) (pgtype.Timestamptz, pgtype.Text, error) {
+// as duplicates. Flooring in Go mirrors MySQL's defensive millisecond floor and
+// makes the "=" branch mechanically satisfiable regardless of how the value is
+// transported. EncodeCursor produces cursors from DB-scanned rows (already
+// microsecond-quantized), so this is a no-op for real cursors.
+func decodeCursorParams(cursor string) (pgtime.NullTime, pgtype.Text, error) {
 	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return pgtype.Timestamptz{}, pgtype.Text{}, err
+		return pgtime.NullTime{}, pgtype.Text{}, err
 	}
 	if c == nil {
-		return pgtype.Timestamptz{}, pgtype.Text{}, nil
+		return pgtime.NullTime{}, pgtype.Text{}, nil
 	}
-	return pgtype.Timestamptz{Time: c.Time.Truncate(time.Microsecond), Valid: true}, pgtype.Text{String: c.ID, Valid: true}, nil
+	return pgtime.NullOf(c.Time), pgtype.Text{String: c.ID, Valid: true}, nil
 }
 
 // withCursor decodes the composite list cursor and applies the dialect's
@@ -85,7 +62,7 @@ func decodeCursorParams(cursor string) (pgtype.Timestamptz, pgtype.Text, error) 
 // LIMIT column requires) here means a change to the cursor decode, the clamp
 // rule, or the probe-row accounting edits ONE site per dialect instead of
 // being copy-pasted across every list builder.
-func withCursor[T any](cursor string, limit int64, fill func(cursorTime pgtype.Timestamptz, cursorID pgtype.Text, fetchLimit int32) T) (T, error) {
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime pgtime.NullTime, cursorID pgtype.Text, fetchLimit int32) T) (T, error) {
 	cursorTime, cursorID, err := decodeCursorParams(cursor)
 	if err != nil {
 		var zero T
@@ -109,13 +86,13 @@ func queryPage[P any, R any, I store.PageCursorer](
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllUsersParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllUsersParams {
 		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.SearchUsersParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.SearchUsersParams {
 		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
 		// '%') at the one shared site, so the match is case-insensitive and literal
 		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
@@ -129,7 +106,7 @@ func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchU
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersByUserIDParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListWorkersByUserIDParams {
 		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -137,7 +114,7 @@ func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.
 // listWorkersAdminParams builds the status=nil, user_id=nil query
 // (ListWorkersAdmin): deleted_at IS NULL, no user filter.
 func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListWorkersAdminParams {
 		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -149,7 +126,7 @@ func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminP
 // interface{}, and binding NULL raised SQLSTATE 42P08 (YugabyteDB inherits the
 // break via this store). See workers.sql for the full 2x2 matrix rationale.
 func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserParams {
 		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -158,7 +135,7 @@ func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (ge
 // (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
 // soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByStatusParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByStatusParams {
 		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -166,67 +143,67 @@ func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string
 // listWorkersAdminByUserAndStatusParams builds the status=set, user_id=set
 // query (ListWorkersAdminByUserAndStatus): required registered_by + status.
 func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListWorkersAdminByUserAndStatusParams {
 		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllActiveSessionsParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllActiveSessionsParams {
 		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListUserSessionsByUserIDParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListUserSessionsByUserIDParams {
 		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllAPITokensParams {
 		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserParams {
 		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllAPITokensIncludingRevokedParams {
 		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllAPITokensByUserIncludingRevokedParams {
 		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensParams {
 		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserParams {
 		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -235,8 +212,8 @@ func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, 
 // registration-key admin listing shares the cursor decode and limit clamp.
 // now is the caller-computed expiry probe (Valid=false when expired rows are
 // included), passed in so the builder stays a pure function of its arguments.
-func listRegistrationKeysAdminParams(cursor string, limit int64, now pgtype.Timestamptz) (gendb.ListRegistrationKeysAdminParams, error) {
-	return withCursor(cursor, limit, func(ct pgtype.Timestamptz, cid pgtype.Text, fl int32) gendb.ListRegistrationKeysAdminParams {
+func listRegistrationKeysAdminParams(cursor string, limit int64, now pgtime.NullTime) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListRegistrationKeysAdminParams {
 		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/postgres/delegation_tokens.go
+++ b/backend/internal/hub/store/postgres/delegation_tokens.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type delegationTokenStore struct{ conn *pgConn }
@@ -23,12 +24,12 @@ func fromDBDelegationToken(t gendb.DelegationToken) store.DelegationToken {
 		IssuedForTabType: t.IssuedForTabType,
 		SecretHash:       t.SecretHash,
 		RefreshHash:      t.RefreshHash,
-		CreatedAt:        tsToTime(t.CreatedAt),
+		CreatedAt:        t.CreatedAt.Time,
 		AuthGeneration:   t.AuthGeneration,
-		LastUsedAt:       tsToTimePtr(t.LastUsedAt),
-		ExpiresAt:        tsToTime(t.ExpiresAt),
-		RefreshExpiresAt: tsToTimePtr(t.RefreshExpiresAt),
-		RevokedAt:        tsToTimePtr(t.RevokedAt),
+		LastUsedAt:       t.LastUsedAt.Ptr(),
+		ExpiresAt:        t.ExpiresAt.Time,
+		RefreshExpiresAt: t.RefreshExpiresAt.Ptr(),
+		RevokedAt:        t.RevokedAt.Ptr(),
 	}
 }
 
@@ -45,8 +46,8 @@ func (s *delegationTokenStore) Create(ctx context.Context, p store.CreateDelegat
 			IssuedForTabType: p.IssuedForTabType,
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
-			ExpiresAt:        timeToTs(p.ExpiresAt),
-			RefreshExpiresAt: timePtrToTs(p.RefreshExpiresAt),
+			ExpiresAt:        pgtime.New(p.ExpiresAt),
+			RefreshExpiresAt: pgtime.NewNull(p.RefreshExpiresAt),
 		}))
 	})
 }

--- a/backend/internal/hub/store/postgres/device_authorizations.go
+++ b/backend/internal/hub/store/postgres/device_authorizations.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type deviceAuthorizationStore struct{ conn *pgConn }
@@ -23,11 +24,11 @@ func fromDBDeviceAuthorization(d gendb.DeviceAuthorization) store.DeviceAuthoriz
 		DeviceName:      d.DeviceName,
 		UserID:          uid,
 		Approved:        int64(d.Approved),
-		LastPolledAt:    tsToTimePtr(d.LastPolledAt),
+		LastPolledAt:    d.LastPolledAt.Ptr(),
 		IntervalSeconds: int64(d.IntervalSeconds),
-		CreatedAt:       tsToTime(d.CreatedAt),
-		ExpiresAt:       tsToTime(d.ExpiresAt),
-		ConsumedAt:      tsToTimePtr(d.ConsumedAt),
+		CreatedAt:       d.CreatedAt.Time,
+		ExpiresAt:       d.ExpiresAt.Time,
+		ConsumedAt:      d.ConsumedAt.Ptr(),
 	}
 }
 
@@ -44,7 +45,7 @@ func (s *deviceAuthorizationStore) Create(ctx context.Context, p store.CreateDev
 		UserCode:        p.UserCode,
 		DeviceName:      p.DeviceName,
 		IntervalSeconds: int32(p.IntervalSeconds),
-		ExpiresAt:       timeToTs(p.ExpiresAt),
+		ExpiresAt:       pgtime.New(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/postgres/lifecycle_outbox.go
+++ b/backend/internal/hub/store/postgres/lifecycle_outbox.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type lifecycleOutboxStore struct {
@@ -37,8 +38,8 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 			OrgID:      r.OrgID,
 			OpType:     r.OpType,
 			Payload:    r.Payload,
-			EnqueuedAt: tsToTime(r.EnqueuedAt),
-			ConsumedAt: tsToTimePtr(r.ConsumedAt),
+			EnqueuedAt: r.EnqueuedAt.Time,
+			ConsumedAt: r.ConsumedAt.Ptr(),
 		}
 	}
 	return out, nil
@@ -47,10 +48,10 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 func (s *lifecycleOutboxStore) MarkConsumed(ctx context.Context, p store.MarkLifecycleOutboxConsumedParams) error {
 	return mapErr(s.conn.q.MarkLifecycleOutboxConsumed(ctx, gendb.MarkLifecycleOutboxConsumedParams{
 		ID:         p.ID,
-		ConsumedAt: timeToTs(p.ConsumedAt),
+		ConsumedAt: pgtime.NullOf(p.ConsumedAt),
 	}))
 }
 
 func (s *lifecycleOutboxStore) DeleteConsumedBefore(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, timeToTs(before)))
+	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, pgtime.NullOf(before)))
 }

--- a/backend/internal/hub/store/postgres/oauth_providers.go
+++ b/backend/internal/hub/store/postgres/oauth_providers.go
@@ -24,7 +24,7 @@ func fromDBOAuthProvider(p gendb.OauthProvider) *store.OAuthProvider {
 			Scopes:       p.Scopes,
 			TrustEmail:   p.TrustEmail,
 			Enabled:      p.Enabled,
-			CreatedAt:    tsToTime(p.CreatedAt),
+			CreatedAt:    p.CreatedAt.Time,
 		},
 		ClientSecret: p.ClientSecret,
 	}
@@ -44,7 +44,7 @@ func fromDBListEnabledOAuthProvidersRow(r gendb.ListEnabledOAuthProvidersRow) st
 		Scopes:       r.Scopes,
 		TrustEmail:   r.TrustEmail,
 		Enabled:      r.Enabled,
-		CreatedAt:    tsToTime(r.CreatedAt),
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 
@@ -58,7 +58,7 @@ func fromDBListAllOAuthProvidersRow(r gendb.ListAllOAuthProvidersRow) store.OAut
 		Scopes:       r.Scopes,
 		TrustEmail:   r.TrustEmail,
 		Enabled:      r.Enabled,
-		CreatedAt:    tsToTime(r.CreatedAt),
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/postgres/oauth_states.go
+++ b/backend/internal/hub/store/postgres/oauth_states.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type oauthStateStore struct {
@@ -19,8 +20,8 @@ func fromDBOAuthState(s gendb.OauthState) *store.OAuthState {
 		ProviderID:   s.ProviderID,
 		PkceVerifier: s.PkceVerifier,
 		RedirectURI:  s.RedirectUri,
-		ExpiresAt:    tsToTime(s.ExpiresAt),
-		CreatedAt:    tsToTime(s.CreatedAt),
+		ExpiresAt:    s.ExpiresAt.Time,
+		CreatedAt:    s.CreatedAt.Time,
 	}
 }
 
@@ -30,7 +31,7 @@ func (s *oauthStateStore) Create(ctx context.Context, p store.CreateOAuthStatePa
 		ProviderID:   p.ProviderID,
 		PkceVerifier: p.PkceVerifier,
 		RedirectUri:  p.RedirectURI,
-		ExpiresAt:    timeToTs(p.ExpiresAt),
+		ExpiresAt:    pgtime.New(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/postgres/oauth_tokens.go
+++ b/backend/internal/hub/store/postgres/oauth_tokens.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type oauthTokenStore struct {
@@ -20,9 +21,9 @@ func fromDBOAuthToken(t gendb.OauthToken) store.OAuthToken {
 		AccessToken:  t.AccessToken,
 		RefreshToken: t.RefreshToken,
 		TokenType:    t.TokenType,
-		ExpiresAt:    tsToTime(t.ExpiresAt),
+		ExpiresAt:    t.ExpiresAt.Time,
 		KeyVersion:   t.KeyVersion,
-		UpdatedAt:    tsToTime(t.UpdatedAt),
+		UpdatedAt:    t.UpdatedAt.Time,
 	}
 }
 
@@ -37,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
-		ExpiresAt:    timeToTs(p.ExpiresAt.UTC()),
+		ExpiresAt:    pgtime.New(p.ExpiresAt),
 		KeyVersion:   p.KeyVersion,
 	}))
 }

--- a/backend/internal/hub/store/postgres/oauth_user_links.go
+++ b/backend/internal/hub/store/postgres/oauth_user_links.go
@@ -18,7 +18,7 @@ func fromDBOAuthUserLink(l gendb.OauthUserLink) store.OAuthUserLink {
 		UserID:          l.UserID,
 		ProviderID:      l.ProviderID,
 		ProviderSubject: l.ProviderSubject,
-		CreatedAt:       tsToTime(l.CreatedAt),
+		CreatedAt:       l.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/postgres/org_op_batches.go
+++ b/backend/internal/hub/store/postgres/org_op_batches.go
@@ -60,7 +60,7 @@ func toOrgOpBatchRow(r gendb.OrgOpBatch) store.OrgOpBatchRow {
 		BatchPayload: r.BatchPayload,
 		OpCount:      int64(r.OpCount),
 		Epoch:        r.Epoch,
-		CommittedAt:  tsToTime(r.CommittedAt),
+		CommittedAt:  r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/postgres/org_recent_batch_ids.go
+++ b/backend/internal/hub/store/postgres/org_recent_batch_ids.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type orgRecentBatchIDStore struct {
@@ -34,7 +35,7 @@ func (s *orgRecentBatchIDStore) Get(ctx context.Context, orgID, batchID string) 
 		CanonicalClient:     row.CanonicalClient,
 		OpCount:             int64(row.OpCount),
 		Epoch:               row.Epoch,
-		ExpiresAt:           tsToTime(row.ExpiresAt),
+		ExpiresAt:           row.ExpiresAt.Time,
 	}, nil
 }
 
@@ -49,10 +50,10 @@ func (s *orgRecentBatchIDStore) Insert(ctx context.Context, p store.InsertOrgRec
 		CanonicalClient:     p.CanonicalClient,
 		OpCount:             int32(p.OpCount),
 		Epoch:               p.Epoch,
-		ExpiresAt:           timeToTs(p.ExpiresAt),
+		ExpiresAt:           pgtime.New(p.ExpiresAt),
 	}))
 }
 
 func (s *orgRecentBatchIDStore) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, timeToTs(before)))
+	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, pgtime.New(before)))
 }

--- a/backend/internal/hub/store/postgres/org_state.go
+++ b/backend/internal/hub/store/postgres/org_state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type orgStateStore struct {
@@ -27,8 +28,8 @@ func (s *orgStateStore) Get(ctx context.Context, orgID string) (*store.OrgStateR
 		OrgID:          row.OrgID,
 		StatePayload:   row.StatePayload,
 		CurrentEpoch:   row.CurrentEpoch,
-		EpochStartedAt: tsToTime(row.EpochStartedAt),
-		UpdatedAt:      tsToTime(row.UpdatedAt),
+		EpochStartedAt: row.EpochStartedAt.Time,
+		UpdatedAt:      row.UpdatedAt.Time,
 	}, nil
 }
 
@@ -37,8 +38,8 @@ func (s *orgStateStore) Upsert(ctx context.Context, p store.UpsertOrgStateParams
 		OrgID:          p.OrgID,
 		StatePayload:   p.StatePayload,
 		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: timeToTs(p.EpochStartedAt),
-		UpdatedAt:      timeToTs(p.UpdatedAt),
+		EpochStartedAt: pgtime.New(p.EpochStartedAt),
+		UpdatedAt:      pgtime.New(p.UpdatedAt),
 	}))
 }
 
@@ -46,7 +47,7 @@ func (s *orgStateStore) AdvanceEpoch(ctx context.Context, p store.AdvanceOrgEpoc
 	return mapErr(s.conn.q.AdvanceOrgEpoch(ctx, gendb.AdvanceOrgEpochParams{
 		OrgID:          p.OrgID,
 		Epoch:          p.Epoch,
-		EpochStartedAt: timeToTs(p.EpochStartedAt),
-		UpdatedAt:      timeToTs(p.UpdatedAt),
+		EpochStartedAt: pgtime.New(p.EpochStartedAt),
+		UpdatedAt:      pgtime.New(p.UpdatedAt),
 	}))
 }

--- a/backend/internal/hub/store/postgres/orgs.go
+++ b/backend/internal/hub/store/postgres/orgs.go
@@ -17,8 +17,8 @@ func fromDBOrg(o gendb.Org) store.Org {
 	return store.Org{
 		ID:        o.ID,
 		Name:      o.Name,
-		CreatedAt: tsToTime(o.CreatedAt),
-		DeletedAt: tsToTimePtr(o.DeletedAt),
+		CreatedAt: o.CreatedAt.Time,
+		DeletedAt: o.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/postgres/pending_oauth_signups.go
+++ b/backend/internal/hub/store/postgres/pending_oauth_signups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type pendingOAuthSignupStore struct {
@@ -23,11 +24,11 @@ func fromDBPendingOAuthSignup(p gendb.PendingOauthSignup) *store.PendingOAuthSig
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  tsToTime(p.TokenExpiresAt),
+		TokenExpiresAt:  p.TokenExpiresAt.Time,
 		KeyVersion:      p.KeyVersion,
 		RedirectURI:     p.RedirectUri,
-		ExpiresAt:       tsToTime(p.ExpiresAt),
-		CreatedAt:       tsToTime(p.CreatedAt),
+		ExpiresAt:       p.ExpiresAt.Time,
+		CreatedAt:       p.CreatedAt.Time,
 	}
 }
 
@@ -41,10 +42,10 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  timeToTs(p.TokenExpiresAt),
+		TokenExpiresAt:  pgtime.New(p.TokenExpiresAt),
 		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
-		ExpiresAt:       timeToTs(p.ExpiresAt),
+		ExpiresAt:       pgtime.New(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/postgres/postgres_test.go
+++ b/backend/internal/hub/store/postgres/postgres_test.go
@@ -5,6 +5,7 @@ package postgres_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -161,4 +162,66 @@ func TestPostgresBinaryCollationLive(t *testing.T) {
 	// means the name heuristic (or the schema) broke, not that fewer pins are
 	// needed.
 	assert.Greater(t, checked, 40, "expected many id/FK TEXT columns; the name heuristic may have broken (got %d)", checked)
+}
+
+// TestPostgresTimestamptzColumnsLive asserts, against information_schema of
+// the actual migrated database, that every `_at` column resolves to
+// timestamptz at the default microsecond precision (6) and that no column of
+// any name resolves to a timezone-naive timestamp (banned outright: it
+// silently reinterprets instants across session timezones). This is the live
+// twin of the static source scan in schema_internal_test.go
+// (TestEveryTimestampColumnDeclaresTimestamptz): the static scan runs without
+// Docker but reads only 00001_initial.sql with a line-shape-sensitive text
+// parse, while this one is migration-count-agnostic and reads the server's
+// resolved column types. Precision below 6 matters because Postgres ROUNDS a
+// fractional second exceeding the column precision, so a TIMESTAMPTZ(p<6)
+// column could store an instant after the microsecond-floored bound the
+// pgtime valuers guarantee. YugabyteDB inherits this pin via the shared
+// migration.
+func TestPostgresTimestamptzColumnsLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	connStr := startPostgresContainer(t)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	sqlDB := stdlib.OpenDBFromPool(pool)
+	st, err := postgres.NewTestableFromPool(pool, sqlDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(ctx))
+
+	rows, err := pool.Query(ctx, `
+		SELECT table_name, column_name, data_type, COALESCE(datetime_precision, 0)
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name <> 'goose_db_version'
+		  AND (column_name LIKE '%\_at'
+		       OR data_type IN ('timestamp with time zone', 'timestamp without time zone'))
+		ORDER BY table_name, ordinal_position`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	atColumns := 0
+	for rows.Next() {
+		var table, column, dataType string
+		var precision int
+		require.NoError(t, rows.Scan(&table, &column, &dataType, &precision))
+		if strings.HasSuffix(column, "_at") {
+			atColumns++
+			assert.Equalf(t, "timestamp with time zone", dataType,
+				"%s.%s resolved to %s; `_at` columns must be timestamptz so the sqlc db_type override retypes them to the flooring valuer", table, column, dataType)
+			assert.Equalf(t, 6, precision,
+				"%s.%s resolved to timestamptz(%d); precision must be the default 6 so the column can hold the microsecond-floored instant (below 6, Postgres ROUNDS past the floor)", table, column, precision)
+		} else {
+			assert.Failf(t, "misnamed time column",
+				"%s.%s resolved to %s; time columns must be named *_at (and timezone-naive timestamp is banned outright)", table, column, dataType)
+		}
+	}
+	require.NoError(t, rows.Err())
+	assert.Greater(t, atColumns, 20, "expected many _at columns in the migrated schema; got %d", atColumns)
 }

--- a/backend/internal/hub/store/postgres/registration_keys.go
+++ b/backend/internal/hub/store/postgres/registration_keys.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type registrationKeyStore struct {
@@ -19,8 +19,8 @@ func fromDBRegistrationKey(r gendb.WorkerRegistrationKey) *store.WorkerRegistrat
 	return &store.WorkerRegistrationKey{
 		ID:        r.ID,
 		CreatedBy: r.CreatedBy,
-		CreatedAt: tsToTime(r.CreatedAt),
-		ExpiresAt: tsToTime(r.ExpiresAt),
+		CreatedAt: r.CreatedAt.Time,
+		ExpiresAt: r.ExpiresAt.Time,
 	}
 }
 
@@ -28,7 +28,7 @@ func (s *registrationKeyStore) Create(ctx context.Context, p store.CreateRegistr
 	return mapErr(s.conn.q.CreateRegistrationKey(ctx, gendb.CreateRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: timeToTs(p.ExpiresAt),
+		ExpiresAt: pgtime.New(p.ExpiresAt),
 	}))
 }
 
@@ -55,8 +55,8 @@ func (s *registrationKeyStore) Extend(ctx context.Context, p store.ExtendRegistr
 	return rowsAffected(s.conn.q.ExtendRegistrationKey(ctx, gendb.ExtendRegistrationKeyParams{
 		ID:           p.ID,
 		CreatedBy:    p.CreatedBy,
-		NewExpiresAt: timeToTs(p.ExpiresAt),
-		Now:          timeToTs(time.Now().UTC()),
+		NewExpiresAt: pgtime.New(p.ExpiresAt),
+		Now:          pgtime.New(time.Now()),
 	}))
 }
 
@@ -64,16 +64,16 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 	return rowsAffected(s.conn.q.SoftDeleteRegistrationKey(ctx, gendb.SoftDeleteRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: timeToTs(time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: pgtime.New(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
 func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.WorkerRegistrationKey, error) {
-	now := time.Now().UTC()
+	now := time.Now()
 	r, err := s.conn.q.ConsumeRegistrationKey(ctx, gendb.ConsumeRegistrationKeyParams{
 		ID:            id,
-		Now:           timeToTs(now),
-		SoftDeletedAt: timeToTs(now.Add(store.RegistrationKeySoftDeleteOffset)),
+		Now:           pgtime.New(now),
+		SoftDeletedAt: pgtime.New(now.Add(store.RegistrationKeySoftDeleteOffset)),
 	})
 	if err != nil {
 		return nil, mapErr(err)
@@ -84,17 +84,17 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (int64, error) {
 	return rowsAffected(s.conn.q.AdminSoftDeleteRegistrationKey(ctx, gendb.AdminSoftDeleteRegistrationKeyParams{
 		ID:        id,
-		ExpiresAt: timeToTs(time.Now().UTC().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: pgtime.New(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
 func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
-	// Leave Valid=false on the pgtype.Timestamptz values so the
+	// Leave Valid=false on the pgtime.NullTime value so the
 	// `($N::timestamptz IS NULL OR …)` short-circuits keep every row /
 	// start from the head.
-	var nowTs pgtype.Timestamptz
+	var nowTs pgtime.NullTime
 	if !p.IncludeExpired {
-		nowTs = timeToTs(time.Now().UTC())
+		nowTs = pgtime.NullOf(time.Now())
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListRegistrationKeysAdminParams, error) {
@@ -109,8 +109,8 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 		WorkerRegistrationKey: store.WorkerRegistrationKey{
 			ID:        r.ID,
 			CreatedBy: r.CreatedBy,
-			CreatedAt: tsToTime(r.CreatedAt),
-			ExpiresAt: tsToTime(r.ExpiresAt),
+			CreatedAt: r.CreatedAt.Time,
+			ExpiresAt: r.ExpiresAt.Time,
 		},
 		CreatorUsername: r.CreatorUsername,
 		CreatorDeleted:  r.CreatorDeleted,

--- a/backend/internal/hub/store/postgres/revocation_events.go
+++ b/backend/internal/hub/store/postgres/revocation_events.go
@@ -10,6 +10,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 // revocationEventStore embeds the shared RevocationCore, which promotes
@@ -55,7 +56,7 @@ func insertRevocationEvent(
 		Kind:               kind,
 		SubjectID:          subjectID,
 		UserID:             userID,
-		RevokedAt:          timeToTs(revokedAt.UTC()),
+		RevokedAt:          pgtime.New(revokedAt),
 		UserAuthGeneration: userAuthGeneration,
 	}))
 }
@@ -75,7 +76,7 @@ func emitCredentialEvent(ctx context.Context, conn *pgConn, event store.Credenti
 // are otherwise identical.
 func revokedCredentialEvent(
 	subjectID, userID string,
-	revokedAt pgtype.Timestamptz,
+	revokedAt pgtime.NullTime,
 	kind string,
 	err error,
 ) (*store.CredentialEvent, error) {
@@ -117,7 +118,7 @@ func newRevocationEventStore(conn *pgConn) *revocationEventStore {
 				return mapErr(err)
 			},
 			CompactPublished: func(ctx context.Context, conn *pgConn, cutoff time.Time) (int64, error) {
-				deleted, err := conn.q.DeleteCompactablePublishedRevocationEvents(ctx, timeToTs(cutoff))
+				deleted, err := conn.q.DeleteCompactablePublishedRevocationEvents(ctx, pgtime.NullOf(cutoff))
 				return deleted, mapErr(err)
 			},
 			InsertLease: func(ctx context.Context, conn *pgConn, lease store.RevocationLease) error {
@@ -160,14 +161,8 @@ func (s *revocationEventStore) ListPublishedAfter(
 		if err != nil {
 			return nil, err
 		}
-		revokedAt, err := sqlutil.RequireTime(row.RevokedAt.Time, row.RevokedAt.Valid, "revoked_at")
-		if err != nil {
-			return nil, err
-		}
-		createdAt, err := sqlutil.RequireTime(row.CreatedAt.Time, row.CreatedAt.Valid, "created_at")
-		if err != nil {
-			return nil, err
-		}
+		revokedAt := row.RevokedAt.Time
+		createdAt := row.CreatedAt.Time
 		publishedAt, err := sqlutil.RequireTime(row.PublishedAt.Time, row.PublishedAt.Valid, "published_at")
 		if err != nil {
 			return nil, err

--- a/backend/internal/hub/store/postgres/schema_internal_test.go
+++ b/backend/internal/hub/store/postgres/schema_internal_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
+)
+
+// TestEveryTimestampColumnDeclaresTimestamptz pins the decltype spelling the
+// sqlc type-keyed override (sqlc.yaml `db_type: "timestamptz"`) matches: every
+// `_at` column must be declared exactly TIMESTAMPTZ so sqlc retypes its params
+// and result fields to the microsecond-flooring pgtime.Time/pgtime.NullTime
+// valuers. The exact-equality assertion also rejects a precision-qualified
+// TIMESTAMPTZ(p) spelling: below the default p=6 Postgres ROUNDS a fractional
+// second that exceeds the column precision, so a lower-precision column could
+// store an instant AFTER the microsecond-floored bound. sqlc silently ignores
+// an override that matches nothing, so a column declared with another time
+// type (e.g. bare TIMESTAMP, which is WITHOUT TIME ZONE) would fall through to
+// a raw, unfloored pgtype.Timestamptz/time.Time with no red flag anywhere --
+// this scan turns that drift into a static test failure at migration time.
+// Bare TIMESTAMP is also rejected outright for any column: besides evading the
+// override, a timezone-naive column silently reinterprets instants across
+// session timezones.
+//
+// This is a static check of the migration source, so it runs without Docker.
+// Its live twin, TestPostgresTimestamptzColumnsLive (postgres_test.go, -tags
+// integration), asserts the same invariant against information_schema of the
+// actual migrated database and is immune to the text parse's line-shape
+// assumptions (see storetest.WalkCreateTableColumns).
+func TestEveryTimestampColumnDeclaresTimestamptz(t *testing.T) {
+	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	require.NoError(t, err)
+
+	atColumns := 0
+	storetest.WalkCreateTableColumns(string(sqlBytes), func(name, typeTok string) {
+		if strings.HasSuffix(name, "_at") {
+			atColumns++
+			assert.Equal(t, "TIMESTAMPTZ", typeTok,
+				"column %s is declared %s; `_at` columns must be exactly TIMESTAMPTZ (default microsecond precision) so the sqlc db_type override retypes them to the flooring valuer and no lower precision can round past the floor", name, typeTok)
+		} else {
+			assert.False(t, strings.HasPrefix(typeTok, "TIMESTAMP"),
+				"column %s is declared %s; time columns must be named *_at (and timezone-naive TIMESTAMP is banned outright)", name, typeTok)
+		}
+	})
+	// Sanity: the scan actually saw the schema's many timestamp columns.
+	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (is the migration readable?)", atColumns)
+}

--- a/backend/internal/hub/store/postgres/sessions.go
+++ b/backend/internal/hub/store/postgres/sessions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type sessionStore struct{ conn *pgConn }
@@ -17,9 +18,9 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	return store.UserSession{
 		ID:             s.ID,
 		UserID:         s.UserID,
-		ExpiresAt:      tsToTime(s.ExpiresAt),
-		CreatedAt:      tsToTime(s.CreatedAt),
-		LastActiveAt:   tsToTime(s.LastActiveAt),
+		ExpiresAt:      s.ExpiresAt.Time,
+		CreatedAt:      s.CreatedAt.Time,
+		LastActiveAt:   s.LastActiveAt.Time,
 		AuthGeneration: s.AuthGeneration,
 		UserAgent:      s.UserAgent,
 		IPAddress:      s.IpAddress,
@@ -32,9 +33,9 @@ func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSessio
 		UserID:       r.UserID,
 		Username:     r.Username,
 		UserDeleted:  r.UserDeleted,
-		CreatedAt:    tsToTime(r.CreatedAt),
-		LastActiveAt: tsToTime(r.LastActiveAt),
-		ExpiresAt:    tsToTime(r.ExpiresAt),
+		CreatedAt:    r.CreatedAt.Time,
+		LastActiveAt: r.LastActiveAt.Time,
+		ExpiresAt:    r.ExpiresAt.Time,
 		IPAddress:    r.IpAddress,
 		UserAgent:    r.UserAgent,
 	}
@@ -45,7 +46,7 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 		return mapErr(tx.(*pgStore).conn.q.CreateUserSession(ctx, gendb.CreateUserSessionParams{
 			ID:        p.ID,
 			UserID:    p.UserID,
-			ExpiresAt: timeToTs(p.ExpiresAt),
+			ExpiresAt: pgtime.New(p.ExpiresAt),
 			UserAgent: p.UserAgent,
 			IpAddress: p.IPAddress,
 		}))
@@ -63,9 +64,9 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
-		ExpiresAt:    timeToTs(p.ExpiresAt),
+		ExpiresAt:    pgtime.New(p.ExpiresAt),
 		ID:           p.ID,
-		LastActiveAt: timeToTs(p.LastActiveAt),
+		LastActiveAt: pgtime.New(p.LastActiveAt),
 	})
 	return n, mapErr(err)
 }
@@ -134,8 +135,8 @@ func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.
 		IsAdmin:        row.IsAdmin,
 		EmailVerified:  row.EmailVerified,
 		Email:          row.Email,
-		CreatedAt:      row.CreatedAt.Time.UTC(),
-		ExpiresAt:      row.ExpiresAt.Time.UTC(),
+		CreatedAt:      row.CreatedAt.UTC(),
+		ExpiresAt:      row.ExpiresAt.UTC(),
 		AuthGeneration: row.AuthGeneration,
 	}, nil
 }

--- a/backend/internal/hub/store/postgres/sqlc.yaml
+++ b/backend/internal/hub/store/postgres/sqlc.yaml
@@ -11,6 +11,32 @@ sql:
         emit_empty_slices: true
         sql_package: "pgx/v5"
         overrides:
+          # Microsecond-floored timestamptz types (#303). Type-keyed: retypes
+          # every timestamptz param and result column. Both spellings are listed
+          # because sqlc may resolve the type as either the pg_catalog-qualified
+          # or bare name depending on context; a spelling that never matches is
+          # harmless. Column-keyed overrides below take precedence.
+          # sqlc silently ignores an override that matches nothing, so the
+          # decltype spelling these keys rely on is pinned statically by
+          # TestEveryTimestampColumnDeclaresTimestamptz (schema_internal_test.go).
+          - db_type: "pg_catalog.timestamptz"
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+              type: "Time"
+          - db_type: "pg_catalog.timestamptz"
+            nullable: true
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+              type: "NullTime"
+          - db_type: "timestamptz"
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+              type: "Time"
+          - db_type: "timestamptz"
+            nullable: true
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+              type: "NullTime"
           # Worker enums
           - column: "workers.status"
             go_type:

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
 type userStore struct {
@@ -27,16 +28,16 @@ func fromDBUser(u gendb.User) store.User {
 		EmailVerified:         u.EmailVerified,
 		PendingEmail:          u.PendingEmail,
 		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: tsToTimePtr(u.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
 		PendingEmailAttempts:  int64(u.PendingEmailAttempts),
 		PasswordSet:           u.PasswordSet,
 		IsAdmin:               u.IsAdmin,
 		Prefs:                 u.Prefs,
-		CreatedAt:             tsToTime(u.CreatedAt),
-		UpdatedAt:             tsToTime(u.UpdatedAt),
-		TokensRevokedAt:       tsToTimePtr(u.TokensRevokedAt),
+		CreatedAt:             u.CreatedAt.Time,
+		UpdatedAt:             u.UpdatedAt.Time,
+		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
 		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             tsToTimePtr(u.DeletedAt),
+		DeletedAt:             u.DeletedAt.Ptr(),
 	}
 }
 
@@ -210,7 +211,7 @@ func (s *userStore) runUserInfoMutation(ctx context.Context, id string, mutate f
 // with changed=true. Shared by every cached-field Update* mutate closure so the
 // not-found / RETURNING-time handling lives in one place instead of five
 // identical tails.
-func updatedUserResult(id string, updatedAt time.Time, valid bool, err error) (string, time.Time, bool, error) {
+func updatedUserResult(id string, updatedAt time.Time, err error) (string, time.Time, bool, error) {
 	if err != nil {
 		mapped := mapErr(err)
 		if errors.Is(mapped, store.ErrNotFound) {
@@ -218,11 +219,7 @@ func updatedUserResult(id string, updatedAt time.Time, valid bool, err error) (s
 		}
 		return "", time.Time{}, false, mapped
 	}
-	at, err := sqlutil.RequireTime(updatedAt, valid, "updated_at")
-	if err != nil {
-		return "", time.Time{}, false, err
-	}
-	return id, at, true, nil
+	return id, updatedAt, true, nil
 }
 
 // UpdateProfile changes the username/display name; RunUserInfoMutation emits a
@@ -241,7 +238,7 @@ func (s *userStore) UpdateProfile(ctx context.Context, p store.UpdateUserProfile
 			ID:                p.ID,
 		})
 		if err != nil {
-			return updatedUserResult("", time.Time{}, false, err)
+			return updatedUserResult("", time.Time{}, err)
 		}
 		// Pair the username with a personal-org rename in the same transaction so
 		// the org name (and /o/ slug) can never go stale -- mirroring the DeleteUser
@@ -254,7 +251,7 @@ func (s *userStore) UpdateProfile(ctx context.Context, p store.UpdateUserProfile
 		})); err != nil {
 			return "", time.Time{}, false, err
 		}
-		return updatedUserResult(row.ID, row.UpdatedAt.Time, row.UpdatedAt.Valid, nil)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, nil)
 	})
 }
 
@@ -275,7 +272,7 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 			EmailVerified: p.EmailVerified,
 			ID:            p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt.Time, row.UpdatedAt.Valid, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -289,7 +286,7 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 			EmailVerified: p.EmailVerified,
 			ID:            p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt.Time, row.UpdatedAt.Valid, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -302,7 +299,7 @@ func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminPara
 			IsAdmin: p.IsAdmin,
 			ID:      p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt.Time, row.UpdatedAt.Valid, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -317,7 +314,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
-		PendingEmailExpiresAt: timePtrToTs(p.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: pgtime.NewNull(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
 	}))
 }
@@ -330,7 +327,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
 		row, err := conn.q.PromotePendingEmail(ctx, id)
-		return updatedUserResult(row.ID, row.UpdatedAt.Time, row.UpdatedAt.Valid, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 

--- a/backend/internal/hub/store/postgres/worker_notifications.go
+++ b/backend/internal/hub/store/postgres/worker_notifications.go
@@ -50,7 +50,7 @@ func fromDBWorkerNotification(n gendb.WorkerNotification) store.WorkerNotificati
 		Status:      n.Status,
 		Attempts:    int64(n.Attempts),
 		MaxAttempts: int64(n.MaxAttempts),
-		CreatedAt:   tsToTime(n.CreatedAt),
-		DeliveredAt: tsToTimePtr(n.DeliveredAt),
+		CreatedAt:   n.CreatedAt.Time,
+		DeliveredAt: n.DeliveredAt.Ptr(),
 	}
 }

--- a/backend/internal/hub/store/postgres/workers.go
+++ b/backend/internal/hub/store/postgres/workers.go
@@ -159,13 +159,13 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 		AuthToken:       w.AuthToken,
 		RegisteredBy:    w.RegisteredBy,
 		Status:          w.Status,
-		CreatedAt:       tsToTime(w.CreatedAt),
-		LastSeenAt:      tsToTimePtr(w.LastSeenAt),
+		CreatedAt:       w.CreatedAt.Time,
+		LastSeenAt:      w.LastSeenAt.Ptr(),
 		PublicKey:       w.PublicKey,
 		MlkemPublicKey:  w.MlkemPublicKey,
 		SlhdsaPublicKey: w.SlhdsaPublicKey,
 		AutoRegistered:  w.AutoRegistered,
-		DeletedAt:       tsToTimePtr(w.DeletedAt),
+		DeletedAt:       w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/postgres/workspace_sections.go
+++ b/backend/internal/hub/store/postgres/workspace_sections.go
@@ -21,7 +21,7 @@ func fromDBWorkspaceSection(s gendb.WorkspaceSection) *store.WorkspaceSection {
 		Position:    s.Position,
 		SectionType: s.SectionType,
 		Sidebar:     s.Sidebar,
-		CreatedAt:   tsToTime(s.CreatedAt),
+		CreatedAt:   s.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/postgres/workspaces.go
+++ b/backend/internal/hub/store/postgres/workspaces.go
@@ -20,8 +20,8 @@ func fromDBWorkspace(w gendb.Workspace) *store.Workspace {
 		OwnerUserID: w.OwnerUserID,
 		Title:       w.Title,
 		IsDeleted:   w.IsDeleted,
-		CreatedAt:   tsToTime(w.CreatedAt),
-		DeletedAt:   tsToTimePtr(w.DeletedAt),
+		CreatedAt:   w.CreatedAt.Time,
+		DeletedAt:   w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/api_tokens.go
+++ b/backend/internal/hub/store/sqlite/api_tokens.go
@@ -7,6 +7,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type apiTokenStore struct{ conn *sqliteConn }
@@ -22,15 +23,15 @@ func fromDBAPIToken(t gendb.ApiToken) store.APIToken {
 		SecretHash:               t.SecretHash,
 		RefreshHash:              t.RefreshHash,
 		PreviousRefreshHash:      t.PreviousRefreshHash,
-		PreviousRefreshExpiresAt: sqlutil.NullTimePtr(t.PreviousRefreshExpiresAt),
+		PreviousRefreshExpiresAt: t.PreviousRefreshExpiresAt.Ptr(),
 		Scope:                    t.Scope,
-		CreatedAt:                t.CreatedAt,
+		CreatedAt:                t.CreatedAt.Time,
 		AuthGeneration:           t.AuthGeneration,
-		LastUsedAt:               sqlutil.NullTimePtr(t.LastUsedAt),
-		LastRotatedAt:            sqlutil.NullTimePtr(t.LastRotatedAt),
-		ExpiresAt:                sqlutil.NullTimePtr(t.ExpiresAt),
-		RefreshExpiresAt:         sqlutil.NullTimePtr(t.RefreshExpiresAt),
-		RevokedAt:                sqlutil.NullTimePtr(t.RevokedAt),
+		LastUsedAt:               t.LastUsedAt.Ptr(),
+		LastRotatedAt:            t.LastRotatedAt.Ptr(),
+		ExpiresAt:                t.ExpiresAt.Ptr(),
+		RefreshExpiresAt:         t.RefreshExpiresAt.Ptr(),
+		RevokedAt:                t.RevokedAt.Ptr(),
 	}
 }
 
@@ -44,8 +45,8 @@ func (s *apiTokenStore) Create(ctx context.Context, p store.CreateAPITokenParams
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
 			Scope:            p.Scope,
-			ExpiresAt:        sqlutil.BindNullTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqltime.NewSQLiteNullTime(p.ExpiresAt),
+			RefreshExpiresAt: sqltime.NewSQLiteNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }
@@ -135,11 +136,11 @@ func (s *apiTokenStore) RotateRefresh(ctx context.Context, p store.RotateAPIToke
 		n, err := rowsAffected(conn.q.RotateAPITokenRefresh(ctx, gendb.RotateAPITokenRefreshParams{
 			ID:                   p.ID,
 			NewSecretHash:        p.NewSecretHash,
-			NewExpiresAt:         sqlutil.BindNullTime(p.NewExpiresAt),
+			NewExpiresAt:         sqltime.NewSQLiteNullTime(p.NewExpiresAt),
 			NewRefreshHash:       p.NewRefreshHash,
-			NewRefreshExpiresAt:  sqlutil.BindNullTime(p.NewRefreshExpiresAt),
+			NewRefreshExpiresAt:  sqltime.NewSQLiteNullTime(p.NewRefreshExpiresAt),
 			PrevRefreshHash:      p.PreviousRefreshHash,
-			PrevRefreshExpiresAt: sqlutil.BindNullTime(p.PreviousRefreshExpiresAt),
+			PrevRefreshExpiresAt: sqltime.NewSQLiteNullTime(p.PreviousRefreshExpiresAt),
 		}))
 		if err != nil || n == 0 {
 			return nil, err

--- a/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
+++ b/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 	"time"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,10 +20,16 @@ import (
 // is the canonical 24-char strftime('%Y-%m-%dT%H:%M:%fZ') layout. Binds use a
 // deliberately non-UTC fixed zone: a raw time.Time bind would store modernc's
 // driver layout with the zone's offset (space at byte 11, '+09:00' suffix),
-// so any write path missing its SQL-side strftime wrap (or Go-side
-// formatSQLiteTime pre-formatting) fails here instead of silently splitting
+// so any write path that binds a raw time.Time instead of a sqltime.SQLiteTime
+// (or misses its SQL-side strftime wrap) fails here instead of silently splitting
 // the store into two timestamp layouts whose raw-string compares diverge as
 // soon as the offsets differ.
+//
+// The test also asserts non-vacuity: every discovered DATETIME column --
+// NOT NULL and nullable alike -- must hold at least one non-null value by the
+// end of the fixtures, so no column's layout contract passes merely because
+// nothing was ever stored in it. A new DATETIME column therefore fails this
+// test until a fixture write for it is added here.
 func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	ctx := context.Background()
 	testable, err := OpenTestable(":memory:")
@@ -41,9 +50,12 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	workspaceID := storetest.SeedWorkspace(t, st, orgID, user.ID, "canon-ws")
 	provider := storetest.SeedOAuthProvider(t, st, "canon-provider")
 
-	// delegation_tokens: expires_at + refresh_expires_at.
+	// delegation_tokens: expires_at + refresh_expires_at on Create (created_at
+	// via its column DEFAULT); last_used_at and revoked_at are exercised by
+	// the Touch/Revoke fixtures further down.
+	delegationID := id.Generate()
 	require.NoError(t, st.DelegationTokens().Create(ctx, store.CreateDelegationTokenParams{
-		ID:               id.Generate(),
+		ID:               delegationID,
 		UserID:           user.ID,
 		WorkerID:         worker.ID,
 		WorkspaceID:      workspaceID,
@@ -203,5 +215,119 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		UpdatedAt:      future,
 	}))
 
+	// user_sessions: expires_at is Go-bound by Create; created_at and
+	// last_active_at fill via their column DEFAULTs.
+	storetest.SeedSession(t, st, user.ID)
+
+	// worker_registration_keys: created_at DEFAULT + Go-bound expires_at.
+	storetest.SeedRegistrationKey(t, st, user.ID, future)
+
+	// worker_notifications: created_at DEFAULT on Create, delivered_at via
+	// MarkDelivered's strftime.
+	notifID := id.Generate()
+	require.NoError(t, st.WorkerNotifications().Create(ctx, store.CreateWorkerNotificationParams{
+		ID:       notifID,
+		WorkerID: worker.ID,
+		Type:     leapmuxv1.NotificationType_NOTIFICATION_TYPE_DEREGISTER,
+		Payload:  `{"reason":"canon"}`,
+	}))
+	require.NoError(t, st.WorkerNotifications().MarkDelivered(ctx, notifID))
+
+	// org_op_batches.committed_at via its column DEFAULT.
+	require.NoError(t, st.OrgOpBatches().Insert(ctx, store.InsertOrgOpBatchParams{
+		OrgID:        orgID,
+		PhysicalMs:   1,
+		Logical:      1,
+		LastLogical:  1,
+		OriginClient: "client",
+		PrincipalID:  user.ID,
+		BatchID:      "canon-opbatch",
+		BodyHash:     []byte("hash"),
+		BatchPayload: []byte("payload"),
+		OpCount:      1,
+		Epoch:        1,
+	}))
+
+	// workspace_sections.created_at via its column DEFAULT.
+	require.NoError(t, st.WorkspaceSections().Create(ctx, store.CreateWorkspaceSectionParams{
+		ID:          id.Generate(),
+		UserID:      user.ID,
+		Name:        "canon-section",
+		Position:    "a0",
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+		Sidebar:     leapmuxv1.Sidebar_SIDEBAR_LEFT,
+	}))
+
+	// oauth_user_links.created_at via its column DEFAULT.
+	require.NoError(t, st.OAuthUserLinks().Create(ctx, store.CreateOAuthUserLinkParams{
+		UserID:          user.ID,
+		ProviderID:      provider.ID,
+		ProviderSubject: "canon-subject",
+	}))
+
+	// users.pending_email_expires_at is Go-bound by SetPendingEmail.
+	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		ID:                    user.ID,
+		PendingEmail:          "canon-pending@example.com",
+		PendingEmailToken:     "canon-token",
+		PendingEmailExpiresAt: ptr(future),
+	}))
+
+	// workers.last_seen_at via UpdateLastSeen's strftime.
+	require.NoError(t, st.Workers().UpdateLastSeen(ctx, worker.ID))
+
+	// api_tokens.last_used_at via Touch.
+	require.NoError(t, st.APITokens().Touch(ctx, rotatedID))
+
+	// delegation_tokens: last_used_at via Touch, revoked_at via Revoke.
+	require.NoError(t, st.DelegationTokens().Touch(ctx, delegationID))
+	revokedDeleg, err := st.DelegationTokens().Revoke(ctx, delegationID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, revokedDeleg)
+
+	// users.tokens_revoked_at via RevokeUserTokens, which also enqueues
+	// another pending revocation event.
+	revokedUsers, err := st.Users().RevokeUserTokens(ctx, user.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, revokedUsers)
+
+	// hub_runtime_lease.lease_expires_at via AcquireHubRuntimeLease's SQL-side
+	// strftime offset; the same call publishes the pending revocation events
+	// enqueued by the Revoke calls above, filling
+	// revocation_events.published_at.
+	_, err = st.RevocationEvents().AcquireHubRuntimeLease(ctx, store.AcquireHubRuntimeLeaseParams{
+		HolderID:      "canon-holder",
+		PublishLimit:  100,
+		LeaseDuration: time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Soft-delete paths, run last so every fixture above wrote against live
+	// rows: users.deleted_at + orgs.deleted_at through the transactional user
+	// delete (which soft-deletes the personal org too); workers.deleted_at and
+	// workspaces.deleted_at through their own strftime-based soft deletes.
+	delOrgID := storetest.SeedOrg(t, st, "canon-org-del")
+	delUser := storetest.SeedUser(t, st, delOrgID, "canon-user-del")
+	require.NoError(t, st.Users().Delete(ctx, delUser.ID))
+	require.NoError(t, st.Workers().MarkDeleted(ctx, worker.ID))
+	deletedWs, err := st.Workspaces().SoftDelete(ctx, store.SoftDeleteWorkspaceParams{
+		ID:          workspaceID,
+		OwnerUserID: user.ID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deletedWs)
+
 	require.NoError(t, CheckCanonicalTimestamps(ctx, testable))
+
+	// Non-vacuity: a column with zero non-null rows passes the layout probe
+	// without ever being exercised, so a raw time.Time bind on that write path
+	// would ship unnoticed. Every discovered column must hold at least one
+	// value by the end of the fixture writes above. This assertion lives here
+	// rather than in CheckCanonicalTimestamps because no single storetest
+	// subtest writes every table -- only this test's fixtures do.
+	db := testable.(*testableSQLiteStore).conn.shared.db
+	_, columns, err := sqlitedb.FindNonCanonicalDatetimes(ctx, db, "goose_db_version")
+	require.NoError(t, err)
+	assert.Empty(t, sqlitedb.UncoveredColumns(columns),
+		"DATETIME column(s) with zero non-null rows -- their canonical-layout check passed vacuously; add a fixture write for each so the contract is actually exercised")
 }

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type cleanupStore struct {
@@ -18,27 +19,27 @@ func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, er
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkspacesBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteWorkersBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteExpiredRegistrationKeysBefore(ctx, sqltime.NewSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) HardDeleteOrgsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.HardDeleteOrgsBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
@@ -50,23 +51,23 @@ func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (in
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteRevokedAPITokensBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
 func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, formatSQLiteTime(cutoff)))
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewSQLiteTime(cutoff)))
 }
 
 func (s *cleanupStore) CompactPublishedRevocationEvents(

--- a/backend/internal/hub/store/sqlite/cli_authorization_codes.go
+++ b/backend/internal/hub/store/sqlite/cli_authorization_codes.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type cliAuthorizationCodeStore struct{ conn *sqliteConn }
@@ -18,9 +18,9 @@ func fromDBCLIAuthorizationCode(c gendb.CliAuthorizationCode) store.CLIAuthoriza
 		UserID:        c.UserID,
 		CodeChallenge: c.CodeChallenge,
 		DeviceName:    c.DeviceName,
-		CreatedAt:     c.CreatedAt,
-		ExpiresAt:     c.ExpiresAt,
-		ConsumedAt:    sqlutil.NullTimePtr(c.ConsumedAt),
+		CreatedAt:     c.CreatedAt.Time,
+		ExpiresAt:     c.ExpiresAt.Time,
+		ConsumedAt:    c.ConsumedAt.Ptr(),
 	}
 }
 
@@ -30,7 +30,7 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 		UserID:        p.UserID,
 		CodeChallenge: p.CodeChallenge,
 		DeviceName:    p.DeviceName,
-		ExpiresAt:     sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:     sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/convert.go
+++ b/backend/internal/hub/store/sqlite/convert.go
@@ -5,39 +5,16 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
-	"github.com/leapmux/leapmux/internal/util/timefmt"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	sqlite3 "modernc.org/sqlite"
 	sqlitelib "modernc.org/sqlite/lib"
 )
-
-// sqliteTimeFormat is the ISO 8601 layout SQLite writes via
-// strftime('%Y-%m-%dT%H:%M:%fZ', ...): fixed 3-digit fractional seconds, the
-// same instant grid as this Go layout's ".000". Every SQL-side write path
-// (column DEFAULTs, the Create/Touch strftime wraps, SoftDelete's
-// strftime('now')) stores canonical 24-char values ON DISK -- for EVERY
-// DATETIME column of every table, enforced mechanically by
-// CheckCanonicalTimestamps in testhelper.go -- so the raw-string
-// keyset predicates and cleanup cutoff compares -- which run SQL-side against
-// the stored bytes -- are byte-exact against formatSQLiteTime-formatted
-// params, including at trailing-zero milliseconds (pinned by
-// TestKeysetCursorTrailingZeroMillisecondTie in sessions_internal_test.go).
-// CAUTION for tests and tooling: modernc TRIMS trailing fractional zeros when
-// a DATETIME column is scanned into a Go string (a stored ".130Z" arrives as
-// ".13Z") -- a driver presentation artifact only; production reads scan into
-// time.Time and are unaffected. Do not mistake a short scanned string for
-// on-disk variability.
-const sqliteTimeFormat = timefmt.ISO8601
-
-func formatSQLiteTime(t time.Time) string {
-	return t.UTC().Format(sqliteTimeFormat)
-}
 
 func mapErr(err error) error {
 	if err == nil {
@@ -57,19 +34,29 @@ func mapErr(err error) error {
 }
 
 // decodeCursorParams decodes the composite list cursor into the two nullable sqlc
-// parameters SQLite's keyset queries bind: the cursor timestamp, formatted as
-// the ISO 8601 string SQLite stores via strftime('%Y-%m-%dT%H:%M:%fZ'), and the
-// id tiebreaker. An empty cursor (first page) returns the zero values so the
-// queries' "cursor_time IS NULL" branch selects every row.
-func decodeCursorParams(cursor string) (cursorTime any, cursorID sql.NullString, err error) {
+// parameters SQLite's keyset queries bind: the cursor timestamp and the id
+// tiebreaker. An empty cursor (first page) returns the zero values so the
+// queries' "cursor_time IS NULL" branch selects every row (an invalid
+// SQLiteNullTime binds NULL).
+//
+// The cursor timestamp stays sqltime.SQLiteNullTime -- its Value() emits the
+// same canonical 24-char bytes SQLite stores on disk, so the raw-string keyset
+// compare and IS-NULL first-page branch are byte-exact, including at
+// trailing-zero milliseconds (pinned by TestKeysetCursorTrailingZeroMillisecondTie).
+// The generated CursorTime params stay interface{}: the sqlite engine does not
+// resolve the `narg IS NULL OR col < narg` OR-chain to a column type, so it
+// cannot type these params. Binding a Valuer through the interface still routes
+// through Value(), so the floor and canonical layout stay mechanical; only
+// compile-time typing is missing here.
+func decodeCursorParams(cursor string) (cursorTime sqltime.SQLiteNullTime, cursorID sql.NullString, err error) {
 	c, err := store.ParseCursor(cursor)
 	if err != nil {
-		return nil, sql.NullString{}, err
+		return sqltime.SQLiteNullTime{}, sql.NullString{}, err
 	}
 	if c == nil {
-		return nil, sql.NullString{}, nil
+		return sqltime.SQLiteNullTime{}, sql.NullString{}, nil
 	}
-	return formatSQLiteTime(c.Time), sql.NullString{String: c.ID, Valid: true}, nil
+	return sqltime.SQLiteNullTimeOf(c.Time), sql.NullString{String: c.ID, Valid: true}, nil
 }
 
 // withCursor decodes the composite list cursor and applies the dialect's
@@ -80,7 +67,7 @@ func decodeCursorParams(cursor string) (cursorTime any, cursorID sql.NullString,
 // dialect instead of being copy-pasted across every list builder -- the prior
 // shape let ListRegistrationKeysAdmin silently bypass ClampListLimit until this
 // commit's pagination rebuild caught it.
-func withCursor[T any](cursor string, limit int64, fill func(cursorTime any, cursorID sql.NullString, fetchLimit int64) T) (T, error) {
+func withCursor[T any](cursor string, limit int64, fill func(cursorTime sqltime.SQLiteNullTime, cursorID sql.NullString, fetchLimit int64) T) (T, error) {
 	cursorTime, cursorID, err := decodeCursorParams(cursor)
 	if err != nil {
 		var zero T
@@ -104,13 +91,13 @@ func queryPage[P any, R any, I store.PageCursorer](
 }
 
 func listAllUsersParams(cursor string, limit int64) (gendb.ListAllUsersParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllUsersParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllUsersParams {
 		return gendb.ListAllUsersParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchUsersParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.SearchUsersParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.SearchUsersParams {
 		// Build the complete LIKE prefix pattern (fold + metachar escape + trailing
 		// '%') at the one shared site, so the match is case-insensitive and literal
 		// cross-dialect. A nil query stays nil (SearchUsers reads it as "no filter").
@@ -124,7 +111,7 @@ func searchUsersParams(query *string, cursor string, limit int64) (gendb.SearchU
 }
 
 func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.ListWorkersByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersByUserIDParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListWorkersByUserIDParams {
 		return gendb.ListWorkersByUserIDParams{RegisteredBy: registeredBy, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -132,7 +119,7 @@ func listWorkersByUserIDParams(registeredBy, cursor string, limit int64) (gendb.
 // listWorkersAdminParams builds the status=nil, user_id=nil query
 // (ListWorkersAdmin): deleted_at IS NULL, no user filter.
 func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListWorkersAdminParams {
 		return gendb.ListWorkersAdminParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -145,7 +132,7 @@ func listWorkersAdminParams(cursor string, limit int64) (gendb.ListWorkersAdminP
 // untyped interface{} param that breaks Postgres (SQLSTATE 42P08). See
 // workers.sql for the full 2x2 matrix rationale.
 func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserParams {
 		return gendb.ListWorkersAdminByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -154,7 +141,7 @@ func listWorkersAdminByUserParams(userID string, cursor string, limit int64) (ge
 // (ListWorkersAdminByStatus): no deleted_at filter (status=3 surfaces
 // soft-deleted rows), no user filter.
 func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string, limit int64) (gendb.ListWorkersAdminByStatusParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByStatusParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListWorkersAdminByStatusParams {
 		return gendb.ListWorkersAdminByStatusParams{Status: status, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
@@ -163,77 +150,80 @@ func listWorkersAdminByStatusParams(status leapmuxv1.WorkerStatus, cursor string
 // query (ListWorkersAdminByUserAndStatus): required registered_by + status,
 // riding the (registered_by, status, created_at, id) composite seek.
 func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID string, cursor string, limit int64) (gendb.ListWorkersAdminByUserAndStatusParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserAndStatusParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListWorkersAdminByUserAndStatusParams {
 		return gendb.ListWorkersAdminByUserAndStatusParams{Status: status, UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllActiveSessionsParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllActiveSessionsParams {
 		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListUserSessionsByUserIDParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListUserSessionsByUserIDParams {
 		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllAPITokensParams {
 		return gendb.ListAllAPITokensParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserParams {
 		return gendb.ListAllAPITokensByUserParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensIncludingRevokedParams(clientType, cursor string, limit int64) (gendb.ListAllAPITokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllAPITokensIncludingRevokedParams {
 		return gendb.ListAllAPITokensIncludingRevokedParams{ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllAPITokensByUserIncludingRevokedParams(userID, clientType, cursor string, limit int64) (gendb.ListAllAPITokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllAPITokensByUserIncludingRevokedParams {
 		return gendb.ListAllAPITokensByUserIncludingRevokedParams{UserID: userID, ClientType: clientType, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensParams(cursor string, limit int64) (gendb.ListAllDelegationTokensParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensParams {
 		return gendb.ListAllDelegationTokensParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserParams {
 		return gendb.ListAllDelegationTokensByUserParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensIncludingRevokedParams(cursor string, limit int64) (gendb.ListAllDelegationTokensIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensIncludingRevokedParams{CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 func listAllDelegationTokensByUserIncludingRevokedParams(userID, cursor string, limit int64) (gendb.ListAllDelegationTokensByUserIncludingRevokedParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllDelegationTokensByUserIncludingRevokedParams {
 		return gendb.ListAllDelegationTokensByUserIncludingRevokedParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
 // listRegistrationKeysAdminParams mirrors the other list builders so the
 // registration-key admin listing shares the cursor decode and limit clamp.
-// now is the caller-computed expiry probe (nil when expired rows are
-// included), passed in so the builder stays a pure function of its arguments.
-func listRegistrationKeysAdminParams(cursor string, limit int64, now any) (gendb.ListRegistrationKeysAdminParams, error) {
-	return withCursor(cursor, limit, func(ct any, cid sql.NullString, fl int64) gendb.ListRegistrationKeysAdminParams {
+// now is the caller-computed expiry probe (invalid, binding NULL, when expired
+// rows are included), passed in so the builder stays a pure function of its
+// arguments. Typed SQLiteNullTime -- the generated Now field is interface{}
+// (narg OR-chain), so the typed signature is what keeps a raw time.Time from
+// reaching the bind.
+func listRegistrationKeysAdminParams(cursor string, limit int64, now sqltime.SQLiteNullTime) (gendb.ListRegistrationKeysAdminParams, error) {
+	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListRegistrationKeysAdminParams {
 		return gendb.ListRegistrationKeysAdminParams{Now: now, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/api_tokens.sql
@@ -10,8 +10,8 @@ INSERT INTO api_tokens (
     sqlc.arg(secret_hash),
     sqlc.arg(refresh_hash),
     sqlc.arg(scope),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(refresh_expires_at)),
+    sqlc.narg(expires_at),
+    sqlc.narg(refresh_expires_at),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
 );
 
@@ -99,11 +99,11 @@ WHERE id = ?;
 -- and deterministically derive the same replacement pair.
 UPDATE api_tokens
 SET secret_hash = sqlc.arg(new_secret_hash),
-    expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_expires_at)),
+    expires_at = sqlc.narg(new_expires_at),
     refresh_hash = sqlc.arg(new_refresh_hash),
-    refresh_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_refresh_expires_at)),
+    refresh_expires_at = sqlc.narg(new_refresh_expires_at),
     previous_refresh_hash = sqlc.arg(prev_refresh_hash),
-    previous_refresh_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(prev_refresh_expires_at)),
+    previous_refresh_expires_at = sqlc.narg(prev_refresh_expires_at),
     last_rotated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = sqlc.arg(id)
   AND revoked_at IS NULL
@@ -122,7 +122,8 @@ WHERE user_id = ? AND revoked_at IS NULL;
 
 -- name: DeleteRevokedAPITokensBefore :execresult
 -- See the matching delegation_tokens query for the rationale: revoked_at is
--- written canonical on every path, so the raw compare against the canonical
--- CAST AS TEXT cutoff is byte-exact and sargable for idx_api_tokens_revoked_at.
+-- written canonical on every path, so the raw compare against the SQLiteTime
+-- cutoff (which binds the same canonical layout) is byte-exact and sargable
+-- for idx_api_tokens_revoked_at.
 DELETE FROM api_tokens
-WHERE revoked_at IS NOT NULL AND revoked_at < CAST(sqlc.arg(cutoff) AS TEXT);
+WHERE revoked_at IS NOT NULL AND revoked_at < sqlc.arg(cutoff);

--- a/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
@@ -6,13 +6,13 @@ INSERT INTO cli_authorization_codes (
     sqlc.arg(user_id),
     sqlc.arg(code_challenge),
     sqlc.arg(device_name),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+    sqlc.arg(expires_at)
 );
 
 -- name: GetActiveCLIAuthorizationCode :one
 -- Raw compare: expires_at is stored canonical (CreateCLIAuthorizationCode
--- wraps the bound instant in strftime), so the liveness guard is
--- millisecond-exact against the same canonical RHS layout.
+-- binds a SQLiteTime), so the liveness guard is millisecond-exact against the
+-- same canonical RHS layout.
 SELECT * FROM cli_authorization_codes
 WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
@@ -23,7 +23,7 @@ WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M
 RETURNING *;
 
 -- name: DeleteExpiredCLIAuthorizationCodes :execresult
--- Raw compare against a formatSQLiteTime-formatted cutoff (CAST AS TEXT ->
--- string param); see DeleteExpiredDelegationTokensBefore for the pattern.
+-- Raw compare against a SQLiteTime cutoff (same canonical layout); see
+-- DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM cli_authorization_codes
-WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT);
+WHERE expires_at < sqlc.arg(cutoff);

--- a/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
@@ -14,8 +14,8 @@ INSERT INTO delegation_tokens (
     sqlc.arg(issued_for_tab_type),
     sqlc.arg(secret_hash),
     sqlc.arg(refresh_hash),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(refresh_expires_at)),
+    sqlc.arg(expires_at),
+    sqlc.narg(refresh_expires_at),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
 );
 
@@ -81,9 +81,9 @@ LIMIT sqlc.arg(limit);
 -- Returns rows that are still usable: not revoked AND not yet expired.
 -- Used by lifecycle hooks (logout, password change, account deactivation)
 -- that want to enumerate live tokens before bulk-revoking them.
--- Raw compare: expires_at is stored canonical (CreateDelegationToken wraps the
--- bound instant in strftime), so the liveness filter is millisecond-exact
--- against the same canonical RHS layout.
+-- Raw compare: expires_at is stored canonical (CreateDelegationToken binds a
+-- SQLiteTime, which serializes the canonical strftime layout), so the liveness
+-- filter is millisecond-exact against the same canonical RHS layout.
 SELECT * FROM delegation_tokens
 WHERE user_id = ?
   AND revoked_at IS NULL
@@ -109,20 +109,19 @@ RETURNING id, user_id, revoked_at;
 -- name: DeleteRevokedDelegationTokensBefore :execresult
 -- Raw compare: every revoked_at write path stores the canonical strftime
 -- layout (RevokeDelegationToken and RevokeDelegationTokensByUserFast both SET
--- strftime('%Y-%m-%dT%H:%M:%fZ','now')), and the Go side binds a
--- formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param), so the
--- lexicographic < is byte-exact. Unlike the previous datetime() wrap on the
--- column, this is sargable: the partial idx_delegation_tokens_revoked_at
--- serves an upper-bounded SEARCH of just the cutoff-eligible rows instead of
--- reading every revoked row on each hourly sweep of this high-churn table.
+-- strftime('%Y-%m-%dT%H:%M:%fZ','now')), and the Go side binds a SQLiteTime
+-- cutoff (same canonical layout), so the lexicographic < is byte-exact. This is
+-- sargable: the partial idx_delegation_tokens_revoked_at serves an
+-- upper-bounded SEARCH of just the cutoff-eligible rows instead of reading
+-- every revoked row on each hourly sweep of this high-churn table.
 DELETE FROM delegation_tokens
-WHERE revoked_at IS NOT NULL AND revoked_at < CAST(sqlc.arg(cutoff) AS TEXT);
+WHERE revoked_at IS NOT NULL AND revoked_at < sqlc.arg(cutoff);
 
 -- name: DeleteExpiredDelegationTokensBefore :execresult
--- Raw compare: expires_at is stored canonical (CreateDelegationToken wraps the
--- bound instant in strftime), and the Go side binds a formatSQLiteTime-
--- formatted cutoff (CAST AS TEXT -> string param), so the lexicographic < is
--- byte-exact and sargable for the partial idx_delegation_tokens_expires_at --
--- the hourly sweep of this high-churn table seeks just the expired live rows.
+-- Raw compare: expires_at is stored canonical (CreateDelegationToken binds a
+-- SQLiteTime), and the Go side binds a SQLiteTime cutoff (same canonical
+-- layout), so the lexicographic < is byte-exact and sargable for the partial
+-- idx_delegation_tokens_expires_at -- the hourly sweep of this high-churn table
+-- seeks just the expired live rows.
 DELETE FROM delegation_tokens
-WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT) AND revoked_at IS NULL;
+WHERE expires_at < sqlc.arg(cutoff) AND revoked_at IS NULL;

--- a/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
@@ -6,7 +6,7 @@ INSERT INTO device_authorizations (
     sqlc.arg(user_code),
     sqlc.arg(device_name),
     sqlc.arg(interval_seconds),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+    sqlc.arg(expires_at)
 );
 
 -- name: GetDeviceAuthorization :one
@@ -17,8 +17,8 @@ SELECT * FROM device_authorizations WHERE user_code = ?;
 
 -- name: ApproveDeviceAuthorization :execresult
 -- Raw compare: expires_at is stored canonical (CreateDeviceAuthorization
--- wraps the bound instant in strftime), so the liveness guard is
--- millisecond-exact against the same canonical RHS layout.
+-- binds a SQLiteTime), so the liveness guard is millisecond-exact against the
+-- same canonical RHS layout.
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
 WHERE device_code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
@@ -45,7 +45,7 @@ SET last_polled_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE device_code = ?;
 
 -- name: DeleteExpiredDeviceAuthorizations :execresult
--- Raw compare against a formatSQLiteTime-formatted cutoff (CAST AS TEXT ->
--- string param); see DeleteExpiredDelegationTokensBefore for the pattern.
+-- Raw compare against a SQLiteTime cutoff (same canonical layout); see
+-- DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM device_authorizations
-WHERE expires_at < CAST(sqlc.arg(cutoff) AS TEXT);
+WHERE expires_at < sqlc.arg(cutoff);

--- a/backend/internal/hub/store/sqlite/db/queries/lifecycle_outbox.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/lifecycle_outbox.sql
@@ -13,12 +13,11 @@ LIMIT ?;
 
 -- name: MarkLifecycleOutboxConsumed :exec
 UPDATE lifecycle_outbox
-SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(consumed_at))
+SET consumed_at = sqlc.arg(consumed_at)
 WHERE id = sqlc.arg(id);
 
 -- name: DeleteConsumedLifecycleOutboxBefore :execresult
 -- Raw compare: consumed_at is stored canonical (MarkLifecycleOutboxConsumed
--- wraps the bound instant in strftime), and the Go side binds a
--- formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param), so the
--- lexicographic < is byte-exact.
-DELETE FROM lifecycle_outbox WHERE consumed_at IS NOT NULL AND consumed_at < CAST(sqlc.arg(before) AS TEXT);
+-- binds a SQLiteTime), and the Go side binds a SQLiteTime cutoff (same
+-- canonical layout), so the lexicographic < is byte-exact.
+DELETE FROM lifecycle_outbox WHERE consumed_at IS NOT NULL AND consumed_at < sqlc.arg(before);

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
@@ -5,7 +5,7 @@ VALUES (
     sqlc.arg(provider_id),
     sqlc.arg(pkce_verifier),
     sqlc.arg(redirect_uri),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+    sqlc.arg(expires_at)
 );
 
 -- name: GetOAuthState :one
@@ -15,7 +15,7 @@ SELECT * FROM oauth_states WHERE state = ?;
 DELETE FROM oauth_states WHERE state = ?;
 
 -- name: DeleteExpiredOAuthStates :execresult
--- Raw compare: expires_at is stored canonical (CreateOAuthState wraps the
--- bound instant in strftime), so the sweep is millisecond-exact against the
--- same canonical RHS layout.
+-- Raw compare: expires_at is stored canonical (CreateOAuthState binds a
+-- SQLiteTime), so the sweep is millisecond-exact against the same canonical RHS
+-- layout.
 DELETE FROM oauth_states WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
@@ -1,9 +1,9 @@
 -- name: UpsertOAuthTokens :exec
--- expires_at is stored in the canonical strftime layout (the wrap converts the
--- driver-bound instant) so ListExpiringOAuthTokens can compare it raw --
--- sargable for idx_oauth_tokens_expires_at -- instead of wrapping the column
--- in datetime() and scanning every row. The DO UPDATE reuses the transformed
--- excluded value, so both insert and update paths store the same layout.
+-- expires_at is stored in the canonical layout (SQLiteTime binds it) so
+-- ListExpiringOAuthTokens can compare it raw -- sargable for
+-- idx_oauth_tokens_expires_at -- instead of wrapping the column in datetime()
+-- and scanning every row. The DO UPDATE reuses the excluded value, so both
+-- insert and update paths store the same layout.
 INSERT INTO oauth_tokens (user_id, provider_id, access_token, refresh_token, token_type, expires_at, key_version)
 VALUES (
     sqlc.arg(user_id),
@@ -11,7 +11,7 @@ VALUES (
     sqlc.arg(access_token),
     sqlc.arg(refresh_token),
     sqlc.arg(token_type),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
+    sqlc.arg(expires_at),
     sqlc.arg(key_version)
 )
 ON CONFLICT (user_id, provider_id) DO UPDATE SET
@@ -27,10 +27,10 @@ SELECT * FROM oauth_tokens
 WHERE user_id = ? AND provider_id = ?;
 
 -- name: ListExpiringOAuthTokens :many
--- Raw compare: expires_at is stored canonical (UpsertOAuthTokens wraps the
--- bound instant in strftime), so comparing it raw against the same canonical
--- RHS layout is byte-exact and sargable -- idx_oauth_tokens_expires_at serves
--- an upper-bounded SEARCH instead of a full scan under a datetime() wrap.
+-- Raw compare: expires_at is stored canonical (UpsertOAuthTokens binds a
+-- SQLiteTime), so comparing it raw against the same canonical RHS layout is
+-- byte-exact and sargable -- idx_oauth_tokens_expires_at serves an
+-- upper-bounded SEARCH instead of a full scan under a datetime() wrap.
 SELECT * FROM oauth_tokens
 WHERE expires_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+5 minutes');
 

--- a/backend/internal/hub/store/sqlite/db/queries/org_recent_batch_ids.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/org_recent_batch_ids.sql
@@ -16,12 +16,12 @@ INSERT INTO org_recent_batch_ids (
     sqlc.arg(canonical_client),
     sqlc.arg(op_count),
     sqlc.arg(epoch),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+    sqlc.arg(expires_at)
 );
 
 -- name: DeleteExpiredRecentBatchIDs :execresult
--- Raw compare: expires_at is stored canonical (InsertRecentBatchID wraps the
--- bound instant in strftime), and the Go side binds a formatSQLiteTime-
--- formatted cutoff (CAST AS TEXT -> string param), so the lexicographic < is
--- byte-exact and sargable for idx_org_recent_batch_ids_expires.
-DELETE FROM org_recent_batch_ids WHERE expires_at < CAST(sqlc.arg(before) AS TEXT);
+-- Raw compare: expires_at is stored canonical (InsertRecentBatchID binds a
+-- SQLiteTime), and the Go side binds a SQLiteTime cutoff (same canonical
+-- layout), so the lexicographic < is byte-exact and sargable for
+-- idx_org_recent_batch_ids_expires.
+DELETE FROM org_recent_batch_ids WHERE expires_at < sqlc.arg(before);

--- a/backend/internal/hub/store/sqlite/db/queries/org_state.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/org_state.sql
@@ -2,15 +2,15 @@
 SELECT * FROM org_state WHERE org_id = ?;
 
 -- name: UpsertOrgState :exec
--- The DO UPDATE reuses the strftime-transformed excluded values, so both the
--- insert and update paths store the canonical layout.
+-- The DO UPDATE reuses the excluded values (SQLiteTime binds the canonical
+-- layout), so both the insert and update paths store the canonical layout.
 INSERT INTO org_state (org_id, state_payload, current_epoch, epoch_started_at, updated_at)
 VALUES (
     sqlc.arg(org_id),
     sqlc.arg(state_payload),
     sqlc.arg(current_epoch),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(epoch_started_at)),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(updated_at))
+    sqlc.arg(epoch_started_at),
+    sqlc.arg(updated_at)
 )
 ON CONFLICT (org_id) DO UPDATE SET
     state_payload    = excluded.state_payload,
@@ -27,6 +27,6 @@ ON CONFLICT (org_id) DO UPDATE SET
 -- as index 5 -- every call failed with "missing argument with index 5".
 UPDATE org_state
 SET current_epoch    = sqlc.arg(epoch),
-    epoch_started_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(epoch_started_at)),
-    updated_at       = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(updated_at))
+    epoch_started_at = sqlc.arg(epoch_started_at),
+    updated_at       = sqlc.arg(updated_at)
 WHERE org_id = sqlc.arg(org_id);

--- a/backend/internal/hub/store/sqlite/db/queries/orgs.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/orgs.sql
@@ -24,9 +24,9 @@ UPDATE orgs SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?;
 -- idx_users_org_id makes the NOT EXISTS lookup an indexed point probe.
 DELETE FROM orgs WHERE rowid IN (
     SELECT o.rowid FROM orgs o
-    -- Raw compare: deleted_at (strftime-written) against the canonical cutoff
-    -- string (CAST AS TEXT -> string param; see HardDeleteWorkersBefore).
-    WHERE o.deleted_at IS NOT NULL AND o.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT)
+    -- Raw compare: deleted_at (canonical on every write) against the SQLiteTime
+    -- cutoff (same canonical layout; see HardDeleteWorkersBefore).
+    WHERE o.deleted_at IS NOT NULL AND o.deleted_at < sqlc.arg(cutoff)
       AND NOT EXISTS (SELECT 1 FROM users u WHERE u.org_id = o.id)
     LIMIT 1000
 );

--- a/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
@@ -9,10 +9,10 @@ VALUES (
     sqlc.arg(access_token),
     sqlc.arg(refresh_token),
     sqlc.arg(token_type),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(token_expires_at)),
+    sqlc.arg(token_expires_at),
     sqlc.arg(key_version),
     sqlc.arg(redirect_uri),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+    sqlc.arg(expires_at)
 );
 
 -- name: GetPendingOAuthSignup :one
@@ -22,7 +22,7 @@ SELECT * FROM pending_oauth_signups WHERE token = ?;
 DELETE FROM pending_oauth_signups WHERE token = ?;
 
 -- name: DeleteExpiredPendingOAuthSignups :execresult
--- Raw compare: expires_at is stored canonical (CreatePendingOAuthSignup wraps
--- the bound instant in strftime), so the sweep is millisecond-exact against
--- the same canonical RHS layout.
+-- Raw compare: expires_at is stored canonical (CreatePendingOAuthSignup binds
+-- a SQLiteTime), so the sweep is millisecond-exact against the same canonical
+-- RHS layout.
 DELETE FROM pending_oauth_signups WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/revocation_events.sql
@@ -6,7 +6,7 @@ INSERT INTO revocation_events (
     sqlc.arg(kind),
     sqlc.arg(subject_id),
     sqlc.arg(user_id),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(revoked_at)),
+    sqlc.arg(revoked_at),
     sqlc.arg(user_auth_generation)
 );
 
@@ -71,8 +71,8 @@ DELETE FROM hub_runtime_lease WHERE singleton_id = 1 AND lease_expires_at <= str
 -- name: DeleteCompactablePublishedRevocationEvents :execresult
 -- Raw compare: published_at is written canonical on its only write path (the
 -- publish UPDATE sets strftime('%Y-%m-%dT%H:%M:%fZ','now')), and the Go side
--- binds a formatSQLiteTime-formatted cutoff (CAST AS TEXT -> string param),
--- so the lexicographic < is byte-exact at full millisecond precision --
+-- binds a SQLiteTime cutoff (same canonical layout), so the lexicographic < is
+-- byte-exact at full millisecond precision --
 -- matching what postgres/mysql compact, with no strftime re-normalization per
 -- row. Unlike a function wrap on the column, this is sargable: the partial
 -- idx_revocation_events_published(published_at, seq) serves an upper-bounded
@@ -82,7 +82,7 @@ DELETE FROM revocation_events
 WHERE id IN (
     SELECT ev.id
     FROM revocation_events AS ev
-    WHERE ev.published_at < CAST(sqlc.arg(cutoff) AS TEXT)
+    WHERE ev.published_at < sqlc.arg(cutoff)
       AND ev.seq <= COALESCE(
           (SELECT cursor_seq FROM hub_runtime_lease WHERE singleton_id = 1),
           (SELECT last_seq FROM revocation_event_sequence WHERE id = 1)

--- a/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
@@ -4,7 +4,7 @@ INSERT INTO user_sessions (
 ) VALUES (
     sqlc.arg(id),
     sqlc.arg(user_id),
-    strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)),
+    sqlc.arg(expires_at),
     sqlc.arg(user_agent),
     sqlc.arg(ip_address),
     (SELECT auth_generation FROM users WHERE users.id = sqlc.arg(user_id))
@@ -12,8 +12,8 @@ INSERT INTO user_sessions (
 
 -- name: GetUserSessionByID :one
 -- expires_at is stored in the canonical strftime('%Y-%m-%dT%H:%M:%fZ') layout
--- (CreateUserSession wraps the bound instant), so the liveness filter compares
--- it raw against the same layout -- millisecond-exact at the expiry boundary.
+-- (CreateUserSession binds a SQLiteTime), so the liveness filter compares it raw
+-- against the same layout -- millisecond-exact at the expiry boundary.
 SELECT * FROM user_sessions WHERE id = ? AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
 
 -- name: DeleteUserSession :one
@@ -42,8 +42,8 @@ WHERE user_sessions.id = sqlc.arg(session_id)
   );
 
 -- name: DeleteExpiredUserSessions :execresult
--- expires_at is stored canonical (CreateUserSession + Touch both wrap the bound
--- instant in strftime), so comparing it raw against the same canonical RHS is
+-- expires_at is stored canonical (CreateUserSession + Touch both bind a
+-- SQLiteTime), so comparing it raw against the same canonical RHS is
 -- sargable for idx_user_sessions_expires_at_last_active (SEARCH expires_at<?,
 -- not a SCAN-with-residual under julianday()) -- the index was orphaned under
 -- the julianday wrap. RHS is strftime('now'), evaluated once, no binding.
@@ -67,11 +67,11 @@ LIMIT sqlc.arg(limit);
 -- name: ListAllActiveSessions :many
 -- Both timestamp filters compare the raw canonical strftime('%Y-%m-%dT%H:%M:%fZ')
 -- column against the same layout. expires_at is stored canonical because BOTH
--- write paths canonicalize it: CreateUserSession wraps the bound instant in
--- strftime, and Touch (the inline UPDATE in sqlite/sessions.go) binds a
--- formatSQLiteTime-pre-formatted string. last_active_at is written SQL-side by
--- the column DEFAULT and Touch. A future session write path MUST keep this
--- invariant -- binding a raw time.Time stores modernc's driver layout
+-- write paths canonicalize it: CreateUserSession binds a SQLiteTime, and Touch
+-- (the inline UPDATE in sqlite/sessions.go) also binds a SQLiteTime.
+-- last_active_at is written SQL-side by the column DEFAULT and Touch. A future
+-- session write path MUST keep this invariant -- binding a raw time.Time stores
+-- modernc's driver layout
 -- ("... ...+00:00", space at byte 10) and silently breaks every raw-string
 -- liveness filter below; see TestTouchStoresExpiresAtCanonical.
 -- last_active_at also carries the keyset cursor (decodeCursorParams formats it

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -150,9 +150,9 @@ WHERE orgs.id = (SELECT users.org_id FROM users WHERE users.id = sqlc.arg(user_i
 -- NOT EXISTS an indexed point probe.
 DELETE FROM users WHERE rowid IN (
     SELECT u.rowid FROM users u
-    -- Raw compare: deleted_at (strftime-written) against the canonical cutoff
-    -- string (CAST AS TEXT -> string param; see HardDeleteWorkersBefore).
-    WHERE u.deleted_at IS NOT NULL AND u.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT)
+    -- Raw compare: deleted_at (canonical on every write) against the SQLiteTime
+    -- cutoff (same canonical layout; see HardDeleteWorkersBefore).
+    WHERE u.deleted_at IS NOT NULL AND u.deleted_at < sqlc.arg(cutoff)
       AND NOT EXISTS (SELECT 1 FROM workspaces w WHERE w.owner_user_id = u.id)
       AND NOT EXISTS (SELECT 1 FROM workers wk WHERE wk.registered_by = u.id)
     LIMIT 1000
@@ -173,13 +173,13 @@ SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1);
 
 -- name: SetPendingEmail :exec
 -- pending_email_expires_at MUST land in the canonical strftime layout, so the
--- bound instant is wrapped rather than stored in the modernc driver layout a
--- raw time.Time bind would produce: ConsumeVerificationAttempt's lockout branch
+-- bound instant is a SQLiteNullTime rather than the modernc driver layout a raw
+-- time.Time bind would produce: ConsumeVerificationAttempt's lockout branch
 -- writes the same column via strftime('now'), and ClearStalePendingEmails
 -- compares it raw against a canonical cutoff -- mixing layouts breaks that
--- lexicographic compare at the ' ' vs 'T' separator byte (byte 10). strftime
--- passes a NULL bind through as NULL.
-UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(pending_email_expires_at)), pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+-- lexicographic compare at the ' ' vs 'T' separator byte (byte 10). An invalid
+-- SQLiteNullTime binds NULL.
+UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = sqlc.narg(pending_email_expires_at), pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = sqlc.arg(id);
 
 -- name: ClearPendingEmail :exec
@@ -207,11 +207,11 @@ WHERE pending_email = ? AND id != ?;
 
 -- name: ClearStalePendingEmails :execresult
 -- Raw compare: pending_email_expires_at is stored canonical on every write path
--- (SetPendingEmail wraps the bound instant in strftime; ConsumeVerificationAttempt's
--- lockout branch writes strftime('now')), so comparing it raw against the canonical
--- cutoff string (CAST AS TEXT -> string param) is byte-exact; see HardDeleteUsersBefore.
+-- (SetPendingEmail binds a SQLiteNullTime; ConsumeVerificationAttempt's lockout
+-- branch writes strftime('now')), so comparing it raw against the SQLiteTime
+-- cutoff (same canonical layout) is byte-exact; see HardDeleteUsersBefore.
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < CAST(sqlc.arg(cutoff) AS TEXT);
+WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < sqlc.arg(cutoff);
 
 -- name: BumpUserTokensRevokedAt :one
 -- Bumps the user-wide revocation timestamp and credential epoch, then

--- a/backend/internal/hub/store/sqlite/db/queries/worker_registration_keys.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/worker_registration_keys.sql
@@ -1,6 +1,6 @@
 -- name: CreateRegistrationKey :exec
 INSERT INTO worker_registration_keys (id, created_by, expires_at)
-VALUES (sqlc.arg(id), sqlc.arg(created_by), strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at)));
+VALUES (sqlc.arg(id), sqlc.arg(created_by), sqlc.arg(expires_at));
 
 -- name: GetRegistrationKeyByID :one
 SELECT * FROM worker_registration_keys WHERE id = ?;
@@ -15,10 +15,10 @@ SELECT * FROM worker_registration_keys WHERE id = ? AND created_by = ?;
 -- not revive the dead row.
 -- name: ExtendRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(new_expires_at))
+SET expires_at = sqlc.arg(new_expires_at)
 WHERE id = sqlc.arg(id)
   AND created_by = sqlc.arg(created_by)
-  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(now));
+  AND expires_at > sqlc.arg(now);
 
 -- SoftDeleteRegistrationKey is the user-initiated path; ownership lives
 -- in the WHERE clause so a single roundtrip both authorizes and acts.
@@ -26,7 +26,7 @@ WHERE id = sqlc.arg(id)
 -- matches by id+owner only); the service layer maps 0 rows to NotFound.
 -- name: SoftDeleteRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+SET expires_at = sqlc.arg(expires_at)
 WHERE id = sqlc.arg(id) AND created_by = sqlc.arg(created_by);
 
 -- ConsumeRegistrationKey atomically marks a live key as consumed and
@@ -34,18 +34,18 @@ WHERE id = sqlc.arg(id) AND created_by = sqlc.arg(created_by);
 -- (March 2021) and is used by all of our prod targets.
 -- name: ConsumeRegistrationKey :one
 UPDATE worker_registration_keys
-SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(soft_deleted_at))
-WHERE id = sqlc.arg(id) AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(now))
+SET expires_at = sqlc.arg(soft_deleted_at)
+WHERE id = sqlc.arg(id) AND expires_at > sqlc.arg(now)
 RETURNING *;
 
 -- name: HardDeleteExpiredRegistrationKeysBefore :execresult
--- Raw compare: expires_at (strftime-written) against the canonical cutoff string
--- (CAST AS TEXT -> string param). Sargable for idx_worker_registration_keys_expires_at.
+-- Raw compare: expires_at (canonical on every write) against the SQLiteTime
+-- cutoff (same canonical layout). Sargable for idx_worker_registration_keys_expires_at.
 DELETE FROM worker_registration_keys
 WHERE rowid IN (
     SELECT k.rowid
     FROM worker_registration_keys k
-    WHERE k.expires_at < CAST(sqlc.arg(cutoff) AS TEXT)
+    WHERE k.expires_at < sqlc.arg(cutoff)
     LIMIT 1000
 );
 
@@ -56,7 +56,7 @@ SELECT k.id, k.created_by, k.created_at, k.expires_at,
        COALESCE(u.username, '') AS creator_username, CAST(u.id IS NULL AS BOOLEAN) AS creator_deleted
 FROM worker_registration_keys k
 LEFT JOIN users u ON k.created_by = u.id AND u.deleted_at IS NULL
-WHERE (sqlc.narg(now) IS NULL OR k.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.narg(now)))
+WHERE (sqlc.narg(now) IS NULL OR k.expires_at > sqlc.narg(now))
   AND (sqlc.narg(cursor_time) IS NULL
        OR k.created_at < sqlc.narg(cursor_time)
        OR (k.created_at = sqlc.narg(cursor_time) AND k.id < sqlc.narg(cursor_id)))
@@ -65,5 +65,5 @@ LIMIT sqlc.arg(limit);
 
 -- name: AdminSoftDeleteRegistrationKey :execresult
 UPDATE worker_registration_keys
-SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(expires_at))
+SET expires_at = sqlc.arg(expires_at)
 WHERE id = sqlc.arg(id);

--- a/backend/internal/hub/store/sqlite/db/queries/workers.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workers.sql
@@ -119,9 +119,8 @@ ORDER BY w.created_at DESC, w.id DESC
 LIMIT sqlc.arg(limit);
 
 -- name: HardDeleteWorkersBefore :execresult
--- Raw compare: deleted_at (strftime-written) against the canonical cutoff string
--- (CAST AS TEXT so sqlc emits a string param the Go layer fills with
--- formatSQLiteTime(cutoff), not a time.Time the driver would serialize in its
--- own layout). Sargable for idx_workers_deleted_at (SEARCH deleted_at<?, not a
--- SCAN-with-residual under datetime()).
-DELETE FROM workers WHERE rowid IN (SELECT w.rowid FROM workers w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
+-- Raw compare: deleted_at (canonical on every write) against the SQLiteTime
+-- cutoff, which binds the same canonical layout instead of the driver layout a
+-- raw time.Time would serialize. Sargable for idx_workers_deleted_at (SEARCH
+-- deleted_at<?, not a SCAN-with-residual under datetime()).
+DELETE FROM workers WHERE rowid IN (SELECT w.rowid FROM workers w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < sqlc.arg(cutoff) LIMIT 1000);

--- a/backend/internal/hub/store/sqlite/db/queries/workspaces.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workspaces.sql
@@ -40,7 +40,7 @@ UPDATE workspaces SET is_deleted = 1, deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ'
 UPDATE workspaces SET is_deleted = 1, deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE owner_user_id = ? AND is_deleted = 0;
 
 -- name: HardDeleteWorkspacesBefore :execresult
--- Raw compare: deleted_at (strftime-written) against the canonical cutoff string
--- bound by the Go layer (formatSQLiteTime). Sargable for idx_workspaces_deleted_at
+-- Raw compare: deleted_at (canonical on every write) against the SQLiteTime
+-- cutoff (same canonical layout). Sargable for idx_workspaces_deleted_at
 -- (SEARCH deleted_at<?, not SCAN-with-residual under datetime()).
-DELETE FROM workspaces WHERE rowid IN (SELECT w.rowid FROM workspaces w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
+DELETE FROM workspaces WHERE rowid IN (SELECT w.rowid FROM workspaces w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < sqlc.arg(cutoff) LIMIT 1000);

--- a/backend/internal/hub/store/sqlite/delegation_tokens.go
+++ b/backend/internal/hub/store/sqlite/delegation_tokens.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type delegationTokenStore struct{ conn *sqliteConn }
@@ -24,12 +24,12 @@ func fromDBDelegationToken(t gendb.DelegationToken) store.DelegationToken {
 		IssuedForTabType: int32(t.IssuedForTabType),
 		SecretHash:       t.SecretHash,
 		RefreshHash:      t.RefreshHash,
-		CreatedAt:        t.CreatedAt,
+		CreatedAt:        t.CreatedAt.Time,
 		AuthGeneration:   t.AuthGeneration,
-		LastUsedAt:       sqlutil.NullTimePtr(t.LastUsedAt),
-		ExpiresAt:        t.ExpiresAt,
-		RefreshExpiresAt: sqlutil.NullTimePtr(t.RefreshExpiresAt),
-		RevokedAt:        sqlutil.NullTimePtr(t.RevokedAt),
+		LastUsedAt:       t.LastUsedAt.Ptr(),
+		ExpiresAt:        t.ExpiresAt.Time,
+		RefreshExpiresAt: t.RefreshExpiresAt.Ptr(),
+		RevokedAt:        t.RevokedAt.Ptr(),
 	}
 }
 
@@ -46,8 +46,8 @@ func (s *delegationTokenStore) Create(ctx context.Context, p store.CreateDelegat
 			IssuedForTabType: int64(p.IssuedForTabType),
 			SecretHash:       p.SecretHash,
 			RefreshHash:      p.RefreshHash,
-			ExpiresAt:        sqlutil.BindTime(p.ExpiresAt),
-			RefreshExpiresAt: sqlutil.BindNullTime(p.RefreshExpiresAt),
+			ExpiresAt:        sqltime.NewSQLiteTime(p.ExpiresAt),
+			RefreshExpiresAt: sqltime.NewSQLiteNullTime(p.RefreshExpiresAt),
 		}))
 	})
 }

--- a/backend/internal/hub/store/sqlite/device_authorizations.go
+++ b/backend/internal/hub/store/sqlite/device_authorizations.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type deviceAuthorizationStore struct{ conn *sqliteConn }
@@ -20,11 +20,11 @@ func fromDBDeviceAuthorization(d gendb.DeviceAuthorization) store.DeviceAuthoriz
 		DeviceName:      d.DeviceName,
 		UserID:          d.UserID.String,
 		Approved:        d.Approved,
-		LastPolledAt:    sqlutil.NullTimePtr(d.LastPolledAt),
+		LastPolledAt:    d.LastPolledAt.Ptr(),
 		IntervalSeconds: d.IntervalSeconds,
-		CreatedAt:       d.CreatedAt,
-		ExpiresAt:       d.ExpiresAt,
-		ConsumedAt:      sqlutil.NullTimePtr(d.ConsumedAt),
+		CreatedAt:       d.CreatedAt.Time,
+		ExpiresAt:       d.ExpiresAt.Time,
+		ConsumedAt:      d.ConsumedAt.Ptr(),
 	}
 }
 
@@ -34,7 +34,7 @@ func (s *deviceAuthorizationStore) Create(ctx context.Context, p store.CreateDev
 		UserCode:        p.UserCode,
 		DeviceName:      p.DeviceName,
 		IntervalSeconds: p.IntervalSeconds,
-		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:       sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/format_internal_test.go
+++ b/backend/internal/hub/store/sqlite/format_internal_test.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
 
 // canonicalStrftimePattern is the ONE strftime layout every SQL-side timestamp
 // write and compare in this dialect must use. It is the strftime spelling of
-// the Go-side sqliteTimeFormat (timefmt.ISO8601, "2006-01-02T15:04:05.000Z"):
-// %Y-%m-%d = 2006-01-02, T literal, %H:%M = 15:04, %f = seconds with fixed
-// 3-digit millis (05.000), Z literal.
+// the Go-side canonical layout (timefmt.ISO8601, "2006-01-02T15:04:05.000Z")
+// that sqltime.SQLiteTime.Value emits: %Y-%m-%d = 2006-01-02, T literal,
+// %H:%M = 15:04, %f = seconds with fixed 3-digit millis (05.000), Z literal.
 const canonicalStrftimePattern = `'%Y-%m-%dT%H:%M:%fZ'`
 
 // TestStrftimeLiteralsAreCanonical is the Docker-less static source scan (twin
@@ -26,14 +28,14 @@ const canonicalStrftimePattern = `'%Y-%m-%dT%H:%M:%fZ'`
 // opportunity for a one-character drift (a missing T, %f -> %S, a stray
 // space) that silently breaks the raw-string keyset/liveness compares while
 // every result-level test stays green -- the "cannot drift" claim in
-// sqliteTimeFormat's doc comment held only for the single Go constant until
+// sqltime.SQLiteTime's doc comment held only for the single Go constant until
 // this scan made it true SQL-side too.
 func TestStrftimeLiteralsAreCanonical(t *testing.T) {
 	// Sanity-pin the Go side of the pairing first, so a change to
 	// timefmt.ISO8601 cannot silently diverge from the SQL pattern this test
 	// enforces.
-	require.Equal(t, "2006-01-02T15:04:05.000Z", sqliteTimeFormat,
-		"sqliteTimeFormat changed: update canonicalStrftimePattern (and every SQL literal) in lockstep")
+	require.Equal(t, "2006-01-02T15:04:05.000Z", timefmt.ISO8601,
+		"timefmt.ISO8601 changed: update canonicalStrftimePattern (and every SQL literal) in lockstep")
 
 	var files []string
 	for _, glob := range []string{"db/migrations/*.sql", "db/queries/*.sql"} {

--- a/backend/internal/hub/store/sqlite/indexes_internal_test.go
+++ b/backend/internal/hub/store/sqlite/indexes_internal_test.go
@@ -339,14 +339,15 @@ func TestRetentionAndBootstrapScansAreSargable(t *testing.T) {
 }
 
 // TestRevokedTokenSweepsAreSargable pins the query PLAN of the two hourly
-// revoked-token retention sweeps: the raw-string `revoked_at < CAST(? AS
-// TEXT)` compare must seek idx_*_revoked_at with an UPPER bound, touching only
-// the cutoff-eligible rows. The prior `datetime(revoked_at) < datetime(?)`
-// shape wrapped the indexed column in a function, so the planner emitted a
-// lower-bound-only SEARCH (`revoked_at>?` -- the partial index's IS NOT NULL
-// floor) and evaluated datetime() per revoked row on every sweep; the
-// regression is plan-level only (deleted rows stay identical), so it needs an
-// EXPLAIN assertion.
+// revoked-token retention sweeps: the raw-string `revoked_at < ?` compare
+// (bound a canonical-layout SQLiteNullTime cutoff) must seek
+// idx_*_revoked_at with an UPPER bound, touching only the cutoff-eligible
+// rows. The prior `datetime(revoked_at) < datetime(?)` shape wrapped the
+// indexed column in a function, so the planner emitted a lower-bound-only
+// SEARCH (`revoked_at>?` -- the partial index's IS NOT NULL floor) and
+// evaluated datetime() per revoked row on every sweep; the regression is
+// plan-level only (deleted rows stay identical), so it needs an EXPLAIN
+// assertion.
 func TestRevokedTokenSweepsAreSargable(t *testing.T) {
 	_, db := newSessionTestStore(t)
 	for _, tc := range []struct{ table, index string }{
@@ -354,7 +355,7 @@ func TestRevokedTokenSweepsAreSargable(t *testing.T) {
 		{"delegation_tokens", "idx_delegation_tokens_revoked_at"},
 	} {
 		rows, err := db.QueryContext(context.Background(),
-			`EXPLAIN QUERY PLAN DELETE FROM `+tc.table+` WHERE revoked_at IS NOT NULL AND revoked_at < CAST(? AS TEXT)`,
+			`EXPLAIN QUERY PLAN DELETE FROM `+tc.table+` WHERE revoked_at IS NOT NULL AND revoked_at < ?`,
 			"2026-01-01T00:00:00.000Z")
 		require.NoError(t, err)
 		var details []string

--- a/backend/internal/hub/store/sqlite/lifecycle_outbox.go
+++ b/backend/internal/hub/store/sqlite/lifecycle_outbox.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type lifecycleOutboxStore struct {
@@ -38,8 +38,8 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 			OrgID:      r.OrgID,
 			OpType:     r.OpType,
 			Payload:    r.Payload,
-			EnqueuedAt: r.EnqueuedAt,
-			ConsumedAt: sqlutil.NullTimePtr(r.ConsumedAt),
+			EnqueuedAt: r.EnqueuedAt.Time,
+			ConsumedAt: r.ConsumedAt.Ptr(),
 		}
 	}
 	return out, nil
@@ -48,10 +48,10 @@ func (s *lifecycleOutboxStore) ListPending(ctx context.Context, p store.ListPend
 func (s *lifecycleOutboxStore) MarkConsumed(ctx context.Context, p store.MarkLifecycleOutboxConsumedParams) error {
 	return mapErr(s.conn.q.MarkLifecycleOutboxConsumed(ctx, gendb.MarkLifecycleOutboxConsumedParams{
 		ID:         p.ID,
-		ConsumedAt: sqlutil.BindTime(p.ConsumedAt),
+		ConsumedAt: sqltime.SQLiteNullTimeOf(p.ConsumedAt),
 	}))
 }
 
 func (s *lifecycleOutboxStore) DeleteConsumedBefore(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, formatSQLiteTime(before)))
+	return rowsAffected(s.conn.q.DeleteConsumedLifecycleOutboxBefore(ctx, sqltime.SQLiteNullTimeOf(before)))
 }

--- a/backend/internal/hub/store/sqlite/oauth_providers.go
+++ b/backend/internal/hub/store/sqlite/oauth_providers.go
@@ -25,7 +25,7 @@ func fromDBOAuthProvider(p gendb.OauthProvider) *store.OAuthProvider {
 			Scopes:       p.Scopes,
 			TrustEmail:   ptrconv.Int64ToBool(p.TrustEmail),
 			Enabled:      ptrconv.Int64ToBool(p.Enabled),
-			CreatedAt:    p.CreatedAt,
+			CreatedAt:    p.CreatedAt.Time,
 		},
 		ClientSecret: p.ClientSecret,
 	}
@@ -45,7 +45,7 @@ func fromDBListEnabledOAuthProvidersRow(r gendb.ListEnabledOAuthProvidersRow) st
 		Scopes:       r.Scopes,
 		TrustEmail:   ptrconv.Int64ToBool(r.TrustEmail),
 		Enabled:      ptrconv.Int64ToBool(r.Enabled),
-		CreatedAt:    r.CreatedAt,
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 
@@ -59,7 +59,7 @@ func fromDBListAllOAuthProvidersRow(r gendb.ListAllOAuthProvidersRow) store.OAut
 		Scopes:       r.Scopes,
 		TrustEmail:   ptrconv.Int64ToBool(r.TrustEmail),
 		Enabled:      ptrconv.Int64ToBool(r.Enabled),
-		CreatedAt:    r.CreatedAt,
+		CreatedAt:    r.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/oauth_states.go
+++ b/backend/internal/hub/store/sqlite/oauth_states.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type oauthStateStore struct {
@@ -20,8 +20,8 @@ func fromDBOAuthState(s gendb.OauthState) *store.OAuthState {
 		ProviderID:   s.ProviderID,
 		PkceVerifier: s.PkceVerifier,
 		RedirectURI:  s.RedirectUri,
-		ExpiresAt:    s.ExpiresAt,
-		CreatedAt:    s.CreatedAt,
+		ExpiresAt:    s.ExpiresAt.Time,
+		CreatedAt:    s.CreatedAt.Time,
 	}
 }
 
@@ -31,7 +31,7 @@ func (s *oauthStateStore) Create(ctx context.Context, p store.CreateOAuthStatePa
 		ProviderID:   p.ProviderID,
 		PkceVerifier: p.PkceVerifier,
 		RedirectUri:  p.RedirectURI,
-		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:    sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/oauth_tokens.go
+++ b/backend/internal/hub/store/sqlite/oauth_tokens.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type oauthTokenStore struct {
@@ -21,9 +21,9 @@ func fromDBOAuthToken(t gendb.OauthToken) store.OAuthToken {
 		AccessToken:  t.AccessToken,
 		RefreshToken: t.RefreshToken,
 		TokenType:    t.TokenType,
-		ExpiresAt:    t.ExpiresAt,
+		ExpiresAt:    t.ExpiresAt.Time,
 		KeyVersion:   t.KeyVersion,
-		UpdatedAt:    t.UpdatedAt,
+		UpdatedAt:    t.UpdatedAt.Time,
 	}
 }
 
@@ -38,7 +38,7 @@ func (s *oauthTokenStore) Upsert(ctx context.Context, p store.UpsertOAuthTokensP
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,
 		TokenType:    p.TokenType,
-		ExpiresAt:    sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:    sqltime.NewSQLiteTime(p.ExpiresAt),
 		KeyVersion:   p.KeyVersion,
 	}))
 }

--- a/backend/internal/hub/store/sqlite/oauth_user_links.go
+++ b/backend/internal/hub/store/sqlite/oauth_user_links.go
@@ -18,7 +18,7 @@ func fromDBOAuthUserLink(l gendb.OauthUserLink) store.OAuthUserLink {
 		UserID:          l.UserID,
 		ProviderID:      l.ProviderID,
 		ProviderSubject: l.ProviderSubject,
-		CreatedAt:       l.CreatedAt,
+		CreatedAt:       l.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/org_op_batches.go
+++ b/backend/internal/hub/store/sqlite/org_op_batches.go
@@ -60,7 +60,7 @@ func toOrgOpBatchRow(r gendb.OrgOpBatch) store.OrgOpBatchRow {
 		BatchPayload: r.BatchPayload,
 		OpCount:      r.OpCount,
 		Epoch:        r.Epoch,
-		CommittedAt:  r.CommittedAt,
+		CommittedAt:  r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/org_recent_batch_ids.go
+++ b/backend/internal/hub/store/sqlite/org_recent_batch_ids.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type orgRecentBatchIDStore struct {
@@ -35,7 +35,7 @@ func (s *orgRecentBatchIDStore) Get(ctx context.Context, orgID, batchID string) 
 		CanonicalClient:     row.CanonicalClient,
 		OpCount:             row.OpCount,
 		Epoch:               row.Epoch,
-		ExpiresAt:           row.ExpiresAt,
+		ExpiresAt:           row.ExpiresAt.Time,
 	}, nil
 }
 
@@ -50,10 +50,10 @@ func (s *orgRecentBatchIDStore) Insert(ctx context.Context, p store.InsertOrgRec
 		CanonicalClient:     p.CanonicalClient,
 		OpCount:             p.OpCount,
 		Epoch:               p.Epoch,
-		ExpiresAt:           sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:           sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 
 func (s *orgRecentBatchIDStore) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, formatSQLiteTime(before)))
+	return rowsAffected(s.conn.q.DeleteExpiredRecentBatchIDs(ctx, sqltime.NewSQLiteTime(before)))
 }

--- a/backend/internal/hub/store/sqlite/org_state.go
+++ b/backend/internal/hub/store/sqlite/org_state.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type orgStateStore struct {
@@ -28,8 +28,8 @@ func (s *orgStateStore) Get(ctx context.Context, orgID string) (*store.OrgStateR
 		OrgID:          row.OrgID,
 		StatePayload:   row.StatePayload,
 		CurrentEpoch:   row.CurrentEpoch,
-		EpochStartedAt: row.EpochStartedAt,
-		UpdatedAt:      row.UpdatedAt,
+		EpochStartedAt: row.EpochStartedAt.Time,
+		UpdatedAt:      row.UpdatedAt.Time,
 	}, nil
 }
 
@@ -38,8 +38,8 @@ func (s *orgStateStore) Upsert(ctx context.Context, p store.UpsertOrgStateParams
 		OrgID:          p.OrgID,
 		StatePayload:   p.StatePayload,
 		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
-		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
+		EpochStartedAt: sqltime.NewSQLiteTime(p.EpochStartedAt),
+		UpdatedAt:      sqltime.NewSQLiteTime(p.UpdatedAt),
 	}))
 }
 
@@ -47,7 +47,7 @@ func (s *orgStateStore) AdvanceEpoch(ctx context.Context, p store.AdvanceOrgEpoc
 	return mapErr(s.conn.q.AdvanceOrgEpoch(ctx, gendb.AdvanceOrgEpochParams{
 		OrgID:          p.OrgID,
 		Epoch:          p.Epoch,
-		EpochStartedAt: sqlutil.BindTime(p.EpochStartedAt),
-		UpdatedAt:      sqlutil.BindTime(p.UpdatedAt),
+		EpochStartedAt: sqltime.NewSQLiteTime(p.EpochStartedAt),
+		UpdatedAt:      sqltime.NewSQLiteTime(p.UpdatedAt),
 	}))
 }

--- a/backend/internal/hub/store/sqlite/orgs.go
+++ b/backend/internal/hub/store/sqlite/orgs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 type orgStore struct {
@@ -18,8 +17,8 @@ func fromDBOrg(o gendb.Org) store.Org {
 	return store.Org{
 		ID:        o.ID,
 		Name:      o.Name,
-		CreatedAt: o.CreatedAt,
-		DeletedAt: sqlutil.NullTimePtr(o.DeletedAt),
+		CreatedAt: o.CreatedAt.Time,
+		DeletedAt: o.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/pending_oauth_signups.go
+++ b/backend/internal/hub/store/sqlite/pending_oauth_signups.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type pendingOAuthSignupStore struct {
@@ -24,11 +24,11 @@ func fromDBPendingOAuthSignup(p gendb.PendingOauthSignup) *store.PendingOAuthSig
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  p.TokenExpiresAt,
+		TokenExpiresAt:  p.TokenExpiresAt.Time,
 		KeyVersion:      p.KeyVersion,
 		RedirectURI:     p.RedirectUri,
-		ExpiresAt:       p.ExpiresAt,
-		CreatedAt:       p.CreatedAt,
+		ExpiresAt:       p.ExpiresAt.Time,
+		CreatedAt:       p.CreatedAt.Time,
 	}
 }
 
@@ -42,10 +42,10 @@ func (s *pendingOAuthSignupStore) Create(ctx context.Context, p store.CreatePend
 		AccessToken:     p.AccessToken,
 		RefreshToken:    p.RefreshToken,
 		TokenType:       p.TokenType,
-		TokenExpiresAt:  sqlutil.BindTime(p.TokenExpiresAt),
+		TokenExpiresAt:  sqltime.NewSQLiteTime(p.TokenExpiresAt),
 		KeyVersion:      p.KeyVersion,
 		RedirectUri:     p.RedirectURI,
-		ExpiresAt:       sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt:       sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/registration_keys.go
+++ b/backend/internal/hub/store/sqlite/registration_keys.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type registrationKeyStore struct {
@@ -19,8 +19,8 @@ func fromDBRegistrationKey(r gendb.WorkerRegistrationKey) *store.WorkerRegistrat
 	return &store.WorkerRegistrationKey{
 		ID:        r.ID,
 		CreatedBy: r.CreatedBy,
-		CreatedAt: r.CreatedAt,
-		ExpiresAt: r.ExpiresAt,
+		CreatedAt: r.CreatedAt.Time,
+		ExpiresAt: r.ExpiresAt.Time,
 	}
 }
 
@@ -28,7 +28,7 @@ func (s *registrationKeyStore) Create(ctx context.Context, p store.CreateRegistr
 	return mapErr(s.conn.q.CreateRegistrationKey(ctx, gendb.CreateRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+		ExpiresAt: sqltime.NewSQLiteTime(p.ExpiresAt),
 	}))
 }
 
@@ -55,8 +55,8 @@ func (s *registrationKeyStore) Extend(ctx context.Context, p store.ExtendRegistr
 	return rowsAffected(s.conn.q.ExtendRegistrationKey(ctx, gendb.ExtendRegistrationKeyParams{
 		ID:           p.ID,
 		CreatedBy:    p.CreatedBy,
-		NewExpiresAt: sqlutil.BindTime(p.ExpiresAt),
-		Now:          sqlutil.BindTime(time.Now()),
+		NewExpiresAt: sqltime.NewSQLiteTime(p.ExpiresAt),
+		Now:          sqltime.NewSQLiteTime(time.Now()),
 	}))
 }
 
@@ -64,16 +64,16 @@ func (s *registrationKeyStore) SoftDelete(ctx context.Context, p store.SoftDelet
 	return rowsAffected(s.conn.q.SoftDeleteRegistrationKey(ctx, gendb.SoftDeleteRegistrationKeyParams{
 		ID:        p.ID,
 		CreatedBy: p.CreatedBy,
-		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: sqltime.NewSQLiteTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
 func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.WorkerRegistrationKey, error) {
-	now := sqlutil.BindTime(time.Now())
+	now := time.Now()
 	r, err := s.conn.q.ConsumeRegistrationKey(ctx, gendb.ConsumeRegistrationKeyParams{
 		ID:            id,
-		Now:           now,
-		SoftDeletedAt: now.Add(store.RegistrationKeySoftDeleteOffset),
+		Now:           sqltime.NewSQLiteTime(now),
+		SoftDeletedAt: sqltime.NewSQLiteTime(now.Add(store.RegistrationKeySoftDeleteOffset)),
 	})
 	if err != nil {
 		return nil, mapErr(err)
@@ -84,27 +84,32 @@ func (s *registrationKeyStore) Consume(ctx context.Context, id string) (*store.W
 func (s *registrationKeyStore) AdminSoftDelete(ctx context.Context, id string) (int64, error) {
 	return rowsAffected(s.conn.q.AdminSoftDeleteRegistrationKey(ctx, gendb.AdminSoftDeleteRegistrationKeyParams{
 		ID:        id,
-		ExpiresAt: sqlutil.BindTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
+		ExpiresAt: sqltime.NewSQLiteTime(time.Now().Add(store.RegistrationKeySoftDeleteOffset)),
 	}))
 }
 
 func (s *registrationKeyStore) ListAdmin(ctx context.Context, p store.ListRegistrationKeysAdminParams) (store.Page[store.WorkerRegistrationKeyWithCreator], error) {
-	// `now` is bound as a time.Time and compared against expires_at through a
-	// strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.narg(now)) wrap in the SQL itself (see
-	// worker_registration_keys.sql ListRegistrationKeysAdmin), so the comparison
-	// is canonical-layout against canonical-layout -- expires_at is written
-	// canonical by every Create/Extend/SoftDelete/Consume/AdminSoftDelete path.
-	// The cursor timestamp is compared against created_at (set via SQL DEFAULT
-	// strftime to ms precision), so the cursor must be formatted via decodeCursorParams
-	// to match that format. The id half of the composite cursor is the
-	// deterministic tiebreaker for rows sharing a millisecond.
-	var nowArg any
+	// `now` is compared against expires_at through sqlc.narg(now) in the SQL (see
+	// worker_registration_keys.sql ListRegistrationKeysAdmin). The GENERATED Now
+	// field stays interface{} because the sqlite engine does not resolve the
+	// `narg IS NULL OR col > narg` OR-chain to a column type, but the builder
+	// takes a typed SQLiteNullTime (matching the mysql/postgres siblings) so a
+	// raw time.Time cannot reach the bind; Value() emits the canonical layout,
+	// so the comparison is canonical-layout against canonical-layout --
+	// expires_at is written canonical by every Create/Extend/SoftDelete/Consume/
+	// AdminSoftDelete path. An invalid (zero-value) SQLiteNullTime binds NULL,
+	// selecting expired rows too. The cursor timestamp is
+	// compared against created_at (set via SQL DEFAULT strftime to ms precision),
+	// so the cursor is formatted via decodeCursorParams to match that format. The
+	// id half of the composite cursor is the deterministic tiebreaker for rows
+	// sharing a millisecond.
+	var now sqltime.SQLiteNullTime
 	if !p.IncludeExpired {
-		nowArg = sqlutil.BindTime(time.Now())
+		now = sqltime.SQLiteNullTimeOf(time.Now())
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListRegistrationKeysAdminParams, error) {
-			return listRegistrationKeysAdminParams(p.Cursor, p.Limit, nowArg)
+			return listRegistrationKeysAdminParams(p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListRegistrationKeysAdmin,
 		fromDBListRegistrationKeysAdminRow)
@@ -115,8 +120,8 @@ func fromDBListRegistrationKeysAdminRow(r gendb.ListRegistrationKeysAdminRow) st
 		WorkerRegistrationKey: store.WorkerRegistrationKey{
 			ID:        r.ID,
 			CreatedBy: r.CreatedBy,
-			CreatedAt: r.CreatedAt,
-			ExpiresAt: r.ExpiresAt,
+			CreatedAt: r.CreatedAt.Time,
+			ExpiresAt: r.ExpiresAt.Time,
 		},
 		CreatorUsername: r.CreatorUsername,
 		CreatorDeleted:  r.CreatorDeleted,

--- a/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
+++ b/backend/internal/hub/store/sqlite/registration_keys_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,6 +38,6 @@ func TestCreateRegistrationKeyStoresExpiresAtCanonical(t *testing.T) {
 	// verbatim instead of trimming trailing fractional zeros on scan.
 	var stored string
 	require.NoError(t, db.QueryRow(`SELECT CAST(expires_at AS TEXT) FROM worker_registration_keys WHERE id = ?`, keyID).Scan(&stored))
-	assert.Equal(t, formatSQLiteTime(expiresAt), stored,
+	assert.Equal(t, timefmt.Format(expiresAt), stored,
 		"expires_at must be stored in the canonical strftime layout the raw-string filters assume; got %q", stored)
 }

--- a/backend/internal/hub/store/sqlite/revocation_events.go
+++ b/backend/internal/hub/store/sqlite/revocation_events.go
@@ -10,6 +10,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 // revocationEventStore embeds the shared RevocationCore, which promotes
@@ -57,7 +58,7 @@ func insertRevocationEvent(
 		Kind:               kind,
 		SubjectID:          subjectID,
 		UserID:             userID,
-		RevokedAt:          sqlutil.BindTime(revokedAt),
+		RevokedAt:          sqltime.NewSQLiteTime(revokedAt),
 		UserAuthGeneration: userAuthGeneration,
 	}))
 }
@@ -76,7 +77,7 @@ func emitCredentialEvent(ctx context.Context, conn *sqliteConn, event store.Cred
 // delegation_tokens, whose Revoke bodies are otherwise identical.
 func revokedCredentialEvent(
 	subjectID, userID string,
-	revokedAt sql.NullTime,
+	revokedAt sqltime.SQLiteNullTime,
 	kind string,
 	err error,
 ) (*store.CredentialEvent, error) {
@@ -117,7 +118,7 @@ func newRevocationEventStore(conn *sqliteConn) *revocationEventStore {
 				return mapErr(err)
 			},
 			CompactPublished: func(ctx context.Context, conn *sqliteConn, cutoff time.Time) (int64, error) {
-				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, formatSQLiteTime(cutoff)))
+				return rowsAffected(conn.q.DeleteCompactablePublishedRevocationEvents(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 			},
 			InsertLease: func(ctx context.Context, conn *sqliteConn, lease store.RevocationLease) error {
 				return mapErr(conn.q.InsertHubRuntimeLease(ctx, gendb.InsertHubRuntimeLeaseParams{

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type sessionStore struct{ conn *sqliteConn }
@@ -20,9 +20,9 @@ func fromDBSession(s gendb.UserSession) store.UserSession {
 	return store.UserSession{
 		ID:             s.ID,
 		UserID:         s.UserID,
-		ExpiresAt:      s.ExpiresAt,
-		CreatedAt:      s.CreatedAt,
-		LastActiveAt:   s.LastActiveAt,
+		ExpiresAt:      s.ExpiresAt.Time,
+		CreatedAt:      s.CreatedAt.Time,
+		LastActiveAt:   s.LastActiveAt.Time,
 		AuthGeneration: s.AuthGeneration,
 		UserAgent:      s.UserAgent,
 		IPAddress:      s.IpAddress,
@@ -35,9 +35,9 @@ func fromDBActiveSessionRow(r gendb.ListAllActiveSessionsRow) store.ActiveSessio
 		UserID:       r.UserID,
 		Username:     r.Username,
 		UserDeleted:  r.UserDeleted,
-		CreatedAt:    r.CreatedAt,
-		LastActiveAt: r.LastActiveAt,
-		ExpiresAt:    r.ExpiresAt,
+		CreatedAt:    r.CreatedAt.Time,
+		LastActiveAt: r.LastActiveAt.Time,
+		ExpiresAt:    r.ExpiresAt.Time,
 		IPAddress:    r.IpAddress,
 		UserAgent:    r.UserAgent,
 	}
@@ -48,7 +48,7 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 		return mapErr(tx.(*sqliteStore).conn.q.CreateUserSession(ctx, gendb.CreateUserSessionParams{
 			ID:        p.ID,
 			UserID:    p.UserID,
-			ExpiresAt: sqlutil.BindTime(p.ExpiresAt),
+			ExpiresAt: sqltime.NewSQLiteTime(p.ExpiresAt),
 			UserAgent: p.UserAgent,
 			IpAddress: p.IPAddress,
 		}))
@@ -66,22 +66,20 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	// sqlite Touch is an inline query rather than a generated one (unlike
-	// postgres/mysql). Both timestamp columns it writes MUST land in the canonical
-	// strftime layout because the read-side liveness/cursor filters in
-	// user_sessions.sql compare them as raw strings; see the ListAllActiveSessions
-	// comment there for the full storage invariant and the modernc driver-layout
-	// hazard that makes binding a raw time.Time unsafe. The SET clause wraps both
-	// values in strftime; the WHERE clause compares against a formatSQLiteTime-
-	// pre-formatted string -- byte-exact, because the on-disk strftime values
-	// carry fixed 3-digit fractional seconds exactly like sqliteTimeFormat (see
-	// its doc in convert.go, including the Go-string-scan caution).
-	lastActiveStr := formatSQLiteTime(p.LastActiveAt)
+	// postgres/mysql). last_active_at is written SQL-side by strftime('now'); the
+	// expires_at write and the last_active_at WHERE comparand are bound as
+	// SQLiteTime values, whose Value() emits the same canonical strftime layout
+	// the read-side liveness/cursor filters in user_sessions.sql compare as raw
+	// strings. See the ListAllActiveSessions comment there for the full storage
+	// invariant and the modernc driver-layout hazard that makes binding a raw
+	// time.Time unsafe -- the SQLiteTime type mechanizes the canonical layout so
+	// a raw bind is a compile error.
 	res, err := s.conn.exec.ExecContext(ctx,
 		`UPDATE user_sessions
 		 SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-		     expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', ?)
+		     expires_at = ?
 		 WHERE id = ? AND last_active_at < ?`,
-		sqlutil.BindTime(p.ExpiresAt), p.ID, lastActiveStr,
+		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt),
 	)
 	if err != nil {
 		return 0, mapErr(err)

--- a/backend/internal/hub/store/sqlite/sessions_internal_test.go
+++ b/backend/internal/hub/store/sqlite/sessions_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,7 +119,7 @@ func TestListAllActiveSessionsPreservesFractionalCursorPrecision(t *testing.T) {
 		tieBelowID:  cursorTime,
 		tieCursorID: cursorTime,
 	} {
-		_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, formatSQLiteTime(lastActive), sessID)
+		_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, timefmt.Format(lastActive), sessID)
 		require.NoError(t, err)
 	}
 
@@ -165,7 +166,7 @@ func TestCreateUserSessionStoresExpiresAtCanonical(t *testing.T) {
 		sessionID,
 	).Scan(&expiresAtStored, &createdAtStored, &lastActiveAtStored))
 	// expires_at is the caller-supplied instant, wrapped canonical by CreateUserSession.
-	assert.Equal(t, formatSQLiteTime(expiresAt), expiresAtStored,
+	assert.Equal(t, timefmt.Format(expiresAt), expiresAtStored,
 		"expires_at must be stored in the canonical strftime layout the raw-string filters assume; got %q", expiresAtStored)
 	// created_at + last_active_at are written by the column DEFAULT
 	// (strftime('%Y-%m-%dT%H:%M:%fZ','now')), NOT by an explicit Go-bound wrap,
@@ -216,7 +217,7 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 	// Pin last_active_at to a known-old canonical instant so Touch's
 	// `last_active_at < ?` guard provably matches and the UPDATE fires.
 	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, formatSQLiteTime(old), sessionID)
+	_, err := db.Exec(`UPDATE user_sessions SET last_active_at = ? WHERE id = ?`, timefmt.Format(old), sessionID)
 	require.NoError(t, err)
 
 	// Same UTC day as "now", with sub-millisecond precision -- the exact shape
@@ -244,16 +245,17 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 		"touched session's expires_at must compare live under the raw-string "+
 			"strftime filter (the path that returned false pre-fix and logged users out)")
 
-	// Direct layout pin: Touch's SET wraps expires_at in strftime, so the
-	// on-disk value must equal formatSQLiteTime(newExpiry) exactly. A future
-	// Touch refactor that binds expires_at raw would store modernc's driver
-	// layout here and this assertion fails before the liveness filter regresses.
+	// Direct layout pin: Touch binds expires_at as a sqltime.SQLiteTime, so the
+	// on-disk value must equal timefmt.Format(newExpiry) exactly. A future
+	// Touch refactor that binds expires_at as a raw time.Time would store
+	// modernc's driver layout here and this assertion fails before the liveness
+	// filter regresses.
 	// CAST strips the column's DATETIME decltype so modernc returns the stored
 	// bytes verbatim -- a bare scan trims trailing fractional zeros (".720Z"
 	// arrives as ".72Z") and fails this pin on every ms-ends-in-zero instant.
 	var expiresAtStored string
 	require.NoError(t, db.QueryRow(`SELECT CAST(expires_at AS TEXT) FROM user_sessions WHERE id = ?`, sessionID).Scan(&expiresAtStored))
-	assert.Equal(t, formatSQLiteTime(newExpiry), expiresAtStored,
+	assert.Equal(t, timefmt.Format(newExpiry), expiresAtStored,
 		"Touch must store expires_at in the canonical strftime layout; got %q", expiresAtStored)
 
 	// The user-visible consequence: GetByID uses that same raw-string filter,
@@ -265,7 +267,7 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 
 // TestKeysetCursorTrailingZeroMillisecondTie pins that the SQL-side strftime
 // write paths store canonical fixed 3-digit fractional seconds ON DISK, so the
-// keyset predicate's "=" tiebreak branch byte-matches a formatSQLiteTime-decoded
+// keyset predicate's "=" tiebreak branch byte-matches a timefmt.Format-decoded
 // cursor even when the boundary millisecond ends in a trailing zero. (modernc
 // trims trailing zeros only when a DATETIME column is scanned into a Go string
 // -- a driver presentation artifact; production reads scan time.Time and the
@@ -295,7 +297,7 @@ func TestKeysetCursorTrailingZeroMillisecondTie(t *testing.T) {
 	tieInstant := time.Date(2026, 1, 2, 3, 4, 5, 130_000_000, time.UTC)
 	set := func(sessionID string, at time.Time) {
 		_, err := db.Exec(`UPDATE user_sessions SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', ?) WHERE id = ?`,
-			formatSQLiteTime(at), sessionID)
+			timefmt.Format(at), sessionID)
 		require.NoError(t, err)
 	}
 	set(below, tieInstant.Add(-time.Millisecond))

--- a/backend/internal/hub/store/sqlite/sqlc.yaml
+++ b/backend/internal/hub/store/sqlite/sqlc.yaml
@@ -10,6 +10,20 @@ sql:
         emit_json_tags: true
         emit_empty_slices: true
         overrides:
+          # Millisecond-floored, canonical-layout DATETIME types (#303). These
+          # type-keyed entries retype every DATETIME param and result column;
+          # the column-keyed enum overrides below take precedence where they
+          # apply. The db_type matches the raw schema decltype text verbatim,
+          # so the spelling is the uppercase "DATETIME" used in the migrations.
+          - db_type: "DATETIME"
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "SQLiteTime"
+          - db_type: "DATETIME"
+            nullable: true
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "SQLiteNullTime"
           # Worker enums
           - column: "workers.status"
             go_type:

--- a/backend/internal/hub/store/sqlite/testhelper.go
+++ b/backend/internal/hub/store/sqlite/testhelper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 var _ store.TestHelper = (*sqliteTestHelper)(nil)
@@ -56,30 +57,30 @@ func (h *sqliteTestHelper) SetLastActiveAt(ctx context.Context, id string, lastA
 	return h.setEntityTime(ctx, store.EntitySessions, "last_active_at", id, lastActiveAt)
 }
 
-// setEntityTime formats t in the canonical fixed-".000" layout and writes it
-// to a fixed column on a validated entity table. This matches every production
-// write path byte-for-byte: Go-bound writes use the same formatSQLiteTime, and
+// setEntityTime binds t as a SQLiteTime and writes it to a fixed column on a
+// validated entity table. This matches every production write path
+// byte-for-byte: Go-bound writes route through the same SQLiteTime.Value(), and
 // the SQL-side strftime writes (column DEFAULTs, SoftDelete's strftime('now'))
-// also store fixed 3-digit fractional seconds on disk -- see sqliteTimeFormat's
-// doc in convert.go, including the caution that modernc trims zeros only when a
-// DATETIME column is scanned into a Go string.
+// also store fixed 3-digit fractional seconds on disk -- see the SQLiteTime doc
+// in the sqltime package, including the caution that modernc trims zeros only
+// when a DATETIME column is scanned into a Go string.
 func (h *sqliteTestHelper) setEntityTime(ctx context.Context, entity store.TestEntity, column, id string, t time.Time) error {
-	return h.setEntityColumn(ctx, entity, column, id, formatSQLiteTime(t))
+	return h.setEntityColumn(ctx, entity, column, id, sqltime.NewSQLiteTime(t))
 }
 
-// setEntityColumn writes a pre-formatted timestamp string to a fixed column on
-// a validated entity table. SQLite stores timestamps as TEXT via strftime
-// ('%Y-%m-%dT%H:%M:%fZ'), so the value is formatted with formatSQLiteTime to
-// match production rows exactly -- a bound time.Time would serialize in the
-// driver's own layout and break byte-sensitive comparisons (the created_at =
-// cursor tiebreaker, the raw-string deleted_at cleanup cutoffs).
-// The column is a hardcoded literal, never caller input.
-func (h *sqliteTestHelper) setEntityColumn(ctx context.Context, entity store.TestEntity, column, id, value string) error {
+// setEntityColumn writes a timestamp value to a fixed column on a validated
+// entity table. The value is a SQLiteTime Valuer so the driver serializes the
+// canonical strftime('%Y-%m-%dT%H:%M:%fZ') layout, matching production rows
+// exactly -- a bound raw time.Time would serialize in the driver's own layout
+// and break byte-sensitive comparisons (the created_at = cursor tiebreaker, the
+// raw-string deleted_at cleanup cutoffs). The column is a hardcoded literal,
+// never caller input.
+func (h *sqliteTestHelper) setEntityColumn(ctx context.Context, entity store.TestEntity, column, id string, value any) error {
 	return sqlutil.SetEntityColumnValue(ctx, h.exec, sqlutil.ParameterStyleQuestionMark, entity, column, id, value)
 }
 
 func (h *sqliteTestHelper) SetRevocationEventRevokedAt(ctx context.Context, id string, revokedAt time.Time) error {
-	return h.setTimestamp(ctx, sqlutil.TimestampColumnRevocationEventRevokedAt, id, formatSQLiteTime(revokedAt))
+	return h.setTimestamp(ctx, sqlutil.TimestampColumnRevocationEventRevokedAt, id, sqltime.NewSQLiteTime(revokedAt))
 }
 
 func (h *sqliteTestHelper) setTimestamp(ctx context.Context, column sqlutil.TimestampColumn, id string, at any) error {
@@ -90,9 +91,9 @@ func (h *sqliteTestHelper) setTimestamp(ctx context.Context, column sqlutil.Time
 // currently holds only canonical 24-char 'T'-separated values on disk
 // (see sqlitedb.FindNonCanonicalDatetimes for the discovery and probe
 // mechanics). Intended to run as a test cleanup after store writes; it walks
-// after each storetest subtest, so a NEW write path that forgets the strftime
-// wrap fails the suite instead of shipping a #287-shaped silent-row-drop. All
-// offending columns are reported at once.
+// after each storetest subtest, so a NEW write path that binds a raw time.Time
+// instead of a SQLiteTime fails the suite instead of shipping a #287-shaped
+// silent-row-drop. All offending columns are reported at once.
 func CheckCanonicalTimestamps(ctx context.Context, st store.TestableStore) error {
 	ts, ok := st.(*testableSQLiteStore)
 	if !ok {
@@ -101,11 +102,16 @@ func CheckCanonicalTimestamps(ctx context.Context, st store.TestableStore) error
 	db := ts.conn.shared.db
 	// goose_db_version is goose's own bookkeeping table (TIMESTAMP via
 	// datetime('now')), not part of the store's canonical-layout contract.
-	offenders, walked, err := sqlitedb.FindNonCanonicalDatetimes(ctx, db, "goose_db_version")
+	// Per-column coverage is deliberately NOT asserted here: no single
+	// storetest subtest writes every table, so a non-vacuity check would fail
+	// spuriously. That assertion lives in the dedicated
+	// TestAllDatetimeColumnsStoreCanonicalLayout tests, whose fixtures do
+	// populate every column.
+	offenders, columns, err := sqlitedb.FindNonCanonicalDatetimes(ctx, db, "goose_db_version")
 	if err != nil {
 		return err
 	}
-	if walked == 0 {
+	if len(columns) == 0 {
 		// A migrator test may have rolled the schema back to zero; with no
 		// application tables there is legitimately nothing to walk. With
 		// tables present, zero DATETIME columns means the discovery query
@@ -123,7 +129,7 @@ func CheckCanonicalTimestamps(ctx context.Context, st store.TestableStore) error
 	}
 	if len(offenders) > 0 {
 		return fmt.Errorf(
-			"non-canonical timestamp value(s) on disk -- a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap, which silently corrupts raw-string compares:\n  %s",
+			"non-canonical timestamp value(s) on disk -- a write path bound a raw time.Time instead of a SQLiteTime, which silently corrupts raw-string compares:\n  %s",
 			strings.Join(offenders, "\n  "))
 	}
 	return nil

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -10,6 +10,7 @@ import (
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
 type userStore struct {
@@ -29,16 +30,16 @@ func fromDBUser(u gendb.User) store.User {
 		EmailVerified:         ptrconv.Int64ToBool(u.EmailVerified),
 		PendingEmail:          u.PendingEmail,
 		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: sqlutil.NullTimePtr(u.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
 		PendingEmailAttempts:  u.PendingEmailAttempts,
 		PasswordSet:           ptrconv.Int64ToBool(u.PasswordSet),
 		IsAdmin:               ptrconv.Int64ToBool(u.IsAdmin),
 		Prefs:                 u.Prefs,
-		CreatedAt:             u.CreatedAt,
-		UpdatedAt:             u.UpdatedAt,
-		TokensRevokedAt:       sqlutil.NullTimePtr(u.TokensRevokedAt),
+		CreatedAt:             u.CreatedAt.Time,
+		UpdatedAt:             u.UpdatedAt.Time,
+		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
 		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             sqlutil.NullTimePtr(u.DeletedAt),
+		DeletedAt:             u.DeletedAt.Ptr(),
 	}
 }
 
@@ -249,7 +250,7 @@ func (s *userStore) UpdateProfile(ctx context.Context, p store.UpdateUserProfile
 		})); err != nil {
 			return "", time.Time{}, false, err
 		}
-		return updatedUserResult(row.ID, row.UpdatedAt, nil)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, nil)
 	})
 }
 
@@ -270,7 +271,7 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 			EmailVerified: ptrconv.BoolToInt64(p.EmailVerified),
 			ID:            p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -284,7 +285,7 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 			EmailVerified: ptrconv.BoolToInt64(p.EmailVerified),
 			ID:            p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -297,7 +298,7 @@ func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminPara
 			IsAdmin: ptrconv.BoolToInt64(p.IsAdmin),
 			ID:      p.ID,
 		})
-		return updatedUserResult(row.ID, row.UpdatedAt, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 
@@ -312,7 +313,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
-		PendingEmailExpiresAt: sqlutil.BindNullTime(p.PendingEmailExpiresAt),
+		PendingEmailExpiresAt: sqltime.NewSQLiteNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
 	}))
 }
@@ -325,7 +326,7 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
 		row, err := conn.q.PromotePendingEmail(ctx, id)
-		return updatedUserResult(row.ID, row.UpdatedAt, err)
+		return updatedUserResult(row.ID, row.UpdatedAt.Time, err)
 	})
 }
 

--- a/backend/internal/hub/store/sqlite/users_internal_test.go
+++ b/backend/internal/hub/store/sqlite/users_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
+	"github.com/leapmux/leapmux/internal/util/timefmt"
 )
 
 // TestSetPendingEmailStoresCanonicalFormat pins the storage contract of the
@@ -30,8 +31,8 @@ func TestSetPendingEmailStoresCanonicalFormat(t *testing.T) {
 
 	// Millisecond-aligned, same UTC day as "now" (matching the session
 	// canonical-layout pins): strftime ROUNDS sub-millisecond digits while
-	// formatSQLiteTime truncates, so a ms-aligned instant isolates the layout
-	// assertion from that sub-ms rounding difference.
+	// sqltime.SQLiteTime/timefmt.Format truncate, so a ms-aligned instant
+	// isolates the layout assertion from that sub-ms rounding difference.
 	expiry := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Millisecond)
 	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    user.ID,
@@ -40,13 +41,13 @@ func TestSetPendingEmailStoresCanonicalFormat(t *testing.T) {
 		PendingEmailExpiresAt: &expiry,
 	}))
 
-	// Direct layout pin: the on-disk value must equal formatSQLiteTime(expiry)
+	// Direct layout pin: the on-disk value must equal timefmt.Format(expiry)
 	// byte-for-byte. Comparing SQL-side (raw = CAST) avoids modernc's
 	// scan-time reformatting, which would hide a non-canonical layout.
 	var canonical bool
 	require.NoError(t, db.QueryRow(
 		`SELECT pending_email_expires_at = CAST(? AS TEXT) FROM users WHERE id = ?`,
-		formatSQLiteTime(expiry), user.ID,
+		timefmt.Format(expiry), user.ID,
 	).Scan(&canonical))
 	assert.True(t, canonical,
 		"SetPendingEmail must store the canonical strftime layout, not the raw driver layout")
@@ -59,8 +60,9 @@ func TestSetPendingEmailStoresCanonicalFormat(t *testing.T) {
 // code bound the cutoff raw (driver layout, ' ' at byte 10): on any run where
 // the stored value and the cutoff shared a UTC calendar day, ' ' < 'T' made
 // `stored < cutoff` false and the sweep silently skipped the row until the
-// dates diverged. The fixed code binds formatSQLiteTime(cutoff), so a cutoff
-// one minute in the future must clear the just-locked-out row.
+// dates diverged. The fixed code binds the cutoff as a sqltime.SQLiteNullTime
+// (canonical layout), so a cutoff one minute in the future must clear the
+// just-locked-out row.
 func TestClearStalePendingEmailsSweepsLockoutRowSameDay(t *testing.T) {
 	st, _ := newSessionTestStore(t)
 	ctx := context.Background()

--- a/backend/internal/hub/store/sqlite/worker_notifications.go
+++ b/backend/internal/hub/store/sqlite/worker_notifications.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 )
 
 // workerNotificationStore implements store.WorkerNotificationStore backed by SQLite.
@@ -51,7 +50,7 @@ func fromDBWorkerNotification(n gendb.WorkerNotification) store.WorkerNotificati
 		Status:      n.Status,
 		Attempts:    n.Attempts,
 		MaxAttempts: n.MaxAttempts,
-		CreatedAt:   n.CreatedAt,
-		DeliveredAt: sqlutil.NullTimePtr(n.DeliveredAt),
+		CreatedAt:   n.CreatedAt.Time,
+		DeliveredAt: n.DeliveredAt.Ptr(),
 	}
 }

--- a/backend/internal/hub/store/sqlite/workers.go
+++ b/backend/internal/hub/store/sqlite/workers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -160,13 +159,13 @@ func fromDBWorker(w gendb.Worker) *store.Worker {
 		AuthToken:       w.AuthToken,
 		RegisteredBy:    w.RegisteredBy,
 		Status:          w.Status,
-		CreatedAt:       w.CreatedAt,
-		LastSeenAt:      sqlutil.NullTimePtr(w.LastSeenAt),
+		CreatedAt:       w.CreatedAt.Time,
+		LastSeenAt:      w.LastSeenAt.Ptr(),
 		PublicKey:       w.PublicKey,
 		MlkemPublicKey:  w.MlkemPublicKey,
 		SlhdsaPublicKey: w.SlhdsaPublicKey,
 		AutoRegistered:  ptrconv.Int64ToBool(w.AutoRegistered),
-		DeletedAt:       sqlutil.NullTimePtr(w.DeletedAt),
+		DeletedAt:       w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/workspace_sections.go
+++ b/backend/internal/hub/store/sqlite/workspace_sections.go
@@ -21,7 +21,7 @@ func fromDBWorkspaceSection(s gendb.WorkspaceSection) *store.WorkspaceSection {
 		Position:    s.Position,
 		SectionType: s.SectionType,
 		Sidebar:     s.Sidebar,
-		CreatedAt:   s.CreatedAt,
+		CreatedAt:   s.CreatedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/workspaces.go
+++ b/backend/internal/hub/store/sqlite/workspaces.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
-	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -22,8 +21,8 @@ func fromDBWorkspace(w gendb.Workspace) *store.Workspace {
 		OwnerUserID: w.OwnerUserID,
 		Title:       w.Title,
 		IsDeleted:   ptrconv.Int64ToBool(w.IsDeleted),
-		CreatedAt:   w.CreatedAt,
-		DeletedAt:   sqlutil.NullTimePtr(w.DeletedAt),
+		CreatedAt:   w.CreatedAt.Time,
+		DeletedAt:   w.DeletedAt.Ptr(),
 	}
 }
 

--- a/backend/internal/hub/store/sqlutil/convert.go
+++ b/backend/internal/hub/store/sqlutil/convert.go
@@ -19,53 +19,6 @@ func RowsAffected(result sql.Result, err error, mapErrFn func(error) error) (int
 	return n, nil
 }
 
-// NullTimePtr converts a sql.NullTime to *time.Time, returning nil for
-// invalid (NULL) values.
-func NullTimePtr(t sql.NullTime) *time.Time {
-	if !t.Valid {
-		return nil
-	}
-	v := t.Time
-	return &v
-}
-
-// BindTime floors a Go instant to the millisecond grid (UTC) before it is
-// handed to a database driver. The dialects that store millisecond columns
-// ROUND sub-millisecond fractions instead of truncating them -- SQLite's
-// strftime('%f') and MySQL/TiDB's DATETIME(3) both round half up -- so an
-// un-floored bind could store an instant up to half a millisecond LATER than
-// the one the caller supplied. That is enough to overclaim a credential
-// deadline by a whole second once a ceil-to-seconds lifetime report is
-// derived from the roundtripped value (pinned by
-// TestAPIAuth_Refresh_CASRecoveryReportsWinnerRemainingLifetime and, per
-// dialect, by the storetest time_floor group). Flooring Go-side keeps every
-// stored instant on the millisecond grid, so stored <= bound always holds.
-// Postgres-family dialects don't need it (pgx floors nanoseconds to
-// timestamptz microseconds natively) but tolerate it.
-//
-// Enforcement is per call site by convention; replacing that with a
-// mechanical choke point (a driver.Valuer time type applied via sqlc db_type
-// overrides) is tracked in https://github.com/leapmux/leapmux/issues/303.
-func BindTime(t time.Time) time.Time { return t.UTC().Truncate(time.Millisecond) }
-
-// BindNullTime is BindTime for optional instants: nil yields an invalid
-// NullTime (NULL on the wire), non-nil is floored to the millisecond grid.
-func BindNullTime(t *time.Time) sql.NullTime {
-	if t == nil {
-		return sql.NullTime{}
-	}
-	return sql.NullTime{Time: BindTime(*t), Valid: true}
-}
-
-// BindTimeValid is BindTime for required instants bound through a nullable
-// column type: the value is floored to the millisecond grid and always
-// marked valid. Callers with an optional *time.Time use BindNullTime
-// instead; hand-assembling sql.NullTime around BindTime at call sites is
-// exactly the pattern this helper exists to remove.
-func BindTimeValid(t time.Time) sql.NullTime {
-	return sql.NullTime{Time: BindTime(t), Valid: true}
-}
-
 // RequireInt64 unwraps a nullable database integer that the schema requires.
 func RequireInt64(value int64, valid bool, column string) (int64, error) {
 	if !valid {

--- a/backend/internal/hub/store/sqlutil/convert_test.go
+++ b/backend/internal/hub/store/sqlutil/convert_test.go
@@ -1,7 +1,6 @@
 package sqlutil
 
 import (
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -43,53 +42,6 @@ func TestRowsAffectedReturnsCount(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), n)
-}
-
-func TestNullTimePtr(t *testing.T) {
-	assert.Nil(t, NullTimePtr(sql.NullTime{}), "invalid (NULL) must map to nil")
-
-	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
-	nt := sql.NullTime{Time: instant, Valid: true}
-	ptr := NullTimePtr(nt)
-	require.NotNil(t, ptr)
-	assert.True(t, ptr.Equal(instant))
-	assert.NotSame(t, &nt.Time, ptr, "must return a copy, not an alias into the NullTime")
-}
-
-func TestBindTimeFloorsToMillisecondGridInUTC(t *testing.T) {
-	// 750us + 999ns of sub-ms residue: a round-half-up conversion would land
-	// on the NEXT millisecond; BindTime must floor to the current one.
-	local := time.Date(2025, 1, 2, 12, 0, 0, 123_750_999, time.FixedZone("test", 9*60*60))
-
-	bound := BindTime(local)
-
-	assert.Equal(t, time.UTC, bound.Location())
-	assert.Equal(t, local.UTC().Truncate(time.Millisecond), bound)
-	assert.Equal(t, 123_000_000, bound.Nanosecond())
-	assert.False(t, bound.After(local), "bound instant must never postdate its input")
-}
-
-func TestBindTimeWholeMillisecondIsIdentity(t *testing.T) {
-	exact := time.Date(2025, 1, 2, 12, 0, 0, 123_000_000, time.UTC)
-	assert.True(t, BindTime(exact).Equal(exact))
-}
-
-func TestBindNullTime(t *testing.T) {
-	assert.False(t, BindNullTime(nil).Valid, "nil must stay NULL on the wire")
-
-	local := time.Date(2025, 1, 2, 12, 0, 0, 999_999_999, time.FixedZone("test", 9*60*60))
-	bound := BindNullTime(&local)
-	require.True(t, bound.Valid)
-	assert.Equal(t, BindTime(local), bound.Time)
-}
-
-func TestBindTimeValid(t *testing.T) {
-	local := time.Date(2025, 1, 2, 12, 0, 0, 999_999_999, time.FixedZone("test", 9*60*60))
-
-	bound := BindTimeValid(local)
-
-	require.True(t, bound.Valid, "a required instant must never bind NULL")
-	assert.Equal(t, BindTime(local), bound.Time)
 }
 
 func TestRequireInt64(t *testing.T) {

--- a/backend/internal/hub/store/storetest/schema_scan.go
+++ b/backend/internal/hub/store/storetest/schema_scan.go
@@ -1,0 +1,58 @@
+package storetest
+
+import "strings"
+
+// StripSQLLineComments removes a SQL line comment (-- to end of line) from
+// each line. The migrations use only line comments (no /* */ block comments,
+// no string literals containing --), so this is a faithful comment strip for
+// the static schema scans: without it, a ';' inside a prose comment (e.g.
+// "...issued; force-expires...") would split a CREATE TABLE body.
+func StripSQLLineComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// WalkCreateTableColumns strips line comments from migration SQL, walks every
+// CREATE TABLE body line by line, and yields each line that tokenizes as a
+// column definition: fn receives the column name (lowercased) and its type
+// token (uppercased, trailing comma removed). Shared by the per-dialect static
+// decltype scans (mysql/postgres schema_internal_test.go) so the fragile text
+// parse lives once and a parser fix cannot land in one dialect and silently
+// miss the other; the dialect-specific type assertions stay at each call site.
+//
+// Parsing limitation, by design: the walk assumes one column per line with the
+// type as the second whitespace token, so a declaration wrapped across lines
+// or an inline expression column is silently skipped. The integration-tagged
+// live twins (TestMySQLDatetimeColumnsLive, TestPostgresTimestamptzColumnsLive)
+// read the resolved types from information_schema and are immune to the
+// migration text's line shape; the static scans exist so the everyday
+// Docker-free suite still guards the decltype spelling.
+func WalkCreateTableColumns(migrationSQL string, fn func(column, typeTok string)) {
+	inTable := false
+	for _, line := range strings.Split(StripSQLLineComments(migrationSQL), "\n") {
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		if strings.HasPrefix(upper, "CREATE TABLE") {
+			inTable = true
+			continue
+		}
+		if inTable && strings.HasPrefix(upper, ")") {
+			inTable = false
+			continue
+		}
+		if !inTable {
+			continue
+		}
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		fn(strings.ToLower(fields[0]), strings.ToUpper(strings.TrimSuffix(fields[1], ",")))
+	}
+}

--- a/backend/internal/hub/store/storetest/schema_scan_test.go
+++ b/backend/internal/hub/store/storetest/schema_scan_test.go
@@ -1,0 +1,60 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripSQLLineComments(t *testing.T) {
+	in := "CREATE TABLE t ( -- issued; force-expires\n  id TEXT, -- trailing\n  n INT\n);\n"
+	// The ';' inside the comment must go; code before '--' must survive. The
+	// helper emits one '\n' per split segment, so input ending in a newline
+	// gains a trailing blank line -- harmless for the scans, pinned here.
+	assert.Equal(t, "CREATE TABLE t ( \n  id TEXT, \n  n INT\n);\n\n", StripSQLLineComments(in))
+	assert.Equal(t, "\n", StripSQLLineComments(""), "empty input yields a single newline (line-join shape)")
+}
+
+func TestWalkCreateTableColumns(t *testing.T) {
+	schema := `
+-- prose with a ; semicolon
+CREATE TABLE alpha (
+  id TEXT PRIMARY KEY,
+  created_at DATETIME(3) NOT NULL, -- comment after column
+  loose_at datetime(2),
+  recorded TIMESTAMP,
+  CONSTRAINT fk FOREIGN KEY (id) REFERENCES other (id)
+);
+CREATE INDEX idx ON alpha (id);
+CREATE TABLE bravo (
+  seen_at TIMESTAMPTZ
+);
+`
+	type col struct{ name, typeTok string }
+	var got []col
+	WalkCreateTableColumns(schema, func(name, typeTok string) {
+		got = append(got, col{name, typeTok})
+	})
+	// Every body line with >= 2 tokens is yielded (constraint lines included --
+	// callers filter by name shape); names lowercased, types uppercased,
+	// trailing comma trimmed; the index statement outside a body is skipped.
+	assert.Equal(t, []col{
+		{"id", "TEXT"},
+		{"created_at", "DATETIME(3)"},
+		{"loose_at", "DATETIME(2)"},
+		{"recorded", "TIMESTAMP"},
+		{"constraint", "FK"},
+		{"seen_at", "TIMESTAMPTZ"},
+	}, got)
+}
+
+func TestWalkCreateTableColumnsNoTables(t *testing.T) {
+	// Empty input and DDL without CREATE TABLE bodies must yield nothing --
+	// the dialect scans' atColumns sanity guard is what turns "walked nothing"
+	// into a failure, so the walker itself stays silent.
+	for _, schema := range []string{"", "CREATE INDEX idx ON alpha (id);\n-- comment only\n"} {
+		WalkCreateTableColumns(schema, func(name, typeTok string) {
+			t.Errorf("unexpected column yielded from %q: %s %s", schema, name, typeTok)
+		})
+	}
+}

--- a/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
+++ b/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
@@ -11,8 +11,9 @@ import (
 )
 
 // boundaryZone keeps every bound instant in this group deliberately non-UTC:
-// each dialect must normalize the offset itself (SQLite via its strftime
-// wraps, Postgres/MySQL via the driver's typed conversion), so a write path
+// each dialect must normalize the offset itself (SQLite via SQLiteTime's
+// canonical UTC serialization, Postgres/MySQL via their valuers' UTC
+// normalization), so a write path
 // that started storing local wall time would shift every boundary by the
 // offset and fail these pins loudly.
 var boundaryZone = time.FixedZone("UTC+9", 9*60*60)

--- a/backend/internal/hub/store/storetest/test_time_floor.go
+++ b/backend/internal/hub/store/storetest/test_time_floor.go
@@ -52,10 +52,10 @@ func assertStoredInstant(t *testing.T, label string, bound, stored time.Time) {
 // testTimeFloor pins that every dialect FLOORS Go-bound instants to its
 // column precision instead of rounding: reading a just-written deadline back
 // must never yield a later instant than the one the caller minted. SQLite
-// enforces this Go-side (sqlutil.BindTime/BindNullTime, because strftime
-// '%f' rounds), MySQL/TiDB likewise Go-side (the server rounds DATETIME(3)
-// inserts half-up), and Postgres-family dialects natively (pgx floors
-// nanoseconds to timestamptz microseconds). Each subtest drives a
+// enforces this Go-side (sqltime.SQLiteTime/SQLiteNullTime.Value floor, because
+// strftime '%f' rounds), MySQL/TiDB likewise Go-side (sqltime.MySQLTime, because
+// the server rounds DATETIME(3) inserts half-up), and Postgres-family dialects
+// via pgtime.Time (pgx floors nanoseconds to timestamptz microseconds). Each subtest drives a
 // deadline-bearing write path through the store API with sub-millisecond
 // probes and pins the readback.
 func (s *Suite) testTimeFloor(t *testing.T) {

--- a/backend/internal/util/sqlitedb/canonical.go
+++ b/backend/internal/util/sqlitedb/canonical.go
@@ -8,6 +8,34 @@ import (
 	"strings"
 )
 
+// ColumnCoverage describes one DATETIME column discovered by
+// FindNonCanonicalDatetimes: its (table, column) identity and how many
+// non-null rows the value probe inspected. NonNullRows == 0 means the column's
+// canonical-layout check passed vacuously -- there was no stored value to
+// contradict it -- so a test that wants a real guarantee for every column must
+// also assert coverage (see UncoveredColumns).
+type ColumnCoverage struct {
+	Table       string
+	Column      string
+	NonNullRows int64
+}
+
+// UncoveredColumns returns the "table.column" names of every discovered
+// DATETIME column whose probe inspected zero non-null rows. The dedicated
+// canonical-storage tests (hub store, worker service) assert this list is
+// empty so no column's canonical-layout contract ships exercised only
+// vacuously; the per-subtest CheckCanonicalTimestamps walk deliberately does
+// NOT (no single subtest writes every table).
+func UncoveredColumns(columns []ColumnCoverage) []string {
+	var uncovered []string
+	for _, c := range columns {
+		if c.NonNullRows == 0 {
+			uncovered = append(uncovered, c.Table+"."+c.Column)
+		}
+	}
+	return uncovered
+}
+
 // FindNonCanonicalDatetimes walks every DATETIME column of every table in the
 // connected SQLite database (excluding sqlite_* internals and the tables named
 // in exclude, typically goose's version table) and reports stored values that
@@ -21,10 +49,12 @@ import (
 // suffix) and silently corrupts raw-string compares (keyset ORDER BY columns,
 // liveness filters, cleanup cutoffs).
 //
-// It returns one human-readable line per offending column and the number of
-// (table, column) pairs walked; walked == 0 means the schema holds no DATETIME
-// columns (e.g. a migrator test rolled it back), which callers should judge
-// for themselves.
+// It returns one human-readable line per offending column plus one
+// ColumnCoverage per discovered (table, column) pair; len(columns) == 0 means
+// the schema holds no DATETIME columns (e.g. a migrator test rolled it back),
+// which callers should judge for themselves. Each ColumnCoverage carries the
+// count of non-null rows the value probe inspected, so callers can also detect
+// a column that passed only vacuously (see UncoveredColumns).
 //
 // The walk's coverage is keyed on the DATETIME decltype, so a timestamp column
 // declared with any other type would silently escape it. To make that drift
@@ -32,9 +62,31 @@ import (
 // (name ending in `_at`) whose decltype is not DATETIME as an offender: a
 // future migration must either declare the column DATETIME (bringing it under
 // the walk) or exclude its table deliberately.
-func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...string) (offenders []string, walked int, err error) {
-	// UPPER: SQLite decltypes are case-insensitive, so a migration that
-	// declares a column as lowercase `datetime` must still be walked.
+func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...string) (offenders []string, columns []ColumnCoverage, err error) {
+	columns, err = discoverDatetimeColumns(ctx, db, exclude)
+	if err != nil {
+		return nil, nil, err
+	}
+	mistyped, err := findMistypedTimestampColumns(ctx, db, exclude)
+	if err != nil {
+		return nil, nil, err
+	}
+	offenders = append(offenders, mistyped...)
+	if len(columns) > 0 {
+		valueOffenders, err := probeColumnValues(ctx, db, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		offenders = append(offenders, valueOffenders...)
+	}
+	return offenders, columns, nil
+}
+
+// discoverDatetimeColumns lists every DATETIME-decltyped (table, column) pair
+// in the live schema, minus sqlite_* internals and the excluded tables.
+// UPPER: SQLite decltypes are case-insensitive, so a migration that declares
+// a column as lowercase `datetime` must still be walked.
+func discoverDatetimeColumns(ctx context.Context, db *sql.DB, exclude []string) ([]ColumnCoverage, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT m.name, ti.name
 		FROM sqlite_master m, pragma_table_info(m.name) ti
@@ -43,27 +95,31 @@ func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...strin
 		  AND UPPER(ti.type) = 'DATETIME'
 		ORDER BY m.name, ti.cid`)
 	if err != nil {
-		return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+		return nil, fmt.Errorf("canonical-timestamp column discovery: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	type tableColumn struct{ table, col string }
-	var columns []tableColumn
+	var columns []ColumnCoverage
 	for rows.Next() {
-		var tc tableColumn
-		if err := rows.Scan(&tc.table, &tc.col); err != nil {
-			return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+		var tc ColumnCoverage
+		if err := rows.Scan(&tc.Table, &tc.Column); err != nil {
+			return nil, fmt.Errorf("canonical-timestamp column discovery: %w", err)
 		}
-		if slices.Contains(exclude, tc.table) {
+		if slices.Contains(exclude, tc.Table) {
 			continue
 		}
 		columns = append(columns, tc)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("canonical-timestamp column discovery: %w", err)
+		return nil, fmt.Errorf("canonical-timestamp column discovery: %w", err)
 	}
-	// Schema-shape guard: a timestamp-named column that is not DATETIME sits
-	// outside the value walk below, so report the declaration itself.
-	declRows, err := db.QueryContext(ctx, `
+	return columns, nil
+}
+
+// findMistypedTimestampColumns is the schema-shape guard: a timestamp-named
+// column that is not DATETIME sits outside the value walk, so it reports the
+// declaration itself as an offender.
+func findMistypedTimestampColumns(ctx context.Context, db *sql.DB, exclude []string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
 		SELECT m.name, ti.name, ti.type
 		FROM sqlite_master m, pragma_table_info(m.name) ti
 		WHERE m.type = 'table'
@@ -72,13 +128,14 @@ func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...strin
 		  AND UPPER(ti.type) != 'DATETIME'
 		ORDER BY m.name, ti.cid`)
 	if err != nil {
-		return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+		return nil, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
 	}
-	defer func() { _ = declRows.Close() }()
-	for declRows.Next() {
+	defer func() { _ = rows.Close() }()
+	var offenders []string
+	for rows.Next() {
 		var table, col, decltype string
-		if err := declRows.Scan(&table, &col, &decltype); err != nil {
-			return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+		if err := rows.Scan(&table, &col, &decltype); err != nil {
+			return nil, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
 		}
 		if slices.Contains(exclude, table) {
 			continue
@@ -86,52 +143,70 @@ func FindNonCanonicalDatetimes(ctx context.Context, db *sql.DB, exclude ...strin
 		offenders = append(offenders,
 			fmt.Sprintf("%s.%s: declared %s, want DATETIME (timestamp-named column outside the canonical walk)", table, col, decltype))
 	}
-	if err := declRows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("canonical-timestamp decltype guard: %w", err)
 	}
-	if len(columns) > 0 {
-		// One compound probe instead of a round trip per column: the walk runs
-		// after every storetest subtest, so ~58 sequential QueryRow calls per
-		// invocation add up across a suite. Table and column names come from
-		// the live schema, never caller input. SQLite caps compound SELECTs at
-		// 500 arms by default; a schema anywhere near that many DATETIME
-		// columns fails this query loudly, not silently.
-		var probe strings.Builder
-		for i, tc := range columns {
-			if i > 0 {
-				probe.WriteString(" UNION ALL ")
-			}
-			fmt.Fprintf(&probe,
-				"SELECT %d, COUNT(*), MIN(CAST(%s AS TEXT)) FROM %s WHERE %s IS NOT NULL AND (length(CAST(%s AS TEXT)) != 24 OR substr(CAST(%s AS TEXT), 11, 1) != 'T')",
-				i, tc.col, tc.table, tc.col, tc.col, tc.col)
+	return offenders, nil
+}
+
+// probeColumnValues runs the compound value probe over the discovered columns,
+// fills each ColumnCoverage's NonNullRows in place (columns is a slice, so the
+// caller's elements are updated), and returns one offender line per column
+// holding non-canonical values.
+//
+// One compound probe instead of a round trip per column: the walk runs after
+// every storetest subtest, so ~58 sequential QueryRow calls per invocation add
+// up across a suite. Table and column names come from the live schema, never
+// caller input. SQLite caps compound SELECTs at 500 arms by default; a schema
+// anywhere near that many DATETIME columns fails this query loudly, not
+// silently.
+func probeColumnValues(ctx context.Context, db *sql.DB, columns []ColumnCoverage) ([]string, error) {
+	var probe strings.Builder
+	for i, tc := range columns {
+		if i > 0 {
+			probe.WriteString(" UNION ALL ")
 		}
-		probeRows, err := db.QueryContext(ctx, probe.String())
-		if err != nil {
-			return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
+		// The offending-value condition moves into FILTER clauses so the
+		// same single-pass aggregate can also report COUNT(col) -- the
+		// total non-null rows inspected -- which feeds ColumnCoverage.
+		// A NULL value never matches the filter (length(NULL) is NULL),
+		// so the IS NOT NULL guard is kept only for clarity.
+		text := fmt.Sprintf("CAST(%s AS TEXT)", tc.Column)
+		bad := fmt.Sprintf("%s IS NOT NULL AND (length(%s) != 24 OR substr(%s, 11, 1) != 'T')",
+			tc.Column, text, text)
+		fmt.Fprintf(&probe,
+			"SELECT %d, COUNT(*) FILTER (WHERE %s), MIN(%s) FILTER (WHERE %s), COUNT(%s) FROM %s",
+			i, bad, text, bad, tc.Column, tc.Table)
+	}
+	rows, err := db.QueryContext(ctx, probe.String())
+	if err != nil {
+		return nil, fmt.Errorf("canonical-timestamp walk: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	counts := make([]int, len(columns))
+	samples := make([]sql.NullString, len(columns))
+	for rows.Next() {
+		var idx, count int
+		var sample sql.NullString
+		var nonNull int64
+		if err := rows.Scan(&idx, &count, &sample, &nonNull); err != nil {
+			return nil, fmt.Errorf("canonical-timestamp walk: %w", err)
 		}
-		defer func() { _ = probeRows.Close() }()
-		counts := make([]int, len(columns))
-		samples := make([]sql.NullString, len(columns))
-		for probeRows.Next() {
-			var idx, count int
-			var sample sql.NullString
-			if err := probeRows.Scan(&idx, &count, &sample); err != nil {
-				return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
-			}
-			if idx < 0 || idx >= len(columns) {
-				return nil, 0, fmt.Errorf("canonical-timestamp walk: probe returned out-of-range column index %d", idx)
-			}
-			counts[idx], samples[idx] = count, sample
+		if idx < 0 || idx >= len(columns) {
+			return nil, fmt.Errorf("canonical-timestamp walk: probe returned out-of-range column index %d", idx)
 		}
-		if err := probeRows.Err(); err != nil {
-			return nil, 0, fmt.Errorf("canonical-timestamp walk: %w", err)
-		}
-		for i, tc := range columns {
-			if counts[i] > 0 {
-				offenders = append(offenders,
-					fmt.Sprintf("%s.%s: %d value(s), e.g. %q", tc.table, tc.col, counts[i], samples[i].String))
-			}
+		counts[idx], samples[idx] = count, sample
+		columns[idx].NonNullRows = nonNull
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("canonical-timestamp walk: %w", err)
+	}
+	var offenders []string
+	for i, tc := range columns {
+		if counts[i] > 0 {
+			offenders = append(offenders,
+				fmt.Sprintf("%s.%s: %d value(s), e.g. %q", tc.Table, tc.Column, counts[i], samples[i].String))
 		}
 	}
-	return offenders, len(columns), nil
+	return offenders, nil
 }

--- a/backend/internal/util/sqlitedb/canonical_test.go
+++ b/backend/internal/util/sqlitedb/canonical_test.go
@@ -62,11 +62,18 @@ func TestFindNonCanonicalDatetimes_CleanSchema(t *testing.T) {
 		canonicalValue, canonicalValue, driverLayoutValue)
 	require.NoError(t, err)
 
-	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db)
 	require.NoError(t, err)
 	assert.Empty(t, offenders, "canonical values, NULLs, and non-DATETIME columns must not be reported")
-	assert.Equal(t, 3, walked,
-		"must walk exactly the DATETIME columns (alpha.created_at, bravo.expires_at, bravo.updated_at), regardless of decltype case")
+	// alpha.created_at holds one canonical row and one NULL row: the NULL must
+	// not count toward NonNullRows, or a NULL-only column would look covered.
+	assert.Equal(t, []ColumnCoverage{
+		{Table: "alpha", Column: "created_at", NonNullRows: 1},
+		{Table: "bravo", Column: "expires_at", NonNullRows: 1},
+		{Table: "bravo", Column: "updated_at", NonNullRows: 1},
+	}, columns,
+		"must walk exactly the DATETIME columns (alpha.created_at, bravo.expires_at, bravo.updated_at), regardless of decltype case, counting only non-null rows")
+	assert.Empty(t, UncoveredColumns(columns))
 }
 
 func TestFindNonCanonicalDatetimes_ReportsEveryOffendingColumn(t *testing.T) {
@@ -82,9 +89,15 @@ func TestFindNonCanonicalDatetimes_ReportsEveryOffendingColumn(t *testing.T) {
 		canonicalValue, driverLayoutValue)
 	require.NoError(t, err)
 
-	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db)
 	require.NoError(t, err)
-	assert.Equal(t, 3, walked)
+	// NonNullRows counts every non-null row, offending or clean: 3 for
+	// alpha.created_at even though only 2 of them are reported below.
+	assert.Equal(t, []ColumnCoverage{
+		{Table: "alpha", Column: "created_at", NonNullRows: 3},
+		{Table: "bravo", Column: "expires_at", NonNullRows: 1},
+		{Table: "bravo", Column: "updated_at", NonNullRows: 1},
+	}, columns)
 	assert.Equal(t, []string{
 		`alpha.created_at: 2 value(s), e.g. "` + driverLayoutValue + `"`,
 		`bravo.updated_at: 1 value(s), e.g. "` + driverLayoutValue + `"`,
@@ -100,13 +113,18 @@ func TestFindNonCanonicalDatetimes_ReportsTimestampNamedColumnWithWrongDecltype(
 	_, err := db.Exec(`CREATE TABLE charlie (id INTEGER PRIMARY KEY, seen_at TEXT, logged_at TIMESTAMP)`)
 	require.NoError(t, err)
 
-	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"charlie.seen_at: declared TEXT, want DATETIME (timestamp-named column outside the canonical walk)",
 		"charlie.logged_at: declared TIMESTAMP, want DATETIME (timestamp-named column outside the canonical walk)",
 	}, offenders)
-	assert.Equal(t, 3, walked, "the guard must not add non-DATETIME columns to the value walk")
+	// No rows were inserted, so every walked column reports zero coverage.
+	assert.Equal(t, []ColumnCoverage{
+		{Table: "alpha", Column: "created_at", NonNullRows: 0},
+		{Table: "bravo", Column: "expires_at", NonNullRows: 0},
+		{Table: "bravo", Column: "updated_at", NonNullRows: 0},
+	}, columns, "the guard must not add non-DATETIME columns to the value walk")
 
 	// Excluding the table silences the decltype guard along with the walk.
 	offenders, _, err = FindNonCanonicalDatetimes(context.Background(), db, "charlie")
@@ -120,10 +138,41 @@ func TestFindNonCanonicalDatetimes_ExcludeSkipsTable(t *testing.T) {
 	_, err := db.Exec(`INSERT INTO bravo (expires_at) VALUES (?)`, driverLayoutValue)
 	require.NoError(t, err)
 
-	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db, "bravo")
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db, "bravo")
 	require.NoError(t, err)
 	assert.Empty(t, offenders, "an excluded table's values must not be probed")
-	assert.Equal(t, 1, walked, "excluded tables must not count toward the walked total")
+	// alpha holds no rows: the surviving column is walked but uncovered, which
+	// UncoveredColumns must surface as the vacuous pass it is.
+	assert.Equal(t, []ColumnCoverage{
+		{Table: "alpha", Column: "created_at", NonNullRows: 0},
+	}, columns, "excluded tables must not count toward the walked columns")
+	assert.Equal(t, []string{"alpha.created_at"}, UncoveredColumns(columns))
+}
+
+// TestFindNonCanonicalDatetimes_ReportsPerColumnCoverage pins the vacuity
+// report itself: a NULL-only column and an untouched column must both surface
+// through UncoveredColumns even though neither produces an offender -- the
+// exact blind spot the dedicated canonical-storage tests close by asserting
+// the uncovered list is empty.
+func TestFindNonCanonicalDatetimes_ReportsPerColumnCoverage(t *testing.T) {
+	db := openCanonicalTestDB(t)
+
+	// alpha.created_at: a row exists but the value is NULL. bravo.expires_at:
+	// one real value. bravo.updated_at: never written at all.
+	_, err := db.Exec(`INSERT INTO alpha (created_at) VALUES (NULL)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO bravo (expires_at) VALUES (?)`, canonicalValue)
+	require.NoError(t, err)
+
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "NULLs and canonical values are not offenders")
+	assert.Equal(t, []ColumnCoverage{
+		{Table: "alpha", Column: "created_at", NonNullRows: 0},
+		{Table: "bravo", Column: "expires_at", NonNullRows: 1},
+		{Table: "bravo", Column: "updated_at", NonNullRows: 0},
+	}, columns)
+	assert.Equal(t, []string{"alpha.created_at", "bravo.updated_at"}, UncoveredColumns(columns))
 }
 
 func TestFindNonCanonicalDatetimes_EmptySchemaWalksNothing(t *testing.T) {
@@ -131,8 +180,9 @@ func TestFindNonCanonicalDatetimes_EmptySchemaWalksNothing(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	offenders, walked, err := FindNonCanonicalDatetimes(context.Background(), db)
+	offenders, columns, err := FindNonCanonicalDatetimes(context.Background(), db)
 	require.NoError(t, err)
 	assert.Empty(t, offenders)
-	assert.Zero(t, walked, "an empty schema must report walked == 0 so callers can judge vacuity")
+	assert.Empty(t, columns, "an empty schema must report zero walked columns so callers can judge vacuity")
+	assert.Empty(t, UncoveredColumns(nil), "no columns means nothing to report as uncovered")
 }

--- a/backend/internal/util/sqltime/pgtime/pgtime.go
+++ b/backend/internal/util/sqltime/pgtime/pgtime.go
@@ -1,0 +1,140 @@
+// Package pgtime provides pgtype.TimestamptzValuer/TimestamptzScanner time types
+// for Postgres-family dialects (Postgres, CockroachDB, YugabyteDB). Unlike the
+// SQLite/MySQL types in the parent sqltime package, these floor to MICROSECONDS,
+// not milliseconds: timestamptz stores microsecond precision, so a ms floor
+// would discard precision Postgres legitimately keeps. pgx already floors
+// nanoseconds to microseconds when it encodes the binary protocol; the explicit
+// Truncate makes the floor mechanical regardless of transport and survives a
+// future text-protocol bind where the server cast would round half-to-even.
+//
+// pgx dispatches on TimestamptzValuer/TimestamptzScanner without codec
+// registration, so wiring these types via sqlc db_type overrides is enough.
+// See https://github.com/leapmux/leapmux/issues/303.
+package pgtime
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// noCompare, embedded as a blank zero-size field, makes the wrapper structs
+// non-comparable: == on time.Time-carrying values compares the wall/monotonic/
+// location fields rather than the instant, so wrapper == wrapper (or map-key
+// use) is a latent bug -- the marker turns it into a compile error. Compare
+// via the promoted/field Equal instead. Mirrors the marker in the parent
+// sqltime package.
+type noCompare [0]func()
+
+// iso8601Micros is the microsecond-precision ISO 8601 layout String() prints:
+// timestamptz stores microseconds, so the printed instant carries the same
+// precision the column does (the parent sqltime package prints milliseconds
+// for the same reason).
+const iso8601Micros = "2006-01-02T15:04:05.000000Z"
+
+// Time is a required (NOT NULL) timestamptz column. The embedded time.Time
+// promotes Equal/UTC/Before/... to the wrapper.
+type Time struct {
+	_ noCompare
+	time.Time
+}
+
+// NullTime is a nullable timestamptz column; the exported Time/Valid fields
+// mirror the shape used across the store layer.
+type NullTime struct {
+	_     noCompare
+	Time  time.Time
+	Valid bool
+}
+
+var (
+	_ pgtype.TimestamptzValuer  = Time{}
+	_ pgtype.TimestamptzScanner = (*Time)(nil)
+	_ pgtype.TimestamptzValuer  = NullTime{}
+	_ pgtype.TimestamptzScanner = (*NullTime)(nil)
+)
+
+func floorMicros(t time.Time) time.Time { return t.UTC().Truncate(time.Microsecond) }
+
+// New floors t to microseconds and wraps it.
+func New(t time.Time) Time { return Time{Time: floorMicros(t)} }
+
+// NewNull mirrors an optional instant: nil yields an invalid (NULL) value,
+// non-nil is floored to microseconds and marked valid.
+func NewNull(t *time.Time) NullTime {
+	if t == nil {
+		return NullTime{}
+	}
+	return NullTime{Time: floorMicros(*t), Valid: true}
+}
+
+// NullOf is a required instant bound through a nullable column type: floored and
+// always valid.
+func NullOf(t time.Time) NullTime {
+	return NullTime{Time: floorMicros(t), Valid: true}
+}
+
+// TimestamptzValue floors to microseconds (UTC) and marks the value finite.
+func (t Time) TimestamptzValue() (pgtype.Timestamptz, error) {
+	return pgtype.Timestamptz{Time: floorMicros(t.Time), Valid: true}, nil
+}
+
+// ScanTimestamptz rejects NULL and non-finite (infinity) timestamps and
+// normalizes the instant to UTC.
+func (t *Time) ScanTimestamptz(v pgtype.Timestamptz) error {
+	if !v.Valid {
+		return fmt.Errorf("cannot scan NULL into pgtime.Time (use pgtime.NullTime)")
+	}
+	if v.InfinityModifier != pgtype.Finite {
+		return fmt.Errorf("cannot scan non-finite timestamp (%v) into pgtime.Time", v.InfinityModifier)
+	}
+	t.Time = v.Time.UTC()
+	return nil
+}
+
+// TimestamptzValue returns an invalid (NULL) value when !Valid, otherwise the
+// microsecond-floored UTC instant.
+func (t NullTime) TimestamptzValue() (pgtype.Timestamptz, error) {
+	if !t.Valid {
+		return pgtype.Timestamptz{}, nil
+	}
+	return pgtype.Timestamptz{Time: floorMicros(t.Time), Valid: true}, nil
+}
+
+// ScanTimestamptz maps NULL to an invalid value, rejects non-finite timestamps,
+// and normalizes to UTC otherwise.
+func (t *NullTime) ScanTimestamptz(v pgtype.Timestamptz) error {
+	if !v.Valid {
+		t.Time, t.Valid = time.Time{}, false
+		return nil
+	}
+	if v.InfinityModifier != pgtype.Finite {
+		return fmt.Errorf("cannot scan non-finite timestamp (%v) into pgtime.NullTime", v.InfinityModifier)
+	}
+	t.Time, t.Valid = v.Time.UTC(), true
+	return nil
+}
+
+// Ptr returns a copy of the instant, or nil when invalid.
+func (t NullTime) Ptr() *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	v := t.Time
+	return &v
+}
+
+// String shadows the promoted time.Time.String so fmt/slog print the stored
+// instant -- microsecond-floored UTC -- rather than time.Time's default layout
+// with sub-microsecond residue the storage floors away.
+func (t Time) String() string { return floorMicros(t.Time).Format(iso8601Micros) }
+
+// String prints NULL when invalid, otherwise the stored instant; see
+// Time.String.
+func (t NullTime) String() string {
+	if !t.Valid {
+		return "NULL"
+	}
+	return floorMicros(t.Time).Format(iso8601Micros)
+}

--- a/backend/internal/util/sqltime/pgtime/pgtime_test.go
+++ b/backend/internal/util/sqltime/pgtime/pgtime_test.go
@@ -1,0 +1,144 @@
+package pgtime
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeValueFloorsToMicroseconds(t *testing.T) {
+	// 999ns tail below the microsecond grid must be dropped, never rounded up.
+	probe := time.Date(2025, 1, 2, 12, 0, 0, 123_456_999, time.FixedZone("UTC+9", 9*60*60))
+	ts, err := New(probe).TimestamptzValue()
+	require.NoError(t, err)
+	require.True(t, ts.Valid)
+	assert.Equal(t, time.UTC, ts.Time.Location())
+	// 12:00 UTC+9 == 03:00 UTC; 123_456_999ns floors to 123_456_000ns.
+	assert.Equal(t, time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC), ts.Time)
+}
+
+func TestTimeValueMicrosecondGridPassesThrough(t *testing.T) {
+	exact := time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC)
+	ts, err := New(exact).TimestamptzValue()
+	require.NoError(t, err)
+	assert.True(t, ts.Time.Equal(exact))
+}
+
+func TestTimestamptzValueFloorsStructLiteral(t *testing.T) {
+	// TimestamptzValue is the choke point: it must floor even when the flooring
+	// constructor is bypassed via struct-literal construction.
+	probe := time.Date(2025, 1, 2, 12, 0, 0, 123_456_999, time.FixedZone("UTC+9", 9*60*60))
+	ts, err := Time{Time: probe}.TimestamptzValue()
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC), ts.Time)
+
+	ts, err = NullTime{Time: probe, Valid: true}.TimestamptzValue()
+	require.NoError(t, err)
+	require.True(t, ts.Valid)
+	assert.Equal(t, time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC), ts.Time)
+}
+
+func TestTimeScanNormalizesUTC(t *testing.T) {
+	var pt Time
+	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.FixedZone("UTC+9", 9*60*60))
+	require.NoError(t, pt.ScanTimestamptz(pgtype.Timestamptz{Time: instant, Valid: true}))
+	assert.Equal(t, time.UTC, pt.Location())
+	assert.True(t, pt.Equal(instant))
+}
+
+func TestTimeScanRejectsNull(t *testing.T) {
+	var pt Time
+	require.Error(t, pt.ScanTimestamptz(pgtype.Timestamptz{Valid: false}))
+}
+
+func TestTimeScanRejectsInfinity(t *testing.T) {
+	var pt Time
+	require.Error(t, pt.ScanTimestamptz(pgtype.Timestamptz{Valid: true, InfinityModifier: pgtype.Infinity}))
+	require.Error(t, pt.ScanTimestamptz(pgtype.Timestamptz{Valid: true, InfinityModifier: pgtype.NegativeInfinity}))
+}
+
+func TestNullTimeValue(t *testing.T) {
+	ts, err := NullTime{}.TimestamptzValue()
+	require.NoError(t, err)
+	assert.False(t, ts.Valid, "invalid must bind NULL")
+
+	local := time.Date(2025, 1, 2, 12, 0, 0, 123_456_999, time.FixedZone("UTC+9", 9*60*60))
+	ts, err = NullOf(local).TimestamptzValue()
+	require.NoError(t, err)
+	require.True(t, ts.Valid)
+	assert.Equal(t, time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC), ts.Time)
+}
+
+func TestNewNull(t *testing.T) {
+	assert.False(t, NewNull(nil).Valid)
+	local := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	assert.True(t, NewNull(&local).Valid)
+}
+
+func TestNullTimeScanNull(t *testing.T) {
+	pt := NullTime{Time: time.Now(), Valid: true}
+	require.NoError(t, pt.ScanTimestamptz(pgtype.Timestamptz{Valid: false}))
+	assert.False(t, pt.Valid)
+}
+
+func TestNullTimeScanRejectsInfinity(t *testing.T) {
+	var pt NullTime
+	require.Error(t, pt.ScanTimestamptz(pgtype.Timestamptz{Valid: true, InfinityModifier: pgtype.Infinity}))
+}
+
+func TestNullTimePtr(t *testing.T) {
+	assert.Nil(t, NullTime{}.Ptr())
+	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	nt := NullOf(instant)
+	ptr := nt.Ptr()
+	require.NotNil(t, ptr)
+	assert.True(t, ptr.Equal(instant))
+	assert.NotSame(t, &nt.Time, ptr)
+}
+
+// TestCodecRoundTrip drives the value through the pgtype.TimestamptzCodec encode
+// and decode plans, the same path pgx uses on the wire, to confirm the Valuer/
+// Scanner integrate without codec registration.
+func TestCodecRoundTrip(t *testing.T) {
+	m := pgtype.NewMap()
+	codec := pgtype.TimestamptzCodec{}
+	oid := uint32(pgtype.TimestamptzOID)
+
+	src := New(time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC))
+	plan := codec.PlanEncode(m, oid, pgtype.BinaryFormatCode, src)
+	require.NotNil(t, plan, "encode plan must exist for pgtime.Time")
+	encoded, err := plan.Encode(src, nil)
+	require.NoError(t, err)
+
+	var dst Time
+	scanPlan := codec.PlanScan(m, oid, pgtype.BinaryFormatCode, &dst)
+	require.NotNil(t, scanPlan, "scan plan must exist for *pgtime.Time")
+	require.NoError(t, scanPlan.Scan(encoded, &dst))
+	assert.True(t, dst.Equal(src.Time))
+}
+
+func TestStringPrintsStoredRepresentation(t *testing.T) {
+	// String() must shadow the promoted time.Time.String so fmt output carries
+	// the stored microsecond precision in UTC. Struct literals (not the
+	// flooring constructors) so the assertions pin String's OWN normalization:
+	// the probe's UTC+9 zone would leak into the output if String printed the
+	// raw embedded time.
+	probe := time.Date(2025, 1, 2, 12, 0, 0, 123_456_999, time.FixedZone("UTC+9", 9*60*60))
+	assert.Equal(t, "2025-01-02T03:00:00.123456Z", Time{Time: probe}.String())
+	assert.Equal(t, "NULL", NullTime{}.String())
+	assert.Equal(t, "2025-01-02T03:00:00.123456Z", NullTime{Time: probe, Valid: true}.String())
+}
+
+func TestWrappersAreNotComparable(t *testing.T) {
+	// The noCompare marker's whole contract: wrapper == wrapper (and map-key
+	// use) must be a compile error, because time.Time field equality is not
+	// instant equality. reflect pins the marker so removing the field fails
+	// here instead of silently re-legalizing ==.
+	for _, typ := range []reflect.Type{reflect.TypeOf(Time{}), reflect.TypeOf(NullTime{})} {
+		assert.False(t, typ.Comparable(), "%s must stay non-comparable (noCompare marker)", typ)
+	}
+}

--- a/backend/internal/util/sqltime/sqltime.go
+++ b/backend/internal/util/sqltime/sqltime.go
@@ -1,0 +1,332 @@
+// Package sqltime provides driver.Valuer/sql.Scanner time types that floor
+// every Go instant to the millisecond grid (UTC) as it crosses into a database
+// driver, and -- for SQLite -- serialize it in the canonical 24-char ISO 8601
+// layout SQLite stores via strftime('%Y-%m-%dT%H:%M:%fZ').
+//
+// Flooring rationale: the dialects that store millisecond columns ROUND
+// sub-millisecond fractions instead of truncating them -- SQLite's
+// strftime('%f') and MySQL/TiDB's DATETIME(3) both round half up -- so an
+// un-floored bind could store an instant up to half a millisecond LATER than
+// the one the caller supplied. That is enough to overclaim a credential
+// deadline by a whole second once a ceil-to-seconds lifetime report is derived
+// from the roundtripped value (pinned per dialect by the storetest time_floor
+// group). Flooring in Value() keeps every stored instant on the millisecond
+// grid, so stored <= bound always holds. Postgres-family dialects floor to
+// microseconds instead (see the pgtime subpackage) because pgx already floors
+// nanoseconds to timestamptz microseconds and ms would discard precision
+// Postgres legitimately stores.
+//
+// Canonical-layout rationale (SQLite only): strftime('%Y-%m-%dT%H:%M:%fZ')
+// writes fixed 3-digit fractional seconds. Every SQL-side write path (column
+// DEFAULTs, strftime('now') soft-deletes) stores canonical 24-char values ON
+// DISK for EVERY DATETIME column, enforced mechanically by the canonical walk
+// in sqlitedb.FindNonCanonicalDatetimes. SQLiteTime.Value() emits byte-exact
+// the same layout, so the raw-string keyset predicates and cleanup cutoff
+// compares -- which run SQL-side against the stored bytes -- stay byte-exact,
+// including at trailing-zero milliseconds. A raw time.Time bind would store the
+// driver's own layout (space at byte 11, offset suffix) and silently corrupt
+// those compares.
+//
+// CAUTION for tests and tooling: modernc TRIMS trailing fractional zeros when a
+// DATETIME column is scanned into a Go string (a stored ".130Z" arrives as
+// ".13Z") -- a driver presentation artifact only. Expression columns that lose
+// their DATETIME decltype also arrive as raw TEXT rather than time.Time. Both
+// are why SQLiteTime.Scan accepts string/[]byte via RFC3339Nano (which tolerates
+// the trailing-zero trim); production DATETIME reads scan into time.Time.
+//
+// Misuse is fenced mechanically where Go allows: every wrapper carries a
+// noCompare marker, so == and map-key use (which would compare time.Time's
+// wall/monotonic/location fields, not the instant) are compile errors --
+// compare via the promoted/field Equal. Each wrapper also overrides String()
+// to print its stored representation, so fmt/slog output matches the DB bytes
+// instead of time.Time's default layout.
+//
+// CAUTION for new queries: sqlc types a result column from its inferred
+// decltype and nullability. A SELECT expression that keeps the DATETIME
+// decltype but can evaluate to NULL (e.g. CASE ... ELSE NULL END) would be
+// typed as the non-null SQLiteTime and hard-error in Scan (loud, not silent);
+// give such an expression an explicit nullable override or CAST so it
+// resolves to SQLiteNullTime. Aggregates and decltype-losing expressions
+// instead surface as interface{} fields in the generated code, which the
+// generated-params allowlist walk (hub store's
+// TestGeneratedInterfaceParamsAreAllowlisted) flags for a conscious typing
+// decision.
+//
+// Why a Valuer type instead of per-call-site convention: passing a raw
+// time.Time to a param typed as one of these becomes a compile error, so the
+// floor/canonical layout cannot be forgotten on a new write path. Value() is
+// the one place every value crosses into a driver -- it guards struct literals,
+// DB-roundtripped rebinds, and cursor parses alike. Applied via sqlc db_type
+// overrides; see https://github.com/leapmux/leapmux/issues/303.
+//
+// Zero value note: a zero time.Time through a non-null type stores
+// "0001-01-01T00:00:00.000Z" (SQLite) or the ms-floored zero instant (MySQL) --
+// use the Null variant for a column that should hold NULL.
+package sqltime
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/util/timefmt"
+)
+
+// noCompare, embedded as a blank zero-size field, makes the wrapper structs
+// non-comparable: == on time.Time-carrying values compares the wall/monotonic/
+// location fields rather than the instant, so wrapper == wrapper (or map-key
+// use) is a latent bug -- the marker turns it into a compile error. Compare
+// via the promoted/field Equal instead.
+type noCompare [0]func()
+
+// SQLiteTime is a required (NOT NULL) SQLite DATETIME column: it floors to the
+// millisecond grid and serializes in the canonical strftime layout on Value(),
+// and normalizes to UTC on Scan. The embedded time.Time promotes Equal/UTC/
+// Before/... to the wrapper.
+type SQLiteTime struct {
+	_ noCompare
+	time.Time
+}
+
+// SQLiteNullTime is a nullable SQLite DATETIME column. The exported Time/Valid
+// fields mirror sql.NullTime so existing RequireTime(row.X.Time, row.X.Valid,
+// ...) call sites compile unchanged.
+type SQLiteNullTime struct {
+	_     noCompare
+	Time  time.Time
+	Valid bool
+}
+
+// MySQLTime is a required (NOT NULL) MySQL DATETIME(3)/DATETIME(6) column. Its
+// Value() returns an ms-floored UTC time.Time (go-sql-driver serializes it);
+// this preserves the prior BindTime behavior for both the DATETIME(3) columns
+// and the nine DATETIME(6) columns. Escape hatch: a Go bind that must STORE
+// microsecond precision needs a distinct type -- ms is the floor on the bind
+// path here by deliberate design.
+//
+// Value/Scan asymmetry: the ms floor is a BIND-path property only. Scan does
+// NOT re-floor -- it normalizes to UTC and keeps whatever precision the
+// column stored. A DATETIME(6) column stamped server-side (DEFAULT
+// CURRENT_TIMESTAMP(6), e.g. revocation_events.created_at, whose microsecond
+// precision is retained deliberately for ordering resolution) therefore
+// delivers sub-millisecond residue into the scanned .Time that domain code
+// reads directly. Do NOT assume a scanned MySQLTime sits on the millisecond
+// grid: compare such a value via Equal against another scanned value, never
+// against a freshly ms-floored instant.
+type MySQLTime struct {
+	_ noCompare
+	time.Time
+}
+
+// MySQLNullTime is a nullable MySQL DATETIME column; see MySQLTime for the floor
+// rationale.
+type MySQLNullTime struct {
+	_     noCompare
+	Time  time.Time
+	Valid bool
+}
+
+var (
+	_ driver.Valuer = SQLiteTime{}
+	_ sql.Scanner   = (*SQLiteTime)(nil)
+	_ driver.Valuer = SQLiteNullTime{}
+	_ sql.Scanner   = (*SQLiteNullTime)(nil)
+	_ driver.Valuer = MySQLTime{}
+	_ sql.Scanner   = (*MySQLTime)(nil)
+	_ driver.Valuer = MySQLNullTime{}
+	_ sql.Scanner   = (*MySQLNullTime)(nil)
+)
+
+// FloorMillis floors t to the millisecond grid in UTC -- the exact floor every
+// SQLite/MySQL valuer in this package applies in Value(). Exported so callers
+// that must mint an in-memory instant equal to its eventual DB roundtrip (e.g.
+// the worker's message stamps) derive it from the storage floor instead of
+// re-rolling UTC().Truncate by hand.
+func FloorMillis(t time.Time) time.Time { return t.UTC().Truncate(time.Millisecond) }
+
+// canonicalSQLite floors to the millisecond grid and formats the canonical
+// 24-char layout. Go's Format truncates (never rounds) fractional seconds to the
+// layout's precision, matching the explicit Truncate.
+func canonicalSQLite(t time.Time) string { return FloorMillis(t).Format(timefmt.ISO8601) }
+
+// scanTimeUTC normalizes the non-text driver shapes a DATETIME read can
+// produce: a time.Time (UTC-normalized), NULL (an error -- use the Null
+// variant), or any other type (an error naming the driver's actual type).
+// SQLite's TEXT expression-column path is parsed in SQLiteTime.Scan before it
+// delegates here; MySQL (parseTime=true) only ever hands back time.Time, so it
+// delegates directly.
+func scanTimeUTC(src any, into *time.Time, typeName string) error {
+	switch v := src.(type) {
+	case time.Time:
+		*into = v.UTC()
+		return nil
+	case nil:
+		return fmt.Errorf("cannot scan NULL into %s (use the Null variant)", typeName)
+	default:
+		return fmt.Errorf("cannot scan %T into %s", src, typeName)
+	}
+}
+
+// NewSQLiteTime floors t and wraps it. The in-memory copy equals the DB
+// roundtrip, so a value held after binding (e.g. an armed due_at) matches what a
+// later read scans back.
+func NewSQLiteTime(t time.Time) SQLiteTime { return SQLiteTime{Time: FloorMillis(t)} }
+
+// NewSQLiteNullTime mirrors the former BindNullTime: nil yields an invalid
+// (NULL) value, non-nil is floored and marked valid.
+func NewSQLiteNullTime(t *time.Time) SQLiteNullTime {
+	if t == nil {
+		return SQLiteNullTime{}
+	}
+	return SQLiteNullTime{Time: FloorMillis(*t), Valid: true}
+}
+
+// SQLiteNullTimeOf mirrors the former BindTimeValid: a required instant bound
+// through a nullable column type, floored and always valid.
+func SQLiteNullTimeOf(t time.Time) SQLiteNullTime {
+	return SQLiteNullTime{Time: FloorMillis(t), Valid: true}
+}
+
+// Value floors to the millisecond grid and serializes the canonical 24-char
+// strftime layout.
+func (t SQLiteTime) Value() (driver.Value, error) { return canonicalSQLite(t.Time), nil }
+
+// String shadows the promoted time.Time.String so fmt/slog print the exact
+// canonical bytes Value() stores, keeping log lines byte-comparable with the
+// DB rows they describe.
+func (t SQLiteTime) String() string { return canonicalSQLite(t.Time) }
+
+// Scan accepts a time.Time (modernc parses a DATETIME decltype into one),
+// normalized to UTC, or a string/[]byte parsed via RFC3339Nano (expression
+// columns lose their decltype and arrive as raw TEXT; RFC3339Nano tolerates
+// modernc's trailing-zero trim). NULL is an error -- use SQLiteNullTime.
+func (t *SQLiteTime) Scan(src any) error {
+	var text string
+	switch v := src.(type) {
+	case string:
+		text = v
+	case []byte:
+		text = string(v)
+	default:
+		return scanTimeUTC(src, &t.Time, "SQLiteTime")
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		return fmt.Errorf("scan SQLiteTime: parse %q: %w", text, err)
+	}
+	t.Time = parsed.UTC()
+	return nil
+}
+
+// Value returns nil when invalid, otherwise the canonical 24-char layout.
+func (t SQLiteNullTime) Value() (driver.Value, error) {
+	if !t.Valid {
+		return nil, nil
+	}
+	return canonicalSQLite(t.Time), nil
+}
+
+// Scan maps NULL to an invalid value; otherwise it delegates to SQLiteTime.Scan.
+func (t *SQLiteNullTime) Scan(src any) error {
+	if src == nil {
+		t.Time, t.Valid = time.Time{}, false
+		return nil
+	}
+	var inner SQLiteTime
+	if err := inner.Scan(src); err != nil {
+		return err
+	}
+	t.Time, t.Valid = inner.Time, true
+	return nil
+}
+
+// Ptr returns a copy of the instant, or nil when invalid. It replaces the former
+// sqlutil.NullTimePtr.
+func (t SQLiteNullTime) Ptr() *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	v := t.Time
+	return &v
+}
+
+// String prints NULL when invalid, otherwise the canonical bytes Value()
+// stores; see SQLiteTime.String.
+func (t SQLiteNullTime) String() string {
+	if !t.Valid {
+		return "NULL"
+	}
+	return canonicalSQLite(t.Time)
+}
+
+// NewMySQLTime floors t and wraps it; see NewSQLiteTime for the copy-equals-
+// roundtrip rationale.
+func NewMySQLTime(t time.Time) MySQLTime { return MySQLTime{Time: FloorMillis(t)} }
+
+// NewMySQLNullTime mirrors the former BindNullTime for MySQL columns.
+func NewMySQLNullTime(t *time.Time) MySQLNullTime {
+	if t == nil {
+		return MySQLNullTime{}
+	}
+	return MySQLNullTime{Time: FloorMillis(*t), Valid: true}
+}
+
+// MySQLNullTimeOf mirrors the former BindTimeValid for MySQL columns.
+func MySQLNullTimeOf(t time.Time) MySQLNullTime {
+	return MySQLNullTime{Time: FloorMillis(t), Valid: true}
+}
+
+// Value returns the ms-floored UTC time.Time; go-sql-driver serializes it.
+func (t MySQLTime) Value() (driver.Value, error) { return FloorMillis(t.Time), nil }
+
+// String shadows the promoted time.Time.String so fmt/slog print the stored
+// instant -- ms-floored UTC in the ISO 8601 ms layout -- rather than
+// time.Time's default layout with sub-ms residue the storage floors away.
+func (t MySQLTime) String() string { return FloorMillis(t.Time).Format(timefmt.ISO8601) }
+
+// Scan accepts a time.Time only (the parseTime=true DSN hands DATETIME columns
+// back as time.Time), normalized to UTC. NULL is an error -- use MySQLNullTime.
+func (t *MySQLTime) Scan(src any) error {
+	return scanTimeUTC(src, &t.Time, "MySQLTime")
+}
+
+// Value returns nil when invalid, otherwise the ms-floored UTC time.Time.
+func (t MySQLNullTime) Value() (driver.Value, error) {
+	if !t.Valid {
+		return nil, nil
+	}
+	return FloorMillis(t.Time), nil
+}
+
+// Scan maps NULL to an invalid value; otherwise it delegates to MySQLTime.Scan.
+func (t *MySQLNullTime) Scan(src any) error {
+	if src == nil {
+		t.Time, t.Valid = time.Time{}, false
+		return nil
+	}
+	var inner MySQLTime
+	if err := inner.Scan(src); err != nil {
+		return err
+	}
+	t.Time, t.Valid = inner.Time, true
+	return nil
+}
+
+// Ptr returns a copy of the instant, or nil when invalid.
+func (t MySQLNullTime) Ptr() *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	v := t.Time
+	return &v
+}
+
+// String prints NULL when invalid, otherwise the stored instant; see
+// MySQLTime.String.
+func (t MySQLNullTime) String() string {
+	if !t.Valid {
+		return "NULL"
+	}
+	return FloorMillis(t.Time).Format(timefmt.ISO8601)
+}

--- a/backend/internal/util/sqltime/sqltime_test.go
+++ b/backend/internal/util/sqltime/sqltime_test.go
@@ -1,0 +1,319 @@
+package sqltime
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// subMsProbe carries 750us + 999ns of sub-millisecond residue: a round-half-up
+// conversion would land on the NEXT millisecond; the floor must land on the
+// current one. It is minted in UTC+9 so tests also pin UTC normalization.
+func subMsProbe() time.Time {
+	return time.Date(2025, 1, 2, 12, 0, 0, 123_750_999, time.FixedZone("UTC+9", 9*60*60))
+}
+
+func TestSQLiteTimeValueFloorsAndCanonicalizes(t *testing.T) {
+	v, err := NewSQLiteTime(subMsProbe()).Value()
+	require.NoError(t, err)
+	// 12:00 UTC+9 == 03:00 UTC; 123_750_999ns floors to .123.
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", v)
+}
+
+func TestSQLiteTimeValueWholeMillisecondIdentity(t *testing.T) {
+	exact := time.Date(2025, 1, 2, 3, 0, 0, 123_000_000, time.UTC)
+	v, err := NewSQLiteTime(exact).Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", v)
+}
+
+func TestSQLiteTimeValueTrailingZeroMillisecond(t *testing.T) {
+	// A whole-decisecond instant must still serialize fixed 3-digit fractional
+	// seconds (".130Z", not ".13Z") so raw-string keyset compares stay byte-exact.
+	v, err := NewSQLiteTime(time.Date(2025, 1, 2, 3, 0, 0, 130_000_000, time.UTC)).Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.130Z", v)
+	assert.Len(t, v, 24)
+}
+
+func TestValueFloorsStructLiteral(t *testing.T) {
+	// Value() is the choke point: it must floor and canonicalize even when the
+	// constructor (which also floors) is bypassed via struct-literal
+	// construction -- e.g. a DB-roundtripped rebind or a hand-built params
+	// struct in a test.
+	v, err := SQLiteTime{Time: subMsProbe()}.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", v)
+
+	v, err = SQLiteNullTime{Time: subMsProbe(), Valid: true}.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", v)
+
+	v, err = MySQLTime{Time: subMsProbe()}.Value()
+	require.NoError(t, err)
+	assert.Equal(t, subMsProbe().UTC().Truncate(time.Millisecond), v)
+
+	v, err = MySQLNullTime{Time: subMsProbe(), Valid: true}.Value()
+	require.NoError(t, err)
+	assert.Equal(t, subMsProbe().UTC().Truncate(time.Millisecond), v)
+}
+
+func TestSQLiteTimeValueNeverRoundsUp(t *testing.T) {
+	v, err := NewSQLiteTime(time.Date(2025, 1, 2, 3, 0, 0, 999_999_999, time.UTC)).Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.999Z", v)
+}
+
+func TestSQLiteTimeScanTimeTime(t *testing.T) {
+	var st SQLiteTime
+	local := time.Date(2025, 1, 2, 12, 0, 0, 0, time.FixedZone("UTC+9", 9*60*60))
+	require.NoError(t, st.Scan(local))
+	assert.Equal(t, time.UTC, st.Location())
+	assert.True(t, st.Equal(local))
+}
+
+func TestSQLiteTimeScanCanonicalString(t *testing.T) {
+	var st SQLiteTime
+	require.NoError(t, st.Scan("2025-01-02T03:00:00.130Z"))
+	assert.True(t, st.Equal(time.Date(2025, 1, 2, 3, 0, 0, 130_000_000, time.UTC)))
+}
+
+func TestSQLiteTimeScanTrimmedString(t *testing.T) {
+	// modernc trims trailing fractional zeros on a Go-string scan (".130Z" ->
+	// ".13Z"); RFC3339Nano must still parse it to the same instant.
+	var st SQLiteTime
+	require.NoError(t, st.Scan("2025-01-02T03:00:00.13Z"))
+	assert.True(t, st.Equal(time.Date(2025, 1, 2, 3, 0, 0, 130_000_000, time.UTC)))
+}
+
+func TestSQLiteTimeScanBytes(t *testing.T) {
+	var st SQLiteTime
+	require.NoError(t, st.Scan([]byte("2025-01-02T03:00:00.500Z")))
+	assert.True(t, st.Equal(time.Date(2025, 1, 2, 3, 0, 0, 500_000_000, time.UTC)))
+}
+
+func TestSQLiteTimeScanNilErrors(t *testing.T) {
+	var st SQLiteTime
+	require.Error(t, st.Scan(nil))
+}
+
+func TestScanUnsupportedTypeErrors(t *testing.T) {
+	// A DATETIME column can only arrive as time.Time or (for SQLite expression
+	// columns) TEXT; anything else is a schema or driver regression that must
+	// fail loudly, not zero out the field.
+	var st SQLiteTime
+	require.Error(t, st.Scan(int64(1736823600)))
+	var snt SQLiteNullTime
+	require.Error(t, snt.Scan(int64(1736823600)))
+	var mt MySQLTime
+	require.Error(t, mt.Scan(int64(1736823600)))
+	var mnt MySQLNullTime
+	require.Error(t, mnt.Scan(int64(1736823600)))
+}
+
+func TestSQLiteTimeScanInvalidStringErrors(t *testing.T) {
+	var st SQLiteTime
+	require.Error(t, st.Scan("not-a-timestamp"))
+	// The driver's own space-separated layout must be rejected too: accepting
+	// it would silently mask a write path that stored a non-canonical layout.
+	require.Error(t, st.Scan("2025-01-02 03:00:00.13+00:00"))
+}
+
+func TestSQLiteTimeValueZero(t *testing.T) {
+	// The documented zero-value contract: a zero time.Time still serializes the
+	// canonical 24-char layout (year 1), never NULL or a short string.
+	v, err := SQLiteTime{}.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "0001-01-01T00:00:00.000Z", v)
+}
+
+func TestSQLiteNullTimeValue(t *testing.T) {
+	v, err := SQLiteNullTime{}.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v, "invalid must bind NULL")
+
+	v, err = SQLiteNullTimeOf(subMsProbe()).Value()
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", v)
+}
+
+func TestNewSQLiteNullTime(t *testing.T) {
+	assert.False(t, NewSQLiteNullTime(nil).Valid, "nil must stay NULL")
+
+	local := subMsProbe()
+	nt := NewSQLiteNullTime(&local)
+	require.True(t, nt.Valid)
+	assert.Equal(t, local.UTC().Truncate(time.Millisecond), nt.Time)
+}
+
+func TestSQLiteNullTimeScanNil(t *testing.T) {
+	st := SQLiteNullTime{Time: time.Now(), Valid: true}
+	require.NoError(t, st.Scan(nil))
+	assert.False(t, st.Valid)
+}
+
+func TestSQLiteNullTimeScanValid(t *testing.T) {
+	// The non-NULL delegation branch: both driver shapes must land Valid=true
+	// with the instant normalized to UTC.
+	var st SQLiteNullTime
+	local := time.Date(2025, 1, 2, 12, 0, 0, 130_000_000, time.FixedZone("UTC+9", 9*60*60))
+	require.NoError(t, st.Scan(local))
+	require.True(t, st.Valid)
+	assert.Equal(t, time.UTC, st.Time.Location())
+	assert.True(t, st.Time.Equal(local))
+
+	var fromText SQLiteNullTime
+	require.NoError(t, fromText.Scan("2025-01-02T03:00:00.130Z"))
+	require.True(t, fromText.Valid)
+	assert.True(t, fromText.Time.Equal(time.Date(2025, 1, 2, 3, 0, 0, 130_000_000, time.UTC)))
+}
+
+func TestSQLiteNullTimePtr(t *testing.T) {
+	assert.Nil(t, SQLiteNullTime{}.Ptr(), "invalid (NULL) must map to nil")
+
+	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	nt := SQLiteNullTimeOf(instant)
+	ptr := nt.Ptr()
+	require.NotNil(t, ptr)
+	assert.True(t, ptr.Equal(instant))
+	assert.NotSame(t, &nt.Time, ptr, "must return a copy, not an alias into the NullTime")
+}
+
+func TestMySQLTimeValueReturnsFlooredTimeNotString(t *testing.T) {
+	v, err := NewMySQLTime(subMsProbe()).Value()
+	require.NoError(t, err)
+	got, ok := v.(time.Time)
+	require.True(t, ok, "MySQL Value must be a time.Time, not a string")
+	assert.Equal(t, time.UTC, got.Location())
+	assert.Equal(t, subMsProbe().UTC().Truncate(time.Millisecond), got)
+	assert.Equal(t, 123_000_000, got.Nanosecond())
+}
+
+func TestMySQLNullTimeValue(t *testing.T) {
+	v, err := MySQLNullTime{}.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v)
+
+	v, err = MySQLNullTimeOf(subMsProbe()).Value()
+	require.NoError(t, err)
+	got, ok := v.(time.Time)
+	require.True(t, ok)
+	assert.Equal(t, subMsProbe().UTC().Truncate(time.Millisecond), got)
+}
+
+func TestMySQLTimeScanTimeTimeOnly(t *testing.T) {
+	var mt MySQLTime
+	local := time.Date(2025, 1, 2, 12, 0, 0, 0, time.FixedZone("UTC+9", 9*60*60))
+	require.NoError(t, mt.Scan(local))
+	assert.Equal(t, time.UTC, mt.Location())
+
+	require.Error(t, mt.Scan("2025-01-02T03:00:00.130Z"), "MySQL must reject string scans")
+	require.Error(t, mt.Scan(nil))
+}
+
+func TestNewMySQLNullTime(t *testing.T) {
+	assert.False(t, NewMySQLNullTime(nil).Valid)
+	local := subMsProbe()
+	nt := NewMySQLNullTime(&local)
+	require.True(t, nt.Valid)
+	assert.Equal(t, local.UTC().Truncate(time.Millisecond), nt.Time)
+}
+
+func TestMySQLNullTimeScanValid(t *testing.T) {
+	var nt MySQLNullTime
+	local := time.Date(2025, 1, 2, 12, 0, 0, 0, time.FixedZone("UTC+9", 9*60*60))
+	require.NoError(t, nt.Scan(local))
+	require.True(t, nt.Valid)
+	assert.Equal(t, time.UTC, nt.Time.Location())
+	assert.True(t, nt.Time.Equal(local))
+
+	require.NoError(t, nt.Scan(nil))
+	assert.False(t, nt.Valid, "a NULL rescan must clear a previously valid value")
+}
+
+func TestMySQLNullTimePtr(t *testing.T) {
+	assert.Nil(t, MySQLNullTime{}.Ptr())
+	instant := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	nt := MySQLNullTimeOf(instant)
+	ptr := nt.Ptr()
+	require.NotNil(t, ptr)
+	assert.True(t, ptr.Equal(instant))
+	assert.NotSame(t, &nt.Time, ptr)
+}
+
+func TestFloorMillis(t *testing.T) {
+	// Floors sub-ms residue (never rounds up) and normalizes to UTC.
+	got := FloorMillis(subMsProbe())
+	assert.Equal(t, time.Date(2025, 1, 2, 3, 0, 0, 123_000_000, time.UTC), got)
+	assert.Equal(t, time.UTC, got.Location())
+	// Idempotent on an already-floored instant.
+	assert.Equal(t, got, FloorMillis(got))
+}
+
+func TestMySQLTimeScanRejectsBytesNamingOriginalType(t *testing.T) {
+	// MySQL DATETIME reads arrive as time.Time under the enforced
+	// parseTime=true DSN; []byte means the DSN contract broke. The error must
+	// name the driver's actual type ([]uint8), not the string it was
+	// normalized to, so the DSN misconfiguration is diagnosable.
+	var mt MySQLTime
+	err := mt.Scan([]byte("2025-01-02T03:00:00.130Z"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[]uint8")
+}
+
+func TestStringPrintsStoredRepresentation(t *testing.T) {
+	// String() must shadow the promoted time.Time.String so fmt output is
+	// byte-comparable with what Value() stores (ms precision, UTC). Struct
+	// literals (not the flooring constructors) so the assertions pin String's
+	// OWN normalization: subMsProbe carries a UTC+9 zone and sub-ms residue
+	// that a String delegating to the raw embedded time would leak.
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", SQLiteTime{Time: subMsProbe()}.String())
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", MySQLTime{Time: subMsProbe()}.String())
+
+	assert.Equal(t, "NULL", SQLiteNullTime{}.String())
+	assert.Equal(t, "NULL", MySQLNullTime{}.String())
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", SQLiteNullTime{Time: subMsProbe(), Valid: true}.String())
+	assert.Equal(t, "2025-01-02T03:00:00.123Z", MySQLNullTime{Time: subMsProbe(), Valid: true}.String())
+}
+
+func TestMySQLTimeScanPreservesSubMillisecondPrecision(t *testing.T) {
+	// The deliberate Value/Scan asymmetry: Value floors to ms on the bind
+	// path, but Scan must preserve the precision the column stored. A
+	// server-stamped DATETIME(6) column (revocation_events.created_at) hands
+	// back microseconds the settled design retains for ordering; a Scan-side
+	// floor would destroy it.
+	micros := time.Date(2025, 1, 2, 3, 0, 0, 123_456_000, time.UTC)
+
+	var mt MySQLTime
+	require.NoError(t, mt.Scan(micros))
+	assert.Equal(t, 123_456_000, mt.Nanosecond(), "Scan must NOT floor: microsecond residue must survive")
+	assert.True(t, mt.Equal(micros))
+
+	var mnt MySQLNullTime
+	require.NoError(t, mnt.Scan(micros))
+	require.True(t, mnt.Valid)
+	assert.Equal(t, 123_456_000, mnt.Time.Nanosecond(), "NullTime Scan must preserve microsecond residue")
+
+	// Pin the other half of the asymmetry so the two are locked as a pair.
+	v, err := NewMySQLTime(micros).Value()
+	require.NoError(t, err)
+	assert.Equal(t, 123_000_000, v.(time.Time).Nanosecond(), "Value floors to ms on the bind path")
+}
+
+func TestWrappersAreNotComparable(t *testing.T) {
+	// The noCompare marker's whole contract: wrapper == wrapper (and map-key
+	// use) must be a compile error, because time.Time field equality is not
+	// instant equality. reflect pins the marker so removing the field fails
+	// here instead of silently re-legalizing ==.
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(SQLiteTime{}),
+		reflect.TypeOf(SQLiteNullTime{}),
+		reflect.TypeOf(MySQLTime{}),
+		reflect.TypeOf(MySQLNullTime{}),
+	} {
+		assert.False(t, typ.Comparable(), "%s must stay non-comparable (noCompare marker)", typ)
+	}
+}

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -145,9 +145,9 @@ UPDATE agents SET workspace_id = ? WHERE id = ?;
 SELECT * FROM agents WHERE id IN (sqlc.slice('ids')) AND closed_at IS NULL;
 
 -- name: DeleteClosedAgentsBefore :execresult
--- Raw compare against a timefmt.Format cutoff (CAST AS TEXT -> string param);
+-- Raw compare against a SQLiteNullTime cutoff (same canonical layout);
 -- see DeleteClosedTerminalsBefore for the rationale.
-DELETE FROM agents WHERE rowid IN (SELECT a.rowid FROM agents a WHERE a.closed_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
+DELETE FROM agents WHERE rowid IN (SELECT a.rowid FROM agents a WHERE a.closed_at < sqlc.arg(cutoff) LIMIT 1000);
 
 -- ListAgentIDsWithPlanInDir returns the IDs of agents whose plan_file_path
 -- begins with the provided literal byte sequence. Used by the plan-archive

--- a/backend/internal/worker/db/queries/auto_continue_schedules.sql
+++ b/backend/internal/worker/db/queries/auto_continue_schedules.sql
@@ -12,11 +12,12 @@ INSERT INTO auto_continue_schedules (
   sqlc.arg(agent_id),
   sqlc.arg(reason),
   sqlc.arg(content),
-  -- Canonical layout, millisecond precision. The Go builders truncate due_at
-  -- to the millisecond BEFORE binding so fireAutoContinue's DueAt.Equal guard
-  -- (in-memory armed instant vs the DB roundtrip of this value) still holds.
-  -- The DO UPDATE below reuses the transformed excluded value.
-  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(due_at)),
+  -- Canonical layout, millisecond precision. SQLiteTime floors due_at to the
+  -- millisecond on bind so fireAutoContinue's DueAt.Equal guard (in-memory armed
+  -- instant vs the DB roundtrip of this value) still holds; the Go builders keep
+  -- a local Truncate so the returned armed dueAt equals the roundtrip. The DO
+  -- UPDATE below reuses the excluded value.
+  sqlc.arg(due_at),
   sqlc.arg(jitter_ms),
   sqlc.arg(next_backoff_ms),
   'active',

--- a/backend/internal/worker/db/queries/messages.sql
+++ b/backend/internal/worker/db/queries/messages.sql
@@ -19,7 +19,7 @@ VALUES (
   sqlc.arg(span_color),
   sqlc.arg(agent_provider),
   sqlc.arg(mark_type),
-  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(created_at))
+  sqlc.arg(created_at)
 )
 RETURNING seq;
 

--- a/backend/internal/worker/db/queries/terminals.sql
+++ b/backend/internal/worker/db/queries/terminals.sql
@@ -17,11 +17,11 @@ VALUES (
   sqlc.arg(rows),
   sqlc.arg(screen),
   sqlc.arg(exit_code),
-  -- The title-update path re-binds a DB-roundtripped closed_at; without this
-  -- wrap that rewrite stores the driver's own layout and splits the column
+  -- The title-update path re-binds a DB-roundtripped closed_at; binding a
+  -- SQLiteNullTime re-canonicalizes it so the rewrite cannot split the column
   -- into two layouts under the raw-string cleanup sweep. The DO UPDATE below
-  -- reuses the transformed excluded value.
-  strftime('%Y-%m-%dT%H:%M:%fZ', sqlc.arg(closed_at))
+  -- reuses the excluded value.
+  sqlc.narg(closed_at)
 )
 ON CONFLICT (id) DO UPDATE SET
   workspace_id    = excluded.workspace_id,
@@ -79,11 +79,11 @@ SELECT * FROM terminals WHERE id IN (sqlc.slice('ids')) AND closed_at IS NULL;
 -- name: DeleteClosedTerminalsBefore :execresult
 -- Raw compare: closed_at is stored canonical on every write path
 -- (CloseTerminal/CloseOpenTerminalsByWorkspace SET strftime, UpsertTerminal
--- wraps its bound value), and the Go side binds a timefmt.Format cutoff
--- (CAST AS TEXT -> string param), so the lexicographic < is byte-exact. A raw
--- time.Time bind here would compare in the driver's own layout and skip every
--- same-day row until the date rolled over.
-DELETE FROM terminals WHERE rowid IN (SELECT t.rowid FROM terminals t WHERE t.closed_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
+-- binds a SQLiteNullTime), and the Go side binds a SQLiteNullTime cutoff (same
+-- canonical layout), so the lexicographic < is byte-exact. A raw time.Time bind
+-- here would compare in the driver's own layout and skip every same-day row
+-- until the date rolled over.
+DELETE FROM terminals WHERE rowid IN (SELECT t.rowid FROM terminals t WHERE t.closed_at < sqlc.arg(cutoff) LIMIT 1000);
 
 -- name: GetTerminalWorkspaceID :one
 SELECT workspace_id FROM terminals WHERE id = ?;

--- a/backend/internal/worker/db/queries/worktrees.sql
+++ b/backend/internal/worker/db/queries/worktrees.sql
@@ -14,9 +14,9 @@ UPDATE worktrees SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id
 UPDATE worktrees SET branch_name = ? WHERE id = ?;
 
 -- name: HardDeleteWorktreesBefore :execresult
--- Raw compare against a timefmt.Format cutoff (CAST AS TEXT -> string param);
+-- Raw compare against a SQLiteNullTime cutoff (same canonical layout);
 -- see DeleteClosedTerminalsBefore for the rationale.
-DELETE FROM worktrees WHERE rowid IN (SELECT w.rowid FROM worktrees w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < CAST(sqlc.arg(cutoff) AS TEXT) LIMIT 1000);
+DELETE FROM worktrees WHERE rowid IN (SELECT w.rowid FROM worktrees w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < sqlc.arg(cutoff) LIMIT 1000);
 
 -- name: AddWorktreeTab :exec
 -- org_id is set only for FILE links (it scopes the worktree_tab_liveness join

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
 	"github.com/leapmux/leapmux/internal/util/optionids"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
@@ -367,7 +368,7 @@ func registerAgentHandlers(d *channel.Dispatcher, svc *Context) {
 			SpanColor:          0,
 			AgentProvider:      dbAgent.AgentProvider,
 			MarkType:           leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
-			CreatedAt:          now,
+			CreatedAt:          sqltime.NewSQLiteTime(now),
 		})
 		if err != nil {
 			slog.Error("failed to persist message", "agent_id", agentID, "error", err)
@@ -1648,7 +1649,7 @@ func (svc *Context) agentToProto(a *db.Agent, isRunning bool, gs *leapmuxv1.Agen
 		AgentSessionId: a.AgentSessionID,
 		HomeDir:        a.HomeDir,
 		WorkerId:       svc.WorkerID,
-		CreatedAt:      timefmt.Format(a.CreatedAt),
+		CreatedAt:      timefmt.Format(a.CreatedAt.Time),
 		GitStatus:      gs,
 		AgentProvider:  a.AgentProvider,
 		OptionGroups:   svc.optionGroupsForAgent(a),
@@ -2990,7 +2991,7 @@ func (svc *Context) sendSyntheticUserMessage(agentID, content string, markType l
 		SpanColor:          0,
 		AgentProvider:      dbAgent.AgentProvider,
 		MarkType:           markType,
-		CreatedAt:          now,
+		CreatedAt:          sqltime.NewSQLiteTime(now),
 	})
 	if err != nil {
 		slog.Error("synthetic user message: failed to persist message", "agent_id", agentID, "error", err)
@@ -3363,7 +3364,7 @@ func messageToProto(m *db.Message) *leapmuxv1.AgentChatMessage {
 		DeliveryError:      m.DeliveryError,
 		ContentCompression: leapmuxv1.ContentCompression(m.ContentCompression),
 		AgentProvider:      m.AgentProvider,
-		CreatedAt:          timefmt.Format(m.CreatedAt),
+		CreatedAt:          timefmt.Format(m.CreatedAt.Time),
 		Depth:              int32(m.Depth),
 		SpanId:             m.SpanID,
 		ParentSpanId:       m.ParentSpanID,

--- a/backend/internal/worker/service/agent_delete_message_test.go
+++ b/backend/internal/worker/service/agent_delete_message_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -34,7 +35,7 @@ func TestDeleteAgentMessage_BroadcastsDeletedSeq(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte(`{"type":"text","text":"hi"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	require.Positive(t, seq)
@@ -101,7 +102,7 @@ func TestDeleteAgentMessage_ReportsNewLatestSeq(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte(`{"type":"text","text":"hi"}`),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		require.NoError(t, svc.Queries.SetMessageDeliveryError(ctx, db.SetMessageDeliveryErrorParams{
@@ -161,7 +162,7 @@ func TestDeleteAgentMessage_RejectsNonFailedUserMessage(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte(`{"type":"text","text":"hi"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	_, err = createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
@@ -170,7 +171,7 @@ func TestDeleteAgentMessage_RejectsNonFailedUserMessage(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
 		Content:       []byte(`{"type":"result"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -13,6 +13,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
 	"github.com/leapmux/leapmux/internal/util/optionids"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -127,7 +128,7 @@ func TestResolveResumeSessionID_IgnoresPreClearMessages(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte(`{"content":"hello"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 
@@ -160,7 +161,7 @@ func TestResolveResumeSessionID_IgnoresPreClearMessages(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte(`{"content":"world"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 
@@ -204,7 +205,7 @@ func TestResolveResumeSessionID_NotAffectedByJustPersistedMessage(t *testing.T) 
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte(`{"content":"hello"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 

--- a/backend/internal/worker/service/auto_continue.go
+++ b/backend/internal/worker/service/auto_continue.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -49,7 +50,7 @@ func (h *OutputHandler) restoreAutoContinueSchedules() {
 	}
 	for _, schedule := range schedules {
 		key := autoContinueKey{AgentID: schedule.AgentID, Reason: agent.AutoContinueReason(schedule.Reason)}
-		h.armAutoContinueTimer(key, schedule.DueAt)
+		h.armAutoContinueTimer(key, schedule.DueAt.Time)
 	}
 }
 
@@ -94,13 +95,10 @@ func (h *OutputHandler) cleanupAutoContinue(agentID string) {
 }
 
 // buildAutoContinueRecord returns the upsert params plus the typed due
-// instant the caller arms its timer with. The params' DueAt field is an
-// interface{} (its bind is strftime-wrapped SQL-side), so the builders hand
-// back the time.Time separately instead of making callers type-assert it out.
-// Converging this and the other strftime-wrapped worker write binds
-// (messages.created_at, terminals.closed_at) on typed CAST(... AS TEXT)
-// string params is tracked in
-// https://github.com/leapmux/leapmux/issues/303.
+// instant the caller arms its timer with. The params' DueAt is a
+// sqltime.SQLiteTime that floors to the millisecond and serializes the
+// canonical layout on bind; the builders also hand back the plain time.Time so
+// the caller arms its in-memory timer without unwrapping record.DueAt.Time.
 func (h *OutputHandler) buildAutoContinueRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, time.Time, error) {
 	switch schedule.Reason {
 	case agent.AutoContinueReasonAPIError:
@@ -137,16 +135,16 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 	}
 
 	jitter := symmetricJitter(delay, autoContinueJitterFrac)
-	// Millisecond-truncated because the upsert stores due_at in the
+	// Floored via sqltime.FloorMillis because the upsert stores due_at in the
 	// millisecond-precision canonical strftime layout: the armed in-memory
 	// instant must survive the DB roundtrip byte-exactly, or
 	// fireAutoContinue's DueAt.Equal guard would reject every firing.
-	dueAt := now.Add(delay + jitter).Truncate(time.Millisecond)
+	dueAt := sqltime.FloorMillis(now.Add(delay + jitter))
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
 		Content:       autoContinueContent,
-		DueAt:         dueAt,
+		DueAt:         sqltime.NewSQLiteTime(dueAt),
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: nextBackoff.Milliseconds(),
 		SourcePayload: cloneOrEmpty(schedule.SourcePayload),
@@ -155,14 +153,14 @@ func (h *OutputHandler) buildAPIErrorScheduleRecord(agentID string, schedule age
 
 func (h *OutputHandler) buildRateLimitScheduleRecord(agentID string, schedule agent.AutoContinueSchedule, now time.Time) (db.UpsertAutoContinueScheduleParams, time.Time) {
 	jitter := positiveRateLimitJitter(schedule.DueAt.Sub(now))
-	// Millisecond-truncated for the same DueAt.Equal roundtrip reason as
-	// buildAPIErrorScheduleRecord above.
-	dueAt := schedule.DueAt.UTC().Add(jitter).Truncate(time.Millisecond)
+	// Floored via sqltime.FloorMillis for the same DueAt.Equal roundtrip
+	// reason as buildAPIErrorScheduleRecord above.
+	dueAt := sqltime.FloorMillis(schedule.DueAt.Add(jitter))
 	return db.UpsertAutoContinueScheduleParams{
 		AgentID:       agentID,
 		Reason:        string(schedule.Reason),
 		Content:       autoContinueContent,
-		DueAt:         dueAt,
+		DueAt:         sqltime.NewSQLiteTime(dueAt),
 		JitterMs:      jitter.Milliseconds(),
 		NextBackoffMs: 0,
 		SourcePayload: cloneOrEmpty(schedule.SourcePayload),

--- a/backend/internal/worker/service/auto_continue_service_test.go
+++ b/backend/internal/worker/service/auto_continue_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -25,7 +26,7 @@ func TestCloseAgent_CancelsPendingSchedules(t *testing.T) {
 		AgentID:       "agent-1",
 		Reason:        string(agent.AutoContinueReasonRateLimit),
 		Content:       autoContinueContent,
-		DueAt:         time.Now().UTC().Add(time.Hour),
+		DueAt:         sqltime.NewSQLiteTime(time.Now().UTC().Add(time.Hour)),
 		JitterMs:      0,
 		NextBackoffMs: 0,
 		SourcePayload: []byte{},
@@ -55,7 +56,7 @@ func TestCleanupWorkspace_CancelsPendingSchedules(t *testing.T) {
 		AgentID:       "agent-1",
 		Reason:        string(agent.AutoContinueReasonAPIError),
 		Content:       autoContinueContent,
-		DueAt:         time.Now().UTC().Add(time.Hour),
+		DueAt:         sqltime.NewSQLiteTime(time.Now().UTC().Add(time.Hour)),
 		JitterMs:      0,
 		NextBackoffMs: 20000,
 		SourcePayload: []byte{},

--- a/backend/internal/worker/service/auto_continue_test.go
+++ b/backend/internal/worker/service/auto_continue_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -30,7 +31,7 @@ func TestAutoContinueSchedule_SurvivesRestart(t *testing.T) {
 		AgentID:       "agent-1",
 		Reason:        string(agent.AutoContinueReasonRateLimit),
 		Content:       autoContinueContent,
-		DueAt:         time.Now().UTC().Add(100 * time.Millisecond),
+		DueAt:         sqltime.NewSQLiteTime(time.Now().UTC().Add(100 * time.Millisecond)),
 		JitterMs:      0,
 		NextBackoffMs: 0,
 		SourcePayload: []byte{},
@@ -135,7 +136,7 @@ func TestAutoContinueSchedule_CancelOneReasonLeavesOtherIntact(t *testing.T) {
 // between the schedule builders and fireAutoContinue's DueAt.Equal guard: the
 // dueAt a builder hands back for arming the in-memory timer must equal the DB
 // roundtrip of the record it built. due_at is stored at millisecond precision
-// (the upsert's strftime wrap), so the builders truncate to the millisecond
+// (SQLiteTime floors due_at on bind), so the builders truncate to the millisecond
 // before binding; without that, every live-armed dueAt carries sub-millisecond
 // residue the storage floors away, the Equal guard rejects every firing, and
 // auto-continue silently never fires on the live path. The restore-path tests
@@ -183,7 +184,7 @@ func TestAutoContinueSchedule_FiresOnceAndDoesNotRefireAfterRestart(t *testing.T
 		AgentID:       "agent-1",
 		Reason:        string(agent.AutoContinueReasonRateLimit),
 		Content:       autoContinueContent,
-		DueAt:         time.Now().UTC().Add(100 * time.Millisecond),
+		DueAt:         sqltime.NewSQLiteTime(time.Now().UTC().Add(100 * time.Millisecond)),
 		JitterMs:      0,
 		NextBackoffMs: 0,
 		SourcePayload: []byte{},

--- a/backend/internal/worker/service/canonical_storage_test.go
+++ b/backend/internal/worker/service/canonical_storage_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	gendb "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -23,6 +23,12 @@ import (
 // store modernc's driver layout with the zone's offset (space at byte 11,
 // '+09:00' suffix), splitting a column into two layouts whose raw-string
 // compares (the closed_at/deleted_at cleanup sweeps) silently diverge.
+//
+// The test also asserts non-vacuity: every discovered DATETIME column --
+// NOT NULL and nullable alike -- must hold at least one non-null value by the
+// end of the fixtures, so no column's layout contract passes merely because
+// nothing was ever stored in it. A new DATETIME column therefore fails this
+// test until a fixture write for it is added here.
 func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	sqlDB, queries := setupTestDB(t)
 	ctx := context.Background()
@@ -52,7 +58,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
 		SpanLines:          "[]",
 		AgentProvider:      leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:          now,
+		CreatedAt:          sqltime.NewSQLiteTime(now),
 	})
 	require.NoError(t, err)
 
@@ -71,7 +77,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		Cols:        80,
 		Rows:        24,
 		Screen:      []byte{},
-		ClosedAt:    sql.NullTime{Time: now, Valid: true},
+		ClosedAt:    sqltime.SQLiteNullTimeOf(now),
 	}))
 	require.NoError(t, queries.UpsertTerminal(ctx, gendb.UpsertTerminalParams{
 		ID:          "term-2",
@@ -100,7 +106,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		AgentID:       "agent-1",
 		Reason:        "rate_limit",
 		Content:       "continue",
-		DueAt:         now.Add(time.Hour),
+		DueAt:         sqltime.NewSQLiteTime(now.Add(time.Hour)),
 		SourcePayload: []byte("{}"),
 	}))
 
@@ -114,10 +120,32 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		Status:  "pending",
 	}))
 
-	offenders, walked, err := sqlitedb.FindNonCanonicalDatetimes(ctx, sqlDB, "goose_db_version")
+	// control_requests.created_at via the column DEFAULT on CreateControlRequest.
+	require.NoError(t, queries.CreateControlRequest(ctx, gendb.CreateControlRequestParams{
+		AgentID:    "agent-1",
+		RequestID:  "req-1",
+		Payload:    []byte("{}"),
+		ClaimToken: "claim-1",
+	}))
+
+	// worker_file_tabs.created_at via the column DEFAULT on UpsertWorkerFileTab.
+	require.NoError(t, queries.UpsertWorkerFileTab(ctx, gendb.UpsertWorkerFileTabParams{
+		OrgID:       "org-1",
+		TabID:       "tab-1",
+		WorkspaceID: "ws-1",
+		FilePath:    "/tmp/file.txt",
+	}))
+
+	offenders, columns, err := sqlitedb.FindNonCanonicalDatetimes(ctx, sqlDB, "goose_db_version")
 	require.NoError(t, err)
-	require.Positive(t, walked, "walk discovered no DATETIME columns; the discovery query is broken")
+	require.NotEmpty(t, columns, "walk discovered no DATETIME columns; the discovery query is broken")
 	assert.Empty(t, offenders,
 		"non-canonical timestamp value(s) on disk -- a write path is missing its strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', ...) wrap:\n  %s",
 		strings.Join(offenders, "\n  "))
+	// Non-vacuity: a column with zero non-null rows passes the layout probe
+	// without ever being exercised, so a raw time.Time bind on that write path
+	// would ship unnoticed. Every discovered column must hold at least one
+	// value by the end of the fixture writes above.
+	assert.Empty(t, sqlitedb.UncoveredColumns(columns),
+		"DATETIME column(s) with zero non-null rows -- their canonical-layout check passed vacuously; add a fixture write for each so the contract is actually exercised")
 }

--- a/backend/internal/worker/service/cleanup.go
+++ b/backend/internal/worker/service/cleanup.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/util/periodic"
-	"github.com/leapmux/leapmux/internal/util/timefmt"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -75,11 +75,12 @@ func (svc *Context) SweepOrphanedAgentState() {
 }
 
 func runCleanup(ctx context.Context, queries *db.Queries) {
-	// Pre-formatted in the canonical strftime layout: the sweeps compare
-	// closed_at/deleted_at as raw strings, so the cutoff must be byte-exact
-	// against the stored bytes (a raw time.Time bind would serialize in the
-	// driver's own layout and skip every same-day row).
-	cutoff := timefmt.Format(time.Now().Add(-cleanupRetention))
+	// Bound as a SQLiteNullTime: the sweeps compare closed_at/deleted_at as raw
+	// strings, so the cutoff must be byte-exact against the stored bytes.
+	// SQLiteNullTime.Value() emits the canonical strftime layout; a raw time.Time
+	// bind would serialize in the driver's own layout (and is now a compile
+	// error) and skip every same-day row.
+	cutoff := sqltime.SQLiteNullTimeOf(time.Now().Add(-cleanupRetention))
 
 	cleanupStep(ctx, "agents", func() (sql.Result, error) { return queries.DeleteClosedAgentsBefore(ctx, cutoff) })
 	cleanupStep(ctx, "terminals", func() (sql.Result, error) { return queries.DeleteClosedTerminalsBefore(ctx, cutoff) })

--- a/backend/internal/worker/service/cleanup_test.go
+++ b/backend/internal/worker/service/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/leapmux/leapmux/internal/worker/db"
 	gendb "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -78,7 +79,7 @@ func TestCleanup_HardDeleteWorktreesBefore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete worktrees older than 7 days.
-	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
+	cutoff := sqltime.SQLiteNullTimeOf(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -108,7 +109,7 @@ func TestCleanup_HardDeleteWorktreesBefore_RetainsRecent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete worktrees older than 7 days. The recent one should survive.
-	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
+	cutoff := sqltime.SQLiteNullTimeOf(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -158,7 +159,7 @@ func TestCleanup_WorktreeTabsCascadeOnHardDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Hard-delete.
-	cutoff := timefmt.Format(time.Now().Add(-7 * 24 * time.Hour))
+	cutoff := sqltime.SQLiteNullTimeOf(time.Now().Add(-7 * 24 * time.Hour))
 	result, err := queries.HardDeleteWorktreesBefore(ctx, cutoff)
 	require.NoError(t, err)
 
@@ -179,7 +180,8 @@ func TestCleanup_WorktreeTabsCascadeOnHardDelete(t *testing.T) {
 
 // TestCleanup_SweepsSameInstantBoundaries pins the millisecond-exact boundary
 // behavior of the three retention sweeps: stored timestamps and cutoffs are
-// both canonical (strftime wrap on write, timefmt.Format on the bound cutoff),
+// both canonical (SQLiteTime/SQLiteNullTime binds floor to the millisecond and
+// serialize the canonical layout for both the stored rows and the cutoff),
 // so `col < cutoff` must delete strictly-older rows and keep the exact-cutoff
 // and newer rows even when everything shares the same second. The existing
 // retention tests use multi-day gaps, which is exactly how the prior
@@ -188,7 +190,7 @@ func TestCleanup_SweepsSameInstantBoundaries(t *testing.T) {
 	sqlDB, queries := setupTestDB(t)
 	ctx := context.Background()
 	cutoffTime := time.Now().UTC().Truncate(time.Millisecond)
-	cutoff := timefmt.Format(cutoffTime)
+	cutoff := sqltime.SQLiteNullTimeOf(cutoffTime)
 
 	seedAgent := func(id string, closedAt time.Time) {
 		require.NoError(t, queries.CreateAgent(ctx, gendb.CreateAgentParams{
@@ -217,7 +219,7 @@ func TestCleanup_SweepsSameInstantBoundaries(t *testing.T) {
 		require.NoError(t, queries.UpsertTerminal(ctx, gendb.UpsertTerminalParams{
 			ID: id, WorkspaceID: "ws-1", WorkingDir: "/tmp", HomeDir: "/home", Shell: "/bin/zsh",
 			Title: id, Cols: 80, Rows: 24, Screen: []byte{},
-			ClosedAt: sql.NullTime{Time: closedAt, Valid: true},
+			ClosedAt: sqltime.SQLiteNullTimeOf(closedAt),
 		}))
 	}
 	seedTerminal("term-expired", cutoffTime.Add(-time.Millisecond))

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"runtime"
 	"strings"
 	"sync"
@@ -17,6 +16,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	noiseutil "github.com/leapmux/leapmux/internal/noise"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
@@ -311,7 +311,7 @@ func TestListAgentMessages_ClosedAgent_ReturnsEmpty(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte("hello"),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestListTerminals_ClosedTerminal_NotReturned(t *testing.T) {
 		Cols:        80,
 		Rows:        24,
 		Screen:      []byte("closed screen"),
-		ClosedAt:    sql.NullTime{Time: time.Now(), Valid: true},
+		ClosedAt:    sqltime.SQLiteNullTimeOf(time.Now()),
 	}))
 
 	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{
@@ -423,7 +423,7 @@ func TestWatchEvents_ClosedAgent_NotWatched(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte("hello"),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	require.NoError(t, svc.Queries.CloseAgent(ctx, "agent-closed"))
@@ -459,7 +459,7 @@ func TestWatchEvents_ClosedTerminal_NotWatched(t *testing.T) {
 		Cols:        80,
 		Rows:        24,
 		Screen:      []byte("some screen"),
-		ClosedAt:    sql.NullTime{Time: time.Now(), Valid: true},
+		ClosedAt:    sqltime.SQLiteNullTimeOf(time.Now()),
 	}))
 
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{

--- a/backend/internal/worker/service/create_message_row_test.go
+++ b/backend/internal/worker/service/create_message_row_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -37,7 +38,7 @@ func TestCreateMessageRow_RejectsUnspecifiedProvider(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
 			Content:       []byte(`{"type":"result"}`),
 			AgentProvider: provider,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		}
 	}
 
@@ -81,7 +82,7 @@ func TestCreateMessageRow_RejectsUnknownMarkType(t *testing.T) {
 		Content:       []byte(`{"type":"result"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		MarkType:      leapmuxv1.MarkType(999),
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mark_type")

--- a/backend/internal/worker/service/get_agent_message_test.go
+++ b/backend/internal/worker/service/get_agent_message_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -44,14 +45,14 @@ func TestGetAgentMessage_ReturnsMessageBySeq(t *testing.T) {
 		Content:       []byte(`{"content":"hello world"}`),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		MarkType:      leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	// A second row at a different seq to prove the handler selects by seq, not "first".
 	_, err = createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
 		ID: "m2", AgentID: "agent-1", Source: leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
 		Content: []byte(`{"content":"other"}`), AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt: time.Now(),
+		CreatedAt: sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 

--- a/backend/internal/worker/service/list_by_ids_test.go
+++ b/backend/internal/worker/service/list_by_ids_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -243,7 +243,7 @@ func TestListTerminals_ClosedTabsFiltered(t *testing.T) {
 	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
 		ID: "t1", WorkspaceID: "ws-A", WorkingDir: "/tmp", HomeDir: "/tmp",
 		Cols: 80, Rows: 24, Screen: []byte("screen"),
-		ClosedAt: sql.NullTime{Time: time.Now(), Valid: true},
+		ClosedAt: sqltime.SQLiteNullTimeOf(time.Now()),
 	}))
 
 	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{

--- a/backend/internal/worker/service/list_messages_anchor_test.go
+++ b/backend/internal/worker/service/list_messages_anchor_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -37,7 +38,7 @@ func TestListAgentMessages_AnchorPaging(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -158,7 +159,7 @@ func TestListAgentMessages_ShipsTodosOnDefaultAnchor(t *testing.T) {
 		Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 		Content:       []byte("hi"),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	require.NoError(t, svc.Queries.InsertAgentTodo(ctx, db.InsertAgentTodoParams{
@@ -237,7 +238,7 @@ func TestWatchEvents_ReplaysLatestPageForFreshSubscriber(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -315,7 +316,7 @@ func TestWatchEvents_ResumeReplaysForwardPageFromCursor(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -389,7 +390,7 @@ func TestWatchEvents_ResumeEmitsCatchUpStart(t *testing.T) {
 		seq, err := createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
 			ID: fmt.Sprintf("msg-%d", i+1), AgentID: "agent-1",
 			Source: leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, Content: []byte("hi"),
-			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, CreatedAt: time.Now(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, CreatedAt: sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -451,7 +452,7 @@ func TestWatchEvents_FreshSubscribeEmitsCatchUpFrames(t *testing.T) {
 		seq, err := createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
 			ID: fmt.Sprintf("msg-%d", i+1), AgentID: "agent-1",
 			Source: leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, Content: []byte("hi"),
-			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, CreatedAt: time.Now(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, CreatedAt: sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		tail = seq
@@ -507,7 +508,7 @@ func TestWatchEvents_AfterCursorWithZeroSeqReplaysLatest(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -565,7 +566,7 @@ func TestWatchEvents_ReplayShipsTodosSnapshot(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)
@@ -623,7 +624,7 @@ func TestWatchEvents_CatchUpCompleteCarriesLatestSeq(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		seqs = append(seqs, seq)

--- a/backend/internal/worker/service/message_marks_test.go
+++ b/backend/internal/worker/service/message_marks_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -25,7 +26,7 @@ func seedMark(t *testing.T, svc *Context, agentID, id string, mark leapmuxv1.Mar
 		Content:       []byte("hi"),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		MarkType:      mark,
-		CreatedAt:     time.Now(),
+		CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 	})
 	require.NoError(t, err)
 	return seq

--- a/backend/internal/worker/service/message_seq_monotonic_test.go
+++ b/backend/internal/worker/service/message_seq_monotonic_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
@@ -30,7 +31,7 @@ func TestMessageSeq_NotReusedAfterTailDelete(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
 			Content:       []byte("hi"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		return seq
@@ -74,7 +75,7 @@ func TestMessageSeq_ReseqUsesHighWater(t *testing.T) {
 			Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_LEAPMUX,
 			Content:       []byte("{}"),
 			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			CreatedAt:     time.Now(),
+			CreatedAt:     sqltime.NewSQLiteTime(time.Now()),
 		})
 		require.NoError(t, err)
 		return seq

--- a/backend/internal/worker/service/now.go
+++ b/backend/internal/worker/service/now.go
@@ -1,14 +1,19 @@
 package service
 
-import "time"
+import (
+	"time"
+
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+)
 
 // nowMillis returns the current instant floored to the millisecond, in UTC.
 // Message and notification stamps must be minted this way so the
 // live-streamed value is byte-identical to the persisted row: created_at is
-// stored at ms precision (the strftime wrap in the queries) and the proto
+// stored at ms precision (the SQLiteTime bind floors it) and the proto
 // echo formats via timefmt (ms truncation). A raw time.Now() would carry
 // sub-millisecond residue the storage floors away, making the streamed and
-// persisted stamps drift apart.
+// persisted stamps drift apart. Delegates to sqltime.FloorMillis so this
+// floor can never drift from the one the storage valuers apply.
 func nowMillis() time.Time {
-	return time.Now().UTC().Truncate(time.Millisecond)
+	return sqltime.FloorMillis(time.Now())
 }

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -22,6 +22,7 @@ import (
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
 	"github.com/leapmux/leapmux/internal/util/optionmap"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/util/timefmt"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -1725,7 +1726,7 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 		SpanLines:          spanLines,
 		AgentProvider:      agentProvider,
 		MarkType:           span.MarkType,
-		CreatedAt:          now,
+		CreatedAt:          sqltime.NewSQLiteTime(now),
 	})
 	if err != nil {
 		return err
@@ -2292,7 +2293,7 @@ func (h *OutputHandler) appendToNotificationThread(agentID string, agentProvider
 		ContentCompression: mergedCompType,
 		Seq:                newSeq,
 		AgentProvider:      agentProvider,
-		CreatedAt:          timefmt.Format(parentRow.CreatedAt),
+		CreatedAt:          timefmt.Format(parentRow.CreatedAt.Time),
 		Depth:              0,
 		SpanLines:          spanLines,
 		// Carry the row's scroll-rail mark so this MOVE broadcast matches what a
@@ -2335,7 +2336,7 @@ func (h *OutputHandler) createNotificationStandalone(agentID string, agentProvid
 		SpanLines:          spanLines,
 		SpanColor:          0,
 		AgentProvider:      agentProvider,
-		CreatedAt:          now,
+		CreatedAt:          sqltime.NewSQLiteTime(now),
 	})
 	if err != nil {
 		return false, err

--- a/backend/internal/worker/sqlc.yaml
+++ b/backend/internal/worker/sqlc.yaml
@@ -10,6 +10,18 @@ sql:
         emit_json_tags: true
         emit_empty_slices: true
         overrides:
+          # Millisecond-floored, canonical-layout DATETIME types (#303). Type-
+          # keyed: retypes every DATETIME param and result column. Column-keyed
+          # enum overrides below take precedence where they apply.
+          - db_type: "DATETIME"
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "SQLiteTime"
+          - db_type: "DATETIME"
+            nullable: true
+            go_type:
+              import: "github.com/leapmux/leapmux/internal/util/sqltime"
+              type: "SQLiteNullTime"
           - column: "messages.source"
             go_type:
               import: "github.com/leapmux/leapmux/generated/proto/leapmux/v1"


### PR DESCRIPTION
## Motivation
Every hub-store dialect (SQLite, MySQL, Postgres) and the worker store bound
`time.Time` values into DATETIME/timestamptz columns using hand-rolled
helpers (`BindTime`, `BindNullTime`, `sqlutil.NullTimePtr`, ad-hoc
`strftime(...)` wraps, the `tsToTime*`/`timeToTs*` adapter quartet, manual
`.UTC().Truncate(...)` calls). This convention-based approach had two classes
of bugs:

1. **Rounding, not flooring.** SQLite's `strftime('%f', ...)` and MySQL's
   `DATETIME(3)` round half-up when a bound instant lands between grid
   points, so the value actually stored in the DB could be *later* than the
   instant the caller supplied. For credential/session lifetime checks that
   compare `now <= expires_at`, this could overclaim a deadline by up to a
   second.
2. **Layout drift.** Nothing stopped a raw `time.Time` from being bound
   directly (bypassing the canonicalization helpers), which serializes using
   the driver's own layout instead of the canonical one. That splits a
   column into two on-disk layouts, silently breaking byte-exact
   raw-string keyset pagination and cleanup-cutoff comparisons for the
   affected rows.

Because these were discipline-based conventions rather than compiler-enforced
invariants, a reviewer had to notice a missing wrapper call by eye. Closes
#303.

## Modifications
- Added `backend/internal/util/sqltime`: `driver.Valuer`/`sql.Scanner`
  wrappers (`SQLiteTime`, `SQLiteNullTime`, `MySQLTime`, `MySQLNullTime`)
  that floor every instant to UTC milliseconds on bind. SQLite variants
  serialize the canonical 24-char ISO 8601 layout so raw-string comparisons
  stay byte-exact and index-sargable. Added `sqltime/pgtime` with the
  Postgres-family equivalents (`Time`, `NullTime`) flooring to microseconds
  to match `timestamptz` precision. All wrappers embed a zero-size
  `noCompare` marker, making `==`/map-key usage of these types a compile
  error.
- Wired the new types into all four sqlc configs (sqlite, mysql, postgres,
  worker) via type-keyed `db_type` overrides, so every generated
  DATETIME/timestamptz param and result is retyped mechanically instead of
  by convention. A raw `time.Time` bind is now a compile error at every
  sqlc-generated call site.
- **Removed** the old convention helpers now made redundant: `sqlutil`'s
  `BindTime`/`BindNullTime`/`BindTimeValid`/`NullTimePtr`, SQLite's
  `formatSQLiteTime`/`sqliteTimeFormat`, and Postgres's
  `tsToTime`/`tsToTimePtr`/`timeToTs`/`timePtrToTs` adapters. Query SQL
  drops the now-redundant `strftime(...)` wraps and `CAST(... AS TEXT)`
  cutoffs, since the valuer already emits canonical bytes.
- Rewired roughly 75 per-table store files (SQLite, MySQL, Postgres, worker)
  and their `*Params` builders onto the new constructors and `.Time`/
  `.Ptr()` accessors.
- Added schema and coverage guards per dialect: SQLite/worker
  canonical-storage tests now assert every discovered DATETIME column holds
  at least one value (closing a blind spot where an unwritten column passed
  vacuously); MySQL gained `TestEveryTimestampColumnDeclaresDatetime` (bans
  bare `TIMESTAMP`, requires `DATETIME(3..6)`) plus a live
  `information_schema` twin; Postgres gained an equivalent static scan
  (rejects precision-qualified `timestamptz(n)` and bare `TIMESTAMP`) plus
  a live twin asserting `timestamp with time zone` at precision 6.
- Added `backend/internal/hub/store/generated_params_internal_test.go`
  (go/types + go/packages across all sqlc-generated packages and the
  hand-written store/worker trees):
  `TestGeneratedInterfaceParamsAreAllowlisted` catches any generated
  `interface{}` param/result not on a documented allowlist (sqlc emits
  these for keyset `narg` OR-chains, which escape the type overrides), and
  `TestNoRawTimeBindsIntoInterfaceParams` statically rejects raw
  `time.Time`/`*time.Time`/`sql.NullTime` at every untyped sink -
  composite-literal fills, `interface{}` assignments, `[]any` appends, and
  variadic `Exec`/`Query`/`QueryRow(Context)` args.
- **Breaking change (internal API only):** the removed `sqlutil` bind
  helpers and Postgres `ts*`/`time*` adapters are no longer available; all
  in-tree call sites were migrated to `sqltime`/`pgtime` constructors as
  part of this change.

## Result
- Closes #303.
- Credential/session/cursor expiry comparisons can no longer be off by up
  to a second due to half-up rounding in SQLite/MySQL DATETIME storage -
  the stored instant is always `<=` the bound instant.
- A raw `time.Time` (or `*time.Time`/`sql.NullTime`) passed into a
  generated store call is now a compile-time type error instead of a
  silent layout-drift bug that could later break raw-string keyset
  pagination or cleanup-sweep comparisons.
- New static and live schema tests fail the build if a future migration
  adds a `TIMESTAMP` column, a precision-qualified `timestamptz(n)`
  column, or a DATETIME column with insufficient fractional-second
  precision, instead of surfacing as an intermittent data bug later.
