### PR TITLE
Close tabs even when git is broken, with a visible warning

### DIFF
--- a/backend/internal/cli/remote/cmd/tab_close.go
+++ b/backend/internal/cli/remote/cmd/tab_close.go
@@ -70,6 +70,7 @@ func RunTabClose(rawCtx any, args []string) error {
 		// side worktree state; file tabs skip both the inspect and the
 		// worker-close dispatch (they're path registrations, no PTY).
 		worktreeAction := wt.worktreeAction()
+		var inspectHint string
 		if tt != leapmuxv1.TabType_TAB_TYPE_FILE {
 			inspected, ierr := inspectLastTabCloseBest(ctx, c, got.WorkerID, tt, got.TabID)
 			if ierr != nil {
@@ -93,6 +94,10 @@ func RunTabClose(rawCtx any, args []string) error {
 					}
 				}
 			}
+			// Carry the degraded-close hint into the output so a CLI user
+			// sees the close proceeded without the git-state check (mirrors
+			// the frontend's warn toast on the same field).
+			inspectHint = inspected.GetErrorHint()
 		}
 
 		if err := cc.submitOps([]*leapmuxv1.OrgOp{opTombstoneTab(cc.bs, tt, got.TabID)}); err != nil {
@@ -114,6 +119,9 @@ func RunTabClose(rawCtx any, args []string) error {
 		}
 		if wt != closeWorktreeUnspecified {
 			out["worktree"] = string(wt)
+		}
+		if inspectHint != "" {
+			out["inspect_hint"] = inspectHint
 		}
 		if closeErr != nil {
 			out["worker_close_error"] = closeErr.Error()

--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -609,16 +610,40 @@ func (t *tabGitContext) commitDir() string {
 	return t.repoRoot
 }
 
+// resolveWorktreeBranchName re-derives the branch a worktree is currently
+// on (an external `git checkout` can drift it off the worktrees.branch_name
+// DB row) via a single rev-parse, falling back to the DB-row name on probe
+// failure. The fallback is safe here because inspectLastTabClose only
+// CARRIES the branch label in its response (as the close's branch_name
+// field, surfaced by the CLI output and the frontend dialog when it opens);
+// nothing destructive keys off it. The mutation helpers
+// (removeWorktreeFromDisk) still refuse the fallback because their
+// `git branch -D <stale>` would touch a real branch. `phase` labels the
+// slog.Warn so the fast- and slow-path probes are distinguishable in logs.
+func resolveWorktreeBranchName(ctx context.Context, wt db.Worktree, phase string) string {
+	branchName := wt.BranchName
+	info, infoErr := queryGitPathInfo(ctx, wt.WorktreePath)
+	if infoErr == nil {
+		return branchOrShortSHA(info)
+	}
+	if !errors.Is(infoErr, errNotGitRepo) {
+		slog.Warn("inspectLastTabClose "+phase+": HEAD probe failed, falling back to DB-row branch name",
+			"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "stale_db_branch", wt.BranchName, "error", infoErr)
+	}
+	return branchName
+}
+
 func (svc *Service) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.TabType, tabID string) (*leapmuxv1.InspectLastTabCloseResponse, error) {
 	trace := func(phase string) { traceTabClosePhase("inspect", tabID, phase) }
 
 	// Fast path: the only reason to run the expensive git subprocesses
 	// (diffStatsForPath, pushStatusForPath) is to populate the dialog.
 	// If the tab count already tells us no dialog will be shown, we can
-	// answer from DB alone and skip every git call below.
+	// answer from the worktree DB row and skip the diff/push forks.
 	//
 	// - Worktree tab with siblings (CountWorktreeTabs > 1) → no prompt.
-	//   Answer entirely from the worktree DB row; don't touch git.
+	//   Answers from the DB row plus a single rev-parse for the branch
+	//   label (resolveWorktreeBranchName); diff/push are skipped.
 	// - Non-worktree tab with other tabs on the same branch (otherTabs
 	//   > 0) → no prompt. We still need the branch name to do the
 	//   sibling count, so loadTabGitContext still runs; but diff/push
@@ -633,35 +658,38 @@ func (svc *Service) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 	}); err == nil {
 		count, countErr := svc.Queries.CountWorktreeTabs(ctx, wt.ID)
 		trace("worktree_count_done")
+		if countErr != nil {
+			// A transient DB error here drops the multi-tab fast path and
+			// falls through to the slow path, which re-derives the close
+			// decision from git (when the worktree dir is reachable) or
+			// short-circuits at the os.Stat check below (when it isn't).
+			// Log so the degradation is observable — every other tolerant
+			// branch in this function logs its fallback.
+			slog.Warn("inspectLastTabClose: CountWorktreeTabs failed; falling through to slow path",
+				"worktree_id", wt.ID, "error", countErr)
+		}
 		if countErr == nil && count > 1 {
 			// Sibling tabs still hold the worktree, so the close will
 			// not prompt. Re-probe HEAD before sending the response:
 			// the worktrees.branch_name row reflects whatever branch
 			// the worktree was created on, but an external `git
 			// checkout` (terminal, IDE, sibling agent) can change it,
-			// and the dialog-less CLI close inspector relies on this
-			// label to render its banner.
+			// and the CLI / frontend surface the returned branch_name
+			// in their close output even on a non-prompting close.
 			//
 			// Fall back to wt.BranchName on ANY queryGitPathInfo
 			// failure (not just errNotGitRepo): inspectLastTabClose's
-			// output is read-only — the response only RENDERS the
-			// branch name in the close-dialog; nothing destructive
-			// keys off it. A transient probe failure (slow disk,
-			// permission flicker, ctx-near-deadline) used to hard-
-			// block the close path with InternalError, leaving the
-			// user with "Worker is unreachable" toasts when a stale
-			// label would have been a far better UX. The mutation
-			// helpers (removeWorktreeFromDisk) STILL refuse the
-			// fallback because their `git branch -D <stale>` would
-			// touch a real branch; the display surface here doesn't.
-			branchName := wt.BranchName
-			info, infoErr := queryGitPathInfo(ctx, wt.WorktreePath)
-			if infoErr == nil {
-				branchName = branchOrShortSHA(info)
-			} else if !errors.Is(infoErr, errNotGitRepo) {
-				slog.Warn("inspectLastTabClose fast-path: HEAD probe failed, falling back to DB-row branch name",
-					"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "stale_db_branch", wt.BranchName, "error", infoErr)
-			}
+			// output is read-only — the response only carries the
+			// branch name as a label; nothing destructive keys off
+			// it. A transient probe failure (slow disk, permission
+			// flicker, ctx-near-deadline) used to hard-block the
+			// close path with InternalError, leaving the user with
+			// "Worker is unreachable" toasts when a stale label
+			// would have been a far better UX. The mutation helpers
+			// (removeWorktreeFromDisk) STILL refuse the fallback
+			// because their `git branch -D <stale>` would touch a
+			// real branch; the display surface here doesn't.
+			branchName := resolveWorktreeBranchName(ctx, wt, "fast-path")
 			trace("fast_path_taken")
 			return &leapmuxv1.InspectLastTabCloseResponse{
 				Target:       leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_WORKTREE,
@@ -672,29 +700,42 @@ func (svc *Service) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 				BranchName:   branchName,
 			}, nil
 		}
+		// Slow path: this is the last tab on the worktree. If the
+		// worktree directory is unreachable — gone (another process, a
+		// manual `git worktree remove`, OS cleanup) OR inaccessible
+		// (EACCES/ENOTDIR on a path component) — there is nothing to
+		// snapshot, so allow the close without a prompt. Any stat error
+		// (not just os.IsNotExist) means `git -C <dir>` cannot run, and
+		// narrowing the check to IsNotExist let EACCES/ENOTDIR fall
+		// through to two deterministically-failing git forks downstream.
+		// This is DELIBERATELY BROADER than removeWorktreeFromDisk's
+		// "already gone" gate (worktree.go: os.IsNotExist → success):
+		// that mutation has already completed its git work by the time
+		// it checks, so IsNotExist is the only "nothing left to do"
+		// signal it needs; this inspect path still has two git forks
+		// ahead of it, so any stat error git cannot survive must short-
+		// circuit. The user is warned via error_hint that the git-state
+		// check was skipped, so real repo trouble is still surfaced
+		// (not just logged server-side).
+		if _, statErr := os.Stat(wt.WorktreePath); statErr != nil {
+			slog.Warn("inspectLastTabClose slow-path: worktree directory unreachable; closing without prompt",
+				"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "stale_db_branch", wt.BranchName, "error", statErr)
+			trace("worktree_dir_missing")
+			return &leapmuxv1.InspectLastTabCloseResponse{
+				Target:     leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE,
+				RepoRoot:   wt.RepoRoot,
+				BranchName: wt.BranchName,
+				ErrorHint:  "worktree directory is gone or inaccessible; closed without checking for uncommitted changes",
+			}, nil
+		}
 		// The worktree DB row carries RepoRoot / WorktreePath which a
 		// `git checkout` can't change. BranchName, however, can drift
 		// (see comment above), so re-derive it from a single rev-parse
 		// before populating tabCtx. The remaining work skipped vs.
 		// loadTabGitContext is GetWorktreeByPath (DB) and an additional
 		// queryGitPathInfo call's worktree-disposition derivation.
-		//
-		// On probe failure, fall back to wt.BranchName + log: this
-		// path also drives display-side rendering (the prompt dialog
-		// shows the branch label), not destructive action. The
-		// stale-name hazard only matters for mutating helpers
-		// (removeWorktreeFromDisk) which now correctly refuse the
-		// fallback. Hard-blocking the inspect on a transient probe
-		// error used to surface as "Worker unreachable" — a stale
-		// label is the lesser evil.
-		branchName := wt.BranchName
-		info, infoErr := queryGitPathInfo(ctx, wt.WorktreePath)
-		if infoErr == nil {
-			branchName = branchOrShortSHA(info)
-		} else if !errors.Is(infoErr, errNotGitRepo) {
-			slog.Warn("inspectLastTabClose slow-path: HEAD probe failed, falling back to DB-row branch name",
-				"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "stale_db_branch", wt.BranchName, "error", infoErr)
-		}
+		// Probe-failure fallback rationale lives on resolveWorktreeBranchName.
+		branchName := resolveWorktreeBranchName(ctx, wt, "slow-path")
 		tabCtx = &tabGitContext{
 			workingDir:   wt.WorktreePath,
 			repoRoot:     wt.RepoRoot,
@@ -710,10 +751,25 @@ func (svc *Service) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 		loaded, err := svc.loadTabGitContext(ctx, tabType, tabID)
 		trace("git_ctx_done")
 		if err != nil {
-			// If the tab's working directory is not (or no longer) a git repository,
-			// there is nothing to prompt about — allow the tab to close normally.
+			// Non-worktree tab whose working dir is not (or no longer)
+			// readable as a git repository. Per "close always wins" we
+			// proceed without a prompt — but this is a degraded close:
+			// the safety dialog (whose sole determinant is the snapshot
+			// we'd run below) is skipped, so the user would silently lose
+			// the uncommitted/unpushed-work warning. Surface an error_hint
+			// so the frontend warns them, matching the os.Stat and
+			// snapshot-failure degraded branches above/below. (loadTabGitContext
+			// collapses both errNotGitRepo and transient probe failures to
+			// this single error; we can't distinguish here, so the hint
+			// covers both. pushBranch — the other loadTabGitContext caller —
+			// is not close-blocking and still returns this error as-is.)
+			workingDir, _ := svc.getTabWorkingDir(ctx, tabType, tabID)
+			slog.Warn("inspectLastTabClose: loadTabGitContext failed; closing without prompt",
+				"tab_type", tabType, "tab_id", tabID, "working_dir", workingDir, "error", err)
+			trace("git_ctx_failed")
 			return &leapmuxv1.InspectLastTabCloseResponse{
-				Target: leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE,
+				Target:    leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE,
+				ErrorHint: "working directory is not readable as a git repository; closed without checking for uncommitted changes",
 			}, nil
 		}
 		tabCtx = loaded
@@ -732,17 +788,86 @@ func (svc *Service) inspectLastTabClose(ctx context.Context, tabType leapmuxv1.T
 		hasOther, err := svc.hasOtherNonWorktreeTabOnBranch(ctx, tabType, tabID, tabCtx.repoRoot, tabCtx.branchName)
 		trace("branch_count_done")
 		if err != nil {
-			return nil, err
-		}
-		if hasOther {
+			// This sibling-count scan used to hard-block the close
+			// (return nil, err → Internal → "Failed to prepare tab
+			// close"), which was inconsistent with the snapshot probe
+			// right below: a flaky sibling count blocked the close
+			// while a flaky snapshot let it through. Under the "close
+			// always wins" policy, fall through to the snapshot and
+			// let IT decide (the snapshot also degrades gracefully on
+			// its own git failures). The only error this scan surfaces
+			// is a collectTabDirs DB-query failure — per-dir rev-parse
+			// probe errors are dropped inside scan (it returns the
+			// hit/miss verdict, not the error) — so this log fires on
+			// DB trouble, not on a sibling's broken working dir (which
+			// resolves to a clean "no match" and never reaches here).
+			slog.Warn("inspectLastTabClose: sibling-count scan failed; falling through to snapshot",
+				"tab_type", tabType, "tab_id", tabID, "repo_root", tabCtx.repoRoot, "branch", tabCtx.branchName, "error", err)
+		} else if hasOther {
 			trace("fast_path_taken")
 			return resp, nil
 		}
 	}
 
-	snap, err := gatherBranchSnapshot(ctx, tabCtx.commitDir(), tabCtx.branchName)
+	// Fail-fast on a cancelled/deadlined ctx before forking the snapshot's
+	// two git subprocesses: resolveWorktreeBranchName / loadTabGitContext
+	// above log-and-swallow probe errors (including ctx errors) to preserve
+	// "close always wins", so a cancelled ctx would otherwise reach here and
+	// pay for diff+push forks that are guaranteed to fail on the same ctx.
+	// Degrade to a no-prompt response with a hint instead. ctx.Err()==nil
+	// is the normal path and skips this block entirely.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		slog.Warn("inspectLastTabClose: ctx cancelled before snapshot; closing without prompt",
+			"tab_type", tabType, "tab_id", tabID, "error", ctxErr)
+		trace("ctx_cancelled")
+		resp.ErrorHint = "close request was cancelled; closed without checking for uncommitted or unpushed changes"
+		return resp, nil
+	}
+
+	snap, pushErr, err := gatherCloseSnapshot(ctx, tabCtx.commitDir(), tabCtx.branchName)
 	if err != nil {
-		return nil, err
+		// The snapshot populates the confirmation dialog (diff stats,
+		// unpushed commit count) AND, for non-worktree last-tab closes,
+		// is the sole determinant of whether to prompt at all (lines
+		// below: should_prompt is set from snap.hasChanges / Unpushed /
+		// RemoteMissing). If the DIFF half of the snapshot failed here
+		// — corrupt repo, a transient .git/index.lock race, a
+		// dubious-ownership rejection that rev-parse tolerated but
+		// `git status` rejected, a gitReadTimeout deadline on a large
+		// diff, or a vanished working tree that slipped past the os.Stat
+		// check above — we skip the prompt rather than block the close:
+		// the user's ability to close takes priority. But because
+		// skipping can hide real uncommitted work, surface an error_hint
+		// so the frontend warns the user (toast) that the check was
+		// skipped, instead of closing silently. The underlying error is
+		// also slog.Warn'd for server-side observability. (A push-only
+		// failure does NOT reach here: gatherCloseSnapshot keeps the
+		// diff result in that case and returns pushErr separately, so
+		// the uncommitted-work warning survives a flaky origin.)
+		slog.Warn("inspectLastTabClose: git snapshot failed; closing without prompt",
+			"tab_type", tabType, "tab_id", tabID,
+			"commit_dir", tabCtx.commitDir(), "branch", tabCtx.branchName, "error", err)
+		trace("snapshot_failed")
+		// Surface the underlying git diagnostic (gitutil.Output already
+		// folds git's stderr into the error message) so the user can act
+		// on the real cause — e.g. dubious-ownership points at the
+		// `safe.directory` fix. Mirrors GetGitInfo's error_hint pattern.
+		// Cap the length so a noisy multi-line stderr stays toast-readable.
+		detail := truncateGitHint(err.Error(), maxDegradedHintDetail)
+		resp.ErrorHint = "git state unavailable; closed without checking for uncommitted or unpushed changes" + detail
+		return resp, nil
+	}
+	if pushErr != nil {
+		// Diff succeeded but push status failed (e.g. a flaky origin, a
+		// transient `git config` read). The uncommitted-work signal — the
+		// higher-value part of the dialog — is intact, so do NOT degrade
+		// the close: keep the snapshot and let shouldPrompt reflect
+		// hasChanges. Log so the skipped unpushed-commit count is
+		// observable server-side; the dialog simply renders 0 unpushed.
+		slog.Warn("inspectLastTabClose: push-status probe failed; keeping diff-driven snapshot",
+			"tab_type", tabType, "tab_id", tabID,
+			"commit_dir", tabCtx.commitDir(), "branch", tabCtx.branchName, "error", pushErr)
+		trace("push_status_failed")
 	}
 	// Single emission covers both parallel calls completing — their
 	// individual timestamps are no longer meaningful once they race.
@@ -1068,6 +1193,33 @@ type branchSnapshot struct {
 	push          pushStatus
 }
 
+// maxDegradedHintDetail caps how much of the underlying git error is appended
+// to a degraded-close error_hint. gitutil.Output folds git's entire trimmed
+// stderr into the error string, which for some failures (a corrupt index, a
+// multi-ref dubious-ownership dump) can be many lines — a warn toast is the
+// wrong surface for a wall of text. The cap keeps the actionable prefix
+// (e.g. "fatal: detected dubious ownership ...") while letting the full
+// diagnostic live in the slog.Warn above for server-side triage.
+const maxDegradedHintDetail = 160
+
+// truncateGitHint renders the appended-detail suffix for a degraded-close
+// error_hint: `: <detail>` when non-empty and within the cap, `: <truncated>`
+// when over, or "" when there is nothing useful to surface. It trims only the
+// first line of a multi-line git stderr so the hint stays a single toast line.
+func truncateGitHint(detail string, cap int) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return ""
+	}
+	if i := strings.IndexByte(detail, '\n'); i >= 0 {
+		detail = detail[:i]
+	}
+	if len(detail) > cap {
+		detail = detail[:cap-1] + "…"
+	}
+	return ": " + detail
+}
+
 // toProto projects the snapshot onto the shared BranchGitState submessage
 // that both InspectLastTabClose and InspectBranchDeletion responses embed.
 func (s branchSnapshot) toProto(branchName string) *leapmuxv1.BranchGitState {
@@ -1110,6 +1262,51 @@ func gatherBranchSnapshot(ctx context.Context, statsPath, branchName string) (br
 		return snap, err
 	}
 	return snap, nil
+}
+
+// gatherCloseSnapshot is the close-path variant of gatherBranchSnapshot: it
+// runs diff and push concurrently but returns their errors INDEPENDENTLY
+// rather than failing the whole group on either error. The close path's
+// "close always wins, but warn" policy wants the higher-value signal (diff /
+// uncommitted-work) to survive a push-only failure (e.g. a flaky origin),
+// instead of degrading the whole dialog and hiding the uncommitted-work
+// warning along with the unpushed-commit count.
+//
+// Returns:
+//   - snap: always populated up to whichever halves succeeded.
+//   - pushErr: non-nil iff push failed (snap.diff*/hasChanges are valid).
+//   - err: non-nil iff DIFF failed — the caller's hard-degrade trigger,
+//     because a failed diff means the uncommitted-work signal itself is
+//     gone and the close must warn. A push-only failure (err == nil,
+//     pushErr != nil) is recoverable: the caller keeps the diff-driven
+//     snapshot and only logs.
+//
+// gatherBranchSnapshot (used by inspectBranchDeletion, where a dialog is
+// always shown and real errors stay actionable) keeps the all-or-nothing
+// contract; only the close path needs the partial-success semantics.
+func gatherCloseSnapshot(ctx context.Context, statsPath, branchName string) (snap branchSnapshot, pushErr error, err error) {
+	g, gctx := errgroup.WithContext(ctx)
+	var diffErr error
+	g.Go(func() error {
+		a, d, u, hc, e := diffStatsForPath(gctx, statsPath)
+		diffErr = e
+		snap.diffAdded, snap.diffDeleted, snap.diffUntracked, snap.hasChanges = a, d, u, hc
+		return nil
+	})
+	g.Go(func() error {
+		ps, e := pushStatusForPath(gctx, statsPath, branchName)
+		if e != nil {
+			pushErr = fmt.Errorf("failed to inspect push status: %w", e)
+			return nil
+		}
+		snap.push = ps
+		return nil
+	})
+	_ = g.Wait()
+	if diffErr != nil {
+		return snap, pushErr, fmt.Errorf("failed to inspect diff stats: %w", diffErr)
+	}
+	return snap, pushErr, nil
 }
 
 // checkoutBranchInDir runs `git checkout <branch>` (or

--- a/backend/internal/worker/service/git_test.go
+++ b/backend/internal/worker/service/git_test.go
@@ -838,6 +838,258 @@ func TestInspectLastTabClose_WorktreeFileTabHoldsWorktree(t *testing.T) {
 	assert.Equal(t, int64(1), count, "file-tab close must drop the worktree_tabs row")
 }
 
+// setupLastTabOnWorktree creates a fresh repo + linked worktree, registers a
+// single AGENT tab on that worktree (the "last tab" case), and returns the
+// repo + worktree dirs and the agent id. The caller corrupts the worktree
+// (deletes the dir, removes `.git`, etc.) before calling inspectLastTabClose.
+// Collapses the shared arrange harness of the worktree-degraded-close tests,
+// which differ only in the corruption step.
+func setupLastTabOnWorktree(t *testing.T, svc *Service, branch string) (repoDir, wtDir, agentID string) {
+	t.Helper()
+	repoDir = initRepo(t)
+	wtDir = filepath.Join(t.TempDir(), branch+"-wt")
+	run(t, repoDir, "git", "worktree", "add", "-b", branch+"-branch", wtDir)
+	wtID, err := svc.ensureTrackedWorktree(context.Background(), wtDir)
+	require.NoError(t, err)
+	agentID = "agent-" + branch
+	createAgentForPath(t, svc, agentID, wtDir)
+	svc.registerTabForWorktree(wtID, leapmuxv1.TabType_TAB_TYPE_AGENT, agentID)
+	return repoDir, wtDir, agentID
+}
+
+// Regression guard: when the last tab on a worktree points at a directory
+// that has been deleted out-of-band (manual `git worktree remove`, another
+// process, OS cleanup), inspectLastTabClose must NOT fail — it must let the
+// tab close without a prompt. Before the fix, the deleted dir made
+// gatherBranchSnapshot's `git -C <gone-dir> diff` exit 128 ("cannot change
+// to '<dir>'"), surfacing as "failed to inspect diff stats" and blocking
+// the close from both the frontend and the CLI.
+func TestInspectLastTabClose_WorktreeDirDeletedClosesWithoutPrompt(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	_, wtDir, agentID := setupLastTabOnWorktree(t, svc, "deleted")
+
+	// Simulate the out-of-band deletion that produced the bug. The DB row
+	// still carries wtDir, but the directory is gone on disk.
+	require.NoError(t, os.RemoveAll(wtDir))
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, agentID)
+	require.NoError(t, err, "close inspection must not fail when the worktree dir is gone")
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE, resp.GetTarget(),
+		"missing worktree dir must not prompt")
+	assert.False(t, resp.GetShouldPrompt())
+	assert.Nil(t, resp.GetGitState(), "no snapshot should run for a missing dir")
+	assert.NotEmpty(t, resp.GetErrorHint(), "a degraded close must surface an error_hint so the user is warned")
+}
+
+// Regression guard for the safety-net branch of the fix: when the worktree
+// directory still exists on disk but git is broken inside it (here: the
+// linked-worktree .git pointer file was removed), inspectLastTabClose must
+// still let the tab close. The os.Stat fast path does NOT fire (dir exists),
+// so gatherBranchSnapshot runs and fails — the fix downgrades that failure
+// from a hard error to a no-prompt response so the close can proceed.
+func TestInspectLastTabClose_WorktreeSnapshotFailureDoesNotBlockClose(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	_, wtDir, agentID := setupLastTabOnWorktree(t, svc, "corrupt")
+
+	// Corrupt git inside the worktree without removing the directory: a
+	// linked worktree's `.git` is a file pointing at the main repo's
+	// worktree admin dir. Removing it makes `git -C wtDir status/diff`
+	// exit 128 ("not a git repository") while os.Stat(wtDir) still
+	// succeeds — exercising the gatherBranchSnapshot failure path.
+	require.NoError(t, os.Remove(filepath.Join(wtDir, ".git")))
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, agentID)
+	require.NoError(t, err, "close inspection must not fail when git is broken in the worktree")
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE, resp.GetTarget(),
+		"broken git must not block the close")
+	assert.False(t, resp.GetShouldPrompt())
+	assert.NotEmpty(t, resp.GetErrorHint(), "a degraded close must surface an error_hint so the user is warned")
+}
+
+// Regression guard for the shared-path tolerance: a NON-worktree tab whose
+// repo is valid enough for queryGitPathInfo's rev-parse probe (so
+// loadTabGitContext succeeds and the shared gatherBranchSnapshot call is
+// reached) but broken enough that the heavier `git status` / `git diff`
+// forks fail. This is the case the commit message's "worktree-only"
+// framing missed: the snapshot tolerance lives on the shared path, so it
+// also governs the non-worktree safety dialog — whose sole purpose is to
+// warn about uncommitted/unpushed changes (should_prompt is decided
+// entirely from the snapshot at the bottom of inspectLastTabClose).
+//
+// The fix's contract: close still wins (no prompt, no error), but an
+// error_hint is populated so the frontend can warn the user that the
+// git-state check was skipped. Pointing HEAD at a bogus SHA splits the two
+// git layers cleanly: rev-parse resolves the ref name and returns the SHA
+// (no object read), while `git diff --shortstat HEAD` / `git status` need
+// to read the commit object and exit 128.
+func TestInspectLastTabClose_NonWorktreeSnapshotFailureDegradesWithHint(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	repoDir := initRepo(t)
+	// A non-worktree agent tab: no worktree DB row, so GetWorktreeForTab
+	// misses and the close path runs through loadTabGitContext.
+	createAgentForPath(t, svc, "agent-broken-head", repoDir)
+
+	// Corrupt HEAD: point the branch ref at a SHA that has no object.
+	// rev-parse still resolves toplevel/git-dir/branch; diff/status fail.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, ".git", "refs", "heads", "main"),
+		[]byte("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"), 0o644))
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-broken-head")
+	require.NoError(t, err, "a snapshot failure on a non-worktree tab must not block the close")
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE, resp.GetTarget(),
+		"broken git must not fabricate a prompt target")
+	assert.False(t, resp.GetShouldPrompt(), "broken git must not prompt")
+	assert.NotEmpty(t, resp.GetErrorHint(),
+		"degraded non-worktree close must surface an error_hint — without it the user silently loses the uncommitted-work warning")
+	// The hint must carry git's own diagnostic (here: the bogus-HEAD
+	// "fatal: bad object HEAD"), not just a generic "git state unavailable"
+	// preamble — so the user can act on the real cause rather than guess.
+	// See truncateGitHint / the GetGitInfo error_hint pattern it mirrors.
+	assert.Contains(t, resp.GetErrorHint(), "git state unavailable",
+		"hint must keep its generic preamble so the toast reads as a warning, not a bare error")
+	assert.Contains(t, resp.GetErrorHint(), "bad object HEAD",
+		"hint must append git's diagnostic so the user can act on the underlying cause")
+}
+
+// Regression guard: an unrelated sibling tab with a broken/deleted working
+// directory must not block closing a HEALTHY tab. hasOtherNonWorktreeTabOnBranch's
+// scan DROPS per-dir rev-parse probe errors (it returns the hit/miss verdict,
+// not the error), so a deleted sibling dir resolves to "no match" rather than a
+// hard failure — the close falls through to the CLOSING tab's snapshot, which is
+// the authoritative prompt determinant. This test pins that the close proceeds
+// and the snapshot still drives the prompt on the healthy closing tab.
+//
+// NOTE: this does NOT exercise the `err != nil` fall-through at git.go:768
+// directly, because the only error source scan propagates is the collectTabDirs
+// DB query (a concrete *db.Queries, not injectable here). The deleted-sibling
+// scenario resolves to (false, nil) from hasOther and reaches the snapshot via
+// the `!hasOther` arm — the same path a clean repo with no siblings takes. The
+// guard is therefore on the OUTCOME (close proceeds, snapshot prompts on the
+// dirty closing repo) rather than on the specific error branch.
+func TestInspectLastTabClose_SiblingCountFailureDoesNotBlockClose(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	closingRepo := initRepo(t)
+	run(t, closingRepo, "git", "checkout", "-b", "shared-feature")
+	// A sibling agent whose working dir is deleted out-of-band. Its rev-parse
+	// probe inside hasOtherNonWorktreeTabOnBranch fails, but scan drops that
+	// error and returns (false, nil) — so the close falls through to the
+	// closing tab's snapshot rather than hard-blocking.
+	siblingRepo := initRepo(t)
+	run(t, siblingRepo, "git", "checkout", "-b", "shared-feature")
+	createAgentForPath(t, svc, "agent-closing", closingRepo)
+	createAgentForPath(t, svc, "agent-sibling-gone", siblingRepo)
+	require.NoError(t, os.RemoveAll(siblingRepo))
+
+	// Dirty the closing repo so a successful snapshot WOULD prompt — proving
+	// the snapshot actually ran and drove the decision (rather than a clean
+	// no-op close that would pass regardless of which path was taken).
+	require.NoError(t, os.WriteFile(filepath.Join(closingRepo, "dirty.txt"), []byte("dirty\n"), 0o644))
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-closing")
+	require.NoError(t, err, "a sibling's broken working dir must not block closing a healthy tab")
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_BRANCH, resp.GetTarget(),
+		"snapshot on the dirty closing repo must still drive the prompt decision")
+	assert.True(t, resp.GetShouldPrompt(), "dirty closing repo must prompt")
+	assert.Empty(t, resp.GetErrorHint(), "healthy closing repo must not carry a degraded hint")
+}
+
+// Regression guard for the loadTabGitContext-failure degraded branch: a
+// NON-worktree tab whose working dir is not (or is no longer) readable as a
+// git repository must close without a prompt AND surface an error_hint, so
+// the user is warned the uncommitted-work check was skipped. Before the fix
+// this branch returned a bare {Target: NONE} response with no hint — the
+// close proceeded silently, asymmetric with the os.Stat and snapshot-failure
+// degraded branches (which do hint). loadTabGitContext collapses both
+// errNotGitRepo and transient probe failures to one error, so this covers
+// the "agent whose dir was deleted out-of-band" case for a non-worktree tab.
+func TestInspectLastTabClose_NonWorktreeNonRepoDegradesWithHint(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	// A plain temp dir with NO `git init` — queryGitPathInfo returns
+	// errNotGitRepo, so loadTabGitContext fails and the inspect hits the
+	// degraded branch. (No worktree DB row, so GetWorktreeForTab misses
+	// and the close path runs through loadTabGitContext.)
+	nonRepoDir := t.TempDir()
+	createAgentForPath(t, svc, "agent-non-repo", nonRepoDir)
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-non-repo")
+	require.NoError(t, err, "a non-repo working dir must not block the close")
+	assert.Equal(t, leapmuxv1.LastTabCloseTarget_LAST_TAB_CLOSE_TARGET_NONE, resp.GetTarget(),
+		"non-repo tab must not fabricate a prompt target")
+	assert.False(t, resp.GetShouldPrompt(), "non-repo tab must not prompt")
+	assert.NotEmpty(t, resp.GetErrorHint(),
+		"degraded non-repo close must surface an error_hint — without it the user silently loses the uncommitted-work warning")
+}
+
+// Regression guard for the partial-snapshot fix: when the DIFF half of the
+// snapshot succeeds but the PUSH half fails (here: a malformed
+// refs/remotes/origin/main ref makes `git show-ref` exit 128 while
+// `git status`/`git diff` still work), the close must NOT degrade — the
+// uncommitted-work signal is intact and should still drive the prompt.
+// Before the fix, gatherBranchSnapshot failed the whole errgroup on either
+// error, so a flaky origin discarded a successful diff and the user lost the
+// uncommitted-work warning along with the unpushed count.
+//
+// Splitter: branch.main.{remote,merge} set + a malformed
+// refs/remotes/origin/main ref → `git show-ref refs/remotes/origin/main`
+// exits 128 (HasRefs propagates a real error) while HEAD is valid so diff
+// and porcelain status succeed.
+func TestInspectLastTabClose_PushOnlyFailureKeepsDiffDrivenPrompt(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	repoDir := initRepo(t)
+	// Configure an upstream so pushStatusForPath reaches the HasRefs probe.
+	run(t, repoDir, "git", "config", "branch.main.remote", "origin")
+	run(t, repoDir, "git", "config", "branch.main.merge", "refs/heads/main")
+	run(t, repoDir, "git", "remote", "add", "origin", "https://example.com/repo.git")
+	// A malformed origin ref: show-ref exits 128 ("bad ref ... (0000...)"),
+	// which HasRefs propagates as an error. HEAD is still valid, so diff
+	// and porcelain status succeed — isolating the failure to push status.
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git", "refs", "remotes", "origin"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, ".git", "refs", "remotes", "origin", "main"),
+		[]byte("0000000000000000000000000000000000000000\n"), 0o644))
+	// Dirty the tree so a successful diff drives shouldPrompt=true — proving
+	// the diff result was kept rather than discarded with the push failure.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644))
+	createAgentForPath(t, svc, "agent-push-broken", repoDir)
+
+	resp, err := svc.inspectLastTabClose(context.Background(), leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-push-broken")
+	require.NoError(t, err, "a push-only snapshot failure must not block the close")
+	assert.True(t, resp.GetShouldPrompt(),
+		"diff succeeded (dirty tree) — must still prompt despite the push-status failure")
+	assert.NotEmpty(t, resp.GetGitState().GetDiffUntracked(),
+		"diff stats must be populated from the successful diff half")
+	assert.Empty(t, resp.GetErrorHint(),
+		"a push-only failure keeps the diff signal — the close is not degraded, no hint")
+}
+
+// Regression guard for the ctx-cancellation fast-exit: when the caller's ctx
+// is already cancelled by the time the close path reaches the snapshot, the
+// inspect must degrade to a no-prompt response with a hint instead of paying
+// for two git forks (diff + push) that are guaranteed to fail on the same
+// ctx. Before the fix, resolveWorktreeBranchName / loadTabGitContext swallowed
+// the ctx error and let the snapshot fork anyway.
+func TestInspectLastTabClose_CancelledCtxDegradesWithoutSnapshot(t *testing.T) {
+	svc, _, _ := setupTestService(t, withWorkspaces("ws-1"))
+	repoDir := initRepo(t)
+	// Dirty the tree so a successful snapshot WOULD prompt — proving the
+	// ctx fast-exit fired before the snapshot ran (otherwise shouldPrompt
+	// would be true from the dirty tree).
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644))
+	createAgentForPath(t, svc, "agent-cancelled", repoDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before the call
+
+	resp, err := svc.inspectLastTabClose(ctx, leapmuxv1.TabType_TAB_TYPE_AGENT, "agent-cancelled")
+	require.NoError(t, err, "a cancelled ctx must not block the close")
+	assert.False(t, resp.GetShouldPrompt(),
+		"cancelled ctx must degrade to no-prompt, not run the snapshot and prompt")
+	assert.Nil(t, resp.GetGitState(), "cancelled ctx must short-circuit before the snapshot populates git_state")
+	assert.NotEmpty(t, resp.GetErrorHint(),
+		"cancelled-ctx degraded close must surface an error_hint so the user knows the check was skipped")
+}
+
 // FILE close with WorktreeAction.REMOVE on the last tab must remove
 // the worktree from disk via closeTabCommon, mirroring the AGENT /
 // TERMINAL last-close pipeline. Regression guard for the original bug
