### PR TITLE
Bound half-closed worker tunnel conn leaks

### DIFF
--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -126,6 +126,25 @@ type Service struct {
 	// them even if a handler panics.
 	Cleanup sync.WaitGroup
 
+	// tunnels is the worker-singleton tunnel manager built in RegisterAll. It
+	// owns the half-closed idle reaper goroutine, which Shutdown stops for clean
+	// teardown hygiene. registerAllClassified stops any prior manager before
+	// reassigning this field, so a re-registration (production reconnect, or a
+	// test that re-runs RegisterAll to inspect the gate map on a throwaway
+	// dispatcher) cannot orphan the prior manager's reaper goroutine -- its Stop
+	// would otherwise never be called, the exact leak the reaper exists to
+	// prevent.
+	//
+	// It is an atomic.Pointer (not a plain field) for the same reason
+	// registeredBy is: the connect loop / a reconnect can re-run RegisterAll on
+	// one goroutine while a signal-driven Shutdown reads it on another, with no
+	// lock ordering them in code. The bootstrap sequence makes that race latent
+	// today, but a plain field would be a data race under -race and a torn/nil
+	// read under a future reconnect-during-shutdown; atomic.Load/Store make the
+	// access safe by construction rather than by convention. nil in tests that
+	// never call RegisterAll; Shutdown's nil guard covers those.
+	tunnels atomic.Pointer[tunnelManager]
+
 	// agentCleanups / terminalCleanups hold per-tab cleanup callbacks
 	// registered by spawn*RemoteIPC and fired on close (or before a
 	// restart mints a new token). Same shape, two embeddings keep the
@@ -441,6 +460,13 @@ func (svc *Service) Shutdown() {
 	// dispatcher goroutine while the worker receives a deregister/SIGTERM.
 	svc.Cleanup.Wait()
 
+	// Stop the tunnel idle reaper goroutine. The worker process is exiting, so
+	// correctness does not depend on it, but stopping it keeps the goroutine
+	// count tidy for an orderly shutdown and for tests that call Shutdown.
+	if t := svc.tunnels.Load(); t != nil {
+		t.Stop()
+	}
+
 	for _, tid := range svc.Terminals.ListTerminalIDs() {
 		// Already-exited terminals were persisted with their real exit
 		// code by makeTerminalExitFn; don't clobber it with the shutdown
@@ -730,7 +756,20 @@ func registerAllClassified(d *channel.Dispatcher, svc *Service) (map[string]meth
 	registerCleanupHandlers(r, svc)
 	registerTabMoveHandlers(r, svc)
 	registerSysInfoHandlers(ownerOnly, svc)
-	registerTunnelHandlers(ownerOnly)
+	tunnels := registerTunnelHandlers(ownerOnly)
+	// Swap in the new manager and Stop the prior one it displaced. A
+	// re-registration (a future reconnect flow, or a test re-running RegisterAll
+	// on a throwaway dispatcher) would otherwise orphan the prior manager's
+	// reaper goroutine -- its Stop would never be called, the exact leak the
+	// reaper exists to prevent. Stopping the displaced manager makes "no orphaned
+	// sweeper" an invariant rather than a convention. Stop is a no-op on a manager
+	// whose sweeper never started (the common case for re-registration before any
+	// half-close). The Swap is atomic so a concurrent Shutdown.Load sees either
+	// the prior or the new manager, never a torn pointer -- the same reason
+	// registeredBy is an atomic.Pointer.
+	if prior := svc.tunnels.Swap(tunnels); prior != nil {
+		prior.Stop()
+	}
 	return r.gates, r.shapes
 }
 

--- a/backend/internal/worker/service/tunnel.go
+++ b/backend/internal/worker/service/tunnel.go
@@ -39,6 +39,27 @@ type tunnelConn struct {
 	// credit is the conn's read-send window: the read loop consumes one per inbound
 	// data frame and blocks at zero. See tunnelflow.Window.
 	credit *tunnelflow.Window
+
+	// halfCloseTrack is set when this conn enters the target-half-closed state
+	// (tunnelReadLoop relayed read-EOF and returned without evicting). Until then
+	// it is nil, so the write hot path's activity bump in writeData is a single
+	// atomic load -> no-op. Once set, writeData bumps its lastActivity lock-free
+	// so a progressing upload is never reaped; the manager's idle sweeper reads it
+	// on each tick. Cleared (to nil) when the conn leaves the half-closed set --
+	// reaped by the sweeper, or fully closed by the client / lifetime watcher.
+	halfCloseTrack atomic.Pointer[halfCloseEntry]
+}
+
+// halfCloseEntry tracks one half-closed conn for the idle reaper. It is the
+// per-conn link between writeData's activity bump (lock-free, via the atomic
+// pointer stored on tunnelConn) and the manager's sweeper (which reads
+// lastActivity under m.mu each tick). lastActivity is unix nanos.
+//
+// The manager owns the map entry; the conn owns the pointer to it. writeData
+// never touches the map, so the write hot path stays lock-free.
+type halfCloseEntry struct {
+	tc           *tunnelConn
+	lastActivity atomic.Int64
 }
 
 // tunnelflow.MaxWriteSeqLookahead (the write-gate NAK bound writeSeqGate.waitTurn enforces) and
@@ -65,10 +86,13 @@ func newTunnelConn(mgr *tunnelManager, connID string, conn net.Conn, sender chan
 	// Eviction matters because the target-half-close path (tunnelReadLoop's
 	// io.EOF branch) returns WITHOUT evicting, to keep the conn open for the
 	// client's remaining writes. Its readLoop has already exited, so on session
-	// death this watcher is the only reclaimer: closing the socket alone would
-	// leak the entry in the worker-lifetime m.conns map. removeIf is a
-	// CompareAndDelete, so it is a harmless no-op when another path already
-	// evicted the conn. A nil mgr (focused unit tests) falls back to a bare close.
+	// death this watcher is the reclaimer that runs immediately: closing the
+	// socket alone would leak the entry in the worker-lifetime m.conns map. The
+	// idle reaper (sweepHalfClosed) is a second, time-bounded reclaimer for the
+	// case the client's best-effort CloseTunnelConn is lost on a long-lived
+	// channel. removeIf is a CompareAndDelete, so it is a harmless no-op when
+	// another path already evicted the conn. A nil mgr (focused unit tests) falls
+	// back to a bare close.
 	if ctx != nil {
 		tc.stopCtxWatch = context.AfterFunc(ctx, func() {
 			if mgr != nil {
@@ -90,13 +114,27 @@ type tunnelManager struct {
 	// beginOpen/store drops the conn the client already gave up on. mu-owned; see
 	// cancelMarkers for its expiry rule.
 	canceled cancelMarkers
+
+	// halfClosed tracks conns whose target half-closed (FIN relayed, read loop
+	// exited) so the idle reaper (sweeper) can reclaim them within
+	// halfCloseIdleTimeout when the client's best-effort CloseTunnelConn is lost.
+	// mu-owned. Only half-closed conns are tracked -- a fully-live bidirectional
+	// conn is never inserted, so a quiet interactive session cannot be mis-reaped.
+	halfClosed map[string]*halfCloseEntry
+
+	// sweeper drives the half-closed idle reaper. Lazily started on the first
+	// markHalfClosed; once started it runs until Stop (it does NOT self-stop when
+	// halfClosed drains). Lazy start means a fully-live workload (the steady state)
+	// and registration-only tests never spawn a goroutine. mu-owned.
+	sweeper halfCloseSweeper
 }
 
 // newTunnelManager creates a new tunnelManager.
 func newTunnelManager() *tunnelManager {
 	return &tunnelManager{
-		opening:  make(map[string]context.CancelFunc),
-		canceled: newCancelMarkers(),
+		opening:    make(map[string]context.CancelFunc),
+		canceled:   newCancelMarkers(),
+		halfClosed: make(map[string]*halfCloseEntry),
 	}
 }
 
@@ -204,6 +242,219 @@ func (m *tunnelManager) removeIf(connID string, tc *tunnelConn) {
 func (m *tunnelManager) closeAndRemove(connID string, tc *tunnelConn) {
 	tc.close()
 	m.removeIf(connID, tc)
+	// Opportunistically drop any half-close tracker for this conn so it does not
+	// linger in m.halfClosed (pinning tc) until the sweeper's next tick reconciles
+	// it. The callers of closeAndRemove (the lifetime watcher, the
+	// open-response-failure path) are all lock-free; the sweeper reaps while
+	// holding m.mu and uses detachHalfClosedLocked directly, so it never reaches
+	// here.
+	m.clearHalfClosed(connID, tc)
+}
+
+// clearHalfClosed drops connID's half-close tracker. Called from every full-close
+// path -- closeAndRemove (the lifetime watcher, open-response-failure) and
+// closeConn (client CloseTunnelConn) -- so a half-closed conn that is fully closed
+// does not wait for the sweeper's next tick to be reconciled out of m.halfClosed.
+// No-op (a single atomic load -> nil) if the conn was never marked half-closed (the
+// common case -- most conns never half-close): the lock-free fast path below skips
+// m.mu entirely for those conns. Pointer-identity match guards a conn_id reused by
+// a fresh OpenTunnelConn after eviction.
+func (m *tunnelManager) clearHalfClosed(connID string, tc *tunnelConn) {
+	// Lock-free fast path: a conn that was never half-closed has a nil tracker, so
+	// it cannot be in m.halfClosed and needs no cleanup. This keeps the close hot
+	// path (churning SOCKS5/port-forward conns that never half-close) off m.mu.
+	if tc.halfCloseTrack.Load() == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detachHalfClosedLocked(connID, tc)
+}
+
+// detachHalfClosedLocked removes connID's tracker from m.halfClosed and clears the
+// conn's tracker pointer. The single owner of the invariant that a tracker's map
+// slot and its atomic pointer are cleared together -- every detach (sweep, every
+// full-close path, and a reuse-mark replacing a stale entry) routes through here.
+// The caller must hold m.mu. Pointer-identity match: a conn_id reused by a fresh
+// OpenTunnelConn after eviction must not detach the new conn's tracker, so this is
+// a no-op unless the tracked entry belongs to tc.
+func (m *tunnelManager) detachHalfClosedLocked(connID string, tc *tunnelConn) {
+	if e, ok := m.halfClosed[connID]; ok && e.tc == tc {
+		delete(m.halfClosed, connID)
+		tc.halfCloseTrack.Store(nil)
+	}
+}
+
+// halfCloseSweeper drives the idle reaper over the manager's half-closed conns.
+// It is mu-owned alongside m.halfClosed. The goroutine is started LAZILY by
+// ensureRunning on the first markHalfClosed and runs until Stop closes stop -- it
+// does NOT self-stop on an empty set. The cost is one always-on ticker per worker
+// once any half-close has ever happened -- negligible (10s tick iterating a small
+// map), and the lazy start means a fully-live workload and registration-only tests
+// never spawn the goroutine at all.
+//
+// stopped makes the sweeper one-shot across the manager's lifetime: once Stop has
+// run, ensureRunning refuses to start a new goroutine. Tunnel read loops run on
+// detached goroutines that the worker's Shutdown does not cancel before
+// svc.tunnels.Stop(), so a read loop can hit EOF and call markHalfClosed AFTER
+// Stop. Without the guard, ensureRunning (started was reset by stopLocked) would
+// spawn a fresh sweeper that nothing ever stops -- a goroutine + ticker leak past
+// shutdown (and, in test suites, across tests).
+//
+// All field access is under m.mu. The goroutine receives stop/done/interval/idle as
+// values captured under m.mu at start, so it never reads the package vars itself (a
+// test restores them in cleanup concurrently with a running sweeper, which would
+// race a per-tick global read).
+type halfCloseSweeper struct {
+	started bool          // goroutine is live; cleared by stopLocked so Stop is re-callable
+	stopped bool          // Stop has run; ensureRunning is a permanent no-op after it
+	stop    chan struct{} // allocated on start; Stop closes it
+	done    chan struct{} // allocated on start; the goroutine closes it on exit
+}
+
+// ensureRunning starts the sweeper goroutine if it has not been started yet. The
+// caller must hold m.mu. Idempotent while running, and a permanent no-op once Stop
+// has run (stopped) so a post-Shutdown markHalfClosed cannot leak a fresh sweeper.
+// It captures the timeout/interval var values under m.mu and passes them to the
+// goroutine so the sweeper never reads the package vars itself -- a test restores
+// them in cleanup (concurrently with a running sweeper), so a per-tick global read
+// would race that restore. Capturing at start is sound: tests set the vars BEFORE
+// triggering the half-close that starts this goroutine.
+func (s *halfCloseSweeper) ensureRunning(m *tunnelManager) {
+	if s.started || s.stopped {
+		return
+	}
+	s.stop = make(chan struct{})
+	s.done = make(chan struct{})
+	s.started = true
+	interval := halfCloseSweepInterval
+	idle := halfCloseIdleTimeout
+	go m.runHalfCloseSweeper(s.stop, s.done, interval, idle)
+}
+
+// stopLocked signals a running sweeper to exit. The caller must hold m.mu. It
+// closes stop, clears started, sets stopped (a permanent bar on ensureRunning), and
+// returns the done channel for the caller to join OUTSIDE the lock. Joining done
+// under m.mu deadlocks: an in-flight sweep must re-acquire m.mu (sweepHalfClosed
+// takes it) before it can observe stop and exit, so Stop holding m.mu across <-done
+// waits for a goroutine blocked on the very lock it holds (reproduced under -race).
+// Splitting the signal (under lock) from the join (outside lock) breaks that cycle.
+func (s *halfCloseSweeper) stopLocked() <-chan struct{} {
+	s.stopped = true
+	if !s.started {
+		return nil
+	}
+	close(s.stop)
+	s.started = false
+	return s.done
+}
+
+// markHalfClosed records connID as parked in the target-half-closed state for the
+// idle reaper, and starts the sweeper if it has not been started yet. Called from
+// tunnelReadLoop's io.EOF branch after read-EOF is relayed -- the conn stays
+// registered and open for the client's remaining writes; if that close is lost,
+// the sweeper reclaims it within halfCloseIdleTimeout instead of leaking until
+// channel death.
+func (m *tunnelManager) markHalfClosed(connID string, tc *tunnelConn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// If a stale entry for this conn_id survived (the prior conn was never
+	// cleared -- e.g. it never reached a full-close path that calls clearHalfClosed
+	// before this mark, or a buggy/hostile client reused a conn_id), detach it so
+	// the old conn's writeData stops bumping a dead entry. detachHalfClosedLocked's
+	// pointer-identity guard makes this a no-op when the entry already belongs to tc.
+	if old := m.halfClosed[connID]; old != nil && old.tc != tc {
+		m.detachHalfClosedLocked(connID, old.tc)
+	}
+	e := &halfCloseEntry{tc: tc}
+	e.lastActivity.Store(time.Now().UnixNano())
+	m.halfClosed[connID] = e
+	tc.halfCloseTrack.Store(e)
+	m.sweeper.ensureRunning(m)
+}
+
+// sweepHalfClosed reaps half-closed conns whose last write activity predates the
+// idle deadline, and reconciles any entry whose conn was fully closed out-of-band
+// since it was marked but whose tracker was not yet cleared. Every full-close path
+// (the lifetime watcher via closeAndRemove, client CloseTunnelConn via closeConn)
+// calls clearHalfClosed, so this reconciliation is a backstop, not the main path.
+//
+// The sweep reaps fully inline under m.mu: decide each entry's fate, detach its
+// tracker, and for a reap also close()+evict -- all under the one lock. Reaping
+// under the lock is safe because tc.close() is a CAS-guarded no-op if another path
+// won the close race, removeIf is a sync.Map CompareAndDelete, and tc.close()'s
+// stopCtxWatch() (context.AfterFunc's stop func) returns immediately without
+// waiting for an in-flight callback (the callback, if running on another goroutine,
+// simply proceeds and, if it reaches clearHalfClosed, blocks on m.mu until this
+// sweep releases it -- no cycle). It does NOT call closeAndRemove/clearHalfClosed
+// (those re-take m.mu and would self-deadlock); it uses detachHalfClosedLocked
+// directly, which expects the caller to already hold m.mu.
+//
+// idle is passed in (captured by the goroutine at start) rather than read off the
+// halfCloseIdleTimeout var, so a test restoring that var in cleanup does not race
+// a per-sweep global read.
+func (m *tunnelManager) sweepHalfClosed(now time.Time, idle time.Duration) {
+	deadline := now.Add(-idle).UnixNano()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for connID, e := range m.halfClosed {
+		if e.tc.closed.Load() {
+			// Closed out-of-band since being marked: drop the stale tracker only
+			// (the conn itself is already closed/evicted by whoever closed it).
+			m.detachHalfClosedLocked(connID, e.tc)
+			continue
+		}
+		if e.lastActivity.Load() < deadline {
+			m.detachHalfClosedLocked(connID, e.tc)
+			slog.Info("tunnel conn reaped after half-close idle", "conn_id", connID)
+			e.tc.close()
+			m.removeIf(connID, e.tc)
+		}
+	}
+}
+
+// runHalfCloseSweeper is the sweeper goroutine body. It ticks every interval and
+// reaps idle half-closed conns until stop closes, then signals done. interval/idle
+// are captured by the caller (ensureRunning) under m.mu and passed in, so this
+// goroutine never reads the package vars -- a test restoring them in cleanup would
+// otherwise race a per-tick read. The ticker interval is guarded against a
+// non-positive value (a misconfigured or test-shortened halfCloseSweepInterval of
+// <=0 would otherwise panic in time.NewTicker); a non-positive interval exits
+// immediately without sweeping -- reaping is disabled, but the goroutine still
+// signals done on stop so Stop joins cleanly.
+func (m *tunnelManager) runHalfCloseSweeper(stop <-chan struct{}, done chan<- struct{}, interval, idle time.Duration) {
+	defer close(done)
+	if interval <= 0 {
+		return // no reap cadence; guard against time.NewTicker panicking on <=0
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			m.sweepHalfClosed(time.Now(), idle)
+		}
+	}
+}
+
+// Stop halts the idle reaper, if running. Called from Service.Shutdown for clean
+// teardown hygiene (the worker process is exiting, so correctness does not depend
+// on it, but it keeps the goroutine count tidy and matches the OrphanReconciler
+// pattern). Safe to call on a manager whose sweeper never started, and idempotent.
+//
+// The sweeper is signalled under m.mu but JOINED outside it (see stopLocked):
+// holding m.mu across <-done deadlocks an in-flight sweep that needs m.mu to
+// observe the stop. Once stopped, the sweeper can never restart (see ensureRunning),
+// so a read loop hitting EOF after Shutdown does not leak a fresh sweeper.
+func (m *tunnelManager) Stop() {
+	m.mu.Lock()
+	done := m.sweeper.stopLocked()
+	m.mu.Unlock()
+	if done != nil {
+		<-done
+	}
 }
 
 const (
@@ -239,6 +490,24 @@ var gracefulCloseTimeout = 5 * time.Second
 // short-lived SOCKS5/port-forward conns) does not spawn a runtime timer per
 // closed conn. It is a var (not a const) so tests can shorten the sweep window.
 var staleCancelMarkerTTL time.Duration = 5 * time.Second
+
+// halfCloseIdleTimeout bounds how long a half-closed worker tunnel conn (target
+// FIN relayed, read loop exited) may linger with no write activity before the
+// idle reaper reclaims it. It bounds the leak from a lost best-effort
+// CloseTunnelConn -- sendCloseTunnelConn retries transient send failures up to
+// remoteCloseSendAttempts before giving up -- to a fixed window instead of the
+// channel's lifetime (pooled SSH/port-forward sessions can last hours). A
+// progressing upload bumps lastActivity per write, so only a TRULY idle
+// half-closed conn is reaped. 60s is conservative: the upload direction has
+// already outlived the target's FIN, and any real client close arrives in well
+// under that. It is a var (not a const) so tests can shorten it.
+var halfCloseIdleTimeout time.Duration = 60 * time.Second
+
+// halfCloseSweepInterval is the idle reaper's tick. Worst-case reclaim latency
+// for an idle half-closed conn is halfCloseIdleTimeout + halfCloseSweepInterval
+// (the conn goes idle just after a tick, then a full tick passes before the next
+// sweep observes it). It is a var (not a const) so tests can shorten it.
+var halfCloseSweepInterval time.Duration = 10 * time.Second
 
 // connRequest constrains a tunnel request message to the shape every tunnel
 // handler's prelude needs: a proto.Message pointer that names a conn. The *T
@@ -288,13 +557,15 @@ func registerConnHandler[T any, PT connRequest[T]](
 //
 // The one manager built here is worker-lifetime and shared across every channel
 // session; each handler is a method on it (see registerConnHandler for the prelude
-// they share).
-func registerTunnelHandlers(d ownerOnlyRegistrar) {
+// they share). It is returned so the caller (Service.Shutdown) can Stop its idle
+// reaper for clean teardown hygiene.
+func registerTunnelHandlers(d ownerOnlyRegistrar) *tunnelManager {
 	tunnels := newTunnelManager()
 	registerConnHandler(d, "OpenTunnelConn", tunnels.openConn)
 	registerConnHandler(d, "SendTunnelData", tunnels.sendData)
 	registerConnHandler(d, "CloseTunnelConn", tunnels.closeConn)
 	registerConnHandler(d, "GrantTunnelReadCredit", tunnels.grantReadCredit)
+	return tunnels
 }
 
 // openConn dials the target address and starts streaming data back.
@@ -444,6 +715,10 @@ func (m *tunnelManager) closeConn(ctx context.Context, _ userid.UserID, r *leapm
 	}
 
 	tc.close()
+	// Drop any half-close tracker so the entry does not linger in m.halfClosed
+	// (pinning tc) until the sweeper's next tick reconciles it. clearHalfClosed's
+	// pointer-identity match guards a conn_id reused by a fresh OpenTunnelConn.
+	m.clearHalfClosed(connID, tc)
 
 	slog.Info("tunnel connection closed by client", "conn_id", connID)
 	sendProtoResponse(sender, &leapmuxv1.CloseTunnelConnResponse{})
@@ -517,6 +792,22 @@ func (tc *tunnelConn) writeData(ctx context.Context, seq uint64, data []byte, cl
 			return io.ErrNoProgress
 		}
 		data = data[n:]
+	}
+	// Bump the half-close idle reaper's activity clock for this conn. A nil
+	// pointer (the common case: a fully-live bidirectional conn, never marked)
+	// makes this a single atomic load and a no-op, keeping the write hot path
+	// lock-free (see the "no per-frame deadline watcher" note above). Only a
+	// half-closed conn -- whose target read loop has already exited on a FIN --
+	// carries a tracker, so its lingering upload direction stays alive while it
+	// progresses and is reaped only when it goes truly idle.
+	//
+	// Gated on !closeWrite: a close_write frame ends the upload direction, so
+	// there is nothing left to keep alive -- let the reaper's clock keep running
+	// so the conn is reclaimed promptly rather than parked for a full idle window.
+	if !closeWrite {
+		if e := tc.halfCloseTrack.Load(); e != nil {
+			e.lastActivity.Store(time.Now().UnixNano())
+		}
 	}
 	if closeWrite {
 		// Half-close the target's write side AFTER this conn's data, forwarding
@@ -619,10 +910,14 @@ func tunnelReadLoop(mgr *tunnelManager, connID string, tc *tunnelConn) {
 				// writeData fails and NAKs the client naturally, the way TCP
 				// surfaces EPIPE.
 				//
-				// A lost CloseTunnelConn with a long-lived channel leaves this
-				// FD/goroutine until channel death. Bounding that with a
-				// per-conn idle reaper is tracked in
-				// https://github.com/leapmux/leapmux/issues/318.
+				// A lost best-effort CloseTunnelConn -- sendCloseTunnelConn
+				// retries transient send failures up to remoteCloseSendAttempts
+				// before giving up -- with a long-lived channel would otherwise
+				// leave this FD/goroutine until channel death. markHalfClosed
+				// arms the idle reaper for this conn: while the upload keeps
+				// progressing writeData bumps its activity clock, but if it goes
+				// truly idle for halfCloseIdleTimeout the reaper closes and evicts
+				// it. See tunnelManager.sweepHalfClosed.
 				if sendErr := sendTunnelEvent(tc.sender, &leapmuxv1.TunnelConnEvent{
 					ConnId: connID,
 					Eof:    true,
@@ -643,6 +938,13 @@ func tunnelReadLoop(mgr *tunnelManager, connID string, tc *tunnelConn) {
 					slog.Warn("failed to relay target half-close EOF; closing tunnel conn",
 						"conn_id", connID, "error", sendErr)
 					break
+				}
+				// Arm the idle reaper for this now-parked half-closed conn before
+				// returning. nil mgr is the focused-unit-test case; a nil sender
+				// means sendTunnelEvent above would have errored and broken out,
+				// so mgr is the only nil guard needed here.
+				if mgr != nil {
+					mgr.markHalfClosed(connID, tc)
 				}
 				slog.Info("tunnel read loop ended on target half-close", "conn_id", connID)
 				return

--- a/backend/internal/worker/service/tunnel_test.go
+++ b/backend/internal/worker/service/tunnel_test.go
@@ -271,7 +271,13 @@ func TestTunnelReadLoopClosesIdleTargetWithChannelContext(t *testing.T) {
 // worker, shared across every channel session).
 func TestTunnelReadLoopHalfCloseEvictsOnLifetimeCancel(t *testing.T) {
 	manager := newTunnelManager()
+	// The half-close EOF branch arms the idle reaper (markHalfClosed -> the
+	// sweeper goroutine), so stop it at cleanup -- otherwise a ticker + goroutine
+	// leak into later tests. The shortened knobs are not needed here (the lifetime
+	// watcher reaps immediately), but Stop() is.
+	t.Cleanup(manager.Stop)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	target, peer := net.Pipe()
 	const connID = "half-closed-target"
 	tc := newTunnelConn(manager, connID, target, newTestWriter(), ctx)
@@ -294,12 +300,571 @@ func TestTunnelReadLoopHalfCloseEvictsOnLifetimeCancel(t *testing.T) {
 	require.False(t, tc.closed.Load(), "the half-close path must not close the conn")
 
 	// Session death: cancelling the lifetime context must evict the conn via the
-	// per-conn watcher, not merely close its socket.
+	// per-conn watcher, not merely close its socket. This path runs IMMEDIATELY on
+	// cancellation -- the idle reaper is a second, time-bounded reclaimer, not a
+	// replacement for it; sweepHalfClosed only reconciles entries whose conns this
+	// watcher already closed on the next tick.
 	cancel()
 	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
 		"a half-closed conn must be evicted on lifetime cancellation, not leaked")
 	assert.True(t, tc.closed.Load())
 	_ = target.Close()
+}
+
+// withShortHalfCloseReaper shortens the idle-reaper knobs for a test and restores
+// them on cleanup, mirroring the staleCancelMarkerTTL pattern. It also stops the
+// manager's sweeper goroutine at cleanup so a self-stopping-but-in-flight sweeper
+// from one test does not leak into the next. Returns the (shortened) idle timeout.
+func withShortHalfCloseReaper(t *testing.T, manager *tunnelManager) time.Duration {
+	t.Helper()
+	idleOrig, sweepOrig := halfCloseIdleTimeout, halfCloseSweepInterval
+	halfCloseIdleTimeout = 60 * time.Millisecond
+	halfCloseSweepInterval = 15 * time.Millisecond
+	t.Cleanup(func() {
+		halfCloseIdleTimeout, halfCloseSweepInterval = idleOrig, sweepOrig
+		if manager != nil {
+			manager.Stop()
+		}
+	})
+	return halfCloseIdleTimeout
+}
+
+// halfCloseTarget drives a target conn into the half-closed state the reaper
+// targets: the worker's read loop reads io.EOF, relays it, returns, and arms the
+// idle reaper. It returns when the read loop has exited. It is for the basic
+// reap-on-idle tests that send NO further writes after the half-close -- the peer
+// is FULLY closed (net.Pipe cannot half-close; a full close still delivers io.EOF
+// to the worker's read side, which is the signal the half-close branch keys on).
+// Tests that need to keep draining the upload direction after the half-close must
+// use a TCP pair (net.Listen + CloseWrite) instead -- see
+// TestTunnelHalfCloseReaper_WriteActivityResetsClock.
+func halfCloseTarget(t *testing.T, manager *tunnelManager, connID, ctxKey string) (
+	workerConn, peerConn net.Conn, tc *tunnelConn, cancel context.CancelFunc,
+) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	worker, peer := net.Pipe()
+	// net.Pipe cannot half-close; for the basic reap tests (no writes after) a
+	// full peer close delivers io.EOF to the worker read, which is the signal the
+	// half-close branch keys on. Tests that need to keep draining writes use a
+	// TCP pair instead (see TestTunnelHalfCloseReaper_WriteActivityResetsClock).
+	tc = newTunnelConn(manager, connID, worker, newTestWriter(), ctx)
+	require.True(t, manager.beginOpen(connID, func() {}))
+	require.True(t, manager.store(connID, tc))
+	loopDone := make(chan struct{})
+	go func() { defer close(loopDone); tunnelReadLoop(manager, connID, tc) }()
+	_ = peer.Close()
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not exit on target half-close")
+	}
+	return worker, peer, tc, cancel
+}
+
+// TestTunnelHalfCloseReaper_ReclaimsOnIdle covers the primary acceptance: a
+// half-closed conn whose client CloseTunnelConn is LOST is reclaimed within the
+// idle deadline WITHOUT waiting for channel death. Before #318 such a conn
+// lingered in the worker-lifetime m.conns map for the channel's lifetime (hours
+// for a pooled SSH/port-forward session); the idle reaper bounds that leak.
+func TestTunnelHalfCloseReaper_ReclaimsOnIdle(t *testing.T) {
+	manager := newTunnelManager()
+	withShortHalfCloseReaper(t, manager)
+	const connID = "half-closed-idle"
+	workerConn, _, tc, cancel := halfCloseTarget(t, manager, connID, connID)
+	defer cancel()
+	t.Cleanup(func() { _ = workerConn.Close() })
+
+	// Precondition: the half-close path parked the conn (registered, not closed)
+	// and armed the reaper.
+	require.NotNil(t, manager.get(connID), "a half-closed conn must stay registered for the client's remaining writes")
+	require.False(t, tc.closed.Load(), "the half-close path must not close the conn")
+
+	// No further writes -> the reaper closes and evicts within the idle window.
+	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
+		"a half-closed conn with a lost CloseTunnelConn must be reaped within the idle deadline, not leaked until channel death")
+	assert.True(t, tc.closed.Load(), "the reaper must close the conn it reaps")
+}
+
+// TestTunnelHalfCloseReaper_WriteActivityResetsClock covers the second
+// acceptance: an ACTIVE upload (writes still progressing) is not reaped
+// mid-transfer. writeData bumps the conn's activity clock on each successful
+// write, so a progressing upload outruns the reaper; once the writes stop, the
+// clock expires and the reaper reclaims the conn.
+//
+// It uses a TCP loopback pair (not net.Pipe) so the peer can half-close its write
+// side -- delivering io.EOF to the worker's read loop -- while keeping its read
+// side open to drain the worker's writes, which is exactly the target-half-close
+// shape the reaper is built for.
+func TestTunnelHalfCloseReaper_WriteActivityResetsClock(t *testing.T) {
+	manager := newTunnelManager()
+	idle := withShortHalfCloseReaper(t, manager)
+	const connID = "half-closed-active"
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	peerAccept := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			peerAccept <- c
+		}
+	}()
+	workerConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = workerConn.Close() })
+	peer := <-peerAccept
+	require.NotNil(t, peer)
+	t.Cleanup(func() { _ = peer.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tc := newTunnelConn(manager, connID, workerConn, newTestWriter(), ctx)
+	require.True(t, manager.beginOpen(connID, func() {}))
+	require.True(t, manager.store(connID, tc))
+
+	// Peer half-closes its WRITE side -> worker reads io.EOF -> read loop relays
+	// EOF, returns, arms the reaper. The peer's read side stays open.
+	loopDone := make(chan struct{})
+	go func() { defer close(loopDone); tunnelReadLoop(manager, connID, tc) }()
+	require.NoError(t, peer.(*net.TCPConn).CloseWrite())
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not exit on target half-close")
+	}
+	require.False(t, tc.closed.Load(), "precondition: the half-close path must not close the conn")
+
+	// Drain the peer's read side on a goroutine so the worker's writes do not
+	// block on a full pipe. The writes below keep the upload direction live.
+	peerDone := make(chan struct{})
+	go func() { defer close(peerDone); _, _ = io.Copy(io.Discard, peer) }()
+
+	// Keep writing well past the idle deadline. Each write bumps lastActivity, so
+	// the reaper must NOT reclaim the conn while the upload progresses.
+	deadline := time.Now().Add(idle * 5)
+	var seq uint64
+	for time.Now().Before(deadline) {
+		if err := tc.writeData(ctx, seq, []byte("x"), false); err != nil {
+			t.Fatalf("writeData failed mid-upload at seq %d: %v", seq, err)
+		}
+		seq++
+		// The conn surviving THIS long proves writes reset the clock: the idle
+		// window elapsed ~5x over while writes were progressing.
+		require.NotNil(t, manager.get(connID),
+			"an active upload must not be reaped mid-transfer (reaped at seq %d)", seq)
+		// Sleep a fraction of the idle window between writes to let a reaper tick
+		// (or several) land; if the clock were not reset, the conn would be gone.
+		time.Sleep(halfCloseSweepInterval)
+	}
+
+	// Stop writing. Now the clock expires and the reaper reclaims the conn.
+	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
+		"a half-closed conn must be reaped once writes stop and the idle window elapses")
+	assert.True(t, tc.closed.Load())
+	cancel()
+	<-peerDone
+}
+
+// TestTunnelHalfCloseReaper_ChannelTeardownStillReapsImmediately re-asserts the
+// third acceptance on top of TestTunnelReadLoopHalfCloseEvictsOnLifetimeCancel:
+// channel teardown (lifetime-context cancellation) evicts a parked half-closed
+// conn IMMEDIATELY via the per-conn watcher -- far faster than the idle deadline
+// -- so the reaper is an addition to, not a replacement for, session-death
+// reclamation.
+//
+// The idle window here is widened deliberately (vs withShortHalfCloseReaper's 60ms)
+// so the "teardown beat the idle window" timing assertion has headroom: the
+// lifetime watcher fires on context.AfterFunc (scheduler latency) and
+// AssertEventually polls every ~10ms, so a 60ms margin is flake-prone under CI
+// load. 250ms keeps the assertion decisive (the reaper cannot have run: a conn
+// parked at mark time is not idle-reapable for the full window) while leaving
+// comfortable room for scheduler + poll jitter.
+func TestTunnelHalfCloseReaper_ChannelTeardownStillReapsImmediately(t *testing.T) {
+	manager := newTunnelManager()
+	// Override to a wider idle window with generous headroom for the timing check.
+	origIdle, origInterval := halfCloseIdleTimeout, halfCloseSweepInterval
+	halfCloseIdleTimeout = 250 * time.Millisecond
+	halfCloseSweepInterval = 50 * time.Millisecond
+	t.Cleanup(func() { halfCloseIdleTimeout, halfCloseSweepInterval = origIdle, origInterval })
+	t.Cleanup(manager.Stop)
+	const connID = "half-closed-teardown"
+	workerConn, _, tc, cancel := halfCloseTarget(t, manager, connID, connID)
+	t.Cleanup(func() { _ = workerConn.Close() })
+
+	require.NotNil(t, manager.get(connID), "precondition: conn parked half-closed")
+	start := time.Now()
+	cancel() // session death
+	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
+		"channel teardown must evict a half-closed conn immediately, not wait for the idle reaper")
+	assert.True(t, tc.closed.Load())
+	// The conn was parked at mark time, so it is not idle-reapable until a full
+	// idle window elapses. Asserting teardown finished well inside that window
+	// proves the lifetime watcher (not the reaper) reclaimed it.
+	assert.Less(t, time.Since(start), halfCloseIdleTimeout,
+		"teardown must reclaim via the lifetime watcher, faster than the idle deadline")
+}
+
+// TestTunnelHalfCloseReaper_ReapsSequentialHalfCloses pins that the sweeper, once
+// running, keeps reaping: after the first half-close is reaped, a SUBSEQUENT
+// half-close on a different conn is also reaped within the idle window. The
+// sweeper runs until Stop (it does not self-stop on an empty set), so this holds
+// structurally; the test exists so a regression that stops the sweeper when the
+// set drains (or otherwise fails to keep it alive) would let the second conn leak.
+// The two conns use DISTINCT ids (conn_id collision is astronomically unlikely
+// with nanoid-generated ids), so the case under test is sequential reaps, not
+// conn_id reuse.
+func TestTunnelHalfCloseReaper_ReapsSequentialHalfCloses(t *testing.T) {
+	manager := newTunnelManager()
+	withShortHalfCloseReaper(t, manager)
+
+	for _, connID := range []string{"half-closed-A", "half-closed-B"} {
+		workerConn, _, _, cancel := halfCloseTarget(t, manager, connID, connID)
+		t.Cleanup(cancel)
+		t.Cleanup(func() { _ = workerConn.Close() })
+		require.NotNil(t, manager.get(connID), "conn %q parked half-closed", connID)
+		testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
+			"half-closed conn %q must be reaped within the idle window", connID)
+	}
+}
+
+// TestTunnelHalfCloseReaper_ReconcilesOutOfBandClose pins that a half-closed conn
+// fully closed OUT-OF-BAND (here, by the lifetime watcher firing mid-park) has its
+// halfClosed tracker entry dropped PROMPTLY by closeAndRemove's clearHalfClosed,
+// without waiting for the sweeper's next tick and without the sweeper re-closing an
+// already-closed conn. close() is idempotent, but the prompt drop keeps the
+// halfClosed map from pinning a closed conn's *tunnelConn until the next tick.
+func TestTunnelHalfCloseReaper_ReconcilesOutOfBandClose(t *testing.T) {
+	manager := newTunnelManager()
+	withShortHalfCloseReaper(t, manager)
+	const connID = "half-closed-reconcile"
+	workerConn, _, tc, cancel := halfCloseTarget(t, manager, connID, connID)
+	t.Cleanup(func() { _ = workerConn.Close() })
+
+	require.NotNil(t, manager.get(connID), "precondition: conn parked half-closed")
+	// The conn is now in m.halfClosed (markHalfClosed) with a non-nil tracker.
+	require.NotNil(t, tc.halfCloseTrack.Load(), "precondition: half-close tracker armed")
+
+	// Out-of-band full close via the lifetime watcher: closeAndRemove closes the
+	// conn, evicts from m.conns, AND (since this diff) drops the halfClosed entry.
+	cancel()
+	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
+		"out-of-band close must evict from m.conns")
+	require.True(t, tc.closed.Load(), "precondition: conn fully closed out-of-band")
+
+	// closeAndRemove's clearHalfClosed must have dropped the tracker entry
+	// already -- without waiting for the sweeper's next tick. Assert it directly
+	// (the map is empty, the tracker pointer is nil) rather than via a sweep, so a
+	// regression that removes the opportunistic cleanup fails here, not silently.
+	manager.mu.Lock()
+	_, present := manager.halfClosed[connID]
+	manager.mu.Unlock()
+	assert.False(t, present, "clearHalfClosed must drop the halfClosed entry on out-of-band close")
+	assert.Nil(t, tc.halfCloseTrack.Load(), "clearHalfClosed must clear the conn's tracker pointer")
+}
+
+// TestRegisterAll_SetsTunnelManagerAndStopStopsSweeper covers the
+// Shutdown->svc.tunnels.Stop() wiring added for this change, in two parts the
+// full Shutdown path (which needs terminal/agent subsystems not relevant here)
+// would obscure: (1) RegisterAll sets svc.tunnels, so Shutdown's nil-guarded
+// `svc.tunnels.Stop()` branch is reachable; (2) that Stop on an armed manager
+// actually joins the sweeper goroutine. Together they pin that an orderly
+// Shutdown reaps the sweeper rather than orphaning it.
+func TestRegisterAll_SetsTunnelManagerAndStopStopsSweeper(t *testing.T) {
+	sqlDB := newServiceTestDB(t)
+	svc := newMinimalService(t, sqlDB)
+	d := channel.NewDispatcher()
+	RegisterAll(d, svc)
+
+	// (1) The wiring: RegisterAll assigns the worker-singleton tunnel manager.
+	tunnels := svc.tunnels.Load()
+	require.NotNil(t, tunnels, "RegisterAll must set svc.tunnels so Shutdown can Stop it")
+
+	// (2) The behavior Shutdown relies on: Stop() on an armed manager joins the
+	// sweeper goroutine. Arm it by parking a half-closed conn via the shared
+	// halfCloseTarget helper (it drives the manager's read loop to EOF -> arm).
+	const connID = "shutdown-reaper"
+	target, _, _, _ := halfCloseTarget(t, tunnels, connID, connID)
+	t.Cleanup(func() { _ = target.Close() })
+
+	tunnels.mu.Lock()
+	doneCh := tunnels.sweeper.done
+	startedBefore := tunnels.sweeper.started
+	tunnels.mu.Unlock()
+	require.True(t, startedBefore && doneCh != nil, "precondition: sweeper armed by the half-close")
+
+	tunnels.Stop() // the exact call Service.Shutdown makes
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tunnels.Stop() did not join the sweeper goroutine")
+	}
+	tunnels.mu.Lock()
+	startedAfter := tunnels.sweeper.started
+	stopped := tunnels.sweeper.stopped
+	tunnels.mu.Unlock()
+	assert.False(t, startedAfter, "Stop must clear sweeper.started")
+	assert.True(t, stopped, "Stop must mark the sweeper stopped so it cannot restart")
+}
+
+// TestRegisterAllReassignmentStopsPriorManager pins that re-registering handlers
+// does not orphan the prior tunnel manager's reaper goroutine: a second RegisterAll
+// (a future reconnect/re-registration flow) must Stop the prior manager before
+// reassigning svc.tunnels. Without the Stop, the prior manager's sweeper goroutine
+// (if armed) leaks for the process lifetime -- the exact leak the reaper exists to
+// prevent. RegisterAll on a manager whose sweeper never started (the common case
+// for test re-registration) is a no-op Stop, so this stays behavior-preserving.
+func TestRegisterAllReassignmentStopsPriorManager(t *testing.T) {
+	sqlDB := newServiceTestDB(t)
+	svc := newMinimalService(t, sqlDB)
+	d := channel.NewDispatcher()
+	RegisterAll(d, svc)
+	prior := svc.tunnels.Load()
+	require.NotNil(t, prior)
+
+	// Arm the prior manager's sweeper so a leaked one would be observable.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	target, peer := net.Pipe()
+	t.Cleanup(func() { _ = target.Close() })
+	t.Cleanup(func() { _ = peer.Close() })
+	const connID = "prior-reaper"
+	tc := newTunnelConn(prior, connID, target, newTestWriter(), ctx)
+	require.True(t, prior.beginOpen(connID, func() {}))
+	require.True(t, prior.store(connID, tc))
+	loopDone := make(chan struct{})
+	go func() { defer close(loopDone); tunnelReadLoop(prior, connID, tc) }()
+	_ = peer.Close()
+	<-loopDone
+	prior.mu.Lock()
+	doneCh := prior.sweeper.done
+	prior.mu.Unlock()
+	require.NotNil(t, doneCh, "precondition: prior manager's sweeper armed")
+
+	// Re-register. The prior manager must be Stopped (its sweeper joined) and
+	// svc.tunnels replaced with a fresh manager.
+	RegisterAll(d, svc)
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-registration did not Stop the prior tunnel manager's sweeper (orphaned goroutine)")
+	}
+	require.NotSame(t, prior, svc.tunnels.Load(), "re-registration must replace svc.tunnels with a fresh manager")
+	// The prior manager is now stopped: ensureRunning is a permanent no-op.
+	prior.mu.Lock()
+	stopped := prior.sweeper.stopped
+	prior.mu.Unlock()
+	assert.True(t, stopped, "the prior manager's sweeper must be marked stopped")
+}
+
+// TestTunnelStopDoesNotDeadlockVsSweep is a regression test for a deadlock where
+// Stop held m.mu while waiting on the sweeper's done channel, but an in-flight
+// sweep needed m.mu to observe the stop and exit. It hammers Stop() against an
+// armed, fast-ticking sweeper; a regression that rejoins under m.mu hangs the
+// test. Found by deep-review and confirmed under -race.
+func TestTunnelStopDoesNotDeadlockVsSweep(t *testing.T) {
+	orig := halfCloseSweepInterval
+	halfCloseSweepInterval = time.Millisecond
+	t.Cleanup(func() { halfCloseSweepInterval = orig })
+
+	for i := 0; i < 500; i++ {
+		manager := newTunnelManager()
+		manager.mu.Lock()
+		manager.sweeper.ensureRunning(manager)
+		manager.mu.Unlock()
+		// Let at least one tick land so the sweeper is likely mid-sweep.
+		time.Sleep(2 * time.Millisecond)
+		done := make(chan struct{})
+		go func() { manager.Stop(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("Stop() deadlocked on iteration %d (Stop held m.mu across <-done while the sweeper blocked on m.mu)", i)
+		}
+	}
+}
+
+// TestTunnelSweepReapsUnderLockWithoutDeadlock pins that sweepHalfClosed reaps
+// inline under m.mu -- closing and evicting each reaped conn while holding the
+// lock -- without self-deadlocking against the conn's lifetime-cancellation
+// AfterFunc callback. That callback (closeAndRemove -> clearHalfClosed) re-takes
+// m.mu, so a sweep that held m.mu across a clearHalfClosed call would deadlock;
+// the sweep instead detaches the tracker via detachHalfClosedLocked (which
+// expects the caller to hold m.mu) and calls tc.close()+removeIf directly,
+// neither of which re-enters m.mu. tc.close()'s stopCtxWatch() is
+// context.AfterFunc's stop func, which does NOT block on an in-flight callback
+// (verified), so holding m.mu across it is safe: a concurrent callback simply
+// blocks on m.mu until the sweep releases it, then proceeds -- no cycle.
+//
+// This races a sweep against a lifetime-context cancellation (which fires the
+// callback) and asserts both finish; a regression that routes the sweep's reap
+// through clearAndRemove (re-entering m.mu) hangs here.
+func TestTunnelSweepReapsUnderLockWithoutDeadlock(t *testing.T) {
+	origInterval, origIdle := halfCloseSweepInterval, halfCloseIdleTimeout
+	halfCloseSweepInterval = 5 * time.Millisecond
+	halfCloseIdleTimeout = 5 * time.Millisecond
+	t.Cleanup(func() { halfCloseSweepInterval, halfCloseIdleTimeout = origInterval, origIdle })
+
+	for i := 0; i < 200; i++ {
+		manager := newTunnelManager()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		target, peer := net.Pipe()
+		t.Cleanup(func() { _ = peer.Close() })
+		t.Cleanup(func() { _ = target.Close() })
+		tc := newTunnelConn(manager, "dlq", target, newTestWriter(), ctx)
+		require.True(t, manager.beginOpen("dlq", func() {}))
+		require.True(t, manager.store("dlq", tc))
+		manager.markHalfClosed("dlq", tc)
+
+		// Race: cancel the lifetime ctx (fires the AfterFunc -> closeAndRemove ->
+		// clearHalfClosed, which needs m.mu) concurrent with a sweeper tick
+		// reaping the same conn under m.mu.
+		go cancel()
+
+		// Drive one synchronous sweep on the test goroutine so the reap-under-lock
+		// path is exercised deterministically, not just via the ticker.
+		sweepDone := make(chan struct{})
+		go func() {
+			manager.sweepHalfClosed(time.Now(), halfCloseIdleTimeout)
+			close(sweepDone)
+		}()
+
+		// Stop joins the sweeper goroutine; if anything self-deadlocked on m.mu,
+		// Stop (which also needs m.mu via stopLocked) hangs.
+		stopDone := make(chan struct{})
+		go func() { manager.Stop(); close(stopDone) }()
+		select {
+		case <-sweepDone:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("sweep did not complete on iteration %d (reap-under-lock self-deadlocked)", i)
+		}
+		select {
+		case <-stopDone:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("Stop hung on iteration %d (sweep held m.mu across a re-entrant clearHalfClosed/closeAndRemove)", i)
+		}
+	}
+}
+
+// TestTunnelClientCloseDropsHalfClosedTracker pins the fix for the gap where the
+// client CloseTunnelConn path (closeConn -> cancel -> tc.close) did NOT call
+// clearHalfClosed, leaving a stale halfClosed entry pinning the dead tc until the
+// sweeper's next tick. Now closeConn clears the tracker, so the entry is gone
+// immediately -- without waiting for a sweep.
+func TestTunnelClientCloseDropsHalfClosedTracker(t *testing.T) {
+	manager := newTunnelManager()
+	// DO NOT shorten the idle window: the fix is that the entry is gone BEFORE any
+	// sweep tick could fire. A long idle window makes a lingering entry
+	// (the regression) detectable: the test would block on the assertion.
+	origIdle, origInterval := halfCloseIdleTimeout, halfCloseSweepInterval
+	halfCloseIdleTimeout = 10 * time.Second
+	halfCloseSweepInterval = 10 * time.Second
+	t.Cleanup(func() { halfCloseIdleTimeout, halfCloseSweepInterval = origIdle, origInterval })
+	t.Cleanup(manager.Stop)
+
+	const connID = "half-closed-client"
+	target, peer, tc, cancel := halfCloseTarget(t, manager, connID, connID)
+	t.Cleanup(func() { _ = target.Close() })
+	t.Cleanup(func() { _ = peer.Close() })
+	t.Cleanup(cancel)
+	require.NotNil(t, tc.halfCloseTrack.Load(), "precondition: half-close tracker armed")
+
+	// Simulate the client CloseTunnelConn's teardown: cancel (evict from conns) +
+	// tc.close() + clearHalfClosed. This mirrors closeConn exactly.
+	evicted := manager.cancel(connID)
+	require.NotNil(t, evicted)
+	evicted.close()
+	manager.clearHalfClosed(connID, evicted)
+
+	// The tracker entry must be gone IMMEDIATELY (no sweep has run -- the idle
+	// window is 10s). Before the fix this assertion failed: the entry lingered.
+	manager.mu.Lock()
+	_, present := manager.halfClosed[connID]
+	manager.mu.Unlock()
+	assert.False(t, present, "client close must drop the halfClosed entry via clearHalfClosed, not wait for a sweep")
+	assert.Nil(t, tc.halfCloseTrack.Load(), "client close must clear the conn's tracker pointer")
+}
+
+// TestTunnelClearHalfClosedIsNoOpForNeverMarkedConn pins the lock-free fast path
+// in clearHalfClosed: a conn that was never marked half-closed has a nil tracker,
+// so clearHalfClosed must short-circuit on a single atomic load without touching
+// m.mu (and without leaving anything in m.halfClosed). Most conns never half-close,
+// so this is the close hot path; a regression that drops the fast path takes m.mu
+// on every full close.
+func TestTunnelClearHalfClosedIsNoOpForNeverMarkedConn(t *testing.T) {
+	manager := newTunnelManager()
+	t.Cleanup(manager.Stop)
+	const connID = "never-marked"
+	tc := &tunnelConn{}
+
+	// The conn was never markHalfClosed'd, so its tracker is nil and it is not in
+	// m.halfClosed.
+	require.Nil(t, tc.halfCloseTrack.Load())
+
+	// clearHalfClosed must be a harmless no-op that changes no state.
+	assert.NotPanics(t, func() { manager.clearHalfClosed(connID, tc) })
+
+	manager.mu.Lock()
+	_, present := manager.halfClosed[connID]
+	manager.mu.Unlock()
+	assert.False(t, present, "a clear on a never-marked conn must not insert into m.halfClosed")
+	assert.Nil(t, tc.halfCloseTrack.Load(), "the conn's tracker stays nil")
+}
+
+// TestTunnelSweepDetachesTrackerAndMapTogether pins the detach invariant
+// detachHalfClosedLocked owns: when the sweeper reaps a conn, BOTH the
+// m.halfClosed map slot AND the conn's halfCloseTrack pointer are cleared in the
+// same step (the conn is then closed+evicted under the same lock). A regression
+// that clears one without the other orphans either a dangling map entry (pinning
+// tc) or a stale tracker pointer (so writeData keeps bumping a dead entry).
+func TestTunnelSweepDetachesTrackerAndMapTogether(t *testing.T) {
+	manager := newTunnelManager()
+	withShortHalfCloseReaper(t, manager)
+	const connID = "sweep-detach"
+	workerConn, _, tc, cancel := halfCloseTarget(t, manager, connID, connID)
+	defer cancel()
+	t.Cleanup(func() { _ = workerConn.Close() })
+	require.NotNil(t, tc.halfCloseTrack.Load(), "precondition: half-close tracker armed")
+
+	// Drive one sweep with a zero idle window so the conn is reaped immediately,
+	// then assert the detach was total (map slot gone, pointer nil, conn closed).
+	manager.sweepHalfClosed(time.Now(), 0)
+
+	manager.mu.Lock()
+	_, present := manager.halfClosed[connID]
+	manager.mu.Unlock()
+	assert.False(t, present, "sweep must delete the reaped conn's halfClosed entry")
+	assert.Nil(t, tc.halfCloseTrack.Load(), "sweep must clear the reaped conn's tracker pointer")
+	assert.True(t, tc.closed.Load(), "sweep must close the reaped conn")
+	assert.Nil(t, manager.get(connID), "sweep must evict the reaped conn from m.conns")
+}
+
+// TestTunnelMarkHalfClosedClearsStaleEntry pins markHalfClosed's pointer-identity
+// guard: if a stale halfClosed entry for the same conn_id survived (the prior conn
+// was never cleared before this mark, e.g. by a buggy/hostile client reusing a
+// conn_id), marking a NEW conn clears the old conn's tracker pointer so its
+// writeData stops bumping a dead entry.
+func TestTunnelMarkHalfClosedClearsStaleEntry(t *testing.T) {
+	manager := newTunnelManager()
+	t.Cleanup(manager.Stop)
+	const connID = "reuse-id"
+	// Bare tunnelConns suffice: markHalfClosed touches only the halfCloseTrack
+	// pointer and the map entry, never read-side state like closed/gate/credit.
+	old := &tunnelConn{}
+	fresh := &tunnelConn{}
+
+	manager.markHalfClosed(connID, old)
+	require.Same(t, old, old.halfCloseTrack.Load().tc, "precondition: old conn's tracker set")
+
+	manager.markHalfClosed(connID, fresh)
+
+	assert.Nil(t, old.halfCloseTrack.Load(), "markHalfClosed must clear a stale entry's tracker pointer")
+	manager.mu.Lock()
+	entry := manager.halfClosed[connID]
+	manager.mu.Unlock()
+	require.NotNil(t, entry)
+	assert.Same(t, fresh, entry.tc, "the map must point at the fresh conn after a reuse-mark")
 }
 
 // writeGate.waitTurn must NAK a provably-illegitimate seq -- a duplicate/replay behind

--- a/backend/tunnel/conn.go
+++ b/backend/tunnel/conn.go
@@ -312,6 +312,28 @@ var remoteCloseLockBudget = 5 * time.Second
 // remoteCloseSendBudget bounds the best-effort CloseTunnelConn send itself.
 var remoteCloseSendBudget = 5 * time.Second
 
+// remoteCloseSendAttempts is the max number of SendRPCNoWait attempts
+// sendCloseTunnelConn makes for a single close. A transient failure (a momentarily
+// full send window, a brief WebSocket write hiccup with the channel still alive)
+// used to permanently drop the close, leaking the worker-side conn until channel
+// death (or, for a half-closed conn, until the worker's idle reaper). A bounded
+// retry -- gated on the channel still being alive, so it does not spin against a
+// dead channel -- recovers the common transient-loss case in ~RTT. It is a var so
+// tests can shorten it. Matches Conn.CloseWrite's "leave closeWriteSent false so a
+// caller can retry after a transient failure" contract, internalized here because
+// sendCloseTunnelConn is fire-and-forget with no caller to retry it.
+//
+// The loop ALWAYS makes at least one attempt (the first send runs before the
+// attempt-count guard), so a value <= 1 means "send once, do not retry" rather
+// than "send nothing"; the close is best-effort and the worker's idle reaper is
+// the ultimate bound, so suppressing it entirely is never the intent.
+var remoteCloseSendAttempts = 3
+
+// remoteCloseSendBackoff is the delay between CloseTunnelConn send attempts. Short
+// on purpose: the transient losses this recovers (a briefly-full send window)
+// clear in well under a round-trip. var so tests can shorten it.
+var remoteCloseSendBackoff = 50 * time.Millisecond
+
 // sendRemoteClose tells the worker to tear down its half of the conn.
 //
 // It tries to order the close after every prior write by reading the write
@@ -348,29 +370,73 @@ func (tc *Conn) readWriteSeqForClose() (seq uint64, ok bool) {
 // sendCloseTunnelConn marshals and sends CloseTunnelConn. forceful reports that
 // the close could not be ordered (writeMu timed out), for logging only -- the
 // wire message is the same shape, just with seq 0 so the worker force-closes.
+//
+// Retries transient send failures up to remoteCloseSendAttempts, gated on the
+// channel still being alive: a SendRPCNoWait failure while the channel is live is
+// transient (a momentarily-full send window, a brief WebSocket write hiccup) and
+// a retry recovers it, but a failure because the channel closed is permanent and
+// retrying would just spin. A dropped close leaks the worker-side conn -- until
+// channel death, or, for a half-closed conn, until the worker's idle reaper
+// (halfCloseIdleTimeout) -- so the retry shrinks the common transient-loss leak
+// window to ~RTT instead of the reaper's 60s. Attempts and backoff stay inside
+// remoteCloseSendBudget via the per-call context timeout.
 func (tc *Conn) sendCloseTunnelConn(seq uint64, forceful bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), remoteCloseSendBudget)
 	defer cancel()
+	// Capture the tuning vars at call start, like the half-close sweeper does, so a
+	// test restoring them in cleanup cannot race a per-iteration global read. (Go
+	// runs non-parallel tests sequentially, so this is latent today, but matching
+	// the sweeper's discipline keeps the two global-var-driven loops in the diff
+	// consistent.)
+	attempts := remoteCloseSendAttempts
+	backoff := remoteCloseSendBackoff
 	payload, err := proto.Marshal(&leapmuxv1.CloseTunnelConnRequest{ConnId: tc.connID, Seq: seq})
 	if err != nil {
 		slog.Warn("tunnel conn close not sent: marshal failed",
 			"conn_id", tc.connID, "error", err)
 		return
 	}
-	// Log rather than discard: a dropped close leaks the worker-side conn, and a
-	// silent drop leaves nothing to diagnose it with. There is no retry -- the conn
-	// is already gone locally, and the channel's own death reaps the worker side.
-	// Bounding the leak with a per-conn idle reaper is tracked in
-	// https://github.com/leapmux/leapmux/issues/318.
-	if _, err := tc.ch.SendRPCNoWait(ctx, "CloseTunnelConn", payload, RPCHandlers{}); err != nil {
-		if forceful {
-			slog.Warn("tunnel conn forceful close not sent",
-				"conn_id", tc.connID, "error", err)
-		} else {
-			slog.Warn("tunnel conn graceful close not sent",
-				"conn_id", tc.connID, "error", err)
+	var lastErr error
+	attempt := 0
+	mode := "graceful"
+	if forceful {
+		mode = "forceful"
+	}
+sendLoop:
+	for {
+		attempt++
+		_, err := tc.ch.SendRPCNoWait(ctx, "CloseTunnelConn", payload, RPCHandlers{})
+		if err == nil {
+			return // delivered
+		}
+		lastErr = err
+		// Stop retrying once the budget is exhausted or the channel is gone. A
+		// closed channel makes every subsequent send fail, so retrying would spin
+		// to the attempt limit for nothing. The FIRST attempt always runs (even
+		// against a closing channel) because the worker side of a canceled open
+		// may still need tearing down and SendRPCNoWait queues/drains where it can.
+		if ctx.Err() != nil || tc.ch.Context().Err() != nil {
+			break
+		}
+		if attempt >= attempts {
+			break
+		}
+		// Transient failure on a live channel: back off and retry. The budget ctx
+		// bounds the total wait, so a slow backoff just exits sooner.
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			break sendLoop
+		case <-timer.C:
 		}
 	}
+	// Log rather than silently drop: a dropped close leaks the worker-side conn
+	// (until channel death, or the worker's idle reaper for a half-closed conn),
+	// and a silent drop leaves nothing to diagnose it with. The mode and the last
+	// error identify whether the graceful/forceful variant failed and why.
+	slog.Warn("tunnel conn close not sent",
+		"conn_id", tc.connID, "mode", mode, "attempts", attempt, "error", lastErr)
 }
 
 // unregister detaches the conn from its channel: it drops the channel's handlers

--- a/backend/tunnel/conn_test.go
+++ b/backend/tunnel/conn_test.go
@@ -383,6 +383,114 @@ func TestSendRemoteCloseForcefulWhenWriteMuHeld(t *testing.T) {
 		"the forceful close carries seq 0 so the worker force-closes without waiting on a flush")
 }
 
+// failNTimesThenSucceedRecorder is a tunnelRPCChannel fake whose SendRPCNoWait
+// fails the first failN CloseTunnelConn sends then succeeds, recording every
+// attempt's seq. It models a transient send failure (a briefly-full send window)
+// on a channel that is still live -- the case a bounded close retry recovers.
+type failNTimesThenSucceedRecorder struct {
+	ctx     context.Context
+	mu      sync.Mutex
+	closes  []uint64
+	failN   int
+	failedN int
+}
+
+func (f *failNTimesThenSucceedRecorder) Context() context.Context { return f.ctx }
+func (*failNTimesThenSucceedRecorder) UnregisterPending(uint64)   {}
+func (*failNTimesThenSucceedRecorder) UnregisterStream(uint64)    {}
+func (f *failNTimesThenSucceedRecorder) SendRPCNoWait(_ context.Context, method string, payload []byte, _ RPCHandlers) (uint64, error) {
+	if method != "CloseTunnelConn" {
+		return 1, nil
+	}
+	var r leapmuxv1.CloseTunnelConnRequest
+	if err := proto.Unmarshal(payload, &r); err == nil {
+		f.mu.Lock()
+		f.closes = append(f.closes, r.GetSeq())
+		f.mu.Unlock()
+	}
+	f.mu.Lock()
+	f.failedN++
+	failed := f.failedN <= f.failN
+	f.mu.Unlock()
+	if failed {
+		return 0, errors.New("transient send failure (full send window)")
+	}
+	return 1, nil
+}
+
+func (f *failNTimesThenSucceedRecorder) recorded() []uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]uint64, len(f.closes))
+	copy(out, f.closes)
+	return out
+}
+
+// sendCloseTunnelConn retries transient send failures on a live channel, so a
+// briefly-full send window that used to permanently drop the close (leaking the
+// worker-side conn) now recovers once the window drains. This test pins that the
+// second attempt succeeds and the close is delivered -- the regression a
+// no-retry implementation would fail.
+func TestSendCloseTunnelConnRetriesTransientFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ch := &failNTimesThenSucceedRecorder{ctx: ctx, failN: 1} // first send fails, second succeeds
+	tc := newConn(ch, "conn-retry", "example.test", 443)
+	// Shorten the backoff so the retry is immediate; restore on cleanup.
+	prevBackoff := remoteCloseSendBackoff
+	remoteCloseSendBackoff = time.Millisecond
+	t.Cleanup(func() { remoteCloseSendBackoff = prevBackoff })
+
+	tc.sendCloseTunnelConn(7, false)
+
+	closes := ch.recorded()
+	require.Len(t, closes, 2, "a transient failure on a live channel must be retried until it succeeds")
+	assert.Equal(t, []uint64{7, 7}, closes, "both attempts carry the same close seq")
+}
+
+// A closed channel makes every send fail permanently, so sendCloseTunnelConn
+// must NOT retry against one -- it makes ONE attempt (the worker side of a
+// canceled open may still need tearing down, and SendRPCNoWait drains where it
+// can) and then stops rather than spinning to the attempt limit. This test pins
+// that exactly one attempt runs against a dead channel, not remoteCloseSendAttempts.
+func TestSendCloseTunnelConnDoesNotRetryDeadChannel(t *testing.T) {
+	deadCtx, cancel := context.WithCancel(context.Background())
+	cancel() // channel is dead before the close is sent
+	ch := &failNTimesThenSucceedRecorder{ctx: deadCtx, failN: remoteCloseSendAttempts + 1}
+	tc := newConn(ch, "conn-dead", "example.test", 443)
+
+	tc.sendCloseTunnelConn(9, false)
+
+	closes := ch.recorded()
+	require.Len(t, closes, 1, "a dead channel gets exactly one close attempt, not a retry storm")
+	assert.Equal(t, uint64(9), closes[0])
+}
+
+// A LIVE channel whose sends keep failing must run exactly remoteCloseSendAttempts
+// attempts and then stop (not spin forever, not over-retry). This pins the
+// attempt-limit cap -- a regression that drops the cap check, off-by-ones it, or
+// lets the budget alone bound a much larger attempt count would fail here. Uses a
+// short backoff so the test does not wait the production 50ms x attempts.
+func TestSendCloseTunnelConnCapsAttemptsOnPersistentlyFailingLiveChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	// failN well beyond the cap so the cap, not recovery, ends the loop.
+	ch := &failNTimesThenSucceedRecorder{ctx: ctx, failN: remoteCloseSendAttempts + 5}
+	tc := newConn(ch, "conn-cap", "example.test", 443)
+	prevBackoff := remoteCloseSendBackoff
+	remoteCloseSendBackoff = time.Millisecond
+	t.Cleanup(func() { remoteCloseSendBackoff = prevBackoff })
+
+	tc.sendCloseTunnelConn(11, false)
+
+	closes := ch.recorded()
+	require.Len(t, closes, remoteCloseSendAttempts,
+		"a persistently-failing live channel must run exactly remoteCloseSendAttempts attempts")
+	for _, seq := range closes {
+		assert.Equal(t, uint64(11), seq, "every attempt carries the same close seq")
+	}
+}
+
 // The ack loop must grant exactly one send-window slot per ack. Under-granting
 // permanently shrinks the window; over-granting would admit more outstanding
 // frames than WriteWindowFrames.


