### PR TITLE
fix(hub): Bound in-flight handler lifetime with a BaseContext

### DIFF
--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -42,6 +42,21 @@ import (
 // failure and on runtime shutdown -- one constant so the two paths cannot drift.
 const crdtShutdownTimeout = 10 * time.Second
 
+// handlerGrace is how long in-flight HTTP handlers are given to finish on their
+// own once shutdown begins before their shared base context is cancelled to force
+// unwinding. It must stay strictly below httpDrainTimeout (asserted in
+// server_handler_context_test.go) so the forced cancellation still leaves the
+// drain time to observe the handlers returning and close their connections. 5s is
+// generous for a handler making progress (a Connect unary is already capped at
+// APITimeout) and far short of the drain's 10s. See BaseContext on the http.Server
+// literal in NewServer and the grace timer in the shutdown goroutine in Serve.
+const handlerGrace = 5 * time.Second
+
+// httpDrainTimeout bounds http.Server.Shutdown's wait for in-flight handlers to
+// return. handlerGrace cancels the laggards before this expires, so the drain
+// should not need its full budget in practice; the constant is the hard ceiling.
+const httpDrainTimeout = 10 * time.Second
+
 // ServerOption configures optional aspects of a Hub server.
 type ServerOption func(*serverOptions)
 
@@ -66,6 +81,7 @@ type Server struct {
 	tcpLn             net.Listener
 	localLn           net.Listener
 	listenURL         string
+	cancelHandlers    context.CancelFunc
 	shutdownCh        chan struct{}
 	authContexts      *auth.AuthContextRegistry
 	workerMgr         *workermgr.Manager
@@ -154,6 +170,16 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	}
 
 	shutdownCh := make(chan struct{})
+
+	// handlerCtx is the parent of every in-flight HTTP handler's request context
+	// (via http.Server.BaseContext below). It is cancelled handlerGrace into
+	// shutdown so a handler the per-registry teardown paths cannot reach (every
+	// mux route, not just the worker Connect streams) is forced to unwind before
+	// the drain's deadline. Created beside shutdownCh so the two shutdown signals
+	// live together; cancelHandlers is released through acquiredResources on any
+	// construction failure.
+	handlerCtx, cancelHandlers := context.WithCancel(context.Background())
+	acquired.cancelHandlers = cancelHandlers
 
 	// The registry is built WITH its gate: ConnForUser cannot serve a
 	// user-supplied worker id without the ownership + delegation-scope check,
@@ -334,9 +360,17 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 
+	// BaseContext seeds the context of EVERY accepted connection (and thus every
+	// request and h2c stream) with handlerCtx. Cancelling handlerCtx during
+	// shutdown cascades to r.Context() for in-flight handlers on both HTTP/1.1
+	// and h2c, without per-handler wiring -- the structural bound for the class
+	// of bug where a mux route doing unbounded I/O parks the drain. net/http
+	// derives connCtx from BaseContext in Serve->conn.serve, and h2c's
+	// sc.baseCtx comes from the same chain.
 	server := &http.Server{
 		Handler:           logging.HTTPMiddleware(metrics.HTTPMiddleware(mux)),
 		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return handlerCtx },
 		Protocols:         protocols,
 		HTTP2: &http.HTTP2Config{
 			MaxConcurrentStreams: 1000,
@@ -379,6 +413,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		tcpLn:             tcpLn,
 		localLn:           localLn,
 		listenURL:         listenURL,
+		cancelHandlers:    cancelHandlers,
 		shutdownCh:        shutdownCh,
 		authContexts:      authContexts,
 		workerMgr:         wMgr,
@@ -529,18 +564,26 @@ func (s *Server) Serve(ctx context.Context) error {
 		// 2. Notify connected workers to delay reconnection, then end their
 		// Connect streams. Both halves matter to the drain below: a notified
 		// worker still holds its stream until it decides to reconnect, and the
-		// drain waits on the handler that stream is parked in.
-		//
-		// This releases the drain for handlers the worker registry knows about.
-		// A handler outside it (a mux route doing outbound I/O) is bounded only
-		// by whatever deadline it sets itself; making that structural, via a
-		// shutdown-scoped BaseContext every handler derives from, is tracked in
-		// https://github.com/leapmux/leapmux/issues/343
+		// drain waits on the handler that stream is parked in. This releases the
+		// drain for the handlers the worker registry knows about. Handlers it
+		// does not are bounded structurally by the handlerCtx cancel below.
 		notifyCtx, cancelNotify := context.WithTimeout(context.Background(), 2*time.Second)
 		s.workerMgr.NotifyShutdownAndFence(notifyCtx, 10)
 		cancelNotify()
 
-		// 3. Drain in-flight HTTP requests, then force-close any connections
+		// 3. Cancel every in-flight handler the per-registry teardown above did
+		// not reach, then drain what is left. handlerCtx is the BaseContext of
+		// the http.Server, so cancelling it cascades to r.Context() for every
+		// in-flight request (HTTP/1.1 and h2c). handlerGrace lets short handlers
+		// finish on their own before the forced unwind, so a quick store read is
+		// not cut off; only a handler parked past the grace (e.g. a mux route on
+		// unbounded outbound I/O) is cancelled. This is the structural bound
+		// FenceAll cannot express, since FenceAll only reaches handlers the
+		// worker registry knows about.
+		graceTimer := time.AfterFunc(handlerGrace, s.cancelHandlers)
+		defer graceTimer.Stop()
+
+		// Drain in-flight HTTP requests, then force-close any connections
 		// the drain left behind. On Windows each accepted named-pipe
 		// connection is its own pipe instance; if any survive, the next
 		// ListenPipe with FILE_FLAG_FIRST_PIPE_INSTANCE on the same name
@@ -562,7 +605,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		// TCP listener needs no equivalent — a lingering accepted TCP conn does
 		// not block rebinding the port, whereas a surviving named-pipe instance
 		// does block the next ListenPipe(FIRST_PIPE_INSTANCE).
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), httpDrainTimeout)
 		defer cancel()
 		httpShutdownErr := s.server.Shutdown(shutdownCtx)
 		httpCloseErr := s.server.Close()
@@ -713,11 +756,12 @@ func (e serverTeardownErrors) finalize() error {
 // same "remember to extend the sites below" trap in miniature: a new acquired.close
 // site added after them would have leaked both.
 type acquiredResources struct {
-	tcpLn        net.Listener
-	localLn      net.Listener
-	store        store.Store
-	authContexts *auth.AuthContextRegistry
-	crdtRegistry *crdt.Registry
+	tcpLn          net.Listener
+	localLn        net.Listener
+	store          store.Store
+	authContexts   *auth.AuthContextRegistry
+	crdtRegistry   *crdt.Registry
+	cancelHandlers context.CancelFunc
 }
 
 // close releases the acquired resources, joining the primary construction
@@ -732,6 +776,9 @@ func (r acquiredResources) close(primary error) error {
 	}
 	if r.authContexts != nil {
 		r.authContexts.Stop()
+	}
+	if r.cancelHandlers != nil {
+		r.cancelHandlers()
 	}
 	return serverTeardownErrors{
 		primary:       primary,

--- a/backend/hub/server_handler_context_test.go
+++ b/backend/hub/server_handler_context_test.go
@@ -1,0 +1,125 @@
+package hub
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// handlerGrace must cancel laggard handlers strictly before the drain's deadline
+// expires, otherwise the forced cancellation leaves the drain no time to observe
+// the handlers returning and close their connections. Pin that ordering so a
+// future constant edit cannot silently invert it.
+//
+// httpDrainTimeout vs crdtShutdownTimeout is deliberately NOT asserted here: the
+// CRDT registry is shut down only after the drain completes (Serve receives
+// shutdownDone before calling crdtRegistry.Shutdown), so no in-flight handler can
+// observe a shut-down registry regardless of the two durations.
+func TestShutdownTimeoutsAreOrdered(t *testing.T) {
+	require.Less(t, handlerGrace, httpDrainTimeout,
+		"handlerGrace must cancel laggards before the drain expires")
+}
+
+// acquiredResources.close releases cancelHandlers on a construction failure, so
+// a failed NewServer cannot leak the handlerCtx cancel (which would otherwise
+// trip go vet's lostcancel and, more importantly, leak a goroutine-blocking
+// resource). Lock that the wiring exists and that a nil field stays a no-op.
+func TestAcquiredResourcesCloseReleasesCancelHandlers(t *testing.T) {
+	t.Run("releases cancel when set", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		_ = acquiredResources{cancelHandlers: cancel}.close(nil)
+
+		require.ErrorIs(t, ctx.Err(), context.Canceled,
+			"close must invoke cancelHandlers so a failed NewServer leaks nothing")
+	})
+
+	t.Run("nil cancel is a no-op and still returns nil", func(t *testing.T) {
+		// The whole accumulator must be nil-safe: a field NewServer never set
+		// (because it failed before reaching that step) must not panic.
+		require.NoError(t, acquiredResources{}.close(nil))
+	})
+}
+
+// TestBaseContextCancelsInFlightHandlerOnShutdown verifies the stdlib mechanism
+// the production wiring in NewServer relies on: that an http.Server whose
+// BaseContext returns a cancellable context propagates that cancellation to
+// r.Context() for every in-flight request, so Shutdown returns nil rather than
+// waiting out its deadline on a parked handler.
+//
+// This exercises the BaseContext -> r.Context() cascade in isolation, NOT the
+// production server literal (NewServer needs a live store, listeners, and
+// keystore, so it is too heavy to stand up here). The production wiring itself
+// -- handlerCtx created in NewServer and set as http.Server.BaseContext -- is
+// covered by go vet's reachability check on cancelHandlers and by the
+// construction-failure test above; this test pins the net/http contract that
+// makes that wiring load-bearing.
+func TestBaseContextCancelsInFlightHandlerOnShutdown(t *testing.T) {
+	handlerCtx, cancelHandlers := context.WithCancel(context.Background())
+	t.Cleanup(cancelHandlers)
+
+	handlerCancelled := make(chan struct{})
+	var served atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/park", func(w http.ResponseWriter, r *http.Request) {
+		served.Store(true)
+		<-r.Context().Done() // park until handlerCtx is cancelled
+		close(handlerCancelled)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	srv := &http.Server{
+		Handler:     mux,
+		BaseContext: func(net.Listener) context.Context { return handlerCtx },
+		Protocols:   protocols,
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	serverDone := make(chan error, 1)
+	go func() { serverDone <- srv.Serve(ln) }()
+
+	// A real connection keeps the request in net/http's activeConn map, which is
+	// what Shutdown waits on.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = conn.Write([]byte("GET /park HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+	require.NoError(t, err)
+
+	// Wait until the handler is parked, else Shutdown could observe zero active
+	// connections and the test would not exercise the path.
+	require.Eventually(t, func() bool { return served.Load() },
+		time.Second, 5*time.Millisecond, "handler never observed the request")
+
+	// Tight drain so a regression (handler NOT cancelled) fails fast.
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelDrain()
+
+	cancelHandlers() // the shutdown goroutine does this handlerGrace after shutdown begins
+	err = srv.Shutdown(drainCtx)
+	require.NoError(t, err, "Shutdown must return nil once the handler's context is cancelled")
+
+	select {
+	case <-handlerCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("handler was not cancelled despite base context cancellation")
+	}
+
+	select {
+	case err := <-serverDone:
+		require.ErrorIs(t, err, http.ErrServerClosed)
+	case <-time.After(time.Second):
+		t.Fatal("server did not stop serving")
+	}
+}

--- a/backend/internal/hub/service/oauth_handler.go
+++ b/backend/internal/hub/service/oauth_handler.go
@@ -176,15 +176,12 @@ func (h *OAuthHandler) handleCallback(w http.ResponseWriter, r *http.Request, pr
 	// that bounds every Connect handler -- and the leg it makes is an outbound
 	// call to a third party. golang.org/x/oauth2 runs it on http.DefaultClient
 	// unless the context carries an oauth2.HTTPClient, and http.DefaultClient
-	// has NO timeout, so an identity provider that accepts the connection and
-	// never answers parks this handler forever. That parks a request net/http
-	// counts as ACTIVE, so a shutdown then waits out its entire drain budget
-	// and reports the deadline as a failed shutdown -- the same operator-facing
-	// failure the worker Connect streams used to cause.
-	//
-	// This bounds one leg. Bounding EVERY handler generally -- a shutdown-scoped
-	// http.Server.BaseContext, so no in-flight handler outlives the grace -- is
-	// tracked in https://github.com/leapmux/leapmux/issues/343
+	// has NO timeout, so without this deadline an identity provider that accepts
+	// the connection and never answers parks this handler until the hub shuts
+	// down (the http.Server's shutdown-scoped BaseContext cancels it then, but a
+	// hung IdP during NORMAL operation would otherwise park it for the process's
+	// life). This per-leg deadline bounds exactly that: a slow or wedged IdP
+	// while the hub is healthy.
 	exchangeCtx, cancelExchange := context.WithTimeout(ctx, h.cfg.APITimeout())
 	defer cancelExchange()
 	tokenSet, claims, err := provider.Exchange(exchangeCtx, code, oauthState.PkceVerifier)


### PR DESCRIPTION
## Motivation

The hub's `http.Server` had no `BaseContext`, so handlers attached to arbitrary mux routes (OAuth callback, CLI auth, `/metrics`, `/version`, frontend) derived their request context from something shutdown could not cancel. Existing teardown only bounds what the worker registry knows about — `FenceAll` for per-registry handlers, `authContexts.Stop` for auth, and the shutdown/timeout interceptors — leaving every other mux route unbounded. A handler parked on unbounded outbound I/O (for example, an OAuth callback hitting a wedged IdP before the per-leg deadline existed) could hold `http.Server.Shutdown` against its 10s drain ceiling and surface that as a failed shutdown. Fixes #343.

## Modifications

- Wire a shutdown-scoped `handlerCtx` through `http.Server.BaseContext` in `NewServer`, so cancelling it cascades to `r.Context()` for every in-flight request on both HTTP/1.1 and h2c.
- Drive the cancel from `Serve`'s shutdown goroutine via a `graceTimer` (`handlerGrace = 5s`): short handlers finish naturally, then laggards parked on unbounded I/O are force-cancelled before the drain deadline. The previously hardcoded `10*time.Second` drain is now the named `httpDrainTimeout` constant, with a test asserting `handlerGrace < httpDrainTimeout` so the forced cancel still leaves drain time to observe handlers returning.
- Plumb `cancelHandlers` through the existing `acquiredResources` accumulator (new `cancelHandlers` field), released in `close()`, so a failed `NewServer` cannot leak the cancel.
- Refresh the `Serve` TODO block and the `oauth_handler.go` comment that referenced the open issue.
- Add `server_handler_context_test.go` pinning the timeout-ordering invariant, the construction-failure cleanup path, and the net/http `BaseContext -> r.Context()` cancellation contract.
- `FenceAll`, `authContexts.Stop`, the shutdown/timeout interceptors, and the OAuth per-leg timeout all stay — they carry semantics a blanket cancel does not replace.

## Result

No in-flight handler can now outlive the shutdown drain. A handler parked on unbounded I/O is force-cancelled at the grace deadline instead of holding `Shutdown` to its 10s ceiling, so shutdown completes deterministically regardless of which mux route the request landed on. The change is internal-only: no public API signatures change, and the new constants and field are unexported.

- Closes #343
