### PR TITLE
fix(workermgr): Own Connect writes with a handler-drained send queue

### DIFF
--- a/backend/internal/hub/service/channel_close_dispatcher.go
+++ b/backend/internal/hub/service/channel_close_dispatcher.go
@@ -61,15 +61,27 @@ func newWorkerCloseDispatcher(workerMgr workerConnRegistry) *workerCloseDispatch
 // alive. Only the sender goroutine count is bounded. The method name matches the
 // channelCloseEnqueuer interface so this dispatcher satisfies it directly.
 func (d *workerCloseDispatcher) enqueueChannelCloses(closed []channelmgr.ClosedChannel) {
-	d.mu.Lock()
-	// defer, not a trailing Unlock: this body calls out to the registry, and a
-	// panic there with the lock held explicitly would wedge every subsequent
-	// channel teardown rather than failing the one call.
-	defer d.mu.Unlock()
+	// Look up live conns outside d.mu so registry RLock does not nest under
+	// the dispatcher lock under large teardown bursts.
+	live := make([]channelmgr.ClosedChannel, 0, len(closed))
 	for _, cc := range closed {
-		if cc.WorkerID == "" || cc.ChannelID == "" || d.workerMgr.ConnForTrustedPath(cc.WorkerID) == nil {
+		if cc.WorkerID == "" || cc.ChannelID == "" {
 			continue
 		}
+		if d.workerMgr.ConnForTrustedPath(cc.WorkerID) == nil {
+			continue
+		}
+		live = append(live, cc)
+	}
+	if len(live) == 0 {
+		return
+	}
+
+	d.mu.Lock()
+	// defer, not a trailing Unlock: this body appends to pending/ready, and a
+	// panic with the lock held would wedge every subsequent channel teardown.
+	defer d.mu.Unlock()
+	for _, cc := range live {
 		workerPending := d.pending[cc.WorkerID]
 		if workerPending == nil {
 			workerPending = &pendingWorkerCloses{}
@@ -111,9 +123,7 @@ func (d *workerCloseDispatcher) runWorker() {
 		// channelmgr.fanOutTeardown defense. d.mu is released above and
 		// deliverWorkerCloses's own locked sections are panic-free map/slice ops, so
 		// recovery can never resume holding the lock; the loop then continues,
-		// keeping this worker and its slot accounting intact. (The innermost
-		// sendChannelCloseNotification also recovers conn.Send; this widens the
-		// guard from that one call to the whole delivery body.)
+		// keeping this worker and its slot accounting intact.
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -155,22 +165,14 @@ func (d *workerCloseDispatcher) deliverWorkerCloses(workerID string) {
 	d.mu.Unlock()
 }
 
-// sendChannelCloseNotification writes one channel-close notification to a
-// worker, recovering from any panic. Conn.Send already fences on a closed flag
-// -- a send racing worker disconnect returns ErrConnectionClosed rather than
-// writing through a finished HTTP/2 response writer -- so the panic the old
-// inline recover guarded against is structurally prevented. The recover remains
-// as defense in depth because this runs on a detached dispatcher goroutine
-// (runWorker) with no caller to propagate an error to: an unrecovered panic
-// here would crash the whole Hub process instead of dropping one notification.
+// sendChannelCloseNotification enqueues one channel-close control frame.
+// The real write runs on the Connect handler's pump; this call is a pure
+// hub-code enqueue that cannot panic through third-party transport code.
 func sendChannelCloseNotification(conn *workermgr.Conn, channelID string) {
-	defer func() {
-		if r := recover(); r != nil {
-			slog.Error("recovered from panic sending channel close",
-				"channel_id", channelID, "worker_id", conn.WorkerID, "panic", r)
-		}
-	}()
-	_ = conn.Send(newChannelCloseResponse(channelID))
+	if err := conn.SendControl(newChannelCloseResponse(channelID)); err != nil {
+		slog.Warn("failed to enqueue channel close control frame",
+			"channel_id", channelID, "worker_id", conn.WorkerID, "error", err)
+	}
 }
 
 // newChannelCloseResponse builds the worker ConnectResponse that notifies a

--- a/backend/internal/hub/service/channel_close_dispatcher_test.go
+++ b/backend/internal/hub/service/channel_close_dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/channelmgr"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
@@ -19,15 +20,13 @@ func TestWorkerCloseDispatcher_DoesNotDropLargeBatch(t *testing.T) {
 	workerMgr := workermgr.New(workermgr.DenyAllReach())
 	var mu sync.Mutex
 	received := make(map[string]struct{})
-	_, _ = workerMgr.Register(&workermgr.Conn{
-		WorkerID: "worker",
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			mu.Lock()
-			received[msg.GetChannelClose().GetChannelId()] = struct{}{}
-			mu.Unlock()
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, "worker", func(msg *leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		received[msg.GetChannelClose().GetChannelId()] = struct{}{}
+		mu.Unlock()
+		return nil
 	})
+	_, _ = workerMgr.Register(conn)
 	dispatcher := newWorkerCloseDispatcher(workerMgr)
 	closed := make([]channelmgr.ClosedChannel, 300)
 	for i := range closed {
@@ -47,21 +46,4 @@ func TestWorkerCloseDispatcher_DoesNotDropLargeBatch(t *testing.T) {
 	mu.Lock()
 	assert.Len(t, received, len(closed))
 	mu.Unlock()
-}
-
-// A panic in conn.Send must not propagate: deliverWorkerCloses runs on a
-// detached dispatcher goroutine where an unrecovered panic would crash the
-// whole Hub process rather than drop one close notification.
-func TestSendChannelCloseNotification_RecoversFromPanic(t *testing.T) {
-	t.Parallel()
-
-	conn := &workermgr.Conn{
-		WorkerID: "worker",
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			panic("worker stream already finished")
-		},
-	}
-	assert.NotPanics(t, func() {
-		sendChannelCloseNotification(conn, "ch-1")
-	})
 }

--- a/backend/internal/hub/service/channel_service.go
+++ b/backend/internal/hub/service/channel_service.go
@@ -120,7 +120,7 @@ func (s *ChannelService) GetWorkerHandshakeParams(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("worker has no public key"))
 	}
 
-	encMode := conn.EncryptionMode
+	encMode := conn.EncryptionMode()
 	if encMode == leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
 		encMode = leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
 	}

--- a/backend/internal/hub/service/channel_service_delegation_test.go
+++ b/backend/internal/hub/service/channel_service_delegation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
@@ -151,13 +152,10 @@ func openMemoryStore(t *testing.T) store.Store {
 func (e *bearerChannelEnv) captureWorker(t *testing.T, workerID string) (chan *leapmuxv1.ConnectResponse, *workermgr.Conn) {
 	t.Helper()
 	ch := make(chan *leapmuxv1.ConnectResponse, 8)
-	conn := &workermgr.Conn{
-		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			ch <- msg
-			return nil
-		},
-	}
+	conn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		ch <- msg
+		return nil
+	})
 	_, _ = e.workerMgr.Register(conn)
 	return ch, conn
 }

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -130,10 +131,9 @@ func (e *channelTestEnv) createWorkerWithKey(t *testing.T, token string, publicK
 
 func registerOnlineWorker(t *testing.T, env *channelTestEnv, workerID string, mode leapmuxv1.EncryptionMode) {
 	t.Helper()
-	_, _ = env.workerMgr.Register(&workermgr.Conn{
-		WorkerID:       workerID,
-		EncryptionMode: mode,
-	})
+	conn, _ := workermgrtest.NewRecordedConn(t, workerID)
+	conn.SetEncryptionMode(mode)
+	_, _ = env.workerMgr.Register(conn)
 }
 
 func TestGetWorkerHandshakeParams(t *testing.T) {
@@ -279,13 +279,12 @@ func TestOpenChannel_WithMockWorker(t *testing.T) {
 
 	// Simulate worker online by registering a mock connection.
 	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
-	conn := &workermgr.Conn{
-		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentCh <- msg
-			return nil
-		},
-	}
+	conn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		sentCh <- msg
+		return nil
+
+	})
+
 	_, _ = env.workerMgr.Register(conn)
 
 	// OpenChannel should fail with timeout because mock worker doesn't respond.
@@ -306,7 +305,7 @@ func TestOpenChannel_WithMockWorker(t *testing.T) {
 		assert.Equal(t, []byte("handshake-msg-1"), sentMsg.GetChannelOpen().GetHandshakePayload())
 		assert.Equal(t, uint64(channelwire.MaxMessageSize), sentMsg.GetChannelOpen().GetMaxMessageSize(),
 			"hub must announce its resolved max_message_size on ChannelOpenRequest")
-	default:
+	case <-time.After(time.Second):
 		require.Fail(t, "expected a message to be sent to worker")
 	}
 }
@@ -386,13 +385,12 @@ func setupDirectOpenChannelEnv(t *testing.T) *directOpenChannelEnv {
 	cMgr := channelmgr.New(0)
 	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return 100 * time.Millisecond })
 	sent := make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = wMgr.Register(&workermgr.Conn{
-		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sent <- msg
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		sent <- msg
+		return nil
+
 	})
+	_, _ = wMgr.Register(conn)
 	return &directOpenChannelEnv{
 		store:       st,
 		user:        user,
@@ -436,24 +434,23 @@ func TestOpenChannel_ClosesWorkerChannelWhenAuthRevokedDuringHandshake(t *testin
 
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 2)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if msg.GetChannelOpen() != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        msg.GetChannelOpen().GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							MaxMessageSize:   msg.GetChannelOpen().GetMaxMessageSize(),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if msg.GetChannelOpen() != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        msg.GetChannelOpen().GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						MaxMessageSize:   msg.GetChannelOpen().GetMaxMessageSize(),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	checker := &freshnessAfterNCalls{staleAfter: 3}
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, checker)
@@ -489,21 +486,19 @@ func TestOpenChannel_ClosesWorkerChannelWhenAuthRevokedDuringHandshake(t *testin
 	}
 }
 
-func TestOpenChannel_ClosesWorkerChannelWhenOpenSendFails(t *testing.T) {
+func TestOpenChannel_ClosesLocalChannelWhenOpenWriteFails(t *testing.T) {
 	t.Parallel()
 
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 2)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if msg.GetChannelOpen() != nil {
-				return errors.New("worker stream reset")
-			}
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if msg.GetChannelOpen() != nil {
+			return errors.New("worker stream reset")
+		}
+		return nil
 	})
+	_, _ = env.worker.Register(conn)
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
 		ID: userid.MustNew(env.user.ID), Username: env.user.Username,
@@ -518,14 +513,14 @@ func TestOpenChannel_ClosesWorkerChannelWhenOpenSendFails(t *testing.T) {
 
 	open := <-env.sent
 	require.NotNil(t, open.GetChannelOpen())
-	select {
-	case closeMsg := <-env.sent:
-		require.NotNil(t, closeMsg.GetChannelClose())
-		assert.Equal(t, open.GetChannelOpen().GetChannelId(), closeMsg.GetChannelClose().GetChannelId())
-	case <-time.After(time.Second):
-		t.Fatal("failed worker open attempt was not compensated with ChannelClose")
-	}
+	// A write failure fences the conn, so ChannelClose compensation cannot be
+	// delivered on the dead stream. The local channel must still be torn down.
 	assert.False(t, env.channels.Exists(open.GetChannelOpen().GetChannelId()))
+	select {
+	case msg := <-env.sent:
+		t.Fatalf("fenced conn must not deliver further frames, got %T", msg.GetPayload())
+	case <-time.After(50 * time.Millisecond):
+	}
 }
 
 func TestOpenChannel_MapsWorkerErrorCodes(t *testing.T) {
@@ -565,24 +560,23 @@ func TestOpenChannel_MapsWorkerErrorCodes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := setupDirectOpenChannelEnv(t)
 			env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-			_, _ = env.worker.Register(&workermgr.Conn{
-				WorkerID: env.workerID,
-				SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-					env.sent <- msg
-					if open := msg.GetChannelOpen(); open != nil {
-						env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-							Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-								ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-									ChannelId: open.GetChannelId(),
-									Error:     "worker reject: " + tc.name,
-									ErrorCode: tc.code,
-								},
+			conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+				env.sent <- msg
+				if open := msg.GetChannelOpen(); open != nil {
+					env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+						Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+							ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+								ChannelId: open.GetChannelId(),
+								Error:     "worker reject: " + tc.name,
+								ErrorCode: tc.code,
 							},
-						})
-					}
-					return nil
-				},
+						},
+					})
+				}
+				return nil
+
 			})
+			_, _ = env.worker.Register(conn)
 
 			channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 			ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -606,25 +600,24 @@ func TestOpenChannel_RejectsErrorCodeOnlyWithoutErrorString(t *testing.T) {
 	// buggy/hostile worker cannot fall through to the success path.
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							ErrorCode:        leapmuxv1.ChannelOpenErrorCode_CHANNEL_OPEN_ERROR_CODE_CHANNEL_ALREADY_ACTIVE,
-							MaxMessageSize:   uint64(channelwire.MaxMessageSize),
-							HandshakePayload: []byte("should-not-matter"),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						ErrorCode:        leapmuxv1.ChannelOpenErrorCode_CHANNEL_OPEN_ERROR_CODE_CHANNEL_ALREADY_ACTIVE,
+						MaxMessageSize:   uint64(channelwire.MaxMessageSize),
+						HandshakePayload: []byte("should-not-matter"),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -648,24 +641,23 @@ func TestOpenChannel_MapsInvalidMaxMessageSizeErrorCode(t *testing.T) {
 	// Kept as a focused alias of the table above for the original skew case.
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId: open.GetChannelId(),
-							Error:     "invalid hub max_message_size: below floor",
-							ErrorCode: leapmuxv1.ChannelOpenErrorCode_CHANNEL_OPEN_ERROR_CODE_INVALID_MAX_MESSAGE_SIZE,
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId: open.GetChannelId(),
+						Error:     "invalid hub max_message_size: below floor",
+						ErrorCode: leapmuxv1.ChannelOpenErrorCode_CHANNEL_OPEN_ERROR_CODE_INVALID_MAX_MESSAGE_SIZE,
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -687,25 +679,24 @@ func TestOpenChannel_UnspecifiedWorkerErrorStaysInternal(t *testing.T) {
 
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId: open.GetChannelId(),
-							Error:     "handshake failed: corrupt",
-							// ErrorCode unspecified → Internal (retryable-looking
-							// worker fault, not a client config mistake).
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId: open.GetChannelId(),
+						Error:     "handshake failed: corrupt",
+						// ErrorCode unspecified → Internal (retryable-looking
+						// worker fault, not a client config mistake).
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -727,25 +718,24 @@ func TestOpenChannel_RejectsWorkerEchoAboveHubMax(t *testing.T) {
 	hubMax := 1 << 20 // 1 MiB — below the protocol default so an oversize echo is visible
 	env.channels = channelmgr.New(hubMax)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							// Valid by itself, but above what this hub announced.
-							MaxMessageSize: uint64(hubMax * 2),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						// Valid by itself, but above what this hub announced.
+						MaxMessageSize: uint64(hubMax * 2),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -776,24 +766,23 @@ func TestOpenChannel_RejectsWorkerEchoInvalidMaxMessageSize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := setupDirectOpenChannelEnv(t)
 			env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-			_, _ = env.worker.Register(&workermgr.Conn{
-				WorkerID: env.workerID,
-				SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-					env.sent <- msg
-					if open := msg.GetChannelOpen(); open != nil {
-						env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-							Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-								ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-									ChannelId:        open.GetChannelId(),
-									HandshakePayload: []byte("worker-handshake"),
-									MaxMessageSize:   tc.echo,
-								},
+			conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+				env.sent <- msg
+				if open := msg.GetChannelOpen(); open != nil {
+					env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+						Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+							ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+								ChannelId:        open.GetChannelId(),
+								HandshakePayload: []byte("worker-handshake"),
+								MaxMessageSize:   tc.echo,
 							},
-						})
-					}
-					return nil
-				},
+						},
+					})
+				}
+				return nil
+
 			})
