### PR TITLE
Scan every migration file in static schema-convention guards

### DIFF
--- a/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
@@ -7,9 +7,10 @@
 -- Every CREATE TABLE here and in future migrations MUST carry
 -- COLLATE=utf8mb4_bin: a table without it silently inherits the server or
 -- database default (typically case-INsensitive), breaking the byte-wise id
--- tiebreak ordering and FK collation consistency. This convention is
--- enforced only by this comment today; a schema test that fails any
--- CREATE TABLE lacking the suffix is tracked in
+-- tiebreak ordering and FK collation consistency. Enforced by
+-- TestEveryCreateTableDeclaresBinaryCollation (schema_internal_test.go), which
+-- scans every migration file in this directory, and by its live twin
+-- TestMySQLBinaryCollationLive (-tags integration). See
 -- https://github.com/leapmux/leapmux/issues/300. The database-level default
 -- is intentionally left to the operator (the app connects to a pre-created
 -- database and owns only its tables).

--- a/backend/internal/hub/store/mysql/mysql_test.go
+++ b/backend/internal/hub/store/mysql/mysql_test.go
@@ -92,10 +92,10 @@ func TestMySQLStore(t *testing.T) {
 // collation so id/FK columns collate byte-wise (case-sensitive) and the
 // composite cursor's `id < ?` tiebreak stays deterministic for mixed-case ids.
 // This is the live twin of the static source scan in schema_internal_test.go
-// (TestEveryCreateTableDeclaresBinaryCollation): the static scan runs without
-// Docker but reads only 00001_initial.sql, while this one is
-// migration-count-agnostic and also catches a column-level collation override
-// the source scan cannot see.
+// (TestEveryCreateTableDeclaresBinaryCollation): the static scan covers every
+// embedded migration file without Docker, while this one asserts against the
+// server's resolved schema and catches column-level collation overrides the
+// source scan cannot see.
 func TestMySQLBinaryCollationLive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -144,12 +144,11 @@ func TestMySQLBinaryCollationLive(t *testing.T) {
 // TIMESTAMP without being `_at`-named (TIMESTAMP is banned outright for its
 // session-timezone semantics). This is the live twin of the static source scan
 // in schema_internal_test.go (TestEveryTimestampColumnDeclaresDatetime): the
-// static scan runs without Docker but reads only 00001_initial.sql with a
-// line-shape-sensitive text parse, while this one is migration-count-agnostic
-// and reads the server's resolved column types. Precision below 3 matters
-// because MySQL ROUNDS a fractional second exceeding the column precision, so
-// a DATETIME(0..2) column could store an instant after the ms-floored bound
-// the sqltime valuers guarantee.
+// static scan covers every embedded migration file without Docker (with a
+// line-shape-sensitive text parse), while this one reads the server's resolved
+// column types. Precision below 3 matters because MySQL ROUNDS a fractional
+// second exceeding the column precision, so a DATETIME(0..2) column could
+// store an instant after the ms-floored bound the sqltime valuers guarantee.
 func TestMySQLDatetimeColumnsLive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/backend/internal/hub/store/mysql/schema_internal_test.go
+++ b/backend/internal/hub/store/mysql/schema_internal_test.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -19,40 +18,35 @@ import (
 // workspace_section_items.sql in the keyset-pagination rebuild, so the
 // table-level collation is now the sole guarantee -- a table added without the
 // suffix silently inherits the database default (typically case-insensitive) and
-// the cursor id tiebreak nondeterministically re-returns or skips rows. Closes
+// the cursor id tiebreak nondeterministically re-returns or skips rows. See
 // https://github.com/leapmux/leapmux/issues/300.
 //
-// This is a static check of the migration source, so it runs without Docker.
-// Its live twin, TestMySQLBinaryCollationLive (mysql_test.go, -tags
-// integration), asserts the same invariant against the actual migrated schema
-// and is migration-count-agnostic.
+// This is a static check of every embedded migration file (migrate.go's
+// //go:embed db/migrations/*.sql), so it runs without Docker: a future
+// migration lacking the suffix fails the default suite. The CREATE TABLE anchor
+// tolerates whitespace, but the COLLATE check is a literal "COLLATE=utf8mb4_bin"
+// substring match, so a spaced-out "COLLATE = utf8mb4_bin" would evade it. Its
+// live twin, TestMySQLBinaryCollationLive (mysql_test.go, -tags integration),
+// asserts the same invariant against the server's resolved schema and is the
+// authoritative guarantee for such spellings, plus column-level collation
+// overrides the source scan cannot see.
 func TestEveryCreateTableDeclaresBinaryCollation(t *testing.T) {
-	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	files, err := storetest.MigrationFiles(migrations)
 	require.NoError(t, err)
-	// Strip line comments (-- to end of line) so a ';' inside a prose comment
-	// (e.g. "...issued; force-expires...") doesn't split a CREATE TABLE body.
-	sql := strings.ToUpper(storetest.StripSQLLineComments(string(sqlBytes)))
 
-	const create = "CREATE TABLE"
-	idx := 0
 	count := 0
-	for {
-		i := strings.Index(sql[idx:], create)
-		if i < 0 {
-			break
-		}
-		i += idx
-		semi := strings.Index(sql[i:], ";")
-		require.GreaterOrEqual(t, semi, 0, "CREATE TABLE at offset %d missing terminating ;", i)
-		stmt := sql[i : i+semi]
-		assert.Contains(t, stmt, "COLLATE=UTF8MB4_BIN",
-			"CREATE TABLE at offset %d must declare COLLATE=utf8mb4_bin so id/FK columns collate byte-wise; the dropped per-query BINARY casts rely on it", i)
-		idx = i + semi
-		count++
+	for _, f := range files {
+		err := storetest.WalkCreateTableStatements(f.SQL, func(stmt string) {
+			assert.Contains(t, stmt, "COLLATE=UTF8MB4_BIN",
+				"%s: CREATE TABLE must declare COLLATE=utf8mb4_bin so id/FK columns collate byte-wise; the dropped per-query BINARY casts rely on it", f.Name)
+			count++
+		})
+		require.NoError(t, err, "%s", f.Name)
 	}
-	require.GreaterOrEqual(t, count, 1, "found no CREATE TABLE statements in the migration")
-	// Sanity: the migration is non-trivial -- a healthy schema has many tables.
-	assert.Greater(t, count, 20, "expected many CREATE TABLE statements; got %d (is the migration readable?)", count)
+	// Sanity: the schema is non-trivial -- a healthy schema has many tables.
+	// Aggregate across files: a future migration may legitimately contain no
+	// CREATE TABLE.
+	assert.Greater(t, count, 20, "expected many CREATE TABLE statements; got %d (are the migrations readable?)", count)
 }
 
 // TestEveryTimestampColumnDeclaresDatetime pins the decltype spelling the sqlc
@@ -71,26 +65,32 @@ func TestEveryCreateTableDeclaresBinaryCollation(t *testing.T) {
 // override, it carries session-timezone conversion semantics DATETIME
 // deliberately avoids.
 //
-// This is a static check of the migration source, so it runs without Docker.
+// This is a static check of every embedded migration file (migrate.go's
+// //go:embed db/migrations/*.sql), so it runs without Docker: a future
+// migration with a wrong decltype fails the default suite as long as its column
+// is declared in the conventional one-per-line form the text scan recognizes.
 // Its live twin, TestMySQLDatetimeColumnsLive (mysql_test.go, -tags
 // integration), asserts the same invariant against information_schema of the
-// actual migrated database and is immune to the text parse's line-shape
-// assumptions (see storetest.WalkCreateTableColumns).
+// actual migrated database and is the authoritative guarantee for the
+// line-shape parse blind spots the source scan cannot see (see
+// storetest.WalkCreateTableColumns).
 func TestEveryTimestampColumnDeclaresDatetime(t *testing.T) {
-	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	files, err := storetest.MigrationFiles(migrations)
 	require.NoError(t, err)
 
 	atColumns := 0
-	storetest.WalkCreateTableColumns(string(sqlBytes), func(name, typeTok string) {
-		if strings.HasSuffix(name, "_at") {
-			atColumns++
-			assert.Regexp(t, `^DATETIME\([3-6]\)$`, typeTok,
-				"column %s is declared %s; `_at` columns must be DATETIME(3..6) so the sqlc db_type override retypes them to the flooring valuer and the stored precision can hold the floored millisecond (below 3, MySQL ROUNDS past the floor)", name, typeTok)
-		} else {
-			assert.False(t, strings.HasPrefix(typeTok, "DATETIME") || strings.HasPrefix(typeTok, "TIMESTAMP"),
-				"column %s is declared %s; time columns must be named *_at (and TIMESTAMP is banned outright)", name, typeTok)
-		}
-	})
+	for _, f := range files {
+		storetest.WalkCreateTableColumns(f.SQL, func(name, typeTok string) {
+			if strings.HasSuffix(name, "_at") {
+				atColumns++
+				assert.Regexp(t, `^DATETIME\([3-6]\)$`, typeTok,
+					"%s: column %s is declared %s; `_at` columns must be DATETIME(3..6) so the sqlc db_type override retypes them to the flooring valuer and the stored precision can hold the floored millisecond (below 3, MySQL ROUNDS past the floor)", f.Name, name, typeTok)
+			} else {
+				assert.False(t, strings.HasPrefix(typeTok, "DATETIME") || strings.HasPrefix(typeTok, "TIMESTAMP"),
+					"%s: column %s is declared %s; time columns must be named *_at (and TIMESTAMP is banned outright)", f.Name, name, typeTok)
+			}
+		})
+	}
 	// Sanity: the scan actually saw the schema's many timestamp columns.
-	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (is the migration readable?)", atColumns)
+	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (are the migrations readable?)", atColumns)
 }

--- a/backend/internal/hub/store/postgres/postgres_test.go
+++ b/backend/internal/hub/store/postgres/postgres_test.go
@@ -170,14 +170,13 @@ func TestPostgresBinaryCollationLive(t *testing.T) {
 // any name resolves to a timezone-naive timestamp (banned outright: it
 // silently reinterprets instants across session timezones). This is the live
 // twin of the static source scan in schema_internal_test.go
-// (TestEveryTimestampColumnDeclaresTimestamptz): the static scan runs without
-// Docker but reads only 00001_initial.sql with a line-shape-sensitive text
-// parse, while this one is migration-count-agnostic and reads the server's
-// resolved column types. Precision below 6 matters because Postgres ROUNDS a
-// fractional second exceeding the column precision, so a TIMESTAMPTZ(p<6)
-// column could store an instant after the microsecond-floored bound the
-// pgtime valuers guarantee. YugabyteDB inherits this pin via the shared
-// migration.
+// (TestEveryTimestampColumnDeclaresTimestamptz): the static scan covers every
+// embedded migration file without Docker (with a line-shape-sensitive text
+// parse), while this one reads the server's resolved column types. Precision
+// below 6 matters because Postgres ROUNDS a fractional second exceeding the
+// column precision, so a TIMESTAMPTZ(p<6) column could store an instant after
+// the microsecond-floored bound the pgtime valuers guarantee. YugabyteDB
+// inherits this pin via the shared migration.
 func TestPostgresTimestamptzColumnsLive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/backend/internal/hub/store/postgres/schema_internal_test.go
+++ b/backend/internal/hub/store/postgres/schema_internal_test.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -27,26 +26,32 @@ import (
 // override, a timezone-naive column silently reinterprets instants across
 // session timezones.
 //
-// This is a static check of the migration source, so it runs without Docker.
+// This is a static check of every embedded migration file (migrate.go's
+// //go:embed db/migrations/*.sql), so it runs without Docker: a future
+// migration with a wrong decltype fails the default suite as long as its column
+// is declared in the conventional one-per-line form the text scan recognizes.
 // Its live twin, TestPostgresTimestamptzColumnsLive (postgres_test.go, -tags
 // integration), asserts the same invariant against information_schema of the
-// actual migrated database and is immune to the text parse's line-shape
-// assumptions (see storetest.WalkCreateTableColumns).
+// actual migrated database and is the authoritative guarantee for the
+// line-shape parse blind spots the source scan cannot see (see
+// storetest.WalkCreateTableColumns).
 func TestEveryTimestampColumnDeclaresTimestamptz(t *testing.T) {
-	sqlBytes, err := os.ReadFile("db/migrations/00001_initial.sql")
+	files, err := storetest.MigrationFiles(migrations)
 	require.NoError(t, err)
 
 	atColumns := 0
-	storetest.WalkCreateTableColumns(string(sqlBytes), func(name, typeTok string) {
-		if strings.HasSuffix(name, "_at") {
-			atColumns++
-			assert.Equal(t, "TIMESTAMPTZ", typeTok,
-				"column %s is declared %s; `_at` columns must be exactly TIMESTAMPTZ (default microsecond precision) so the sqlc db_type override retypes them to the flooring valuer and no lower precision can round past the floor", name, typeTok)
-		} else {
-			assert.False(t, strings.HasPrefix(typeTok, "TIMESTAMP"),
-				"column %s is declared %s; time columns must be named *_at (and timezone-naive TIMESTAMP is banned outright)", name, typeTok)
-		}
-	})
+	for _, f := range files {
+		storetest.WalkCreateTableColumns(f.SQL, func(name, typeTok string) {
+			if strings.HasSuffix(name, "_at") {
+				atColumns++
+				assert.Equal(t, "TIMESTAMPTZ", typeTok,
+					"%s: column %s is declared %s; `_at` columns must be exactly TIMESTAMPTZ (default microsecond precision) so the sqlc db_type override retypes them to the flooring valuer and no lower precision can round past the floor", f.Name, name, typeTok)
+			} else {
+				assert.False(t, strings.HasPrefix(typeTok, "TIMESTAMP"),
+					"%s: column %s is declared %s; time columns must be named *_at (and timezone-naive TIMESTAMP is banned outright)", f.Name, name, typeTok)
+			}
+		})
+	}
 	// Sanity: the scan actually saw the schema's many timestamp columns.
-	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (is the migration readable?)", atColumns)
+	assert.Greater(t, atColumns, 20, "expected many _at columns; got %d (are the migrations readable?)", atColumns)
 }

--- a/backend/internal/hub/store/storetest/schema_scan.go
+++ b/backend/internal/hub/store/storetest/schema_scan.go
@@ -1,6 +1,48 @@
 package storetest
 
-import "strings"
+import (
+	"fmt"
+	"io/fs"
+	"regexp"
+	"strings"
+)
+
+// MigrationFile is the name and contents of one embedded migration SQL file.
+type MigrationFile struct {
+	Name string // e.g. "db/migrations/00001_initial.sql"
+	SQL  string
+}
+
+// MigrationFiles returns the name and contents of every *.sql file under
+// db/migrations in fsys -- pass the dialect's embedded migration FS
+// (migrate.go's //go:embed db/migrations/*.sql) so the static schema scans
+// cover exactly the set of migration files newMigrator feeds goose, current
+// and future. Using the embed FS (not os.ReadDir) scans the shipped artifact
+// and is cwd-independent, so the scanned file set cannot drift from what ships.
+// (On CockroachDB, newMigrator strips COLLATE "C" from the bytes it hands goose
+// via transformFS; the raw file text read here is unaffected, and no static
+// scan inspects that clause, so the divergence does not matter.) Returns an
+// error when zero files match so a layout/pattern drift fails loudly instead of
+// making every scan vacuously pass. Names from fs.Glob are sorted, so order is
+// deterministic.
+func MigrationFiles(fsys fs.FS) ([]MigrationFile, error) {
+	names, err := fs.Glob(fsys, "db/migrations/*.sql")
+	if err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no db/migrations/*.sql files in fsys")
+	}
+	out := make([]MigrationFile, 0, len(names))
+	for _, name := range names {
+		b, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, MigrationFile{Name: name, SQL: string(b)})
+	}
+	return out, nil
+}
 
 // StripSQLLineComments removes a SQL line comment (-- to end of line) from
 // each line. The migrations use only line comments (no /* */ block comments,
@@ -18,6 +60,50 @@ func StripSQLLineComments(s string) string {
 	}
 	return b.String()
 }
+
+// WalkCreateTableStatements strips line comments from migrationSQL, uppercases
+// it, and yields each CREATE TABLE statement -- the text from "CREATE TABLE" up
+// to (not including) its terminating ";". It returns an error if a CREATE TABLE
+// has no terminating ";" (a malformed migration) so the caller can fail loudly
+// instead of silently skipping the unterminated table.
+//
+// This is the statement-level sibling of WalkCreateTableColumns: the MySQL
+// collation static scan (mysql/schema_internal_test.go) uses it so the fragile
+// "CREATE TABLE ... ;" text split lives -- and is unit-tested -- in one place
+// next to the column-level walk, instead of open-coded inline in the test where
+// a parser fix could land for one and miss the other. It matches CREATE TABLE
+// tolerant of the horizontal whitespace between the two keywords (so a future
+// "CREATE TABLE" written with two spaces or a tab is still caught) and splits on
+// the first ";" after it, so a ";" inside a string literal or /* block comment */
+// (neither of which the migrations use) would split a statement early; the
+// integration-tagged live twins are the immune backstop.
+func WalkCreateTableStatements(migrationSQL string, fn func(stmt string)) error {
+	sql := strings.ToUpper(StripSQLLineComments(migrationSQL))
+	idx := 0
+	for {
+		loc := createTableRe.FindStringIndex(sql[idx:])
+		if loc == nil {
+			break
+		}
+		i := idx + loc[0]
+		semi := strings.Index(sql[i:], ";")
+		if semi < 0 {
+			return fmt.Errorf("CREATE TABLE at offset %d missing terminating ;", i)
+		}
+		fn(sql[i : i+semi])
+		idx = i + semi
+	}
+	return nil
+}
+
+// createTableRe matches the CREATE TABLE keyword pair on an uppercased blob,
+// tolerant of any horizontal whitespace (spaces or tabs) between the two words,
+// so a future migration that does not use the single-space spelling is still
+// scanned. It deliberately does NOT span a newline, staying consistent with the
+// line-based WalkCreateTableColumns, which cannot match a keyword pair split
+// across lines: a cross-line "CREATE\nTABLE" is a line-shape blind spot both
+// walks share and the live twins backstop.
+var createTableRe = regexp.MustCompile(`CREATE[ \t]+TABLE`)
 
 // WalkCreateTableColumns strips line comments from migration SQL, walks every
 // CREATE TABLE body line by line, and yields each line that tokenizes as a
@@ -38,7 +124,10 @@ func WalkCreateTableColumns(migrationSQL string, fn func(column, typeTok string)
 	inTable := false
 	for _, line := range strings.Split(StripSQLLineComments(migrationSQL), "\n") {
 		upper := strings.ToUpper(strings.TrimSpace(line))
-		if strings.HasPrefix(upper, "CREATE TABLE") {
+		// Match "CREATE TABLE" tolerant of the whitespace between the keywords
+		// (Fields collapses any run) and stricter than HasPrefix, which would
+		// also match "CREATE TABLEX".
+		if flds := strings.Fields(upper); len(flds) >= 2 && flds[0] == "CREATE" && flds[1] == "TABLE" {
 			inTable = true
 			continue
 		}

--- a/backend/internal/hub/store/storetest/schema_scan_test.go
+++ b/backend/internal/hub/store/storetest/schema_scan_test.go
@@ -1,10 +1,113 @@
 package storetest
 
 import (
+	"io/fs"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestMigrationFiles(t *testing.T) {
+	fsys := fstest.MapFS{
+		"db/migrations/00001_a.sql": {Data: []byte("CREATE TABLE a ();")},
+		"db/migrations/00002_b.sql": {Data: []byte("CREATE TABLE b ();")},
+		"db/migrations/readme.md":   {Data: []byte("not sql")},
+		"other/00003_c.sql":         {Data: []byte("CREATE TABLE c ();")},
+		// The glob must not recurse: neither goose nor the //go:embed
+		// db/migrations/*.sql pattern picks up nested files, so the scan
+		// must not either.
+		"db/migrations/sub/00004_d.sql": {Data: []byte("CREATE TABLE d ();")},
+	}
+	got, err := MigrationFiles(fsys)
+	require.NoError(t, err)
+	assert.Equal(t, []MigrationFile{
+		{Name: "db/migrations/00001_a.sql", SQL: "CREATE TABLE a ();"},
+		{Name: "db/migrations/00002_b.sql", SQL: "CREATE TABLE b ();"},
+	}, got)
+}
+
+func TestMigrationFilesEmpty(t *testing.T) {
+	_, err := MigrationFiles(fstest.MapFS{
+		"db/migrations/readme.md": {Data: []byte("not sql")},
+		"other/00001.sql":         {Data: []byte("CREATE TABLE t ();")},
+	})
+	require.ErrorContains(t, err, "no db/migrations")
+}
+
+func TestMigrationFilesReadError(t *testing.T) {
+	// A directory whose name matches the glob (fs.Glob matches dirs too) makes
+	// fs.ReadFile fail; the error must propagate, not be swallowed. Pin the
+	// path in the error so this exercises the read branch, not the
+	// no-files-matched branch.
+	_, err := MigrationFiles(fstest.MapFS{
+		"db/migrations/baddir.sql": {Mode: fs.ModeDir},
+	})
+	require.ErrorContains(t, err, "baddir.sql")
+}
+
+func TestWalkCreateTableStatements(t *testing.T) {
+	sql := `
+CREATE TABLE alpha (
+  id TEXT -- a ; semicolon inside a comment must not terminate the statement
+) COLLATE=utf8mb4_bin;
+CREATE INDEX idx ON alpha (id);
+CREATE TABLE bravo (n INT) COLLATE=utf8mb4_bin;
+`
+	var got []string
+	err := WalkCreateTableStatements(sql, func(stmt string) { got = append(got, stmt) })
+	require.NoError(t, err)
+	// Statements are uppercased and span "CREATE TABLE" to the first real ';'.
+	// The ';' inside the stripped comment must not end alpha; the CREATE INDEX
+	// between the tables is not a CREATE TABLE, so it is skipped, not yielded.
+	require.Len(t, got, 2)
+	assert.Contains(t, got[0], "CREATE TABLE ALPHA")
+	assert.Contains(t, got[0], "COLLATE=UTF8MB4_BIN")
+	assert.NotContains(t, got[0], "CREATE INDEX", "alpha must end at its own ';', not swallow the following DDL")
+	assert.Contains(t, got[1], "CREATE TABLE BRAVO")
+}
+
+func TestWalkCreateTableStatementsNoTables(t *testing.T) {
+	// Empty input and DDL without a CREATE TABLE must yield nothing and no
+	// error -- the collation guard's aggregate count sanity is what turns
+	// "walked nothing" into a failure, so the walker itself stays silent.
+	for _, sql := range []string{"", "CREATE INDEX idx ON alpha (id);\n-- comment only\n"} {
+		err := WalkCreateTableStatements(sql, func(stmt string) {
+			t.Errorf("unexpected statement yielded from %q: %s", sql, stmt)
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestWalkCreateTableStatementsMissingSemicolon(t *testing.T) {
+	// A CREATE TABLE with no terminating ';' is a malformed migration; the walk
+	// must surface an error so the caller fails loudly instead of silently
+	// skipping (or panicking on) the unterminated table.
+	err := WalkCreateTableStatements("CREATE TABLE alpha (id TEXT)", func(string) {
+		t.Error("no complete statement should be yielded for unterminated SQL")
+	})
+	require.ErrorContains(t, err, "missing terminating ;")
+}
+
+func TestWalkCreateTableStatementsToleratesWhitespace(t *testing.T) {
+	// A future migration writing "CREATE  TABLE" with two spaces or a tab must
+	// not hide the statement from the collation scan -- the CREATE TABLE anchor
+	// tolerates any horizontal whitespace so the table's COLLATE clause is still
+	// checked. A newline between the keywords is out of contract (a line-shape
+	// blind spot shared with WalkCreateTableColumns, backstopped by the live
+	// twin), so it is not asserted here.
+	for _, gap := range []string{"  ", "\t"} {
+		var got []string
+		err := WalkCreateTableStatements("CREATE"+gap+"TABLE gamma (n INT) COLLATE=utf8mb4_bin;", func(stmt string) {
+			got = append(got, stmt)
+		})
+		require.NoError(t, err, "gap=%q", gap)
+		require.Len(t, got, 1, "gap=%q", gap)
+		assert.Contains(t, got[0], "TABLE GAMMA", "gap=%q", gap)
+		assert.Contains(t, got[0], "COLLATE=UTF8MB4_BIN", "gap=%q", gap)
+	}
+}
 
 func TestStripSQLLineComments(t *testing.T) {
 	in := "CREATE TABLE t ( -- issued; force-expires\n  id TEXT, -- trailing\n  n INT\n);\n"
@@ -46,6 +149,22 @@ CREATE TABLE bravo (
 		{"constraint", "FK"},
 		{"seen_at", "TIMESTAMPTZ"},
 	}, got)
+}
+
+func TestWalkCreateTableColumnsToleratesWhitespace(t *testing.T) {
+	// A future migration writing "CREATE  TABLE" with two spaces or a tab must
+	// still be walked, so the table's columns are not silently dropped from the
+	// decltype scan. A newline between the keywords is out of contract (a
+	// line-shape blind spot shared with WalkCreateTableStatements, backstopped
+	// by the live twin), so it is not asserted here.
+	for _, gap := range []string{"  ", "\t"} {
+		schema := "CREATE" + gap + "TABLE charlie (\n  touched_at DATETIME(3)\n);\n"
+		var got [][2]string
+		WalkCreateTableColumns(schema, func(name, typeTok string) {
+			got = append(got, [2]string{name, typeTok})
+		})
+		assert.Equal(t, [][2]string{{"touched_at", "DATETIME(3)"}}, got, "gap=%q", gap)
+	}
 }
 
 func TestWalkCreateTableColumnsNoTables(t *testing.T) {


### PR DESCRIPTION
## Motivation
The static (Docker-free) schema-convention guards — binary collation for MySQL, `DATETIME(3..6)` precision for MySQL, and `TIMESTAMPTZ` for Postgres — only ever inspected `00001_initial.sql` via a hardcoded `os.ReadFile`. Only the integration-tagged "live twin" tests (which require Docker) actually applied every migration and checked the resulting schema, so a future migration that violated one of these conventions (e.g. a new table missing `COLLATE=utf8mb4_bin`) would silently pass the default test suite that runs on every PR and only be caught by the Docker-gated suite, if at all.

Closes #300.

## Modifications
- Added `storetest.MigrationFiles(fs.FS)`, which globs `db/migrations/*.sql` from each dialect's `//go:embed` FS (the same set fed to goose), reads and sorts them deterministically, and errors if zero files match so a glob/layout drift fails loudly instead of silently passing.
- Extracted the inline `CREATE TABLE ... ;` statement splitting into a reusable `storetest.WalkCreateTableStatements`, alongside the existing `WalkCreateTableColumns`, with its own unit tests. It now errors on an unterminated `CREATE TABLE` (missing `;`).
- Hardened `CREATE TABLE` keyword matching in both walkers to tolerate arbitrary horizontal whitespace between the keywords, and made the column walker stricter (previously a `HasPrefix` check would also incorrectly match `CREATE TABLEX`).
- Rewrote the three static tests (MySQL collation, MySQL datetime, Postgres timestamptz) to loop over every embedded migration file, prefix assertion failures with the file name, and aggregate the `>20` sanity count across all files (since any single future migration may legitimately contain no `CREATE TABLE`).
- Updated comments in the initial MySQL migration and in the live-twin integration tests to describe the new all-files static coverage and the remaining line-shape/spacing edge cases that only the live twins still backstop.

No production code or schema changed; this is test infrastructure and comment-only.

## Result
- Closes #300
- A migration file added anywhere in `db/migrations/` that violates the binary-collation, MySQL datetime-precision, or Postgres timestamptz conventions now fails the default (Docker-free) test suite, naming the offending file, instead of only failing the Docker-gated integration tests.
- `storetest` gains reusable, independently-tested helpers (`MigrationFiles`, `WalkCreateTableStatements`) for future schema-convention guards to build on.
