### PR TITLE
fix(frontend): Stop silently losing restored state, contexts and faults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ plugin behind an interface method.
 ### Tests
 
 - Backend: `testify/assert`, `testify/require`.
-- Frontend: `vitest`. `describe` names must be lowercase.
+- Frontend: `vitest`. `describe` names must not be Title Case — start them lowercase (`describe('parses empty input')`). Naming one after the symbol under test keeps that symbol's own casing: `describe('createStableContext')`, `describe('channelManager openChannel')`.
 - **Unit tests are co-located** with the code they test: `foo.ts` → `foo.test.ts` in the same directory. Do **not** add a second test file for a module under `tests/unit/` — that mirror has been retired (see `src/test-support/noMirroredUnitTests.test.ts`, which fails the suite if it comes back). Shared unit-test helpers live in `src/test-support/` (imported via `~/test-support/…`). Only Playwright **E2E** specs live outside `src/`, under `tests/e2e/`.
 - E2E: do NOT pass per-call `{ timeout: … }` overrides to `expect`, `locator.waitFor`, etc. Playwright's global timeout (configured in `playwright.config.ts`) already applies; per-call overrides are redundant noise. If a specific assertion legitimately needs a longer-than-global timeout (e.g. waiting on a slow worker spawn), discuss it before silently adding one.
 - Unused imports cause lint failures (strict).

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -66,6 +66,7 @@
         "jiti": "^2.7.0",
         "jsdom": "^29.1.1",
         "magic-string": "^0.30.21",
+        "solid-refresh": "^0.6.3",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
         "vite-plugin-solid": "^2.11.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
     "jiti": "^2.7.0",
     "jsdom": "^29.1.1",
     "magic-string": "^0.30.21",
+    "solid-refresh": "^0.6.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vite-plugin-solid": "^2.11.12",

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,10 +1,10 @@
 import type { ParentComponent } from 'solid-js'
 import { Router } from '@solidjs/router'
 import { FileRoutes } from '@solidjs/start/router'
-import { createEffect, createResource, createSignal, ErrorBoundary, getOwner, Match, onCleanup, onMount, runWithOwner, Show, Suspense, Switch } from 'solid-js'
+import { createEffect, createSignal, ErrorBoundary, getOwner, Match, onCleanup, onMount, runWithOwner, Show, Suspense, Switch } from 'solid-js'
 import { getRuntimeState, isTauriApp, platformBridge, refreshRuntimeState } from '~/api/platformBridge'
 import { channelManager } from '~/api/workerRpc'
-import { showInfoToast } from '~/components/common/Toast'
+import { renderErrorFallback } from '~/components/common/ErrorFallback'
 import { LauncherView } from '~/components/desktop/LauncherView'
 import { AboutDialog } from '~/components/shell/AboutDialog'
 import { DesktopMinimalChrome, DesktopRouteChrome } from '~/components/shell/DesktopChrome'
@@ -15,7 +15,6 @@ import { PreferencesProvider, usePreferences } from '~/context/PreferencesContex
 import { useCoreShortcuts } from '~/hooks/useCoreShortcuts'
 import { initStorageCleanup, KEY_BROWSER_PREFS, loadBrowserPrefs } from '~/lib/browserStorage'
 import { createLogger } from '~/lib/logger'
-import { resolveStack } from '~/lib/resolveStack'
 import { disableTextSubstitutions } from '~/lib/textInputBehavior'
 import { heightFull } from '~/styles/shared.css'
 import '~/lib/oat'
@@ -90,30 +89,6 @@ const DesktopFadeIn: ParentComponent = (props) => {
   )
 }
 
-function AppErrorFallback(error: Error) {
-  const rawStack = () => error?.stack || ''
-  const [resolved] = createResource(rawStack, resolveStack)
-  const message = () => error?.message || String(error)
-  const displayText = () => `${message()}\n\n${resolved() ?? rawStack()}`
-
-  const handleClick = async () => {
-    await navigator.clipboard.writeText(displayText())
-    showInfoToast('Stack trace copied to clipboard')
-  }
-
-  return (
-    <div class="flex flex-col items-center justify-center p-4" style={{ position: 'fixed', inset: '0' }}>
-      <h1>Uncaught Error</h1>
-      <pre
-        style={{ 'max-width': '80vw', 'max-height': '50vh', 'cursor': 'pointer' }}
-        onClick={handleClick}
-      >
-        {displayText()}
-      </pre>
-    </div>
-  )
-}
-
 export default function App() {
   const disposeStorageCleanup = initStorageCleanup()
   onCleanup(disposeStorageCleanup)
@@ -161,19 +136,19 @@ export default function App() {
     }
   })
 
-  // Listen for localStorage changes from other tabs.
+  // Follow theme changes made in other tabs.
+  //
+  // The event is only used to learn WHICH key changed; the value is read back
+  // through `loadBrowserPrefs`. Parsing `e.newValue` directly -- which this did
+  // -- reads the raw `{ v, e }` TTL envelope that `localStorageSet` writes, so
+  // `JSON.parse(e.newValue).theme` was always `undefined`, the comparison
+  // against an equally-undefined old value was never true, and cross-tab theme
+  // sync had silently done nothing: a second tab kept the old theme until it
+  // was reloaded.
   const handleStorage = (e: StorageEvent) => {
-    if (e.key === KEY_BROWSER_PREFS) {
-      const oldPrefs = e.oldValue ? JSON.parse(e.oldValue) : {}
-      const newPrefs = e.newValue ? JSON.parse(e.newValue) : {}
-      if (oldPrefs.theme !== newPrefs.theme) {
-        const val = newPrefs.theme
-        if (val === 'light' || val === 'dark' || val === 'system')
-          setThemePreference(val)
-        else
-          setThemePreference('system')
-      }
-    }
+    if (e.key !== KEY_BROWSER_PREFS)
+      return
+    setThemePreference(getStoredTheme())
   }
   window.addEventListener('storage', handleStorage)
   onCleanup(() => window.removeEventListener('storage', handleStorage))
