### PR TITLE
feat(hub): Fence live streams on privilege reduction

### DIFF
--- a/backend/cmd/leapmux/admin_test.go
+++ b/backend/cmd/leapmux/admin_test.go
@@ -834,6 +834,10 @@ func TestCLI_UserGrantAdmin(t *testing.T) {
 	updated, err := q.GetUserByID(context.Background(), user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), updated.IsAdmin)
+	// A grant (is_admin false->true) is not a reduction: it stays on the soft
+	// user_info cache signal and must NOT bump auth_generation (no logout).
+	assert.Equal(t, user.AuthGeneration, updated.AuthGeneration,
+		"grant-admin must not bump auth_generation")
 }
 
 func TestCLI_UserGrantAdmin_AlreadyAdmin(t *testing.T) {
@@ -887,6 +891,12 @@ func TestCLI_UserRevokeAdmin(t *testing.T) {
 	updated, err := q.GetUserByID(context.Background(), user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), updated.IsAdmin)
+	// A demotion (is_admin true->false) is an auth-gate reduction: the store
+	// escalates it to a generation-bearing user_tokens revocation that fences
+	// the user's live streams and logs them out. Assert the generation bumped
+	// so the CLI path stays wired to that fence end-to-end.
+	assert.Equal(t, user.AuthGeneration+1, updated.AuthGeneration,
+		"revoke-admin must bump auth_generation to fence the demoted user")
 }
 
 func TestCLI_UserRevokeAdmin_AlreadyNonAdmin(t *testing.T) {
@@ -902,6 +912,12 @@ func TestCLI_UserRevokeAdmin_AlreadyNonAdmin(t *testing.T) {
 	updated, err := q.GetUserByID(context.Background(), user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), updated.IsAdmin)
+	// Revoking admin from a non-admin is a no-op: it fences nothing, so
+	// auth_generation must stay put. The CLI's "nothing to revoke" message
+	// depends on this (there is no reduction to escalate to a user_tokens
+	// revocation).
+	assert.Equal(t, user.AuthGeneration, updated.AuthGeneration,
+		"revoke-admin on a non-admin must not bump auth_generation")
 }
 
 func TestCLI_UserListSessions(t *testing.T) {

--- a/backend/cmd/leapmux/admin_user.go
+++ b/backend/cmd/leapmux/admin_user.go
@@ -410,11 +410,19 @@ func runUserSetAdmin(cmd adminCmdCtx, args []string, admin bool) error {
 			return fmt.Errorf("update admin: %w", err)
 		}
 
-		action := "Granted"
 		if !admin {
-			action = "Revoked"
+			// Only claim a fence when the user was actually an admin: a demotion
+			// (is_admin true->false) is the auth-gate reduction that revokes
+			// sessions/tokens, whereas revoking admin from a non-admin is a
+			// no-op that fences nothing.
+			if user.IsAdmin {
+				fmt.Printf("Revoked admin privileges for user %q (id: %s); active sessions and tokens revoked.\n", user.Username, user.ID)
+			} else {
+				fmt.Printf("User %q (id: %s) is not an admin; nothing to revoke.\n", user.Username, user.ID)
+			}
+			return nil
 		}
-		fmt.Printf("%s admin privileges for user %q (id: %s)\n", action, user.Username, user.ID)
+		fmt.Printf("Granted admin privileges for user %q (id: %s)\n", user.Username, user.ID)
 		return nil
 	})
 }

--- a/backend/internal/hub/revocationwatcher/admin_paths_test.go
+++ b/backend/internal/hub/revocationwatcher/admin_paths_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
@@ -137,5 +138,49 @@ func TestAdminPath_SessionRevokeUser_TearsDownAllChannels(t *testing.T) {
 
 	require.NoError(t, env.watcher.RunOnce(context.Background()))
 	assert.Empty(t, env.closer.bearerSnapshot())
+	assert.Equal(t, []string{env.userID}, env.closer.userSnapshot())
+}
+
+// TestAdminPath_RevokeAdmin_FencesUserCredentials mirrors
+// `leapmux admin user revoke-admin`. A grant stays on the soft user_info
+// path (no channel teardown); a demotion emits a generation-bearing
+// user_tokens event that CloseChannelsByUserRevocation fences.
+func TestAdminPath_RevokeAdmin_FencesUserCredentials(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+	// Use a non-admin so UpdateAdmin(true) is a real grant, not a no-op on
+	// the already-admin fixture.
+	targetID := hubtestutil.CreateTestUser(t, env.st, "gate-user", "password-gate-user-123")
+
+	require.NoError(t, env.st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+		ID: targetID, IsAdmin: true,
+	}))
+	require.NoError(t, env.watcher.RunOnce(ctx))
+	assert.Empty(t, env.closer.userSnapshot(), "grant must not fence live streams")
+
+	require.NoError(t, env.st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+		ID: targetID, IsAdmin: false,
+	}))
+	require.NoError(t, env.watcher.RunOnce(ctx))
+	assert.Equal(t, []string{targetID}, env.closer.userSnapshot())
+}
+
+// TestAdminPath_UnverifyEmail_FencesUserCredentials mirrors an admin
+// `user update --email-verified=false`. Verify (grant) stays soft; un-verify
+// fences via the same user_tokens watcher path as revoke-admin.
+func TestAdminPath_UnverifyEmail_FencesUserCredentials(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, env.st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+		ID: env.userID, EmailVerified: true,
+	}))
+	require.NoError(t, env.watcher.RunOnce(ctx))
+	assert.Empty(t, env.closer.userSnapshot(), "verify grant must not fence live streams")
+
+	require.NoError(t, env.st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+		ID: env.userID, EmailVerified: false,
+	}))
+	require.NoError(t, env.watcher.RunOnce(ctx))
 	assert.Equal(t, []string{env.userID}, env.closer.userSnapshot())
 }

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -200,12 +200,31 @@ func loadUserInfoCacheFields(ctx context.Context, conn *mysqlConn, id string) (s
 // runUserInfoMutation wires the shared RunUserInfoMutation to this dialect's
 // projection read, locked clock reading, and user_info event insert, so the
 // durable cache-invalidation is derived from the before/after cached-field
-// projection rather than a hand-computed flag. MySQL has no RETURNING, so it
+// projection rather than a hand-computed flag. Soft path only (nil fence):
+// grants and non-gate changes stay on user_info. MySQL has no RETURNING, so it
 // locks the row FOR UPDATE to fix a single clock reading (shared by the UPDATE
 // and the emitted event) before running update; a missing id is a no-op. update
 // runs against the locked row and reports ok=false to force a no-op (e.g. a
 // promote that matched no pending email).
 func (s *userStore) runUserInfoMutation(ctx context.Context, id string, update func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, update, nil)
+}
+
+// runAuthGateMutation is the UpdateAdmin / UpdateEmailVerified sibling of
+// runUserInfoMutation: a privilege reduction (is_admin / email_verified
+// true→false) escalates to a generation-bearing user_tokens revocation that
+// fences live streams and logs the user out; a grant stays on the soft
+// user_info signal.
+func (s *userStore) runAuthGateMutation(ctx context.Context, id string, update func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, update, fenceUserTokensLocked)
+}
+
+func (s *userStore) runCachedUserMutation(
+	ctx context.Context,
+	id string,
+	update func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (ok bool, err error),
+	fence func(context.Context, *mysqlConn, string, time.Time) error,
+) error {
 	// Lock the user row before the before-read so a concurrent same-user mutation
 	// cannot commit between the before and after cached-field projections and hide
 	// a change (which would drop the durable user_info invalidation for that field).
@@ -239,7 +258,36 @@ func (s *userStore) runUserInfoMutation(ctx context.Context, id string, update f
 		func(ctx context.Context, conn *mysqlConn, userID string, updatedAt time.Time) error {
 			return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserInfo, userID, userID, updatedAt, 0)
 		},
+		fence,
 	)
