### PR TITLE
refactor!(backoff): rewrite retry engine to eliminate refund-race bugs

### DIFF
--- a/backend/internal/cli/remote/cmd/agent_messages.go
+++ b/backend/internal/cli/remote/cmd/agent_messages.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff/v6"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/cli/remote"
 	"github.com/leapmux/leapmux/internal/cli/remote/streamevents"
@@ -300,10 +299,10 @@ func decodeJSON(data []byte) (any, bool) {
 // where the old duration-only rule kept reconnect latency pinned high through a
 // run of sub-maxBackoff flaps.
 type reconnectBackoff struct {
-	inner *backoff.ExponentialBackOff
+	inner *backoffutil.Backoff
 	// pending is the wait the NEXT afterSession returns. It exists because this
 	// loop's contract is "wait the current value, then grow", whereas
-	// NextBackOff grows as it returns -- so the first value has to be taken
+	// Backoff.Next grows as it returns -- so the first value has to be taken
 	// eagerly and each later call returns what the previous one produced.
 	pending time.Duration
 }
@@ -311,8 +310,8 @@ type reconnectBackoff struct {
 func newReconnectBackoff(initial, maxInterval time.Duration) reconnectBackoff {
 	// Deterministic (no jitter): the follower is one process reconnecting to
 	// its own worker, not a fleet, and the sequence is asserted directly.
-	b := backoffutil.NewCapped(initial, maxInterval, 0)
-	return reconnectBackoff{inner: b, pending: b.NextBackOff()}
+	b := backoffutil.NewBackoff(initial, maxInterval, 0)
+	return reconnectBackoff{inner: b, pending: b.Next()}
 }
 
 // afterSession returns how long to wait before the next reconnect and advances
@@ -327,10 +326,10 @@ func newReconnectBackoff(initial, maxInterval time.Duration) reconnectBackoff {
 func (b *reconnectBackoff) afterSession(deliveredEvent bool) time.Duration {
 	if deliveredEvent {
 		b.inner.Reset()
-		b.pending = b.inner.NextBackOff()
+		b.pending = b.inner.Next()
 	}
 	wait := b.pending
-	b.pending = b.inner.NextBackOff()
+	b.pending = b.inner.Next()
 	return wait
 }
 
@@ -524,6 +523,12 @@ func tailAgentMessages(ctx context.Context, c *remote.Client, workerID, agentID 
 				if err := em.Err(); err != nil {
 					return err
 				}
+				return nil
+			}
+			// ErrSubscriptionClosed means the Subscription was Cancelled (the
+			// process is shutting down via the deferred Cancel); it is not a
+			// subscribe failure and must not surface to the user as one.
+			if errors.Is(err, streamevents.ErrSubscriptionClosed) {
 				return nil
 			}
 			if emitErr := em.emitError(agentID, "subscribe_failed", err); emitErr != nil {

--- a/backend/internal/cli/remote/streamevents/subscription.go
+++ b/backend/internal/cli/remote/streamevents/subscription.go
@@ -2,13 +2,27 @@ package streamevents
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
+
+// ErrSubscriptionClosed is returned by Update after Cancel retired the
+// subscription. It stops a late LOOKUP_FAILED retry (whose generation check
+// beat Cancel, but whose Update then loses the race) from re-opening a stream
+// the caller tore down. Callers that drive Update in a loop should treat it as
+// an expected, non-fatal outcome of their own Cancel — distinct from a real
+// subscribe failure — not surface it as an error to the user.
+var ErrSubscriptionClosed = errors.New("streamevents: subscription is closed")
+
+// errSubscriptionClosed aliases ErrSubscriptionClosed for in-package use so the
+// retry path's errors.Is reads as a local sentinel.
+var errSubscriptionClosed = ErrSubscriptionClosed
 
 // Subscription owns the cursor map plus one in-flight Transport
 // subscription. Callers can `Update(req)` to revise the entry list on
@@ -20,6 +34,13 @@ import (
 // operations are single-flight: Update and Cancel serialize the whole
 // open/update/store sequence, not just field reads/writes, so concurrent
 // callers cannot orphan a newly-opened stream.
+//
+// Cancel is terminal: once it returns, Update refuses with
+// ErrSubscriptionClosed for the life of the Subscription (the closed flag is
+// never cleared). Callers that need to re-subscribe after Cancel must build a
+// new Subscription. The CLI's agent-messages --follow reconnect loop honors
+// this by reusing one Subscription across transport reconnects (which never
+// Cancel) and tearing it down only at process exit.
 type Subscription struct {
 	transport Transport
 	agents    *AgentCursor
@@ -41,44 +62,88 @@ type Subscription struct {
 	onCursorReset func(terminalID string)
 
 	lifecycleMu sync.Mutex
-	mu          sync.Mutex
-	handle      Handle
+	// closed is set by Cancel under lifecycleMu and read by Update under the
+	// same lock. It is the closed-defense that stops a LOOKUP_FAILED retry
+	// whose timer fired from re-opening a stream AFTER Cancel returned: the
+	// retry's Update blocks on lifecycleMu until Cancel finishes, then sees
+	// closed=true and bails instead of orphaning a worker-side stream.
+	closed bool
+	mu     sync.Mutex
+	handle Handle
 	// lastReq is the most recent interest statement; LOOKUP_FAILED acks
 	// re-issue it after a short delay so CLI follow matches the UI retry.
 	lastReq *leapmuxv1.WatchEventsRequest
-	// retryCtx / retryCancel gate LOOKUP_FAILED retries. Cancel retires
-	// retryCancel so an in-flight retry bails before re-opening a stream the
-	// caller tore down — without it the retry (which uses context.Background)
-	// could orphan a worker-side subscription for the process lifetime, and a
-	// fresh open would re-arm the gate a prior Cancel had set. Re-opened on a
-	// clean fresh open so a transient miss after a reconnect gets a fresh
-	// budget. Guarded by lifecycleMu.
+	// inflightUpdateId is the update_id assigned to the last request put on the
+	// wire (open or revise). UpdateAcks echo it back; a stale ack (one whose
+	// update_id is below the inflight id) is dropped before it can arm a retry,
+	// mirroring the frontend's handleUpdateAck. Guarded by s.mu.
+	inflightUpdateId uint64
+	// nextUpdateId is the next update_id to assign. Monotonic for the life of
+	// the subscription (never reset on fresh-open) so a stale ack from a prior
+	// stream generation cannot masquerade as current. Guarded by s.mu.
+	nextUpdateId uint64
+	// retryInFlight is true while a LOOKUP_FAILED retry goroutine is armed and
+	// has not yet fired or bailed. It coalesces a burst of acks into one
+	// in-flight retry per slot, mirroring the frontend's
+	// createExponentialBackoff.schedule (which no-ops while a timer is pending
+	// for the key). Guarded by s.mu.
+	retryInFlight bool
+	// retryCtx is cancelled by Cancel to wake an armed retry goroutine
+	// immediately (it selects on retryCtx.Done() alongside its timer). Unlike
+	// the generation counter (which is also bumped by fresh-open), retryCtx is
+	// cancelled ONLY by Cancel — a fresh-open does NOT retire it — so a retry
+	// whose stream recovered via a fresh-open can still restate against the new
+	// stream. Cancel retires both: it bumps generation (so the goroutine refunds
+	// and bails) AND cancels retryCtx (so the goroutine does not linger for up
+	// to lookupRetryMaxInterval after shutdown). Guarded by lifecycleMu.
 	retryCtx    context.Context
 	retryCancel context.CancelFunc
-	// lookupAttempts bounds LOOKUP_FAILED retries per stream open. A new open
-	// (handle == nil → OpenWatchEvents) resets it so a transient miss after a
-	// clean reconnect gets a fresh budget.
-	lookupAttempts int
+	// retryExhaustedLogged is the once-guard for the budget-exhausted Warn: it
+	// fires once per budget cycle (cleared on Reset) so a perpetually-flapping
+	// worker does not log a Warn per ack after exhaustion. Guarded by s.mu.
+	retryExhaustedLogged bool
+	// generation is bumped on every fresh-open and on Cancel. A LOOKUP_FAILED
+	// retry captures the generation at arm time and re-checks it after its
+	// timer fires: if the generation moved (Cancel or a fresh-open won the
+	// race), the retry refunds its slot and bails instead of re-opening against
+	// a stream that moved on. This replaces the prior retryCtx gate + the
+	// context.WithoutCancel workaround: there is no gate for a fresh-open to
+	// retire, so a retry's own Update can no longer be born-dead, and the only
+	// re-open defense needed is the `closed` flag in Update. Guarded by s.mu.
+	generation uint64
+	// retry is the LOOKUP_FAILED retry budget (attempt cap + backoff interval).
+	// All access is serialized under s.mu, satisfying backoffutil.Retry's
+	// single-owner contract. Reset on each fresh open so a transient miss after
+	// a clean reconnect gets a fresh budget.
+	retry *backoffutil.Retry
 }
 
-// LOOKUP_FAILED retry bounds. The first retry lands quickly (a transient
-// List*ByIDs miss often recovers in milliseconds); later ones back off. The
-// cap stops a flapping worker from spawning an unbounded retry ladder (each
-// retry produces another LOOKUP_FAILED ack that would spawn another goroutine).
+// LOOKUP_FAILED retry policy. Mirrors the frontend's rejectionBackoff so the
+// CLI and the UI use the same backoff shape under a flapping worker: jittered
+// exponential, 500ms → 15s, ±20% jitter, 8 attempts. The bounded attempt count
+// stops a flapping worker from compounding into an unbounded retry ladder (each
+// retry produces another LOOKUP_FAILED ack that would spawn another goroutine),
+// and the in-flight retry guard coalesces a burst of acks into one retry per
+// slot (matching the frontend's createExponentialBackoff.schedule).
 //
-// This is a one-off fixed-delay table; the frontend's equivalent
-// (useWatchEventsStreams → createExponentialBackoff) is a jittered exponential.
-// Sharing one backoff primitive across both is tracked in
-// https://github.com/leapmux/leapmux/issues/349.
-var lookupRetryDelays = [...]time.Duration{
-	200 * time.Millisecond,
-	500 * time.Millisecond,
-	time.Second,
-	2 * time.Second,
-	5 * time.Second,
-}
-
-const lookupRetryMax = len(lookupRetryDelays)
+// The frontend defines the same shape at
+// frontend/src/hooks/useWatchEventsStreams.ts (rejectionBackoff) on top of
+// createExponentialBackoff (frontend/src/lib/retry.ts). Cross-language constant
+// sharing is impractical, so the two are kept in sync by mirror + the pinning
+// test TestSubscription_LookupRetryPolicyMirrorsFrontend, which fails if the
+// values here drift from the documented frontend shape.
+//
+// One deliberate divergence: the frontend resets the budget per clean ack
+// (event-gated per worker); the CLI resets only on a fresh stream open, so a
+// long-lived subscription that revises its entry list without a reconnect does
+// not re-arm the budget. A fresh open is the CLI's natural recovery boundary,
+// and resetting per-ack would let one entity's success mask another's failure.
+const (
+	lookupRetryInitial     = 500 * time.Millisecond
+	lookupRetryMaxInterval = 15 * time.Second
+	lookupRetryJitter      = 0.2
+	lookupRetryMaxAttempts = 8
+)
 
 // NewSubscription wires the transport and cursors. Callbacks fire
 // before the cursor map updates, so consumers see the raw event
@@ -90,6 +155,15 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 	onCursorReset func(terminalID string),
 ) *Subscription {
 	retryCtx, retryCancel := context.WithCancel(context.Background())
+	// lookupRetry* are compile-time constants, so NewRetry cannot fail; a panic
+	// here turns a bad future edit to the constants into a startup failure
+	// instead of a zero/negative-delay burst at runtime. Every test that calls
+	// NewSubscription exercises this path, so the panic also fires under go test.
+	retry, err := backoffutil.NewRetry(lookupRetryInitial, lookupRetryMaxInterval, lookupRetryJitter, lookupRetryMaxAttempts)
+	if err != nil {
+		retryCancel()
+		panic(fmt.Sprintf("streamevents: invalid LOOKUP_FAILED retry policy: %v", err))
+	}
 	return &Subscription{
 		transport:     t,
 		agents:        agents,
@@ -99,7 +173,49 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 		onCursorReset: onCursorReset,
 		retryCtx:      retryCtx,
 		retryCancel:   retryCancel,
+		retry:         retry,
 	}
+}
+
+// assignUpdateId stamps req with the next monotonic update_id and records it
+// as inflight. Must run under s.mu (every caller already holds it). The id is
+// monotonic for the subscription's life so a stale ack from a prior stream
+// generation (update_id=0 from older callers, or a buffered ack) cannot be
+// mistaken for current interest.
+func (s *Subscription) assignUpdateId(req *leapmuxv1.WatchEventsRequest) {
+	s.nextUpdateId++
+	id := s.nextUpdateId
+	s.inflightUpdateId = id
+	req.UpdateId = id
+}
+
+// applyFreshOpen publishes a freshly-opened stream as the live handle and
+// starts a new LOOKUP_FAILED retry epoch. It must run under s.mu (the caller
+// holds it). A fresh open is a clean slate: bumping the generation retires any
+// retry armed against the prior stream (an in-flight retry's post-timer check
+// fails, so it rolls back its peeked slot and bails), the budget is restored so
+// a transient miss after a clean reconnect gets a fresh budget, and the
+// once-guard is cleared so exhaustion can log again on the new epoch. Only an
+// explicit fresh open from the caller earns a new epoch — a transport-level
+// reconnect that does not go through Update does not.
+func (s *Subscription) applyFreshOpen(h Handle, req *leapmuxv1.WatchEventsRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.generation++
+	s.handle = h
+	s.lastReq = req
+	s.retry.Reset()
+	s.retryExhaustedLogged = false
+}
+
+// applyRevision records a successfully-sent revision as the live interest. It
+// must run under s.mu (the caller holds it). Only the interest pointer moves;
+// the budget, generation, and once-guard are untouched (a revision is not a
+// recovery boundary).
+func (s *Subscription) applyRevision(req *leapmuxv1.WatchEventsRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastReq = req
 }
 
 // Update opens (if needed) or revises the WatchEvents stream with `req`
@@ -112,6 +228,16 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 func (s *Subscription) Update(ctx context.Context, req *leapmuxv1.WatchEventsRequest) error {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
+
+	// Cancel closed the subscription; refuse to re-open. This is the closed-
+	// defense against the late-cancel race: a LOOKUP_FAILED retry whose timer
+	// fired still reaches Update, but lifecycleMu serializes the retry's Update
+	// against Cancel, so by the time this read runs Cancel has either not
+	// started (closed=false, the open is legit) or fully returned (closed=true,
+	// the open is an orphan).
+	if s.closed {
+		return errSubscriptionClosed
+	}
 
 	s.mu.Lock()
 	handle := s.handle
@@ -131,55 +257,58 @@ func (s *Subscription) Update(ctx context.Context, req *leapmuxv1.WatchEventsReq
 	}
 
 	if handle == nil {
+		s.mu.Lock()
+		s.assignUpdateId(req)
+		s.mu.Unlock()
 		h, err := s.transport.OpenWatchEvents(ctx, req, s.dispatch)
 		if err != nil {
 			return fmt.Errorf("open watch events: %w", err)
 		}
-		// A fresh open is a clean slate for the LOOKUP_FAILED retry budget and
-		// re-arms the retry gate a prior Cancel retired. The gate is recreated
-		// (not un-cancelled) so a retry that lost the race with a Cancel-during-
-		// open cannot revive it via this path; only an explicit fresh open from
-		// the caller earns a new budget.
-		retryCtx, retryCancel := context.WithCancel(context.Background())
-		s.mu.Lock()
-		prevRetryCancel := s.retryCancel
-		s.retryCtx = retryCtx
-		s.retryCancel = retryCancel
-		s.handle = h
-		s.lastReq = req
-		s.lookupAttempts = 0
-		s.mu.Unlock()
-		// Retire the previous gate after publishing the new one so a retry
-		// snapshotting under s.mu never observes a cancelled-but-not-replaced
-		// ctx; the new ctx is the live one.
-		prevRetryCancel()
+		s.applyFreshOpen(h, req)
 		return nil
 	}
+	s.mu.Lock()
+	prevInflight := s.inflightUpdateId
+	s.assignUpdateId(req)
+	s.mu.Unlock()
 	if err := handle.Update(req); err != nil {
+		// Roll back the inflight id: assignUpdateId bumped it before the send,
+		// but this revision never reached the wire, so leaving it advanced would
+		// make a subsequent LOOKUP_FAILED ack for the still-current prior revision
+		// test as stale (ackId < inflightUpdateId) and drop it. Restore the id of
+		// the interest that is actually live.
+		s.mu.Lock()
+		s.inflightUpdateId = prevInflight
+		s.mu.Unlock()
 		return fmt.Errorf("update watch events: %w", err)
 	}
-	s.mu.Lock()
-	s.lastReq = req
-	s.mu.Unlock()
+	s.applyRevision(req)
 	return nil
 }
 
 // Cancel stops the in-flight subscription, if any. Safe to call from
-// any goroutine; idempotent.
+// any goroutine; idempotent. Terminal: after Cancel returns, Update refuses
+// with errSubscriptionClosed for the life of the Subscription.
 func (s *Subscription) Cancel() {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
 
-	// Retire the retry gate so in-flight LOOKUP_FAILED retry goroutines bail
-	// (their timer selects on retryCtx) before they re-open a stream on
-	// context.Background — without this, a retry that wakes after Cancel
-	// orphans a worker-side subscription for the process lifetime.
+	// Bump the generation so in-flight LOOKUP_FAILED retry goroutines see the
+	// subscription has moved on when their timer fires, and refund their slot
+	// instead of re-opening a stream on a torn-down subscription. Cancel the
+	// retryCtx so an armed retry wakes immediately instead of lingering for up
+	// to lookupRetryMaxInterval after shutdown (a fresh-open does NOT cancel
+	// retryCtx — only Cancel does).
 	s.mu.Lock()
-	retryCancel := s.retryCancel
+	s.generation++
 	handle := s.handle
 	s.handle = nil
 	s.mu.Unlock()
-	retryCancel()
+	s.retryCancel()
 	if handle != nil {
 		handle.Cancel()
 		<-handle.Done()
@@ -219,62 +348,224 @@ func (s *Subscription) dispatch(resp *leapmuxv1.WatchEventsResponse) {
 	}
 }
 
+// logRejections logs each rejection at Debug and returns the entity_ids of the
+// ones carrying LOOKUP_FAILED — the one reason that arms a retry. The agent and
+// terminal rejection lists share this shape; the kind labels the log line. The
+// caller then gates the retry on whether any rejected entity is still in the
+// current interest (mirroring the frontend's shouldRetryRejection+tabExists),
+// so a LOOKUP_FAILED for an entity the CLI already stopped caring about does
+// not burn the shared budget.
+func logRejections(kind string, rejections []*leapmuxv1.WatchRejection) []string {
+	var lookupFailed []string
+	for _, r := range rejections {
+		slog.Debug("streamevents: "+kind+" watch rejected",
+			"entity_id", r.GetEntityId(), "reason", r.GetReason().String())
+		if r.GetReason() == leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED {
+			lookupFailed = append(lookupFailed, r.GetEntityId())
+		}
+	}
+	return lookupFailed
+}
+
+// wantAgent reports whether agentID is in req's current agent interest. Mirrors
+// the frontend's tabExists predicate, gated on the live interest so a
+// LOOKUP_FAILED for an entity the caller already dropped does not arm a retry
+// against it.
+func wantAgent(req *leapmuxv1.WatchEventsRequest, agentID string) bool {
+	for _, a := range req.GetAgents() {
+		if a.GetAgentId() == agentID {
+			return true
+		}
+	}
+	return false
+}
+
+// wantTerminal reports whether terminalID is in req's current terminal interest.
+func wantTerminal(req *leapmuxv1.WatchEventsRequest, terminalID string) bool {
+	for _, te := range req.GetTerminals() {
+		if te.GetTerminalId() == terminalID {
+			return true
+		}
+	}
+	return false
+}
+
+// anyRetryableInterest reports whether any LOOKUP_FAILED-rejected entity (across
+// the agent and terminal rejection lists) is still in the current interest req,
+// mirroring the frontend's anyRetryable(agents, terminals) gated on tabExists.
+// A LOOKUP_FAILED for an entity the caller no longer wants is not retried, so it
+// cannot burn the shared budget against an entity that was intentionally
+// dropped mid-flap.
+func anyRetryableInterest(req *leapmuxv1.WatchEventsRequest,
+	rejectedAgents, rejectedTerminals []*leapmuxv1.WatchRejection) bool {
+	for _, r := range rejectedAgents {
+		if r.GetReason() == leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED &&
+			wantAgent(req, r.GetEntityId()) {
+			return true
+		}
+	}
+	for _, r := range rejectedTerminals {
+		if r.GetReason() == leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED &&
+			wantTerminal(req, r.GetEntityId()) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Subscription) dispatchUpdateAck(ack *leapmuxv1.WatchUpdateAck) {
 	if ack == nil {
 		return
 	}
-	retry := false
-	for _, r := range ack.GetRejectedAgents() {
-		slog.Debug("streamevents: agent watch rejected",
-			"entity_id", r.GetEntityId(), "reason", r.GetReason().String())
-		if r.GetReason() == leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED {
-			retry = true
+	logRejections("agent", ack.GetRejectedAgents())
+	logRejections("terminal", ack.GetRejectedTerminals())
+	// Pending actions deferred until after s.mu is released, so the lock is held
+	// for the shortest scope and neither the slog.Warn nor the retry goroutine
+	// (whose Update may block in OpenWatchEvents) runs under it.
+	var (
+		armed    bool
+		armGen   uint64
+		delay    time.Duration
+		ok       bool
+		logOnce  bool
+		attempts int
+	)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer func() {
+		if armed {
+			go s.armLookupRetry(s.retryCtx, delay, armGen)
 		}
-	}
-	for _, r := range ack.GetRejectedTerminals() {
-		slog.Debug("streamevents: terminal watch rejected",
-			"entity_id", r.GetEntityId(), "reason", r.GetReason().String())
-		if r.GetReason() == leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED {
-			retry = true
+		if logOnce {
+			slog.Warn("streamevents: LOOKUP_FAILED retry budget exhausted",
+				"attempts", attempts)
 		}
+	}()
+	// Stale-ack filter: drop an ack whose update_id is below the inflight id.
+	// The worker echoes the request's update_id on the ack; an ack for a
+	// superseded revision is stale (the newer revision already restated the
+	// interest), and retrying on it would burn the budget on a LOOKUP_FAILED
+	// the newer revision may already be resolving. Mirrors the frontend's
+	// handleUpdateAck. update_id=0 (older callers / the open itself) is always
+	// processed — it carries no revision information.
+	ackId := ack.GetUpdateId()
+	if ackId != 0 && s.inflightUpdateId != 0 && ackId < s.inflightUpdateId {
+		return
 	}
-	if !retry {
+	if s.lastReq == nil {
+		// No interest to restate. Check before consuming an attempt so a spurious
+		// LOOKUP_FAILED ack (e.g. one racing a fresh open before lastReq is set)
+		// does not silently erode the budget.
+		return
+	}
+	// Per-entity liveness: only arm a retry if at least one LOOKUP_FAILED-
+	// rejected entity is still in the current interest. Mirrors the frontend's
+	// anyRetryable+tabExists: a LOOKUP_FAILED for an entity the caller already
+	// dropped (a tab removed mid-flap) is not retried, so it cannot burn the
+	// shared budget against an entity no one wants anymore. Read lastReq here
+	// under s.mu so the interest set is consistent with the ack's update_id.
+	if !anyRetryableInterest(s.lastReq, ack.GetRejectedAgents(), ack.GetRejectedTerminals()) {
+		return
+	}
+	if s.retryInFlight {
+		// A retry is already armed for this slot; coalesce. Mirrors the
+		// frontend's createExponentialBackoff.schedule, which no-ops while a timer
+		// is pending for the key. Without this, a burst of acks would
+		// consume one budget slot each and spawn one goroutine each, exhausting
+		// the 8-attempt budget N×faster than the frontend under a flapping
+		// worker. The in-flight retry re-reads lastReq when it fires, so no
+		// interest is lost.
+		return
+	}
+	// Peek the next delay under s.mu so two acks racing on the frame goroutine
+	// cannot both arm against the same slot, and mark in-flight so a burst
+	// coalesces into one retry. Peek does NOT consume the slot — the goroutine
+	// Commits only when the retry actually fires its Update, and Rolls back if it
+	// bails (Cancel or generation moved). So a Cancel that wins the race cannot
+	// erode the budget or ratchet the interval: the consume-on-fire design makes
+	// the refund-and-erode class of bug mechanically impossible.
+	delay, ok = s.retry.Peek()
+	if !ok {
+		// Budget spent. Log once per budget cycle (cleared on Reset): a
+		// perpetually-flapping worker emits a LOOKUP_FAILED ack per retry cycle,
+		// and logging a Warn on each post-exhaustion ack floods the operator's
+		// log with no new information.
+		if !s.retryExhaustedLogged {
+			s.retryExhaustedLogged = true
+			logOnce = true
+			attempts = s.retry.Attempts()
+		}
+		return
+	}
+	s.retryInFlight = true
+	armGen = s.generation
+	armed = true
+}
+
+// armLookupRetry sleeps for delay and then restates the latest interest after a
+// transient List*ByIDs miss. It selects on retryCtx so Cancel wakes it
+// immediately instead of lingering for up to lookupRetryMaxInterval after
+// shutdown (a fresh-open does NOT cancel retryCtx — only Cancel does — so a
+// retry whose stream recovered via a fresh-open can still restate against the
+// new stream). After the wait it re-checks generation under s.mu: if the stream
+// moved on (Cancel or fresh-open won the race) it Rolls back the peeked slot
+// (no budget consumed, no interval ratchet — the consume-on-fire design) and
+// bails without restating. It re-reads lastReq at fire time (not the arm-time
+// snapshot) so a revise issued during the backoff window is honored, matching
+// the frontend's fire-time plan read. The re-open runs on context.Background
+// (no gate for a fresh-open to retire), so it cannot be born-dead; the `closed`
+// flag in Update is the only re-open defense needed. It Commits the slot only
+// once the Update is dispatched, so a fire that then loses the lifecycleMu race
+// to Cancel still counts as a real attempt.
+func (s *Subscription) armLookupRetry(retryCtx context.Context, delay time.Duration, armGen uint64) {
+	t := time.NewTimer(delay)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-retryCtx.Done():
+		// Cancel retired the subscription while the timer was pending. Roll back
+		// the peeked slot (no budget consumed) and bail. retryInFlight stays set:
+		// a Cancelled subscription never arms another retry, so the stale flag
+		// cannot suppress a future retry.
+		s.mu.Lock()
+		s.retry.Rollback()
+		s.mu.Unlock()
 		return
 	}
 	s.mu.Lock()
-	req := s.lastReq
-	attempt := s.lookupAttempts
-	retryCtx := s.retryCtx
-	if attempt >= lookupRetryMax {
+	// The generation moved (Cancel or a fresh-open won the race) while the
+	// timer was pending. Roll back the peeked slot so the budget and interval
+	// are untouched (the attempt never fired), clear in-flight, and bail
+	// without re-stating against a stream that moved on. A fresh-open that
+	// already Reset the budget makes the rollback a harmless no-op on the
+	// interval; Reset is the stronger operation.
+	if s.generation != armGen {
+		s.retry.Rollback()
+		s.retryInFlight = false
 		s.mu.Unlock()
-		slog.Warn("streamevents: LOOKUP_FAILED retry budget exhausted",
-			"attempts", attempt)
 		return
 	}
-	s.lookupAttempts++
+	req := s.lastReq
+	s.retryInFlight = false
+	// Commit the slot now: the retry is about to fire its Update irreversibly,
+	// so this attempt counts. Committing under s.mu keeps the budget consistent
+	// with the in-flight flag we just cleared.
+	s.retry.Commit()
 	s.mu.Unlock()
 	if req == nil {
 		return
 	}
-	// Best-effort: restate the last interest after a short delay so a
-	// transient List*ByIDs miss recovers without an external reconnect. The
-	// retryCtx gate stops a retry that lost the race with Cancel from re-opening
-	// a stream the caller tore down; the bounded attempts stop a flapping worker
-	// from compounding into an unbounded retry ladder.
-	delay := lookupRetryDelays[attempt]
-	go func(r *leapmuxv1.WatchEventsRequest, delay time.Duration) {
-		t := time.NewTimer(delay)
-		defer t.Stop()
-		select {
-		case <-t.C:
-		case <-retryCtx.Done():
-			return
+	if err := s.Update(context.Background(), req); err != nil {
+		// errSubscriptionClosed is expected when Cancel won the race after
+		// the generation check passed; the re-open was correctly refused.
+		// Surface every other failure: this is the recovery path the budget
+		// drives, and a silent drop would mask the transport error that
+		// doomed the retry.
+		if !errors.Is(err, errSubscriptionClosed) {
+			slog.Warn("streamevents: LOOKUP_FAILED retry Update failed",
+				"err", err)
 		}
-		if retryCtx.Err() != nil {
-			return
-		}
-		_ = s.Update(retryCtx, r)
-	}(req, delay)
+	}
 }
 
 func (s *Subscription) dispatchAgentEvent(ae *leapmuxv1.AgentEvent) {

--- a/backend/internal/cli/remote/streamevents/subscription_test.go
+++ b/backend/internal/cli/remote/streamevents/subscription_test.go
@@ -1,8 +1,11 @@
 package streamevents
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
 // fakeHandle is an in-memory Handle for subscription tests.
@@ -185,6 +189,47 @@ func TestSubscription_TurnEndNotifyDoesNotForward(t *testing.T) {
 
 func protoInt32(v int32) *int32 { return &v }
 
+// fastRetry is a fast LOOKUP_FAILED backoff for tests that need to observe
+// retry/exhaust behavior without waiting on the production 15s cap.
+func fastRetry() *backoffutil.Retry {
+	r, err := backoffutil.NewRetry(10*time.Millisecond, 30*time.Millisecond, 0, 3)
+	if err != nil {
+		panic(err) // constants are known-valid
+	}
+	return r
+}
+
+// lookupFailedAck builds a WatchEventsResponse carrying a LOOKUP_FAILED
+// rejection for entityID. The three LOOKUP_FAILED tests share this frame shape.
+func lookupFailedAck(entityID string) *leapmuxv1.WatchEventsResponse {
+	return &leapmuxv1.WatchEventsResponse{
+		Event: &leapmuxv1.WatchEventsResponse_UpdateAck{UpdateAck: &leapmuxv1.WatchUpdateAck{
+			RejectedAgents: []*leapmuxv1.WatchRejection{{
+				EntityId: entityID,
+				Reason:   leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED,
+			}},
+		}},
+	}
+}
+
+// pushLookupFailed delivers a LOOKUP_FAILED ack for entityID through tr's
+// frame callback, the shape a flapping worker emits.
+func pushLookupFailed(tr *fakeTransport, entityID string) {
+	tr.pushFrame(lookupFailedAck(entityID))
+}
+
+// pushAgentMessage delivers a live agent chat message frame for agentID with the
+// given seq through tr's frame callback. Shared by the tests that exercise
+// cursor/callback delivery, mirroring pushLookupFailed for the message shape.
+func pushAgentMessage(tr *fakeTransport, agentID string, seq int64) {
+	tr.pushFrame(&leapmuxv1.WatchEventsResponse{
+		Event: &leapmuxv1.WatchEventsResponse_AgentEvent{AgentEvent: &leapmuxv1.AgentEvent{
+			AgentId: agentID,
+			Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: seq}},
+		}},
+	})
+}
+
 // TestSubscription_DedupsOverlapMessageBySeq verifies the
 // register-before-replay overlap is collapsed: a WatchEvents subscription
 // registers its watcher BEFORE replaying history, so a message created in that
@@ -210,14 +255,7 @@ func TestSubscription_DedupsOverlapMessageBySeq(t *testing.T) {
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
-	push := func(seq int64) {
-		tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-			Event: &leapmuxv1.WatchEventsResponse_AgentEvent{AgentEvent: &leapmuxv1.AgentEvent{
-				AgentId: "a-1",
-				Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: seq}},
-			}},
-		})
-	}
+	push := func(seq int64) { pushAgentMessage(tr, "a-1", seq) }
 
 	push(17) // live broadcast
 	push(17) // the same message's replay copy -- a duplicate, must be skipped
@@ -251,14 +289,7 @@ func TestSubscription_OverlapDedupIsOrderIndependent(t *testing.T) {
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
-	push := func(seq int64) {
-		tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-			Event: &leapmuxv1.WatchEventsResponse_AgentEvent{AgentEvent: &leapmuxv1.AgentEvent{
-				AgentId: "a-1",
-				Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: seq}},
-			}},
-		})
-	}
+	push := func(seq int64) { pushAgentMessage(tr, "a-1", seq) }
 
 	// Replay copy arrives BEFORE the live copy (the order the old gate mishandled).
 	push(9) // first copy of the overlap message -- forwarded, cursor -> 9
@@ -294,14 +325,7 @@ func TestSubscription_ForwardsEphemeralNegativeSeqFrames(t *testing.T) {
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
-	push := func(seq int64) {
-		tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-			Event: &leapmuxv1.WatchEventsResponse_AgentEvent{AgentEvent: &leapmuxv1.AgentEvent{
-				AgentId: "a-1",
-				Event:   &leapmuxv1.AgentEvent_AgentMessage{AgentMessage: &leapmuxv1.AgentChatMessage{Seq: seq}},
-			}},
-		})
-	}
+	push := func(seq int64) { pushAgentMessage(tr, "a-1", seq) }
 
 	push(7)  // a real message advances the cursor to 7
 	push(-1) // ephemeral session-info: must forward despite -1 <= 7
@@ -491,14 +515,7 @@ func TestSubscription_LookupFailedAckRetriesLastReq(t *testing.T) {
 	require.NoError(t, sub.Update(context.Background(), req))
 	require.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened))
 
-	tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-		Event: &leapmuxv1.WatchEventsResponse_UpdateAck{UpdateAck: &leapmuxv1.WatchUpdateAck{
-			RejectedAgents: []*leapmuxv1.WatchRejection{{
-				EntityId: "a-1",
-				Reason:   leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED,
-			}},
-		}},
-	})
+	pushLookupFailed(tr, "a-1")
 
 	require.Eventually(t, func() bool {
 		tr.mu.Lock()
@@ -525,14 +542,267 @@ func TestSubscription_LookupFailedAckRetriesLastReq(t *testing.T) {
 	assert.Equal(t, "a-1", last.GetAgents()[0].GetAgentId())
 }
 
+// TestSubscription_LookupFailedRetryReadsLatestLastReqAtFireTime pins the
+// fire-time re-read fix (SCAN-1): the LOOKUP_FAILED retry goroutine must re-read
+// s.lastReq when its timer fires, not restate the arm-time snapshot. Before the
+// fix the goroutine captured the arm-time lastReq pointer and called Update with
+// it at fire time, so a revise issued during the backoff window was clobbered
+// when the stale plan was revised back onto the live handle — the new entity's
+// events stalled until the next external reconnect. This mirrors the frontend's
+// useWatchEventsStreams fire-time plan read.
+func TestSubscription_LookupFailedRetryReadsLatestLastReqAtFireTime(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // 10-30ms, jitterless
+	t.Cleanup(sub.Cancel)
+
+	// Open with {a-1}; the retry will arm against this interest.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Arm a retry by pushing a LOOKUP_FAILED ack for a-1.
+	pushLookupFailed(tr, "a-1")
+
+	// While the retry is pending (10-30ms window), revise the live stream to add
+	// a-2. The retry must fire against THIS interest, not the arm-time {a-1}.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{
+			{AgentId: "a-1"}, {AgentId: "a-2"},
+		}}))
+
+	// Wait for the retry's restatement to land as a SECOND update on the handle
+	// (the first is the manual revise above). The discriminator: the retry's
+	// restatement is the LAST update, and it must carry BOTH agents. An arm-time
+	// snapshot would restate only {a-1}, so the final update would drop a-2.
+	require.Eventually(t, func() bool {
+		tr.mu.Lock()
+		h := tr.handle
+		tr.mu.Unlock()
+		if h == nil {
+			return false
+		}
+		h.mu.Lock()
+		count := len(h.updates)
+		var ids map[string]bool
+		if count >= 2 {
+			last := h.updates[count-1]
+			ids = make(map[string]bool, len(last.GetAgents()))
+			for _, a := range last.GetAgents() {
+				ids[a.GetAgentId()] = true
+			}
+		}
+		h.mu.Unlock()
+		return count >= 2 && ids["a-1"] && ids["a-2"]
+	}, time.Second, 5*time.Millisecond,
+		"retry's restatement (the 2nd update) must carry the fire-time lastReq (both a-1 and a-2), not the arm-time {a-1}")
+}
+
+// TestSubscription_LookupFailedRetryWakesImmediatelyOnCancel pins the
+// retryCtx fix (REMOVALS-1): an armed LOOKUP_FAILED retry goroutine must NOT
+// linger for up to lookupRetryMaxInterval after Cancel returns. Before the fix
+// the goroutine blocked on a bare <-t.C with no cancellation, so it (and its
+// captured request) stayed alive for up to the 15s cap after shutdown. The
+// goroutine now selects on retryCtx.Done(), which Cancel cancels, so it bails
+// promptly.
+func TestSubscription_LookupFailedRetryWakesImmediatelyOnCancel(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	// A long delay so that without the retryCtx select the goroutine would
+	// demonstrably outlive Cancel by a wide margin.
+	r, err := backoffutil.NewRetry(30*time.Second, 60*time.Second, 0, 3)
+	require.NoError(t, err)
+	sub.retry = r
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Arm the retry (30s delay). Without the retryCtx select this goroutine would
+	// sleep for 30s; Cancel must wake it well before that.
+	pushLookupFailed(tr, "a-1")
+
+	// Give the goroutine a moment to arm, then Cancel. The retry must bail via
+	// retryCtx.Done() and refund its slot — observable as Attempts()==0 (the slot
+	// was refunded, not spent).
+	time.Sleep(20 * time.Millisecond)
+	start := time.Now()
+	sub.Cancel()
+	elapsed := time.Since(start)
+
+	// Cancel returns promptly (it does not block on the handle's Done for long,
+	// and the retry goroutine bails via retryCtx without waiting on the 30s
+	// timer). Assert it returned in well under the 30s delay.
+	assert.Less(t, elapsed, time.Second,
+		"Cancel must wake the retry promptly, not wait on the 30s timer")
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	sub.mu.Unlock()
+	assert.Equal(t, 0, attempts, "a Cancelled retry must refund its consumed slot")
+}
+
+// TestSubscription_ReviseFailureRollsBackInflightUpdateId pins the
+// stale-ack-filter invariant fix (ALTITUDE-2): when a revise's handle.Update
+// fails, the inflight update_id must roll back to the prior value, so a
+// subsequent LOOKUP_FAILED ack for the still-current prior revision is not
+// dropped as stale. Before the fix assignUpdateId bumped the id before the send,
+// and a failed send left it advanced past a revision never put on the wire.
+func TestSubscription_ReviseFailureRollsBackInflightUpdateId(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry()
+	t.Cleanup(sub.Cancel)
+
+	// Open with {a-1}; this sets inflightUpdateId = 1.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	sub.mu.Lock()
+	openInflight := sub.inflightUpdateId
+	sub.mu.Unlock()
+	require.Equal(t, uint64(1), openInflight)
+
+	// Make the next revise (handle.Update) fail.
+	tr.mu.Lock()
+	tr.handle.updateFn = func(*leapmuxv1.WatchEventsRequest) error { return errors.New("send failed") }
+	tr.mu.Unlock()
+
+	// Revise to {a-2}; the send fails, so the wire still carries {a-1} (id 1).
+	err := sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-2"}}})
+	require.Error(t, err)
+
+	// The inflight id must be rolled back to the open's id (1), not left at 2.
+	// If it were left at 2, a LOOKUP_FAILED ack for the still-live {a-1} (id 1)
+	// would be dropped as stale by the filter.
+	sub.mu.Lock()
+	inflight := sub.inflightUpdateId
+	sub.mu.Unlock()
+	assert.Equal(t, openInflight, inflight,
+		"a failed revise must roll back inflightUpdateId so the prior (live) revision's acks are not stale")
+}
+
+// TestSubscription_FreshOpenClearsExhaustionOnceGuard pins SWEEP-3: a fresh
+// stream open must clear retryExhaustedLogged so the budget-exhausted Warn can
+// fire again on the new stream's own exhaustion cycle. Without this, a budget
+// that exhausted on one stream would never log exhaustion again after a
+// reconnect.
+func TestSubscription_FreshOpenClearsExhaustionOnceGuard(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry()
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Exhaust the budget and set the once-guard directly.
+	sub.mu.Lock()
+	for !sub.retry.Done() {
+		sub.retry.Peek()
+		sub.retry.Commit()
+	}
+	sub.retryExhaustedLogged = true
+	sub.mu.Unlock()
+	require.True(t, sub.retry.Done(), "budget pre-exhausted")
+
+	// End the handle and re-open via Update (the fresh-open path).
+	tr.mu.Lock()
+	h := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, h)
+	h.Cancel()
+	<-h.Done()
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// The fresh open must have cleared both the budget and the once-guard.
+	sub.mu.Lock()
+	done := sub.retry.Done()
+	logged := sub.retryExhaustedLogged
+	sub.mu.Unlock()
+	assert.False(t, done, "fresh open must reset the budget")
+	assert.False(t, logged, "fresh open must clear retryExhaustedLogged")
+}
+
+// TestSubscription_ErrSubscriptionClosedIsExported pins that the sentinel
+// returned by Update after Cancel is the exported ErrSubscriptionClosed, so
+// cross-package callers (agent_messages.go's reconnect loop) can distinguish it
+// from a real subscribe failure via errors.Is.
+func TestSubscription_ErrSubscriptionClosedIsExported(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	require.NoError(t, sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{}))
+	sub.Cancel()
+	err := sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{})
+	require.ErrorIs(t, err, ErrSubscriptionClosed,
+		"post-Cancel Update must return the exported ErrSubscriptionClosed sentinel")
+}
+
+// TestSubscription_LookupRetryPolicyMirrorsFrontend pins the LOOKUP_FAILED
+// retry policy values against the documented frontend shape
+// (frontend/src/hooks/useWatchEventsStreams.ts rejectionBackoff over
+// createExponentialBackoff: initialMs=500, maxMs=15000, multiplier=2,
+// jitterFactor=0.2, maxAttempts=8). Cross-language constant sharing is
+// impractical, so this test is the drift alarm: a change to the values here
+// without a matching frontend change (or a deliberate divergence documented in
+// the constant block) fails the suite.
+func TestSubscription_LookupRetryPolicyMirrorsFrontend(t *testing.T) {
+	assert.Equal(t, 500*time.Millisecond, lookupRetryInitial,
+		"initial must mirror frontend initialMs=500")
+	assert.Equal(t, 15*time.Second, lookupRetryMaxInterval,
+		"maxInterval must mirror frontend maxMs=15000")
+	assert.InDelta(t, 0.2, lookupRetryJitter, 1e-9,
+		"jitter must mirror frontend jitterFactor=0.2")
+	assert.Equal(t, 8, lookupRetryMaxAttempts,
+		"maxAttempts must mirror frontend maxAttempts=8")
+}
+
+// TestSubscription_LookupFailedAckWithNilLastReqDoesNotConsumeBudget pins the
+// nil-check-before-Next fix: a LOOKUP_FAILED ack that arrives when lastReq is
+// nil (e.g. a spurious rejection racing a fresh open) must NOT consume a retry
+// attempt. Without the check, dispatchUpdateAck called Next() before testing
+// req == nil, silently eroding the 8-attempt budget on no-op acks until a real
+// LOOKUP_FAILED got ok=false and the CLI stopped retrying for the stream's life.
+func TestSubscription_LookupFailedAckWithNilLastReqDoesNotConsumeBudget(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry()
+	t.Cleanup(sub.Cancel)
+
+	// Construct a sub with a live handle but no lastReq. Update sets lastReq, so
+	// nil it directly under s.mu to simulate the race window before the first
+	// interest is published (or after it's cleared).
+	require.NoError(t, sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
+	}))
+	sub.mu.Lock()
+	sub.lastReq = nil
+	sub.retry.Reset()
+	sub.mu.Unlock()
+
+	// A LOOKUP_FAILED ack with no lastReq to restate must be a no-op on the budget.
+	pushLookupFailed(tr, "a-1")
+
+	// Give the (non-)retry a moment to settle, then assert no attempt was consumed.
+	time.Sleep(50 * time.Millisecond)
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	sub.mu.Unlock()
+	assert.Equal(t, 0, attempts, "LOOKUP_FAILED ack with nil lastReq must not consume a retry attempt")
+}
+
 // TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel pins the fix for a
 // goroutine-leak / orphaned-subscription bug: the LOOKUP_FAILED retry used
 // context.Background with no Cancel guard, so a retry that woke after Cancel