@@ -3002,6 +3254,35 @@ func TestParseDiffShortstat(t *testing.T) {
 			added, deleted := parseDiffShortstat(c.in)
 			assert.Equal(t, c.added, added)
 			assert.Equal(t, c.deleted, deleted)
+		})
+	}
+}
+
+// truncateGitHint renders the appended-detail suffix for a degraded-close
+// error_hint. The table pins its four branches: empty (no suffix), single-
+// line, multi-line (first line only — a toast must stay one line), and
+// over-cap (truncated with an ellipsis so a noisy git stderr doesn't overflow
+// the toast). The cap is exercised at the boundary (exactly cap → unchanged,
+// cap+1 → truncated).
+func TestTruncateGitHint(t *testing.T) {
+	const cap = 160
+	cases := []struct {
+		name   string
+		detail string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \t\n  ", ""},
+		{"single line", "fatal: bad object HEAD", ": fatal: bad object HEAD"},
+		{"multi-line keeps first only", "fatal: bad object HEAD\nwarning: loquacious second line\nthird", ": fatal: bad object HEAD"},
+		{"trims surrounding whitespace", "  fatal: dubious ownership  ", ": fatal: dubious ownership"},
+		{"exactly cap is unchanged", strings.Repeat("x", cap), ": " + strings.Repeat("x", cap)},
+		{"over cap truncates with ellipsis", strings.Repeat("x", cap+1), ": " + strings.Repeat("x", cap-1) + "…"},
+		{"over cap with multi-line truncates the first line", strings.Repeat("y", cap+5) + "\nsecond", ": " + strings.Repeat("y", cap-1) + "…"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, truncateGitHint(c.detail, cap))
 		})
 	}
 }