+}
+
+// fenceUserTokensLocked bumps auth_generation + tokens_revoked_at and inserts a
+// user_tokens event inside the already-open, row-locked transaction. Same effect
+// as RevokeUserTokens's mutate body, done in-transaction so an auth-gate
+// reduction and its fence share one commit. GetUserTokensRevocationForUpdate
+// re-locks the row (re-entrant within the tx) to read the current generation.
+func fenceUserTokensLocked(ctx context.Context, conn *mysqlConn, id string, _ time.Time) error {
+	row, err := conn.q.GetUserTokensRevocationForUpdate(ctx, id)
+	if err != nil {
+		return mapErr(err)
+	}
+	updatedAt := row.NowAt.UTC()
+	revokedAt := updatedAt
+	nextGeneration := row.AuthGeneration + 1
+	n, err := rowsAffected(conn.q.SetUserTokensRevokedAt(ctx, gendb.SetUserTokensRevokedAtParams{
+		ID:              row.ID,
+		TokensRevokedAt: sqltime.MySQLNullTimeOf(revokedAt),
+		AuthGeneration:  nextGeneration,
+		UpdatedAt:       sqltime.NewMySQLTime(updatedAt),
+	}))
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("bump user token revocation %q: updated %d rows after locking live row", row.ID, n)
+	}
+	return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserTokens, row.ID, row.ID, revokedAt, nextGeneration)
 }
 
 // requireSingleRowUpdate maps a rowsAffected result into the (changed, err) pair
@@ -300,8 +348,13 @@ func (s *userStore) UpdatePassword(ctx context.Context, p store.UpdateUserPasswo
 }
 
 // UpdateEmail changes the email and its verified flag; runUserInfoMutation emits
-// a user_info cache-invalidation event iff a cached field (email/email_verified,
-// an auth gate) actually changed. A missing id is a no-op with no event.
+// a user_info cache-invalidation event iff a cached field (email/email_verified)
+// actually changed. Stays on the soft path even when email_verified drops
+// true→false: this is also the self-service email-change path
+// (RequestEmailChange → SetEmailAndClearCompeting), and fencing would log the
+// user out for changing their own address. The pure un-verify
+// (UpdateEmailVerified false) is the canonical gate flip and does fence. A
+// missing id is a no-op with no event.
 func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailParams) error {
 	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.UpdateUserEmail(ctx, gendb.UpdateUserEmailParams{
@@ -314,12 +367,12 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 	})
 }
 
-// UpdateEmailVerified flips the email_verified auth gate; runUserInfoMutation
-// emits a user_info cache-invalidation event iff the gate actually changed, so
-// the change is observed cross-process without waiting out the cache TTL. A
-// missing id is a no-op with no event.
+// UpdateEmailVerified flips the email_verified auth gate. A reduction
+// (true→false) escalates to a generation-bearing user_tokens revocation that
+// fences the user's live streams and logs them out; a grant (false→true) stays
+// on the soft user_info cache signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserEmailVerifiedParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.UpdateUserEmailVerified(ctx, gendb.UpdateUserEmailVerifiedParams{
 			EmailVerified: p.EmailVerified,
 			UpdatedAt:     sqltime.NewMySQLTime(updatedAt),
@@ -329,11 +382,12 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 	})
 }
 
-// UpdateAdmin flips the IsAdmin flag; runUserInfoMutation emits a user_info
-// cache-invalidation event iff is_admin actually changed, dropping a stale
-// cached UserInfo cross-process. A missing id is a no-op with no event.
+// UpdateAdmin flips the IsAdmin flag. A reduction (true→false) escalates to a
+// generation-bearing user_tokens revocation that fences the user's live streams
+// and logs them out; a grant (false→true) stays on the soft user_info cache
+// signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.UpdateUserAdmin(ctx, gendb.UpdateUserAdminParams{
 			IsAdmin:   p.IsAdmin,
 			UpdatedAt: sqltime.NewMySQLTime(updatedAt),
