### PR TITLE
fix(time): Prefer monotonic clocks for in-process intervals

### DIFF
--- a/backend/internal/util/tofupins/store.go
+++ b/backend/internal/util/tofupins/store.go
@@ -77,6 +77,14 @@ type Store struct {
 	opts Options
 	mu   sync.Mutex
 	pins map[string]Entry
+	// lastBumpAt holds the mono-carrying time.Now() of the most recent
+	// in-memory LastUsedAt bump per worker. Entry.LastUsedAt is wall-only
+	// (UTC for JSON); measuring the persist throttle against those stamps
+	// would strip the monotonic clock and make the hot path sensitive to
+	// NTP steps. After Open, the first Verify for a loaded pin falls back
+	// to Entry.LastUsedAt (wall) so a restart does not immediately rewrite
+	// every recently-used pin.
+	lastBumpAt map[string]time.Time
 }
 
 // Open loads the pin file at opts.Path (creating its parent
@@ -91,7 +99,7 @@ func Open(opts Options) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(opts.Path), opts.DirMode); err != nil {
 		return nil, fmt.Errorf("mkdir: %w", err)
 	}
-	s := &Store{opts: opts, pins: map[string]Entry{}}
+	s := &Store{opts: opts, pins: map[string]Entry{}, lastBumpAt: map[string]time.Time{}}
 	data, err := os.ReadFile(opts.Path)
 	if err == nil {
 		var f onDiskFile
@@ -112,10 +120,13 @@ func Open(opts Options) (*Store, error) {
 // an error whose message appends the configured clear-command hint.
 //
 // `LastUsedAt` is bumped in-memory on every successful match but the
-// on-disk JSON is rewritten only when the bump exceeds
-// `lastUsedPersistMinGap` past the previously-persisted value. This
-// keeps the field useful for `pins list` without paying a JSON
-// marshal+rename on every hot-path tunnel handshake.
+// on-disk JSON is rewritten only when the inter-call gap exceeds
+// `LastUsedPersistMinGap`. The gap is measured with a mono-carrying
+// clock (see lastBumpAt); after a process restart the first Verify for
+// a loaded pin falls back to the persisted wall LastUsedAt so a warm
+// restart does not rewrite every pin. This keeps the field useful for
+// `pins list` without paying a JSON marshal+rename on every hot-path
+// tunnel handshake.
 func (s *Store) Verify(workerID string, public, mlkem, slhdsa []byte) error {
 	if workerID == "" {
 		return errors.New("worker_id required")
@@ -126,15 +137,20 @@ func (s *Store) Verify(workerID string, public, mlkem, slhdsa []byte) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	now := time.Now().UTC()
+	now := time.Now()
+	wall := now.UTC()
 	if existing, ok := s.pins[workerID]; ok {
 		if existing.X25519PublicKey != x || existing.MlkemPublicKey != m || existing.SlhdsaPublicKey != sl {
 			return fmt.Errorf("worker %s key mismatch — %s", workerID, fmt.Sprintf(s.opts.MismatchHintTmpl, workerID))
 		}
-		prevPersisted := existing.LastUsedAt
-		existing.LastUsedAt = now
+		prevBump, hadBump := s.lastBumpAt[workerID]
+		if !hadBump {
+			prevBump = existing.LastUsedAt
+		}
+		existing.LastUsedAt = wall
 		s.pins[workerID] = existing
-		if s.opts.LastUsedPersistMinGap > 0 && now.Sub(prevPersisted) < s.opts.LastUsedPersistMinGap {
+		s.lastBumpAt[workerID] = now
+		if s.opts.LastUsedPersistMinGap > 0 && now.Sub(prevBump) < s.opts.LastUsedPersistMinGap {
 			// Skip on-disk write — the bump is within the throttle
 			// window. Subsequent calls will eventually flush once the
 			// gap is exceeded.
@@ -146,9 +162,10 @@ func (s *Store) Verify(workerID string, public, mlkem, slhdsa []byte) error {
 		X25519PublicKey: x,
 		MlkemPublicKey:  m,
 		SlhdsaPublicKey: sl,
-		FirstSeenAt:     now,
-		LastUsedAt:      now,
+		FirstSeenAt:     wall,
+		LastUsedAt:      wall,
 	}
+	s.lastBumpAt[workerID] = now
 	return s.persistLocked()
 }
 
@@ -161,6 +178,7 @@ func (s *Store) Remove(workerID string) error {
 		return nil
 	}
 	delete(s.pins, workerID)
+	delete(s.lastBumpAt, workerID)
 	return s.persistLocked()
 }
 

--- a/backend/internal/util/tofupins/store_test.go
+++ b/backend/internal/util/tofupins/store_test.go
@@ -294,6 +294,27 @@ func TestStore_VerifyRepeatedMatchesSkipDiskWritesWithinThrottleWindow(t *testin
 		"in-memory LastUsedAt must still advance even when persistence is throttled")
 }
 
+func TestStore_VerifyAfterReopenHonorsPersistedLastUsedAtThrottle(t *testing.T) {
+	// After Open reloads wall-only LastUsedAt from disk, the first Verify
+	// must still honor the throttle against that stamp (wall fallback)
+	// rather than immediately rewriting every pin on process restart.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pins.json")
+	s1 := openStore(t, path)
+	require.NoError(t, s1.Verify("w", []byte("x"), []byte("m"), []byte("sl")))
+
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	s2 := openStore(t, path)
+	require.NoError(t, s2.Verify("w", []byte("x"), []byte("m"), []byte("sl")))
+
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime(),
+		"reopen+Verify within the throttle window must not rewrite the pin file")
+}
+
 func TestStore_VerifyFlushesLastUsedAtPastThrottleWindow(t *testing.T) {
 	// With a very small throttle (1ns) every subsequent Verify must
 	// rewrite the file because the bump is always past the window.

--- a/backend/internal/worker/hub/client_test.go
+++ b/backend/internal/worker/hub/client_test.go
@@ -682,7 +682,12 @@ func TestClientLastSendTimeAdvancesOnEnqueue(t *testing.T) {
 	c.mu.Unlock()
 	assert.True(t, after.After(before), "lastSendTime must advance on enqueue")
 
-	before = after
+	// Reset before TrySend so the assertion does not depend on wall-clock
+	// ticks between two rapid enqueues (Windows time.Now can share a tick).
+	c.mu.Lock()
+	c.lastSendTime = time.Now().Add(-time.Hour)
+	before = c.lastSendTime
+	c.mu.Unlock()
 	require.True(t, c.TrySend(heartbeatMsg()))
 	c.mu.Lock()
 	after = c.lastSendTime

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -16,6 +16,7 @@ import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
 import { createInflightCache } from '~/lib/inflightCache'
+import { monotonicNow } from '~/lib/monotonicNow'
 import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '~/lib/terminal'
 import { resolveOptimisticGitInfo, tabKey } from '~/stores/tab.helpers'
 
@@ -186,7 +187,7 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
       terminalId,
       title,
     }).catch(() => {})
-    titleLastSent.set(terminalId, Date.now())
+    titleLastSent.set(terminalId, monotonicNow())
   }
 
   const handleTerminalTitleChange = (terminalId: string, title: string) => {
@@ -197,8 +198,11 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
     if (existing)
       clearTimeout(existing)
 
-    const last = titleLastSent.get(terminalId) ?? 0
-    const elapsed = Date.now() - last
+    // Missing entry = never sent: treat as fully elapsed so the first
+    // update fires immediately (performance.now() starts near 0, so a
+    // `?? 0` sentinel would incorrectly delay early-session titles).
+    const last = titleLastSent.get(terminalId)
+    const elapsed = last === undefined ? TITLE_THROTTLE_MS : monotonicNow() - last
     const delay = Math.max(0, TITLE_THROTTLE_MS - elapsed)
     if (delay === 0) {
       sendTitleToBackend(terminalId, title)

--- a/frontend/src/components/shell/useTurnEnd.ts
+++ b/frontend/src/components/shell/useTurnEnd.ts
@@ -1,4 +1,5 @@
 import type { createActiveClientStore } from '~/lib/presence/activeClient'
+import { monotonicNow } from '~/lib/monotonicNow'
 
 /**
  * Builds the debounced turn-end handler that drives:
@@ -45,7 +46,9 @@ export function useTurnEnd(opts: UseTurnEndOpts): (agentId: string, numToolUses?
   if (!turnEndAudio)
     turnEndAudio = new Audio('/sounds/benkirb-electronic-doorbell-262895.mp3')
 
-  let lastSoundPlayedAt = 0
+  // undefined = never played. A numeric zero would suppress the first ding
+  // for ~60s after page load because performance.now() starts near 0.
+  let lastSoundPlayedAt: number | undefined
 
   return (agentId: string, numToolUses?: number) => {
     if (opts.isAgentClosing(agentId))
@@ -63,8 +66,8 @@ export function useTurnEnd(opts: UseTurnEndOpts): (agentId: string, numToolUses?
       if (active !== '' && effective !== '' && active !== effective)
         return
     }
-    const now = Date.now()
-    if (now - lastSoundPlayedAt < TURN_END_SOUND_COOLDOWN_MS)
+    const now = monotonicNow()
+    if (lastSoundPlayedAt !== undefined && now - lastSoundPlayedAt < TURN_END_SOUND_COOLDOWN_MS)
       return
     const sound = opts.preferences.turnEndSound()
     if (sound === 'ding-dong') {

--- a/frontend/src/lib/presence/heartbeat.test.ts
+++ b/frontend/src/lib/presence/heartbeat.test.ts
@@ -3,11 +3,9 @@ import { mountPresenceHeartbeat } from './heartbeat'
 
 describe('mountPresenceHeartbeat', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
-    // Make Date.now advance with the fake clock so the throttle logic
-    // observes elapsed time. Without this the throttle never expires
-    // because Date.now stays constant across `vi.advanceTimersByTime`.
-    vi.setSystemTime(new Date(0))
+    // Fake performance so monotonicNow (throttle clock) advances with
+    // vi.advanceTimersByTime — wall Date.now is irrelevant here.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'performance'] })
   })
   afterEach(() => {
     vi.useRealTimers()

--- a/frontend/src/lib/presence/heartbeat.ts
+++ b/frontend/src/lib/presence/heartbeat.ts
@@ -1,5 +1,6 @@
 import { onCleanup } from 'solid-js'
 import { orgCRDTClient } from '~/api/clients'
+import { monotonicNow } from '~/lib/monotonicNow'
 
 /**
  * HEARTBEAT_THROTTLE_MS bounds how often input events translate into
@@ -68,15 +69,17 @@ export interface HeartbeatHandle {
  * the client misses its own `PresenceUpdate`.
  */
 export function mountPresenceHeartbeat(opts: HeartbeatOpts): HeartbeatHandle {
-  let lastSent = 0
+  // undefined = never sent. A numeric zero would throttle the first input
+  // for ~5s after page load because performance.now() starts near 0.
+  let lastSent: number | undefined
 
   const send = (immediate = false) => {
     const orgId = opts.orgId()
     const workspaceId = opts.workspaceId() ?? ''
     if (!orgId || !workspaceId)
       return
-    const now = Date.now()
-    if (!immediate && now - lastSent < HEARTBEAT_THROTTLE_MS)
+    const now = monotonicNow()
+    if (!immediate && lastSent !== undefined && now - lastSent < HEARTBEAT_THROTTLE_MS)
       return
     lastSent = now
     const sender = opts.sender ?? defaultSender

--- a/frontend/src/lib/suppressResizeObserverLoopError.test.ts
+++ b/frontend/src/lib/suppressResizeObserverLoopError.test.ts
@@ -104,7 +104,8 @@ describe('installresizeobserverlooperrorsuppressor', () => {
     // emits the same message for both); the suppressor keeps that signal observable
     // as at most one console.debug per window, with a count a real loop makes climb.
     const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
-    const nowSpy = vi.spyOn(Date, 'now')
+    // Rate limit reads monotonicNow → performance.now().
+    const nowSpy = vi.spyOn(performance, 'now')
     nowSpy.mockReturnValue(100_000)
     install()
 

--- a/frontend/src/lib/suppressResizeObserverLoopError.ts
+++ b/frontend/src/lib/suppressResizeObserverLoopError.ts
@@ -1,3 +1,5 @@
+import { monotonicNow } from './monotonicNow'
+
 /**
  * Swallow the benign "ResizeObserver loop ..." browser error so it can't pop the
  * @solidjs/start dev overlay.
@@ -86,7 +88,7 @@ export function installResizeObserverLoopErrorSuppressor(
     event.stopImmediatePropagation()
     event.preventDefault()
     suppressedCount += 1
-    const now = Date.now()
+    const now = monotonicNow()
     if (now - lastDebugLogAt >= SUPPRESSED_DEBUG_LOG_INTERVAL_MS) {
       lastDebugLogAt = now
       // eslint-disable-next-line no-console -- deliberate dev-only diagnostic; the logger would re-enter the error path this suppressor guards

--- a/frontend/src/lib/webglTerminalPool.ts
+++ b/frontend/src/lib/webglTerminalPool.ts
@@ -1,5 +1,6 @@
 import type { TerminalInstance } from './terminal'
 import { createLogger } from './logger'
+import { monotonicNow } from './monotonicNow'
 import { attachWebgl, detachWebgl } from './terminal'
 
 const log = createLogger('webgl-pool')
@@ -78,8 +79,8 @@ export interface WebglTerminalPoolDeps {
   /** Detach the WebGL renderer, reverting the instance to the DOM renderer. */
   detach: (instance: TerminalInstance) => void
   /**
-   * Wall-clock source (ms) for the context-loss decay window. Injected so tests
-   * can drive it deterministically; defaults to Date.now.
+   * Monotonic clock source (ms) for the context-loss decay window. Injected so
+   * tests can drive it deterministically; defaults to monotonicNow.
    */
   now?: () => number
 }
@@ -112,7 +113,7 @@ interface Slot {
   /** Count of browser-forced context losses, for the retry bound. */
   contextLossCount: number
   /**
-   * Wall-clock time (ms) this slot last reached the 'webgl' state, or undefined
+   * Monotonic time (ms) this slot last reached the 'webgl' state, or undefined
    * while on DOM / mid-attach. Used to decay the context-loss budget: a loss
    * that arrives after the context survived CONTEXT_LOSS_BUDGET_RESET_MS resets
    * the count. Cleared by doDetach so a re-attach re-stamps it.
@@ -139,7 +140,7 @@ interface Slot {
  */
 export function createWebglTerminalPool(deps: WebglTerminalPoolDeps): WebglTerminalPool {
   const { capacity, attach, detach } = deps
-  const now = deps.now ?? (() => Date.now())
+  const now = deps.now ?? monotonicNow
 
   // The per-id record for every terminal the pool knows about. A slot is
   // created on the first `acquire` for an id and dropped by `reconcile` once


### PR DESCRIPTION
## Motivation
In-process throttle, cooldown, and idle gates were measuring elapsed time with wall clocks (`Date.now()` on the frontend; `time.Now().UTC()` in tofupins). That makes them sensitive to NTP steps and to coarse Windows timer resolution — the latter already failed CI in `TestClientLastSendTimeAdvancesOnEnqueue` when two rapid enqueues shared a tick. Persist/display timestamps still need wall time; interval math does not.

## Modifications
- Route frontend presence heartbeat, terminal title throttle, turn-end sound cooldown, ResizeObserver debug rate-limit, and WebGL context-loss decay through `monotonicNow()`, and replace `0` / `?? 0` "never fired" sentinels with `undefined` so early-session `performance.now()` values near zero do not falsely throttle.
- Measure the tofupins `LastUsedAt` persist gap with a mono-carrying `time.Now()` (`lastBumpAt`), while keeping stored `FirstSeenAt` / `LastUsedAt` as UTC wall stamps for JSON and `pins list`; after reopen, the first Verify falls back to the persisted wall stamp so a warm restart does not rewrite every pin.
- Reset `lastSendTime` before the TrySend assertion in `TestClientLastSendTimeAdvancesOnEnqueue` so the test does not depend on wall ticks between two rapid enqueues.

## Result
- Windows CI no longer flakes on `TestClientLastSendTimeAdvancesOnEnqueue` when two enqueues land in the same clock tick.
- In-session throttles and cooldowns keep steady intervals across NTP adjustments and do not suppress the first event after page load.
- TOFU pin files are not rewritten on every hot-path Verify within the throttle window, including immediately after process restart when `LastUsedAt` is still fresh on disk.
