### PR TITLE
Fix cleared branch name reverting to random slug

### DIFF
--- a/frontend/src/components/shell/GitOptions.test.tsx
+++ b/frontend/src/components/shell/GitOptions.test.tsx
@@ -391,3 +391,98 @@ describe('gitOptions activeMode ownership', () => {
     expect(screen.getByLabelText('Use current state')).toBeInTheDocument()
   })
 })
+
+describe('gitOptions branch name field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(workerRpc.listGitBranches).mockResolvedValue({
+      $typeName: 'leapmux.v1.ListGitBranchesResponse',
+      branches: [],
+      currentBranch: 'main',
+    })
+    vi.mocked(workerRpc.listGitWorktrees).mockResolvedValue({
+      $typeName: 'leapmux.v1.ListGitWorktreesResponse',
+      worktrees: [],
+    })
+  })
+
+  // Regression guard for the `|| randomSlug()` fallback that used to live
+  // in the derived branchName() accessor: clearing the seeded random name
+  // snapped the displayed value back to the stored slug, so the field
+  // could never be empty and the "must not be empty" validation never
+  // fired. The single-signal model now binds the literal value to the
+  // input (matching the NewWorkspace title field), so an empty input
+  // stays empty and surfaces the validation error instead of resetting.
+  it('keeps the field empty and shows an error when the default name is cleared', async () => {
+    const [mode] = createSignal<GitMode>(GitMode.CreateBranch)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[GitMode.CreateBranch]}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Create new branch')).toBeChecked())
+
+    const input = screen.getByPlaceholderText('feature-branch') as HTMLInputElement
+    // Seeded with a non-empty random slug.
+    expect(input.value).not.toBe('')
+
+    // Clear the field. The fix removes the `|| randomSlug()` fallback, so
+    // the value must stay empty rather than snapping back to the slug.
+    fireEvent.input(input, { target: { value: '' } })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(input.value).toBe('')
+
+    // The existing validateBranchName('') error is now reachable and must
+    // render the message below the field (same UX as the NewWorkspace
+    // title field).
+    expect(screen.getByText('Branch name must not be empty')).toBeInTheDocument()
+  })
+
+  // The single-signal refactor changed Randomize from "swap the stored
+  // slug AND clear the typed value" to "replace the field's value". The
+  // observable difference is the post-clear case: after the user empties
+  // the field, Randomize must repopulate it with a fresh slug (and clear
+  // the now-stale empty-name error) rather than leaving it blank because
+  // the empty typed value kept winning the old `||` fallback.
+  it('repopulates the field with a fresh random name on Randomize after clearing', async () => {
+    const [mode] = createSignal<GitMode>(GitMode.CreateBranch)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[GitMode.CreateBranch]}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Create new branch')).toBeChecked())
+
+    const input = screen.getByPlaceholderText('feature-branch') as HTMLInputElement
+    fireEvent.input(input, { target: { value: '' } })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(input.value).toBe('')
+
+    // Randomize must write a fresh slug back into the single signal,
+    // displacing the empty value and clearing the validation error. The
+    // button's `title` surfaces as an aria-label via Tooltip.
+    fireEvent.click(screen.getByLabelText('Generate random name'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(input.value).not.toBe('')
+    expect(screen.queryByText('Branch name must not be empty')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shell/GitOptions.tsx
+++ b/frontend/src/components/shell/GitOptions.tsx
@@ -190,13 +190,14 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
 
   // Branch-name UX. CreateBranch and CreateWorktree are mutually
   // exclusive radios that both render the same "Branch name" input +
-  // Randomize button. One shared typed signal keeps a user-entered value
-  // alive across a toggle, and one shared random slug is shown when the
-  // input is empty — clicking Randomize swaps the slug, which is visible
-  // in whichever mode is currently active.
-  const [typedBranchName, setTypedBranchName] = createSignal('')
-  const [randomSlug, setRandomSlug] = createSignal(generateSlug(3, { format: 'kebab' }))
-  const branchName = () => typedBranchName() || randomSlug()
+  // Randomize button. One shared signal holds the name (seeded with a
+  // random slug), staying alive across a toggle; Randomize swaps in a
+  // fresh slug, which is visible in whichever mode is currently active.
+  // The literal value is bound directly to the input, so clearing it
+  // leaves the field empty and surfaces the existing "must not be empty"
+  // validation — matching the NewWorkspace title field, rather than
+  // silently snapping back to a stored slug.
+  const [branchName, setBranchName] = createSignal(generateSlug(3, { format: 'kebab' }))
 
   // Branch list for switch-branch and base branch selector. Either driven
   // by the internal `ListGitBranches` fetcher OR seeded from the parent's
@@ -427,7 +428,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   }, { defer: true }))
 
   // Single uni-directional emit point: radio clicks and typed input
-  // changes flow through `setActiveMode` / `setTypedBranchName` / etc.
+  // changes flow through `setActiveMode` / `setBranchName` / etc.
   // → `intentFor` recomputes → this effect fires → parent's `setIntent`
   // lands. Dedup lives at the parent's signal (its `equals: shallowEqual`
   // skips notification for identity-equal intents) so no-op recomputes
@@ -435,8 +436,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   createEffect(() => props.onGitModeChange(intentFor(activeMode())))
 
   const randomizeBranch = () => {
-    setRandomSlug(generateSlug(3, { format: 'kebab' }))
-    setTypedBranchName('')
+    setBranchName(generateSlug(3, { format: 'kebab' }))
   }
 
   const renderDirtyWarning = (mode: GitMode) => (
@@ -478,7 +478,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
         <input
           type="text"
           value={branchName()}
-          onInput={e => setTypedBranchName(e.currentTarget.value)}
+          onInput={e => setBranchName(e.currentTarget.value)}
           placeholder="feature-branch"
         />
         <Show when={branchError()}>


### PR DESCRIPTION
## Motivation
The branch name field in `GitOptions` used two signals combined with `||`, so the derived value could never be empty. Clearing the input snapped it back to the stored random slug, which made the existing "Branch name must not be empty" validation effectively unreachable — the field simply refused to be empty.

## Modifications
- Collapsed `typedBranchName` (user input) and `randomSlug` (seeded random) into a single `branchName` signal seeded with a kebab slug and bound directly to the input, matching the `NewWorkspace` title-field pattern.
- Simplified `randomizeBranch` to a single `setBranchName(generateSlug(...))` and updated `onInput` to write `setBranchName(e.currentTarget.value)`; rewrote the stale comment to describe the single-signal model.
- Added a `gitOptions branch name field` regression block: clearing the seeded name leaves the field empty and surfaces the validation error, and Randomize after clearing repopulates with a fresh slug and clears the error.
- No breaking changes or deprecations. No new public APIs; the `GitOptions` external contract is unchanged — only internal signal wiring changed.

## Result
In the New Agent, New Terminal, and Change Branch dialogs (all routed through the shared `GitOptions` component), clearing the branch name field now leaves it empty and shows "Branch name must not be empty", blocking submit until a valid name is entered. Randomize still drops in a fresh slug as before.
