### PR TITLE
Skip channelmgr write lock on no-op ConnID rebind

### DIFF
--- a/backend/internal/hub/channelmgr/channel_bind.go
+++ b/backend/internal/hub/channelmgr/channel_bind.go
@@ -1,0 +1,133 @@
+package channelmgr
+
+// channelBind is the ConnID protocol for useChannel.
+// bindModeNone leaves ConnID untouched; bindModeConn reuses or writes connID.
+type channelBind struct {
+	mode   bindMode
+	connID string
+}
+
+type bindMode int
+
+const (
+	bindModeNone bindMode = iota // UseChannelIf: never write ConnID
+	bindModeConn                 // UseAuthorizedChannel: reuse or bind connID
+)
+
+func bindNone() channelBind { return channelBind{mode: bindModeNone} }
+
+func bindConn(connID string) channelBind {
+	return channelBind{mode: bindModeConn, connID: connID}
+}
+
+// bindPeek is the tagged RLock peek outcome for useChannel's ConnID protocol.
+// Only ready carries an authorized ChannelInfo; reject and needWrite do not.
+type bindPeek struct {
+	kind bindPeekKind
+	info ChannelInfo
+}
+
+type bindPeekKind int
+
+const (
+	bindPeekReject bindPeekKind = iota
+	bindPeekReady
+	bindPeekNeedWrite
+)
+
+func rejectBindPeek() bindPeek { return bindPeek{kind: bindPeekReject} }
+
+func readyBindPeek(info ChannelInfo) bindPeek {
+	return bindPeek{kind: bindPeekReady, info: info}
+}
+
+func needWriteBindPeek() bindPeek { return bindPeek{kind: bindPeekNeedWrite} }
+
+// liveAndAuthorizeLocked snapshots a live channel and runs authorize. Caller
+// holds m.mu (read or write). Shared by the RLock reuse path, the Lock bind
+// path, and SendToFrontendIf so the live/auth gate cannot drift between them.
+//
+// authorize must not call Manager methods that take m.mu: under RLock a nested
+// RLock can deadlock when a writer is waiting (sync.RWMutex writer preference),
+// and under Lock any nested RLock/Lock deadlocks. Snapshot what you need from
+// ChannelInfo instead.
+func (m *Manager) liveAndAuthorizeLocked(
+	channelID string,
+	ch *channel,
+	authorize func(ChannelInfo) bool,
+) (ChannelInfo, bool) {
+	if !m.channelLiveLocked(channelID, ch) {
+		return ChannelInfo{}, false
+	}
+	info := channelInfo(ch)
+	if authorize != nil && !authorize(info) {
+		return ChannelInfo{}, false
+	}
+	return info, true
+}
+
+// peekBindDecision takes m.mu.RLock, decides whether ConnID already matches
+// (authorize under RLock) or a write bind is required (defer authorize to Lock).
+// Panic-safe: deferred RUnlock releases even if authorize panics.
+func (m *Manager) peekBindDecision(
+	channelID string,
+	ch *channel,
+	bind channelBind,
+	authorize func(ChannelInfo) bool,
+) bindPeek {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if bind.mode == bindModeNone || ch.ConnID == bind.connID {
+		// Non-empty reuse still requires a registered user conn so UnbindUser
+		// (no cleanup) cannot keep feeding FE→worker on a dead binding. Empty
+		// ConnID equality is the Ready shortcut for holding opMu without
+		// writing a binding.
+		if bind.mode == bindModeConn && bind.connID != "" && !m.hasUserConnLocked(ch.UserID, bind.connID) {
+			return rejectBindPeek()
+		}
+		info, ok := m.liveAndAuthorizeLocked(channelID, ch, authorize)
+		if !ok {
+			return rejectBindPeek()
+		}
+		return readyBindPeek(info)
+	}
+	if !m.channelLiveLocked(channelID, ch) {
+		return rejectBindPeek()
+	}
+	return needWriteBindPeek()
+}
+
+// bindConnWithWriteLock takes m.mu.Lock, authorizes once, refuses a gone
+// registered conn, and writes ConnID. Caller must have observed
+// bindPeekNeedWrite (bind.mode == bindModeConn). Panic-safe: deferred Unlock
+// releases even if authorize panics.
+func (m *Manager) bindConnWithWriteLock(
+	channelID string,
+	ch *channel,
+	bindConnID string,
+	authorize func(ChannelInfo) bool,
+) (ChannelInfo, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.liveAndAuthorizeLocked(channelID, ch, authorize); !ok {
+		return ChannelInfo{}, false
+	}
+	// Never write ConnID unless that user conn is currently registered. Covers
+	// the RUnlock→Lock upgrade gap and any earlier Unbind that left the channel
+	// alive because another user conn was still present.
+	if !m.hasUserConnLocked(ch.UserID, bindConnID) {
+		return ChannelInfo{}, false
+	}
+	if ch.ConnID != bindConnID {
+		ch.ConnID = bindConnID
+	}
+	return channelInfo(ch), true
+}
+
+// hasUserConnLocked reports whether userID has a registered connID entry.
+// Caller holds m.mu. Unlike getConnSender, this is presence-only and does not
+// treat a nil SendFunc as "missing" — bind policy keys off registration.
+func (m *Manager) hasUserConnLocked(userID, connID string) bool {
+	conns := m.userSenders[userID]
+	return conns != nil && conns[connID] != nil
+}