@@ -362,8 +416,10 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 // PromotePendingEmail moves pending_email into email (email_verified=1). A row
 // with no pending email matches zero rows and is a no-op; otherwise
 // runUserInfoMutation emits a user_info cache-invalidation event iff the
-// promotion changed a cached field (email/email_verified, an auth gate) -- the
-// same guarantee its sibling UpdateEmail/UpdateEmailVerified give.
+// promotion changed a cached field (email/email_verified, an auth gate). Like
+// UpdateEmail, it stays on the soft path (runUserInfoMutation, nil fence): a
+// promotion only grants email_verified (false→true), so it never reduces an
+// auth gate and never fences.
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *mysqlConn, updatedAt time.Time) (bool, error) {
 		n, err := rowsAffected(conn.q.PromotePendingEmail(ctx, gendb.PromotePendingEmailParams{

--- a/backend/internal/hub/store/postgres/db/queries/users.sql
+++ b/backend/internal/hub/store/postgres/db/queries/users.sql
@@ -197,11 +197,14 @@ WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pen
 
 -- name: BumpUserTokensRevokedAt :one
 -- The query itself has no deleted_at guard, so it would act on a
--- soft-deleted row -- but the only caller (RevokeAllUserCredentials) runs
--- inside RunInUserAuthTransaction, whose LockUserAuthState filters
--- deleted_at IS NULL, so revoking an already-soft-deleted user aborts
--- before this runs. Every revoke path revokes before soft-deleting, so
--- that ordering is not exercised today. Only a missing id is a no-op.
+-- soft-deleted row -- but neither caller can reach one: RevokeUserTokens
+-- (via RevokeAllUserCredentials) runs inside RunInUserAuthTransaction, whose
+-- LockUserAuthState filters deleted_at IS NULL; fenceUserTokensLocked (the
+-- auth-gate reduction fence) runs only in RunUserInfoMutation's
+-- existedBefore && existedAfter branch, and both existence reads use
+-- GetUserByID, which also filters deleted_at IS NULL. Every revoke path
+-- revokes before soft-deleting, so that ordering is not exercised today.
+-- Only a missing id is a no-op.
 UPDATE users
 SET tokens_revoked_at = revocation_clock.now_at,
     auth_generation   = auth_generation + 1,

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -181,8 +181,27 @@ func loadUserInfoCacheFields(ctx context.Context, conn *pgConn, id string) (stor
 // runUserInfoMutation wires the shared RunUserInfoMutation to this dialect's
 // projection read and user_info event insert, so each Update* method supplies
 // only its UPDATE and the durable cache-invalidation is derived from the
-// before/after projection rather than a hand-computed flag.
+// before/after projection rather than a hand-computed flag. Soft path only
+// (nil fence): grants and non-gate changes stay on user_info.
 func (s *userStore) runUserInfoMutation(ctx context.Context, id string, mutate func(ctx context.Context, conn *pgConn) (userID string, updatedAt time.Time, ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, mutate, nil)
+}
+
+// runAuthGateMutation is the UpdateAdmin / UpdateEmailVerified sibling of
+// runUserInfoMutation: a privilege reduction (is_admin / email_verified
+// true→false) escalates to a generation-bearing user_tokens revocation that
+// fences live streams and logs the user out; a grant stays on the soft
+// user_info signal.
+func (s *userStore) runAuthGateMutation(ctx context.Context, id string, mutate func(ctx context.Context, conn *pgConn) (userID string, updatedAt time.Time, ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, mutate, fenceUserTokensLocked)
+}
+
+func (s *userStore) runCachedUserMutation(
+	ctx context.Context,
+	id string,
+	mutate func(ctx context.Context, conn *pgConn) (userID string, updatedAt time.Time, ok bool, err error),
+	fence func(context.Context, *pgConn, string, time.Time) error,
+) error {
 	// Lock the user row before the before-read so a concurrent same-user mutation
 	// cannot commit between the before and after cached-field projections and hide
 	// a change (which would drop the durable user_info invalidation for that field).
@@ -202,7 +221,24 @@ func (s *userStore) runUserInfoMutation(ctx context.Context, id string, mutate f
 		func(ctx context.Context, conn *pgConn, userID string, updatedAt time.Time) error {
 			return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserInfo, userID, userID, updatedAt, 0)
 		},
+		fence,
 	)
+}
+
+// fenceUserTokensLocked bumps auth_generation + tokens_revoked_at and inserts a
+// user_tokens event inside the already-open, row-locked transaction. Same effect
+// as RevokeUserTokens's mutate body, done in-transaction so an auth-gate
+// reduction and its fence share one commit.
+func fenceUserTokensLocked(ctx context.Context, conn *pgConn, id string, _ time.Time) error {
+	row, err := conn.q.BumpUserTokensRevokedAt(ctx, id)
+	if err != nil {
+		return mapErr(err)
+	}
+	revokedAt, err := sqlutil.RequireTime(row.TokensRevokedAt.Time, row.TokensRevokedAt.Valid, "tokens_revoked_at")
+	if err != nil {
+		return err
+	}
+	return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserTokens, row.ID, row.ID, revokedAt, row.AuthGeneration)
 }
 
 // updatedUserResult maps a RETURNING (id, updated_at) row plus error into the
@@ -264,8 +300,13 @@ func (s *userStore) UpdatePassword(ctx context.Context, p store.UpdateUserPasswo
 }
 
 // UpdateEmail changes the email and its verified flag; runUserInfoMutation emits
-// a user_info cache-invalidation event iff a cached field (email/email_verified,
-// an auth gate) actually changed. A missing id is a no-op with no event.
+// a user_info cache-invalidation event iff a cached field (email/email_verified)
+// actually changed. Stays on the soft path even when email_verified drops
+// true→false: this is also the self-service email-change path
+// (RequestEmailChange → SetEmailAndClearCompeting), and fencing would log the
+// user out for changing their own address. The pure un-verify
+// (UpdateEmailVerified false) is the canonical gate flip and does fence. A
+// missing id is a no-op with no event.
 func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailParams) error {
 	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserEmail(ctx, gendb.UpdateUserEmailParams{
@@ -277,12 +318,12 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 	})
 }
 
-// UpdateEmailVerified flips the email_verified auth gate; runUserInfoMutation
-// emits a user_info cache-invalidation event iff the gate actually changed, so
-// the change is observed cross-process without waiting out the cache TTL. A
-// missing id is a no-op with no event.
+// UpdateEmailVerified flips the email_verified auth gate. A reduction
+// (true→false) escalates to a generation-bearing user_tokens revocation that
+// fences the user's live streams and logs them out; a grant (false→true) stays
+// on the soft user_info cache signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserEmailVerifiedParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserEmailVerified(ctx, gendb.UpdateUserEmailVerifiedParams{
 			EmailVerified: p.EmailVerified,
 			ID:            p.ID,
@@ -291,11 +332,12 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 	})
 }
 
