### PR TITLE
refactor(watch): Delete the unguarded WatcherManager test surface

### DIFF
--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -93,7 +93,7 @@ func TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning(t *test
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
 		AgentId: "agent-1",
@@ -146,7 +146,7 @@ func TestSendAgentMessage_AutoStartFailureRevertsToInactive(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
 		AgentId: "agent-1",

--- a/backend/internal/worker/service/agent_clear_test.go
+++ b/backend/internal/worker/service/agent_clear_test.go
@@ -104,7 +104,7 @@ func TestSendAgentMessage_SlashClearBroadcastsUserBeforeContextCleared(t *testin
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
 		AgentId: "agent-1",
@@ -166,7 +166,7 @@ func TestSendAgentMessage_SlashClearBroadcastsStartingDuringRestart(t *testing.T
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
 		AgentId: "agent-1",
@@ -244,7 +244,7 @@ func TestSendAgentMessage_SlashClearRestartFailureSkipsContextCleared(t *testing
 		return nil, errors.New("forced restart failure")
 	}
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
 		AgentId: "agent-1",
@@ -293,7 +293,7 @@ func TestSendAgentRawMessage_CodexInterruptPersistsSyntheticUserMarker(t *testin
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-codex", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-codex", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentRawMessage", &leapmuxv1.SendAgentRawMessageRequest{
 		AgentId: "agent-codex",
@@ -343,7 +343,7 @@ func TestSendAgentRawMessage_ClaudeInterruptDoesNotPersistSyntheticUserMarker(t 
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-claude", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-claude", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendAgentRawMessage", &leapmuxv1.SendAgentRawMessageRequest{
 		AgentId: "agent-claude",

--- a/backend/internal/worker/service/agent_delete_message_test.go
+++ b/backend/internal/worker/service/agent_delete_message_test.go
@@ -44,7 +44,7 @@ func TestDeleteAgentMessage_BroadcastsDeletedSeq(t *testing.T) {
 		DeliveryError: "delivery failed", ID: "msg-1", AgentID: "agent-1",
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "DeleteAgentMessage", &leapmuxv1.DeleteAgentMessageRequest{
 		AgentId:   "agent-1",
@@ -114,7 +114,7 @@ func TestDeleteAgentMessage_ReportsNewLatestSeq(t *testing.T) {
 	require.Less(t, seq1, seq2)
 	require.Less(t, seq2, seq3)
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// Delete a NON-tail row (msg-1): the live tail is unchanged (still seq3).
 	dispatch(d, "DeleteAgentMessage", &leapmuxv1.DeleteAgentMessageRequest{AgentId: "agent-1", MessageId: "msg-1"}, w)
@@ -171,7 +171,7 @@ func TestDeleteAgentMessage_RejectsNonFailedUserMessage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	for _, id := range []string{"user-ok", "agent-msg"} {
 		dispatch(d, "DeleteAgentMessage", &leapmuxv1.DeleteAgentMessageRequest{

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -300,7 +300,7 @@ func TestUpdateAgentSettings_BroadcastsGenericExtraSettingChanges(t *testing.T) 
 		Options:      []*leapmuxv1.AvailableOption{{Id: "safe"}, {Id: "fast"}},
 	}})
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId: "agent-1",
@@ -366,7 +366,7 @@ func TestUpdateAgentSettings_CursorModelSwitchOmitsEffortChange(t *testing.T) {
 		Options:       `{"model":"auto"}`,
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId: "agent-1",
@@ -428,7 +428,7 @@ func TestUpdateAgentSettings_ModelSwitchEffortBySupport(t *testing.T) {
 				AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 				Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "xhigh"}),
 			}))
-			svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+			registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 			dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 				AgentId: "agent-1",
@@ -468,7 +468,7 @@ func TestUpdateAgentSettings_UnknownModelKeepsExplicitEffort(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "sonnet", agent.OptionIDEffort: agent.EffortAuto}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// A model the static Claude seed does not list, plus an explicit effort the live catalog would
 	// offer for it. The agent is stopped, so OptionGroups serves the static fallback (no such model).
@@ -516,7 +516,7 @@ func TestUpdateAgentSettings_UnsupportedEffortWithoutModelSwitch(t *testing.T) {
 				AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 				Options:       marshalOptions(map[string]string{agent.OptionIDModel: "sonnet", agent.OptionIDEffort: "medium"}),
 			}))
-			svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+			registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 			// No model in the request: this is NOT a model switch, only an effort edit.
 			dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
@@ -559,7 +559,7 @@ func TestUpdateAgentSettings_InheritedUnsupportedEffortResets(t *testing.T) {
 			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
 		}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// The edit changes ONLY permission mode -- no model, no effort -- so the stale xhigh is
 	// inherited via the merge, not explicitly sent.
@@ -599,7 +599,7 @@ func TestUpdateAgentSettings_EmptyOptionValueIsNoOp(t *testing.T) {
 			agent.CodexOptionSandboxPolicy: agent.CodexSandboxReadOnly,
 		}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId:  "agent-1",
@@ -724,7 +724,7 @@ func TestUpdateAgentSettings_RespelledModelKeepsEffort(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "xhigh"}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// "OPUS[1M]" normalizes to the stored "opus[1m]" -- same model, just a different spelling.
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
@@ -763,7 +763,7 @@ func TestUpdateAgentSettings_AliasedModelKeepsExplicitEffort(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "xhigh"}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// Fully-qualified alias for the SAME model, plus an explicit "max" -- a tier opus[1m]
 	// supports. The alias normalizes to the stored "opus[1m]", so this is not a switch, and
@@ -801,7 +801,7 @@ func TestUpdateAgentSettings_OfflineEffortLabelUsesNewModelCatalog(t *testing.T)
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "opus[1m]", agent.OptionIDEffort: "medium"}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	// Switch to sonnet and to a tier sonnet offers (high), so effort actually changes and the
 	// label must resolve against sonnet's catalog.
@@ -839,7 +839,7 @@ func TestUpdateAgentSettings_DropsForeignSecondaryAxis(t *testing.T) {
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "anthropic/claude-x"}),
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId:  "agent-1",
@@ -892,7 +892,7 @@ func TestUpdateAgentSettings_DropsForeignNonSecondaryAxes(t *testing.T) {
 				AgentProvider: tc.provider,
 				Options:       marshalOptions(map[string]string{agent.OptionIDModel: "auto"}),
 			}))