+			_, _ = env.worker.Register(conn)
 
 			channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 			ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -823,26 +812,25 @@ func TestOpenChannel_AdoptsWorkerLoweredMaxMessageSize(t *testing.T) {
 	lowered := 100_000
 	env.channels = channelmgr.New(hubMax)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				assert.Equal(t, uint64(hubMax), open.GetMaxMessageSize(),
-					"hub must announce its configured payload budget")
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							MaxMessageSize:   uint64(lowered),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			assert.Equal(t, uint64(hubMax), open.GetMaxMessageSize(),
+				"hub must announce its configured payload budget")
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						MaxMessageSize:   uint64(lowered),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -892,24 +880,23 @@ func TestOpenChannel_ReturnsNegotiatedMaxMessageSize(t *testing.T) {
 
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							MaxMessageSize:   open.GetMaxMessageSize(),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						MaxMessageSize:   open.GetMaxMessageSize(),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -935,25 +922,24 @@ func TestOpenChannel_PropagatesAuthenticatedUserId(t *testing.T) {
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 1)
 	var announcedToWorker string
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				announcedToWorker = open.GetUserId()
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							MaxMessageSize:   open.GetMaxMessageSize(),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			announcedToWorker = open.GetUserId()
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						MaxMessageSize:   open.GetMaxMessageSize(),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -976,24 +962,23 @@ func TestOpenChannel_ClosesWhenCredentialExpires(t *testing.T) {
 
 	env := setupDirectOpenChannelEnv(t)
 	env.sent = make(chan *leapmuxv1.ConnectResponse, 2)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			env.sent <- msg
-			if open := msg.GetChannelOpen(); open != nil {
-				env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
-					Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
-						ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
-							ChannelId:        open.GetChannelId(),
-							HandshakePayload: []byte("worker-handshake"),
-							MaxMessageSize:   open.GetMaxMessageSize(),
-						},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		env.sent <- msg
+		if open := msg.GetChannelOpen(); open != nil {
+			env.pending.Complete(msg.GetRequestId(), &leapmuxv1.ConnectRequest{
+				Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+					ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{
+						ChannelId:        open.GetChannelId(),
+						HandshakePayload: []byte("worker-handshake"),
+						MaxMessageSize:   open.GetMaxMessageSize(),
 					},
-				})
-			}
-			return nil
-		},
+				},
+			})
+		}
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
@@ -1032,14 +1017,13 @@ func TestCloseChannelsByBearer_DoesNotBlockOnWorkerSend(t *testing.T) {
 	env := setupDirectOpenChannelEnv(t)
 	blocked := make(chan struct{})
 	started := make(chan struct{})
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			close(started)
-			<-blocked
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		close(started)
+		<-blocked
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 	t.Cleanup(func() { close(blocked) })
 
 	env.channels.RegisterWithAuthInfo("blocked-close", env.workerID, env.user.ID, channelmgr.AuthInfo{
@@ -1070,28 +1054,26 @@ func TestCloseChannelsByUserRevocation_BlockedWorkerDoesNotStarveHealthyWorker(t
 	env := setupDirectOpenChannelEnv(t)
 	blocked := make(chan struct{})
 	blockedStarted := make(chan struct{}, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: env.workerID,
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			select {
-			case blockedStarted <- struct{}{}:
-			default:
-			}
-			<-blocked
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, env.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		select {
+		case blockedStarted <- struct{}{}:
+		default:
+		}
+		<-blocked
+		return nil
+
 	})
+	_, _ = env.worker.Register(conn)
 	t.Cleanup(func() { close(blocked) })
 
 	healthyWorkerID := id.Generate()
 	healthySent := make(chan *leapmuxv1.ConnectResponse, 1)
-	_, _ = env.worker.Register(&workermgr.Conn{
-		WorkerID: healthyWorkerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			healthySent <- msg
-			return nil
-		},
+	healthyConn := workermgrtest.NewConnWithWrite(t, healthyWorkerID, func(msg *leapmuxv1.ConnectResponse) error {
+		healthySent <- msg
+		return nil
+
 	})
+	_, _ = env.worker.Register(healthyConn)
 
 	for i := 0; i < 8; i++ {
 		env.channels.RegisterWithAuthInfo(id.Generate(), env.workerID, env.user.ID, channelmgr.AuthInfo{}, nil)
@@ -1117,41 +1099,39 @@ func TestCloseChannelsByUserRevocation_BlockedWorkerDoesNotStarveHealthyWorker(t
 	}
 }
 
-func TestCloseChannelsByUserRevocation_BoundsBlockedWorkerSenders(t *testing.T) {
+func TestCloseChannelsByUserRevocation_DoesNotBlockOnParkedWorkerWrites(t *testing.T) {
 	t.Parallel()
 
 	env := setupDirectOpenChannelEnv(t)
 	blocked := make(chan struct{})
-	var active atomic.Int32
-	var peak atomic.Int32
+	var started atomic.Int32
 
 	const workerCount = 20
 	for i := 0; i < workerCount; i++ {
 		workerID := id.Generate()
-		_, _ = env.worker.Register(&workermgr.Conn{
-			WorkerID: workerID,
-			SendFn: func(*leapmuxv1.ConnectResponse) error {
-				current := active.Add(1)
-				for {
-					previous := peak.Load()
-					if current <= previous || peak.CompareAndSwap(previous, current) {
-						break
-					}
-				}
-				<-blocked
-				active.Add(-1)
-				return nil
-			},
+		conn := workermgrtest.NewConnWithWrite(t, workerID, func(*leapmuxv1.ConnectResponse) error {
+			started.Add(1)
+			<-blocked
+			return nil
 		})
+		_, _ = env.worker.Register(conn)
 		env.channels.RegisterWithAuthInfo(id.Generate(), workerID, env.user.ID, channelmgr.AuthInfo{}, nil)
 	}
 	t.Cleanup(func() { close(blocked) })
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
-	assert.Equal(t, workerCount, channelSvc.CloseChannelsByUserRevocation(env.user.ID, 1))
-	require.Eventually(t, func() bool { return peak.Load() > 0 }, time.Second, time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
-	assert.LessOrEqual(t, peak.Load(), int32(4), "blocked worker sends must use a bounded goroutine pool")
+	returned := make(chan int, 1)
+	go func() {
+		returned <- channelSvc.CloseChannelsByUserRevocation(env.user.ID, 1)
+	}()
+	select {
+	case count := <-returned:
+		assert.Equal(t, workerCount, count, "local teardown must finish without waiting for drained writes")
+	case <-time.After(time.Second):
+		require.Fail(t, "revocation teardown blocked behind parked worker writes")
+	}
+	require.Eventually(t, func() bool { return started.Load() > 0 }, time.Second, time.Millisecond,
+		"at least one close frame must still reach a worker drain")
 }
 
 func TestCloseChannel_NotFound(t *testing.T) {
@@ -1291,14 +1271,13 @@ func TestOpenChannel_PostQuantumHandshake(t *testing.T) {
 	workerID := env.createWorkerWithKey(t, token, []byte("key"))
 
 	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
-	conn := &workermgr.Conn{
-		WorkerID:       workerID,
-		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentCh <- msg
-			return nil
-		},
-	}
+	conn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		sentCh <- msg
+		return nil
+
+	})
+	conn.SetEncryptionMode(leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM)
+
 	_, _ = env.workerMgr.Register(conn)
 
 	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -1331,14 +1310,13 @@ func TestOpenChannel_ClassicHandshake(t *testing.T) {
 	workerID := env.createWorkerWithKey(t, token, []byte("key"))
 
 	sentCh := make(chan *leapmuxv1.ConnectResponse, 1)
-	conn := &workermgr.Conn{
-		WorkerID:       workerID,
-		EncryptionMode: leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentCh <- msg
-			return nil
-		},
-	}
+	conn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		sentCh <- msg
+		return nil
+
+	})
+	conn.SetEncryptionMode(leapmuxv1.EncryptionMode_ENCRYPTION_MODE_CLASSIC)
+
 	_, _ = env.workerMgr.Register(conn)
 
 	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)

--- a/backend/internal/hub/service/channel_teardown_test.go
+++ b/backend/internal/hub/service/channel_teardown_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
@@ -141,15 +142,14 @@ func (e *teardownEnv) seedDelegationRow(t *testing.T) (tokenID string) {
 // captureWorker registers a fake online worker that records every
 // ConnectResponse the hub sends; tests assert the ChannelClose
 // notification fires after a delegation revoke.
-func (e *teardownEnv) captureWorker() chan *leapmuxv1.ConnectResponse {
+func (e *teardownEnv) captureWorker(t *testing.T) chan *leapmuxv1.ConnectResponse {
+	t.Helper()
 	ch := make(chan *leapmuxv1.ConnectResponse, 16)
-	_, _ = e.workerMgr.Register(&workermgr.Conn{
-		WorkerID: e.workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			ch <- msg
-			return nil
-		},
+	conn := workermgrtest.NewConnWithWrite(t, e.workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		ch <- msg
+		return nil
 	})
+	_, _ = e.workerMgr.Register(conn)
 	return ch
 }
 
@@ -175,7 +175,7 @@ func TestWorkerDelegationRevoke_TearsDownOpenChannels(t *testing.T) {
 	}, nil)
 	require.True(t, env.channelMgr.Exists(channelID))
 
-	workerSent := env.captureWorker()
+	workerSent := env.captureWorker(t)
 
 	// Hit the revoke endpoint as the worker that minted the bearer.
 	req, err := http.NewRequest(http.MethodPost, env.revokeURL, nil)
@@ -225,7 +225,7 @@ func TestWorkerDelegationRevoke_LeavesOtherChannelsUntouched(t *testing.T) {
 	}, nil)
 	env.channelMgr.RegisterWithAuthInfo(cookieCh, env.workerID, env.userID, channelmgr.AuthInfo{}, nil)
 
-	env.captureWorker()
+	env.captureWorker(t)
 
 	req, _ := http.NewRequest(http.MethodPost, env.revokeURL, nil)
 	req.Header.Set("Authorization", "Bearer "+env.workerAuthTok)
@@ -273,24 +273,20 @@ func TestChannelService_CloseChannelsByUserRevocationNotifiesWorkers(t *testing.
 
 	closesA := make(chan *leapmuxv1.ConnectResponse, 4)
 	closesB := make(chan *leapmuxv1.ConnectResponse, 4)
-	_, _ = env.workerMgr.Register(&workermgr.Conn{
-		WorkerID: workerA,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			if msg.GetChannelClose() != nil {
-				closesA <- msg
-			}
-			return nil
-		},
+	connA := workermgrtest.NewConnWithWrite(t, workerA, func(msg *leapmuxv1.ConnectResponse) error {
+		if msg.GetChannelClose() != nil {
+			closesA <- msg
+		}
+		return nil
 	})
-	_, _ = env.workerMgr.Register(&workermgr.Conn{
-		WorkerID: workerB,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			if msg.GetChannelClose() != nil {
-				closesB <- msg
-			}
-			return nil
-		},
+	_, _ = env.workerMgr.Register(connA)
+	connB := workermgrtest.NewConnWithWrite(t, workerB, func(msg *leapmuxv1.ConnectResponse) error {
+		if msg.GetChannelClose() != nil {
+			closesB <- msg
+		}
+		return nil
 	})
+	_, _ = env.workerMgr.Register(connB)
 
 	closed := env.channelSvc.CloseChannelsByUserRevocation(env.userID, 1)
 	assert.Equal(t, 2, closed, "both of the user's channels should be torn down")

--- a/backend/internal/hub/service/reconcile_nudger.go
+++ b/backend/internal/hub/service/reconcile_nudger.go
@@ -47,7 +47,7 @@ func (n *ReconcileNudger) NudgeReconcile(workerID string) {
 	if conn == nil {
 		return
 	}
-	err := conn.Send(&leapmuxv1.ConnectResponse{
+	err := conn.SendControl(&leapmuxv1.ConnectResponse{
 		Payload: &leapmuxv1.ConnectResponse_ReconcileNudge{
 			ReconcileNudge: &leapmuxv1.ReconcileNudge{},
 		},

--- a/backend/internal/hub/service/worker_channel_relay_test.go
+++ b/backend/internal/hub/service/worker_channel_relay_test.go
@@ -2,14 +2,16 @@ package service
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/channelmgr"
-	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 )
 
 func TestProcessWorkerMessage_RoutingFailureClosesChannelAndChunkState(t *testing.T) {
@@ -17,11 +19,14 @@ func TestProcessWorkerMessage_RoutingFailureClosesChannelAndChunkState(t *testin
 
 	channels := channelmgr.New(0)
 	channels.RegisterWithAuthInfo("channel", "worker", "user", channelmgr.AuthInfo{}, nil)
+	var mu sync.Mutex
 	var sent []*leapmuxv1.ConnectResponse
-	conn := &workermgr.Conn{WorkerID: "worker", SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+	conn := workermgrtest.NewConnWithWrite(t, "worker", func(msg *leapmuxv1.ConnectResponse) error {
+		mu.Lock()
 		sent = append(sent, msg)
+		mu.Unlock()
 		return nil
-	}}
+	})
 	svc := &WorkerConnectorService{channelMgr: channels}
 
 	err := svc.processWorkerMessage(context.Background(), conn, "worker", "user", &leapmuxv1.ConnectRequest{
@@ -37,7 +42,13 @@ func TestProcessWorkerMessage_RoutingFailureClosesChannelAndChunkState(t *testin
 
 	require.NoError(t, err)
 	assert.False(t, channels.Exists("channel"))
-	require.Len(t, sent, 1)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(sent) == 1
+	}, time.Second, 5*time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Equal(t, "channel", sent[0].GetChannelClose().GetChannelId())
 	require.NoError(t, channels.ChunkTracker.Track("channel", "w2fe", 2, 32, true),
 		"terminal close must remove the previous in-flight chunk sequence")
@@ -48,10 +59,10 @@ func TestProcessWorkerMessage_RejectsChannelOwnedByAnotherWorker(t *testing.T) {
 
 	channels := channelmgr.New(0)
 	channels.RegisterWithAuthInfo("channel", "owner", "user", channelmgr.AuthInfo{}, nil)
-	conn := &workermgr.Conn{WorkerID: "attacker", SendFn: func(*leapmuxv1.ConnectResponse) error {
+	conn := workermgrtest.NewConnWithWrite(t, "attacker", func(*leapmuxv1.ConnectResponse) error {
 		t.Fatal("attacking worker must not receive a close for another worker's channel")
 		return nil
-	}}
+	})
 	svc := &WorkerConnectorService{channelMgr: channels}
 
 	err := svc.processWorkerMessage(context.Background(), conn, "attacker", "user", &leapmuxv1.ConnectRequest{

--- a/backend/internal/hub/service/worker_connector_service.go
+++ b/backend/internal/hub/service/worker_connector_service.go
@@ -177,25 +177,23 @@ func (s *WorkerConnectorService) Connect(
 	// the newly connected worker.
 	connCtx, cancelConn := context.WithCancel(ctx)
 	defer cancelConn()
-	conn := &workermgr.Conn{
-		WorkerID: worker.ID,
-		Stream:   stream,
-		Cancel:   cancelConn,
-		// Greet the worker with its own identity. Register sends this before it
-		// publishes the conn, so it lands before any ChannelOpen this connection could
-		// carry -- which the worker needs, because requireWorkerOwner gates every
-		// machine-scoped family on the owner and a session can exist the moment the
-		// conn is reachable. Handing it to Register rather than sending it here is what
-		// makes that ordering impossible to get wrong.
+	conn, pump := workermgr.NewConn(connCtx, cancelConn, worker.ID, stream.Send,
+		// Greet the worker with its own identity. Register enqueues this before
+		// it publishes the conn, so with a single handler drain it is
+		// mechanically the first frame written -- which the worker needs,
+		// because requireWorkerOwner gates every machine-scoped family on the
+		// owner and a session can exist the moment the conn is reachable.
+		// Handing it to Register rather than sending it here is what makes
+		// that ordering impossible to get wrong.
 		//
-		// worker.RegisteredBy is already in hand from the GetByAuthToken above, so this
-		// costs no query.
-		Greeting: &leapmuxv1.ConnectResponse{
+		// worker.RegisteredBy is already in hand from the GetByAuthToken above,
+		// so this costs no query.
+		&leapmuxv1.ConnectResponse{
 			Payload: &leapmuxv1.ConnectResponse_WorkerIdentity{
 				WorkerIdentity: &leapmuxv1.WorkerIdentity{RegisteredBy: worker.RegisteredBy},
 			},
 		},
-	}
+	)
 	replaced, err := s.workerMgr.Register(conn)
 	if err != nil {
 		if errors.Is(err, workermgr.ErrRegistryFenced) {
@@ -219,11 +217,18 @@ func (s *WorkerConnectorService) Connect(
 		s.cleanupWorker(worker.ID)
 	}
 	ctx = connCtx
+	// Teardown order is deliberate and lives in ONE defer so it cannot drift
+	// via LIFO comment mistakes:
+	//  1. Unregister removes the conn from the registry (no new Hub sends).
+	//  2. Drain writes every remaining frame while this handler still owns
+	//     the stream (write-after-finish proof).
+	//  3. Fence closes the queue and cancels Done.
+	//  4. cleanupWorker only if we were still the registered conn.
 	defer func() {
-		// Only run cleanup if this connection is still the registered one.
-		// A newer worker process may have already replaced it, in which
-		// case we must not unregister the replacement or close its agents.
-		if s.workerMgr.Unregister(worker.ID, conn) {
+		removed := s.workerMgr.Unregister(worker.ID, conn)
+		_ = pump.Drain()
+		conn.Fence()
+		if removed {
 			s.cleanupWorker(worker.ID)
 		}
 	}()
@@ -236,17 +241,23 @@ func (s *WorkerConnectorService) Connect(
 	slog.Info("worker connected", "worker_id", worker.ID, "status", worker.Status)
 	defer slog.Info("worker disconnected", "worker_id", worker.ID)
 
-	// Process pending notifications.
+	// Process pending notifications. A deregistering worker used to early-
+	// return after the inline ProcessPendingNotifications call, before the
+	// receive goroutine and main loop. Under enqueue semantics nothing drains
+	// that path, so the deregister instruction would reach the wire only via
+	// the final Drain defer -- racing stream teardown -- and pending.Complete
+	// (which only runs from the loop) could never fire, so MarkDeleted /
+	// ClearDeregistering never ran on the ack path. Both cases now run through
+	// the main loop, which drains and routes acks.
+	var notifyDone chan struct{} // nil for a normal worker: a nil select case blocks forever
 	if s.notifier != nil {
 		if worker.Status == leapmuxv1.WorkerStatus_WORKER_STATUS_DEREGISTERING {
-			// Worker is being deregistered — process notifications inline, then close.
-			if err := s.notifier.ProcessPendingNotifications(ctx, worker.ID); err != nil {
-				slog.Error("failed to process pending notifications (deregistering)", "worker_id", worker.ID, "error", err)
-			}
-			return nil
+			notifyDone = make(chan struct{})
 		}
-		// Normal worker: process pending notifications in background.
 		go func() {
+			if notifyDone != nil {
+				defer close(notifyDone)
+			}
 			if err := s.notifier.ProcessPendingNotifications(ctx, worker.ID); err != nil {
 				slog.Error("failed to process pending notifications", "worker_id", worker.ID, "error", err)
 			}
@@ -278,11 +289,21 @@ func (s *WorkerConnectorService) Connect(
 	const workerIdleTimeout = 10 * time.Second
 	idleTimer := time.NewTimer(workerIdleTimeout)
 	defer idleTimer.Stop()
+	// Deregistering workers must not compete with the receive-idle timer:
+	// ProcessPendingNotifications parks in SendAndWait and a quiet worker
+	// would otherwise be torn down mid-ack. Nil select case blocks forever.
+	var idleC <-chan time.Time
+	if notifyDone == nil {
+		idleC = idleTimer.C
+	}
 
 	// resetIdle stops + drains + re-arms the idle timer. Folded into a
 	// helper so every successful receive (both branches) reuses one
 	// implementation instead of repeating the drain dance.
 	resetIdle := func() {
+		if notifyDone != nil {
+			return
+		}
 		if !idleTimer.Stop() {
 			select {
 			case <-idleTimer.C:
@@ -313,7 +334,7 @@ func (s *WorkerConnectorService) Connect(
 				return err
 			}
 
-		case <-idleTimer.C:
+		case <-idleC:
 			// A message may have arrived at the same instant the timer
 			// fired. Go's select picks randomly among ready cases, so
 			// drain msgCh before deciding to disconnect.
@@ -329,6 +350,17 @@ func (s *WorkerConnectorService) Connect(
 			default:
 			}
 			slog.Warn("worker idle timeout, assuming disconnected", "worker_id", worker.ID)
+			return nil
+
+		case <-pump.Ready():
+			// Bounded turn so a large outbound backlog yields to receives /
+			// idle / ctx. Remaining frames re-signal Ready. Teardown uses
+			// the full Drain in the defer above.
+			if err := pump.DrainTurn(); err != nil {
+				return nil // give-up already fenced + cancelled
+			}
+
+		case <-notifyDone:
 			return nil
 
 		case <-ctx.Done():
@@ -363,14 +395,14 @@ func (s *WorkerConnectorService) processWorkerMessage(
 		// Cache encryption mode on the live connection (not persisted to DB).
 		encMode := hb.GetEncryptionMode()
 		if encMode == leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
-			if conn.EncryptionMode != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
+			if conn.EncryptionMode() != leapmuxv1.EncryptionMode_ENCRYPTION_MODE_UNSPECIFIED {
 				// The worker already declared a mode; sending UNSPECIFIED
 				// afterwards is a bug — reject the connection.
-				return fmt.Errorf("worker sent unspecified encryption mode after previously declaring %v", conn.EncryptionMode)
+				return fmt.Errorf("worker sent unspecified encryption mode after previously declaring %v", conn.EncryptionMode())
 			}
 			encMode = leapmuxv1.EncryptionMode_ENCRYPTION_MODE_POST_QUANTUM
 		}
-		conn.EncryptionMode = encMode
+		conn.SetEncryptionMode(encMode)
 		// Persist worker's public keys if provided (sent with the initial heartbeat).
 		if pk := hb.GetPublicKey(); len(pk) > 0 {
 			mlkemPK := hb.GetMlkemPublicKey()
@@ -390,9 +422,8 @@ func (s *WorkerConnectorService) processWorkerMessage(
 				slog.Warn("failed to update worker public key", "worker_id", workerID, "error", err)
 			}
 		}
-		// Send heartbeat response via conn.Send() to serialize with
-		// other writes (e.g. channel relay) on the same bidi stream.
-		if err := conn.Send(&leapmuxv1.ConnectResponse{
+		// Heartbeat is a must-deliver control frame.
+		if err := conn.SendControl(&leapmuxv1.ConnectResponse{
 			Payload: &leapmuxv1.ConnectResponse_Heartbeat{
 				Heartbeat: &leapmuxv1.Heartbeat{},
 			},
@@ -477,7 +508,7 @@ func (s *WorkerConnectorService) closeWorkerChannel(conn *workermgr.Conn, worker
 	if len(closed) == 0 {
 		return
 	}
-	if err := conn.Send(newChannelCloseResponse(channelID)); err != nil {
+	if err := conn.SendControl(newChannelCloseResponse(channelID)); err != nil {
 		slog.Debug("failed to close terminal worker channel",
 			"worker_id", workerID, "channel_id", channelID, "error", err)
 	}
@@ -633,7 +664,7 @@ func (s *WorkerConnectorService) handleWorkspaceTabsSync(
 	// Always send a response even when both lists are empty so the
 	// worker can rely on the round-trip to mark its initial sync
 	// complete.
-	if err := conn.Send(&leapmuxv1.ConnectResponse{
+	if err := conn.SendControl(&leapmuxv1.ConnectResponse{
 		RequestId: requestID,
 		Payload: &leapmuxv1.ConnectResponse_WorkerTabInventoryResp{
 			WorkerTabInventoryResp: resp,

--- a/backend/internal/hub/service/worker_connector_service_internal_test.go
+++ b/backend/internal/hub/service/worker_connector_service_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
-	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
@@ -155,14 +156,14 @@ func TestHandleWorkspaceTabsSync_TombstonesOnlyTheRegistrant(t *testing.T) {
 	reg := newRecordingRegistry(t, journal)
 	svc := NewWorkerConnectorService(st, nil, nil, nil, nil, nil, reg, nil)
 
+	var mu sync.Mutex
 	var sent []*leapmuxv1.ConnectResponse
-	conn := &workermgr.Conn{
-		WorkerID: "w1",
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sent = append(sent, msg)
-			return nil
-		},
-	}
+	conn := workermgrtest.NewConnWithWrite(t, "w1", func(msg *leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		sent = append(sent, msg)
+		mu.Unlock()
+		return nil
+	})
 
 	// Empty worker report: the worker hosts nothing, so every row the hub
 	// listed for this registrant is stale.
@@ -173,7 +174,11 @@ func TestHandleWorkspaceTabsSync_TombstonesOnlyTheRegistrant(t *testing.T) {
 	assert.Equal(t, []string{"tab-a"}, journal.tombstonedTabs(userA.ID))
 	assert.Empty(t, journal.tombstonedTabs(userB.ID),
 		"a row owned by someone other than the registrant is out of scope entirely")
-	assert.Len(t, sent, 1, "the worker must still get its sync response")
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(sent) == 1
+	}, time.Second, time.Millisecond, "the worker must still get its sync response")
 
 	// Batch ids must stay unique per submit within one sync, otherwise a
 	// second batch would dedup against the first.
@@ -200,17 +205,18 @@ func TestHandleWorkspaceTabsSync_ManagerGetFailureStillResponds(t *testing.T) {
 	reg.failFor = userA.ID
 	svc := NewWorkerConnectorService(st, nil, nil, nil, nil, nil, reg, nil)
 
-	sent := 0
-	conn := &workermgr.Conn{
-		WorkerID: "w1",
-		SendFn:   func(*leapmuxv1.ConnectResponse) error { sent++; return nil },
-	}
+	var sent atomic.Int32
+	conn := workermgrtest.NewConnWithWrite(t, "w1", func(*leapmuxv1.ConnectResponse) error {
+		sent.Add(1)
+		return nil
+	})
 
 	svc.handleWorkspaceTabsSync(context.Background(), conn, "w1", userA.ID, "req-1", &leapmuxv1.WorkerTabInventory{})
 
 	assert.Equal(t, []string{userA.ID}, reg.seen())
 	assert.Empty(t, journal.tombstonedTabs(userA.ID), "nothing commits when the manager cannot be resolved")
-	assert.Equal(t, 1, sent, "the worker still gets its sync response")
+	require.Eventually(t, func() bool { return sent.Load() == 1 }, time.Second, time.Millisecond,
+		"the worker still gets its sync response")
 }
 
 // TestHandleWorkspaceTabsSync_ForeignOwnerTabIDCollisionIsInvisible pins what
@@ -232,11 +238,14 @@ func TestHandleWorkspaceTabsSync_ForeignOwnerTabIDCollisionIsInvisible(t *testin
 
 	journal := newTabSyncJournal()
 	svc := NewWorkerConnectorService(st, nil, nil, nil, nil, nil, newRecordingRegistry(t, journal), nil)
+	var mu sync.Mutex
 	var sent []*leapmuxv1.ConnectResponse
-	conn := &workermgr.Conn{WorkerID: "w1", SendFn: func(msg *leapmuxv1.ConnectResponse) error {
+	conn := workermgrtest.NewConnWithWrite(t, "w1", func(msg *leapmuxv1.ConnectResponse) error {
+		mu.Lock()
 		sent = append(sent, msg)
+		mu.Unlock()
 		return nil
-	}}
+	})
 
 	// The worker hosts the tab, in alice's workspace, exactly as her row says.
 	svc.handleWorkspaceTabsSync(context.Background(), conn, "w1", userA.ID, "req-1", &leapmuxv1.WorkerTabInventory{
@@ -245,8 +254,14 @@ func TestHandleWorkspaceTabsSync_ForeignOwnerTabIDCollisionIsInvisible(t *testin
 		},
 	})
 
-	require.Len(t, sent, 1)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(sent) == 1
+	}, time.Second, time.Millisecond)
+	mu.Lock()
 	require.NotNil(t, sent[0].GetWorkerTabInventoryResp(), "the sync is acknowledged")
+	mu.Unlock()
 	// The tombstone journal is now the only observable: the response carries no
 	// per-tab classification (see WorkerTabInventoryResponse). Alice's tab
 	// matched her own row, so nothing of hers is stale -- and Bob's
@@ -270,7 +285,10 @@ func TestHandleWorkspaceTabsSync_BlankRegistrantIsRefused(t *testing.T) {
 	journal := newTabSyncJournal()
 	svc := NewWorkerConnectorService(st, nil, nil, nil, nil, nil, newRecordingRegistry(t, journal), nil)
 	sent := 0
-	conn := &workermgr.Conn{WorkerID: "w1", SendFn: func(*leapmuxv1.ConnectResponse) error { sent++; return nil }}
+	conn := workermgrtest.NewConnWithWrite(t, "w1", func(msg *leapmuxv1.ConnectResponse) error {
+		sent++
+		return nil
+	})
 
 	svc.handleWorkspaceTabsSync(context.Background(), conn, "w1", "", "req-1", &leapmuxv1.WorkerTabInventory{
 		Tabs: []*leapmuxv1.TabRef{

--- a/backend/internal/hub/service/ws_channel_relay.go
+++ b/backend/internal/hub/service/ws_channel_relay.go
@@ -268,6 +268,9 @@ func (h *ChannelRelayHandler) relayFrontendMessageToWorker(info channelmgr.Chann
 			ChannelMessage: msg,
 		},
 	}); err != nil {
+		// Over-budget on the data path fences the worker connection. Unlike
+		// the frontend relay there is no documented replay for this
+		// direction; recovery is the frontend reopening the channel.
 		slog.Debug("channel relay: failed to relay to worker",
 			"channel_id", channelID, "error", err)
 		return errTerminalChannelRelay

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
+	"github.com/leapmux/leapmux/internal/hub/workermgr/workermgrtest"
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
@@ -486,13 +488,11 @@ func TestChannelRelay_DelegationCannotAttachUnscopedChannel(t *testing.T) {
 	}, nil)
 
 	workerMsgs := make(chan *leapmuxv1.ConnectResponse, 4)
-	_, _ = wm.Register(&workermgr.Conn{
-		WorkerID: workerID,
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			workerMsgs <- msg
-			return nil
-		},
+	wconn := workermgrtest.NewConnWithWrite(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+		workerMsgs <- msg
+		return nil
 	})
+	_, _ = wm.Register(wconn)
 
 	srv := httptest.NewServer(NewChannelRelayHandler(st, wm, cm, newTestAuthContexts(t), nil, false).WithTokenValidator(tv))
 	t.Cleanup(srv.Close)
@@ -559,25 +559,35 @@ func TestRelayFrontendMessageToWorker(t *testing.T) {
 
 	t.Run("live worker receives the wrapped ciphertext", func(t *testing.T) {
 		wm := workermgr.New(workermgr.DenyAllReach())
+		var mu sync.Mutex
 		var got []*leapmuxv1.ConnectResponse
-		_, _ = wm.Register(&workermgr.Conn{WorkerID: "w1", SendFn: func(m *leapmuxv1.ConnectResponse) error {
+		conn := workermgrtest.NewConnWithWrite(t, "w1", func(m *leapmuxv1.ConnectResponse) error {
+			mu.Lock()
 			got = append(got, m)
+			mu.Unlock()
 			return nil
-		}})
+		})
+		_, _ = wm.Register(conn)
 		h := &ChannelRelayHandler{workerMgr: wm, channelMgr: channelmgr.New(0)}
 		err := h.relayFrontendMessageToWorker(
 			channelmgr.ChannelInfo{ChannelID: "ch", WorkerID: "w1"}, msg("ch"))
 		require.NoError(t, err)
-		require.Len(t, got, 1)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(got) == 1
+		}, time.Second, 5*time.Millisecond)
+		mu.Lock()
+		defer mu.Unlock()
 		assert.Equal(t, "ch", got[0].GetChannelMessage().GetChannelId())
 		assert.Equal(t, []byte("ct"), got[0].GetChannelMessage().GetCiphertext())
 	})
 
-	t.Run("broken worker stream is terminal", func(t *testing.T) {
+	t.Run("fenced worker stream is terminal", func(t *testing.T) {
 		wm := workermgr.New(workermgr.DenyAllReach())
-		_, _ = wm.Register(&workermgr.Conn{WorkerID: "w1", SendFn: func(*leapmuxv1.ConnectResponse) error {
-			return errors.New("stream closed")
-		}})
+		conn, _ := workermgrtest.NewRecordedConn(t, "w1")
+		_, _ = wm.Register(conn)
+		conn.Fence()
 		h := &ChannelRelayHandler{workerMgr: wm, channelMgr: channelmgr.New(0)}
 		err := h.relayFrontendMessageToWorker(
 			channelmgr.ChannelInfo{ChannelID: "ch", WorkerID: "w1"}, msg("ch"))

--- a/backend/internal/hub/workermgr/conn.go
+++ b/backend/internal/hub/workermgr/conn.go
@@ -1,0 +1,238 @@
+package workermgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/sendq"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// Queue bounds are sendq.Default* so Hub and worker stay on one definition
+	// (see https://github.com/leapmux/leapmux/issues/313 for the aggregate
+	// cap). A wall-clock stall cutoff on a server-to-server link invites a
+	// reconnect storm under sustained load, so there is none -- the byte
+	// budget alone disconnects a worker that cannot keep up.
+
+	// connDrainMaxFrames / connDrainMaxDuration bound one Connect-select Drain
+	// turn so a large outbound backlog cannot starve receives, idle, or
+	// ctx.Done. The deferred full Drain on teardown still empties the queue.
+	connDrainMaxFrames   = 32
+	connDrainMaxDuration = 5 * time.Millisecond
+)
+
+// ErrConnectionClosed is returned when a sender races worker disconnect.
+var ErrConnectionClosed = errors.New("worker connection closed")
+
+// ErrControlSaturated is returned when SendControl cannot enqueue because the
+// byte budget (including the control reserve) is full. Distinct from
+// ErrConnectionClosed so callers can retry or re-queue without treating the
+// worker as offline.
+var ErrControlSaturated = errors.New("worker connection control queue saturated")
+
+// Conn represents a connected worker's bidirectional stream. Sends enqueue
+// onto a handler-drained queue; the Connect handler alone holds the matching
+// SendPump and is the only goroutine that ever writes.
+type Conn struct {
+	WorkerID string
+	// Greeting, when non-nil at Register, is enqueued before the connection is
+	// published -- at the head of the queue, with a single handler drain, so
+	// it is mechanically the first frame written. Register clears it after a
+	// successful enqueue so the live Conn does not retain a second copy.
+	Greeting *leapmuxv1.ConnectResponse
+
+	ctx        context.Context
+	cancel     context.CancelFunc
+	cancelOnce sync.Once
+	q          *sendq.Writer[*leapmuxv1.ConnectResponse]
+
+	encryptionMode atomic.Int32
+}
+
+// SendPump is the Connect handler's exclusive write capability. The registry
+// hands out *Conn, which has no drain method; only the handler holds the
+// pump. Sole ownership of the transport write is therefore unforgeable rather
+// than a documentation comment -- across package boundaries. Same-package
+// tests must keep the pump returned by NewConn rather than reconstructing one.
+type SendPump struct{ c *Conn }
+
+// Ready returns the queue's wake channel. The handler selects on it and calls
+// DrainTurn (or Drain on teardown). Exactly one goroutine may consume it.
+func (p *SendPump) Ready() <-chan struct{} { return p.c.q.Wake() }
+
+// DrainTurn writes up to a bounded batch of queued frames and returns so the
+// Connect select can service receives. Remaining frames re-signal Ready.
+func (p *SendPump) DrainTurn() (err error) {
+	return p.drain(sendq.DrainLimits{
+		MaxFrames:   connDrainMaxFrames,
+		MaxDuration: connDrainMaxDuration,
+	})
+}
+
+// Drain pops and writes every currently queued frame. Returns a non-nil error
+// once the queue has given up (write failure or watchdog); give-up already
+// fenced and cancelled the conn. Used on Connect teardown after the conn is
+// removed from the registry, so the final flush cannot race new enqueues.
+//
+// A panicking Write is recovered here so it cannot escape the handler's drain
+// select into an unrecovered crash of the Hub process. Concurrent Drain
+// panics are re-raised: they are ownership bugs, not transport failures.
+func (p *SendPump) Drain() (err error) {
+	return p.drain(sendq.DrainLimits{})
+}
+
+func (p *SendPump) drain(lim sendq.DrainLimits) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if sendq.IsConcurrentDrainPanic(r) {
+				panic(r)
+			}
+			slog.Error("recovered from panic draining worker connect stream",
+				"worker_id", p.c.WorkerID, "panic", r)
+			p.c.Fence()
+			err = fmt.Errorf("worker connect stream write panicked: %v", r)
+		}
+	}()
+	return p.c.q.DrainLimited(lim)
+}
+
+// NewConn builds a handler-drained worker connection. write is injected rather
+// than stored on Conn -- production passes stream.Send, tests pass a capture
+// -- so there is one source of truth about who the writer is. The returned
+// SendPump is the only way to drain; callers that only need to send receive
+// the *Conn.
+func NewConn(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	workerID string,
+	write func(*leapmuxv1.ConnectResponse) error,
+	greeting *leapmuxv1.ConnectResponse,
+) (*Conn, *SendPump) {
+	c := &Conn{
+		WorkerID: workerID,
+		Greeting: greeting,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+	c.q = sendq.NewUnstarted(ctx, sendq.Config[*leapmuxv1.ConnectResponse]{
+		Write: func(_ context.Context, m *leapmuxv1.ConnectResponse) error {
+			return write(m)
+		},
+		Size: func(m *leapmuxv1.ConnectResponse) int {
+			return proto.Size(m)
+		},
+		MaxBytes:       sendq.DefaultMaxBytes,
+		ControlReserve: sendq.DefaultControlReserve,
+		FrameOverhead:  sendq.DefaultFrameOverhead,
+		WriteTimeout:   sendq.DefaultWriteTimeout,
+		OnGiveUp: func(err error) {
+			slog.Warn("worker connect stream writer gave up; fencing",
+				"worker_id", workerID, "error", err)
+			c.Fence()
+		},
+		OnDiscard: func(frames, bytes int) {
+			slog.Debug("worker connect stream discarded queued frames",
+				"worker_id", workerID, "frames", frames, "bytes", bytes)
+		},
+	})
+	return c, &SendPump{c: c}
+}
+
+// Send enqueues a data-path frame. Over budget gives up, fences the conn, and
+// returns ErrConnectionClosed. Non-blocking: a parked drain write does not
+// stall this call. Used by the frontend→worker channel relay; over-budget
+// disconnects the worker, and recovery is the frontend reopening the channel
+// -- there is no documented replay for this direction.
+func (c *Conn) Send(msg *leapmuxv1.ConnectResponse) error {
+	if err := c.q.Enqueue(msg); err != nil {
+		return ErrConnectionClosed
+	}
+	return nil
+}
+
+// SendWait enqueues a data-path frame, parking until the byte budget frees,
+// ctx ends, or the writer closes. Used by request/response RPCs (ChannelOpen,
+// pending notifications) that must not compete with the tiny-control reserve
+// and can afford to wait.
+func (c *Conn) SendWait(ctx context.Context, msg *leapmuxv1.ConnectResponse) error {
+	if err := c.q.EnqueueWait(ctx, msg); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return ErrConnectionClosed
+	}
+	return nil
+}
+
+// SendControl tries to enqueue a reserved-budget control frame (greeting,
+// heartbeat, shutdown, channel close, reconcile nudge, tab sync). Closed →
+// ErrConnectionClosed. Reserve gone → Fence + ErrControlSaturated, matching
+// the worker's TrySendOrReset policy: a peer that cannot accept control is
+// discarded so reconnect recovers handshake/teardown rather than leaving a
+// half-live session. A nil return only means the frame was queued.
+func (c *Conn) SendControl(msg *leapmuxv1.ConnectResponse) error {
+	if c.q.IsClosed() {
+		return ErrConnectionClosed
+	}
+	if !c.q.TryEnqueueControl(msg) {
+		if c.q.IsClosed() {
+			return ErrConnectionClosed
+		}
+		c.Fence()
+		return ErrControlSaturated
+	}
+	return nil
+}
+
+// Flush blocks until every frame enqueued before the call has been handed to
+// the transport (or the queue has closed / given up). It is a pure observer
+// -- it never writes -- so it adds no second writer alongside the handler pump.
+// Its only escape besides a drain is the caller's deadline or a fence; every
+// caller MUST pass a bounded context. ErrConnectionClosed means the queue
+// tore down before delivery -- not success.
+func (c *Conn) Flush(ctx context.Context) error {
+	if err := c.q.Flush(ctx); err != nil {
+		if errors.Is(err, sendq.ErrClosed) {
+			return ErrConnectionClosed
+		}
+		return err
+	}
+	return nil
+}
+
+// Done closes when the connection is fenced, the queue gives up, or the
+// request context ends.
+func (c *Conn) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+// Fence rejects future enqueues and cancels the connection handler without
+// waiting for a drain already in progress. Returns promptly: there is no lock
+// to wait on. Manager replacement and handler teardown both use this. Idempotent.
+func (c *Conn) Fence() {
+	c.q.Close()
+	c.cancelOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+	})
+}
+
+// EncryptionMode returns the encryption mode cached from the worker's
+// heartbeat. Safe for concurrent use with SetEncryptionMode.
+func (c *Conn) EncryptionMode() leapmuxv1.EncryptionMode {
+	return leapmuxv1.EncryptionMode(c.encryptionMode.Load())
+}
+
+// SetEncryptionMode records the encryption mode from a heartbeat. Safe for
+// concurrent use with EncryptionMode.
+func (c *Conn) SetEncryptionMode(mode leapmuxv1.EncryptionMode) {
+	c.encryptionMode.Store(int32(mode))
+}

--- a/backend/internal/hub/workermgr/conn_test.go
+++ b/backend/internal/hub/workermgr/conn_test.go
@@ -1,0 +1,447 @@
+package workermgr
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/sendq"
+)
+
+func TestConnSendReturnsWhileWriteParked(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	conn, pump := NewConn(context.Background(), func() {}, "w1", func(*leapmuxv1.ConnectResponse) error {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.Send(channelMsg(1)))
+	drainErr := make(chan error, 1)
+	go func() { drainErr <- pump.Drain() }()
+	<-started
+
+	sendDone := make(chan error, 1)
+	go func() { sendDone <- conn.Send(channelMsg(2)) }()
+	select {
+	case err := <-sendDone:
+		require.NoError(t, err, "Send must return while a drain write is parked")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Send blocked behind a parked drain write")
+	}
+}
+
+func TestConnOverBudgetFencesAndCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, _ := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		select {} // never drain — fill the queue
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	const chunk = 1 << 20
+	var err error
+	for i := 0; i < (sendq.DefaultMaxBytes/chunk)+4; i++ {
+		err = conn.Send(&leapmuxv1.ConnectResponse{
+			Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+				ChannelMessage: &leapmuxv1.ChannelMessage{
+					Ciphertext: make([]byte, chunk),
+				},
+			},
+		})
+		if err != nil {
+			break
+		}
+	}
+	require.ErrorIs(t, err, ErrConnectionClosed)
+	select {
+	case <-conn.Done():
+	case <-time.After(time.Second):
+		t.Fatal("over-budget give-up must cancel the conn")
+	}
+	assert.ErrorIs(t, conn.Send(channelMsg(1)), ErrConnectionClosed)
+}
+
+func TestConnSendControlSucceedsWhenDataCeilingFull(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, _ := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		select {}
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	ceiling := sendq.DefaultMaxBytes - sendq.DefaultControlReserve
+	payload := sizedCiphertext(t, ceiling)
+	require.NoError(t, conn.Send(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+			ChannelMessage: &leapmuxv1.ChannelMessage{Ciphertext: payload},
+		},
+	}))
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}), "control reserve must remain usable when the data ceiling is full")
+
+	// A further data-path enqueue must give up (tear down), not merely refuse.
+	assert.ErrorIs(t, conn.Send(channelMsg(99)), ErrConnectionClosed)
+	select {
+	case <-conn.Done():
+	default:
+		t.Fatal("over-budget data Send must fence via give-up")
+	}
+}
+
+func TestConnSendControlFencesWhenFullySaturated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, _ := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		select {}
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	// Fill via the control path until TryEnqueueControl refuses. Control
+	// saturating the full MaxBytes budget Fences — same recovery policy as
+	// the worker's TrySendOrReset.
+	hb := &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}
+	refused := false
+	for i := 0; i < 1<<20; i++ {
+		if err := conn.SendControl(hb); err != nil {
+			require.ErrorIs(t, err, ErrControlSaturated)
+			refused = true
+			break
+		}
+	}
+	require.True(t, refused, "control path must eventually hit MaxBytes")
+	select {
+	case <-conn.Done():
+	case <-time.After(time.Second):
+		t.Fatal("SendControl must fence when the control budget is exhausted")
+	}
+}
+
+func TestConnFlushReturnsImmediatelyWhenIdle(t *testing.T) {
+	conn, _ := NewConn(context.Background(), func() {}, "w1", func(*leapmuxv1.ConnectResponse) error {
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.NoError(t, conn.Flush(ctx))
+}
+
+func TestConnDrainWriteErrorFences(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, pump := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		return errors.New("stream reset")
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	require.Error(t, pump.Drain())
+	select {
+	case <-conn.Done():
+	case <-time.After(time.Second):
+		t.Fatal("write failure must give up and fence")
+	}
+	assert.ErrorIs(t, conn.Send(channelMsg(1)), ErrConnectionClosed)
+}
+
+func TestConnFenceIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var cancels atomic.Int32
+	conn, _ := NewConn(ctx, func() {
+		cancels.Add(1)
+		cancel()
+	}, "w1", func(*leapmuxv1.ConnectResponse) error { return nil }, nil)
+
+	conn.Fence()
+	conn.Fence()
+	assert.Equal(t, int32(1), cancels.Load(), "cancel runs at most once")
+	assert.ErrorIs(t, conn.Send(channelMsg(1)), ErrConnectionClosed)
+}
+
+// sizedCiphertext returns a ciphertext whose ConnectResponse charges exactly
+// targetBytes against the sendq budget (proto.Size + sendq.DefaultFrameOverhead).
+func sizedCiphertext(t *testing.T, targetBytes int) []byte {
+	t.Helper()
+	lo, hi := 0, targetBytes
+	best := -1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		msg := &leapmuxv1.ConnectResponse{
+			Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+				ChannelMessage: &leapmuxv1.ChannelMessage{Ciphertext: make([]byte, mid)},
+			},
+		}
+		charged := proto.Size(msg) + sendq.DefaultFrameOverhead
+		if charged <= targetBytes {
+			best = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	require.GreaterOrEqual(t, best, 0)
+	return make([]byte, best)
+}
+
+func TestConnDoneClosesOnFence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, _ := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error { return nil }, nil)
+	conn.Fence()
+	select {
+	case <-conn.Done():
+	default:
+		t.Fatal("Fence must close Done")
+	}
+}
+
+func TestConnDrainAfterFenceWritesNothing(t *testing.T) {
+	var wrote int
+	conn, pump := NewConn(context.Background(), func() {}, "w1", func(*leapmuxv1.ConnectResponse) error {
+		wrote++
+		return nil
+	}, nil)
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{}))
+	conn.Fence()
+	require.NoError(t, pump.Drain())
+	assert.Zero(t, wrote, "Drain after Fence must not write discarded frames")
+}
+
+func TestConnFlushWaitsForEveryQueuedFrame(t *testing.T) {
+	var mu sync.Mutex
+	var wrote []int
+	gate := make(chan struct{})
+
+	conn, pump := NewConn(context.Background(), func() {}, "w1", func(msg *leapmuxv1.ConnectResponse) error {
+		<-gate
+		mu.Lock()
+		wrote = append(wrote, int(msg.GetChannelMessage().GetCorrelationId()))
+		mu.Unlock()
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.Send(channelMsg(1)))
+	require.NoError(t, conn.Send(channelMsg(2)))
+
+	flushDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		flushDone <- conn.Flush(ctx)
+	}()
+
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- pump.Drain() }()
+
+	select {
+	case <-flushDone:
+		t.Fatal("Flush returned before any frame reached the transport")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(gate)
+	require.NoError(t, <-drainDone)
+	require.NoError(t, <-flushDone)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{1, 2}, wrote)
+}
+
+func TestConnEncryptionModeConcurrent(t *testing.T) {
+	conn, _ := NewConn(context.Background(), func() {}, "w1", func(*leapmuxv1.ConnectResponse) error {
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			conn.SetEncryptionMode(leapmuxv1.EncryptionMode(i%3 + 1))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = conn.EncryptionMode()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSendPumpDrain_WritePanicDoesNotEscape(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, pump := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		panic("worker stream already finished")
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+
+	var drainErr error
+	assert.NotPanics(t, func() {
+		drainErr = pump.Drain()
+	}, "a panicking write must not escape SendPump.Drain")
+	require.Error(t, drainErr)
+	select {
+	case <-conn.Done():
+	default:
+		t.Fatal("panicking write must fence the conn")
+	}
+	assert.ErrorIs(t, conn.SendControl(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
+}
+
+func TestConnSendWaitEnqueuesAndHonoursDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wrote atomic.Int32
+	conn, pump := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		wrote.Add(1)
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, conn.SendWait(context.Background(), channelMsg(1)))
+	require.Eventually(t, func() bool { return wrote.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// Leave a never-drained conn one frame short of the data ceiling, then
+	// park SendWait on a frame that cannot fit until budget frees.
+	fillCtx, fillCancel := context.WithCancel(context.Background())
+	defer fillCancel()
+	fill, _ := NewConn(fillCtx, fillCancel, "w2", func(*leapmuxv1.ConnectResponse) error {
+		select {}
+	}, nil)
+	t.Cleanup(fill.Fence)
+	ceiling := sendq.DefaultMaxBytes - sendq.DefaultControlReserve
+	pad := sizedCiphertext(t, ceiling-512)
+	require.NoError(t, fill.Send(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+			ChannelMessage: &leapmuxv1.ChannelMessage{Ciphertext: pad},
+		},
+	}))
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer waitCancel()
+	blocked := &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+			ChannelMessage: &leapmuxv1.ChannelMessage{Ciphertext: make([]byte, 1024)},
+		},
+	}
+	require.ErrorIs(t, fill.SendWait(waitCtx, blocked), context.DeadlineExceeded)
+}
+
+func TestConnFlushReturnsErrConnectionClosedAfterDiscard(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, _ := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		select {}
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	conn.Fence() // discards the queued frame without writing
+
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), time.Second)
+	defer flushCancel()
+	assert.ErrorIs(t, conn.Flush(flushCtx), ErrConnectionClosed,
+		"Flush must map a discarded queue to ErrConnectionClosed, not success")
+}
+
+func TestSendPumpDrainTurnBoundsBatchAndResignals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wrote atomic.Int32
+	conn, pump := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		wrote.Add(1)
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	// Enqueue more frames than one DrainTurn admits (connDrainMaxFrames=32).
+	const n = connDrainMaxFrames + 8
+	for i := 0; i < n; i++ {
+		require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+			Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+		}))
+	}
+	require.NoError(t, pump.DrainTurn())
+	assert.Equal(t, int32(connDrainMaxFrames), wrote.Load(), "DrainTurn must stop at the frame budget")
+
+	// Remaining frames re-signal Ready so the Connect select can turn again.
+	select {
+	case <-pump.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("DrainTurn must re-signal Ready when frames remain")
+	}
+	require.NoError(t, pump.Drain())
+	assert.Equal(t, int32(n), wrote.Load())
+}
+
+func TestSendPumpRePanicsConcurrentDrain(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	conn, pump := NewConn(ctx, cancel, "w1", func(*leapmuxv1.ConnectResponse) error {
+		close(started)
+		<-release
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	go func() { _ = pump.Drain() }()
+	<-started
+
+	assert.Panics(t, func() { _ = pump.Drain() },
+		"concurrent Drain must re-panic as an ownership bug, not recover into an error")
+}
+
+func channelMsg(id uint64) *leapmuxv1.ConnectResponse {
+	return &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_ChannelMessage{
+			ChannelMessage: &leapmuxv1.ChannelMessage{CorrelationId: id},
+		},
+	}
+}

--- a/backend/internal/hub/workermgr/manager.go
+++ b/backend/internal/hub/workermgr/manager.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -16,93 +15,10 @@ import (
 	"github.com/leapmux/leapmux/internal/util/nilcheck"
 )
 
-// Conn represents a connected worker's bidirectional stream.
-type Conn struct {
-	WorkerID       string
-	EncryptionMode leapmuxv1.EncryptionMode // Set from the initial heartbeat.
-	Stream         *connect.BidiStream[leapmuxv1.ConnectRequest, leapmuxv1.ConnectResponse]
-	SendFn         func(*leapmuxv1.ConnectResponse) error // Optional: overrides Stream.Send for testing.
-	Cancel         context.CancelFunc
-
-	// Greeting, when non-nil, is sent by Register BEFORE the connection is
-	// published -- so it is guaranteed to reach the worker ahead of anything any
-	// other goroutine can send, because until Register returns nothing else can find
-	// this conn to send on.
-	//
-	// It is DATA on the conn rather than a call the caller sequences itself because
-	// that ordering is the whole value: the Hub greets a worker with its identity
-	// (leapmuxv1.WorkerIdentity), which the worker needs before the first ChannelOpen
-	// creates a session, since every machine-scoped handler gates on it. A caller that
-	// sent the greeting itself would have to remember to do so before Register, and a
-	// later edit reordering the two lines would turn a permanent, obvious outage into
-	// an intermittent race -- strictly worse. Here it cannot be reordered.
-	Greeting *leapmuxv1.ConnectResponse
-
-	mu     sync.Mutex
-	closed atomic.Bool
-}
-
-// ErrConnectionClosed is returned when a sender races worker disconnect.
-var ErrConnectionClosed = errors.New("worker connection closed")
-
 // ErrRegistryFenced is returned by Register once the Hub has fenced every
 // connection. The worker is not rejected because anything is wrong with it --
 // the Hub is going away -- so callers should map it to a retryable status.
 var ErrRegistryFenced = errors.New("worker registry fenced: hub is shutting down")
-
-// Send sends a message to the worker via the bidi stream.
-// The mutex serializes writes to prevent concurrent HTTP/2 frame corruption.
-//
-// It is held across the wire write, so a worker that stalls its HTTP/2
-// flow-control window blocks every other sender to it until the process exits,
-// and Send honours no caller deadline because it takes no context. Replacing
-// this with a handler-owned send queue is tracked in
-// https://github.com/leapmux/leapmux/issues/344
-func (c *Conn) Send(msg *leapmuxv1.ConnectResponse) error {
-	if c.closed.Load() {
-		return ErrConnectionClosed
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.closed.Load() {
-		return ErrConnectionClosed
-	}
-
-	if c.SendFn != nil {
-		return c.SendFn(msg)
-	}
-	if c.Stream == nil {
-		return fmt.Errorf("stream is nil")
-	}
-	return c.Stream.Send(msg)
-}
-
-// Close prevents new sends and waits for any in-flight send to finish. Worker
-// handlers call this before returning so background senders cannot retain and
-// write through a completed Connect stream.
-//
-// Fence stops sends that have not started. The LOCK is what waits for one
-// already inside Stream.Send, which holds c.mu for the whole write -- so this
-// critical section is the barrier, not the flag it sets. Storing closed again
-// under the lock is idempotent (nothing ever clears it) and kept only because
-// an empty critical section reads like a mistake; deleting the lock would
-// silently delete the wait.
-func (c *Conn) Close() {
-	c.Fence()
-	c.mu.Lock()
-	c.closed.Store(true)
-	c.mu.Unlock()
-}
-
-// Fence rejects future sends and cancels the connection handler without
-// waiting for a send already in progress. Manager replacement uses this so a
-// wedged old stream cannot delay publication of its successor.
-func (c *Conn) Fence() {
-	c.closed.Store(true)
-	if c.Cancel != nil {
-		c.Cancel()
-	}
-}
 
 // Manager tracks connected workers. Thread-safe.
 type Manager struct {
@@ -231,14 +147,25 @@ func New(a ReachAuthorizer) *Manager {
 // Register adds a worker connection, replacing any existing one, and reports
 // whether it replaced one.
 //
-// A non-nil c.Greeting is sent FIRST, before the connection is published. That
-// ordering is the point: until this returns, no other goroutine can look the conn up
-// to send on it, so the greeting is mechanically the worker's first message. A failed
-// greeting is returned and the conn is NOT published -- a stream that cannot carry
-// its greeting cannot carry a channel either, and publishing it would advertise a
-// worker as reachable on a connection already known to be broken.
+// A non-nil c.Greeting is enqueued via SendControl BEFORE the connection is
+// published. With a single handler drain that makes it mechanically the first
+// frame written: until this returns, no other goroutine can look the conn up
+// to enqueue after it, so the greeting stays at the head of the queue. The
+// Hub greets a worker with its identity (leapmuxv1.WorkerIdentity), which the
+// worker needs before the first ChannelOpen creates a session, since every
+// machine-scoped handler gates on it. Handing it to Register rather than
+// sending it from the caller is what makes that ordering impossible to get
+// wrong.
+//
+// A greeting that cannot be enqueued (fenced / closed queue) is returned and
+// the conn is NOT published. A stream that cannot carry its greeting on the
+// wire is a narrower case: the greeting sits at the head of the queue, the
+// conn is published, and the first Drain that fails fences it microseconds
+// later. Publishing a connection already known to be broken on the wire is
+// accepted because the alternative is a synchronous write on the registration
+// path, which is the bug this queue exists to eliminate.
 func (m *Manager) Register(c *Conn) (bool, error) {
-	// Cheap pre-check so a Hub that is already fencing does not write a
+	// Cheap pre-check so a Hub that is already fencing does not enqueue a
 	// greeting onto a stream it is about to refuse -- the worker would
 	// otherwise read its identity and only then see the stream end. NOT the
 	// authoritative check: the one that closes the race is under the lock
@@ -248,9 +175,10 @@ func (m *Manager) Register(c *Conn) (bool, error) {
 		return false, ErrRegistryFenced
 	}
 	if c.Greeting != nil {
-		if err := c.Send(c.Greeting); err != nil {
+		if err := c.SendControl(c.Greeting); err != nil {
 			return false, err
 		}
+		c.Greeting = nil
 	}
 	m.mu.Lock()
 	// The fenced check and the map write share this critical section, which is
@@ -258,7 +186,7 @@ func (m *Manager) Register(c *Conn) (bool, error) {
 	// sees the flag, or FenceAll's snapshot sees this conn. There is no third
 	// outcome. Without it a handler that passed the shutdown interceptor before
 	// shutdownCh closed -- it is a one-shot check, and a store round trip plus
-	// the greeting write sit between it and here -- would publish a connection
+	// the greeting enqueue sit between it and here -- would publish a connection
 	// nothing ever fences, and hold the Hub's drain until workerIdleTimeout.
 	if m.fenced {
 		m.mu.Unlock()
@@ -272,9 +200,9 @@ func (m *Manager) Register(c *Conn) (bool, error) {
 	}
 	m.mu.Unlock()
 	if replaced != nil && replaced != c {
-		// Fence, not Close: this runs on the SUCCESSOR's goroutine, and a wedged
-		// predecessor must not delay publication of the connection replacing it.
-		// The predecessor's own handler does the waiting -- see Unregister.
+		// Fence so a wedged predecessor cannot delay publication of the
+		// connection replacing it. The predecessor's own handler reaps the
+		// queue -- see Unregister.
 		replaced.Fence()
 	}
 	return replaced != nil, nil
@@ -285,14 +213,11 @@ func (m *Manager) Register(c *Conn) (bool, error) {
 // deferred cleanup from accidentally removing a newer replacement connection.
 // Returns true if the connection was actually removed.
 //
-// Close runs on BOTH paths, replaced or not. The caller is the connection's own
-// handler, about to return, and Close is what waits for a send already inside
-// Stream.Send. Returning while one is in flight hands net/http a write against
-// a finished handler, which panics ("Write called after Handler finished") on
-// the sender's goroutine -- and, worse, the response-writer state has by then
-// been recycled into a pool. A conn that lost its slot to a replacement is
-// exactly the one likely to have a wedged send outstanding, so it is the last
-// one that may skip the wait.
+// Unregister does NOT Fence: the Connect handler removes the conn from the
+// registry first (so no new Hub sender can look it up), then drains the
+// remaining queue while it still owns the stream, then Fences. That order
+// closes the window where SendControl could return nil and then be discarded
+// by Close. See WorkerConnectorService.Connect.
 func (m *Manager) Unregister(workerID string, conn *Conn) bool {
 	m.mu.Lock()
 	removed := false
@@ -302,7 +227,6 @@ func (m *Manager) Unregister(workerID string, conn *Conn) bool {
 		removed = true
 	}
 	m.mu.Unlock()
-	conn.Close()
 	return removed
 }
 
@@ -385,23 +309,31 @@ func (m *Manager) WaitForRegistrationChange(ctx context.Context, regToken string
 // The name carries both effects because both are load-bearing and the order
 // between them is the whole point: the notification has to be on the wire
 // first, or a worker reconnects on its ordinary backoff instead of the delay
-// the Hub asked for. Delivery is best-effort; errors are logged but do not
+// the Hub asked for. Each per-conn goroutine does SendControl THEN Flush;
+// success means the frame reached the transport before the deadline. Flush
+// never writes, so this adds no second writer alongside the handler pump. Its
+// only escape besides a drain is the caller's deadline or a fence -- which is
+// correct in production (server.go bounds it) and means every test MUST pass
+// a bounded context. Delivery is best-effort; errors are logged but do not
 // abort the sequence. Fencing is not optional -- see FenceAll.
 func (m *Manager) NotifyShutdownAndFence(ctx context.Context, retryDelaySeconds int32) {
 	connections := m.snapshotConns()
 
 	// done carries per-worker delivery success so the completion tally reflects
-	// notifications that were actually sent, not merely attempted.
+	// notifications that reached the wire, not merely queued.
 	done := make(chan bool, len(connections))
 	for _, conn := range connections {
 		go func() {
-			err := conn.Send(&leapmuxv1.ConnectResponse{
+			err := conn.SendControl(&leapmuxv1.ConnectResponse{
 				Payload: &leapmuxv1.ConnectResponse_HubShuttingDown{
 					HubShuttingDown: &leapmuxv1.HubShuttingDownNotification{
 						RetryDelaySeconds: retryDelaySeconds,
 					},
 				},
 			})
+			if err == nil {
+				err = conn.Flush(ctx)
+			}
 			if err != nil {
 				slog.Warn("failed to send shutdown notification to worker", "worker_id", conn.WorkerID, "error", err)
 			}
@@ -438,10 +370,10 @@ func (m *Manager) isFenced() bool {
 }
 
 // snapshotConns copies the live connections so the caller can do blocking work
-// on them without holding the registry lock. Both broadcasts need that: Send
-// parks on the wire, and Cancel wakes a handler whose defer takes the WRITE
-// lock -- so fencing under the read lock would make the Hub's own shutdown the
-// thing that wedges it.
+// on them without holding the registry lock. Both broadcasts need that: Flush
+// parks until the drain hands frames to the transport, and Fence wakes a
+// handler whose defer takes the WRITE lock -- so fencing under the read lock
+// would make the Hub's own shutdown the thing that wedges it.
 func (m *Manager) snapshotConns() []*Conn {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -472,13 +404,15 @@ func (m *Manager) connsLocked() []*Conn {
 // polite, would therefore spend the Hub's entire shutdown budget -- and past it
 // the drain reports a deadline the operator sees as a failed shutdown.
 //
-// One dependency on the worker survives, deliberately: Conn.Send holds the
-// conn's mutex across the wire write, and the handler's Unregister waits for
-// that send before returning. A peer that has stopped draining its socket is
-// bounded by the server's HTTP/2 write timeout (see hub.Server); a peer that
-// merely stalls its HTTP/2 flow-control window is not, because no socket write
-// is attempted. Making that impossible needs the handler to own every Send --
-// tracked in https://github.com/leapmux/leapmux/issues/344
+// One residual remains: a handler parked inside its OWN drain write is still
+// freed only by server.Close() after the drain deadline. connWriteTimeout
+// bounds the queue (give up, discard, fence) but cannot unpark the handler --
+// connect.BidiStream.Send has no context and bottoms out in
+// http.ResponseWriter.Write; cancelling connCtx does not interrupt an
+// in-flight HTTP/2 DATA write blocked on peer flow control. Spawning a
+// second Write against ctx.Done would race the transport. The cross-sender
+// pile-up, the deadline-ignoring block, and the Unregister deadlock that
+// motivated https://github.com/leapmux/leapmux/issues/344 are gone.
 func (m *Manager) FenceAll() {
 	m.mu.Lock()
 	m.fenced = true

--- a/backend/internal/hub/workermgr/manager_shutdown_test.go
+++ b/backend/internal/hub/workermgr/manager_shutdown_test.go
@@ -14,29 +14,34 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
+func boundedNotifyCtx(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 2*time.Second)
+}
+
 func TestNotifyShutdownAndFence_SendsToAllWorkers(t *testing.T) {
 	m := New(DenyAllReach())
 
 	var mu sync.Mutex
 	var received []*leapmuxv1.ConnectResponse
 
-	makeMockConn := func(workerID string) *Conn {
-		return &Conn{
-			WorkerID: workerID,
-			SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-				mu.Lock()
-				defer mu.Unlock()
-				received = append(received, msg)
-				return nil
-			},
-		}
+	makeConn := func(workerID string) *Conn {
+		conn, pump := newTestConn(t, workerID, func(msg *leapmuxv1.ConnectResponse) error {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, msg)
+			return nil
+		}, nil)
+		pumpStart(t, pump, conn)
+		return conn
 	}
+	_, _ = m.Register(makeConn("w1"))
+	_, _ = m.Register(makeConn("w2"))
+	_, _ = m.Register(makeConn("w3"))
 
-	_, _ = m.Register(makeMockConn("w1"))
-	_, _ = m.Register(makeMockConn("w2"))
-	_, _ = m.Register(makeMockConn("w3"))
-
-	m.NotifyShutdownAndFence(context.Background(), 10)
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -49,20 +54,40 @@ func TestNotifyShutdownAndFence_SendsToAllWorkers(t *testing.T) {
 	}
 }
 
+func pumpStart(t *testing.T, pump *SendPump, conn *Conn) {
+	t.Helper()
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+}
+
 func TestNotifyShutdownAndFence_CustomRetryDelay(t *testing.T) {
 	m := New(DenyAllReach())
 
+	var mu sync.Mutex
 	var received *leapmuxv1.ConnectResponse
-	_, _ = m.Register(&Conn{
-		WorkerID: "w1",
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			received = msg
-			return nil
-		},
-	})
+	conn, pump := newTestConn(t, "w1", func(msg *leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		defer mu.Unlock()
+		received = msg
+		return nil
+	}, nil)
+	pumpStart(t, pump, conn)
+	_, _ = m.Register(conn)
 
-	m.NotifyShutdownAndFence(context.Background(), 30)
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 30)
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.NotNil(t, received)
 	payload, ok := received.GetPayload().(*leapmuxv1.ConnectResponse_HubShuttingDown)
 	require.True(t, ok)
@@ -71,8 +96,9 @@ func TestNotifyShutdownAndFence_CustomRetryDelay(t *testing.T) {
 
 func TestNotifyShutdownAndFence_NoWorkers(t *testing.T) {
 	m := New(DenyAllReach())
-	// Should not panic when no workers are connected.
-	m.NotifyShutdownAndFence(context.Background(), 10)
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
 }
 
 func TestNotifyShutdownAndFence_ContinuesOnSendError(t *testing.T) {
@@ -81,61 +107,66 @@ func TestNotifyShutdownAndFence_ContinuesOnSendError(t *testing.T) {
 	sendCount := 0
 	var mu sync.Mutex
 
-	// First worker: send fails.
-	_, _ = m.Register(&Conn{
-		WorkerID: "w-fail",
-		SendFn: func(_ *leapmuxv1.ConnectResponse) error {
-			mu.Lock()
-			defer mu.Unlock()
-			sendCount++
-			return fmt.Errorf("connection reset")
-		},
-	})
+	failConn, failPump := newTestConn(t, "w-fail", func(*leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		defer mu.Unlock()
+		sendCount++
+		return fmt.Errorf("connection reset")
+	}, nil)
+	pumpStart(t, failPump, failConn)
+	_, _ = m.Register(failConn)
 
-	// Second worker: send succeeds.
-	_, _ = m.Register(&Conn{
-		WorkerID: "w-ok",
-		SendFn: func(_ *leapmuxv1.ConnectResponse) error {
-			mu.Lock()
-			defer mu.Unlock()
-			sendCount++
-			return nil
-		},
-	})
+	okConn, okPump := newTestConn(t, "w-ok", func(*leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		defer mu.Unlock()
+		sendCount++
+		return nil
+	}, nil)
+	pumpStart(t, okPump, okConn)
+	_, _ = m.Register(okConn)
 
-	// Should not panic or abort; best-effort delivery.
-	m.NotifyShutdownAndFence(context.Background(), 10)
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, 2, sendCount, "should attempt to send to all workers even on error")
 }
 
-// The notification alone leaves the stream open -- a worker holds it until it
-// decides to reconnect -- so NotifyShutdownAndFence must also end the handler, or the
-// Hub's HTTP drain waits on a connection nothing is going to close.
 func TestNotifyShutdownAndFence_FencesConnectionsAfterDelivering(t *testing.T) {
 	m := New(DenyAllReach())
 
 	var delivered, cancelled atomic.Int32
 	makeConn := func(workerID string) *Conn {
-		return &Conn{
-			WorkerID: workerID,
-			SendFn: func(*leapmuxv1.ConnectResponse) error {
-				// Fencing must come after delivery: a worker that never hears
-				// the notification reconnects on its ordinary backoff instead
-				// of the delay the Hub asked for.
-				assert.Zero(t, cancelled.Load(), "connection fenced before its notification was sent")
-				delivered.Add(1)
-				return nil
-			},
-			Cancel: func() { cancelled.Add(1) },
-		}
+		ctx, cancel := context.WithCancel(context.Background())
+		conn, pump := NewConn(ctx, func() {
+			cancelled.Add(1)
+			cancel()
+		}, workerID, func(*leapmuxv1.ConnectResponse) error {
+			assert.Zero(t, cancelled.Load(), "connection fenced before its notification was sent")
+			delivered.Add(1)
+			return nil
+		}, nil)
+		t.Cleanup(conn.Fence)
+		go func() {
+			for {
+				select {
+				case <-pump.Ready():
+					_ = pump.Drain()
+				case <-conn.Done():
+					return
+				}
+			}
+		}()
+		return conn
 	}
 	_, _ = m.Register(makeConn("w1"))
 	_, _ = m.Register(makeConn("w2"))
 
-	m.NotifyShutdownAndFence(context.Background(), 10)
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
 
 	assert.Equal(t, int32(2), delivered.Load(), "both workers notified")
 	assert.Equal(t, int32(2), cancelled.Load(), "both Connect handlers cancelled")
@@ -143,9 +174,6 @@ func TestNotifyShutdownAndFence_FencesConnectionsAfterDelivering(t *testing.T) {
 		"a fenced connection must refuse further sends")
 }
 
-// A worker that cannot be notified inside the budget is exactly the one that
-// would otherwise hold the drain open for the full idle timeout, so the fence
-// has to run on the deadline path too.
 func TestNotifyShutdownAndFence_FencesConnectionsWhenContextExpires(t *testing.T) {
 	m := New(DenyAllReach())
 
@@ -153,15 +181,28 @@ func TestNotifyShutdownAndFence_FencesConnectionsWhenContextExpires(t *testing.T
 	t.Cleanup(func() { close(release) })
 	started := make(chan struct{})
 	var cancelled atomic.Bool
-	_, _ = m.Register(&Conn{
-		WorkerID: "wedged",
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			close(started)
-			<-release
-			return nil
-		},
-		Cancel: func() { cancelled.Store(true) },
-	})
+
+	ctxConn, cancelConn := context.WithCancel(context.Background())
+	conn, pump := NewConn(ctxConn, func() {
+		cancelled.Store(true)
+		cancelConn()
+	}, "wedged", func(*leapmuxv1.ConnectResponse) error {
+		close(started)
+		<-release
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+	_, _ = m.Register(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
@@ -181,102 +222,90 @@ func TestNotifyShutdownAndFence_FencesConnectionsWhenContextExpires(t *testing.T
 
 func TestFenceAll_NoConnections(t *testing.T) {
 	m := New(DenyAllReach())
-	// Nothing registered is the state a Hub that never had a worker shuts down
-	// in; the copy-then-fence walk must not panic on it.
 	assert.NotPanics(t, m.FenceAll)
 }
 
-// A registered connection is not obliged to carry a Cancel -- the test doubles
-// throughout this package do not, and neither would a conn published before its
-// handler context exists. Fencing one must still stop its sends.
 func TestFenceAll_ConnectionWithoutCancel(t *testing.T) {
 	m := New(DenyAllReach())
-	_, _ = m.Register(&Conn{
-		WorkerID: "no-cancel",
-		SendFn:   func(*leapmuxv1.ConnectResponse) error { return nil },
-	})
+	conn, _ := newAutoDrainedConn(t, "no-cancel", nil)
+	// NewConn always has cancel; clearing it still must stop sends via queue Close.
+	conn.cancel = nil
+	_, _ = m.Register(conn)
 
 	assert.NotPanics(t, m.FenceAll)
 	assert.ErrorIs(t, m.ConnForTrustedPath("no-cancel").Send(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
 }
 
-// The registry lock must not be held while a connection is cancelled. Cancel
-// wakes the Connect handler, whose defer runs Unregister -- and Unregister
-// takes the write lock. Fencing under the read lock would make the Hub's own
-// shutdown the thing that wedges it.
 func TestFenceAll_DoesNotHoldManagerLockDuringCancel(t *testing.T) {
 	m := New(DenyAllReach())
 
 	reRegistered := make(chan struct{})
-	_, _ = m.Register(&Conn{
-		WorkerID: "fenced",
-		Cancel: func() {
-			go func() {
-				// Refused (the latch is already set) -- what matters here is
-				// that it RETURNS rather than blocking, which it could only do
-				// by acquiring the registry lock.
-				_, _ = m.Register(&Conn{WorkerID: "successor"})
-				close(reRegistered)
-			}()
-			select {
-			case <-reRegistered:
-			case <-time.After(time.Second):
-				assert.Fail(t, "Register blocked behind FenceAll's registry lock")
-			}
-		},
-	})
+	var once sync.Once
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, _ := NewConn(ctx, func() {
+		cancel()
+		go func() {
+			succ, _ := newTestConn(t, "successor", nil, nil)
+			_, _ = m.Register(succ)
+			once.Do(func() { close(reRegistered) })
+		}()
+		select {
+		case <-reRegistered:
+		case <-time.After(time.Second):
+			assert.Fail(t, "Register blocked behind FenceAll's registry lock")
+		}
+	}, "fenced", func(*leapmuxv1.ConnectResponse) error { return nil }, nil)
+	t.Cleanup(conn.Fence)
+	_, _ = m.Register(conn)
 
 	m.FenceAll()
 	<-reRegistered
 }
 
-// A Connect handler can pass the shutdown interceptor -- a one-shot check --
-// microseconds before the Hub starts shutting down, then spend a store round
-// trip and a greeting write getting here. Fencing a snapshot would let it
-// publish a connection nothing ever cancels, and that handler holds the Hub's
-// HTTP drain open until workerIdleTimeout.
 func TestRegister_RefusedOnceFenced(t *testing.T) {
 	m := New(DenyAllReach())
 	m.FenceAll()
 
 	var cancelled atomic.Bool
-	var sends atomic.Int32
-	late := &Conn{
-		WorkerID: "late",
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			sends.Add(1)
-			return nil
+	var writes atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	late, pump := NewConn(ctx, func() {
+		cancelled.Store(true)
+		cancel()
+	}, "late", func(*leapmuxv1.ConnectResponse) error {
+		writes.Add(1)
+		return nil
+	}, &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_WorkerIdentity{
+			WorkerIdentity: &leapmuxv1.WorkerIdentity{RegisteredBy: "someone"},
 		},
-		Cancel: func() { cancelled.Store(true) },
-		Greeting: &leapmuxv1.ConnectResponse{
-			Payload: &leapmuxv1.ConnectResponse_WorkerIdentity{
-				WorkerIdentity: &leapmuxv1.WorkerIdentity{RegisteredBy: "someone"},
-			},
-		},
-	}
+	})
+	t.Cleanup(late.Fence)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-late.Done():
+				return
+			}
+		}
+	}()
+
 	replaced, err := m.Register(late)
 
 	require.ErrorIs(t, err, ErrRegistryFenced, "a fenced registry must refuse a late registration")
 	assert.False(t, replaced)
 	assert.True(t, cancelled.Load(), "the refused connection's handler must still be ended")
-	// The refusal has to come BEFORE the greeting write, or the worker reads
-	// its own identity and only then sees the stream end -- a sequence that
-	// reads like the Hub accepted it and then dropped it.
-	assert.Zero(t, sends.Load(), "a refused connection must not be greeted first")
+	assert.Zero(t, writes.Load(), "a refused connection must not write a greeting")
 	assert.ErrorIs(t, late.Send(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
 	assert.Nil(t, m.ConnForTrustedPath("late"), "a refused connection must not be published")
 }
 
-// The latch is what makes the fence total rather than point-in-time: whichever
-// order these two run in, the connection must end up fenced. Without it, a
-// Register that lands after FenceAll's snapshot leaves a live, unfenced conn.
 func TestRegister_RacingFenceAllNeverLeavesALiveConn(t *testing.T) {
 	for i := range 200 {
 		m := New(DenyAllReach())
-		conn := &Conn{
-			WorkerID: "racer",
-			SendFn:   func(*leapmuxv1.ConnectResponse) error { return nil },
-		}
+		conn, _ := newTestConn(t, "racer", nil, nil)
 
 		var wg sync.WaitGroup
 		wg.Add(2)
@@ -289,84 +318,54 @@ func TestRegister_RacingFenceAllNeverLeavesALiveConn(t *testing.T) {
 	}
 }
 
-// Unregister must wait for an in-flight send on BOTH paths, replaced or not.
-// The caller is the connection's own handler, about to return; if it returns
-// while a background sender is inside Stream.Send, net/http panics
-// ("Write called after Handler finished") on the sender's goroutine and the
-// response-writer state has already been recycled into a pool.
-func TestUnregister_WaitsForInFlightSendWhenReplaced(t *testing.T) {
-	m := New(DenyAllReach())
-
-	sendStarted := make(chan struct{})
-	releaseSend := make(chan struct{})
-	old := &Conn{
-		WorkerID: "w",
-		SendFn: func(*leapmuxv1.ConnectResponse) error {
-			close(sendStarted)
-			<-releaseSend
-			return nil
-		},
-	}
-	_, _ = m.Register(old)
-
-	sendDone := make(chan struct{})
-	go func() {
-		defer close(sendDone)
-		_ = old.Send(&leapmuxv1.ConnectResponse{})
-	}()
-	<-sendStarted
-
-	// A reconnect publishes a successor, so Unregister will take its
-	// "not the registered conn" path -- the one that used to skip the wait.
-	_, _ = m.Register(&Conn{WorkerID: "w", SendFn: func(*leapmuxv1.ConnectResponse) error { return nil }})
-
-	unregistered := make(chan bool, 1)
-	go func() { unregistered <- m.Unregister("w", old) }()
-
-	select {
-	case <-unregistered:
-		t.Fatal("Unregister returned while a send was still on the old stream; the handler would return into a write-after-finish panic")
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	close(releaseSend)
-	<-sendDone
-	select {
-	case removed := <-unregistered:
-		assert.False(t, removed, "the superseded conn must not remove its replacement's registration")
-	case <-time.After(5 * time.Second):
-		t.Fatal("Unregister never returned after the in-flight send finished")
-	}
-}
-
-func TestNotifyShutdownAndFence_DoesNotHoldManagerLockDuringSend(t *testing.T) {
+func TestNotifyShutdownAndFence_DoesNotBlockRegisterWhileAWriteIsParked(t *testing.T) {
 	m := New(DenyAllReach())
 	started := make(chan struct{})
 	release := make(chan struct{})
-	_, _ = m.Register(&Conn{WorkerID: "blocked", SendFn: func(*leapmuxv1.ConnectResponse) error {
+	t.Cleanup(func() { close(release) })
+
+	ctxConn, cancelConn := context.WithCancel(context.Background())
+	conn, pump := NewConn(ctxConn, cancelConn, "blocked", func(*leapmuxv1.ConnectResponse) error {
 		close(started)
 		<-release
 		return nil
-	}})
+	}, nil)
+	t.Cleanup(conn.Fence)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+	_, _ = m.Register(conn)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	done := make(chan struct{})
 	go func() {
-		m.NotifyShutdownAndFence(context.Background(), 10)
+		m.NotifyShutdownAndFence(ctx, 10)
 		close(done)
 	}()
 	<-started
 
 	registered := make(chan struct{})
 	go func() {
-		_, _ = m.Register(&Conn{WorkerID: "new"})
+		// Registry is fenced by Notify's deferred FenceAll once ctx expires
+		// or delivery completes; registering a new worker while the write is
+		// parked must not block on the manager lock either way.
+		succ, _ := newTestConn(t, "new", nil, nil)
+		_, _ = m.Register(succ)
 		close(registered)
 	}()
 	select {
 	case <-registered:
 	case <-time.After(time.Second):
-		t.Fatal("Register blocked behind a shutdown notification send")
+		t.Fatal("Register blocked behind a parked shutdown write")
 	}
-	close(release)
 	<-done
 }
 
@@ -375,11 +374,26 @@ func TestNotifyShutdownAndFence_ReturnsWhenContextExpires(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
-	_, _ = m.Register(&Conn{WorkerID: "blocked", SendFn: func(*leapmuxv1.ConnectResponse) error {
+
+	ctxConn, cancelConn := context.WithCancel(context.Background())
+	conn, pump := NewConn(ctxConn, cancelConn, "blocked", func(*leapmuxv1.ConnectResponse) error {
 		close(started)
 		<-release
 		return nil
-	}})
+	}, nil)
+	t.Cleanup(conn.Fence)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+	_, _ = m.Register(conn)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	done := make(chan struct{})
@@ -393,4 +407,78 @@ func TestNotifyShutdownAndFence_ReturnsWhenContextExpires(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("NotifyShutdownAndFence ignored context expiration")
 	}
+}
+
+func TestNotifyShutdownAndFence_CountsOnlyFramesThatReachedTheWire(t *testing.T) {
+	m := New(DenyAllReach())
+
+	var wrote atomic.Int32
+	drained, drainedPump := newTestConn(t, "drained", func(*leapmuxv1.ConnectResponse) error {
+		wrote.Add(1)
+		return nil
+	}, nil)
+	pumpStart(t, drainedPump, drained)
+	_, _ = m.Register(drained)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	started := make(chan struct{})
+	parked, pump := newTestConn(t, "parked", func(*leapmuxv1.ConnectResponse) error {
+		close(started)
+		<-release
+		return nil
+	}, nil)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-parked.Done():
+				return
+			}
+		}
+	}()
+	_, _ = m.Register(parked)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
+	<-started
+
+	// Only the drained conn's write completed inside the budget; the parked
+	// one is still mid-write when Flush times out. NotifySuccess counts
+	// frames that reached the wire — drained succeeded, parked did not.
+	assert.Equal(t, int32(1), wrote.Load(), "only the drained conn's notification reached the wire")
+}
+
+func TestNotifyShutdownAndFence_FencesAfterTheNotificationDrains(t *testing.T) {
+	m := New(DenyAllReach())
+
+	var mu sync.Mutex
+	var order []string
+	conn, pump := newTestConn(t, "w1", func(*leapmuxv1.ConnectResponse) error {
+		mu.Lock()
+		order = append(order, "write")
+		mu.Unlock()
+		return nil
+	}, nil)
+	// Observe cancel ordering.
+	prev := conn.cancel
+	conn.cancel = func() {
+		mu.Lock()
+		order = append(order, "fence")
+		mu.Unlock()
+		prev()
+	}
+	pumpStart(t, pump, conn)
+	_, _ = m.Register(conn)
+
+	ctx, cancel := boundedNotifyCtx(t)
+	defer cancel()
+	m.NotifyShutdownAndFence(ctx, 10)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"write", "fence"}, order,
+		"notification must reach the wire before the connection is fenced")
 }

--- a/backend/internal/hub/workermgr/manager_test.go
+++ b/backend/internal/hub/workermgr/manager_test.go
@@ -3,6 +3,7 @@ package workermgr
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,67 @@ import (
 	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
+// local equivalents of workermgrtest — this package cannot import that one
+// without a cycle (workermgrtest imports workermgr).
+
+type testRecorder struct {
+	mu   sync.Mutex
+	msgs []*leapmuxv1.ConnectResponse
+	err  error
+}
+
+func (r *testRecorder) Write(msg *leapmuxv1.ConnectResponse) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.msgs = append(r.msgs, msg)
+	return nil
+}
+
+func (r *testRecorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.msgs)
+}
+
+func (r *testRecorder) Messages() []*leapmuxv1.ConnectResponse {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*leapmuxv1.ConnectResponse, len(r.msgs))
+	copy(out, r.msgs)
+	return out
+}
+
+func newTestConn(t *testing.T, workerID string, write func(*leapmuxv1.ConnectResponse) error, greeting *leapmuxv1.ConnectResponse) (*Conn, *SendPump) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	if write == nil {
+		write = func(*leapmuxv1.ConnectResponse) error { return nil }
+	}
+	conn, pump := NewConn(ctx, cancel, workerID, write, greeting)
+	t.Cleanup(conn.Fence)
+	return conn, pump
+}
+
+func newAutoDrainedConn(t *testing.T, workerID string, greeting *leapmuxv1.ConnectResponse) (*Conn, *testRecorder) {
+	t.Helper()
+	rec := &testRecorder{}
+	conn, pump := newTestConn(t, workerID, rec.Write, greeting)
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+	return conn, rec
+}
+
 func TestWaitForRegistrationChange_Notified(t *testing.T) {
 	m := New(DenyAllReach())
 
@@ -23,7 +85,6 @@ func TestWaitForRegistrationChange_Notified(t *testing.T) {
 		done <- m.WaitForRegistrationChange(context.Background(), "token-1", 5*time.Second)
 	}()
 
-	// Wait for the goroutine to register the waiter.
 	testutil.AssertEventually(t, func() bool {
 		m.regMu.Lock()
 		defer m.regMu.Unlock()
@@ -59,7 +120,6 @@ func TestWaitForRegistrationChange_ContextCancel(t *testing.T) {
 		done <- m.WaitForRegistrationChange(ctx, "token-3", 5*time.Second)
 	}()
 
-	// Wait for the goroutine to register the waiter.
 	testutil.AssertEventually(t, func() bool {
 		m.regMu.Lock()
 		defer m.regMu.Unlock()
@@ -79,7 +139,6 @@ func TestWaitForRegistrationChange_ContextCancel(t *testing.T) {
 
 func TestNotifyRegistrationChange_NoWaiters(t *testing.T) {
 	m := New(DenyAllReach())
-	// Should not panic.
 	m.NotifyRegistrationChange("nonexistent-token")
 }
 
@@ -91,35 +150,28 @@ func TestMarkDeregistering(t *testing.T) {
 	m.MarkDeregistering("b1")
 	assert.True(t, m.IsDeregistering("b1"))
 
-	// Other workers should not be affected.
 	assert.False(t, m.IsDeregistering("b2"))
 }
 
 func TestRegister_ReturnsReplacedFlag(t *testing.T) {
 	m := New(DenyAllReach())
 
-	conn1 := &Conn{WorkerID: "w1"}
-	conn2 := &Conn{WorkerID: "w1"}
-	conn3 := &Conn{WorkerID: "w2"}
+	conn1, _ := newTestConn(t, "w1", nil, nil)
+	conn2, _ := newTestConn(t, "w1", nil, nil)
+	conn3, _ := newTestConn(t, "w2", nil, nil)
 
-	// First registration for w1: not a replacement.
 	replaced, err := m.Register(conn1)
 	require.NoError(t, err)
 	assert.False(t, replaced)
-	// Second registration for w1: replaces conn1.
 	replaced, err = m.Register(conn2)
 	require.NoError(t, err)
 	assert.True(t, replaced)
-	// First registration for w2: not a replacement.
 	replaced, err = m.Register(conn3)
 	require.NoError(t, err)
 	assert.False(t, replaced)
 
-	// Verify conn2 is the current connection for w1.
 	assert.Equal(t, conn2, m.ConnForTrustedPath("w1"))
-	// Unregister with old conn1 should return false (already replaced).
 	assert.False(t, m.Unregister("w1", conn1))
-	// Unregister with current conn2 should return true.
 	assert.True(t, m.Unregister("w1", conn2))
 }
 
@@ -127,13 +179,20 @@ func TestRegister_FencesReplacedConnection(t *testing.T) {
 	m := New(DenyAllReach())
 	oldSends := 0
 	cancelled := false
-	oldConn := &Conn{WorkerID: "w1", SendFn: func(*leapmuxv1.ConnectResponse) error {
+	oldConn, _ := newTestConn(t, "w1", func(*leapmuxv1.ConnectResponse) error {
 		oldSends++
 		return nil
-	}, Cancel: func() { cancelled = true }}
+	}, nil)
+	// Swap cancel so we can observe fencing.
+	oldCancel := oldConn.cancel
+	oldConn.cancel = func() {
+		cancelled = true
+		oldCancel()
+	}
 	_, _ = m.Register(oldConn)
 
-	replaced2, err2 := m.Register(&Conn{WorkerID: "w1"})
+	newConn, _ := newTestConn(t, "w1", nil, nil)
+	replaced2, err2 := m.Register(newConn)
 	require.NoError(t, err2)
 	assert.True(t, replaced2)
 	assert.ErrorIs(t, oldConn.Send(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
@@ -141,13 +200,13 @@ func TestRegister_FencesReplacedConnection(t *testing.T) {
 	assert.True(t, cancelled)
 }
 
-func TestConnCloseRejectsLaterSend(t *testing.T) {
+func TestConnFenceRejectsLaterSend(t *testing.T) {
 	sent := 0
-	conn := &Conn{SendFn: func(*leapmuxv1.ConnectResponse) error {
+	conn, _ := newTestConn(t, "w1", func(*leapmuxv1.ConnectResponse) error {
 		sent++
 		return nil
-	}}
-	conn.Close()
+	}, nil)
+	conn.Fence()
 
 	err := conn.Send(&leapmuxv1.ConnectResponse{})
 
@@ -155,61 +214,76 @@ func TestConnCloseRejectsLaterSend(t *testing.T) {
 	assert.Zero(t, sent)
 }
 
-func TestConnCloseWaitsForInFlightSend(t *testing.T) {
+func TestFenceReturnsWhileAWriteIsParked(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
-	conn := &Conn{SendFn: func(*leapmuxv1.ConnectResponse) error {
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	conn, pump := newTestConn(t, "w1", func(*leapmuxv1.ConnectResponse) error {
 		close(started)
 		<-release
 		return nil
-	}}
-	sendDone := make(chan error, 1)
-	go func() { sendDone <- conn.Send(&leapmuxv1.ConnectResponse{}) }()
+	}, nil)
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{}))
+	go func() { _ = pump.Drain() }()
 	<-started
-	closeDone := make(chan struct{})
-	go func() {
-		conn.Close()
-		close(closeDone)
-	}()
 
+	fenceDone := make(chan struct{})
+	go func() {
+		conn.Fence()
+		close(fenceDone)
+	}()
 	select {
-	case <-closeDone:
-		t.Fatal("Close returned while a send was still using the stream")
-	case <-time.After(20 * time.Millisecond):
+	case <-fenceDone:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Fence blocked behind a parked drain write")
 	}
-	close(release)
-	require.NoError(t, <-sendDone)
-	select {
-	case <-closeDone:
-	case <-time.After(time.Second):
-		t.Fatal("Close did not return after the in-flight send completed")
-	}
-	assert.ErrorIs(t, conn.Send(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
 }
 
-func TestUnregisterStopsRoutingBeforeWaitingForInFlightSend(t *testing.T) {
+func TestUnregisterReturnsWhileAWriteIsParked(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
-	conn := &Conn{WorkerID: "worker", SendFn: func(*leapmuxv1.ConnectResponse) error {
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	conn, pump := newTestConn(t, "worker", func(*leapmuxv1.ConnectResponse) error {
 		close(started)
 		<-release
 		return nil
-	}}
+	}, nil)
 	mgr := New(DenyAllReach())
 	_, _ = mgr.Register(conn)
-	go func() { _ = conn.Send(&leapmuxv1.ConnectResponse{}) }()
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{}))
+	go func() { _ = pump.Drain() }()
 	<-started
+
 	unregistered := make(chan bool, 1)
 	go func() { unregistered <- mgr.Unregister("worker", conn) }()
 
-	testutil.AssertEventually(t, func() bool { return !mgr.OnlineForTrustedPath("worker") })
 	select {
-	case <-unregistered:
-		t.Fatal("Unregister returned before the in-flight send completed")
-	default:
+	case removed := <-unregistered:
+		assert.True(t, removed)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Unregister blocked behind a parked drain write")
 	}
-	close(release)
-	assert.True(t, <-unregistered)
+	assert.False(t, mgr.OnlineForTrustedPath("worker"))
+
+	// Unregister no longer Fences: the handler drains then Fences so leftover
+	// frames are not discarded. Send may still enqueue until Fence.
+	require.NoError(t, conn.Send(&leapmuxv1.ConnectResponse{}))
+	conn.Fence()
+	assert.ErrorIs(t, conn.Send(&leapmuxv1.ConnectResponse{}), ErrConnectionClosed)
 }
 
 func TestManager_ConnForTrustedPath_NotRegistered(t *testing.T) {
@@ -232,69 +306,66 @@ func TestClearDeregistering(t *testing.T) {
 	m.ClearDeregistering("b1")
 	assert.False(t, m.IsDeregistering("b1"))
 
-	// ClearDeregistering on non-existent key should not panic.
 	m.ClearDeregistering("nonexistent")
 }
 
-// Register must send a Conn's Greeting BEFORE publishing it.
-//
-// The ordering is the greeting's entire purpose: the Hub greets a worker with its
-// own identity, which the worker needs before the first ChannelOpen creates a
-// session (every machine-scoped handler gates on it). Until Register publishes the
-// conn, nothing else can look it up to send on -- so a greeting sent here is
-// mechanically first. This pins that the send happens on the pre-publication side.
+// Register enqueues a Conn's Greeting BEFORE publishing it. With a single
+// handler drain that makes it mechanically the first frame written.
 func TestRegisterSendsGreetingBeforePublishing(t *testing.T) {
 	m := New(DenyAllReach())
 
-	var sentWhilePublished []bool
-	conn := &Conn{
-		WorkerID: "w1",
-		Greeting: &leapmuxv1.ConnectResponse{},
+	rec := &testRecorder{}
+	greeting := &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_WorkerIdentity{
+			WorkerIdentity: &leapmuxv1.WorkerIdentity{RegisteredBy: "alice"},
+		},
 	}
-	conn.SendFn = func(*leapmuxv1.ConnectResponse) error {
-		// If the conn were already published, ConnForTrustedPath would find it.
-		sentWhilePublished = append(sentWhilePublished, m.ConnForTrustedPath("w1") != nil)
-		return nil
-	}
+	conn, pump := newTestConn(t, "w1", rec.Write, greeting)
 
 	replaced, err := m.Register(conn)
 	require.NoError(t, err)
 	assert.False(t, replaced)
+	assert.Nil(t, conn.Greeting, "Register clears Greeting after enqueue")
+	assert.Same(t, conn, m.ConnForTrustedPath("w1"), "conn must be published after Register")
+	assert.Zero(t, rec.Len(), "greeting is queued, not written, until Drain")
 
-	require.Len(t, sentWhilePublished, 1, "the greeting must be sent exactly once")
-	assert.False(t, sentWhilePublished[0],
-		"the greeting must be sent BEFORE the conn is published, or a ChannelOpen can precede it")
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	require.NoError(t, pump.Drain())
+
+	msgs := rec.Messages()
+	require.Len(t, msgs, 2)
+	assert.NotNil(t, msgs[0].GetWorkerIdentity(), "greeting must be frame 0")
+	assert.NotNil(t, msgs[1].GetHeartbeat(), "post-Register enqueue drains after the greeting")
 }
 
-// A conn whose greeting cannot be delivered must NOT be published: a stream that
-// cannot carry its greeting cannot carry a channel either, and publishing it would
-// advertise the worker as reachable on a connection already known to be broken.
-func TestRegisterDoesNotPublishOnGreetingFailure(t *testing.T) {
+// A greeting that cannot be enqueued (fenced queue) must not be published.
+func TestRegisterRefusesGreetingOnAFencedConn(t *testing.T) {
 	m := New(DenyAllReach())
-	boom := errors.New("stream gone")
-	conn := &Conn{
-		WorkerID: "w1",
-		Greeting: &leapmuxv1.ConnectResponse{},
-		SendFn:   func(*leapmuxv1.ConnectResponse) error { return boom },
-	}
+	conn, _ := newTestConn(t, "w1", nil, &leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_WorkerIdentity{
+			WorkerIdentity: &leapmuxv1.WorkerIdentity{RegisteredBy: "alice"},
+		},
+	})
+	conn.Fence()
 
 	replaced, err := m.Register(conn)
-	require.ErrorIs(t, err, boom)
+	require.ErrorIs(t, err, ErrConnectionClosed)
 	assert.False(t, replaced)
-
-	assert.Nil(t, m.ConnForTrustedPath("w1"), "a conn whose greeting failed must not be published")
+	assert.Nil(t, m.ConnForTrustedPath("w1"), "a conn whose greeting cannot be enqueued must not be published")
 }
 
 // A conn with no greeting registers exactly as before -- the field is optional.
 func TestRegisterWithoutGreetingPublishes(t *testing.T) {
 	m := New(DenyAllReach())
-	replaced, err := m.Register(&Conn{WorkerID: "w1"})
+	conn, _ := newTestConn(t, "w1", nil, nil)
+	replaced, err := m.Register(conn)
 	require.NoError(t, err)
 	assert.False(t, replaced)
 	assert.NotNil(t, m.ConnForTrustedPath("w1"))
 }
 
-// fakeReachAuthorizer records what it was asked and answers a fixed verdict.
 type fakeReachAuthorizer struct {
 	err   error
 	asked []string
@@ -305,14 +376,6 @@ func (f *fakeReachAuthorizer) AuthorizeWorkerReach(_ context.Context, _ *auth.Us
 	return f.err
 }
 
-// A Manager cannot be constructed without a gate.
-//
-// This is what makes the gate structural rather than a wiring convention:
-// "ungated" is not a reachable state, so a hub composition that forgets the
-// authorizer fails at construction instead of serving the registry unchecked
-// (or denying everything and looking like a permissions bug). The typed-nil
-// case is checked too -- a nil *T in an interface is a NON-nil interface, so
-// `a == nil` alone would let it through and panic on the first reach.
 func TestNew_RequiresReachAuthorizer(t *testing.T) {
 	assert.Panics(t, func() { New(nil) },
 		"a registry with no gate must not be constructible")
@@ -322,10 +385,9 @@ func TestNew_RequiresReachAuthorizer(t *testing.T) {
 		"a typed-nil authorizer is still no gate")
 }
 
-// DenyAllReach is a real deny, not a placeholder that happens to work.
 func TestDenyAllReach_Denies(t *testing.T) {
 	m := New(DenyAllReach())
-	conn := &Conn{WorkerID: "w1"}
+	conn, _ := newTestConn(t, "w1", nil, nil)
 	_, err := m.Register(conn)
 	require.NoError(t, err)
 
@@ -335,16 +397,10 @@ func TestDenyAllReach_Denies(t *testing.T) {
 	assert.Nil(t, got, "no connection may be returned by a deny-all registry")
 }
 
-// A nil principal is a deny, not a panic.
-//
-// ConnForUser is the fail-closed gate, so its own degenerate input has to have
-// a defined answer: every authorizer dereferences user.ID, so passing nil
-// through would crash the request goroutine instead of refusing. The authorizer
-// must not even be consulted.
 func TestManager_ConnForUser_NilUserDenies(t *testing.T) {
 	allow := &fakeReachAuthorizer{}
 	m := New(allow)
-	conn := &Conn{WorkerID: "w1"}
+	conn, _ := newTestConn(t, "w1", nil, nil)
 	_, err := m.Register(conn)
 	require.NoError(t, err)
 
@@ -354,23 +410,12 @@ func TestManager_ConnForUser_NilUserDenies(t *testing.T) {
 	assert.Empty(t, allow.asked, "the authorizer must never be handed a nil principal")
 }
 
-// A worker being deregistered is not reachable by its user, even while its
-// connection is still open.
-//
-// Deregistration is asynchronous -- the flag is set when the notification is
-// SENT and cleared only when the worker ACKS it -- and for an offline worker
-// the notification sits queued until it reconnects, so the window is unbounded.
-// Before this, the operator's containment action left the machine fully
-// reachable for all of it. The trusted path must stay open in the same state,
-// because that is how the deregister notification reaches the worker at all: a
-// gate there would make the teardown unable to complete and the flag permanent.
 func TestManager_ConnForUser_DeregisteringWorkerIsUnreachable(t *testing.T) {
 	m := New(&fakeReachAuthorizer{})
-	conn := &Conn{WorkerID: "w1"}
+	conn, _ := newTestConn(t, "w1", nil, nil)
 	_, err := m.Register(conn)
 	require.NoError(t, err)
 
-	// Control: reachable before the operator acts.
 	got, err := m.ConnForUser(context.Background(), &auth.UserInfo{}, "w1")
 	require.NoError(t, err)
 	require.Same(t, conn, got, "control: an ordinary worker is reachable")
@@ -383,37 +428,24 @@ func TestManager_ConnForUser_DeregisteringWorkerIsUnreachable(t *testing.T) {
 	assert.Same(t, conn, m.ConnForTrustedPath("w1"),
 		"the trusted path stays open: it is how the deregister notification is delivered")
 
-	// The worker acks, the flag clears, and reach is restored -- so the gate is
-	// the flag rather than the registration being torn down underneath it.
 	m.ClearDeregistering("w1")
 	got, err = m.ConnForUser(context.Background(), &auth.UserInfo{}, "w1")
 	require.NoError(t, err)
 	assert.Same(t, conn, got, "clearing the flag restores user-directed reach")
 }
 
-// The deny has to reach the client as a PERMANENT refusal.
-//
-// requireOnlineWorker forwards this error verbatim to the RPC boundary, next to
-// the coded denials the real authorizer returns. A bare error maps to
-// CodeUnknown, which a client reads as a transient fault -- so a decision that
-// will never change would drive an endless retry loop against it.
 func TestErrReachDenied_IsPermissionDenied(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(ErrReachDenied),
 		"a permanent deny must not reach the client as an unknown fault")
 }
 
-// A denied reach must not disclose the online/offline bit.
-//
-// Returning the conn (or a distinguishable nil) after a failed check would keep
-// the liveness oracle open, which is the exact exposure the gate closes.
 func TestManager_ConnForUser_DeniedDoesNotLeakLiveness(t *testing.T) {
 	denied := &fakeReachAuthorizer{err: errors.New("not your worker")}
 	m := New(denied)
-	online := &Conn{WorkerID: "online"}
+	online, _ := newTestConn(t, "online", nil, nil)
 	_, err := m.Register(online)
 	require.NoError(t, err)
 
-	// A worker that IS connected and one that is not must be indistinguishable.
 	for _, workerID := range []string{"online", "never-registered"} {
 		got, err := m.ConnForUser(context.Background(), &auth.UserInfo{}, workerID)
 		require.Error(t, err, "a denied reach must error")
@@ -423,12 +455,10 @@ func TestManager_ConnForUser_DeniedDoesNotLeakLiveness(t *testing.T) {
 		"the authorizer runs for both, so neither answer depends on connectedness")
 }
 
-// An authorized reach returns the live connection, and a nil conn means
-// "authorized but offline" -- not "denied".
 func TestManager_ConnForUser_AuthorizedReturnsConn(t *testing.T) {
 	allow := &fakeReachAuthorizer{}
 	m := New(allow)
-	conn := &Conn{WorkerID: "w1"}
+	conn, _ := newTestConn(t, "w1", nil, nil)
 	_, err := m.Register(conn)
 	require.NoError(t, err)
 

--- a/backend/internal/hub/workermgr/pending.go
+++ b/backend/internal/hub/workermgr/pending.go
@@ -64,15 +64,32 @@ func (p *PendingRequests) SendAndWait(
 		p.mu.Unlock()
 	}()
 
-	if err := conn.Send(msg); err != nil {
+	// Request/response RPCs (ChannelOpen, notifications) ride the waitable
+	// data path: they must not consume the tiny-control reserve, and they
+	// can park under backpressure instead of soft-failing.
+	if err := conn.SendWait(ctx, msg); err != nil {
 		return nil, fmt.Errorf("send to worker: %w", err)
 	}
 
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	case resp := <-ch:
 		return resp, nil
+	case <-ctx.Done():
+		// Prefer an already-buffered response over timeout/cancel when both
+		// are ready (Go select is random among ready cases).
+		select {
+		case resp := <-ch:
+			return resp, nil
+		default:
+			return nil, ctx.Err()
+		}
+	case <-conn.Done():
+		select {
+		case resp := <-ch:
+			return resp, nil
+		default:
+			return nil, ErrConnectionClosed
+		}
 	}
 }
 

--- a/backend/internal/hub/workermgr/pending_test.go
+++ b/backend/internal/hub/workermgr/pending_test.go
@@ -14,7 +14,6 @@ import (
 func TestPendingRequests_Complete(t *testing.T) {
 	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 
-	// We can't use a real stream, so test Complete directly.
 	ch := make(chan *leapmuxv1.ConnectRequest, 1)
 	p.mu.Lock()
 	p.pending["req-1"] = ch
@@ -50,38 +49,115 @@ func TestPendingRequests_SendAndWait_NilConn(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestPendingRequests_SendAndWait_ContextCancel(t *testing.T) {
+func TestPendingRequests_SendAndWait_FencedConn(t *testing.T) {
 	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
+	conn, _ := newTestConn(t, "b1", nil, nil)
+	conn.Fence()
 
-	// Create a conn with nil stream — Send will fail.
-	conn := &Conn{WorkerID: "b1"}
+	_, err := p.SendAndWait(context.Background(), conn, &leapmuxv1.ConnectResponse{})
+	require.ErrorIs(t, err, ErrConnectionClosed)
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
+func TestSendAndWait_PrefersBufferedResponseOverDone(t *testing.T) {
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
+	conn, rec := newAutoDrainedConn(t, "b1", nil)
 
-	_, err := p.SendAndWait(ctx, conn, &leapmuxv1.ConnectResponse{})
-	require.Error(t, err)
+	errCh := make(chan error, 1)
+	respCh := make(chan *leapmuxv1.ConnectRequest, 1)
+	go func() {
+		resp, err := p.SendAndWait(context.Background(), conn, &leapmuxv1.ConnectResponse{
+			Payload: &leapmuxv1.ConnectResponse_ChannelOpen{
+				ChannelOpen: &leapmuxv1.ChannelOpenRequest{ChannelId: "ch-1"},
+			},
+		})
+		respCh <- resp
+		errCh <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return len(p.pending) > 0
+	}, time.Second, 5*time.Millisecond)
+
+	var reqID string
+	require.Eventually(t, func() bool {
+		msgs := rec.Messages()
+		if len(msgs) == 0 {
+			return false
+		}
+		reqID = msgs[0].GetRequestId()
+		return reqID != ""
+	}, time.Second, 5*time.Millisecond)
+
+	require.True(t, p.Complete(reqID, &leapmuxv1.ConnectRequest{
+		RequestId: reqID,
+		Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
+			ChannelOpenResp: &leapmuxv1.ChannelOpenResponse{ChannelId: "ch-1"},
+		},
+	}))
+	conn.Fence()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "buffered response must win over Done")
+		got := <-respCh
+		require.NotNil(t, got)
+		assert.Equal(t, "ch-1", got.GetChannelOpenResp().GetChannelId())
+	case <-time.After(time.Second):
+		t.Fatal("SendAndWait did not return")
+	}
+}
+
+func TestSendAndWait_FailsFastWhenTheConnIsFenced(t *testing.T) {
+	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
+	conn, rec := newAutoDrainedConn(t, "b1", nil)
+	_ = rec
+
+	// Enqueue succeeds; fence while waiting for the response so Done fires
+	// before the default timeout.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := p.SendAndWait(context.Background(), conn, &leapmuxv1.ConnectResponse{
+			Payload: &leapmuxv1.ConnectResponse_ChannelOpen{
+				ChannelOpen: &leapmuxv1.ChannelOpenRequest{ChannelId: "ch-1"},
+			},
+		})
+		errCh <- err
+	}()
+
+	// Wait until the request is pending, then fence.
+	require.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return len(p.pending) > 0
+	}, time.Second, 5*time.Millisecond)
+
+	conn.Fence()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, ErrConnectionClosed)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("SendAndWait must fail fast on Done, not burn the default timeout")
+	}
 }
 
 func TestPendingRequests_OutOfOrder(t *testing.T) {
 	p := NewPendingRequests(func() time.Duration { return 30 * time.Second })
 
-	// Use a channel to safely capture sent messages from concurrent goroutines.
 	sentMsgs := make(chan *leapmuxv1.ConnectResponse, 2)
-	conn := &Conn{
-		WorkerID: "b1",
-		SendFn: func(msg *leapmuxv1.ConnectResponse) error {
-			sentMsgs <- msg
-			return nil
-		},
-	}
+	conn, pump := newTestConn(t, "b1", func(msg *leapmuxv1.ConnectResponse) error {
+		sentMsgs <- msg
+		return nil
+	}, nil)
+	pumpStart(t, pump, conn)
 
 	type result struct {
 		resp *leapmuxv1.ConnectRequest
 		err  error
 	}
 
-	// Launch two concurrent SendAndWait calls using ChannelOpen messages.
 	ch1Result := make(chan result, 1)
 	ch2Result := make(chan result, 1)
 
@@ -103,7 +179,6 @@ func TestPendingRequests_OutOfOrder(t *testing.T) {
 		ch2Result <- result{resp, err}
 	}()
 
-	// Collect both sent messages and capture their request IDs.
 	var reqID1, reqID2 string
 	for i := 0; i < 2; i++ {
 		select {
@@ -125,7 +200,6 @@ func TestPendingRequests_OutOfOrder(t *testing.T) {
 	require.NotEmpty(t, reqID1, "missing request ID for ch-1")
 	require.NotEmpty(t, reqID2, "missing request ID for ch-2")
 
-	// Complete ch-2 first, then ch-1 (out of order).
 	require.True(t, p.Complete(reqID2, &leapmuxv1.ConnectRequest{
 		RequestId: reqID2,
 		Payload: &leapmuxv1.ConnectRequest_ChannelOpenResp{
@@ -140,7 +214,6 @@ func TestPendingRequests_OutOfOrder(t *testing.T) {
 		},
 	}))
 
-	// Verify each goroutine received its correct response.
 	select {
 	case r := <-ch1Result:
 		require.NoError(t, r.err, "ch-1 error")

--- a/backend/internal/hub/workermgr/workermgrtest/conn.go
+++ b/backend/internal/hub/workermgr/workermgrtest/conn.go
@@ -1,0 +1,103 @@
+// Package workermgrtest provides shared Conn fixtures for hub packages that
+// exercise the worker registry without owning the Connect handler.
+package workermgrtest
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/workermgr"
+)
+
+// Recorder is a mutex-guarded capture of ConnectResponse frames. A drained
+// Conn invokes Write from the pump goroutine, so unguarded counters race under
+// -race.
+type Recorder struct {
+	mu      sync.Mutex
+	msgs    []*leapmuxv1.ConnectResponse
+	err     error
+	onWrite func(*leapmuxv1.ConnectResponse)
+}
+
+// Write records msg (or returns a previously SetErr). Safe for concurrent use.
+func (r *Recorder) Write(msg *leapmuxv1.ConnectResponse) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.msgs = append(r.msgs, msg)
+	if r.onWrite != nil {
+		r.onWrite(msg)
+	}
+	return nil
+}
+
+// Messages returns a snapshot of recorded frames.
+func (r *Recorder) Messages() []*leapmuxv1.ConnectResponse {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*leapmuxv1.ConnectResponse, len(r.msgs))
+	copy(out, r.msgs)
+	return out
+}
+
+// Len returns the number of recorded frames.
+func (r *Recorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.msgs)
+}
+
+// SetErr makes subsequent Write calls return err.
+func (r *Recorder) SetErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+// SetOnWrite installs a hook invoked under the recorder lock after each
+// successful write. Use it to Complete pending requests or signal channels.
+func (r *Recorder) SetOnWrite(fn func(*leapmuxv1.ConnectResponse)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onWrite = fn
+}
+
+// NewRecordedConn builds a Conn whose pump is drained by a background
+// goroutine, so Send/SendControl become observable via the Recorder. The conn
+// is fenced on cleanup.
+func NewRecordedConn(tb testing.TB, workerID string) (*workermgr.Conn, *Recorder) {
+	tb.Helper()
+	rec := &Recorder{}
+	return NewConnWithWrite(tb, workerID, rec.Write), rec
+}
+
+// NewConnWithWrite builds an auto-drained Conn with a custom write function.
+// Use when the test needs to park, fail, or otherwise intercept the write.
+// The pump is owned exclusively by the background drain goroutine and is not
+// returned -- a second Drain would panic.
+func NewConnWithWrite(tb testing.TB, workerID string, write func(*leapmuxv1.ConnectResponse) error) *workermgr.Conn {
+	tb.Helper()
+	require.NotNil(tb, write)
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, pump := workermgr.NewConn(ctx, cancel, workerID, write, nil)
+	tb.Cleanup(conn.Fence)
+	go drainUntilDone(conn, pump)
+	return conn
+}
+
+func drainUntilDone(conn *workermgr.Conn, pump *workermgr.SendPump) {
+	for {
+		select {
+		case <-pump.Ready():
+			_ = pump.Drain()
+		case <-conn.Done():
+			return
+		}
+	}
+}

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -1,21 +1,38 @@
 // Package sendq is the bounded outbound queue every long-lived stream in this
 // system writes through.
 //
-// Two connections own one today: the Hub's frontend websocket relay
-// (internal/hub/service.relayWriter) and the worker's Connect bidi stream
-// (internal/worker/hub.Client). Both face the same hazard -- a synchronous
+// Three connections own one today: the Hub's frontend websocket relay
+// (internal/hub/service.relayWriter), the worker's Connect bidi stream
+// (internal/worker/hub.Client), and the Hub's Connect server handler
+// (internal/hub/workermgr.Conn). All face the same hazard -- a synchronous
 // write under shared infrastructure turns one slow peer into a stall of every
-// multiplexed producer behind it -- and both recover the same way: queue,
-// drain from one goroutine, disconnect (or park) when the peer cannot keep up.
+// multiplexed producer behind it -- and all recover the same way: queue,
+// drain from one owner, disconnect (or park) when the peer cannot keep up.
 //
-// Frames are never dropped mid-stream on the Enqueue path: an ordered,
-// encrypted ciphertext stream has no resync for a hole, and reconnect +
-// replay-from-DB (Hub) or producer backpressure (worker) already exist.
-// TryEnqueue is the deliberate exception for best-effort frames issued from a
-// shared receive goroutine that must never block. TryEnqueueControl is the
-// must-deliver twin: it may consume a reserved ControlReserve slice of the
-// byte budget that data paths leave free, so a saturated data burst cannot
-// silently drop an open-response / access-ack / teardown CLOSE.
+// Two drain modes share one queue:
+//
+//   - Goroutine-drained (New): a background goroutine owns the transport
+//     Write. Used by the frontend relay and the worker's Hub client, where the
+//     owner is free to spawn one and the write has no handler-lifetime
+//     coupling.
+//   - Handler-drained (NewUnstarted + Drain): the Connect *server* handler
+//     owns every Write by selecting on Wake and calling Drain from its own
+//     goroutine. A write that outlives that handler panics
+//     ("Write called after Handler finished"); spawning a drain goroutine
+//     would recreate that hazard whenever Unregister returned first. The
+//     handler must call Close before it returns (via Fence), which latches
+//     the queue so Drain cannot start a write afterward.
+//
+// Delivery classes (three deliberate APIs, not one "must"):
+//
+//   - Enqueue / EnqueueWait: data path. Over budget disconnects (Enqueue) or
+//     parks (EnqueueWait). Ordered ciphertext has no resync for a hole.
+//   - TryEnqueue: best-effort, never blocks, never tears down.
+//   - TryEnqueueControl: reserved-budget TRY-enqueue. Data paths leave
+//     ControlReserve free so a saturated bulk burst cannot starve tiny
+//     control frames (acks, CLOSE, heartbeat). A false return means even
+//     the reserve is gone -- callers must treat that as soft fail or reset;
+//     the name is not a delivery guarantee.
 //
 // Nothing here bounds how MANY writers exist. A shared pool, and the eviction
 // policy it would need, is tracked in
@@ -34,8 +51,9 @@ import (
 // Config configures a Writer. MaxBytes is required; every other bound may be
 // zeroed to disable it.
 type Config[T any] struct {
-	// Write is the ONLY caller of the underlying transport. The drain
-	// goroutine owns it exclusively.
+	// Write is the ONLY caller of the underlying transport. Exactly one drain
+	// owner -- the goroutine New starts, or the caller of NewUnstarted via
+	// Drain -- invokes it.
 	Write func(context.Context, T) error
 	// Size returns the bytes charged for an item, excluding FrameOverhead.
 	Size func(T) int
@@ -64,20 +82,50 @@ type Config[T any] struct {
 }
 
 var (
-	// ErrClosed is returned by Enqueue once the writer is torn down.
+	// ErrClosed is returned by Enqueue once the writer is torn down, and by
+	// Flush when the writer closed or gave up before the waited-for frames
+	// reached the transport (including when Close discarded them).
 	ErrClosed = errors.New("sendq: writer closed")
 	// ErrOverBudget is the cause passed to OnGiveUp when Enqueue blows the
 	// byte budget. Callers of Enqueue itself still see ErrClosed: a client
 	// that cannot keep up is disconnected, and further enqueues must stop.
 	ErrOverBudget = errors.New("sendq: queue over byte budget")
+	// errConcurrentDrain is the panic value Drain raises when a second
+	// goroutine tries to own the drain. Typed so recoverers can re-panic it
+	// without treating a programming invariant as a transport write panic.
+	errConcurrentDrain = errors.New("sendq: concurrent Drain")
 )
+
+// IsConcurrentDrainPanic reports whether a recovered panic value is the
+// intentional concurrent-Drain ownership panic.
+func IsConcurrentDrainPanic(r any) bool {
+	return r == errConcurrentDrain
+}
+
+// Default Connect-stream queue bounds shared by the Hub workermgr.Conn and
+// the worker hub.Client. Keeping one definition stops the two sides of the
+// bidi link from drifting on budget or watchdog behaviour.
+const (
+	DefaultMaxBytes       = 32 * 1024 * 1024
+	DefaultControlReserve = 256 * 1024
+	DefaultFrameOverhead  = 256
+	DefaultWriteTimeout   = 30 * time.Second
+)
+
+// DrainLimits bounds one Drain turn so a handler select can yield to receives.
+// Zero MaxFrames and MaxDuration means unlimited (full drain).
+type DrainLimits struct {
+	MaxFrames   int
+	MaxDuration time.Duration
+}
 
 type queued[T any] struct {
 	item T
 	size int
 }
 
-// Writer is a bounded outbound queue drained by a single goroutine.
+// Writer is a bounded outbound queue drained by exactly one owner -- either
+// the goroutine New starts, or the caller of NewUnstarted via Drain.
 type Writer[T any] struct {
 	cfg Config[T]
 	ctx context.Context
@@ -88,12 +136,16 @@ type Writer[T any] struct {
 	watchdogArmed atomic.Bool
 	lastProgress  time.Time
 
+	// draining is set for the duration of Drain so a concurrent second
+	// drainer panics rather than racing finishWrite / writing.
+	draining atomic.Bool
+
 	mu          sync.Mutex
 	queue       []queued[T]
 	queuedBytes int
 	closed      bool
 	gaveUp      bool
-	// writing is true from the moment the drain goroutine pops a frame until
+	// writing is true from the moment the drain pops a frame until
 	// its Write returns. Flush needs it because pop() removes the frame before
 	// the write happens, so an empty queue alone does not mean the last frame
 	// reached the transport.
@@ -118,9 +170,22 @@ func New[T any](ctx context.Context, cfg Config[T]) *Writer[T] {
 	return w
 }
 
+// NewUnstarted constructs a Writer without starting a drain goroutine. The
+// caller owns the drain: it must call Drain from exactly one goroutine (the
+// typical pattern is select{ case <-w.Wake(): w.Drain() }), and must call
+// Close before that goroutine goes away so no write can outlive it.
+//
+// The Connect server handler uses this mode because a write against a finished
+// handler panics; a background drain would recreate that hazard whenever the
+// handler returned first.
+func NewUnstarted[T any](ctx context.Context, cfg Config[T]) *Writer[T] {
+	return newWriter(ctx, cfg)
+}
+
 // newWriter constructs a Writer without starting the drain. Tests that drive
 // writeItem or the budget accounting directly use it so they do not race the
-// drain goroutine on lastProgress.
+// drain goroutine on lastProgress. Production handler-drain callers use
+// NewUnstarted instead.
 func newWriter[T any](ctx context.Context, cfg Config[T]) *Writer[T] {
 	if cfg.MaxBytes <= 0 {
 		panic("sendq: Config.MaxBytes must be positive")
@@ -241,10 +306,11 @@ func (w *Writer[T]) TryEnqueue(item T) bool {
 }
 
 // TryEnqueueControl appends item if the FULL MaxBytes budget allows. It is the
-// must-deliver path for receive-goroutine control frames: data paths leave
-// ControlReserve free so a saturated bulk burst cannot starve an open
-// response, access ack, or teardown CLOSE. Still never blocks and never
-// tears the connection down — a false return means even the reserve is gone.
+// reserved-budget try path for receive-goroutine control frames: data paths
+// leave ControlReserve free so a saturated bulk burst cannot starve an open
+// response, access ack, or teardown CLOSE. Still never blocks and never tears
+// the connection down — a false return means even the reserve is gone, and
+// the caller must decide soft-fail vs reset. It is not a delivery guarantee.
 func (w *Writer[T]) TryEnqueueControl(item T) bool {
 	return w.tryEnqueueAgainst(item, w.cfg.MaxBytes)
 }
@@ -354,17 +420,18 @@ func (w *Writer[T]) signalDrained() {
 // Flush blocks until the queue is empty AND the in-flight write has returned,
 // so every frame enqueued before the call has been handed to the transport.
 //
-// Returns nil on a full drain, and also once the writer is closed or has given
-// up: the queue was discarded, so there is nothing left to wait for and no
-// later call could do better. Returns an error only when the WAIT was cut
-// short -- ctx expired, or the writer's own connection context ended -- because
-// only then might frames still have been drainable.
+// Returns nil only when the queue is idle (empty and not writing) while the
+// writer is still open. Returns ErrClosed if the writer closed or gave up --
+// including when Close discarded queued frames -- so a caller that needs
+// "reached the wire" (shutdown notify) cannot mistakingly treat a discard as
+// success. Returns ctx.Err / the writer's context error when the wait was cut
+// short while frames were still drainable.
 //
 // This is what makes a graceful shutdown's last words actually leave the
 // machine. Enqueue and EnqueueWait return once a frame is QUEUED, so a caller
 // that broadcasts and then tears the connection down is racing the drain
 // goroutine: on an idle box the drain wins and nobody notices, under load it
-// loses and the frames are discarded by Close with no error anywhere.
+// loses and the frames are discarded by Close -- Flush reports ErrClosed.
 func (w *Writer[T]) Flush(ctx context.Context) error {
 	for {
 		// Capture the current generation channel under the same lock that read
@@ -372,10 +439,13 @@ func (w *Writer[T]) Flush(ctx context.Context) error {
 		// closes the channel this iteration parks on.
 		w.mu.Lock()
 		idle := len(w.queue) == 0 && !w.writing
-		done := w.closed || w.gaveUp
+		tornDown := w.closed || w.gaveUp
 		drained := w.drained
 		w.mu.Unlock()
-		if idle || done {
+		if idle {
+			if tornDown {
+				return ErrClosed
+			}
 			return nil
 		}
 		select {
@@ -450,6 +520,89 @@ func (w *Writer[T]) giveUp(err error) {
 	}
 }
 
+// Wake returns the depth-1 wake channel that fires when a frame is enqueued
+// (or the writer closes). Exactly one goroutine may select on it: a second
+// consumer would steal the coalesced signal that signalNonBlocking depends on.
+// The goroutine-drained path parks on it inside run(); a handler-drained
+// caller parks on it in its own select and then calls Drain.
+func (w *Writer[T]) Wake() <-chan struct{} {
+	return w.wake
+}
+
+// Drain pops and writes every currently queued frame (unlimited), then
+// returns. See DrainLimited for a bounded turn used by handler selects.
+func (w *Writer[T]) Drain() error {
+	return w.DrainLimited(DrainLimits{})
+}
+
+// DrainLimited pops and writes queued frames until the queue is empty, a write
+// fails, or the limits are hit. A non-nil error means the drain gave up (write
+// failure, stall, or watchdog) and the caller should stop -- the queue is
+// already closed. Nil with limits hit leaves remaining frames queued and
+// re-signals Wake so a handler select can run another turn after servicing
+// receives.
+//
+// Popping one at a time is load-bearing: pop sets writing atomically with
+// removal, which is the only thing that keeps Flush from returning between
+// two frames of the same batch. A concurrent second Drain panics with
+// errConcurrentDrain.
+//
+// The caller must own the drain exclusively. run() is the goroutine-drained
+// implementation of that ownership; a NewUnstarted caller is the handler-
+// drained one.
+func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
+	if !w.draining.CompareAndSwap(false, true) {
+		panic(errConcurrentDrain)
+	}
+	defer w.draining.Store(false)
+
+	// Restart the stall clock: reaching here means the peer owed us nothing
+	// until this wake-up. Idle time is not stalled time, and this socket may
+	// have no keepalive to refresh the clock for us.
+	w.lastProgress = w.now()
+	start := w.now()
+	frames := 0
+
+	for {
+		if lim.MaxFrames > 0 && frames >= lim.MaxFrames {
+			w.signalWakeIfQueued()
+			return nil
+		}
+		if lim.MaxDuration > 0 && w.now().Sub(start) >= lim.MaxDuration {
+			w.signalWakeIfQueued()
+			return nil
+		}
+		frame, ok := w.pop()
+		if !ok {
+			return nil
+		}
+		frames++
+		// Wake EnqueueWait parkers as soon as the bytes leave the queue,
+		// not after the (up to WriteTimeout-long) write finishes. The
+		// budget is already free; delaying the signal couples backpressure
+		// relief to write latency for no functional reason.
+		w.signalBudgetFreed()
+		err := w.writeItem(frame.item)
+		w.finishWrite()
+		if err != nil {
+			if w.isClosed() {
+				return err
+			}
+			w.giveUp(err)
+			return err
+		}
+	}
+}
+
+func (w *Writer[T]) signalWakeIfQueued() {
+	w.mu.Lock()
+	has := !w.closed && len(w.queue) > 0
+	w.mu.Unlock()
+	if has {
+		w.signalWake()
+	}
+}
+
 func (w *Writer[T]) run() {
 	defer w.Close()
 	w.lastProgress = w.now()
@@ -460,31 +613,8 @@ func (w *Writer[T]) run() {
 		case <-w.wake:
 		}
 
-		// Restart the stall clock: the inner loop below only ever exits
-		// with an empty queue, so reaching here means the client owed us
-		// nothing until this wake-up. Idle time is not stalled time, and
-		// this socket may have no keepalive to refresh the clock for us.
-		w.lastProgress = w.now()
-
-		for {
-			frame, ok := w.pop()
-			if !ok {
-				break
-			}
-			// Wake EnqueueWait parkers as soon as the bytes leave the queue,
-			// not after the (up to WriteTimeout-long) write finishes. The
-			// budget is already free; delaying the signal couples backpressure
-			// relief to write latency for no functional reason.
-			w.signalBudgetFreed()
-			err := w.writeItem(frame.item)
-			w.finishWrite()
-			if err != nil {
-				if w.isClosed() {
-					return
-				}
-				w.giveUp(err)
-				return
-			}
+		if err := w.Drain(); err != nil {
+			return
 		}
 		if w.isClosed() {
 			return
@@ -579,10 +709,4 @@ func (w *Writer[T]) SetLastProgressForTest(t time.Time) {
 // through the queue. For tests of the stall bound in isolation.
 func (w *Writer[T]) WriteItemForTest(item T) error {
 	return w.writeItem(item)
-}
-
-// WakeChForTest exposes the wake channel so over-budget teardown tests can
-// assert the drain was nudged. For tests.
-func (w *Writer[T]) WakeChForTest() <-chan struct{} {
-	return w.wake
 }

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -413,7 +413,7 @@ func TestWriterOverBudgetTeardownMatchesClose(t *testing.T) {
 	assert.Zero(t, w.QueuedBytes())
 
 	select {
-	case <-w.WakeChForTest():
+	case <-w.Wake():
 	default:
 		t.Fatal("the budget kill must wake the drain goroutine rather than rely on the context")
 	}
@@ -927,4 +927,185 @@ func TestSignalDrainedWakesEveryWaiter(t *testing.T) {
 			t.Fatalf("waiter %d was not woken by signalDrained", i)
 		}
 	}
+}
+
+func TestWriterDrainWritesFIFOAndReturnsNilWhenEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var got []uint64
+	w := NewUnstarted(ctx, Config[*leapmuxv1.ChannelMessage]{
+		Write: func(_ context.Context, m *leapmuxv1.ChannelMessage) error {
+			got = append(got, m.GetCorrelationId())
+			return nil
+		},
+		Size: frameSize, MaxBytes: testMaxBytes, FrameOverhead: testFrameOverhead,
+	})
+	defer w.Close()
+
+	require.NoError(t, w.Enqueue(testFrame(1)))
+	require.NoError(t, w.Enqueue(testFrame(2)))
+	require.NoError(t, w.Drain())
+	assert.Equal(t, []uint64{1, 2}, got)
+	require.NoError(t, w.Drain(), "empty drain returns nil")
+	assert.Equal(t, []uint64{1, 2}, got)
+}
+
+func TestWriterDrainAfterCloseWritesNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wrote int
+	w := NewUnstarted(ctx, Config[*leapmuxv1.ChannelMessage]{
+		Write: func(context.Context, *leapmuxv1.ChannelMessage) error {
+			wrote++
+			return nil
+		},
+		Size: frameSize, MaxBytes: testMaxBytes, FrameOverhead: testFrameOverhead,
+	})
+	require.NoError(t, w.Enqueue(testFrame(1)))
+	w.Close()
+	require.NoError(t, w.Drain())
+	assert.Zero(t, wrote)
+}
+
+func TestWriterFlushReturnsErrClosedWhenQueueWasDiscarded(t *testing.T) {
+	t.Parallel()
+	w := NewUnstarted(context.Background(), Config[string]{
+		Write:    func(context.Context, string) error { return nil },
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+	})
+	require.NoError(t, w.Enqueue("frame"))
+	w.Close() // discards without writing
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.ErrorIs(t, w.Flush(ctx), ErrClosed,
+		"Flush must not report success when Close discarded queued frames")
+}
+
+func TestWriterDrainLimitedYieldsAndResignals(t *testing.T) {
+	t.Parallel()
+	wrote := make([]string, 0, 4)
+	w := NewUnstarted(context.Background(), Config[string]{
+		Write: func(_ context.Context, s string) error {
+			wrote = append(wrote, s)
+			return nil
+		},
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+	})
+	t.Cleanup(w.Close)
+	for i := 0; i < 4; i++ {
+		require.NoError(t, w.Enqueue(string(rune('a'+i))))
+	}
+	require.NoError(t, w.DrainLimited(DrainLimits{MaxFrames: 2}))
+	require.Equal(t, []string{"a", "b"}, wrote)
+	require.Equal(t, 2, w.QueuedLen())
+	// Remaining frames must re-arm Wake so a handler select can turn again.
+	select {
+	case <-w.Wake():
+	case <-time.After(time.Second):
+		t.Fatal("DrainLimited must re-signal Wake when frames remain")
+	}
+	require.NoError(t, w.DrainLimited(DrainLimits{MaxFrames: 2}))
+	require.Equal(t, []string{"a", "b", "c", "d"}, wrote)
+}
+
+func TestWriterConcurrentDrainPanics(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	w := NewUnstarted(ctx, Config[*leapmuxv1.ChannelMessage]{
+		Write: func(context.Context, *leapmuxv1.ChannelMessage) error {
+			close(started)
+			<-release
+			return nil
+		},
+		Size: frameSize, MaxBytes: testMaxBytes, FrameOverhead: testFrameOverhead,
+	})
+	defer w.Close()
+	t.Cleanup(func() { close(release) })
+
+	require.NoError(t, w.Enqueue(testFrame(1)))
+	go func() { _ = w.Drain() }()
+	<-started
+	assert.Panics(t, func() { _ = w.Drain() })
+}
+
+func TestWriterFlushStaysParkedAcrossMultiFrameDrain(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gate := make(chan struct{})
+	var wrote atomic.Int32
+	w := NewUnstarted(ctx, Config[*leapmuxv1.ChannelMessage]{
+		Write: func(context.Context, *leapmuxv1.ChannelMessage) error {
+			<-gate
+			wrote.Add(1)
+			return nil
+		},
+		Size: frameSize, MaxBytes: testMaxBytes, FrameOverhead: testFrameOverhead,
+	})
+	defer w.Close()
+
+	require.NoError(t, w.Enqueue(testFrame(1)))
+	require.NoError(t, w.Enqueue(testFrame(2)))
+
+	flushDone := make(chan error, 1)
+	go func() {
+		fctx, fcancel := context.WithTimeout(context.Background(), time.Second)
+		defer fcancel()
+		flushDone <- w.Flush(fctx)
+	}()
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- w.Drain() }()
+
+	select {
+	case <-flushDone:
+		t.Fatal("Flush returned before all frames left the drain")
+	case <-time.After(20 * time.Millisecond):
+	}
+	assert.Equal(t, int32(0), wrote.Load())
+
+	close(gate)
+	require.NoError(t, <-drainDone)
+	require.NoError(t, <-flushDone)
+	assert.Equal(t, int32(2), wrote.Load())
+}
+
+func TestWriterWriteTimeoutGivesUpUnderHandlerDrain(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gaveUp := make(chan error, 1)
+	w := NewUnstarted(ctx, Config[*leapmuxv1.ChannelMessage]{
+		Write: func(context.Context, *leapmuxv1.ChannelMessage) error {
+			select {}
+		},
+		Size: frameSize, MaxBytes: testMaxBytes, FrameOverhead: testFrameOverhead,
+		WriteTimeout: testShortWriteTimeout,
+		OnGiveUp: func(err error) {
+			cancel()
+			select {
+			case gaveUp <- err:
+			default:
+			}
+		},
+	})
+	defer w.Close()
+
+	require.NoError(t, w.Enqueue(testFrame(1)))
+	go func() { _ = w.Drain() }()
+
+	select {
+	case err := <-gaveUp:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("WriteTimeout must give up under handler drain")
+	}
+	assert.True(t, w.IsClosed(), "give-up must close the queue even while Drain is parked in Write")
+	assert.ErrorIs(t, w.Enqueue(testFrame(2)), ErrClosed)
 }

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -29,31 +29,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const (
-	// connectQueueMaxBytes caps the Connect bidi stream's outbound queue by
-	// payload plus per-frame overhead. It is the memory bound for one worker's
-	// Hub link: a wall-clock stall cutoff on a server-to-server connection
-	// invites a reconnect storm under sustained load, so there is none -- the
-	// byte budget alone disconnects a Hub that cannot keep up.
-	connectQueueMaxBytes = 32 * 1024 * 1024
-
-	// connectControlReserve is the slice of connectQueueMaxBytes that data
-	// paths (Send / EnqueueWait) leave free for must-deliver receive-goroutine
-	// control frames (ChannelOpenResp, DeregisterAck,
-	// nonce-desync CLOSE). Sized for many tiny control frames; a saturated
-	// bulk burst must not silently drop a handshake/teardown frame.
-	connectControlReserve = 256 * 1024
-
-	// connectWriteTimeout bounds ONE stream.Send. A frame that cannot leave
-	// the process within this window means the Hub's receive window has been
-	// full for that long.
-	connectWriteTimeout = 30 * time.Second
-
-	// connectFrameOverhead is charged per queued ConnectRequest on top of its
-	// marshalled size, so many tiny frames (heartbeats, acks) still cost the
-	// budget something.
-	connectFrameOverhead = 256
-)
+// Connect-stream queue bounds are sendq.Default* so Hub and worker stay on
+// one definition. A wall-clock stall cutoff on a server-to-server connection
+// invites a reconnect storm under sustained load, so there is none -- the
+// byte budget alone disconnects a Hub that cannot keep up.
 
 // ErrNotConnected is returned by Send when no Connect stream is active.
 var ErrNotConnected = errors.New("not connected")
@@ -365,10 +344,10 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 		Size: func(m *leapmuxv1.ConnectRequest) int {
 			return proto.Size(m)
 		},
-		MaxBytes:       connectQueueMaxBytes,
-		ControlReserve: connectControlReserve,
-		FrameOverhead:  connectFrameOverhead,
-		WriteTimeout:   connectWriteTimeout,
+		MaxBytes:       sendq.DefaultMaxBytes,
+		ControlReserve: sendq.DefaultControlReserve,
+		FrameOverhead:  sendq.DefaultFrameOverhead,
+		WriteTimeout:   sendq.DefaultWriteTimeout,
 		OnGiveUp: func(err error) {
 			slog.Warn("hub connect stream writer gave up; reconnecting", "error", err)
 			connCancel()

--- a/backend/internal/worker/hub/client_test.go
+++ b/backend/internal/worker/hub/client_test.go
@@ -532,8 +532,8 @@ func TestClientSendDoesNotBlockReceiveWhenTransportBlocked(t *testing.T) {
 			return nil
 		},
 		Size:          connectReqSize,
-		MaxBytes:      connectQueueMaxBytes,
-		FrameOverhead: connectFrameOverhead,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
 		OnGiveUp:      func(error) { cancel() },
 	})
 	t.Cleanup(func() { c.writer.Close() })
@@ -575,8 +575,8 @@ func TestClientWriteFailureCancelsConnection(t *testing.T) {
 			return errors.New("stream write failed")
 		},
 		Size:          connectReqSize,
-		MaxBytes:      connectQueueMaxBytes,
-		FrameOverhead: connectFrameOverhead,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
 		OnGiveUp: func(error) {
 			c.cancelConn()
 		},
@@ -707,8 +707,8 @@ func TestClientLastSendTimeAdvancesOnEnqueue(t *testing.T) {
 	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
 		Write:         func(context.Context, *leapmuxv1.ConnectRequest) error { return nil },
 		Size:          connectReqSize,
-		MaxBytes:      connectQueueMaxBytes,
-		FrameOverhead: connectFrameOverhead,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
 	})
 	t.Cleanup(func() { c.writer.Close() })
 


### PR DESCRIPTION
## Motivation
`Conn.Send` held the mutex across `Stream.Send` with no deadline, so a stalled worker blocked every sender, ignored caller contexts, and deadlocked `Unregister` during shutdown (issue #344). Writes need a single owner that can drain under a deadline and let `Unregister` return without fencing on a blocked send.

## Modifications
- **sendq:** Add `NewUnstarted`/`Wake`/`Drain`/`DrainLimited` for handler-owned writes; `Flush` returns `ErrClosed` on discard; share `Default*` budgets with the worker hub client. Fix `Flush` false-success; remove `WakeChForTest`.
- **workermgr:** Replace mutex-held `Stream.Send` with `Conn`+`SendPump` enqueue (`Send`/`SendWait`/`SendControl`/`Flush`), bounded `DrainTurn`, and handler drain-then-fence teardown. `NotifyShutdown` flushes so only frames that reached the wire count as sent; add `ErrControlSaturated` and workermgrtest helpers. Breaking internal `Conn` API (no `SendFn`/`Close`/`Stream` fields).
- **hub service:** Wire Connect through `NewConn`+pump; teardown `Unregister`→`Drain`→`Fence`; `DrainTurn` in the loop; `SendControl` for control frames; close-dispatcher lock-order fix; tests made async-aware.

## Result
- Connect writes are exclusively owned by the handler via sendq; stalled workers no longer block all senders or deadlock `Unregister` on shutdown.
- Callers get context-aware enqueue/wait paths and bounded drain turns instead of unbounded mutex-held stream sends.
- Closes #344