-// reopened a fresh worker-side stream nobody would ever tear down. Cancel must
-// set the closed flag so the in-flight retry bails instead of re-opening.
+// reopened a fresh worker-side stream nobody would ever tear down. Cancel bumps
+// the generation, cancels retryCtx (waking the sleeper), and sets the closed
+// flag so the in-flight retry bails (and Update refuses the re-open) instead of
+// re-opening. It also pins the consume-on-fire budget invariant: a retry whose
+// generation moved mid-wait Rolled back its peeked slot (never committed), so a
+// Cancel does not silently erode the attempt budget.
 func TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel(t *testing.T) {
 	tr := &fakeTransport{}
 	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // fast, jitterless; Cancel below runs synchronously
 
 	req := &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
@@ -542,30 +812,30 @@ func TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel(t *testing.T) {
 	require.Equal(t, int32(1), openedBefore)
 
 	// Push LOOKUP_FAILED, then Cancel inside the retry delay window.
-	tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-		Event: &leapmuxv1.WatchEventsResponse_UpdateAck{UpdateAck: &leapmuxv1.WatchUpdateAck{
-			RejectedAgents: []*leapmuxv1.WatchRejection{{
-				EntityId: "a-1",
-				Reason:   leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED,
-			}},
-		}},
-	})
-	// Cancel before the 200ms retry fires.
+	pushLookupFailed(tr, "a-1")
+	// Cancel before the 10ms retry fires.
 	sub.Cancel()
 