--- a/frontend/src/components/shell/LastTabCloseDialog.test.tsx
+++ b/frontend/src/components/shell/LastTabCloseDialog.test.tsx
@@ -342,6 +342,29 @@ describe('lastTabCloseDialog', () => {
     expect(onStatusRefreshed).not.toHaveBeenCalled()
   })
 
+  it('post-push degraded refresh: error_hint surfaces a warn toast, parent still notified', async () => {
+    // The push succeeded, but the re-probe hit a degraded state (worktree
+    // vanished mid-push, transient git failure) — inspect returns a
+    // response (not a rejection) with shouldPrompt=false + errorHint. The
+    // dialog stays open showing the pre-push state, but the post-push
+    // safety check was skipped, so the user must be warned (mirrors
+    // useTabOperations.handleTabClose's error_hint handling). The parent
+    // is still notified so it can merge the refreshed (degraded) status.
+    const { showWarnToast } = await import('~/components/common/Toast')
+    const degraded = makeState({ shouldPrompt: false, errorHint: 'git state unavailable; closed without checking for uncommitted or unpushed changes' })
+    vi.mocked(workerRpc.pushBranch).mockResolvedValueOnce({} as never)
+    vi.mocked(workerRpc.inspectLastTabClose).mockResolvedValueOnce(degraded as never)
+    const onStatusRefreshed = vi.fn<(s: InspectLastTabCloseResponse) => void>()
+    renderDialog(makeState({ canPush: true, unpushedCommitCount: 1 }), vi.fn(), onStatusRefreshed)
+    fireEvent.click(screen.getByRole('button', { name: 'Push' }))
+    await waitFor(() => {
+      expect(showWarnToast).toHaveBeenCalledWith('git state unavailable; closed without checking for uncommitted or unpushed changes')
+    })
+    // The refresh resolved (did not reject), so the parent is notified —
+    // unlike the rejection case above, a degraded response is real data.
+    expect(onStatusRefreshed).toHaveBeenCalledWith(degraded)
+  })
+
   it('renders both uncommitted-change and unpushed-commit lines when both apply', () => {
     renderDialog(makeState({
       hasUncommittedChanges: true,

--- a/frontend/src/components/shell/LastTabCloseDialog.tsx
+++ b/frontend/src/components/shell/LastTabCloseDialog.tsx
@@ -5,6 +5,7 @@ import { Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Dialog } from '~/components/common/Dialog'
+import { showWarnToast } from '~/components/common/Toast'
 import { BranchStatusInfo, hasPushableWork } from '~/components/workspace/BranchStatusInfo'
 import { PushBranchButton } from '~/components/workspace/PushBranchButton'
 import { LastTabCloseTarget } from '~/generated/leapmux/v1/git_pb'
@@ -49,12 +50,22 @@ export const LastTabCloseDialog: Component<LastTabCloseDialogProps> = (props) =>
   // rejection from inspectLastTabClose would surface a misleading
   // "Failed to push branch" toast (via PushBranchButton's useDialogSubmit
   // onError) and skip the success toast. Treat the refresh as best-effort.
+  //
+  // A degraded refresh (worktree vanished, git broke) returns a response
+  // with shouldPrompt=false + errorHint instead of rejecting. The dialog
+  // stays open so the user still sees the pre-push branch state, but the
+  // post-push safety check was skipped — surface the hint as a warn toast
+  // so the user isn't silently left looking at stale state. Mirrors
+  // useTabOperations.handleTabClose's error_hint handling.
   const refreshStatus = async () => {
     try {
       const updated = await workerRpc.inspectLastTabClose(props.state.workerId, {
         tabType: props.state.tabType,
         tabId: props.state.tabId,
       })
+      if (updated.errorHint) {
+        showWarnToast(updated.errorHint)
+      }
       props.onStatusRefreshed?.(updated)
     }
     catch (err) {

--- a/frontend/src/components/shell/useTabOperations.test.ts
+++ b/frontend/src/components/shell/useTabOperations.test.ts
@@ -431,6 +431,30 @@ describe('useTabOperations', () => {
     })
   })
 
+  it('degraded close: error_hint surfaces a warn toast but the close still proceeds', async () => {
+    await createRoot(async (dispose) => {
+      try {
+        const { tabStore, ops, handleAgentClose } = setup()
+        const tab = tabStore.state.tabs.find(t => t.id === 'agent-a')!
+        // Worker let the close proceed without a prompt only because git
+        // was unavailable — shouldPrompt is false but error_hint is set.
+        // The close must still win (KEEP), and the user must be warned.
+        mockInspectLastTabClose.mockResolvedValueOnce({
+          shouldPrompt: false,
+          errorHint: 'git state unavailable; closed without checking for uncommitted or unpushed changes',
+        })
+
+        await ops.handleTabClose(tab)
+
+        expect(mockShowWarnToast).toHaveBeenCalledWith('git state unavailable; closed without checking for uncommitted or unpushed changes')
+        expect(handleAgentClose).toHaveBeenCalledWith('agent-a', WorktreeAction.KEEP)
+      }
+      finally {
+        dispose()
+      }
+    })
+  })
+
   it('rapid double-close dedupes during decide phase', async () => {
     await createRoot(async (dispose) => {
       try {

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -432,6 +432,17 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
           showInfoToast('Worktree will be removed')
         }
       }
+      else if (status.errorHint) {
+        // The worker let the close proceed without a prompt only because
+        // git was unavailable (worktree dir gone, transient git failure,
+        // corrupt repo) — see InspectLastTabCloseResponse.error_hint. The
+        // close still wins (we fall through to commit), but warn the user
+        // that the usual uncommitted/unpushed-work check was skipped, so a
+        // broken repo doesn't silently swallow the safety dialog. The hint
+        // IS the user-facing message (a complete sentence), so it goes in
+        // the toast directly rather than as an error attachment.
+        showWarnToast(status.errorHint)
+      }
     }
     catch (err) {
       if (!isWorkerUnreachable(err)) {

--- a/proto/leapmux/v1/git.proto
+++ b/proto/leapmux/v1/git.proto
@@ -80,6 +80,15 @@ message InspectLastTabCloseResponse {
   // Fresh tag (16) for the BranchGitState bundle. Picking a new number
   // avoids the wire-type-reuse hazard on tag 7 above.
   BranchGitState git_state = 16;
+  // Non-empty when the worker let the close proceed WITHOUT a prompt only
+  // because git was unavailable (worktree dir gone, transient git failure,
+  // corrupt repo). The close still succeeds — should_prompt is false and
+  // the frontend commits the close — but the frontend surfaces this hint
+  // as a warn toast so the user knows the usual uncommitted/unpushed-work
+  // check was skipped. Mirrors GetGitFileStatusResponse.error_hint's role
+  // of turning a generic "Internal error" into an actionable diagnostic.
+  // Empty on a normal (clean or genuinely promptable) close.
+  string error_hint = 17;
 }
 
 message PushBranchRequest {


### PR DESCRIPTION
## Motivation

Closing the last tab on a worktree whose directory was deleted out-of-band
(a manual `git worktree remove`, another process, OS cleanup) — or whose git
was otherwise broken (corrupt index, dubious-ownership rejection, flaky
origin) — failed with a generic Internal RPC error:

> Failed to inspect diff stats: exit status 128: fatal: cannot change to '\<dir\>'

`inspectLastTabClose` (the worker RPC gating tab close) built its context
from the now-stale DB worktree path and handed it to `gatherBranchSnapshot`,
whose `git -C <gone-dir>` exited 128. The frontend (`useTabOperations`) and
CLI (`tab close`) both treat that as fatal, so the close was blocked with no
way past it — even though the underlying worktree state had already changed
out from under the tab.

The chosen design policy is **"close always wins, but warn the user"**: a tab
must always be closeable, and a degraded close (where the uncommitted /
unpushed-work safety check had to be skipped) must surface a user-visible
warning rather than silently swallowing the safety dialog.

## Modifications

- **New `InspectLastTabCloseResponse.error_hint` proto field (tag 17)** —
  non-empty only on a degraded close (worktree dir gone, transient git
  failure, corrupt repo, cancelled ctx). Mirrors the existing
  `GetGitFileStatusResponse.error_hint` pattern of turning a generic error
  into an actionable diagnostic.

- **`inspectLastTabClose` now tolerates git failures at each close-critical
  probe** (`backend/internal/worker/service/git.go`):
  - **`os.Stat` fast-exit** on the worktree slow-path when the dir is
    unreachable for *any* reason (gone, EACCES, ENOTDIR) — deliberately
    broader than `removeWorktreeFromDisk`'s `os.IsNotExist` gate, since this
    path still has two git forks ahead of it.
  - **Non-fatal snapshot**: on a diff failure (corrupt repo, `.git/index.lock`
    race, dubious-ownership that rev-parse tolerated but `git status`
    rejected, `gitReadTimeout`), degrade to no-prompt with a hint instead of
    hard-failing. The hint **appends git's own diagnostic** (truncated,
    single-line) so the user can act on the real cause — e.g.
    dubious-ownership points at the `safe.directory` fix.
  - **Partial-snapshot**: the new `gatherCloseSnapshot` helper returns diff
    and push errors *independently*, so a flaky-origin **push** failure keeps
    the successful **diff** result and `shouldPrompt` still reflects
    `hasChanges` — the uncommitted-work warning survives. (The existing
    `gatherBranchSnapshot`, used by `inspectBranchDeletion` where the dialog
    always shows, keeps its all-or-nothing contract.)
  - **`loadTabGitContext` failure** (non-worktree tab whose dir is not / no
    longer a git repo) now sets a hint too — previously it closed silently.
  - **`ctx`-cancellation guard** before the snapshot skips two doomed git
    forks when the request is already cancelled.
  - **Sibling-count fall-through**: `hasOtherNonWorktreeTabOnBranch` errors no
    longer hard-block; they fall through to the snapshot.

- **Frontend** (`useTabOperations.ts`, `LastTabCloseDialog.tsx`): a degraded
  close shows a warn toast with the hint and still commits the close (KEEP);
  the post-push re-probe inside the open dialog surfaces the same toast so a
  degraded refresh doesn't leave the user looking at stale state.

- **CLI** (`tab_close.go`): carries the hint into the `tab close` output as
  `inspect_hint`, mirroring the frontend toast.

- `resolveWorktreeBranchName` consolidates the two previously-duplicated
  fast-/slow-path HEAD-reprobe blocks into one helper.

## Result

A tab is now **always closeable**, even when its worktree directory has been
removed or git is broken underneath it. Instead of a hard "Failed to inspect
diff stats" error with no recourse, a degraded close proceeds and the user
sees a warn toast (frontend) / `inspect_hint` field (CLI) explaining that the
uncommitted/unpushed-work check was skipped — and, when git reported a
specific cause (dubious-ownership, bad object, etc.), what that cause was so
they can fix it. A flaky origin no longer discards the uncommitted-work
warning along with the unpushed count.

No breaking changes: the proto field is additive (tag 17 on a response), and
every behavioral change is in the tolerant direction (close proceeds where it
previously errored). Other `gatherBranchSnapshot` callers
(`inspectBranchDeletion`, branch mutations) still surface real git errors —
those aren't close-blocking and their errors are actionable.