--- a/backend/internal/hub/channelmgr/channelmgr.go
+++ b/backend/internal/hub/channelmgr/channelmgr.go
@@ -146,14 +146,19 @@ type ChannelInfo struct {
 
 // RegisterWithAuthInfo records the full authentication basis for a channel.
 // OpenChannel callers must provide UserAuthGeneration so user-wide revocation
-// can use the persisted credential epoch.
+// can use the persisted credential epoch. Returns false when channelID is
+// already registered, leaving existing state unchanged — callers must treat
+// that as a programming error (production IDs are unique).
 func (m *Manager) RegisterWithAuthInfo(
 	channelID, workerID, userID string,
 	authInfo AuthInfo,
 	cancel context.CancelFunc,
-) {
+) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if _, exists := m.channels[channelID]; exists {
+		return false
+	}
 	ch := &channel{
 		ChannelID:   channelID,
 		WorkerID:    workerID,
@@ -164,6 +169,7 @@ func (m *Manager) RegisterWithAuthInfo(
 	}
 	m.channels[channelID] = ch
 	m.indexChannel(ch)
+	return true
 }
 
 // indexChannel adds ch to every credential/routing reverse index. Mirror of
@@ -257,16 +263,22 @@ func (m *Manager) unbindLocked(userID, connID string) (*userConn, bool) {
 	return uc, false
 }
 
-// UseAuthorizedChannel binds a relay connection and performs one routed
-// operation while holding the channel's operation lock. Credential teardown
-// waits for the operation to finish before removing the channel and publishing
-// close notifications, so no routed message can cross the revocation boundary.
+// UseAuthorizedChannel authorizes a live channel and performs one routed
+// operation while holding the channel's operation lock. When connID already
+// matches the channel's binding (or both are empty), the steady-state path
+// reuses under RLock without rewriting ConnID. A real first-bind or rebind
+// takes Lock, requires a registered user conn for connID, then writes ConnID.
+// ok=false covers dead/missing channel, failed authorize, and refuse-to-bind
+// when the target conn is gone — callers must not treat it as authorize-only.
+// Credential teardown waits for the operation to finish before removing the
+// channel and publishing close notifications, so no routed message can cross
+// the revocation boundary.
 func (m *Manager) UseAuthorizedChannel(
 	channelID, connID string,
 	authorize func(ChannelInfo) bool,
 	operation func(ChannelInfo) error,
 ) (ChannelInfo, bool, error) {
-	return m.useChannel(channelID, &connID, authorize, operation)
+	return m.useChannel(channelID, bindConn(connID), authorize, operation)
 }
 
 // UseChannelIf performs one operation on a live channel without changing its
@@ -277,7 +289,7 @@ func (m *Manager) UseChannelIf(
 	authorize func(ChannelInfo) bool,
 	operation func(ChannelInfo) error,
 ) (ChannelInfo, bool, error) {
-	return m.useChannel(channelID, nil, authorize, operation)
+	return m.useChannel(channelID, bindNone(), authorize, operation)
 }
 
 // acquireChannelOp looks up a channel and acquires its operation lock (opMu),
@@ -309,7 +321,7 @@ func (m *Manager) channelLiveLocked(channelID string, ch *channel) bool {
 
 func (m *Manager) useChannel(
 	channelID string,
-	bindConnID *string,
+	bind channelBind,
 	authorize func(ChannelInfo) bool,
 	operation func(ChannelInfo) error,
 ) (ChannelInfo, bool, error) {
@@ -325,31 +337,27 @@ func (m *Manager) useChannel(
 	// manager exists to enforce.
 	defer ch.opMu.Unlock()
 
-	// The liveness re-check, authorize callback, and ConnID bind run under m.mu;
-	// scope them to a closure with a deferred Unlock so a panicking authorize
-	// releases the manager-wide lock instead of freezing the whole manager.
-	//
-	// The ConnID re-bind below is the ONLY mutation forcing m.mu.Lock() here --
-	// every reader/writer of ch.ConnID already holds this channel's opMu, so
-	// making ConnID opMu-guarded would let this take m.mu.RLock() instead,
-	// demoting a global write lock taken once per frontend->worker frame to a
-	// read lock. See https://github.com/leapmux/leapmux/issues/279.
-	info, ok := func() (ChannelInfo, bool) {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		if !m.channelLiveLocked(channelID, ch) {
-			return ChannelInfo{}, false
+	// ConnID stays m.mu-guarded (GetChannelInfo and Unbind's first pass read it
+	// without opMu). Steady-state frontend->worker frames re-bind the same
+	// ConnID, so peek under RLock and authorize there when unchanged (or
+	// bindModeNone). Upgrade to Lock only for a real first-bind or rebind:
+	// peek only detects needWrite and defers authorize so authorize+bind stay
+	// one critical section. Never write ConnID without a registered user conn
+	// (R→W gap or earlier Unbind). See https://github.com/leapmux/leapmux/issues/279.
+	peek := m.peekBindDecision(channelID, ch, bind, authorize)
+	var info ChannelInfo
+	switch peek.kind {
+	case bindPeekReject:
+		return ChannelInfo{}, false, nil
+	case bindPeekReady:
+		info = peek.info
+	case bindPeekNeedWrite:
+		info, ok = m.bindConnWithWriteLock(channelID, ch, bind.connID, authorize)
+		if !ok {
+			return ChannelInfo{}, false, nil
 		}
-		info := channelInfo(ch)
-		if authorize != nil && !authorize(info) {
-			return ChannelInfo{}, false
-		}
-		if bindConnID != nil {
-			ch.ConnID = *bindConnID
-		}
-		return info, true
-	}()
-	if !ok {
+	default:
+		// Exhaustiveness guard: bindPeekKind is package-private iota.
 		return ChannelInfo{}, false, nil
 	}
 
@@ -988,10 +996,7 @@ func (m *Manager) SendToFrontendIf(msg *leapmuxv1.ChannelMessage, authorize func
 	connID, sender, ok := func() (string, SendFunc, bool) {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		if !m.channelLiveLocked(msg.GetChannelId(), ch) {
-			return "", nil, false
-		}
-		if authorize != nil && !authorize(channelInfo(ch)) {
+		if _, authOK := m.liveAndAuthorizeLocked(msg.GetChannelId(), ch, authorize); !authOK {
 			return "", nil, false
 		}
 		connID := ch.ConnID
@@ -1083,7 +1088,8 @@ func channelInfo(ch *channel) ChannelInfo {
 }
 
 // getConnSender returns the SendFunc for a specific connection of a user.
-// Must be called while holding m.mu (read or write). Returns nil if not found.
+// Must be called while holding m.mu (read or write). Returns nil if not found
+// or if the registered conn has a nil SendFunc.
 func (m *Manager) getConnSender(userID, connID string) SendFunc {
 	conns := m.userSenders[userID]
 	if conns == nil {

--- a/backend/internal/hub/channelmgr/channelmgr_test.go
+++ b/backend/internal/hub/channelmgr/channelmgr_test.go
@@ -19,8 +19,15 @@ var noopSender = func(*leapmuxv1.ChannelMessage) error { return nil }
 func bindChannelConn(t testing.TB, m *Manager, channelID, connID string) bool {
 	t.Helper()
 	// UseAuthorizedChannel with a nil operation binds the conn and reports
-	// liveness, the same atomic check-and-bind the retired BindChannelConnIf did.
+	// liveness. Callers must BindUser the target conn first — first-bind
+	// refuses when the conn is not registered.
 	_, ok, _ := m.UseAuthorizedChannel(channelID, connID, nil, nil)
+	if !ok {
+		if info, exists := m.GetChannelInfo(channelID); exists {
+			t.Fatalf("bindChannelConn(%s, %s) failed; BindUser(%s, %s, ...) must run first (ConnID=%q)",
+				channelID, connID, info.UserID, connID, info.ConnID)
+		}
+	}
 	return ok
 }
 
@@ -28,12 +35,48 @@ func TestRegisterAndExists(t *testing.T) {
 	m := New(0)
 	assert.False(t, m.Exists("ch1"))
 
-	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	require.True(t, m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil))
 	assert.True(t, m.Exists("ch1"))
 	info, ok := m.GetChannelInfo("ch1")
 	require.True(t, ok)
 	assert.Equal(t, "w1", info.WorkerID)
 	assert.Equal(t, "u1", info.UserID)
+}
+
+// TestRegisterWithAuthInfo_RejectsDuplicateID ensures a second register for the
+// same channelID is refused and leaves the original entry (and reverse indexes)
+// untouched — previously an overwrite orphaned the old worker index.
+func TestRegisterWithAuthInfo_RejectsDuplicateID(t *testing.T) {
+	m := New(0)
+	require.True(t, m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil))
+
+	assert.False(t, m.RegisterWithAuthInfo("ch1", "w2", "u2", AuthInfo{}, nil),
+		"duplicate channelID must be rejected")
+
+	info, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "w1", info.WorkerID)
+	assert.Equal(t, "u1", info.UserID)
+
+	assert.Empty(t, m.UnregisterByWorker("w2"), "rejected register must not index the new worker")
+	removed := m.UnregisterByWorker("w1")
+	require.Equal(t, []string{"ch1"}, removed)
+	assert.False(t, m.Exists("ch1"))
+}
+
+// TestRegisterWithAuthInfo_AllowsReuseAfterClose: once CloseByID removes the
+// map entry, the same channelID may be registered again.
+func TestRegisterWithAuthInfo_AllowsReuseAfterClose(t *testing.T) {
+	m := New(0)
+	require.True(t, m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil))
+	m.CloseByID("ch1")
+	assert.False(t, m.Exists("ch1"))
+
+	require.True(t, m.RegisterWithAuthInfo("ch1", "w2", "u2", AuthInfo{}, nil))
+	info, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "w2", info.WorkerID)
+	assert.Equal(t, "u2", info.UserID)
 }
 
 func TestUnregister(t *testing.T) {
@@ -246,6 +289,7 @@ func TestCloseByIDIfLeavesUnauthorizedChannelOpen(t *testing.T) {
 func TestUseAuthorizedChannelOrdersCloseAfterInFlightOperation(t *testing.T) {
 	m := New(0)
 	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
 	started := make(chan struct{})
 	release := make(chan struct{})
 	operationDone := make(chan struct{})
@@ -650,12 +694,15 @@ func TestUnbindUserAndCleanup_RechecksConcurrentBindAfterChannelOperation(t *tes
 	operationStarted := make(chan struct{})
 	releaseOperation := make(chan struct{})
 	m.BindUser("u1", "old", noopSender, nil)
+	m.BindUser("u1", "new", noopSender, nil)
 	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
 
 	operationDone := make(chan struct{})
 	go func() {
 		defer close(operationDone)
-		_, found, err := m.UseAuthorizedChannel("ch1", "", nil, func(ChannelInfo) error {
+		// Hold opMu on the Lock bind path (first write of ConnID) so cleanup
+		// can drop "old" while a concurrent BindUser("new") races the recheck.
+		_, found, err := m.UseAuthorizedChannel("ch1", "new", nil, func(ChannelInfo) error {
 			close(operationStarted)
 			<-releaseOperation
 			return nil
@@ -670,14 +717,17 @@ func TestUnbindUserAndCleanup_RechecksConcurrentBindAfterChannelOperation(t *tes
 	require.Eventually(t, func() bool {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		return len(m.userSenders["u1"]) == 0
+		_, hasOld := m.userSenders["u1"]["old"]
+		return !hasOld
 	}, time.Second, time.Millisecond)
 
-	m.BindUser("u1", "new", noopSender, nil)
 	close(releaseOperation)
 	<-operationDone
 	require.Empty(t, <-cleanupDone)
 	assert.True(t, m.Exists("ch1"), "a concurrent relay bind must preserve the unbound channel")
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "new", got.ConnID)
 }
 
 func TestUnbindUser_ReturnsNoConns(t *testing.T) {
@@ -1541,4 +1591,459 @@ func TestCloseByIDIfSkipsAChannelReboundToAnotherConnection(t *testing.T) {
 
 	assert.Empty(t, closed, "a stale conn id must not close the rebound channel")
 	assert.True(t, m.Exists("ch1"), "the new binding survives")
+}
+
+// TestUseAuthorizedChannel_SameConnReusePreservesBinding covers the #279
+// steady-state path: after the first bind, a later frame with the same ConnID
+// must succeed and leave the binding unchanged (RLock-only, no write).
+func TestUseAuthorizedChannel_SameConnReusePreservesBinding(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+
+	info, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "conn1", info.ConnID, "first bind must return the newly written ConnID in the snapshot")
+
+	var ops atomic.Int32
+	info, ok, err = m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error {
+			ops.Add(1)
+			return nil
+		})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "conn1", info.ConnID)
+	assert.Equal(t, int32(1), ops.Load(), "RLock reuse path must still run the operation")
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn1", got.ConnID)
+
+	closed := m.CloseByIDIf("ch1", func(info ChannelInfo) bool {
+		return info.ConnID == "conn1"
+	})
+	assert.Len(t, closed, 1)
+}
+
+// TestUseAuthorizedChannel_ReuseAuthorizeHoldsRLockOnly proves the steady-state
+// path authorizes under RLock: a concurrent GetChannelInfo (another reader)
+// must complete while authorize is still inside the critical section. Nested
+// Manager calls inside authorize are forbidden (see liveAndAuthorizeLocked) —
+// under Lock, or under RLock with a waiting writer, they deadlock.
+func TestUseAuthorizedChannel_ReuseAuthorizeHoldsRLockOnly(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	authorizeEntered := make(chan struct{})
+	releaseAuthorize := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	go func() {
+		<-authorizeEntered
+		_, infoOK := m.GetChannelInfo("ch1")
+		assert.True(t, infoOK)
+		close(readerDone)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+			func(ChannelInfo) bool {
+				close(authorizeEntered)
+				<-releaseAuthorize
+				return true
+			},
+			func(ChannelInfo) error { return nil })
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	}()
+
+	waitOrDeadlock(t, "reuse authorize blocked concurrent GetChannelInfo (path took write lock)", func() {
+		<-readerDone
+	})
+	close(releaseAuthorize)
+	waitOrDeadlock(t, "reuse authorize did not finish after reader", func() {
+		<-done
+	})
+}
+
+// TestUseAuthorizedChannel_RebindUpdatesConnID covers the write-lock upgrade:
+// a real ConnID change must update the snapshot and leave stale-conn closes alone.
+func TestUseAuthorizedChannel_RebindUpdatesConnID(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn-old", noopSender, nil)
+	m.BindUser("u1", "conn-new", noopSender, nil)
+
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn-old",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	info, ok, err := m.UseAuthorizedChannel("ch1", "conn-new",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "conn-new", info.ConnID)
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn-new", got.ConnID)
+
+	assert.Empty(t, m.CloseByIDIf("ch1", func(info ChannelInfo) bool {
+		return info.ConnID == "conn-old"
+	}), "stale conn must not close the rebound channel")
+	assert.True(t, m.Exists("ch1"))
+}
+
+// TestUseChannelIf_NilBindLeavesConnIDEmpty covers bindModeNone: the RLock
+// path must succeed without ever writing ConnID.
+func TestUseChannelIf_NilBindLeavesConnIDEmpty(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+
+	info, ok, err := m.UseChannelIf("ch1", nil, func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Empty(t, info.ConnID)
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Empty(t, got.ConnID)
+}
+
+// TestUseChannelIf_PreservesExistingConnID: bindModeNone must not clear or
+// rewrite an already-bound ConnID (and must not require hasUserConn).
+func TestUseChannelIf_PreservesExistingConnID(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+	m.UnbindUser("u1", "conn1") // sender gone; bindModeNone must still operate
+
+	info, ok, err := m.UseChannelIf("ch1", nil, func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "conn1", info.ConnID)
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn1", got.ConnID, "UseChannelIf must leave ConnID untouched")
+}
+
+// TestUseAuthorizedChannel_RefuseClearToEmptyString: clearing ConnID via
+// bindModeConn("") is a NeedWrite that refuses when "" is not registered.
+func TestUseAuthorizedChannel_RefuseClearToEmptyString(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	_, ok, err := m.UseAuthorizedChannel("ch1", "",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn1", got.ConnID, "refuse-to-clear must preserve the prior binding")
+}
+
+// TestUseAuthorizedChannel_RejectDoesNotBindConnID ensures a failing authorize
+// on the first-bind Lock path leaves ConnID empty (authorize runs once under
+// Lock with the ConnID write, not under the RLock needBind peek).
+func TestUseAuthorizedChannel_RejectDoesNotBindConnID(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+
+	var calls atomic.Int32
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool {
+			calls.Add(1)
+			return false
+		},
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), calls.Load(), "bind-path authorize must run once under Lock")
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Empty(t, got.ConnID, "rejected authorize must not bind ConnID")
+}
+
+// TestUseAuthorizedChannel_RejectOnRebindPreservesPriorConnID covers authorize
+// failing under Lock during a real ConnID change: the prior binding must stay.
+func TestUseAuthorizedChannel_RejectOnRebindPreservesPriorConnID(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn-old", noopSender, nil)
+	m.BindUser("u1", "conn-new", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn-old"))
+
+	var calls atomic.Int32
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn-new",
+		func(ChannelInfo) bool {
+			calls.Add(1)
+			return false
+		},
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), calls.Load())
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn-old", got.ConnID, "failed rebind authorize must not clear or overwrite ConnID")
+}
+
+// TestUseAuthorizedChannel_SteadyStateRejectPreservesConnID: once bound, a
+// later authorize failure on the RLock reuse path must leave ConnID intact.
+func TestUseAuthorizedChannel_SteadyStateRejectPreservesConnID(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	var calls atomic.Int32
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool {
+			calls.Add(1)
+			return false
+		},
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), calls.Load())
+
+	got, ok := m.GetChannelInfo("ch1")
+	require.True(t, ok)
+	assert.Equal(t, "conn1", got.ConnID, "steady-state reject must not clear the binding")
+}
+
+// TestUseAuthorizedChannel_RefuseBindWhenTargetConnGone: if the bind target is
+// no longer a registered user conn (Unbind finished before bind — same outcome
+// as an RUnlock→Lock gap), refuse rather than attaching a dead ConnID while
+// another user conn kept the unbound-channel sweep from closing ch1.
+func TestUseAuthorizedChannel_RefuseBindWhenTargetConnGone(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn-dead", noopSender, nil)
+	m.BindUser("u1", "conn-alive", noopSender, nil)
+
+	closed := m.UnbindUserAndCleanup("u1", "conn-dead")
+	assert.Empty(t, closed, "alive conn must keep the unbound channel out of the sweep")
+
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn-dead",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok, "must refuse bind to an unbound conn")
+
+	got, exists := m.GetChannelInfo("ch1")
+	require.True(t, exists)
+	assert.Empty(t, got.ConnID, "must not bind a dead conn")
+}
+
+// TestUseAuthorizedChannel_RefuseReuseWhenBoundConnUnbound: Ready/reuse must
+// reject when ConnID still matches but UnbindUser dropped the registration
+// without cleanup (channel kept alive by another conn).
+func TestUseAuthorizedChannel_RefuseReuseWhenBoundConnUnbound(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	m.BindUser("u1", "conn2", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	assert.False(t, m.UnbindUser("u1", "conn1"), "conn2 keeps the user map alive")
+
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok, "reuse must refuse a matching but unbound ConnID")
+
+	got, exists := m.GetChannelInfo("ch1")
+	require.True(t, exists)
+	assert.Equal(t, "conn1", got.ConnID, "refuse must not clear the stale binding")
+}
+
+// TestUseAuthorizedChannel_RefuseRebindWhenTargetConnGone: a rebind to a conn
+// that was unbound must fail under Lock and leave the prior ConnID intact.
+func TestUseAuthorizedChannel_RefuseRebindWhenTargetConnGone(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn-old", noopSender, nil)
+	m.BindUser("u1", "conn-gone", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn-old"))
+
+	assert.Empty(t, m.UnbindUserAndCleanup("u1", "conn-gone"))
+
+	_, ok, err := m.UseAuthorizedChannel("ch1", "conn-gone",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	got, exists := m.GetChannelInfo("ch1")
+	require.True(t, exists)
+	assert.Equal(t, "conn-old", got.ConnID, "failed rebind must preserve the prior binding")
+}
+
+// TestUseChannelIf_RejectAuthorizeLeavesChannel: nil-bind peek path must reject
+// under RLock without ever taking the write upgrade. Concurrent GetChannelInfo
+// while authorize runs proves the critical section is still a shared RLock.
+func TestUseChannelIf_RejectAuthorizeLeavesChannel(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+
+	authorizeEntered := make(chan struct{})
+	releaseAuthorize := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	go func() {
+		<-authorizeEntered
+		_, infoOK := m.GetChannelInfo("ch1")
+		assert.True(t, infoOK)
+		close(readerDone)
+	}()
+
+	var calls atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, ok, err := m.UseChannelIf("ch1",
+			func(ChannelInfo) bool {
+				calls.Add(1)
+				close(authorizeEntered)
+				<-releaseAuthorize
+				return false
+			},
+			func(ChannelInfo) error { return nil })
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	}()
+
+	waitOrDeadlock(t, "nil-bind reject took write lock (blocked concurrent GetChannelInfo)", func() {
+		<-readerDone
+	})
+	close(releaseAuthorize)
+	waitOrDeadlock(t, "nil-bind reject did not finish", func() {
+		<-done
+	})
+	assert.Equal(t, int32(1), calls.Load())
+	assert.True(t, m.Exists("ch1"))
+}
+
+// TestUseAuthorizedChannel_AuthorizePanicOnBindLockReleasesLocks ensures a
+// panic in authorize under the Lock bind path still releases m.mu and opMu
+// and leaves ConnID unbound.
+func TestUseAuthorizedChannel_AuthorizePanicOnBindLockReleasesLocks(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+
+	var calls atomic.Int32
+	func() {
+		defer func() { _ = recover() }()
+		_, _, _ = m.UseAuthorizedChannel("ch1", "conn1",
+			func(ChannelInfo) bool {
+				calls.Add(1)
+				panic("boom on bind authorize")
+			},
+			nil)
+	}()
+	assert.Equal(t, int32(1), calls.Load(), "panic must occur on the Lock bind authorize")
+
+	got, exists := m.GetChannelInfo("ch1")
+	require.True(t, exists)
+	assert.Empty(t, got.ConnID, "panic before ConnID write must leave the channel unbound")
+
+	waitOrDeadlock(t, "Register blocked: bind authorize panic leaked m.mu", func() {
+		m.RegisterWithAuthInfo("ch2", "w2", "u2", AuthInfo{}, nil)
+	})
+	waitOrDeadlock(t, "CloseByID blocked: bind authorize panic leaked opMu", func() {
+		m.CloseByID("ch1")
+	})
+	assert.False(t, m.Exists("ch1"))
+}
+
+// TestUseAuthorizedChannel_AuthorizePanicOnReuseReleasesLocks covers Ready-path
+// authorize panic with a matching ConnID (not only nil-bind UseChannelIf).
+func TestUseAuthorizedChannel_AuthorizePanicOnReuseReleasesLocks(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	var calls atomic.Int32
+	func() {
+		defer func() { _ = recover() }()
+		_, _, _ = m.UseAuthorizedChannel("ch1", "conn1",
+			func(ChannelInfo) bool {
+				calls.Add(1)
+				panic("boom on reuse authorize")
+			},
+			nil)
+	}()
+	assert.Equal(t, int32(1), calls.Load())
+
+	got, exists := m.GetChannelInfo("ch1")
+	require.True(t, exists)
+	assert.Equal(t, "conn1", got.ConnID, "reuse panic must not clear the binding")
+
+	waitOrDeadlock(t, "Register blocked: reuse authorize panic leaked m.mu", func() {
+		m.RegisterWithAuthInfo("ch2", "w2", "u2", AuthInfo{}, nil)
+	})
+	waitOrDeadlock(t, "CloseByID blocked: reuse authorize panic leaked opMu", func() {
+		m.CloseByID("ch1")
+	})
+}
+
+// TestUseAuthorizedChannel_HasUserConnIgnoresNilSendFn: bind presence keys off
+// registration, not SendFunc — a registered conn with nil sendFn still binds.
+func TestUseAuthorizedChannel_HasUserConnIgnoresNilSendFn(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", nil, nil)
+
+	info, ok, err := m.UseAuthorizedChannel("ch1", "conn1",
+		func(ChannelInfo) bool { return true },
+		func(ChannelInfo) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "conn1", info.ConnID)
+}
+
+// TestSendToFrontendIf_AuthorizeRejectSharesLiveGate: SendToFrontendIf must
+// refuse via the shared liveAndAuthorizeLocked helper (same gate as useChannel).
+func TestSendToFrontendIf_AuthorizeRejectSharesLiveGate(t *testing.T) {
+	m := New(0)
+	m.RegisterWithAuthInfo("ch1", "w1", "u1", AuthInfo{}, nil)
+	m.BindUser("u1", "conn1", noopSender, nil)
+	require.True(t, bindChannelConn(t, m, "ch1", "conn1"))
+
+	var calls atomic.Int32
+	ok := m.SendToFrontendIf(
+		&leapmuxv1.ChannelMessage{ChannelId: "ch1", Ciphertext: []byte("x")},
+		func(ChannelInfo) bool {
+			calls.Add(1)
+			return false
+		},
+	)
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), calls.Load())
+	assert.True(t, m.Exists("ch1"))
 }

--- a/backend/internal/hub/service/channel_service.go
+++ b/backend/internal/hub/service/channel_service.go
@@ -172,7 +172,9 @@ func (s *ChannelService) OpenChannel(
 	// The credential identity is recorded so per-token revoke paths
 	// (CloseChannelsByBearer / CloseChannelsByUserRevocation) can find every
 	// channel an `lmx_…` token authorized.
-	s.channelMgr.RegisterWithAuthInfo(channelID, workerID, user.ID.String(), channelAuthInfo(user), nil)
+	if !s.channelMgr.RegisterWithAuthInfo(channelID, workerID, user.ID.String(), channelAuthInfo(user), nil) {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("channel id collision"))
+	}
 	openAttempted := false
 	registrationCommitted := false
 	defer func() {

--- a/backend/internal/hub/service/ws_channel_relay.go
+++ b/backend/internal/hub/service/ws_channel_relay.go
@@ -195,7 +195,9 @@ func (h *ChannelRelayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			},
 		)
 		if !ok {
-			slog.Debug("channel relay: channel not authorized for user",
+			// ok=false is authorize failure, dead channel, or refuse-to-bind
+			// when the target conn is gone — not authorize-only.
+			slog.Debug("channel relay: channel unavailable for user",
 				"channel_id", channelID, "user_id", user.ID)
 			continue
 		}


### PR DESCRIPTION
## Motivation
`Manager.mu` in channelmgr is a single `sync.RWMutex` for all channels of all users. On the frontend→worker path, every frame called `UseAuthorizedChannel` → `useChannel` → `m.mu.Lock()`, even when the only “mutation” was reassigning an unchanged `ConnID`. That serialized unrelated users against each other and against all readers.

The lock ordering and panic-safe unlocks were already correct — this is a contention fix, not a correctness rewrite. See https://github.com/leapmux/leapmux/issues/279.

## Modifications
- Steady-state same-`ConnID` reuse (and `UseChannelIf` / no-bind) peeks under `m.mu.RLock` and authorizes there; first-bind / rebind upgrades to `Lock`, authorizes once in that critical section, then writes `ConnID`.
- Never write or reuse a non-empty `ConnID` unless that user conn is currently registered (`hasUserConnLocked`), covering the R→W gap and `Unbind` without cleanup.
- ConnID protocol lives in `channel_bind.go` behind `bindModeNone` / `bindModeConn` and a tagged `bindPeek` result.
- Shared `liveAndAuthorizeLocked` keeps the live+auth gate aligned between `useChannel` and `SendToFrontendIf`.
- **Breaking:** `RegisterWithAuthInfo` now returns `bool` and rejects duplicate `channelID`s instead of silently overwriting reverse indexes; `OpenChannel` maps collision to `CodeInternal`.
- Relay debug log treats `ok=false` as “channel unavailable” (authorize failure, dead channel, or refuse-to-bind).

## Result
- Closes #279
- Steady-state frontend→worker traffic no longer takes the manager-wide write lock for a no-op ConnID rebind, so unrelated users/channels stop contending on that path.
- Binds to gone connections are refused instead of attaching a dead `ConnID` while another user conn keeps the channel alive.
- Duplicate channel registration fails closed instead of corrupting worker/user indexes.