-	// Wait past the longest possible retry delay and assert no re-open landed.
-	time.Sleep(lookupRetryDelays[len(lookupRetryDelays)-1] + 200*time.Millisecond)
+	// Wait past the first retry delay and assert no re-open landed.
+	time.Sleep(300 * time.Millisecond)
 	assert.Equal(t, openedBefore, atomic.LoadInt32(&tr.callsOpened),
 		"LOOKUP_FAILED retry must not re-open a stream after Cancel")
+	// The retry bailed when its gate retired, so it must refund the slot it
+	// consumed -- without this, a Cancel mid-retry would burn budget for nothing.
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	sub.mu.Unlock()
+	assert.Equal(t, 0, attempts, "a retry cancelled mid-wait must refund its attempt slot")
 }
 
 // TestSubscription_LookupFailedRetryBudgetExhausts pins the bounded-retry fix:
 // previously every LOOKUP_FAILED ack spawned a fresh goroutine that produced
 // another LOOKUP_FAILED ack, compounding without limit on a flapping worker.
-// The retry must stop after lookupRetryMax attempts.
+// The retry must stop after the budget is spent.
 func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 	tr := &fakeTransport{}
 	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // 3 attempts, 10-30ms, jitterless
 	t.Cleanup(sub.Cancel)
 
 	req := &leapmuxv1.WatchEventsRequest{
@@ -573,9 +843,12 @@ func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 	}
 	require.NoError(t, sub.Update(context.Background(), req))
 
