### PR TITLE
Cut scroll-rail markdown previews at markdown-safe boundaries

### DIFF
--- a/frontend/src/components/chat/markPreviewShared.ts
+++ b/frontend/src/components/chat/markPreviewShared.ts
@@ -6,7 +6,9 @@ import { truncatePreview } from '~/lib/textTruncate'
 // ---------------------------------------------------------------------------
 // Scroll-rail mark preview -- shared, provider-neutral extraction
 //
-// A LEAF module (only pure json/text utils) so every provider plugin can import
+// A LEAF module w.r.t. the chat plugin machinery (it imports only lib utils:
+// jsonPick, and textTruncate -- which pulls the shared markdown parser for
+// markdown-safe truncation) so every provider plugin can import
 // `defaultMarkPreview` as the fallback for its `Provider.previewText` WITHOUT pulling in
 // the plugin registry / classifier (chatMarkPreview.ts, which orchestrates the plugins) --
 // that would be a module-init cycle. Provider-specific extraction lives in each plugin's

--- a/frontend/src/lib/markdownParse.ts
+++ b/frontend/src/lib/markdownParse.ts
@@ -1,0 +1,14 @@
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+/**
+ * Shared remark-parse + remark-gfm parser used by both the markdown render
+ * pipeline and markdown-aware truncation. Keeping parse config in one place
+ * makes "can't drift from render behavior" structural rather than by convention.
+ */
+export function createMarkdownParser() {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+}

--- a/frontend/src/lib/markdownProcessor.ts
+++ b/frontend/src/lib/markdownProcessor.ts
@@ -4,11 +4,9 @@ import type { HighlighterCore } from 'shiki/core'
 import type { Processor } from 'unified'
 import rehypeShikiFromHighlighter from '@shikijs/rehype/core'
 import rehypeStringify from 'rehype-stringify'
-import remarkGfm from 'remark-gfm'
-import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
-import { unified } from 'unified'
 import { visit } from 'unist-util-visit'
+import { createMarkdownParser } from './markdownParse'
 import { rehypeBlockRemoteImages } from './rehypeBlockRemoteImages'
 import { shikiStyleClassTransformer } from './shikiStyleClass'
 import { DUAL_THEME_TOKEN_OPTIONS } from './shikiThemes'