### PR DESCRIPTION
## Motivation

When a tunnel target half-closes (sends a FIN), the worker's `tunnelReadLoop` relays read-EOF to the client and returns **without evicting** the conn — deliberately, so the client→target upload direction can finish. Reclamation then depended on the client's best-effort `CloseTunnelConn` (no retry) or on channel death. A lost close on a long-lived channel (pooled SSH / port-forward sessions last hours) leaked the FD and goroutine until the channel finally died — a leak bounded by channel lifetime, not by idle time.

This is [#318](https://github.com/leapmux/leapmux/issues/318).

## Modifications

**Idle reaper (`backend/internal/worker/service/tunnel.go`).** A shared reaper tracks *only* half-closed conns and reclaims them after `halfCloseIdleTimeout` (60s) with no write activity. Tracking only half-closed conns — rather than every conn — means a legitimately quiet live session can never be mis-reaped, since fully-live bidirectional conns are never inserted.

- The sweeper starts lazily on the first `markHalfClosed` and runs until `Service.Shutdown` stops it (no self-stop on an empty set). Once `Stop` has run, the sweeper is permanently barred from restarting, so a read loop hitting EOF after Shutdown can't re-arm a leaked sweeper.
- The write hot path stays allocation-free and lock-free: the per-write activity bump is a single atomic load → no-op for non-half-closed conns (the tracker pointer on `tunnelConn` is nil until half-close). `writeData` bumps `lastActivity` on each successful write, gated on `!closeWrite` (a `close_write` frame ends the upload, so the clock keeps running for prompt reclaim).
- The sweep reaps fully inline under `m.mu` (decide → detach tracker → close+evict, all under one lock). This is safe because `tc.close()` is CAS-idempotent, `removeIf` is a `sync.Map` CompareAndDelete, and `context.AfterFunc`'s stop func does not block on an in-flight callback. The sweep detaches via `detachHalfClosedLocked` (not `clearHalfClosed`, which re-takes `m.mu` and would self-deadlock) — the single owner of the invariant that a tracker's map slot and atomic pointer are cleared together.
- `Service.Shutdown`'s `Stop()` mirrors the lock discipline: it signals the sweeper under `m.mu` but joins its done channel *outside* the lock, so an in-flight sweep needing `m.mu` to observe the stop isn't blocked by `Stop` holding it.
- Every full-close path calls `clearHalfClosed`, which short-circuits on a single atomic load when the conn was never half-closed (the common case), so the close hot path never touches `m.mu`. `markHalfClosed` pointer-identity-guards against a reused conn_id orphaning a stale tracker.

**Manager ownership (`service.go`).** `svc.tunnels` is an `atomic.Pointer` (matching `registeredBy`, for the same reconnect-vs-shutdown race reason), and `RegisterAll` swaps in the new manager and `Stop`s the prior one it displaced, so a re-registration can't orphan the prior reaper goroutine.

**Close-path retry (`backend/tunnel/conn.go`).** `sendCloseTunnelConn` now retries transient send failures up to `remoteCloseSendAttempts` (3) with `remoteCloseSendBackoff` (50ms), gated on the channel still being alive: a transient failure (a momentarily-full send window, a brief WebSocket hiccup) is retried to ~RTT, but a failure because the channel closed is permanent and not spun against. This shrinks the common transient close-loss leak window to ~RTT instead of the reaper's 60s; the reaper remains the ultimate bound.

**Tests.** Added coverage for the reaper (idle reclaim, write-activity clock reset, teardown-still-reaps-immediately, sequential half-closes, out-of-band-close reconciliation), the `Stop`/sweep deadlock regressions, the `detachHalfClosedLocked` invariant, the `clearHalfClosed` lock-free fast path, the `svc.tunnels` atomic wiring + reassignment-Stops-prior, and the close-retry attempt cap / dead-channel no-retry.

## Result

A half-closed worker tunnel conn whose client `CloseTunnelConn` is lost is now reclaimed within a fixed 60s idle window instead of leaking until the channel dies (hours, for pooled sessions). An active upload is never reaped mid-transfer, and channel teardown still reclaims a parked half-closed conn immediately via the existing lifetime watcher.

- Closes #318
