### PR TITLE
Route workspace lifecycle through internal submit ops

### DIFF
--- a/backend/internal/cli/remote/cmd/events.go
+++ b/backend/internal/cli/remote/cmd/events.go
@@ -205,6 +205,10 @@ func opKindName(op *leapmuxv1.OrgOp) string {
 		return "tombstone_floating_window"
 	case *leapmuxv1.OrgOp_SetWorkspaceRootNode:
 		return "set_workspace_root_node"
+	case *leapmuxv1.OrgOp_SetWorkspaceRegister:
+		return "set_workspace_register"
+	case *leapmuxv1.OrgOp_TombstoneWorkspace:
+		return "tombstone_workspace"
 	}
 	return "unknown"
 }

--- a/backend/internal/cli/remote/cmd/events_test.go
+++ b/backend/internal/cli/remote/cmd/events_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestOpKindName_ClassifiesEveryOrgOpBody pins that `events watch` renders
+// a snake_case label for every OrgOp body kind. A new op body that the hub
+// broadcasts (e.g. the hub-only SetWorkspaceRegister / TombstoneWorkspace
+// lifecycle ops) must get a real label here, not "unknown" — operators
+// filter `events watch` JSON by `type`, so an "unknown" label silently
+// breaks scripts watching the lifecycle path.
+func TestOpKindName_ClassifiesEveryOrgOpBody(t *testing.T) {
+	cases := []struct {
+		name string
+		op   *leapmuxv1.OrgOp
+		want string
+	}{
+		{"SetNodeRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{}}}, "set_node_register"},
+		{"TombstoneNode", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneNode{TombstoneNode: &leapmuxv1.TombstoneNodeOp{}}}, "tombstone_node"},
+		{"SetTabRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{}}}, "set_tab_register"},
+		{"TombstoneTab", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneTab{TombstoneTab: &leapmuxv1.TombstoneTabOp{}}}, "tombstone_tab"},
+		{"SetFloatingWindowRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetFloatingWindowRegister{SetFloatingWindowRegister: &leapmuxv1.SetFloatingWindowRegisterOp{}}}, "set_floating_window_register"},
+		{"TombstoneFloatingWindow", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneFloatingWindow{TombstoneFloatingWindow: &leapmuxv1.TombstoneFloatingWindowOp{}}}, "tombstone_floating_window"},
+		{"SetWorkspaceRootNode", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{}}}, "set_workspace_root_node"},
+		// The two hub-only lifecycle ops added when workspace create/delete
+		// moved onto the serialized submit pipeline — now broadcast to
+		// subscribers, so `events watch` must label them, not "unknown".
+		{"SetWorkspaceRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{}}}, "set_workspace_register"},
+		{"TombstoneWorkspace", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneWorkspace{TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{}}}, "tombstone_workspace"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, opKindName(tc.op))
+		})
+	}
+}

--- a/backend/internal/hub/crdt/broadcast_test.go
+++ b/backend/internal/hub/crdt/broadcast_test.go
@@ -282,6 +282,123 @@ func TestBroadcast_AlwaysVisible_ForwardsRawOps(t *testing.T) {
 	assert.Equal(t, 0, materializedOrRemoved, "always-visible subscriber must NOT receive a redacted event")
 }
 
+// TestBroadcast_WorkspaceLifecycleOps_DeliveredToAdmittingSubscriber pins that
+// the workspace membership ops (SetWorkspaceRegister / TombstoneWorkspace) —
+// which replaced the old out-of-band MutateInternal and now flow through the
+// serialized submit pipeline — are broadcast to subscribers that admit the
+// workspace. The EntityKindWorkspaceRoot arm of batchVisibleOpsEvent keeps an
+// op when EITHER pre or post is visible (distinct from the
+// preVisible && postVisible rule for other entities), so a subscriber whose
+// filter contains the workspace must receive both ops as raw batch ops. A
+// regression that dropped these would leave the client's local workspaces map
+// diverged from the hub's (stale record after delete, missing record after
+// create) until reconnect.
+func TestBroadcast_WorkspaceLifecycleOps_DeliveredToAdmittingSubscriber(t *testing.T) {
+	mgr, _, _ := runManager(t, "org", allowAll{}, 120_000)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	snapshot, unsub := subscribeCapturing(t, mgr, map[string]bool{"w1": true})
+	defer unsub()
+
+	// Submit the create and delete as SEPARATE batches, mirroring the real
+	// lifecycle (a create batch, then a later delete batch). Within a single
+	// batch a register+tombstone pair would net to no workspaces-map change
+	// and be filtered as not-visible-to-anyone; separate batches each
+	// produce a real pre→post transition the EntityKindWorkspaceRoot arm
+	// keeps (preVisible || postVisible).
+	registerBatch := []*leapmuxv1.OrgOp{{
+		OpId: "ws-reg", Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		},
+	}}
+	_, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		OrgID: "org", Epoch: epoch, Batches: []*leapmuxv1.OpBatch{{BatchId: "lifecycle-create-w1", Ops: registerBatch}},
+	})
+	require.NoError(t, err)
+
+	tombstoneBatch := []*leapmuxv1.OrgOp{{
+		OpId: "ws-del", Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		},
+	}}
+	_, err = mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		OrgID: "org", Epoch: epoch, Batches: []*leapmuxv1.OpBatch{{BatchId: "lifecycle-delete-w1", Ops: tombstoneBatch}},
+	})
+	require.NoError(t, err)
+
+	// Both ops must reach the admitting subscriber's Batch event stream.
+	var seenRegister, seenTombstone bool
+	for _, evt := range snapshot() {
+		if b := evt.GetBatch(); b != nil {
+			for _, op := range b.GetOps() {
+				switch op.GetBody().(type) {
+				case *leapmuxv1.OrgOp_SetWorkspaceRegister:
+					seenRegister = true
+				case *leapmuxv1.OrgOp_TombstoneWorkspace:
+					seenTombstone = true
+				}
+			}
+		}
+	}
+	assert.True(t, seenRegister, "admitting subscriber must receive the SetWorkspaceRegister op")
+	assert.True(t, seenTombstone, "admitting subscriber must receive the TombstoneWorkspace op")
+}
+
+// TestBroadcast_WorkspaceTombstone_NoEmptyEntityRemovedFrame is the
+// regression pin for a 0-byte WS frame bug in the broadcast layer.
+//
+// A TombstoneWorkspace op classifies as EntityKindWorkspaceRoot and
+// produces an AffectedEntities transition {Pre: wsID, Post: ""} (the
+// record is removed, and IsTombstoneOp excludes it so the post-pin
+// override does not fire). For a subscriber admitting wsID that is a
+// pre→post OUT transition, so broadcastBatchToSubscriber calls
+// removed(ref). buildEntityRemovedEvent has NO EntityKindWorkspaceRoot
+// arm (the proto EntityRemoved oneof has no workspace variant), so it
+// returns nil. The removed() closure must nil-guard before wrapping
+// (mirroring materialized()) — otherwise NewMarshaledEvent(nil) ships a
+// non-nil wrapper around a nil proto, and proto.Marshal(nil) → []byte{}
+// yields a 0-byte WS frame to every admitting subscriber on every
+// workspace delete.
+//
+// captureSubscriber.send stores evt.Event (the proto pointer), so a
+// 0-byte-frame event shows up as a nil entry in the snapshot. This test
+// asserts no snapshot entry is nil — failing against the unguarded
+// removed() and passing once it nil-guards.
+func TestBroadcast_WorkspaceTombstone_NoEmptyEntityRemovedFrame(t *testing.T) {
+	mgr, _, _ := runManager(t, "org", allowAll{}, 121_000)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	snapshot, unsub := subscribeCapturing(t, mgr, map[string]bool{"w1": true})
+	defer unsub()
+
+	// Seed the record so the tombstone has a real pre→post OUT transition.
+	registerBatch := []*leapmuxv1.OrgOp{{
+		OpId: "ws-reg", Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		},
+	}}
+	_, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		OrgID: "org", Epoch: epoch, Batches: []*leapmuxv1.OpBatch{{BatchId: "lifecycle-create-w1", Ops: registerBatch}},
+	})
+	require.NoError(t, err)
+
+	tombstoneBatch := []*leapmuxv1.OrgOp{{
+		OpId: "ws-del", Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		},
+	}}
+	_, err = mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		OrgID: "org", Epoch: epoch, Batches: []*leapmuxv1.OpBatch{{BatchId: "lifecycle-delete-w1", Ops: tombstoneBatch}},
+	})
+	require.NoError(t, err)
+
+	events := snapshot()
+	require.NotEmpty(t, events, "subscriber should have received the lifecycle batch events")
+	for i, evt := range events {
+		assert.NotNilf(t, evt, "event %d must not be nil — a nil entry is a 0-byte WS frame from an unguarded removed() closure", i)
+	}
+}
+
 // TestBroadcast_NilFilter_SeesAllWorkspaces covers the all-workspaces
 // (nil filter) arm: a subscriber whose Filter.WorkspaceIDs is nil must
 // see raw ops across every workspace, exactly like an explicit