@@ -119,9 +117,7 @@ function withHardeningTail<P extends Processor<any, any, Root, any, any>>(pipeli
  * own — the rest of the chain (and thus the output) is identical.
  */
 export function createMarkdownProcessor(highlighter: HighlighterCore) {
-  const base = unified()
-    .use(remarkParse)
-    .use(remarkGfm)
+  const base = createMarkdownParser()
     .use(remarkLowercaseCodeLang)
     .use(remarkRehype)
     .use(rehypeShikiFromHighlighter, highlighter as Parameters<typeof rehypeShikiFromHighlighter>[0], {
@@ -157,9 +153,7 @@ export function createMarkdownProcessor(highlighter: HighlighterCore) {
  * container-styled but not theme-colored until the highlighted result swaps in.
  */
 export const plainMarkdownProcessor = withHardeningTail(
-  unified()
-    .use(remarkParse)
-    .use(remarkGfm)
+  createMarkdownParser()
     .use(remarkRehype),
 )
 

--- a/frontend/src/lib/markdownSafeCut.test.ts
+++ b/frontend/src/lib/markdownSafeCut.test.ts
@@ -1,0 +1,540 @@
+import type { Blockquote, Code, Root } from 'mdast'
+import { describe, expect, it } from 'vitest'
+import { createMarkdownParser } from './markdownParse'
+import { markdownSafeCut, PREVIEW_ELLIPSIS } from './markdownSafeCut'
+
+// Re-parse a cut result with the SAME parser markdownSafeCut uses, to assert the
+// output actually re-parses to the intended structure -- the core guarantee, which
+// exact-string assertions alone do not prove.
+const reparser = createMarkdownParser()
+function reparse(md: string): Root {
+  return reparser.parse(md) as Root
+}
+
+describe('markdownSafeCut', () => {
+  describe('clean cuts', () => {
+    it('cuts plain text mid-word at limitOffset', () => {
+      expect(markdownSafeCut('hello world', 8)).toBe(`hello wo${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('trims trailing spaces from the chosen prefix', () => {
+      expect(markdownSafeCut('hello world   ', 8)).toBe(`hello wo${PREVIEW_ELLIPSIS}`)
+      // Candidate at a word end with spaces before limit: trimEnd eats them.
+      expect(markdownSafeCut('hello     world', 10)).toBe(`hello${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('picks the largest candidate at or before the limit', () => {
+      // Both "aa " (end of first text) and mid-word in "more" are ≤ limit; mid-word wins.
+      expect(markdownSafeCut('aa more text', 7)).toBe(`aa more${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('at limitOffset === length (scan-cap shape) keeps content and appends inline ellipsis', () => {
+      // text/paragraph/root all end at length; inline must beat block so we get
+      // `hello…` not `hello\n\n…`.
+      expect(markdownSafeCut('hello', 5)).toBe(`hello${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('cuts inside a second paragraph at a text-safe offset', () => {
+      expect(markdownSafeCut('first para\n\nsecond para here', 20))
+        .toBe(`first para\n\nsecond p${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('cuts inside a single-line blockquote', () => {
+      expect(markdownSafeCut('> quote line one and more', 15))
+        .toBe(`> quote line on${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('cuts inside a list item', () => {
+      expect(markdownSafeCut('- item one and more text', 12))
+        .toBe(`- item one a${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps an ATX heading a heading when cutting its interior', () => {
+      const out = markdownSafeCut('# Heading text here\n\nbody', 12)
+      expect(out.startsWith('# ')).toBe(true)
+      expect(out).toBe(`# Heading te${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('cuts before a straddling link when that boundary is at/above FLOOR', () => {
+      const text = `${'x'.repeat(60)} [label](https://example.com/very/long/path) end`
+      const out = markdownSafeCut(text, 80)
+      expect(out).toBe(`${'x'.repeat(60)}${PREVIEW_ELLIPSIS}`)
+      expect(out.includes('[')).toBe(false)
+    })
+
+    it('keeps a complete emphasis/strong/inline-code construct before the limit', () => {
+      expect(markdownSafeCut('aa *em text* bb more', 14)).toBe(`aa *em text* b${PREVIEW_ELLIPSIS}`)
+      expect(markdownSafeCut('aa **bold text** bb more', 18)).toBe(`aa **bold text** b${PREVIEW_ELLIPSIS}`)
+      expect(markdownSafeCut('aa `code` bb more', 12)).toBe(`aa \`code\` bb${PREVIEW_ELLIPSIS}`)
+    })
+  })
+
+  describe('block ellipsis placement', () => {
+    it('puts block ellipsis after a complete fenced code block', () => {
+      // best = code-block end → `\n\n…`, never inline (which would un-close the fence).
+      expect(markdownSafeCut('before\n```\nx\n```\n\nafter more', 16))
+        .toBe(`before\n\`\`\`\nx\n\`\`\`\n\n${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('puts block ellipsis after a setext heading', () => {
+      expect(markdownSafeCut('Heading\n=======\n\nbody text', 15))
+        .toBe(`Heading\n=======\n\n${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('puts block ellipsis after a thematic break', () => {
+      expect(markdownSafeCut('aaa\n\n---\n\nbbb more', 8))
+        .toBe(`aaa\n\n---\n\n${PREVIEW_ELLIPSIS}`)
+    })
+  })
+
+  describe('fence fallback', () => {
+    it('closes a straddling fenced block at the cut', () => {
+      const text = 'before\n```js\nconst x = 1\nconst y = 2\n```\nafter'
+      expect(markdownSafeCut(text, 25))
+        .toBe(`before\n\`\`\`js\nconst x = 1\n${PREVIEW_ELLIPSIS}\n\`\`\``)
+    })
+
+    it('matches a ~~~ opener', () => {
+      expect(markdownSafeCut('~~~\nlong content here\n~~~', 10))
+        .toBe(`~~~\nlong c${PREVIEW_ELLIPSIS}\n~~~`)
+    })
+
+    it('matches a 4+-backtick fence run', () => {
+      expect(markdownSafeCut('````\ncode with ``` inside\n````', 15))
+        .toBe(`\`\`\`\`\ncode with ${PREVIEW_ELLIPSIS}\n\`\`\`\``)
+    })
+
+    it('still closes an unterminated fence in the input', () => {
+      expect(markdownSafeCut('before\n```js\nconst x = 1\nstill going', 25))
+        .toBe(`before\n\`\`\`js\nconst x = 1\n${PREVIEW_ELLIPSIS}\n\`\`\``)
+    })
+
+    it('falls through when the limit is inside the opening fence line', () => {
+      const text = 'before\n```js\nconst x = 1\nconst y = 2\n```\nafter'
+      expect(markdownSafeCut(text, 10)).toBe(`before${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('clamps to content end when the limit is inside the closing fence line', () => {
+      const text = 'before\n```js\nconst x = 1\nconst y = 2\n```\nafter'
+      const out = markdownSafeCut(text, 38)
+      expect(out).toBe(`before\n\`\`\`js\nconst x = 1\nconst y = 2${PREVIEW_ELLIPSIS}\n\`\`\``)
+      // No doubled fence.
+      expect(out.match(/```/g)?.length).toBe(2)
+    })
+
+    it('preserves the blockquote prefix on a nested fence closer', () => {
+      expect(markdownSafeCut('> ```\n> long code content here\n> ```', 20))
+        .toBe(`> \`\`\`\n> long code co${PREVIEW_ELLIPSIS}\n> \`\`\``)
+    })
+
+    it('keeps the blockquote prefix on the ellipsis line at a content-line boundary', () => {
+      // Cut lands right after the first content line's newline (offset 29). The
+      // `…` opens a fresh code line, so it must carry the `> ` prefix -- otherwise
+      // it escapes the blockquote and the closing fence re-parses as a second,
+      // empty code block.
+      expect(markdownSafeCut('> ```\n> aaaaaaaaaaaaaaaaaaaa\n> bbbbbbbbbbbbbbbbbbbb\n> ```', 29))
+        .toBe(`> \`\`\`\n> aaaaaaaaaaaaaaaaaaaa\n> ${PREVIEW_ELLIPSIS}\n> \`\`\``)
+    })
+
+    it('keeps the nested blockquote prefix on the ellipsis line at a boundary', () => {
+      expect(markdownSafeCut('> > ```\n> > code line one here\n> > code line two here\n> > ```', 31))
+        .toBe(`> > \`\`\`\n> > code line one here\n> > ${PREVIEW_ELLIPSIS}\n> > \`\`\``)
+    })
+
+    it('does not add a prefix at a mid-line cut inside plain fence content', () => {
+      // Non-container fence: the opener prefix is empty, so a boundary cut just
+      // starts the `…` on its own (unprefixed) code line -- unchanged behavior.
+      expect(markdownSafeCut('```\naaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbbb\n```', 25))
+        .toBe(`\`\`\`\naaaaaaaaaaaaaaaaaaaa\n${PREVIEW_ELLIPSIS}\n\`\`\``)
+    })
+  })
+
+  describe('delimiter fallback', () => {
+    it('closes straddling strong with …**', () => {
+      expect(markdownSafeCut('**bold text that continues**', 10))
+        .toBe(`**bold tex${PREVIEW_ELLIPSIS}**`)
+    })
+
+    it('reads __ openers/closers from the source', () => {
+      expect(markdownSafeCut('__bold text here__', 10))
+        .toBe(`__bold tex${PREVIEW_ELLIPSIS}__`)
+    })
+
+    it('closes nested emphasis inside strong innermost-first', () => {
+      expect(markdownSafeCut('**a *b c d e* f**', 8))
+        .toBe(`**a *b c${PREVIEW_ELLIPSIS}***`)
+    })
+
+    it('closes ~~ and single-~ delete markers from the source', () => {
+      expect(markdownSafeCut('~~strike text~~', 8)).toBe(`~~strike${PREVIEW_ELLIPSIS}~~`)
+      expect(markdownSafeCut('~strike text~', 8)).toBe(`~strike ${PREVIEW_ELLIPSIS}~`)
+    })
+
+    it('closes multi-backtick inline code with a matching run', () => {
+      expect(markdownSafeCut('`` code ` tick here ``', 12))
+        .toBe(`\`\` code \` ti${PREVIEW_ELLIPSIS}\`\``)
+    })
+
+    it('cuts at the construct start when the limit is inside the opening run', () => {
+      expect(markdownSafeCut('xx **bold text**', 4)).toBe(`xx${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('closes still-open outer constructs when the limit is inside a nested opening run', () => {
+      // Limit inside the inner `**` opening run: the inner construct is dropped
+      // (cut at its start) and the outer emphasis still gets its closer.
+      expect(markdownSafeCut('*aa **bold text here** bb*', 5))
+        .toBe(`*aa${PREVIEW_ELLIPSIS}*`)
+    })
+
+    it('clamps to content end when the limit is in the closing region', () => {
+      expect(markdownSafeCut('**bold text**', 11))
+        .toBe(`**bold text${PREVIEW_ELLIPSIS}**`)
+    })
+
+    it('hard-cuts when a link straddles inside bold (no synthesizable closer)', () => {
+      const out = markdownSafeCut('**a [link](http://x.com) b**', 15)
+      expect(out).toBe(`**a [link](http${PREVIEW_ELLIPSIS}`)
+      expect(out.endsWith('**')).toBe(false)
+    })
+  })
+
+  describe('table', () => {
+    it('drops the table when the limit falls in the header, delimiter, or first body row', () => {
+      const prefix = `${'p'.repeat(40)}\n\n`
+      const table = '| a | b |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n'
+      const text = prefix + table
+      // Header cell.
+      expect(markdownSafeCut(text, prefix.length + 5)).toBe(`${'p'.repeat(40)}${PREVIEW_ELLIPSIS}`)
+      // Delimiter row (not an AST node -- sits between header and first body row).
+      expect(markdownSafeCut(text, prefix.length + 15)).toBe(`${'p'.repeat(40)}${PREVIEW_ELLIPSIS}`)
+      // First body row (its end is past the limit, so it is not yet a candidate).
+      expect(markdownSafeCut(text, prefix.length + 25)).toBe(`${'p'.repeat(40)}${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('cuts after the first body row when the limit is in the second', () => {
+      const table = '| a | b |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n'
+      expect(markdownSafeCut(table, 35))
+        .toBe(`| a | b |\n| - | - |\n| 1 | 2 |\n\n${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps a table that ends fully before the limit', () => {
+      const text = `| a | b |\n| - | - |\n| 1 | 2 |\n\n${'z'.repeat(30)}`
+      const limit = text.length - 5
+      const out = markdownSafeCut(text, limit)
+      expect(out.startsWith('| a | b |\n| - | - |\n| 1 | 2 |')).toBe(true)
+      expect(out.endsWith(PREVIEW_ELLIPSIS)).toBe(true)
+    })
+  })
+
+  describe('misc', () => {
+    it('hard-cuts a straddling html node when no earlier candidate clears FLOOR', () => {
+      expect(markdownSafeCut('<span>hello world content</span>', 15))
+        .toBe(`<span>hello wor${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('puts block ellipsis after a complete block-html section', () => {
+      // A block HTML section runs until a blank line, so an inline `…` glued to
+      // `</div>` would be absorbed into the block and dropped by the renderer
+      // (raw HTML is stripped). The blank line keeps the ellipsis a paragraph.
+      expect(markdownSafeCut('<div>hello</div>\n\n**bold text straddles here**', 30))
+        .toBe(`<div>hello</div>\n\n${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps the ellipsis inline after inline html inside a paragraph', () => {
+      // `<x>`/`</x>` are inline html nodes inside the paragraph; the trailing
+      // strong straddles the limit, so the cut lands right after the inline
+      // html (at the following text node's end; trimEnd makes them coincide)
+      // and the ellipsis must stay inline, not become its own paragraph.
+      expect(markdownSafeCut('aa <x>y</x> **bold text straddling**', 20))
+        .toBe(`aa <x>y</x>${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('hard-cuts a straddling autolink with a bounded garble', () => {
+      expect(markdownSafeCut('go https://example.com/foo end', 15))
+        .toBe(`go https://exam${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('falls back to a hard cut when a chosen cut would trim to empty', () => {
+      // Opening-run cut at offset 0 for a leading delimiter → empty prefix → hard cut.
+      expect(markdownSafeCut('**bold**', 1)).toBe(`*${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('hard-cuts defensively at a zero or negative limitOffset', () => {
+      // truncatePreview never passes ≤ 0, but the exported API guards it: keep
+      // at least one character so the result is never a bare ellipsis.
+      expect(markdownSafeCut('abc', 0)).toBe(`a${PREVIEW_ELLIPSIS}`)
+      expect(markdownSafeCut('abc', -5)).toBe(`a${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('hard-cuts defensively at a NaN limitOffset instead of emitting a bare ellipsis', () => {
+      // Every comparison against NaN is false, which would skip the ≤0 guard,
+      // void FLOOR, and slice(0, NaN) -- leaving nothing but the ellipsis.
+      // A NaN limit must degrade exactly like limitOffset 0.
+      expect(markdownSafeCut('abc', Number.NaN)).toBe(`a${PREVIEW_ELLIPSIS}`)
+      expect(markdownSafeCut('```js\nconst x = 1\n```\nafter', Number.NaN)).toBe(`\`${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps a leading astral character whole at a zero limitOffset', () => {
+      // The 1-code-unit floor of the defensive hard cut must not bisect a
+      // surrogate pair into a lone (malformed) high surrogate.
+      expect(markdownSafeCut('😀bc', 0)).toBe(`😀${PREVIEW_ELLIPSIS}`)
+    })
+  })
+
+  describe('pathological input', () => {
+    it('degrades to a bounded hard cut on pathologically deep nesting instead of overflowing the stack', () => {
+      // ~4000 nested blockquote markers parse fine (micromark iterates), but a
+      // recursive AST walk would overflow the call stack; the analysis must
+      // degrade to the bounded hard cut instead of throwing.
+      const out = markdownSafeCut(`${'>'.repeat(3990)} x`, 3900)
+      expect(out.endsWith(PREVIEW_ELLIPSIS)).toBe(true)
+      expect(out.length).toBeGreaterThan(1)
+    })
+  })
+
+  describe('entity atomicity', () => {
+    it('snaps past a named entity straddling the limit', () => {
+      // Cut at offset 7 lands inside `&amp;` (span [4, 9)); the entity is kept
+      // whole so the tooltip shows `Tom &` instead of a literal `Tom &am`.
+      expect(markdownSafeCut('Tom &amp; Jerry forever', 7)).toBe(`Tom &amp;${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('snaps past a numeric (hex) entity straddling the limit', () => {
+      expect(markdownSafeCut('star &#x2B50; twinkle', 8)).toBe(`star &#x2B50;${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('does not snap on a bare ampersand that is not an entity', () => {
+      // `&T ` has no terminating `;`, so the cut stays a plain mid-word cut.
+      expect(markdownSafeCut('AT&T stock is up today', 4)).toBe(`AT&T${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('does not snap when the entity ends exactly at the limit', () => {
+      // `&amp;` spans [2, 7); a cut AT 7 does not split it -- no snap needed.
+      expect(markdownSafeCut('a &amp; b more words here', 7)).toBe(`a &amp;${PREVIEW_ELLIPSIS}`)
+    })
+  })
+
+  describe('dangling references', () => {
+    it('rewrites a full link reference whose definition is past the cut', () => {
+      const out = markdownSafeCut(
+        'See [the docs][ref] and much more here\n\n[ref]: https://example.com/docs',
+        30,
+      )
+      expect(out).toBe(`See the docs and much m${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps a link reference whose definition survives before the cut', () => {
+      const out = markdownSafeCut(
+        '[ref]: https://example.com\n\nSee [docs][ref] and more content words',
+        55,
+      )
+      expect(out).toContain('[docs][ref]')
+    })
+
+    it('leaves a reference with no definition anywhere literal, matching the full render', () => {
+      const out = markdownSafeCut('Go [here][nowhere] then keep reading this text', 30)
+      expect(out).toBe(`Go [here][nowhere] then keep r${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('strips a dangling image reference', () => {
+      const out = markdownSafeCut(
+        'Look ![alt pic][img] here and more after\n\n[img]: https://x.com/p.png',
+        30,
+      )
+      // The doubled space where the image sat collapses in HTML rendering.
+      expect(out).toBe(`Look  here and${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('rewrites a shortcut-form reference to its label text', () => {
+      const out = markdownSafeCut(
+        'Read [manual] plus other helpful words\n\n[manual]: https://m.io',
+        25,
+      )
+      expect(out).toBe(`Read manual plus other${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('rewrites a collapsed-form reference to its label text', () => {
+      const out = markdownSafeCut(
+        'Read [docs][] and other stuff here\n\n[docs]: https://d.io',
+        25,
+      )
+      expect(out).toBe(`Read docs and other s${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('rewrites every dangling reference in the prefix', () => {
+      const out = markdownSafeCut(
+        'A [one][1] B [two][2] C plus tail words\n\n[1]: https://a.io\n\n[2]: https://b.io',
+        30,
+      )
+      expect(out).toBe(`A one B two C plus t${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('leaves a reference straddling the cut to the bounded hard-cut garble', () => {
+      // The clean boundary before the ref sits below FLOOR and an atomic inline
+      // has no synthesizable closer, so the hard cut slices mid-ref; the partial
+      // ref must stay raw (rewriting applies only to refs fully inside the cut).
+      expect(markdownSafeCut('go [label here][ref] x\n\n[ref]: https://r.io', 15))
+        .toBe(`go [label here]${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('strips a dangling footnote reference', () => {
+      const out = markdownSafeCut(
+        'Fact[^1] and further discussion text\n\n[^1]: the source',
+        20,
+      )
+      expect(out).toBe(`Fact and further${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('keeps nested formatting inside a rewritten link label', () => {
+      const out = markdownSafeCut(
+        'See [**bold** docs][ref] plus more trailing words\n\n[ref]: https://e.com',
+        35,
+      )
+      expect(out).toBe(`See **bold** docs plus more${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('forward-scans to the next real content when the rewrite empties the prefix', () => {
+      // Everything before the limit is a dangling image reference, so the
+      // rewritten prefix is empty; the hard cut must scan past the reference
+      // (and its definition) to the prose instead of dumping raw `![…][…]`.
+      expect(markdownSafeCut('![alt][img] tail\n\n[img]: u', 12)).toBe(`tail${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('previews the prose after a reference-style image gallery', () => {
+      const out = markdownSafeCut(
+        '![aa][r0]\n![aa][r1]\n\nReal prose here after gallery\n\n[r0]: https://a.io\n\n[r1]: https://b.io',
+        10,
+      )
+      expect(out).toBe(`Real prose${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('falls back to the bounded raw slice when no renderable content exists anywhere', () => {
+      // The whole text is one dangling image reference plus its definition:
+      // nothing renderable remains after the rewrite, so the raw slice is the
+      // accepted last resort (a bare ellipsis stays forbidden).
+      expect(markdownSafeCut('![alt][img]\n\n[img]: https://x.io', 11))
+        .toBe(`![alt][img]${PREVIEW_ELLIPSIS}`)
+    })
+
+    it('re-parses a rewritten prefix with no reference nodes left', () => {
+      const out = markdownSafeCut(
+        'See [the docs][ref] and much more here\n\n[ref]: https://example.com/docs',
+        30,
+      )
+      expect(JSON.stringify(reparse(out))).not.toContain('linkReference')
+    })
+  })
+
+  describe('re-parse invariant', () => {
+    it('re-parses a straddling blockquote fence to a single closed code block', () => {
+      // Pre-fix, the boundary cut dropped the `> ` on the ellipsis line, so this
+      // re-parsed to blockquote / paragraph / blockquote -- the ellipsis escaped
+      // the quote and the closing fence opened a second, empty code block.
+      const out = markdownSafeCut('> ```\n> aaaaaaaaaaaaaaaaaaaa\n> bbbbbbbbbbbbbbbbbbbb\n> ```', 29)
+      const tree = reparse(out)
+      expect(tree.children.map(c => c.type)).toEqual(['blockquote'])
+      const bq = tree.children[0] as Blockquote
+      expect(bq.children.map(c => c.type)).toEqual(['code'])
+      expect((bq.children[0] as Code).value).toContain(PREVIEW_ELLIPSIS)
+    })
+
+    it('keeps the block ellipsis inside a blockquote that continues past the cut', () => {
+      // Best boundary = the first (closed) fence's end INSIDE the quote; the
+      // quote continues with a second fence past the limit. The ellipsis
+      // paragraph must carry the `> ` marker so it stays inside the quote,
+      // mirroring the fence fallback's prefix preservation.
+      const text = [
+        '> ```',
+        '> aaaaaaaaaaaaaaaaaaaa',
+        '> aaaaaaaaaaaaaaaaaaaa',
+        '> aaaaaaaaaaaaaaaaaaaa',
+        '> ```',
+        '> ```',
+        '> cccccccccccccccccccc',
+        '> cccccccccccccccccccc',
+        '> ```',
+      ].join('\n')
+      const out = markdownSafeCut(text, 100)
+      const tree = reparse(out)
+      expect(tree.children.map(c => c.type)).toEqual(['blockquote'])
+      const bq = tree.children[0] as Blockquote
+      expect(bq.children.map(c => c.type)).toEqual(['code', 'paragraph'])
+      expect(JSON.stringify(bq.children[1])).toContain(PREVIEW_ELLIPSIS)
+    })
+
+    it('carries every open blockquote level onto the block ellipsis line', () => {
+      // Doubly-nested quote: the ellipsis line needs `> > `, not a single `> `
+      // (which would strand it in the outer quote, one level out from the
+      // content it truncates).
+      const text = [
+        '> > ```',
+        '> > aaaaaaaaaaaaaaaaaaaa',
+        '> > aaaaaaaaaaaaaaaaaaaa',
+        '> > ```',
+        '> > ```',
+        '> > cccccccccccccccccccc',
+        '> > ```',
+      ].join('\n')
+      const tree = reparse(markdownSafeCut(text, 80))
+      expect(tree.children.map(c => c.type)).toEqual(['blockquote'])
+      const outer = tree.children[0] as Blockquote
+      expect(outer.children.map(c => c.type)).toEqual(['blockquote'])
+      const inner = outer.children[0] as Blockquote
+      expect(inner.children.map(c => c.type)).toEqual(['code', 'paragraph'])
+      expect(JSON.stringify(inner.children[1])).toContain(PREVIEW_ELLIPSIS)
+    })
+
+    it('leaves the block ellipsis outside a blockquote that ends before the cut', () => {
+      // The quote completes before the boundary; the truncated remainder sits
+      // outside it, so the ellipsis paragraph must NOT gain a `> ` marker.
+      const text = [
+        '> ```',
+        '> aaaaaaaaaaaaaaaaaaaa',
+        '> aaaaaaaaaaaaaaaaaaaa',
+        '> ```',
+        '',
+        '```',
+        'cccccccccccccccccccc',
+        'cccccccccccccccccccc',
+        'cccccccccccccccccccc',
+        '```',
+      ].join('\n')
+      const out = markdownSafeCut(text, 80)
+      const tree = reparse(out)
+      expect(tree.children.map(c => c.type)).toEqual(['blockquote', 'paragraph'])
+      expect(JSON.stringify(tree.children[1])).toContain(PREVIEW_ELLIPSIS)
+    })
+
+    it('re-parses each delimiter fallback to a single closed construct', () => {
+      // Every synthesized-closer output must re-parse so the delimiter run is a
+      // real strong/emphasis/delete/inlineCode node -- not literal stray markers.
+      const cases: [string, number, string][] = [
+        ['**bold text that continues**', 10, 'strong'],
+        ['__bold text here__', 10, 'strong'],
+        ['*emphasis text that continues*', 10, 'emphasis'],
+        ['~~strike text here~~', 8, 'delete'],
+        ['`` code ` tick here ``', 12, 'inlineCode'],
+      ]
+      for (const [input, limit, nodeType] of cases) {
+        const out = markdownSafeCut(input, limit)
+        const tree = reparse(out)
+        expect(tree.children.map(c => c.type)).toEqual(['paragraph'])
+        const para = tree.children[0] as { children: { type: string }[] }
+        // The paragraph holds exactly the closed construct (no trailing text node
+        // carrying a stray `*`/`` ` ``/`~` marker).
+        expect(para.children.map(c => c.type)).toEqual([nodeType])
+      }
+    })
+  })
+
+  describe('collect prune', () => {
+    it('is unaffected by markdown structure past the cut', () => {
+      // The `start >= limitOffset` prune skips subtrees beyond the cut; the chosen
+      // boundary must not change when trailing blocks are appended.
+      const base = 'first para\n\nsecond para here'
+      const trailer = `\n\n${'| a | b |\n| - | - |\n| 1 | 2 |\n'.repeat(20)}`
+      expect(markdownSafeCut(base + trailer, 20)).toBe(markdownSafeCut(base, 20))
+      expect(markdownSafeCut(base + trailer, 20)).toBe(`first para\n\nsecond p${PREVIEW_ELLIPSIS}`)
+    })
+  })
+})

--- a/frontend/src/lib/markdownSafeCut.ts
+++ b/frontend/src/lib/markdownSafeCut.ts
@@ -1,0 +1,622 @@
+import type { Definition, FootnoteDefinition, LinkReference, Nodes, Root } from 'mdast'
+import { createMarkdownParser } from './markdownParse'
+
+/** Trailing ellipsis appended to truncated previews (U+2026). */
+export const PREVIEW_ELLIPSIS = '…'
+
+const parser = createMarkdownParser()
+
+type CutKind = 'inline' | 'block'
+
+interface Candidate {
+  offset: number
+  kind: CutKind
+}
+
+interface PathEntry {
+  type: string
+  start: number
+  end: number
+  node: Nodes
+}
+
+interface DelimiterMarkers {
+  closer: string
+  contentStart: number
+  contentEnd: number
+}
+
+/** A link/image/footnote reference in source order, with its label span. */
+interface RefEntry {
+  kind: 'linkReference' | 'imageReference' | 'footnoteReference'
+  identifier: string
+  start: number
+  end: number
+  /** Label-content span (linkReference only): the source between the brackets. */
+  contentStart: number | null
+  contentEnd: number | null
+}
+
+/**
+ * Cut `s` at code-unit offset `at`, never splitting a surrogate pair: a cut
+ * landing between a high and low surrogate extends by one unit to keep the
+ * astral character whole, so the result is always well-formed UTF-16.
+ */
+function cutAtCodeUnit(s: string, at: number): string {
+  const i = Math.min(Math.max(at, 0), s.length)
+  if (i === 0 || i >= s.length)
+    return s.slice(0, i)
+  const prev = s.charCodeAt(i - 1)
+  return prev >= 0xD800 && prev <= 0xDBFF ? s.slice(0, i + 1) : s.slice(0, i)
+}
+
+/** The node's children, or `[]` for leaf nodes -- the one home for the narrowing cast. */
+function childrenOf(node: Nodes): Nodes[] {
+  return 'children' in node && Array.isArray(node.children) ? node.children as Nodes[] : []
+}
+
+const ATOMIC_INLINE = new Set([
+  'link',
+  'image',
+  'linkReference',
+  'imageReference',
+  'footnoteReference',
+  'html',
+])
+
+const DELIMITER = new Set(['strong', 'emphasis', 'delete', 'inlineCode'])
+
+// `[ \t>]` (not `[>\s]`): `\s` would also match `\n`, letting the prefix class
+// walk across lines if an exec slice ever spanned one -- same reasoning as
+// FENCE_LANG_RE in markdownProcessor.ts.
+const FENCE_OPENER_RE = /^([ \t>]*)(`{3,}|~{3,})/
+const FENCE_CLOSER_LINE_RE = /^[ \t>]*(`{3,}|~{3,})[ \t]*$/
+
+// `&name;` / `&#123;` / `&#x1F600;`. The longest named HTML entity is 33 chars
+// total (`&CounterClockwiseContourIntegral;`), so a 32-char name cap covers all.
+const ENTITY_RE = /^&(?:[a-z][a-z0-9]{1,31}|#\d{1,7}|#x[0-9a-f]{1,6});/i
+
+/**
+ * Treat an HTML entity as one character: when `offset` falls strictly inside an
+ * `&…;` run, return the offset just past the `;` so the entity is kept whole
+ * instead of being split into a literal fragment (`&am` + ellipsis). A false
+ * positive (`&notreal;` is not a real entity) merely keeps a literal run whole,
+ * which renders identically to the full view -- harmless.
+ */
+function snapPastEntity(text: string, offset: number): number {
+  const amp = text.lastIndexOf('&', offset - 1)
+  if (amp === -1 || amp < offset - 34)
+    return offset
+  const match = ENTITY_RE.exec(text.slice(amp, amp + 35))
+  if (!match)
+    return offset
+  const entityEnd = amp + match[0].length
+  return offset < entityEnd ? entityEnd : offset
+}
+
+/**
+ * Cut `text` at/before `limitOffset` so the prefix re-parses cleanly as markdown,
+ * then append an ellipsis. `limitOffset` is a code-unit offset (typically at a
+ * grapheme boundary from the caller). An HTML entity straddling the limit is
+ * kept whole -- the cut snaps just past its `;`.
+ *
+ * Output may exceed the limit by a small synthesized suffix (closers / fence /
+ * paragraph break before `…`) or a snapped-past entity -- still length-bounded
+ * for tooltip rendering.
+ *
+ * References whose definition falls PAST the cut are rewritten to what the
+ * definition-less prefix can actually render: a link reference keeps its label
+ * text, image and footnote references are dropped (their fallback rendering is
+ * pure bracket noise). A reference with no definition anywhere in the text is
+ * left literal -- it renders that way in the full view too. When that rewrite
+ * empties the whole prefix (a leading reference-style image gallery), the cut
+ * scans FORWARD past the references and their definitions to the first content
+ * that renders, rather than dumping the raw markup it just suppressed.
+ *
+ * Accepted imperfections (cosmetic, none worse than a hard mid-token cut):
+ * - Setext headings demoted when the underline is dropped
+ */
+export function markdownSafeCut(text: string, limitOffset: number): string {
+  return new MarkdownCutter(text, limitOffset).cut()
+}
+
+/**
+ * Single-use cutter: holds the input, the (entity-snapped) limit, and the
+ * accumulators the tree walks fill, so the strategy methods don't have to
+ * thread `text`/`limitOffset`/out-params through every signature.
+ */
+class MarkdownCutter {
+  private readonly text: string
+  private readonly limitOffset: number
+  private readonly candidates: Candidate[] = []
+  private readonly path: PathEntry[] = []
+  /** References in source order (a parent precedes its nested references). */
+  private readonly refs: RefEntry[] = []
+  /** identifier -> end offset of its earliest definition / footnote definition. */
+  private readonly defEnds = new Map<string, number>()
+  /** Definition spans in source order, for the forward-scan fallback to elide. */
+  private readonly defSpans: { start: number, end: number }[] = []
+
+  constructor(text: string, limitOffset: number) {
+    this.text = text
+    // NaN would compare false against everything below -- skipping the ≤0
+    // guard, voiding FLOOR, and slicing to an empty string, so a broken caller
+    // would get a bare ellipsis. Degrade it to the defensive hard-cut path.
+    const limit = Number.isNaN(limitOffset) ? 0 : limitOffset
+    this.limitOffset = limit > 0 ? snapPastEntity(text, limit) : limit
+  }
+
+  cut(): string {
+    if (this.limitOffset <= 0)
+      return this.hardCut()
+
+    try {
+      const tree = parser.parse(this.text) as Root
+      this.collectRefs(tree)
+      this.collect(tree)
+    }
+    catch {
+      // Parse failures AND walk failures degrade to the bounded hard cut. The
+      // recursive walks can genuinely throw: ~4000 nested blockquote markers
+      // parse fine (micromark iterates) but overflow the call stack when
+      // walked, and the cutter must never leak an exception -- its contract is
+      // "always return a bounded preview string".
+      return this.hardCut()
+    }
+
+    // Reject a clean boundary that throws away more than half the budget: below
+    // this floor we prefer a fence/delimiter synth (which keeps ~limitOffset
+    // chars) or, if none applies, a bounded hard cut, over a very short clean
+    // preview.
+    const FLOOR = Math.max(1, Math.floor(this.limitOffset / 2))
+    const best = this.pickBest()
+
+    if (best && best.offset >= FLOOR) {
+      const prefix = this.prefixUpTo(best.offset).trimEnd()
+      if (prefix.length === 0)
+        return this.hardCut()
+      if (best.kind === 'inline')
+        return prefix + PREVIEW_ELLIPSIS
+      // Block ellipsis on its own paragraph: appending `…` to a closing fence
+      // line (or setext underline / thematic break / table row) would corrupt
+      // the construct. A blank line keeps the ellipsis as a following
+      // paragraph -- carrying the `> ` markers of every blockquote still open
+      // at the cut (on the straddle path and opened before the boundary), so
+      // the ellipsis cannot escape the container it was cut from; the fence
+      // fallback preserves its prefix the same way. List containers need no
+      // marker: an ellipsis paragraph after a list item correctly ends the
+      // list.
+      const quoteDepth = this.path.filter(e => e.type === 'blockquote' && e.start < best.offset).length
+      const quotePrefix = '> '.repeat(quoteDepth)
+      return `${prefix}\n${quotePrefix.trimEnd()}\n${quotePrefix}${PREVIEW_ELLIPSIS}`
+    }
+
+    const straddlingCode = this.path.find(e => e.type === 'code')
+    if (straddlingCode) {
+      const fenced = this.finalize(this.tryFenceFallback(straddlingCode))
+      if (fenced != null)
+        return fenced
+    }
+
+    const delimiterCut = this.finalize(this.tryDelimiterFallback())
+    if (delimiterCut != null)
+      return delimiterCut
+
+    return this.hardCut()
+  }
+
+  /**
+   * Normalize a fallback strategy's result: `null` means "not applicable" (the
+   * caller tries the next strategy); a degenerate result (empty or a bare
+   * ellipsis) collapses to a hard cut so no synth path can ever emit a
+   * content-free preview.
+   */
+  private finalize(result: string | null): string | null {
+    if (result == null)
+      return null
+    if (result.length === 0 || result === PREVIEW_ELLIPSIS)
+      return this.hardCut()
+    return result
+  }
+
+  private hardCut(): string {
+    const prefix = this.prefixUpTo(Math.max(0, this.limitOffset)).trimEnd()
+    if (prefix.length > 0)
+      return prefix + PREVIEW_ELLIPSIS
+
+    // The prefix is empty: either the limit is ≤ 0, or the dangling-reference
+    // rewrite dropped everything before it (a leading reference-style image
+    // gallery whose definitions sit at the end). Raw-slicing here would dump
+    // the literal `![…][…]` markup the rewrite exists to suppress, so first
+    // look past the noise for content that can actually render.
+    if (this.limitOffset > 0) {
+      const forward = this.renderableContent().trim()
+      if (forward.length > 0)
+        return cutAtCodeUnit(forward, this.limitOffset).trimEnd() + PREVIEW_ELLIPSIS
+    }
+    // Nothing renderable anywhere (an all-references message): the bounded raw
+    // slice is the accepted last resort, since a bare ellipsis is forbidden.
+    return cutAtCodeUnit(this.text, Math.max(1, this.limitOffset)) + PREVIEW_ELLIPSIS
+  }
+
+  /**
+   * The whole text as the definition-less preview would render it: dangling
+   * references rewritten away and every definition / footnote-definition span
+   * elided (they render as nothing, so leaving them in would surface raw
+   * `[ref]: url` lines). Used only by the empty-prefix fallback, so the cost of
+   * scanning past the limit is paid on that path alone.
+   */
+  private renderableContent(): string {
+    let out = ''
+    let cursor = 0
+    for (const span of this.defSpans) {
+      // Definitions nested inside an earlier elided span are already covered.
+      if (span.start < cursor)
+        continue
+      out += this.rewriteRange(cursor, span.start, this.limitOffset)
+      cursor = span.end
+    }
+    return out + this.rewriteRange(cursor, this.text.length, this.limitOffset)
+  }
+
+  /** The source up to `cutOffset` with dangling references rewritten. */
+  private prefixUpTo(cutOffset: number): string {
+    return this.rewriteRange(0, cutOffset, cutOffset)
+  }
+
+  /**
+   * A reference dangles when its definition exists in the full text but ends
+   * past the cut -- the truncation dropped it, so the kept reference would
+   * render as literal `[text][ref]` brackets. A reference with NO definition
+   * anywhere renders literally in the full view too and is left alone.
+   */
+  private isDanglingAt(ref: RefEntry, cutOffset: number): boolean {
+    const defEnd = this.defEnds.get(ref.identifier)
+    return defEnd != null && defEnd > cutOffset
+  }
+
+  /**
+   * Slice `[start, end)` of the source with every dangling reference rewritten:
+   * a link reference keeps its label text (outer brackets and `[ref]` dropped),
+   * image and footnote references vanish. A reference straddling `end` is left
+   * to the caller's raw slicing (bounded garble, like any atomic construct).
+   * Recurses into a rewritten link label so a nested dangling reference inside
+   * it is handled too; a resolved reference's interior is covered by the main
+   * scan, since skipping it does not advance the cursor past its span.
+   */
+  private rewriteRange(start: number, end: number, cutOffset: number): string {
+    let out = ''
+    let cursor = start
+    for (const ref of this.refs) {
+      if (ref.start < cursor || ref.end > end)
+        continue
+      if (!this.isDanglingAt(ref, cutOffset))
+        continue
+      out += this.text.slice(cursor, ref.start)
+      if (ref.kind === 'linkReference' && ref.contentStart != null && ref.contentEnd != null)
+        out += this.rewriteRange(ref.contentStart, ref.contentEnd, cutOffset)
+      cursor = ref.end
+    }
+    return out + this.text.slice(cursor, end)
+  }
+
+  /**
+   * Gather every reference and definition in the FULL tree. Deliberately not
+   * folded into `collect()`: that walk prunes past the limit, but definitions
+   * conventionally sit at the document end -- past the cut -- and resolving
+   * "does this reference's definition survive the cut?" needs them all.
+   */
+  private collectRefs(node: Nodes): void {
+    const start = node.position?.start?.offset
+    const end = node.position?.end?.offset
+    if (start == null || end == null)
+      return
+
+    const type = node.type
+    if (type === 'definition' || type === 'footnoteDefinition') {
+      const { identifier } = node as Definition | FootnoteDefinition
+      const known = this.defEnds.get(identifier)
+      // The first definition wins in CommonMark; keep the earliest end.
+      if (known == null || end < known)
+        this.defEnds.set(identifier, end)
+      this.defSpans.push({ start, end })
+    }
+    else if (type === 'linkReference' || type === 'imageReference' || type === 'footnoteReference') {
+      let contentStart: number | null = null
+      let contentEnd: number | null = null
+      if (type === 'linkReference') {
+        const children = (node as LinkReference).children
+        if (children.length > 0) {
+          contentStart = children[0]!.position?.start?.offset ?? null
+          contentEnd = children[children.length - 1]!.position?.end?.offset ?? null
+        }
+      }
+      this.refs.push({
+        kind: type,
+        identifier: (node as { identifier: string }).identifier,
+        start,
+        end,
+        contentStart,
+        contentEnd,
+      })
+    }
+
+    for (const child of childrenOf(node))
+      this.collectRefs(child)
+  }
+
+  private pickBest(): Candidate | null {
+    let best: Candidate | null = null
+    for (const c of this.candidates) {
+      if (c.offset > this.limitOffset)
+        continue
+      if (
+        !best
+        || c.offset > best.offset
+        // At equal offset, inline beats block -- critical for the scan-cap case
+        // where text/paragraph/root all end at text.length and the expected
+        // output is `hello…`, not `hello\n\n…`.
+        || (c.offset === best.offset && c.kind === 'inline' && best.kind === 'block')
+      ) {
+        best = c
+      }
+    }
+    return best
+  }
+
+  private collect(node: Nodes, inInlineContext = false): void {
+    const start = node.position?.start?.offset
+    const end = node.position?.end?.offset
+    // Skip nodes with undefined position.end.offset (types force the narrowing).
+    if (start == null || end == null)
+      return
+
+    // A node starting at/after the limit yields no usable candidate (`pickBest`
+    // discards offset > limitOffset) and never lands on the straddle path
+    // (`onPath` needs start < limitOffset), so walking its subtree is wasted
+    // work -- children only start later. Prune once the walk crosses the limit.
+    if (start >= this.limitOffset)
+      return
+
+    const type = node.type
+    const onPath = start < this.limitOffset && this.limitOffset < end
+    if (onPath)
+      this.path.push({ type, start, end, node })
+
+    if (type === 'break')
+      return
+
+    if (type === 'html') {
+      // mdast has ONE `html` type for both block and inline HTML. A block HTML
+      // section continues until a blank line, so an inline `…` appended right
+      // after it would be absorbed into the block -- which remark-rehype then
+      // drops entirely (no allowDangerousHtml), losing the ellipsis. Only HTML
+      // inside a paragraph/heading is inline.
+      this.candidates.push({ offset: end, kind: inInlineContext ? 'inline' : 'block' })
+      return
+    }
+
+    if (ATOMIC_INLINE.has(type)) {
+      this.candidates.push({ offset: end, kind: 'inline' })
+      return
+    }
+
+    if (DELIMITER.has(type)) {
+      this.candidates.push({ offset: end, kind: 'inline' })
+      // No descent for candidates. Still walk children when straddling so nested
+      // delimiters (and any atomic inline that blocks delimiter fallback) land on
+      // the path.
+      if (onPath) {
+        for (const child of childrenOf(node))
+          this.collectDelimiterPath(child)
+      }
+      return
+    }
+
+    if (type === 'text') {
+      this.candidates.push({ offset: end, kind: 'inline' })
+      // Mid-word cut in literal text is safe -- same as the pre-markdown status quo.
+      if (start < this.limitOffset && this.limitOffset < end)
+        this.candidates.push({ offset: this.limitOffset, kind: 'inline' })
+      return
+    }
+
+    if (type === 'table') {
+      this.candidates.push({ offset: end, kind: 'block' })
+      // Body rows only (children[1..]). Never the header row: GFM's `|---|`
+      // delimiter row is not an AST node, so a header-row-end cut reparses with
+      // no table at all. Never descend into cells.
+      const rows = childrenOf(node)
+      for (let i = 1; i < rows.length; i++) {
+        const rowEnd = rows[i]?.position?.end?.offset
+        if (rowEnd != null)
+          this.candidates.push({ offset: rowEnd, kind: 'block' })
+      }
+      return
+    }
+
+    if (type === 'code' || type === 'definition' || type === 'thematicBreak') {
+      this.candidates.push({ offset: end, kind: 'block' })
+      return
+    }
+
+    // root, paragraph, heading, blockquote, list, listItem, footnoteDefinition, …
+    this.candidates.push({ offset: end, kind: 'block' })
+    // Paragraph/heading children are inline content; every other container
+    // (root, blockquote, list, listItem, footnoteDefinition) holds blocks.
+    const childrenInline = type === 'paragraph' || type === 'heading'
+    for (const child of childrenOf(node))
+      this.collect(child, childrenInline)
+  }
+
+  /**
+   * Path-only walk under a delimiter: records nested delimiters and atomic
+   * inlines that contain limitOffset, without adding candidates (the parent
+   * delimiter owns that).
+   */
+  private collectDelimiterPath(node: Nodes): void {
+    const start = node.position?.start?.offset
+    const end = node.position?.end?.offset
+    if (start == null || end == null)
+      return
+    if (!(start < this.limitOffset && this.limitOffset < end))
+      return
+
+    const type = node.type
+    if (ATOMIC_INLINE.has(type) || DELIMITER.has(type)) {
+      this.path.push({ type, start, end, node })
+      if (DELIMITER.has(type)) {
+        for (const child of childrenOf(node))
+          this.collectDelimiterPath(child)
+      }
+      return
+    }
+
+    for (const child of childrenOf(node))
+      this.collectDelimiterPath(child)
+  }
+
+  private tryFenceFallback(entry: PathEntry): string | null {
+    const { start: nodeStart, end: nodeEnd } = entry
+    const lineStart = this.text.lastIndexOf('\n', nodeStart - 1) + 1
+    const openerMatch = FENCE_OPENER_RE.exec(this.text.slice(lineStart))
+    if (!openerMatch)
+      return null // indented code (or non-fence) -- no synthesizable closer
+
+    const prefix = openerMatch[1]
+    const fenceRun = openerMatch[2]
+    const fenceChar = fenceRun[0]!
+    const fenceLen = fenceRun.length
+
+    const openerLineNl = this.text.indexOf('\n', nodeStart)
+    // Opening fence line with no following content line: nothing to close usefully.
+    if (openerLineNl === -1 || openerLineNl >= nodeEnd)
+      return null
+
+    // Limit inside the opening fence line → cut at the code node's start instead
+    // (fall through to an earlier candidate / hard cut).
+    if (this.limitOffset <= openerLineNl)
+      return null
+
+    const contentStart = openerLineNl + 1
+
+    // Detect a closing fence as the last line of the node.
+    let contentEnd = nodeEnd
+    let closingFenceLineStart = -1
+    const lastNl = this.text.lastIndexOf('\n', nodeEnd - 1)
+    if (lastNl >= contentStart - 1) {
+      const closingLineStart = lastNl + 1
+      if (closingLineStart >= contentStart && closingLineStart < nodeEnd) {
+        const closingLine = this.text.slice(closingLineStart, nodeEnd)
+        const closerMatch = FENCE_CLOSER_LINE_RE.exec(closingLine)
+        if (
+          closerMatch
+          && closerMatch[1]![0] === fenceChar
+          && closerMatch[1]!.length >= fenceLen
+        ) {
+          closingFenceLineStart = closingLineStart
+          // Exclusive content end: exclude the newline before the closer line.
+          contentEnd = closingLineStart - 1
+        }
+      }
+    }
+
+    let cutAt = Math.min(this.limitOffset, contentEnd)
+    // Limit inside the closing fence line → clamp cut to content end (no doubled fence).
+    if (closingFenceLineStart >= 0 && this.limitOffset >= closingFenceLineStart)
+      cutAt = contentEnd
+    if (cutAt < contentStart)
+      return null
+
+    // Skip trimEnd inside fence content -- trailing spaces in code are significant,
+    // and trimming could eat the newline structure before the synthesized closer.
+    const sliced = this.prefixUpTo(cutAt)
+    // When the cut lands at a content-line boundary (`sliced` ends in a newline)
+    // the `…` opens a fresh code line. Inside a container (e.g. a blockquote)
+    // that line needs the same prefix the fence opener carried, or the `…`
+    // escapes the container and the synthesized closing fence re-parses as a
+    // second, empty fence.
+    const ellipsisLinePrefix = sliced.endsWith('\n') ? prefix : ''
+    const closer = `\n${prefix}${fenceRun}`
+    return sliced + ellipsisLinePrefix + PREVIEW_ELLIPSIS + closer
+  }
+
+  private tryDelimiterFallback(): string | null {
+    // Delimiter chain with no link/image/html below it -- those have no
+    // synthesizable closer from source markers alone.
+    const delimiters: PathEntry[] = []
+    for (const entry of this.path) {
+      if (ATOMIC_INLINE.has(entry.type))
+        return null
+      if (DELIMITER.has(entry.type))
+        delimiters.push(entry)
+    }
+    if (delimiters.length === 0)
+      return null
+
+    const innermost = delimiters[delimiters.length - 1]!
+    const markers = delimiters.map(d => this.delimiterMarkers(d))
+    if (markers.some(m => m == null))
+      return null
+    const resolved = markers as DelimiterMarkers[]
+
+    const inner = resolved[resolved.length - 1]!
+    // Limit inside the innermost construct's opening run (path membership
+    // guarantees innermost.start < limitOffset, so the run containing the limit
+    // is always the innermost one): drop that construct entirely -- cut at its
+    // start and close the still-open outer constructs, innermost-first.
+    if (this.limitOffset < inner.contentStart) {
+      const prefix = this.prefixUpTo(innermost.start).trimEnd()
+      if (prefix.length === 0)
+        return null // empty → hard cut at caller
+      const outerClosers = resolved.slice(0, -1).map(m => m.closer).reverse().join('')
+      return prefix + PREVIEW_ELLIPSIS + outerClosers
+    }
+
+    // Clamp to innermost content range (opener/closer runs excluded). Limit in
+    // the closing region clamps to content end.
+    const cutAt = Math.min(Math.max(this.limitOffset, inner.contentStart), inner.contentEnd)
+    // `…` between content and closers keeps closers validly right-flanking and
+    // prevents backtick-run merging (e.g. cut content ending in `` ` `` would
+    // otherwise merge with a closing `` ` `` run).
+    const closers = resolved.map(m => m.closer).reverse().join('')
+    return this.prefixUpTo(cutAt) + PREVIEW_ELLIPSIS + closers
+  }
+
+  private delimiterMarkers(entry: PathEntry): DelimiterMarkers | null {
+    const { start, end, node, type } = entry
+
+    if (type === 'inlineCode') {
+      const openMatch = /^(`+)/.exec(this.text.slice(start, end))
+      if (!openMatch)
+        return null
+      const ticks = openMatch[1]!
+      return {
+        closer: ticks,
+        contentStart: start + ticks.length,
+        contentEnd: end - ticks.length,
+      }
+    }
+
+    // strong / emphasis / delete: the closer read verbatim from source at the
+    // construct's end (so `**` vs `__`, `*` vs `_`, `~`/`~~` stay accurate).
+    const children = childrenOf(node)
+    if (children.length > 0) {
+      const contentStart = children[0]!.position?.start?.offset
+      const contentEnd = children[children.length - 1]!.position?.end?.offset
+      if (contentStart == null || contentEnd == null)
+        return null
+      return {
+        closer: this.text.slice(contentEnd, end),
+        contentStart,
+        contentEnd,
+      }
+    }
+
+    // Empty delimiter construct: unreachable with the pinned parser (CommonMark
+    // requires non-empty emphasis/strong/delete content -- `****` parses as a
+    // thematic break, not empty strong), but the mdast types allow it. Bail to
+    // the bounded hard cut rather than guess at marker runs.
+    return null
+  }
+}

--- a/frontend/src/lib/textTruncate.test.ts
+++ b/frontend/src/lib/textTruncate.test.ts
@@ -1,5 +1,9 @@
+import type { Root } from 'mdast'
 import { describe, expect, it } from 'vitest'
+import { createMarkdownParser } from './markdownParse'
 import { __setGraphemeSegmenterForTest, truncatePreview } from './textTruncate'
+
+const reparser = createMarkdownParser()
 
 describe('truncate preview', () => {
   it('tidies horizontal whitespace but preserves newlines (for markdown structure)', () => {
@@ -81,5 +85,81 @@ describe('truncate preview', () => {
 
   it('does not split a combining-character grapheme at the truncation boundary', () => {
     expect(truncatePreview(`${'x'.repeat(199)}e\u0301tail`)).toBe(`${'x'.repeat(199)}e\u0301…`)
+  })
+
+  it('closes bold that straddles the limit (no dangling **)', () => {
+    // 200-grapheme budget = `**` opener + 198 a's; the closer is read from the source.
+    expect(truncatePreview(`**${'a'.repeat(250)}**`)).toBe(`**${'a'.repeat(198)}…**`)
+  })
+
+  it('closes a fenced code block that straddles the limit', () => {
+    // 200-grapheme budget = fence line (4 graphemes incl. newline) + 196 x's;
+    // the synthesized closing fence follows the in-code ellipsis.
+    expect(truncatePreview(`\`\`\`\n${'x'.repeat(250)}\n\`\`\``))
+      .toBe(`\`\`\`\n${'x'.repeat(196)}…\n\`\`\``)
+  })
+
+  it('cuts before a late link that straddles the limit', () => {
+    expect(truncatePreview(`${'a'.repeat(180)} [label](https://example.com/path) more`))
+      .toBe(`${'a'.repeat(180)}…`)
+  })
+
+  it('keeps an html entity whole at the truncation boundary', () => {
+    // The 200-grapheme limit lands between `&` and `amp;`; the cut snaps past
+    // the entity instead of splitting it into a literal `&a` fragment.
+    expect(truncatePreview(`${'x'.repeat(198)}&amp;${'y'.repeat(30)}`))
+      .toBe(`${'x'.repeat(198)}&amp;…`)
+  })
+
+  it('rewrites a link reference whose definition is truncated away', () => {
+    const out = truncatePreview(`See [the docs][ref] ${'w'.repeat(250)}\n\n[ref]: https://example.com/docs`)!
+    expect(out.startsWith('See the docs ')).toBe(true)
+    expect(out.includes('[')).toBe(false)
+  })
+
+  it('truncates a long blockquote fenced code block to a single closed code block', () => {
+    // The `> ` markers survive tidying, so the cut lands inside a blockquoted
+    // fence; the synthesized closer (and any boundary ellipsis line) must keep the
+    // `> ` prefix so the result re-parses as one blockquote, not a broken quote +
+    // stray paragraph + second fence.
+    const body = `> \`\`\`\n${Array.from({ length: 30 }, (_, i) => `> code content line number ${i}`).join('\n')}\n> \`\`\``
+    const out = truncatePreview(body)!
+    expect(out.endsWith('…') || out.endsWith('```')).toBe(true)
+    const tree = reparser.parse(out) as Root
+    expect(tree.children.map(c => c.type)).toEqual(['blockquote'])
+  })
+
+  it('previews the prose past a preview-filling dangling image reference', () => {
+    // The first 200 tidied graphemes are one giant dangling image reference;
+    // the rewrite empties the prefix, and the preview must surface the prose
+    // that follows instead of a wall of literal reference markup.
+    const body = `![${'a'.repeat(190)}][ref]\n\nNext paragraph of prose content here\n\n[ref]: https://example.com/image.png`
+    const out = truncatePreview(body)!
+    expect(out.startsWith('Next paragraph of prose content here')).toBe(true)
+    expect(out.includes('[')).toBe(false)
+  })
+
+  it('survives pathologically deep blockquote nesting without a stack overflow', () => {
+    // 5000 `>` markers tidy to a 4000-grapheme run that parses into ~4000
+    // nested blockquotes; the recursive AST walks must degrade to the bounded
+    // hard cut instead of throwing RangeError through the preview pipeline.
+    const out = truncatePreview(`${'>'.repeat(5000)} hello`)!
+    expect(out.endsWith('…')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(250)
+  })
+
+  it('does not append an ellipsis for exactly-limit content followed by a trailing newline', () => {
+    // Latent-bug fix: trailing-whitespace pop used to leave truncated=true from the
+    // newline append even though the kept content is exactly MAX_PREVIEW_LEN.
+    const out = truncatePreview(`${'b'.repeat(200)}\n`)!
+    expect(out).toBe('b'.repeat(200))
+    expect(out.endsWith('…')).toBe(false)
+  })
+
+  it('composes grapheme safety with markdown delimiter closing around an emoji', () => {
+    // The 200th grapheme is the first `*` of the closing run, so the code-unit
+    // limit lands inside it; the cut clamps back to the bold content's end
+    // (keeping the surrogate-pair emoji whole) and closes with …**.
+    expect(truncatePreview(`**${'c'.repeat(196)}😀**tail`)).toBe(`**${'c'.repeat(196)}😀…**`)
   })
 })

--- a/frontend/src/lib/textTruncate.ts
+++ b/frontend/src/lib/textTruncate.ts
@@ -3,22 +3,30 @@
 //
 // Tidies an arbitrary text body into a bounded, single-snippet preview: collapse
 // horizontal whitespace, cap blank-line runs, and truncate at a grapheme boundary
-// with a trailing ellipsis. Provider- and feature-neutral (no mark-preview / message
-// concerns), so any surface that needs a short snippet of a longer body can reuse it.
+// with a trailing ellipsis. When truncated, the cut is markdown-aware via
+// `markdownSafeCut` so the preview re-parses cleanly (the scroll-rail tooltip
+// renders it as markdown). Provider- and feature-neutral (no mark-preview /
+// message concerns), so any surface that needs a short snippet of a longer body
+// can reuse it.
 //
 // Extracted from `~/components/chat/markPreviewShared` -- the scroll-rail mark preview
 // was its first caller, which is why the exported names keep the `preview` prefix.
 // ---------------------------------------------------------------------------
 
+import { markdownSafeCut } from './markdownSafeCut'
+
 /** Longest preview kept; longer content is truncated with an ellipsis. */
 const MAX_PREVIEW_LEN = 200
-const PREVIEW_ELLIPSIS = '…'
-// Hard cap on graphemes SCANNED (not just appended). The MAX_PREVIEW_LEN break bounds appended
-// CONTENT, but whitespace / post-cap blank-line graphemes append nothing while the loop keeps
-// segmenting, so a whitespace-dominated input (a huge leading/embedded run in a pasted body or a
-// large tool_result) would segment its whole prefix on the main thread. 20x the output cap -- far
-// more than any content-dense input needs to reach MAX_PREVIEW_LEN -- so it never truncates normal
-// content, only bounds the pathological run.
+// Hard cap on graphemes SCANNED (not just appended). This is now the ONLY loop
+// bound -- deliberate, so the markdown parser sees construct closers past the
+// 200-grapheme preview limit (needed to recognize e.g. `**bold**` closing at
+// 210). Whitespace / post-cap blank-line graphemes append nothing while the loop
+// keeps segmenting, so a whitespace-dominated input (a huge leading/embedded run
+// in a pasted body or a large tool_result) would otherwise segment its whole
+// prefix on the main thread. 20x the output cap -- far more than any
+// content-dense input needs to fill a tidy preview -- so it never truncates
+// normal content short of a closer the parser needs; it only bounds the
+// pathological run.
 const MAX_PREVIEW_SCAN = MAX_PREVIEW_LEN * 20
 
 interface GraphemeSegment {
@@ -70,7 +78,7 @@ function* previewSegments(text: string): Iterable<string> {
   // '\r\n' pair as ONE segment so a CRLF line ending matches the Segmenter's single grapheme.
   // Without this, the '\r' and the '\n' each hit truncatePreview's newline branch and one CRLF
   // double-counts into a paragraph break, diverging from the Segmenter path. Kept lazy (a
-  // one-code-point lookahead) so truncatePreview's early break still bounds the iteration.
+  // one-code-point lookahead) so truncatePreview's scan-cap break still bounds the iteration.
   const it = text[Symbol.iterator]()
   let cur = it.next()
   while (!cur.done) {
@@ -87,11 +95,14 @@ function* previewSegments(text: string): Iterable<string> {
 }
 
 /**
- * Tidy a message body into a bounded snippet for the tooltip. Horizontal whitespace
- * runs collapse to a single space and blank-line runs cap at one, but NEWLINES ARE
- * PRESERVED so the tooltip's markdown renderer keeps paragraph / blockquote / list
- * structure. The result is capped at MAX_PREVIEW_LEN with a trailing ellipsis. Returns
- * null for empty input so callers fall back to a mark-type label.
+ * Tidy a message body into a bounded snippet for the tooltip. Mid-line horizontal
+ * whitespace runs collapse to a single space, LINE-LEADING runs are dropped
+ * entirely (indented code / nested-list indentation deliberately flattens to a
+ * compact snippet), and blank-line runs cap at one -- but NEWLINES ARE PRESERVED
+ * so the tooltip's markdown renderer keeps paragraph / blockquote / list
+ * structure. Overlong content is truncated with a trailing ellipsis at a
+ * markdown-safe boundary (see `markdownSafeCut`). Returns null for empty input so
+ * callers fall back to a mark-type label.
  */
 export function truncatePreview(text: string | null | undefined): string | null {
   if (!text)
@@ -100,30 +111,18 @@ export function truncatePreview(text: string | null | undefined): string | null 
   let seenContent = false
   let pendingSpace = false
   let newlineRun = 0
-  let truncated = false
+  let scanCapHit = false
   let scanned = 0
 
-  const append = (part: string) => {
-    out.push(part)
-    if (out.length > MAX_PREVIEW_LEN) {
-      truncated = true
-      return false
-    }
-    return true
-  }
-
   for (const ch of previewSegments(text)) {
-    // Stop after MAX_PREVIEW_SCAN graphemes even if none appended: content-dense input hits the
-    // append cap (out.length > MAX_PREVIEW_LEN) at scanned ~= MAX_PREVIEW_LEN, far below this, so
-    // normal previews are unaffected -- this only bounds a whitespace-dominated run that would
-    // otherwise segment the whole (possibly huge) input. Both segmenter paths are generators, so
-    // breaking stops pulling, structurally bounding the work.
+    // Stop after MAX_PREVIEW_SCAN graphemes: the sole loop bound (see constant
+    // comment). Both segmenter paths are generators, so breaking stops pulling,
+    // structurally bounding the work.
     if (++scanned > MAX_PREVIEW_SCAN) {
-      // Stopped scanning before consuming all input, so any content past this whitespace-dominated
-      // run is dropped -- mark truncated so the trailing ellipsis signals it (the append cap already
-      // sets `truncated` for content-dense input; this covers the scan-cap path, which otherwise
-      // returned a silently-cut snippet with no `…`).
-      truncated = true
+      // Stopped scanning before consuming all input, so any content past this
+      // whitespace-dominated run is dropped -- mark so the trailing ellipsis
+      // signals it.
+      scanCapHit = true
       break
     }
     // A bare '\r' (classic-Mac line ending) is its own grapheme, distinct from the '\r\n'
@@ -133,8 +132,8 @@ export function truncatePreview(text: string | null | undefined): string | null 
       pendingSpace = false
       if (!seenContent)
         continue
-      if (newlineRun < 2 && !append('\n'))
-        break
+      if (newlineRun < 2)
+        out.push('\n')
       newlineRun = Math.min(newlineRun + 1, 2)
       continue
     }
@@ -145,11 +144,10 @@ export function truncatePreview(text: string | null | undefined): string | null 
       continue
     }
 
-    if (pendingSpace && newlineRun === 0 && !append(' '))
-      break
+    if (pendingSpace && newlineRun === 0)
+      out.push(' ')
     pendingSpace = false
-    if (!append(ch))
-      break
+    out.push(ch)
     seenContent = true
     newlineRun = 0
   }
@@ -158,5 +156,13 @@ export function truncatePreview(text: string | null | undefined): string | null 
     out.pop()
   if (out.length === 0)
     return null
-  return truncated ? `${out.slice(0, MAX_PREVIEW_LEN).join('')}${PREVIEW_ELLIPSIS}` : out.join('')
+  // Recompute after the trailing-whitespace pop: exactly-MAX_PREVIEW_LEN content
+  // plus a trailing newline must NOT get a spurious ellipsis.
+  const truncated = scanCapHit || out.length > MAX_PREVIEW_LEN
+  if (!truncated)
+    return out.join('')
+  // limitOffset is a code-unit offset at a grapheme boundary. One formula covers
+  // both the >200 case and the scan-cap case (out.length ≤ 200 → limitOffset ===
+  // text.length → text-end candidate → content unchanged + `…`).
+  return markdownSafeCut(out.join(''), out.slice(0, MAX_PREVIEW_LEN).join('').length)
 }


### PR DESCRIPTION
## Motivation
The scroll-rail dot-hover preview tooltip renders a truncated snippet of the underlying message as markdown. `truncatePreview` previously hard-sliced the tidied body at 200 graphemes with no awareness of markdown structure, so the cut regularly landed mid-token: a `**bold**` span would leave a stray `**`, a link would be cut in half, and a cut inside an unterminated code fence would swallow the trailing ellipsis entirely, leaving the tooltip visibly broken. This closes #255.

## Modifications
- Added `frontend/src/lib/markdownSafeCut.ts`, a new module exporting `markdownSafeCut(text, limitOffset)`. It parses the tidied preview text and walks the resulting tree to find the largest *safe* boundary at or before the limit, closing straddling constructs instead of slicing through them:
  - Straddling `strong`/`emphasis`/`delete`/`inlineCode` spans are closed with the delimiter read verbatim from source; a straddling fenced code block is closed with a matching closer that repeats the opener's blockquote/indent prefix.
  - Block-level cuts (fence, setext underline, thematic break, table row, block HTML) emit the ellipsis as its own paragraph, carrying the `> ` markers of every still-open blockquote so it doesn't escape its container.
  - Constructs with no synthesizable closer (links, images, raw HTML) fall back to the previous bounded hard-cut behavior.
  - A `FLOOR` of half the limit rejects "clean" boundaries that would throw away too much of the budget in favor of a synthesized closer.
  - Guards against HTML entities split mid-entity, dangling link/image/footnote references whose definitions fall past the cut, pathologically deep trees (tree walks wrapped in try/catch, degrading to a hard cut instead of a stack overflow), and `NaN`/`≤0` limits.
- Extracted `createMarkdownParser()` into a new shared `frontend/src/lib/markdownParse.ts` and switched both `markdownProcessor.ts` and `markdownSafeCut.ts` to use it, so the render pipeline and the truncation safety judgment can't structurally drift apart.
- Reworked `textTruncate.ts`'s scan loop: removed the separate append cap so `MAX_PREVIEW_SCAN` (4000 graphemes, 20x the 200-grapheme output cap) is now the sole loop bound, letting the parser see construct closers past the preview limit (e.g. recognizing `**bold**` closing at grapheme 210). The truncation flag is now recomputed after trailing-whitespace trimming so exactly-200-grapheme content followed by a newline no longer gets a spurious ellipsis. `PREVIEW_ELLIPSIS` moved to (and is now exported from) `markdownSafeCut.ts`.
- No breaking changes: `truncatePreview`'s public signature is unchanged. Behaviorally, a truncated preview may now be a little longer than 200 characters when a synthesized closer, fence, ellipsis paragraph, or entity snap requires it, and line-leading whitespace is now documented as dropped entirely (existing behavior, now explicit).

## Result
- Closes #255
- The scroll-rail hover preview no longer shows a stray `**`, a half-rendered link, or an ellipsis swallowed by an unterminated code fence when the 200-character cut lands inside a markdown construct.
- Content that ends exactly at the preview limit followed by a trailing newline no longer gets an unnecessary ellipsis appended.
- Truncated previews stay inside their originating blockquote/fence instead of the ellipsis escaping into the wrong container.
- Covered by 620 lines of new co-located tests, including re-parse assertions that the cut output actually parses back to the intended structure. Full frontend suite passes (6692 tests), lint and both typecheck configs clean.
