### PR TITLE
test(hub): Stop revocation lease tests racing their own leases

### DIFF
--- a/backend/internal/hub/revocationwatcher/watcher_test.go
+++ b/backend/internal/hub/revocationwatcher/watcher_test.go
@@ -794,10 +794,16 @@ func (c *blockingCloser) CloseChannelsByBearer(ref auth.BearerRef) int {
 // decoupling, runOnce held w.lease.mu across teardown so the lease could not be
 // renewed and the Hub self-fenced.
 func TestWatcher_SlowTeardownDoesNotSelfFence(t *testing.T) {
+	// renewalLoop renews at the lease half-life, so the slack between a renewal
+	// falling due and the lease actually lapsing is leaseDuration/2 -- the window
+	// in which the heartbeat goroutine must get scheduled. At 40ms that slack was
+	// 20ms, which a loaded CI runner exceeds outright, and the watcher then
+	// self-fenced for real. 200ms buys a 100ms margin while keeping the test fast.
+	const leaseDuration = 200 * time.Millisecond
 	env := setupUnseeded(t)
 	blocking := newBlockingCloser()
 	w := revocationwatcher.New(env.st, auth.NewCredentialLifecycleEffects(env.cache, blocking, nil),
-		revocationwatcher.WithLeaseDuration(40*time.Millisecond),
+		revocationwatcher.WithLeaseDuration(leaseDuration),
 		revocationwatcher.WithInterval(20*time.Millisecond),
 	)
 	require.NoError(t, w.SeedCursor(context.Background()))
@@ -817,13 +823,25 @@ func TestWatcher_SlowTeardownDoesNotSelfFence(t *testing.T) {
 		t.Fatal("teardown never started")
 	}
 
-	// Hold the teardown for several lease durations. A healthy heartbeat keeps
-	// the lease alive; a self-fence here would surface on the Errors channel.
+	// Hold the teardown for three lease durations: long enough that only a live
+	// heartbeat can still hold the lease, so the test would catch a regression
+	// that let teardown block renewal. A self-fence surfaces on Errors.
 	select {
 	case err := <-w.Errors():
 		t.Fatalf("watcher self-fenced during a slow teardown: %v", err)
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(3 * leaseDuration):
 	}
+
+	// A quiet Errors channel only proves the watcher never *noticed* a lost
+	// lease. Assert the durable row too: three lease durations into the
+	// teardown, a rival can only be fenced out if the heartbeat kept renewing.
+	// (A failing acquire rolls its transaction back, so this probe is inert.)
+	_, err = env.st.RevocationEvents().AcquireHubRuntimeLease(
+		context.Background(),
+		store.AcquireHubRuntimeLeaseParams{HolderID: "rival", PublishLimit: 10, LeaseDuration: time.Hour},
+	)
+	require.ErrorIs(t, err, store.ErrHubAlreadyRunning,
+		"the heartbeat must keep the durable lease alive across a slow teardown")
 
 	blocking.release()
 	require.Eventually(t, func() bool {

--- a/backend/internal/hub/store/storetest/test_token_revocation.go
+++ b/backend/internal/hub/store/storetest/test_token_revocation.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// expiringLeaseDuration is the lease life used by the cases that need a lease to
+// lapse. Every assertion that depends on it waits a multiple of it, never races
+// it: a test must not require a lease to still be live across a store round-trip,
+// because a loaded CI runner (or a distributed store, where a single statement
+// costs tens of milliseconds) makes that a coin flip.
+const expiringLeaseDuration = 25 * time.Millisecond
+
 func (s *Suite) testTokenRevocation(t *testing.T) {
 	t.Run("API refresh rotation creates one cache-invalidation event", func(t *testing.T) {
 		st := s.NewStore(t)
@@ -552,10 +559,17 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 		_, err = st.RevocationEvents().PublishPending(ctx, 10)
 		require.NoError(t, err)
 
+		// Park the cursor at seq 1 under a LONG lease. The bound this asserts is
+		// the live lease's cursor_seq, and CompactPublished deletes the expired
+		// lease row before compacting, so a lease that lapses between this renew
+		// and the compaction below would silently unbound the sweep to last_seq
+		// and delete all three events. Under a short lease that gap is two store
+		// round-trips wide -- survivable on SQLite, not on a distributed store.
+		// The expiry half of this test drives its own short lease further down.
 		advanced, err = st.RevocationEvents().RenewHubRuntimeLease(ctx, store.RenewHubRuntimeLeaseParams{
 			HolderID:      "first",
 			CursorSeq:     1,
-			LeaseDuration: 25 * time.Millisecond,
+			LeaseDuration: time.Hour,
 		})
 		require.NoError(t, err)
 		require.True(t, advanced)
@@ -564,20 +578,32 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 			Cutoff: time.Now().UTC().Add(time.Hour),
 		})
 		require.NoError(t, err)
-		require.Equal(t, int64(1), deleted)
+		require.Equal(t, int64(1), deleted, "a live lease must bound compaction to its cursor")
 		events, err := st.RevocationEvents().ListPublishedAfter(ctx, 0, 10)
 		require.NoError(t, err)
 		require.Len(t, events, 2)
 		assert.Equal(t, int64(2), events[0].Seq)
 
-		time.Sleep(100 * time.Millisecond)
+		// Now shorten the lease and outlive it. Re-renewing at the same cursor is
+		// permitted (the guard is cursor_seq <= arg), so this only pulls the
+		// deadline in. Unlike the compaction above, what follows needs the lease
+		// merely to have lapsed -- a lower bound that CI load can only help.
+		advanced, err = st.RevocationEvents().RenewHubRuntimeLease(ctx, store.RenewHubRuntimeLeaseParams{
+			HolderID:      "first",
+			CursorSeq:     1,
+			LeaseDuration: expiringLeaseDuration,
+		})
+		require.NoError(t, err)
+		require.True(t, advanced)
+
+		time.Sleep(4 * expiringLeaseDuration)
 		advanced, err = st.RevocationEvents().RenewHubRuntimeLease(ctx, store.RenewHubRuntimeLeaseParams{
 			HolderID:      "first",
 			CursorSeq:     3,
 			LeaseDuration: time.Hour,
 		})
 		require.NoError(t, err)
-		require.False(t, advanced)
+		require.False(t, advanced, "an expired lease must not renew itself")
 
 		fence, err = st.RevocationEvents().AcquireHubRuntimeLease(ctx, store.AcquireHubRuntimeLeaseParams{
 			HolderID: "second", PublishLimit: 10, LeaseDuration: time.Hour,
@@ -601,6 +627,59 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 			HolderID: "third", PublishLimit: 10, LeaseDuration: time.Hour,
 		})
 		require.NoError(t, err, "clean release must permit immediate handoff")
+	})
+
+	// The bound compaction applies is the LIVE lease's cursor; an abandoned Hub
+	// must not pin the backlog forever. CompactPublished deletes the expired
+	// lease row before compacting, so the COALESCE bound falls back to last_seq
+	// once the lease lapses. That fallback is exactly what a lease which quietly
+	// expired mid-test turned into a full sweep, so assert it deliberately here
+	// rather than leaving it as the silent failure mode of another case.
+	t.Run("an expired Hub lease stops bounding compaction", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "org")
+		user := SeedUser(t, st, orgID, "user")
+
+		_, err := st.RevocationEvents().AcquireHubRuntimeLease(ctx, store.AcquireHubRuntimeLeaseParams{
+			HolderID: "first", PublishLimit: 10, LeaseDuration: time.Hour,
+		})
+		require.NoError(t, err)
+
+		for range 2 {
+			tokenID := seedAPIToken(t, st, user.ID)
+			_, err := st.APITokens().Revoke(ctx, tokenID)
+			require.NoError(t, err)
+		}
+		published, err := st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), published)
+
+		compact := func() int64 {
+			deleted, compactErr := st.Cleanup().CompactPublishedRevocationEvents(
+				ctx,
+				store.CompactRevocationEventsParams{Cutoff: time.Now().UTC().Add(time.Hour)},
+			)
+			require.NoError(t, compactErr)
+			return deleted
+		}
+
+		// The lease was acquired before either event existed, so its cursor sits at
+		// seq 0: a live Hub has consumed nothing, and no cutoff may collect events
+		// it still owes delivery on.
+		require.Zero(t, compact(), "a live lease at cursor 0 must block compaction entirely")
+
+		// Same holder, deliberately short lease -- then outlive it.
+		advanced, err := st.RevocationEvents().RenewHubRuntimeLease(ctx, store.RenewHubRuntimeLeaseParams{
+			HolderID: "first", CursorSeq: 0, LeaseDuration: expiringLeaseDuration,
+		})
+		require.NoError(t, err)
+		require.True(t, advanced)
+		time.Sleep(4 * expiringLeaseDuration)
+
+		require.Equal(t, int64(2), compact(), "an expired lease must stop bounding compaction")
+		events, err := st.RevocationEvents().ListPublishedAfter(ctx, 0, 10)
+		require.NoError(t, err)
+		require.Empty(t, events)
 	})
 }
 