@@ -554,10 +671,12 @@ func TestBroadcast_TombstoneFloatingWindow_SendsRawOp_NotEntityRemoved(t *testin
 	seedRootInternal(t, mgr, "w1", "root1")
 	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
 
-	// Seed a complete floating window in w1 via MutateInternal — bypasses
+	// Seed a complete floating window in w1 via SeedStateForTest — bypasses
 	// completeness validation, which would otherwise demand all 7 register
-	// writes in the seeding batch.
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	// writes in the seeding batch, and pins hand-picked LWW HLCs the LWW-merge
+	// path would overwrite. SeedStateForTest runs the seed on the manager
+	// goroutine (the sole writer) so it cannot race the goroutine's bare reads.
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Nodes["fwroot"] = &leapmuxv1.NodeRecord{
 			NodeId: "fwroot",
 			Kind:   &leapmuxv1.LWWNodeKind{Value: leapmuxv1.NodeKind_NODE_KIND_LEAF, Hlc: &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "seed"}},

--- a/backend/internal/hub/crdt/manager.go
+++ b/backend/internal/hub/crdt/manager.go
@@ -105,20 +105,19 @@ type Manager struct {
 
 	mu    sync.RWMutex
 	state *leapmuxv1.OrgCrdtState
-	// stateWriteMu serializes every writer of m.state against each other: the
-	// manager goroutine's read-modify-swap in processSubmit / maybeAdvanceEpoch
-	// and MutateInternal's in-place write from the lifecycle-consumer request
-	// goroutine. The manager goroutine reads m.state's maps BARE (it is normally
-	// the sole writer), so without this an out-of-band MutateInternal add/delete of
-	// a workspace would race those bare reads in ValidateBatch / DiffProjectionForBatch
-	// -- a Go-fatal "concurrent map read and map write" that crashes the Hub -- and
-	// could be clobbered by the commit swap. m.mu still guards the maps against the
-	// RLock readers (Materialized, currentEpoch, broadcast). Lock order: stateWriteMu
-	// is outermost (stateWriteMu -> projection -> m.mu); nothing takes projection or
-	// m.mu and then stateWriteMu, so there is no inversion.
-	stateWriteMu sync.Mutex
-	subscribers  *SubscriberController
-	projection   sync.Mutex
+	// The manager goroutine (Start's select loop) is the SOLE writer of
+	// m.state: every mutation -- including workspace lifecycle create/delete,
+	// which flows through SubmitInternal as SetWorkspaceRegisterOp /
+	// TombstoneWorkspaceOp -- goes through processSubmit / maybeAdvanceEpoch on
+	// that one goroutine. That makes the bare m.state map reads in
+	// ValidateBatch / DiffProjectionForBatch legitimately lock-free.
+	// m.mu (RWMutex) guards m.state only against the RLock readers
+	// (Materialized, currentEpoch, broadcast, WithStateRLock) and the commit
+	// swap (m.state = working). The lone non-production writer is
+	// SeedStateForTest, which also runs on the manager goroutine (via seedCh)
+	// so it cannot race those bare reads; see its doc.
+	subscribers *SubscriberController
+	projection  sync.Mutex
 	// subscribeExpandMu serializes SubscribeWithACL's resolve+register against
 	// ExpandSubscribersForWorkspace's read-ACL-then-apply (workspace create).
 	// Without it, a subscriber that resolved its filter BEFORE a concurrent
@@ -133,15 +132,14 @@ type Manager struct {
 	// goroutine, so without this two mutations in the same org drain
 	// concurrently -- and the per-row apply logic is written against a single
 	// sequential consumer (contractSubscribersForWorkspace's single-key-delete
-	// safety argument, applyLifecycleCreate's optimistic state add, and the
-	// fixed "lifecycle-<op>-<ws>" batch ids all assume a create and a delete of
-	// the same workspace are never in flight at once). It is held across
-	// ListPending too, so a drain that starts while another is in flight
-	// observes the first drain's consume-marks instead of re-listing and
-	// re-applying its rows. Lock order: lifecycleMu is outermost of the
-	// lifecycle path (lifecycleMu -> stateWriteMu / subscribeExpandMu ->
-	// projection -> m.mu); nothing acquires lifecycleMu while holding another
-	// manager lock.
+	// safety argument, applyLifecycleCreate's filter expand + seed batch, and
+	// the fixed "lifecycle-<op>-<ws>" batch ids all assume a create and a
+	// delete of the same workspace are never in flight at once). It is held
+	// across ListPending too, so a drain that starts while another is in
+	// flight observes the first drain's consume-marks instead of re-listing
+	// and re-applying its rows. Lock order: lifecycleMu is outermost of the
+	// lifecycle path (lifecycleMu -> subscribeExpandMu -> projection -> m.mu);
+	// nothing acquires lifecycleMu while holding another manager lock.
 	lifecycleMu sync.Mutex
 	// undecodableLogged tracks lifecycle_outbox row IDs whose decode failure has
 	// already been logged at Error, so a row whose MarkLifecycleOutboxConsumed
@@ -178,8 +176,25 @@ type Manager struct {
 
 	submitCh   chan submitJob
 	internalCh chan submitJob
-	stop       chan struct{}
-	done       chan struct{}
+	// seedCh carries SeedStateForTest closures to the manager goroutine, so
+	// test seeds of m.state run on the sole writer (see seedJob). Unbuffered:
+	// SeedStateForTest blocks until the goroutine services the job, giving the
+	// seed a happens-before edge against any later submit's bare reads.
+	seedCh chan seedJob
+	// startedOnce closes startedChan exactly once, the first time Start runs,
+	// BEFORE the select loop begins servicing jobs. startedChan is the readiness
+	// signal the registry waits on before handing the manager out, so any caller
+	// that observes the manager after Get sees started() as closed and routes its
+	// seed through the goroutine (the sole writer) rather than the pre-Start
+	// direct-write branch -- closing the race the old atomic.Bool left open (Get
+	// spawned `go Start()` and returned before Start had set the flag, so a
+	// post-Get SeedStateForTest could read started==false and write m.state on
+	// the caller's goroutine while the manager goroutine was already doing bare
+	// reads in ValidateBatch).
+	startedOnce sync.Once
+	startedChan chan struct{}
+	stop        chan struct{}
+	done        chan struct{}
 	// stopOnce makes Stop safe to call concurrently: two callers (e.g. the
 	// registry's Shutdown and a test, or SweepIdle racing a manual Stop) would
 	// otherwise both pass the select-default arm and both close(m.stop), the
@@ -327,6 +342,15 @@ type submitResponse struct {
 	err     error
 }
 
+// seedJob carries a SeedStateForTest closure through the manager goroutine.
+// Running the seed on that goroutine makes the write mechanically
+// single-writer: it cannot race the goroutine's bare m.state reads in
+// ValidateBatch / DiffProjectionForBatch. done is closed once fn has run.
+type seedJob struct {
+	fn   func(*leapmuxv1.OrgCrdtState)
+	done chan struct{}
+}
+
 type presenceJob struct {
 	workspaceID string
 	clientID    string
@@ -379,6 +403,8 @@ func NewManager(orgID string, journal Journal, auth AuthChecker, logger *slog.Lo
 		clearGrace:  PresenceClearGrace,
 		submitCh:    make(chan submitJob, 64),
 		internalCh:  make(chan submitJob, 16),
+		seedCh:      make(chan seedJob),
+		startedChan: make(chan struct{}),
 		stop:        make(chan struct{}),
 		done:        make(chan struct{}),
 		subscribers: newSubscriberController(),
@@ -411,7 +437,7 @@ func (m *Manager) Bootstrap(ctx context.Context) error {
 		}
 	}
 	m.clock.Observe(state.GetMaxHlc())
-	m.state = state
+	m.commitState(state)
 	// Stamp activity so a freshly-bootstrapped manager isn't eligible
 	// for immediate eviction. The registry's idle-eviction window
 	// applies from the bootstrap moment onward; without this, a manager
@@ -437,6 +463,13 @@ func (m *Manager) Bootstrap(ctx context.Context) error {
 // deferred wait below ensures the presence loop is fully torn down
 // before the main loop's close(m.done) wakes Stop's waiter.
 func (m *Manager) Start(ctx context.Context) error {
+	// Signal readiness exactly once, before the loop begins servicing jobs.
+	// The registry waits on started() before handing this manager out, so any
+	// caller observing the manager post-Get routes its seed through seedCh (the
+	// sole writer) instead of the pre-Start direct-write branch -- closing the
+	// race the old atomic.Bool left open (Get spawned `go Start()` and returned
+	// before Start had set the flag).
+	m.startedOnce.Do(func() { close(m.startedChan) })
 	defer close(m.done)
 	presenceExited := make(chan struct{})
 	go func() {
@@ -458,10 +491,52 @@ func (m *Manager) Start(ctx context.Context) error {
 			job.respCh <- m.processSubmit(ctx, job)
 		case job := <-m.internalCh:
 			job.respCh <- m.processSubmit(ctx, job)
+		case job := <-m.seedCh:
+			// SeedStateForTest seed: run on this goroutine (the sole writer).
+			// The race-safety against processSubmit / DiffProjectionForBatch
+			// comes from same-goroutine sequencing (these are select cases on
+			// one loop, so the goroutine is never mid-ValidateBatch while
+			// servicing a seed); m.mu.Lock additionally excludes the
+			// cross-goroutine RLock readers (Materialized, currentEpoch,
+			// broadcast) while the maps change. Deferred unlock + close(done)
+			// so a panicking test seed neither leaves m.mu locked for the RLock
+			// readers nor wedges the caller on <-done; the panic itself still
+			// propagates (crashing the goroutine) so a buggy seed is visible,
+			// but Start's defer close(m.done) runs first so Stop's waiter and
+			// the caller's <-done both release.
+			func() {
+				defer func() {
+					m.mu.Unlock()
+					close(job.done)
+				}()
+				m.mu.Lock()
+				job.fn(m.state)
+			}()
 		case <-ticker.C:
 			m.tickHousekeeping(ctx)
 		}
 	}
+}
+
+// started returns a channel that is closed the first time Start runs, before
+// its select loop begins servicing jobs. Callers can wait on it to observe that
+// the manager goroutine is (or was, before a Stop) servicing the loop -- a
+// stronger signal than a bare atomic flag, because the registry waits on it
+// before handing the manager out. The channel is never re-opened, so after Stop
+// it stays closed (callers that need to distinguish "stopped" from "never
+// started" consult done, which Start closes on return).
+func (m *Manager) started() <-chan struct{} {
+	return m.startedChan
+}
+
+// WaitForStartForTest blocks until Start has been called and its select loop is
+// servicing jobs (or Start has returned). Test harnesses that spawn Start in a
+// goroutine and then call SeedStateForTest must wait on this first, otherwise
+// SeedStateForTest's pre-Start branch could run on the test goroutine racing
+// the just-spawned manager goroutine's bare reads. The registry's Get already
+// waits internally, so callers that obtain the manager via Get do not need this.
+func (m *Manager) WaitForStartForTest() {
+	<-m.startedChan
 }
 
 // touchActivity stamps the manager as freshly active. Called on every
@@ -765,12 +840,13 @@ func (m *Manager) processSubmit(ctx context.Context, job submitJob) submitRespon
 		return submitResponse{err: fmt.Errorf("manager %q received submit for org %q", m.orgID, in.OrgID)}
 	}
 
-	// Hold stateWriteMu across this submit's read-modify-write of m.state so an
-	// out-of-band MutateInternal (a lifecycle create/delete on a request goroutine)
-	// cannot interleave with the bare m.state map reads in ValidateBatch /
-	// DiffProjectionForBatch or the commit swap below. See the stateWriteMu field.
-	m.stateWriteMu.Lock()
-	defer m.stateWriteMu.Unlock()
+	// This submit's read-modify-write of m.state runs on the manager goroutine,
+	// which is the sole writer -- so the bare m.state map reads in ValidateBatch
+	// / DiffProjectionForBatch and the commit swap below need no extra lock
+	// beyond m.mu (which guards the RLock readers and the swap itself).
+	// Workspace lifecycle create/delete now flow through SubmitInternal as
+	// SetWorkspaceRegisterOp / TombstoneWorkspaceOp, so no out-of-band writer
+	// remains.
 
 	// 1. epoch_required + stale_epoch (request-level).
 	if !job.internal {
@@ -1012,10 +1088,23 @@ func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.O
 		return fmt.Errorf("commit batch: %w", err)
 	}
 
-	m.mu.Lock()
-	m.state = working
-	m.mu.Unlock()
+	m.commitState(working)
 	return nil
+}
+
+// commitState is the SOLE mutator of m.state: it swaps in a new generation
+// under m.mu.Lock, excluding the RLock readers (Materialized, currentEpoch,
+// broadcast, WithStateRLock) for the duration of the pointer swap. Routing
+// every state replacement through this one method makes the single-writer
+// invariant structurally visible -- the only places that assign m.state are
+// Bootstrap (pre-Start, before the goroutine exists) and commit (on the
+// manager goroutine, after a validated batch). A future debug path that tried
+// to assign m.state directly would have to add a third call site here, which
+// is exactly the review checkpoint the invariant needs.
+func (m *Manager) commitState(state *leapmuxv1.OrgCrdtState) {
+	m.mu.Lock()
+	m.state = state
+	m.mu.Unlock()
 }
 
 // State returns a deep clone of the current state. Used by tests +
@@ -1069,29 +1158,58 @@ func (m *Manager) currentEpoch() int64 {
 	return m.state.GetCurrentEpoch()
 }
 
-// MutateInternal lets the lifecycle outbox consumer mutate manager-internal
-// state (workspaces map, current_epoch) from a request goroutine. It takes
-// stateWriteMu — the same lock processSubmit / maybeAdvanceEpoch hold across the
-// manager goroutine's read-modify-write of m.state — so an in-place write here
-// cannot race the manager goroutine's bare m.state reads (a concurrent map
-// read+write) nor be clobbered by the commit swap. m.mu still excludes the RLock
-// readers (Materialized, currentEpoch, broadcast) while the maps change.
+// SeedStateForTest runs fn against m.state as the sole writer, so the write
+// cannot race the manager goroutine's bare m.state reads in ValidateBatch /
+// DiffProjectionForBatch. It is a TEST-ONLY seam for seeds that genuinely
+// cannot be a valid op batch — e.g. bumping CurrentEpoch to exercise a
+// stale-epoch gate (no op writes CurrentEpoch; only maybeAdvanceEpoch does) or
+// constructing a record with hand-picked LWW HLCs that bypass the LWW-merge
+// path. Every workspace-record seed that CAN be an op batch should go through
+// SubmitInternal as a SetWorkspaceRegisterOp, mirroring the production
+// lifecycle create path.
 //
-// Do NOT call this from the manager goroutine itself (inside processSubmit /
-// maybeAdvanceEpoch): those already hold stateWriteMu, so re-taking it would
-// deadlock. maybeCompact -- the other tickHousekeeping arm -- does NOT hold
-// stateWriteMu, but it never races this method: it touches m.state only under
-// m.mu (RLock to clone, Lock to advance the monotonic watermark / prune
-// tombstones), and runs on the same single Start-loop goroutine as
-// processSubmit, so it cannot overlap the manager goroutine's bare m.state
-// reads. The lifecycle-outbox consumer runs on the request goroutine, which is
-// the intended caller.
-func (m *Manager) MutateInternal(fn func(state *leapmuxv1.OrgCrdtState)) {
-	m.stateWriteMu.Lock()
-	defer m.stateWriteMu.Unlock()
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	fn(m.state)
+// Once Start has been called, fn runs ON the manager goroutine (via seedCh)
+// under m.mu.Lock — the same goroutine that owns the bare reads, so there is
+// no cross-goroutine write to race them. The registry waits on started()
+// before handing the manager out, so any caller that observes the manager via
+// Get routes its seed through the goroutine (closing the race an off-goroutine
+// pre-Start write would otherwise open). Before Start has been called (the
+// registry-factory shape, where the seed runs inside the factory closure
+// before Get spawns the goroutine), fn runs directly under m.mu.Lock,
+// mirroring Bootstrap's no-concurrent-reader assumption.
+//
+// fn MUST NOT call back into Submit / SubmitInternal / SeedStateForTest: those
+// channel sends would be made from the manager goroutine that is supposed to
+// receive on them, deadlocking the sole consumer.
+//
+// After Stop, the goroutine has exited and the seedCh send falls through to
+// <-m.done, so a post-Stop SeedStateForTest returns without running fn (it
+// cannot race, but it also cannot seed) rather than wedging the caller.
+//
+// Test-only: production state writes flow exclusively through SubmitInternal.
+func (m *Manager) SeedStateForTest(fn func(state *leapmuxv1.OrgCrdtState)) {
+	select {
+	case <-m.startedChan:
+		// Start has been called: route through the manager goroutine (the sole
+		// writer). The select on m.done returns if the goroutine has since
+		// exited (Stop) instead of wedging the caller on the unbuffered seedCh.
+		done := make(chan struct{})
+		select {
+		case m.seedCh <- seedJob{fn: fn, done: done}:
+			<-done
+		case <-m.done:
+		}
+	default:
+		// Start has not been called: no manager goroutine exists to race, so
+		// run fn directly under m.mu (mirrors Bootstrap). Safe only from the
+		// registry-factory shape, where this runs inside the factory closure
+		// before Get spawns Start; a direct caller that spawned `go Start()`
+		// and then reached this branch would race the goroutine it just
+		// launched -- route through the registry instead.
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		fn(m.state)
+	}
 }
 
 func rejectAll(batches []*leapmuxv1.OpBatch, reason leapmuxv1.BatchRejectionReason, opID string) submitResponse {

--- a/backend/internal/hub/crdt/manager_broadcast.go
+++ b/backend/internal/hub/crdt/manager_broadcast.go
@@ -66,6 +66,19 @@ func (m *Manager) broadcastBatch(batch *leapmuxv1.OpBatch, res ValidationResult)
 	// Pre == "" resolves to nil (IsAllowed("") is false for every filter, so no
 	// subscriber had the entity visible before the batch and the pre && !post
 	// caller condition can never fire for it).
+	//
+	// buildEntityRemovedEvent returns nil for an EntityKind with no Removed arm
+	// (notably EntityKindWorkspaceRoot — the proto EntityRemoved oneof has no
+	// workspace variant). A TombstoneWorkspace op no longer reaches this path:
+	// IsTombstoneOp includes it, so validate.go's post-pin records a stable
+	// {Pre: wsID, Post: wsID} transition (no OUT) and the op is delivered as
+	// the raw op via the Batch frame's EntityKindWorkspaceRoot arm (preVisible
+	// || postVisible). The `event != nil` guard mirrors materialized() below
+	// and is retained as defense-in-depth: if a future change re-introduces an
+	// EntityKindWorkspaceRoot OUT transition, the guard makes buildEntityRemovedEvent's
+	// nil a nil wrapper the caller skips instead of shipping a non-nil
+	// MarshaledEvent around a nil proto that marshals to a 0-byte WS frame
+	// (proto.Marshal(nil) → []byte{}).
 	removedCache := map[EntityRef]*MarshaledEvent{}
 	removed := func(ref EntityRef) *MarshaledEvent {
 		if evt, built := removedCache[ref]; built {
@@ -73,7 +86,9 @@ func (m *Manager) broadcastBatch(batch *leapmuxv1.OpBatch, res ValidationResult)
 		}
 		var evt *MarshaledEvent
 		if res.AffectedEntities[ref].Pre != "" {
-			evt = NewMarshaledEvent(buildEntityRemovedEvent(ref, atHLC))
+			if event := buildEntityRemovedEvent(ref, atHLC); event != nil {
+				evt = NewMarshaledEvent(event)
+			}
 		}
 		removedCache[ref] = evt
 		return evt
@@ -83,15 +98,13 @@ func (m *Manager) broadcastBatch(batch *leapmuxv1.OpBatch, res ValidationResult)
 	// subscriber that transitions INTO visibility (!pre && post) -- rare for the
 	// common in-place edit. Build them lazily and memoize (nil results included),
 	// so the clone happens at most once per ref and only when a subscriber needs
-	// it. Re-taking m.mu.RLock per first build is safe: the RLock is mutually
-	// exclusive with every writer of m.state's maps -- the manager goroutine's own
-	// commit swap (m.mu.Lock) and MutateInternal (m.mu.Lock, from the lifecycle-
-	// outbox consumer goroutine) -- so each read sees an un-torn map. And the only
-	// cross-goroutine writer, MutateInternal, mutates only the Workspaces map,
-	// which buildEntityMaterializedEvent never reads (it reads Tabs/Nodes/
-	// FloatingWindows), so per-ref materializations stay mutually consistent even
-	// across a concurrent lifecycle create/delete. buildEntityMaterializedEvent
-	// requires that read lock held.
+	// it. Re-taking m.mu.RLock per first build is safe: the manager goroutine is
+	// the sole writer of m.state, and its commit swap (m.state = working) takes
+	// m.mu.Lock, so each RLock read sees an un-torn map. (Workspace lifecycle
+	// create/delete now flow through SubmitInternal as
+	// SetWorkspaceRegisterOp / TombstoneWorkspaceOp on the manager goroutine,
+	// so there is no cross-goroutine writer of m.state.)
+	// buildEntityMaterializedEvent requires that read lock held.
 	materializedCache := map[EntityRef]*MarshaledEvent{}
 	materialized := func(ref EntityRef) *MarshaledEvent {
 		if evt, built := materializedCache[ref]; built {
@@ -330,8 +343,12 @@ func buildEntityMaterializedEvent(state *leapmuxv1.OrgCrdtState, ref EntityRef, 
 }
 
 // buildEntityRemovedEvent constructs the EntityRemoved wrapper for a
-// ref. Unlike Materialized, this is pure metadata (no state lookup) so
-// it never returns nil except for unrecognised kinds.
+// ref. Unlike Materialized, this is pure metadata (no state lookup).
+// Returns nil for an EntityKind the EntityRemoved oneof has no variant
+// for — EntityKindUnknown, and EntityKindWorkspaceRoot (workspace
+// membership has no per-entity Removed event; a TombstoneWorkspace op's
+// visibility transition is delivered as the raw op in the Batch frame).
+// Callers must nil-guard the result before wrapping (see removed()).
 func buildEntityRemovedEvent(ref EntityRef, atHLC *leapmuxv1.HLC) *leapmuxv1.WatchOrgEvent {
 	switch ref.Kind {
 	case EntityKindTab:

--- a/backend/internal/hub/crdt/manager_compaction.go
+++ b/backend/internal/hub/crdt/manager_compaction.go
@@ -28,12 +28,10 @@ func (m *Manager) tickHousekeeping(ctx context.Context) {
 }
 
 func (m *Manager) maybeAdvanceEpoch(ctx context.Context) {
-	// Hold stateWriteMu across the epoch read-modify-write so a concurrent
-	// MutateInternal (which may write current_epoch from a request goroutine)
-	// cannot race these bare reads or clobber the write below. See the
-	// stateWriteMu field on Manager.
-	m.stateWriteMu.Lock()
-	defer m.stateWriteMu.Unlock()
+	// maybeAdvanceEpoch runs on the manager goroutine (via tickHousekeeping),
+	// which is the sole writer of m.state, so the bare reads below need no
+	// lock beyond m.mu (taken for the final write to exclude the RLock
+	// readers).
 	if m.state.GetEpochStartedAt() == nil {
 		return
 	}

--- a/backend/internal/hub/crdt/manager_integration_test.go
+++ b/backend/internal/hub/crdt/manager_integration_test.go
@@ -37,6 +37,11 @@ func runManager(t *testing.T, orgID string, auth crdt.AuthChecker, nowSeed int64
 	require.NoError(t, mgr.Bootstrap(context.Background()))
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { _ = mgr.Start(ctx) }()
+	// Wait until the goroutine is servicing the loop before returning, so any
+	// subsequent SeedStateForTest routes through the goroutine (the sole writer)
+	// instead of the pre-Start direct-write branch (which would race the
+	// goroutine's bare m.state reads). Mirrors the registry's internal wait.
+	mgr.WaitForStartForTest()
 	t.Cleanup(func() {
 		cancel()
 		mgr.Stop()
@@ -44,19 +49,20 @@ func runManager(t *testing.T, orgID string, auth crdt.AuthChecker, nowSeed int64
 	return mgr, j, cancel
 }
 
-// seedRootInternal seeds the workspace + root node via the lifecycle
-// path (manager-internal mutation + SubmitInternal SetWorkspaceRootNode).
+// seedRootInternal seeds the workspace record + root node via the lifecycle
+// path: a SetWorkspaceRegister op (seeds the WorkspaceContentsRecord) followed
+// by the root-node kind + root-assignment ops, all in one atomic batch — the
+// same shape as the production applyLifecycleCreate seed. Routing the record
+// seed through SubmitInternal keeps the manager goroutine the sole writer of
+// m.state (no off-goroutine MutateInternal write).
 func seedRootInternal(t *testing.T, mgr *crdt.Manager, workspaceID, rootID string) {
 	t.Helper()
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
-		s.Workspaces[workspaceID] = &leapmuxv1.WorkspaceContentsRecord{
+	setRegister := &leapmuxv1.OrgOp{
+		OpId: "seed-workspace-register-" + workspaceID,
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{
 			WorkspaceId: workspaceID,
-			RootNodeId:  "",
-		}
-		if s.GetEpochStartedAt() == nil {
-			s.EpochStartedAt = nil
-		}
-	})
+		}},
+	}
 	rootKind := &leapmuxv1.OrgOp{
 		OpId: "seed-root-kind-" + workspaceID,
 		Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
@@ -73,7 +79,7 @@ func seedRootInternal(t *testing.T, mgr *crdt.Manager, workspaceID, rootID strin
 	}
 	results, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
 		OrgID:   "org",
-		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed-" + workspaceID, Ops: []*leapmuxv1.OrgOp{rootKind, rootRegister}}},
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed-" + workspaceID, Ops: []*leapmuxv1.OrgOp{setRegister, rootKind, rootRegister}}},
 	})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
@@ -102,40 +108,285 @@ func addTabBatch(t *testing.T, batchID string, tabID, tileID, workerID, position
 	}
 }
 
-// The lifecycle-outbox consumer calls MutateInternal (workspace add/delete) on a
-// request goroutine while the manager goroutine reads m.state.Workspaces bare in
-// ValidateBatch -> registeredRoots. Without stateWriteMu serializing the two, a
-// client submit racing a workspace create/delete is a Go-fatal "concurrent map
-// read and map write" that kills the Hub. This hammers both paths; it must run
-// clean (and clean under -race) with the fix.
-func TestManager_MutateInternalRacesClientSubmit(t *testing.T) {
+// TestManager_LifecycleOpsSerializeWithClientSubmit exercises the model that
+// replaced the old out-of-band MutateInternal: workspace lifecycle create/delete
+// now flow through SubmitInternal as SetWorkspaceRegisterOp / TombstoneWorkspaceOp,
+// so the manager goroutine stays the SOLE writer of m.state and its bare
+// Workspaces reads in ValidateBatch -> registeredRoots stay race-free WITHOUT a
+// stateWriteMu across the DB commit.
+//
+// This hammers concurrent client Submit (which iterates m.state.Workspaces bare
+// in ValidateBatch) against the lifecycle-outbox drain (which now mutates
+// Workspaces via internal submit ops). It must run clean -- and clean under
+// -race -- with no "concurrent map read and map write", and the churned
+// workspaces must end absent (every create was paired with a delete).
+func TestManager_LifecycleOpsSerializeWithClientSubmit(t *testing.T) {
 	mgr, _, _ := runManager(t, "org", allowAll{}, 900_000)
 	seedRootInternal(t, mgr, "w1", "root1")
 	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
 
-	const iterations = 1500
+	outbox := newControllableOutbox()
+	const iterations = 400
 	var wg sync.WaitGroup
 	wg.Add(2)
-	// Manager goroutine: each Submit validates against m.state, iterating Workspaces.
+	// Client path: each Submit validates against m.state, iterating Workspaces
+	// bare in registeredRoots. Ops target the stable root1 so they commit.
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			_, _ = mgr.Submit(context.Background(), crdt.SubmitInput{
+			res, err := mgr.Submit(context.Background(), crdt.SubmitInput{
 				OrgID: "org", Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
 				Batches: []*leapmuxv1.OpBatch{addTabBatch(t,
 					"b-"+strconv.Itoa(i), "tab-"+strconv.Itoa(i), "root1", "wkr", "p"+strconv.Itoa(i))},
 			})
+			// require (not assert): a Submit error returns (nil, err), and the
+			// next line indexes res[0] -- assert continues on failure and would
+			// nil-deref into a panic instead of a clean failure.
+			require.NoError(t, err)
+			require.NotNil(t, res[0].GetCommitted(), "client submit should commit; got %v", res[0])
 		}
 	}()
-	// Request goroutine: in-place workspace add/delete via MutateInternal.
+	// Lifecycle path: stage create+delete rows for fresh workspaces and drain
+	// them through SubmitLifecycle (the production request-goroutine entry).
+	// Every Workspaces mutation here goes through the manager goroutine as an
+	// internal submit op -- never an out-of-band write.
+	var (
+		lifecycleErrMu sync.Mutex
+		lastLifecycle  error
+	)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			id := "churn-" + strconv.Itoa(i)
-			mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+			ws := "churn-" + strconv.Itoa(i)
+			root := "root-" + strconv.Itoa(i)
+			createPayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+				OpType: crdt.LifecycleOpCreate, WorkspaceID: ws, RootNodeID: root,
+			}, []*leapmuxv1.OrgOp{
+				{OpId: "seed-kind-" + ws, Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+					NodeId: root, Field: &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+				}}},
+				{OpId: "seed-root-" + ws, Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{
+					WorkspaceId: ws, RootNodeId: root,
+				}}},
+			})
+			require.NoError(t, err)
+			outbox.push("org", crdt.LifecycleOpCreate, createPayload)
+			deletePayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+				OpType: crdt.LifecycleOpDelete, WorkspaceID: ws,
+			}, nil)
+			require.NoError(t, err)
+			outbox.push("org", crdt.LifecycleOpDelete, deletePayload)
+			// Drain after each pair so the create lands before the delete
+			// enumerates it (deletion of a not-yet-created workspace would
+			// skip the tombstone batch and leave the record seeded by create).
+			// Capture the error so a permanently-failing lifecycle path fails
+			// the test instead of the assertion below passing tautologically.
+			if err := mgr.SubmitLifecycle(context.Background(), outbox); err != nil {
+				lifecycleErrMu.Lock()
+				lastLifecycle = err
+				lifecycleErrMu.Unlock()
+			}
+		}
+	}()
+	wg.Wait()
+
+	// The lifecycle path must have committed (otherwise the absence of churned
+	// workspaces below would be tautological -- it holds whether the create
+	// committed-then-deleted OR never committed at all). Assert the final drain
+	// succeeded and the outbox is fully consumed.
+	lifecycleErrMu.Lock()
+	require.NoError(t, lastLifecycle, "lifecycle drain must not error (a permanently-failing create/delete would make the workspace-absence assertion below tautological)")
+	lifecycleErrMu.Unlock()
+	pending, err := outbox.ListPendingLifecycleOutbox(context.Background(), "org")
+	require.NoError(t, err)
+	require.Empty(t, pending, "every pushed create+delete row must be consumed (a non-empty outbox means the lifecycle path did not commit)")
+
+	// Every churned workspace was created then deleted; none may remain in
+	// state. The seed workspace w1 must be untouched.
+	state := mgr.Materialized(crdt.SubscriberFilter{})
+	for ws := range state.GetWorkspaces() {
+		if ws == "w1" {
+			continue
+		}
+		t.Fatalf("churned workspace %q still present after paired create/delete", ws)
+	}
+}
+
+// TestManager_SeedStateForTest_RunsOnManagerGoroutine pins the property
+// MutateInternal lacked: a SeedStateForTest write of m.state cannot race a
+// concurrent client Submit's bare m.state reads in ValidateBatch, because the
+// seed runs ON the manager goroutine (the sole writer). Hammer both paths in
+// parallel; under -race this must stay clean (the old off-goroutine
+// MutateInternal was a latent "concurrent map read and map write").
+func TestManager_SeedStateForTest_RunsOnManagerGoroutine(t *testing.T) {
+	mgr, _, _ := runManager(t, "org", allowAll{}, 800_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	const iterations = 400
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Client path: each Submit iterates m.state.Workspaces bare in
+	// registeredRoots (no m.mu) on the manager goroutine.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			res, err := mgr.Submit(context.Background(), crdt.SubmitInput{
+				OrgID: "org", Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+				Batches: []*leapmuxv1.OpBatch{addTabBatch(t,
+					"b-"+strconv.Itoa(i), "tab-"+strconv.Itoa(i), "root1", "wkr", "p"+strconv.Itoa(i))},
+			})
+			// require (not assert): a Submit error returns (nil, err), and the
+			// next line indexes res[0] -- assert continues on failure and would
+			// nil-deref into a panic instead of a clean failure.
+			require.NoError(t, err)
+			require.NotNil(t, res[0].GetCommitted(), "client submit should commit; got %v", res[0])
+		}
+	}()
+	// Seed path: each SeedStateForTest write of m.state.Workspaces runs on the
+	// manager goroutine — serialized with the client submits, never racing them.
+	// The final iteration leaves a sentinel workspace in place (no paired
+	// delete) so the post-condition assertion below is non-tautological: a
+	// buggy seedCh arm that silently dropped fn would leave the sentinel
+	// absent, failing the test, instead of the absence-of-churned check
+	// passing whether or not seeds applied.
+	const sentinel = "seed-sentinel"
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			id := "seed-" + strconv.Itoa(i)
+			mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 				s.Workspaces[id] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: id}
 			})
