### PR TITLE
fix(desktop): Replace clock-anchored relay-id scheme with an unbounded counter

### DIFF
--- a/frontend/src/components/shell/useOrgEvents.test.ts
+++ b/frontend/src/components/shell/useOrgEvents.test.ts
@@ -157,6 +157,12 @@ class FakeSocket {
 }
 
 beforeEach(() => {
+  // Clear persisted state so the relay-id allocator tests below start from a
+  // fresh seed (mark = null), independent of whatever the bridge-path tests
+  // above persisted to KEY_ORG_EVENTS_RELAY_SEQ. Without this, the first test
+  // in the nextorgeventsrelayid block reads a non-null mark left by prior
+  // tests and its assertions become order-dependent.
+  localStorage.clear()
   bridge.isTauri = false
   bridge.handlers.clear()
   bridge.registrations.length = 0
@@ -861,12 +867,12 @@ describe('useorgevents (desktop bridge path)', () => {
   })
 })
 
-// The relay ids must stay ordered across webview reloads even when the wall clock
-// steps BACKWARD between two page loads (NTP, a manual adjustment): the sidecar
-// outlives the reload holding the previous page's owner id, and an open seeded
-// below it refuses itself as superseded on every attempt -- org events silently
-// never bootstrap. The persisted high-water mark is what carries the ordering
-// through a clock regression.
+// The relay ids must stay ordered across webview reloads: the sidecar outlives
+// the reload holding the previous page's owner id, and an open seeded below it
+// refuses itself as superseded on every attempt -- org events silently never
+// bootstrap. The persisted high-water mark is what carries the ordering through
+// a reload. The mark is a plain monotonic counter (NOT the wall clock), so the
+// ordering holds regardless of any clock step between page loads.
 describe('nextorgeventsrelayid', () => {
   it('hands out strictly increasing ids and persists the high-water mark', () => {
     const first = nextOrgEventsRelayId()
@@ -884,23 +890,28 @@ describe('nextorgeventsrelayid', () => {
     expect(markAfterSecond).toBeGreaterThan(markAfterFirst!)
   })
 
-  it('keeps ids above the persisted mark when the clock steps backward across a reload', async () => {
-    // The previous page ran with a clock 5 minutes ahead and left its last id as
-    // the persisted mark; the sidecar still holds a relay owned by that id. A
-    // reload re-seeds the module -- simulated with a fresh module registry.
-    const staleOwner = Date.now() + 5 * 60_000
+  it('continues above the persisted mark across a reload', async () => {
+    // The previous page left its last id as the persisted mark; the sidecar
+    // still holds a relay owned by that id. A reload re-seeds the module --
+    // simulated with a fresh module registry -- and must continue above it.
+    const staleOwner = 1_000_000
     localStorageSet(KEY_ORG_EVENTS_RELAY_SEQ, staleOwner)
     vi.resetModules()
     const fresh = await import('./useOrgEvents')
     expect(fresh.nextOrgEventsRelayId()).toBeGreaterThan(staleOwner)
   })
 
-  it('seeds from the clock when it is ahead of the persisted mark', async () => {
+  it('honors a small persisted mark rather than seeding from the clock', async () => {
+    // The mark is a counter, not the clock: a small persisted mark is honored
+    // and the next id advances from it, regardless of the (much larger) wall
+    // clock.
     localStorageSet(KEY_ORG_EVENTS_RELAY_SEQ, 1234)
     vi.resetModules()
     const fresh = await import('./useOrgEvents')
-    const before = Date.now()
     const id = fresh.nextOrgEventsRelayId()
-    expect(id).toBeGreaterThan(before)
+    // The id advances from the persisted mark (1235 * stride), which for any
+    // TAB_BITS >= 1 is far below Date.now() (~1.78e12). A clock-seeded scheme
+    // would instead produce an id above Date.now().
+    expect(id).toBeLessThan(Date.now())
   })
 })

--- a/frontend/src/components/shell/useOrgEvents.ts
+++ b/frontend/src/components/shell/useOrgEvents.ts
@@ -42,10 +42,10 @@ function isTerminalCloseCode(code: number): boolean {
 // sidecar compares them to ignore a close whose relay a later open already replaced,
 // and to ignore an open a later one has superseded. A stale-looking open matters
 // here because the hub only sends OrgMaterialized at subscribe time -- a dropped
-// open means org events silently never bootstrap. The persisted clock-seeded
-// sequence (shared with the channel relay's claim ids -- see createPersistedSeq
-// for the reload/clock-regression rationale) keeps a fresh page's ids above
-// whatever the still-live sidecar already holds.
+// open means org events silently never bootstrap. The persisted monotonic counter
+// (shared with the channel relay's claim ids -- see createPersistedSeq for the
+// reload rationale) keeps a fresh page's ids above whatever the still-live sidecar
+// already holds.
 /** Exported for tests; production code reaches it only through useOrgEvents. */
 export const nextOrgEventsRelayId = createPersistedSeq(KEY_ORG_EVENTS_RELAY_SEQ)
 

--- a/frontend/src/lib/persistedSeq.test.ts
+++ b/frontend/src/lib/persistedSeq.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { KEY_CHANNEL_RELAY_SEQ, KEY_ORG_EVENTS_RELAY_SEQ, localStorageGet } from './browserStorage'
+import { KEY_CHANNEL_RELAY_SEQ, KEY_ORG_EVENTS_RELAY_SEQ, localStorageGet, localStorageSet } from './browserStorage'
 import { createPersistedSeq } from './persistedSeq'
 
 // The seeding/clock-regression behavior is pinned through both consumers
@@ -51,8 +51,9 @@ describe('createPersistedSeq', () => {
     const first = next()
     const second = next()
 
-    // The mark increments by 1 and is what storage holds.
-    expect(localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)).toBeGreaterThan(0)
+    // A fresh install seeds the mark from 0, then ++ on each call, so after two
+    // allocations the persisted mark is exactly 2.
+    expect(localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)).toBe(2)
     // Consecutive ids from one allocator advance by a constant stride (the low
     // bits are fixed per allocator; the high mark advances by 1).
     expect(second).toBeGreaterThan(first)
@@ -63,6 +64,21 @@ describe('createPersistedSeq', () => {
     // Same low bits across consecutive allocations within one allocator. Modulo,
     // not &, because the id exceeds 32 bits and JS bitwise ops truncate.
     expect(first % stride).toBe(second % stride)
+  })
+
+  // The counter continues from EXACTLY the persisted mark (then +1), not "some
+  // value above it" -- the sidecar's strict-greater owner fence requires the
+  // reload's first id to land above the stale owner, and a value that merely
+  // exceeded the mark by an unspecified amount would not pin that property to
+  // the mark itself.
+  it('continues from exactly the persisted mark on the first call', () => {
+    installCryptoMock()
+    const persistedMark = 42
+    localStorageSet(KEY_CHANNEL_RELAY_SEQ, persistedMark)
+    const next = createPersistedSeq(KEY_CHANNEL_RELAY_SEQ)
+    next()
+    // The persisted mark was honored as-is and advanced by exactly 1.
+    expect(localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)).toBe(persistedMark + 1)
   })
 
   it('keeps sequences over different keys independent', () => {
@@ -95,11 +111,8 @@ describe('createPersistedSeq', () => {
     // Pre-seed the mark so both allocators read the same starting value,
     // simulating two processes that share localStorage and read the same mark
     // before either has written.
-    const sharedMark = Date.now()
-    const writeShared = () => localStorage.setItem(
-      `leapmux:${KEY_CHANNEL_RELAY_SEQ}`,
-      JSON.stringify({ v: sharedMark, e: Date.now() + 86_400_000 }),
-    )
+    const sharedMark = 1_000_000
+    const writeShared = () => localStorageSet(KEY_CHANNEL_RELAY_SEQ, sharedMark)
     writeShared()
 
     installCryptoMock()
@@ -117,8 +130,9 @@ describe('createPersistedSeq', () => {
     expect(a).not.toBe(b)
     // Both ids are above the shared mark (each process incremented it by 1),
     // and they differ in the low bits -- the per-process differentiator that
-    // breaks the cross-process collision. Modulo (not &) because the id
-    // exceeds 32 bits.
+    // breaks the cross-process collision. The composed id = mark * stride +
+    // random; with mark = sharedMark + 1 it is strictly greater than the mark
+    // for any TAB_BITS >= 1.
     expect(a).toBeGreaterThan(sharedMark)
     expect(b).toBeGreaterThan(sharedMark)
     // Derive the stride from a single allocator's two consecutive ids.
@@ -149,71 +163,86 @@ describe('createPersistedSeq', () => {
     expect(id3).toBeGreaterThan(id1)
   })
 
-  // A NaN reaching the persisted mark (a corrupted or hand-edited storage value,
-  // or any future caller that computes the seed arithmetically) must NOT poison
-  // the sequence: Math.max(epochClock(), NaN) === NaN, and once the mark is NaN
-  // every later mark++ stays NaN for the install's life. The relay owner-fence
-  // (claimId > ownerId) is always false against NaN, so every open would refuse
-  // itself until the key is cleared. Number.isFinite rejects NaN so the seed
-  // falls back to the (epoch-anchored) clock instead.
-  it('rejects a NaN persisted mark and falls back to the clock', () => {
+  // A corrupted persisted value must NOT poison the sequence: mark = NaN; mark++
+  // stays NaN for the install's life, and the relay owner-fence (claimId >
+  // ownerId) is always false against NaN, so every open would refuse itself until
+  // the key was cleared. localStorageGet unwraps the `{v, e}` cell via JSON.parse,
+  // and JSON has no NaN/Infinity literal -- a stored NaN/Infinity surfaces as
+  // `null`, which the `typeof persisted === 'number'` guard rejects. The values
+  // that CAN reach the validation predicate are real numbers that fail
+  // Number.isSafeInteger (negative, fractional, beyond MAX_SAFE_INTEGER) or fail
+  // the composition bound (above MARK_LIMIT); the table below covers each, and the
+  // null/NaN-arrival case is pinned separately. Anything rejected re-seeds from 0.
+  it.each([
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['a non-integer beyond MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
+    ['above the composition ceiling (MARK_LIMIT + 1)', 2_199_023_255_552],
+  ])('rejects a %s persisted mark and re-seeds from 0', (_label, corrupted) => {
     installCryptoMock()
-    localStorage.setItem(
-      `leapmux:${KEY_CHANNEL_RELAY_SEQ}`,
-      JSON.stringify({ v: Number.NaN, e: Date.now() + 86_400_000 }),
-    )
+    // localStorageSet (not raw setItem): every value here round-trips through
+    // JSON faithfully (none are NaN/Infinity), so the helper is the correct
+    // production path to exercise. The repo's browser-storage rule routes
+    // writes through it, and the {v, e} wrapper it produces is what readDynamic
+    // unwraps on the next read.
+    localStorageSet(KEY_CHANNEL_RELAY_SEQ, corrupted)
     const next = createPersistedSeq(KEY_CHANNEL_RELAY_SEQ)
     const first = next()
-    // The NaN was rejected: the id is a finite, positive, exact integer rather
-    // than NaN. (The mark is epoch-anchored, so it is far below the raw wall
-    // clock -- the assertion is finiteness/positivity, not a clock comparison.)
+    // The corrupted value was rejected; the mark starts at 0 and the first id
+    // is exactly 1 * stride + (per-process random low bits).
     expect(Number.isSafeInteger(first)).toBe(true)
     expect(first).toBeGreaterThan(0)
-    // The poisoned value is overwritten with a finite, positive mark on the first call.
-    const persisted = localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)
-    expect(Number.isFinite(persisted)).toBe(true)
-    expect(persisted!).toBeGreaterThan(0)
+    const mark = localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)
+    expect(mark).toBe(1)
   })
 
-  // The id must stay under Number.MAX_SAFE_INTEGER so it serializes through
-  // Tauri IPC and the Rust u64 exactly. A mark that would overflow once shifted
-  // into the high bits is re-seeded from the clock.
-  it('keeps ids below Number.MAX_SAFE_INTEGER even with a large persisted mark', () => {
+  // A stored NaN/Infinity (or any value JSON coerces to null) reaches the
+  // allocator as `null`, not as the original value -- JSON has no NaN/Infinity
+  // literal, so JSON.stringify({v: NaN}) writes `{"v":null}`. The allocator must
+  // reject `null` (via `typeof === 'number'`) exactly as it rejects a non-number,
+  // re-seeding from 0. This pins the arrival-as-null reality the JSON path
+  // produces, distinct from the real-number corruptions above.
+  it('rejects a NaN that JSON coerced to null and re-seeds from 0', () => {
     installCryptoMock()
-    // A persisted mark at the very top of the range -- larger than fits under
-    // MAX_SAFE_INTEGER once shifted -- must be re-seeded rather than producing
-    // an overflowing id.
-    const oversized = Number.MAX_SAFE_INTEGER
-    localStorage.setItem(
-      `leapmux:${KEY_CHANNEL_RELAY_SEQ}`,
-      JSON.stringify({ v: oversized, e: Date.now() + 86_400_000 }),
-    )
+    localStorageSet(KEY_CHANNEL_RELAY_SEQ, Number.NaN)
+    // Sanity-check the arrival path the test depends on: JSON serialized NaN
+    // to null, so the cell the allocator reads holds null, not NaN. (KEY_*
+    // already carries the `leapmux:` prefix, so read it verbatim.)
+    const raw = localStorage.getItem(KEY_CHANNEL_RELAY_SEQ)
+    expect(raw).toContain('"v":null')
     const next = createPersistedSeq(KEY_CHANNEL_RELAY_SEQ)
     const first = next()
-    expect(first).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER)
     expect(Number.isSafeInteger(first)).toBe(true)
+    expect(first).toBeGreaterThan(0)
+    const persisted = localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)
+    expect(persisted).toBe(1)
   })
 
-  // The mark is seeded from an app-anchored clock (Date.now() - APP_EPOCH_MS), not
-  // the raw Unix-epoch millisecond. A raw Date.now() (~1.78e12 in 2026) sits close
-  // to MARK_LIMIT (~2.199e12) and crosses it around 2039, after which composed ids
-  // go inexact; the epoch anchoring keeps the mark far below MARK_LIMIT into the
-  // 2090s so the id stays an exact integer.
-  it('anchors the mark to the app epoch, keeping it well clear of the safe-integer ceiling', () => {
+  // The mark is a plain monotonic counter, NOT derived from the wall clock. This
+  // is the whole point of issue #298: a clock-seeded mark carries a finite
+  // horizon (it eventually crosses Number.MAX_SAFE_INTEGER once packed into the
+  // high bits), whereas a counter has no horizon. Pin the invariant so a future
+  // change cannot quietly reintroduce a clock dependency: with the clock mocked
+  // far below a persisted mark, the allocator still honors the persisted mark.
+  // (The allocator itself no longer calls Date.now, so the spy is a regression
+  // guard against re-introducing a clock seed, not a direct exercise of
+  // allocator code -- the `first > persistedMark` assertion is what pins the
+  // behavior, identical to the exact-continuation test above.)
+  it('does not seed from the wall clock', () => {
     installCryptoMock()
-    const next = createPersistedSeq(KEY_CHANNEL_RELAY_SEQ)
-    const id = next()
-    const mark = localStorageGet<number>(KEY_CHANNEL_RELAY_SEQ)
-    expect(Number.isFinite(mark)).toBe(true)
-    // Epoch-anchored: the mark is strictly below the raw wall clock (a raw
-    // Date.now() seed would instead sit AT or above it). This is the headroom the
-    // anchoring buys.
-    expect(mark!).toBeGreaterThan(0)
-    expect(mark!).toBeLessThan(Date.now())
-    // MARK_LIMIT = floor(MAX_SAFE_INTEGER / (2^12)); the epoch-anchored mark sits
-    // far below it, so the composed id is exact.
-    const markLimit = Math.floor(Number.MAX_SAFE_INTEGER / 4096)
-    expect(mark!).toBeLessThan(markLimit)
-    expect(Number.isSafeInteger(id)).toBe(true)
+    const persistedMark = 1_000_000
+    localStorageSet(KEY_CHANNEL_RELAY_SEQ, persistedMark)
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1)
+    try {
+      const next = createPersistedSeq(KEY_CHANNEL_RELAY_SEQ)
+      const first = next()
+      // The persisted mark is honored (1_000_001 * stride), not the mocked
+      // Date.now()=1: the composed id is far above what a clock seed of 1
+      // could produce, regardless of TAB_BITS.
+      expect(first).toBeGreaterThan(persistedMark)
+    }
+    finally {
+      dateSpy.mockRestore()
+    }
   })
 })

--- a/frontend/src/lib/persistedSeq.ts
+++ b/frontend/src/lib/persistedSeq.ts
@@ -1,18 +1,14 @@
-// A persisted, clock-seeded, monotonic id sequence whose ids are also unique
-// across concurrent processes that share a sidecar.
+// A persisted, monotonic id sequence whose ids are also unique across concurrent
+// processes that share a sidecar.
 //
 // Both desktop relays (the channel relay via relayClaim, the org-events relay
 // via useOrgEvents) order their opens and closes by an id the Go sidecar
 // compares, and the sidecar OUTLIVES a webview reload: a per-load counter
 // would restart below the ids the previous page already handed out, and the
 // fresh page's open -- the one that must win -- would be refused by the
-// sidecar's owner fence as superseded. The wall clock alone is not monotonic
-// either: a backward step (NTP, a manual adjustment) between two page loads
-// would seed the fresh page BELOW the stale owner id the sidecar still holds,
-// and every open would refuse itself until the clock caught back up. The
-// persisted high-water mark keeps ids advancing through a regression; the
-// clock is the seed only when the mark is absent (first run, cleared storage)
-// or already behind it.
+// sidecar's owner fence as superseded. The persisted high-water mark keeps ids
+// advancing across reloads instead, so a fresh page's open always supersedes
+// the stale owner the sidecar still holds.
 //
 // Uniqueness across concurrent processes: the high-water mark is the ONLY
 // shared state, persisted to localStorage -- and localStorage is shared by
@@ -30,49 +26,43 @@
 // the per-process random makes the ids globally distinct anyway, which keeps
 // logs and any future shared state unambiguous.
 //
+// The mark is a plain monotonic counter, NOT the wall clock. A clock-seeded
+// mark carries a finite horizon -- the composed id packs mark * 2^TAB_BITS +
+// random into a JS number, which must stay <= Number.MAX_SAFE_INTEGER to
+// round-trip through Tauri IPC and the Rust u64 owner fence exactly, so a
+// clock value eventually crosses the ceiling and silently corrupts the fence.
+// A counter has no such horizon on its natural path: a fresh install starts at 1
+// and advances by one per allocation, leaving ~2^41 headroom (MARK_LIMIT) --
+// centuries at any realistic rate. A corrupted or hand-edited persisted value
+// CAN sit above MARK_LIMIT, so the validation below re-seeds from 0 when it
+// does; this closes the corruption class without reintroducing the clock. (The
+// sidecar's relay ids are uint64 on the wire; the JS-number ceiling is purely a
+// frontend concern.)
+//
 // One allocator serves both relays so a fix to the seeding rule cannot land on
 // one and silently miss the other; each caller keeps its own storage key and
 // therefore its own id space.
 
 import { localStorageGet, localStorageSet } from './browserStorage'
+import { createLogger } from './logger'
+
+const log = createLogger('persistedSeq')
 
 // TAB_BITS is the width of the per-process random low bits. The mark occupies
-// the remaining high bits and must stay below Number.MAX_SAFE_INTEGER once
-// shifted, so the mark's useful range is 2^(53 - TAB_BITS). 12 bits gives
-// 4096 distinct process fingerprints (birthday collision at ~75 concurrent
-// processes on one origin, far beyond any realistic desktop-app fan-out) while
-// leaving 41 bits for the mark -- enough for an epoch-anchored clock value
-// (see APP_EPOCH_MS) into the 2090s.
+// the remaining high bits. 12 bits gives 4096 distinct process fingerprints
+// (birthday collision at ~75 concurrent processes on one origin, far beyond any
+// realistic desktop-app fan-out).
 const TAB_BITS = 12
 const TAB_MASK = (1 << TAB_BITS) - 1
-// MARK_LIMIT is the largest mark that fits under MAX_SAFE_INTEGER once placed
-// in the high bits. Division, not >>, because the mark exceeds 32 bits and JS
-// bitwise ops truncate to Int32. A persisted mark above this (a stale value
-// from a prior scheme, or a corrupted cell) is re-seeded from the clock rather
-// than producing an id that overflows the exact-integer range.
+// MARK_LIMIT is the largest mark whose composed id `mark * (TAB_MASK + 1) +
+// processBits` still round-trips through Tauri IPC / the Rust u64 owner fence as
+// an exact integer (<= Number.MAX_SAFE_INTEGER). It is the composition ceiling,
+// NOT a clock horizon: a counter minted from 0 never approaches it (centuries of
+// headroom), but a corrupted or hand-edited persisted value can sit above it, so
+// the validation below re-seeds from 0 when it does. Coupled to TAB_MASK so a
+// future bump of TAB_BITS cannot silently shrink the mark headroom. Division, not
+// >>, because the operands exceed 32 bits and JS bitwise ops truncate to Int32.
 const MARK_LIMIT = Math.floor(Number.MAX_SAFE_INTEGER / (TAB_MASK + 1))
-
-// APP_EPOCH_MS anchors the mark's clock component to a fixed recent instant rather
-// than the Unix epoch, so `Date.now() - APP_EPOCH_MS` stays far below MARK_LIMIT for
-// decades longer. A raw Date.now() (ms since 1970) crosses MARK_LIMIT (~2.199e12)
-// around 2039 -- after which the overflow re-seed below can no longer bring the mark
-// back under the limit and composed ids go inexact -- whereas the epoch-relative
-// clock does not cross it until ~APP_EPOCH_MS + MARK_LIMIT, i.e. the 2090s. It must
-// never change once shipped (a change would shift every future clock-seeded mark);
-// the persisted high-water mark bridges the transition from any older scheme, since
-// a larger stale value is carried forward by the Math.max below.
-//
-// This is a horizon EXTENSION, not a fix: the 2090s ceiling is still finite. Replacing
-// the JS-number packing with an unbounded id (bigint / u64 end to end) so there is no
-// horizon and no APP_EPOCH_MS to maintain is tracked in
-// https://github.com/leapmux/leapmux/issues/298.
-const APP_EPOCH_MS = 1_735_689_600_000 // 2025-01-01T00:00:00Z
-
-// epochClock is the mark's clock component: milliseconds since APP_EPOCH_MS, floored
-// at 0 so a device clock set before the epoch cannot seed a negative mark.
-function epochClock(): number {
-  return Math.max(0, Date.now() - APP_EPOCH_MS)
-}
 
 // randomLowBits returns a uniformly random integer in [0, 2^TAB_BITS), sourced
 // from the platform CSPRNG when available. window.crypto.getRandomValues is
@@ -89,12 +79,12 @@ function randomLowBits(): number {
 }
 
 /**
- * Returns an allocator for `key`'s persisted monotonic sequence. The seed is
- * computed lazily on the first call (`max(epochClock(), persisted mark)`), and
- * every allocated id is persisted as the new high-water mark. The id carries a
- * per-process random in its low bits so two processes sharing the origin
- * (same localStorage) cannot mint the same id. The key must be registered in
- * browserStorage's TTL tables.
+ * Returns an allocator for `key`'s persisted monotonic sequence. The mark is
+ * seeded lazily from the persisted value on the first call, and every allocated
+ * id is persisted as the new high-water mark. The id carries a per-process
+ * random in its low bits so two processes sharing the origin (same localStorage)
+ * cannot mint the same id. The key must be registered in browserStorage's TTL
+ * tables.
  */
 export function createPersistedSeq(key: string): () => number {
   let mark: number | null = null
@@ -105,38 +95,47 @@ export function createPersistedSeq(key: string): () => number {
   return () => {
     if (mark === null) {
       const persisted = localStorageGet<number>(key)
-      // Number.isFinite rather than `typeof === 'number'`: NaN is typeof
-      // 'number', and once NaN reaches the seed (Math.max(Date.now(), NaN) ===
-      // NaN) every later mark++ stays NaN -- the allocator hands out NaN for
-      // the install's life, and the relay owner-fence (claimId > ownerId) is
-      // always false against NaN, so every open refuses itself until the key is
-      // manually cleared. A corrupted or hand-edited storage value, or any
-      // future caller that computes the seed arithmetically, could land NaN
-      // here; isFinite rejects NaN, Infinity, and non-numbers in one check.
-      // `typeof persisted === 'number'` narrows the number | undefined that
-      // localStorageGet returns to a number, and the isFinite check then rejects
-      // NaN (which is itself typeof 'number') per the hazard above -- so seed is
-      // always a real number and Math.max cannot produce NaN.
-      const seed = typeof persisted === 'number' && Number.isFinite(persisted) ? persisted : 0
-      mark = Math.max(epochClock(), seed)
-      // A persisted mark above MARK_LIMIT would overflow MAX_SAFE_INTEGER once
-      // shifted into the high bits. Re-seed from the epoch clock so the id stays
-      // within the exact-integer range the wire boundary requires. This path
-      // also reclaims the id space after a backward clock step that left a
-      // stale high-water mark above the current clock-derived ceiling.
-      if (mark > MARK_LIMIT) {
-        mark = epochClock()
-      }
+      // The seed must be (a) a real integer, not NaN/Infinity/a non-number, and
+      // (b) within the composition range so the id `mark * stride + processBits`
+      // stays an exact integer under MAX_SAFE_INTEGER. localStorageGet unwraps
+      // the `{v, e}` cell via JSON.parse, so NaN/Infinity cannot actually arrive
+      // (JSON has no such literals -- they surface as null, rejected by `typeof
+      // === 'number'`); but a fractional, negative, or oversized value can. Once
+      // a bad value reaches the mark it poisons the sequence for the install's
+      // life: NaN makes the relay owner-fence (claimId > ownerId) always false,
+      // so every open refuses itself; an oversized mark composes to an inexact
+      // id that corrupts the fence (see MARK_LIMIT). Number.isSafeInteger &&
+      // persisted >= 0 && persisted <= MARK_LIMIT rejects all of these, and the
+      // counter only ever advances forward from a sound base. (Note: `-0`
+      // satisfies all three -- `-0 === 0` -- but `-0 + 1 === 1` advances
+      // forward correctly, and the JSON path cannot deliver it anyway since
+      // JSON.stringify(-0) yields 0.) Anything rejected re-seeds from 0.
+      mark = typeof persisted === 'number'
+        && Number.isSafeInteger(persisted)
+        && persisted >= 0
+        && persisted <= MARK_LIMIT
+        ? persisted
+        : 0
     }
     mark++
     localStorageSet(key, mark)
+    // localStorageSet swallows write errors (e.g. quota exceeded) silently, so
+    // verify the mark landed: within this process the in-memory `mark` is
+    // authoritative and only advances, so the ids minted this session are
+    // correct regardless. The hazard is the NEXT reload, which reads the stale
+    // lower persisted value and could mint an id below the owner the still-live
+    // sidecar holds (the relay then refuses every open as superseded until an
+    // app restart). The old clock-seeded scheme masked this with a clock floor
+    // -- but at the cost of a clock-regression hole (a backward NTP step
+    // between reloads seeded below the stale owner), so re-introducing the
+    // clock is not a fix. Loud-logging makes the rare failure diagnosable.
+    if (localStorageGet<number>(key) !== mark) {
+      log.warn('relay-seq mark did not persist; reload after this session may wedge the relay until restart', { key })
+    }
     // High bits = monotonic mark (reload-safe, shared across processes via
     // localStorage); low bits = per-process random (distinguishes concurrent
     // processes that read the same mark). Multiplication, not <<, because the
-    // mark exceeds 32 bits and JS bitwise ops truncate to Int32. The result fits
-    // under Number.MAX_SAFE_INTEGER while mark <= MARK_LIMIT, which the
-    // epoch-anchored clock keeps true into the 2090s (see APP_EPOCH_MS); a
-    // persisted mark past MARK_LIMIT is reclaimed by the re-seed above.
+    // mark exceeds 32 bits and JS bitwise ops truncate to Int32.
     return mark * (TAB_MASK + 1) + processBits
   }
 }

--- a/frontend/src/lib/relayClaim.ts
+++ b/frontend/src/lib/relayClaim.ts
@@ -13,12 +13,13 @@
 // makes the check deterministic rather than a narrowed race. The claim is an id
 // rather than the wrapper itself, so a superseded wrapper is not retained.
 //
-// The id sequence is a persisted, clock-seeded high-water mark rather than a
-// counter starting at 0 -- the sidecar's relay owner outlives a webview reload,
-// and a restarted counter would have the fresh page's open (the one that must
-// win) refused by the sidecar's owner fence (`current.owner > relayID`) as
-// superseded, wedging the channel until an app restart. The seeding rule lives
-// in createPersistedSeq, shared with the org-events relay's id sequence.
+// The id sequence is a monotonic counter persisted across reloads, not a
+// counter that resets to 0 on each page load -- the sidecar's relay owner
+// outlives a webview reload, and a reset counter would have the fresh page's
+// open (the one that must win) refused by the sidecar's owner fence
+// (`current.owner > relayID`) as superseded, wedging the channel until an app
+// restart. The seeding rule lives in createPersistedSeq, shared with the
+// org-events relay's id sequence.
 
 import { KEY_CHANNEL_RELAY_SEQ } from './browserStorage'
 import { createPersistedSeq } from './persistedSeq'


### PR DESCRIPTION
## Motivation

The persisted relay-id allocator (`persistedSeq.ts`) seeded its monotonic high-water mark from the wall clock (`Date.now() - APP_EPOCH_MS`), packing `mark * 2^TAB_BITS + random` into a JS number that must stay `<= Number.MAX_SAFE_INTEGER` to round-trip exactly through Tauri IPC and the Rust `u64` owner fence. That gave the scheme a finite horizon: a raw clock crossed it ~2039, and `APP_EPOCH_MS` (anchored to 2025-01-01) only pushed it to the 2090s — a band-aid a future maintainer would have to bump. Issue #298 tracks replacing it with an unbounded scheme.

## Modifications

- **Counter, not clock.** Replace the clock-seeded mark with a plain persisted monotonic counter (fresh install starts at 1; +1 per allocation). `APP_EPOCH_MS`, `epochClock()`, and the clock floor are deleted. The counter never approaches `2^53` on its natural path, so there is no horizon and no timestamp dependency.
- **No wire changes.** The relay id is already `uint64` end-to-end (`frame.proto` → Rust `u64` handlers → Go `uint64` owner compared with `>`/`<=`/`!=`), so the `MAX_SAFE_INTEGER` ceiling was purely a frontend concern. `bigint`/u64 would have touched proto + Rust + Go + serde for no benefit (Tauri's JSON deser doesn't accept JS `bigint`); the counter needs zero wire changes.
- **Composition-ceiling guard.** The deleted `MARK_LIMIT` was the *composition ceiling* (largest mark whose `mark*4096+random` stays an exact integer), not clock machinery. Restored as a bound tied to `TAB_MASK`: the seed validation `Number.isSafeInteger(persisted) && persisted >= 0 && persisted <= MARK_LIMIT` rejects NaN/Infinity/non-numbers (which arrive as `null` via JSON), fractions, negatives, and oversized values, re-seeding from 0. This closes the corruption class (a hand-edited/huge persisted cell could otherwise compose to an inexact id that silently corrupts the owner fence, or exceed `u64::MAX` and be rejected by serde) without reintroducing the clock. Coupling to `TAB_MASK` means a future bump of `TAB_BITS` can't silently shrink the headroom.
- **Persist-failure read-back.** `localStorageSet` swallows write errors (e.g. quota exceeded) silently. The allocator now reads the key back after writing and logs loudly if it didn't land, so the rare reload-after-quota-exhausted-session wedge (reload mints below the still-live sidecar's owner → open refused as superseded) is diagnosable. Within a process the in-memory mark is already authoritative (it only advances), so the current session stays correct regardless. The old clock floor masked this case but at the cost of a clock-regression hole (a backward NTP step seeded below the stale owner), so re-adding the clock is explicitly rejected.
- **Tests.** Corruption coverage switched to the `localStorageSet` production path with a parametrized table (negative, fractional, beyond `MAX_SAFE_INTEGER`, and above `MARK_LIMIT + 1`); a dedicated test pins the JSON-coerces-NaN-to-`null` arrival reality; a clock-mock test guards against reintroducing a clock seed; reload-exact-continuation and cross-process-distinctness are pinned. `useOrgEvents.test.ts` adds `localStorage.clear()` to `beforeEach` so the relay-id tests are independently runnable.

## Result

The relay-id allocator has no finite horizon on its natural path and no `APP_EPOCH_MS` to maintain, closing #298. The composition-ceiling guard makes the "id fits in a safe integer" invariant mechanically enforced for corrupted persisted values (not just prose-asserted), and silent persist failures are now diagnosable. All 2523 frontend tests pass; typecheck and lint clean.

Closes #298.