### PR DESCRIPTION
## Motivation

Two revocation-lease tests failed on CI:

- `TestCockroachDBStore/token_revocation/singleton_Hub_lease_bounds_compaction_and_supports_takeover` — `expected: 1, actual: 3`
- `TestWatcher_SlowTeardownDoesNotSelfFence` — `watcher self-fenced during a slow teardown: revocation watcher lease lost`

Both assert behavior that only holds while a lease is still live, but gave the lease less time than the work it had to survive.

**Store suite.** It renewed the cursor to seq 1 with a **25ms** lease and then compacted. `RevocationCore.CompactPublished` deletes the expired lease row *before* compacting, so a lease that lapsed in between unbound the sweep: the `COALESCE` bound fell through from `cursor_seq` to `last_seq` and swept all three events instead of one. That gap spans two store round-trips — survivable on SQLite, not on CockroachDB, where a single statement costs tens of milliseconds. `deleted == 3` was only reachable that way, since `advanced == true` proves the cursor was 1.

**Watcher.** It ran a **40ms** lease. `renewalLoop` ticks at `leaseDuration/4` and renews at the half-life, so the heartbeat goroutine had a 20ms window to get scheduled. A loaded runner starves it past that and the watcher self-fences for real — confirmed by tagging the two identically-worded error sites, which showed `renewLocked` waking 2-4ms *after* expiry.