-// UpdateAdmin flips the IsAdmin flag; runUserInfoMutation emits a user_info
-// cache-invalidation event iff is_admin actually changed, dropping a stale
-// cached UserInfo cross-process. A missing id is a no-op with no event.
+// UpdateAdmin flips the IsAdmin flag. A reduction (true→false) escalates to a
+// generation-bearing user_tokens revocation that fences the user's live streams
+// and logs them out; a grant (false→true) stays on the soft user_info cache
+// signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserAdmin(ctx, gendb.UpdateUserAdminParams{
 			IsAdmin: p.IsAdmin,
 			ID:      p.ID,
@@ -323,8 +365,9 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 // PromotePendingEmail moves pending_email into email (email_verified=TRUE). A
 // row with no pending email is a no-op; otherwise runUserInfoMutation emits a
 // user_info cache-invalidation event iff the promotion changed a cached field
-// (email/email_verified, an auth gate) -- the same guarantee its sibling
-// UpdateEmail/UpdateEmailVerified give.
+// (email/email_verified, an auth gate). Like UpdateEmail, it stays on the soft
+// path (runUserInfoMutation, nil fence): a promotion only grants email_verified
+// (false→true), so it never reduces an auth gate and never fences.
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *pgConn) (string, time.Time, bool, error) {
 		row, err := conn.q.PromotePendingEmail(ctx, id)

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -217,12 +217,15 @@ WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pen
 -- Bumps the user-wide revocation timestamp and credential epoch, then
 -- returns the row that moved so the store layer can emit a durable
 -- revocation event carrying the new epoch. The query itself has no
--- deleted_at guard, so it would act on a soft-deleted row -- but the only
--- caller (RevokeAllUserCredentials) runs inside RunInUserAuthTransaction,
--- whose LockUserAuthState filters deleted_at IS NULL, so revoking an
--- already-soft-deleted user aborts before this runs. Every revoke path
--- revokes before soft-deleting, so that ordering is not exercised today.
--- Only a truly missing row (no id match) is a no-op.
+-- deleted_at guard, so it would act on a soft-deleted row -- but neither
+-- caller can reach one: RevokeUserTokens (via RevokeAllUserCredentials)
+-- runs inside RunInUserAuthTransaction, whose LockUserAuthState filters
+-- deleted_at IS NULL; fenceUserTokensLocked (the auth-gate reduction fence)
+-- runs only in RunUserInfoMutation's existedBefore && existedAfter branch,
+-- and both existence reads use GetUserByID, which also filters
+-- deleted_at IS NULL. Every revoke path revokes before soft-deleting, so
+-- that ordering is not exercised today. Only a truly missing row (no id
+-- match) is a no-op.
 UPDATE users
 SET tokens_revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
     auth_generation   = auth_generation + 1,

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -182,8 +182,27 @@ func loadUserInfoCacheFields(ctx context.Context, conn *sqliteConn, id string) (
 // runUserInfoMutation wires the shared RunUserInfoMutation to this dialect's
 // projection read and user_info event insert, so each Update* method supplies
 // only its UPDATE and the durable cache-invalidation is derived from the
-// before/after projection rather than a hand-computed flag.
+// before/after projection rather than a hand-computed flag. Soft path only
+// (nil fence): grants and non-gate changes stay on user_info.
 func (s *userStore) runUserInfoMutation(ctx context.Context, id string, mutate func(ctx context.Context, conn *sqliteConn) (userID string, updatedAt time.Time, ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, mutate, nil)
+}
+
+// runAuthGateMutation is the UpdateAdmin / UpdateEmailVerified sibling of
+// runUserInfoMutation: a privilege reduction (is_admin / email_verified
+// true→false) escalates to a generation-bearing user_tokens revocation that
+// fences live streams and logs the user out; a grant stays on the soft
+// user_info signal.
+func (s *userStore) runAuthGateMutation(ctx context.Context, id string, mutate func(ctx context.Context, conn *sqliteConn) (userID string, updatedAt time.Time, ok bool, err error)) error {
+	return s.runCachedUserMutation(ctx, id, mutate, fenceUserTokensLocked)
+}
+
+func (s *userStore) runCachedUserMutation(
+	ctx context.Context,
+	id string,
+	mutate func(ctx context.Context, conn *sqliteConn) (userID string, updatedAt time.Time, ok bool, err error),
+	fence func(context.Context, *sqliteConn, string, time.Time) error,
+) error {
 	// Lock the user row before the before-read so a concurrent same-user mutation
 	// cannot commit between the before and after cached-field projections and hide
 	// a change (which would drop the durable user_info invalidation for that field).
@@ -203,7 +222,24 @@ func (s *userStore) runUserInfoMutation(ctx context.Context, id string, mutate f
 		func(ctx context.Context, conn *sqliteConn, userID string, updatedAt time.Time) error {
 			return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserInfo, userID, userID, updatedAt, 0)
 		},
+		fence,
 	)
+}
+
+// fenceUserTokensLocked bumps auth_generation + tokens_revoked_at and inserts a
+// user_tokens event inside the already-open, row-locked transaction. Same effect
+// as RevokeUserTokens's mutate body, done in-transaction so an auth-gate
+// reduction and its fence share one commit.
+func fenceUserTokensLocked(ctx context.Context, conn *sqliteConn, id string, _ time.Time) error {
+	row, err := conn.q.BumpUserTokensRevokedAt(ctx, id)
+	if err != nil {
+		return mapErr(err)
+	}
+	revokedAt, err := sqlutil.RequireTime(row.TokensRevokedAt.Time, row.TokensRevokedAt.Valid, "tokens_revoked_at")
+	if err != nil {
+		return err
+	}
+	return insertRevocationEvent(ctx, conn, store.RevocationEventKindUserTokens, row.ID, row.ID, revokedAt, row.AuthGeneration)
 }
 
 // updatedUserResult maps a RETURNING (id, updated_at) row plus error into the
@@ -263,8 +299,13 @@ func (s *userStore) UpdatePassword(ctx context.Context, p store.UpdateUserPasswo
 }
 
 // UpdateEmail changes the email and its verified flag; runUserInfoMutation emits
-// a user_info cache-invalidation event iff a cached field (email/email_verified,
-// an auth gate) actually changed. A missing id is a no-op with no event.
+// a user_info cache-invalidation event iff a cached field (email/email_verified)
+// actually changed. Stays on the soft path even when email_verified drops
+// true→false: this is also the self-service email-change path
+// (RequestEmailChange → SetEmailAndClearCompeting), and fencing would log the
+// user out for changing their own address. The pure un-verify
+// (UpdateEmailVerified false) is the canonical gate flip and does fence. A
+// missing id is a no-op with no event.
 func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailParams) error {
 	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserEmail(ctx, gendb.UpdateUserEmailParams{
@@ -276,12 +317,12 @@ func (s *userStore) UpdateEmail(ctx context.Context, p store.UpdateUserEmailPara
 	})
 }
 
-// UpdateEmailVerified flips the email_verified auth gate; runUserInfoMutation
-// emits a user_info cache-invalidation event iff the gate actually changed, so
-// the change is observed cross-process without waiting out the cache TTL. A
-// missing id is a no-op with no event.
+// UpdateEmailVerified flips the email_verified auth gate. A reduction
+// (true→false) escalates to a generation-bearing user_tokens revocation that
+// fences the user's live streams and logs them out; a grant (false→true) stays
+// on the soft user_info cache signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserEmailVerifiedParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserEmailVerified(ctx, gendb.UpdateUserEmailVerifiedParams{
 			EmailVerified: ptrconv.BoolToInt64(p.EmailVerified),
 			ID:            p.ID,
@@ -290,11 +331,12 @@ func (s *userStore) UpdateEmailVerified(ctx context.Context, p store.UpdateUserE
 	})
 }
 