-			mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) { delete(s.Workspaces, id) })
+			mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) { delete(s.Workspaces, id) })
+		}
+		// A final seed with no paired delete: must persist, proving seeds land.
+		mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
+			s.Workspaces[sentinel] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: sentinel}
+		})
+	}()
+	wg.Wait()
+
+	// The sentinel proves SeedStateForTest actually applied fn (non-tautological
+	// evidence the seed path committed). w1 (the seeded root) must be untouched;
+	// every other churned seed was paired with a delete.
+	state := mgr.Materialized(crdt.SubscriberFilter{})
+	require.Contains(t, state.GetWorkspaces(), sentinel,
+		"sentinel seed (no paired delete) must persist -- its presence proves SeedStateForTest applied fn, making this assertion non-tautological")
+	require.Contains(t, state.GetWorkspaces(), "w1", "the seeded root w1 must be untouched")
+	for ws := range state.GetWorkspaces() {
+		if ws == "w1" || ws == sentinel {
+			continue
+		}
+		t.Fatalf("seeded workspace %q still present after paired seed/delete", ws)
+	}
+}
+
+// TestManager_SeedStateForTest_PreStart covers the pre-Start branch
+// (started=false): SeedStateForTest runs fn directly under m.mu.Lock, mirroring
+// Bootstrap's no-concurrent-reader assumption. This is the registry-factory
+// shape, where state is seeded before the goroutine launches.
+func TestManager_SeedStateForTest_PreStart(t *testing.T) {
+	j := newFakeJournal()
+	mgr := crdt.NewManager("org", j, allowAll{}, nil, func() time.Time { return time.UnixMilli(1) })
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+
+	// Seed BEFORE Start — the !started branch.
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
+		s.Workspaces["pre-w1"] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: "pre-w1"}
+	})
+	assert.Contains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "pre-w1",
+		"pre-Start SeedStateForTest must seed the record")
+
+	// Start the goroutine and confirm the seed survived. WaitForStartForTest
+	// ensures the goroutine is servicing the loop before the post-Start seed
+	// below runs, so that seed routes through the goroutine (not the pre-Start
+	// direct-write branch, which would race the just-launched goroutine).
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+	mgr.WaitForStartForTest()
+	assert.Contains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "pre-w1",
+		"pre-Start seed must survive Start")
+
+	// A post-Start seed runs via the goroutine and lands too.
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
+		s.Workspaces["post-w1"] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: "post-w1"}
+	})
+	assert.Contains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "post-w1",
+		"post-Start SeedStateForTest must seed the record via the goroutine")
+}
+
+// TestManager_SeedStateForTest_AfterRegistryGetDoesNotRace is the regression pin
+// for the FOOTGUNS-6 race: Registry.Get spawns `go Start()` and returns, so
+// without Get waiting on started(), a caller that immediately calls
+// SeedStateForTest could observe started==false (Start hasn't closed it yet) and
+// write m.state on the caller's goroutine while the manager goroutine runs
+// ValidateBatch's bare (lock-free) read of m.state.Workspaces -- a Go-fatal
+// "concurrent map read and map write" (the exact crash this refactor exists to
+// eliminate). Get now waits on started() internally, so the post-Get seed always
+// routes through the goroutine. This test hammers the post-Get seed against a
+// concurrent client submit and must stay clean under -race.
+func TestManager_SeedStateForTest_AfterRegistryGetDoesNotRace(t *testing.T) {
+	j := newFakeJournal()
+	var (
+		clockMu sync.Mutex
+		clock   = int64(700_000)
+	)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		clock++
+		return time.UnixMilli(clock)
+	}
+	var mgr *crdt.Manager
+	registry := crdt.NewRegistry(func(ctx context.Context, want string) (*crdt.Manager, error) {
+		m := crdt.NewManager("org", j, allowAll{}, nil, now)
+		if err := m.Bootstrap(ctx); err != nil {
+			return nil, err
+		}
+		mgr = m
+		return m, nil
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	// Get spawns the manager goroutine and returns only once it is servicing
+	// the loop (the internal started() wait).
+	_, err := registry.Get(context.Background(), "org")
+	require.NoError(t, err)
+	seedRootInternal(t, mgr, "w1", "root1")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	const iterations = 300
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Client path: each Submit reads m.state.Workspaces bare in registeredRoots.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			res, err := mgr.Submit(context.Background(), crdt.SubmitInput{
+				OrgID: "org", Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+				Batches: []*leapmuxv1.OpBatch{addTabBatch(t,
+					"b-"+strconv.Itoa(i), "tab-"+strconv.Itoa(i), "root1", "wkr", "p"+strconv.Itoa(i))},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, res[0].GetCommitted(), "client submit should commit; got %v", res[0])
+		}
+	}()
+	// Seed path: post-Get SeedStateForTest must route through the goroutine
+	// (never the pre-Start direct-write branch), so it cannot race the bare
+	// reads the client path is issuing.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			id := "rg-" + strconv.Itoa(i)
+			mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
+				s.Workspaces[id] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: id}
+			})
+			mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) { delete(s.Workspaces, id) })
 		}
 	}()
 	wg.Wait()
@@ -224,13 +475,14 @@ func TestManager_RestartReplay(t *testing.T) {
 // renders and the frontend times out at 30s":
 //
 // The workspace's WorkspaceContentsRecord placeholder is added to
-// `state.Workspaces` via non-journaled MutateInternal in
-// applyLifecycleCreate. The seed batch's SetWorkspaceRootNodeOp is
-// journaled and re-applied on Bootstrap replay; but its apply path
-// (applySetWorkspaceRootNode) silently dropped the op when the
-// placeholder was missing. So on Bootstrap-from-empty-snapshot the
-// workspace record vanished and the frontend's awaitWorkspaceBootstrap
-// polled `workspaces[wsID].rootNodeId` forever.
+// `state.Workspaces` by the SetWorkspaceRegisterOp in the lifecycle
+// create seed batch (journaled alongside the SetWorkspaceRootNodeOp).
+// On Bootstrap replay the seed batch re-applies; but applySetWorkspaceRootNode
+// silently dropped the op when the placeholder was missing — so on
+// Bootstrap-from-empty-snapshot (an op log written before
+// SetWorkspaceRegisterOp existed), the workspace record vanished and the
+// frontend's awaitWorkspaceBootstrap polled `workspaces[wsID].rootNodeId`
+// forever.
 //
 // The contract: after restart, the workspace record (and its
 // root_node_id register) MUST survive replay; the projection
@@ -423,7 +675,9 @@ func TestManager_StaleEpoch_Rejected(t *testing.T) {
 	currentEpoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
 
 	// Bump the in-memory epoch by 2 directly; emulates 28 days of advance.
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	// SeedStateForTest (not an op batch — no op writes CurrentEpoch; only
+	// maybeAdvanceEpoch does) routes the write through the manager goroutine.
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.CurrentEpoch = currentEpoch + 2
 	})
 
@@ -1090,8 +1344,9 @@ func TestManager_DedupHitOldEpoch_FallsThroughToStaleEpoch(t *testing.T) {
 	require.NotNil(t, first[0].GetCommitted())
 
 	// Advance current_epoch by 2; the dedup row's stored epoch is now
-	// `current_epoch - 2`, outside the one-epoch grace window.
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) { s.CurrentEpoch = epoch + 2 })
+	// `current_epoch - 2`, outside the one-epoch grace window. SeedStateForTest
+	// (no op writes CurrentEpoch) routes the write through the manager goroutine.
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) { s.CurrentEpoch = epoch + 2 })
 	newEpoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
 	require.Equal(t, epoch+2, newEpoch)
 

--- a/backend/internal/hub/crdt/manager_lifecycle.go
+++ b/backend/internal/hub/crdt/manager_lifecycle.go
@@ -23,6 +23,19 @@ const (
 	LifecycleOpDelete LifecycleOpType = "delete"
 )
 
+// lifecycleCreateBatchIDPrefix / lifecycleDeleteBatchIDPrefix prefix the fixed
+// BatchId the create/delete seed batches submit under. The fixed id (prefix +
+// workspace id) is the dedup key that makes a re-drained lifecycle batch
+// idempotent within DedupTTL: a second drain of the same row hits the cached
+// committed result instead of re-applying. Naming the prefixes keeps the dedup
+// contract greppable and a typo (which would silently break idempotent re-drain)
+// impossible. ApplyLifecycleCreate's ROOT_IMMUTABLE / TOMBSTONED_TARGET arms
+// rely on these exact ids to recognize a re-drain after DedupTTL expiry.
+const (
+	lifecycleCreateBatchIDPrefix = "lifecycle-create-"
+	lifecycleDeleteBatchIDPrefix = "lifecycle-delete-"
+)
+
 // LifecyclePayload is the body of a single lifecycle_outbox row. The
 // CRDT manager parses this into a batch of internal-origin ops plus
 // an associated event broadcast. Encoded as JSON because it's