-			svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+			registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 			dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 				AgentId:  "agent-1",
@@ -924,7 +924,7 @@ func TestUpdateAgentSettings_KeepsKnownProviderExtra(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "gpt-5.5"}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId: "agent-1",
@@ -958,7 +958,7 @@ func TestUpdateAgentSettings_KeepsKnownWellKnownAxis(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "sonnet"}),
 	}))
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId:  "agent-1",
@@ -1036,7 +1036,7 @@ func TestApplySettingsViaRestartBroadcastsConfirmedCatalog(t *testing.T) {
 	restartCalls := 0
 	svc.startAgentFn = mockAgentStarter(t, svc, func(agent.Options) { restartCalls++ })
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: agentID, mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, agentID, leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dbAgent, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
@@ -1632,7 +1632,7 @@ func TestUpdateAgentSettings_BroadcastsGoosePermissionModeLabels(t *testing.T) {
 		}),
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-goose", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-goose", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId: "agent-goose",
@@ -1694,7 +1694,7 @@ func TestNotifyPermissionModeChanged_ResolvesLabels(t *testing.T) {
 		Options:       marshalOptions(map[string]string{agent.OptionIDModel: "auto", agent.OptionIDPermissionMode: "auto"}),
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: "agent-goose", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, "agent-goose", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	sink := svc.Output.NewSink("agent-goose", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE)
 	sink.NotifyPermissionModeChanged("auto", "approve")

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -110,6 +110,18 @@ func newTestWriter() *testResponseWriter {
 	return &testResponseWriter{channelID: testChannelID}
 }
 
+// registerAgentWatch installs sender as a watcher for agentID on channelID in
+// mode, bypassing session ownership. Handler tests use it so broadcasts reach a
+// capture writer; production always registers through SetAgentWatchesForSession.
+func registerAgentWatch(svc *Service, channelID, agentID string, mode leapmuxv1.WatchMode, sender channel.ResponseWriter) {
+	svc.Watchers.agents.setWatches(channelID, []watchEntry{{id: agentID, mode: mode}}, sender)
+}
+
+// registerTerminalWatch is the terminal twin of registerAgentWatch.
+func registerTerminalWatch(svc *Service, channelID, terminalID string, mode leapmuxv1.WatchMode, sender channel.ResponseWriter) {
+	svc.Watchers.terminals.setWatches(channelID, []watchEntry{{id: terminalID, mode: mode}}, sender)
+}
+
 // rejections returns every error the handler reported, in whichever
 // shape it used: a unary InnerRpcResponse error for a unary method, or an
 // InnerStreamMessage carrying IsError for a streaming one.

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -541,7 +541,7 @@ func TestSendControlResponse_BroadcastsCancelBeforeSyntheticMessage(t *testing.T
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
-	svc.Watchers.SetAgentWatches("test-ch", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, "test-ch", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	dispatch(d, "SendControlResponse", &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",
@@ -995,7 +995,7 @@ func TestSendControlResponse_DuplicateAnswerDeletesRequestOnce(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Agents.StopAgent("agent-1")
 
-	svc.Watchers.SetAgentWatches("test-ch", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, "test-ch", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	answer := &leapmuxv1.SendControlResponseRequest{
 		AgentId: "agent-1",

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -1314,7 +1314,7 @@ func TestOpenAgent_BroadcastsRollbackLabelOnStartFailure(t *testing.T) {
 		if err := svc.Queries.CreateAgent(ctx, params); err != nil {
 			return err
 		}
-		svc.Watchers.SetAgentWatches(wWatch.channelID, []watchEntry{{id: params.ID, mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, wWatch)
+		registerAgentWatch(svc, wWatch.channelID, params.ID, leapmuxv1.WatchMode_WATCH_MODE_FULL, wWatch)
 		return nil
 	}
 

--- a/backend/internal/worker/service/output_cleanup_callsites_test.go
+++ b/backend/internal/worker/service/output_cleanup_callsites_test.go
@@ -39,7 +39,7 @@ func seedPendingControlRequest(t *testing.T, ctx context.Context, svc *Service, 
 		Payload:   []byte(`{"jsonrpc":"2.0","id":1,"method":"tool/permission"}`),
 	}))
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: agentID, mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, agentID, leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 	return requestID
 }
 

--- a/backend/internal/worker/service/output_cleanup_test.go
+++ b/backend/internal/worker/service/output_cleanup_test.go
@@ -39,7 +39,7 @@ func TestClearAgentRuntimeState_DeletesPendingAndBroadcastsCancels(t *testing.T)
 	}))
 
 	// Register a watcher so broadcasts have somewhere to go.
-	svc.Watchers.SetAgentWatches("test-ch", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, "test-ch", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	svc.Output.ClearAgentRuntimeState("agent-1")
 
@@ -70,7 +70,7 @@ func TestClearAgentRuntimeState_NoPendingIsNoOp(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	svc.Watchers.SetAgentWatches("test-ch", []watchEntry{{id: "agent-empty", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, "test-ch", "agent-empty", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 
 	svc.Output.ClearAgentRuntimeState("agent-empty")
 

--- a/backend/internal/worker/service/output_git_status_test.go
+++ b/backend/internal/worker/service/output_git_status_test.go
@@ -84,7 +84,7 @@ func newGitStatusFixture(t *testing.T) (*agentOutputSink, *agentEventCapturingWr
 	}))
 
 	mock := &agentEventCapturingWriter{channelID: "ch-1"}
-	svc.Watchers.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	registerAgentWatch(svc, "ch-1", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, mock)
 
 	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE).(*agentOutputSink)
 	return sink, mock

--- a/backend/internal/worker/service/output_reseq_broadcast_test.go
+++ b/backend/internal/worker/service/output_reseq_broadcast_test.go
@@ -72,7 +72,7 @@ func TestNotificationReseqBroadcast_CarriesPreviousSeq(t *testing.T) {
 	}))
 
 	mock := &agentMessageCapturingWriter{channelID: "ch-1"}
-	svc.Watchers.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	registerAgentWatch(svc, "ch-1", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, mock)
 
 	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 	first, err := json.Marshal(map[string]any{"type": "context_cleared"})
@@ -116,7 +116,7 @@ func TestNotificationReseqBroadcast_CarriesMarkType(t *testing.T) {
 	}))
 
 	mock := &agentMessageCapturingWriter{channelID: "ch-1"}
-	svc.Watchers.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	registerAgentWatch(svc, "ch-1", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, mock)
 
 	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 	first, err := json.Marshal(map[string]any{"type": "context_cleared"})

--- a/backend/internal/worker/service/output_session_info_dedup_test.go
+++ b/backend/internal/worker/service/output_session_info_dedup_test.go
@@ -88,7 +88,7 @@ func newSessionInfoFixture(t *testing.T) (agent.OutputSink, *sessionInfoCapturin
 	}))
 
 	mock := &sessionInfoCapturingWriter{channelID: "ch-1"}