-	// Drive enough ack cycles to exhaust the budget. Each retry re-states the
-	// plan; we approximate the worker's perpetual LOOKUP_FAILED by pushing an
-	// ack whenever a retry Update lands.
+	// Simulate a worker that perpetually rejects "a-missing" with LOOKUP_FAILED.
+	// The feedback loop: a retry re-states the plan, the worker rejects again.
+	// We bootstrap the first ack (opening the stream does not call handle.Update,
+	// so lastUpdate() is nil until the first retry lands), then perpetuate.
+	pushLookupFailed(tr, "a-missing") // bootstrap the retry ladder
+
 	stop := make(chan struct{})
 	go func() {
 		for {
@@ -584,33 +857,128 @@ func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 				return
 			default:
 				if tr.lastUpdate() != nil {
-					tr.pushFrame(&leapmuxv1.WatchEventsResponse{
-						Event: &leapmuxv1.WatchEventsResponse_UpdateAck{UpdateAck: &leapmuxv1.WatchUpdateAck{
-							RejectedAgents: []*leapmuxv1.WatchRejection{{
-								EntityId: "a-missing",
-								Reason:   leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED,
-							}},
-						}},
-					})
+					pushLookupFailed(tr, "a-missing")
 				}
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(2 * time.Millisecond)
 			}
 		}
 	}()
+
+	// The budget must exhaust after exactly maxAttempts retries. Read retry state
+	// under s.mu -- the same lock production serializes retry access through.
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		return sub.retry.Done()
+	}, 500*time.Millisecond, 5*time.Millisecond,
+		"retry budget should exhaust after maxAttempts LOOKUP_FAILED acks")
 	close(stop)
 
-	// Wait well past the sum of all retry delays, then assert opens stayed at 1.
-	time.Sleep(sumLookupRetryDelays() + 300*time.Millisecond)
+	// Let any in-flight retry settle, then read the final attempt count under s.mu.
+	time.Sleep(50 * time.Millisecond)
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	sub.mu.Unlock()
+
 	assert.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened),
-		"LOOKUP_FAILED retries must stop after the budget is exhausted (no re-open ladder)")
+		"LOOKUP_FAILED retries must not re-open the stream (no re-open ladder)")
+	assert.Equal(t, 3, attempts, "exactly maxAttempts retries consumed")
 }
 
-func sumLookupRetryDelays() time.Duration {
-	var d time.Duration
-	for _, dd := range lookupRetryDelays {
-		d += dd
+// TestSubscription_FreshOpenResetsRetryBudget pins that a fresh stream open
+// (handle dead -> Update re-opens) re-arms a previously-exhausted LOOKUP_FAILED
+// budget. Without this, a transient miss after a reconnect would inherit a spent
+// budget and never retry.
+func TestSubscription_FreshOpenResetsRetryBudget(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // 3 attempts, jitterless
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Exhaust the budget directly under s.mu (the lock production uses).
+	sub.mu.Lock()
+	for !sub.retry.Done() {
+		sub.retry.Peek()
+		sub.retry.Commit()
 	}
-	return d
+	sub.mu.Unlock()
+	require.True(t, sub.retry.Done(), "budget pre-exhausted")
+
+	// End the handle the way a natural transport disconnect would, then Update.
+	tr.mu.Lock()
+	h := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, h)
+	h.Cancel()
+	<-h.Done()
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&tr.callsOpened), "Update re-opened the stream")
+
+	// The fresh open must have restored the budget.
+	sub.mu.Lock()
+	done := sub.retry.Done()
+	sub.mu.Unlock()
+	assert.False(t, done, "fresh open must reset the LOOKUP_FAILED retry budget")
+}
+
+// TestSubscription_LookupFailedRetryReopenSurvivesGateRetire pins the
+// born-dead-stream regression: a LOOKUP_FAILED retry whose Update takes the
+// fresh-open path must NOT open a stream that immediately dies. The retry re-
+// opens on context.Background (no gate for a fresh-open to retire mid-open),
+// so the born-dead failure mode is structurally impossible. This test stays as
+// a regression guard against any future re-introduction of a gate the retry's
+// own Update would cancel.
+func TestSubscription_LookupFailedRetryReopenSurvivesGateRetire(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // fast, jitterless
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	require.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened))
+
+	// End the handle the way a natural transport disconnect would, so the retry's
+	// Update takes the fresh-open path (handle == nil -> OpenWatchEvents).
+	tr.mu.Lock()
+	first := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, first)
+	first.Cancel()
+	<-first.Done()
+
+	// Push LOOKUP_FAILED so a retry arms. The retry fires after ~10ms and calls
+	// Update, which re-opens (fresh-open). The re-open runs on context.Background
+	// (no gate), so nothing inside Update can cancel the newborn stream.
+	pushLookupFailed(tr, "a-1")
+
+	// Wait for the retry's re-open to land.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&tr.callsOpened) >= 2
+	}, time.Second, 5*time.Millisecond, "LOOKUP_FAILED retry must re-open the stream")
+
+	// Let the retry's Update finish so the assertion observes the post-open
+	// state. (The re-open publishes under s.mu; Cancel/next-Update serialize on
+	// lifecycleMu, so this settle only waits for the in-flight Update.)
+	time.Sleep(50 * time.Millisecond)
+
+	// The re-opened stream must be alive. A generation/WithoutCancel regression
+	// that re-introduced a gate the retry's own Update cancels would close
+	// Done() immediately and discard the recovery.
+	tr.mu.Lock()
+	reopened := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, reopened)
+	select {
+	case <-reopened.Done():
+		t.Fatal("re-opened stream must not be born dead")
+	default:
+	}
 }
 
 // TestSubscription_UpdateErrorAfterSuccessLeavesCleanState covers the
@@ -786,6 +1154,315 @@ func TestSubscription_DoneOnFreshSubReturnsClosed(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Done() on un-Updated Subscription must return a closed channel")
 	}