@@ -210,20 +223,6 @@ func (m *Manager) applyLifecycleRow(ctx context.Context, row LifecycleOutboxRow,
 
 func (m *Manager) applyLifecycleCreate(ctx context.Context, row LifecycleOutboxRow, p LifecyclePayload, ops []*leapmuxv1.OrgOp, reader LifecycleOutboxReader) error {
 	wsID := p.WorkspaceID
-	// Add the (workspace_id, root_node_id="") map entry first so the
-	// SetWorkspaceRootNodeOp below has somewhere to land.
-	m.MutateInternal(func(state *leapmuxv1.OrgCrdtState) {
-		if _, exists := state.Workspaces[wsID]; !exists {
-			state.Workspaces[wsID] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: wsID}
-		}
-	})
-
-	rollback := func() {
-		m.MutateInternal(func(state *leapmuxv1.OrgCrdtState) { delete(state.Workspaces, wsID) })
-		// Undo the optimistic filter expansion so a future
-		// CanAccessWorkspace flip can't smuggle stale visibility through.
-		m.contractSubscribersForWorkspace(wsID)
-	}
 
 	// Expand each existing subscriber's Filter to include the new
 	// workspace BEFORE SubmitInternal broadcasts the seed batch.
@@ -233,18 +232,34 @@ func (m *Manager) applyLifecycleCreate(ctx context.Context, row LifecycleOutboxR
 	// frontend never learns the workspace's root_node_id, and the
 	// agent tab the user just opened never lands in the CRDT
 	// projection. A read-ACL LOOKUP failure here must not silently drop
-	// the seed: roll back the optimistic add and return WITHOUT consuming
-	// the outbox row so the create retries whenever the outbox is next drained
-	// -- the next lifecycle mutation in this org, not a periodic tick (the fixed
-	// BatchId + idempotent MutateInternal make retry safe).
+	// the seed: contract the (possibly partially) expanded filters and
+	// return WITHOUT consuming the outbox row so the create retries
+	// whenever the outbox is next drained -- the next lifecycle mutation
+	// in this org, not a periodic tick (the fixed BatchId + idempotent
+	// apply make retry safe).
 	if err := m.ExpandSubscribersForWorkspace(ctx, wsID); err != nil {
-		rollback()
+		m.contractSubscribersForWorkspace(wsID)
 		return fmt.Errorf("expand subscribers for workspace %s: %w", wsID, err)
 	}
 
+	// Build the seed batch: SetWorkspaceRegister seeds the
+	// WorkspaceContentsRecord map entry (root_node_id empty) so the
+	// accompanying SetNodeRegister + SetWorkspaceRootNode ops have a
+	// record to land on. Folding all three into one atomic batch means
+	// the workspace record and its root either commit together or not at
+	// all -- no out-of-band m.state mutation, so the manager goroutine
+	// stays the sole writer and its bare map reads stay race-free.
+	seedOps := make([]*leapmuxv1.OrgOp, 0, len(ops)+1)
+	seedOps = append(seedOps, &leapmuxv1.OrgOp{
+		OpId: id.Generate(),
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: wsID},
+		},
+	})
+	seedOps = append(seedOps, ops...)
 	batch := &leapmuxv1.OpBatch{
-		BatchId: "lifecycle-create-" + wsID,
-		Ops:     ops,
+		BatchId: lifecycleCreateBatchIDPrefix + wsID,
+		Ops:     seedOps,
 	}
 	results, err := m.SubmitInternal(ctx, SubmitInput{
 		OrgID:        m.orgID,
@@ -254,27 +269,60 @@ func (m *Manager) applyLifecycleCreate(ctx context.Context, row LifecycleOutboxR
 		OriginClient: m.hubClientID,
 	})
 	if err != nil {
-		rollback()
+		// SubmitInternal surfaces a transient error (e.g. a journal store
+		// fault) before any op applied, so no m.state mutation landed.
+		// Contract the filter expansion so a future CanAccessWorkspace flip
+		// can't smuggle stale visibility through; the row is NOT consumed
+		// and retries on the next drain.
+		m.contractSubscribersForWorkspace(wsID)
 		return err
 	}
-	// A ROOT_IMMUTABLE rejection on re-drain means the seed already landed on a
-	// prior drain whose MarkLifecycleOutboxConsumed then failed (a transient DB
-	// write fault) and whose dedup row has since expired past DedupTTL. The
-	// workspace exists, the root is set, the filter expansion already happened,
-	// and the user may have added tabs in the meantime -- so rolling back would
-	// corrupt CRDT state (delete(state.Workspaces, wsID) while the DB row, root
-	// node, and tabs stay behind) and strand the row in a permanent rejection
-	// loop. Treat ROOT_IMMUTABLE as the idempotent-success signal it is: the
-	// create already happened, so do NOT roll back, consume the row, and
-	// re-broadcast (subscribers either see it as new or dedupe via state).
+	// A re-drained create seed batch can reject for one of two reasons that
+	// BOTH mean "the create already happened on a prior drain whose
+	// MarkLifecycleOutboxConsumed then failed (a transient DB write fault) and
+	// whose dedup row has since expired past DedupTTL":
+	//
+	//  1. ROOT_IMMUTABLE -- the workspace exists with its root set (the create
+	//     landed and has not been deleted). Contracting would drop the workspace
+	//     from live subscribers' filters while the DB row, root node, and any
+	//     tabs the user added stay behind, and re-expanding on the next drain
+	//     pays the ACL lookup again.
+	//  2. TOMBSTONED_TARGET -- the create's SetNodeRegister(root) op hits a root
+	//     node that the delete batch already tombstoned, i.e. the create landed
+	//     AND was since deleted. The workspace record is gone (the delete's
+	//     TombstoneWorkspace op removed it), so re-applying the create would be
+	//     wrong. Without this arm the row rejects on every subsequent drain,
+	//     stalling permanently and (once SubmitLifecycle marks the workspace
+	//     blocked) deferring every later row for the same workspace.
+	//
+	// Both are the idempotent-success signal: the create already happened, so do
+	// NOT contract, consume the row, and re-broadcast (subscribers either see it
+	// as new or dedupe via state). The TOMBSTONED_TARGET arm is scoped to "the
+	// workspace record is currently absent" so it only fires for the
+	// create-then-deleted shape, never masking a genuinely corrupt seed batch.
+	recordAbsent := false
+	m.WithStateRLock(func(state *leapmuxv1.OrgCrdtState) {
+		_, recordAbsent = state.GetWorkspaces()[wsID]
+	})
+	recordAbsent = !recordAbsent
 	for _, r := range results {
 		if rj := r.GetRejected(); rj != nil {
-			if rj.GetReason() == leapmuxv1.BatchRejectionReason_BATCH_REJECTION_ROOT_IMMUTABLE {
+			switch rj.GetReason() {
+			case leapmuxv1.BatchRejectionReason_BATCH_REJECTION_ROOT_IMMUTABLE:
 				m.logger.Warn("lifecycle create re-drained after a prior apply; treating as idempotent",
-					"workspace_id", wsID, "row_id", row.ID)
+					"workspace_id", wsID, "row_id", row.ID, "reason", "ROOT_IMMUTABLE")
 				continue
+			case leapmuxv1.BatchRejectionReason_BATCH_REJECTION_TOMBSTONED_TARGET:
+				if recordAbsent {
+					m.logger.Warn("lifecycle create re-drained after a prior apply + delete; treating as idempotent",
+						"workspace_id", wsID, "row_id", row.ID, "reason", "TOMBSTONED_TARGET (root tombstoned, record absent)")
+					continue
+				}
 			}
-			rollback()
+			// Any other rejection means the seed batch never committed, so no
+			// m.state mutation landed: contract the filter expansion and surface
+			// the error so the row is NOT consumed and retries on the next drain.
+			m.contractSubscribersForWorkspace(wsID)
 			return fmt.Errorf("seed batch rejected: %v", rj.GetReason())
 		}
 	}
@@ -285,7 +333,7 @@ func (m *Manager) applyLifecycleCreate(ctx context.Context, row LifecycleOutboxR
 	// workspace would be invisible in live subscriptions until a reconnect. The
 	// retry the order exists to make reachable is now SAFE because the
 	// ROOT_IMMUTABLE arm above treats a re-seed as idempotent success rather than
-	// the rollback that would corrupt state.
+	// a contraction that would drop live subscribers.
 	m.broadcastWorkspaceCreatedEvent(wsID, p.Title, p.RootNodeID)
 	if err := reader.MarkLifecycleOutboxConsumed(ctx, row.ID, m.now()); err != nil {
 		return err
@@ -329,46 +377,57 @@ func (m *Manager) applyLifecycleDelete(ctx context.Context, row LifecycleOutboxR
 	m.WithStateRLock(func(state *leapmuxv1.OrgCrdtState) {
 		enumOps = enumerateWorkspaceDeleteOps(state, wsID)
 	})
-	combined := make([]*leapmuxv1.OrgOp, 0, len(ops)+len(enumOps))
+	combined := make([]*leapmuxv1.OrgOp, 0, len(ops)+len(enumOps)+1)
 	combined = append(combined, ops...)
 	combined = append(combined, enumOps...)
-	if len(combined) > 0 {
-		batch := &leapmuxv1.OpBatch{BatchId: "lifecycle-delete-" + p.WorkspaceID, Ops: combined}
-		results, err := m.SubmitInternal(ctx, SubmitInput{
-			OrgID:        m.orgID,
-			Epoch:        m.currentEpoch(),
-			Batches:      []*leapmuxv1.OpBatch{batch},
-			PrincipalID:  HubReservedPrincipal,
-			OriginClient: m.hubClientID,
-		})
-		if err != nil {
-			return err
-		}
-		for _, r := range results {
-			if rj := r.GetRejected(); rj != nil {
-				return fmt.Errorf("delete batch rejected: %v", rj.GetReason())
-			}
+	// Append a TombstoneWorkspaceOp so the WorkspaceContentsRecord map
+	// entry is removed in the same atomic batch as the subtree
+	// tombstones. Folding it into the batch (rather than an out-of-band
+	// MutateInternal after) keeps every m.state mutation on the manager
+	// goroutine: the record and its contents commit or roll back
+	// together, and the manager goroutine's bare m.state reads stay
+	// race-free.
+	combined = append(combined, &leapmuxv1.OrgOp{
+		OpId: id.Generate(),
+		Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: p.WorkspaceID},
+		},
+	})
+	batch := &leapmuxv1.OpBatch{BatchId: lifecycleDeleteBatchIDPrefix + p.WorkspaceID, Ops: combined}
+	results, err := m.SubmitInternal(ctx, SubmitInput{
+		OrgID:        m.orgID,
+		Epoch:        m.currentEpoch(),
+		Batches:      []*leapmuxv1.OpBatch{batch},
+		PrincipalID:  HubReservedPrincipal,
+		OriginClient: m.hubClientID,
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range results {
+		if rj := r.GetRejected(); rj != nil {
+			return fmt.Errorf("delete batch rejected: %v", rj.GetReason())
 		}
 	}
-	m.MutateInternal(func(state *leapmuxv1.OrgCrdtState) { delete(state.Workspaces, p.WorkspaceID) })
 	// Broadcast the deletion and contract subscriber filters BEFORE marking the
 	// outbox row consumed. The in-memory state already reflects the delete (the
-	// tombstone batch above ran and the Workspaces map entry is gone), so the
-	// broadcast describes committed state either way -- but ordering it before
-	// the consume closes a window the old order left open: if MarkLifecycleOutboxConsumed
-	// fails (a transient DB write fault) the row stays pending and the only re-drain
-	// trigger is the next lifecycle RPC in this org, which for a delete that removed
-	// the org's last workspace may not come for a long time. Subscribers would keep
-	// the dead workspace in their Filter and keep routing tabs to it until reconnect.
-	// Broadcasting first means a consume failure delays only the outbox bookkeeping,
-	// not the subscriber-visible event. A successful re-drain re-broadcasts, which
-	// is idempotent on the subscriber side (deleting an already-absent workspace and
-	// re-running the lifecycle-changed refresh).
+	// tombstone batch above committed and the Workspaces map entry is gone), so
+	// the broadcast describes committed state either way -- but ordering it
+	// before the consume closes a window the old order left open: if
+	// MarkLifecycleOutboxConsumed fails (a transient DB write fault) the row
+	// stays pending and the only re-drain trigger is the next lifecycle RPC in
+	// this org, which for a delete that removed the org's last workspace may not
+	// come for a long time. Subscribers would keep the dead workspace in their
+	// Filter and keep routing tabs to it until reconnect. Broadcasting first
+	// means a consume failure delays only the outbox bookkeeping, not the
+	// subscriber-visible event. A successful re-drain re-broadcasts, which is
+	// idempotent on the subscriber side (deleting an already-absent workspace
+	// and re-running the lifecycle-changed refresh).
 	m.BroadcastWorkspaceDeleted(p.WorkspaceID, p.WorkerIDs)
 	// Drop the deleted workspace from every subscriber's Filter so a
 	// long-lived subscription doesn't accumulate dead workspace_ids
-	// across the manager's lifetime. Mirrors the rollback path's
-	// contraction in applyLifecycleCreate.
+	// across the manager's lifetime. Mirrors the contraction on a failed
+	// create in applyLifecycleCreate.
 	m.contractSubscribersForWorkspace(p.WorkspaceID)
 	if err := reader.MarkLifecycleOutboxConsumed(ctx, row.ID, m.now()); err != nil {
 		return err

--- a/backend/internal/hub/crdt/manager_lifecycle_test.go
+++ b/backend/internal/hub/crdt/manager_lifecycle_test.go
@@ -164,6 +164,24 @@ func TestLifecycleCreate_ThroughOutbox_SeedsRootAndBroadcasts(t *testing.T) {
 	consumed := outbox.consumedSnapshot()
 	require.Contains(t, consumed, rowID)
 
+	// The seed batch landed on the journal with a SetWorkspaceRegister op
+	// FIRST (seeding the WorkspaceContentsRecord map entry in the same
+	// atomic batch as the root node + root assignment — no out-of-band
+	// m.state mutation). This is the crux of the #269 fix: workspace
+	// lifecycle create flows through the serialized submit pipeline.
+	var seedBatch *leapmuxv1.OpBatch
+	for _, b := range j.batches {
+		if b.GetBatchId() == "lifecycle-create-w1" {
+			seedBatch = b
+			break
+		}
+	}
+	require.NotNil(t, seedBatch, "lifecycle-create-w1 batch should be committed")
+	require.NotEmpty(t, seedBatch.GetOps())
+	_, isFirstSetWorkspaceRegister := seedBatch.GetOps()[0].GetBody().(*leapmuxv1.OrgOp_SetWorkspaceRegister)
+	assert.True(t, isFirstSetWorkspaceRegister,
+		"seed batch's first op should be SetWorkspaceRegister; got %T", seedBatch.GetOps()[0].GetBody())
+
 	// State has w1 with rootNodeId pointing at root-w1.
 	mat := mgr.Materialized(crdt.SubscriberFilter{})
 	require.Contains(t, mat.GetWorkspaces(), "w1")
@@ -267,6 +285,172 @@ func TestLifecycleCreate_RedrainAfterDedupExpiryIsIdempotent(t *testing.T) {
 	assert.Contains(t, mat.GetWorkspaces(), "w1", "the workspace must not be rolled back by a ROOT_IMMUTABLE re-drain")
 	assert.Equal(t, "root-w1", mat.GetWorkspaces()["w1"].GetRootNodeId(), "the root node must survive the re-drain")
 	assert.Contains(t, mat.GetNodes(), "root-w1", "the root node record must survive the re-drain")
+}
+
+// TestLifecycleCreate_RedrainAfterDeleteAndDedupExpiryIsIdempotent pins the
+// create→delete→(DedupTTL expiry)→re-drain-create path: the re-drained create's
+// SetNodeRegister(root) op hits a root node the delete batch already tombstoned,
+// so the seed batch rejects with TOMBSTONED_TARGET (not ROOT_IMMUTABLE). Without
+// the TOMBSTONED_TARGET idempotent-success arm this rejection stalls the create
+// row permanently (it rejects on every subsequent drain) and, because
+// SubmitLifecycle marks the workspace blocked, defers every later same-workspace
+// row. The create already happened on the prior drain and has since been
+// deleted, so the rejection must be treated as idempotent success: consume the
+// row, do not re-add the workspace.
+func TestLifecycleCreate_RedrainAfterDeleteAndDedupExpiryIsIdempotent(t *testing.T) {
+	outbox := newControllableOutbox()
+	j := newFakeJournal()
+	var (
+		clockMu sync.Mutex
+		clock   = int64(100_000)
+	)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		clock++
+		return time.UnixMilli(clock)
+	}
+	mgr := crdt.NewManager("org", j, allowAll{}, nil, now)
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+
+	seedOps := []*leapmuxv1.OrgOp{
+		{OpId: "seed-kind", Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+			NodeId: "root-w1",
+			Field:  &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+		}}},
+		{OpId: "seed-register", Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{
+			WorkspaceId: "w1", RootNodeId: "root-w1",
+		}}},
+	}
+	createPayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpCreate, WorkspaceID: "w1", Title: "First", RootNodeID: "root-w1",
+	}, seedOps)
+	require.NoError(t, err)
+
+	// 1. Create W1, then delete it (the delete tombstones root-w1 and removes
+	//    the workspace record in one atomic batch).
+	rowCreate := outbox.push("org", crdt.LifecycleOpCreate, createPayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+	require.Contains(t, outbox.consumedSnapshot(), rowCreate)
+	deletePayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpDelete, WorkspaceID: "w1",
+	}, nil)
+	require.NoError(t, err)
+	rowDelete := outbox.push("org", crdt.LifecycleOpDelete, deletePayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+	require.Contains(t, outbox.consumedSnapshot(), rowDelete)
+	raw := mgr.State()
+	require.NotContains(t, raw.GetWorkspaces(), "w1", "delete must remove the workspace record")
+	require.False(t, crdt.HLCIsZero(raw.GetNodes()["root-w1"].GetTombstoneAt()), "delete must tombstone root-w1")
+
+	// 2. Simulate DedupTTL expiry: clear the dedup table so the next drain
+	//    re-validates the create seed batch (fixed BatchId) instead of
+	//    short-circuiting on a dedup hit.
+	clockMu.Lock()
+	clockNow := clock
+	clockMu.Unlock()
+	cleared, err := j.CleanupExpiredRecentBatchIDs(context.Background(), time.UnixMilli(clockNow).Add(30*24*time.Hour))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, cleared, int64(1), "dedup rows must be expired to simulate >DedupTTL inactivity")
+
+	// 3. Re-drain the create (its prior consume "failed", leaving it pending).
+	//    The SetNodeRegister(root-w1) op now hits the tombstoned root node, so
+	//    the seed batch rejects with TOMBSTONED_TARGET. This must be treated as
+	//    idempotent success: no error, the row is consumed, the workspace stays
+	//    deleted (not resurrected).
+	rowRedrain := outbox.push("org", crdt.LifecycleOpCreate, createPayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox),
+		"a re-drained create whose root is tombstoned must be treated as idempotent success, not a permanent rejection")
+	require.Contains(t, outbox.consumedSnapshot(), rowRedrain, "the re-drained create row is consumed (no permanent rejection loop)")
+	raw = mgr.State()
+	require.NotContains(t, raw.GetWorkspaces(), "w1", "the re-drained create must NOT resurrect the deleted workspace")
+}
+
+// TestLifecycleDelete_RedrainAfterDedupExpiryIsIdempotent is the parity
+// counterpart to TestLifecycleCreate_RedrainAfterDedupExpiryIsIdempotent: it
+// pins that a delete batch re-drained after DedupTTL expiry (so dedup misses and
+// the batch re-validates) commits cleanly. This must hold because every op
+// enumerateWorkspaceDeleteOps emits is idempotent (TombstoneNode/Tab/FloatingWindow
+// pass preApplyTombstoneCheck's redundant-tombstone allowance; TombstoneWorkspace
+// is a hard delete of a key), so the re-validation sees the already-tombstoned
+// state and re-commits the same idempotent ops. Without this pin a future
+// non-idempotent op added to the delete enumeration would silently break delete
+// re-drain (the row would reject permanently, like the SWEEP-1 create stall).
+func TestLifecycleDelete_RedrainAfterDedupExpiryIsIdempotent(t *testing.T) {
+	outbox := newControllableOutbox()
+	j := newFakeJournal()
+	var (
+		clockMu sync.Mutex
+		clock   = int64(100_000)
+	)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		clock++
+		return time.UnixMilli(clock)
+	}
+	mgr := crdt.NewManager("org", j, allowAll{}, nil, now)
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+
+	// Create W1 so the delete has something to enumerate.
+	seedOps := []*leapmuxv1.OrgOp{
+		{OpId: "seed-kind", Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+			NodeId: "root-w1",
+			Field:  &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+		}}},
+		{OpId: "seed-register", Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{
+			WorkspaceId: "w1", RootNodeId: "root-w1",
+		}}},
+	}
+	createPayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpCreate, WorkspaceID: "w1", Title: "First", RootNodeID: "root-w1",
+	}, seedOps)
+	require.NoError(t, err)
+	rowCreate := outbox.push("org", crdt.LifecycleOpCreate, createPayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+	require.Contains(t, outbox.consumedSnapshot(), rowCreate)
+
+	// First delete: commits, consumes the row.
+	deletePayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpDelete, WorkspaceID: "w1",
+	}, nil)
+	require.NoError(t, err)
+	rowDelete := outbox.push("org", crdt.LifecycleOpDelete, deletePayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+	require.Contains(t, outbox.consumedSnapshot(), rowDelete)
+	raw := mgr.State()
+	require.NotContains(t, raw.GetWorkspaces(), "w1", "first delete must remove the workspace record")
+
+	// Simulate DedupTTL expiry: clear the dedup table so the next drain
+	// re-validates the delete batch (fixed BatchId) instead of short-circuiting.
+	clockMu.Lock()
+	clockNow := clock
+	clockMu.Unlock()
+	cleared, err := j.CleanupExpiredRecentBatchIDs(context.Background(), time.UnixMilli(clockNow).Add(30*24*time.Hour))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, cleared, int64(1), "dedup rows must be expired to simulate >DedupTTL inactivity")
+
+	// Re-drain the delete. Every op in the delete batch is idempotent, so the
+	// re-validation sees the already-tombstoned state and re-commits cleanly --
+	// no rejection, the row is consumed.
+	rowRedrain := outbox.push("org", crdt.LifecycleOpDelete, deletePayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox),
+		"a re-drained delete batch whose ops are all idempotent must commit, not reject")
+	require.Contains(t, outbox.consumedSnapshot(), rowRedrain, "the re-drained delete row is consumed (no permanent rejection loop)")
+	raw = mgr.State()
+	require.NotContains(t, raw.GetWorkspaces(), "w1", "the re-drained delete must not resurrect the workspace")
 }
 
 // TestLifecycleCreate_SeedOpsReachExistingSubscriber pins the bug
