### PR TITLE
fix(desktop): Replace drain WaitGroups with a selectable waitCounter

### DIFF
--- a/desktop/go/drain.go
+++ b/desktop/go/drain.go
@@ -12,9 +12,9 @@ import (
 // Every bounded drain in the sidecar routes through here -- the operation drain
 // (App.drainOperations), the RPC handler drains before and after the writer is
 // interrupted (RPCSession.drainHandlers), and the relay read-loop drain
-// (drainRelay, after wsRelay.detach). Each had hand-rolled the same spawn-waiter/stoppable-timer/
-// select/warn dance, and their comments already cross-referenced one another as
-// mirrors; one helper means the contract they share -- a promptly-finished waiter
+// (drainRelay, after wsRelay.detach). Each had hand-rolled the same
+// stoppable-timer/select/warn dance, and their comments already cross-referenced
+// one another as mirrors; one helper means the contract they share -- a promptly-finished waiter
 // never leaves a live timer on the runtime heap, and a straggler is abandoned
 // rather than allowed to wedge teardown -- cannot drift between them.
 //
@@ -43,21 +43,68 @@ func waitBounded(done <-chan struct{}, timeout time.Duration, warnMsg string) bo
 	}
 }
 
-// waitGroupDone returns a channel that closes once wg's counter reaches zero, so
-// a WaitGroup can be handed to waitBounded.
-//
-// The spawned waiter parks on wg.Wait() until the counter hits zero. If a
-// handler/operation never returns (a non-cancellable exec or filesystem scan),
-// that waiter leaks -- but only doubling an already-unavoidable leak, since Go
-// cannot kill the stuck goroutine and wg.Wait() cannot be select'd on, and the
-// waiter exits cleanly the moment the straggler ever returns. Replacing the
-// WaitGroups with a cancellable counter to remove it is tracked (with the
-// recommendation to leave it) in https://github.com/leapmux/leapmux/issues/297.
-func waitGroupDone(wg *sync.WaitGroup) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	return done
+// waitCounter counts in-flight work like a sync.WaitGroup, but exposes
+// completion as a channel so a drain can wait with a deadline. sync.WaitGroup
+// was unusable here: Wait() cannot be select'ed on, so handing it to
+// waitBounded required a spawned waiter goroutine that leaked (parked forever
+// on Wait) whenever a permanently-stuck straggler was abandoned -- issue #297.
+type waitCounter struct {
+	mu   sync.Mutex
+	n    int
+	zero chan struct{} // created lazily by doneChan while n > 0; closed and nil'd when n reaches 0
+}
+
+func (c *waitCounter) add() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.n++
+}
+
+func (c *waitCounter) done() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.n == 0 {
+		// Panic BEFORE mutating (unlike sync.WaitGroup, which decrements first):
+		// if a future recover-middleware swallows this panic, the counter is still
+		// consistent. Decrement-then-panic would leave n at -1, where the next
+		// add() lands on 0 and a concurrent drain's doneChan would report an idle
+		// counter while that operation is live.
+		panic("waitCounter: negative counter")
+	}
+	c.n--
+	if c.n == 0 && c.zero != nil {
+		close(c.zero)
+		c.zero = nil
+	}
+}
+
+// doneChan reports the counter's next zero-crossing as of the call. Adds after
+// that crossing do not reopen the returned channel -- a new cycle needs a fresh
+// doneChan call -- so a caller must not let an add() slip in between sampling
+// and the wait the sample is meant to cover. (sync.WaitGroup's best-effort
+// misuse check would usually have panicked on "Add called concurrently with
+// Wait" -- it fires only when Add catches a parked waiter at that instant;
+// waitCounter silently legalizes the race outright, so each drain call site
+// documents why its ordering upholds the contract.)
+func (c *waitCounter) doneChan() <-chan struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.n == 0 {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	if c.zero == nil {
+		c.zero = make(chan struct{})
+	}
+	return c.zero
+}
+
+// wait blocks, bounded by timeout, for the zero-crossing current as of this
+// call -- it samples doneChan itself, so the caller never holds the raw
+// channel -- and reports whether the counter hit zero in time. On timeout it
+// logs warnMsg (omitted when empty) and gives up; the straggling work is the
+// caller's to abandon.
+func (c *waitCounter) wait(timeout time.Duration, warnMsg string) bool {
+	return waitBounded(c.doneChan(), timeout, warnMsg)
 }