@@ -227,7 +202,11 @@ export default function App() {
   })
 
   return (
-    <ErrorBoundary fallback={AppErrorFallback}>
+    // The outermost net. Anything it catches -- the providers, the launcher,
+    // the desktop chrome -- can only be retried by rebuilding all of them, so
+    // its reset does re-run the auth bootstrap. The boundary inside the router
+    // below exists so that a *route* fault never has to pay that price.
+    <ErrorBoundary fallback={renderErrorFallback}>
       <div class={heightFull}>
         <Switch>
           <Match when={desktopState() === 'connected'}>
@@ -237,7 +216,22 @@ export default function App() {
                   <PreferencesApplier>
                     <Router root={props => (
                       <Suspense>
-                        <DesktopRouteChrome>{props.children}</DesktopRouteChrome>
+                        <DesktopRouteChrome>
+                          {/*
+                            Scoped below AuthProvider and PreferencesProvider deliberately:
+                            a render fault in a route resets to a freshly-rendered route and
+                            leaves the session, preferences and pooled channels alone. The
+                            outer boundary would have torn all of them down and re-bootstrapped.
+
+                            Being INSIDE the Suspense above is what forces `ErrorFallback` to
+                            keep every suspending read out of its render: a suspended Suspense
+                            with no `fallback` renders nothing, so a fallback that read a
+                            pending resource would show a blank page instead of the error.
+                          */}
+                          <ErrorBoundary fallback={renderErrorFallback}>
+                            {props.children}
+                          </ErrorBoundary>
+                        </DesktopRouteChrome>
                       </Suspense>
                     )}
                     >

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -38,7 +38,7 @@ import { JsonHighlightHtml, ToolHeaderActions } from './toolRenderers'
 
 const logger = createLogger('MessageBubble')
 
-function renderErrorFallback(label: string) {
+function messageErrorFallback(label: string) {
   return (err: unknown) => {
     logger.warn(label, err)
     const message = formatErrorMessage(err)
@@ -479,7 +479,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
           data-role={sourceLabel(props.message.source)}
         >
           <div ref={contentRef} data-testid="message-content">
-            <ErrorBoundary fallback={renderErrorFallback('Failed to render message:')}>
+            <ErrorBoundary fallback={messageErrorFallback('Failed to render message:')}>
               {category().kind === 'hidden'
                 ? rawJsonBlock()
                 : category().kind === 'notification'

--- a/frontend/src/components/common/ErrorFallback.css.ts
+++ b/frontend/src/components/common/ErrorFallback.css.ts
@@ -1,0 +1,66 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * Fills its CONTAINER, not the viewport.
+ *
+ * Two boundaries render this component and the whole point of the pair is that
+ * they have different blast radii: the app-level one replaces the shell, the
+ * route-level one replaces only the route's slot inside `DesktopRouteChrome`.
+ * A `position: fixed; inset: 0` overlay -- which this was -- erases that
+ * distinction, and on the desktop build paints straight over `CustomTitlebar`,
+ * whose drag region and window buttons are then unreachable: the window cannot
+ * be moved, minimised or closed. Sizing to the container instead lets each
+ * boundary's placement decide the footprint, which is the thing the scoping was
+ * added to buy.
+ *
+ * Works in both slots because each is a filling box already: the route slot is
+ * `minimalTitlebarContent` (`flex: 1`), and the app-level one replaces a
+ * `height: 100%` root.
+ */
+export const container = style({
+  position: 'relative',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 'var(--space-4)',
+  flex: 1,
+  width: '100%',
+  height: '100%',
+  minHeight: 0,
+  overflow: 'auto',
+  padding: 'var(--space-4)',
+  // `role="alert"` is the correct semantics for this screen -- it is what makes
+  // a screen reader announce the failure -- but @knadh/oat skins that selector
+  // as a small inline notice box: border, radius, background, and
+  // `font-size: var(--text-7)`. `Alert.tsx` wants exactly that; stretched over
+  // a full-height container it draws a ring around the whole area and shrinks
+  // the stack trace. vanilla-extract emits UNLAYERED rules and oat's live in
+  // `@layer components`, so simply restating these wins the cascade.
+  border: 'none',
+  borderRadius: 0,
+  backgroundColor: 'transparent',
+  fontSize: 'inherit',
+})
+
+/**
+ * A column sized by the stack trace rather than by the viewport, so the action
+ * lands on the trace's right edge instead of floating centred under a block
+ * whose width depends on whatever the error happened to say.
+ */
+export const traceColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: 'var(--space-2)',
+  maxWidth: '80vw',
+  minHeight: 0,
+})
+
+export const trace = style({
+  maxWidth: '100%',
+  maxHeight: '50vh',
+  overflow: 'auto',
+  cursor: 'pointer',
+})

--- a/frontend/src/components/common/ErrorFallback.test.tsx
+++ b/frontend/src/components/common/ErrorFallback.test.tsx
@@ -1,0 +1,229 @@
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { createSignal, ErrorBoundary, Show, Suspense } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ErrorFallback, renderErrorFallback } from './ErrorFallback'
+
+const showInfoToast = vi.hoisted(() => vi.fn())
+vi.mock('~/components/common/Toast', () => ({ showInfoToast }))
+
+// resolveStack fetches source maps over the network; the fallback must render
+// the raw stack until (and if) it resolves.
+const resolveStack = vi.hoisted(() => vi.fn(async (stack: string) => `resolved:\n${stack}`))
+vi.mock('~/lib/resolveStack', () => ({ resolveStack }))
+
+const copyTextToClipboard = vi.hoisted(() => vi.fn(async (_text: string) => true))
+vi.mock('~/lib/clipboard', () => ({ copyTextToClipboard }))
+
+function errorWith(message: string, stack: string) {
+  const error = new Error(message)
+  error.stack = stack
+  return error
+}
+
+describe('errorFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveStack.mockImplementation(async (stack: string) => `resolved:\n${stack}`)
+    copyTextToClipboard.mockImplementation(async () => true)
+  })
+
+  it('renders the message and resolves the stack', async () => {
+    render(() => <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />)
+
+    expect(screen.getByText('Uncaught Error')).toBeTruthy()
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('resolved:')
+    })
+    expect(screen.getByRole('alert').textContent).toContain('boom')
+  })
+
+  it('falls back to the raw stack before resolution completes', () => {
+    resolveStack.mockImplementation(() => new Promise<string>(() => {}))
+    render(() => <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('at frame.ts:1:1')
+  })
+
+  // The last screen standing must not be the one that goes dark. A rejected
+  // `createResource` re-throws on every read, so a source-map fetch that failed
+  // would take the error UI down with it and leave a blank page -- the error it
+  // was mounted to display now unreadable.
+  it('still renders when stack resolution rejects', async () => {
+    resolveStack.mockRejectedValue(new Error('source map fetch failed'))
+    render(() => <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />)
+
+    await waitFor(() => expect(resolveStack).toHaveBeenCalled())
+    expect(screen.getByRole('alert').textContent).toContain('boom')
+    expect(screen.getByRole('alert').textContent).toContain('at frame.ts:1:1')
+    expect(screen.getByText('Try again')).toBeTruthy()
+  })
+
+  // The route-scoped boundary in `app.tsx` sits inside a `<Suspense>` with no
+  // `fallback`, and such a Suspense renders NOTHING while suspended. Reading a
+  // pending `createResource` during render registers with it, so a fallback
+  // built that way shows a blank page for the length of the source-map fetch --
+  // permanently, if the fetch never settles. The raw stack has to paint
+  // synchronously, before any of that.
+  it('paints synchronously inside a fallback-less Suspense', () => {
+    resolveStack.mockImplementation(() => new Promise<string>(() => {}))
+    const { container } = render(() => (
+      <Suspense>
+        <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />
+      </Suspense>
+    ))
+
+    // Synchronously, with no waitFor: a suspended subtree would be empty here.
+    expect(container.textContent).toContain('boom')
+    expect(container.textContent).toContain('at frame.ts:1:1')
+    expect(container.querySelector('[data-testid="error-fallback"]')).toBeTruthy()
+  })
+
+  it('survives an error carrying no stack', () => {
+    const error = new Error('stackless')
+    error.stack = undefined
+    render(() => <ErrorFallback error={error} reset={() => {}} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('stackless')
+    // Nothing to symbolicate, so nothing should be fetched.
+    expect(resolveStack).not.toHaveBeenCalled()
+  })
+
+  // `formatErrorMessage` returns '' for a message-less Error -- deliberately, so
+  // that other callers render nothing -- and here the raw stack is '' too, so
+  // without a placeholder the <pre> holds "\n\n" and the screen's entire payload
+  // is gone.
+  it('shows a placeholder for an error carrying neither message nor stack', () => {
+    const error = new Error('placeholder')
+    // Blanked after construction: `unicorn/error-message` forbids writing the
+    // `new Error('')` literal, but a handler can genuinely throw one.
+    error.message = ''
+    error.stack = undefined
+    render(() => <ErrorFallback error={error} reset={() => {}} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('Unknown error')
+    expect(resolveStack).not.toHaveBeenCalled()
+  })
+
+  // Solid types the fallback argument `any` and `throw 'oops'` is legal, so a
+  // non-Error throw reaches this component in production.
+  it('renders a thrown non-Error value', () => {
+    render(() => <ErrorFallback error="just a string" reset={() => {}} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('just a string')
+    expect(resolveStack).not.toHaveBeenCalled()
+  })
+
+  it('copies the displayed text on click', async () => {
+    render(() => <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />)
+    fireEvent.click(screen.getByText(/boom/))
+
+    await waitFor(() => expect(copyTextToClipboard).toHaveBeenCalled())
+    expect(copyTextToClipboard.mock.calls[0][0]).toContain('boom')
+    expect(showInfoToast).toHaveBeenCalledWith('Stack trace copied to clipboard')
+  })
+
+  // A non-secure origin exposes no clipboard at all. Claiming to have copied
+  // when nothing was copied is worse than staying silent, on the one screen
+  // where the trace is the only thing the user can carry away.
+  it('does not claim success when the clipboard is unavailable', async () => {
+    copyTextToClipboard.mockImplementation(async () => false)
+    render(() => <ErrorFallback error={errorWith('boom', 'at frame.ts:1:1')} reset={() => {}} />)
+    fireEvent.click(screen.getByText(/boom/))
+
+    await waitFor(() => expect(copyTextToClipboard).toHaveBeenCalled())
+    expect(showInfoToast).not.toHaveBeenCalled()
+  })
+
+  it('invokes reset when "Try again" is pressed', () => {
+    const reset = vi.fn()
+    render(() => <ErrorFallback error={errorWith('boom', '')} reset={reset} />)
+
+    fireEvent.click(screen.getByText('Try again'))
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  describe('as an ErrorBoundary fallback', () => {
+    it('re-renders the children when the fault has cleared', () => {
+      // Stands in for a transient fault (the HMR race this was built for):
+      // the first render throws, the retry succeeds.
+      const [broken, setBroken] = createSignal(true)
+      const Boom = () => {
+        if (broken())
+          throw new Error('transient')
+        return <span>recovered</span>
+      }
+
+      render(() => (
+        <ErrorBoundary fallback={renderErrorFallback}>
+          <Boom />
+        </ErrorBoundary>
+      ))
+      expect(screen.getByRole('alert').textContent).toContain('transient')
+
+      setBroken(false)
+      fireEvent.click(screen.getByText('Try again'))
+
+      expect(screen.getByText('recovered')).toBeTruthy()
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    // A deterministic fault must land back on the fallback rather than, say,
+    // rendering nothing. Asserting the alert is still present would hold
+    // trivially -- it was there before the click -- so this counts renders: an
+    // unwired button leaves the ORIGINAL fallback in place and never re-throws.
+    it('re-throws into a fresh fallback when the fault persists', () => {
+      const renders = vi.fn()
+      const Boom = () => {
+        renders()
+        throw new Error('permanent')
+      }
+
+      render(() => (
+        <ErrorBoundary fallback={renderErrorFallback}>
+          <Boom />
+        </ErrorBoundary>
+      ))
+      expect(renders).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(screen.getByText('Try again'))
+
+      expect(renders).toHaveBeenCalledTimes(2)
+      expect(screen.getByRole('alert').textContent).toContain('permanent')
+    })
+
+    it('contains the fault so state outside the boundary survives a reset', () => {
+      // The reason the router-level boundary exists: an outer provider must not
+      // be torn down and re-initialised because a route threw.
+      const providerMounts = vi.fn()
+      const [broken, setBroken] = createSignal(true)
+
+      const Boom = () => {
+        if (broken())
+          throw new Error('route fault')
+        return <span>route</span>
+      }
+      const Provider = () => {
+        providerMounts()
+        return (
+          <ErrorBoundary fallback={renderErrorFallback}>
+            <Boom />
+          </ErrorBoundary>
+        )
+      }
+
+      render(() => (
+        <Show when={true}>
+          <Provider />
+        </Show>
+      ))
+      expect(providerMounts).toHaveBeenCalledTimes(1)
+
+      setBroken(false)
+      fireEvent.click(screen.getByText('Try again'))
+
+      expect(screen.getByText('route')).toBeTruthy()
+      expect(providerMounts).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/components/common/ErrorFallback.tsx
+++ b/frontend/src/components/common/ErrorFallback.tsx
@@ -1,0 +1,111 @@
+import type { Component } from 'solid-js'
+import { createEffect, createSignal, on } from 'solid-js'
+import { showInfoToast } from '~/components/common/Toast'
+import { copyTextToClipboard } from '~/lib/clipboard'
+import { formatErrorMessage } from '~/lib/errors'
+import { resolveStack } from '~/lib/resolveStack'
+import * as styles from './ErrorFallback.css'
+
+export interface ErrorFallbackProps {
+  /**
+   * Typed `unknown` because that is what it is. Solid hands the fallback
+   * whatever was thrown -- its own signature says `any` -- and `throw 'oops'`
+   * is legal JavaScript, so narrowing to `Error` here would only be a claim the
+   * component then has to defend against at runtime anyway.
+   */
+  error: unknown
+  /**
+   * Clear the error and re-render the boundary's children. How much of the app
+   * that rebuilds is the boundary's choice, not this component's -- see the two
+   * boundaries in `app.tsx`.
+   */
+  reset: () => void
+}
+
+/**
+ * The presentation for a caught render error, shared by every `ErrorBoundary`
+ * so a failure looks and behaves the same wherever it is contained.
+ *
+ * "Try again" is worth offering even though a deterministic fault lands
+ * straight back here: the errors that reach a boundary are not all
+ * deterministic. A dev-mode HMR update that re-renders a consumer against a
+ * half-patched module graph is the motivating case -- the next render, against
+ * the settled graph, succeeds. Before this, the only exit was a page reload,
+ * which also threw away the auth session and every bit of shell state.
+ */
+export const ErrorFallback: Component<ErrorFallbackProps> = (props) => {
+  const rawStack = () => (props.error instanceof Error ? props.error.stack : undefined) ?? ''
+  const [resolved, setResolved] = createSignal<string>()
+
+  // A plain signal, deliberately NOT `createResource`.
+  //
+  // Two ways a resource takes this screen down, and it is the one screen whose
+  // entire job is to stay up:
+  //
+  //   - Reading a PENDING resource during render registers with the nearest
+  //     enclosing `<Suspense>`. The route-scoped boundary sits inside one that
+  //     has no `fallback`, and a suspended Suspense with no fallback renders
+  //     NOTHING -- so the error, the stack and "Try again" would all be a blank
+  //     page for as long as the source maps take to fetch and parse. The
+  //     app-level boundary escaped this only by sitting outside every Suspense.
+  //   - Reading a REJECTED resource re-throws, every time, so a source map that
+  //     fails to load would throw out of the render below.
+  //
+  // Neither hazard exists through a signal: the raw stack paints immediately
+  // and the symbolicated one swaps in if and when it arrives.
+  //
+  // The generation counter is what keeps a second error from having its stack
+  // overwritten by a slower resolution of the first. Counted rather than
+  // re-reading `rawStack()`, so the async callback holds no reactive read.
+  let generation = 0
+  createEffect(on(rawStack, (stack) => {
+    const mine = ++generation
+    setResolved(undefined)
+    if (!stack)
+      return
+    void resolveStack(stack).then(
+      text => generation === mine && setResolved(text),
+      () => {},
+    )
+  }))
+
+  // `formatErrorMessage` returns `Error.message` verbatim, and an EMPTY one is a
+  // deliberate part of its contract (`errors.test.ts` pins it): a handler that
+  // throws a message-less Error is saying "no message", which every other caller
+  // can render as nothing. This one cannot -- `new Error('')` with no stack would
+  // leave the <pre> holding `"\n\n"`, i.e. the boundary's entire payload gone.
+  // Substituted here rather than by widening the shared helper.
+  const message = () => formatErrorMessage(props.error) || 'Unknown error'
+  const displayText = () => `${message()}\n\n${resolved() ?? rawStack()}`
+
+  const handleCopy = async () => {
+    if (await copyTextToClipboard(displayText()))
+      showInfoToast('Stack trace copied to clipboard')
+  }
+
+  return (
+    <div class={styles.container} role="alert" data-testid="error-fallback">
+      <h1>Uncaught Error</h1>
+      <div class={styles.traceColumn}>
+        <pre class={styles.trace} onClick={() => void handleCopy()}>
+          {displayText()}
+        </pre>
+        <button type="button" class="outline" onClick={() => props.reset()}>
+          Try again
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Adapts Solid's `(error, reset)` fallback signature to {@link ErrorFallback}.
+ *
+ * Lives here rather than beside each boundary so every one of them shares a
+ * single wiring. The app-level boundary spent its whole existence passing a
+ * one-argument fallback, which silently dropped `reset` and left the screen
+ * with no way out but a page reload.
+ */
+export function renderErrorFallback(error: unknown, reset: () => void) {
+  return <ErrorFallback error={error} reset={reset} />
+}

--- a/frontend/src/components/common/FileActionsMenu.tsx
+++ b/frontend/src/components/common/FileActionsMenu.tsx
@@ -138,7 +138,7 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
       <button
         role="menuitem"
         data-testid={tid('copy-path-button')}
-        onClick={() => copyTextToClipboard(props.path)}
+        onClick={() => void copyTextToClipboard(props.path)}
       >
         <Icon icon={Copy} size="sm" />
         Copy path
@@ -149,7 +149,7 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
           data-testid={tid('copy-relative-path-button')}
           onClick={() => {
             const rel = relativizePath(props.path, props.rootPath!, props.homeDir, props.flavor)
-            copyTextToClipboard(rel)
+            void copyTextToClipboard(rel)
           }}
         >
           <Icon icon={Copy} size="sm" />

--- a/frontend/src/components/common/SelectionQuotePopover.test.tsx
+++ b/frontend/src/components/common/SelectionQuotePopover.test.tsx
@@ -163,4 +163,61 @@ describe('selection quote popover', () => {
       cancelFrame.mockRestore()
     }
   })
+
+  // A non-secure origin (plain http:// on a LAN) exposes no `navigator.clipboard`
+  // at all. The handler used to call `navigator.clipboard.writeText` bare, so it
+  // died on a TypeError right there and never reached the three statements after
+  // it -- leaving the text highlighted and the popover stuck open on top of not
+  // copying.
+  it('still clears the selection when the platform exposes no clipboard', () => {
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 1
+    })
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    const removeAllRanges = vi.fn()
+    const onSelectionActiveChange = vi.fn()
+    try {
+      render(() => (
+        <SelectionQuotePopover
+          onQuote={vi.fn()}
+          onSelectionActiveChange={onSelectionActiveChange}
+        >
+          <p data-testid="selectable">selected text</p>
+        </SelectionQuotePopover>
+      ))
+      const textNode = screen.getByTestId('selectable').firstChild!
+      const selectedFragment = document.createDocumentFragment()
+      selectedFragment.append(document.createTextNode('selected text'))
+
+      mockSelection({
+        isCollapsed: false,
+        rangeCount: 1,
+        anchorNode: textNode,
+        focusNode: textNode,
+        toString: () => 'selected text',
+        removeAllRanges,
+        getRangeAt: () => ({
+          getClientRects: () => [{ left: 0, right: 10, top: 10, bottom: 20 }],
+          cloneContents: () => selectedFragment.cloneNode(true),
+        }) as unknown as Range,
+      })
+
+      fireEvent.mouseUp(screen.getByTestId('selectable'))
+      fireEvent.click(screen.getByTestId('copy-selection-button'))
+
+      expect(removeAllRanges).toHaveBeenCalled()
+      expect(onSelectionActiveChange).toHaveBeenLastCalledWith(false)
+    }
+    finally {
+      if (clipboardDescriptor)
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
+      else
+        Reflect.deleteProperty(navigator, 'clipboard')
+      requestFrame.mockRestore()
+      cancelFrame.mockRestore()
+    }
+  })
 })

--- a/frontend/src/components/common/SelectionQuotePopover.tsx
+++ b/frontend/src/components/common/SelectionQuotePopover.tsx
@@ -3,6 +3,7 @@ import Copy from 'lucide-solid/icons/copy'
 import Quote from 'lucide-solid/icons/quote'
 import { createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { Icon } from '~/components/common/Icon'
+import { copyTextToClipboard } from '~/lib/clipboard'
 import { extractLineRange, extractSelectionMarkdown } from '~/lib/quoteUtils'
 import * as styles from './SelectionQuotePopover.css'
 
@@ -141,7 +142,12 @@ export function SelectionQuotePopover(props: SelectionQuotePopoverProps): JSX.El
 
     const lineRange = extractLineRange(selection)
     const text = lineRange ? selection.toString() : extractSelectionMarkdown(selection)
-    void navigator.clipboard.writeText(text)
+    // Guarded, because the three statements below depend on reaching them. A
+    // non-secure origin exposes no `navigator.clipboard` at all, so the bare
+    // `navigator.clipboard.writeText` this replaced threw a TypeError right
+    // here -- leaving the selection highlighted and the popover stuck open, on
+    // top of not copying.
+    void copyTextToClipboard(text)
     selection.removeAllRanges()
     setSelectionActive(false)
     hidePopover()

--- a/frontend/src/components/shell/GridPopoverHost.tsx
+++ b/frontend/src/components/shell/GridPopoverHost.tsx
@@ -1,5 +1,6 @@
 import type { ParentComponent } from 'solid-js'
-import { createContext, createSignal, useContext } from 'solid-js'
+import { createSignal, useContext } from 'solid-js'
+import { createStableContext } from '~/lib/createStableContext'
 import { GridSizePopover } from './GridSizePopover'
 
 /**
@@ -17,7 +18,7 @@ export interface GridPopoverHost {
   open: (request: GridPopoverRequest) => void
 }
 
-const GridPopoverContext = createContext<GridPopoverHost | undefined>(undefined)
+const GridPopoverContext = createStableContext<GridPopoverHost | undefined>('shell/GridPopoverHost', undefined)
 
 /**
  * Read the host from context. Returns `undefined` when no

--- a/frontend/src/components/shell/SectionDragContext.tsx
+++ b/frontend/src/components/shell/SectionDragContext.tsx
@@ -1,8 +1,9 @@
 import type { JSX } from 'solid-js'
 import type { Section } from '~/generated/leapmux/v1/section_pb'
 import { closestCenter, DragDropProvider, DragDropSensors, DragOverlay } from '@thisbeyond/solid-dnd'
-import { createContext, createSignal, useContext } from 'solid-js'
+import { createSignal, useContext } from 'solid-js'
 import { Sidebar } from '~/generated/leapmux/v1/section_pb'
+import { createStableContext } from '~/lib/createStableContext'
 import { mid } from '~/lib/lexorank'
 import { dragOverlayAboveFloating } from './FloatingWindowContainer.css'
 import {
@@ -40,7 +41,7 @@ interface SectionDragState {
   addExternalOverlayRenderer: (renderer: ExternalOverlayRenderer) => () => void
 }
 
-const SectionDragCtx = createContext<SectionDragState>()
+const SectionDragCtx = createStableContext<SectionDragState>('shell/SectionDragContext')
 
 export function useSectionDrag(): SectionDragState {
   const ctx = useContext(SectionDragCtx)

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -126,7 +126,10 @@ export function buildCommonSidebarProps(opts: SidebarElementsOpts, display?: Sid
   // object. Sidebar code cannot reach them -- both sidebars are typed
   // SidebarCommonProps, which does not declare them -- so this is runtime
   // surface, not API surface.
-  return mergeProps(opts, {
+  // Captured rather than returned inline so `solid/reactivity` can see what the
+  // merged object is and check its use; returning the call directly leaves the
+  // rule unable to analyse it.
+  const commonProps = mergeProps(opts, {
     get isCollapsed() { return display?.isCollapsed() ?? false },
     onExpand: display?.onExpand ?? (() => {}),
     initialOpenSections: display?.initialOpenSections,
@@ -145,6 +148,7 @@ export function buildCommonSidebarProps(opts: SidebarElementsOpts, display?: Sid
       return opts.isActiveWorkspaceArchived ? undefined : openTerminal
     },
   })
+  return commonProps
 }
 
 export function createLeftSidebarElement(opts: SidebarElementsOpts, display?: SidebarDisplayOpts): JSX.Element {

--- a/frontend/src/components/shell/TabDragContext.tsx
+++ b/frontend/src/components/shell/TabDragContext.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'solid-js'
-import { createContext, createSignal, onCleanup, useContext } from 'solid-js'
+import { createSignal, onCleanup, useContext } from 'solid-js'
+import { createStableContext } from '~/lib/createStableContext'
 import { useOptionalSectionDrag } from './SectionDragContext'
 
 /** Prefix used for tab-bar zone droppable IDs. */
@@ -20,7 +21,7 @@ interface TabDragState {
   draggedTabKey: () => string | null
 }
 
-const TabDragContext = createContext<TabDragState>()
+const TabDragContext = createStableContext<TabDragState>('shell/TabDragContext')
 
 export function useTabDrag(): TabDragState {
   const ctx = useContext(TabDragContext)

--- a/frontend/src/components/shell/restoreTabSelection.ts
+++ b/frontend/src/components/shell/restoreTabSelection.ts
@@ -76,6 +76,17 @@ export function createTabSelectionRestorer(opts: RestoreTabSelectionOpts) {
     // tick this workspace is active — outlives the thing it was waiting for.
     // The other two exits below cover "the tab arrived" and "someone chose"; a
     // workspace that disappears matched neither.
+    //
+    // There is deliberately NO fourth exit for a tab that was tombstoned or
+    // removed before it could be delivered. Every signal that could detect one
+    // — absence from the projection, an elapsed-tick budget — is
+    // indistinguishable from the late arrival this retry exists for, and only a
+    // tombstoned record is monotonic enough to be safe to act on. The cost of
+    // the gap is bounded and small (this function's three lookups re-run while
+    // the entry is stranded, until the user selects anything), and
+    // `useTabPersistence` only ever persists a key that was live when written,
+    // so reaching the state at all needs the tab to die between that write and
+    // the next load.
     if (!opts.hasWorkspace(workspaceId)) {
       pendingTileBackfill.delete(workspaceId)
       return
@@ -154,10 +165,11 @@ export function createTabSelectionRestorer(opts: RestoreTabSelectionOpts) {
 
     // The stored tab can land in a LATER frame than the rest of its workspace —
     // and, without any race at all, whenever it MOVED tile since it was last
-    // activated (nothing rewrites `activeByTile` on a move, and `tileActivesFor`
-    // narrows to current tile ids, so the workspace key names a tab whose tile
-    // has no stored entry). `selection.restore` filed the workspace pointer
-    // regardless; its tile back-fill is what needs the retry.
+    // activated (nothing rewrites `activeByTile` on a move, and
+    // `chosenTileActivesFor` drops the entry of a tile the tab has left, so the
+    // workspace key names a tab whose tile has no stored entry).
+    // `selection.restore` filed the workspace pointer regardless; its tile
+    // back-fill is what needs the retry.
     if (activeKey && !opts.view.get(activeKey))
       pendingTileBackfill.set(workspaceId, activeKey)
 

--- a/frontend/src/components/shell/useTabPersistence.test.ts
+++ b/frontend/src/components/shell/useTabPersistence.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/globals" />
+import type { TestBridgeHandle } from '~/test-support/crdtBridge'
 import { createRoot, createSignal } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { activeTabKey, focusedTileKey, tileActiveTabsKey } from '~/components/shell/tabPersistenceKeys'
@@ -6,8 +7,8 @@ import { useTabPersistence } from '~/components/shell/useTabPersistence'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { setCRDTBridge } from '~/lib/crdt'
-import { emitAddTab } from '~/stores/tabOps'
-import { withTestBridge } from '~/test-support/crdtBridge'
+import { emitAddTab, emitMoveTabToWorkspace, emitRemoveTab } from '~/stores/tabOps'
+import { seedWorkspace, withTestBridge } from '~/test-support/crdtBridge'
 import { createTestTabStores } from '~/test-support/tabStores'
 
 beforeEach(() => {
@@ -26,7 +27,10 @@ const WS = 'ws-persist'
  * microtask so the effects have written before the assertions run.
  */
 async function withPersistence(
-  body: (ctx: ReturnType<typeof createTestTabStores> & { rootTileId: string }) => void,
+  body: (ctx: ReturnType<typeof createTestTabStores> & {
+    rootTileId: string
+    harness: TestBridgeHandle
+  }) => void,
   opts: { loading?: boolean } = {},
 ): Promise<void> {
   await withTestBridge(async (harness) => {
@@ -44,7 +48,7 @@ async function withPersistence(
           hasWorkspace: () => bootstrapped(),
         })
         try {
-          body({ ...stores, rootTileId: harness.rootTileId })
+          body({ ...stores, rootTileId: harness.rootTileId, harness })
         }
         catch (err) {
           dispose()
@@ -134,10 +138,14 @@ describe('useTabPersistence', () => {
   // Regression: the writers used to share `workspaceLoading` with the paint
   // gate, which a watchdog clears on a timer when the bootstrap is slow or never
   // arrives. That timer then authorised these writes against an EMPTY
-  // projection, and both derived effects fall through to `clearIfPresent` --
+  // projection, and both derived effects fell through to their clear branch --
   // deleting last session's keys while `restoreTabSelection`, gated on the
-  // projection, had not yet spent its one attempt to read them. Gating on the
-  // same predicate as the restore is what makes the writer unable to outrun it.
+  // projection, had not yet spent its one attempt to read them.
+  //
+  // The gate is NOT what makes this safe, though it was once described that
+  // way: it is not an ordering guarantee against the restore, which carries
+  // extra conditions of its own. What makes it safe is that nothing has been
+  // CHOSEN yet, so the writers touch nothing -- see the two tests below.
   it('does not delete a previous session\'s keys when the bootstrap has not landed', async () => {
     sessionStorageSet(activeTabKey(WS), `${TabType.AGENT}:from-last-session`)
     sessionStorageSet(tileActiveTabsKey(WS), JSON.stringify({ 'tile-1': `${TabType.AGENT}:from-last-session` }))
@@ -150,15 +158,110 @@ describe('useTabPersistence', () => {
     expect(sessionStorageGet(tileActiveTabsKey(WS))).not.toBeUndefined()
   })
 
-  // Closing the last tab must ERASE the pointer, not leave it naming a dead tab:
+  // Closing the LAST tab must erase the pointer, not leave it naming a dead tab:
   // the next load's `restoreTabSelection` reads `hasStoredState` off it and
   // spends its one restore attempt applying a previous session's selection.
-  it('clears the workspace active-tab key once the workspace has no tabs', async () => {
-    sessionStorageSet(activeTabKey(WS), `${TabType.AGENT}:gone`)
-    await withPersistence(({ view }) => {
-      expect(view.forWorkspace(WS), 'the workspace really is empty').toHaveLength(0)
+  //
+  // The tab has to be genuinely chosen and then genuinely closed. Nothing in
+  // the store rewrites `activeByWorkspace` on a close -- a tombstone is a CRDT
+  // op, not a store call -- so the pointer outlives its own tab, and a version
+  // of this test that only asserted on an empty workspace with nothing ever
+  // chosen would pass against a writer that never reclaims anything.
+  it('clears the workspace active-tab key when the last tab is closed', async () => {
+    await withPersistence(({ selection, view, rootTileId }) => {
+      emitAddTab({ type: TabType.AGENT, id: 'only', tileId: rootTileId, position: 'a' })
+      selection.setActiveById(TabType.AGENT, 'only')
+      emitRemoveTab(TabType.AGENT, 'only')
+      expect(view.forWorkspace(WS), 'the workspace really is empty now').toHaveLength(0)
+      expect(selection.state.activeByWorkspace[WS], 'but the pointer outlived its tab')
+        .toBe(`${TabType.AGENT}:only`)
     })
     expect(sessionStorageGet(activeTabKey(WS))).toBeUndefined()
+  })
+
+  // The per-tile half of the same reclamation. `activeByTile` is swept only for
+  // dead TILES, so a tile that outlives its tabs keeps pointing at one of them.
+  it('clears the per-tile keys when the last tab is closed', async () => {
+    await withPersistence(({ selection, rootTileId }) => {
+      emitAddTab({ type: TabType.AGENT, id: 'only', tileId: rootTileId, position: 'a' })
+      selection.setActiveById(TabType.AGENT, 'only')
+      emitRemoveTab(TabType.AGENT, 'only')
+      expect(selection.state.activeByTile[rootTileId], 'the tile pointer outlived its tab')
+        .toBe(`${TabType.AGENT}:only`)
+    })
+    expect(sessionStorageGet(tileActiveTabsKey(WS))).toBeUndefined()
+  })
+
+  // Closing the ACTIVE tab of a workspace that still has others. The pointer is
+  // now dead, but a choice WAS made, so the resolver's promotion is a real
+  // answer rather than an invented one -- and it is the tab the user is looking
+  // at. Persisting the dead key instead would send the next load through
+  // `mruHead` with every stamp back at zero, i.e. to the FIRST tab.
+  it('persists the promoted survivor when the active tab is closed', async () => {
+    await withPersistence(({ selection, rootTileId }) => {
+      emitAddTab({ type: TabType.AGENT, id: 'first', tileId: rootTileId, position: 'a' })
+      emitAddTab({ type: TabType.AGENT, id: 'second', tileId: rootTileId, position: 'b' })
+      emitAddTab({ type: TabType.AGENT, id: 'third', tileId: rootTileId, position: 'c' })
+      selection.setActiveById(TabType.AGENT, 'second')
+      selection.setActiveById(TabType.AGENT, 'third')
+      emitRemoveTab(TabType.AGENT, 'third')
+      expect(selection.state.activeByWorkspace[WS], 'the raw pointer is dead')
+        .toBe(`${TabType.AGENT}:third`)
+    })
+    // 'second' -- the most recently used survivor. NOT 'third' (dead), and not
+    // 'first', which is what a zero-MRU fallback picks.
+    expect(sessionStorageGet(activeTabKey(WS))).toBe(`${TabType.AGENT}:second`)
+  })
+
+  // A tab dragged to another workspace is still LIVE, so a liveness check alone
+  // keeps satisfying the pointer of the workspace it left. `belongs` is what
+  // makes it a real check; without it this workspace persists a key naming a tab
+  // that is now somebody else's, and the next load heals it to the first tab.
+  it('does not persist a pointer to a tab that moved to another workspace', async () => {
+    await withPersistence(({ selection, view, rootTileId, harness }) => {
+      const elsewhere = seedWorkspace(harness, 'other-ws', 'other-tile')
+      emitAddTab({ type: TabType.AGENT, id: 'stays', tileId: rootTileId, position: 'a' })
+      emitAddTab({ type: TabType.AGENT, id: 'moves', tileId: rootTileId, position: 'b' })
+      selection.setActiveById(TabType.AGENT, 'stays')
+      selection.setActiveById(TabType.AGENT, 'moves')
+      emitMoveTabToWorkspace(TabType.AGENT, 'moves', elsewhere, 'a')
+      expect(view.get(`${TabType.AGENT}:moves`)?.workspaceId, 'the tab really did move').toBe('other-ws')
+      expect(selection.state.activeByWorkspace[WS], 'the pointer still names the departed tab')
+        .toBe(`${TabType.AGENT}:moves`)
+    })
+    expect(sessionStorageGet(activeTabKey(WS))).toBe(`${TabType.AGENT}:stays`)
+  })
+
+  // The reload window: the workspace is projected with its tabs, but nothing has
+  // been chosen yet because `restoreTabSelection` has not run. `mru` is never
+  // persisted, so every tab comes back scoring zero and `activeKeyForWorkspace`
+  // synthesises the FIRST tab. Persisting that invented answer overwrote the
+  // stored key before the restore could read it, which is how a reload put the
+  // sidebar on the first tab while the tab bar -- reading the per-tile pointer,
+  // which is never synthesised -- correctly stayed on the second.
+  it('does NOT overwrite the stored active-tab key before anything is chosen', async () => {
+    sessionStorageSet(activeTabKey(WS), `${TabType.AGENT}:second`)
+    await withPersistence(({ selection, view, rootTileId }) => {
+      emitAddTab({ type: TabType.AGENT, id: 'first', tileId: rootTileId, position: 'a' })
+      emitAddTab({ type: TabType.AGENT, id: 'second', tileId: rootTileId, position: 'b' })
+      expect(view.forWorkspace(WS), 'the tabs really are projected').toHaveLength(2)
+      expect(selection.state.activeByWorkspace[WS], 'nothing chosen yet').toBeUndefined()
+      // What the writer must not persist: the synthesised first-tab answer.
+      expect(selection.activeKeyForWorkspace(WS)).toBe(`${TabType.AGENT}:first`)
+    })
+    expect(sessionStorageGet(activeTabKey(WS))).toBe(`${TabType.AGENT}:second`)
+  })
+
+  // Same window, per-tile half. An empty `activeByTile` means "no tile has a
+  // pointer", which is true on every reload until the restore runs -- clearing
+  // then destroys the snapshot that keeps the tab bar on the right tab.
+  it('does NOT clear the stored per-tile keys before anything is chosen', async () => {
+    sessionStorageSet(tileActiveTabsKey(WS), JSON.stringify({ 'tile-1': `${TabType.AGENT}:second` }))
+    await withPersistence(({ selection, rootTileId }) => {
+      emitAddTab({ type: TabType.AGENT, id: 'first', tileId: rootTileId, position: 'a' })
+      expect(selection.state.activeByTile[rootTileId], 'nothing chosen yet').toBeUndefined()
+    })
+    expect(sessionStorageGet(tileActiveTabsKey(WS))).toBe(JSON.stringify({ 'tile-1': `${TabType.AGENT}:second` }))
   })
 
   // The focus pointer is a user CHOICE that outlives the tab set -- tiles do not

--- a/frontend/src/components/shell/useTabPersistence.ts
+++ b/frontend/src/components/shell/useTabPersistence.ts
@@ -24,19 +24,39 @@ import { activeTabKey, focusedTileKey, tileActiveTabsKey } from './tabPersistenc
  * keyed by user, because unlike these three it has to survive a tab close.
  *
  * `hasWorkspace` gates every write until the CRDT bootstrap has delivered THIS
- * workspace. The gate matters because before it lands the selection is empty
- * and the projected tree is a placeholder — writing then deletes
- * `tileActiveTabs` (nothing to write, so it clears), destroying the state the
- * restore is about to read.
+ * workspace. The gate matters because before it lands the projected tree is a
+ * placeholder, so there is nothing worth recording.
  *
  * It asks the projection directly rather than riding `workspaceLoading`, which
  * is the PAINT gate: a watchdog clears that one on a timer so a wedged
  * bootstrap still renders a shell instead of a blank pane. Sharing it here
- * meant the timer also authorised these writes, and the three effects would
- * then run against an empty projection and clear the very keys
- * `restoreTabSelection` was still waiting — on the same predicate — to read.
- * That is the destructive case above, reached on every slow load rather than
- * avoided. Same predicate as the restore, so the writer cannot outrun it.
+ * meant the timer also authorised these writes against an empty projection.
+ *
+ * The gate is NOT, however, an ordering guarantee against
+ * `restoreTabSelection`. Both wait on the same predicate, which once read as
+ * "the writer cannot outrun it" — it can, and did: the restore carries extra
+ * conditions of its own, so there are ticks where this hook writes and the
+ * restore has not yet run. Every write below is therefore built to be harmless
+ * in that window rather than relying on losing the race, and the one question
+ * that decides it is **has anything been chosen in this session at all**. The
+ * store's `chosen*` accessors answer exactly that, in three parts:
+ *
+ *   - `undefined` — nothing chosen. Touch nothing. This is the reload window,
+ *     and writing here is what clobbered the restore: the only answer available
+ *     is `activeKeyForWorkspace`'s synthesised `mruHead`, and since `mru` is
+ *     never persisted every tab comes back scoring zero, so that answer is
+ *     always the FIRST tab. (Persisting `mru` would fix the fallback at its
+ *     root: https://github.com/leapmux/leapmux/issues/345)
+ *   - `null` — chosen, but the tab is gone (closed, or moved away). HEAL it and
+ *     persist that: the user is looking at the promoted survivor, and the MRU
+ *     stamps behind it are live in memory. Clearing instead would drop them
+ *     back to the first tab on the next load.
+ *   - a key — a live choice. Persist it.
+ *
+ * That the heal is safe in the second case but not the first is not a
+ * coincidence: `restoreTabSelection` yields to an in-memory pointer the moment
+ * one exists, so "a choice exists" and "the stored key has already been
+ * consumed" are the same condition.
  *
  * History: the prior `useTabPersistence` was deleted by the CRDT
  * workspace-sync refactor (commit e8870a1a). The hub-side `SaveLayout`
@@ -62,50 +82,90 @@ export interface UseTabPersistenceOpts {
   hasWorkspace: (workspaceId: string) => boolean
 }
 
-function writeIfChanged(key: string, value: string, last: Map<string, string>) {
-  if (last.get(key) === value)
-    return
-  sessionStorageSet(key, value)
-  last.set(key, value)
-}
-
-function clearIfPresent(key: string, last: Map<string, string>) {
-  if (!last.has(key) && !sessionStorageHas(key))
-    return
-  sessionStorageRemove(key)
-  last.delete(key)
+/**
+ * A sessionStorage writer that skips redundant work.
+ *
+ * The persistence effects re-fire whenever any tracked dependency changes, but
+ * the underlying string is often unchanged (`chosenTileActivesFor` re-fires on
+ * any leaf write). Caching the last value per key avoids re-serialising and
+ * re-storing the same JSON payload on every store mutation.
+ *
+ * The cache lives inside the closure rather than being threaded through every
+ * call as a trailing argument, so no call site can be handed the wrong one.
+ */
+function createDedupedSessionWriter() {
+  const lastWritten = new Map<string, string>()
+  return {
+    write(key: string, value: string) {
+      if (lastWritten.get(key) === value)
+        return
+      sessionStorageSet(key, value)
+      lastWritten.set(key, value)
+    },
+    clear(key: string) {
+      if (!lastWritten.has(key) && !sessionStorageHas(key))
+        return
+      sessionStorageRemove(key)
+      lastWritten.delete(key)
+    },
+  }
 }
 
 export function useTabPersistence(opts: UseTabPersistenceOpts) {
   const { selection, layoutStore, floatingWindowStore, getActiveWorkspaceId, hasWorkspace } = opts
-  // Cache the last-written value per key. The persistence effects re-fire
-  // whenever any tracked dependency changes, but the underlying string is
-  // often unchanged (e.g. tileActiveTabKeys re-fires on any leaf write).
-  // Skipping equal writes avoids re-serialising and re-storing the JSON
-  // payload on every store mutation.
-  const lastWritten = new Map<string, string>()
+  const session = createDedupedSessionWriter()
 
-  createEffect(() => {
-    const wsId = getActiveWorkspaceId()
-    const activeKey = selection.activeKeyForWorkspace(wsId ?? '')
-    if (!wsId || !hasWorkspace(wsId))
+  /**
+   * Run `write` for the active workspace, once the bootstrap has delivered it.
+   *
+   * All three writers share this gate and must keep sharing it -- see the module
+   * doc for why it is `hasWorkspace` and not the paint gate. Naming it once is
+   * what stops a fourth writer being added without it, and hands each writer a
+   * non-null workspace id rather than making each re-narrow one.
+   */
+  function gatedEffect(write: (wsId: string) => void): void {
+    createEffect(() => {
+      const wsId = getActiveWorkspaceId()
+      if (!wsId || !hasWorkspace(wsId))
+        return
+      write(wsId)
+    })
+  }
+
+  gatedEffect((wsId) => {
+    const chosen = selection.chosenKeyForWorkspace(wsId)
+    // NOTHING has been chosen in this session. Leave the stored key completely
+    // alone -- neither write nor clear. Overwhelmingly this is the reload
+    // window before `restoreTabSelection` has read it back, and writing here is
+    // what clobbered it: `activeKeyForWorkspace` would have answered with a
+    // synthesised `mruHead`, and since `mru` is never persisted every tab comes
+    // back scoring zero, so that answer is always the FIRST tab.
+    //
+    // Not writing is safe even if the restore never runs, because the restore
+    // yields to an in-memory pointer anyway: the moment one exists it marks the
+    // workspace restored and returns. So "a pointer exists" and "the stored key
+    // has been consumed" are the same condition, which is what makes the heal
+    // below trustworthy.
+    if (chosen === undefined)
       return
-    // Clear, don't just skip. `activeKeyForWorkspace` answers null ONLY when the
-    // workspace has no tabs at all (`resolve` falls through to `mruHead` of an
-    // empty list), so "nothing to write" here means "nothing left to point at":
-    // returning would leave the key naming the tab the user just closed, and the
-    // next load's restore would see `hasStoredState` and spend its one attempt
-    // on it. Same reasoning as the per-tile effect below, which already clears.
-    if (activeKey)
-      writeIfChanged(activeTabKey(wsId), activeKey, lastWritten)
+    // A choice EXISTS. If its tab is gone -- closed, or moved to another
+    // workspace -- the resolver's heal is what the user is now looking at, and
+    // here it is a real answer rather than an invented one: the MRU stamps that
+    // drive it are live in memory. Persisting it keeps the tab they were left
+    // on across the next reload, where clearing would drop them back to the
+    // first tab.
+    const key = chosen ?? selection.activeKeyForWorkspace(wsId)
+    if (key)
+      session.write(activeTabKey(wsId), key)
+    // The heal came back null too: the workspace has no tabs at all, so there
+    // is nothing left to point at. Clear, don't just skip -- leaving the key
+    // would let the next load's restore see `hasStoredState` and spend its one
+    // attempt on a pointer to nothing.
     else
-      clearIfPresent(activeTabKey(wsId), lastWritten)
+      session.clear(activeTabKey(wsId))
   })
 
-  createEffect(() => {
-    const wsId = getActiveWorkspaceId()
-    if (!wsId || !hasWorkspace(wsId))
-      return
+  gatedEffect((wsId) => {
     // Narrow to THIS workspace's tiles: `activeByTile` is keyed by globally
     // unique tile id and therefore spans every workspace. Both owners are
     // unioned -- a floating window's tiles are this workspace's too, and
@@ -117,22 +177,32 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
     // the store rather than by the narrowing this comment claims -- so the day
     // this effect ran for any other workspace it would silently persist none of
     // its floating tiles.
-    const tileActiveTabKeys = selection.tileActivesFor([
+    const chosenByTile = selection.chosenTileActivesFor([
       ...layoutStore.tileOrderFor(wsId),
       ...floatingWindowStore.getAllTileIdsFor(wsId),
     ])
     const key = tileActiveTabsKey(wsId)
-    const entries = Object.entries(tileActiveTabKeys).filter(([, v]) => v != null)
-    if (entries.length > 0)
-      writeIfChanged(key, JSON.stringify(Object.fromEntries(entries)), lastWritten)
-    else
-      clearIfPresent(key, lastWritten)
+    // Exactly the workspace effect's reasoning, per tile. A tile nobody has
+    // chosen on is ABSENT from the map, so "no entries at all" -- what every
+    // reload looks like until the restore runs -- writes and clears nothing,
+    // leaving the snapshot that keeps the tab bar on the right tab. A tile
+    // whose choice is dead maps to null and is healed the same way, because the
+    // same thing makes the heal trustworthy: a choice exists.
+    const live: [string, string][] = []
+    for (const [tileId, chosen] of Object.entries(chosenByTile)) {
+      const healed = chosen ?? selection.activeKeyForTile(tileId)
+      if (healed)
+        live.push([tileId, healed])
+    }
+    if (live.length > 0)
+      session.write(key, JSON.stringify(Object.fromEntries(live)))
+    // Every tile that was chosen on has had its tabs taken away, so the stored
+    // snapshot names nothing that exists.
+    else if (Object.keys(chosenByTile).length > 0)
+      session.clear(key)
   })
 
-  createEffect(() => {
-    const wsId = getActiveWorkspaceId()
-    if (!wsId || !hasWorkspace(wsId))
-      return
+  gatedEffect((wsId) => {
     // `focusedTileIdFor`, NOT `focusedTileId()`. The latter falls back to
     // `firstLeafId(projectedRoot())` when the user has not focused anything,
     // and persisting a synthesised answer records a choice the user never made
@@ -141,15 +211,17 @@ export function useTabPersistence(opts: UseTabPersistenceOpts) {
     // has since changed (another client split or closed the root tile) it names
     // a tile that no longer exists.
     const focusedTileId = layoutStore.focusedTileIdFor(wsId)
-    // Deliberately does NOT clear when null, unlike the two effects above.
-    // Those persist values DERIVED from the tab set, so an empty tab set makes
-    // the stored value dead. This one persists a user CHOICE that outlives the
-    // tab set — tiles do not disappear when their tabs do — and null here means
-    // "not picked in this session", not "unfocused". Clearing would destroy the
-    // key in exactly the case where the restore has not run yet: a zero-tab
-    // workspace with stored state early-returns in `restoreTabSelection`.
+    // Deliberately has no clear branch at all, unlike the two effects above.
+    // All three persist a user CHOICE, but only theirs can be told apart from
+    // "never chosen": the store answers null for a choice whose TAB is gone,
+    // and a tab set can empty. A tile does not disappear when its tabs do, so
+    // null here means only "not picked in this session" — never "the stored
+    // tile is dead" — and clearing on it would destroy the key in exactly the
+    // case where the restore has not run yet: a zero-tab workspace with stored
+    // state early-returns in `restoreTabSelection`. `useFocusInvariant` is what
+    // repairs a focused tile that really did disappear.
     if (!focusedTileId)
       return
-    writeIfChanged(focusedTileKey(wsId), focusedTileId, lastWritten)
+    session.write(focusedTileKey(wsId), focusedTileId)
   })
 }

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -6,7 +6,7 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import File from 'lucide-solid/icons/file'
 import FolderClosed from 'lucide-solid/icons/folder-closed'
 import FolderOpen from 'lucide-solid/icons/folder-open'
-import { batch, createContext, createEffect, createMemo, createSignal, For, Match, on, onCleanup, onMount, Show, Switch, useContext } from 'solid-js'
+import { batch, createEffect, createMemo, createSignal, For, Match, on, onCleanup, onMount, Show, Switch, useContext } from 'solid-js'
 import { createStore, produce, reconcile } from 'solid-js/store'
 import * as workerRpc from '~/api/workerRpc'
 import { FileActionsMenu } from '~/components/common/FileActionsMenu'
@@ -14,6 +14,7 @@ import { Icon } from '~/components/common/Icon'
 import { StartupSpinner } from '~/components/common/StartupPanel'
 import { Tooltip } from '~/components/common/Tooltip'
 import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
+import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { basename, detectFlavor, isAbsolute, relativeUnder, tildify, untildify } from '~/lib/paths'
 import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
@@ -116,7 +117,7 @@ interface TreeContextValue {
   isTruncated: (path: string) => boolean
 }
 
-const TreeContext = createContext<TreeContextValue>()
+const TreeContext = createStableContext<TreeContextValue>('tree/DirectoryTree')
 
 function useTree(): TreeContextValue {
   const ctx = useContext(TreeContext)

--- a/frontend/src/components/workers/WorkerContextMenu.test.tsx
+++ b/frontend/src/components/workers/WorkerContextMenu.test.tsx
@@ -1,7 +1,13 @@
 /// <reference types="vitest/globals" />
-import { render, screen } from '@solidjs/testing-library'
+import { render, screen, waitFor } from '@solidjs/testing-library'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { WorkerContextMenu } from './WorkerContextMenu'
+
+const showInfoToast = vi.hoisted(() => vi.fn())
+vi.mock('~/components/common/Toast', () => ({ showInfoToast }))
+
+const copyTextToClipboard = vi.hoisted(() => vi.fn(async (_text: string) => true))
+vi.mock('~/lib/clipboard', () => ({ copyTextToClipboard }))
 
 // Mock the modules that affect visibility.
 vi.mock('~/api/platformBridge', async (importOriginal) => {
@@ -45,6 +51,9 @@ function renderMenu(opts?: { hasTunnels?: boolean, autoRegistered?: boolean }) {
 describe('workerContextMenu', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    showInfoToast.mockClear()
+    copyTextToClipboard.mockClear()
+    copyTextToClipboard.mockImplementation(async () => true)
   })
 
   it('"add tunnel..." hidden when tunnel not available', async () => {
@@ -82,5 +91,28 @@ describe('workerContextMenu', () => {
     // on next launch — the menu item would be a dead-end click.
     renderMenu({ autoRegistered: true })
     expect(screen.queryByText('Deregister...')).not.toBeInTheDocument()
+  })
+
+  describe('copying worker info', () => {
+    it('copies the info JSON and confirms', async () => {
+      renderMenu()
+      screen.getByText('linux (amd64)').click()
+
+      await waitFor(() => expect(copyTextToClipboard).toHaveBeenCalled())
+      expect(copyTextToClipboard.mock.calls[0][0]).toContain('linux')
+      expect(showInfoToast).toHaveBeenCalledWith('Worker info copied to clipboard')
+    })
+
+    // The toast used to fire unconditionally, so it claimed success on any
+    // platform without a clipboard (a non-secure origin exposes none) and even
+    // when there was nothing to copy at all.
+    it('stays silent when the copy does not land', async () => {
+      copyTextToClipboard.mockImplementation(async () => false)
+      renderMenu()
+      screen.getByText('linux (amd64)').click()
+
+      await waitFor(() => expect(copyTextToClipboard).toHaveBeenCalled())
+      expect(showInfoToast).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/workers/WorkerContextMenu.tsx
+++ b/frontend/src/components/workers/WorkerContextMenu.tsx
@@ -6,6 +6,7 @@ import { RelativeTime } from '~/components/chat/RelativeTime'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
 import { showInfoToast } from '~/components/common/Toast'
+import { copyTextToClipboard } from '~/lib/clipboard'
 import { prettifyJson } from '~/lib/jsonFormat'
 import { dangerMenuItem } from '~/styles/shared.css'
 import * as styles from './workerContextMenu.css'
@@ -61,6 +62,17 @@ export const WorkerContextMenu: Component<WorkerContextMenuProps> = (props) => {
     })
   }
 
+  // Routed through `copyTextToClipboard`, which is guarded: a non-secure origin
+  // exposes no `navigator.clipboard` at all, so the bare
+  // `navigator.clipboard.writeText` this replaced threw a TypeError into an
+  // unhandled rejection. The toast is now conditional on the write actually
+  // landing -- it used to fire even when there was no info to copy.
+  const copyInfo = async () => {
+    const json = infoJson()
+    if (json && await copyTextToClipboard(json))
+      showInfoToast('Worker info copied to clipboard')
+  }
+
   return (
     <DropdownMenu trigger={rowContextMenuTrigger()}>
       <Show when={infoRows()}>
@@ -68,12 +80,7 @@ export const WorkerContextMenu: Component<WorkerContextMenuProps> = (props) => {
           <button
             role="menuitem"
             class={styles.infoButton}
-            onClick={() => {
-              const json = infoJson()
-              if (json)
-                navigator.clipboard.writeText(json)
-              showInfoToast('Worker info copied to clipboard')
-            }}
+            onClick={() => void copyInfo()}
           >
             <span class={styles.infoGrid}>
               <For each={rows()}>

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -6,13 +6,14 @@ import ChevronRight from 'lucide-solid/icons/chevron-right'
 import FolderGit from 'lucide-solid/icons/folder-git'
 import GitBranch from 'lucide-solid/icons/git-branch'
 import X from 'lucide-solid/icons/x'
-import { createContext, createMemo, createSignal, on, Show, useContext } from 'solid-js'
+import { createMemo, createSignal, on, Show, useContext } from 'solid-js'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { TabTypeIcon } from '~/components/common/TabTypeIcon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { SIDEBAR_TAB_PREFIX } from '~/components/shell/TabDragContext'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { PREFIX_TAB_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
+import { createStableContext } from '~/lib/createStableContext'
 import { createKeyedRows, createStableKeys, KeyedFor } from '~/lib/keyedRows'
 import { basename, flavorFromOs, tildify } from '~/lib/paths'
 import { shallowEqualArrays } from '~/lib/shallowEqual'
@@ -133,6 +134,9 @@ const TabLeaf: Component<{
         props.onClose?.()
       }}
       data-testid="tab-tree-leaf"
+      // The tree's own statement of which row is active, so a test asserts on
+      // that rather than on the presence of a hashed style class.
+      data-active={props.isActive ? 'true' : 'false'}
       data-tab-id={props.tab.id}
       data-terminal-status={isTerminalTab(props.tab) ? props.tab.status : undefined}
     >
@@ -241,9 +245,9 @@ interface BranchActionsContextValue {
   isWorkerKnownOnline?: (workerId: string) => boolean
 }
 
-const RowSelectionContext = createContext<RowSelectionContextValue>()
-const RowEditingContext = createContext<RowEditingContextValue>()
-const BranchActionsContext = createContext<BranchActionsContextValue>({})
+const RowSelectionContext = createStableContext<RowSelectionContextValue>('workspace/WorkspaceTabTree#rowSelection')
+const RowEditingContext = createStableContext<RowEditingContextValue>('workspace/WorkspaceTabTree#rowEditing')
+const BranchActionsContext = createStableContext<BranchActionsContextValue>('workspace/WorkspaceTabTree#branchActions', {})
 
 function useRowSelection(): RowSelectionContextValue {
   const ctx = useContext(RowSelectionContext)

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,12 +2,13 @@ import type { ParentComponent } from 'solid-js'
 import type { User } from '~/generated/leapmux/v1/auth_pb'
 import { create } from '@bufbuild/protobuf'
 import { Code, ConnectError } from '@connectrpc/connect'
-import { createContext, createEffect, createSignal, on, onMount, useContext } from 'solid-js'
+import { createEffect, createSignal, on, onMount, useContext } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { platformBridge } from '~/api/platformBridge'
 import { loadTimeouts, setOnAuthError } from '~/api/transport'
 import { channelManager } from '~/api/workerRpc'
 import { LoginRequestSchema } from '~/generated/leapmux/v1/auth_pb'
+import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { createLogger } from '~/lib/logger'
 import { isSoloMode, loadSystemInfo } from '~/lib/systemInfo'
@@ -43,7 +44,7 @@ export interface AuthState {
   isAuthenticated: () => boolean
 }
 
-const AuthContext = createContext<AuthState>()
+const AuthContext = createStableContext<AuthState>('context/AuthContext')
 
 export const AuthProvider: ParentComponent = (props) => {
   const [user, setUser] = createSignal<User | null>(null)

--- a/frontend/src/context/PreferencesContext.tsx
+++ b/frontend/src/context/PreferencesContext.tsx
@@ -3,10 +3,11 @@ import type { ThemePreference } from '~/app'
 import type { BrowserPreferences, EnterKeyMode } from '~/lib/browserStorage'
 import type { UserKeybindingOverride } from '~/lib/shortcuts/types'
 import type { TerminalThemePreference } from '~/lib/terminal'
-import { createContext, createEffect, createSignal, onMount, useContext } from 'solid-js'
+import { createEffect, createSignal, onMount, useContext } from 'solid-js'
 import { userClient } from '~/api/clients'
 import { DiffView, TurnEndSound } from '~/generated/leapmux/v1/user_pb'
 import { KEY_BROWSER_PREFS, loadBrowserPrefs, localStorageSet } from '~/lib/browserStorage'
+import { createStableContext } from '~/lib/createStableContext'
 import { setDebugEnabled } from '~/lib/logger'
 
 const DEFAULT_MONO_FONT_FAMILY = '"Hack NF", Hack, "SF Mono", Consolas, monospace'
@@ -100,7 +101,7 @@ interface PreferencesState {
   reload: () => Promise<void>
 }
 
-const PreferencesContext = createContext<PreferencesState>()
+const PreferencesContext = createStableContext<PreferencesState>('context/PreferencesContext')
 
 /** Build a CSS font-family string by quoting each font name and joining with commas. */
 function buildFontFamily(fonts: string[]): string {

--- a/frontend/src/context/TunnelContext.tsx
+++ b/frontend/src/context/TunnelContext.tsx
@@ -1,8 +1,9 @@
 import type { ParentComponent } from 'solid-js'
 import type { TunnelStore } from '~/stores/tunnel.store'
-import { createContext, useContext } from 'solid-js'
+import { useContext } from 'solid-js'
+import { createStableContext } from '~/lib/createStableContext'
 
-const TunnelContext = createContext<TunnelStore>()
+const TunnelContext = createStableContext<TunnelStore>('context/TunnelContext')
 
 export const TunnelProvider: ParentComponent<{ store: TunnelStore }> = (props) => {
   // eslint-disable-next-line solid/reactivity -- store is a stable object, not a reactive primitive

--- a/frontend/src/context/WorkspaceContext.tsx
+++ b/frontend/src/context/WorkspaceContext.tsx
@@ -1,12 +1,13 @@
 import type { ParentComponent } from 'solid-js'
-import { createContext, createSignal, useContext } from 'solid-js'
+import { createSignal, useContext } from 'solid-js'
+import { createStableContext } from '~/lib/createStableContext'
 
 interface WorkspaceState {
   activeWorkspaceId: () => string | null
   setActiveWorkspaceId: (id: string | null) => void
 }
 
-const WorkspaceContext = createContext<WorkspaceState>()
+const WorkspaceContext = createStableContext<WorkspaceState>('context/WorkspaceContext')
 
 export const WorkspaceProvider: ParentComponent = (props) => {
   const [activeWorkspaceId, setActiveWorkspaceId] = createSignal<string | null>(null)

--- a/frontend/src/entry-client.tsx
+++ b/frontend/src/entry-client.tsx
@@ -1,5 +1,7 @@
 // @refresh reload
 import { mount, StartClient } from '@solidjs/start/client'
+import { showWarnToast } from '~/components/common/Toast'
+import { installGlobalErrorSink } from '~/lib/installGlobalErrorSink'
 import { scheduleRenderPipelineWarmup } from '~/lib/renderPipelineWarmup'
 import { installResizeObserverLoopErrorSuppressor } from '~/lib/suppressResizeObserverLoopError'
 
@@ -12,6 +14,18 @@ import { installResizeObserverLoopErrorSuppressor } from '~/lib/suppressResizeOb
 // browser's native error reporting untouched.
 if (import.meta.env.DEV)
   installResizeObserverLoopErrorSuppressor()
+
+// Catch what the ErrorBoundaries structurally cannot: faults thrown from event
+// handlers, promise rejections, timers and socket callbacks never touch the
+// render graph, so before this they were invisible to the user and unlogged in
+// prod. Installed AFTER the suppressor so its capture-phase listener still wins
+// on the benign ResizeObserver events (the sink filters them too, for prod,
+// where the suppressor is not installed at all).
+//
+// `showWarnToast` is passed in rather than imported by the sink: it both renders
+// the toast and logs at warn level, so the sink deliberately does neither and
+// the fault is reported exactly once.
+installGlobalErrorSink({ report: showWarnToast })
 
 // Vinxi's generated client handler probes this module for a default export even
 // though the Solid client entry only needs the side-effectful mount call below.

--- a/frontend/src/hooks/useCopyButton.test.ts
+++ b/frontend/src/hooks/useCopyButton.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="vitest/globals" />
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCopyButton } from './useCopyButton'
+
+const copyTextToClipboard = vi.hoisted(() => vi.fn(async (_text: string) => true))
+vi.mock('~/lib/clipboard', () => ({ copyTextToClipboard }))
+
+describe('useCopyButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    copyTextToClipboard.mockImplementation(async () => true)
+  })
+
+  it('flashes copied after a successful write', async () => {
+    await createRoot(async (dispose) => {
+      const { copied, copy } = useCopyButton(() => 'payload')
+      expect(copied()).toBe(false)
+
+      await copy()
+
+      expect(copyTextToClipboard).toHaveBeenCalledWith('payload')
+      expect(copied()).toBe(true)
+      dispose()
+    })
+  })
+
+  // The feedback has to track the WRITE, not the click. A non-secure origin
+  // exposes no clipboard at all, and the previous version -- which called
+  // `navigator.clipboard.writeText` inside a bare try/catch -- was one small
+  // refactor away from flashing "Copied!" over a clipboard that never changed.
+  it('does not flash copied when the write does not land', async () => {
+    copyTextToClipboard.mockImplementation(async () => false)
+    await createRoot(async (dispose) => {
+      const { copied, copy } = useCopyButton(() => 'payload')
+
+      await copy()
+
+      expect(copied()).toBe(false)
+      dispose()
+    })
+  })
+
+  it('does not touch the clipboard when there is nothing to copy', async () => {
+    await createRoot(async (dispose) => {
+      const { copied, copy } = useCopyButton(() => undefined)
+
+      await copy()
+
+      expect(copyTextToClipboard).not.toHaveBeenCalled()
+      expect(copied()).toBe(false)
+      dispose()
+    })
+  })
+
+  it('resets the flash after the timeout elapses', async () => {
+    vi.useFakeTimers()
+    try {
+      await createRoot(async (dispose) => {
+        const { copied, copy } = useCopyButton(() => 'payload')
+        await copy()
+        expect(copied()).toBe(true)
+
+        vi.advanceTimersByTime(2000)
+
+        expect(copied()).toBe(false)
+        dispose()
+      })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/hooks/useCopyButton.ts
+++ b/frontend/src/hooks/useCopyButton.ts
@@ -1,20 +1,24 @@
 import { createSignal } from 'solid-js'
+import { copyTextToClipboard } from '~/lib/clipboard'
 
-/** Reusable clipboard-copy-with-feedback hook. Returns a `copied` signal and a `copy` handler. */
+/**
+ * Reusable clipboard-copy-with-feedback hook. Returns a `copied` signal and a
+ * `copy` handler.
+ *
+ * Routed through `copyTextToClipboard` rather than touching
+ * `navigator.clipboard` directly, so the "no clipboard API on a non-secure
+ * origin" case is handled in one place -- and so the "Copied!" flash only fires
+ * when something was actually copied, instead of on any platform where the
+ * write silently could not happen.
+ */
 export function useCopyButton(getText: () => string | undefined) {
   const [copied, setCopied] = createSignal(false)
   const copy = async () => {
     const text = getText()
-    if (!text)
+    if (!text || !await copyTextToClipboard(text))
       return
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(setCopied, 2000, false)
-    }
-    catch {
-      // ignore clipboard errors
-    }
+    setCopied(true)
+    setTimeout(setCopied, 2000, false)
   }
   return { copied, copy }
 }

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,40 +1,42 @@
 import { describe, expect, it, vi } from 'vitest'
 import { copyTextToClipboard } from './clipboard'
 
+function stubClipboard(value: unknown) {
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value })
+}
+
 describe('copyTextToClipboard', () => {
   it('writes non-empty text to the clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    stubClipboard({ writeText })
 
-    copyTextToClipboard('hello')
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true)
 
     expect(writeText).toHaveBeenCalledWith('hello')
   })
 
-  it('skips empty strings (avoids clobbering the clipboard on deselect)', () => {
+  it('skips empty strings (avoids clobbering the clipboard on deselect)', async () => {
     const writeText = vi.fn()
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    stubClipboard({ writeText })
 
-    copyTextToClipboard('')
+    await expect(copyTextToClipboard('')).resolves.toBe(false)
 
     expect(writeText).not.toHaveBeenCalled()
   })
 
   it('swallows clipboard errors so callers do not have to', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'))
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    stubClipboard({ writeText })
 
-    expect(() => copyTextToClipboard('hello')).not.toThrow()
-    // Allow the rejected promise to settle without an unhandled rejection.
-    await Promise.resolve()
+    await expect(copyTextToClipboard('hello')).resolves.toBe(false)
+  })
+
+  // A non-secure origin -- plain `http://` on a LAN -- exposes no
+  // `navigator.clipboard` at all, so an unguarded `navigator.clipboard.writeText`
+  // throws a TypeError rather than rejecting.
+  it('reports failure when the platform exposes no clipboard', async () => {
+    stubClipboard(undefined)
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(false)
   })
 })

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,13 +1,23 @@
 /**
- * Write `text` to the system clipboard, ignoring empty inputs and
- * environments without a clipboard API. Errors (e.g. permission denied
- * on a non-secure context) are swallowed — auto-copy is a convenience,
- * not a contract.
+ * Write `text` to the system clipboard, reporting whether it landed.
+ *
+ * Never rejects and never throws: an empty input, a missing clipboard API (any
+ * non-secure origin — plain `http://` on a LAN — has no `navigator.clipboard`),
+ * a denied permission, or an unfocused document all resolve `false`. Callers
+ * that treat copying as a convenience can ignore the result with `void`; a
+ * caller that reports success to the user should await it, so it cannot claim
+ * to have copied something it did not.
  */
-export function copyTextToClipboard(text: string): void {
+export async function copyTextToClipboard(text: string): Promise<boolean> {
   if (text.length === 0)
-    return
+    return false
   if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText)
-    return
-  void navigator.clipboard.writeText(text).catch(() => {})
+    return false
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  }
+  catch {
+    return false
+  }
 }

--- a/frontend/src/lib/createStableContext.test.tsx
+++ b/frontend/src/lib/createStableContext.test.tsx
@@ -1,0 +1,182 @@
+/// <reference types="vitest/globals" />
+import type { Component, Context, ParentComponent, ParentProps } from 'solid-js'
+import type { Registry } from 'solid-refresh'
+import { render } from '@solidjs/testing-library'
+import { createContext, useContext } from 'solid-js'
+import { $$component, $$context, $$refresh, $$registry } from 'solid-refresh'
+import { describe, expect, it } from 'vitest'
+import { createStableContext } from './createStableContext'
+
+/**
+ * A stand-in for Vite's `import.meta.hot`, faithful to the parts solid-refresh
+ * touches: `data` persists across re-evaluations of the module it belongs to,
+ * `accept(cb)` records the patch callback, and `fire()` runs the recorded
+ * callbacks once every module in an update batch has executed.
+ *
+ * One deliberate simplification: Vite runs exactly ONE generation's callbacks
+ * (`HMRContext`'s constructor clears `mod.callbacks`, and `fetchUpdate`
+ * snapshots them before re-importing), whereas `fire()` replays every
+ * generation's. That is harmless here and kept for the simpler helper: each
+ * `$$refreshESM` callback closes only over `hot` and re-reads
+ * `hot.data['solid-refresh']` at call time, so a repeat is an idempotent
+ * re-`patchRegistry`. A test that adds a THIRD generation, or a callback that
+ * is not idempotent, would need this to drop the stale ones first.
+ */
+function makeHot() {
+  const callbacks: ((module?: unknown) => void)[] = []
+  return {
+    // Vite hands over an empty bag; solid-refresh populates both keys on first use.
+    data: {} as { 'solid-refresh': Registry, 'solid-refresh-prev': Registry },
+    accept: (cb: (module?: unknown) => void) => {
+      callbacks.push(cb)
+    },
+    invalidate: () => {},
+    decline: () => {},
+    fire: () => {
+      for (const cb of callbacks) cb({})
+    },
+  }
+}
+
+type FakeHot = ReturnType<typeof makeHot>
+
+/**
+ * Evaluate one generation of a two-module pair under solid-refresh: module A
+ * owns a context and its Provider, module B consumes it. Calling this twice
+ * with the same `hot` objects is what an HMR batch does to both modules.
+ */
+function evaluateModules(makeCtx: () => Context<string | undefined>, hotA: FakeHot, hotB: FakeHot) {
+  const regA = $$registry()
+  const Ctx = $$context(regA, 'Ctx', makeCtx())
+  const Provider: ParentComponent = $$component(regA, 'Provider', (props: ParentProps) => (
+    <Ctx.Provider value="ok">{props.children}</Ctx.Provider>
+  ))
+  const useCtx = () => {
+    const value = useContext(Ctx)
+    if (!value)
+      throw new Error('useCtx must be used within Provider')
+    return value
+  }
+  $$refresh('vite', hotA, regA)
+
+  // Module B is rewritten to import THIS generation of A, so it closes over
+  // whichever context object A just handed out.
+  const regB = $$registry()
+  const Guard: Component = $$component(regB, 'Guard', () => <span>{useCtx()}</span>)
+  $$refresh('vite', hotB, regB)
+
+  return { Provider, Guard }
+}
+
+/**
+ * Mount the pair, re-evaluate both modules as an HMR batch, then fire the patch
+ * callbacks in `order`. Returns the thunk that applies the patches so callers
+ * can assert on whether it throws.
+ */
+function hmrBatch(makeCtx: () => Context<string | undefined>, order: 'consumer-first' | 'context-first') {
+  const hotA = makeHot()
+  const hotB = makeHot()
+
+  const first = evaluateModules(makeCtx, hotA, hotB)
+  const { container } = render(() => (
+    <first.Provider><first.Guard /></first.Provider>
+  ))
+  expect(container.textContent).toBe('ok')
+
+  evaluateModules(makeCtx, hotA, hotB)
+
+  return () => {
+    for (const hot of order === 'consumer-first' ? [hotB, hotA] : [hotA, hotB])
+      hot.fire()
+  }
+}
+
+describe('createStableContext', () => {
+  it('returns the same context for a repeated key', () => {
+    const first = createStableContext<string>('test/repeat')
+    const second = createStableContext<string>('test/repeat')
+    expect(second).toBe(first)
+  })
+
+  it('returns distinct contexts for distinct keys', () => {
+    expect(createStableContext<string>('test/a')).not.toBe(createStableContext<string>('test/b'))
+  })
+
+  it('serves the default value when no Provider is above the consumer', () => {
+    const ctx = createStableContext<string>('test/default', 'fallback')
+    const { container } = render(() => <span>{useContext(ctx)}</span>)
+    expect(container.textContent).toBe('fallback')
+  })
+
+  it('adopts the newest default value on re-evaluation', () => {
+    const first = createStableContext<string>('test/redefault', 'stale')
+    const second = createStableContext<string>('test/redefault', 'fresh')
+    expect(second).toBe(first)
+
+    const { container } = render(() => <span>{useContext(first)}</span>)
+    expect(container.textContent).toBe('fresh')
+  })
+
+  // A falsy default is still a default. Anything that reached for `||` rather
+  // than an explicit undefined check -- here, or in the cache hit that
+  // re-assigns it -- would silently swap `0` for the no-default behaviour.
+  //
+  // The two defaults must DIFFER, and the falsy one must come second: passing
+  // `0` both times makes `defaultValue || cached.defaultValue` compute `0 || 0`
+  // and the assertion holds against the very bug it is written to catch.
+  it('serves a falsy default value', () => {
+    const first = createStableContext<number>('test/falsy', 5)
+    const second = createStableContext<number>('test/falsy', 0)
+    expect(second).toBe(first)
+
+    const { container } = render(() => <span>{String(useContext(second))}</span>)
+    expect(container.textContent).toBe('0')
+  })
+
+  it('lets a Provider from one call serve a consumer holding another call', () => {
+    const provided = createStableContext<string>('test/crossCall')
+    const consumed = createStableContext<string>('test/crossCall')
+
+    const { container } = render(() => (
+      <provided.Provider value="shared">
+        <span>{useContext(consumed) ?? 'missing'}</span>
+      </provided.Provider>
+    ))
+    expect(container.textContent).toBe('shared')
+  })
+
+  it('does not share state between two plain createContext calls', () => {
+    // The contrast that makes the case above meaningful: this is precisely what
+    // a module re-evaluation does without the pinning.
+    const provided = createContext<string>()
+    const consumed = createContext<string>()
+
+    const { container } = render(() => (
+      <provided.Provider value="shared">
+        <span>{useContext(consumed) ?? 'missing'}</span>
+      </provided.Provider>
+    ))
+    expect(container.textContent).toBe('missing')
+  })
+
+  describe('under an hmr batch touching a context module and its consumer', () => {
+    it('reproduces the failure with plain createContext when the consumer patches first', () => {
+      const apply = hmrBatch(() => createContext<string>(), 'consumer-first')
+      expect(apply).toThrow('useCtx must be used within Provider')
+    })
+
+    it('survives with plain createContext when the context module patches first', () => {
+      // Only the ordering differs, which is what makes the failure intermittent.
+      const apply = hmrBatch(() => createContext<string>(), 'context-first')
+      expect(apply).not.toThrow()
+    })
+
+    it('survives either ordering with createStableContext', () => {
+      const consumerFirst = hmrBatch(() => createStableContext<string>('test/hmrConsumerFirst'), 'consumer-first')
+      expect(consumerFirst).not.toThrow()
+
+      const contextFirst = hmrBatch(() => createStableContext<string>('test/hmrContextFirst'), 'context-first')
+      expect(contextFirst).not.toThrow()
+    })
+  })
+})

--- a/frontend/src/lib/createStableContext.ts
+++ b/frontend/src/lib/createStableContext.ts
@@ -1,0 +1,63 @@
+import type { Context } from 'solid-js'
+import { createContext } from 'solid-js'
+
+/**
+ * The process-wide context cache.
+ *
+ * `Symbol.for` rather than a module-level `const`: the whole point is to
+ * outlive a module re-evaluation, and this module is no more immune to being
+ * re-executed than the ones calling it. A registry held in module scope would
+ * reset exactly when it is needed most.
+ */
+const CONTEXTS = Symbol.for('leapmux.stableContexts')
+
+interface ContextHost {
+  [CONTEXTS]?: Map<string, Context<unknown>>
+}
+
+/**
+ * `createContext` whose identity survives re-evaluation of the calling module.
+ *
+ * Solid keys every `useContext` lookup by an id minted inside `createContext`,
+ * so a module that runs twice hands out two unrelated contexts -- a Provider
+ * from the first writes an id the second's consumers never read. Vite's HMR
+ * does precisely that: an update batch re-executes each changed module, and
+ * solid-refresh repairs the split afterwards by rewriting the new context's id
+ * back to the original. That repair is ordering-dependent. Accept callbacks
+ * fire in the update payload's order, so an edit touching a context module and
+ * one of its consumers together can re-render the consumer first, against an
+ * id no mounted Provider ever wrote. `useContext` then returns undefined and
+ * the consumer's guard throws -- "useAuth must be used within AuthProvider",
+ * with nobody having touched the app.
+ *
+ * Pinning the object under a stable key removes the ordering dependence
+ * entirely: every re-evaluation returns the first context, and solid-refresh's
+ * repair degrades to a self-assignment. Production evaluates each module once,
+ * so the cache is a single miss there; the path is shared rather than
+ * dev-only so there is one behaviour to reason about.
+ *
+ * `key` must be unique app-wide -- two modules sharing one silently share a
+ * context. Name it after the owning module's path (`'context/AuthContext'`),
+ * which is unique by construction. A module owning several contexts
+ * distinguishes them with a suffix (`'workspace/WorkspaceTabTree#rowSelection'`).
+ */
+export function createStableContext<T>(key: string): Context<T | undefined>
+export function createStableContext<T>(key: string, defaultValue: T): Context<T>
+export function createStableContext<T>(key: string, defaultValue?: T): Context<T | undefined> {
+  const host = globalThis as ContextHost
+  const cache = (host[CONTEXTS] ??= new Map<string, Context<unknown>>())
+
+  const cached = cache.get(key) as Context<T | undefined> | undefined
+  if (cached) {
+    // Adopt the newest default rather than freezing whichever one the first
+    // evaluation happened to pass. Rewriting `defaultValue` is the one thing
+    // solid-refresh's context patch did that pinning does not make redundant,
+    // and dropping it would quietly require a reload to pick up an edit to it.
+    cached.defaultValue = defaultValue
+    return cached
+  }
+
+  const created = createContext<T | undefined>(defaultValue)
+  cache.set(key, created as Context<unknown>)
+  return created
+}

--- a/frontend/src/lib/installGlobalErrorSink.test.ts
+++ b/frontend/src/lib/installGlobalErrorSink.test.ts
@@ -1,0 +1,165 @@
+/// <reference types="vitest/globals" />
+import type { GlobalErrorTarget } from './installGlobalErrorSink'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installGlobalErrorSink } from './installGlobalErrorSink'
+import { installResizeObserverLoopErrorSuppressor } from './suppressResizeObserverLoopError'
+
+/**
+ * A stand-in for `window` that records its listeners, so a test can fire an
+ * event without jsdom's global error plumbing (which reports an uncaught
+ * `ErrorEvent` to the console and would make a passing run look broken).
+ */
+function fakeTarget() {
+  const listeners = new Map<string, Set<(event: Event) => void>>()
+  const target: GlobalErrorTarget = {
+    addEventListener: (type, listener) => {
+      const set = listeners.get(type) ?? new Set()
+      set.add(listener)
+      listeners.set(type, set)
+    },
+    removeEventListener: (type, listener) => {
+      listeners.get(type)?.delete(listener)
+    },
+  }
+  return {
+    target,
+    listenerCount: (type: string) => listeners.get(type)?.size ?? 0,
+    fire: (type: string, event: Partial<Event> & Record<string, unknown>) => {
+      for (const listener of listeners.get(type) ?? [])
+        listener(event as unknown as Event)
+    },
+  }
+}
+
+describe('installGlobalErrorSink', () => {
+  const disposers: Array<() => void> = []
+
+  afterEach(() => {
+    while (disposers.length)
+      disposers.pop()!()
+    vi.restoreAllMocks()
+  })
+
+  function install(report: (message: string, err: unknown) => void) {
+    const t = fakeTarget()
+    disposers.push(installGlobalErrorSink({ report, target: t.target }))
+    return t
+  }
+
+  it('reports an uncaught error, passing the thrown value through', () => {
+    const report = vi.fn()
+    const t = install(report)
+    const error = new Error('handler blew up')
+
+    t.fire('error', { error, message: 'handler blew up' })
+
+    expect(report).toHaveBeenCalledTimes(1)
+    expect(report.mock.calls[0][1]).toBe(error)
+  })
+
+  // The whole reason this exists: a rejected promise touches no part of the
+  // render graph, so neither ErrorBoundary ever sees it.
+  it('reports an unhandled rejection', () => {
+    const report = vi.fn()
+    const t = install(report)
+    const reason = new Error('fetch rejected')
+
+    t.fire('unhandledrejection', { reason })
+
+    expect(report).toHaveBeenCalledTimes(1)
+    expect(report.mock.calls[0][1]).toBe(reason)
+  })
+
+  it('reports a rejection carrying a non-Error value', () => {
+    const report = vi.fn()
+    const t = install(report)
+
+    t.fire('unhandledrejection', { reason: 'just a string' })
+
+    expect(report).toHaveBeenCalledTimes(1)
+    expect(report.mock.calls[0][1]).toBe('just a string')
+  })
+
+  // Chromium fires this once per frame while a long transcript settles. It is
+  // self-healing, and a toast per frame would bury the app.
+  it('ignores the benign ResizeObserver loop error', () => {
+    const report = vi.fn()
+    const t = install(report)
+
+    t.fire('error', { message: 'ResizeObserver loop limit exceeded' })
+    t.fire('error', { message: 'ResizeObserver loop completed with undelivered notifications' })
+
+    expect(report).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates a repeating fault', () => {
+    const report = vi.fn()
+    const t = install(report)
+
+    for (let i = 0; i < 5; i++)
+      t.fire('error', { error: new Error('same every time') })
+
+    expect(report).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reports a different fault while one is deduplicated', () => {
+    const report = vi.fn()
+    const t = install(report)
+
+    t.fire('error', { error: new Error('first') })
+    t.fire('error', { error: new Error('first') })
+    t.fire('error', { error: new Error('second') })
+
+    expect(report).toHaveBeenCalledTimes(2)
+    expect(report.mock.calls[1][1]).toHaveProperty('message', 'second')
+  })
+
+  // A message carrying a request id or timestamp differs every time, so the
+  // dedupe map must not grow with it.
+  it('bounds the messages it remembers', () => {
+    const report = vi.fn()
+    const t = install(report)
+
+    // Well past the cap, then re-fire the very first message: it must have been
+    // evicted, so it reports again rather than being treated as a duplicate.
+    for (let i = 0; i < 100; i++)
+      t.fire('error', { error: new Error(`unique ${i}`) })
+    report.mockClear()
+
+    t.fire('error', { error: new Error('unique 0') })
+
+    expect(report).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops reporting once disposed', () => {
+    const report = vi.fn()
+    const t = install(report)
+    disposers.pop()!()
+
+    t.fire('error', { error: new Error('after disposal') })
+
+    expect(report).not.toHaveBeenCalled()
+    expect(t.listenerCount('error')).toBe(0)
+    expect(t.listenerCount('unhandledrejection')).toBe(0)
+  })
+
+  it('is a no-op outside a DOM', () => {
+    expect(() => installGlobalErrorSink({ report: vi.fn(), target: undefined })()).not.toThrow()
+  })
+
+  // In dev the suppressor is registered first and in the capture phase, so it
+  // stops the RO event before this sink's bubble-phase listener runs. Pinned
+  // because the two installers' ORDER in `entry-client.tsx` is load-bearing.
+  it('never sees an RO error the dev-mode suppressor already stopped', () => {
+    const report = vi.fn()
+    disposers.push(installResizeObserverLoopErrorSuppressor(window))
+    disposers.push(installGlobalErrorSink({ report, target: window }))
+
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'ResizeObserver loop limit exceeded',
+      cancelable: true,
+    }))
+
+    expect(report).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/installGlobalErrorSink.ts
+++ b/frontend/src/lib/installGlobalErrorSink.ts
@@ -1,0 +1,120 @@
+import { monotonicNow } from './monotonicNow'
+import { isResizeObserverLoopError } from './suppressResizeObserverLoopError'
+
+/**
+ * Surface faults that never reach an `ErrorBoundary`.
+ *
+ * Solid's boundaries catch what throws inside the render/reactive graph, and
+ * nothing else. Event handlers, `.then`/`.catch`, `setTimeout` callbacks and
+ * WebSocket handlers all bypass them, so until this existed an async failure was
+ * invisible to the user AND to the developer in production -- the app simply did
+ * not do the thing. That is not a hypothetical class: two live instances were
+ * found in one review pass (a bare `navigator.clipboard.writeText` in the worker
+ * context menu, and another in the selection popover that also aborted the three
+ * statements after it).
+ *
+ * Deliberately a TOAST, not the full-screen fallback. A stray rejection -- from
+ * a browser extension, a cancelled fetch, a third-party script -- must not
+ * tombstone a working app; the boundaries stay the mechanism for "this subtree
+ * cannot render". Reporting is left to the caller for the same reason the level
+ * is not decided here: `showWarnToast` both toasts and logs at warn, so this
+ * module must not log as well or every fault appears twice.
+ *
+ * Passive: it neither `preventDefault`s nor stops propagation, so the browser's
+ * native reporting and the dev overlay still see everything.
+ */
+
+/** The subset of `Window` this needs, so tests can pass a double. */
+export interface GlobalErrorTarget {
+  addEventListener: (type: string, listener: (event: Event) => void) => void
+  removeEventListener: (type: string, listener: (event: Event) => void) => void
+}
+
+export interface GlobalErrorSinkOpts {
+  /**
+   * Where a surfaced fault goes. The app passes `showWarnToast`, which toasts
+   * AND logs at warn level -- this module deliberately does neither itself.
+   *
+   * Injected rather than imported so `lib/` keeps no dependency on a component,
+   * and so the composition root stays the one place that decides how a fault is
+   * presented.
+   */
+  report: (message: string, err: unknown) => void
+  target?: GlobalErrorTarget
+}
+
+/**
+ * How long the same message stays deduplicated.
+ *
+ * A failing handler on a hot path (a rejected send retried per keystroke) would
+ * otherwise queue one toast per occurrence and bury the app under them. Repeats
+ * inside the window are dropped entirely: the first one already told the user,
+ * and `showWarnToast` already logged it.
+ */
+const DEDUPE_WINDOW_MS = 10_000
+
+/**
+ * Cap on remembered messages, so a fault whose text varies every time (a message
+ * carrying a timestamp or a request id) cannot grow the map without bound.
+ */
+const MAX_TRACKED_MESSAGES = 32
+
+const FALLBACK_MESSAGE = 'Something went wrong'
+
+function defaultTarget(): GlobalErrorTarget | undefined {
+  return typeof window === 'undefined' ? undefined : window
+}
+
+/** The thrown value behind either event shape, for `formatErrorMessage`. */
+function causeOf(event: Event): unknown {
+  if ('reason' in event)
+    return (event as PromiseRejectionEvent).reason
+  const errorEvent = event as ErrorEvent
+  return errorEvent.error ?? errorEvent.message
+}
+
+/**
+ * Install `error` + `unhandledrejection` listeners that report anything neither
+ * boundary would have caught. Returns a disposer.
+ *
+ * No-op outside a DOM (SSR / non-browser), where `target` resolves to undefined.
+ */
+export function installGlobalErrorSink(opts: GlobalErrorSinkOpts): () => void {
+  const target = opts.target ?? defaultTarget()
+  if (!target)
+    return () => {}
+
+  const lastReportedAt = new Map<string, number>()
+
+  const shouldReport = (key: string): boolean => {
+    const now = monotonicNow()
+    const previous = lastReportedAt.get(key)
+    if (previous !== undefined && now - previous < DEDUPE_WINDOW_MS)
+      return false
+    // Re-inserting moves the key to the end of the Map's insertion order, so the
+    // eviction below always drops the least recently reported one.
+    lastReportedAt.delete(key)
+    lastReportedAt.set(key, now)
+    if (lastReportedAt.size > MAX_TRACKED_MESSAGES)
+      lastReportedAt.delete(lastReportedAt.keys().next().value!)
+    return true
+  }
+
+  const onFault = (event: Event) => {
+    const cause = causeOf(event)
+    // In dev the capture-phase suppressor stops these before they get here; in
+    // prod it is not installed at all, and a self-healing browser delivery
+    // warning is not something to put in front of the user.
+    if (isResizeObserverLoopError(cause) || isResizeObserverLoopError((event as ErrorEvent).message))
+      return
+    if (shouldReport(cause instanceof Error ? cause.message : String(cause)))
+      opts.report(FALLBACK_MESSAGE, cause)
+  }
+
+  target.addEventListener('error', onFault)
+  target.addEventListener('unhandledrejection', onFault)
+  return () => {
+    target.removeEventListener('error', onFault)
+    target.removeEventListener('unhandledrejection', onFault)
+  }
+}

--- a/frontend/src/lib/shikiLazyHighlighter.test.ts
+++ b/frontend/src/lib/shikiLazyHighlighter.test.ts
@@ -94,7 +94,12 @@ describe('createLazyOnigurumaHighlighter', () => {
         desynced.push(key)
     }
     expect(desynced).toEqual([])
-  })
+    // Loads every bundled grammar -- 200-odd -- serially through the Oniguruma
+    // WASM engine, which takes 7-10s on a loaded machine. Vitest's 5s default
+    // made this the one test in the suite that failed on CPU contention rather
+    // than on the invariant it guards. Exhaustiveness is the point of the test,
+    // so the budget moves rather than the coverage.
+  }, 60_000)
 
   it('deduplicates concurrent loads of the same language (same in-flight promise)', async () => {
     const hl = createLazyOnigurumaHighlighter()

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -324,7 +324,7 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   // (e.g. a click that clears highlight) are skipped so we don't
   // clobber whatever the user has on the clipboard.
   terminal.onSelectionChange(() => {
-    copyTextToClipboard(terminal.getSelection())
+    void copyTextToClipboard(terminal.getSelection())
   })
 
   return {

--- a/frontend/src/stores/tabMetadata.store.ts
+++ b/frontend/src/stores/tabMetadata.store.ts
@@ -73,6 +73,13 @@ export interface SharedMeta {
    * Local-only monotonic activation counter. Higher = more recently activated.
    * Never persisted and never in the projection; it orders the MRU views within
    * a single client session.
+   *
+   * The cost of "never persisted" is that after a RELOAD every tab scores zero,
+   * and since `mruHead` compares with a strict `>` the winner stays `tabs[0]` --
+   * so every MRU-driven answer silently degrades to position order until the
+   * user activates something. `useTabPersistence` is built to not make that
+   * worse (it never persists a synthesised `mruHead`), but the fallback itself
+   * is still wrong: https://github.com/leapmux/leapmux/issues/345
    */
   mru?: number
   workingDir?: string

--- a/frontend/src/stores/tabSelection.store.test.ts
+++ b/frontend/src/stores/tabSelection.store.test.ts
@@ -418,6 +418,111 @@ describe('tabSelection', () => {
       })
     })
   })
+
+  /**
+   * The VALIDATED-but-never-synthesised half of the pointer API, and the one
+   * anything persisting must use.
+   *
+   * `activeKeyForWorkspace` heals all the way to `mruHead`, which is right for
+   * rendering -- the UI always needs something to highlight -- and destructive to
+   * persist, because `mru` is never stored: after a reload every tab scores zero
+   * and the invented answer is always the FIRST tab. These accessors keep the
+   * three cases apart so a writer can tell "nobody has chosen yet" (leave the
+   * stored key for the restore) from "the choice is dead" (reclaim it).
+   */
+  describe('chosen pointers', () => {
+    it('answers undefined when nothing has been chosen, even with tabs present', () => {
+      withStores(({ selection, rootTileId }) => {
+        add('first', rootTileId)
+        add('second', rootTileId)
+
+        expect(selection.chosenKeyForWorkspace(WS)).toBeUndefined()
+        // The contrast that makes it worth having: the rendering accessor
+        // invents an answer from the same state.
+        expect(selection.activeKeyForWorkspace(WS)).toBe(key('first'))
+      })
+    })
+
+    it('answers the key while the choice is live', () => {
+      withStores(({ selection, rootTileId }) => {
+        add('a', rootTileId)
+        selection.setActiveById(TabType.AGENT, 'a')
+
+        expect(selection.chosenKeyForWorkspace(WS)).toBe(key('a'))
+      })
+    })
+
+    it('answers null once the chosen tab is closed', () => {
+      withStores(({ selection, rootTileId }) => {
+        add('a', rootTileId)
+        add('b', rootTileId)
+        selection.setActiveById(TabType.AGENT, 'a')
+        emitRemoveTab(TabType.AGENT, 'a')
+
+        // Nothing rewrites the raw pointer on a close -- a tombstone is a CRDT
+        // op, not a store call -- so only the validation tells them apart.
+        expect(selection.state.activeByWorkspace[WS], 'the raw pointer outlives its tab').toBe(key('a'))
+        expect(selection.chosenKeyForWorkspace(WS)).toBeNull()
+      })
+    })
+
+    it('answers null when the chosen tab moved to another workspace', () => {
+      withStores(({ selection, view, harness, rootTileId }) => {
+        const elsewhere = seedWorkspace(harness, 'ws-other', 'tile-other')
+        add('moves', rootTileId)
+        selection.setActiveById(TabType.AGENT, 'moves')
+        emitMoveTabToTile(TabType.AGENT, 'moves', elsewhere)
+
+        // Still LIVE globally -- a liveness check alone would keep satisfying
+        // this workspace's pointer. `belongs` is what makes it a real check.
+        expect(view.get(key('moves'))?.workspaceId).toBe('ws-other')
+        expect(selection.chosenKeyForWorkspace(WS)).toBeNull()
+      })
+    })
+
+    it('omits a tile nobody has chosen on, rather than reporting null', () => {
+      withStores(({ selection, rootTileId }) => {
+        add('a', rootTileId)
+
+        // Absent, NOT null: "no tile has been chosen on" is every reload before
+        // the restore runs, and a caller that saw null there would clear the
+        // snapshot it was about to read.
+        expect(selection.chosenTileActivesFor([rootTileId])).toEqual({})
+      })
+    })
+
+    it('reports a live per-tile choice and nulls a dead one', () => {
+      withStores(({ selection, layoutStore, rootTileId }) => {
+        const otherTile = layoutStore.splitTile(rootTileId, 'horizontal')!
+        const homeTile = layoutStore.getAllTileIds().find(id => id !== otherTile)!
+        add('stays', homeTile)
+        add('goes', otherTile)
+        selection.setActiveById(TabType.AGENT, 'stays')
+        selection.setActiveById(TabType.AGENT, 'goes')
+        emitRemoveTab(TabType.AGENT, 'goes')
+
+        expect(selection.chosenTileActivesFor([homeTile, otherTile])).toEqual({
+          [homeTile]: key('stays'),
+          [otherTile]: null,
+        })
+      })
+    })
+
+    it('nulls a per-tile choice whose tab moved to another tile', () => {
+      withStores(({ selection, layoutStore, rootTileId }) => {
+        const otherTile = layoutStore.splitTile(rootTileId, 'horizontal')!
+        const homeTile = layoutStore.getAllTileIds().find(id => id !== otherTile)!
+        add('moves', homeTile)
+        selection.setActiveById(TabType.AGENT, 'moves')
+        emitMoveTabToTile(TabType.AGENT, 'moves', otherTile)
+
+        // The source tile's pointer is dead even though the tab is alive and in
+        // the same workspace -- without this the tile persists, and then
+        // renders, a tab it no longer holds.
+        expect(selection.chosenTileActivesFor([homeTile])).toEqual({ [homeTile]: null })
+      })
+    })
+  })
 })
 
 /**

--- a/frontend/src/stores/tabSelection.store.ts
+++ b/frontend/src/stores/tabSelection.store.ts
@@ -99,6 +99,40 @@ export function createTabSelectionStore(view: TabView, metadata: TabMetadataStor
   }
 
   /**
+   * A stored pointer, VALIDATED but never synthesised. Three answers, and a
+   * caller that persists needs all three kept apart:
+   *
+   *   - `undefined` — nothing was ever chosen for this scope. After a reload
+   *     that is every scope until `restoreTabSelection` runs, so a writer must
+   *     leave whatever is on disk alone.
+   *   - `null` — something WAS chosen and the tab it named is gone: closed
+   *     here, closed on another device, or moved to another workspace/tile.
+   *     The stored key is dead and should be cleared.
+   *   - a key — the choice still names a live tab of this scope. Persist it.
+   *
+   * {@link resolve} collapses the first two into `mruHead`. That is right for
+   * RENDERING — the UI always needs something to highlight — and wrong to
+   * persist, in a way that only bites across a reload: `mru` is never stored,
+   * so every tab comes back scoring zero and `mruHead` invents the FIRST tab.
+   * A writer that persisted that answer would overwrite the real key before
+   * the restore had read it back, and the restore would then read its own
+   * clobbered value.
+   *
+   * Same `belongs` discipline as `resolve`, and for the same reason: `view.get`
+   * is a global lookup, so a tab that merely MOVED is still "live" and would
+   * otherwise keep satisfying the pointer of the scope it left.
+   */
+  function chosen(
+    storedKey: string | null | undefined,
+    belongs: (tab: Tab) => boolean,
+  ): string | null | undefined {
+    if (storedKey == null)
+      return undefined
+    const tab = view.get(storedKey)
+    return tab && belongs(tab) ? storedKey : null
+  }
+
+  /**
    * The two writes that accompany EVERY activation, whatever its scope: stamp
    * MRU so the tab wins the next promotion, and dismiss the badge the user has
    * now seen. Keeping them together is what stops a caller from selecting a tab
@@ -125,6 +159,18 @@ export function createTabSelectionStore(view: TabView, metadata: TabMetadataStor
     activeTabForWorkspace(workspaceId: string): Tab | undefined {
       const key = this.activeKeyForWorkspace(workspaceId)
       return key ? view.get(key) : undefined
+    },
+
+    /**
+     * The workspace's CHOSEN pointer -- see {@link chosen} for the three-way
+     * answer and why persisting {@link activeKeyForWorkspace} instead is
+     * destructive across a reload.
+     */
+    chosenKeyForWorkspace(workspaceId: string): string | null | undefined {
+      return chosen(
+        state.activeByWorkspace[workspaceId],
+        tab => tab.workspaceId === workspaceId,
+      )
     },
 
     activeKeyForTile(tileId: string): string | null {
@@ -251,16 +297,25 @@ export function createTabSelectionStore(view: TabView, metadata: TabMetadataStor
     },
 
     /**
-     * Per-tile actives limited to `tileIds`. `activeByTile` spans every
-     * workspace (tile ids are global), so a caller persisting one workspace's
-     * slice must narrow it or it writes other workspaces' tiles under that
-     * workspace's key.
+     * Per-tile CHOSEN pointers, limited to `tileIds`.
+     *
+     * `activeByTile` spans every workspace (tile ids are global), so a caller
+     * persisting one workspace's slice must narrow it or it writes other
+     * workspaces' tiles under that workspace's key.
+     *
+     * Each entry carries {@link chosen}'s answer, and the three cases stay
+     * apart in the result: a tile nobody has chosen on is ABSENT, a tile whose
+     * choice is dead maps to `null`, and a live choice maps to its key. A
+     * caller that only filtered out the nulls could not tell "no tile has been
+     * chosen on yet" -- true on every reload until the restore runs -- from
+     * "every tile's choice is dead", and clearing on the first is what destroys
+     * the snapshot the restore was about to read.
      */
-    tileActivesFor(tileIds: Iterable<string>): Record<string, string | null> {
+    chosenTileActivesFor(tileIds: Iterable<string>): Record<string, string | null> {
       const out: Record<string, string | null> = {}
       for (const id of tileIds) {
-        const key = state.activeByTile[id]
-        if (key)
+        const key = chosen(state.activeByTile[id], tab => tab.tileId === id)
+        if (key !== undefined)
           out[id] = key
       }
       return out

--- a/frontend/src/test-support/stableContextUsage.test.ts
+++ b/frontend/src/test-support/stableContextUsage.test.ts
@@ -1,0 +1,116 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Guards the two rules `createStableContext` runs on, both of which were
+// documented in a comment and enforced by nothing.
+//
+// 1. Every context goes through the helper. Solid's `createContext` mints a
+//    fresh id per call, so a module that HMR re-evaluates hands out a context
+//    its already-mounted Provider never wrote to -- and the consumer's guard
+//    throws "useX must be used within XProvider" with nobody having touched the
+//    app. The helper pins identity under a stable key; a raw call opts straight
+//    back out of that, and the next context added is the one that does it.
+//
+// 2. Keys are unique app-wide. They are hand-typed path-shaped strings, so a
+//    copy-pasted module that forgets to change its key silently SHARES the
+//    other module's context: the second Provider writes its own value shape
+//    under the first module's id, both sides type-check, and the failure
+//    surfaces as a TypeError on an unrelated field deep in a component.
+//
+// Same shape as `noMirroredUnitTests.test.ts`: a source scan, because the thing
+// being guarded is a property of the source tree rather than of any runtime.
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const srcRoot = join(frontendRoot, 'src')
+const helperPath = join(srcRoot, 'lib', 'createStableContext.ts')
+
+/** Every installed copy of `name` under `node_modules`, nested ones included. */
+function installedCopies(name: string, dir = join(frontendRoot, 'node_modules')): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory())
+      continue
+    if (entry.name === name)
+      found.push(join(dir, entry.name))
+    else if (entry.name === 'node_modules' || entry.name.startsWith('@'))
+      found.push(...installedCopies(name, join(dir, entry.name)))
+  }
+  return found
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory())
+      found.push(...collectSourceFiles(full))
+    else if (/\.tsx?$/.test(entry.name) && !/\.(?:test|spec)\.tsx?$/.test(entry.name))
+      found.push(full)
+  }
+  return found
+}
+
+const sourceFiles = collectSourceFiles(srcRoot)
+
+describe('createStableContext usage', () => {
+  it('is the only way a context is created', () => {
+    const offenders = sourceFiles
+      // The helper is where the one legitimate `createContext` call lives.
+      .filter(file => file !== helperPath)
+      .filter(file => /\bcreateContext\b/.test(readFileSync(file, 'utf8')))
+      .map(file => relative(frontendRoot, file))
+
+    expect(
+      offenders,
+      `Use \`createStableContext\` from \`~/lib/createStableContext\` instead of Solid's `
+      + `\`createContext\`, so the context survives an HMR module re-evaluation:\n  `
+      + `${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('gives every context a unique key', () => {
+    const byKey = new Map<string, string[]>()
+    for (const file of sourceFiles) {
+      const source = readFileSync(file, 'utf8')
+      for (const [, key] of source.matchAll(/createStableContext(?:\s*<[^>]*>)?\s*\(\s*'([^']+)'/g)) {
+        const owners = byKey.get(key) ?? []
+        owners.push(relative(frontendRoot, file))
+        byKey.set(key, owners)
+      }
+    }
+
+    // Sanity: a regex that matched nothing would make the assertion below pass
+    // for the wrong reason, quietly retiring the guard.
+    expect(byKey.size, 'the scan found no createStableContext keys at all').toBeGreaterThan(0)
+
+    const duplicated = [...byKey.entries()]
+      .filter(([, owners]) => owners.length > 1)
+      .map(([key, owners]) => `${key} (${owners.join(', ')})`)
+
+    expect(
+      duplicated,
+      `Two modules share a createStableContext key and therefore share ONE context. `
+      + `Name the key after the owning module's path:\n  ${duplicated.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  // `solid-refresh` is a direct devDependency purely so `createStableContext`'s
+  // HMR reproduction can drive the real runtime. The copy the DEV SERVER runs is
+  // whatever `vite-plugin-solid` resolves, so one behaviour is modelled by two
+  // independently-floating ranges. They dedupe to a single hoisted install
+  // today; the day a plugin bump moves to a major the direct range no longer
+  // covers, the package manager installs a NESTED second copy and that test
+  // starts exercising a patch ordering the dev server has stopped running --
+  // silently, and still green.
+  it('resolves one shared solid-refresh, not a second nested copy', () => {
+    const copies = installedCopies('solid-refresh').map(p => relative(frontendRoot, p))
+
+    expect(
+      copies,
+      `Bump \`solid-refresh\` in package.json to match vite-plugin-solid's range, `
+      + `so the HMR test and the dev server run the same runtime:\n  ${copies.join('\n  ')}`,
+    ).toHaveLength(1)
+  })
+})

--- a/frontend/tests/e2e/161-sidebar-selection-reload.spec.ts
+++ b/frontend/tests/e2e/161-sidebar-selection-reload.spec.ts
@@ -1,0 +1,85 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { openTerminalViaUI, sidebarLeaves, waitForWorkspaceReady } from './helpers/ui'
+
+/**
+ * The sidebar tab tree and the tab bar read DIFFERENT pointers -- the tree asks
+ * `activeKeyForWorkspace`, the bar asks `activeKeyForTile` -- so a reload is the
+ * one moment they can disagree, and nothing exercised it.
+ *
+ * They did disagree. `activeKeyForWorkspace` heals on read by synthesising
+ * `mruHead` when nothing is chosen, `mru` is never persisted, and
+ * `useTabPersistence` had no ordering guarantee against `restoreTabSelection`:
+ * on the ticks where the writer ran first it persisted that synthesised
+ * first-tab answer over the real stored key, and the restore then read back its
+ * own clobbered value. The per-tile key was never synthesised, so the bar
+ * stayed correct while the tree jumped to the first tab.
+ *
+ * Only a real reload reproduces it -- the unit tests in
+ * `useTabPersistence.test.ts` pin the window itself, this pins the symptom.
+ */
+
+const TAB_COUNT = 3
+
+/** Tab-bar tabs, scoped to the rendered copy: the shell mounts the shell twice. */
+function tabs(page: Page): Locator {
+  return page.locator('[data-testid="tab"]:visible')
+}
+
+/**
+ * The sidebar tab-tree row the tree reports as active, scoped to THIS
+ * workspace's subtree.
+ *
+ * `sidebarLeaves` carries the scoping this needs and a bare
+ * `[data-testid="tab-tree-leaf"]` locator does not: the app mounts the sidebar
+ * twice, and every EXPANDED workspace publishes its own `data-active` row, so
+ * an app-wide locator can resolve to two nodes and fail on a strict-mode
+ * violation that has nothing to do with the selection under test.
+ */
+function activeSidebarRow(page: Page, workspaceId: string): Locator {
+  return sidebarLeaves(page, workspaceId).and(page.locator('[data-active="true"]'))
+}
+
+test.describe('sidebar selection across a reload', () => {
+  test('the sidebar tree and the tab bar agree on the active tab', async ({ page, authenticatedWorkspace }) => {
+    const wsId = authenticatedWorkspace.workspaceId
+    await waitForWorkspaceReady(page)
+
+    // A fixed number of opens, each awaited to completion, rather than looping
+    // on the count: `openTerminalViaUI` returns when the RPC resolves, which is
+    // BEFORE the CRDT op projects the tab, so a count-driven loop reads a stale
+    // total and clicks again -- landing four tabs and failing its own
+    // assertion.
+    const startingTabs = await tabs(page).count()
+    for (let i = startingTabs; i < TAB_COUNT; i++) {
+      await openTerminalViaUI(page)
+      await expect(tabs(page)).toHaveCount(i + 1)
+    }
+    await expect(tabs(page)).toHaveCount(TAB_COUNT)
+
+    // Activate the MIDDLE tab: first and last are what a broken fallback picks.
+    await tabs(page).nth(1).click()
+    await expect(tabs(page).nth(1)).toHaveAttribute('aria-selected', 'true')
+
+    // Identify the tab by id, not by its rendered label. Two terminals can
+    // carry the same title -- the shell's OSC title wins, and two shells in one
+    // cwd report the same one -- so a text assertion would pass even if the
+    // tree landed on the wrong terminal.
+    const activeTabId = await tabs(page).nth(1).getAttribute('data-tab-id')
+    expect(activeTabId).toBeTruthy()
+    await expect(activeSidebarRow(page, wsId)).toHaveAttribute('data-tab-id', activeTabId!)
+
+    await page.reload()
+    await waitForWorkspaceReady(page)
+    await expect(tabs(page)).toHaveCount(TAB_COUNT)
+
+    // The tab bar reads the per-tile pointer and always survived the reload.
+    await expect(tabs(page).nth(1)).toHaveAttribute('aria-selected', 'true')
+    await expect(tabs(page).nth(1)).toHaveAttribute('data-tab-id', activeTabId!)
+
+    // The tree reads the per-workspace pointer, which is what the writer used
+    // to overwrite with the first tab.
+    await expect(activeSidebarRow(page, wsId)).toHaveCount(1)
+    await expect(activeSidebarRow(page, wsId)).toHaveAttribute('data-tab-id', activeTabId!)
+  })
+})


### PR DESCRIPTION
## Motivation

Four independent frontend reliability bugs, traced to their root causes and fixed together:

1. **Sidebar selection reset on reload.** `useTabPersistence` and `restoreTabSelection` both gated on `hasWorkspace`, but that was never an ordering guarantee between writer and restorer. On ticks where the writer ran first it persisted `activeKeyForWorkspace`'s synthesised `mruHead` fallback — and since `mru` is never persisted, every tab scores 0 after a reload, so `mruHead` always resolves to the *first* tab. That clobbered the real stored selection before the restore could read it: the sidebar tree jumped to the first tab on every reload, while the tab bar (reading a different, never-synthesised pointer) stayed correct.
2. **Intermittent "must be used within Provider" crashes.** Solid's `createContext` mints a fresh id on every call. When Vite HMR re-executes a context module and a consumer in the same batch, the consumer can render against an id no mounted Provider ever wrote. `solid-refresh` patches the id afterwards, but patch callbacks fire in payload order, so the repair itself was ordering-dependent — producing crashes with nobody having touched the app.
3. **Error handling gaps.** The app-level fallback took only `(error)`, silently dropping Solid's `reset`, so the only recovery from a caught render error was a full page reload — destroying the auth session and all shell state. As a `position: fixed` overlay it also covered `CustomTitlebar`'s drag region and window buttons, leaving the desktop window unmovable and unclosable. And faults from event handlers, timers and promise rejections never touch the render graph at all, so they were invisible to users and unlogged in production.
4. **Clipboard crash on insecure origins.** Call sites invoked `navigator.clipboard.writeText` directly, which throws a `TypeError` where `navigator.clipboard` is unavailable (any non-secure origin, e.g. plain `http://` on a LAN). In `SelectionQuotePopover` that aborted the handler mid-flight, leaving the selection un-cleared and the popover stuck open.

## Modifications

- **`tabSelection.store.ts`**: new three-valued "chosen" pointer API — `chosenKeyForWorkspace` / `chosenTileActivesFor` return `undefined` (nothing chosen yet — leave storage untouched), `null` (chosen tab is dead or moved away — heal and persist the promoted survivor), or a live key (persist as-is). This lets the writer distinguish "reload window, nothing chosen yet" from "a real choice needs reclaiming" instead of collapsing both into one derived value. Validation checks liveness *and* ownership, since a tab that merely moved is still live but no longer owns that pointer. `tileActivesFor` renamed `chosenTileActivesFor` (internal; all call sites updated here).
- **`useTabPersistence.ts`**: the three writers' bootstrap gate folded into one `gatedEffect`; the deduped sessionStorage writer closes over its own cache instead of threading it through every call.
- `data-active` on sidebar tab-tree leaves so tests assert the tree's own answer rather than a hashed CSS class.
- A related, separate root cause — `mru` is never persisted, so the MRU fallback degrades to position order after any reload — is documented in `tabMetadata.store.ts` and tracked at https://github.com/leapmux/leapmux/issues/345.
- **New `createStableContext(key, defaultValue?)`**: pins the `Context` object in a `Symbol.for('leapmux.stableContexts')` map on `globalThis`, so re-evaluation under HMR returns the same object and the repair degrades to a self-assignment. All 11 contexts across 9 modules migrated. New `stableContextUsage.test.ts` scans the source tree to enforce that no file outside the helper calls raw `createContext`, that no two keys collide, and that `solid-refresh` resolves to a single install. `solid-refresh` added as a direct devDependency so the test can drive the real HMR runtime.
- **New `ErrorFallback`** + `renderErrorFallback` adapter, replacing `app.tsx`'s private fallback and wiring `reset` to a working "Try again". `app.tsx` nests a second `ErrorBoundary` inside the router, below `AuthProvider`/`PreferencesProvider`, so a route fault resets just that route. That placement sits inside a `fallback`-less `Suspense`, where a suspended subtree renders *nothing* — so the stack resolves through a plain signal rather than `createResource`, which would blank the screen for the length of a source-map fetch and re-throw once rejected. `ErrorFallback.css.ts` sizes the fallback to its container instead of the viewport.
- **New `installGlobalErrorSink`** (wired in `entry-client.tsx`): listens for `window` `error`/`unhandledrejection`, dedupes repeats (10s window, 32 messages), filters the benign ResizeObserver loop error, and reports through an injected `showWarnToast` — which both toasts and logs at warn, so the sink deliberately does neither itself and a fault is reported once. A toast rather than the full-screen fallback: a stray rejection must not tombstone a working app.
- Cross-tab theme sync fixed: the `storage` handler parsed `e.newValue` directly, but `localStorageSet` wraps values in a `{v, e}` TTL envelope, so `.theme` was always `undefined` and the sync never once fired.
- `MessageBubble.tsx`'s private `renderErrorFallback` renamed `messageErrorFallback` to avoid colliding with the new shared export (no behaviour change).
- **Internal API change**: `copyTextToClipboard` goes from `(text) => void` to `(text) => Promise<boolean>`, and never throws or rejects — empty text, a missing clipboard, a denied permission or a write error all resolve `false`. All call sites updated: fire-and-forget ones `void` the promise; report-success ones await it and only show feedback when the write landed (`WorkerContextMenu`'s toast previously fired unconditionally).
- Misc: `CLAUDE.md`'s `describe` naming rule expanded; `SidebarElements.tsx` captures `mergeProps(...)` in a variable for `solid/reactivity`; `shikiLazyHighlighter.test.ts` gets a 60s budget for a test that serially loads ~200 WASM grammars.

## Result

- Reloading no longer resets the sidebar's selected tab to the first tab.
- Editing unrelated files during development no longer triggers intermittent "must be used within Provider" crashes.
- A render error in one route recovers via "Try again" instead of forcing a reload that logs you out and discards shell state.
- The error screen no longer covers the desktop titlebar, so the window stays movable and closable while an error shows.
- Background faults (event handlers, timers, rejected promises) now surface as a toast and get logged instead of vanishing.
- Theme changes in one browser tab now reach other open tabs.
- Copying no longer throws on insecure origins, and success messages only appear when the copy actually happened.