@@ -659,6 +843,25 @@ func TestLifecycleDelete_TombstonesAllLeftoverContent(t *testing.T) {
 	outbox.push("org", crdt.LifecycleOpDelete, delPayload)
 	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
 
+	// The delete batch landed on the journal with a TombstoneWorkspace op
+	// LAST (removing the WorkspaceContentsRecord map entry in the same
+	// atomic batch as the subtree tombstones — no out-of-band m.state
+	// mutation). This is the crux of the #269 fix: workspace lifecycle
+	// delete flows through the serialized submit pipeline.
+	var delBatch *leapmuxv1.OpBatch
+	for _, b := range j.batches {
+		if b.GetBatchId() == "lifecycle-delete-w1" {
+			delBatch = b
+			break
+		}
+	}
+	require.NotNil(t, delBatch, "lifecycle-delete-w1 batch should be committed")
+	require.NotEmpty(t, delBatch.GetOps())
+	lastOp := delBatch.GetOps()[len(delBatch.GetOps())-1]
+	_, isLastTombstoneWorkspace := lastOp.GetBody().(*leapmuxv1.OrgOp_TombstoneWorkspace)
+	assert.True(t, isLastTombstoneWorkspace,
+		"delete batch's last op should be TombstoneWorkspace; got %T", lastOp.GetBody())
+
 	// Workspace map entry removed.
 	mat := mgr.Materialized(crdt.SubscriberFilter{})
 	assert.NotContains(t, mat.GetWorkspaces(), "w1")
@@ -679,6 +882,161 @@ func TestLifecycleDelete_TombstonesAllLeftoverContent(t *testing.T) {
 	assert.NotContains(t, mat.GetNodes(), "root-w1")
 	assert.NotContains(t, mat.GetNodes(), "leaf-1")
 	assert.NotContains(t, mat.GetTabs(), "tab-1")
+}
+
+// TestLifecycleDelete_EmptyWorkspace_SubmitsSingleTombstoneOp covers the
+// path where a workspace has NO live content (no root node, tabs, or floating
+// windows — only the WorkspaceContentsRecord itself). enumerateWorkspaceDeleteOps
+// returns nil, but the delete batch still submits because the TombstoneWorkspaceOp
+// is always appended — so the batch is a single-op tombstone that removes the
+// record atomically. Pins that this path doesn't skip the batch or panic on an
+// empty combined slice.
+func TestLifecycleDelete_EmptyWorkspace_SubmitsSingleTombstoneOp(t *testing.T) {
+	outbox := newControllableOutbox()
+	j := newFakeJournal()
+	var (
+		clockMu sync.Mutex
+		clock   = int64(200_000)
+	)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		clock++
+		return time.UnixMilli(clock)
+	}
+	mgr := crdt.NewManager("org", j, allowAll{}, nil, now)
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+
+	// Seed w1's WorkspaceContentsRecord with NO root node (empty workspace)
+	// via SubmitInternal SetWorkspaceRegister — the lifecycle-create shape
+	// minus the root, keeping the manager goroutine the sole writer.
+	_, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		OrgID: "org",
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed-record-w1", Ops: []*leapmuxv1.OrgOp{{
+			OpId: "seed-record-w1",
+			Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{
+				WorkspaceId: "w1",
+			}},
+		}}}},
+	})
+	require.NoError(t, err)
+	require.Contains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "w1")
+
+	delPayload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpDelete, WorkspaceID: "w1",
+	}, nil)
+	require.NoError(t, err)
+	outbox.push("org", crdt.LifecycleOpDelete, delPayload)
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+
+	// The delete batch landed as a single TombstoneWorkspace op.
+	var delBatch *leapmuxv1.OpBatch
+	for _, b := range j.batches {
+		if b.GetBatchId() == "lifecycle-delete-w1" {
+			delBatch = b
+			break
+		}
+	}
+	require.NotNil(t, delBatch, "lifecycle-delete-w1 batch should be committed")
+	require.Len(t, delBatch.GetOps(), 1, "empty-workspace delete batch should be a single TombstoneWorkspace op")
+	_, isTombstoneWorkspace := delBatch.GetOps()[0].GetBody().(*leapmuxv1.OrgOp_TombstoneWorkspace)
+	assert.True(t, isTombstoneWorkspace, "the single op should be TombstoneWorkspace")
+
+	// Workspace record is gone.
+	assert.NotContains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "w1")
+}
+
+// TestLifecycleCreate_TransientSubmitError_ContractsFilterAndLeavesRowPending
+// covers the SubmitInternal error arm of applyLifecycleCreate: a transient
+// journal commit fault (surfaced by SubmitInternal before any op applied) must
+// (a) propagate as an error, (b) leave the outbox row unconsumed so the next
+// drain retries, and (c) contract the optimistic filter expansion so a later
+// CanAccessWorkspace flip can't smuggle stale visibility through. No m.state
+// mutation lands (the batch never committed), so the workspace record stays
+// absent.
+func TestLifecycleCreate_TransientSubmitError_ContractsFilterAndLeavesRowPending(t *testing.T) {
+	outbox := newControllableOutbox()
+	j := newFakeJournal()
+	var (
+		clockMu sync.Mutex
+		clock   = int64(150_000)
+	)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		clock++
+		return time.UnixMilli(clock)
+	}
+	mgr := crdt.NewManager("org", j, allowAll{}, nil, now)
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+
+	// Subscriber whose filter does NOT yet admit w1.
+	listener := &captureSubscriber{}
+	listenerSub := &crdt.Subscriber{
+		Filter: crdt.SubscriberFilter{WorkspaceIDs: map[string]bool{"unrelated-ws": true}},
+		Send:   listener.send,
+	}
+	_, unsub := mgr.Subscribe(listenerSub)
+	defer unsub()
+	require.False(t, listenerSub.Filter.IsAllowed("w1"), "precondition: filter excludes w1")
+
+	// Inject a transient commit fault so SubmitInternal fails after
+	// ExpandSubscribersForWorkspace already widened the filter.
+	j.mu.Lock()
+	j.commitErr = errCommitFailed
+	j.mu.Unlock()
+
+	seedOps := []*leapmuxv1.OrgOp{
+		{OpId: "seed-kind", Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+			NodeId: "root-w1",
+			Field:  &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+		}}},
+		{OpId: "seed-register", Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{
+			WorkspaceId: "w1", RootNodeId: "root-w1",
+		}}},
+	}
+	payload, err := crdt.EncodeLifecyclePayload(crdt.LifecyclePayload{
+		OpType: crdt.LifecycleOpCreate, WorkspaceID: "w1", Title: "Fresh", RootNodeID: "root-w1",
+	}, seedOps)
+	require.NoError(t, err)
+	rowID := outbox.push("org", crdt.LifecycleOpCreate, payload)
+
+	drainErr := mgr.SubmitLifecycle(context.Background(), outbox)
+	require.Error(t, drainErr, "transient SubmitInternal failure must surface from SubmitLifecycle")
+
+	// Row NOT consumed — retries on the next drain.
+	require.NotContains(t, outbox.consumedSnapshot(), rowID,
+		"row must stay pending after a transient submit failure")
+
+	// Filter contracted back — no stale visibility leak.
+	assert.False(t, listenerSub.Filter.IsAllowed("w1"),
+		"filter must be contracted after the seed batch failed to commit")
+
+	// No m.state mutation landed — the workspace record is absent.
+	assert.NotContains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "w1",
+		"workspace record must not exist when the seed batch never committed")
+
+	// Clearing the fault and re-draining succeeds: the row is consumed and
+	// the workspace is seeded.
+	j.mu.Lock()
+	j.commitErr = nil
+	j.mu.Unlock()
+	require.NoError(t, mgr.SubmitLifecycle(context.Background(), outbox))
+	require.Contains(t, outbox.consumedSnapshot(), rowID, "row consumed after the fault clears")
+	assert.Contains(t, mgr.Materialized(crdt.SubscriberFilter{}).GetWorkspaces(), "w1",
+		"workspace seeded on re-drain after the fault clears")
 }
 
 // TestLifecycleDelete_ThenCreate_NewSeedSucceeds is the regression

--- a/backend/internal/hub/crdt/manager_registry.go
+++ b/backend/internal/hub/crdt/manager_registry.go
@@ -119,6 +119,21 @@ func (r *Registry) Get(ctx context.Context, orgID string) (*Manager, error) {
 			r.logger.Error("manager exited", "org_id", orgID, "err", err)
 		}
 	}()
+	// Wait until the goroutine has started servicing the select loop before
+	// handing the manager out. SeedStateForTest's post-Start branch routes a
+	// seed through seedCh, which only the manager goroutine drains -- without
+	// this wait, Get would return with the goroutine spawned but not yet
+	// servicing, and a caller that won the race to read started()==closed
+	// (set inside Start) could route through seedCh before the receiver
+	// existed. The wait also guarantees any caller observing the manager
+	// post-Get sees started() closed, so its SeedStateForTest takes the
+	// goroutine-routed branch instead of the pre-Start direct-write branch
+	// (which would race the goroutine's bare m.state reads).
+	select {
+	case <-m.started():
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	return m, nil
 }
 

--- a/backend/internal/hub/crdt/op.go
+++ b/backend/internal/hub/crdt/op.go
@@ -203,14 +203,43 @@ type EntityRef struct {
 	WorkspaceID string
 }
 
-// IsTombstoneOp reports whether `op` is one of the three entity-tombstone
-// ops. Tombstone ops strip the registers used to resolve the entity's
-// owning workspace (parent_id / tile_id / workspace_id), so callers that
-// drive visibility transitions need to handle them specially — the
-// post-state workspace can't be recovered from the entity record.
+// isHubOnlyOp reports whether `op` is one of the hub-only ops — ops that
+// clients may never submit and the hub drives exclusively through the internal
+// submit pipeline. The set is: SetWorkspaceRootNode (lifecycle create root
+// assignment), SetWorkspaceRegister (lifecycle create record seed), and
+// TombstoneWorkspace (lifecycle delete record removal). validateSetOnce calls
+// this once at the top so the hub-only policy is enumerable in one place
+// rather than re-stated as a `!internal` arm inside each op's case.
+func isHubOnlyOp(op *leapmuxv1.OrgOp) bool {
+	switch op.GetBody().(type) {
+	case *leapmuxv1.OrgOp_SetWorkspaceRootNode,
+		*leapmuxv1.OrgOp_SetWorkspaceRegister,
+		*leapmuxv1.OrgOp_TombstoneWorkspace:
+		return true
+	}
+	return false
+}
+
+// IsTombstoneOp reports whether `op` is one of the entity-tombstone ops that
+// wipe the registers used to resolve the entity's owning workspace. Tombstone
+// ops wipe those registers (parent_id / tile_id / workspace_id) or — for
+// TombstoneWorkspace — remove the WorkspaceContentsRecord outright, so callers
+// that drive visibility transitions need to handle them specially: the
+// post-state workspace can't be recovered from the entity record, and the
+// broadcast layer must pin the entity to its pre-workspace (validate.go's
+// post-pin) instead of treating it as a becoming-hidden transition.
+//
+// TombstoneWorkspace is included even though it targets the Workspaces map
+// rather than a register-stripping entity: including it makes validate.go's
+// post-pin fire for workspace deletes, so a TombstoneWorkspace op records a
+// stable {Pre: wsID, Post: wsID} transition (no OUT) and is delivered via the
+// Batch frame's EntityKindWorkspaceRoot arm (preVisible || postVisible) —
+// instead of producing a spurious OUT transition that calls removed(), which
+// returns nil because the proto EntityRemoved oneof has no workspace variant
+// (the 0-byte-frame bug the removed() nil-guard patched at the call site).
 func IsTombstoneOp(op *leapmuxv1.OrgOp) bool {
 	switch op.GetBody().(type) {
-	case *leapmuxv1.OrgOp_TombstoneNode, *leapmuxv1.OrgOp_TombstoneTab, *leapmuxv1.OrgOp_TombstoneFloatingWindow:
+	case *leapmuxv1.OrgOp_TombstoneNode, *leapmuxv1.OrgOp_TombstoneTab, *leapmuxv1.OrgOp_TombstoneFloatingWindow, *leapmuxv1.OrgOp_TombstoneWorkspace:
 		return true
 	}
 	return false
@@ -262,6 +291,10 @@ func OpTarget(op *leapmuxv1.OrgOp) EntityRef {
 		return EntityRef{Kind: EntityKindFloatingWindow, WindowID: body.TombstoneFloatingWindow.GetWindowId()}
 	case *leapmuxv1.OrgOp_SetWorkspaceRootNode:
 		return EntityRef{Kind: EntityKindWorkspaceRoot, WorkspaceID: body.SetWorkspaceRootNode.GetWorkspaceId()}
+	case *leapmuxv1.OrgOp_SetWorkspaceRegister:
+		return EntityRef{Kind: EntityKindWorkspaceRoot, WorkspaceID: body.SetWorkspaceRegister.GetWorkspaceId()}
+	case *leapmuxv1.OrgOp_TombstoneWorkspace:
+		return EntityRef{Kind: EntityKindWorkspaceRoot, WorkspaceID: body.TombstoneWorkspace.GetWorkspaceId()}
 	}
 	return EntityRef{}
 }