--- a/desktop/go/drain_test.go
+++ b/desktop/go/drain_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDrainDoesNotLeakWaiterOnAbandonedStraggler is the operationGate side of
+// the #297 reproducer (rpc_test.go's
+// TestDrainHandlersDoesNotLeakWaiterOnAbandonedStraggler covers the
+// drainHandlers side the leak was reported on): a permanently-stuck operation
+// (released only in Cleanup) must not leave a waiter goroutine parked per
+// timed-out drain. Pre-fix waitGroupDone spawned one such waiter per drain;
+// post-fix waitCounter removes the spawn entirely.
+//
+// The scan keys on sync.(*WaitGroup).Wait / drain.go frames -- not the
+// waitGroupDone symbol -- so the assertion stays meaningful after the fix
+// deletes that helper.
+func TestDrainDoesNotLeakWaiterOnAbandonedStraggler(t *testing.T) {
+	var g operationGate
+	done, ok := g.begin()
+	require.True(t, ok)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+		done()
+	})
+	// Keep a live reference to release so the stuck admission is "an operation"
+	// that never returns until Cleanup -- mirroring a non-cancellable exec.
+	go func() { <-release }()
+
+	const drains = 8
+	for range drains {
+		g.drain(time.Millisecond, "")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastDump string
+	for {
+		lastDump = allGoroutineStacks()
+		leaked := countDrainWaiterFrames(lastDump)
+		if leaked == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected no drain waiter goroutines after abandoning a straggler %d times; found %d\n%s",
+				drains, leaked, lastDump)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func allGoroutineStacks() string {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// countDrainWaiterFrames counts goroutines whose stacks show a leaked drain
+// waiter: parked in sync.(*WaitGroup).Wait (the shape the pre-fix waitGroupDone
+// bridge leaked), or carrying a desktop/go/drain.go frame (insurance against a
+// reintroduced waiter of any other shape -- nothing legitimately runs drain.go
+// code once every drain has returned, and the leak tests scan only then, with
+// no concurrent test executing a drain). The stuck operation itself waits on a
+// channel and does not match.
+func countDrainWaiterFrames(dump string) int {
+	count := 0
+	for _, block := range strings.Split(dump, "\n\n") {
+		if strings.Contains(block, "sync.(*WaitGroup).Wait") ||
+			strings.Contains(block, "desktop/go/drain.go") {
+			count++
+		}
+	}
+	return count
+}
+
+// assertClosed fails the test unless ch is already closed. waitCounter channels
+// are only ever closed, never sent on, so a ready receive means closed.
+func assertClosed(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatal(msg)
+	}
+}
+
+// assertOpen fails the test if ch is already closed.
+func assertOpen(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(msg)
+	default:
+	}
+}
+
+func TestWaitCounterIdleDoneChanIsAlreadyClosed(t *testing.T) {
+	var c waitCounter
+	assertClosed(t, c.doneChan(), "idle doneChan must return an already-closed channel")
+}
+
+func TestWaitCounterDoneChanClosesOnlyAtZero(t *testing.T) {
+	var c waitCounter
+	c.add()
+	c.add()
+	done := c.doneChan()
+	c.done()
+	assertOpen(t, done, "doneChan must stay open while the counter is still positive")
+	c.done()
+	assertClosed(t, done, "doneChan must close when the counter reaches zero")
+}
+
+func TestWaitCounterDoneChanReuseAfterZeroCrossing(t *testing.T) {
+	var c waitCounter
+	c.add()
+	a := c.doneChan()
+	c.done()
+	assertClosed(t, a, "channel A must close on the first zero-crossing")
+
+	c.add()
+	b := c.doneChan()
+	assert.True(t, a != b, "a new cycle must return a fresh channel, not reopen A")
+	assertOpen(t, b, "channel B must start open")
+	c.done()
+	assertClosed(t, b, "channel B must close on the second zero-crossing")
+	assertClosed(t, a, "channel A must stay closed after the later cycle")
+}
+
+func TestWaitCounterDoneChanSameWhileBusy(t *testing.T) {
+	var c waitCounter
+	c.add()
+	a := c.doneChan()
+	b := c.doneChan()
+	assert.True(t, a == b, "both drain phases must observe one signal channel")
+	c.done()
+}
+
+func TestWaitCounterDoneOnIdlePanics(t *testing.T) {
+	var idle waitCounter
+	assert.PanicsWithValue(t, "waitCounter: negative counter", func() { idle.done() })
+
+	var cycled waitCounter
+	cycled.add()
+	cycled.done()
+	assert.PanicsWithValue(t, "waitCounter: negative counter", func() { cycled.done() })
+
+	// The panic fires before the counter mutates, so a caller that recovers it
+	// (a future recover-middleware) finds the counter consistent: still idle, and
+	// a fresh add/done cycle still works. A decrement-then-panic ordering would
+	// leave n at -1 here, where one add() masks the corruption as "idle" and a
+	// concurrent drain would report completion under live work.
+	assertClosed(t, cycled.doneChan(), "a recovered negative-counter panic must leave the counter idle")
+	cycled.add()
+	relatch := cycled.doneChan()
+	assertOpen(t, relatch, "the counter must still track new work after a recovered panic")
+	cycled.done()
+	assertClosed(t, relatch, "the counter must still close at zero after a recovered panic")
+}
+
+// TestWaitCounterWaitReportsCompletionWithinBudget pins the wait() facade both
+// callers drain through: an idle counter wins even on an exhausted budget
+// (waitBounded's fast path), a held counter times out with false, and a counter
+// released mid-wait reports true promptly.
+func TestWaitCounterWaitReportsCompletionWithinBudget(t *testing.T) {
+	var idle waitCounter
+	assert.True(t, idle.wait(0, ""), "an idle counter must win even on an exhausted budget")
+
+	var busy waitCounter
+	busy.add()
+	assert.False(t, busy.wait(time.Millisecond, ""), "a held counter must report a timed-out wait")
+	assert.False(t, busy.wait(0, ""),
+		"a held counter must fail fast, not hang, on an exhausted budget -- the shape drainHandlers' shared deadline feeds it")
+	busy.done()
+
+	var joined waitCounter
+	joined.add()
+	result := make(chan bool, 1)
+	go func() { result <- joined.wait(2*time.Second, "") }()
+	joined.done()
+	select {
+	case ok := <-result:
+		assert.True(t, ok, "wait must report success once the straggler finishes")
+	case <-time.After(time.Second):
+		t.Fatal("wait did not return after the counter reached zero")
+	}
+}
+
+func TestWaitCounterConcurrentAddDoneWithWaiter(t *testing.T) {
+	var c waitCounter
+	const n = 64
+	for range n {
+		c.add()
+	}
+	done := c.doneChan()
+	var started sync.WaitGroup
+	started.Add(n)
+	for range n {
+		go func() {
+			started.Done()
+			c.done()
+		}()
+	}
+	started.Wait()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("doneChan must close exactly once after concurrent dones")
+	}
+	// A second receive must not block: closed exactly once.
+	assertClosed(t, done, "doneChan must stay closed after the single close")
+}
+
+// TestWaitCounterConcurrentDoneChanGrabsShareOneChannel drives many concurrent
+// doneChan grabs while the counter is held positive: all of them must return
+// the one shared channel (the lazily-created c.zero), and all must observe the
+// close once the final done() fires AFTER every grab has completed. The grabs
+// race each other, not the close -- that interleaving is
+// TestWaitCounterDoneChanRacesFinalDone's job.
+func TestWaitCounterConcurrentDoneChanGrabsShareOneChannel(t *testing.T) {
+	var c waitCounter
+	c.add()
+	const grabbers = 32
+	ch := make(chan (<-chan struct{}), grabbers)
+	var ready sync.WaitGroup
+	ready.Add(grabbers)
+	for range grabbers {
+		go func() {
+			got := c.doneChan()
+			ready.Done()
+			ch <- got
+		}()
+	}
+	ready.Wait()
+	c.done()
+	// One stopped timer shared across all receives, not a time.After per
+	// iteration: each of those would pin a live 2s timer on the runtime heap
+	// (the cost waitBounded's own doc warns about) for receives that are
+	// expected to be instantly ready.
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+	var first <-chan struct{}
+	for range grabbers {
+		got := <-ch
+		if first == nil {
+			first = got
+		} else {
+			assert.True(t, first == got)
+		}
+		select {
+		case <-got:
+		case <-timeout.C:
+			t.Fatal("every concurrent doneChan grab must observe the close")
+		}
+	}
+}
+
+// TestWaitCounterDoneChanRacesFinalDone interleaves doneChan grabs with the
+// final done()'s zero-crossing itself: a grabber may win the lock before the
+// crossing (shared c.zero, closed by done) or after it (a fresh pre-closed
+// channel). Either way the channel it holds must be closed -- no interleaving
+// may hand out a channel that never closes. Iterated to actually hit both
+// sides of the crossing under -race.
+func TestWaitCounterDoneChanRacesFinalDone(t *testing.T) {
+	for range 200 {
+		var c waitCounter
+		c.add()
+		const grabbers = 8
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(grabbers)
+		for range grabbers {
+			go func() {
+				defer wg.Done()
+				<-start
+				got := c.doneChan()
+				// NewTimer+Stop, not time.After: 200 iterations x 8 grabbers
+				// would otherwise strand 1,600 live 2s timers on the runtime
+				// heap for receives that are almost always instantly ready.
+				timeout := time.NewTimer(2 * time.Second)
+				defer timeout.Stop()
+				select {
+				case <-got:
+				case <-timeout.C:
+					t.Error("a doneChan grabbed while the final done raced must still close")
+				}
+			}()
+		}
+		close(start)
+		c.done()
+		wg.Wait()
+	}
+}