Neither is a product defect: production runs `DefaultLeaseDuration = 30s` with a 15s renewal margin.

Both reproduce locally under CPU load — the CockroachDB subtest failed 1-of-6 at `GOMAXPROCS=2`, and the watcher test failed repeatedly at `-count=80 -race`.

## Modifications

**`storetest/test_token_revocation.go`**

- Compact under an hour-long lease, then renew short purely to drive the expiry/takeover half of the case. The assertion that needs a *live* lease no longer races a store round-trip; the one that needs a *lapsed* lease depends only on a lower bound, which CI load can only help.
- Add `expiringLeaseDuration`, the single lease life used where a lease must lapse, documenting that no assertion may require a lease to outlive a round-trip.
- Add a subtest covering the expired-lease compaction fallback head-on. No test asserted it before — it was only ever the silent failure mode of another case.

**`revocationwatcher/watcher_test.go`**

- Raise the lease to 200ms (a 100ms heartbeat margin) and scale the teardown hold to three lease durations, so the test still proves teardown cannot block renewal.
- Assert the durable lease survives the hold via a rival `AcquireHubRuntimeLease` that must fail with `ErrHubAlreadyRunning`. A quiet `Errors` channel alone only proves the watcher never *noticed* a lost lease.

## Result

Both previously-failing tests pass under the load that reproduced the failures: the watcher test 60/60 at `GOMAXPROCS=2 -race` under load averages of 29-49 (previously failing at 11-18), and the CockroachDB subtest 6/6 under load reaching 83.

Both new assertions are mutation-verified rather than assumed:

- Disabling `DeleteExpiredLease` in `CompactPublished` fails the new compaction subtest (`expected: 2, actual: 0`) — and **no pre-existing test caught it**.
- Making the heartbeat skip renewal while swallowing fatal signals fails the new rival-acquire assertion, with the rest of the test passing silently.

Full verification: `revocationwatcher`, `store/...` and `cleanup` suites pass with `-race`; the shared `storetest` changes pass on all four dialects (SQLite, Postgres, MySQL, CockroachDB); `task lint-backend` reports 0 issues.