--- a/backend/internal/hub/crdt/op_test.go
+++ b/backend/internal/hub/crdt/op_test.go
@@ -1,0 +1,97 @@
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// TestOpTarget_ClassifiesEveryOpKind pins the EntityRef each OrgOp body
+// resolves to. The broadcast filter's EntityKindWorkspaceRoot arm
+// (manager_broadcast.go: keep on preVisible || postVisible, distinct from the
+// preVisible && postVisible rule for other entities) depends on the two
+// workspace membership ops classifying as EntityKindWorkspaceRoot; this is the
+// direct assertion that the lifecycle create/delete ops reach that arm.
+func TestOpTarget_ClassifiesEveryOpKind(t *testing.T) {
+	cases := []struct {
+		name string
+		op   *leapmuxv1.OrgOp
+		want crdt.EntityRef
+	}{
+		{
+			name: "SetWorkspaceRegister -> WorkspaceRoot",
+			op: &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+				SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+			}},
+			want: crdt.EntityRef{Kind: crdt.EntityKindWorkspaceRoot, WorkspaceID: "w1"},
+		},
+		{
+			name: "TombstoneWorkspace -> WorkspaceRoot",
+			op: &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+				TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+			}},
+			want: crdt.EntityRef{Kind: crdt.EntityKindWorkspaceRoot, WorkspaceID: "w1"},
+		},
+		{
+			name: "SetWorkspaceRootNode -> WorkspaceRoot",
+			op: &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{
+				SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{WorkspaceId: "w1", RootNodeId: "r"},
+			}},
+			want: crdt.EntityRef{Kind: crdt.EntityKindWorkspaceRoot, WorkspaceID: "w1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, crdt.OpTarget(tc.op))
+		})
+	}
+}
+
+// TestOpTarget_UnknownBodyIsKindUnknown pins the fall-through: a nil body
+// yields EntityKindUnknown, which batchVisibleOpsEvent treats as not-visible
+// (IsAllowed("") is false) so a malformed op is dropped rather than crashing.
+func TestOpTarget_UnknownBodyIsKindUnknown(t *testing.T) {
+	ref := crdt.OpTarget(&leapmuxv1.OrgOp{})
+	assert.Equal(t, crdt.EntityKindUnknown, ref.Kind)
+}
+
+// TestIsTombstoneOp pins the membership of the tombstone-op set. The set is
+// load-bearing in two places: validate.go skips the redundant post-state
+// workspace walk for these ops, and validate.go's post-pin pins postW to preW
+// so they record a stable {Pre, Post} transition (no OUT) and reach
+// subscribers via the raw-op-in-Batch path. TombstoneWorkspace is included so
+// a workspace delete does not produce a spurious OUT transition that would
+// call removed() — which returns nil for EntityKindWorkspaceRoot (the proto
+// EntityRemoved oneof has no workspace variant) and would ship a 0-byte WS
+// frame without the removed() nil-guard.
+func TestIsTombstoneOp(t *testing.T) {
+	cases := []struct {
+		name string
+		op   *leapmuxv1.OrgOp
+		want bool
+	}{
+		{"TombstoneNode", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneNode{
+			TombstoneNode: &leapmuxv1.TombstoneNodeOp{NodeId: "n1"}}}, true},
+		{"TombstoneTab", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneTab{
+			TombstoneTab: &leapmuxv1.TombstoneTabOp{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "t1"}}}, true},
+		{"TombstoneFloatingWindow", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneFloatingWindow{
+			TombstoneFloatingWindow: &leapmuxv1.TombstoneFloatingWindowOp{WindowId: "fw1"}}}, true},
+		{"TombstoneWorkspace", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"}}}, true},
+		{"SetWorkspaceRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"}}}, false},
+		{"SetWorkspaceRootNode", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{
+			SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{WorkspaceId: "w1", RootNodeId: "r"}}}, false},
+		{"SetNodeRegister", &leapmuxv1.OrgOp{Body: &leapmuxv1.OrgOp_SetNodeRegister{
+			SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{NodeId: "n1"}}}, false},
+		{"nil body", &leapmuxv1.OrgOp{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, crdt.IsTombstoneOp(tc.op))
+		})
+	}
+}

--- a/backend/internal/hub/crdt/state.go
+++ b/backend/internal/hub/crdt/state.go
@@ -72,8 +72,10 @@ func PruneTombstonesAtOrBelow(state *leapmuxv1.OrgCrdtState, watermark *leapmuxv
 }
 
 // NewState returns an empty OrgCrdtState seeded with the given org id.
-// The workspaces map is initialized empty; lifecycle paths add entries
-// via manager-internal mutation, not via the op log.
+// The workspaces map is initialized empty; the lifecycle create/delete
+// paths add and remove entries via SetWorkspaceRegisterOp /
+// TombstoneWorkspaceOp in the op log (the same serialized pipeline every
+// other op flows through).
 func NewState(orgID string) *leapmuxv1.OrgCrdtState {
 	return &leapmuxv1.OrgCrdtState{
 		OrgId:           orgID,
@@ -123,6 +125,10 @@ func Apply(state *leapmuxv1.OrgCrdtState, op *leapmuxv1.OrgOp) {
 		applyTombstoneFloatingWindow(state, body.TombstoneFloatingWindow, canon)
 	case *leapmuxv1.OrgOp_SetWorkspaceRootNode:
 		applySetWorkspaceRootNode(state, body.SetWorkspaceRootNode)
+	case *leapmuxv1.OrgOp_SetWorkspaceRegister:
+		applySetWorkspaceRegister(state, body.SetWorkspaceRegister)
+	case *leapmuxv1.OrgOp_TombstoneWorkspace:
+		applyTombstoneWorkspace(state, body.TombstoneWorkspace)
 	}
 }
 
@@ -362,11 +368,18 @@ func applySetWorkspaceRootNode(state *leapmuxv1.OrgCrdtState, op *leapmuxv1.SetW
 	wsID := op.GetWorkspaceId()
 	rec, ok := state.Workspaces[wsID]
 	if !ok {
-		// Live-session path: the lifecycle outbox seeds an empty entry
-		// via MutateInternal before submitting this op. Bootstrap-replay
-		// path: that MutateInternal is non-journaled, so on restart the
-		// op arrives with no placeholder; we must create the record here
-		// or `state.Workspaces[wsID]` stays absent and the subscriber's
+		// Live-session path: the lifecycle create batch seeds the record
+		// via a SetWorkspaceRegisterOp in the SAME batch as this op, so
+		// `rec` is normally already present when this runs. This lazy
+		// create is the bootstrap-replay safety net for op logs written
+		// before SetWorkspaceRegisterOp existed: on restart such a log is
+		// replayed against a state blob, and a SetWorkspaceRootNode op
+		// with no companion register would arrive with no placeholder.
+		// (Compaction can't strand the op this way — SetWorkspaceRegister
+		// and SetWorkspaceRootNode share one atomic batch, and compaction
+		// drops whole batches, never single ops; PruneTombstonesAtOrBelow
+		// never touches the Workspaces map.) Without creating the record
+		// here, `state.Workspaces[wsID]` stays absent and the subscriber's
 		// projection never surfaces the workspace's root_node_id (the
 		// frontend's awaitWorkspaceBootstrap then polls forever and
 		// surfaces the 30s "Workspace load timed out" toast).
@@ -382,6 +395,33 @@ func applySetWorkspaceRootNode(state *leapmuxv1.OrgCrdtState, op *leapmuxv1.SetW
 	if rec.GetRootNodeId() == "" {
 		rec.RootNodeId = op.GetRootNodeId()
 	}
+}
+
+// applySetWorkspaceRegister seeds the WorkspaceContentsRecord map entry
+// for a workspace (root_node_id empty). Idempotent: a workspace that
+// already exists is left untouched, so a re-drained create seed batch
+// (after a transient consume fault) never clobbers a workspace the user
+// has since rooted or populated. The accompanying SetWorkspaceRootNodeOp
+// in the same batch fills root_node_id.
+func applySetWorkspaceRegister(state *leapmuxv1.OrgCrdtState, op *leapmuxv1.SetWorkspaceRegisterOp) {
+	wsID := op.GetWorkspaceId()
+	if wsID == "" {
+		return
+	}
+	if _, exists := state.Workspaces[wsID]; !exists {
+		state.Workspaces[wsID] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: wsID}
+	}
+}
+
+// applyTombstoneWorkspace removes the WorkspaceContentsRecord map entry.
+// Idempotent: deleting an already-absent workspace is a no-op, so a
+// re-drained delete batch (after a transient consume fault) is safe.
+func applyTombstoneWorkspace(state *leapmuxv1.OrgCrdtState, op *leapmuxv1.TombstoneWorkspaceOp) {
+	wsID := op.GetWorkspaceId()
+	if wsID == "" {
+		return
+	}
+	delete(state.Workspaces, wsID)
 }
 
 // CloneState returns a deep copy of an OrgCrdtState. Used by paths

--- a/backend/internal/hub/crdt/state_clone_for_batch_test.go
+++ b/backend/internal/hub/crdt/state_clone_for_batch_test.go
@@ -231,3 +231,70 @@ func TestCloneStateForBatch_TouchedNodeNotInPreIsHarmless(t *testing.T) {
 	_, leakedToPre := pre.Nodes["fresh"]
 	assert.False(t, leakedToPre, "creating fresh node in working must not leak to pre")
 }
+
+// SetWorkspaceRegisterOp / TombstoneWorkspaceOp write to the Workspaces map,
+// so CloneStateForBatch must treat a lifecycle batch as touching workspaces
+// (deep-cloning that map and leaving the others shared with pre). This pins
+// the entity-kind contract the CloneStateForBatch doc rests on for the
+// workspace-root ops added in the #269 lifecycle-as-ops conversion.
+func TestCloneStateForBatch_WorkspaceOpsCloneWorkspacesMapOnly(t *testing.T) {
+	pre := &leapmuxv1.OrgCrdtState{
+		OrgId: "org-1",
+		Nodes: map[string]*leapmuxv1.NodeRecord{"A": nodeRec("A")},
+		Workspaces: map[string]*leapmuxv1.WorkspaceContentsRecord{
+			"w1": {WorkspaceId: "w1", RootNodeId: "root-w1"},
+		},
+		MaxHlc: hlc(10, 0, "seed"),
+	}
+	// A lifecycle delete batch: a node tombstone + the workspace tombstone.
+	batch := []*leapmuxv1.OrgOp{
+		tombstoneNodeOp("root-w1", hlc(20, 0, "hub")),
+		{
+			OpId:         "ws-del",
+			CanonicalHlc: hlc(20, 1, "hub"),
+			Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+				TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+			},
+		},
+	}
+	working := crdt.CloneStateForBatch(pre, batch)
+
+	// Apply mutates the working copy only.
+	for _, op := range batch {
+		crdt.Apply(working, op)
+	}
+
+	// pre's workspace record is untouched (deep-cloned, not shared).
+	assert.Contains(t, pre.Workspaces, "w1", "pre.Workspaces[w1] must survive Apply on working")
+	assert.NotContains(t, working.Workspaces, "w1", "working should have removed w1")
+
+	// The Nodes map is also touched (by the tombstone), so it's cloned too;
+	// pre.Nodes["root-w1"] must be tombstone-free.
+	assert.True(t, crdt.HLCIsZero(pre.Nodes["root-w1"].GetTombstoneAt()),
+		"pre.Nodes[root-w1] must not be tombstoned by Apply on working")
+}
+
+// A SetWorkspaceRegisterOp on a brand-new workspace must not leak into pre when
+// Apply runs on the working copy — the symmetric create-side contract.
+func TestCloneStateForBatch_SetWorkspaceRegisterDoesNotLeakToPre(t *testing.T) {
+	pre := &leapmuxv1.OrgCrdtState{
+		OrgId:      "org-1",
+		Workspaces: map[string]*leapmuxv1.WorkspaceContentsRecord{},
+		MaxHlc:     hlc(0, 0, "seed"),
+	}
+	batch := []*leapmuxv1.OrgOp{
+		{
+			OpId:         "ws-reg",
+			CanonicalHlc: hlc(1, 0, "hub"),
+			Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+				SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "fresh"},
+			},
+		},
+	}
+	working := crdt.CloneStateForBatch(pre, batch)
+	for _, op := range batch {
+		crdt.Apply(working, op)
+	}
+	assert.Contains(t, working.Workspaces, "fresh", "Apply must seed the workspace in working")
+	assert.NotContains(t, pre.Workspaces, "fresh", "seeding in working must not leak to pre")
+}

--- a/backend/internal/hub/crdt/state_test.go
+++ b/backend/internal/hub/crdt/state_test.go
@@ -136,6 +136,64 @@ func TestApply_ParentIdSetOnce(t *testing.T) {
 	assert.Equal(t, "P1", state.Nodes["n1"].GetParentId())
 }
 
+func TestApply_SetWorkspaceRegister_SeedsEmptyRecord(t *testing.T) {
+	state := crdt.NewState("org")
+	crdt.Apply(state, &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "seed-w1", CanonicalHlc: hlcAt(1, 0, "hub"),
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		},
+	})
+	rec, ok := state.Workspaces["w1"]
+	require.True(t, ok, "workspace record should be seeded")
+	assert.Equal(t, "w1", rec.GetWorkspaceId())
+	assert.Empty(t, rec.GetRootNodeId(), "root_node_id should start empty")
+}
+
+func TestApply_SetWorkspaceRegister_IdempotentDoesNotClobberRootedRecord(t *testing.T) {
+	// A rooted workspace (root_node_id already set by SetWorkspaceRootNodeOp
+	// or seeded directly) must NOT be clobbered by a re-drained create seed
+	// whose SetWorkspaceRegisterOp re-applies after a transient consume fault.
+	state := crdt.NewState("org")
+	state.Workspaces["w1"] = &leapmuxv1.WorkspaceContentsRecord{
+		WorkspaceId: "w1", RootNodeId: "root1",
+	}
+	crdt.Apply(state, &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "reseed-w1", CanonicalHlc: hlcAt(2, 0, "hub"),
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		},
+	})
+	assert.Equal(t, "root1", state.Workspaces["w1"].GetRootNodeId(),
+		"a re-applied SetWorkspaceRegisterOp must not clear an existing root_node_id")
+}
+
+func TestApply_TombstoneWorkspace_RemovesRecord(t *testing.T) {
+	state := crdt.NewState("org")
+	state.Workspaces["w1"] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: "w1", RootNodeId: "root1"}
+	crdt.Apply(state, &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "del-w1", CanonicalHlc: hlcAt(3, 0, "hub"),
+		Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		},
+	})
+	_, ok := state.Workspaces["w1"]
+	assert.False(t, ok, "workspace record should be removed")
+}
+
+func TestApply_TombstoneWorkspace_IdempotentOnAbsent(t *testing.T) {
+	// Deleting a workspace whose record is already gone (re-drain after a
+	// consume fault) must be a no-op, not a panic.
+	state := crdt.NewState("org")
+	crdt.Apply(state, &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "del-w1", CanonicalHlc: hlcAt(3, 0, "hub"),
+		Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		},
+	})
+	assert.Empty(t, state.Workspaces)
+}
+
 func TestApply_NegativeZeroNormalization(t *testing.T) {
 	state := crdt.NewState("org")
 	// math.Copysign(0, -1) is the only portable way to construct

--- a/backend/internal/hub/crdt/validate.go
+++ b/backend/internal/hub/crdt/validate.go
@@ -334,9 +334,14 @@ func preApplyTombstoneCheck(pre *leapmuxv1.OrgCrdtState, op *leapmuxv1.OrgOp) st
 	return ""
 }
 