+}
+
+// TestSubscription_UpdateAfterCancelReturnsClosed pins the closed-defense that
+// stops the late-cancel orphan race: a LOOKUP_FAILED retry whose timer fired
+// still reaches Update, and nothing in the retry path (generation check, no
+// gate) can stop the re-open once the timer has fired. The `closed` flag — set
+// by Cancel under lifecycleMu and checked by Update under the same lock — is
+// what refuses the re-open. Without it, the retry would fresh-open a
+// worker-side stream the caller already tore down.
+func TestSubscription_UpdateAfterCancelReturnsClosed(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	require.NoError(t, sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
+	}))
+	require.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened))
+
+	sub.Cancel()
+
+	// A post-Cancel Update (the path a late retry takes) must NOT re-open: it
+	// returns the closed sentinel and leaves callsOpened at 1.
+	err := sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
+	})
+	require.ErrorIs(t, err, errSubscriptionClosed)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened),
+		"Update after Cancel must not re-open a stream (no orphan)")
+}
+
+// TestSubscription_LateCancelRetryDoesNotOrphan exercises the late-cancel race
+// window the closed-flag defends: the retry's timer fires and the generation
+// check passes (the generation has not moved yet), so the retry proceeds into
+// Update. The retry's Update blocks inside OpenWatchEvents (via releaseOpen);
+// Cancel then runs and blocks on lifecycleMu. Releasing the open lets the
+// retry's Update finish and publish a handle, which Cancel (next in line for
+// lifecycleMu) then tears down. The assertion: after Cancel returns, no stream
+// is active (active==0) -- the retry's re-open did not survive shutdown as an
+// orphan. Before the closed-flag defense the re-open's handle was published
+// after Cancel snapshotted-and-nilled the prior handle, so Cancel never
+// cancelled it.
+func TestSubscription_LateCancelRetryDoesNotOrphan(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // fast, jitterless
+
+	require.NoError(t, sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
+	}))
+	require.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened))
+
+	// End the handle the way a natural transport disconnect would, so the retry's
+	// Update takes the fresh-open path (handle == nil -> OpenWatchEvents).
+	tr.mu.Lock()
+	first := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, first)
+	first.Cancel()
+	<-first.Done()
+
+	// Block the retry's re-open inside OpenWatchEvents so Cancel can race it.
+	// openStarted fires when OpenWatchEvents is entered; releaseOpen gates when
+	// it returns. The retry's open blocks between the two.
+	openStarted := make(chan struct{}, 4)
+	releaseOpen := make(chan struct{})
+	tr.mu.Lock()
+	tr.openStarted = openStarted
+	tr.releaseOpen = releaseOpen
+	tr.mu.Unlock()
+
+	// Arm the retry. It fires after ~10ms, passes the gate check (the gate is
+	// still live), enters Update, and blocks on releaseOpen mid-open.
+	pushLookupFailed(tr, "a-1")
+
+	// Wait for the retry's re-open to enter OpenWatchEvents.
+	select {
+	case <-openStarted:
+	case <-time.After(time.Second):
+		t.Fatal("retry's re-open never entered OpenWatchEvents")
+	}
+
+	// Cancel while the retry's Update holds lifecycleMu inside OpenWatchEvents.
+	// Cancel blocks on lifecycleMu until the retry's Update returns.
+	cancelDone := make(chan struct{})
+	go func() {
+		sub.Cancel()
+		close(cancelDone)
+	}()
+
+	// Let the retry's Update finish its open (publishing a handle), then Cancel
+	// acquires lifecycleMu and must tear that handle down.
+	close(releaseOpen)
+
+	select {
+	case <-cancelDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cancel did not return after the retry's Update completed")
+	}
+
+	// After Cancel returns, no stream may be active: the retry's re-open did not
+	// survive as an orphan. (callsOpened may be 2 -- the open happened -- but the
+	// stream is cancelled, so active drops to 0 once the handle's ctx fires.)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&tr.active) == 0
+	}, time.Second, 5*time.Millisecond,
+		"the retry's late re-open must be torn down by Cancel, not orphaned")
+}
+
+// TestSubscription_UpdateAssignsMonotonicUpdateId pins the update_id
+// instrumentation (SWEEP-8): every Update stamps the request with a monotonic
+// id, so the stale-ack filter can tell a current ack from one for a superseded
+// revision. The open and each revise must carry strictly increasing ids.
+func TestSubscription_UpdateAssignsMonotonicUpdateId(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	t.Cleanup(sub.Cancel)
+
+	// Open.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	tr.mu.Lock()
+	openReq := tr.calls[len(tr.calls)-1]
+	tr.mu.Unlock()
+	require.Equal(t, uint64(1), openReq.GetUpdateId(), "open carries the first update_id")
+
+	// Revise twice; each must carry a strictly larger id.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-2"}}}))
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-3"}}}))
+
+	tr.mu.Lock()
+	h := tr.handle
+	tr.mu.Unlock()
+	require.NotNil(t, h)
+	h.mu.Lock()
+	require.Greater(t, h.updates[0].GetUpdateId(), openReq.GetUpdateId())
+	require.Greater(t, h.updates[1].GetUpdateId(), h.updates[0].GetUpdateId())
+	h.mu.Unlock()
+}
+
+// TestSubscription_StaleLookupFailedAckDoesNotConsumeBudget pins the stale-ack
+// filter (SWEEP-8): a LOOKUP_FAILED ack whose update_id is below the inflight id
+// is dropped before it can arm a retry. Without this, a stale ack from a
+// superseded revision would burn the budget on a LOOKUP_FAILED the newer
+// revision is already resolving. update_id=0 (no revision info) is always
+// processed, matching the frontend.
+func TestSubscription_StaleLookupFailedAckDoesNotConsumeBudget(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry()
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	// Bump the inflight id so a stale ack (update_id=1) is below it.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-2"}}}))
+
+	// A stale ack (update_id=1, below the current inflight id of 2) must be
+	// dropped — no retry armed, no budget consumed.
+	tr.pushFrame(&leapmuxv1.WatchEventsResponse{
+		Event: &leapmuxv1.WatchEventsResponse_UpdateAck{UpdateAck: &leapmuxv1.WatchUpdateAck{
+			UpdateId: 1,
+			RejectedAgents: []*leapmuxv1.WatchRejection{{
+				EntityId: "a-1",
+				Reason:   leapmuxv1.WatchRejectionReason_WATCH_REJECTION_REASON_LOOKUP_FAILED,
+			}},
+		}},
+	})
+	time.Sleep(50 * time.Millisecond)
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	inFlight := sub.retryInFlight
+	sub.mu.Unlock()
+	assert.Equal(t, 0, attempts, "a stale ack must not consume the retry budget")
+	assert.False(t, inFlight, "a stale ack must not arm a retry")
+
+	// A current ack (update_id=0 is always processed, matching the frontend)
+	// for an entity STILL in the interest arms a retry and consumes a slot.
+	pushLookupFailed(tr, "a-2")
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		return sub.retry.Attempts() >= 1
+	}, time.Second, 5*time.Millisecond, "a current ack for a wanted entity must arm a retry")
+}
+
+// TestSubscription_LookupFailedAckForDroppedEntityDoesNotRetry pins the per-
+// entity liveness check (ALTITUDE-12): a LOOKUP_FAILED for an entity the CLI
+// already dropped from its interest must NOT arm a retry, so it cannot burn the
+// shared budget against an entity no one wants anymore. Mirrors the frontend's
+// shouldRetryRejection+tabExists gate. Without this, a flapping worker that
+// keeps rejecting a tab the user closed mid-flap would exhaust the 8-attempt
+// budget for the whole subscription.
+func TestSubscription_LookupFailedAckForDroppedEntityDoesNotRetry(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry()
+	t.Cleanup(sub.Cancel)
+
+	// Open with {a-1}, then revise to {a-2} — dropping a-1 from the interest.
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-2"}}}))
+
+	// A LOOKUP_FAILED for the dropped a-1 must not arm a retry.
+	pushLookupFailed(tr, "a-1")
+	time.Sleep(50 * time.Millisecond)
+	sub.mu.Lock()
+	attempts := sub.retry.Attempts()
+	inFlight := sub.retryInFlight
+	sub.mu.Unlock()
+	assert.Equal(t, 0, attempts, "a LOOKUP_FAILED for a dropped entity must not consume a retry slot")
+	assert.False(t, inFlight, "a LOOKUP_FAILED for a dropped entity must not arm a retry")
+
+	// A LOOKUP_FAILED for the still-wanted a-2 DOES arm a retry.
+	pushLookupFailed(tr, "a-2")
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		return sub.retry.Attempts() >= 1
+	}, time.Second, 5*time.Millisecond, "a LOOKUP_FAILED for a wanted entity must arm a retry")
+}
+
+// TestSubscription_LookupFailedRetryCoalescesInFlight pins the in-flight retry
+// guard (REMOVALS-2): a burst of LOOKUP_FAILED acks while a retry is already
+// armed coalesces into one retry per slot, matching the frontend's
+// createExponentialBackoff.schedule. Without this, a burst would consume one
+// budget slot per ack and exhaust the 8-attempt budget N×faster than the
+// frontend under a flapping worker.
+func TestSubscription_LookupFailedRetryCoalescesInFlight(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // 3 attempts, 10-30ms, jitterless
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Push a burst of LOOKUP_FAILED acks while NO retry has fired yet (delays
+	// are 10-30ms; these all land within the first retry's window). Each ack
+	// after the first must coalesce into the single armed retry.
+	for i := 0; i < 5; i++ {
+		pushLookupFailed(tr, "a-1")
+	}
+
+	// Within the first retry window (before the 10ms delay elapses), exactly one
+	// retry must be armed. With consume-on-fire, no slot is committed yet (the
+	// retry hasn't fired its Update); the discriminator is that ONE retry is
+	// in-flight and the others were coalesced away.
+	time.Sleep(5 * time.Millisecond)
+	sub.mu.Lock()
+	inFlight := sub.retryInFlight
+	sub.mu.Unlock()
+	assert.True(t, inFlight, "a burst of acks must coalesce into one in-flight retry")
+
+	// After the retry fires, exactly one slot must be committed (not 5).
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		return sub.retry.Attempts() == 1
+	}, time.Second, 5*time.Millisecond,
+		"a burst of acks must coalesce into one committed retry (one slot consumed, not 5)")
+}
+
+// TestSubscription_BudgetExhaustionLogsOnce pins the once-guard (EFFICIENCY-2):
+// after the budget is spent, the exhaustion Warn fires once per budget cycle,
+// not once per subsequent LOOKUP_FAILED ack. Without this, a perpetually-
+// flapping worker would flood the operator's log with a Warn per ack.
+func TestSubscription_BudgetExhaustionLogsOnce(t *testing.T) {
+	tr := &fakeTransport{}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
+	sub.retry = fastRetry() // 3 attempts, jitterless
+	t.Cleanup(sub.Cancel)
+
+	require.NoError(t, sub.Update(context.Background(),
+		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
+
+	// Exhaust the budget directly under s.mu.
+	sub.mu.Lock()
+	for !sub.retry.Done() {
+		sub.retry.Peek()
+		sub.retry.Commit()
+	}
+	sub.mu.Unlock()
+	require.True(t, sub.retry.Done(), "budget pre-exhausted")
+
+	// Reset the once-guard so we observe the first-exhaustion transition; the
+	// production code sets it on the transition, so simulate a fresh cycle.
+	sub.mu.Lock()
+	sub.retryExhaustedLogged = false
+	sub.mu.Unlock()
+
+	// Capture slog output during the ack dispatches.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	// Drive several LOOKUP_FAILED acks post-exhaustion. Only the FIRST must log.
+	for i := 0; i < 4; i++ {
+		pushLookupFailed(tr, "a-1")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	count := strings.Count(buf.String(), "LOOKUP_FAILED retry budget exhausted")
+	assert.Equal(t, 1, count,
+		"the budget-exhausted Warn must fire once per cycle, not once per ack")
 }
 
 // TestSubscription_RapidSequentialUpdates pins back-to-back Update behaviour:

--- a/backend/internal/util/backoffutil/backoffutil.go
+++ b/backend/internal/util/backoffutil/backoffutil.go
@@ -1,8 +1,10 @@
 // Package backoffutil is the one place capped exponential backoff is
-// configured.
+// configured. It owns the doubling/jitter/cap math so callers depend on
+// backoffutil, not on cenkalti/backoff/v6 — the third-party type never crosses
+// the package boundary.
 //
-// Three loops in this tree retry the same shape -- double, cap, reset on
-// success -- and each had hand-rolled or hand-configured it: the hub client's
+// Three loops in this tree retry the same shape — double, cap, reset on
+// success — and each had hand-rolled or hand-configured it: the hub client's
 // reconnect, the `leapmux remote` follower's WatchEvents reconnect, and the
 // worker's orphan-reconciler pass. Three copies of `min(prev*2, cap)` is three
 // places to get the arithmetic wrong, and it HAD been: the follower carried a
@@ -10,33 +12,258 @@
 // `cur` runs past `max` whenever `max` is not a power-of-two multiple of the
 // floor.
 //
-// What differs between the three is only WHEN the backoff resets -- a duration
-// threshold, stream activity, or a converged pass -- so that stays at each call
+// What differs between the three is only WHEN the backoff resets — a duration
+// threshold, stream activity, or a converged pass — so that stays at each call
 // site, where it is the interesting part.
+//
+// Two constructors cover the two shapes: NewBackoff for an unbounded loop that
+// resets on success/activity (the three reconnect loops), and NewRetry for a
+// count-bounded loop that gives up after a fixed attempt budget (v6 dropped
+// MaxElapsedTime, so the budget lives here). NewRetry wraps the same capped,
+// jittered exponential NewBackoff produces, and consumes the budget only when
+// an attempt actually fires (Peek + Commit), so a retry that arms but bails
+// before firing never erodes the budget or ratchets the interval.
 package backoffutil
 
 import (
+	"fmt"
+	"math/rand/v2"
 	"time"
-
-	"github.com/cenkalti/backoff/v6"
 )
 
-// NewCapped returns an exponential backoff that starts at initial, doubles, and
-// never exceeds maxInterval.
+// Backoff is a capped, jittered exponential backoff that owns its interval
+// math. It starts at initial, doubles on each advance, and never exceeds
+// maxInterval. jitter fuzzes each sampled delay by ±jitter (0 disables it).
+//
+// The doubling sequence advances on the UN-jittered base interval, and jitter
+// only fuzzes the sampled value — matching the frontend's
+// createExponentialBackoff and cenkalti/v6's shape. Unlike cenkalti's
+// ExponentialBackOff (which couples get-delay with advance inside NextBackOff),
+// Backoff separates Peek (sample without advancing) from Commit (advance), so a
+// caller that samples a delay but then bails before firing can discard the
+// sample without ratcheting the interval forward.
+//
+// NOT safe for concurrent use — each retry loop owns its own, which every
+// current caller does (a single goroutine driving one loop, or a caller that
+// serializes all access under its own mutex, as the LOOKUP_FAILED retry does).
+type Backoff struct {
+	initial     time.Duration
+	maxInterval time.Duration
+	jitter      float64
+
+	base    time.Duration // un-jittered interval the next sample is drawn from
+	pending time.Duration // the most recent Peek result, awaiting Commit; 0 = none
+}
+
+// NewBackoff returns a capped, jittered exponential backoff that starts at
+// initial, doubles, and never exceeds maxInterval.
 //
 // jitter is the randomization factor (0 disables it entirely, which makes the
 // sequence exactly initial, 2×initial, 4×initial, … capped). Reserve 0 for
 // loops whose timing is asserted; anything retrying against a shared peer wants
 // jitter, so a fleet that failed together does not retry together.
 //
-// The returned value is NOT safe for concurrent use -- each retry loop owns its
-// own, which every current caller does (a single goroutine driving one loop).
-func NewCapped(initial, maxInterval time.Duration, jitter float64) *backoff.ExponentialBackOff {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = initial
-	b.MaxInterval = maxInterval
-	b.Multiplier = 2.0
-	b.RandomizationFactor = jitter
-	b.Reset()
-	return b
+// Panics on invalid inputs (initial <= 0, maxInterval < initial, jitter outside
+// [0,1)) — these are programming errors that would produce zero/negative
+// delays (which panic in time.NewTimer) or an unbounded loop, and every caller
+// passes compile-time constants.
+func NewBackoff(initial, maxInterval time.Duration, jitter float64) *Backoff {
+	switch {
+	case initial <= 0:
+		panic(fmt.Sprintf("backoffutil: initial must be > 0 (got %v)", initial))
+	case maxInterval < initial:
+		panic(fmt.Sprintf("backoffutil: maxInterval (%v) must be >= initial (%v)", maxInterval, initial))
+	case jitter < 0 || jitter >= 1:
+		panic(fmt.Sprintf("backoffutil: jitter must be in [0, 1) (got %v)", jitter))
+	}
+	return &Backoff{
+		initial:     initial,
+		maxInterval: maxInterval,
+		jitter:      jitter,
+		base:        initial,
+	}
 }
+
+// Next samples the next delay and advances the base interval, in one step. Use
+// this for unbounded reconnect loops that always act on the sampled delay. For
+// a loop that may sample-then-bail, use Peek + Commit so a discarded sample
+// does not ratchet the interval forward.
+func (b *Backoff) Next() time.Duration {
+	d := b.sample(b.base)
+	b.advance()
+	return d
+}
+
+// Peek samples the next delay WITHOUT advancing the base interval, staging it
+// for a later Commit. Calling Peek again before Commit overwrites the staged
+// sample with a fresh draw (the previous peek is discarded, no advance). Use
+// Commit once the attempt actually fires so the base interval advances only on
+// a real attempt; a peeked-but-uncommitted sample is dropped on Reset or the
+// next Peek with no effect on the sequence.
+func (b *Backoff) Peek() time.Duration {
+	b.pending = b.sample(b.base)
+	return b.pending
+}
+
+// Commit advances the base interval, consuming the most recent Peek. A
+// Commit with no pending Peek advances from the current base (treating the
+// peek as implicit), matching Next's semantics for callers that do not peek.
+func (b *Backoff) Commit() {
+	b.pending = 0
+	b.advance()
+}
+
+// Rollback discards the most recent Peek without advancing the base interval.
+// No-op when there is no pending Peek. Use after a Peek when the attempt will
+// not fire, so the interval the next Peek draws from is unchanged.
+func (b *Backoff) Rollback() {
+	b.pending = 0
+}
+
+// Reset restarts the base interval at initial and drops any pending Peek, so
+// the next Peek/Next begins a fresh backoff sequence.
+func (b *Backoff) Reset() {
+	b.base = b.initial
+	b.pending = 0
+}
+
+// sample draws a jittered delay around base. With jitter == 0 it returns base
+// unchanged. The upper bound is inclusive (+1ns) to match the
+// cenkalti/v6 RandomizationFactor window callers have historically asserted
+// against.
+func (b *Backoff) sample(base time.Duration) time.Duration {
+	if b.jitter == 0 {
+		return base
+	}
+	delta := b.jitter * float64(base)
+	lo := float64(base) - delta
+	hi := float64(base) + delta
+	// rand/v2's Float64 is uniform [0,1); scale to [lo, hi] inclusive of hi.
+	return time.Duration(lo + rand.Float64()*(hi-lo+1))
+}
+
+// advance doubles the base interval, capping at maxInterval.
+func (b *Backoff) advance() {
+	next := time.Duration(float64(b.base) * 2)
+	if next > b.maxInterval || next < b.base {
+		// Overflow guard: a doubling that wraps negative or exceeds the cap
+		// pins to the cap.
+		next = b.maxInterval
+	}
+	b.base = next
+}
+
+// Retry is a count-bounded, reset-aware exponential backoff for a single retry
+// loop. It wraps the same capped, jittered exponential NewBackoff produces and
+// adds a per-loop attempt budget, which v6's ExponentialBackOff no longer ships
+// (it dropped MaxElapsedTime). The behavior mirrors the frontend's
+// createExponentialBackoff: the doubling sequence advances on the un-jittered
+// base interval, and jitter only fuzzes the value Peek returns.
+//
+// The budget is consumed only when an attempt actually fires: Peek samples a
+// delay without consuming a slot, and Commit consumes the slot (and advances
+// the interval) only when the caller confirms the attempt fired. A retry that
+// peeks but bails before firing calls Rollback and the slot is untouched — so
+// a Cancel/generation race that retires an armed retry cannot erode the budget
+// or ratchet the interval. This makes the refund-and-erode class of bug
+// mechanically impossible, instead of relying on every caller to thread a
+// Release through every bail path.
+//
+// maxAttempts == 0 retries forever (use this for "keep trying" loops); any
+// positive value turns "retry until it works" into "retry until it clearly
+// won't" — the shape every bounded caller wants.
+//
+// NOT safe for concurrent use — each retry loop owns its own, or serializes all
+// access under its own mutex (which is exactly what the LOOKUP_FAILED caller
+// does under s.mu).
+type Retry struct {
+	b   *Backoff
+	max int // 0 = unlimited
+
+	attempt int
+}
+
+// NewRetry returns a bounded exponential backoff: starting at initial, doubling,
+// capped at maxInterval, with symmetric jitter of `jitter` (0 disables it; see
+// NewBackoff's jitter doc for why shared-peer loops want jitter). After
+// maxAttempts successful Next calls the budget is spent and Next returns ok=false.
+// Pass maxAttempts == 0 for an unbounded loop.
+//
+// Returns an error for invalid inputs: initial <= 0, maxInterval < initial,
+// jitter outside [0,1), or negative maxAttempts. These mirror the frontend's
+// createExponentialBackoff rejections with one deliberate exception: the
+// backend accepts maxAttempts == 0 as a first-class "unbounded" mode (see
+// Retry.max above), while the frontend rejects maxAttempts < 1. An out-of-range
+// value otherwise silently turns a bounded caller into an unbounded one
+// (negative maxAttempts) or produces zero/negative delays (initial <= 0,
+// jitter >= 1), the latter of which panic in time.NewTimer.
+func NewRetry(initial, maxInterval time.Duration, jitter float64, maxAttempts int) (*Retry, error) {
+	switch {
+	case initial <= 0:
+		return nil, fmt.Errorf("backoffutil: initial must be > 0 (got %v)", initial)
+	case maxInterval < initial:
+		return nil, fmt.Errorf("backoffutil: maxInterval (%v) must be >= initial (%v)", maxInterval, initial)
+	case jitter < 0 || jitter >= 1:
+		return nil, fmt.Errorf("backoffutil: jitter must be in [0, 1) (got %v)", jitter)
+	case maxAttempts < 0:
+		return nil, fmt.Errorf("backoffutil: maxAttempts must be >= 0 (got %d)", maxAttempts)
+	}
+	return &Retry{b: NewBackoff(initial, maxInterval, jitter), max: maxAttempts}, nil
+}
+
+// Peek samples the delay for the next attempt WITHOUT consuming a slot or
+// advancing the interval, and reports whether the budget has one. ok is false
+// when the budget is spent (and always true when unbounded). A caller that
+// proceeds to fire the attempt must call Commit to consume the slot; a caller
+// that bails calls Rollback (or simply peeks again / resets) and the slot is
+// untouched. Two peeks in a row overwrite the staged sample with no advance.
+func (r *Retry) Peek() (delay time.Duration, ok bool) {
+	if r.max > 0 && r.attempt >= r.max {
+		return 0, false
+	}
+	return r.b.Peek(), true
+}
+
+// Commit consumes one attempt slot and advances the interval, finalizing the
+// most recent Peek. Call this once the attempt the Peek armed has actually
+// fired (or is about to fire irreversibly). No-op when unbounded AND the
+// budget is irrelevant is NOT the rule: Commit always advances the interval
+// (so an unbounded caller that peeks and commits still sees the doubling
+// sequence progress), but only counts toward the budget when max > 0.
+func (r *Retry) Commit() {
+	r.b.Commit()
+	if r.max > 0 {
+		r.attempt++
+	}
+}
+
+// Rollback discards the most recent Peek without consuming a slot or advancing
+// the interval. Use after a Peek when the attempt will not fire, so neither
+// the budget nor the interval is touched. No-op when there is no pending Peek
+// or when unbounded (where the interval advance is the only effect, and a
+// bail should not ratchet it — Rollback drops the pending Peek so a subsequent
+// Commit-from-Next path still advances; for the peek/commit caller this keeps
+// the interval a function of fired attempts only).
+func (r *Retry) Rollback() {
+	r.b.Rollback()
+}
+
+// Done reports whether the attempt budget is spent. Always false when the Retry
+// is unbounded. It is a non-advancing peek of the identical predicate Peek's ok
+// return tests (`r.max > 0 && r.attempt >= r.max`); the two are kept in
+// lockstep so a caller that peeks with Done and then calls Peek sees the
+// verdict the peek promised.
+func (r *Retry) Done() bool {
+	return r.max > 0 && r.attempt >= r.max
+}
+
+// Reset restores the full attempt budget and restarts the interval at
+// initial, so the next Peek begins a fresh backoff sequence.
+func (r *Retry) Reset() {
+	r.attempt = 0
+	r.b.Reset()
+}
+
+// Attempts returns the number of attempts consumed (via Commit) since
+// construction or the last Reset. Intended for logging and assertions.
+func (r *Retry) Attempts() int { return r.attempt }

--- a/backend/internal/util/backoffutil/backoffutil_test.go
+++ b/backend/internal/util/backoffutil/backoffutil_test.go
@@ -1,0 +1,305 @@
+package backoffutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustNewRetry wraps NewRetry for tests with known-valid policy; a bad test
+// constant should fail the test, not compile.
+func mustNewRetry(t *testing.T, initial, maxInterval time.Duration, jitter float64, maxAttempts int) *Retry {
+	t.Helper()
+	r, err := NewRetry(initial, maxInterval, jitter, maxAttempts)
+	require.NoError(t, err)
+	return r
+}
+
+// assertBaseSequence drives next with jitter==0 (deterministic) and asserts the
+// un-jittered doubling sequence initial, 2*initial, ..., capped at maxInterval.
+// It takes a next() closure so it can assert the same shape for both *Retry
+// (via Peek+Commit) and the raw *Backoff.
+func assertBaseSequence(t *testing.T, next func() time.Duration, initial, maxInterval time.Duration, n int) {
+	t.Helper()
+	want := initial
+	for i := 0; i < n; i++ {
+		assert.Equal(t, want, next(), "attempt %d base delay", i)
+		nx := time.Duration(float64(want) * 2)
+		if nx > maxInterval {
+			nx = maxInterval
+		}
+		want = nx
+	}
+}
+
+// commitPeek advances a Retry one real attempt (Peek then Commit), returning the
+// peeked delay. Used by the sequence tests to drive the consume-on-fire API the
+// way the production caller does.
+func commitPeek(r *Retry) time.Duration {
+	d, ok := r.Peek()
+	if !ok {
+		panic("commitPeek: budget spent")
+	}
+	r.Commit()
+	return d
+}
+
+func TestRetry_DoublesAndCapsJitterless(t *testing.T) {
+	// 100ms -> 200 -> 400 -> 500 (cap), 500 ... unlimited budget, 6 samples.
+	r := mustNewRetry(t, 100*time.Millisecond, 500*time.Millisecond, 0, 0)
+	assertBaseSequence(t, func() time.Duration { return commitPeek(r) },
+		100*time.Millisecond, 500*time.Millisecond, 6)
+}
+
+func TestRetry_PeekReturnsFalseWhenBudgetSpent(t *testing.T) {
+	r := mustNewRetry(t, 1*time.Millisecond, 10*time.Millisecond, 0, 3)
+	for i := 0; i < 3; i++ {
+		_, ok := r.Peek()
+		assert.True(t, ok, "attempt %d within budget", i)
+		r.Commit()
+	}
+	assert.True(t, r.Done(), "Done after budget spent")
+	_, ok := r.Peek()
+	assert.False(t, ok, "Peek past budget returns ok=false")
+	// The exhausted Retry must not keep advancing: this is the property that
+	// stops a flapping worker's LOOKUP_FAILED ladder from compounding.
+	assert.Equal(t, 3, r.Attempts(), "exhausted Peek does not advance the counter")
+}
+
+func TestRetry_DoneFalseBeforeExhaustion(t *testing.T) {
+	r := mustNewRetry(t, 1*time.Millisecond, 10*time.Millisecond, 0, 3)
+	assert.False(t, r.Done(), "not done at zero attempts")
+	r.Commit()
+	assert.False(t, r.Done(), "not done one before the cap")
+	r.Commit()
+	assert.False(t, r.Done(), "not done at the last allowed attempt's start")
+	r.Commit()
+	assert.True(t, r.Done(), "done only once the budget is fully consumed")
+}
+
+func TestRetry_ResetRestartsUnboundedInterval(t *testing.T) {
+	// Reset on an unbounded retry has no budget to restore, but must still
+	// restart the interval at InitialInterval.
+	r := mustNewRetry(t, 100*time.Millisecond, 1*time.Second, 0, 0)
+	commitPeek(r) // 100ms
+	commitPeek(r) // 200ms
+	r.Reset()
+	assert.False(t, r.Done(), "unbounded is never Done after Reset")
+	d, ok := r.Peek()
+	require.True(t, ok)
+	assert.Equal(t, 100*time.Millisecond, d, "interval restarts at initial after Reset")
+}
+
+func TestRetry_DoneFalseForUnbounded(t *testing.T) {
+	r := mustNewRetry(t, 1*time.Millisecond, 10*time.Millisecond, 0, 0)
+	for i := 0; i < 50; i++ {
+		commitPeek(r)
+	}
+	assert.False(t, r.Done(), "unbounded Retry is never Done")
+}
+
+func TestRetry_ResetRestoresBudgetAndInterval(t *testing.T) {
+	r := mustNewRetry(t, 100*time.Millisecond, 1*time.Second, 0, 2)
+	commitPeek(r) // 100ms, attempt 1
+	commitPeek(r) // 200ms, attempt 2 -- budget spent
+	_, ok := r.Peek()
+	require.False(t, ok)
+
+	r.Reset()
+	assert.False(t, r.Done(), "budget restored")
+	assert.Equal(t, 0, r.Attempts())
+	d, ok := r.Peek()
+	require.True(t, ok)
+	assert.Equal(t, 100*time.Millisecond, d, "interval restarts at initial")
+}
+
+func TestRetry_AttemptsCounter(t *testing.T) {
+	r := mustNewRetry(t, 1*time.Millisecond, 10*time.Millisecond, 0, 5)
+	for i := 0; i < 3; i++ {
+		r.Peek()
+		r.Commit()
+	}
+	assert.Equal(t, 3, r.Attempts())
+}
+
+// TestRetry_PeekDoesNotConsumeSlot pins the consume-on-fire contract: a Peek
+// that the caller discards (via Rollback or a fresh Peek) consumes NO budget
+// slot and does NOT advance the interval. This is the property that makes a
+// Cancel/generation race that retires an armed retry mechanically unable to
+// erode the budget or ratchet the interval — the retry peeked but never
+// committed.
+func TestRetry_PeekDoesNotConsumeSlot(t *testing.T) {
+	r := mustNewRetry(t, 100*time.Millisecond, 1*time.Second, 0, 3)
+	d1, ok := r.Peek()
+	require.True(t, ok)
+	require.Equal(t, 100*time.Millisecond, d1, "first peek at the initial interval")
+	// Discard the peek without committing — Rollback.
+	r.Rollback()
+	assert.Equal(t, 0, r.Attempts(), "a peeked-but-rolled-back attempt consumes no slot")
+	assert.False(t, r.Done(), "the budget is untouched after a rolled-back peek")
+
+	// The next peek must return the SAME interval (no advance): the rolled-back
+	// peek left the base interval where it was.
+	d2, ok := r.Peek()
+	require.True(t, ok)
+	assert.Equal(t, d1, d2, "a rolled-back peek does not advance the interval")
+
+	// Only a Commit advances the interval and consumes the slot.
+	r.Commit()
+	assert.Equal(t, 1, r.Attempts(), "Commit consumes the slot")
+	d3, ok := r.Peek()
+	require.True(t, ok)
+	assert.Equal(t, 200*time.Millisecond, d3, "Commit advanced the interval to 2x")
+}
+
+// TestRetry_RollbackNoOpWithoutPeek pins that Rollback is a harmless no-op when
+// there is no pending peek — so a caller that bails unconditionally (without
+// knowing whether it peeked) cannot corrupt the state.
+func TestRetry_RollbackNoOpWithoutPeek(t *testing.T) {
+	r := mustNewRetry(t, 1*time.Millisecond, 10*time.Millisecond, 0, 3)
+	r.Rollback() // no pending peek
+	r.Rollback() // still no pending peek
+	assert.Equal(t, 0, r.Attempts(), "Rollback without a peek is a no-op")
+	d, ok := r.Peek()
+	require.True(t, ok)
+	assert.Equal(t, 1*time.Millisecond, d, "interval unchanged after no-op Rollback")
+}
+
+// TestRetry_RepeatedPeekOverwrites pins that two Peeks in a row (without a
+// Commit between them) overwrite the staged sample and advance nothing — the
+// previous peek is simply discarded.
+func TestRetry_RepeatedPeekOverwrites(t *testing.T) {
+	r := mustNewRetry(t, 100*time.Millisecond, 1*time.Second, 0, 3)
+	_, ok := r.Peek()
+	require.True(t, ok)
+	_, ok = r.Peek()
+	require.True(t, ok)
+	// Two peeks, zero commits: no slot consumed.
+	assert.Equal(t, 0, r.Attempts(), "two peeks consume no slot")
+	r.Commit()
+	assert.Equal(t, 1, r.Attempts(), "a single Commit consumes one slot regardless of prior peeks")
+}
+
+// TestRetry_JitterStaysWithinWindow fuzzes many samples: with jitterFactor j,
+// every returned delay must lie in [base*(1-j), base*(1+j)]. Because the first
+// attempt's base is `initial`, all first-attempt samples are directly comparable.
+func TestRetry_JitterStaysWithinWindow(t *testing.T) {
+	const j = 0.2
+	initial := 100 * time.Millisecond
+	for s := 0; s < 1000; s++ {
+		// Fresh Retry so every sample is the first attempt (base == initial).
+		r := mustNewRetry(t, initial, 15*time.Second, j, 1)
+		d, ok := r.Peek()
+		require.True(t, ok)
+		lo := time.Duration(float64(initial) * (1 - j))
+		hi := time.Duration(float64(initial) * (1 + j))
+		assert.GreaterOrEqual(t, int64(d), int64(lo), "below window: %v", d)
+		// +1ns: the inclusive upper bound matches cenkalti v6's
+		// getRandomValueFromInterval window callers have historically asserted.
+		assert.LessOrEqual(t, int64(d), int64(hi)+1, "above window: %v", d)
+	}
+}
+
+func TestBackoff_DoublesAndCapsJitterless(t *testing.T) {
+	// NewBackoff coverage (the raw type Retry wraps); shares assertBaseSequence
+	// with the Retry sequence test so the two cannot drift.
+	b := NewBackoff(100*time.Millisecond, 500*time.Millisecond, 0)
+	assertBaseSequence(t, b.Next, 100*time.Millisecond, 500*time.Millisecond, 6)
+}
+
+// TestBackoff_PeekCommitMatchesNext pins that a Peek+Commit cycle produces the
+// same interval a Next would — the peek/commit split is a faithful
+// decomposition, not a different sequence.
+func TestBackoff_PeekCommitMatchesNext(t *testing.T) {
+	peekCommit := NewBackoff(10*time.Millisecond, 100*time.Millisecond, 0)
+	next := NewBackoff(10*time.Millisecond, 100*time.Millisecond, 0)
+	for i := 0; i < 5; i++ {
+		dPC := peekCommit.Peek()
+		peekCommit.Commit()
+		dN := next.Next()
+		assert.Equal(t, dN, dPC, "attempt %d: Peek+Commit must match Next", i)
+	}
+}
+
+// TestNewRetry_RejectsInvalidPolicy pins the validation that stops a bad
+// runtime policy from silently producing a zero/negative-delay burst (initial
+// <= 0, jitter >= 1) or an unbounded loop from a negative maxAttempts. These
+// match the frontend's createExponentialBackoff rejections.
+func TestNewRetry_RejectsInvalidPolicy(t *testing.T) {
+	cases := []struct {
+		name         string
+		initial, max time.Duration
+		jitter       float64
+		maxAttempts  int
+	}{{
+		name: "zero initial", initial: 0, max: time.Second, jitter: 0, maxAttempts: 1,
+	}, {
+		name: "negative initial", initial: -1, max: time.Second, jitter: 0, maxAttempts: 1,
+	}, {
+		name: "max below initial", initial: time.Second, max: time.Millisecond, jitter: 0, maxAttempts: 1,
+	}, {
+		name: "negative jitter", initial: time.Millisecond, max: time.Second, jitter: -0.1, maxAttempts: 1,
+	}, {
+		name: "jitter at 1", initial: time.Millisecond, max: time.Second, jitter: 1, maxAttempts: 1,
+	}, {
+		name: "negative maxAttempts", initial: time.Millisecond, max: time.Second, jitter: 0, maxAttempts: -1,
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NewRetry(c.initial, c.max, c.jitter, c.maxAttempts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "backoffutil:")
+		})
+	}
+}
+
+// TestNewRetry_AcceptsBoundaryPolicy confirms the boundary values validation
+// must NOT reject: initial == max (no doubling room), maxAttempts == 0
+// (unbounded), jitter == 0 (disabled).
+func TestNewRetry_AcceptsBoundaryPolicy(t *testing.T) {
+	for _, c := range []struct {
+		name         string
+		initial, max time.Duration
+		jitter       float64
+		maxAttempts  int
+	}{
+		{name: "initial==max", initial: time.Second, max: time.Second, jitter: 0, maxAttempts: 1},
+		{name: "unbounded", initial: time.Millisecond, max: time.Second, jitter: 0, maxAttempts: 0},
+		{name: "jitterless", initial: time.Millisecond, max: time.Second, jitter: 0, maxAttempts: 1},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NewRetry(c.initial, c.max, c.jitter, c.maxAttempts)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestNewBackoff_PanicsOnInvalid pins that the unbounded constructor panics on
+// invalid inputs (it has no error return), so a bad constant fails loudly at
+// startup instead of producing a zero/negative-delay burst.
+func TestNewBackoff_PanicsOnInvalid(t *testing.T) {
+	cases := []struct {
+		name         string
+		initial, max time.Duration
+		jitter       float64
+		wantSubstr   string
+	}{
+		{name: "zero initial", initial: 0, max: time.Second, jitter: 0, wantSubstr: "initial must be > 0"},
+		{name: "max below initial", initial: time.Second, max: time.Millisecond, jitter: 0, wantSubstr: "maxInterval"},
+		{name: "jitter at 1", initial: time.Millisecond, max: time.Second, jitter: 1, wantSubstr: "jitter"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var msg string
+			func() {
+				defer func() { msg, _ = recover().(string) }()
+				_ = NewBackoff(c.initial, c.max, c.jitter)
+			}()
+			require.NotEmpty(t, msg, "NewBackoff must panic on invalid input")
+			assert.Contains(t, msg, c.wantSubstr, "panic message names the invalid field")
+			assert.Contains(t, msg, "backoffutil:", "panic message carries the package prefix")
+		})
+	}
+}

--- a/backend/internal/worker/hub/backoff.go
+++ b/backend/internal/worker/hub/backoff.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"time"
 
-	"github.com/cenkalti/backoff/v6"
 	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
@@ -13,10 +12,17 @@ const (
 	resetThreshold = 30 * time.Second
 )
 
+// backoff is the subset of *backoffutil.Backoff the hub reconnect loops use.
+// Declared locally so the hub depends on backoffutil, not on cenkalti/backoff/v6.
+type backoff interface {
+	Next() time.Duration
+	Reset()
+}
+
 // newDefaultBackoff creates an exponential backoff: 1s → 180s, multiplier 2x, ±20% jitter.
 //
 // Jitter matters here specifically: every worker reconnecting to one hub after
 // an outage would otherwise retry in lockstep.
-func newDefaultBackoff() *backoff.ExponentialBackOff {
-	return backoffutil.NewCapped(1*time.Second, 180*time.Second, 0.2)
+func newDefaultBackoff() *backoffutil.Backoff {
+	return backoffutil.NewBackoff(1*time.Second, 180*time.Second, 0.2)
 }

--- a/backend/internal/worker/hub/backoff_test.go
+++ b/backend/internal/worker/hub/backoff_test.go
@@ -3,16 +3,10 @@ package hub
 import (
 	"time"
 
-	"github.com/cenkalti/backoff/v6"
+	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
 // newFastBackoff creates a fast exponential backoff for testing.
-func newFastBackoff() *backoff.ExponentialBackOff {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = 1 * time.Millisecond
-	b.MaxInterval = 10 * time.Millisecond
-	b.Multiplier = 2.0
-	b.RandomizationFactor = 0
-	b.Reset()
-	return b
+func newFastBackoff() *backoffutil.Backoff {
+	return backoffutil.NewBackoff(1*time.Millisecond, 10*time.Millisecond, 0)
 }

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -15,7 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff/v6"
 	"golang.org/x/net/http2"
 
 	"connectrpc.com/connect"
@@ -614,7 +613,7 @@ func (c *Client) ConnectWithReconnect(ctx context.Context, authToken string) {
 	c.connectWithReconnect(ctx, authToken, c.Connect, newDefaultBackoff(), resetThreshold)
 }
 
-func (c *Client) connectWithReconnect(ctx context.Context, authToken string, connect connectFn, bo backoff.BackOff, threshold time.Duration) {
+func (c *Client) connectWithReconnect(ctx context.Context, authToken string, connect connectFn, bo backoff, threshold time.Duration) {
 	for {
 		start := time.Now()
 		err := connect(ctx, authToken)
@@ -651,7 +650,7 @@ func (c *Client) connectWithReconnect(ctx context.Context, authToken string, con
 			bo.Reset()
 		}
 
-		interval := bo.NextBackOff()
+		interval := bo.Next()
 		slog.Warn("disconnected from hub, reconnecting...", "error", err, "backoff", interval)
 		select {
 		case <-ctx.Done():

--- a/backend/internal/worker/hub/client_test.go
+++ b/backend/internal/worker/hub/client_test.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/cenkalti/backoff/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/sendq"
+	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
 // TestNew_DispatchesOnURLScheme verifies the scheme-dispatch branches in
@@ -226,12 +226,7 @@ func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 	client := &Client{}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	bo := backoff.NewExponentialBackOff()
-	bo.InitialInterval = 10 * time.Millisecond
-	bo.MaxInterval = 500 * time.Millisecond
-	bo.Multiplier = 4.0
-	bo.RandomizationFactor = 0
-	bo.Reset()
+	bo := backoffutil.NewBackoff(10*time.Millisecond, 500*time.Millisecond, 0)
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
@@ -241,10 +236,10 @@ func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 			// First call: fail immediately → backoff=10ms.
 			return fmt.Errorf("fail 1")
 		case 2:
-			// Second call: fail immediately → backoff=40ms.
+			// Second call: fail immediately → backoff=20ms.
 			return fmt.Errorf("fail 2")
 		case 3:
-			// Third call: fail immediately → backoff=160ms.
+			// Third call: fail immediately → backoff=40ms.
 			return fmt.Errorf("fail 3")
 		case 4:
 			// Fourth call: succeed for longer than threshold → should reset backoff.
@@ -263,7 +258,7 @@ func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 
 	require.GreaterOrEqual(t, len(timestamps), 6, "expected at least 6 timestamps")
 
-	// Gap between call 3 and 4 should be large (160ms backoff).
+	// Gap between call 3 and 4 should be large (40ms backoff).
 	// Gap between call 5 and 6 should be small (10ms, reset to InitialInterval).
 	gap34 := timestamps[3].Sub(timestamps[2])
 	gap56 := timestamps[5].Sub(timestamps[4])
@@ -279,12 +274,8 @@ func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 	client := &Client{}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	bo := backoff.NewExponentialBackOff()
-	bo.InitialInterval = 2 * time.Millisecond
-	bo.MaxInterval = 10 * time.Millisecond
-	bo.Multiplier = 2.0
-	bo.RandomizationFactor = 0
-	bo.Reset()
+	const maxInterval = 10 * time.Millisecond
+	bo := backoffutil.NewBackoff(2*time.Millisecond, maxInterval, 0)
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
@@ -303,7 +294,7 @@ func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 	tolerance := 50 * time.Millisecond
 	for i := 1; i < len(timestamps); i++ {
 		gap := timestamps[i].Sub(timestamps[i-1])
-		assert.LessOrEqual(t, gap, bo.MaxInterval+tolerance, "gap[%d]=%v exceeds MaxInterval=%v", i, gap, bo.MaxInterval)
+		assert.LessOrEqual(t, gap, maxInterval+tolerance, "gap[%d]=%v exceeds MaxInterval=%v", i, gap, maxInterval)
 	}
 }
 

--- a/backend/internal/worker/hub/registration.go
+++ b/backend/internal/worker/hub/registration.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/cenkalti/backoff/v6"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
@@ -51,7 +50,7 @@ func registerWithClient(
 	registrationKey string,
 	version string,
 	publicKey, mlkemPublicKey, slhdsaPublicKey []byte,
-	bo backoff.BackOff,
+	bo backoff,
 ) (*RegistrationResult, error) {
 	if registrationKey == "" {
 		return nil, errors.New("registration key is required")
@@ -99,7 +98,7 @@ func registerWithClient(
 			}
 		}
 
-		interval := bo.NextBackOff()
+		interval := bo.Next()
 		slog.Warn("hub unavailable, retrying registration...", "error", err, "backoff", interval)
 		select {
 		case <-ctx.Done():

--- a/backend/internal/worker/hub/registration_test.go
+++ b/backend/internal/worker/hub/registration_test.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/cenkalti/backoff/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
+	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
 // mockConnectorClient implements WorkerConnectorServiceClient for
@@ -110,16 +110,16 @@ func TestRegisterWithClient_DoesNotRetryUnauthenticated(t *testing.T) {
 	assert.Equal(t, int32(1), attempts.Load(), "Unauthenticated must not be retried")
 }
 
-// recordingBackoff records each NextBackOff result so tests can assert
+// recordingBackoff records each Next result so tests can assert
 // on the values requested rather than wall-clock elapsed time, which is
 // noisy on Windows where the scheduler tick (~15.6ms) dwarfs 10ms sleeps.
 type recordingBackoff struct {
-	inner     backoff.BackOff
+	inner     *backoffutil.Backoff
 	intervals []time.Duration
 }
 
-func (r *recordingBackoff) NextBackOff() time.Duration {
-	d := r.inner.NextBackOff()
+func (r *recordingBackoff) Next() time.Duration {
+	d := r.inner.Next()
 	r.intervals = append(r.intervals, d)
 	return d
 }
@@ -140,12 +140,7 @@ func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
 		},
 	}
 
-	inner := backoff.NewExponentialBackOff()
-	inner.InitialInterval = 10 * time.Millisecond
-	inner.MaxInterval = 100 * time.Millisecond
-	inner.Multiplier = 2.0
-	inner.RandomizationFactor = 0
-	inner.Reset()
+	inner := backoffutil.NewBackoff(10*time.Millisecond, 100*time.Millisecond, 0)
 	rec := &recordingBackoff{inner: inner}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/backend/internal/worker/service/orphan_reconciler.go
+++ b/backend/internal/worker/service/orphan_reconciler.go
@@ -174,7 +174,7 @@ func (r *OrphanReconciler) Run(ctx context.Context) {
 	// budget. Capped at the ordinary interval, so a worker that is genuinely
 	// offline decays into the hourly cadence instead of hammering a hub that
 	// cannot answer.
-	retryBackoff := backoffutil.NewCapped(reconcileRetryBase, r.interval, 0)
+	retryBackoff := backoffutil.NewBackoff(reconcileRetryBase, r.interval, 0)
 	var (
 		retryTimer *time.Timer
 		retryC     <-chan time.Time
@@ -191,7 +191,7 @@ func (r *OrphanReconciler) Run(ctx context.Context) {
 			retryBackoff.Reset()
 			return
 		}
-		retryTimer = time.NewTimer(retryBackoff.NextBackOff())
+		retryTimer = time.NewTimer(retryBackoff.Next())
 		retryC = retryTimer.C
 	}
 	defer func() {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -219,7 +219,13 @@ message WatchEventsRequest {
   repeated WatchAgentEntry agents = 1;
   repeated WatchTerminalEntry terminals = 2;
   // Echoed on WatchUpdateAck. Client-chosen, monotonic per stream; 0 is fine
-  // for a client that does not track revisions.
+  // for a client that does not track revisions. "Per stream" here means per the
+  // client's logical subscription lifetime: a client that resets update_id on
+  // each fresh stream open MUST treat acks from prior stream generations as
+  // stale (the generation boundary does not by itself make a buffered ack from
+  // the prior stream current). Clients that keep a single monotonic counter for
+  // the whole subscription life (never resetting on reconnect) are immune; this
+  // is the stronger form both known clients (frontend and CLI) implement.
   uint64 update_id = 3;
 }
 


### PR DESCRIPTION
## Motivation

The retry/backoff machinery in the backend had a class of "refund-and-erode"
bugs: sampling a delay, advancing the interval, and consuming an attempt were
coupled through the third-party `cenkalti/backoff/v6` type, so every caller had
to thread a `Release` through each bail path. Any path that forgot (or raced,
e.g. a `Cancel`/generation collision that retired an armed retry) silently
eroded the attempt budget and ratcheted the interval forward. Concrete
manifestations in the `streamevents` LOOKUP_FAILED path (#349): the retry
goroutine leaked/orphaned a stream after `Cancel`, lingered up to 15s after
shutdown, clobbered a `revise` that landed during the backoff window, dropped
budget on nil-`lastReq` acks, burst-exhausted on a flurry of acks, and re-fired
its exhaustion `Warn` repeatedly. Fixes #349.

## Modifications

**`backoffutil` package rewrite.** Dropped the `cenkalti/backoff/v6`
dependency (the third-party type no longer crosses the package boundary).
Replaced `NewCapped` with two purpose-built types:
- `NewBackoff(...)` — unbounded, reset-on-success, returns a new `Backoff`.
- `NewRetry(...)` — count-bounded, gives up after a fixed attempt budget,
  returns a new `Retry` (errors on invalid input; `NewBackoff` panics, matching
  the frontend's `createExponentialBackoff` rejections with the deliberate
  exception that `maxAttempts == 0` is a first-class unbounded mode).

Both expose a **Peek / Commit / Rollback** contract: sampling a delay is
decoupled from advancing the interval / consuming an attempt. A peeked-but-
discarded attempt (a Cancel/generation race that retires an armed retry) no
longer erodes the budget or ratchets the interval — making the refund-and-erode
class of bug mechanically impossible rather than caller-disciplined. `Release`
is removed. Uses `math/rand/v2`. Added a 305-line test suite (the package
previously had none): deterministic doubling-then-cap sequences, budget
exhaustion/`Done` semantics, jitter bounds (1000-sample fuzz), peek/commit-vs-
`Next` equivalence, the consume-on-fire contract, and boundary-policy
acceptance.

> **Breaking:** `NewCapped(...)` is removed. The hub API method `NextBackOff()`
> is renamed to `Next()` (`client.go`, `registration.go`,
> `orphan_reconciler.go`). All current call sites migrated.

**`streamevents` subscription + `agent_messages`.** Rewrote the LOOKUP_FAILED
retry engine around `backoffutil.Retry`: jittered exponential constants
mirroring the frontend's `rejectionBackoff` (500ms→15s, ±20% jitter, 8
attempts), replacing the fixed 5-hop 200ms→5s table and the per-open
`retryCtx`/`lookupAttempts` machinery. The retry `Peek()`s a delay, arms a
goroutine, and `Commit`s the slot only when it fires (or `Rollback`s on
Cancel/race).
- New exported sentinel `ErrSubscriptionClosed`; `Cancel` sets a terminal
  `closed` flag (never cleared) and `Update` returns it post-Cancel. The
  `agent_messages --follow` reconnect loop `errors.Is`-checks it as expected
  shutdown rather than a subscribe failure.
- Generation counter + immediate-wake `retryCtx`: each fresh-open/Cancel bumps
  `generation`; an armed retry captures and re-checks it at fire time.
  `Cancel` cancels `retryCtx` so an armed retry wakes immediately (fresh-open
  deliberately does not, so a retry can still restate against a recovered
  stream).
- Ported frontend staleness/coalescing semantics: monotonic `update_id`
  (stale acks dropped, with rollback on a failed `revise` send so the live prior
  revision's acks survive), per-entity liveness gating (`anyRetryableInterest`,
  mirroring `tabExists`) so a LOOKUP_FAILED for a dropped entity doesn't burn
  the budget, and a `retryInFlight` coalescer so an ack burst arms one retry per
  slot. Budget + once-guard reset only on a clean fresh-open.
- Migrated `agent_messages.go`'s reconnect backoff from cenkalti to
  `backoffutil.NewBackoff`/`.Next()`.
- Fixes: (1) retry goroutine no longer leaks/orphans a stream after Cancel;
  (2) retry no longer lingers up to 15s post-shutdown; (3) retry re-reads
  `lastReq` at fire time so a revise during the backoff window isn't clobbered;
  (4) failed revise send rolls back `inflightUpdateId`; (5) nil-`lastReq` ack
  no longer erodes the budget; (6) coalescing prevents burst-exhaustion;
  (7) exhaustion `Warn` fires once per cycle.

**`hub` + `orphan_reconciler`.** Removed the direct cenkalti dependency; the
hub now declares a local `backoff` interface (`Next` + `Reset`) over the in-tree
`backoffutil`. `NewCapped` → `NewBackoff` in `backoff.go`,
`backoff_test.go`, `orphan_reconciler.go`; `NextBackOff()` → `Next()` across
callers. Test backoff construction collapsed from hand-rolled cenkalti
boilerplate to one-line `NewBackoff(...)` calls (test comment corrected 4× → 2×
multiplier).

**`proto`.** Clarified the `WatchEventsRequest.update_id` comment to spell out
per-stream semantics: resetting on each fresh open requires treating prior-
generation acks as stale, and a single never-reset monotonic counter is the
stronger form both known clients implement.

## Result

The refund-and-erode class of retry bug is now mechanically impossible:
sampling a delay can never consume a budget slot or advance the interval unless
the caller explicitly commits. The `streamevents` LOOKUP_FAILED path no longer
leaks, lingers, or clobbers in-flight revises, shuts down promptly on Cancel,
and resists burst-exhaustion and stale-ack erosion. The third-party
`cenkalti/backoff/v6` dependency is gone from `backoffutil` and `hub`, replaced
by a small, in-tree, fully-tested abstraction. Closes #349.
