### PR TITLE
test(desktop): Pin lifetime-cancel release of port-forward conns

### DIFF
--- a/desktop/go/tunnel_test.go
+++ b/desktop/go/tunnel_test.go
@@ -1152,6 +1152,86 @@ func TestPortForwardReleasesConnWhenClientAborts(t *testing.T) {
 	assert.Zero(t, remaining, "both ends must be released back to the tunnel")
 }
 
+// TestPortForwardReleasesConnsOnLifetimeCancel pins the context.AfterFunc arm of
+// handlePortForward (issue #280): cancelling the parent lifetime ctx — without
+// tunnel teardown (t.close / DeleteTunnel) and without a client abort — is the
+// only path that closes both conn ends. The AfterFunc callback force-closes
+// local and remote, unblocking the parked copyHalf goroutines so the handler
+// returns and clears tun.connections. Teardown tests go through t.close(),
+// which hard-closes tracked conns independently of the ctx, so they do not
+// exercise this arm.
+func TestPortForwardReleasesConnsOnLifetimeCancel(t *testing.T) {
+	m := NewTunnelManager()
+	defer m.CloseAll()
+	ctx, cancel := context.WithCancel(context.Background())
+	// Do not register cancel on t.Cleanup: the test cancels explicitly as the
+	// trigger under test. A deferred CloseAll still tears the manager down.
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	tun := &tunnel{
+		info: TunnelInfo{
+			ID: "pf-lifetime", WorkerID: "w", Type: tunnelTypePortForward,
+			TargetAddr: "target", TargetPort: 80,
+			BindAddr: "127.0.0.1", BindPort: listener.Addr().(*net.TCPAddr).Port,
+		},
+		hubURL:      "http://hub",
+		listener:    listener,
+		cancel:      cancel,
+		connections: make(map[net.Conn]struct{}),
+	}
+	m.mu.Lock()
+	m.tunnels[tun.info.ID] = tun
+	m.mu.Unlock()
+
+	target, targetPeer := net.Pipe()
+	t.Cleanup(func() {
+		_ = target.Close()
+		_ = targetPeer.Close()
+	})
+	dialed := make(chan struct{})
+	m.dial = func(_ context.Context, _ *managedChannel, _ string, _ uint32) (net.Conn, error) {
+		close(dialed)
+		return target, nil
+	}
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	local, err := listener.Accept()
+	require.NoError(t, err)
+
+	handled := make(chan struct{})
+	go func() {
+		defer close(handled)
+		m.handlePortForward(ctx, local, tun, nil)
+	}()
+
+	select {
+	case <-dialed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("port forward never dialled the target")
+	}
+
+	// Cancel only the lifetime ctx — no t.close(), DeleteTunnel, or client abort.
+	// Both copyHalf directions are parked (nothing written); AfterFunc must
+	// force-close both ends so the handler returns.
+	cancel()
+
+	select {
+	case <-handled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handlePortForward did not release on lifetime cancel")
+	}
+	assertConnectionClosed(t, client, "client connection remained open after lifetime cancel")
+	assertConnectionClosed(t, targetPeer, "remote tunnel connection remained open after lifetime cancel")
+	tun.mu.Lock()
+	remaining := len(tun.connections)
+	tun.mu.Unlock()
+	assert.Zero(t, remaining, "both ends must be released back to the tunnel")
+}
+
 // gatedTunnelListener lets a test place an accepted conn into the serve loop at a
 // chosen instant: the first Accept parks until the gate opens (or the serve ctx
 // dies), later ones park until the serve ctx dies. Only the Serve goroutine calls


### PR DESCRIPTION
## Motivation
Issue #280 asked to replace a parked per-connection watcher goroutine in `handlePortForward` with `context.AfterFunc`, which force-closes the local and remote connection ends when the per-connection context is cancelled (a `copyHalf` hard error, or the parent lifetime context ending). That fix landed in commit b2ab3883 (PR #299), and issue #280 was closed with a reference to this follow-up regression test.

The issue itself calls out the lifetime-cancel trigger as "the one case where the watcher arm is strictly load-bearing, since it bypasses `t.close`" — i.e. it's the only path that depends on the `AfterFunc` callback rather than on `t.close`/`DeleteTunnel` teardown or a client abort. Despite that, no test exercised it: the existing coverage (`TestPortForwardReleasesConnWhenClientAborts` and `TestTunnelManager_TeardownClosesPortForwardConnections`) only exercises client-abort and `t.close()` teardown paths. As a result, removing the `AfterFunc` arm entirely would have passed the full test suite with no failures.

## Modifications
- Add `TestPortForwardReleasesConnsOnLifetimeCancel` in `desktop/go/tunnel_test.go`, targeting the `context.AfterFunc` force-close arm of `handlePortForward` (`desktop/go/tunnel.go` lines ~840-857).
- The test builds a `TunnelManager` with a real TCP listener, a stubbed `m.dial` returning a `net.Pipe` target, and a live client connection, then runs `handlePortForward` in a goroutine and waits for the target to be dialled.
- It cancels only the lifetime context directly (no `t.close`/`DeleteTunnel`, no client abort, both `copyHalf` directions parked with no data written), then asserts the handler returns, both the client and remote peer connections are closed, and `tun.connections` drains back to zero.
- Deliberately omits registering `cancel` on `t.Cleanup` so the explicit `cancel()` call is the sole trigger under test; a deferred `m.CloseAll()` still tears down the manager for cleanup.
- Test-only change: no production code, public API, or behavior is modified.

## Result
- The regression test for issue #280 (already fixed in PR #299 and closed referencing this test) is now in place.
- The `AfterFunc` force-close path in `handlePortForward` is covered: neutering that callback makes the new test fail with "handlePortForward did not release on lifetime cancel," so a future refactor that silently drops the lifetime-cancel handling will be caught immediately instead of shipping undetected.