-// validateSetOnce enforces parent_id set-once, root_node_id
-// set-once, and the hub-only gate on SetWorkspaceRootNodeOp.
+// validateSetOnce enforces the set-once rules (parent_id, root_node_id) and the
+// hub-only gate. The hub-only gate is hoisted to the top via isHubOnlyOp so the
+// set of hub-only ops is enumerable in one place; the per-op cases below carry
+// only the set-once rules.
 func validateSetOnce(pre *leapmuxv1.OrgCrdtState, op *leapmuxv1.OrgOp, internal bool) (leapmuxv1.BatchRejectionReason, string) {
+	if isHubOnlyOp(op) && !internal {
+		return leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, op.GetOpId()
+	}
 	switch body := op.GetBody().(type) {
 	case *leapmuxv1.OrgOp_SetNodeRegister:
 		setOp := body.SetNodeRegister
@@ -355,9 +360,8 @@ func validateSetOnce(pre *leapmuxv1.OrgCrdtState, op *leapmuxv1.OrgOp, internal 
 			}
 		}
 	case *leapmuxv1.OrgOp_SetWorkspaceRootNode:
-		if !internal {
-			return leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, op.GetOpId()
-		}
+		// SetWorkspaceRegister / TombstoneWorkspace are hub-only (gated above)
+		// and idempotent on apply, so they have no set-once case here.
 		setOp := body.SetWorkspaceRootNode
 		if rec, ok := pre.GetWorkspaces()[setOp.GetWorkspaceId()]; ok && rec.GetRootNodeId() != "" {
 			return leapmuxv1.BatchRejectionReason_BATCH_REJECTION_ROOT_IMMUTABLE, op.GetOpId()

--- a/backend/internal/hub/crdt/validate_test.go
+++ b/backend/internal/hub/crdt/validate_test.go
@@ -177,6 +177,81 @@ func TestValidate_HubOnlyOp_RejectsClient(t *testing.T) {
 	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, res.Reason)
 }
 
+// SetWorkspaceRegisterOp / TombstoneWorkspaceOp are the lifecycle create/delete
+// ops that now carry workspace-map membership through the serialized pipeline.
+// Both must be rejected as HUB_ONLY_OP when a client sends them (only the
+// internal lifecycle path may submit them) and accepted under internal=true.
+func TestValidate_SetWorkspaceRegister_HubOnlyGate(t *testing.T) {
+	pre := crdt.NewState("org")
+	op := &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "ws-reg", CanonicalHlc: hlcAt(10, 0, "a"),
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		},
+	}
+	// Client path (internal=false): rejected as hub-only.
+	res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.OrgOp{op}, false, "p1", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, res.Reason)
+
+	// Internal path (internal=true): accepted.
+	res, working := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.OrgOp{op}, true, "hub", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_UNSPECIFIED, res.Reason)
+	require.NotNil(t, working)
+	assert.Contains(t, working.GetWorkspaces(), "w1", "internal SetWorkspaceRegisterOp should seed the record")
+}
+
+func TestValidate_TombstoneWorkspace_HubOnlyGate(t *testing.T) {
+	// Seed a workspace record with NO live root node, so removing the
+	// record alone doesn't orphan anything (the lifecycle delete path
+	// always pairs TombstoneWorkspace with the subtree tombstones; this
+	// isolates the hub-only gate from the completeness check).
+	pre := crdt.NewState("org")
+	pre.Workspaces["w1"] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: "w1"}
+	op := &leapmuxv1.OrgOp{
+		OrgId: "org", OpId: "ws-del", CanonicalHlc: hlcAt(10, 0, "a"),
+		Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		},
+	}
+	// Client path (internal=false): rejected as hub-only.
+	res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.OrgOp{op}, false, "p1", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, res.Reason)
+
+	// Internal path (internal=true): accepted, record removed.
+	res, working := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.OrgOp{op}, true, "hub", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_UNSPECIFIED, res.Reason)
+	require.NotNil(t, working)
+	assert.NotContains(t, working.GetWorkspaces(), "w1", "internal TombstoneWorkspaceOp should remove the record")
+}
+
+// TestValidate_HubOnlyOps_RejectEveryClientArm pins that EVERY hub-only op
+// body is rejected as HUB_ONLY_OP on the client path. The hub-only gate is
+// the access boundary that keeps clients from seeding/removing workspace
+// records or re-assigning roots directly; this table-driven guard fails if
+// a future hub-only op is added to the proto without a matching arm in
+// validateSetOnce (it would slip through as UNSPECIFIED on the client path).
+func TestValidate_HubOnlyOps_RejectEveryClientArm(t *testing.T) {
+	hlc := hlcAt(10, 0, "a")
+	hubOnlyOps := map[string]*leapmuxv1.OrgOp{
+		"SetWorkspaceRootNode": {OrgId: "org", OpId: "root", CanonicalHlc: hlc, Body: &leapmuxv1.OrgOp_SetWorkspaceRootNode{
+			SetWorkspaceRootNode: &leapmuxv1.SetWorkspaceRootNodeOp{WorkspaceId: "w1"},
+		}},
+		"SetWorkspaceRegister": {OrgId: "org", OpId: "reg", CanonicalHlc: hlc, Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{
+			SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{WorkspaceId: "w1"},
+		}},
+		"TombstoneWorkspace": {OrgId: "org", OpId: "del", CanonicalHlc: hlc, Body: &leapmuxv1.OrgOp_TombstoneWorkspace{
+			TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: "w1"},
+		}},
+	}
+	for name, op := range hubOnlyOps {
+		t.Run(name, func(t *testing.T) {
+			res, _ := crdt.ValidateBatch(context.Background(), crdt.NewState("org"), []*leapmuxv1.OrgOp{op}, false, "p1", allowAll{})
+			assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_HUB_ONLY_OP, res.Reason,
+				"client-sent %s must be rejected as hub-only", name)
+		})
+	}
+}
+
 func TestValidate_TabIDCollisionAcrossTypes(t *testing.T) {
 	pre := seedWorkspaceWithRoot("w1", "root1")
 	// First op claims tab_id=X under TAB_TYPE_AGENT.

--- a/backend/internal/hub/service/crdt_service_test.go
+++ b/backend/internal/hub/service/crdt_service_test.go
@@ -168,7 +168,7 @@ func setupCRDTService(t *testing.T) *crdtServiceEnv {
 	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
 
 	// Force the registry to load the manager up front (so the tests
-	// can pre-seed via MutateInternal / SubmitInternal directly).
+	// can pre-seed via SubmitInternal directly).
 	_, err := registry.Get(context.Background(), orgID)
 	require.NoError(t, err)
 
@@ -176,10 +176,15 @@ func setupCRDTService(t *testing.T) *crdtServiceEnv {
 
 	// Seed a workspace + root so the tests can submit ops that pass
 	// validation. This mirrors what the lifecycle outbox would do in
-	// production after CreateWorkspace.
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
-		s.Workspaces["w1"] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: "w1", RootNodeId: ""}
-	})
+	// production after CreateWorkspace: SetWorkspaceRegister seeds the
+	// record in the same atomic batch as the root (no off-goroutine
+	// m.state write).
+	setRegister := &leapmuxv1.OrgOp{
+		OpId: "seed-workspace-register",
+		Body: &leapmuxv1.OrgOp_SetWorkspaceRegister{SetWorkspaceRegister: &leapmuxv1.SetWorkspaceRegisterOp{
+			WorkspaceId: "w1",
+		}},
+	}
 	rootKind := &leapmuxv1.OrgOp{
 		OpId: "seed-kind",
 		Body: &leapmuxv1.OrgOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
@@ -195,7 +200,7 @@ func setupCRDTService(t *testing.T) *crdtServiceEnv {
 	}
 	_, err = mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
 		OrgID:   orgID,
-		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed", Ops: []*leapmuxv1.OrgOp{rootKind, rootRegister}}},
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed", Ops: []*leapmuxv1.OrgOp{setRegister, rootKind, rootRegister}}},
 	})
 	require.NoError(t, err)
 

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -373,7 +373,7 @@ func TestWorkspaceService_LocateTile_FindsByWorkspaceRoot(t *testing.T) {
 	ws := storetest.SeedWorkspace(t, st, orgID, user.ID, "WS")
 
 	env := setupLocateTileEnv(t, orgID)
-	env.mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	env.mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Workspaces[ws] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: ws, RootNodeId: "root-1"}
 		s.Nodes["root-1"] = &leapmuxv1.NodeRecord{NodeId: "root-1"}
 	})
@@ -412,7 +412,7 @@ func TestWorkspaceService_LocateTile_WalksUpToOwningWorkspace(t *testing.T) {
 	ws := storetest.SeedWorkspace(t, st, orgID, user.ID, "WS")
 
 	env := setupLocateTileEnv(t, orgID)
-	env.mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	env.mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Workspaces[ws] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: ws, RootNodeId: "root-1"}
 		s.Nodes["root-1"] = &leapmuxv1.NodeRecord{NodeId: "root-1"}
 		s.Nodes["mid-1"] = &leapmuxv1.NodeRecord{NodeId: "mid-1", ParentId: "root-1"}
@@ -440,7 +440,7 @@ func TestWorkspaceService_LocateTile_DelegationCollapsesToNotFound(t *testing.T)
 	forbiddenWS := storetest.SeedWorkspace(t, st, orgID, user.ID, "Forbidden")
 
 	env := setupLocateTileEnv(t, orgID)
-	env.mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	env.mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Workspaces[forbiddenWS] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: forbiddenWS, RootNodeId: "root-forbidden"}
 		s.Nodes["root-forbidden"] = &leapmuxv1.NodeRecord{NodeId: "root-forbidden"}
 	})
@@ -482,7 +482,7 @@ func TestWorkspaceService_LocateTile_DelegationUsesPinnedWorkspaceOrg(t *testing
 	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
 	_, err := registry.Get(context.Background(), agentOrgID)
 	require.NoError(t, err)
-	mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Workspaces[pinned] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: pinned, RootNodeId: "root-pinned"}
 		s.Nodes["root-pinned"] = &leapmuxv1.NodeRecord{NodeId: "root-pinned"}
 	})
@@ -513,7 +513,7 @@ func TestWorkspaceService_LocateTile_ForeignWorkspaceTileIsNotFound(t *testing.T
 	secretWS := storetest.SeedWorkspace(t, st, ownerOrg, owner.ID, "Secret")
 
 	registry, managers := newMultiOrgRegistry(t, homeOrg, ownerOrg)
-	managers[ownerOrg].MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+	managers[ownerOrg].SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 		s.Workspaces[secretWS] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: secretWS, RootNodeId: "root-secret"}
 		s.Nodes["root-secret"] = &leapmuxv1.NodeRecord{NodeId: "root-secret"}
 	})
@@ -561,7 +561,7 @@ func TestWorkspaceService_LocateTile_NotFoundForUnknownTile(t *testing.T) {
 }
 
 // locateTileEnv bundles a registry-backed manager so each LocateTile
-// test can seed the in-memory state via MutateInternal without
+// test can seed the in-memory state via SeedStateForTest without
 // driving real lifecycle events through the journal.
 type locateTileEnv struct {
 	mgr      *crdt.Manager
@@ -616,7 +616,7 @@ func TestWorkspaceService_LocateTile_TransientOrgErrorWithNoMatchIsRetryable(t *
 
 // newMultiOrgRegistry builds a CRDT registry that lazily serves an independent
 // (memory-journal, allow-all-auth) manager per allowed org, and eagerly creates
-// each so tests can MutateInternal state before the RPC. Returns the registry and
+// each so tests can SeedStateForTest state before the RPC. Returns the registry and
 // the orgID -> Manager map. Any org not in orgIDs is rejected by the factory, so a
 // test that walks an unexpected org fails loudly rather than silently.
 func newMultiOrgRegistry(t *testing.T, orgIDs ...string) (*crdt.Registry, map[string]*crdt.Manager) {

--- a/backend/internal/hub/service/ws_orgevents_test.go
+++ b/backend/internal/hub/service/ws_orgevents_test.go
@@ -136,7 +136,7 @@ func TestOrgEventsHandler_DelegationScopesInitialMaterialized(t *testing.T) {
 		require.Equal(t, orgID, want)
 		mgr = crdt.NewManager(orgID, j, allowAllAuth{}, nil, time.Now)
 		require.NoError(t, mgr.Bootstrap(ctx))
-		mgr.MutateInternal(func(s *leapmuxv1.OrgCrdtState) {
+		mgr.SeedStateForTest(func(s *leapmuxv1.OrgCrdtState) {
 			s.Workspaces[allowedWS] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: allowedWS, RootNodeId: "root-allowed"}
 			s.Workspaces[siblingWS] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: siblingWS, RootNodeId: "root-sibling"}
 			s.Nodes["root-allowed"] = &leapmuxv1.NodeRecord{NodeId: "root-allowed"}

--- a/frontend/src/lib/crdt/apply.test.ts
+++ b/frontend/src/lib/crdt/apply.test.ts
@@ -6,9 +6,11 @@ import {
   SetFloatingWindowRegisterOpSchema,
   SetNodeRegisterOpSchema,
   SetTabRegisterOpSchema,
+  SetWorkspaceRegisterOpSchema,
   SetWorkspaceRootNodeOpSchema,
   TombstoneNodeOpSchema,
   TombstoneTabOpSchema,
+  TombstoneWorkspaceOpSchema,
 } from '~/generated/leapmux/v1/org_ops_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { applyOp, newState } from './apply'
@@ -154,13 +156,16 @@ describe('applyOp', () => {
 
   // Regression pin: when the seed-batch `SetWorkspaceRootNode` op
   // arrives on a subscriber whose `OrgMaterialized` predated the
-  // workspace, `state.workspaces[wsID]` is absent — the hub seeds
-  // the record via `MutateInternal` which is NOT itself broadcast.
-  // The apply layer must lazy-create the record; without this the
-  // op was a silent no-op, `state.workspaces[wsID].rootNodeId` stayed
-  // empty, `seedTabIntoNewWorkspace` timed out, and the new
-  // workspace rendered an empty tile via the layout store's
-  // FALLBACK_LEAF instead of the real root.
+  // workspace, `state.workspaces[wsID]` is absent. The hub's lifecycle
+  // create batch seeds the record via a `SetWorkspaceRegisterOp` in the
+  // same batch, but a subscriber whose filter drops that seed batch (or
+  // a replay where the companion op was compacted away) reaches this op
+  // with no record. The apply layer must lazy-create the record;
+  // without this the op was a silent no-op,
+  // `state.workspaces[wsID].rootNodeId` stayed empty,
+  // `seedTabIntoNewWorkspace` timed out, and the new workspace rendered
+  // an empty tile via the layout store's FALLBACK_LEAF instead of the
+  // real root.
   it('setWorkspaceRootNode lazy-creates the workspace record when absent', () => {
     const state = newState('org')
     expect(state.workspaces.w1).toBeUndefined()
@@ -195,5 +200,81 @@ describe('applyOp', () => {
     }))
     // Set-once semantics: the second register must not overwrite.
     expect(state.workspaces.w1.rootNodeId).toBe('first-root')
+  })
+
+  // setWorkspaceRegister seeds the WorkspaceContentsRecord map entry. It is
+  // the lifecycle create op that now carries workspace-map membership through
+  // the serialized submit pipeline (replacing the old out-of-band
+  // MutateInternal). Mirrors backend `applySetWorkspaceRegister`.
+  it('setWorkspaceRegister seeds an empty workspace record', () => {
+    const state = newState('org')
+    expect(state.workspaces.w1).toBeUndefined()
+    applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(10n, 0n, 'hub'),
+      body: {
+        case: 'setWorkspaceRegister',
+        value: create(SetWorkspaceRegisterOpSchema, { workspaceId: 'w1' }),
+      },
+    }))
+    expect(state.workspaces.w1).toBeDefined()
+    expect(state.workspaces.w1.workspaceId).toBe('w1')
+    expect(state.workspaces.w1.rootNodeId).toBe('')
+  })
+
+  it('setWorkspaceRegister is idempotent and does not clobber a rooted record', () => {
+    // A re-drained create seed batch (after a transient consume fault) must
+    // not clear an existing root_node_id the user has since populated.
+    const state = newState('org')
+    applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(10n, 0n, 'hub'),
+      body: {
+        case: 'setWorkspaceRootNode',
+        value: create(SetWorkspaceRootNodeOpSchema, { workspaceId: 'w1', rootNodeId: 'root-w1' }),
+      },
+    }))
+    applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(20n, 0n, 'hub'),
+      body: {
+        case: 'setWorkspaceRegister',
+        value: create(SetWorkspaceRegisterOpSchema, { workspaceId: 'w1' }),
+      },
+    }))
+    expect(state.workspaces.w1.rootNodeId).toBe('root-w1')
+  })
+
+  // tombstoneWorkspace removes the WorkspaceContentsRecord map entry — the
+  // lifecycle delete op. Without an apply case the client would keep a stale
+  // record after a delete until reconnect; this pins that it removes it.
+  it('tombstoneWorkspace removes the workspace record', () => {
+    const state = newState('org')
+    applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(10n, 0n, 'hub'),
+      body: {
+        case: 'setWorkspaceRegister',
+        value: create(SetWorkspaceRegisterOpSchema, { workspaceId: 'w1' }),
+      },
+    }))
+    applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(20n, 0n, 'hub'),
+      body: {
+        case: 'tombstoneWorkspace',
+        value: create(TombstoneWorkspaceOpSchema, { workspaceId: 'w1' }),
+      },
+    }))
+    expect(state.workspaces.w1).toBeUndefined()
+  })
+
+  it('tombstoneWorkspace is idempotent on an already-absent workspace', () => {
+    // Re-draining a delete batch (after a consume fault) must be a no-op,
+    // not a throw on a missing key.
+    const state = newState('org')
+    expect(() => applyOp(state, create(OrgOpSchema, {
+      canonicalHlc: hlc(10n, 0n, 'hub'),
+      body: {
+        case: 'tombstoneWorkspace',
+        value: create(TombstoneWorkspaceOpSchema, { workspaceId: 'w1' }),
+      },
+    }))).not.toThrow()
+    expect(state.workspaces.w1).toBeUndefined()
   })
 })