-	svc.Watchers.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	registerAgentWatch(svc, "ch-1", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, mock)
 
 	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_PI)
 	return sink, mock

--- a/backend/internal/worker/service/output_settings_refreshed_test.go
+++ b/backend/internal/worker/service/output_settings_refreshed_test.go
@@ -61,7 +61,7 @@ func newRefreshTestFixture(t *testing.T, seed settingsSeed) refreshTestFixture {
 	}))
 
 	mock := newTestWatcher("ch-1")
-	svc.Watchers.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	registerAgentWatch(svc, "ch-1", "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, mock)
 
 	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 	return refreshTestFixture{svc: svc, sink: sink, mock: mock}

--- a/backend/internal/worker/service/output_turn_end_test.go
+++ b/backend/internal/worker/service/output_turn_end_test.go
@@ -62,7 +62,7 @@ func newTurnEndFixture(t *testing.T) (*agentOutputSink, *turnEndCapturingWriter)
 	}))
 
 	mock := &turnEndCapturingWriter{channelID: "ch-turn-end"}
-	svc.Watchers.SetAgentWatches("ch-turn-end", []watchEntry{{id: "agent-turn-end", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	registerAgentWatch(svc, "ch-turn-end", "agent-turn-end", leapmuxv1.WatchMode_WATCH_MODE_NOTIFY, mock)
 
 	sink := svc.Output.NewSink("agent-turn-end", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE).(*agentOutputSink)
 	return sink, mock

--- a/backend/internal/worker/service/output_user_span_lines_test.go
+++ b/backend/internal/worker/service/output_user_span_lines_test.go
@@ -67,7 +67,7 @@ func setupAgentWithWatcher(t *testing.T, svc *Service, w *testResponseWriter, ag
 	require.NoError(t, err)
 	t.Cleanup(func() { svc.Agents.StopAgent(agentID) })
 
-	svc.Watchers.SetAgentWatches(w.channelID, []watchEntry{{id: agentID, mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, w)
+	registerAgentWatch(svc, w.channelID, agentID, leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
 	return sink
 }
 

--- a/backend/internal/worker/service/terminal_signals_test.go
+++ b/backend/internal/worker/service/terminal_signals_test.go
@@ -39,9 +39,7 @@ func dbUpsertTerminalParams(id, workingDir string) db.UpsertTerminalParams {
 func registerTerminalNotifyWatch(t *testing.T, svc *Service, terminalID string) *testResponseWriter {
 	t.Helper()
 	w := newTestWriter()
-	svc.Watchers.SetTerminalWatches("ch-signals", []watchEntry{{
-		id: terminalID, mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY,
-	}}, w)
+	registerTerminalWatch(svc, "ch-signals", terminalID, leapmuxv1.WatchMode_WATCH_MODE_NOTIFY, w)
 	return w
 }
 

--- a/backend/internal/worker/service/watcher.go
+++ b/backend/internal/worker/service/watcher.go
@@ -268,8 +268,8 @@ func modeIsFull(mode leapmuxv1.WatchMode) bool {
 // the entity in FULL mode, so a worker whose tabs are all backgrounded pays
 // neither the snapshot nor the marshal for chat deltas / terminal bytes. This
 // is the single interest gate: callers (e.g. makeTerminalOutputFn) do not need
-// their own HasFullTerminalWatcher check, and adding a new content event does
-// not require remembering to gate it. Marshal is still lazy per-watcher, so a
+// their own FULL-mode check, and adding a new content event does not require
+// remembering to gate it. Marshal is still lazy per-watcher, so a
 // mixed FULL/NOTIFY audience only encodes once the first eligible watcher is
 // reached.
 func (r *watcherRegistry) broadcast(entityID string, resp *leapmuxv1.WatchEventsResponse, class eventClass) {
@@ -363,19 +363,9 @@ func (m *WatcherManager) isOwner(channelID string, sessionID uint64) bool {
 	return m.channelOwners[channelID] == sessionID
 }
 
-// SetAgentWatches makes channelID's agent subscriptions exactly entries.
-//
-// Production routes through SetAgentWatchesForSession (session-scoped, so a
-// cancelled/superseded watchSession cannot re-register). This non-session
-// variant survives as the registry's primitive test surface — see
-// https://github.com/leapmux/leapmux/issues/348 for the retire-or-document
-// decision.
-func (m *WatcherManager) SetAgentWatches(channelID string, entries []watchEntry, sender channel.ResponseWriter) {
-	m.agents.setWatches(channelID, entries, sender)
-}
-
-// SetAgentWatchesForSession is SetAgentWatches gated on session ownership —
-// a cancelled or superseded session cannot re-register after UnwatchAll.
+// SetAgentWatchesForSession makes channelID's agent subscriptions exactly
+// entries, but only if sessionID still owns channelID — a cancelled or
+// superseded watchSession cannot re-register after UnwatchAll.
 func (m *WatcherManager) SetAgentWatchesForSession(channelID string, sessionID uint64, entries []watchEntry, sender channel.ResponseWriter) {
 	if !m.isOwner(channelID, sessionID) {
 		return
@@ -383,15 +373,8 @@ func (m *WatcherManager) SetAgentWatchesForSession(channelID string, sessionID u
 	m.agents.setWatches(channelID, entries, sender)
 }
 
-// SetTerminalWatches makes channelID's terminal subscriptions exactly entries.
-//
-// See SetAgentWatches: production uses SetTerminalWatchesForSession; this
-// variant is the registry's primitive test surface (issue #348).
-func (m *WatcherManager) SetTerminalWatches(channelID string, entries []watchEntry, sender channel.ResponseWriter) {
-	m.terminals.setWatches(channelID, entries, sender)
-}
-
-// SetTerminalWatchesForSession is SetTerminalWatches gated on session ownership.
+// SetTerminalWatchesForSession makes channelID's terminal subscriptions exactly
+// entries, gated on session ownership (see SetAgentWatchesForSession).
 func (m *WatcherManager) SetTerminalWatchesForSession(channelID string, sessionID uint64, entries []watchEntry, sender channel.ResponseWriter) {
 	if !m.isOwner(channelID, sessionID) {
 		return
@@ -432,20 +415,6 @@ func (m *WatcherManager) UnwatchSession(channelID string, sessionID uint64) {
 	m.ownerMu.Unlock()
 	m.agents.unwatchAll(channelID)
 	m.terminals.unwatchAll(channelID)
-}
-
-// HasFullAgentWatcher reports whether any channel watches agentID in FULL mode.
-//
-// Currently unused in production (the terminal path gates on
-// HasFullTerminalWatcher; the agent path relies on broadcast's lazy marshal).
-// Retained as primitive test surface — see issue #348.
-func (m *WatcherManager) HasFullAgentWatcher(agentID string) bool {
-	return m.agents.hasFullWatcher(agentID)
-}
-
-// HasFullTerminalWatcher reports whether any channel watches terminalID in FULL mode.
-func (m *WatcherManager) HasFullTerminalWatcher(terminalID string) bool {
-	return m.terminals.hasFullWatcher(terminalID)
 }
 
 // BroadcastAgentEvent sends an AgentEvent to all watchers of the given agent.

--- a/backend/internal/worker/service/watcher_test.go
+++ b/backend/internal/worker/service/watcher_test.go
@@ -123,7 +123,7 @@ func TestBroadcastTerminalEvent_DeduplicatesWithinPerTerminal(t *testing.T) {
 
 	// Register the same channel 5 times for the same terminal.
 	for i := 0; i < 5; i++ {
-		m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+		m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	}
 
 	m.BroadcastTerminalEvent("term-1", testTerminalEvent("term-1", []byte("a")))
@@ -138,7 +138,7 @@ func TestBroadcastAgentEvent_DeduplicatesWithinWatchers(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 
 	for i := 0; i < 5; i++ {
-		m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+		m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	}
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
@@ -153,8 +153,8 @@ func TestBroadcastTerminalEvent_DistinctWatchersAllReceive(t *testing.T) {
 	mock1 := newTestWatcher("ch-1")
 	mock2 := newTestWatcher("ch-2")
 
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
-	m.SetTerminalWatches("ch-2", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
+	m.terminals.setWatches("ch-2", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
 
 	m.BroadcastTerminalEvent("term-1", testTerminalEvent("term-1", []byte("a")))
 
@@ -173,7 +173,7 @@ func TestWatchTerminal_IdempotentRegistration(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 
 	for i := 0; i < 5; i++ {
-		m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+		m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	}
 
 	assert.Equal(t, 1, m.terminals.count("term-1"))
@@ -191,7 +191,7 @@ func TestWatchAgent_IdempotentRegistration(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 
 	for i := 0; i < 5; i++ {
-		m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+		m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	}
 
 	assert.Equal(t, 1, m.agents.count("agent-1"))
@@ -212,8 +212,8 @@ func TestWatchAgent_ReRegisterReplacesTheSender(t *testing.T) {
 	first := newTestWatcher("ch-1")
 	second := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, first)
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, second)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, first)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, second)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
@@ -228,7 +228,7 @@ func TestAgentEvent_DoesNotReachTerminalWatchers(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 
 	// Only register for terminal events.
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
@@ -242,7 +242,7 @@ func TestTerminalEvent_DoesNotReachAgentWatchers(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 
 	// Only register for agent events.
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.BroadcastTerminalEvent("term-1", testTerminalEvent("term-1", []byte("a")))
 
@@ -255,8 +255,8 @@ func TestUnwatchAll_RemovesFromAllLists(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "term-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "term-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.UnwatchAll("ch-1")
 
@@ -315,11 +315,11 @@ func TestModesForChannel_ReflectsCurrentRegistrations(t *testing.T) {
 
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
-	m.SetAgentWatches("ch-1", []watchEntry{
+	m.agents.setWatches("ch-1", []watchEntry{
 		{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL},
 		{id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY},
 	}, mock)
-	m.SetTerminalWatches("ch-1", []watchEntry{
+	m.terminals.setWatches("ch-1", []watchEntry{
 		{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL},
 	}, mock)
 
@@ -330,7 +330,7 @@ func TestModesForChannel_ReflectsCurrentRegistrations(t *testing.T) {
 	assert.Empty(t, m.AgentModesForChannel("ch-other"))
 
 	// After replace, omitted entities disappear from the snapshot.
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 	agentModes = m.AgentModesForChannel("ch-1")
 	require.Equal(t, leapmuxv1.WatchMode_WATCH_MODE_NOTIFY, agentModes["agent-1"])
 	_, has2 := agentModes["agent-2"]
@@ -361,7 +361,7 @@ func TestBroadcast_DropsWatcherOnSendError(t *testing.T) {
 	mock := newTestWatcher("ch-dead")
 	mock.failSends(errors.New("transport gone"))
 
-	m.SetAgentWatches("ch-dead", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-dead", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	// First broadcast hits the dead sender once.
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
@@ -381,7 +381,7 @@ func TestBroadcast_TerminalDropsWatcherOnSendError(t *testing.T) {
 	mock := newTestWatcher("ch-dead")
 	mock.failSends(errors.New("transport gone"))
 
-	m.SetTerminalWatches("ch-dead", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-dead", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.BroadcastTerminalEvent("term-1", testTerminalEvent("term-1", []byte("a")))
 	assert.Equal(t, int64(1), mock.streamCount.Load())
@@ -400,8 +400,8 @@ func TestBroadcast_DropsOnlyDeadWatcher(t *testing.T) {
 	mockDead.failSends(errors.New("transport gone"))
 	mockLive := newTestWatcher("ch-live")
 
-	m.SetAgentWatches("ch-dead", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDead)
-	m.SetAgentWatches("ch-live", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockLive)
+	m.agents.setWatches("ch-dead", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDead)
+	m.agents.setWatches("ch-live", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockLive)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 	assert.Equal(t, int64(1), mockDead.streamCount.Load())
@@ -428,7 +428,7 @@ func TestBroadcast_KeepsWatcherWhenChannelRejectsOneMessage(t *testing.T) {
 	mock := newTestWatcher("ch-1")
 	mock.failSends(fmt.Errorf("message too large: 99 > 10: %w", channel.ErrMessageRejected))
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
 	assert.Equal(t, 1, m.agents.count("agent-1"),
@@ -450,7 +450,7 @@ func TestBroadcast_TerminalKeepsWatcherWhenChannelRejectsOneMessage(t *testing.T
 	mock := newTestWatcher("ch-1")
 	mock.failSends(fmt.Errorf("message too large: 99 > 10: %w", channel.ErrMessageRejected))
 
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	m.BroadcastTerminalEvent("term-1", testTerminalEvent("term-1", []byte("a")))
 
 	assert.Equal(t, 1, m.terminals.count("term-1"),
@@ -470,14 +470,14 @@ func TestWatcher_ReSubscribeAfterInvalidate(t *testing.T) {
 	// First registration: send fails, watcher gets dropped.
 	mockDead := newTestWatcher("ch-1")
 	mockDead.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDead)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDead)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 	assert.Equal(t, 0, m.agents.count("agent-1"), "precondition: dead watcher should be dropped")
 
 	// Re-subscribe on the same channel ID with a fresh sender.
 	mockAlive := newTestWatcher("ch-1")
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockAlive)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockAlive)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 	assert.Equal(t, int64(1), mockAlive.streamCount.Load(), "re-subscribed watcher should receive broadcasts")
@@ -500,7 +500,7 @@ func TestWatcher_InvalidateScopedToEntity(t *testing.T) {
 	mock := newTestWatcher("ch-multi")
 	mock.failSends(errors.New("transport gone"))
 
-	m.SetAgentWatches("ch-multi", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-multi", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	// First send to agent-1 fails — should drop the agent-1 registration
 	// but leave agent-2's intact (same channel, same sender).
@@ -536,13 +536,13 @@ func TestWatcher_AnotherChannelRegisteringDoesNotDisarmTheSweep(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 	mock.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	// Subscribe the other channel from inside the (unlocked) send loop so
 	// the interleaving is deterministic rather than timing-dependent.
 	other := newTestWatcher("ch-2")
 	registerOther := func() {
-		m.SetAgentWatches("ch-2", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, other)
+		m.agents.setWatches("ch-2", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, other)
 	}
 	mock.onSend.Store(&registerOther)
 
@@ -554,20 +554,20 @@ func TestWatcher_AnotherChannelRegisteringDoesNotDisarmTheSweep(t *testing.T) {
 }
 
 // TestWatcher_TerminalRegistrationDoesNotDisarmTheAgentSweep is the
-// cross-registry twin, and models the real handler shape: WatchEvents
-// calls SetAgentWatches and SetTerminalWatches separately, so an agent
-// broadcast can land between the two. The terminal call must not perturb
-// the agent registration's generation.
+// cross-registry twin, and models the real handler shape: a watchSession
+// calls SetAgentWatchesForSession and SetTerminalWatchesForSession
+// separately, so an agent broadcast can land between the two. The terminal
+// call must not perturb the agent registration's generation.
 func TestWatcher_TerminalRegistrationDoesNotDisarmTheAgentSweep(t *testing.T) {
 	t.Parallel()
 
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 	mock.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	registerTerminal := func() {
-		m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+		m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	}
 	mock.onSend.Store(&registerTerminal)
 
@@ -587,10 +587,10 @@ func TestUnwatchAll_PreservesOtherChannels(t *testing.T) {
 	mock1 := newTestWatcher("ch-1")
 	mock2 := newTestWatcher("ch-2")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
-	m.SetAgentWatches("ch-2", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
-	m.SetTerminalWatches("ch-2", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
+	m.agents.setWatches("ch-2", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock1)
+	m.terminals.setWatches("ch-2", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock2)
 
 	// Unwatch only ch-1.
 	m.UnwatchAll("ch-1")
@@ -621,7 +621,7 @@ func TestWatcher_ResubscribeDuringBroadcastDoesNotRaceSender(t *testing.T) {
 
 	m := NewWatcherManager()
 	firstMock := newTestWatcher("ch-race")
-	m.SetAgentWatches("ch-race", []watchEntry{{id: "agent-race", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, firstMock)
+	m.agents.setWatches("ch-race", []watchEntry{{id: "agent-race", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, firstMock)
 
 	const rounds = 200
 	event := testAgentEvent("agent-race")
@@ -635,7 +635,7 @@ func TestWatcher_ResubscribeDuringBroadcastDoesNotRaceSender(t *testing.T) {
 		for i := 0; i < rounds; i++ {
 			nextMock := newTestWatcher("ch-race")
 			mocks = append(mocks, nextMock)
-			m.SetAgentWatches("ch-race", []watchEntry{{id: "agent-race", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, nextMock)
+			m.agents.setWatches("ch-race", []watchEntry{{id: "agent-race", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, nextMock)
 		}
 	}()
 
@@ -669,11 +669,11 @@ func TestWatcher_FailedSendDoesNotDropAFresherResubscribe(t *testing.T) {
 	m := NewWatcherManager()
 	staleMock := newTestWatcher("ch-1")
 	staleMock.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, staleMock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, staleMock)
 
 	freshMock := newTestWatcher("ch-1")
 	resubscribe := func() {
-		m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, freshMock)
+		m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, freshMock)
 	}
 	staleMock.onSend.Store(&resubscribe)
 
@@ -707,12 +707,12 @@ func TestWatcher_StaleFailureDoesNotDropAReusedChannelID(t *testing.T) {
 	m := NewWatcherManager()
 	staleMock := newTestWatcher("ch-1")
 	staleMock.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, staleMock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, staleMock)
 
 	freshMock := newTestWatcher("ch-1")
 	teardownAndResubscribe := func() {
 		m.UnwatchAll("ch-1")
-		m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, freshMock)
+		m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, freshMock)
 	}
 	staleMock.onSend.Store(&teardownAndResubscribe)
 
@@ -744,9 +744,9 @@ func TestBroadcast_DropsEverySimultaneouslyFailingWatcher(t *testing.T) {
 	mockDeadA.failSends(errors.New("transport gone"))
 	mockDeadB.failSends(errors.New("peer dropped"))
 
-	m.SetAgentWatches("ch-dead-a", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDeadA)
-	m.SetAgentWatches("ch-live", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockLive)
-	m.SetAgentWatches("ch-dead-b", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDeadB)
+	m.agents.setWatches("ch-dead-a", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDeadA)
+	m.agents.setWatches("ch-live", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockLive)
+	m.agents.setWatches("ch-dead-b", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mockDeadB)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
@@ -769,7 +769,7 @@ func TestRetire_RemovesTheEntityEntryWhenItEmpties(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 	mock.failSends(errors.New("transport gone"))
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
@@ -784,8 +784,8 @@ func TestUnwatchAll_RemovesTheEntityEntryWhenItEmpties(t *testing.T) {
 
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	m.UnwatchAll("ch-1")
 
@@ -807,11 +807,11 @@ func TestSetAgentWatches_DropsEntitiesTheNewRequestOmits(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	require.Equal(t, 1, m.agents.count("agent-2"), "precondition: both agents watched")
 
 	// The tab for agent-2 closed; the client re-issues with the rest.
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	assert.Equal(t, 0, m.agents.count("agent-2"), "the omitted agent must be unsubscribed")
 	m.BroadcastAgentEvent("agent-2", testAgentEvent("agent-2"))
@@ -829,8 +829,8 @@ func TestSetTerminalWatches_DropsEntitiesTheNewRequestOmits(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "term-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "term-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.terminals.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	assert.Equal(t, 0, m.terminals.count("term-2"), "the omitted terminal must be unsubscribed")
 	assert.Equal(t, 1, m.terminals.count("term-1"), "the retained terminal stays")
@@ -846,11 +846,11 @@ func TestSetAgentWatches_LeavesOtherChannelsAlone(t *testing.T) {
 	mine := newTestWatcher("ch-1")
 	theirs := newTestWatcher("ch-2")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mine)
-	m.SetAgentWatches("ch-2", []watchEntry{{id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, theirs)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mine)
+	m.agents.setWatches("ch-2", []watchEntry{{id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, theirs)
 
 	// ch-1 drops agent-2; ch-2 still wants it.
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mine)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mine)
 
 	assert.Equal(t, []string{"ch-2"}, m.agents.channelIDs("agent-2"),
 		"pruning one channel must not disturb another channel's subscription")
@@ -868,8 +868,8 @@ func TestSetAgentWatches_EmptySetUnsubscribesEverything(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
-	m.SetAgentWatches("ch-1", nil, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", nil, mock)
 
 	assert.False(t, m.agents.hasEntity("agent-1"), "agent-1 entry must be gone")
 	assert.False(t, m.agents.hasEntity("agent-2"), "agent-2 entry must be gone")
@@ -884,7 +884,7 @@ func TestSetAgentWatches_RepeatedIDRegistersOnce(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}, {id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 
 	assert.Equal(t, 1, m.agents.count("agent-1"))
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
@@ -907,8 +907,8 @@ func TestSetAgentWatches_SecondStreamOnSameChannelReplacesTheFirst(t *testing.T)
 	firstStream := newTestWatcher("ch-1")
 	secondStream := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, firstStream)
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, secondStream)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, firstStream)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-2", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, secondStream)
 
 	assert.False(t, m.agents.hasEntity("agent-1"),
 		"the first stream's exclusive subscription is dropped, silently")
@@ -1068,7 +1068,7 @@ func TestBroadcast_ModeReregisterChangesDelivery(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
 		Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: 1}},
@@ -1076,7 +1076,7 @@ func TestBroadcast_ModeReregisterChangesDelivery(t *testing.T) {
 	assert.Equal(t, int64(0), mock.streamCount.Load(), "NOTIFY skips content")
 
 	// Same channel, same entity, new mode — no extra registration.
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
 	assert.Equal(t, 1, m.agents.count("agent-1"))
 
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
@@ -1085,7 +1085,7 @@ func TestBroadcast_ModeReregisterChangesDelivery(t *testing.T) {
 	})
 	assert.Equal(t, int64(1), mock.streamCount.Load(), "FULL receives content after mode flip")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
 		Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: 3}},
@@ -1099,7 +1099,7 @@ func TestBroadcast_ContentSkippedForNotifyOnlyRegistration(t *testing.T) {
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
@@ -1118,12 +1118,12 @@ func TestBroadcast_ContentSelfGatesWithoutFullWatcher(t *testing.T) {
 	// caller): when no channel holds the entity in FULL, a classContent event
 	// must short-circuit before any snapshot/send — whether the audience is
 	// NOTIFY-only, empty, or a mix. Pin the contract so a new content event
-	// does not need to remember its own HasFull*Watcher guard.
+	// does not need to remember its own FULL-mode guard.
 	t.Run("NOTIFY-only audience skips content", func(t *testing.T) {
 		t.Parallel()
 		m := NewWatcherManager()
 		notify := newTestWatcher("ch-1")
-		m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
+		m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
 		m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 			AgentId: "agent-1",
 			Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: 1}},
@@ -1146,8 +1146,8 @@ func TestBroadcast_ContentSelfGatesWithoutFullWatcher(t *testing.T) {
 		m := NewWatcherManager()
 		notify := newTestWatcher("ch-notify")
 		full := newTestWatcher("ch-full")
-		m.SetAgentWatches("ch-notify", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
-		m.SetAgentWatches("ch-full", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, full)
+		m.agents.setWatches("ch-notify", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
+		m.agents.setWatches("ch-full", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, full)
 		m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 			AgentId: "agent-1",
 			Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: 1}},
@@ -1164,8 +1164,8 @@ func TestBroadcast_NotifyDeliveredToBothModes(t *testing.T) {
 	notify := newTestWatcher("ch-notify")
 	full := newTestWatcher("ch-full")
 
-	m.SetAgentWatches("ch-notify", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
-	m.SetAgentWatches("ch-full", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, full)
+	m.agents.setWatches("ch-notify", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, notify)
+	m.agents.setWatches("ch-full", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, full)
 
 	m.BroadcastAgentEvent("agent-1", testAgentEvent("agent-1"))
 
@@ -1189,7 +1189,7 @@ func TestBroadcast_LazyMarshalSkipsWhenAllNotify(t *testing.T) {
 	m := NewWatcherManager()
 	mock := &payloadCountingWriter{mockResponseWriter: *newTestWatcher("ch-1")}
 
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
@@ -1235,7 +1235,7 @@ func TestBroadcast_MessageDeletedReachesNotifyWatcher(t *testing.T) {
 
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
@@ -1257,7 +1257,7 @@ func TestBroadcast_TodosChangedReachesNotifyWatcher(t *testing.T) {
 
 	m := NewWatcherManager()
 	mock := newTestWatcher("ch-1")
-	m.SetAgentWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	m.agents.setWatches("ch-1", []watchEntry{{id: "agent-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
 
 	m.BroadcastAgentEvent("agent-1", &leapmuxv1.AgentEvent{
 		AgentId: "agent-1",
@@ -1268,18 +1268,18 @@ func TestBroadcast_TodosChangedReachesNotifyWatcher(t *testing.T) {
 	assert.Equal(t, int64(1), mock.streamCount.Load())
 }
 
-func TestHasFullTerminalWatcher(t *testing.T) {
+func TestHasFullWatcher(t *testing.T) {
 	t.Parallel()
 
-	m := NewWatcherManager()
+	r := newWatcherRegistry()
 	mock := newTestWatcher("ch-1")
-	assert.False(t, m.HasFullTerminalWatcher("term-1"))
+	assert.False(t, r.hasFullWatcher("term-1"))
 
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
-	assert.False(t, m.HasFullTerminalWatcher("term-1"))
+	r.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, mock)
+	assert.False(t, r.hasFullWatcher("term-1"))
 
-	m.SetTerminalWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
-	assert.True(t, m.HasFullTerminalWatcher("term-1"))
+	r.setWatches("ch-1", []watchEntry{{id: "term-1", mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}}, mock)
+	assert.True(t, r.hasFullWatcher("term-1"))
 }
 
 func TestEventClassCoversEveryTerminalOneofArm(t *testing.T) {


### PR DESCRIPTION
## Motivation

Closes #348. `WatcherManager` exposed four exported methods (`SetAgentWatches`, `SetTerminalWatches`, `HasFullAgentWatcher`, `HasFullTerminalWatcher`) that were thin forwarders to `watcherRegistry` primitives but **bypassed the `isOwner(channelID, sessionID)` session-ownership guard**. Production code always routes through the session-scoped variants (`SetAgentWatchesForSession` / `SetTerminalWatchesForSession`), which check ownership before mutating so that a cancelled or superseded `watchSession` cannot re-register watches after `UnwatchAll`. The non-session methods had zero production callers — they existed only as a "primitive test surface" — but their presence as exported API was a latent footgun. The issue called for either documenting them or deleting them; this PR deletes them.

## Modifications

- **`watcher.go`**: Deleted `SetAgentWatches`, `SetTerminalWatches`, `HasFullAgentWatcher`, and `HasFullTerminalWatcher` from `WatcherManager`. Updated stale doc comments in `broadcast` (and the surviving session-scoped methods) that referenced the removed symbols.
- **`closed_tab_test.go`**: Added two shared, unexported test helpers — `registerAgentWatch` and `registerTerminalWatch` — that call `svc.Watchers.agents.setWatches` / `svc.Watchers.terminals.setWatches` directly. These intentionally bypass session ownership so handler/broadcast tests can direct a capture writer, while documenting that production always registers through the session-gated API.
- **`terminal_signals_test.go`**: Rewrote `registerTerminalNotifyWatch` to delegate to the new `registerTerminalWatch` helper instead of the deleted `SetTerminalWatches`.
- **`watcher_test.go`**: Mechanical rename of ~70 call sites from the deleted manager forwarders to the underlying registry primitives (`m.agents.setWatches(...)` / `m.terminals.setWatches(...)`). Renamed `TestHasFullTerminalWatcher` to `TestHasFullWatcher` and reworked it to assert against a bare `watcherRegistry`. Fixed stale doc comments referencing the removed `HasFull*Watcher` guards.
- **14 handler test files** (`agent_settings_test.go`, `agent_clear_test.go`, `agent_delete_message_test.go`, `agent_auto_start_test.go`, `control_response_test.go`, `output_cleanup_test.go`, `output_reseq_broadcast_test.go`, and seven others): Uniform 1:1 migration of `svc.Watchers.SetAgentWatches(ch, []watchEntry{...}, w)` to `registerAgentWatch(svc, ch, id, mode, w)`. Argument order preserved; all sites keep `WATCH_MODE_FULL` except `output_turn_end_test.go` which keeps `WATCH_MODE_NOTIFY`.

## Result

The four exported `WatcherManager` methods that bypassed session ownership are gone; `git grep` confirms no remaining references in production or test code. Production behavior is unchanged — no runtime paths were touched. The only way to mutate watches from this point is through the session-gated API, eliminating the footgun identified in #348. Tests retain the same coverage by calling the registry primitives directly (and via the new helpers), rather than through deleted forwarders.
