### PR TITLE
Decompose desktop god-files and harden the sidecar SID/relay seams

### DIFF
--- a/desktop/go/app.go
+++ b/desktop/go/app.go
@@ -52,18 +52,10 @@ type App struct {
 	// lifecycleMu is released across it rather than held for the whole boot.
 	startSolo  func(context.Context) (*soloRuntime, error)
 	binaryHash string
-	// eventSinkMu/eventSink are a self-contained pub-sub bolted onto App;
-	// extracting them into their own type to shrink App's mutex surface is
-	// tracked in https://github.com/leapmux/leapmux/issues/295.
-	eventSinkMu sync.RWMutex
-	eventSink   func(*desktoppb.Event)
-	// eventSinkForRelay is the relay-aware variant of eventSink: it carries the
-	// owning wrapper id of the relay that emitted the event, so a frame that
-	// cannot be delivered (failFrameForRelay) can close ONLY that relay rather than
-	// whichever relay happens to be installed by the time the close goroutine
-	// runs. Set alongside eventSink by the RPCSession. nil outside a session,
-	// in which case EmitRelayEvent falls back to the generic (non-relay) sink.
-	eventSinkForRelay func(owner uint64, event *desktoppb.Event)
+	// events is the event pub-sub: a generic sink and a relay-aware variant
+	// behind one RWMutex. Extracted into its own type so App's mutex surface is
+	// just the lifecycle/config locks. See event_sink.go and #295.
+	events eventSink
 }
 
 type desktopConnection struct {
@@ -352,10 +344,12 @@ func (a *App) closeUndeliverableRelay(getRelay func(*desktopConnection) *wsRelay
 	a.EmitEvent(closeEvent)
 }
 
+// The five methods below are thin forwarders onto a.events (see event_sink.go);
+// they preserve the call sites in rpc.go, channel_relay.go, orgevents_relay.go,
+// solo.go, and the tests, which keep calling a.SetEventSink / a.EmitEvent / etc.
+
 func (a *App) SetEventSink(sink func(*desktoppb.Event)) {
-	a.eventSinkMu.Lock()
-	defer a.eventSinkMu.Unlock()
-	a.eventSink = sink
+	a.events.Set(sink)
 }
 
 // SetEventSinkForRelay installs the relay-aware sink the RPCSession provides
@@ -363,9 +357,7 @@ func (a *App) SetEventSink(sink func(*desktoppb.Event)) {
 // (via EmitRelayEvent) so a frame that cannot be delivered carries the emitting
 // relay's owner id forward to the close path.
 func (a *App) SetEventSinkForRelay(sink func(owner uint64, event *desktoppb.Event)) {
-	a.eventSinkMu.Lock()
-	defer a.eventSinkMu.Unlock()
-	a.eventSinkForRelay = sink
+	a.events.SetRelay(sink)
 }
 
 // emitForOwner returns a func the relay read loops call in place of a bare
@@ -376,7 +368,7 @@ func (a *App) SetEventSinkForRelay(sink func(owner uint64, event *desktoppb.Even
 // replaces connection.relay, not this relay's owner field), so the read loop's
 // emit always reports the id this relay was installed under.
 func (a *App) emitForOwner(relay *wsRelay) func(*desktoppb.Event) {
-	return func(event *desktoppb.Event) { a.EmitRelayEvent(relay.owner, event) }
+	return a.events.forOwner(relay)
 }
 
 // EmitRelayEvent routes a relay-sourced event through the relay-aware sink when
@@ -386,23 +378,11 @@ func (a *App) emitForOwner(relay *wsRelay) func(*desktoppb.Event) {
 // session without a sink has no shell pipe to deliver an undeliverable frame
 // over in the first place.
 func (a *App) EmitRelayEvent(owner uint64, event *desktoppb.Event) {
-	a.eventSinkMu.RLock()
-	sink := a.eventSinkForRelay
-	a.eventSinkMu.RUnlock()
-	if sink != nil {
-		sink(owner, event)
-		return
-	}
-	a.EmitEvent(event)
+	a.events.EmitRelay(owner, event)
 }
 
 func (a *App) EmitEvent(event *desktoppb.Event) {
-	a.eventSinkMu.RLock()
-	sink := a.eventSink
-	a.eventSinkMu.RUnlock()
-	if sink != nil {
-		sink(event)
-	}
+	a.events.Emit(event)
 }
 
 func (a *App) SidecarInfo() *desktoppb.SidecarInfo {

--- a/desktop/go/app.go
+++ b/desktop/go/app.go
@@ -316,7 +316,7 @@ func (a *App) CloseRelayForUndeliverableEvent(emitterOwner uint64, event *deskto
 // log says, and which close event the frontend receives, so those ride as
 // parameters the way wsRelay.emitClose takes its event builder.
 //
-// The ownership gate (getRelay(...).owner == emitterOwner) is the point of the
+// The ownership gate (getRelay(...).ownerNow() == emitterOwner) is the point of the
 // emitterOwner parameter: without it, a close spawned by emitter A's read loop
 // could execute after emitter B's open superseded A and tear down B's relay,
 // forcing B to reconnect for A's fault. The gate makes the close a no-op when
@@ -327,7 +327,7 @@ func (a *App) closeUndeliverableRelay(getRelay func(*desktopConnection) *wsRelay
 	a.lifecycleMu.Lock()
 	var drain <-chan struct{}
 	if a.connection != nil {
-		if relay := getRelay(a.connection); relay != nil && relay.owner == emitterOwner {
+		if relay := getRelay(a.connection); relay != nil && relay.ownerNow() == emitterOwner {
 			drain = closeRelay()
 		}
 	}
@@ -360,13 +360,9 @@ func (a *App) SetEventSinkForRelay(sink func(owner uint64, event *desktoppb.Even
 	a.events.SetRelay(sink)
 }
 
-// emitForOwner returns a func the relay read loops call in place of a bare
-// EmitEvent, capturing the emitting relay so the owner id at emit time rides
-// alongside the event. The closure reads relay.owner at CALL time rather than
-// capturing its value, because owner is stamped AFTER newWSRelay constructs the
-// relay -- but it is stable for the relay's lifetime once stamped (a supersede
-// replaces connection.relay, not this relay's owner field), so the read loop's
-// emit always reports the id this relay was installed under.
+// emitForOwner is a thin forwarder onto eventSink.forOwner; see that method for
+// why the closure reads relay.owner at call time (via an atomic load against the
+// lifecycleMu-guarded re-stamp an adopt performs) rather than capturing its value.
 func (a *App) emitForOwner(relay *wsRelay) func(*desktoppb.Event) {
 	return a.events.forOwner(relay)
 }

--- a/desktop/go/channel_relay.go
+++ b/desktop/go/channel_relay.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
@@ -58,8 +59,41 @@ type wsRelay struct {
 	// It lives on the relay, not on desktopConnection, so ownership is a property of
 	// "a relay has an owner" -- both relays get the same fence (closeIfOwner), and the
 	// id cannot outlive the relay it named.
+	//
+	// owner is read RACE-FREE by the relay read loop's emit closure
+	// (eventSink.forOwner -> EmitRelay(wsRelay.ownerNow)) while that relay is still
+	// running, but re-stamped under lifecycleMu by OpenChannelRelay's adoptLiveRelay
+	// -- the only path that transfers ownership of a LIVE relay.
+	// OpenOrgEventsRelay does not re-stamp: its rejectIfSuperseded only LOADS owner
+	// (to refuse a stale open), and a fresh org-events relay is stamped once at
+	// construction and never mutated again, so the atomic load on its read loop is
+	// defense-in-depth rather than a race guard. The writes (wsRelay.stampOwner) all
+	// happen under lifecycleMu; the only lock-free access is the read loop's ownerNow.
+	// A stale read can observe the immediately-prior owner, which only affects which
+	// relay an undeliverable frame can close -- never delivery itself.
+	//
+	// All reads/writes go through ownerNow/stampOwner, the named accessors below; a
+	// future bare `relay.owner` read bypasses the atomic and races. (atomic.Uint64
+	// would make the field self-protecting, but it carries a noCopy that wsRelay's
+	// value-embedding in ChannelRelay/OrgEventsRelay cannot stomach; standalone
+	// atomic ops behind accessors are safe on every target LeapMux builds for --
+	// macOS/Linux/Windows, all 64-bit.)
 	owner uint64
 }
+
+// ownerNow returns the id of the frontend wrapper this relay was last handed to.
+// It is the ONLY race-free way to read owner: the read loop's emit closure reads
+// it (via eventSink.forOwner) without holding lifecycleMu while an adopt
+// re-stamps it under lifecycleMu (see the owner field doc). Routing every read
+// through this method keeps the atomic load at one site so a future bare
+// `relay.owner` read cannot silently race.
+func (r *wsRelay) ownerNow() uint64 { return atomic.LoadUint64(&r.owner) }
+
+// stampOwner records id as the frontend wrapper this relay was last handed to.
+// Caller holds lifecycleMu for writing; the Store is atomic only so the read
+// loop's lock-free ownerNow stays race-free against it. Routing every write
+// through this method keeps the atomic store at one site.
+func (r *wsRelay) stampOwner(id uint64) { atomic.StoreUint64(&r.owner, id) }
 
 // newWSRelay constructs the shared wsRelay core both ChannelRelay and
 // OrgEventsRelay embed, wiring the per-relay lifetime context + cancel the
@@ -78,7 +112,7 @@ func newWSRelay(ws *websocket.Conn, ctx context.Context, cancel context.CancelFu
 // rule is defined once for every relay (see wsRelay.owner). Caller holds lifecycleMu
 // for writing.
 func closeIfOwner(relay *wsRelay, relayID uint64, closeRelay func() <-chan struct{}) <-chan struct{} {
-	if relay.owner != relayID {
+	if relay.ownerNow() != relayID {
 		// Stale: the relay has already been handed to someone else. Not an error --
 		// the caller's intent, "my relay should be closed", is already satisfied.
 		return nil
@@ -295,8 +329,8 @@ type ChannelRelay struct {
 }
 
 // OpenChannelRelay establishes (or adopts) the channel relay for relayID, the
-// frontend wrapper making the request. See desktopConnection.relayOwner for why the
-// id travels with the request.
+// frontend wrapper making the request. See wsRelay.owner for why the id travels
+// with the request.
 func (a *App) OpenChannelRelay(requestCtx context.Context, relayID uint64) error {
 	// Reuse an existing healthy relay -- both before the dial and again at
 	// install, where a concurrent open may have beaten us to it. The sidecar
@@ -316,10 +350,10 @@ func (a *App) OpenChannelRelay(requestCtx context.Context, relayID uint64) error
 		if current == nil || current.ctx.Err() != nil {
 			return false, nil
 		}
-		if current.owner > relayID {
+		if current.ownerNow() > relayID {
 			return false, fmt.Errorf("channel relay superseded by a newer open")
 		}
-		current.owner = relayID
+		current.stampOwner(relayID)
 		return true, nil
 	}
 	return a.openRelay(requestCtx, relayOpenSpec{
@@ -335,7 +369,7 @@ func (a *App) OpenChannelRelay(requestCtx context.Context, relayID uint64) error
 			// names whoever the frontend last handed the relay to -- which is
 			// exactly who a legitimate close can come from. Stamped before the
 			// relay is installed, so no close can ever observe it unowned.
-			relay.owner = relayID
+			relay.stampOwner(relayID)
 			// Route the read loop's emits through the relay-aware sink so an
 			// undeliverable frame carries this relay's owner id forward to the
 			// close path (the closure reads relay.owner at call time; it is

--- a/desktop/go/channel_relay_test.go
+++ b/desktop/go/channel_relay_test.go
@@ -313,7 +313,7 @@ func TestCloseChannelRelayDetachIsPromptUnderLock(t *testing.T) {
 func TestCloseChannelRelayDrainsOffLockWithoutFreezingReaders(t *testing.T) {
 	base, releaseEmit, emitEntered, readDone := parkedEmitRelay(t, "channel-relay")
 	relay := &ChannelRelay{wsRelay: base}
-	relay.owner = 1
+	relay.stampOwner(1)
 	go func() {
 		defer close(readDone)
 		relay.runReadLoop()
@@ -537,7 +537,8 @@ func TestCloseChannelRelayBoundedByDrainTimeout(t *testing.T) {
 	stallRelease := make(chan struct{})
 	t.Cleanup(func() { close(stallRelease) })
 	ws := newStalledEmitRelayWS(t)
-	relay := &ChannelRelay{wsRelay: wsRelay{ws: ws, ctx: ctx, cancel: cancel, done: make(chan struct{}), owner: 1, emit: func(*desktoppb.Event) { <-stallRelease }}}
+	relay := &ChannelRelay{wsRelay: wsRelay{ws: ws, ctx: ctx, cancel: cancel, done: make(chan struct{}), emit: func(*desktoppb.Event) { <-stallRelease }}}
+	relay.stampOwner(1)
 	go relay.runReadLoop()
 
 	app := &App{connection: &desktopConnection{relay: relay}}
@@ -660,7 +661,7 @@ func TestApp_CloseChannelRelay_IgnoresStaleOwner(t *testing.T) {
 	relayBefore := app.connection.relay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayBefore, "the relay must be live after B adopted it")
-	require.Equal(t, uint64(2), relayBefore.owner, "adopting the relay must transfer ownership to B")
+	require.Equal(t, uint64(2), relayBefore.ownerNow(), "adopting the relay must transfer ownership to B")
 
 	// A's close arrives late. It must not touch B's relay.
 	require.NoError(t, app.CloseChannelRelay(1), "a stale close is satisfied, not an error")
@@ -706,7 +707,7 @@ func TestApp_CloseChannelRelay_DropsOwnerOnTeardown(t *testing.T) {
 	relay := app.connection.relay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relay, "a stale owner must not close a relay opened after its own")
-	assert.Equal(t, uint64(8), relay.owner, "the fresh relay belongs to the wrapper that opened it")
+	assert.Equal(t, uint64(8), relay.ownerNow(), "the fresh relay belongs to the wrapper that opened it")
 }
 
 // channelRelayTestServer accepts channel-relay WebSockets and holds each open until
@@ -798,7 +799,7 @@ func TestApp_OpenChannelRelay_StaleOpenDoesNotStealFromSuccessor(t *testing.T) {
 	relayBefore := app.connection.relay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayBefore)
-	require.Equal(t, uint64(2), relayBefore.owner)
+	require.Equal(t, uint64(2), relayBefore.ownerNow())
 
 	// Wrapper 1 -- an EARLIER request the sidecar ran late -- must not steal it.
 	require.Error(t, app.OpenChannelRelay(context.Background(), 1),
@@ -809,7 +810,7 @@ func TestApp_OpenChannelRelay_StaleOpenDoesNotStealFromSuccessor(t *testing.T) {
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayAfter, "the successor's relay must survive the stale open")
 	assert.Same(t, relayBefore, relayAfter, "the stale open must not have replaced the relay")
-	assert.Equal(t, uint64(2), relayAfter.owner, "the stale open must not have re-stamped the owner")
+	assert.Equal(t, uint64(2), relayAfter.ownerNow(), "the stale open must not have re-stamped the owner")
 	assert.NoError(t, relayAfter.ctx.Err(), "the surviving relay must still be live")
 }
 
@@ -836,7 +837,7 @@ func TestApp_OpenChannelRelay_ConcurrentOpenDoesNotStealFromSuccessor(t *testing
 	relay2 := app.connection.relay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relay2, "wrapper 2's relay must be installed")
-	require.Equal(t, uint64(2), relay2.owner)
+	require.Equal(t, uint64(2), relay2.ownerNow())
 
 	close(release)
 	require.Error(t, <-open1,
@@ -847,6 +848,6 @@ func TestApp_OpenChannelRelay_ConcurrentOpenDoesNotStealFromSuccessor(t *testing
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayAfter, "the successor's relay must survive the loser's install")
 	assert.Same(t, relay2, relayAfter, "the loser must not have replaced the successor's relay")
-	assert.Equal(t, uint64(2), relayAfter.owner, "the loser must not have re-stamped the owner")
+	assert.Equal(t, uint64(2), relayAfter.ownerNow(), "the loser must not have re-stamped the owner")
 	assert.NoError(t, relayAfter.ctx.Err(), "the surviving relay must still be live")
 }

--- a/desktop/go/event_sink.go
+++ b/desktop/go/event_sink.go
@@ -70,11 +70,13 @@ func (s *eventSink) EmitRelay(owner uint64, event *desktoppb.Event) {
 
 // forOwner returns a func the relay read loops call in place of a bare Emit,
 // capturing the emitting relay so the owner id at emit time rides alongside the
-// event. The closure reads relay.owner at CALL time rather than capturing its
-// value, because owner is stamped AFTER newWSRelay constructs the relay -- but
-// it is stable for the relay's lifetime once stamped (a supersede replaces
-// connection.relay, not this relay's owner field), so the read loop's emit
-// always reports the id this relay was installed under.
+// event. The closure reads relay.owner at CALL time (via wsRelay.ownerNow) rather
+// than capturing its value, because owner is stamped AFTER newWSRelay constructs
+// the relay. See wsRelay.owner for the full rationale -- why the load is atomic
+// (the read loop runs lock-free against the lifecycleMu-guarded re-stamp an adopt
+// performs), why a stale read only ever affects which relay an undeliverable frame
+// can close (never delivery itself), and why access is encapsulated behind
+// ownerNow/stampOwner rather than the field being an atomic.Uint64.
 func (s *eventSink) forOwner(relay *wsRelay) func(*desktoppb.Event) {
-	return func(event *desktoppb.Event) { s.EmitRelay(relay.owner, event) }
+	return func(event *desktoppb.Event) { s.EmitRelay(relay.ownerNow(), event) }
 }

--- a/desktop/go/event_sink.go
+++ b/desktop/go/event_sink.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"sync"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+// eventSink is App's event pub-sub, extracted from the App god-object so App's
+// mutex surface shrinks to the lifecycle/config locks a reader must reason
+// about together. It carries two sinks behind one RWMutex: a generic
+// event sink and a relay-aware variant that threads the emitting relay's owner
+// id alongside the event. Both are installed by the RPCSession at session start
+// and cleared on teardown. The zero value is a usable nil-safe sink, so a bare
+// App{} keeps working without initialization.
+//
+// See https://github.com/leapmux/leapmux/issues/295.
+type eventSink struct {
+	mu        sync.RWMutex
+	sink      func(*desktoppb.Event)
+	relaySink func(owner uint64, event *desktoppb.Event)
+}
+
+// Set installs the generic event sink. Pass nil to clear it (e.g. on session
+// teardown).
+func (s *eventSink) Set(sink func(*desktoppb.Event)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sink = sink
+}
+
+// SetRelay installs the relay-aware sink the RPCSession provides alongside the
+// generic sink. The relay read loops route their emits through it (via
+// EmitRelay) so a frame that cannot be delivered carries the emitting relay's
+// owner id forward to the close path. Pass nil to clear it.
+func (s *eventSink) SetRelay(sink func(owner uint64, event *desktoppb.Event)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.relaySink = sink
+}
+
+// Emit delivers event through the generic sink when one is installed. A sink
+// installed later than a relay's read loop starts (or no sink at all, as in a
+// bare App{}) is the nil case this guards.
+func (s *eventSink) Emit(event *desktoppb.Event) {
+	s.mu.RLock()
+	sink := s.sink
+	s.mu.RUnlock()
+	if sink != nil {
+		sink(event)
+	}
+}
+
+// EmitRelay routes a relay-sourced event through the relay-aware sink when one
+// is installed, falling back to the generic Emit otherwise (e.g. when the relay
+// emits before the RPCSession has wired its sink, or in a focused test that
+// constructs a bare App). The fallback loses the owner id, but a session
+// without a sink has no shell pipe to deliver an undeliverable frame over in
+// the first place.
+func (s *eventSink) EmitRelay(owner uint64, event *desktoppb.Event) {
+	s.mu.RLock()
+	relaySink := s.relaySink
+	s.mu.RUnlock()
+	if relaySink != nil {
+		relaySink(owner, event)
+		return
+	}
+	s.Emit(event)
+}
+
+// forOwner returns a func the relay read loops call in place of a bare Emit,
+// capturing the emitting relay so the owner id at emit time rides alongside the
+// event. The closure reads relay.owner at CALL time rather than capturing its
+// value, because owner is stamped AFTER newWSRelay constructs the relay -- but
+// it is stable for the relay's lifetime once stamped (a supersede replaces
+// connection.relay, not this relay's owner field), so the read loop's emit
+// always reports the id this relay was installed under.
+func (s *eventSink) forOwner(relay *wsRelay) func(*desktoppb.Event) {
+	return func(event *desktoppb.Event) { s.EmitRelay(relay.owner, event) }
+}

--- a/desktop/go/event_sink_test.go
+++ b/desktop/go/event_sink_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -90,9 +91,47 @@ func TestEventSink_ForOwnerReadsOwnerAtCallTime(t *testing.T) {
 
 	// Stamping owner AFTER forOwner captured the relay must still be observed,
 	// because the closure reads relay.owner when invoked, not when built.
-	relay.owner = 123
+	relay.stampOwner(123)
 	emit(&desktoppb.Event{})
 	if got.Load() != 123 {
 		t.Fatalf("owner after stamp = %d, want 123 (must read at call time)", got.Load())
 	}
+}
+
+// forOwner's closure reads relay.owner (via wsRelay.ownerNow) while an adopt
+// re-stamps it (via wsRelay.stampOwner) -- the concurrent shape of the relay
+// read loop emitting while OpenChannelRelay's adoptLiveRelay transfers
+// ownership under lifecycleMu. Before owner became atomic, the race detector
+// flagged this exact pattern; this test pins it race-free. Run with -race for
+// the meaningful check.
+func TestEventSink_ForOwnerReadsOwnerConcurrentlyWithReStamp(t *testing.T) {
+	var s eventSink
+	s.SetRelay(func(owner uint64, _ *desktoppb.Event) {})
+
+	relay := &wsRelay{}
+	emit := s.forOwner(relay)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	const iterations = 200
+	// Reader: the relay read loop's emit, hitting the lock-free owner load.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			emit(&desktoppb.Event{})
+		}
+	}()
+	// Writer: an adopt re-stamping owner under (simulated) lifecycleMu.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			relay.stampOwner(uint64(i % 8))
+		}
+	}()
+
+	wg.Wait()
+	// No assertion on values -- the contract under test is the absence of a
+	// data race (detected by -race), not a specific interleaving. The worst
+	// case the design accepts is one emit observing the immediately-prior owner.
 }

--- a/desktop/go/event_sink_test.go
+++ b/desktop/go/event_sink_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+
+	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+)
+
+// eventSink was extracted from App's god-object in #295. These tests pin its
+// contract directly so a regression in the pub-sub's own semantics (rather
+// than App's forwarding of them) fails here instead of only surfacing through
+// an integration path.
+
+// A bare eventSink -- as constructed by a bare App{} or before the RPCSession
+// installs a sink -- must drop events silently rather than panic. The relay
+// read loops can emit before SetEventSink runs (see rpc_test.go), so this
+// nil-safety is load-bearing.
+func TestEventSink_EmitsAreNoOpsBeforeASinkIsInstalled(t *testing.T) {
+	var s eventSink
+	s.Emit(&desktoppb.Event{})          // must not panic
+	s.EmitRelay(42, &desktoppb.Event{}) // must not panic, must not recurse into a nil sink
+}
+
+// Emit routes through the generic sink installed by Set, and clearing it
+// (Set(nil), as the RPCSession does on teardown) makes Emits no-ops again.
+func TestEventSink_EmitRoutesThroughTheInstalledSink(t *testing.T) {
+	var s eventSink
+	var got atomic.Int32
+	s.Set(func(*desktoppb.Event) { got.Add(1) })
+
+	s.Emit(&desktoppb.Event{})
+	s.Emit(&desktoppb.Event{})
+	if got.Load() != 2 {
+		t.Fatalf("generic sink called %d times, want 2", got.Load())
+	}
+
+	s.Set(nil)
+	s.Emit(&desktoppb.Event{})
+	if got.Load() != 2 {
+		t.Fatalf("Emits after Set(nil) must be dropped, got %d calls", got.Load())
+	}
+}
+
+// EmitRelay routes through the relay-aware sink when one is installed,
+// forwarding the emitting relay's owner id alongside the event.
+func TestEventSink_EmitRelayUsesTheRelaySinkWhenInstalled(t *testing.T) {
+	var s eventSink
+	type captured struct {
+		owner uint64
+	}
+	var got captured
+	s.SetRelay(func(owner uint64, _ *desktoppb.Event) { got = captured{owner: owner} })
+
+	s.EmitRelay(7, &desktoppb.Event{})
+	if got.owner != 7 {
+		t.Fatalf("relay sink received owner %d, want 7", got.owner)
+	}
+}
+
+// When no relay sink is installed, EmitRelay must fall back to the generic
+// sink -- this is the path a relay hits when it emits before the RPCSession
+// has wired its relay sink, and it is why EmitRelay cannot just drop the event.
+func TestEventSink_EmitRelayFallsBackToTheGenericSink(t *testing.T) {
+	var s eventSink
+	var genericCalls atomic.Int32
+	s.Set(func(*desktoppb.Event) { genericCalls.Add(1) })
+	// No SetRelay: EmitRelay must fall back.
+
+	s.EmitRelay(99, &desktoppb.Event{})
+	if genericCalls.Load() != 1 {
+		t.Fatalf("fallback to generic sink called it %d times, want 1", genericCalls.Load())
+	}
+}
+
+// forOwner returns a closure that threads the emitting relay's owner id into
+// EmitRelay, reading relay.owner at CALL time (so a stamp after construction is
+// observed). This pins the deferred-read contract the relay read loops rely on.
+func TestEventSink_ForOwnerReadsOwnerAtCallTime(t *testing.T) {
+	var s eventSink
+	var got atomic.Uint64
+	s.SetRelay(func(owner uint64, _ *desktoppb.Event) { got.Store(owner) })
+
+	relay := &wsRelay{} // owner starts at its zero value
+	emit := s.forOwner(relay)
+	emit(&desktoppb.Event{})
+	if got.Load() != 0 {
+		t.Fatalf("owner before stamp = %d, want 0", got.Load())
+	}
+
+	// Stamping owner AFTER forOwner captured the relay must still be observed,
+	// because the closure reads relay.owner when invoked, not when built.
+	relay.owner = 123
+	emit(&desktoppb.Event{})
+	if got.Load() != 123 {
+		t.Fatalf("owner after stamp = %d, want 123 (must read at call time)", got.Load())
+	}
+}

--- a/desktop/go/orgevents_relay.go
+++ b/desktop/go/orgevents_relay.go
@@ -96,7 +96,7 @@ func (a *App) OpenOrgEventsRelay(requestCtx context.Context, relayID uint64, org
 				wsRelay: newWSRelay(ws, ctx, cancel, a.EmitEvent),
 			}
 			// Stamped before the relay is installed, so no close can ever observe it unowned.
-			relay.owner = relayID
+			relay.stampOwner(relayID)
 			// Route the read loop's emits through the relay-aware sink so an
 			// undeliverable frame carries this relay's owner id forward to the close
 			// path (mirrors the channel relay's commit closure).
@@ -115,7 +115,7 @@ func (a *App) OpenOrgEventsRelay(requestCtx context.Context, relayID uint64, org
 // Caller holds lifecycleMu.
 func (a *App) rejectIfSuperseded(connection *desktopConnection, relayID uint64) error {
 	current := connection.orgEventsRelay
-	if current == nil || current.owner <= relayID {
+	if current == nil || current.ownerNow() <= relayID {
 		return nil
 	}
 	return fmt.Errorf("org events relay superseded by a newer open")

--- a/desktop/go/orgevents_relay_test.go
+++ b/desktop/go/orgevents_relay_test.go
@@ -79,7 +79,7 @@ func TestApp_OpenOrgEventsRelay_ConcurrentOpenDoesNotTearDownTheSuccessor(t *tes
 	relayB := app.connection.orgEventsRelay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayB, "B's relay must be installed")
-	require.Equal(t, uint64(2), relayB.owner, "the relay belongs to the attempt that opened it")
+	require.Equal(t, uint64(2), relayB.ownerNow(), "the relay belongs to the attempt that opened it")
 
 	close(release)
 	require.Error(t, <-openA,

--- a/desktop/go/rpc_test.go
+++ b/desktop/go/rpc_test.go
@@ -491,7 +491,7 @@ func TestRPCSessionClosesRelayOnUndeliverableEventFrame(t *testing.T) {
 	relay := &ChannelRelay{
 		wsRelay: wsRelay{ws: ws, ctx: relayCtx, cancel: relayCancel, done: make(chan struct{}), emit: app.EmitEvent},
 	}
-	relay.owner = 1 // the wrapper id this relay was installed under
+	relay.stampOwner(1) // the wrapper id this relay was installed under
 	go relay.runReadLoop()
 	app.connection.relay = relay
 
@@ -549,7 +549,7 @@ func TestCloseRelayForUndeliverableEvent_LeavesSuccessorRelayAlone(t *testing.T)
 			emit:   app.EmitEvent,
 		},
 	}
-	successor.owner = 2
+	successor.stampOwner(2)
 	app.lifecycleMu.Lock()
 	app.connection.relay = successor
 	app.lifecycleMu.Unlock()

--- a/desktop/rust/src/alloc_probe.rs
+++ b/desktop/rust/src/alloc_probe.rs
@@ -1,0 +1,63 @@
+//! Test-only peak-allocation tracker.
+//!
+//! `#[global_allocator]` is declared in `main.rs` against `alloc_probe::PeakTracking`;
+//! the per-test high-water-mark is read via `peak_alloc_of`. Lives in its own file so
+//! the allocator plumbing stays out of the 4000-line `main.rs`.
+
+#![cfg(test)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    // Deliberately thread-local rather than a global counter: the test
+    // harness runs tests in parallel threads, and a shared counter would
+    // make one test's allocations visible to another. `const` init keeps
+    // this free of a destructor, so the allocator can't re-enter TLS setup.
+    static PEAK: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record(size: usize) {
+    // `try_with` (not `with`): the allocator stays live during TLS
+    // teardown, after PEAK has been destroyed. Nothing to record then.
+    let _ = PEAK.try_with(|peak| peak.set(peak.get().max(size)));
+}
+
+pub struct PeakTracking;
+
+// SAFETY: every method forwards to `System` with the same arguments it was
+// given; the only added work is recording the requested size.
+unsafe impl GlobalAlloc for PeakTracking {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+
+    // `vec![0u8; n]` lands here, not in `alloc`, via the zeroing
+    // specialization -- which is exactly the allocation under test.
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        record(new_size);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+/// Runs `f` on the current thread, returning its value alongside the
+/// largest single allocation it requested.
+///
+/// Only allocations on the calling thread are counted, so `f` must do the
+/// work itself rather than hand it to another thread. `Runtime::block_on`
+/// qualifies: it drives the future on the caller.
+pub fn peak_alloc_of<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    PEAK.with(|peak| peak.set(0));
+    let out = f();
+    (out, PEAK.with(|peak| peak.get()))
+}

--- a/desktop/rust/src/file_save.rs
+++ b/desktop/rust/src/file_save.rs
@@ -1,0 +1,791 @@
+//! Streaming file-save subsystem.
+//!
+//! Saves are streamed through a `file_save_open[_dialog] → file_save_write* →
+//! file_save_commit | file_save_abort` chain. The Rust side keeps the destination
+//! `File` open in a registry between calls, so the JS caller pipes each 1 MiB
+//! worker chunk straight through `file_save_write` without materializing the
+//! whole file (bounding peak transient memory to a few MiB even for
+//! multi-hundred-MB downloads). Writes go to a sibling temp file
+//! (`<final>.leapmux.tmp`); commit atomic-renames it onto the final path, abort
+//! deletes it -- so the final name never appears on disk until the save
+//! completes, and (for Save as...) the user's existing file is preserved on
+//! failure.
+//!
+//! Extracted from `main.rs`.
+
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+use std::time::{Duration, Instant};
+
+use tauri::State;
+use tokio::sync::oneshot;
+
+use serde::Serialize;
+
+use crate::{decode_b64, recover};
+
+// Saves are streamed through a `file_save_open[_dialog] → file_save_write* →
+// file_save_commit | file_save_abort` chain. The Rust side keeps the
+// destination `File` open in a registry between calls, so the JS caller
+// can pipe each 1 MiB worker chunk straight through `file_save_write`
+// without ever materializing the whole file. This bounds the peak
+// transient memory (per chunk × ~3 copies across the IPC boundary) to
+// a few MiB even for multi-hundred-MB downloads.
+//
+// Writes go to a sibling temp file (`<final>.leapmux.tmp`); on commit we
+// atomic-rename it onto the final path, and on abort we delete it.
+// Consequence: the final name never appears on disk until the save is
+// complete, and (for Save as...) the user's existing file at the chosen
+// path is preserved if the save fails. The Downloads variant iterates
+// candidate names ("foo.ext",
+// "foo (1).ext", ...) skipping any whose final path already exists and
+// claiming each candidate's `<name>.leapmux.tmp` with `create_new` — that
+// single open both reserves the iteration spot against concurrent
+// LeapMux saves of the same basename and provides the file the bytes
+// stream into.
+
+fn read_header_str<'a>(
+    request: &'a tauri::ipc::Request<'_>,
+    name: &str,
+) -> Result<&'a str, String> {
+    request
+        .headers()
+        .get(name)
+        .ok_or_else(|| format!("missing {name} header"))?
+        .to_str()
+        .map_err(|err| format!("invalid {name} header: {err}"))
+}
+
+fn read_b64_header(request: &tauri::ipc::Request<'_>, name: &str) -> Result<String, String> {
+    let bytes = decode_b64(read_header_str(request, name)?)?;
+    String::from_utf8(bytes).map_err(|err| format!("invalid {name} utf-8: {err}"))
+}
+
+/// Parse the decimal `handle-id` header shared by `file_save_write`,
+/// `file_save_commit`, and `file_save_abort`.
+fn read_handle_id(request: &tauri::ipc::Request<'_>) -> Result<u64, String> {
+    read_header_str(request, "handle-id")?
+        .parse()
+        .map_err(|err| format!("invalid handle-id: {err}"))
+}
+
+/// Run a blocking closure on the dedicated blocking-thread pool and
+/// return its result, surfacing a join failure as an error string. Used
+/// for save-stream operations that touch the disk and shouldn't tie up
+/// the async executor thread servicing other Tauri commands.
+async fn run_blocking<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|err| format!("spawn_blocking join: {err}"))?
+}
+
+/// Cap on collision-dedup attempts. With "foo (N).ext" picking from
+/// `1..MAX`, this bounds the directory scan and the suffix the user
+/// sees ("foo (1023).ext" is well past the point where a different
+/// filename is more useful than another increment).
+pub(crate) const MAX_SAVE_COLLISION_ATTEMPTS: u32 = 1024;
+
+/// Suffix appended to the final path to form the streaming partial.
+/// Shared by the producer (`tmp_path_for`), the matcher (`is_partial_name`,
+/// used by `sweep_orphan_tmps`), and the defuser (`defuse_final_path`) so
+/// the three cannot drift.
+///
+/// Two invariants load-bearing for #285:
+/// - Distinctive (`.leapmux.tmp`, not a bare `.tmp`): distinctive enough
+///   that the startup sweep never matches a generic `*.tmp` some other
+///   tool left in Downloads. This is a naming convention, not a hard
+///   guarantee against a foreign file that deliberately reuses the
+///   suffix; what makes the sweep safe for *our* files is that
+///   `defuse_final_path` keeps every LeapMux final clear of the suffix,
+///   so a match is a LeapMux partial by construction.
+/// - Deterministic (no PID/randomness): `create_new` on this fixed
+///   sibling name is what reserves a collision slot against concurrent
+///   same-name saves.
+pub(crate) const SAVE_TMP_SUFFIX: &str = ".leapmux.tmp";
+
+/// Appended to a chosen final whose own name would match `is_partial_name`,
+/// so a committed final can never be mistaken for a partial by the sweep.
+/// The single source of truth for the defuse marker, shared by both defuse
+/// sites (`defuse_final_path` and the inline defuse in `open_unique_tmp`) so
+/// the two cannot drift — the same role `SAVE_TMP_SUFFIX` plays for the
+/// partial suffix. Must not itself end in `SAVE_TMP_SUFFIX`.
+pub(crate) const SAVE_DEFUSE_SUFFIX: &str = ".download";
+
+/// How often the idle-handle GC scans the registry for handles whose
+/// JS pump appears to have died. 60s keeps the scan cost negligible
+/// while still bounding orphan-disk-junk lifetime to roughly
+/// `SAVE_HANDLE_GC_INTERVAL + SAVE_HANDLE_IDLE_TIMEOUT`.
+pub(crate) const SAVE_HANDLE_GC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a handle can sit without a `write_chunk` (or `close`)
+/// before the GC discards it. An active save touches `last_write_at`
+/// per chunk, so the gap can only widen if the JS pump is wedged or
+/// the renderer process died. 5 min is well above any realistic
+/// per-chunk latency (1 MiB chunks rarely take more than seconds) but
+/// short enough that an orphan partial is gone before the user notices.
+pub(crate) const SAVE_HANDLE_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Registry entry for a save in progress: the open file plus the
+/// paths needed to finalize or discard. Distinct from
+/// `SaveStreamHandle`, which is the id+path token JS holds; this
+/// struct is Rust-only and never crosses the IPC boundary.
+pub(crate) struct OpenSaveStream {
+    /// `Arc<Mutex<File>>` rather than `Mutex<File>` so `write_chunk` can
+    /// short-lock the registry to clone the Arc, drop the registry
+    /// lock, and then take the per-file lock — writes to different
+    /// streams run in parallel instead of serializing on a registry-
+    /// wide mutex.
+    pub(crate) file: Arc<Mutex<std::fs::File>>,
+    /// Sibling `<final>.leapmux.tmp` path that bytes stream into.
+    tmp_path: PathBuf,
+    /// Final destination — the partial is atomic-renamed onto this on success.
+    final_path: PathBuf,
+    /// Updated on insert and on every `write_chunk`. The idle-handle
+    /// GC compares this against `SAVE_HANDLE_IDLE_TIMEOUT` to detect
+    /// JS pumps that died without calling `file_save_commit` or
+    /// `file_save_abort`. Lives under the registry `Mutex<HashMap>`
+    /// lock so it shares the existing critical section instead of
+    /// needing its own atomic.
+    last_write_at: Instant,
+}
+
+/// Open destination files keyed by a monotonic u64 id. The JS caller
+/// receives the id from `file_save_open[_dialog]` and submits it back
+/// with each `file_save_write` and the final `file_save_commit` or
+/// `file_save_abort`.
+pub(crate) struct SaveStreamRegistry {
+    /// Starts at 1 so a freshly constructed registry never hands out 0 —
+    /// keeps "0 == sentinel" assumptions on the JS side safe.
+    next_id: AtomicU64,
+    // Recovers from poisoning via the `recover` helper; the per-handle
+    // `Arc<Mutex<File>>` in `write_chunk` is the exception and fails closed.
+    // See the PendingMap comment above and
+    // https://github.com/leapmux/leapmux/issues/277.
+    pub(crate) handles: Mutex<HashMap<u64, OpenSaveStream>>,
+}
+
+impl SaveStreamRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            handles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Insert a freshly-opened file into the registry and return the
+    /// JS-facing handle (id + the final path as a UTF-8 string).
+    /// Both `file_save_open` and `file_save_open_dialog` end with this,
+    /// so it lives here to keep the id/path packaging in one spot.
+    pub(crate) fn insert(
+        &self,
+        file: std::fs::File,
+        tmp_path: PathBuf,
+        final_path: PathBuf,
+    ) -> SaveStreamHandle {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let path = final_path.to_string_lossy().into_owned();
+        recover(&self.handles).insert(
+            id,
+            OpenSaveStream {
+                file: Arc::new(Mutex::new(file)),
+                tmp_path,
+                final_path,
+                last_write_at: Instant::now(),
+            },
+        );
+        SaveStreamHandle { id, path }
+    }
+
+    fn take(&self, id: u64) -> Option<OpenSaveStream> {
+        recover(&self.handles).remove(&id)
+    }
+
+    /// Finalize the save: take the handle, ensure no write is still in flight,
+    /// then atomic-rename the partial onto the final path. On any failure the
+    /// partial is discarded.
+    ///
+    /// The in-flight-write check is load-bearing. `write_chunk` clones the
+    /// per-handle `Arc<Mutex<File>>` and writes with the registry lock
+    /// released, so a duplicated/overlapping `file_save_write` (a buggy or
+    /// retrying JS pump that does not await the previous write) could still be
+    /// holding a clone when commit runs. Committing anyway would, on Windows,
+    /// fail the rename with an opaque "used by another process" error, and on
+    /// Unix SUCCEED while the in-flight write appends to the just-renamed file
+    /// -- silent corruption. So after `take` (which removes the registry's own
+    /// clone, and after which `write_chunk` can create no new one -- its
+    /// `get_mut` returns None), `Arc::try_unwrap` is the reliable
+    /// sole-ownership test: if it fails, a write clone is live, and commit
+    /// fails loudly and discards the partial rather than racing it.
+    pub(crate) fn commit(&self, id: u64) -> Result<(), String> {
+        let Some(stream) = self.take(id) else {
+            return Err(format!("unknown save handle {id}"));
+        };
+        let OpenSaveStream {
+            file,
+            tmp_path,
+            final_path,
+            last_write_at: _,
+        } = stream;
+        // Sole-ownership check: see the method doc. Arc::try_unwrap returns the
+        // inner Mutex only when this is the last reference.
+        let file = match Arc::try_unwrap(file) {
+            Ok(file) => file,
+            Err(_) => {
+                discard_partials(&tmp_path);
+                return Err(format!(
+                    "save handle {id} has a write still in progress; commit refused"
+                ));
+            }
+        };
+        // No `sync_all` before the rename -- intentional. A `sync_all` on a
+        // multi-hundred-MB save blocks for seconds while the OS flushes the
+        // page cache, and neither flow has a contract that needs it: the
+        // Downloads variant only ever writes to a path that was empty when we
+        // picked the name (so a power-loss window between rename and OS flush
+        // just loses the new file, it can't corrupt anything else), and the
+        // Save-as variant's overwrite is already non-atomic at the
+        // user-content level (the user picked a path knowing it would be
+        // replaced, and can re-save on crash). Don't add a sync here without
+        // matching the latency cost to a concrete guarantee we actually need to
+        // make.
+        //
+        // Drop the File before the rename: Windows refuses `rename`/
+        // `remove_file` while the handle is open. try_unwrap above proved this
+        // is the sole owner, so this drop releases the underlying File.
+        drop(file);
+        // `std::fs::rename` replaces the destination on both Unix and Windows.
+        // For save-as that overwrites the user's prior content (the path they
+        // chose). For the Downloads flow the final path was empty when we
+        // picked the name (`open_unique_tmp` skips candidates whose final
+        // already exists); a file appearing there mid-stream is a TOCTOU race
+        // we accept.
+        let result =
+            std::fs::rename(&tmp_path, &final_path).map_err(|err| format!("rename: {err}"));
+        if result.is_err() {
+            discard_partials(&tmp_path);
+        }
+        result
+    }
+
+    pub(crate) fn write_chunk(&self, id: u64, bytes: &[u8]) -> Result<(), String> {
+        // Lock the registry only long enough to refresh the idle
+        // timestamp and clone the per-handle Arc, then drop the
+        // registry lock before acquiring the file lock. Concurrent
+        // writes targeting different handles can then proceed in
+        // parallel.
+        let file = {
+            let mut guard = recover(&self.handles);
+            let handle = guard
+                .get_mut(&id)
+                .ok_or_else(|| format!("unknown save handle {id}"))?;
+            handle.last_write_at = Instant::now();
+            handle.file.clone()
+        };
+        // The per-handle file lock is the one lock in this crate that does NOT
+        // recover from poisoning. Poisoning here means the guard was held
+        // across a panic (realistically: an allocator OOM or a future panicking
+        // op inside the critical section -- `File::write_all` itself returns
+        // `Result` and does not panic on I/O errors), leaving the tmp file in
+        // an indeterminate state.
+        //
+        // Recovering silently and continuing to write would corrupt the save.
+        // But surfacing the error alone is NOT enough either: a panic unwinds
+        // and drops this frame's `Arc` clone, so by the time the caller acts
+        // the registry's clone is again the sole owner. `commit` would then
+        // `take` the handle, `Arc::try_unwrap` would SUCCEED (`try_unwrap`
+        // catches a *live* write clone, not a *panicked* one whose clone has
+        // unwound away), and `rename` would atomically promote the corrupted
+        // -- or, for save-as on a first write, 0-byte -- partial onto the
+        // user's chosen final path, reported as success. In the save-as flow
+        // (`open_tmp_for_write` opens with `truncate`), that silently destroys
+        // the user's original file.
+        //
+        // So discard the handle and its partial on this path: `take` removes
+        // the registry entry (and `commit`/`write_chunk` now find "unknown
+        // save handle {id}" -- commit cannot rename what is gone), and
+        // `discard_stream` drops the poisoned `Arc<Mutex<File>>` and removes
+        // the tmp in the documented Windows-safe order (File dropped before
+        // remove). The caller still gets the error to surface. See
+        // https://github.com/leapmux/leapmux/issues/277.
+        let mut guard = match file.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                if let Some(stream) = self.take(id) {
+                    discard_stream(stream);
+                }
+                return Err(format!(
+                    "save handle {id} write failed: a prior write panicked"
+                ));
+            }
+        };
+        guard
+            .write_all(bytes)
+            .map_err(|err| format!("write: {err}"))
+    }
+
+    /// Drop all open handles and remove any partial files. Called from
+    /// the app exit path so an interrupted save doesn't leave junk on
+    /// disk.
+    pub(crate) fn cleanup_all(&self) {
+        let drained: Vec<_> = recover(&self.handles).drain().collect();
+        for (_, stream) in drained {
+            discard_stream(stream);
+        }
+    }
+
+    /// Discard handles whose `last_write_at` is older than `max_idle`.
+    /// Two-phase: snapshot stale ids under a brief lock, then `take`
+    /// each individually so the per-discard `remove_file` syscalls
+    /// never run under the registry lock. A handle being actively
+    /// written to during the scan window is fine — a racing
+    /// `write_chunk` refreshes `last_write_at`, and the take in phase
+    /// 2 re-checks against `max_idle` and skips it.
+    ///
+    /// This cleanup is in-memory only: it (and `cleanup_all` on graceful
+    /// exit) covers a dead JS pump or a normal quit, but a hard process
+    /// death (SIGKILL, crash, power loss) takes this registry down with it
+    /// and strands the partial on disk. `sweep_orphan_tmps` reclaims those
+    /// left in Downloads at the next startup (a Save-as partial stranded
+    /// elsewhere is inert, not swept -- see `open_tmp_for_write`); until
+    /// then a stale partial is indistinguishable from a live reservation
+    /// and forces a spurious "(N)" suffix (see `open_unique_tmp`). See
+    /// https://github.com/leapmux/leapmux/issues/285.
+    pub(crate) fn gc_idle(&self, max_idle: Duration) {
+        let now = Instant::now();
+        let stale_ids: Vec<u64> = {
+            let guard = recover(&self.handles);
+            guard
+                .iter()
+                .filter(|(_, h)| now.duration_since(h.last_write_at) >= max_idle)
+                .map(|(id, _)| *id)
+                .collect()
+        };
+        for id in stale_ids {
+            // Re-check under lock: a `write_chunk` racing between
+            // snapshot and take may have refreshed the timestamp. If
+            // it has, leave the stream alone.
+            let stream = {
+                let mut guard = recover(&self.handles);
+                match guard.get(&id) {
+                    Some(h) if now.duration_since(h.last_write_at) >= max_idle => guard.remove(&id),
+                    _ => None,
+                }
+            };
+            if let Some(stream) = stream {
+                discard_stream(stream);
+            }
+        }
+    }
+
+    /// Delete orphaned save partials under `dir` left by a prior hard
+    /// process death. Safe at the sole (startup) call site because three
+    /// legs hold together there:
+    ///
+    /// 1. Distinctive suffix (`is_partial_name`) — a match is a LeapMux
+    ///    save partial by construction: `defuse_final_path` keeps every
+    ///    LeapMux *final* clear of `SAVE_TMP_SUFFIX`, and a generic `*.tmp`
+    ///    from another tool never matches.
+    /// 2. `tauri-plugin-single-instance` — no other LeapMux process can
+    ///    be mid-save when this runs at startup.
+    /// 3. The registry is empty and not yet `manage`d at the call site, so
+    ///    none of our own saves is in flight.
+    ///
+    /// The live-`tmp_path` cross-check below spares any partial already in
+    /// the registry, but it is NOT enough on its own to make a *periodic*
+    /// call safe: `live` is snapshotted before `read_dir`, so a save that
+    /// starts afterward is on disk yet absent from the snapshot, and the
+    /// comparison is byte-exact on uncanonicalized paths. A future periodic
+    /// caller must first close that race (snapshot under the same lock that
+    /// guards insert, or re-check membership immediately before each
+    /// remove) and pass the identical `dirs::download_dir()` value
+    /// `file_save_open` uses. See https://github.com/leapmux/leapmux/issues/285.
+    pub(crate) fn sweep_orphan_tmps(&self, dir: &Path) {
+        let live: HashSet<PathBuf> = {
+            let guard = recover(&self.handles);
+            guard.values().map(|h| h.tmp_path.clone()).collect()
+        };
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            // A missing Downloads dir is benign (fresh machine, or a
+            // relocated/unmounted volume) -- return quietly. Any other
+            // failure (permissions, transient I/O) leaves orphans behind,
+            // so log it rather than no-op invisibly, matching the per-entry
+            // branches below.
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return,
+            Err(err) => {
+                eprintln!("leapmux: sweep read dir {}: {err}", dir.display());
+                return;
+            }
+        };
+        for entry in entries {
+            // Log and skip a per-entry read error rather than silently
+            // dropping it (as `entries.flatten()` would): an orphan behind a
+            // transient error self-heals on a later launch, but the failure
+            // should not be invisible. Mirrors the remove_file branch below.
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    eprintln!("leapmux: sweep read dir entry in {}: {err}", dir.display());
+                    continue;
+                }
+            };
+            if !is_partial_name(&entry.file_name()) {
+                continue;
+            }
+            // Don't follow symlinks: dirs/symlinks named like partials
+            // are spared. Log a stat failure rather than skip it silently,
+            // as the read-dir and remove_file branches do.
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(err) => {
+                    eprintln!("leapmux: sweep file type {}: {err}", entry.path().display());
+                    continue;
+                }
+            };
+            if !ft.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if live.contains(&path) {
+                continue;
+            }
+            if let Err(err) = std::fs::remove_file(&path) {
+                eprintln!(
+                    "leapmux: sweep orphan save partial {}: {err}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+/// Append `SAVE_TMP_SUFFIX` to `path` while preserving the existing
+/// OsString (handles non-UTF-8 paths cleanly).
+pub(crate) fn tmp_path_for(final_path: &Path) -> PathBuf {
+    let mut name = final_path.as_os_str().to_owned();
+    name.push(SAVE_TMP_SUFFIX);
+    PathBuf::from(name)
+}
+
+/// Whether `name` is a save partial produced by `tmp_path_for`: it ends
+/// in `SAVE_TMP_SUFFIX` and is *strictly* longer than the bare suffix. A
+/// real final name is never empty, so a partial's name always exceeds the
+/// suffix — a file named exactly `.leapmux.tmp` is therefore not ours and
+/// is spared. This is the inverse of `tmp_path_for`, kept beside it so the
+/// two can't drift, and the exact predicate `sweep_orphan_tmps` deletes
+/// on and `defuse_final_path` protects finals against. Byte-wise, so
+/// non-UTF-8 names are handled like `tmp_path_for`.
+pub(crate) fn is_partial_name(name: &OsStr) -> bool {
+    let bytes = name.as_encoded_bytes();
+    bytes.len() > SAVE_TMP_SUFFIX.len() && bytes.ends_with(SAVE_TMP_SUFFIX.as_bytes())
+}
+
+/// Rewrite a chosen final `path` whose file name would be swept as an
+/// orphan partial (`is_partial_name`) by appending `.download`, so a
+/// committed final can never be mistaken for — and silently deleted as —
+/// a partial by `sweep_orphan_tmps`. The OsString is preserved for
+/// non-UTF-8 names. Both save entry points route their final through the
+/// same reserved-suffix defuse: the Downloads auto-name flow inside
+/// `open_unique_tmp`, and the Save-as dialog via this helper. Without it a
+/// server-supplied name like `report.leapmux.tmp` (or a Save-as target
+/// typed into Downloads) would commit a real final the next startup sweep
+/// removes. See https://github.com/leapmux/leapmux/issues/285.
+pub(crate) fn defuse_final_path(path: PathBuf) -> PathBuf {
+    if path.file_name().is_some_and(is_partial_name) {
+        let mut name = path.into_os_string();
+        name.push(SAVE_DEFUSE_SUFFIX);
+        PathBuf::from(name)
+    } else {
+        path
+    }
+}
+
+/// Resolve a Save-as chosen path to its final write target, applying the
+/// reserved-suffix defuse (`defuse_final_path`) and refusing when that defuse
+/// redirects the write onto a pre-existing `.download` file the native dialog
+/// never confirmed. The dialog's overwrite prompt only covers the name the
+/// user picked; when that name ends in `SAVE_TMP_SUFFIX` the bytes actually
+/// land on `<name>.download`, so silently replacing an existing file there
+/// would destroy data the user was never asked about. The check runs only
+/// when the defuse actually rewrote the path (the rare case), so a normal
+/// dialog-confirmed overwrite is untouched. A residual TOCTOU window before
+/// the commit rename degrades to the prior silent replace -- strictly better
+/// than replacing unconditionally. See
+/// https://github.com/leapmux/leapmux/issues/285.
+pub(crate) fn resolve_save_as_final(chosen: PathBuf) -> Result<PathBuf, String> {
+    let final_path = defuse_final_path(chosen.clone());
+    if final_path != chosen {
+        match final_path.try_exists() {
+            Ok(true) => {
+                return Err(format!(
+                    "cannot save: {} already exists (a name ending in \
+                     {SAVE_TMP_SUFFIX} was redirected to avoid the startup sweep)",
+                    final_path.display()
+                ))
+            }
+            Ok(false) => {}
+            Err(err) => return Err(format!("stat {}: {err}", final_path.display())),
+        }
+    }
+    Ok(final_path)
+}
+
+/// Open (or create+truncate) the temp sibling of `final_path` for
+/// streaming writes. Used by the Save-as dialog flow
+/// (`file_save_open_dialog`); the Downloads flow reserves and opens its
+/// partial with `create_new` inside `open_unique_tmp` instead.
+///
+/// A hard death here strands the partial in the user's chosen directory.
+/// `sweep_orphan_tmps` only reclaims Downloads, so a Save-as partial
+/// elsewhere lingers until the user deletes it -- but it is inert: the
+/// truncating open takes no collision reservation, so unlike a Downloads
+/// orphan it forces no "(N)" suffix on later saves (#285).
+pub(crate) fn open_tmp_for_write(final_path: &Path) -> Result<(std::fs::File, PathBuf), String> {
+    let tmp_path = tmp_path_for(final_path);
+    let tmp_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+        .map_err(|err| format!("open tmp file: {err}"))?;
+    Ok((tmp_file, tmp_path))
+}
+
+/// Remove the partial temp file. Used by both `discard_stream` and the
+/// failure branches of `file_save_commit`, which have already dropped
+/// the `File` themselves. The final path is never ours to remove —
+/// nothing was ever created there.
+pub(crate) fn discard_partials(tmp_path: &Path) {
+    let _ = std::fs::remove_file(tmp_path);
+}
+
+/// Drop the file handle and remove the partial temp file.
+pub(crate) fn discard_stream(stream: OpenSaveStream) {
+    let OpenSaveStream { file, tmp_path, .. } = stream;
+    // Drop before remove: Windows refuses `remove_file` while the
+    // file handle is open.
+    drop(file);
+    discard_partials(&tmp_path);
+}
+
+/// JS-facing handle to an open save stream. Returned by
+/// `file_save_open[_dialog]` and submitted back (as `id`) with each
+/// `file_save_write` and the final `file_save_commit` /
+/// `file_save_abort`. Mirrors the `SaveStreamHandle` interface in
+/// `platformBridge.ts`.
+#[derive(Serialize)]
+pub(crate) struct SaveStreamHandle {
+    pub(crate) id: u64,
+    path: String,
+}
+
+/// Pick a non-colliding "foo (N).ext" candidate under `dir` and open
+/// its `<candidate>.leapmux.tmp` sibling with `create_new`. The partial
+/// open serves double duty: it both reserves the iteration spot against
+/// concurrent LeapMux saves of the same basename and provides the file
+/// the bytes stream into. The candidate itself is skipped if it already
+/// exists, preserving the "don't silently overwrite a user file in
+/// Downloads" behavior.
+///
+/// A stale orphaned partial left by a hard process crash is
+/// indistinguishable from a live reservation, so it forces "(N)"
+/// suffixes on later downloads of the same name until the next launch's
+/// `sweep_orphan_tmps` reclaims it (#285). Filenames that themselves end
+/// in `SAVE_TMP_SUFFIX` are defused by appending `.download` before the
+/// collision loop — otherwise a committed final ending in the suffix
+/// would be deleted by the next startup sweep.
+pub(crate) fn open_unique_tmp(
+    dir: PathBuf,
+    filename: String,
+) -> Result<(std::fs::File, PathBuf, PathBuf), String> {
+    // Defuse reserved-suffix finals: a server-supplied name like
+    // `report.leapmux.tmp` would otherwise commit a final the next
+    // startup sweep would delete. Collision candidates built from the
+    // defused name (`evil.leapmux.tmp (1).download`) never end in the
+    // suffix. `file_save_open_dialog` applies the same defuse
+    // (`defuse_final_path`) to Save-as targets.
+    let filename = if is_partial_name(OsStr::new(&filename)) {
+        format!("{filename}{SAVE_DEFUSE_SUFFIX}")
+    } else {
+        filename
+    };
+    let as_path = std::path::Path::new(&filename);
+    let stem = as_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let ext = as_path
+        .extension()
+        .map(|s| s.to_string_lossy().into_owned());
+    for i in 0..MAX_SAVE_COLLISION_ATTEMPTS {
+        let candidate_name = if i == 0 {
+            filename.clone()
+        } else {
+            match &ext {
+                Some(e) if !e.is_empty() => format!("{stem} ({i}).{e}"),
+                _ => format!("{stem} ({i})"),
+            }
+        };
+        let final_path = dir.join(&candidate_name);
+        match final_path.try_exists() {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(err) => return Err(format!("stat {candidate_name}: {err}")),
+        }
+        let tmp_path = tmp_path_for(&final_path);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            Ok(f) => return Ok((f, tmp_path, final_path)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(format!("create tmp file: {err}")),
+        }
+    }
+    Err(format!(
+        "too many collisions for {filename} (gave up after {MAX_SAVE_COLLISION_ATTEMPTS})"
+    ))
+}
+
+/// Open a destination in the OS Downloads directory and return a
+/// streaming handle. `filename` (from the `filename-b64` header) is
+/// sanitized to its basename and collision-dedupped with " (N)".
+#[tauri::command]
+pub(crate) async fn file_save_open(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<SaveStreamHandle, String> {
+    let filename = read_b64_header(&request, "filename-b64")?;
+    let downloads = dirs::download_dir().ok_or_else(|| "no downloads directory".to_string())?;
+    // Disallow separators in the supplied filename so callers can't
+    // escape the Downloads directory.
+    let safe_name = std::path::Path::new(&filename)
+        .file_name()
+        .ok_or_else(|| "invalid filename".to_string())?
+        .to_string_lossy()
+        .into_owned();
+    let registry = registry.inner().clone();
+    let (file, tmp_path, final_path) =
+        run_blocking(move || open_unique_tmp(downloads, safe_name)).await?;
+    Ok(registry.insert(file, tmp_path, final_path))
+}
+
+/// Show a native save-as dialog and return a streaming handle for the
+/// chosen path. Returns `None` when the user cancels — JS callers
+/// should short-circuit before any worker fetch so a cancellation
+/// costs nothing.
+#[tauri::command]
+pub(crate) async fn file_save_open_dialog(
+    app: tauri::AppHandle,
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<Option<SaveStreamHandle>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let default_name = read_b64_header(&request, "default-name-b64")?;
+    let (tx, rx) = oneshot::channel();
+    app.dialog()
+        .file()
+        .set_file_name(&default_name)
+        .save_file(move |path| {
+            let _ = tx.send(path);
+        });
+    let path_opt = rx.await.map_err(|e| e.to_string())?;
+    let Some(file_path) = path_opt else {
+        return Ok(None);
+    };
+    // Defuse a Save-as target whose name ends in the reserved partial
+    // suffix so the next startup sweep can't mistake the committed final
+    // for an orphan and delete it (#285) -- the same guard `open_unique_tmp`
+    // applies to the Downloads flow. This runs after the native dialog's
+    // own overwrite prompt, so for such a name the `.download` variant is
+    // what actually gets written; it is unconditional (not scoped to
+    // Downloads) so no reserved-suffix final ever reaches disk to be swept,
+    // whatever the directory's path spelling. Only a name literally ending
+    // in `.leapmux.tmp` is affected, which a real download never produces --
+    // and if that redirect would land on an existing `.download` the dialog
+    // never confirmed, `resolve_save_as_final` errors rather than clobber it.
+    let final_path = resolve_save_as_final(file_path.into_path().map_err(|e| e.to_string())?)?;
+    let registry = registry.inner().clone();
+    let (file, tmp_path) = run_blocking({
+        let final_path = final_path.clone();
+        move || open_tmp_for_write(&final_path)
+    })
+    .await?;
+    Ok(Some(registry.insert(file, tmp_path, final_path)))
+}
+
+/// Append the request body bytes to the open file identified by the
+/// decimal `handle-id` header. Uses `block_in_place` rather than
+/// `spawn_blocking` so the body slice can be borrowed directly from
+/// the request without a per-chunk clone — for a 100 MB save that
+/// avoids ~100 MiB of memcpy traffic.
+#[tauri::command]
+pub(crate) async fn file_save_write(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let bytes = match request.body() {
+        tauri::ipc::InvokeBody::Raw(b) => b.as_slice(),
+        _ => return Err("expected raw bytes body".to_string()),
+    };
+    // Tauri's command executor runs on a multi-thread tokio runtime,
+    // so `block_in_place` is safe here: it parks the current worker
+    // for the duration of the write and lets the runtime steal other
+    // tasks. The write is bounded to one chunk (~1 MiB). The debug
+    // assertion makes a future runtime-config regression (e.g. switching
+    // to `current_thread`) fail with a clear message instead of tokio's
+    // generic "can call `blocking` only from a `MultiThread`" panic.
+    debug_assert_eq!(
+        tokio::runtime::Handle::current().runtime_flavor(),
+        tokio::runtime::RuntimeFlavor::MultiThread,
+        "file_save_write uses block_in_place; requires a multi-thread runtime",
+    );
+    tokio::task::block_in_place(|| registry.write_chunk(handle_id, bytes))
+}
+
+/// Finalize the save identified by `handle-id`: sync bytes to disk and
+/// atomic-rename the partial onto the final path. Discards partials on
+/// failure so a partial sync doesn't leave a junk file under the
+/// chosen name.
+#[tauri::command]
+pub(crate) async fn file_save_commit(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let registry = registry.inner().clone();
+    run_blocking(move || registry.commit(handle_id)).await
+}
+
+/// Discard the save identified by `handle-id`: drop the open file and
+/// remove the partial. Idempotent against an already-removed
+/// handle (e.g. the idle GC raced the JS pump) so the failure path on
+/// the JS side stays simple.
+#[tauri::command]
+pub(crate) async fn file_save_abort(
+    registry: State<'_, Arc<SaveStreamRegistry>>,
+    request: tauri::ipc::Request<'_>,
+) -> Result<(), String> {
+    let handle_id = read_handle_id(&request)?;
+    let registry = registry.inner().clone();
+    run_blocking(move || {
+        if let Some(stream) = registry.take(handle_id) {
+            discard_stream(stream);
+        }
+        Ok(())
+    })
+    .await
+}

--- a/desktop/rust/src/frame.rs
+++ b/desktop/rust/src/frame.rs
@@ -1,0 +1,334 @@
+//! Frame read/write utilities for the desktop sidecar wire format.
+//!
+//! The sync and async halves below are two transports over ONE wire format: the
+//! sync half drives stdio (and, on Windows, the named pipe via
+//! `sidecar_ipc::windows`'s `SyncPipeReader`/`SyncPipeWriter`), the async half
+//! drives tokio streams. Every decision that is part of the FORMAT -- the
+//! encoding, the size cap, the decode error mapping, the varint state machine --
+//! lives in the shared helpers here and is called by both, so the twins can only
+//! ever differ in their I/O loop. See the `#[cfg(any(windows, test))]` gates on
+//! the async half: `test` is what makes them compile and run off Windows, so
+//! drift fails CI in front of its author instead of on the one OS nobody built.
+//!
+//! Extracted from `main.rs` in <https://github.com/leapmux/leapmux/issues/282>.
+//! This module depends only on `crate::proto` and the two consts below.
+
+use std::io::{self, Read, Write};
+
+use prost::Message;
+
+use crate::proto;
+
+// Must stay in sync with maxFrameSize in desktop/go/frame.go: it must exceed the
+// 16 MiB org-events read limit plus its Frame/Event envelope so a full-size
+// OrgMaterialized bootstrap is not rejected on read.
+const MAX_FRAME_SIZE: u64 = 20 * 1024 * 1024; // 20 MiB
+                                              // A base-128 varint carries 7 bits per byte, so a u64 length prefix needs at
+                                              // most 10 bytes. A reader that has consumed this many without seeing a
+                                              // terminating byte is being fed a malformed (or malicious) prefix.
+const MAX_VARINT_BYTES: usize = 10;
+
+/// The `GetSidecarInfo` request method, the handshake every connect path uses
+/// to confirm the peer is the sidecar it claims to be (matching protocol version
+/// and binary hash). Shared by every caller -- the handshake read/write loops
+/// (sync and async) wrap it in a `Frame{Request{id, method: Some(...)}}`, and
+/// the post-handshake `send_request(_async)` callers pass it directly. Centralizing
+/// the shape keeps the wire contract grep-able from one site.
+pub(crate) fn get_sidecar_info_request() -> proto::request::Method {
+    proto::request::Method::GetSidecarInfo(proto::GetSidecarInfoRequest {})
+}
+
+/// Encodes `frame` into a length-delimited buffer ready to hand to a writer.
+fn encode_frame(frame: &proto::Frame) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(frame.encoded_len() + MAX_VARINT_BYTES);
+    frame.encode_length_delimited(&mut buf).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("encode frame: {err}"))
+    })?;
+    Ok(buf)
+}
+
+/// Checks a decoded length prefix against `MAX_FRAME_SIZE` and narrows it to a
+/// payload length.
+///
+/// Callers MUST call this BEFORE allocating the payload buffer: rejecting the
+/// size is what stops a peer from making us allocate gigabytes off a bogus
+/// varint, and a check that runs after the allocation protects nothing. The cap
+/// is also what makes the `as usize` narrowing lossless on every target we
+/// build for.
+fn frame_len(size: u64) -> io::Result<usize> {
+    if size > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame too large: {size} bytes (max {MAX_FRAME_SIZE})"),
+        ));
+    }
+    Ok(size as usize)
+}
+
+/// Decodes a frame body -- the bytes AFTER the length prefix, exactly
+/// `frame_len` of them.
+fn decode_frame(data: &[u8]) -> io::Result<proto::Frame> {
+    proto::Frame::decode(data)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, format!("decode frame: {err}")))
+}
+
+/// Folds one wire byte into an in-progress varint decode.
+///
+/// Returns `Some(value)` when `b` terminates the varint (high bit clear), and
+/// `None` when more bytes are needed -- so a reader keeps only its own read
+/// loop and shares the state machine.
+fn varint_step(x: &mut u64, s: &mut u32, b: u8) -> Option<u64> {
+    if b < 0x80 {
+        return Some(*x | (b as u64) << *s);
+    }
+    *x |= ((b & 0x7f) as u64) << *s;
+    *s += 7;
+    None
+}
+
+/// The error a reader returns once a varint has run past `MAX_VARINT_BYTES`
+/// without terminating.
+fn varint_overflow() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "varint overflow")
+}
+
+pub(crate) fn write_frame(w: &mut impl Write, frame: &proto::Frame) -> io::Result<()> {
+    w.write_all(&encode_frame(frame)?)?;
+    w.flush()
+}
+
+// Note: prost's `decode_length_delimited` requires an in-memory `Buf`, not
+// an `io::Read` stream. For streaming stdio reads we must manually decode the
+// varint length prefix, then `read_exact` the payload before decoding.
+pub(crate) fn read_frame(r: &mut impl Read) -> io::Result<proto::Frame> {
+    let len = frame_len(read_varint(r)?)?;
+    let mut data = vec![0u8; len];
+    r.read_exact(&mut data)?;
+    decode_frame(&data)
+}
+
+fn read_varint(r: &mut impl Read) -> io::Result<u64> {
+    let mut x: u64 = 0;
+    let mut s: u32 = 0;
+    let mut buf = [0u8; 1];
+    for _ in 0..MAX_VARINT_BYTES {
+        r.read_exact(&mut buf)?;
+        if let Some(v) = varint_step(&mut x, &mut s, buf[0]) {
+            return Ok(v);
+        }
+    }
+    Err(varint_overflow())
+}
+
+#[cfg(any(windows, test))]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[cfg(any(windows, test))]
+pub(crate) async fn write_frame_async<W: tokio::io::AsyncWrite + Unpin>(
+    w: &mut W,
+    frame: &proto::Frame,
+) -> io::Result<()> {
+    w.write_all(&encode_frame(frame)?).await?;
+    w.flush().await
+}
+
+#[cfg(any(windows, test))]
+pub(crate) async fn read_frame_async<R: tokio::io::AsyncRead + Unpin>(
+    r: &mut R,
+) -> io::Result<proto::Frame> {
+    // frame_len rejects an oversize prefix before the vec! below allocates.
+    let len = frame_len(read_varint_async(r).await?)?;
+    let mut data = vec![0u8; len];
+    r.read_exact(&mut data).await?;
+    decode_frame(&data)
+}
+
+#[cfg(any(windows, test))]
+async fn read_varint_async<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> io::Result<u64> {
+    let mut x: u64 = 0;
+    let mut s: u32 = 0;
+    let mut buf = [0u8; 1];
+    for _ in 0..MAX_VARINT_BYTES {
+        r.read_exact(&mut buf).await?;
+        if let Some(v) = varint_step(&mut x, &mut s, buf[0]) {
+            return Ok(v);
+        }
+    }
+    Err(varint_overflow())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc_probe;
+    use crate::proto;
+    use std::io;
+
+    // The async tests need a single-worker multi-thread runtime to drive
+    // `block_on`; a private one here keeps `frame.rs` from depending on the
+    // sidecar-IPC layer's `pipe_runtime`. Built once per test that needs it.
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_io()
+            .enable_time()
+            .thread_name("leapmux-frame-test")
+            .build()
+            .expect("build frame-test runtime")
+    }
+
+    // The handshake's identity check hinges on the GetSidecarInfo exchange; pin
+    // that the shared request builder returns the right variant so a future
+    // proto rename fails here instead of silently sending the wrong request.
+    #[test]
+    fn get_sidecar_info_request_returns_the_get_sidecar_info_variant() {
+        assert!(matches!(
+            get_sidecar_info_request(),
+            proto::request::Method::GetSidecarInfo(_)
+        ));
+    }
+
+    // A frame whose encoded body exceeds 127 bytes forces the length-delimited
+    // prefix into a multi-byte varint, exercising the loop in read_varint_async.
+    #[cfg(any(windows, test))]
+    #[test]
+    fn read_frame_async_roundtrips_multibyte_varint_frame() {
+        test_runtime().block_on(async {
+            let (mut writer, mut reader) = tokio::io::duplex(64 * 1024);
+            // A Response carrying a 200-byte error string is enough body to push
+            // the length prefix past one byte; the precise message shape is
+            // irrelevant to the varint path under test.
+            let frame = proto::Frame {
+                message: Some(proto::frame::Message::Response(proto::Response {
+                    id: 7,
+                    error: "x".repeat(200),
+                    result: None,
+                })),
+            };
+            assert!(
+                frame.encoded_len() > 127,
+                "test precondition: frame must exceed 1-byte varint range, got {}",
+                frame.encoded_len()
+            );
+
+            write_frame_async(&mut writer, &frame).await.expect("write");
+            drop(writer);
+            let received = read_frame_async(&mut reader).await.expect("read");
+            assert_eq!(received.encoded_len(), frame.encoded_len());
+            match received.message {
+                Some(proto::frame::Message::Response(r)) => assert_eq!(r.id, 7),
+                other => panic!("unexpected message: {other:?}"),
+            }
+        });
+    }
+
+    // frame_len and varint_step are the two decisions the sync and async readers
+    // SHARE. The reader tests above reach them only through a socket, and only at
+    // sizes a real frame happens to take -- so the boundary itself (exactly at the
+    // cap vs. one byte over) is asserted here, where it can be stated exactly.
+    #[test]
+    fn frame_len_admits_the_cap_and_refuses_one_byte_past_it() {
+        assert_eq!(frame_len(0).expect("an empty frame is a frame"), 0);
+        // Exactly at the cap is legal: the check is `>`, not `>=`, and a frame of
+        // precisely MAX_FRAME_SIZE must still be readable.
+        assert_eq!(
+            frame_len(MAX_FRAME_SIZE).expect("a frame at the cap is legal"),
+            MAX_FRAME_SIZE as usize
+        );
+
+        let err = frame_len(MAX_FRAME_SIZE + 1).expect_err("one byte past the cap is refused");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("frame too large"),
+            "operators and the sync reader's tests key on this text: {err}"
+        );
+
+        // A bogus varint is the case the cap exists for: u64::MAX must be refused as
+        // a size rather than narrowed by `as usize` into a plausible allocation.
+        frame_len(u64::MAX).expect_err("a bogus length prefix is refused, not truncated");
+    }
+
+    #[test]
+    fn varint_step_terminates_on_a_clear_high_bit_and_accumulates_otherwise() {
+        // Single byte, high bit clear: terminates immediately with its own value.
+        let (mut x, mut s) = (0u64, 0u32);
+        assert_eq!(varint_step(&mut x, &mut s, 0x01), Some(1));
+
+        // Two bytes: the first only accumulates (returns None and advances the
+        // shift), the second terminates and contributes its bits at that shift.
+        // 0xAC 0x02 is protobuf's canonical varint for 300.
+        let (mut x, mut s) = (0u64, 0u32);
+        assert_eq!(
+            varint_step(&mut x, &mut s, 0xAC),
+            None,
+            "high bit set: more bytes needed"
+        );
+        assert_eq!(s, 7, "each continuation byte carries 7 payload bits");
+        assert_eq!(varint_step(&mut x, &mut s, 0x02), Some(300));
+    }
+
+    // A length prefix exceeding MAX_FRAME_SIZE must be rejected without
+    // attempting to allocate the payload, so a peer can't make us allocate
+    // gigabytes by sending a bogus varint.
+    //
+    // The error assertions below are necessary but NOT sufficient: the same
+    // error surfaces even if the check runs after the `vec!`. So measure the
+    // allocation too -- that, and only that, pins the ordering that gives the
+    // check its value. `test_runtime()` is resolved outside the probe so
+    // one-time runtime construction isn't attributed to the read.
+    #[cfg(any(windows, test))]
+    #[test]
+    fn read_frame_async_rejects_oversize_varint_before_allocating() {
+        let runtime = test_runtime();
+        let (_, peak) = alloc_probe::peak_alloc_of(|| {
+            runtime.block_on(async {
+                let (mut writer, mut reader) = tokio::io::duplex(64);
+                let mut buf = Vec::new();
+                let mut v: u64 = MAX_FRAME_SIZE + 1;
+                loop {
+                    let byte = (v & 0x7f) as u8;
+                    v >>= 7;
+                    if v == 0 {
+                        buf.push(byte);
+                        break;
+                    }
+                    buf.push(byte | 0x80);
+                }
+                tokio::io::AsyncWriteExt::write_all(&mut writer, &buf)
+                    .await
+                    .expect("write varint");
+                drop(writer);
+
+                let err = read_frame_async(&mut reader)
+                    .await
+                    .expect_err("oversize frame must error");
+                assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+                assert!(
+                    err.to_string().contains("frame too large"),
+                    "unexpected error message: {err}"
+                );
+            })
+        });
+        assert!(
+            (peak as u64) < MAX_FRAME_SIZE,
+            "read_frame_async allocated {peak} bytes for a rejected {} byte prefix; \
+             the MAX_FRAME_SIZE check must run BEFORE the payload is allocated",
+            MAX_FRAME_SIZE + 1
+        );
+    }
+
+    // The reader thread distinguishes UnexpectedEof from real errors so a clean
+    // peer-close doesn't log a noisy error line. Pin that contract here.
+    #[cfg(any(windows, test))]
+    #[test]
+    fn read_frame_async_returns_eof_when_peer_closes() {
+        test_runtime().block_on(async {
+            let (writer, mut reader) = tokio::io::duplex(64);
+            drop(writer);
+            let err = read_frame_async(&mut reader)
+                .await
+                .expect_err("eof must be reported");
+            assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        });
+    }
+}

--- a/desktop/rust/src/frame.rs
+++ b/desktop/rust/src/frame.rs
@@ -195,14 +195,20 @@ mod tests {
     fn read_frame_async_roundtrips_multibyte_varint_frame() {
         test_runtime().block_on(async {
             let (mut writer, mut reader) = tokio::io::duplex(64 * 1024);
-            // A Response carrying a 200-byte error string is enough body to push
-            // the length prefix past one byte; the precise message shape is
-            // irrelevant to the varint path under test.
+            // A Response carrying a SidecarInfo whose binary_hash is 200 bytes
+            // pushes the length prefix past one byte AND exercises the
+            // handshake-response shape (the realistic payload this codec
+            // round-trips in production), not just an arbitrary long string.
+            let info = proto::SidecarInfo {
+                protocol_version: "1".to_string(),
+                binary_hash: "x".repeat(200),
+                ..Default::default()
+            };
             let frame = proto::Frame {
                 message: Some(proto::frame::Message::Response(proto::Response {
                     id: 7,
-                    error: "x".repeat(200),
-                    result: None,
+                    result: Some(proto::response::Result::SidecarInfo(info.clone())),
+                    ..Default::default()
                 })),
             };
             assert!(
@@ -216,7 +222,22 @@ mod tests {
             let received = read_frame_async(&mut reader).await.expect("read");
             assert_eq!(received.encoded_len(), frame.encoded_len());
             match received.message {
-                Some(proto::frame::Message::Response(r)) => assert_eq!(r.id, 7),
+                Some(proto::frame::Message::Response(r)) => {
+                    assert_eq!(r.id, 7);
+                    // The SidecarInfo payload survives the encode/decode round
+                    // trip intact -- pinning the handshake-response shape, not
+                    // just the varint framing.
+                    let got = r
+                        .result
+                        .as_ref()
+                        .and_then(|res| match res {
+                            proto::response::Result::SidecarInfo(si) => Some(si),
+                            _ => None,
+                        })
+                        .expect("SidecarInfo result survived the round trip");
+                    assert_eq!(got.binary_hash, info.binary_hash);
+                    assert_eq!(got.protocol_version, info.protocol_version);
+                }
                 other => panic!("unexpected message: {other:?}"),
             }
         });

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -10,6 +10,13 @@ pub(crate) mod proto {
 
 mod sidecar_ipc;
 
+// Windows-only connect/handshake + its tests. A single module-level gate (here)
+// replaces the per-import `#[cfg(windows)]` attributes the inline version grew --
+// every windows-only import inside `windows_impl` is windows-gated automatically,
+// so a new one cannot compile silently on macOS and fail only on Windows CI.
+#[cfg(windows)]
+mod windows_impl;
+
 #[cfg(target_os = "linux")]
 mod tabfix_linux;
 
@@ -17,27 +24,22 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
-// `windows_handshake_async` still names `NamedPipeClient` directly as its return
-// type (the raw async client the handshake exchanges frames on), and the windows
-// `require_same_user_pipe_peer` test uses `ClientOptions` to open a raw client.
-#[cfg(windows)]
-use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 
 use crate::frame::{get_sidecar_info_request, read_frame, write_frame};
-#[cfg(windows)]
-use crate::frame::{read_frame_async, write_frame_async};
-#[cfg(windows)]
-use crate::sidecar_ipc::connect_sidecar_endpoint_async;
-#[cfg(windows)]
-use crate::sidecar_ipc::pipe_runtime;
 use crate::sidecar_ipc::{
     cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, dev_sidecar_endpoint,
-    dev_sidecar_metadata_path, endpoint_holder_pid, finalize_sidecar_streams, is_sidecar_gone,
-    private_dev_sidecar_endpoint, restrict_dir_permissions, restrict_file_permissions,
-    SidecarReader, SidecarWriter,
+    dev_sidecar_metadata_path, endpoint_holder_pid, is_sidecar_gone, private_dev_sidecar_endpoint,
+    restrict_dir_permissions, restrict_file_permissions, SidecarReader, SidecarWriter,
 };
-#[cfg(windows)]
-use crate::sidecar_ipc::{SyncPipeReader, SyncPipeWriter};
+// `finalize_sidecar_streams` clears the handshake read/write timeouts the unix
+// `connect_sidecar_endpoint` sets; named pipes have no socket timeout to clear,
+// so the helper is unix-only and has no windows twin.
+#[cfg(unix)]
+use crate::sidecar_ipc::finalize_sidecar_streams;
+// The Windows-only connect/handshake surface (and its windows-only imports)
+// lives in `windows_impl`, gated by a single module-level `#[cfg(windows)]` --
+// see `mod windows_impl` below -- so the next windows-only import lands there
+// and cannot rot invisibly on a macOS dev host.
 // Unix-only peer-credential helpers; referenced by the unix sidecar-IPC tests.
 #[cfg(all(unix, test))]
 use crate::sidecar_ipc::{
@@ -74,7 +76,7 @@ const SHOW_ABOUT_MENU_ID: &str = "show-about";
 const SHOW_PREFERENCES_MENU_ID: &str = "show-preferences";
 #[cfg(target_os = "macos")]
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
-const SIDECAR_PROTOCOL_VERSION: &str = "1";
+pub(crate) const SIDECAR_PROTOCOL_VERSION: &str = "1";
 const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 // CONNECT_TIMEOUT is the outer loop budget for "endpoint reachable +
 // handshake succeeds"; HANDSHAKE_TIMEOUT bounds a single attempt. Keep
@@ -507,68 +509,7 @@ fn connect_and_handshake_dev_sidecar(
 }
 
 #[cfg(windows)]
-fn connect_and_handshake_dev_sidecar(
-    endpoint: &str,
-) -> Result<Option<(SidecarReader, SidecarWriter, proto::SidecarInfo)>, String> {
-    // `tokio::time::timeout(...)` must be constructed inside a runtime
-    // context so its `Sleep` can register with the timer driver, so the
-    // async block stays.
-    let result = pipe_runtime()
-        .block_on(async {
-            tokio::time::timeout(
-                DEV_SIDECAR_HANDSHAKE_TIMEOUT,
-                windows_handshake_async(endpoint),
-            )
-            .await
-        })
-        .map_err(|_| {
-            format!(
-                "named-pipe handshake timed out after {:?}",
-                DEV_SIDECAR_HANDSHAKE_TIMEOUT
-            )
-        })??;
-    let (client, info) = match result {
-        Some(pair) => pair,
-        None => return Ok(None),
-    };
-    let (r, w) = tokio::io::split(client);
-    Ok(Some((
-        SyncPipeReader { inner: r },
-        SyncPipeWriter { inner: w },
-        info,
-    )))
-}
-
-#[cfg(windows)]
-async fn windows_handshake_async(
-    pipe_name: &str,
-) -> Result<Option<(NamedPipeClient, proto::SidecarInfo)>, String> {
-    // Route through the transport layer so the same-user SID check gates this
-    // connect (see connect_sidecar_endpoint_async); only the handshake exchange
-    // itself is async, because it races against tokio::time::timeout.
-    let mut client = match connect_sidecar_endpoint_async(pipe_name).await? {
-        Some(c) => c,
-        None => return Ok(None),
-    };
-    let request = proto::Frame {
-        message: Some(proto::frame::Message::Request(proto::Request {
-            id: 1,
-            method: Some(get_sidecar_info_request()),
-        })),
-    };
-    write_frame_async(&mut client, &request)
-        .await
-        .map_err(|err| format!("request sidecar info: {err}"))?;
-    let frame = read_frame_async(&mut client)
-        .await
-        .map_err(|err| format!("read sidecar info: {err}"))?;
-    let resp = match frame.message {
-        Some(proto::frame::Message::Response(resp)) => resp,
-        _ => return Err("unexpected frame while reading sidecar info".to_string()),
-    };
-    let info = sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")?;
-    Ok(Some((client, info)))
-}
+use windows_impl::connect_and_handshake_dev_sidecar;
 
 /// Asks whatever is listening on `endpoint` to shut down, and reports whether it
 /// actually went away.
@@ -641,7 +582,7 @@ fn fetch_sidecar_info(
     sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")
 }
 
-fn write_sidecar_metadata(
+pub(crate) fn write_sidecar_metadata(
     metadata_path: &Path,
     endpoint: &str,
     binary_hash: &str,
@@ -832,7 +773,7 @@ async fn send_sidecar_request(
 
 // --- Response helpers ---
 
-fn check_response(resp: proto::Response) -> Result<proto::Response, String> {
+pub(crate) fn check_response(resp: proto::Response) -> Result<proto::Response, String> {
     if resp.error.is_empty() {
         Ok(resp)
     } else {
@@ -840,7 +781,7 @@ fn check_response(resp: proto::Response) -> Result<proto::Response, String> {
     }
 }
 
-fn sidecar_info_from_response(
+pub(crate) fn sidecar_info_from_response(
     resp: proto::Response,
     context: &str,
 ) -> Result<proto::SidecarInfo, String> {
@@ -2845,13 +2786,13 @@ mod tests {
     use super::*;
     use std::io;
     use std::sync::atomic::AtomicU64;
-    use std::time::SystemTime;
 
     #[cfg(unix)]
     use std::os::unix::net::UnixListener;
-
-    #[cfg(windows)]
-    use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+    // SystemTime backs the unix unique_test_socket_path helper; the windows twin
+    // moved to windows_impl, so this import is unix-only now.
+    #[cfg(unix)]
+    use std::time::SystemTime;
 
     static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -3074,348 +3015,6 @@ mod tests {
         let _ = fs::remove_file(&socket_path);
     }
 
-    // ---- Windows-specific helpers and tests ----
-
-    #[cfg(windows)]
-    fn unique_test_pipe_name() -> String {
-        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let nanos = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let pid = std::process::id();
-        format!("\\\\.\\pipe\\leapmux-test-{pid}-{nanos}-{counter}")
-    }
-
-    // `ServerOptions::create` must run inside the pipe runtime so the new
-    // NamedPipeServer registers with the right I/O driver.
-    #[cfg(windows)]
-    fn start_test_pipe_server(pipe_name: &str) -> NamedPipeServer {
-        pipe_runtime().block_on(async {
-            ServerOptions::new()
-                .first_pipe_instance(true)
-                .create(pipe_name)
-                .expect("create named pipe server")
-        })
-    }
-
-    #[cfg(windows)]
-    fn spawn_fake_sidecar_pipe(pipe_name: String) -> thread::JoinHandle<()> {
-        let server = start_test_pipe_server(&pipe_name);
-        thread::spawn(move || {
-            pipe_runtime().block_on(async move {
-                let mut server = server;
-                server.connect().await.expect("connect named pipe");
-                let _ = read_frame_async(&mut server)
-                    .await
-                    .expect("read handshake request");
-                let mut info = sidecar_info(proto::SidecarShellMode::Unspecified, false, "");
-                info.pid = std::process::id() as i64;
-                let response = proto::Frame {
-                    message: Some(proto::frame::Message::Response(proto::Response {
-                        id: 1,
-                        error: String::new(),
-                        result: Some(proto::response::Result::SidecarInfo(info)),
-                    })),
-                };
-                write_frame_async(&mut server, &response)
-                    .await
-                    .expect("write handshake response");
-                // Wait for the client to drop the connection.
-                let mut scratch = [0u8; 1];
-                let _ = server.read(&mut scratch).await;
-            });
-        })
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn connect_and_handshake_pipe_returns_sidecar_info() {
-        let pipe_name = unique_test_pipe_name();
-        let server = spawn_fake_sidecar_pipe(pipe_name.clone());
-
-        let (reader, writer, info) = connect_and_handshake_dev_sidecar(&pipe_name)
-            .expect("handshake ok")
-            .expect("server present");
-
-        assert_eq!(info.protocol_version, SIDECAR_PROTOCOL_VERSION);
-        assert_eq!(info.binary_hash, "test-hash");
-        assert_eq!(info.pid as u32, std::process::id());
-
-        drop(reader);
-        drop(writer);
-        server.join().expect("fake sidecar thread");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn connect_returns_none_when_pipe_absent() {
-        let pipe_name = unique_test_pipe_name();
-        let result = connect_sidecar_endpoint(&pipe_name).expect("no error");
-        assert!(
-            result.is_none(),
-            "expected None for nonexistent pipe, got Some"
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn handshake_timeout_surfaces_when_server_never_replies() {
-        let pipe_name = unique_test_pipe_name();
-        // Create the server *before* spawning the accept thread, otherwise
-        // the client races and returns Ok(None) (pipe absent) before the
-        // timeout fires.
-        let server = start_test_pipe_server(&pipe_name);
-        let server_thread = thread::spawn(move || {
-            pipe_runtime().block_on(async move {
-                let _ = server.connect().await;
-                tokio::time::sleep(Duration::from_secs(3)).await;
-            });
-        });
-
-        let start = Instant::now();
-        let result = pipe_runtime().block_on(async {
-            tokio::time::timeout(
-                Duration::from_millis(500),
-                windows_handshake_async(&pipe_name),
-            )
-            .await
-        });
-        let elapsed = start.elapsed();
-        assert!(result.is_err(), "expected handshake to time out");
-        assert!(
-            elapsed < Duration::from_secs(2),
-            "timeout should fire quickly, elapsed {:?}",
-            elapsed
-        );
-
-        let _ = server_thread.join();
-    }
-
-    // Regression test for the FILE_OBJECT-lock deadlock that motivated the
-    // tokio overlapped-I/O switch: under the pre-fix synchronous handles +
-    // DuplicateHandle setup, the writer's WriteFile would queue behind the
-    // reader's in-flight ReadFile on the shared FILE_OBJECT and hang
-    // forever.
-    #[cfg(windows)]
-    #[test]
-    fn split_halves_allow_concurrent_read_and_write() {
-        let pipe_name = unique_test_pipe_name();
-        let server = start_test_pipe_server(&pipe_name);
-        let server_thread = thread::spawn(move || {
-            pipe_runtime().block_on(async move {
-                let mut server = server;
-                server.connect().await.expect("server connect");
-                let request = read_frame_async(&mut server)
-                    .await
-                    .expect("server reads request");
-                let id = match request.message {
-                    Some(proto::frame::Message::Request(r)) => r.id,
-                    other => panic!("expected request, got {other:?}"),
-                };
-                let response = proto::Frame {
-                    message: Some(proto::frame::Message::Response(proto::Response {
-                        id,
-                        error: String::new(),
-                        result: Some(proto::response::Result::BoolValue(proto::BoolValue {
-                            value: true,
-                        })),
-                    })),
-                };
-                write_frame_async(&mut server, &response)
-                    .await
-                    .expect("server writes response");
-                let mut scratch = [0u8; 1];
-                let _ = server.read(&mut scratch).await;
-            });
-        });
-
-        let (mut reader, mut writer) = connect_sidecar_endpoint(&pipe_name)
-            .expect("connect ok")
-            .expect("server reachable");
-
-        // Park the reader on a blocking read first so the write below is
-        // *concurrent* with an in-flight read — the scenario that deadlocked
-        // under synchronous handles.
-        let (tx, rx) = std::sync::mpsc::channel();
-        thread::spawn(move || {
-            let result = read_frame(&mut reader);
-            let _ = tx.send(result);
-        });
-        thread::sleep(Duration::from_millis(100));
-
-        let request = proto::Frame {
-            message: Some(proto::frame::Message::Request(proto::Request {
-                id: 42,
-                method: Some(get_sidecar_info_request()),
-            })),
-        };
-        write_frame(&mut writer, &request).expect("client write");
-
-        let response = rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("response not received within 5s — deadlock regression?")
-            .expect("read frame");
-        match response.message {
-            Some(proto::frame::Message::Response(r)) => assert_eq!(r.id, 42),
-            other => panic!("expected response with id=42, got {other:?}"),
-        }
-
-        drop(writer);
-        server_thread.join().expect("server thread");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn is_sidecar_gone_reports_true_for_absent_pipe() {
-        let pipe_name = unique_test_pipe_name();
-        assert!(is_sidecar_gone(&pipe_name));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn is_sidecar_gone_reports_false_when_server_listening() {
-        let pipe_name = unique_test_pipe_name();
-        let _server = start_test_pipe_server(&pipe_name);
-        assert!(!is_sidecar_gone(&pipe_name));
-    }
-
-    // ---- Windows peer-identity check (the connect-side half of the boundary
-    // requirePrivateDir / userOnlySDDL defend on the bind side). Mirrors
-    // require_peer_uid_refuses_a_foreign_owner on Unix. ----
-
-    // Two minimal valid SIDs that differ only in their last sub-authority byte.
-    // S-1-5-32 (BUILTIN) and S-1-5-42 -- both 12 bytes, both well-formed, so
-    // EqualSid's behaviour is defined and FALSE rather than undefined.
-    #[cfg(windows)]
-    const FOREIGN_SID_A: [u8; 12] = [
-        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x20, 0x00, 0x00, 0x00,
-    ];
-    #[cfg(windows)]
-    const FOREIGN_SID_B: [u8; 12] = [
-        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x2a, 0x00, 0x00, 0x00,
-    ];
-
-    #[cfg(windows)]
-    #[test]
-    fn require_peer_sid_accepts_same_sid() {
-        require_peer_sid(&FOREIGN_SID_A, &FOREIGN_SID_A, "\\\\?\\pipe\\test")
-            .expect("same SID is accepted");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn require_peer_sid_refuses_a_foreign_sid() {
-        let err = require_peer_sid(&FOREIGN_SID_A, &FOREIGN_SID_B, "\\\\?\\pipe\\test")
-            .expect_err("a pipe answered by another SID must be refused");
-        assert!(err.contains("refusing sidecar"), "{err}");
-        assert!(
-            err.contains("\\\\?\\pipe\\test"),
-            "names the endpoint: {err}"
-        );
-    }
-
-    // The pipe server is in this process, so the peer is us. Same shape as
-    // require_same_user_peer_accepts_our_own_socket on Unix.
-    #[cfg(windows)]
-    #[test]
-    fn require_same_user_pipe_peer_accepts_our_own_pipe() {
-        let pipe_name = unique_test_pipe_name();
-        let _server = start_test_pipe_server(&pipe_name);
-        let client = pipe_runtime().block_on(async {
-            ClientOptions::new()
-                .open(&pipe_name)
-                .expect("open named pipe client")
-        });
-        require_same_user_pipe_peer(&client, &pipe_name).expect("our own pipe is accepted");
-    }
-
-    // endpoint_holder_pid now reports the kernel-recorded server pid on Windows
-    // (GetNamedPipeServerProcessId), retiring the previous unconditional None.
-    #[cfg(windows)]
-    #[test]
-    fn endpoint_holder_pid_reports_the_kernel_recorded_holder() {
-        let pipe_name = unique_test_pipe_name();
-        let _server = start_test_pipe_server(&pipe_name);
-        assert_eq!(
-            endpoint_holder_pid(&pipe_name),
-            Some(std::process::id()),
-            "the holder of our own pipe is this process",
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn endpoint_holder_pid_is_none_for_an_absent_endpoint() {
-        let pipe_name = unique_test_pipe_name();
-        assert_eq!(endpoint_holder_pid(&pipe_name), None);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn sanitize_sid_for_pipe_replaces_forbidden_chars() {
-        // A real Windows SID is preserved verbatim.
-        assert_eq!(
-            sanitize_sid_for_pipe("S-1-5-21-1234567890-1234567890-1234567890-1001"),
-            "S-1-5-21-1234567890-1234567890-1234567890-1001"
-        );
-        // Forbidden chars become `_`.
-        assert_eq!(
-            sanitize_sid_for_pipe("alice/bob\\carol\\@dave"),
-            "alice_bob_carol__dave"
-        );
-        // Whitespace, dot, and other punctuation all map to `_`.
-        assert_eq!(sanitize_sid_for_pipe("a b.c:d"), "a_b_c_d");
-        // Hyphen and ASCII alphanumerics are preserved.
-        assert_eq!(sanitize_sid_for_pipe("Abc-123-XYZ"), "Abc-123-XYZ");
-        // Non-ASCII becomes `_` (one per char).
-        assert_eq!(sanitize_sid_for_pipe("zoé"), "zo_");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn dev_sidecar_endpoint_uses_full_pipe_format() {
-        // Pin the full endpoint string, including the variable identity, so a
-        // regression in prefix/suffix or identity placement is caught.
-        let identity = sidecar_identity().expect("sidecar_identity");
-        let expected = format!("\\\\.\\pipe\\leapmux-desktop-{identity}-sidecar");
-        let actual = dev_sidecar_endpoint().expect("endpoint");
-        assert_eq!(actual, expected);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn dev_sidecar_metadata_path_joins_base_with_subdir_and_file() {
-        // Drive the path builder with a known base so the full result is
-        // pinned, not just the trailing components.
-        let base = PathBuf::from("C:\\Users\\alice\\AppData\\Local");
-        let path = dev_sidecar_metadata_path_in(&base);
-        assert_eq!(
-            path,
-            PathBuf::from("C:\\Users\\alice\\AppData\\Local")
-                .join("leapmux-desktop")
-                .join("sidecar.json")
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn write_sidecar_metadata_roundtrips_json() {
-        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let path = std::env::temp_dir().join(format!("leapmux-test-metadata-{counter}.json"));
-        let _ = fs::remove_file(&path);
-
-        write_sidecar_metadata(&path, "\\\\.\\pipe\\test", "hash-abc").expect("write metadata");
-        let data = fs::read_to_string(&path).expect("read metadata");
-        assert!(data.contains("\\\\\\\\.\\\\pipe\\\\test"));
-        assert!(data.contains("\"binary_hash\": \"hash-abc\""));
-        assert!(data.contains(&format!(
-            "\"protocol_version\": \"{SIDECAR_PROTOCOL_VERSION}\""
-        )));
-
-        let _ = fs::remove_file(&path);
-    }
-
     #[derive(Clone, Default)]
     struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
 
@@ -3492,7 +3091,7 @@ mod tests {
         ));
     }
 
-    fn sidecar_info(
+    pub(super) fn sidecar_info(
         mode: proto::SidecarShellMode,
         connected: bool,
         hub_url: &str,

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -8,6 +8,10 @@ pub(crate) mod proto {
     include!(concat!(env!("OUT_DIR"), "/leapmux.desktop.v1.rs"));
 }
 
+// Test-only peak-allocation tracker; `#[global_allocator]` is wired below.
+#[cfg(test)]
+mod alloc_probe;
+
 mod sidecar_ipc;
 
 // Windows-only connect/handshake + its tests. A single module-level gate (here)
@@ -17,25 +21,26 @@ mod sidecar_ipc;
 #[cfg(windows)]
 mod windows_impl;
 
+// Sidecar process bootstrap/connect/handshake/shutdown -- the layer above
+// `sidecar_ipc` (transport) and `frame` (codec).
+mod sidecar;
+
+// Streaming file-save subsystem (file_save_open/write/commit/abort chain).
+mod file_save;
+
 #[cfg(target_os = "linux")]
 mod tabfix_linux;
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sha2::{Digest, Sha256};
 
-use crate::frame::{get_sidecar_info_request, read_frame, write_frame};
-use crate::sidecar_ipc::{
-    cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, dev_sidecar_endpoint,
-    dev_sidecar_metadata_path, endpoint_holder_pid, is_sidecar_gone, private_dev_sidecar_endpoint,
-    restrict_dir_permissions, restrict_file_permissions, SidecarReader, SidecarWriter,
+use crate::file_save::{
+    file_save_abort, file_save_commit, file_save_open, file_save_open_dialog, file_save_write,
+    SaveStreamRegistry, SAVE_HANDLE_GC_INTERVAL, SAVE_HANDLE_IDLE_TIMEOUT,
 };
-// `finalize_sidecar_streams` clears the handshake read/write timeouts the unix
-// `connect_sidecar_endpoint` sets; named pipes have no socket timeout to clear,
-// so the helper is unix-only and has no windows twin.
-#[cfg(unix)]
-use crate::sidecar_ipc::finalize_sidecar_streams;
+use crate::frame::{get_sidecar_info_request, read_frame, write_frame};
+use crate::sidecar::bootstrap_sidecar;
 // The Windows-only connect/handshake surface (and its windows-only imports)
 // lives in `windows_impl`, gated by a single module-level `#[cfg(windows)]` --
 // see `mod windows_impl` below -- so the next windows-only import lands there
@@ -43,24 +48,40 @@ use crate::sidecar_ipc::finalize_sidecar_streams;
 // Unix-only peer-credential helpers; referenced by the unix sidecar-IPC tests.
 #[cfg(all(unix, test))]
 use crate::sidecar_ipc::{
-    require_peer_uid, require_same_user_peer, socket_peer_pid, socket_peer_uid,
+    dev_sidecar_endpoint, endpoint_holder_pid, private_dev_sidecar_endpoint, require_peer_uid,
+    require_same_user_peer, socket_peer_pid, socket_peer_uid,
 };
+// The unix connect/handshake twin lives in `sidecar`; the tests exercise it
+// directly.
+#[cfg(all(unix, test))]
+use crate::sidecar::connect_and_handshake_dev_sidecar;
 #[cfg(all(unix, test))]
 use std::os::unix::net::UnixStream;
 use std::{
-    collections::{HashMap, HashSet},
-    ffi::OsStr,
-    fs,
-    io::{self, BufReader, BufWriter, Read, Write},
-    path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    collections::HashMap,
+    io::{self, BufReader, Read, Write},
+    path::PathBuf,
+    process::Child,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     thread,
-    time::{Duration, Instant},
+    time::Duration,
 };
+// `Command` is used only by the macOS relaunch helper (it shells out to
+// `/usr/bin/open -n` via LaunchServices); gate it so non-macOS targets don't
+// trip `-D unused-imports`.
+#[cfg(target_os = "macos")]
+use std::process::Command;
+// `OsStr`, `Path`, and `Instant` are referenced unqualified only by the test
+// module below (plus the `Path`/`OsStr`/`Instant` save code, now in
+// `file_save`). `fs` is referenced unqualified only by the unix socket tests.
+// Gate them so the production binary stays warning-free on every platform.
+#[cfg(all(unix, test))]
+use std::fs;
+#[cfg(test)]
+use std::{ffi::OsStr, path::Path, time::Instant};
 #[cfg(target_os = "macos")]
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID};
 use tauri::{
@@ -77,17 +98,17 @@ const SHOW_PREFERENCES_MENU_ID: &str = "show-preferences";
 #[cfg(target_os = "macos")]
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
 pub(crate) const SIDECAR_PROTOCOL_VERSION: &str = "1";
-const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 // CONNECT_TIMEOUT is the outer loop budget for "endpoint reachable +
 // handshake succeeds"; HANDSHAKE_TIMEOUT bounds a single attempt. Keep
 // CONNECT meaningfully larger so the loop can retry after a wedged probe.
-const DEV_SIDECAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const DEV_SIDECAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const DEV_SIDECAR_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 const SIDECAR_INITIAL_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // Cross-language env-var contract; see desktop/go/main.go for semantics.
-const ENV_DEV_ENDPOINT: &str = "LEAPMUX_DESKTOP_DEV_ENDPOINT";
-const ENV_BINARY_HASH: &str = "LEAPMUX_DESKTOP_BINARY_HASH";
+pub(crate) const ENV_DEV_ENDPOINT: &str = "LEAPMUX_DESKTOP_DEV_ENDPOINT";
+pub(crate) const ENV_BINARY_HASH: &str = "LEAPMUX_DESKTOP_BINARY_HASH";
 
 /// The shell's own record of the dev sidecar it last bootstrapped, written for
 /// human/debug inspection and read back by nothing.
@@ -101,10 +122,10 @@ const ENV_BINARY_HASH: &str = "LEAPMUX_DESKTOP_BINARY_HASH";
 /// misused, whereas one that merely LOOKS authoritative invites the next reader to
 /// trust it.
 #[derive(Serialize)]
-struct SidecarMetadata {
-    endpoint: String,
-    binary_hash: String,
-    protocol_version: String,
+pub(crate) struct SidecarMetadata {
+    pub(crate) endpoint: String,
+    pub(crate) binary_hash: String,
+    pub(crate) protocol_version: String,
 }
 
 // --- Tauri types ---
@@ -282,11 +303,8 @@ struct DesktopShell {
     state: Mutex<ShellState>,
 }
 
-struct SidecarBootstrap {
-    child: Option<Child>,
-    reader: Box<dyn Read + Send>,
-    writer: Box<dyn Write + Send>,
-}
+#[cfg(windows)]
+use windows_impl::connect_and_handshake_dev_sidecar;
 
 fn start_sidecar_reader_thread(
     app_handle: AppHandle,
@@ -337,289 +355,6 @@ fn start_sidecar_writer_thread(
         recover(&pending).clear();
     });
     tx
-}
-
-fn bootstrap_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
-    #[cfg(any(unix, windows))]
-    if cfg!(debug_assertions) {
-        return bootstrap_dev_sidecar(sidecar_path);
-    }
-    spawn_stdio_sidecar(sidecar_path)
-}
-
-// bootstrap_dev_sidecar tries to reuse a live dev sidecar at the well-known
-// endpoint (unix socket on Unix, named pipe on Windows) and falls back to
-// spawning a fresh one when the endpoint is stale, incompatible, or missing.
-#[cfg(any(unix, windows))]
-fn bootstrap_dev_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
-    #[cfg(unix)]
-    let (endpoint, private_endpoint) = (dev_sidecar_endpoint(), private_dev_sidecar_endpoint());
-    #[cfg(windows)]
-    let (endpoint, private_endpoint) = (dev_sidecar_endpoint()?, private_dev_sidecar_endpoint()?);
-    let metadata_path = dev_sidecar_metadata_path();
-    let binary_hash = hash_sidecar_binary(sidecar_path)?;
-
-    // Whatever is already on the endpoint decides how we proceed. The one thing we
-    // never do is kill it: on this path the peer is by definition NOT our child, so
-    // the only PID available would be the one it reports about itself -- the
-    // arbitrary-process-kill primitive `force_kill_sidecar` used to be. When we cannot
-    // reclaim the endpoint we move to a private one instead, so a stale or foreign
-    // holder is routed around rather than blocking the launch.
-    let mut endpoint = endpoint;
-    match try_connect_dev_sidecar(&endpoint) {
-        Ok(Some((reader, writer, info)))
-            if info.protocol_version == SIDECAR_PROTOCOL_VERSION
-                && info.binary_hash == binary_hash =>
-        {
-            write_sidecar_metadata(&metadata_path, &endpoint, &binary_hash)?;
-            return Ok(SidecarBootstrap {
-                child: None,
-                reader,
-                writer,
-            });
-        }
-        // Ours, but a stale build or protocol. Ask it to go; if it ignores us, leave
-        // it holding the path.
-        Ok(Some(_)) => {
-            if !request_sidecar_shutdown(&endpoint) {
-                endpoint = private_endpoint;
-            }
-        }
-        // Nothing is listening: the endpoint is ours to take.
-        Ok(None) => {}
-        // Unreachable or answered by another user (see require_same_user_peer). Their
-        // socket is not ours to unlink -- /tmp is sticky -- so binding here would just
-        // fail. Take a private endpoint.
-        Err(err) => {
-            eprintln!("leapmux: cannot use dev sidecar endpoint {endpoint}: {err}");
-            endpoint = private_endpoint;
-        }
-    }
-    cleanup_dev_sidecar_artifacts(&endpoint, &metadata_path);
-
-    let mut command = Command::new(sidecar_path);
-    command
-        .env(ENV_DEV_ENDPOINT, &endpoint)
-        .env(ENV_BINARY_HASH, &binary_hash)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit());
-    let child = command
-        .spawn()
-        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
-
-    let start = Instant::now();
-    loop {
-        match try_connect_dev_sidecar(&endpoint) {
-            Ok(Some((reader, writer, info))) => {
-                if info.protocol_version != SIDECAR_PROTOCOL_VERSION {
-                    return Err(format!(
-                        "unexpected sidecar protocol version: {}",
-                        info.protocol_version,
-                    ));
-                }
-                if info.binary_hash != binary_hash {
-                    return Err("spawned sidecar reported an unexpected binary hash".to_string());
-                }
-                write_sidecar_metadata(&metadata_path, &endpoint, &binary_hash)?;
-                return Ok(SidecarBootstrap {
-                    child: Some(child),
-                    reader,
-                    writer,
-                });
-            }
-            Ok(None) => {}
-            Err(err) => return Err(err),
-        }
-
-        if start.elapsed() > DEV_SIDECAR_CONNECT_TIMEOUT {
-            return Err("timed out waiting for desktop sidecar endpoint".to_string());
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-}
-
-fn spawn_stdio_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
-    let mut command = Command::new(sidecar_path);
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = command
-        .spawn()
-        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "desktop sidecar stdin unavailable".to_string())?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "desktop sidecar stdout unavailable".to_string())?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "desktop sidecar stderr unavailable".to_string())?;
-    start_sidecar_stderr_thread(stderr);
-    Ok(SidecarBootstrap {
-        child: Some(child),
-        reader: Box::new(stdout),
-        writer: Box::new(BufWriter::new(stdin)),
-    })
-}
-
-fn start_sidecar_stderr_thread(stderr: impl Read + Send + 'static) {
-    thread::spawn(move || {
-        let reader = BufReader::new(stderr);
-        use io::BufRead;
-        for line in reader.lines().map_while(Result::ok) {
-            eprintln!("desktop-sidecar: {line}");
-        }
-    });
-}
-
-type DevSidecarConnection = (
-    Box<dyn Read + Send>,
-    Box<dyn Write + Send>,
-    proto::SidecarInfo,
-);
-
-fn try_connect_dev_sidecar(endpoint: &str) -> Result<Option<DevSidecarConnection>, String> {
-    match connect_and_handshake_dev_sidecar(endpoint)? {
-        Some((reader, writer, info)) => Ok(Some((
-            Box::new(reader),
-            Box::new(BufWriter::new(writer)),
-            info,
-        ))),
-        None => Ok(None),
-    }
-}
-
-#[cfg(unix)]
-fn connect_and_handshake_dev_sidecar(
-    endpoint: &str,
-) -> Result<Option<(SidecarReader, SidecarWriter, proto::SidecarInfo)>, String> {
-    let (mut reader, mut writer) = match connect_sidecar_endpoint(endpoint)? {
-        Some(pair) => pair,
-        None => return Ok(None),
-    };
-    let info = fetch_sidecar_info(&mut reader, &mut writer)?;
-    finalize_sidecar_streams(&reader, &writer)?;
-    Ok(Some((reader, writer, info)))
-}
-
-#[cfg(windows)]
-use windows_impl::connect_and_handshake_dev_sidecar;
-
-/// Asks whatever is listening on `endpoint` to shut down, and reports whether it
-/// actually went away.
-///
-/// It deliberately does NOT force-kill. This runs on the path where the peer
-/// reported a protocol/binary mismatch, which means it is emphatically *not* this
-/// shell's child -- so the only PID available is the one the peer reported over
-/// the socket about itself. Trusting that made this an arbitrary-process-kill
-/// primitive running at the developer's uid: anything able to answer on the
-/// endpoint (the dev socket lives at a predictable path) could name any PID it
-/// liked and have the shell SIGTERM then SIGKILL it. A stale sidecar that ignores
-/// a cooperative shutdown is a dev-box annoyance; killing an arbitrary process is
-/// not an acceptable way to resolve it.
-fn request_sidecar_shutdown(endpoint: &str) -> bool {
-    if let Ok(Some((mut reader, mut writer))) = connect_sidecar_endpoint(endpoint) {
-        let frame = proto::Frame {
-            message: Some(proto::frame::Message::Request(proto::Request {
-                id: 1,
-                method: Some(proto::request::Method::Shutdown(proto::ShutdownRequest {})),
-            })),
-        };
-        let _ = write_frame(&mut writer, &frame);
-        let _ = read_frame(&mut reader);
-    }
-
-    let deadline = Instant::now() + DEV_SIDECAR_SHUTDOWN_TIMEOUT;
-    while Instant::now() < deadline {
-        if is_sidecar_gone(endpoint) {
-            return true;
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    // Name the KERNEL-verified holder pid so the developer can stop it by hand.
-    // We deliberately do NOT kill it: adopting/killing on a self-reported
-    // identity is the arbitrary-process-kill primitive this shell gave up (see
-    // above). The kernel pid is trustworthy (unlike a wire-reported one) but is
-    // used only to make this message actionable.
-    let holder = match endpoint_holder_pid(endpoint) {
-        Some(pid) => format!("process {pid}"),
-        None => "an unidentified process".to_string(),
-    };
-    eprintln!(
-        "leapmux: a sidecar ({holder}) is holding {endpoint} and did not shut down \
-         when asked; starting on a private endpoint instead. Stop it manually if it \
-         should not be running -- in SOLO mode it also holds the shared DB's runtime \
-         lease, so ConnectSolo will keep failing until it is gone (a launcher-mode \
-         orphan only costs the sidecar-reuse optimisation)."
-    );
-    false
-}
-
-#[cfg(unix)]
-fn fetch_sidecar_info(
-    reader: &mut impl Read,
-    writer: &mut impl Write,
-) -> Result<proto::SidecarInfo, String> {
-    let frame = proto::Frame {
-        message: Some(proto::frame::Message::Request(proto::Request {
-            id: 1,
-            method: Some(get_sidecar_info_request()),
-        })),
-    };
-    write_frame(writer, &frame).map_err(|err| format!("request sidecar info: {err}"))?;
-    let frame = read_frame(reader).map_err(|err| format!("read sidecar info: {err}"))?;
-    let resp = match frame.message {
-        Some(proto::frame::Message::Response(resp)) => resp,
-        _ => return Err("unexpected frame while reading sidecar info".to_string()),
-    };
-    sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")
-}
-
-pub(crate) fn write_sidecar_metadata(
-    metadata_path: &Path,
-    endpoint: &str,
-    binary_hash: &str,
-) -> Result<(), String> {
-    let metadata = SidecarMetadata {
-        endpoint: endpoint.to_string(),
-        binary_hash: binary_hash.to_string(),
-        protocol_version: SIDECAR_PROTOCOL_VERSION.to_string(),
-    };
-    if let Some(parent) = metadata_path.parent() {
-        fs::create_dir_all(parent).map_err(|err| format!("create sidecar metadata dir: {err}"))?;
-        restrict_dir_permissions(parent)?;
-    }
-    let data = serde_json::to_vec_pretty(&metadata)
-        .map_err(|err| format!("serialize sidecar metadata: {err}"))?;
-    fs::write(metadata_path, data).map_err(|err| format!("write sidecar metadata: {err}"))?;
-    restrict_file_permissions(metadata_path)?;
-    Ok(())
-}
-
-fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
-    let file = fs::File::open(sidecar_path)
-        .map_err(|err| format!("read desktop sidecar binary: {err}"))?;
-    let mut reader = BufReader::new(file);
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 64 * 1024];
-    loop {
-        let n = reader
-            .read(&mut buf)
-            .map_err(|err| format!("read desktop sidecar binary: {err}"))?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let digest = hasher.finalize();
-    Ok(digest.iter().map(|b| format!("{:02x}", b)).collect())
 }
 
 impl DesktopShell {
@@ -1452,7 +1187,7 @@ async fn open_in_editor(
     Ok(())
 }
 
-fn decode_b64(b64: &str) -> Result<Vec<u8>, String> {
+pub(crate) fn decode_b64(b64: &str) -> Result<Vec<u8>, String> {
     base64::engine::general_purpose::STANDARD
         .decode(b64)
         .map_err(|e| e.to_string())
@@ -1466,765 +1201,6 @@ fn decode_b64(b64: &str) -> Result<Vec<u8>, String> {
 // in a custom header, base64-encoded so HTTP-style ASCII restrictions
 // don't mangle Unicode names.
 //
-// Saves are streamed through a `file_save_open[_dialog] → file_save_write* →
-// file_save_commit | file_save_abort` chain. The Rust side keeps the
-// destination `File` open in a registry between calls, so the JS caller
-// can pipe each 1 MiB worker chunk straight through `file_save_write`
-// without ever materializing the whole file. This bounds the peak
-// transient memory (per chunk × ~3 copies across the IPC boundary) to
-// a few MiB even for multi-hundred-MB downloads.
-//
-// Writes go to a sibling temp file (`<final>.leapmux.tmp`); on commit we
-// atomic-rename it onto the final path, and on abort we delete it.
-// Consequence: the final name never appears on disk until the save is
-// complete, and (for Save as...) the user's existing file at the chosen
-// path is preserved if the save fails. The Downloads variant iterates
-// candidate names ("foo.ext",
-// "foo (1).ext", ...) skipping any whose final path already exists and
-// claiming each candidate's `<name>.leapmux.tmp` with `create_new` — that
-// single open both reserves the iteration spot against concurrent
-// LeapMux saves of the same basename and provides the file the bytes
-// stream into.
-
-fn read_header_str<'a>(
-    request: &'a tauri::ipc::Request<'_>,
-    name: &str,
-) -> Result<&'a str, String> {
-    request
-        .headers()
-        .get(name)
-        .ok_or_else(|| format!("missing {name} header"))?
-        .to_str()
-        .map_err(|err| format!("invalid {name} header: {err}"))
-}
-
-fn read_b64_header(request: &tauri::ipc::Request<'_>, name: &str) -> Result<String, String> {
-    let bytes = decode_b64(read_header_str(request, name)?)?;
-    String::from_utf8(bytes).map_err(|err| format!("invalid {name} utf-8: {err}"))
-}
-
-/// Parse the decimal `handle-id` header shared by `file_save_write`,
-/// `file_save_commit`, and `file_save_abort`.
-fn read_handle_id(request: &tauri::ipc::Request<'_>) -> Result<u64, String> {
-    read_header_str(request, "handle-id")?
-        .parse()
-        .map_err(|err| format!("invalid handle-id: {err}"))
-}
-
-/// Run a blocking closure on the dedicated blocking-thread pool and
-/// return its result, surfacing a join failure as an error string. Used
-/// for save-stream operations that touch the disk and shouldn't tie up
-/// the async executor thread servicing other Tauri commands.
-async fn run_blocking<F, T>(f: F) -> Result<T, String>
-where
-    F: FnOnce() -> Result<T, String> + Send + 'static,
-    T: Send + 'static,
-{
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|err| format!("spawn_blocking join: {err}"))?
-}
-
-/// Cap on collision-dedup attempts. With "foo (N).ext" picking from
-/// `1..MAX`, this bounds the directory scan and the suffix the user
-/// sees ("foo (1023).ext" is well past the point where a different
-/// filename is more useful than another increment).
-const MAX_SAVE_COLLISION_ATTEMPTS: u32 = 1024;
-
-/// Suffix appended to the final path to form the streaming partial.
-/// Shared by the producer (`tmp_path_for`), the matcher (`is_partial_name`,
-/// used by `sweep_orphan_tmps`), and the defuser (`defuse_final_path`) so
-/// the three cannot drift.
-///
-/// Two invariants load-bearing for #285:
-/// - Distinctive (`.leapmux.tmp`, not a bare `.tmp`): distinctive enough
-///   that the startup sweep never matches a generic `*.tmp` some other
-///   tool left in Downloads. This is a naming convention, not a hard
-///   guarantee against a foreign file that deliberately reuses the
-///   suffix; what makes the sweep safe for *our* files is that
-///   `defuse_final_path` keeps every LeapMux final clear of the suffix,
-///   so a match is a LeapMux partial by construction.
-/// - Deterministic (no PID/randomness): `create_new` on this fixed
-///   sibling name is what reserves a collision slot against concurrent
-///   same-name saves.
-const SAVE_TMP_SUFFIX: &str = ".leapmux.tmp";
-
-/// Appended to a chosen final whose own name would match `is_partial_name`,
-/// so a committed final can never be mistaken for a partial by the sweep.
-/// The single source of truth for the defuse marker, shared by both defuse
-/// sites (`defuse_final_path` and the inline defuse in `open_unique_tmp`) so
-/// the two cannot drift — the same role `SAVE_TMP_SUFFIX` plays for the
-/// partial suffix. Must not itself end in `SAVE_TMP_SUFFIX`.
-const SAVE_DEFUSE_SUFFIX: &str = ".download";
-
-/// How often the idle-handle GC scans the registry for handles whose
-/// JS pump appears to have died. 60s keeps the scan cost negligible
-/// while still bounding orphan-disk-junk lifetime to roughly
-/// `SAVE_HANDLE_GC_INTERVAL + SAVE_HANDLE_IDLE_TIMEOUT`.
-const SAVE_HANDLE_GC_INTERVAL: Duration = Duration::from_secs(60);
-
-/// How long a handle can sit without a `write_chunk` (or `close`)
-/// before the GC discards it. An active save touches `last_write_at`
-/// per chunk, so the gap can only widen if the JS pump is wedged or
-/// the renderer process died. 5 min is well above any realistic
-/// per-chunk latency (1 MiB chunks rarely take more than seconds) but
-/// short enough that an orphan partial is gone before the user notices.
-const SAVE_HANDLE_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
-
-/// Registry entry for a save in progress: the open file plus the
-/// paths needed to finalize or discard. Distinct from
-/// `SaveStreamHandle`, which is the id+path token JS holds; this
-/// struct is Rust-only and never crosses the IPC boundary.
-struct OpenSaveStream {
-    /// `Arc<Mutex<File>>` rather than `Mutex<File>` so `write_chunk` can
-    /// short-lock the registry to clone the Arc, drop the registry
-    /// lock, and then take the per-file lock — writes to different
-    /// streams run in parallel instead of serializing on a registry-
-    /// wide mutex.
-    file: Arc<Mutex<std::fs::File>>,
-    /// Sibling `<final>.leapmux.tmp` path that bytes stream into.
-    tmp_path: PathBuf,
-    /// Final destination — the partial is atomic-renamed onto this on success.
-    final_path: PathBuf,
-    /// Updated on insert and on every `write_chunk`. The idle-handle
-    /// GC compares this against `SAVE_HANDLE_IDLE_TIMEOUT` to detect
-    /// JS pumps that died without calling `file_save_commit` or
-    /// `file_save_abort`. Lives under the registry `Mutex<HashMap>`
-    /// lock so it shares the existing critical section instead of
-    /// needing its own atomic.
-    last_write_at: Instant,
-}
-
-/// Open destination files keyed by a monotonic u64 id. The JS caller
-/// receives the id from `file_save_open[_dialog]` and submits it back
-/// with each `file_save_write` and the final `file_save_commit` or
-/// `file_save_abort`.
-struct SaveStreamRegistry {
-    /// Starts at 1 so a freshly constructed registry never hands out 0 —
-    /// keeps "0 == sentinel" assumptions on the JS side safe.
-    next_id: AtomicU64,
-    // Recovers from poisoning via the `recover` helper; the per-handle
-    // `Arc<Mutex<File>>` in `write_chunk` is the exception and fails closed.
-    // See the PendingMap comment above and
-    // https://github.com/leapmux/leapmux/issues/277.
-    handles: Mutex<HashMap<u64, OpenSaveStream>>,
-}
-
-impl SaveStreamRegistry {
-    fn new() -> Self {
-        Self {
-            next_id: AtomicU64::new(1),
-            handles: Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Insert a freshly-opened file into the registry and return the
-    /// JS-facing handle (id + the final path as a UTF-8 string).
-    /// Both `file_save_open` and `file_save_open_dialog` end with this,
-    /// so it lives here to keep the id/path packaging in one spot.
-    fn insert(
-        &self,
-        file: std::fs::File,
-        tmp_path: PathBuf,
-        final_path: PathBuf,
-    ) -> SaveStreamHandle {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let path = final_path.to_string_lossy().into_owned();
-        recover(&self.handles).insert(
-            id,
-            OpenSaveStream {
-                file: Arc::new(Mutex::new(file)),
-                tmp_path,
-                final_path,
-                last_write_at: Instant::now(),
-            },
-        );
-        SaveStreamHandle { id, path }
-    }
-
-    fn take(&self, id: u64) -> Option<OpenSaveStream> {
-        recover(&self.handles).remove(&id)
-    }
-
-    /// Finalize the save: take the handle, ensure no write is still in flight,
-    /// then atomic-rename the partial onto the final path. On any failure the
-    /// partial is discarded.
-    ///
-    /// The in-flight-write check is load-bearing. `write_chunk` clones the
-    /// per-handle `Arc<Mutex<File>>` and writes with the registry lock
-    /// released, so a duplicated/overlapping `file_save_write` (a buggy or
-    /// retrying JS pump that does not await the previous write) could still be
-    /// holding a clone when commit runs. Committing anyway would, on Windows,
-    /// fail the rename with an opaque "used by another process" error, and on
-    /// Unix SUCCEED while the in-flight write appends to the just-renamed file
-    /// -- silent corruption. So after `take` (which removes the registry's own
-    /// clone, and after which `write_chunk` can create no new one -- its
-    /// `get_mut` returns None), `Arc::try_unwrap` is the reliable
-    /// sole-ownership test: if it fails, a write clone is live, and commit
-    /// fails loudly and discards the partial rather than racing it.
-    fn commit(&self, id: u64) -> Result<(), String> {
-        let Some(stream) = self.take(id) else {
-            return Err(format!("unknown save handle {id}"));
-        };
-        let OpenSaveStream {
-            file,
-            tmp_path,
-            final_path,
-            last_write_at: _,
-        } = stream;
-        // Sole-ownership check: see the method doc. Arc::try_unwrap returns the
-        // inner Mutex only when this is the last reference.
-        let file = match Arc::try_unwrap(file) {
-            Ok(file) => file,
-            Err(_) => {
-                discard_partials(&tmp_path);
-                return Err(format!(
-                    "save handle {id} has a write still in progress; commit refused"
-                ));
-            }
-        };
-        // No `sync_all` before the rename -- intentional. A `sync_all` on a
-        // multi-hundred-MB save blocks for seconds while the OS flushes the
-        // page cache, and neither flow has a contract that needs it: the
-        // Downloads variant only ever writes to a path that was empty when we
-        // picked the name (so a power-loss window between rename and OS flush
-        // just loses the new file, it can't corrupt anything else), and the
-        // Save-as variant's overwrite is already non-atomic at the
-        // user-content level (the user picked a path knowing it would be
-        // replaced, and can re-save on crash). Don't add a sync here without
-        // matching the latency cost to a concrete guarantee we actually need to
-        // make.
-        //
-        // Drop the File before the rename: Windows refuses `rename`/
-        // `remove_file` while the handle is open. try_unwrap above proved this
-        // is the sole owner, so this drop releases the underlying File.
-        drop(file);
-        // `std::fs::rename` replaces the destination on both Unix and Windows.
-        // For save-as that overwrites the user's prior content (the path they
-        // chose). For the Downloads flow the final path was empty when we
-        // picked the name (`open_unique_tmp` skips candidates whose final
-        // already exists); a file appearing there mid-stream is a TOCTOU race
-        // we accept.
-        let result =
-            std::fs::rename(&tmp_path, &final_path).map_err(|err| format!("rename: {err}"));
-        if result.is_err() {
-            discard_partials(&tmp_path);
-        }
-        result
-    }
-
-    fn write_chunk(&self, id: u64, bytes: &[u8]) -> Result<(), String> {
-        // Lock the registry only long enough to refresh the idle
-        // timestamp and clone the per-handle Arc, then drop the
-        // registry lock before acquiring the file lock. Concurrent
-        // writes targeting different handles can then proceed in
-        // parallel.
-        let file = {
-            let mut guard = recover(&self.handles);
-            let handle = guard
-                .get_mut(&id)
-                .ok_or_else(|| format!("unknown save handle {id}"))?;
-            handle.last_write_at = Instant::now();
-            handle.file.clone()
-        };
-        // The per-handle file lock is the one lock in this crate that does NOT
-        // recover from poisoning. Poisoning here means the guard was held
-        // across a panic (realistically: an allocator OOM or a future panicking
-        // op inside the critical section -- `File::write_all` itself returns
-        // `Result` and does not panic on I/O errors), leaving the tmp file in
-        // an indeterminate state.
-        //
-        // Recovering silently and continuing to write would corrupt the save.
-        // But surfacing the error alone is NOT enough either: a panic unwinds
-        // and drops this frame's `Arc` clone, so by the time the caller acts
-        // the registry's clone is again the sole owner. `commit` would then
-        // `take` the handle, `Arc::try_unwrap` would SUCCEED (`try_unwrap`
-        // catches a *live* write clone, not a *panicked* one whose clone has
-        // unwound away), and `rename` would atomically promote the corrupted
-        // -- or, for save-as on a first write, 0-byte -- partial onto the
-        // user's chosen final path, reported as success. In the save-as flow
-        // (`open_tmp_for_write` opens with `truncate`), that silently destroys
-        // the user's original file.
-        //
-        // So discard the handle and its partial on this path: `take` removes
-        // the registry entry (and `commit`/`write_chunk` now find "unknown
-        // save handle {id}" -- commit cannot rename what is gone), and
-        // `discard_stream` drops the poisoned `Arc<Mutex<File>>` and removes
-        // the tmp in the documented Windows-safe order (File dropped before
-        // remove). The caller still gets the error to surface. See
-        // https://github.com/leapmux/leapmux/issues/277.
-        let mut guard = match file.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                if let Some(stream) = self.take(id) {
-                    discard_stream(stream);
-                }
-                return Err(format!(
-                    "save handle {id} write failed: a prior write panicked"
-                ));
-            }
-        };
-        guard
-            .write_all(bytes)
-            .map_err(|err| format!("write: {err}"))
-    }
-
-    /// Drop all open handles and remove any partial files. Called from
-    /// the app exit path so an interrupted save doesn't leave junk on
-    /// disk.
-    fn cleanup_all(&self) {
-        let drained: Vec<_> = recover(&self.handles).drain().collect();
-        for (_, stream) in drained {
-            discard_stream(stream);
-        }
-    }
-
-    /// Discard handles whose `last_write_at` is older than `max_idle`.
-    /// Two-phase: snapshot stale ids under a brief lock, then `take`
-    /// each individually so the per-discard `remove_file` syscalls
-    /// never run under the registry lock. A handle being actively
-    /// written to during the scan window is fine — a racing
-    /// `write_chunk` refreshes `last_write_at`, and the take in phase
-    /// 2 re-checks against `max_idle` and skips it.
-    ///
-    /// This cleanup is in-memory only: it (and `cleanup_all` on graceful
-    /// exit) covers a dead JS pump or a normal quit, but a hard process
-    /// death (SIGKILL, crash, power loss) takes this registry down with it
-    /// and strands the partial on disk. `sweep_orphan_tmps` reclaims those
-    /// left in Downloads at the next startup (a Save-as partial stranded
-    /// elsewhere is inert, not swept -- see `open_tmp_for_write`); until
-    /// then a stale partial is indistinguishable from a live reservation
-    /// and forces a spurious "(N)" suffix (see `open_unique_tmp`). See
-    /// https://github.com/leapmux/leapmux/issues/285.
-    fn gc_idle(&self, max_idle: Duration) {
-        let now = Instant::now();
-        let stale_ids: Vec<u64> = {
-            let guard = recover(&self.handles);
-            guard
-                .iter()
-                .filter(|(_, h)| now.duration_since(h.last_write_at) >= max_idle)
-                .map(|(id, _)| *id)
-                .collect()
-        };
-        for id in stale_ids {
-            // Re-check under lock: a `write_chunk` racing between
-            // snapshot and take may have refreshed the timestamp. If
-            // it has, leave the stream alone.
-            let stream = {
-                let mut guard = recover(&self.handles);
-                match guard.get(&id) {
-                    Some(h) if now.duration_since(h.last_write_at) >= max_idle => guard.remove(&id),
-                    _ => None,
-                }
-            };
-            if let Some(stream) = stream {
-                discard_stream(stream);
-            }
-        }
-    }
-
-    /// Delete orphaned save partials under `dir` left by a prior hard
-    /// process death. Safe at the sole (startup) call site because three
-    /// legs hold together there:
-    ///
-    /// 1. Distinctive suffix (`is_partial_name`) — a match is a LeapMux
-    ///    save partial by construction: `defuse_final_path` keeps every
-    ///    LeapMux *final* clear of `SAVE_TMP_SUFFIX`, and a generic `*.tmp`
-    ///    from another tool never matches.
-    /// 2. `tauri-plugin-single-instance` — no other LeapMux process can
-    ///    be mid-save when this runs at startup.
-    /// 3. The registry is empty and not yet `manage`d at the call site, so
-    ///    none of our own saves is in flight.
-    ///
-    /// The live-`tmp_path` cross-check below spares any partial already in
-    /// the registry, but it is NOT enough on its own to make a *periodic*
-    /// call safe: `live` is snapshotted before `read_dir`, so a save that
-    /// starts afterward is on disk yet absent from the snapshot, and the
-    /// comparison is byte-exact on uncanonicalized paths. A future periodic
-    /// caller must first close that race (snapshot under the same lock that
-    /// guards insert, or re-check membership immediately before each
-    /// remove) and pass the identical `dirs::download_dir()` value
-    /// `file_save_open` uses. See https://github.com/leapmux/leapmux/issues/285.
-    fn sweep_orphan_tmps(&self, dir: &Path) {
-        let live: HashSet<PathBuf> = {
-            let guard = recover(&self.handles);
-            guard.values().map(|h| h.tmp_path.clone()).collect()
-        };
-        let entries = match std::fs::read_dir(dir) {
-            Ok(entries) => entries,
-            // A missing Downloads dir is benign (fresh machine, or a
-            // relocated/unmounted volume) -- return quietly. Any other
-            // failure (permissions, transient I/O) leaves orphans behind,
-            // so log it rather than no-op invisibly, matching the per-entry
-            // branches below.
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return,
-            Err(err) => {
-                eprintln!("leapmux: sweep read dir {}: {err}", dir.display());
-                return;
-            }
-        };
-        for entry in entries {
-            // Log and skip a per-entry read error rather than silently
-            // dropping it (as `entries.flatten()` would): an orphan behind a
-            // transient error self-heals on a later launch, but the failure
-            // should not be invisible. Mirrors the remove_file branch below.
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(err) => {
-                    eprintln!("leapmux: sweep read dir entry in {}: {err}", dir.display());
-                    continue;
-                }
-            };
-            if !is_partial_name(&entry.file_name()) {
-                continue;
-            }
-            // Don't follow symlinks: dirs/symlinks named like partials
-            // are spared. Log a stat failure rather than skip it silently,
-            // as the read-dir and remove_file branches do.
-            let ft = match entry.file_type() {
-                Ok(ft) => ft,
-                Err(err) => {
-                    eprintln!("leapmux: sweep file type {}: {err}", entry.path().display());
-                    continue;
-                }
-            };
-            if !ft.is_file() {
-                continue;
-            }
-            let path = entry.path();
-            if live.contains(&path) {
-                continue;
-            }
-            if let Err(err) = std::fs::remove_file(&path) {
-                eprintln!(
-                    "leapmux: sweep orphan save partial {}: {err}",
-                    path.display()
-                );
-            }
-        }
-    }
-}
-
-/// Append `SAVE_TMP_SUFFIX` to `path` while preserving the existing
-/// OsString (handles non-UTF-8 paths cleanly).
-fn tmp_path_for(final_path: &Path) -> PathBuf {
-    let mut name = final_path.as_os_str().to_owned();
-    name.push(SAVE_TMP_SUFFIX);
-    PathBuf::from(name)
-}
-
-/// Whether `name` is a save partial produced by `tmp_path_for`: it ends
-/// in `SAVE_TMP_SUFFIX` and is *strictly* longer than the bare suffix. A
-/// real final name is never empty, so a partial's name always exceeds the
-/// suffix — a file named exactly `.leapmux.tmp` is therefore not ours and
-/// is spared. This is the inverse of `tmp_path_for`, kept beside it so the
-/// two can't drift, and the exact predicate `sweep_orphan_tmps` deletes
-/// on and `defuse_final_path` protects finals against. Byte-wise, so
-/// non-UTF-8 names are handled like `tmp_path_for`.
-fn is_partial_name(name: &OsStr) -> bool {
-    let bytes = name.as_encoded_bytes();
-    bytes.len() > SAVE_TMP_SUFFIX.len() && bytes.ends_with(SAVE_TMP_SUFFIX.as_bytes())
-}
-
-/// Rewrite a chosen final `path` whose file name would be swept as an
-/// orphan partial (`is_partial_name`) by appending `.download`, so a
-/// committed final can never be mistaken for — and silently deleted as —
-/// a partial by `sweep_orphan_tmps`. The OsString is preserved for
-/// non-UTF-8 names. Both save entry points route their final through the
-/// same reserved-suffix defuse: the Downloads auto-name flow inside
-/// `open_unique_tmp`, and the Save-as dialog via this helper. Without it a
-/// server-supplied name like `report.leapmux.tmp` (or a Save-as target
-/// typed into Downloads) would commit a real final the next startup sweep
-/// removes. See https://github.com/leapmux/leapmux/issues/285.
-fn defuse_final_path(path: PathBuf) -> PathBuf {
-    if path.file_name().is_some_and(is_partial_name) {
-        let mut name = path.into_os_string();
-        name.push(SAVE_DEFUSE_SUFFIX);
-        PathBuf::from(name)
-    } else {
-        path
-    }
-}
-
-/// Resolve a Save-as chosen path to its final write target, applying the
-/// reserved-suffix defuse (`defuse_final_path`) and refusing when that defuse
-/// redirects the write onto a pre-existing `.download` file the native dialog
-/// never confirmed. The dialog's overwrite prompt only covers the name the
-/// user picked; when that name ends in `SAVE_TMP_SUFFIX` the bytes actually
-/// land on `<name>.download`, so silently replacing an existing file there
-/// would destroy data the user was never asked about. The check runs only
-/// when the defuse actually rewrote the path (the rare case), so a normal
-/// dialog-confirmed overwrite is untouched. A residual TOCTOU window before
-/// the commit rename degrades to the prior silent replace -- strictly better
-/// than replacing unconditionally. See
-/// https://github.com/leapmux/leapmux/issues/285.
-fn resolve_save_as_final(chosen: PathBuf) -> Result<PathBuf, String> {
-    let final_path = defuse_final_path(chosen.clone());
-    if final_path != chosen {
-        match final_path.try_exists() {
-            Ok(true) => {
-                return Err(format!(
-                    "cannot save: {} already exists (a name ending in \
-                     {SAVE_TMP_SUFFIX} was redirected to avoid the startup sweep)",
-                    final_path.display()
-                ))
-            }
-            Ok(false) => {}
-            Err(err) => return Err(format!("stat {}: {err}", final_path.display())),
-        }
-    }
-    Ok(final_path)
-}
-
-/// Open (or create+truncate) the temp sibling of `final_path` for
-/// streaming writes. Used by the Save-as dialog flow
-/// (`file_save_open_dialog`); the Downloads flow reserves and opens its
-/// partial with `create_new` inside `open_unique_tmp` instead.
-///
-/// A hard death here strands the partial in the user's chosen directory.
-/// `sweep_orphan_tmps` only reclaims Downloads, so a Save-as partial
-/// elsewhere lingers until the user deletes it -- but it is inert: the
-/// truncating open takes no collision reservation, so unlike a Downloads
-/// orphan it forces no "(N)" suffix on later saves (#285).
-fn open_tmp_for_write(final_path: &Path) -> Result<(std::fs::File, PathBuf), String> {
-    let tmp_path = tmp_path_for(final_path);
-    let tmp_file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(&tmp_path)
-        .map_err(|err| format!("open tmp file: {err}"))?;
-    Ok((tmp_file, tmp_path))
-}
-
-/// Remove the partial temp file. Used by both `discard_stream` and the
-/// failure branches of `file_save_commit`, which have already dropped
-/// the `File` themselves. The final path is never ours to remove —
-/// nothing was ever created there.
-fn discard_partials(tmp_path: &Path) {
-    let _ = std::fs::remove_file(tmp_path);
-}
-
-/// Drop the file handle and remove the partial temp file.
-fn discard_stream(stream: OpenSaveStream) {
-    let OpenSaveStream { file, tmp_path, .. } = stream;
-    // Drop before remove: Windows refuses `remove_file` while the
-    // file handle is open.
-    drop(file);
-    discard_partials(&tmp_path);
-}
-
-/// JS-facing handle to an open save stream. Returned by
-/// `file_save_open[_dialog]` and submitted back (as `id`) with each
-/// `file_save_write` and the final `file_save_commit` /
-/// `file_save_abort`. Mirrors the `SaveStreamHandle` interface in
-/// `platformBridge.ts`.
-#[derive(Serialize)]
-struct SaveStreamHandle {
-    id: u64,
-    path: String,
-}
-
-/// Pick a non-colliding "foo (N).ext" candidate under `dir` and open
-/// its `<candidate>.leapmux.tmp` sibling with `create_new`. The partial
-/// open serves double duty: it both reserves the iteration spot against
-/// concurrent LeapMux saves of the same basename and provides the file
-/// the bytes stream into. The candidate itself is skipped if it already
-/// exists, preserving the "don't silently overwrite a user file in
-/// Downloads" behavior.
-///
-/// A stale orphaned partial left by a hard process crash is
-/// indistinguishable from a live reservation, so it forces "(N)"
-/// suffixes on later downloads of the same name until the next launch's
-/// `sweep_orphan_tmps` reclaims it (#285). Filenames that themselves end
-/// in `SAVE_TMP_SUFFIX` are defused by appending `.download` before the
-/// collision loop — otherwise a committed final ending in the suffix
-/// would be deleted by the next startup sweep.
-fn open_unique_tmp(
-    dir: PathBuf,
-    filename: String,
-) -> Result<(std::fs::File, PathBuf, PathBuf), String> {
-    // Defuse reserved-suffix finals: a server-supplied name like
-    // `report.leapmux.tmp` would otherwise commit a final the next
-    // startup sweep would delete. Collision candidates built from the
-    // defused name (`evil.leapmux.tmp (1).download`) never end in the
-    // suffix. `file_save_open_dialog` applies the same defuse
-    // (`defuse_final_path`) to Save-as targets.
-    let filename = if is_partial_name(OsStr::new(&filename)) {
-        format!("{filename}{SAVE_DEFUSE_SUFFIX}")
-    } else {
-        filename
-    };
-    let as_path = std::path::Path::new(&filename);
-    let stem = as_path
-        .file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let ext = as_path
-        .extension()
-        .map(|s| s.to_string_lossy().into_owned());
-    for i in 0..MAX_SAVE_COLLISION_ATTEMPTS {
-        let candidate_name = if i == 0 {
-            filename.clone()
-        } else {
-            match &ext {
-                Some(e) if !e.is_empty() => format!("{stem} ({i}).{e}"),
-                _ => format!("{stem} ({i})"),
-            }
-        };
-        let final_path = dir.join(&candidate_name);
-        match final_path.try_exists() {
-            Ok(true) => continue,
-            Ok(false) => {}
-            Err(err) => return Err(format!("stat {candidate_name}: {err}")),
-        }
-        let tmp_path = tmp_path_for(&final_path);
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-        {
-            Ok(f) => return Ok((f, tmp_path, final_path)),
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(err) => return Err(format!("create tmp file: {err}")),
-        }
-    }
-    Err(format!(
-        "too many collisions for {filename} (gave up after {MAX_SAVE_COLLISION_ATTEMPTS})"
-    ))
-}
-
-/// Open a destination in the OS Downloads directory and return a
-/// streaming handle. `filename` (from the `filename-b64` header) is
-/// sanitized to its basename and collision-dedupped with " (N)".
-#[tauri::command]
-async fn file_save_open(
-    registry: State<'_, Arc<SaveStreamRegistry>>,
-    request: tauri::ipc::Request<'_>,
-) -> Result<SaveStreamHandle, String> {
-    let filename = read_b64_header(&request, "filename-b64")?;
-    let downloads = dirs::download_dir().ok_or_else(|| "no downloads directory".to_string())?;
-    // Disallow separators in the supplied filename so callers can't
-    // escape the Downloads directory.
-    let safe_name = std::path::Path::new(&filename)
-        .file_name()
-        .ok_or_else(|| "invalid filename".to_string())?
-        .to_string_lossy()
-        .into_owned();
-    let registry = registry.inner().clone();
-    let (file, tmp_path, final_path) =
-        run_blocking(move || open_unique_tmp(downloads, safe_name)).await?;
-    Ok(registry.insert(file, tmp_path, final_path))
-}
-
-/// Show a native save-as dialog and return a streaming handle for the
-/// chosen path. Returns `None` when the user cancels — JS callers
-/// should short-circuit before any worker fetch so a cancellation
-/// costs nothing.
-#[tauri::command]
-async fn file_save_open_dialog(
-    app: tauri::AppHandle,
-    registry: State<'_, Arc<SaveStreamRegistry>>,
-    request: tauri::ipc::Request<'_>,
-) -> Result<Option<SaveStreamHandle>, String> {
-    use tauri_plugin_dialog::DialogExt;
-
-    let default_name = read_b64_header(&request, "default-name-b64")?;
-    let (tx, rx) = oneshot::channel();
-    app.dialog()
-        .file()
-        .set_file_name(&default_name)
-        .save_file(move |path| {
-            let _ = tx.send(path);
-        });
-    let path_opt = rx.await.map_err(|e| e.to_string())?;
-    let Some(file_path) = path_opt else {
-        return Ok(None);
-    };
-    // Defuse a Save-as target whose name ends in the reserved partial
-    // suffix so the next startup sweep can't mistake the committed final
-    // for an orphan and delete it (#285) -- the same guard `open_unique_tmp`
-    // applies to the Downloads flow. This runs after the native dialog's
-    // own overwrite prompt, so for such a name the `.download` variant is
-    // what actually gets written; it is unconditional (not scoped to
-    // Downloads) so no reserved-suffix final ever reaches disk to be swept,
-    // whatever the directory's path spelling. Only a name literally ending
-    // in `.leapmux.tmp` is affected, which a real download never produces --
-    // and if that redirect would land on an existing `.download` the dialog
-    // never confirmed, `resolve_save_as_final` errors rather than clobber it.
-    let final_path = resolve_save_as_final(file_path.into_path().map_err(|e| e.to_string())?)?;
-    let registry = registry.inner().clone();
-    let (file, tmp_path) = run_blocking({
-        let final_path = final_path.clone();
-        move || open_tmp_for_write(&final_path)
-    })
-    .await?;
-    Ok(Some(registry.insert(file, tmp_path, final_path)))
-}
-
-/// Append the request body bytes to the open file identified by the
-/// decimal `handle-id` header. Uses `block_in_place` rather than
-/// `spawn_blocking` so the body slice can be borrowed directly from
-/// the request without a per-chunk clone — for a 100 MB save that
-/// avoids ~100 MiB of memcpy traffic.
-#[tauri::command]
-async fn file_save_write(
-    registry: State<'_, Arc<SaveStreamRegistry>>,
-    request: tauri::ipc::Request<'_>,
-) -> Result<(), String> {
-    let handle_id = read_handle_id(&request)?;
-    let bytes = match request.body() {
-        tauri::ipc::InvokeBody::Raw(b) => b.as_slice(),
-        _ => return Err("expected raw bytes body".to_string()),
-    };
-    // Tauri's command executor runs on a multi-thread tokio runtime,
-    // so `block_in_place` is safe here: it parks the current worker
-    // for the duration of the write and lets the runtime steal other
-    // tasks. The write is bounded to one chunk (~1 MiB). The debug
-    // assertion makes a future runtime-config regression (e.g. switching
-    // to `current_thread`) fail with a clear message instead of tokio's
-    // generic "can call `blocking` only from a `MultiThread`" panic.
-    debug_assert_eq!(
-        tokio::runtime::Handle::current().runtime_flavor(),
-        tokio::runtime::RuntimeFlavor::MultiThread,
-        "file_save_write uses block_in_place; requires a multi-thread runtime",
-    );
-    tokio::task::block_in_place(|| registry.write_chunk(handle_id, bytes))
-}
-
-/// Finalize the save identified by `handle-id`: sync bytes to disk and
-/// atomic-rename the partial onto the final path. Discards partials on
-/// failure so a partial sync doesn't leave a junk file under the
-/// chosen name.
-#[tauri::command]
-async fn file_save_commit(
-    registry: State<'_, Arc<SaveStreamRegistry>>,
-    request: tauri::ipc::Request<'_>,
-) -> Result<(), String> {
-    let handle_id = read_handle_id(&request)?;
-    let registry = registry.inner().clone();
-    run_blocking(move || registry.commit(handle_id)).await
-}
-
-/// Discard the save identified by `handle-id`: drop the open file and
-/// remove the partial. Idempotent against an already-removed
-/// handle (e.g. the idle GC raced the JS pump) so the failure path on
-/// the JS side stays simple.
-#[tauri::command]
-async fn file_save_abort(
-    registry: State<'_, Arc<SaveStreamRegistry>>,
-    request: tauri::ipc::Request<'_>,
-) -> Result<(), String> {
-    let handle_id = read_handle_id(&request)?;
-    let registry = registry.inner().clone();
-    run_blocking(move || {
-        if let Some(stream) = registry.take(handle_id) {
-            discard_stream(stream);
-        }
-        Ok(())
-    })
-    .await
-}
 
 #[tauri::command]
 async fn switch_mode(
@@ -2719,71 +1695,16 @@ fn main() {
 /// the two apart, and the difference is the whole point of the check: a peer
 /// that sends a bogus varint must not be able to make us allocate gigabytes.
 #[cfg(test)]
-mod alloc_probe {
-    use std::alloc::{GlobalAlloc, Layout, System};
-    use std::cell::Cell;
-
-    thread_local! {
-        // Deliberately thread-local rather than a global counter: the test
-        // harness runs tests in parallel threads, and a shared counter would
-        // make one test's allocations visible to another. `const` init keeps
-        // this free of a destructor, so the allocator can't re-enter TLS setup.
-        static PEAK: Cell<usize> = const { Cell::new(0) };
-    }
-
-    fn record(size: usize) {
-        // `try_with` (not `with`): the allocator stays live during TLS
-        // teardown, after PEAK has been destroyed. Nothing to record then.
-        let _ = PEAK.try_with(|peak| peak.set(peak.get().max(size)));
-    }
-
-    pub struct PeakTracking;
-
-    // SAFETY: every method forwards to `System` with the same arguments it was
-    // given; the only added work is recording the requested size.
-    unsafe impl GlobalAlloc for PeakTracking {
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            record(layout.size());
-            unsafe { System.alloc(layout) }
-        }
-
-        // `vec![0u8; n]` lands here, not in `alloc`, via the zeroing
-        // specialization -- which is exactly the allocation under test.
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-            record(layout.size());
-            unsafe { System.alloc_zeroed(layout) }
-        }
-
-        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-            record(new_size);
-            unsafe { System.realloc(ptr, layout, new_size) }
-        }
-
-        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            unsafe { System.dealloc(ptr, layout) }
-        }
-    }
-
-    /// Runs `f` on the current thread, returning its value alongside the
-    /// largest single allocation it requested.
-    ///
-    /// Only allocations on the calling thread are counted, so `f` must do the
-    /// work itself rather than hand it to another thread. `Runtime::block_on`
-    /// qualifies: it drives the future on the caller.
-    pub fn peak_alloc_of<T>(f: impl FnOnce() -> T) -> (T, usize) {
-        PEAK.with(|peak| peak.set(0));
-        let out = f();
-        (out, PEAK.with(|peak| peak.get()))
-    }
-}
-
-#[cfg(test)]
 #[global_allocator]
 static PEAK_TRACKING_ALLOCATOR: alloc_probe::PeakTracking = alloc_probe::PeakTracking;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_save::{
+        defuse_final_path, is_partial_name, open_unique_tmp, resolve_save_as_final, tmp_path_for,
+        SaveStreamRegistry, SAVE_DEFUSE_SUFFIX, SAVE_TMP_SUFFIX,
+    };
     use std::io;
     use std::sync::atomic::AtomicU64;
 

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -3,20 +3,48 @@
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 compile_error!("LeapMux Desktop only supports macOS, Linux, and Windows");
 
-mod proto {
+mod frame;
+pub(crate) mod proto {
     include!(concat!(env!("OUT_DIR"), "/leapmux.desktop.v1.rs"));
 }
+
+mod sidecar_ipc;
 
 #[cfg(target_os = "linux")]
 mod tabfix_linux;
 
 use base64::Engine;
-use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
-#[cfg(unix)]
-use std::os::unix::{fs::PermissionsExt, net::UnixStream};
+// `windows_handshake_async` still names `NamedPipeClient` directly as its return
+// type (the raw async client the handshake exchanges frames on), and the windows
+// `require_same_user_pipe_peer` test uses `ClientOptions` to open a raw client.
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+
+use crate::frame::{get_sidecar_info_request, read_frame, write_frame};
+#[cfg(windows)]
+use crate::frame::{read_frame_async, write_frame_async};
+#[cfg(windows)]
+use crate::sidecar_ipc::connect_sidecar_endpoint_async;
+#[cfg(windows)]
+use crate::sidecar_ipc::pipe_runtime;
+use crate::sidecar_ipc::{
+    cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, dev_sidecar_endpoint,
+    dev_sidecar_metadata_path, endpoint_holder_pid, finalize_sidecar_streams, is_sidecar_gone,
+    private_dev_sidecar_endpoint, restrict_dir_permissions, restrict_file_permissions,
+    SidecarReader, SidecarWriter,
+};
+#[cfg(windows)]
+use crate::sidecar_ipc::{SyncPipeReader, SyncPipeWriter};
+// Unix-only peer-credential helpers; referenced by the unix sidecar-IPC tests.
+#[cfg(all(unix, test))]
+use crate::sidecar_ipc::{
+    require_peer_uid, require_same_user_peer, socket_peer_pid, socket_peer_uid,
+};
+#[cfg(all(unix, test))]
+use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,
@@ -46,21 +74,13 @@ const SHOW_ABOUT_MENU_ID: &str = "show-about";
 const SHOW_PREFERENCES_MENU_ID: &str = "show-preferences";
 #[cfg(target_os = "macos")]
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
-// Must stay in sync with maxFrameSize in desktop/go/frame.go: it must exceed the
-// 16 MiB org-events read limit plus its Frame/Event envelope so a full-size
-// OrgMaterialized bootstrap is not rejected on read.
-const MAX_FRAME_SIZE: u64 = 20 * 1024 * 1024; // 20 MiB
-                                              // A base-128 varint carries 7 bits per byte, so a u64 length prefix needs at
-                                              // most 10 bytes. A reader that has consumed this many without seeing a
-                                              // terminating byte is being fed a malformed (or malicious) prefix.
-const MAX_VARINT_BYTES: usize = 10;
 const SIDECAR_PROTOCOL_VERSION: &str = "1";
 const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 // CONNECT_TIMEOUT is the outer loop budget for "endpoint reachable +
 // handshake succeeds"; HANDSHAKE_TIMEOUT bounds a single attempt. Keep
 // CONNECT meaningfully larger so the loop can retry after a wedged probe.
 const DEV_SIDECAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
-const DEV_SIDECAR_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEV_SIDECAR_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 const SIDECAR_INITIAL_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // Cross-language env-var contract; see desktop/go/main.go for semantics.
@@ -83,105 +103,6 @@ struct SidecarMetadata {
     endpoint: String,
     binary_hash: String,
     protocol_version: String,
-}
-
-// --- Frame read/write utilities ---
-//
-// The sync and async halves below are two transports over ONE wire format: the
-// sync half drives stdio (and, on Windows, the named pipe via SyncPipeReader/
-// SyncPipeWriter), the async half drives tokio streams. Every decision that is
-// part of the FORMAT -- the encoding, the size cap, the decode error mapping,
-// the varint state machine -- lives in the shared helpers here and is called by
-// both, so the twins can only ever differ in their I/O loop. See the
-// `#[cfg(any(windows, test))]` gates on the async half: `test` is what makes
-// them compile and run off Windows, so drift fails CI in front of its author
-// instead of on the one OS nobody built.
-//
-// This section is already self-delimited by this banner and has no dependency
-// beyond `mod proto` and the two consts above -- the proposed first extraction
-// out of this 4000+-line file into its own frame.rs module. See
-// https://github.com/leapmux/leapmux/issues/282.
-
-/// Encodes `frame` into a length-delimited buffer ready to hand to a writer.
-fn encode_frame(frame: &proto::Frame) -> io::Result<Vec<u8>> {
-    let mut buf = Vec::with_capacity(frame.encoded_len() + MAX_VARINT_BYTES);
-    frame.encode_length_delimited(&mut buf).map_err(|err| {
-        io::Error::new(io::ErrorKind::InvalidData, format!("encode frame: {err}"))
-    })?;
-    Ok(buf)
-}
-
-/// Checks a decoded length prefix against `MAX_FRAME_SIZE` and narrows it to a
-/// payload length.
-///
-/// Callers MUST call this BEFORE allocating the payload buffer: rejecting the
-/// size is what stops a peer from making us allocate gigabytes off a bogus
-/// varint, and a check that runs after the allocation protects nothing. The cap
-/// is also what makes the `as usize` narrowing lossless on every target we
-/// build for.
-fn frame_len(size: u64) -> io::Result<usize> {
-    if size > MAX_FRAME_SIZE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("frame too large: {size} bytes (max {MAX_FRAME_SIZE})"),
-        ));
-    }
-    Ok(size as usize)
-}
-
-/// Decodes a frame body -- the bytes AFTER the length prefix, exactly
-/// `frame_len` of them.
-fn decode_frame(data: &[u8]) -> io::Result<proto::Frame> {
-    proto::Frame::decode(data)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, format!("decode frame: {err}")))
-}
-
-/// Folds one wire byte into an in-progress varint decode.
-///
-/// Returns `Some(value)` when `b` terminates the varint (high bit clear), and
-/// `None` when more bytes are needed -- so a reader keeps only its own read
-/// loop and shares the state machine.
-fn varint_step(x: &mut u64, s: &mut u32, b: u8) -> Option<u64> {
-    if b < 0x80 {
-        return Some(*x | (b as u64) << *s);
-    }
-    *x |= ((b & 0x7f) as u64) << *s;
-    *s += 7;
-    None
-}
-
-/// The error a reader returns once a varint has run past `MAX_VARINT_BYTES`
-/// without terminating.
-fn varint_overflow() -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, "varint overflow")
-}
-
-fn write_frame(w: &mut impl Write, frame: &proto::Frame) -> io::Result<()> {
-    w.write_all(&encode_frame(frame)?)?;
-    w.flush()
-}
-
-// Note: prost's `decode_length_delimited` requires an in-memory `Buf`, not
-// an `io::Read` stream. For streaming stdio reads we must manually decode the
-// varint length prefix, then `read_exact` the payload before decoding.
-fn read_frame(r: &mut impl Read) -> io::Result<proto::Frame> {
-    let len = frame_len(read_varint(r)?)?;
-    let mut data = vec![0u8; len];
-    r.read_exact(&mut data)?;
-    decode_frame(&data)
-}
-
-fn read_varint(r: &mut impl Read) -> io::Result<u64> {
-    let mut x: u64 = 0;
-    let mut s: u32 = 0;
-    let mut buf = [0u8; 1];
-    for _ in 0..MAX_VARINT_BYTES {
-        r.read_exact(&mut buf)?;
-        if let Some(v) = varint_step(&mut x, &mut s, buf[0]) {
-            return Ok(v);
-        }
-    }
-    Err(varint_overflow())
 }
 
 // --- Tauri types ---
@@ -561,11 +482,6 @@ type DevSidecarConnection = (
     proto::SidecarInfo,
 );
 
-#[cfg(unix)]
-type SidecarReader = UnixStream;
-#[cfg(unix)]
-type SidecarWriter = UnixStream;
-
 fn try_connect_dev_sidecar(endpoint: &str) -> Result<Option<DevSidecarConnection>, String> {
     match connect_and_handshake_dev_sidecar(endpoint)? {
         Some((reader, writer, info)) => Ok(Some((
@@ -627,19 +543,17 @@ fn connect_and_handshake_dev_sidecar(
 async fn windows_handshake_async(
     pipe_name: &str,
 ) -> Result<Option<(NamedPipeClient, proto::SidecarInfo)>, String> {
-    let mut client = match open_named_pipe_client(pipe_name).await? {
-        PipeConnect::Connected(c) => c,
-        PipeConnect::NotFound => return Ok(None),
-        PipeConnect::Busy => {
-            return Err(format!("named pipe {pipe_name} is busy (sidecar alive)"));
-        }
+    // Route through the transport layer so the same-user SID check gates this
+    // connect (see connect_sidecar_endpoint_async); only the handshake exchange
+    // itself is async, because it races against tokio::time::timeout.
+    let mut client = match connect_sidecar_endpoint_async(pipe_name).await? {
+        Some(c) => c,
+        None => return Ok(None),
     };
     let request = proto::Frame {
         message: Some(proto::frame::Message::Request(proto::Request {
             id: 1,
-            method: Some(proto::request::Method::GetSidecarInfo(
-                proto::GetSidecarInfoRequest {},
-            )),
+            method: Some(get_sidecar_info_request()),
         })),
     };
     write_frame_async(&mut client, &request)
@@ -654,38 +568,6 @@ async fn windows_handshake_async(
     };
     let info = sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")?;
     Ok(Some((client, info)))
-}
-
-#[cfg(any(windows, test))]
-async fn write_frame_async<W: tokio::io::AsyncWrite + Unpin>(
-    w: &mut W,
-    frame: &proto::Frame,
-) -> io::Result<()> {
-    w.write_all(&encode_frame(frame)?).await?;
-    w.flush().await
-}
-
-#[cfg(any(windows, test))]
-async fn read_frame_async<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> io::Result<proto::Frame> {
-    // frame_len rejects an oversize prefix before the vec! below allocates.
-    let len = frame_len(read_varint_async(r).await?)?;
-    let mut data = vec![0u8; len];
-    r.read_exact(&mut data).await?;
-    decode_frame(&data)
-}
-
-#[cfg(any(windows, test))]
-async fn read_varint_async<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> io::Result<u64> {
-    let mut x: u64 = 0;
-    let mut s: u32 = 0;
-    let mut buf = [0u8; 1];
-    for _ in 0..MAX_VARINT_BYTES {
-        r.read_exact(&mut buf).await?;
-        if let Some(v) = varint_step(&mut x, &mut s, buf[0]) {
-            return Ok(v);
-        }
-    }
-    Err(varint_overflow())
 }
 
 /// Asks whatever is listening on `endpoint` to shut down, and reports whether it
@@ -739,270 +621,6 @@ fn request_sidecar_shutdown(endpoint: &str) -> bool {
     false
 }
 
-/// A dev sidecar endpoint private to THIS shell process.
-///
-/// The shared per-user endpoint is what lets a dev reload reuse a running sidecar, so
-/// it is the default. But it is only a cache: when it cannot be reclaimed -- a wedged
-/// leftover that ignores a cooperative shutdown, or another user's socket -- the
-/// launch must still succeed. Suffixing our own PID gives a path nothing else holds,
-/// so a fresh sidecar always starts. In LAUNCHER mode a single unkillable orphan then
-/// costs only the reuse optimisation. In SOLO mode it costs more: the orphan also
-/// holds the shared user-data DB's runtime lease, so the fresh sidecar's ConnectSolo
-/// fails against the locked DB until the orphan is stopped by hand (surfaced by the
-/// request_sidecar_shutdown diagnostic, which names the kernel-verified holder pid).
-///
-/// The previous behaviour, aborting the launch, made one leftover from a SIGKILLed
-/// `task test-e2e` run block every subsequent `task dev` until the dev hunted it down
-/// by hand.
-#[cfg(unix)]
-fn private_dev_sidecar_endpoint() -> String {
-    dev_sidecar_runtime_dir()
-        .join(format!(
-            "{}-sidecar-{}.sock",
-            sidecar_identity(),
-            std::process::id()
-        ))
-        .display()
-        .to_string()
-}
-
-#[cfg(unix)]
-/// Refuses a dev sidecar socket answered by anyone but this user.
-///
-/// Everything downstream of the connect trusts the peer on its own word: the shell
-/// adopts whatever answers here as its sidecar if it self-reports a matching protocol
-/// version and binary hash — and a hash is exactly as forgeable as the PID that
-/// `force_kill_sidecar` used to trust before it was deleted for that reason. The
-/// endpoint sits at a predictable path (the shell derives it from
-/// `std::env::temp_dir()`), so "whoever bound it first" is not an authorization.
-///
-/// The Go side hardens the *bind* (see `requirePrivateDir` in
-/// desktop/go/socket_unix.go, which refuses a socket dir it does not own): this is
-/// the same boundary from the connect side, and it must be checked here too, because
-/// an honest sidecar refusing to bind a squatted directory does nothing to stop this
-/// shell from connecting to whatever a squatter bound instead.
-///
-/// `peer_cred` reads the credentials the KERNEL recorded for the peer, so unlike the
-/// hash it is not something the peer can assert. Dev-only, like the endpoint itself:
-/// a bundled build spawns its own child over stdio pipes and never comes here.
-#[cfg(unix)]
-fn require_same_user_peer(stream: &UnixStream, endpoint: &str) -> Result<(), String> {
-    require_peer_uid(
-        socket_peer_uid(stream)?,
-        unsafe { libc::getuid() },
-        endpoint,
-    )
-}
-
-/// The refusal decision itself, split from the socket so it can be tested against a
-/// foreign uid — binding a socket as another user needs root, so the branch that
-/// actually matters here is otherwise reachable only in production.
-#[cfg(unix)]
-fn require_peer_uid(peer_uid: u32, our_uid: u32, endpoint: &str) -> Result<(), String> {
-    if peer_uid != our_uid {
-        return Err(format!(
-            "refusing sidecar at {endpoint}: it is answered by uid {peer_uid}, not {our_uid}; \
-             something else is holding this endpoint"
-        ));
-    }
-    Ok(())
-}
-
-/// Reads the peer's uid from a connected Unix socket.
-///
-/// std's `UnixStream::peer_cred` is still unstable, so this goes to libc. The two
-/// families expose the same fact through different calls: Linux via the `SO_PEERCRED`
-/// socket option, macOS/BSD via `getpeereid(3)`.
-#[cfg(all(unix, target_os = "linux"))]
-fn socket_peer_uid(stream: &UnixStream) -> Result<u32, String> {
-    use std::os::fd::AsRawFd;
-
-    let mut cred = libc::ucred {
-        pid: 0,
-        uid: 0,
-        gid: 0,
-    };
-    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-    // SAFETY: `cred` and `len` are live, correctly sized, and only written by the
-    // kernel on success; the fd is owned by `stream` for the duration of the call.
-    let rc = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_PEERCRED,
-            std::ptr::from_mut(&mut cred).cast::<libc::c_void>(),
-            &mut len,
-        )
-    };
-    if rc != 0 {
-        return Err(format!(
-            "read sidecar socket peer credentials: {}",
-            io::Error::last_os_error()
-        ));
-    }
-    Ok(cred.uid)
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-fn socket_peer_uid(stream: &UnixStream) -> Result<u32, String> {
-    use std::os::fd::AsRawFd;
-
-    let mut uid: libc::uid_t = 0;
-    let mut gid: libc::gid_t = 0;
-    // SAFETY: both out-params are live for the call and only written on success; the
-    // fd is owned by `stream` for the duration.
-    let rc = unsafe { libc::getpeereid(stream.as_raw_fd(), &mut uid, &mut gid) };
-    if rc != 0 {
-        return Err(format!(
-            "read sidecar socket peer credentials: {}",
-            io::Error::last_os_error()
-        ));
-    }
-    Ok(uid)
-}
-
-/// The KERNEL-recorded pid of the socket peer -- the process actually on the
-/// other end, not a pid it reported about itself over the wire. Used only to
-/// make the "an orphan is holding the endpoint" diagnostic actionable
-/// (`request_sidecar_shutdown`); it is NOT an authorization signal and nothing
-/// is killed by it. Linux reads it from the `SO_PEERCRED` ucred whose uid we
-/// already consult; macOS/BSD from `LOCAL_PEERPID`. Returns None on any error
-/// rather than failing the caller: a missing pid only weakens a log line.
-#[cfg(all(unix, target_os = "linux"))]
-fn socket_peer_pid(stream: &UnixStream) -> Option<u32> {
-    use std::os::fd::AsRawFd;
-
-    let mut cred = libc::ucred {
-        pid: 0,
-        uid: 0,
-        gid: 0,
-    };
-    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-    // SAFETY: as in socket_peer_uid -- kernel writes `cred`/`len` on success; the
-    // fd is owned by `stream` for the call.
-    let rc = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_PEERCRED,
-            std::ptr::from_mut(&mut cred).cast::<libc::c_void>(),
-            &mut len,
-        )
-    };
-    if rc != 0 || cred.pid <= 0 {
-        return None;
-    }
-    Some(cred.pid as u32)
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-fn socket_peer_pid(stream: &UnixStream) -> Option<u32> {
-    use std::os::fd::AsRawFd;
-
-    let mut pid: libc::pid_t = 0;
-    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
-    // SAFETY: `pid`/`len` are live for the call and only written on success; the fd
-    // is owned by `stream`. LOCAL_PEERPID reports the kernel-recorded peer pid.
-    let rc = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_LOCAL,
-            libc::LOCAL_PEERPID,
-            std::ptr::from_mut(&mut pid).cast::<libc::c_void>(),
-            &mut len,
-        )
-    };
-    if rc != 0 || pid <= 0 {
-        return None;
-    }
-    Some(pid as u32)
-}
-
-/// The kernel-verified pid holding `endpoint`, for diagnostics only (see
-/// socket_peer_pid). On unix it opens a throwaway connection and reads the
-/// peer pid; on Windows it does the same through `GetNamedPipeServerProcessId`
-/// on a freshly opened client handle.
-#[cfg(unix)]
-fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
-    let stream = UnixStream::connect(endpoint).ok()?;
-    socket_peer_pid(&stream)
-}
-
-#[cfg(windows)]
-fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
-    use std::os::windows::io::AsRawHandle;
-
-    let client = pipe_runtime().block_on(open_named_pipe_client(endpoint)).ok()?;
-    let client = match client {
-        PipeConnect::Connected(client) => client,
-        // No listener (or every instance busy, which we cannot query) means
-        // no pid to report -- the diagnostic falls back to naming no holder.
-        _ => return None,
-    };
-    let mut pid: u32 = 0;
-    let rc = unsafe { GetNamedPipeServerProcessId(client.as_raw_handle() as HANDLE, &mut pid) };
-    if rc == 0 || pid == 0 {
-        None
-    } else {
-        Some(pid)
-    }
-}
-
-// The sidecar-IPC layer exists as per-platform twins (unix socket vs Windows
-// named pipe) scattered through this file: connect_sidecar_endpoint,
-// is_sidecar_gone, sidecar_identity, the *_dev_sidecar_endpoint pair, the
-// peer-credential helpers, and cleanup_dev_sidecar_artifacts. Grouping the twins
-// into sidecar_ipc_unix.rs / sidecar_ipc_windows.rs so the two OS
-// implementations are diffable side-by-side is tracked in
-// https://github.com/leapmux/leapmux/issues/296 (distinct from the frame-codec
-// extraction in #282).
-#[cfg(unix)]
-fn connect_sidecar_endpoint(
-    endpoint: &str,
-) -> Result<Option<(SidecarReader, SidecarWriter)>, String> {
-    let stream = match UnixStream::connect(endpoint) {
-        Ok(stream) => stream,
-        Err(err)
-            if err.kind() == io::ErrorKind::NotFound
-                || err.kind() == io::ErrorKind::ConnectionRefused =>
-        {
-            return Ok(None);
-        }
-        Err(err) => return Err(format!("connect desktop sidecar socket: {err}")),
-    };
-    require_same_user_peer(&stream, endpoint)?;
-    let reader = stream
-        .try_clone()
-        .map_err(|err| format!("clone sidecar socket: {err}"))?;
-    let writer = stream;
-    writer
-        .set_write_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
-        .map_err(|err| format!("set sidecar socket write timeout: {err}"))?;
-    reader
-        .set_read_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
-        .map_err(|err| format!("set sidecar socket read timeout: {err}"))?;
-    Ok(Some((reader, writer)))
-}
-
-// Handshake timeouts must be cleared before streams are handed to the
-// long-lived reader thread; otherwise reads fail with EAGAIN after a few
-// seconds of idle and tear the connection down.
-#[cfg(unix)]
-fn finalize_sidecar_streams(reader: &SidecarReader, writer: &SidecarWriter) -> Result<(), String> {
-    reader
-        .set_read_timeout(None)
-        .map_err(|err| format!("clear sidecar socket read timeout: {err}"))?;
-    writer
-        .set_write_timeout(None)
-        .map_err(|err| format!("clear sidecar socket write timeout: {err}"))?;
-    Ok(())
-}
-
-#[cfg(unix)]
-fn is_sidecar_gone(endpoint: &str) -> bool {
-    !Path::new(endpoint).exists()
-}
-
 #[cfg(unix)]
 fn fetch_sidecar_info(
     reader: &mut impl Read,
@@ -1011,9 +629,7 @@ fn fetch_sidecar_info(
     let frame = proto::Frame {
         message: Some(proto::frame::Message::Request(proto::Request {
             id: 1,
-            method: Some(proto::request::Method::GetSidecarInfo(
-                proto::GetSidecarInfoRequest {},
-            )),
+            method: Some(get_sidecar_info_request()),
         })),
     };
     write_frame(writer, &frame).map_err(|err| format!("request sidecar info: {err}"))?;
@@ -1023,12 +639,6 @@ fn fetch_sidecar_info(
         _ => return Err("unexpected frame while reading sidecar info".to_string()),
     };
     sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")
-}
-
-#[cfg(unix)]
-fn cleanup_dev_sidecar_artifacts(endpoint: &str, metadata_path: &Path) {
-    let _ = fs::remove_file(endpoint);
-    let _ = fs::remove_file(metadata_path);
 }
 
 fn write_sidecar_metadata(
@@ -1052,62 +662,6 @@ fn write_sidecar_metadata(
     Ok(())
 }
 
-#[cfg(unix)]
-fn restrict_dir_permissions(path: &Path) -> Result<(), String> {
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-        .map_err(|err| format!("set sidecar metadata dir permissions: {err}"))
-}
-
-#[cfg(unix)]
-fn restrict_file_permissions(path: &Path) -> Result<(), String> {
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
-        .map_err(|err| format!("set sidecar metadata permissions: {err}"))
-}
-
-#[cfg(windows)]
-fn restrict_dir_permissions(_: &Path) -> Result<(), String> {
-    Ok(())
-}
-
-#[cfg(windows)]
-fn restrict_file_permissions(_: &Path) -> Result<(), String> {
-    Ok(())
-}
-
-#[cfg(unix)]
-fn dev_sidecar_endpoint() -> String {
-    dev_sidecar_runtime_dir()
-        .join(format!("{}-sidecar.sock", sidecar_identity()))
-        .display()
-        .to_string()
-}
-
-#[cfg(unix)]
-fn dev_sidecar_metadata_path() -> PathBuf {
-    dev_sidecar_runtime_dir().join(format!("{}-sidecar.json", sidecar_identity()))
-}
-
-#[cfg(unix)]
-fn dev_sidecar_runtime_dir() -> PathBuf {
-    std::env::temp_dir().join("leapmux-desktop")
-}
-
-#[cfg(unix)]
-fn sidecar_identity() -> String {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<String> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            std::env::var("USER")
-                .or_else(|_| std::env::var("USERNAME"))
-                .unwrap_or_else(|_| "default".to_string())
-                .chars()
-                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                .collect()
-        })
-        .clone()
-}
-
 fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
     let file = fs::File::open(sidecar_path)
         .map_err(|err| format!("read desktop sidecar binary: {err}"))?;
@@ -1125,381 +679,6 @@ fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
     }
     let digest = hasher.finalize();
     Ok(digest.iter().map(|b| format!("{:02x}", b)).collect())
-}
-
-// --- Windows named-pipe dev-mode sidecar reconnect ---
-//
-// Why tokio's overlapped-I/O client and not a raw CreateFileW/ReadFile/
-// WriteFile wrapper: a named-pipe handle opened without FILE_FLAG_OVERLAPPED
-// serializes all I/O through the FILE_OBJECT lock, even across duplicated
-// handles. A blocked long-lived ReadFile would prevent any concurrent
-// WriteFile from making progress and deadlock the reader/writer threads.
-
-#[cfg(any(windows, test))]
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-#[cfg(windows)]
-use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
-#[cfg(windows)]
-use windows_sys::Win32::{
-    Foundation::{
-        CloseHandle, GetLastError, LocalFree, ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER,
-        ERROR_PIPE_BUSY, HANDLE, HLOCAL,
-    },
-    Security::{
-        Authorization::ConvertSidToStringSidW, EqualSid, GetLengthSid, GetTokenInformation,
-        TokenUser, PSID, TOKEN_QUERY, TOKEN_USER,
-    },
-    System::{Pipes::GetNamedPipeServerProcessId, Threading::{
-        GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
-    }},
-};
-
-#[cfg(windows)]
-type SidecarReader = SyncPipeReader;
-#[cfg(windows)]
-type SidecarWriter = SyncPipeWriter;
-
-// `new_multi_thread` with one worker is deliberate: the reader and writer
-// threads both call `block_on` on this runtime, and `current_thread` would
-// serialize them through the runtime mutex (defeating the parallelism the
-// FILE_OBJECT-lock fix exists to enable).
-#[cfg(any(windows, test))]
-fn pipe_runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
-    RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_io()
-            .enable_time()
-            .thread_name("leapmux-named-pipe")
-            .build()
-            .expect("build named-pipe runtime")
-    })
-}
-
-#[cfg(windows)]
-pub struct SyncPipeReader {
-    inner: tokio::io::ReadHalf<NamedPipeClient>,
-}
-
-#[cfg(windows)]
-impl Read for SyncPipeReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        pipe_runtime().block_on(self.inner.read(buf))
-    }
-}
-
-#[cfg(windows)]
-pub struct SyncPipeWriter {
-    inner: tokio::io::WriteHalf<NamedPipeClient>,
-}
-
-#[cfg(windows)]
-impl Write for SyncPipeWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        pipe_runtime().block_on(self.inner.write(buf))
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        pipe_runtime().block_on(self.inner.flush())
-    }
-}
-
-/// Outcome of a named-pipe connect attempt. The THREE states must stay
-/// distinct: a pipe that does not exist (`NotFound`) and a pipe whose every
-/// server instance is momentarily busy (`Busy`) are opposite facts about the
-/// sidecar's liveness -- NotFound means it is gone, Busy means it is alive and
-/// serving -- and collapsing both to "no client" (the old `Ok(None)`) let a
-/// live-but-busy sidecar read as gone during the shutdown poll, so the shell
-/// double-spawned onto an endpoint a zombie still held.
-#[cfg(windows)]
-enum PipeConnect {
-    Connected(NamedPipeClient),
-    NotFound,
-    Busy,
-}
-
-// ERROR_PIPE_BUSY gets a short retry loop; if every instance stays busy across
-// the retries the pipe is alive but saturated, reported as Busy (NOT NotFound).
-// ERROR_FILE_NOT_FOUND is NotFound; any other error is fatal.
-#[cfg(windows)]
-async fn open_named_pipe_client(pipe_name: &str) -> Result<PipeConnect, String> {
-    const MAX_BUSY_RETRIES: u32 = 3;
-    for _ in 0..=MAX_BUSY_RETRIES {
-        match ClientOptions::new().open(pipe_name) {
-            Ok(client) => return Ok(PipeConnect::Connected(client)),
-            Err(err) if err.raw_os_error() == Some(ERROR_FILE_NOT_FOUND as i32) => {
-                return Ok(PipeConnect::NotFound);
-            }
-            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-                continue;
-            }
-            Err(err) => return Err(format!("open named pipe {pipe_name}: {err}")),
-        }
-    }
-    // Retries exhausted while every instance was busy: alive, not gone.
-    Ok(PipeConnect::Busy)
-}
-
-#[cfg(windows)]
-fn is_sidecar_gone(pipe_name: &str) -> bool {
-    // ONLY NotFound means gone. A Busy pipe is a live sidecar whose instances
-    // are all in use -- reporting it gone here is exactly what let the shell
-    // abandon a healthy-but-busy sidecar mid-shutdown-poll and double-spawn.
-    pipe_runtime().block_on(async {
-        matches!(open_named_pipe_client(pipe_name).await, Ok(PipeConnect::NotFound))
-    })
-}
-
-/// Refuses a dev sidecar named pipe answered by anyone but this user, the
-/// Windows counterpart of the unix `connect_sidecar_endpoint`'s
-/// `require_same_user_peer`. See `require_same_user_pipe_peer` for the
-/// mechanism and the bind-side pair (`userOnlySDDL` in
-/// `backend/locallisten/locallisten_windows.go`) that hardens the *listener*
-/// the same way Unix's `requirePrivateDir` does.
-#[cfg(windows)]
-fn connect_sidecar_endpoint(
-    pipe_name: &str,
-) -> Result<Option<(SidecarReader, SidecarWriter)>, String> {
-    let client = match pipe_runtime().block_on(open_named_pipe_client(pipe_name))? {
-        PipeConnect::Connected(client) => client,
-        // Gone: the caller's "try again later / endpoint is free" signal.
-        PipeConnect::NotFound => return Ok(None),
-        // Alive but saturated. NOT free to take -- surfaced as an error so the
-        // bootstrap routes around it onto a private endpoint rather than
-        // colliding on an endpoint a live sidecar still holds.
-        PipeConnect::Busy => {
-            return Err(format!("named pipe {pipe_name} is busy (sidecar alive)"));
-        }
-    };
-    require_same_user_pipe_peer(&client, pipe_name)?;
-    let (r, w) = tokio::io::split(client);
-    Ok(Some((
-        SyncPipeReader { inner: r },
-        SyncPipeWriter { inner: w },
-    )))
-}
-
-#[cfg(windows)]
-fn cleanup_dev_sidecar_artifacts(_endpoint: &str, metadata_path: &Path) {
-    // Named pipes release themselves when the server closes the listener;
-    // only the metadata file persists on disk.
-    let _ = fs::remove_file(metadata_path);
-}
-
-/// Windows counterpart of the unix private endpoint (see there for why it exists).
-/// Named pipes carry no filesystem path, so the PID goes in the pipe name.
-#[cfg(windows)]
-fn private_dev_sidecar_endpoint() -> Result<String, String> {
-    Ok(format!(
-        "\\\\.\\pipe\\leapmux-desktop-{}-sidecar-{}",
-        sidecar_identity()?,
-        std::process::id()
-    ))
-}
-
-#[cfg(windows)]
-fn dev_sidecar_endpoint() -> Result<String, String> {
-    Ok(format!(
-        "\\\\.\\pipe\\leapmux-desktop-{}-sidecar",
-        sidecar_identity()?
-    ))
-}
-
-#[cfg(windows)]
-fn dev_sidecar_metadata_path() -> PathBuf {
-    let base = std::env::var_os("LOCALAPPDATA")
-        .map(PathBuf::from)
-        .unwrap_or_else(std::env::temp_dir);
-    dev_sidecar_metadata_path_in(&base)
-}
-
-#[cfg(windows)]
-fn dev_sidecar_metadata_path_in(base: &Path) -> PathBuf {
-    base.join("leapmux-desktop").join("sidecar.json")
-}
-
-#[cfg(windows)]
-fn sanitize_sid_for_pipe(raw: &str) -> String {
-    raw.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-#[cfg(windows)]
-fn sidecar_identity() -> Result<String, String> {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<Result<String, String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            current_user_sid()
-                .and_then(|bytes| sid_to_string(&bytes))
-                .map(|raw| sanitize_sid_for_pipe(&raw))
-        })
-        .clone()
-}
-
-/// The current process's user SID, copied into an owned buffer so callers can
-/// hold it past the token handle. Used both to name the per-user dev pipe
-/// (via `sidecar_identity`) and as the comparison point for the connect-side
-/// identity check (`require_same_user_pipe_peer`) -- the two callers that need
-/// to agree on what "us" means go through one place to find out.
-#[cfg(windows)]
-fn current_user_sid() -> Result<Vec<u8>, String> {
-    let mut token: HANDLE = std::ptr::null_mut();
-    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
-        return Err(format!("open process token: error {}", unsafe { GetLastError() }));
-    }
-    let sid = token_user_sid(token);
-    unsafe { CloseHandle(token) };
-    sid
-}
-
-/// Renders a SID (as raw bytes) into the `S-1-5-...` string form. Wraps the
-/// `ConvertSidToStringSidW` + `LocalFree` pair so neither caller has to.
-#[cfg(windows)]
-fn sid_to_string(sid: &[u8]) -> Result<String, String> {
-    let mut sid_string_ptr: *mut u16 = std::ptr::null_mut();
-    if unsafe { ConvertSidToStringSidW(sid.as_ptr() as PSID, &mut sid_string_ptr) } == 0 {
-        return Err(format!("convert sid to string: error {}", unsafe { GetLastError() }));
-    }
-    let mut len = 0;
-    while unsafe { *sid_string_ptr.add(len) } != 0 {
-        len += 1;
-    }
-    let slice = unsafe { std::slice::from_raw_parts(sid_string_ptr, len) };
-    let sid = String::from_utf16_lossy(slice);
-    unsafe { LocalFree(sid_string_ptr as HLOCAL) };
-    Ok(sid)
-}
-
-/// Queries `TokenUser` out of a token handle and returns the SID it points to,
-/// copied into an owned buffer.
-///
-/// `GetTokenInformation` writes a `TOKEN_USER` whose `User.Sid` points *into*
-/// the same buffer, so the SID borrows from it; copying into a fresh `Vec<u8>`
-/// hands the caller a SID whose lifetime is independent of the token query.
-/// `GetLengthSid` reports the kernel's byte count for a valid SID, so the copy
-/// is exactly sized.
-///
-/// The size-probe call is EXPECTED to fail with ERROR_INSUFFICIENT_BUFFER (that
-/// is how it reports the required size in `needed`). Checking its return
-/// distinguishes that expected failure from a real one: without the check, any
-/// other failure leaves `needed` at 0, the second call runs against an empty
-/// buffer, and the error reported below is the SECOND call's -- masking the
-/// true cause (a bad token handle, a denied query).
-#[cfg(windows)]
-fn token_user_sid(token: HANDLE) -> Result<Vec<u8>, String> {
-    let mut needed: u32 = 0;
-    if unsafe { GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed) } == 0 {
-        let probe_err = unsafe { GetLastError() };
-        if probe_err != ERROR_INSUFFICIENT_BUFFER {
-            return Err(format!("probe token user info size: error {probe_err}"));
-        }
-    }
-    let mut buffer = vec![0u8; needed as usize];
-    let ok = unsafe {
-        GetTokenInformation(
-            token,
-            TokenUser,
-            buffer.as_mut_ptr() as *mut _,
-            needed,
-            &mut needed,
-        )
-    };
-    let token_err = if ok == 0 { unsafe { GetLastError() } } else { 0 };
-    if ok == 0 {
-        return Err(format!("get token user info: error {token_err}"));
-    }
-    let user_info = unsafe { &*(buffer.as_ptr() as *const TOKEN_USER) };
-    let sid_ptr = user_info.User.Sid;
-    let len = unsafe { GetLengthSid(sid_ptr) } as usize;
-    if len == 0 {
-        return Err("token user sid: GetLengthSid returned 0".to_string());
-    }
-    let mut sid = vec![0u8; len];
-    unsafe { std::ptr::copy_nonoverlapping(sid_ptr as *const u8, sid.as_mut_ptr(), len) };
-    Ok(sid)
-}
-
-/// Reads the server process's user SID from a connected named-pipe client
-/// handle. The PID is the kernel's report about which process bound this pipe
-/// instance (not a value the peer asserts over the wire), and the SID is read
-/// from that PID's primary token -- so the same chain of trust as Unix's
-/// `SO_PEERCRED` / `getpeereid`: a fact the peer cannot forge.
-///
-/// `PROCESS_QUERY_LIMITED_INFORMATION` is the least-privilege access right
-/// that lets us read another process's token's user; same-user processes hold
-/// it by default, and any failure here fails closed in the caller.
-#[cfg(windows)]
-fn pipe_peer_sid(client: &NamedPipeClient) -> Result<Vec<u8>, String> {
-    use std::os::windows::io::AsRawHandle;
-
-    let mut server_pid: u32 = 0;
-    if unsafe { GetNamedPipeServerProcessId(client.as_raw_handle() as HANDLE, &mut server_pid) }
-        == 0
-    {
-        return Err(format!(
-            "query named pipe server pid: error {}",
-            unsafe { GetLastError() }
-        ));
-    }
-    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, server_pid) };
-    if process.is_null() {
-        return Err(format!(
-            "open server process {server_pid}: error {}",
-            unsafe { GetLastError() }
-        ));
-    }
-    let mut token: HANDLE = std::ptr::null_mut();
-    let token_rc = unsafe { OpenProcessToken(process, TOKEN_QUERY, &mut token) };
-    unsafe { CloseHandle(process) };
-    if token_rc == 0 {
-        return Err(format!(
-            "open server process token: error {}",
-            unsafe { GetLastError() }
-        ));
-    }
-    let sid = token_user_sid(token);
-    unsafe { CloseHandle(token) };
-    sid
-}
-
-/// The refusal decision itself, split from the pipe so it can be tested
-/// against a foreign SID -- binding a pipe as another user needs admin, so the
-/// branch that actually matters here is otherwise reachable only in production.
-/// Mirrors `require_peer_uid` on Unix.
-#[cfg(windows)]
-fn require_peer_sid(peer: &[u8], ours: &[u8], pipe_name: &str) -> Result<(), String> {
-    // EqualSid is the canonical Win32 SID comparison; it returns FALSE for
-    // unequal SIDs (different lengths or different bytes), so a peer whose SID
-    // differs in any way is a clean refusal rather than a panic.
-    let equal = unsafe { EqualSid(peer.as_ptr() as PSID, ours.as_ptr() as PSID) } != 0;
-    if !equal {
-        return Err(format!(
-            "refusing sidecar at {pipe_name}: it is answered by a different user; \
-             something else is holding this endpoint"
-        ));
-    }
-    Ok(())
-}
-
-/// Refuses a dev sidecar named pipe answered by anyone but this user. Windows
-/// counterpart of Unix's `require_same_user_peer`; see that function for why
-/// the connect side must check this even though the Go side already restricts
-/// the bind to our SID (via `userOnlySDDL` in locallisten_windows.go).
-#[cfg(windows)]
-fn require_same_user_pipe_peer(client: &NamedPipeClient, pipe_name: &str) -> Result<(), String> {
-    let peer_sid = pipe_peer_sid(client)?;
-    let our_sid = current_user_sid()?;
-    require_peer_sid(&peer_sid, &our_sid, pipe_name)
 }
 
 impl DesktopShell {
@@ -1568,12 +747,7 @@ impl DesktopShell {
     }
 
     async fn refresh_state_from_sidecar(&self) -> Result<(), String> {
-        let resp = check_response(
-            self.send_request_async(proto::request::Method::GetSidecarInfo(
-                proto::GetSidecarInfoRequest {},
-            ))
-            .await?,
-        )?;
+        let resp = check_response(self.send_request_async(get_sidecar_info_request()).await?)?;
         let info = sidecar_info_from_response(resp, "get_sidecar_info")?;
         apply_sidecar_info(&self.state, info);
         Ok(())
@@ -2590,7 +1764,8 @@ impl SaveStreamRegistry {
         // picked the name (`open_unique_tmp` skips candidates whose final
         // already exists); a file appearing there mid-stream is a TOCTOU race
         // we accept.
-        let result = std::fs::rename(&tmp_path, &final_path).map_err(|err| format!("rename: {err}"));
+        let result =
+            std::fs::rename(&tmp_path, &final_path).map_err(|err| format!("rename: {err}"));
         if result.is_err() {
             discard_partials(&tmp_path);
         }
@@ -3594,9 +2769,10 @@ fn main() {
 /// A test-only global allocator that records the largest single allocation made
 /// on each thread.
 ///
-/// It exists for `read_frame_async_rejects_oversize_varint_before_allocating`.
-/// That test's contract -- reject an oversize length prefix *without allocating
-/// the payload* -- cannot be pinned by asserting on the returned error: the very
+/// It exists for `frame::tests::read_frame_async_rejects_oversize_varint_before_allocating`
+/// (which reaches it via `crate::alloc_probe::peak_alloc_of`). That test's
+/// contract -- reject an oversize length prefix *without allocating the
+/// payload* -- cannot be pinned by asserting on the returned error: the very
 /// same "frame too large" surfaces whether the `MAX_FRAME_SIZE` check runs
 /// before the payload `vec!` or after it. Only measuring the allocation tells
 /// the two apart, and the difference is the whole point of the check: a peer
@@ -4071,9 +3247,7 @@ mod tests {
         let request = proto::Frame {
             message: Some(proto::frame::Message::Request(proto::Request {
                 id: 42,
-                method: Some(proto::request::Method::GetSidecarInfo(
-                    proto::GetSidecarInfoRequest {},
-                )),
+                method: Some(get_sidecar_info_request()),
             })),
         };
         write_frame(&mut writer, &request).expect("client write");
@@ -4153,8 +3327,7 @@ mod tests {
                 .open(&pipe_name)
                 .expect("open named pipe client")
         });
-        require_same_user_pipe_peer(&client, &pipe_name)
-            .expect("our own pipe is accepted");
+        require_same_user_pipe_peer(&client, &pipe_name).expect("our own pipe is accepted");
     }
 
     // endpoint_holder_pid now reports the kernel-recorded server pid on Windows
@@ -4176,151 +3349,6 @@ mod tests {
     fn endpoint_holder_pid_is_none_for_an_absent_endpoint() {
         let pipe_name = unique_test_pipe_name();
         assert_eq!(endpoint_holder_pid(&pipe_name), None);
-    }
-
-    #[cfg(any(windows, test))]
-    #[test]
-    fn read_frame_async_roundtrips_multibyte_varint_frame() {
-        // A frame whose encoded body exceeds 127 bytes forces the
-        // length-delimited prefix into a multi-byte varint, exercising the
-        // loop in read_varint_async.
-        pipe_runtime().block_on(async {
-            let (mut writer, mut reader) = tokio::io::duplex(64 * 1024);
-            let mut info = sidecar_info(
-                proto::SidecarShellMode::Distributed,
-                true,
-                "https://example.invalid/path/to/hub",
-            );
-            info.binary_hash = "x".repeat(200);
-            let frame = proto::Frame {
-                message: Some(proto::frame::Message::Response(proto::Response {
-                    id: 7,
-                    error: String::new(),
-                    result: Some(proto::response::Result::SidecarInfo(info)),
-                })),
-            };
-            assert!(
-                frame.encoded_len() > 127,
-                "test precondition: frame must exceed 1-byte varint range, got {}",
-                frame.encoded_len()
-            );
-
-            write_frame_async(&mut writer, &frame).await.expect("write");
-            drop(writer);
-            let received = read_frame_async(&mut reader).await.expect("read");
-            assert_eq!(received.encoded_len(), frame.encoded_len());
-            match received.message {
-                Some(proto::frame::Message::Response(r)) => assert_eq!(r.id, 7),
-                other => panic!("unexpected message: {other:?}"),
-            }
-        });
-    }
-
-    // frame_len and varint_step are the two decisions the sync and async readers
-    // SHARE. The reader tests above reach them only through a socket, and only at
-    // sizes a real frame happens to take -- so the boundary itself (exactly at the
-    // cap vs. one byte over) is asserted here, where it can be stated exactly.
-    #[test]
-    fn frame_len_admits_the_cap_and_refuses_one_byte_past_it() {
-        assert_eq!(frame_len(0).expect("an empty frame is a frame"), 0);
-        // Exactly at the cap is legal: the check is `>`, not `>=`, and a frame of
-        // precisely MAX_FRAME_SIZE must still be readable.
-        assert_eq!(
-            frame_len(MAX_FRAME_SIZE).expect("a frame at the cap is legal"),
-            MAX_FRAME_SIZE as usize
-        );
-
-        let err = frame_len(MAX_FRAME_SIZE + 1).expect_err("one byte past the cap is refused");
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-        assert!(
-            err.to_string().contains("frame too large"),
-            "operators and the sync reader's tests key on this text: {err}"
-        );
-
-        // A bogus varint is the case the cap exists for: u64::MAX must be refused as
-        // a size rather than narrowed by `as usize` into a plausible allocation.
-        frame_len(u64::MAX).expect_err("a bogus length prefix is refused, not truncated");
-    }
-
-    #[test]
-    fn varint_step_terminates_on_a_clear_high_bit_and_accumulates_otherwise() {
-        // Single byte, high bit clear: terminates immediately with its own value.
-        let (mut x, mut s) = (0u64, 0u32);
-        assert_eq!(varint_step(&mut x, &mut s, 0x01), Some(1));
-
-        // Two bytes: the first only accumulates (returns None and advances the
-        // shift), the second terminates and contributes its bits at that shift.
-        // 0xAC 0x02 is protobuf's canonical varint for 300.
-        let (mut x, mut s) = (0u64, 0u32);
-        assert_eq!(varint_step(&mut x, &mut s, 0xAC), None, "high bit set: more bytes needed");
-        assert_eq!(s, 7, "each continuation byte carries 7 payload bits");
-        assert_eq!(varint_step(&mut x, &mut s, 0x02), Some(300));
-    }
-
-    #[cfg(any(windows, test))]
-    #[test]
-    fn read_frame_async_rejects_oversize_varint_before_allocating() {
-        // A length prefix exceeding MAX_FRAME_SIZE must be rejected without
-        // attempting to allocate the payload, so a peer can't make us
-        // allocate gigabytes by sending a bogus varint.
-        //
-        // The error assertions below are necessary but NOT sufficient: the same
-        // error surfaces even if the check runs after the `vec!`. So measure the
-        // allocation too -- that, and only that, pins the ordering that gives
-        // the check its value. `pipe_runtime()` is resolved outside the probe so
-        // one-time runtime construction isn't attributed to the read.
-        let runtime = pipe_runtime();
-        let (_, peak) = alloc_probe::peak_alloc_of(|| {
-            runtime.block_on(async {
-                let (mut writer, mut reader) = tokio::io::duplex(64);
-                let mut buf = Vec::new();
-                let mut v: u64 = MAX_FRAME_SIZE + 1;
-                loop {
-                    let byte = (v & 0x7f) as u8;
-                    v >>= 7;
-                    if v == 0 {
-                        buf.push(byte);
-                        break;
-                    }
-                    buf.push(byte | 0x80);
-                }
-                tokio::io::AsyncWriteExt::write_all(&mut writer, &buf)
-                    .await
-                    .expect("write varint");
-                drop(writer);
-
-                let err = read_frame_async(&mut reader)
-                    .await
-                    .expect_err("oversize frame must error");
-                assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-                assert!(
-                    err.to_string().contains("frame too large"),
-                    "unexpected error message: {err}"
-                );
-            })
-        });
-        assert!(
-            (peak as u64) < MAX_FRAME_SIZE,
-            "read_frame_async allocated {peak} bytes for a rejected {} byte prefix; \
-             the MAX_FRAME_SIZE check must run BEFORE the payload is allocated",
-            MAX_FRAME_SIZE + 1
-        );
-    }
-
-    #[cfg(any(windows, test))]
-    #[test]
-    fn read_frame_async_returns_eof_when_peer_closes() {
-        // The reader thread distinguishes UnexpectedEof from real errors so
-        // a clean peer-close doesn't log a noisy error line. Pin that
-        // contract here.
-        pipe_runtime().block_on(async {
-            let (writer, mut reader) = tokio::io::duplex(64);
-            drop(writer);
-            let err = read_frame_async(&mut reader)
-                .await
-                .expect_err("eof must be reported");
-            assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
-        });
     }
 
     #[cfg(windows)]
@@ -4731,11 +3759,7 @@ mod tests {
             for _ in 0..N {
                 let s = sidecar.clone();
                 handles.push(tokio::spawn(async move {
-                    send_sidecar_request(
-                        &s,
-                        proto::request::Method::GetSidecarInfo(proto::GetSidecarInfoRequest {}),
-                    )
-                    .await
+                    send_sidecar_request(&s, get_sidecar_info_request()).await
                 }));
             }
             for h in handles {
@@ -4937,8 +3961,14 @@ mod tests {
             err.contains("write still in progress"),
             "unexpected error: {err}"
         );
-        assert!(!tmp_path.exists(), "the partial tmp is discarded, not left behind");
-        assert!(!final_path.exists(), "no corrupt file is renamed into place");
+        assert!(
+            !tmp_path.exists(),
+            "the partial tmp is discarded, not left behind"
+        );
+        assert!(
+            !final_path.exists(),
+            "no corrupt file is renamed into place"
+        );
         drop(in_flight_clone);
     }
 
@@ -5042,15 +4072,22 @@ mod tests {
         // instead of renaming the corrupted/empty partial onto the final path.
         // Before the discard-on-fail-closed fix this would `Ok(())` and
         // atomically replace `final_path` with the truncated tmp.
-        assert!(!tmp_path.exists(), "the corrupted tmp is discarded, not left");
+        assert!(
+            !tmp_path.exists(),
+            "the corrupted tmp is discarded, not left"
+        );
         let retry = registry.write_chunk(handle.id, b"more");
         assert!(
-            retry.as_ref().is_err_and(|err| err.contains("unknown save handle")),
+            retry
+                .as_ref()
+                .is_err_and(|err| err.contains("unknown save handle")),
             "after the fail-closed discard the handle is gone; got: {retry:?}"
         );
         let commit = registry.commit(handle.id);
         assert!(
-            commit.as_ref().is_err_and(|err| err.contains("unknown save handle")),
+            commit
+                .as_ref()
+                .is_err_and(|err| err.contains("unknown save handle")),
             "commit must refuse a poisoned id instead of renaming the partial; got: {commit:?}"
         );
         assert!(

--- a/desktop/rust/src/sidecar.rs
+++ b/desktop/rust/src/sidecar.rs
@@ -1,0 +1,338 @@
+//! Sidecar process bootstrap, connect, handshake, and shutdown.
+//!
+//! Distinct from `sidecar_ipc` (the kernel transport: unix socket / named pipe)
+//! and from `frame` (the wire codec): this module is the layer ABOVE both -- it
+//! spawns the sidecar process (or reuses a live dev one), drives the
+//! GetSidecarInfo handshake over the transport, writes the dev-sidecar metadata
+//! record, and asks a stale peer to shut down. The live runtime handle
+//! (`SidecarProcess` + reader/writer threads) lives in `main.rs`'s `DesktopShell`;
+//! this module only produces the `SidecarBootstrap` (child + reader/writer halves)
+//! the shell installs.
+//!
+//! Extracted from `main.rs`.
+
+use std::fs;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use sha2::{Digest, Sha256};
+
+use crate::frame::{read_frame, write_frame};
+use crate::proto;
+use crate::sidecar_ipc::{
+    cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, dev_sidecar_endpoint,
+    dev_sidecar_metadata_path, endpoint_holder_pid, is_sidecar_gone, private_dev_sidecar_endpoint,
+    restrict_dir_permissions, restrict_file_permissions,
+};
+#[cfg(unix)]
+use crate::sidecar_ipc::{finalize_sidecar_streams, SidecarReader, SidecarWriter};
+use crate::{
+    SidecarMetadata, DEV_SIDECAR_CONNECT_TIMEOUT, DEV_SIDECAR_SHUTDOWN_TIMEOUT, ENV_BINARY_HASH,
+    ENV_DEV_ENDPOINT, SIDECAR_PROTOCOL_VERSION,
+};
+// `get_sidecar_info_request` / `check_response` / `sidecar_info_from_response`
+// back the unix `fetch_sidecar_info` handshake; the Windows twin lives in
+// `windows_impl`, so these are unix-only here.
+#[cfg(unix)]
+use crate::{check_response, frame::get_sidecar_info_request, sidecar_info_from_response};
+// The Windows handshake twin (overlapped-I/O named pipe, raced against a timeout)
+// lives in `windows_impl`; `main.rs` re-exports it at the crate root for every
+// caller including this module.
+#[cfg(windows)]
+use crate::connect_and_handshake_dev_sidecar;
+
+/// The freshly-spawned (or reused) sidecar a `DesktopShell` installs: the child
+/// process (owned, when we spawned it) plus the reader/writer halves of the
+/// transport the reader/writer threads will own.
+pub(crate) struct SidecarBootstrap {
+    pub(crate) child: Option<Child>,
+    pub(crate) reader: Box<dyn Read + Send>,
+    pub(crate) writer: Box<dyn Write + Send>,
+}
+
+/// Spawn (dev) or spawn-via-stdio (release) the sidecar, returning its bootstrap.
+pub(crate) fn bootstrap_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
+    #[cfg(any(unix, windows))]
+    if cfg!(debug_assertions) {
+        return bootstrap_dev_sidecar(sidecar_path);
+    }
+    spawn_stdio_sidecar(sidecar_path)
+}
+
+// bootstrap_dev_sidecar tries to reuse a live dev sidecar at the well-known
+// endpoint (unix socket on Unix, named pipe on Windows) and falls back to
+// spawning a fresh one when the endpoint is stale, incompatible, or missing.
+#[cfg(any(unix, windows))]
+fn bootstrap_dev_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
+    #[cfg(unix)]
+    let (endpoint, private_endpoint) = (dev_sidecar_endpoint(), private_dev_sidecar_endpoint());
+    #[cfg(windows)]
+    let (endpoint, private_endpoint) = (dev_sidecar_endpoint()?, private_dev_sidecar_endpoint()?);
+    let metadata_path = dev_sidecar_metadata_path();
+    let binary_hash = hash_sidecar_binary(sidecar_path)?;
+
+    // Whatever is already on the endpoint decides how we proceed. The one thing we
+    // never do is kill it: on this path the peer is by definition NOT our child, so
+    // the only PID available would be the one it reports about itself -- the
+    // arbitrary-process-kill primitive `force_kill_sidecar` used to be. When we cannot
+    // reclaim the endpoint we move to a private one instead, so a stale or foreign
+    // holder is routed around rather than blocking the launch.
+    let mut endpoint = endpoint;
+    match try_connect_dev_sidecar(&endpoint) {
+        Ok(Some((reader, writer, info)))
+            if info.protocol_version == SIDECAR_PROTOCOL_VERSION
+                && info.binary_hash == binary_hash =>
+        {
+            write_sidecar_metadata(&metadata_path, &endpoint, &binary_hash)?;
+            return Ok(SidecarBootstrap {
+                child: None,
+                reader,
+                writer,
+            });
+        }
+        // Ours, but a stale build or protocol. Ask it to go; if it ignores us, leave
+        // it holding the path.
+        Ok(Some(_)) => {
+            if !request_sidecar_shutdown(&endpoint) {
+                endpoint = private_endpoint;
+            }
+        }
+        // Nothing is listening: the endpoint is ours to take.
+        Ok(None) => {}
+        // Unreachable or answered by another user (see require_same_user_peer). Their
+        // socket is not ours to unlink -- /tmp is sticky -- so binding here would just
+        // fail. Take a private endpoint.
+        Err(err) => {
+            eprintln!("leapmux: cannot use dev sidecar endpoint {endpoint}: {err}");
+            endpoint = private_endpoint;
+        }
+    }
+    cleanup_dev_sidecar_artifacts(&endpoint, &metadata_path);
+
+    let mut command = Command::new(sidecar_path);
+    command
+        .env(ENV_DEV_ENDPOINT, &endpoint)
+        .env(ENV_BINARY_HASH, &binary_hash)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    let child = command
+        .spawn()
+        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
+
+    let start = Instant::now();
+    loop {
+        match try_connect_dev_sidecar(&endpoint) {
+            Ok(Some((reader, writer, info))) => {
+                if info.protocol_version != *SIDECAR_PROTOCOL_VERSION {
+                    return Err(format!(
+                        "unexpected sidecar protocol version: {}",
+                        info.protocol_version,
+                    ));
+                }
+                if info.binary_hash != binary_hash {
+                    return Err("spawned sidecar reported an unexpected binary hash".to_string());
+                }
+                write_sidecar_metadata(&metadata_path, &endpoint, &binary_hash)?;
+                return Ok(SidecarBootstrap {
+                    child: Some(child),
+                    reader,
+                    writer,
+                });
+            }
+            Ok(None) => {}
+            Err(err) => return Err(err),
+        }
+
+        if start.elapsed() > DEV_SIDECAR_CONNECT_TIMEOUT {
+            return Err("timed out waiting for desktop sidecar endpoint".to_string());
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn spawn_stdio_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String> {
+    let mut command = Command::new(sidecar_path);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("spawn desktop sidecar: {err}"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "desktop sidecar stdin unavailable".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "desktop sidecar stdout unavailable".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "desktop sidecar stderr unavailable".to_string())?;
+    start_sidecar_stderr_thread(stderr);
+    Ok(SidecarBootstrap {
+        child: Some(child),
+        reader: Box::new(stdout),
+        writer: Box::new(BufWriter::new(stdin)),
+    })
+}
+
+fn start_sidecar_stderr_thread(stderr: impl Read + Send + 'static) {
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            eprintln!("desktop-sidecar: {line}");
+        }
+    });
+}
+
+type DevSidecarConnection = (
+    Box<dyn Read + Send>,
+    Box<dyn Write + Send>,
+    proto::SidecarInfo,
+);
+
+fn try_connect_dev_sidecar(endpoint: &str) -> Result<Option<DevSidecarConnection>, String> {
+    match connect_and_handshake_dev_sidecar(endpoint)? {
+        Some((reader, writer, info)) => Ok(Some((
+            Box::new(reader),
+            Box::new(BufWriter::new(writer)),
+            info,
+        ))),
+        None => Ok(None),
+    }
+}
+
+// The unix handshake runs the GetSidecarInfo exchange synchronously over the
+// connected socket. The Windows twin (overlapped-I/O named pipe, raced against
+// a handshake timeout) lives in `windows_impl` and is re-exported into the
+// crate root for this module to call.
+#[cfg(unix)]
+pub(crate) fn connect_and_handshake_dev_sidecar(
+    endpoint: &str,
+) -> Result<Option<(SidecarReader, SidecarWriter, proto::SidecarInfo)>, String> {
+    let (mut reader, mut writer) = match connect_sidecar_endpoint(endpoint)? {
+        Some(pair) => pair,
+        None => return Ok(None),
+    };
+    let info = fetch_sidecar_info(&mut reader, &mut writer)?;
+    finalize_sidecar_streams(&reader, &writer)?;
+    Ok(Some((reader, writer, info)))
+}
+
+/// Asks whatever is listening on `endpoint` to shut down, and reports whether it
+/// actually went away.
+///
+/// It deliberately does NOT force-kill. This runs on the path where the peer
+/// reported a protocol/binary mismatch, which means it is emphatically *not* this
+/// shell's child -- so the only PID available is the one the peer reported over the
+/// socket about itself. Trusting that made this an arbitrary-process-kill
+/// primitive running at the developer's uid: anything able to answer on the
+/// endpoint (the dev socket lives at a predictable path) could name any PID it
+/// liked and have the shell SIGTERM then SIGKILL it. A stale sidecar that ignores
+/// a cooperative shutdown is a dev-box annoyance; killing an arbitrary process is
+/// not an acceptable way to resolve it.
+fn request_sidecar_shutdown(endpoint: &str) -> bool {
+    if let Ok(Some((mut reader, mut writer))) = connect_sidecar_endpoint(endpoint) {
+        let frame = proto::Frame {
+            message: Some(proto::frame::Message::Request(proto::Request {
+                id: 1,
+                method: Some(proto::request::Method::Shutdown(proto::ShutdownRequest {})),
+            })),
+        };
+        let _ = write_frame(&mut writer, &frame);
+        let _ = read_frame(&mut reader);
+    }
+
+    let deadline = Instant::now() + DEV_SIDECAR_SHUTDOWN_TIMEOUT;
+    while Instant::now() < deadline {
+        if is_sidecar_gone(endpoint) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    // Name the KERNEL-verified holder pid so the developer can stop it by hand.
+    // We deliberately do NOT kill it: adopting/killing on a self-reported
+    // identity is the arbitrary-process-kill primitive this shell gave up (see
+    // above). The kernel pid is trustworthy (unlike a wire-reported one) but is
+    // used only to make this message actionable.
+    let holder = match endpoint_holder_pid(endpoint) {
+        Some(pid) => format!("process {pid}"),
+        None => "an unidentified process".to_string(),
+    };
+    eprintln!(
+        "leapmux: a sidecar ({holder}) is holding {endpoint} and did not shut down \
+         when asked; starting on a private endpoint instead. Stop it manually if it \
+         should not be running -- in SOLO mode it also holds the shared DB's runtime \
+         lease, so ConnectSolo will keep failing until it is gone (a launcher-mode \
+         orphan only costs the sidecar-reuse optimisation)."
+    );
+    false
+}
+
+#[cfg(unix)]
+fn fetch_sidecar_info(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+) -> Result<proto::SidecarInfo, String> {
+    let frame = proto::Frame {
+        message: Some(proto::frame::Message::Request(proto::Request {
+            id: 1,
+            method: Some(get_sidecar_info_request()),
+        })),
+    };
+    write_frame(writer, &frame).map_err(|err| format!("request sidecar info: {err}"))?;
+    let frame = read_frame(reader).map_err(|err| format!("read sidecar info: {err}"))?;
+    let resp = match frame.message {
+        Some(proto::frame::Message::Response(resp)) => resp,
+        _ => return Err("unexpected frame while reading sidecar info".to_string()),
+    };
+    sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")
+}
+
+pub(crate) fn write_sidecar_metadata(
+    metadata_path: &Path,
+    endpoint: &str,
+    binary_hash: &str,
+) -> Result<(), String> {
+    let metadata = SidecarMetadata {
+        endpoint: endpoint.to_string(),
+        binary_hash: binary_hash.to_string(),
+        protocol_version: SIDECAR_PROTOCOL_VERSION.to_string(),
+    };
+    if let Some(parent) = metadata_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| format!("create sidecar metadata dir: {err}"))?;
+        restrict_dir_permissions(parent)?;
+    }
+    let data = serde_json::to_vec_pretty(&metadata)
+        .map_err(|err| format!("serialize sidecar metadata: {err}"))?;
+    fs::write(metadata_path, data).map_err(|err| format!("write sidecar metadata: {err}"))?;
+    restrict_file_permissions(metadata_path)?;
+    Ok(())
+}
+
+fn hash_sidecar_binary(sidecar_path: &Path) -> Result<String, String> {
+    let file = fs::File::open(sidecar_path)
+        .map_err(|err| format!("read desktop sidecar binary: {err}"))?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .map_err(|err| format!("read desktop sidecar binary: {err}"))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest = hasher.finalize();
+    Ok(digest.iter().map(|b| format!("{:02x}", b)).collect())
+}

--- a/desktop/rust/src/sidecar_ipc/mod.rs
+++ b/desktop/rust/src/sidecar_ipc/mod.rs
@@ -13,13 +13,42 @@
 //! Distinct from the frame-codec module (`frame.rs`, #282): this layer sits
 //! BELOW the wire format and is consumed by it only through the reader/writer
 //! halves `connect_sidecar_endpoint` returns.
+//!
+//! Only the items re-exported below are part of the contract `main.rs` (and its
+//! tests) depend on. Internal helpers -- `open_named_pipe_client`/`PipeConnect`
+//! and the raw SID/token Win32 wrappers on Windows, the libc `socket_peer_*`
+//! building blocks on Unix -- stay module-private so a future connect path
+//! cannot reach past the SID-checking seam the way the handshake once did.
 
 #[cfg(unix)]
 mod unix;
 #[cfg(windows)]
 mod windows;
 
+// The connect/handshake/bootstrap surface main.rs uses in production.
 #[cfg(unix)]
-pub(crate) use unix::*;
+pub(crate) use unix::{
+    cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, dev_sidecar_endpoint,
+    dev_sidecar_metadata_path, endpoint_holder_pid, finalize_sidecar_streams, is_sidecar_gone,
+    private_dev_sidecar_endpoint, restrict_dir_permissions, restrict_file_permissions,
+    SidecarReader, SidecarWriter,
+};
 #[cfg(windows)]
-pub(crate) use windows::*;
+pub(crate) use windows::{
+    cleanup_dev_sidecar_artifacts, connect_sidecar_endpoint, connect_sidecar_endpoint_async,
+    dev_sidecar_endpoint, dev_sidecar_metadata_path, endpoint_holder_pid, is_sidecar_gone,
+    pipe_runtime, private_dev_sidecar_endpoint, restrict_dir_permissions,
+    restrict_file_permissions, SidecarReader, SidecarWriter, SyncPipeReader, SyncPipeWriter,
+};
+
+// Peer-credential / identity primitives the sidecar-IPC tests drive directly
+// (binding as another user needs root/admin, so the refusal branch is otherwise
+// reachable only in production). Production paths reach these through the
+// transport layer, not these imports.
+#[cfg(all(unix, test))]
+pub(crate) use unix::{require_peer_uid, require_same_user_peer, socket_peer_pid, socket_peer_uid};
+#[cfg(all(windows, test))]
+pub(crate) use windows::{
+    dev_sidecar_metadata_path_in, require_peer_sid, require_same_user_pipe_peer,
+    sanitize_sid_for_pipe, sidecar_identity,
+};

--- a/desktop/rust/src/sidecar_ipc/mod.rs
+++ b/desktop/rust/src/sidecar_ipc/mod.rs
@@ -1,0 +1,25 @@
+//! Platform-specific sidecar IPC transport.
+//!
+//! The desktop shell talks to its sidecar over one of two kernel transports:
+//! a Unix domain socket (`unix.rs`) or a Windows named pipe (`windows.rs`).
+//! Each platform exposes the SAME surface -- `connect_sidecar_endpoint`,
+//! `is_sidecar_gone`, `endpoint_holder_pid`, the dev-endpoint helpers, and the
+//! peer-credential checks -- so the connect/handshake/bootstrap logic in
+//! `main.rs` is platform-agnostic. The two implementations live as siblings so
+//! they are diffable side-by-side, which is exactly what mitigates the drift
+//! risk of maintaining cfg-gated twins.
+//!
+//! Extracted from `main.rs` in <https://github.com/leapmux/leapmux/issues/296>.
+//! Distinct from the frame-codec module (`frame.rs`, #282): this layer sits
+//! BELOW the wire format and is consumed by it only through the reader/writer
+//! halves `connect_sidecar_endpoint` returns.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+pub(crate) use unix::*;
+#[cfg(windows)]
+pub(crate) use windows::*;

--- a/desktop/rust/src/sidecar_ipc/unix.rs
+++ b/desktop/rust/src/sidecar_ipc/unix.rs
@@ -1,0 +1,314 @@
+//! Unix-domain-socket sidecar IPC transport.
+//!
+//! The dev sidecar endpoint is a per-user socket at a predictable path. Matching
+//! pairs below mirror `windows.rs` so the two OS implementations are diffable
+//! side-by-side.
+
+use std::io;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+
+use crate::DEV_SIDECAR_HANDSHAKE_TIMEOUT;
+
+#[cfg(unix)]
+pub(crate) type SidecarReader = UnixStream;
+#[cfg(unix)]
+pub(crate) type SidecarWriter = UnixStream;
+
+/// A dev sidecar endpoint private to THIS shell process.
+///
+/// The shared per-user endpoint is what lets a dev reload reuse a running sidecar, so
+/// it is the default. But it is only a cache: when it cannot be reclaimed -- a wedged
+/// leftover that ignores a cooperative shutdown, or another user's socket -- the
+/// launch must still succeed. Suffixing our own PID gives a path nothing else holds,
+/// so a fresh sidecar always starts. In LAUNCHER mode a single unkillable orphan then
+/// costs only the reuse optimisation. In SOLO mode it costs more: the orphan also
+/// holds the shared user-data DB's runtime lease, so the fresh sidecar's ConnectSolo
+/// fails against the locked DB until the orphan is stopped by hand (surfaced by the
+/// `request_sidecar_shutdown` diagnostic, which names the kernel-verified holder pid).
+///
+/// The previous behaviour, aborting the launch, made one leftover from a SIGKILLed
+/// `task test-e2e` run block every subsequent `task dev` until the dev hunted it down
+/// by hand.
+#[cfg(unix)]
+pub(crate) fn private_dev_sidecar_endpoint() -> String {
+    dev_sidecar_runtime_dir()
+        .join(format!(
+            "{}-sidecar-{}.sock",
+            sidecar_identity(),
+            std::process::id()
+        ))
+        .display()
+        .to_string()
+}
+
+#[cfg(unix)]
+/// Refuses a dev sidecar socket answered by anyone but this user.
+///
+/// Everything downstream of the connect trusts the peer on its own word: the shell
+/// adopts whatever answers here as its sidecar if it self-reports a matching protocol
+/// version and binary hash — and a hash is exactly as forgeable as the PID that
+/// `force_kill_sidecar` used to trust before it was deleted for that reason. The
+/// endpoint sits at a predictable path (the shell derives it from
+/// `std::env::temp_dir()`), so "whoever bound it first" is not an authorization.
+///
+/// The Go side hardens the *bind* (see `requirePrivateDir` in
+/// desktop/go/socket_unix.go, which refuses a socket dir it does not own): this is
+/// the same boundary from the connect side, and it must be checked here too, because
+/// an honest sidecar refusing to bind a squatted directory does nothing to stop this
+/// shell from connecting to whatever a squatter bound instead.
+///
+/// `peer_cred` reads the credentials the KERNEL recorded for the peer, so unlike the
+/// hash it is not something the peer can assert. Dev-only, like the endpoint itself:
+/// a bundled build spawns its own child over stdio pipes and never comes here.
+#[cfg(unix)]
+pub(crate) fn require_same_user_peer(stream: &UnixStream, endpoint: &str) -> Result<(), String> {
+    require_peer_uid(
+        socket_peer_uid(stream)?,
+        unsafe { libc::getuid() },
+        endpoint,
+    )
+}
+
+/// The refusal decision itself, split from the socket so it can be tested against a
+/// foreign uid — binding a socket as another user needs root, so the branch that
+/// actually matters here is otherwise reachable only in production.
+#[cfg(unix)]
+pub(crate) fn require_peer_uid(peer_uid: u32, our_uid: u32, endpoint: &str) -> Result<(), String> {
+    if peer_uid != our_uid {
+        return Err(format!(
+            "refusing sidecar at {endpoint}: it is answered by uid {peer_uid}, not {our_uid}; \
+             something else is holding this endpoint"
+        ));
+    }
+    Ok(())
+}
+
+/// Reads the peer's uid from a connected Unix socket.
+///
+/// std's `UnixStream::peer_cred` is still unstable, so this goes to libc. The two
+/// families expose the same fact through different calls: Linux via the `SO_PEERCRED`
+/// socket option, macOS/BSD via `getpeereid(3)`.
+#[cfg(all(unix, target_os = "linux"))]
+pub(crate) fn socket_peer_uid(stream: &UnixStream) -> Result<u32, String> {
+    use std::os::fd::AsRawFd;
+
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: `cred` and `len` are live, correctly sized, and only written by the
+    // kernel on success; the fd is owned by `stream` for the duration of the call.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            std::ptr::from_mut(&mut cred).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(format!(
+            "read sidecar socket peer credentials: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    Ok(cred.uid)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) fn socket_peer_uid(stream: &UnixStream) -> Result<u32, String> {
+    use std::os::fd::AsRawFd;
+
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    // SAFETY: both out-params are live for the call and only written on success; the
+    // fd is owned by `stream` for the duration.
+    let rc = unsafe { libc::getpeereid(stream.as_raw_fd(), &mut uid, &mut gid) };
+    if rc != 0 {
+        return Err(format!(
+            "read sidecar socket peer credentials: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    Ok(uid)
+}
+
+/// The KERNEL-recorded pid of the socket peer -- the process actually on the
+/// other end, not a pid it reported about itself over the wire. Used only to
+/// make the "an orphan is holding the endpoint" diagnostic actionable
+/// (`request_sidecar_shutdown`); it is NOT an authorization signal and nothing
+/// is killed by it. Linux reads it from the `SO_PEERCRED` ucred whose uid we
+/// already consult; macOS/BSD from `LOCAL_PEERPID`. Returns None on any error
+/// rather than failing the caller: a missing pid only weakens a log line.
+#[cfg(all(unix, target_os = "linux"))]
+pub(crate) fn socket_peer_pid(stream: &UnixStream) -> Option<u32> {
+    use std::os::fd::AsRawFd;
+
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: as in socket_peer_uid -- kernel writes `cred`/`len` on success; the
+    // fd is owned by `stream` for the call.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            std::ptr::from_mut(&mut cred).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    if rc != 0 || cred.pid <= 0 {
+        return None;
+    }
+    Some(cred.pid as u32)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) fn socket_peer_pid(stream: &UnixStream) -> Option<u32> {
+    use std::os::fd::AsRawFd;
+
+    let mut pid: libc::pid_t = 0;
+    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    // SAFETY: `pid`/`len` are live for the call and only written on success; the fd
+    // is owned by `stream`. LOCAL_PEERPID reports the kernel-recorded peer pid.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            std::ptr::from_mut(&mut pid).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    if rc != 0 || pid <= 0 {
+        return None;
+    }
+    Some(pid as u32)
+}
+
+/// The kernel-verified pid holding `endpoint`, for diagnostics only (see
+/// socket_peer_pid). On unix it opens a throwaway connection and reads the
+/// peer pid; on Windows it does the same through `GetNamedPipeServerProcessId`
+/// on a freshly opened client handle.
+#[cfg(unix)]
+pub(crate) fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
+    let stream = UnixStream::connect(endpoint).ok()?;
+    socket_peer_pid(&stream)
+}
+
+// The sidecar-IPC layer exists as per-platform twins (unix socket vs Windows
+// named pipe) grouped here and in windows.rs so the two OS implementations are
+// diffable side-by-side. See https://github.com/leapmux/leapmux/issues/296
+// (distinct from the frame-codec extraction in #282).
+#[cfg(unix)]
+pub(crate) fn connect_sidecar_endpoint(
+    endpoint: &str,
+) -> Result<Option<(SidecarReader, SidecarWriter)>, String> {
+    let stream = match UnixStream::connect(endpoint) {
+        Ok(stream) => stream,
+        Err(err)
+            if err.kind() == io::ErrorKind::NotFound
+                || err.kind() == io::ErrorKind::ConnectionRefused =>
+        {
+            return Ok(None);
+        }
+        Err(err) => return Err(format!("connect desktop sidecar socket: {err}")),
+    };
+    require_same_user_peer(&stream, endpoint)?;
+    let reader = stream
+        .try_clone()
+        .map_err(|err| format!("clone sidecar socket: {err}"))?;
+    let writer = stream;
+    writer
+        .set_write_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
+        .map_err(|err| format!("set sidecar socket write timeout: {err}"))?;
+    reader
+        .set_read_timeout(Some(DEV_SIDECAR_HANDSHAKE_TIMEOUT))
+        .map_err(|err| format!("set sidecar socket read timeout: {err}"))?;
+    Ok(Some((reader, writer)))
+}
+
+// Handshake timeouts must be cleared before streams are handed to the
+// long-lived reader thread; otherwise reads fail with EAGAIN after a few
+// seconds of idle and tear the connection down.
+#[cfg(unix)]
+pub(crate) fn finalize_sidecar_streams(
+    reader: &SidecarReader,
+    writer: &SidecarWriter,
+) -> Result<(), String> {
+    reader
+        .set_read_timeout(None)
+        .map_err(|err| format!("clear sidecar socket read timeout: {err}"))?;
+    writer
+        .set_write_timeout(None)
+        .map_err(|err| format!("clear sidecar socket write timeout: {err}"))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn is_sidecar_gone(endpoint: &str) -> bool {
+    !Path::new(endpoint).exists()
+}
+
+#[cfg(unix)]
+pub(crate) fn cleanup_dev_sidecar_artifacts(endpoint: &str, metadata_path: &Path) {
+    let _ = std::fs::remove_file(endpoint);
+    let _ = std::fs::remove_file(metadata_path);
+}
+
+#[cfg(unix)]
+pub(crate) fn restrict_dir_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|err| format!("set sidecar metadata dir permissions: {err}"))
+}
+
+#[cfg(unix)]
+pub(crate) fn restrict_file_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|err| format!("set sidecar metadata permissions: {err}"))
+}
+
+#[cfg(unix)]
+pub(crate) fn dev_sidecar_endpoint() -> String {
+    dev_sidecar_runtime_dir()
+        .join(format!("{}-sidecar.sock", sidecar_identity()))
+        .display()
+        .to_string()
+}
+
+#[cfg(unix)]
+pub(crate) fn dev_sidecar_metadata_path() -> PathBuf {
+    dev_sidecar_runtime_dir().join(format!("{}-sidecar.json", sidecar_identity()))
+}
+
+#[cfg(unix)]
+fn dev_sidecar_runtime_dir() -> PathBuf {
+    std::env::temp_dir().join("leapmux-desktop")
+}
+
+#[cfg(unix)]
+pub(crate) fn sidecar_identity() -> String {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<String> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .unwrap_or_else(|_| "default".to_string())
+                .chars()
+                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+                .collect()
+        })
+        .clone()
+}

--- a/desktop/rust/src/sidecar_ipc/unix.rs
+++ b/desktop/rust/src/sidecar_ipc/unix.rs
@@ -196,12 +196,22 @@ pub(crate) fn socket_peer_pid(stream: &UnixStream) -> Option<u32> {
 }
 
 /// The kernel-verified pid holding `endpoint`, for diagnostics only (see
-/// socket_peer_pid). On unix it opens a throwaway connection and reads the
-/// peer pid; on Windows it does the same through `GetNamedPipeServerProcessId`
-/// on a freshly opened client handle.
+/// socket_peer_pid). On unix it opens a throwaway connection, confirms the peer
+/// is this user, then reads the peer pid; on Windows it does the same through
+/// `GetNamedPipeServerProcessId` on a freshly opened, SID-checked client handle.
+///
+/// The same-user check mirrors the Windows twin: we only ever want the holder pid
+/// of OUR sidecar, and a foreign-user socket is not that. It runs on the throwaway
+/// stream before the pid is read, so a socket a different user squats on the dev
+/// endpoint reports no holder rather than poisoning the diagnostic with the
+/// squatter's pid. A check failure maps to `None`, identical to "no listener" --
+/// both mean the diagnostic falls back to naming no holder.
 #[cfg(unix)]
 pub(crate) fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
     let stream = UnixStream::connect(endpoint).ok()?;
+    // require_same_user_peer failing means this is not our sidecar -- report no
+    // holder rather than the squatter's pid.
+    require_same_user_peer(&stream, endpoint).ok()?;
     socket_peer_pid(&stream)
 }
 

--- a/desktop/rust/src/sidecar_ipc/windows.rs
+++ b/desktop/rust/src/sidecar_ipc/windows.rs
@@ -1,0 +1,464 @@
+//! Windows named-pipe sidecar IPC transport.
+//!
+//! The dev sidecar endpoint is a per-user named pipe. Matching pairs below
+//! mirror `unix.rs` so the two OS implementations are diffable side-by-side.
+//! This file cannot be compiled or lint-checked on a non-Windows host -- one
+//! more reason the twins deserve a dedicated, deliberately-reviewed module.
+//!
+//! Why tokio's overlapped-I/O client and not a raw CreateFileW/ReadFile/
+//! WriteFile wrapper: a named-pipe handle opened without FILE_FLAG_OVERLAPPED
+//! serializes all I/O through the FILE_OBJECT lock, even across duplicated
+//! handles. A blocked long-lived ReadFile would prevent any concurrent
+//! WriteFile from making progress and deadlock the reader/writer threads --
+//! the regression pinned by `split_halves_allow_concurrent_read_and_write`
+//! in `main.rs`.
+
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+use windows_sys::Win32::{
+    Foundation::{
+        CloseHandle, GetLastError, LocalFree, ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER,
+        ERROR_PIPE_BUSY, HANDLE, HLOCAL,
+    },
+    Security::{
+        Authorization::ConvertSidToStringSidW, EqualSid, GetLengthSid, GetTokenInformation,
+        TokenUser, PSID, TOKEN_QUERY, TOKEN_USER,
+    },
+    System::{
+        Pipes::GetNamedPipeServerProcessId,
+        Threading::{
+            GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+        },
+    },
+};
+
+pub(crate) type SidecarReader = SyncPipeReader;
+pub(crate) type SidecarWriter = SyncPipeWriter;
+
+// `new_multi_thread` with one worker is deliberate: the reader and writer
+// threads both call `block_on` on this runtime, and `current_thread` would
+// serialize them through the runtime mutex (defeating the parallelism the
+// FILE_OBJECT-lock fix exists to enable).
+#[cfg(windows)]
+pub(crate) fn pipe_runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_io()
+            .enable_time()
+            .thread_name("leapmux-named-pipe")
+            .build()
+            .expect("build named-pipe runtime")
+    })
+}
+
+#[cfg(windows)]
+pub struct SyncPipeReader {
+    pub(crate) inner: tokio::io::ReadHalf<NamedPipeClient>,
+}
+
+#[cfg(windows)]
+impl Read for SyncPipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        pipe_runtime().block_on(self.inner.read(buf))
+    }
+}
+
+#[cfg(windows)]
+pub struct SyncPipeWriter {
+    pub(crate) inner: tokio::io::WriteHalf<NamedPipeClient>,
+}
+
+#[cfg(windows)]
+impl Write for SyncPipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        pipe_runtime().block_on(self.inner.write(buf))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        pipe_runtime().block_on(self.inner.flush())
+    }
+}
+
+/// Outcome of a named-pipe connect attempt. The THREE states must stay
+/// distinct: a pipe that does not exist (`NotFound`) and a pipe whose every
+/// server instance is momentarily busy (`Busy`) are opposite facts about the
+/// sidecar's liveness -- NotFound means it is gone, Busy means it is alive and
+/// serving -- and collapsing both to "no client" (the old `Ok(None)`) let a
+/// live-but-busy sidecar read as gone during the shutdown poll, so the shell
+/// double-spawned onto an endpoint a zombie still held.
+#[cfg(windows)]
+pub(crate) enum PipeConnect {
+    Connected(NamedPipeClient),
+    NotFound,
+    Busy,
+}
+
+// ERROR_PIPE_BUSY gets a short retry loop; if every instance stays busy across
+// the retries the pipe is alive but saturated, reported as Busy (NOT NotFound).
+// ERROR_FILE_NOT_FOUND is NotFound; any other error is fatal.
+#[cfg(windows)]
+pub(crate) async fn open_named_pipe_client(pipe_name: &str) -> Result<PipeConnect, String> {
+    const MAX_BUSY_RETRIES: u32 = 3;
+    for _ in 0..=MAX_BUSY_RETRIES {
+        match ClientOptions::new().open(pipe_name) {
+            Ok(client) => return Ok(PipeConnect::Connected(client)),
+            Err(err) if err.raw_os_error() == Some(ERROR_FILE_NOT_FOUND as i32) => {
+                return Ok(PipeConnect::NotFound);
+            }
+            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+            Err(err) => return Err(format!("open named pipe {pipe_name}: {err}")),
+        }
+    }
+    // Retries exhausted while every instance was busy: alive, not gone.
+    Ok(PipeConnect::Busy)
+}
+
+#[cfg(windows)]
+pub(crate) fn is_sidecar_gone(pipe_name: &str) -> bool {
+    // ONLY NotFound means gone. A Busy pipe is a live sidecar whose instances
+    // are all in use -- reporting it gone here is exactly what let the shell
+    // abandon a healthy-but-busy sidecar mid-shutdown-poll and double-spawn.
+    pipe_runtime().block_on(async {
+        matches!(
+            open_named_pipe_client(pipe_name).await,
+            Ok(PipeConnect::NotFound)
+        )
+    })
+}
+
+/// Refuses a dev sidecar named pipe answered by anyone but this user, the
+/// Windows counterpart of the unix `connect_sidecar_endpoint`'s
+/// `require_same_user_peer`. See `require_same_user_pipe_peer` for the
+/// mechanism and the bind-side pair (`userOnlySDDL` in
+/// `backend/locallisten/locallisten_windows.go`) that hardens the *listener*
+/// the same way Unix's `requirePrivateDir` does.
+#[cfg(windows)]
+pub(crate) fn connect_sidecar_endpoint(
+    pipe_name: &str,
+) -> Result<Option<(SidecarReader, SidecarWriter)>, String> {
+    let client = match pipe_runtime().block_on(open_named_pipe_client(pipe_name))? {
+        PipeConnect::Connected(client) => client,
+        // Gone: the caller's "try again later / endpoint is free" signal.
+        PipeConnect::NotFound => return Ok(None),
+        // Alive but saturated. NOT free to take -- surfaced as an error so the
+        // bootstrap routes around it onto a private endpoint rather than
+        // colliding on an endpoint a live sidecar still holds.
+        PipeConnect::Busy => {
+            return Err(format!("named pipe {pipe_name} is busy (sidecar alive)"));
+        }
+    };
+    require_same_user_pipe_peer(&client, pipe_name)?;
+    let (r, w) = tokio::io::split(client);
+    Ok(Some((
+        SyncPipeReader { inner: r },
+        SyncPipeWriter { inner: w },
+    )))
+}
+
+/// The async twin of `connect_sidecar_endpoint`, returning the raw
+/// `NamedPipeClient` for callers that need async I/O on the client itself -- the
+/// dev-sidecar handshake (`windows_handshake_async`), which races the
+/// GetSidecarInfo exchange against `tokio::time::timeout` and so cannot use the
+/// sync `SyncPipeReader`/`SyncPipeWriter` pair its sibling returns.
+///
+/// This twin exists so the handshake routes through the transport layer instead
+/// of calling `open_named_pipe_client` directly. The point is the same-user SID
+/// check: `require_same_user_pipe_peer` MUST gate every connect that can adopt a
+/// peer as the sidecar, because everything downstream trusts the peer on its own
+/// word (protocol version + binary hash, both forgeable -- see
+/// `require_same_user_pipe_peer`). The sync `connect_sidecar_endpoint` already
+/// enforces it; before this twin existed, the handshake bypassed it, so the
+/// Windows dev-sidecar connect had NO identity check where Unix had one. The
+/// check borrows the client immutably and does no I/O (it reads the kernel-recorded
+/// server pid via `AsRawHandle`), so the returned client is fully usable for the
+/// handshake exchange that follows.
+#[cfg(windows)]
+pub(crate) async fn connect_sidecar_endpoint_async(
+    pipe_name: &str,
+) -> Result<Option<NamedPipeClient>, String> {
+    let client = match open_named_pipe_client(pipe_name).await? {
+        PipeConnect::Connected(client) => client,
+        // Gone: the caller's "try again later / endpoint is free" signal.
+        PipeConnect::NotFound => return Ok(None),
+        // Alive but saturated. NOT free to take -- surfaced as an error so the
+        // bootstrap routes around it onto a private endpoint rather than
+        // colliding on an endpoint a live sidecar still holds.
+        PipeConnect::Busy => {
+            return Err(format!("named pipe {pipe_name} is busy (sidecar alive)"));
+        }
+    };
+    require_same_user_pipe_peer(&client, pipe_name)?;
+    Ok(Some(client))
+}
+
+#[cfg(windows)]
+pub(crate) fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
+    use std::os::windows::io::AsRawHandle;
+
+    let client = pipe_runtime()
+        .block_on(open_named_pipe_client(endpoint))
+        .ok()?;
+    let client = match client {
+        PipeConnect::Connected(client) => client,
+        // No listener (or every instance busy, which we cannot query) means
+        // no pid to report -- the diagnostic falls back to naming no holder.
+        _ => return None,
+    };
+    let mut pid: u32 = 0;
+    let rc = unsafe { GetNamedPipeServerProcessId(client.as_raw_handle() as HANDLE, &mut pid) };
+    if rc == 0 || pid == 0 {
+        None
+    } else {
+        Some(pid)
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn cleanup_dev_sidecar_artifacts(_endpoint: &str, metadata_path: &Path) {
+    // Named pipes release themselves when the server closes the listener;
+    // only the metadata file persists on disk.
+    let _ = std::fs::remove_file(metadata_path);
+}
+
+#[cfg(windows)]
+pub(crate) fn restrict_dir_permissions(_: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn restrict_file_permissions(_: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+/// Windows counterpart of the unix private endpoint (see `unix.rs`'s
+/// `private_dev_sidecar_endpoint` for why a per-PID private endpoint exists at
+/// all). Named pipes carry no filesystem path, so the PID goes in the pipe name.
+#[cfg(windows)]
+pub(crate) fn private_dev_sidecar_endpoint() -> Result<String, String> {
+    Ok(format!(
+        "\\\\.\\pipe\\leapmux-desktop-{}-sidecar-{}",
+        sidecar_identity()?,
+        std::process::id()
+    ))
+}
+
+#[cfg(windows)]
+pub(crate) fn dev_sidecar_endpoint() -> Result<String, String> {
+    Ok(format!(
+        "\\\\.\\pipe\\leapmux-desktop-{}-sidecar",
+        sidecar_identity()?
+    ))
+}
+
+#[cfg(windows)]
+pub(crate) fn dev_sidecar_metadata_path() -> PathBuf {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    dev_sidecar_metadata_path_in(&base)
+}
+
+#[cfg(windows)]
+pub(crate) fn dev_sidecar_metadata_path_in(base: &Path) -> PathBuf {
+    base.join("leapmux-desktop").join("sidecar.json")
+}
+
+#[cfg(windows)]
+pub(crate) fn sanitize_sid_for_pipe(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+pub(crate) fn sidecar_identity() -> Result<String, String> {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<Result<String, String>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            current_user_sid()
+                .and_then(|bytes| sid_to_string(&bytes))
+                .map(|raw| sanitize_sid_for_pipe(&raw))
+        })
+        .clone()
+}
+
+/// The current process's user SID, copied into an owned buffer so callers can
+/// hold it past the token handle. Used both to name the per-user dev pipe
+/// (via `sidecar_identity`) and as the comparison point for the connect-side
+/// identity check (`require_same_user_pipe_peer`) -- the two callers that need
+/// to agree on what "us" means go through one place to find out.
+#[cfg(windows)]
+fn current_user_sid() -> Result<Vec<u8>, String> {
+    let mut token: HANDLE = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(format!("open process token: error {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let sid = token_user_sid(token);
+    unsafe { CloseHandle(token) };
+    sid
+}
+
+/// Renders a SID (as raw bytes) into the `S-1-5-...` string form. Wraps the
+/// `ConvertSidToStringSidW` + `LocalFree` pair so neither caller has to.
+#[cfg(windows)]
+fn sid_to_string(sid: &[u8]) -> Result<String, String> {
+    let mut sid_string_ptr: *mut u16 = std::ptr::null_mut();
+    if unsafe { ConvertSidToStringSidW(sid.as_ptr() as PSID, &mut sid_string_ptr) } == 0 {
+        return Err(format!("convert sid to string: error {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let mut len = 0;
+    while unsafe { *sid_string_ptr.add(len) } != 0 {
+        len += 1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(sid_string_ptr, len) };
+    let sid = String::from_utf16_lossy(slice);
+    unsafe { LocalFree(sid_string_ptr as HLOCAL) };
+    Ok(sid)
+}
+
+/// Queries `TokenUser` out of a token handle and returns the SID it points to,
+/// copied into an owned buffer.
+///
+/// `GetTokenInformation` writes a `TOKEN_USER` whose `User.Sid` points *into*
+/// the same buffer, so the SID borrows from it; copying into a fresh `Vec<u8>`
+/// hands the caller a SID whose lifetime is independent of the token query.
+/// `GetLengthSid` reports the kernel's byte count for a valid SID, so the copy
+/// is exactly sized.
+///
+/// The size-probe call is EXPECTED to fail with ERROR_INSUFFICIENT_BUFFER (that
+/// is how it reports the required size in `needed`). Checking its return
+/// distinguishes that expected failure from a real one: without the check, any
+/// other failure leaves `needed` at 0, the second call runs against an empty
+/// buffer, and the error reported below is the SECOND call's -- masking the
+/// true cause (a bad token handle, a denied query).
+#[cfg(windows)]
+fn token_user_sid(token: HANDLE) -> Result<Vec<u8>, String> {
+    let mut needed: u32 = 0;
+    if unsafe { GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed) } == 0 {
+        let probe_err = unsafe { GetLastError() };
+        if probe_err != ERROR_INSUFFICIENT_BUFFER {
+            return Err(format!("probe token user info size: error {probe_err}"));
+        }
+    }
+    let mut buffer = vec![0u8; needed as usize];
+    let ok = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr() as *mut _,
+            needed,
+            &mut needed,
+        )
+    };
+    let token_err = if ok == 0 {
+        unsafe { GetLastError() }
+    } else {
+        0
+    };
+    if ok == 0 {
+        return Err(format!("get token user info: error {token_err}"));
+    }
+    let user_info = unsafe { &*(buffer.as_ptr() as *const TOKEN_USER) };
+    let sid_ptr = user_info.User.Sid;
+    let len = unsafe { GetLengthSid(sid_ptr) } as usize;
+    if len == 0 {
+        return Err("token user sid: GetLengthSid returned 0".to_string());
+    }
+    let mut sid = vec![0u8; len];
+    unsafe { std::ptr::copy_nonoverlapping(sid_ptr as *const u8, sid.as_mut_ptr(), len) };
+    Ok(sid)
+}
+
+/// Reads the server process's user SID from a connected named-pipe client
+/// handle. The PID is the kernel's report about which process bound this pipe
+/// instance (not a value the peer asserts over the wire), and the SID is read
+/// from that PID's primary token -- so the same chain of trust as Unix's
+/// `SO_PEERCRED` / `getpeereid`: a fact the peer cannot forge.
+///
+/// `PROCESS_QUERY_LIMITED_INFORMATION` is the least-privilege access right
+/// that lets us read another process's token's user; same-user processes hold
+/// it by default, and any failure here fails closed in the caller.
+#[cfg(windows)]
+fn pipe_peer_sid(client: &NamedPipeClient) -> Result<Vec<u8>, String> {
+    use std::os::windows::io::AsRawHandle;
+
+    let mut server_pid: u32 = 0;
+    if unsafe { GetNamedPipeServerProcessId(client.as_raw_handle() as HANDLE, &mut server_pid) }
+        == 0
+    {
+        return Err(format!("query named pipe server pid: error {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, server_pid) };
+    if process.is_null() {
+        return Err(format!(
+            "open server process {server_pid}: error {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    let mut token: HANDLE = std::ptr::null_mut();
+    let token_rc = unsafe { OpenProcessToken(process, TOKEN_QUERY, &mut token) };
+    unsafe { CloseHandle(process) };
+    if token_rc == 0 {
+        return Err(format!("open server process token: error {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let sid = token_user_sid(token);
+    unsafe { CloseHandle(token) };
+    sid
+}
+
+/// The refusal decision itself, split from the pipe so it can be tested
+/// against a foreign SID -- binding a pipe as another user needs admin, so the
+/// branch that actually matters here is otherwise reachable only in production.
+/// Mirrors `require_peer_uid` on Unix.
+#[cfg(windows)]
+pub(crate) fn require_peer_sid(peer: &[u8], ours: &[u8], pipe_name: &str) -> Result<(), String> {
+    // EqualSid is the canonical Win32 SID comparison; it returns FALSE for
+    // unequal SIDs (different lengths or different bytes), so a peer whose SID
+    // differs in any way is a clean refusal rather than a panic.
+    let equal = unsafe { EqualSid(peer.as_ptr() as PSID, ours.as_ptr() as PSID) } != 0;
+    if !equal {
+        return Err(format!(
+            "refusing sidecar at {pipe_name}: it is answered by a different user; \
+             something else is holding this endpoint"
+        ));
+    }
+    Ok(())
+}
+
+/// Refuses a dev sidecar named pipe answered by anyone but this user. Windows
+/// counterpart of Unix's `require_same_user_peer`; see that function for why
+/// the connect side must check this even though the Go side already restricts
+/// the bind to our SID (via `userOnlySDDL` in locallisten_windows.go).
+#[cfg(windows)]
+pub(crate) fn require_same_user_pipe_peer(
+    client: &NamedPipeClient,
+    pipe_name: &str,
+) -> Result<(), String> {
+    let peer_sid = pipe_peer_sid(client)?;
+    let our_sid = current_user_sid()?;
+    require_peer_sid(&peer_sid, &our_sid, pipe_name)
+}

--- a/desktop/rust/src/sidecar_ipc/windows.rs
+++ b/desktop/rust/src/sidecar_ipc/windows.rs
@@ -26,7 +26,7 @@ use windows_sys::Win32::{
     },
     Security::{
         Authorization::ConvertSidToStringSidW, EqualSid, GetLengthSid, GetTokenInformation,
-        TokenUser, PSID, TOKEN_QUERY, TOKEN_USER,
+        TokenUser, PSID, SECURITY_MAX_SID_SIZE, TOKEN_QUERY, TOKEN_USER,
     },
     System::{
         Pipes::GetNamedPipeServerProcessId,
@@ -93,7 +93,7 @@ impl Write for SyncPipeWriter {
 /// live-but-busy sidecar read as gone during the shutdown poll, so the shell
 /// double-spawned onto an endpoint a zombie still held.
 #[cfg(windows)]
-pub(crate) enum PipeConnect {
+enum PipeConnect {
     Connected(NamedPipeClient),
     NotFound,
     Busy,
@@ -103,7 +103,7 @@ pub(crate) enum PipeConnect {
 // the retries the pipe is alive but saturated, reported as Busy (NOT NotFound).
 // ERROR_FILE_NOT_FOUND is NotFound; any other error is fatal.
 #[cfg(windows)]
-pub(crate) async fn open_named_pipe_client(pipe_name: &str) -> Result<PipeConnect, String> {
+async fn open_named_pipe_client(pipe_name: &str) -> Result<PipeConnect, String> {
     const MAX_BUSY_RETRIES: u32 = 3;
     for _ in 0..=MAX_BUSY_RETRIES {
         match ClientOptions::new().open(pipe_name) {
@@ -141,22 +141,18 @@ pub(crate) fn is_sidecar_gone(pipe_name: &str) -> bool {
 /// mechanism and the bind-side pair (`userOnlySDDL` in
 /// `backend/locallisten/locallisten_windows.go`) that hardens the *listener*
 /// the same way Unix's `requirePrivateDir` does.
+///
+/// Both this and `endpoint_holder_pid` route through `connect_sidecar_endpoint_async`,
+/// the single connect+SID-check core, so the same-user check is structural rather
+/// than a convention each caller must remember.
 #[cfg(windows)]
 pub(crate) fn connect_sidecar_endpoint(
     pipe_name: &str,
 ) -> Result<Option<(SidecarReader, SidecarWriter)>, String> {
-    let client = match pipe_runtime().block_on(open_named_pipe_client(pipe_name))? {
-        PipeConnect::Connected(client) => client,
-        // Gone: the caller's "try again later / endpoint is free" signal.
-        PipeConnect::NotFound => return Ok(None),
-        // Alive but saturated. NOT free to take -- surfaced as an error so the
-        // bootstrap routes around it onto a private endpoint rather than
-        // colliding on an endpoint a live sidecar still holds.
-        PipeConnect::Busy => {
-            return Err(format!("named pipe {pipe_name} is busy (sidecar alive)"));
-        }
+    let client = match pipe_runtime().block_on(connect_sidecar_endpoint_async(pipe_name))? {
+        Some(client) => client,
+        None => return Ok(None),
     };
-    require_same_user_pipe_peer(&client, pipe_name)?;
     let (r, w) = tokio::io::split(client);
     Ok(Some((
         SyncPipeReader { inner: r },
@@ -164,23 +160,23 @@ pub(crate) fn connect_sidecar_endpoint(
     )))
 }
 
-/// The async twin of `connect_sidecar_endpoint`, returning the raw
-/// `NamedPipeClient` for callers that need async I/O on the client itself -- the
-/// dev-sidecar handshake (`windows_handshake_async`), which races the
-/// GetSidecarInfo exchange against `tokio::time::timeout` and so cannot use the
-/// sync `SyncPipeReader`/`SyncPipeWriter` pair its sibling returns.
+/// Connects `pipe_name` and verifies the server is this user (the same-user SID
+/// check), returning the raw `NamedPipeClient` for callers that need async I/O
+/// on the client itself -- the dev-sidecar handshake (`windows_handshake_async`),
+/// which races the GetSidecarInfo exchange against `tokio::time::timeout` and so
+/// cannot use the sync `SyncPipeReader`/`SyncPipeWriter` pair its sibling returns.
 ///
-/// This twin exists so the handshake routes through the transport layer instead
-/// of calling `open_named_pipe_client` directly. The point is the same-user SID
-/// check: `require_same_user_pipe_peer` MUST gate every connect that can adopt a
-/// peer as the sidecar, because everything downstream trusts the peer on its own
-/// word (protocol version + binary hash, both forgeable -- see
-/// `require_same_user_pipe_peer`). The sync `connect_sidecar_endpoint` already
-/// enforces it; before this twin existed, the handshake bypassed it, so the
-/// Windows dev-sidecar connect had NO identity check where Unix had one. The
-/// check borrows the client immutably and does no I/O (it reads the kernel-recorded
-/// server pid via `AsRawHandle`), so the returned client is fully usable for the
-/// handshake exchange that follows.
+/// This is the SINGLE connect core both `connect_sidecar_endpoint` (sync, via
+/// `pipe_runtime().block_on`) and `endpoint_holder_pid` route through, so the
+/// same-user SID check gates EVERY connect that can adopt or query a peer.
+/// Everything downstream trusts the peer on its own word (protocol version +
+/// binary hash, both forgeable -- see `require_same_user_pipe_peer`), so the
+/// check MUST be unavoidable; before this core existed, the handshake and the
+/// holder-pid diagnostic both bypassed it, so the Windows dev-sidecar connect
+/// paths had NO identity check where Unix had one. The check borrows the client
+/// immutably and does no I/O (it reads the kernel-recorded server pid via
+/// `AsRawHandle`), so the returned client is fully usable for the exchange that
+/// follows.
 #[cfg(windows)]
 pub(crate) async fn connect_sidecar_endpoint_async(
     pipe_name: &str,
@@ -204,15 +200,14 @@ pub(crate) async fn connect_sidecar_endpoint_async(
 pub(crate) fn endpoint_holder_pid(endpoint: &str) -> Option<u32> {
     use std::os::windows::io::AsRawHandle;
 
+    // Route through connect_sidecar_endpoint_async so the same-user SID check
+    // gates this path too: we only ever want the holder pid of OUR sidecar, and
+    // a foreign-user pipe is not that. Gone (NotFound) and busy/unreadable
+    // (Err) both mean no pid to report -- the diagnostic falls back to naming
+    // no holder.
     let client = pipe_runtime()
-        .block_on(open_named_pipe_client(endpoint))
-        .ok()?;
-    let client = match client {
-        PipeConnect::Connected(client) => client,
-        // No listener (or every instance busy, which we cannot query) means
-        // no pid to report -- the diagnostic falls back to naming no holder.
-        _ => return None,
-    };
+        .block_on(connect_sidecar_endpoint_async(endpoint))
+        .ok()??;
     let mut pid: u32 = 0;
     let rc = unsafe { GetNamedPipeServerProcessId(client.as_raw_handle() as HANDLE, &mut pid) };
     if rc == 0 || pid == 0 {
@@ -303,17 +298,29 @@ pub(crate) fn sidecar_identity() -> Result<String, String> {
 /// (via `sidecar_identity`) and as the comparison point for the connect-side
 /// identity check (`require_same_user_pipe_peer`) -- the two callers that need
 /// to agree on what "us" means go through one place to find out.
+///
+/// The SID is constant for the process's lifetime, so the first successful read
+/// is cached and reused. `require_same_user_pipe_peer` runs on the dev-sidecar
+/// connect path, which the bootstrap polls every 100ms while waiting for the
+/// sidecar to bind (up to `DEV_SIDECAR_CONNECT_TIMEOUT`); an uncached read would
+/// re-open and re-query our own process token on every iteration.
 #[cfg(windows)]
 fn current_user_sid() -> Result<Vec<u8>, String> {
-    let mut token: HANDLE = std::ptr::null_mut();
-    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
-        return Err(format!("open process token: error {}", unsafe {
-            GetLastError()
-        }));
-    }
-    let sid = token_user_sid(token);
-    unsafe { CloseHandle(token) };
-    sid
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<Result<Vec<u8>, String>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            let mut token: HANDLE = std::ptr::null_mut();
+            if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+                return Err(format!("open process token: error {}", unsafe {
+                    GetLastError()
+                }));
+            }
+            let sid = token_user_sid(token);
+            unsafe { CloseHandle(token) };
+            sid
+        })
+        .clone()
 }
 
 /// Renders a SID (as raw bytes) into the `S-1-5-...` string form. Wraps the
@@ -383,6 +390,18 @@ fn token_user_sid(token: HANDLE) -> Result<Vec<u8>, String> {
     let len = unsafe { GetLengthSid(sid_ptr) } as usize;
     if len == 0 {
         return Err("token user sid: GetLengthSid returned 0".to_string());
+    }
+    // Cap the allocation off the SDK's own SID ceiling. SECURITY_MAX_SID_SIZE (68)
+    // is the maximum byte length of any valid SID the kernel ever produces, so 4x
+    // it is far above any legitimate SID and far below a dangerous allocation.
+    // GetLengthSid reads kernel-recorded data for a valid SID, but this whole chain
+    // is reached on the connect path off a peer-controlled pipe name, so a
+    // malformed/huge length must fail closed rather than drive a multi-GiB vec!.
+    const MAX_SID_BYTES: usize = SECURITY_MAX_SID_SIZE as usize * 4;
+    if len > MAX_SID_BYTES {
+        return Err(format!(
+            "token user sid: GetLengthSid returned {len} bytes (max {MAX_SID_BYTES})"
+        ));
     }
     let mut sid = vec![0u8; len];
     unsafe { std::ptr::copy_nonoverlapping(sid_ptr as *const u8, sid.as_mut_ptr(), len) };

--- a/desktop/rust/src/windows_impl.rs
+++ b/desktop/rust/src/windows_impl.rs
@@ -1,0 +1,433 @@
+//! Windows-only dev-sidecar connect + handshake, plus its tests.
+//!
+//! Extracted from `main.rs` so the windows-only imports (`NamedPipeClient`,
+//! `ClientOptions`, `AsyncReadExt`, `NamedPipeServer`/`ServerOptions` in tests)
+//! live next to the code that uses them. A module-level `#[cfg(windows)]` gate
+//! (see `main.rs: mod windows_impl`) replaces the per-import `#[cfg]` attributes
+//! the inline version needed -- the next windows-only import added here is
+//! windows-gated automatically, instead of compiling silently on a macOS dev
+//! host and failing on Windows CI (the trap the original extraction hit).
+
+use tokio::net::windows::named_pipe::NamedPipeClient;
+
+use crate::frame::{read_frame_async, write_frame_async};
+use crate::proto;
+use crate::sidecar_ipc::{
+    connect_sidecar_endpoint_async, pipe_runtime, SyncPipeReader, SyncPipeWriter,
+};
+use crate::{
+    check_response, get_sidecar_info_request, sidecar_info_from_response, SidecarReader,
+    SidecarWriter, DEV_SIDECAR_HANDSHAKE_TIMEOUT,
+};
+
+/// The Windows twin of the unix `connect_and_handshake_dev_sidecar`. Runs the
+/// handshake inside the named-pipe runtime so `tokio::time::timeout` can register
+/// with its timer driver, then splits the client into the sync reader/writer pair
+/// the bootstrap hands to its reader/writer threads.
+pub(crate) fn connect_and_handshake_dev_sidecar(
+    endpoint: &str,
+) -> Result<Option<(SidecarReader, SidecarWriter, proto::SidecarInfo)>, String> {
+    // `tokio::time::timeout(...)` must be constructed inside a runtime
+    // context so its `Sleep` can register with the timer driver, so the
+    // async block stays.
+    let result = pipe_runtime()
+        .block_on(async {
+            tokio::time::timeout(
+                DEV_SIDECAR_HANDSHAKE_TIMEOUT,
+                windows_handshake_async(endpoint),
+            )
+            .await
+        })
+        .map_err(|_| {
+            format!(
+                "named-pipe handshake timed out after {:?}",
+                DEV_SIDECAR_HANDSHAKE_TIMEOUT
+            )
+        })??;
+    let (client, info) = match result {
+        Some(pair) => pair,
+        None => return Ok(None),
+    };
+    let (r, w) = tokio::io::split(client);
+    Ok(Some((
+        SyncPipeReader { inner: r },
+        SyncPipeWriter { inner: w },
+        info,
+    )))
+}
+
+/// Connects `pipe_name` (through the transport layer so the same-user SID check
+/// gates it -- see `connect_sidecar_endpoint_async`) and runs the GetSidecarInfo
+/// exchange. Only the handshake itself is async, because it races against
+/// `tokio::time::timeout`.
+async fn windows_handshake_async(
+    pipe_name: &str,
+) -> Result<Option<(NamedPipeClient, proto::SidecarInfo)>, String> {
+    let mut client = match connect_sidecar_endpoint_async(pipe_name).await? {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+    let request = proto::Frame {
+        message: Some(proto::frame::Message::Request(proto::Request {
+            id: 1,
+            method: Some(get_sidecar_info_request()),
+        })),
+    };
+    write_frame_async(&mut client, &request)
+        .await
+        .map_err(|err| format!("request sidecar info: {err}"))?;
+    let frame = read_frame_async(&mut client)
+        .await
+        .map_err(|err| format!("read sidecar info: {err}"))?;
+    let resp = match frame.message {
+        Some(proto::frame::Message::Response(resp)) => resp,
+        _ => return Err("unexpected frame while reading sidecar info".to_string()),
+    };
+    let info = sidecar_info_from_response(check_response(resp)?, "get_sidecar_info")?;
+    Ok(Some((client, info)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::{
+        get_sidecar_info_request, read_frame, read_frame_async, write_frame, write_frame_async,
+    };
+    use crate::sidecar_ipc::{
+        connect_sidecar_endpoint, dev_sidecar_endpoint, dev_sidecar_metadata_path_in,
+        endpoint_holder_pid, is_sidecar_gone, require_peer_sid, require_same_user_pipe_peer,
+        sanitize_sid_for_pipe, sidecar_identity,
+    };
+    use crate::tests::sidecar_info;
+    use crate::{write_sidecar_metadata, SIDECAR_PROTOCOL_VERSION};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
+    use std::time::{Duration, Instant, SystemTime};
+
+    use tokio::io::AsyncReadExt;
+    use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_test_pipe_name() -> String {
+        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let nanos = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let pid = std::process::id();
+        format!("\\\\.\\pipe\\leapmux-test-{pid}-{nanos}-{counter}")
+    }
+
+    // `ServerOptions::create` must run inside the pipe runtime so the new
+    // NamedPipeServer registers with the right I/O driver.
+    fn start_test_pipe_server(pipe_name: &str) -> NamedPipeServer {
+        pipe_runtime().block_on(async {
+            ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(pipe_name)
+                .expect("create named pipe server")
+        })
+    }
+
+    fn spawn_fake_sidecar_pipe(pipe_name: String) -> thread::JoinHandle<()> {
+        let server = start_test_pipe_server(&pipe_name);
+        thread::spawn(move || {
+            pipe_runtime().block_on(async move {
+                let mut server = server;
+                server.connect().await.expect("connect named pipe");
+                let _ = read_frame_async(&mut server)
+                    .await
+                    .expect("read handshake request");
+                let mut info = sidecar_info(proto::SidecarShellMode::Unspecified, false, "");
+                info.pid = std::process::id() as i64;
+                let response = proto::Frame {
+                    message: Some(proto::frame::Message::Response(proto::Response {
+                        id: 1,
+                        error: String::new(),
+                        result: Some(proto::response::Result::SidecarInfo(info)),
+                    })),
+                };
+                write_frame_async(&mut server, &response)
+                    .await
+                    .expect("write handshake response");
+                // Wait for the client to drop the connection.
+                let mut scratch = [0u8; 1];
+                let _ = server.read(&mut scratch).await;
+            });
+        })
+    }
+
+    #[test]
+    fn connect_and_handshake_pipe_returns_sidecar_info() {
+        let pipe_name = unique_test_pipe_name();
+        let server = spawn_fake_sidecar_pipe(pipe_name.clone());
+
+        let (reader, writer, info) = connect_and_handshake_dev_sidecar(&pipe_name)
+            .expect("handshake ok")
+            .expect("server present");
+
+        assert_eq!(info.protocol_version, SIDECAR_PROTOCOL_VERSION);
+        assert_eq!(info.binary_hash, "test-hash");
+        assert_eq!(info.pid as u32, std::process::id());
+
+        drop(reader);
+        drop(writer);
+        server.join().expect("fake sidecar thread");
+    }
+
+    #[test]
+    fn connect_returns_none_when_pipe_absent() {
+        let pipe_name = unique_test_pipe_name();
+        let result = connect_sidecar_endpoint(&pipe_name).expect("no error");
+        assert!(
+            result.is_none(),
+            "expected None for nonexistent pipe, got Some"
+        );
+    }
+
+    #[test]
+    fn handshake_timeout_surfaces_when_server_never_replies() {
+        let pipe_name = unique_test_pipe_name();
+        // Create the server *before* spawning the accept thread, otherwise
+        // the client races and returns Ok(None) (pipe absent) before the
+        // timeout fires.
+        let server = start_test_pipe_server(&pipe_name);
+        let server_thread = thread::spawn(move || {
+            pipe_runtime().block_on(async move {
+                let _ = server.connect().await;
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            });
+        });
+
+        let start = Instant::now();
+        let result = pipe_runtime().block_on(async {
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                windows_handshake_async(&pipe_name),
+            )
+            .await
+        });
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "expected handshake to time out");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "timeout should fire quickly, elapsed {:?}",
+            elapsed
+        );
+
+        let _ = server_thread.join();
+    }
+
+    // Regression test for the FILE_OBJECT-lock deadlock that motivated the
+    // tokio overlapped-I/O switch: under the pre-fix synchronous handles +
+    // DuplicateHandle setup, the writer's WriteFile would queue behind the
+    // reader's in-flight ReadFile on the shared FILE_OBJECT and hang
+    // forever.
+    #[test]
+    fn split_halves_allow_concurrent_read_and_write() {
+        let pipe_name = unique_test_pipe_name();
+        let server = start_test_pipe_server(&pipe_name);
+        let server_thread = thread::spawn(move || {
+            pipe_runtime().block_on(async move {
+                let mut server = server;
+                server.connect().await.expect("server connect");
+                let request = read_frame_async(&mut server)
+                    .await
+                    .expect("server reads request");
+                let id = match request.message {
+                    Some(proto::frame::Message::Request(r)) => r.id,
+                    other => panic!("expected request, got {other:?}"),
+                };
+                let response = proto::Frame {
+                    message: Some(proto::frame::Message::Response(proto::Response {
+                        id,
+                        error: String::new(),
+                        result: Some(proto::response::Result::BoolValue(proto::BoolValue {
+                            value: true,
+                        })),
+                    })),
+                };
+                write_frame_async(&mut server, &response)
+                    .await
+                    .expect("server writes response");
+                let mut scratch = [0u8; 1];
+                let _ = server.read(&mut scratch).await;
+            });
+        });
+
+        let (mut reader, mut writer) = connect_sidecar_endpoint(&pipe_name)
+            .expect("connect ok")
+            .expect("server reachable");
+
+        // Park the reader on a blocking read first so the write below is
+        // *concurrent* with an in-flight read — the scenario that deadlocked
+        // under synchronous handles.
+        let (tx, rx) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            let result = read_frame(&mut reader);
+            let _ = tx.send(result);
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        let request = proto::Frame {
+            message: Some(proto::frame::Message::Request(proto::Request {
+                id: 42,
+                method: Some(get_sidecar_info_request()),
+            })),
+        };
+        write_frame(&mut writer, &request).expect("client write");
+
+        let response = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("response not received within 5s — deadlock regression?")
+            .expect("read frame");
+        match response.message {
+            Some(proto::frame::Message::Response(r)) => assert_eq!(r.id, 42),
+            other => panic!("expected response with id=42, got {other:?}"),
+        }
+
+        drop(writer);
+        server_thread.join().expect("server thread");
+    }
+
+    #[test]
+    fn is_sidecar_gone_reports_true_for_absent_pipe() {
+        let pipe_name = unique_test_pipe_name();
+        assert!(is_sidecar_gone(&pipe_name));
+    }
+
+    #[test]
+    fn is_sidecar_gone_reports_false_when_server_listening() {
+        let pipe_name = unique_test_pipe_name();
+        let _server = start_test_pipe_server(&pipe_name);
+        assert!(!is_sidecar_gone(&pipe_name));
+    }
+
+    // ---- Windows peer-identity check (the connect-side half of the boundary
+    // requirePrivateDir / userOnlySDDL defend on the bind side). Mirrors
+    // require_peer_uid_refuses_a_foreign_owner on Unix. ----
+
+    // Two minimal valid SIDs that differ only in their last sub-authority byte.
+    // S-1-5-32 (BUILTIN) and S-1-5-42 -- both 12 bytes, both well-formed, so
+    // EqualSid's behaviour is defined and FALSE rather than undefined.
+    const FOREIGN_SID_A: [u8; 12] = [
+        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x20, 0x00, 0x00, 0x00,
+    ];
+    const FOREIGN_SID_B: [u8; 12] = [
+        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x2a, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn require_peer_sid_accepts_same_sid() {
+        require_peer_sid(&FOREIGN_SID_A, &FOREIGN_SID_A, "\\\\?\\pipe\\test")
+            .expect("same SID is accepted");
+    }
+
+    #[test]
+    fn require_peer_sid_refuses_a_foreign_sid() {
+        let err = require_peer_sid(&FOREIGN_SID_A, &FOREIGN_SID_B, "\\\\?\\pipe\\test")
+            .expect_err("a pipe answered by another SID must be refused");
+        assert!(err.contains("refusing sidecar"), "{err}");
+        assert!(
+            err.contains("\\\\?\\pipe\\test"),
+            "names the endpoint: {err}"
+        );
+    }
+
+    // The pipe server is in this process, so the peer is us. Same shape as
+    // require_same_user_peer_accepts_our_own_socket on Unix.
+    #[test]
+    fn require_same_user_pipe_peer_accepts_our_own_pipe() {
+        let pipe_name = unique_test_pipe_name();
+        let _server = start_test_pipe_server(&pipe_name);
+        let client = pipe_runtime().block_on(async {
+            ClientOptions::new()
+                .open(&pipe_name)
+                .expect("open named pipe client")
+        });
+        require_same_user_pipe_peer(&client, &pipe_name).expect("our own pipe is accepted");
+    }
+
+    // endpoint_holder_pid now reports the kernel-recorded server pid on Windows
+    // (GetNamedPipeServerProcessId), retiring the previous unconditional None.
+    #[test]
+    fn endpoint_holder_pid_reports_the_kernel_recorded_holder() {
+        let pipe_name = unique_test_pipe_name();
+        let _server = start_test_pipe_server(&pipe_name);
+        assert_eq!(
+            endpoint_holder_pid(&pipe_name),
+            Some(std::process::id()),
+            "the holder of our own pipe is this process",
+        );
+    }
+
+    #[test]
+    fn endpoint_holder_pid_is_none_for_an_absent_endpoint() {
+        let pipe_name = unique_test_pipe_name();
+        assert_eq!(endpoint_holder_pid(&pipe_name), None);
+    }
+
+    #[test]
+    fn sanitize_sid_for_pipe_replaces_forbidden_chars() {
+        // A real Windows SID is preserved verbatim.
+        assert_eq!(
+            sanitize_sid_for_pipe("S-1-5-21-1234567890-1234567890-1234567890-1001"),
+            "S-1-5-21-1234567890-1234567890-1234567890-1001"
+        );
+        // Forbidden chars become `_`.
+        assert_eq!(
+            sanitize_sid_for_pipe("alice/bob\\carol\\@dave"),
+            "alice_bob_carol__dave"
+        );
+        // Whitespace, dot, and other punctuation all map to `_`.
+        assert_eq!(sanitize_sid_for_pipe("a b.c:d"), "a_b_c_d");
+        // Hyphen and ASCII alphanumerics are preserved.
+        assert_eq!(sanitize_sid_for_pipe("Abc-123-XYZ"), "Abc-123-XYZ");
+        // Non-ASCII becomes `_` (one per char).
+        assert_eq!(sanitize_sid_for_pipe("zoé"), "zo_");
+    }
+
+    #[test]
+    fn dev_sidecar_endpoint_uses_full_pipe_format() {
+        // Pin the full endpoint string, including the variable identity, so a
+        // regression in prefix/suffix or identity placement is caught.
+        let identity = sidecar_identity().expect("sidecar_identity");
+        let expected = format!("\\\\.\\pipe\\leapmux-desktop-{identity}-sidecar");
+        let actual = dev_sidecar_endpoint().expect("endpoint");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn dev_sidecar_metadata_path_joins_base_with_subdir_and_file() {
+        // Drive the path builder with a known base so the full result is
+        // pinned, not just the trailing components.
+        let base = PathBuf::from("C:\\Users\\alice\\AppData\\Local");
+        let path = dev_sidecar_metadata_path_in(&base);
+        assert_eq!(
+            path,
+            PathBuf::from("C:\\Users\\alice\\AppData\\Local")
+                .join("leapmux-desktop")
+                .join("sidecar.json")
+        );
+    }
+
+    #[test]
+    fn write_sidecar_metadata_roundtrips_json() {
+        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!("leapmux-test-metadata-{counter}.json"));
+        let _ = fs::remove_file(&path);
+
+        write_sidecar_metadata(&path, "\\\\.\\pipe\\test", "hash-abc").expect("write metadata");
+        let data = fs::read_to_string(&path).expect("read metadata");
+        assert!(data.contains("\\\\\\\\.\\\\pipe\\\\test"));
+        assert!(data.contains("\"binary_hash\": \"hash-abc\""));
+        assert!(data.contains(&format!(
+            "\"protocol_version\": \"{SIDECAR_PROTOCOL_VERSION}\""
+        )));
+
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/desktop/rust/src/windows_impl.rs
+++ b/desktop/rust/src/windows_impl.rs
@@ -13,11 +13,12 @@ use tokio::net::windows::named_pipe::NamedPipeClient;
 use crate::frame::{read_frame_async, write_frame_async};
 use crate::proto;
 use crate::sidecar_ipc::{
-    connect_sidecar_endpoint_async, pipe_runtime, SyncPipeReader, SyncPipeWriter,
+    connect_sidecar_endpoint_async, pipe_runtime, SidecarReader, SidecarWriter, SyncPipeReader,
+    SyncPipeWriter,
 };
 use crate::{
-    check_response, get_sidecar_info_request, sidecar_info_from_response, SidecarReader,
-    SidecarWriter, DEV_SIDECAR_HANDSHAKE_TIMEOUT,
+    check_response, get_sidecar_info_request, sidecar_info_from_response,
+    DEV_SIDECAR_HANDSHAKE_TIMEOUT,
 };
 
 /// The Windows twin of the unix `connect_and_handshake_dev_sidecar`. Runs the
@@ -99,7 +100,8 @@ mod tests {
         sanitize_sid_for_pipe, sidecar_identity,
     };
     use crate::tests::sidecar_info;
-    use crate::{write_sidecar_metadata, SIDECAR_PROTOCOL_VERSION};
+    use crate::{SIDECAR_PROTOCOL_VERSION};
+    use crate::sidecar::write_sidecar_metadata;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};


### PR DESCRIPTION
## Motivation
The desktop sidecar had grown two "god files": `desktop/rust/src/main.rs` (~4100 lines mixing the frame codec, platform sidecar transport, the sidecar process lifecycle, the streaming file-save subsystem, and app wiring) and `desktop/go/app.go` (an inline event pub-sub bolted onto the `App` struct). They mixed unrelated concerns, made platform-specific code hard to follow, and left the pub-sub and relay-ownership behavior untestable in isolation. Decomposing them also surfaced (and fixed) a Windows compile break from the first extraction, a `-race` data race on the relay owner field, and a gap in the Windows same-user SID check.

Closes #282, #295, #296.

## Modifications

### Decomposition — Rust (`main.rs`: ~4100 → ~3000 lines)
- **`frame.rs` (#282):** the wire codec — frame encode/decode, the 20 MiB `MAX_FRAME_SIZE` / 10-byte `MAX_VARINT_BYTES` caps, `frame_len`/`varint_step`, and both sync (`read_frame`/`write_frame`) and async (`read_frame_async`/`write_frame_async`) transports over one format, plus `get_sidecar_info_request()` centralizing the handshake shape. The async half is `#[cfg(any(windows, test))]` so drift fails CI on every host.
- **`sidecar_ipc/{mod,unix,windows}.rs` (#296):** the platform transport layer (unix socket vs Windows named pipe) behind one dispatch surface — `connect_sidecar_endpoint`, `is_sidecar_gone`, `endpoint_holder_pid`, the dev-endpoint/metadata helpers, and the peer-credential primitives. The Windows named-pipe transport uses tokio overlapped I/O (a non-overlapped handle serializes through the FILE_OBJECT lock and deadlocks the reader/writer threads) and keeps "gone" (`NotFound`) and "alive-but-saturated" (`Busy`) distinct so a busy sidecar can't be read as gone during the shutdown poll.
- **`sidecar.rs`:** the sidecar process bootstrap/connect/handshake/shutdown layer that sits *above* `sidecar_ipc` and `frame` — spawn or reuse a dev sidecar, drive the `GetSidecarInfo` handshake, write the dev-sidecar metadata, and ask a stale peer to shut down. Produces a `SidecarBootstrap` the shell installs; the live `SidecarProcess` + reader/writer threads stay in `main.rs`.
- **`file_save.rs`:** the streaming file-save subsystem — the `file_save_open[_dialog] → write* → commit | abort` chain, the `SaveStreamRegistry`, `<final>.leapmux.tmp` sibling-temp + atomic-rename commit, the idle-handle GC, and the startup orphan sweep.
- **`windows_impl.rs`:** the Windows-only connect/handshake + its tests, consolidated under one `#[cfg(windows)] mod` so a single module-level cfg gate replaces the per-import `#[cfg(windows)]` attributes — the next windows-only import can't compile silently on macOS and fail only on Windows CI (the rot trap the first extraction hit).
- **`alloc_probe.rs`:** the test-only peak-tracking `#[global_allocator]`, lifted out of an inline `mod`.

### Decomposition — Go (`app.go` event pub-sub → `event_sink.go`, #295)
- The `eventSinkMu`/`eventSink`/`eventSinkForRelay` fields and their locking are pulled out of the `App` god-object into a standalone `eventSink` type. `App` embeds `events eventSink`; `SetEventSink`/`SetEventSinkForRelay`/`EmitEvent`/`EmitRelayEvent`/`emitForOwner` become one-line forwarders so every call site is unchanged. The zero value stays a usable nil-safe sink.

### Hardening
- **Structural SID check (Windows):** `connect_sidecar_endpoint` (sync) and `endpoint_holder_pid` now route through `connect_sidecar_endpoint_async`, the single connect+SID-check core, so `require_same_user_pipe_peer` gates every connect that can adopt or query a peer. Previously the handshake and holder-pid diagnostic bypassed it — Windows had no identity check where Unix had one. The unix `endpoint_holder_pid` twin got the matching `require_same_user_peer` call so the "we only ever want the holder pid of OUR sidecar" invariant holds on both OSes.
- **`-race` relay-owner fix (Go):** `wsRelay.owner` was read lock-free by the relay read loop's emit closure while `adoptLiveRelay` re-stamped it under `lifecycleMu`. All reads/writes now go through `wsRelay.ownerNow()`/`stampOwner()` (`atomic.LoadUint64`/`StoreUint64`), closing the race. `atomic.Uint64` was deliberately avoided (its `noCopy` conflicts with `wsRelay`'s value-embedding); a stale read only ever changes which relay an undeliverable frame can close, never delivery itself.
- **SID allocation cap:** `token_user_sid` caps the `GetLengthSid` allocation at `SECURITY_MAX_SID_SIZE * 4` so a malformed/huge length off a peer-controlled pipe name fails closed instead of driving a multi-GiB `vec!`. `current_user_sid` is cached for the process lifetime (it ran every iteration of the ~600-iteration cold-start connect retry loop).
- **Tests:** new `event_sink_test.go` pins the pub-sub contract directly (nil-safety, generic-vs-relay routing, `forOwner` call-time read, and a `-race` concurrent re-stamp test); the frame roundtrip test uses a realistic `SidecarInfo` payload.

## Result
`main.rs` (4100 → 3000 lines) and `app.go` are focused on orchestration; the frame codec, platform transports, sidecar lifecycle, file-save subsystem, Windows handshake, and event pub-sub each live in one reviewable module. The Windows SID check is structural rather than convention-enforced, the relay-owner race is closed at the access-seam, and the previously-integration-only event-sink behavior has direct unit tests.