--- a/frontend/src/lib/crdt/apply.ts
+++ b/frontend/src/lib/crdt/apply.ts
@@ -20,8 +20,9 @@ import { hlcClone, hlcCmp, hlcIsZero } from './hlc'
 
 /**
  * NewState returns an empty OrgCrdtState seeded with the given org id.
- * Workspaces map is initialized empty; lifecycle paths add entries
- * via manager-internal mutation, not via the op log.
+ * Workspaces map is initialized empty; the lifecycle create/delete paths add
+ * and remove entries via SetWorkspaceRegisterOp / TombstoneWorkspaceOp in the
+ * op log (the same serialized pipeline every other op flows through).
  */
 export function newState(orgId: string): OrgCrdtState {
   return create(OrgCrdtStateSchema, {
@@ -74,6 +75,12 @@ export function applyOp(state: OrgCrdtState, op: OrgOp, canonOverride?: HLC): vo
       break
     case 'setWorkspaceRootNode':
       applySetWorkspaceRootNode(state, body.value.workspaceId, body.value.rootNodeId)
+      break
+    case 'setWorkspaceRegister':
+      applySetWorkspaceRegister(state, body.value.workspaceId)
+      break
+    case 'tombstoneWorkspace':
+      applyTombstoneWorkspace(state, body.value.workspaceId)
       break
   }
 }
@@ -340,14 +347,16 @@ function applyTombstoneRecord<R extends { tombstoneAt?: HLC }>(
 
 function applySetWorkspaceRootNode(state: OrgCrdtState, workspaceId: string, rootNodeId: string): void {
   // Lazy-create the `WorkspaceContentsRecord` if this client hasn't
-  // seen it yet. The hub seeds an empty record via `MutateInternal`
-  // before broadcasting the seed batch, but that mutation is NOT
-  // itself broadcast — for any subscriber whose initial
-  // `OrgMaterialized` predated the workspace, the
-  // `SetWorkspaceRootNode` op is the FIRST signal that the workspace
-  // exists. Without lazy-create, this op early-returned and
-  // `seedTabIntoNewWorkspace` / `awaitWorkspaceBootstrap` waited
-  // forever on `state.workspaces[wsID].rootNodeId`, leaving the
+  // seen it yet. The hub's lifecycle create batch seeds the record via a
+  // `SetWorkspaceRegisterOp` in the SAME batch as this op, so a subscriber
+  // that admits the workspace receives both and the record is normally
+  // already present when this runs. This lazy-create is the bootstrap-replay
+  // safety net for op logs written before `SetWorkspaceRegisterOp` existed
+  // (a `SetWorkspaceRootNode` op with no companion register), or for a
+  // subscriber whose initial `OrgMaterialized` predated the workspace and
+  // whose filter misses the seed batch. Either leaves the op with no record
+  // to land on — and `seedTabIntoNewWorkspace` / `awaitWorkspaceBootstrap`
+  // would wait forever on `state.workspaces[wsID].rootNodeId`, leaving the
   // newly-created workspace tile-less in the UI.
   let rec = state.workspaces[workspaceId]
   if (!rec) {
@@ -356,4 +365,31 @@ function applySetWorkspaceRootNode(state: OrgCrdtState, workspaceId: string, roo
   }
   if (rec.rootNodeId === '')
     rec.rootNodeId = rootNodeId
+}
+
+/**
+ * applySetWorkspaceRegister seeds the WorkspaceContentsRecord map entry for a
+ * workspace (root_node_id empty). Idempotent: a workspace that already exists
+ * is left untouched, so a re-drained create seed batch (after a transient
+ * consume fault) never clobbers a workspace the user has since rooted or
+ * populated. Mirrors backend `applySetWorkspaceRegister`.
+ */
+function applySetWorkspaceRegister(state: OrgCrdtState, workspaceId: string): void {
+  if (!workspaceId)
+    return
+  if (!state.workspaces[workspaceId]) {
+    state.workspaces[workspaceId] = create(WorkspaceContentsRecordSchema, { workspaceId })
+  }
+}
+
+/**
+ * applyTombstoneWorkspace removes the WorkspaceContentsRecord map entry.
+ * Idempotent: deleting an already-absent workspace is a no-op, so a re-drained
+ * delete batch (after a transient consume fault) is safe. Mirrors backend
+ * `applyTombstoneWorkspace`.
+ */
+function applyTombstoneWorkspace(state: OrgCrdtState, workspaceId: string): void {
+  if (!workspaceId)
+    return
+  delete state.workspaces[workspaceId]
 }

--- a/frontend/src/lib/crdt/crdt.test.ts
+++ b/frontend/src/lib/crdt/crdt.test.ts
@@ -126,15 +126,15 @@ describe('crdt apply', () => {
   })
 
   // Regression: pre-fix, `applySetWorkspaceRootNode` early-returned
-  // when `state.workspaces[workspaceId]` was missing. The hub seeds
-  // an empty `WorkspaceContentsRecord` via MutateInternal before
-  // broadcasting the seed batch — but that internal mutation is not
-  // itself part of the broadcast. For any subscriber whose initial
-  // `OrgMaterialized` predated the workspace, the
-  // `SetWorkspaceRootNode` op is the FIRST signal that the workspace
-  // exists. The old early-return left `state.workspaces[wsId]`
-  // undefined, the agent tab seed waited forever for `rootNodeId !=
-  // ''`, and the new workspace appeared tile-less.
+  // when `state.workspaces[workspaceId]` was missing. The hub's
+  // lifecycle create batch seeds the record via a
+  // `SetWorkspaceRegisterOp` in the same batch as this op — but a
+  // subscriber whose filter drops that seed batch (or a replay where
+  // the companion op was compacted away) reaches this op with no
+  // record. The lazy-create is the bootstrap-replay safety net; the old
+  // early-return left `state.workspaces[wsId]` undefined, the agent tab
+  // seed waited forever for `rootNodeId != ''`, and the new workspace
+  // appeared tile-less.
   it('setWorkspaceRootNode lazy-creates the WorkspaceContentsRecord', () => {
     const state = newState('org')
     expect(state.workspaces.w1).toBeUndefined()

--- a/frontend/src/lib/crdt/parity.test.ts
+++ b/frontend/src/lib/crdt/parity.test.ts
@@ -9,6 +9,7 @@ import {
   NodeRecordSchema,
 
   TabRecordSchema,
+  WorkspaceContentsRecordSchema,
 } from '~/generated/leapmux/v1/org_crdt_pb'
 import {
 
@@ -16,7 +17,9 @@ import {
   SetFloatingWindowRegisterOpSchema,
   SetNodeRegisterOpSchema,
   SetTabRegisterOpSchema,
+  SetWorkspaceRegisterOpSchema,
   TombstoneTabOpSchema,
+  TombstoneWorkspaceOpSchema,
 } from '~/generated/leapmux/v1/org_ops_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { applyOp, newState } from './apply'
@@ -26,6 +29,9 @@ import { applyOp, newState } from './apply'
  * canonicalizeState helper: sort each map's keys, marshal each entry
  * with deterministic binary proto, concatenate. The hex output is
  * suitable for byte-equal comparison between independent runs.
+ *
+ * Covers the workspaces map (section 04) just like the backend helper, so
+ * SetWorkspaceRegister / TombstoneWorkspace convergence is observable.
  */
 function canonicalize(state: OrgCrdtState): string {
   const parts: string[] = []
@@ -41,6 +47,10 @@ function canonicalize(state: OrgCrdtState): string {
   parts.push('|03:')
   for (const k of Object.keys(state.floatingWindows).sort()) {
     parts.push(`${k}=${bytesToHex(toBinary(FloatingWindowRecordSchema, state.floatingWindows[k]))};`)
+  }
+  parts.push('|04:')
+  for (const k of Object.keys(state.workspaces).sort()) {
+    parts.push(`${k}=${bytesToHex(toBinary(WorkspaceContentsRecordSchema, state.workspaces[k]))};`)
   }
   return parts.join('')
 }
@@ -173,5 +183,38 @@ describe('parity', () => {
       }) },
     })
     expect(canonicalize(applyAll([posOp]))).toBe(canonicalize(applyAll([negOp])))
+  })
+
+  // Workspace lifecycle create/delete now flow through the op log as
+  // SetWorkspaceRegister / TombstoneWorkspace. Workspace IDs are fresh
+  // nanoids per CreateWorkspace and soft-deleted IDs are never recycled,
+  // so a register and a tombstone for the SAME workspace id never co-occur
+  // in a real op log — the commuting case is independent workspaces, which
+  // this pins: permuting creates/deletes of distinct workspaces converges.
+  it('workspace register/tombstone ops on distinct ids converge under any permutation', () => {
+    const ops: OrgOp[] = [
+      create(OrgOpSchema, {
+        canonicalHlc: hlc(10n, 0n, 'hub'),
+        body: { case: 'setWorkspaceRegister', value: create(SetWorkspaceRegisterOpSchema, { workspaceId: 'w1' }) },
+      }),
+      create(OrgOpSchema, {
+        canonicalHlc: hlc(20n, 0n, 'hub'),
+        body: { case: 'tombstoneWorkspace', value: create(TombstoneWorkspaceOpSchema, { workspaceId: 'w2' }) },
+      }),
+      create(OrgOpSchema, {
+        canonicalHlc: hlc(30n, 0n, 'hub'),
+        body: { case: 'setWorkspaceRegister', value: create(SetWorkspaceRegisterOpSchema, { workspaceId: 'w3' }) },
+      }),
+    ]
+    const baseline = canonicalize(applyAll(ops))
+    for (let i = 0; i < 50; i++) {
+      const got = canonicalize(applyAll(shuffle(ops, i)))
+      expect(got).toBe(baseline)
+    }
+    // w1 and w3 seeded, w2 tombstoned (was never created) — final state.
+    const final = applyAll(ops).workspaces
+    expect(final.w1).toBeDefined()
+    expect(final.w2).toBeUndefined()
+    expect(final.w3).toBeDefined()
   })
 })

--- a/frontend/src/lib/crdt/pendingOps.ts
+++ b/frontend/src/lib/crdt/pendingOps.ts
@@ -364,6 +364,10 @@ function applySpeculative(state: OrgCrdtState, op: OrgOp): void {
  * tombstone ops REPLACE the map slot with a fresh record — those
  * don't need pre-cloning. Similarly setWorkspaceRootNode mutates the
  * workspace record in place, so we pre-clone its slot when present.
+ * setWorkspaceRegister only creates a record when absent (never mutates
+ * an existing one) and tombstoneWorkspace `delete`s the slot — both land
+ * in the shallow-copied `workspaces` map without touching the shared
+ * record, so neither needs a pre-clone (same reasoning as tombstone ops).
  *
  * Mirrors the backend's `CloneStateForBatch` (state.go).
  */

--- a/proto/leapmux/v1/org_ops.proto
+++ b/proto/leapmux/v1/org_ops.proto
@@ -40,6 +40,8 @@ message OrgOp {
     SetFloatingWindowRegisterOp set_floating_window_register  = 14;
     TombstoneFloatingWindowOp   tombstone_floating_window     = 15;
     SetWorkspaceRootNodeOp      set_workspace_root_node       = 16;
+    SetWorkspaceRegisterOp      set_workspace_register        = 17;
+    TombstoneWorkspaceOp        tombstone_workspace           = 18;
   }
 }
 
@@ -105,6 +107,28 @@ message TombstoneFloatingWindowOp { string window_id = 1; }
 message SetWorkspaceRootNodeOp {
   string workspace_id = 1;
   string root_node_id = 2;
+}
+
+// SetWorkspaceRegisterOp seeds the WorkspaceContentsRecord map entry for a
+// freshly created workspace (root_node_id empty). Hub-only — submitted
+// exclusively via the internal lifecycle create path (the first op in the
+// create seed batch, so the record exists when the accompanying
+// SetWorkspaceRootNodeOp applies); rejected as hub_only_op when sent by a
+// client. Idempotent: re-applying on a workspace that already exists is a
+// no-op (it never overwrites an existing record, so a rooted workspace is
+// never clobbered).
+message SetWorkspaceRegisterOp {
+  string workspace_id = 1;
+}
+
+// TombstoneWorkspaceOp removes the WorkspaceContentsRecord map entry for a
+// deleted workspace. Hub-only — submitted exclusively via the internal
+// lifecycle delete path (appended to the workspace's tombstone batch, so
+// the record is removed in the same atomic batch as its contents);
+// rejected as hub_only_op when sent by a client. Idempotent: deleting an
+// already-absent workspace is a no-op.
+message TombstoneWorkspaceOp {
+  string workspace_id = 1;
 }
 
 // SubmitOpsRequest groups one or more atomic OpBatches in a single


### PR DESCRIPTION
## Motivation

The per-org CRDT Manager is single-writer by design: the manager goroutine
reads `m.state.Workspaces` **bare** (no lock) inside `ValidateBatch` and
`DiffProjectionForBatch`. Workspace lifecycle create/delete violated that
invariant — they mutated the `Workspaces` map out of band from a request
goroutine (via `MutateInternal`), racing the manager goroutine's bare reads.
That race is a Go-fatal "concurrent map read and map write" that crashes the
Hub. The stopgap in place (`stateWriteMu`, a third hot-path lock held across
the DB commit) closed the crash but left the single-writer invariant resting
on convention rather than structure — and added a lock held across the
journal commit on every submit.

Closes #269.

## Modifications

**New hub-only ops.** Adds two `OrgOp` oneof variants (proto fields 17/18):
`SetWorkspaceRegisterOp` (idempotent workspace-record upsert) and
`TombstoneWorkspaceOp` (idempotent removal). Both are submitted exclusively
through the internal lifecycle create/delete path and rejected as
`HUB_ONLY_OP` when sent by a client.

**Lifecycle paths fold into op batches.** `applyLifecycleCreate` prepends a
`SetWorkspaceRegister` op to the seed batch (one atomic batch with the root
node + root assignment) and drops the optimistic out-of-band add/rollback.
`applyLifecycleDelete` appends a `TombstoneWorkspace` op to the tombstone
batch and drops the trailing out-of-band delete. The fixed `BatchId`
prefixes (`lifecycle-create-` / `lifecycle-delete-`) are named constants —
they are the dedup keys that make a re-drained batch idempotent within
`DedupTTL`.

**Manager core: sole writer, mechanically enforced.**
- Removes `stateWriteMu` entirely; the manager goroutine is again the sole
  writer and bare reads in `ValidateBatch` / `DiffProjectionForBatch` are
  legitimately lock-free.
- `m.state` is mutated only through `commitState(state)`, the single
  chokepoint (called from `Bootstrap` pre-Start and from `commit` on the
  manager goroutine).
- (Deprecated) `MutateInternal` is removed, replaced by `SeedStateForTest`,
  a test-only seam that runs the seed **on** the manager goroutine via a new
  `seedCh`. A `startedChan` readiness signal (closed once at the top of
  `Start`) lets `Registry.Get` wait until the goroutine is servicing the loop
  before handing the manager out, so a post-Get seed always routes through
  the goroutine instead of racing it. The `seedCh` send is shutdown-aware
  (selects on `m.done`) and the goroutine arm defers `m.mu.Unlock` +
  `close(done)` so a panicking seed neither wedges the caller nor leaves the
  mutex locked.

**Re-drain idempotency.** `applyLifecycleCreate`'s rejection loop now treats
both `ROOT_IMMUTABLE` (create landed, not since deleted) **and**
`TOMBSTONED_TARGET`-with-record-absent (create landed AND since deleted) as
idempotent success. Without the `TOMBSTONED_TARGET` arm, a
create→delete→(>DedupTTL)→re-drained-create would reject permanently (the
delete tombstoned the root node) and stall every later same-workspace row.

**Broadcast + classification.** `IsTombstoneOp` now includes
`TombstoneWorkspace` so a workspace delete records a stable
`{Pre, Post}` transition (no spurious OUT) and reaches admitting subscribers
as a raw op in the Batch frame — instead of producing an OUT transition that
calls `removed()`, which returns nil for `EntityKindWorkspaceRoot` (the proto
`EntityRemoved` oneof has no workspace variant) and would marshal to a 0-byte
WS frame. The `removed()` nil-guard is retained as defense-in-depth. A single
`isHubOnlyOp` predicate gates the three hub-only ops; `validateSetOnce`
carries only the set-once rules.

**Frontend + CLI.** `apply.ts` mirrors the backend apply functions byte-for-byte
(pinned by `parity.test.ts`). `opKindName` gains arms for the new ops so
`events watch` renders them by name.

## Result

- The Hub no longer has a latent Go-fatal "concurrent map read and map write"
  on the workspace-lifecycle path; the single-writer invariant is now
  structurally enforced (`commitState` chokepoint + goroutine-routed seeds),
  and the third hot-path lock across the DB commit is gone.
- A workspace delete no longer ships a 0-byte WS frame to every admitting
  subscriber.
- A create whose outbox-consume failed, followed by a delete and >14 days of
  inactivity, no longer strands the org in a permanent lifecycle-outbox
  rejection loop.