-// UpdateAdmin flips the IsAdmin flag; runUserInfoMutation emits a user_info
-// cache-invalidation event iff is_admin actually changed, dropping a stale
-// cached UserInfo cross-process. A missing id is a no-op with no event.
+// UpdateAdmin flips the IsAdmin flag. A reduction (true→false) escalates to a
+// generation-bearing user_tokens revocation that fences the user's live streams
+// and logs them out; a grant (false→true) stays on the soft user_info cache
+// signal. A missing id is a no-op with no event.
 func (s *userStore) UpdateAdmin(ctx context.Context, p store.UpdateUserAdminParams) error {
-	return s.runUserInfoMutation(ctx, p.ID, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
+	return s.runAuthGateMutation(ctx, p.ID, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
 		row, err := conn.q.UpdateUserAdmin(ctx, gendb.UpdateUserAdminParams{
 			IsAdmin: ptrconv.BoolToInt64(p.IsAdmin),
 			ID:      p.ID,
@@ -322,8 +364,9 @@ func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmail
 // PromotePendingEmail moves pending_email into email (email_verified=1). A row
 // with no pending email is a no-op; otherwise runUserInfoMutation emits a
 // user_info cache-invalidation event iff the promotion changed a cached field
-// (email/email_verified, an auth gate) -- the same guarantee its sibling
-// UpdateEmail/UpdateEmailVerified give.
+// (email/email_verified, an auth gate). Like UpdateEmail, it stays on the soft
+// path (runUserInfoMutation, nil fence): a promotion only grants email_verified
+// (false→true), so it never reduces an auth gate and never fences.
 func (s *userStore) PromotePendingEmail(ctx context.Context, id string) error {
 	return s.runUserInfoMutation(ctx, id, func(ctx context.Context, conn *sqliteConn) (string, time.Time, bool, error) {
 		row, err := conn.q.PromotePendingEmail(ctx, id)

--- a/backend/internal/hub/store/storetest/test_token_revocation.go
+++ b/backend/internal/hub/store/storetest/test_token_revocation.go
@@ -236,6 +236,7 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 		orgID := SeedOrg(t, st, "org")
 		user := SeedUser(t, st, orgID, "user")
 
+		// Grant (false→true) stays on the soft user_info path.
 		require.NoError(t, st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
 			ID:      user.ID,
 			IsAdmin: true,
@@ -252,6 +253,42 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 		assert.Equal(t, user.ID, events[0].Event.UserID)
 		assert.Equal(t, int64(0), events[0].Event.UserAuthGeneration, "user_info is a cache signal, not generation-bearing")
 		assert.False(t, events[0].Event.RevokedAt.IsZero())
+	})
+
+	t.Run("admin demotion (is_admin true->false) emits a generation-bearing user_tokens revocation", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "org")
+		user := SeedUser(t, st, orgID, "user")
+
+		require.NoError(t, st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			ID: user.ID, IsAdmin: true,
+		}))
+		published, err := st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		before, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		genBefore := before.AuthGeneration
+
+		require.NoError(t, st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			ID: user.ID, IsAdmin: false,
+		}))
+		published, err = st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		events, err := st.RevocationEvents().ListPublishedAfter(ctx, 0, 10)
+		require.NoError(t, err)
+		require.Len(t, events, 2)
+		ev := events[1].Event
+		assert.Equal(t, store.RevocationEventKindUserTokens, ev.Kind)
+		assert.Greater(t, ev.UserAuthGeneration, int64(0))
+		assert.Equal(t, user.ID, ev.SubjectID)
+		assert.Equal(t, user.ID, ev.UserID)
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, genBefore+1, after.AuthGeneration)
+		assert.Equal(t, after.AuthGeneration, ev.UserAuthGeneration)
 	})
 
 	t.Run("admin change on missing user emits nothing", func(t *testing.T) {
@@ -357,15 +394,109 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 	t.Run("email_verified change emits a user_info cache-invalidation event", func(t *testing.T) {
 		st := s.NewStore(t)
 		orgID := SeedOrg(t, st, "org")
-		user := SeedUser(t, st, orgID, "user") // seeded email_verified = true
-		assertUserInfoEvent(t, st, user.ID, func() error {
-			// Flip the gate off -- a real change to the cached field, so the
-			// projection compare must emit.
+		// Seed unverified so the flip to true is a grant (soft user_info path).
+		userID := id.Generate()
+		require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+			ID:            userID,
+			OrgID:         orgID,
+			Username:      "unverified-grant",
+			PasswordHash:  "hash",
+			DisplayName:   "Unverified",
+			Email:         "unverified-grant@example.com",
+			EmailVerified: false,
+			PasswordSet:   true,
+			IsAdmin:       false,
+		}))
+		assertUserInfoEvent(t, st, userID, func() error {
 			return st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
-				ID:            user.ID,
-				EmailVerified: false,
+				ID:            userID,
+				EmailVerified: true,
 			})
 		})
+	})
+
+	t.Run("email un-verify (email_verified true->false) emits a generation-bearing user_tokens revocation", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "org")
+		userID := id.Generate()
+		require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+			ID:            userID,
+			OrgID:         orgID,
+			Username:      "to-unverify",
+			PasswordHash:  "hash",
+			DisplayName:   "To Unverify",
+			Email:         "to-unverify@example.com",
+			EmailVerified: false,
+			PasswordSet:   true,
+			IsAdmin:       false,
+		}))
+
+		require.NoError(t, st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+			ID: userID, EmailVerified: true,
+		}))
+		published, err := st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		before, err := st.Users().GetByID(ctx, userID)
+		require.NoError(t, err)
+		genBefore := before.AuthGeneration
+
+		require.NoError(t, st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+			ID: userID, EmailVerified: false,
+		}))
+		published, err = st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		events, err := st.RevocationEvents().ListPublishedAfter(ctx, 0, 10)
+		require.NoError(t, err)
+		require.Len(t, events, 2)
+		ev := events[1].Event
+		assert.Equal(t, store.RevocationEventKindUserTokens, ev.Kind)
+		assert.Greater(t, ev.UserAuthGeneration, int64(0))
+		assert.Equal(t, userID, ev.SubjectID)
+		assert.Equal(t, userID, ev.UserID)
+
+		after, err := st.Users().GetByID(ctx, userID)
+		require.NoError(t, err)
+		assert.Equal(t, genBefore+1, after.AuthGeneration)
+		assert.Equal(t, after.AuthGeneration, ev.UserAuthGeneration)
+	})
+
+	t.Run("email address change dropping verified stays on the soft user_info path", func(t *testing.T) {
+		st := s.NewStore(t)
+		orgID := SeedOrg(t, st, "org")
+		user := SeedUser(t, st, orgID, "user") // seeded email_verified = true
+
+		// Establish a distinct email+verified state via UpdateEmail (soft), drain it.
+		require.NoError(t, st.Users().UpdateEmail(ctx, store.UpdateUserEmailParams{
+			ID: user.ID, Email: "verified@example.com", EmailVerified: true,
+		}))
+		published, err := st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		before, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		genBefore := before.AuthGeneration
+
+		// Address change that also drops verified must NOT fence (self-service path).
+		require.NoError(t, st.Users().UpdateEmail(ctx, store.UpdateUserEmailParams{
+			ID: user.ID, Email: "new@example.com", EmailVerified: false,
+		}))
+		published, err = st.RevocationEvents().PublishPending(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), published)
+		events, err := st.RevocationEvents().ListPublishedAfter(ctx, 0, 10)
+		require.NoError(t, err)
+		require.Len(t, events, 2)
+		ev := events[1].Event
+		assert.Equal(t, store.RevocationEventKindUserInfo, ev.Kind)
+		assert.Equal(t, int64(0), ev.UserAuthGeneration)
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, genBefore, after.AuthGeneration)
+		assert.False(t, after.EmailVerified)
+		assert.Equal(t, "new@example.com", after.Email)
 	})
 
 	t.Run("no-op update to a cached field emits no user_info event", func(t *testing.T) {

--- a/backend/internal/hub/store/storetest/test_users.go
+++ b/backend/internal/hub/store/storetest/test_users.go
@@ -415,6 +415,10 @@ func (s *Suite) testUsers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		before, err := st.Users().GetByID(ctx, userID)
+		require.NoError(t, err)
+		genBefore := before.AuthGeneration
+
 		err = st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
 			ID:            userID,
 			EmailVerified: true,
@@ -424,6 +428,18 @@ func (s *Suite) testUsers(t *testing.T) {
 		updated, err := st.Users().GetByID(ctx, userID)
 		require.NoError(t, err)
 		assert.True(t, updated.EmailVerified)
+		assert.Equal(t, genBefore, updated.AuthGeneration, "grant must not bump auth_generation")
+
+		err = st.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+			ID:            userID,
+			EmailVerified: false,
+		})
+		require.NoError(t, err)
+
+		reduced, err := st.Users().GetByID(ctx, userID)
+		require.NoError(t, err)
+		assert.False(t, reduced.EmailVerified)
+		assert.Equal(t, genBefore+1, reduced.AuthGeneration, "reduction must bump auth_generation")
 	})
 
 	t.Run("update admin", func(t *testing.T) {
@@ -431,7 +447,11 @@ func (s *Suite) testUsers(t *testing.T) {
 		orgID := SeedOrg(t, st, "user-org")
 		user := SeedUser(t, st, orgID, "admin-user")
 
-		err := st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+		before, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		genBefore := before.AuthGeneration
+
+		err = st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
 			ID:      user.ID,
 			IsAdmin: true,
 		})
@@ -440,6 +460,18 @@ func (s *Suite) testUsers(t *testing.T) {
 		updated, err := st.Users().GetByID(ctx, user.ID)
 		require.NoError(t, err)
 		assert.True(t, updated.IsAdmin)
+		assert.Equal(t, genBefore, updated.AuthGeneration, "grant must not bump auth_generation")
+
+		err = st.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			ID:      user.ID,
+			IsAdmin: false,
+		})
+		require.NoError(t, err)
+
+		reduced, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.False(t, reduced.IsAdmin)
+		assert.Equal(t, genBefore+1, reduced.AuthGeneration, "reduction must bump auth_generation")
 	})
 
 	t.Run("update prefs", func(t *testing.T) {

--- a/backend/internal/hub/store/user_info_core.go
+++ b/backend/internal/hub/store/user_info_core.go
@@ -32,12 +32,27 @@ func UserInfoCacheFieldsOf(u User) UserInfoCacheFields {
 	}
 }
 
+// AuthGateReduced reports whether a UserInfoCacheFields transition is a
+// privilege reduction on an auth gate (is_admin or email_verified true→false).
+// Callers that opt into fencing escalate such a reduction from the soft
+// user_info cache signal to a generation-bearing user_tokens revocation, which
+// tears down the user's live streams and logs them out. Grants (false→true)
+// and unrelated field changes return false.
+func AuthGateReduced(before, after UserInfoCacheFields) bool {
+	return (before.IsAdmin && !after.IsAdmin) || (before.EmailVerified && !after.EmailVerified)
+}
+
 // RunUserInfoMutation runs a user-row mutation inside a transaction and emits a
 // durable user_info cache-invalidation event iff the mutation changed a cached
 // UserInfo field, derived by comparing the projection loadFields reports before
 // and after the change. This makes a forgotten invalidation mechanically
 // impossible for any mutation routed through it and removes the need for callers
 // to hand-signal "did a cached field change".
+//
+// When fence is non-nil and AuthGateReduced(before, after) is true, fence runs
+// instead of emit so an opted-in auth-gate mutation can escalate a privilege
+// reduction to a generation-bearing user_tokens revocation. A nil fence keeps
+// the soft emit path for every change (including reductions).
 //
 // loadFields reports the target row's cached-field projection and whether the
 // row exists. mutate runs the UPDATE and returns the row id, the updated_at to
@@ -52,6 +67,7 @@ func RunUserInfoMutation[C any](
 	loadFields func(context.Context, C) (fields UserInfoCacheFields, exists bool, err error),
 	mutate func(context.Context, C) (userID string, updatedAt time.Time, ok bool, err error),
 	emit func(context.Context, C, string, time.Time) error,
+	fence func(context.Context, C, string, time.Time) error,
 ) error {
 	return inTransaction(ctx, func(conn C) error {
 		before, existedBefore, err := loadFields(ctx, conn)
@@ -66,9 +82,20 @@ func RunUserInfoMutation[C any](
 		if err != nil {
 			return err
 		}
-		if existedBefore && existedAfter && before == after {
-			return nil
+		if existedBefore && existedAfter {
+			if before == after {
+				return nil
+			}
+			if fence != nil && AuthGateReduced(before, after) {
+				return fence(ctx, conn, userID, updatedAt)
+			}
+			return emit(ctx, conn, userID, updatedAt)
 		}
+		// Existence flipped around an id-keyed single-row update (not expected):
+		// fail-safe to the soft emit, preserving prior behavior. A reduction that
+		// somehow reaches here is only soft-emitted, never fenced -- unreachable
+		// today because LockUserRow plus the deleted_at-filtered existence reads
+		// keep a live mutation's before and after both existing.
 		return emit(ctx, conn, userID, updatedAt)
 	})
 }

--- a/backend/internal/hub/store/user_info_core_test.go
+++ b/backend/internal/hub/store/user_info_core_test.go
@@ -1,0 +1,160 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthGateReduced(t *testing.T) {
+	base := UserInfoCacheFields{
+		Username:      "u",
+		Email:         "u@example.com",
+		EmailVerified: false,
+		IsAdmin:       false,
+	}
+
+	t.Run("admin true to false", func(t *testing.T) {
+		before := base
+		before.IsAdmin = true
+		after := base
+		assert.True(t, AuthGateReduced(before, after))
+	})
+
+	t.Run("email verified true to false", func(t *testing.T) {
+		before := base
+		before.EmailVerified = true
+		after := base
+		assert.True(t, AuthGateReduced(before, after))
+	})
+
+	t.Run("admin false to true", func(t *testing.T) {
+		before := base
+		after := base
+		after.IsAdmin = true
+		assert.False(t, AuthGateReduced(before, after))
+	})
+
+	t.Run("email verified false to true", func(t *testing.T) {
+		before := base
+		after := base
+		after.EmailVerified = true
+		assert.False(t, AuthGateReduced(before, after))
+	})
+
+	t.Run("both gates stay false", func(t *testing.T) {
+		assert.False(t, AuthGateReduced(base, base))
+	})
+
+	t.Run("both gates stay true", func(t *testing.T) {
+		before := base
+		before.IsAdmin = true
+		before.EmailVerified = true
+		after := before
+		assert.False(t, AuthGateReduced(before, after))
+	})
+
+	t.Run("unrelated field change", func(t *testing.T) {
+		before := base
+		before.IsAdmin = true
+		before.EmailVerified = true
+		after := before
+		after.Username = "renamed"
+		after.Email = "new@example.com"
+		assert.False(t, AuthGateReduced(before, after))
+	})
+}
+
+type fakeConn struct{}
+
+func TestRunUserInfoMutationRouting(t *testing.T) {
+	type outcome struct {
+		emitted bool
+		fenced  bool
+	}
+
+	runSeq := func(
+		t *testing.T,
+		before, after UserInfoCacheFields,
+		existedBefore, existedAfter bool,
+		fenceEnabled bool,
+	) outcome {
+		t.Helper()
+		var out outcome
+		loads := 0
+		var fence func(context.Context, fakeConn, string, time.Time) error
+		if fenceEnabled {
+			fence = func(context.Context, fakeConn, string, time.Time) error {
+				out.fenced = true
+				return nil
+			}
+		}
+		err := RunUserInfoMutation(context.Background(),
+			func(_ context.Context, fn func(fakeConn) error) error {
+				return fn(fakeConn{})
+			},
+			func(context.Context, fakeConn) (UserInfoCacheFields, bool, error) {
+				loads++
+				if loads == 1 {
+					return before, existedBefore, nil
+				}
+				return after, existedAfter, nil
+			},
+			func(context.Context, fakeConn) (string, time.Time, bool, error) {
+				return "user-1", time.Unix(1, 0).UTC(), true, nil
+			},
+			func(context.Context, fakeConn, string, time.Time) error {
+				out.emitted = true
+				return nil
+			},
+			fence,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, loads)
+		return out
+	}
+
+	gateOn := UserInfoCacheFields{IsAdmin: true, EmailVerified: true}
+	gateOff := UserInfoCacheFields{}
+	grantAdmin := UserInfoCacheFields{IsAdmin: true}
+	usernameChange := UserInfoCacheFields{Username: "renamed", IsAdmin: true, EmailVerified: true}
+
+	t.Run("fence on gate reduction when fence enabled", func(t *testing.T) {
+		out := runSeq(t, gateOn, gateOff, true, true, true)
+		assert.True(t, out.fenced)
+		assert.False(t, out.emitted)
+	})
+
+	t.Run("emit on grant when fence enabled", func(t *testing.T) {
+		out := runSeq(t, gateOff, grantAdmin, true, true, true)
+		assert.True(t, out.emitted)
+		assert.False(t, out.fenced)
+	})
+
+	t.Run("emit on non-gate change when fence enabled", func(t *testing.T) {
+		out := runSeq(t, gateOn, usernameChange, true, true, true)
+		assert.True(t, out.emitted)
+		assert.False(t, out.fenced)
+	})
+
+	t.Run("neither on no-op", func(t *testing.T) {
+		out := runSeq(t, gateOn, gateOn, true, true, true)
+		assert.False(t, out.emitted)
+		assert.False(t, out.fenced)
+	})
+
+	t.Run("emit not fence when fence nil even on reduction", func(t *testing.T) {
+		out := runSeq(t, gateOn, gateOff, true, true, false)
+		assert.True(t, out.emitted)
+		assert.False(t, out.fenced)
+	})
+
+	t.Run("emit on existence flip even with fence", func(t *testing.T) {
+		out := runSeq(t, gateOn, gateOff, true, false, true)
+		assert.True(t, out.emitted)
+		assert.False(t, out.fenced)
+	})
+}


### PR DESCRIPTION
## Motivation

When an admin demoted a user (`is_admin` true->false) or un-verified their email (`email_verified` true->false), the store emitted only the soft `user_info` cache-invalidation event. An already-open long-lived stream therefore kept its stale `is_admin`/`email_verified` snapshot until the connection ended -- a privilege reduction did **not** tear down the user's live sessions or log them out. This is a security/session gap: revoking admin or email-verified status left active sessions running with the old privileges.

## Modifications

- **Shared routing core** (`user_info_core.go`): add `AuthGateReduced(before, after)` and a nil-able `fence` callback to `RunUserInfoMutation`. When `fence` is non-nil and a reduction is detected, the fence runs instead of the soft emit; grants, non-gate changes, no-ops, and the existence-flip fail-safe keep prior behavior.
- **Per-dialect wiring** (mysql/postgres/sqlite `users.go`): refactor `runUserInfoMutation` into a shared `runCachedUserMutation(...)`, add `runAuthGateMutation` (fence enabled) plus a per-dialect `fenceUserTokensLocked` that bumps `auth_generation` + `tokens_revoked_at` and inserts a `user_tokens` revocation event inside the same row-locked transaction. `UpdateAdmin`/`UpdateEmailVerified` use the fenced path; `UpdateEmail` and `PromotePendingEmail` stay soft.
- Detection happens at the store's before/after mutation chokepoint under `LockUserRow`, deriving direction from real DB state -- bypass-proof, race-safe, and cross-process via the existing revocation watcher.
- `UpdateEmail` deliberately stays soft even when it drops `email_verified`, because it is also the self-service email-change path (`RequestEmailChange` -> `SetEmailAndClearCompeting`); fencing there would log a user out for changing their own address. Only the dedicated `UpdateEmailVerified(false)` un-verify fences.
- Corrected the postgres/sqlite `BumpUserTokensRevokedAt` query comments to name both callers (`RevokeUserTokens` and the fence) and document that each avoids soft-deleted rows via its own `deleted_at` guard.
- **CLI** (`admin_user.go`): `revoke-admin` reports "active sessions and tokens revoked" only for an actual demotion; revoking a non-admin prints an accurate "nothing to revoke" message.

## Result

- Demoting an admin or un-verifying a user's email now tears down their live streams and logs them out immediately, in-process and cross-process, instead of leaving stale-privilege sessions open until the connection drops.
- Grants (`false->true`) and self-service email changes stay on the soft `user_info` path -- no punitive logout.
- The `store.UserStore` interface is unchanged; the behavior change is confined to the two auth-gate reductions.
- Covered by unit tests (`AuthGateReduced`, fence-vs-emit routing), three-dialect store effect tests (demotion, un-verify, soft email-change, grant-vs-reduction generation), cross-process watcher fencing tests, and end-to-end CLI generation-bump assertions.
- Closes #268.