--- a/desktop/go/operation_gate.go
+++ b/desktop/go/operation_gate.go
@@ -20,7 +20,7 @@ import (
 // owns the flag rather than reading ctx.Err().
 type operationGate struct {
 	mu     sync.Mutex
-	wg     sync.WaitGroup
+	wc     waitCounter
 	closed bool
 }
 
@@ -30,7 +30,7 @@ type operationGate struct {
 // The returned func is safe to call any number of times: it routes through a
 // per-admission sync.Once so a caller that defers done() AND calls it on a
 // manual cleanup path (or any other double-invocation) cannot drive the
-// WaitGroup negative and panic the sidecar. sync.Once also makes the
+// waitCounter negative and panic the sidecar. sync.Once also makes the
 // "exactly-once" contract mechanical rather than a caller-discipline rule,
 // matching the loudness sync.Mutex already chooses for unlock-of-unlocked.
 func (g *operationGate) begin() (func(), bool) {
@@ -39,9 +39,9 @@ func (g *operationGate) begin() (func(), bool) {
 	if g.closed {
 		return nil, false
 	}
-	g.wg.Add(1)
+	g.wc.add()
 	var once sync.Once
-	done := func() { once.Do(g.wg.Done) }
+	done := func() { once.Do(g.wc.done) }
 	return done, true
 }
 
@@ -61,6 +61,11 @@ func (g *operationGate) close(cancel func()) {
 // side effects complete before shared state is torn down. A straggler that
 // ignores cancellation -- a non-cancellable editor launch or filesystem scan --
 // is abandoned after the timeout and reclaimed at process exit.
+//
+// waitCounter's no-add-after-sample contract holds here by ordering: the one
+// production caller (App.Shutdown) runs close() before drain, and close flips
+// closed under the same lock begin checks, so once wait samples the counter no
+// operation can be admitted.
 func (g *operationGate) drain(timeout time.Duration, warnMsg string) {
-	waitBounded(waitGroupDone(&g.wg), timeout, warnMsg)
+	g.wc.wait(timeout, warnMsg)
 }

--- a/desktop/go/operation_gate_test.go
+++ b/desktop/go/operation_gate_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -10,7 +11,7 @@ import (
 // TestOperationGateBeginDoneIsIdempotent pins FOOTGUNS-2: the func returned by
 // begin() must be safe to call more than once. A caller that defers done() AND
 // invokes it on a manual cleanup path (or any refactor that reaches done twice)
-// must not drive the WaitGroup negative and panic the sidecar. Routing through a
+// must not drive the waitCounter negative and panic the sidecar. Routing through a
 // per-admission sync.Once makes "exactly once" mechanical rather than a
 // caller-discipline rule.
 func TestOperationGateBeginDoneIsIdempotent(t *testing.T) {
@@ -19,15 +20,15 @@ func TestOperationGateBeginDoneIsIdempotent(t *testing.T) {
 	done, ok := g.begin()
 	assert.True(t, ok, "an open gate must admit the operation")
 
-	// Calling done() more than once must not panic. Under the raw g.wg.Done
-	// method value this would crash with "sync: negative WaitGroup counter".
+	// Calling done() more than once must not panic. Under the raw g.wc.done
+	// method value this would crash with "waitCounter: negative counter".
 	assert.NotPanics(t, func() {
 		done()
 		done()
 		done()
 	})
 
-	// drain still returns promptly: the WaitGroup reached zero on the first call.
+	// drain still returns promptly: the waitCounter reached zero on the first call.
 	assert.NotPanics(t, func() { g.drain(0, "") })
 }
 
@@ -45,7 +46,7 @@ func TestOperationGateBeginRejectsAfterClose(t *testing.T) {
 }
 
 // TestOperationGateConcurrentBeginDone exercises the once-wrapper under
-// concurrent begin/done pairs to confirm the WaitGroup never goes negative under
+// concurrent begin/done pairs to confirm the waitCounter never goes negative under
 // the racing done() invocations the wrapper exists to make safe.
 func TestOperationGateConcurrentBeginDone(t *testing.T) {
 	var g operationGate
@@ -66,4 +67,45 @@ func TestOperationGateConcurrentBeginDone(t *testing.T) {
 	}
 	wg.Wait()
 	assert.NotPanics(t, func() { g.drain(0, "") })
+}
+
+// TestOperationGateDrainJoinsOperationReleasedMidWait covers the released-mid-drain
+// path every other gate test skips by draining an already-idle gate with timeout 0:
+// begin, start drain in a goroutine, release, assert drain returns promptly.
+func TestOperationGateDrainJoinsOperationReleasedMidWait(t *testing.T) {
+	var g operationGate
+	done, ok := g.begin()
+	assert.True(t, ok)
+
+	finished := make(chan struct{})
+	go func() {
+		g.drain(2*time.Second, "")
+		close(finished)
+	}()
+
+	// Wait until the drain has observably parked: doneChan creates wc.zero only
+	// while the counter is positive, so a non-nil zero proves the drain goroutine
+	// holds the live channel done() must close. A bare sleep could lose this race
+	// -- done() would zero the counter first and the drain would take the idle
+	// pre-closed fast path, passing without ever exercising the mid-wait join.
+	parkDeadline := time.Now().Add(time.Second)
+	for {
+		g.wc.mu.Lock()
+		parked := g.wc.zero != nil
+		g.wc.mu.Unlock()
+		if parked {
+			break
+		}
+		if time.Now().After(parkDeadline) {
+			t.Fatal("drain goroutine never parked on the counter's zero channel")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	done()
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("drain must return promptly once the in-flight operation finishes")
+	}
 }

--- a/desktop/go/rpc.go
+++ b/desktop/go/rpc.go
@@ -36,7 +36,7 @@ type frameReadResult struct {
 // every request is accepted and dispatched to its own handler goroutine, so a
 // burst of concurrent calls (or one large proxy upload) never drops an
 // in-flight response or forces a reconnect. Teardown stays bounded: handlers
-// are tracked by a WaitGroup and drained (interruptably) in Run's defer. Do not
+// are tracked by a waitCounter and drained (interruptably) in Run's defer. Do not
 // reintroduce an admission/budget gate without reconsidering that contract.
 
 // handlerDrainTimeout is the hard cap on waiting for in-flight handlers, both
@@ -56,7 +56,7 @@ var handlerDrainTimeout time.Duration = 5 * time.Second
 // It has to be its own budget, because reaching that phase on the clean path
 // means the shared budget is already spent by construction: waitBounded only
 // returns false once its timer has fired. Without a floor the post-interrupt wait
-// would be a single non-blocking look at `done`, which a handler that the
+// would be a single non-blocking look at the counter, which a handler that the
 // interrupt just unblocked cannot win in the microseconds it needs to unwind --
 // so every clean drain past the flush window would warn and abandon handlers that
 // were about to finish. A small fixed grace is the right shape here: interrupting
@@ -82,7 +82,7 @@ func (s *RPCSession) Run() error {
 	sessionCtx, cancelSession := context.WithCancelCause(s.app.ctx)
 	readResults := make(chan frameReadResult, 1)
 	go s.readFrames(readResults, cancelSession)
-	var handlers sync.WaitGroup
+	var handlers waitCounter
 	defer func() {
 		cancelSession(nil)
 		s.app.SetEventSink(nil)
@@ -106,9 +106,9 @@ func (s *RPCSession) Run() error {
 			if req == nil {
 				continue
 			}
-			handlers.Add(1)
+			handlers.add()
 			go func(req *desktoppb.Request) {
-				defer handlers.Done()
+				defer handlers.done()
 				s.dispatch(sessionCtx, req)
 			}(req)
 		}
@@ -136,8 +136,7 @@ func (s *RPCSession) dispatch(sessionCtx context.Context, req *desktoppb.Request
 	s.handleRequest(sessionCtx, req)
 }
 
-func (s *RPCSession) drainHandlers(handlers *sync.WaitGroup, cause error) {
-	done := waitGroupDone(handlers)
+func (s *RPCSession) drainHandlers(handlers *waitCounter, cause error) {
 	// On a clean shutdown (no cause, or a plain Canceled) let handlers flush their
 	// final responses BEFORE the writer is interrupted; on an error teardown the
 	// peer is already gone, so there is nothing to flush and we interrupt at once.
@@ -171,12 +170,17 @@ func (s *RPCSession) drainHandlers(handlers *sync.WaitGroup, cause error) {
 	// the stopSolo teardown that follows runs unbounded; main.go also calls
 	// App.Shutdown (through the same shutdownOnce) on its way out. So this budget
 	// makes the drain give up promptly; it does not promise the process is gone.
+	//
+	// waitCounter's no-add-after-sample contract holds here by ordering: only
+	// Run's loop calls handlers.add(), and that loop has exited before this
+	// deferred drain runs, so the counter only decreases from here on and each
+	// phase's wait may safely re-sample it.
 	deadline := time.Now().Add(handlerDrainTimeout)
 	if cause == nil || errors.Is(cause, context.Canceled) {
 		// No warning on this phase: exceeding the flush window is not itself a
 		// failure, it just means the writer is interrupted and the wait below
 		// reports any straggler.
-		if waitBounded(done, time.Until(deadline), "") {
+		if handlers.wait(time.Until(deadline), "") {
 			return
 		}
 	}
@@ -184,7 +188,7 @@ func (s *RPCSession) drainHandlers(handlers *sync.WaitGroup, cause error) {
 	// Whatever is left of the shared budget, but never less than interruptGrace: the
 	// clean path only gets here once the budget is spent, so without the floor this
 	// phase would never actually wait on the interrupt it just issued.
-	waitBounded(done, max(time.Until(deadline), interruptGrace),
+	handlers.wait(max(time.Until(deadline), interruptGrace),
 		"rpc session: handler drain timed out; abandoning in-flight handlers")
 }
 

--- a/desktop/go/rpc_test.go
+++ b/desktop/go/rpc_test.go
@@ -389,12 +389,12 @@ func TestDrainHandlersSharesOneBudgetAcrossBothPhases(t *testing.T) {
 
 	// A handler that ignores sessionCtx entirely: it outlives any budget, so the
 	// drain must be bounded by the budget rather than by the handler.
-	var handlers sync.WaitGroup
-	handlers.Add(1)
+	var handlers waitCounter
+	handlers.add()
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
 	go func() {
-		defer handlers.Done()
+		defer handlers.done()
 		<-release
 	}()
 
@@ -406,6 +406,57 @@ func TestDrainHandlersSharesOneBudgetAcrossBothPhases(t *testing.T) {
 		"both phases must come out of one budget, not one each")
 	assert.GreaterOrEqual(t, elapsed, handlerDrainTimeout,
 		"the drain must still spend its budget waiting for the straggler")
+}
+
+// TestDrainHandlersDoesNotLeakWaiterOnAbandonedStraggler is the drainHandlers
+// side of the #297 reproducer -- the path the leak was actually reported on
+// (one timed-out handler drain per webview reconnect in dev-socket mode).
+// drain_test.go's TestDrainDoesNotLeakWaiterOnAbandonedStraggler covers the
+// operationGate side; both drains share waitCounter today, but only a per-path
+// test catches a future divergence that reintroduces a spawn-waiter on one
+// side alone.
+func TestDrainHandlersDoesNotLeakWaiterOnAbandonedStraggler(t *testing.T) {
+	original := handlerDrainTimeout
+	handlerDrainTimeout = time.Millisecond
+	t.Cleanup(func() { handlerDrainTimeout = original })
+	originalGrace := interruptGrace
+	interruptGrace = time.Millisecond
+	t.Cleanup(func() { interruptGrace = originalGrace })
+
+	app := NewApp("")
+	var output bytes.Buffer
+	session := NewRPCSession(app, bytes.NewReader(nil), &output, nil)
+
+	// A handler that never returns until Cleanup: every drain against it times
+	// out and abandons it, exactly the straggler that leaked one parked waiter
+	// per drain pre-fix.
+	var handlers waitCounter
+	handlers.add()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	go func() {
+		defer handlers.done()
+		<-release
+	}()
+
+	const drains = 8
+	for range drains {
+		session.drainHandlers(&handlers, nil)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		dump := allGoroutineStacks()
+		leaked := countDrainWaiterFrames(dump)
+		if leaked == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected no drain waiter goroutines after %d abandoned handler drains; found %d\n%s",
+				drains, leaked, dump)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // An event frame that cannot be delivered must tear down its RELAY and tell the
@@ -983,11 +1034,11 @@ func TestDrainHandlersJoinsHandlerReleasedByTheInterrupt(t *testing.T) {
 	writer := newBlockingWriteCloser()
 	session := NewRPCSession(app, bytes.NewReader(nil), writer, nil)
 
-	var handlers sync.WaitGroup
-	handlers.Add(1)
+	var handlers waitCounter
+	handlers.add()
 	var finished atomic.Bool
 	go func() {
-		defer handlers.Done()
+		defer handlers.done()
 		// Blocked writing its response to a peer that stopped reading: exactly the
 		// handler interruptWriter exists to release.
 		session.writeOK(1)


### PR DESCRIPTION
## Motivation
Every bounded drain in the sidecar (`operationGate`, `RPCSession.drainHandlers`) waited on a `sync.WaitGroup`, but `WaitGroup.Wait()` cannot be select'ed on with a timeout. To make it selectable, each drain spawned a bridge goroutine (`waitGroupDone`) that parked on `Wait()` and closed a channel when it returned. When the tracked operation or handler was a permanently-stuck straggler (a non-cancellable exec call or filesystem scan), the drain correctly gave up after its budget, but the bridge goroutine had no way to unpark - it leaked forever, one per timed-out drain. In dev-socket mode this meant one leaked goroutine per webview reconnect. Fixes #297.

## Modifications
- Adds `waitCounter` (desktop/go/drain.go): a mutex-guarded in-flight counter that lazily exposes a channel closed at the next zero-crossing, so a drain can `select` on completion directly with no bridge goroutine to leak. An already-idle counter returns a pre-closed channel, so the already-finished case is deterministic instead of racing an unstarted goroutine.
- Migrates both drain call sites off `sync.WaitGroup`: `operationGate` (`wg` -> `wc`, `Add`/`Done` -> `add`/`done`) and `RPCSession.drainHandlers`/`Run` (local `handlers` WaitGroup -> `waitCounter`). The two-phase bounded drain protocol and shared timeout budget are unchanged.
- `done()` panics *before* decrementing (the opposite order from `sync.WaitGroup`), so a recovered negative-counter panic can never leave the count at -1, which would let a later `add()` disguise live work as an idle counter.
- Removes the `waitGroupDone` bridge helper; drain call sites go through `waitCounter.wait()`, which samples the zero-crossing channel internally so no raw channel escapes the counter.
- Adds drain_test.go covering `waitCounter` semantics (zero-crossing, channel reuse across cycles, negative-counter panic and post-recovery consistency, budgeted `wait()`, concurrent `add`/`done` races) plus a goroutine-leak regression test, and extends operation_gate_test.go / rpc_test.go with per-path leak and mid-wait-join reproducers. Leak assertions key on `WaitGroup.Wait`/drain.go stack frames rather than the deleted `waitGroupDone` symbol, so they can't pass vacuously.

## Result
- Closes #297
- A drain that times out waiting on a stuck operation or RPC handler no longer leaks a parked goroutine. Long-running dev sessions with repeated webview reconnects no longer accumulate one extra stuck goroutine per reconnect.
